### PR TITLE
Add Terms of Service document

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,30 @@
+# Supported AI Providers
+
+**TeXRA — AI-Powered LaTeX Research Assistant**
+
+*Last Updated: February 10, 2026*
+
+The following table lists the AI model providers supported by TeXRA, along with their operating headquarters and links to their respective terms and privacy policies. When you select a provider, your content is transmitted to that provider's API endpoints and is subject to their terms.
+
+| Provider | Headquarters | Terms / Privacy |
+|----------|-------------|-----------------|
+| Anthropic (Claude) | San Francisco, CA, USA | [Terms](https://www.anthropic.com/legal/consumer-terms) · [Privacy](https://www.anthropic.com/legal/privacy) · [AUP](https://www.anthropic.com/legal/aup) |
+| OpenAI (GPT) | San Francisco, CA, USA | [Terms](https://openai.com/policies/terms-of-use) · [Privacy](https://openai.com/policies/privacy-policy) · [Usage](https://openai.com/policies/usage-policies) |
+| Google (Gemini) | Mountain View, CA, USA | [Terms](https://ai.google.dev/gemini-api/terms) · [Privacy](https://policies.google.com/privacy) |
+| xAI (Grok) | San Francisco, CA, USA | [Terms](https://x.ai/legal/terms-of-service) · [Privacy](https://x.ai/legal/privacy-policy) |
+| OpenRouter | San Francisco, CA, USA | [Terms](https://openrouter.ai/terms) · [Privacy](https://openrouter.ai/privacy) |
+| DeepSeek | Hangzhou, China | [Terms](https://www.deepseek.com/terms_of_use) · [Privacy](https://www.deepseek.com/privacy_policy) |
+| Moonshot AI (Kimi) | Beijing, China | [Terms](https://www.moonshot.cn/user-agreement) · [Privacy](https://www.moonshot.cn/privacy-policy) |
+| DashScope (Alibaba) | Hangzhou, China | [Terms](https://www.alibabacloud.com/help/legal) · [Privacy](https://www.alibabacloud.com/help/legal/privacy-policy) |
+| Wolfram | Champaign, IL, USA | [Terms](https://www.wolfram.com/legal/terms/) · [Privacy](https://www.wolfram.com/legal/privacy/wolfram/) |
+
+## Access Modes
+
+- **Personal API Keys**: When you use your own API keys, requests go directly from your local VS Code instance to the provider. No data passes through TeXRA servers.
+- **Researcher Access Program**: When you use the Researcher Access Program, requests are routed through a TeXRA-operated relay (`remote.texra.ai`) before being forwarded to the provider. Your content temporarily transits our infrastructure but is not permanently stored.
+
+## Your Responsibility
+
+You are responsible for selecting providers that comply with the data protection laws applicable to you (e.g., GDPR, UK GDPR, CCPA). Some providers operate in jurisdictions with different data protection standards. Review each provider's policies before use.
+
+See also: [Terms of Service](TERMS_OF_SERVICE.md)

--- a/README.md
+++ b/README.md
@@ -72,3 +72,5 @@ Report issues and feature requests on the
 ## License
 
 © TeXRA Team 2025. All rights reserved.
+
+[Terms of Service](TERMS_OF_SERVICE.md) · [Provider List](https://texra.ai/providers)

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,7 +1,5 @@
 # Terms of Service
 
-**TeXRA — AI-Powered Research Assistant**
-
 *Effective Date: February 9, 2026*
 
 *Last Updated: February 9, 2026*

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -83,15 +83,9 @@ The Extension integrates with third-party services, including AI model providers
 
 ## 12. International Data Transfers
 
-The Extension supports AI providers headquartered in various jurisdictions, including providers based outside the European Union and the United States. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates. This may include jurisdictions that do not provide the same level of data protection as your home country or the EU/EEA.
+The Extension supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
 
-Notably:
-
-- **DeepSeek** is operated by DeepSeek (深度求索), headquartered in Hangzhou, China.
-- **Moonshot AI (Kimi)** is operated by Moonshot AI (月之暗面), headquartered in Beijing, China.
-- **DashScope** is operated by Alibaba Cloud, headquartered in Hangzhou, China.
-
-Data sent to these providers is subject to the laws of the People's Republic of China, including the Personal Information Protection Law (PIPL) and the Cybersecurity Law, which may differ significantly from GDPR, CCPA, or other data protection frameworks you are accustomed to.
+A current list of supported providers and their operating jurisdictions is available at [https://texra.ai/providers](https://texra.ai/providers). This list may be updated from time to time as providers are added or removed.
 
 **You are solely responsible for ensuring that your use of any AI provider complies with applicable data protection laws in your jurisdiction**, including but not limited to the EU General Data Protection Regulation (GDPR), the UK GDPR, the California Consumer Privacy Act (CCPA), and any institutional or organizational data policies that apply to you. If you are subject to regulations that restrict international data transfers, you should only select providers that meet your compliance requirements. We do not make any representations regarding the data protection practices of third-party AI providers.
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -10,27 +10,27 @@
 
 ## 1. Acceptance of Terms
 
-By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+By installing, accessing, or using TeXRA — including the Visual Studio Code extension, any web applications, APIs, desktop or mobile applications, or other software or services we make available now or in the future (collectively, the "Service") — you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install, access, or use the Service.
 
-These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Extension. References to "TeXRA" refer to the Extension and its associated services, not a corporate entity.
+These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Service. References to "TeXRA" refer to the Service and its associated offerings, not a corporate entity.
 
 ## 2. Description of Service
 
-TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
+TeXRA is an AI-powered platform for LaTeX research and writing. The Service currently includes a Visual Studio Code extension and may expand to include web applications, APIs, and other interfaces. The Service connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
 
-We reserve the right to modify, suspend, or discontinue the Extension (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Extension.
+We reserve the right to modify, suspend, or discontinue the Service (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.
 
 ## 3. Eligibility
 
-You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
+You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Service. By using TeXRA, you represent that you meet this requirement.
 
 ## 4. License Grant
 
-Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Extension for your personal or internal business purposes. This license does not include the right to:
+Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Service for your personal or internal business purposes. This license does not include the right to:
 
-1. Modify, adapt, or create derivative works of the Extension.
-2. Distribute, sublicense, lease, lend, or sell the Extension to any third party.
-3. Use the Extension to build a competing product or service.
+1. Modify, adapt, or create derivative works of the Service.
+2. Distribute, sublicense, lease, lend, or sell the Service to any third party.
+3. Use the Service to build a competing product or service.
 
 We reserve all rights not expressly granted in these Terms.
 
@@ -41,32 +41,32 @@ We reserve all rights not expressly granted in these Terms.
 
 ## 6. Acceptable Use
 
-You agree not to use the Extension to:
+You agree not to use the Service to:
 
 1. Violate any applicable law, regulation, or third-party rights.
 2. Generate, submit, or distribute content that is unlawful, harmful, threatening, abusive, defamatory, or otherwise objectionable.
 3. Infringe upon intellectual property rights of any party.
-4. Interfere with or disrupt the Extension or any connected services.
-5. Attempt to reverse-engineer, decompile, or disassemble the Extension beyond what applicable law expressly permits.
+4. Interfere with or disrupt the Service or any connected services.
+5. Attempt to reverse-engineer, decompile, or disassemble the Service beyond what applicable law expressly permits.
 6. Circumvent any access controls, rate limits, or usage restrictions.
-7. Use the Extension for automated bulk processing in a manner that abuses third-party API services.
+7. Use the Service for automated bulk processing in a manner that abuses third-party API services.
 8. Misrepresent AI-generated content as solely human-authored in contexts where disclosure is required.
 
 ## 7. Intellectual Property
 
-- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
-- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
+- **Service**: TeXRA is proprietary software. All rights, title, and interest in the Service, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
+- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Service ("Your Content"). We do not claim any ownership rights over Your Content.
 
 ## 8. Feedback
 
-If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Extension ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Extension without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Service without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
 
 ## 9. Privacy and Data Handling
 
-- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local VS Code instance to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to us.
+- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
 - **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
-- **Telemetry**: The Extension collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through VS Code's standard telemetry settings.
+- **Telemetry**: The Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through the applicable platform settings (e.g., VS Code's telemetry settings).
 
 ## 10. AI and Machine Learning
 
@@ -79,11 +79,11 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 
 ## 11. Third-Party Services
 
-The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
+The Service integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
 
 ## 12. International Data Transfers
 
-The Extension supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
+The Service supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
 
 A current list of supported providers and their operating jurisdictions is available at [https://texra.ai/providers](https://texra.ai/providers). This list may be updated from time to time as providers are added or removed.
 
@@ -91,7 +91,7 @@ A current list of supported providers and their operating jurisdictions is avail
 
 ## 13. Free and Beta Services
 
-Certain features of the Extension, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
+Certain features of the Service, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
 
 ## 14. Assumption of Risk
 
@@ -99,7 +99,7 @@ You acknowledge that:
 
 1. **AI Outputs**: AI-generated content is inherently unpredictable and may be inaccurate, incomplete, or unsuitable. You assume all risk associated with your reliance on AI-generated outputs, including in academic publications, professional work, or any other context.
 2. **API Costs**: When using your own API keys, you are solely responsible for any charges incurred from third-party AI providers. We have no control over and accept no responsibility for third-party pricing, rate limits, or billing disputes.
-3. **Data Loss**: While the Extension operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Extension.
+3. **Data Loss**: While the Service operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Service.
 
 ## 15. Disclaimer of Warranties
 
@@ -107,11 +107,11 @@ THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY K
 
 We do not warrant that:
 
-1. The Extension will meet your specific requirements.
-2. The Extension will be uninterrupted, timely, secure, or error-free.
+1. The Service will meet your specific requirements.
+2. The Service will be uninterrupted, timely, secure, or error-free.
 3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
-4. Any defects in the Extension will be corrected.
-5. The Extension will be compatible with any particular third-party software, hardware, or AI provider.
+4. Any defects in the Service will be corrected.
+5. The Service will be compatible with any particular third-party software, hardware, or AI provider.
 6. Third-party AI providers will remain available or maintain their current terms.
 
 YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
@@ -122,27 +122,27 @@ TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA T
 
 WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
 
-Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
+Our total cumulative liability to you for all claims arising from or related to the Service shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Service during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
 
 ## 17. Indemnification
 
-You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Service, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
 
 ## 18. Dispute Resolution
 
 - **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
 - **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
 - **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
-- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Extension must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
+- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Service must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
 - **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
 ## 19. Modifications to the Terms
 
-We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Extension (e.g., via a notification or changelog entry) or by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
+We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Service, our website, or other reasonable means (e.g., via an in-app notification, changelog entry, or email) or by updating the "Last Updated" date at the top of this document. Your continued use of the Service after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
 
 ## 20. Termination
 
-We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
+We may suspend or terminate your access to the Service at any time, with or without cause, and with or without notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
 
 ## 21. Governing Law
 
@@ -170,7 +170,7 @@ If any provision of these Terms is found to be unenforceable or invalid, that pr
 
 ## 27. Entire Agreement
 
-These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and the TeXRA team regarding the Extension and supersede all prior agreements and understandings.
+These Terms, together with any additional terms you agree to when using particular features of the Service, constitute the entire agreement between you and the TeXRA team regarding the Service and supersede all prior agreements and understandings.
 
 ## 28. Contact
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**TeXRA — AI-Powered LaTeX Research Assistant**
+**TeXRA — AI-Powered Research Assistant**
 
 *Effective Date: February 9, 2026*
 
@@ -59,12 +59,12 @@ You agree not to use the Service to:
 
 ## 8. Feedback
 
-If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Service without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+If you voluntarily provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), we may use that Feedback to improve the Service without any obligation or compensation to you. You are never required to provide Feedback.
 
 ## 9. Privacy and Data Handling
 
 - **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
-- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
+- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not read, analyze, or permanently store Your Content on the relay — it transits our servers solely for the purpose of forwarding the request to the AI provider.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
 - **Telemetry**: When you are signed in to TeXRA (e.g., through the Researcher Access Program), the Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. If you are not signed in, no telemetry data is collected or transmitted.
 
@@ -126,14 +126,12 @@ Our total cumulative liability to you for all claims arising from or related to 
 
 ## 17. Indemnification
 
-You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Service, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+To the extent permitted by applicable law, you agree to hold harmless the TeXRA team and its members from any claims, liabilities, damages, or expenses (including reasonable attorneys' fees) arising from: (a) your violation of these Terms, (b) your infringement of any third-party rights, or (c) your use of the Service in a manner not authorized by these Terms.
 
 ## 18. Dispute Resolution
 
 - **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
-- **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
-- **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
-- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Service must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
+- **Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
 - **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
 ## 19. Modifications to the Terms
@@ -142,7 +140,7 @@ We reserve the right to update or modify these Terms at any time. Material chang
 
 ## 20. Termination
 
-We may suspend or terminate your access to the Service at any time, with or without cause, and with or without notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
+We may suspend or terminate your access to the Service if you violate these Terms, or for any other reason with reasonable notice. In urgent circumstances (such as abuse, fraud, or legal requirements), we may act immediately without prior notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
 
 ## 21. Governing Law
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,104 @@
+# Terms of Service
+
+**TeXRA — AI-Powered LaTeX Research Assistant**
+
+*Effective Date: February 9, 2026*
+
+*Last Updated: February 9, 2026*
+
+---
+
+## 1. Acceptance of Terms
+
+By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+
+## 2. Description of Service
+
+TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers—including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini)—to deliver its features. TeXRA is published by TeXRA.ai ("we," "us," or "our").
+
+## 3. Eligibility
+
+You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
+
+## 4. User Accounts and API Keys
+
+- **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers.
+- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. Participation in such programs may be subject to additional terms.
+
+## 5. Acceptable Use
+
+You agree not to use the Extension to:
+
+1. Violate any applicable law, regulation, or third-party rights.
+2. Generate, submit, or distribute content that is unlawful, harmful, threatening, abusive, defamatory, or otherwise objectionable.
+3. Infringe upon intellectual property rights of any party.
+4. Interfere with or disrupt the Extension or any connected services.
+5. Attempt to reverse-engineer, decompile, or disassemble the Extension beyond what applicable law expressly permits.
+6. Circumvent any access controls, rate limits, or usage restrictions.
+7. Use the Extension for automated bulk processing in a manner that abuses third-party API services.
+
+## 6. Intellectual Property
+
+- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by TeXRA.ai. These Terms do not grant you any rights to use our trademarks, trade names, or branding.
+- **Your Content**: You retain ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
+
+## 7. Privacy and Data Handling
+
+- **Local Processing**: API calls to AI providers are made directly from your local VS Code instance. Your document content and API keys are not sent to or stored on TeXRA servers.
+- **Third-Party Providers**: When using third-party AI models, your content is transmitted to the respective provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
+- **Telemetry**: The Extension may collect anonymized usage telemetry (such as feature usage and error reports) to improve the product. You can opt out of telemetry through VS Code's standard telemetry settings.
+
+## 8. Third-Party Services
+
+The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies.
+
+## 9. Disclaimer of Warranties
+
+THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+
+We do not warrant that:
+
+1. The Extension will meet your specific requirements.
+2. The Extension will be uninterrupted, timely, secure, or error-free.
+3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
+4. Any defects in the Extension will be corrected.
+
+**AI Output Disclaimer**: AI-generated content may contain errors, inaccuracies, or biases. You are solely responsible for reviewing, verifying, and validating all AI-generated outputs before use in research, publications, or any other context.
+
+## 10. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL TEXRA.AI, ITS OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim.
+
+## 11. Indemnification
+
+You agree to indemnify, defend, and hold harmless TeXRA.ai and its affiliates, officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with your use of the Extension, your violation of these Terms, or your infringement of any third-party rights.
+
+## 12. Modifications to the Terms
+
+We reserve the right to update or modify these Terms at any time. Changes will be indicated by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
+
+## 13. Termination
+
+We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 6, 9, 10, 11, and 14 shall survive termination.
+
+## 14. Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of the jurisdiction in which TeXRA.ai operates, without regard to conflict of law principles. Any disputes arising under these Terms shall be resolved in the competent courts of that jurisdiction.
+
+## 15. Severability
+
+If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
+
+## 16. Entire Agreement
+
+These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and TeXRA.ai regarding the Extension and supersede all prior agreements and understandings.
+
+## 17. Contact
+
+If you have questions or concerns about these Terms, please contact us:
+
+- **Email**: contact@texra.ai
+- **GitHub**: [https://github.com/texra-ai/texra-issues](https://github.com/texra-ai/texra-issues)
+- **Website**: [https://texra.ai](https://texra.ai)

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -18,6 +18,8 @@ These Terms are entered into between you and the TeXRA team ("we," "us," or "our
 
 TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
 
+We reserve the right to modify, suspend, or discontinue the Extension (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Extension.
+
 ## 3. Eligibility
 
 You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
@@ -79,13 +81,35 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 
 The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
 
-## 12. Free and Beta Services
+## 12. International Data Transfers
+
+The Extension supports AI providers headquartered in various jurisdictions, including providers based outside the European Union and the United States. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates. This may include jurisdictions that do not provide the same level of data protection as your home country or the EU/EEA.
+
+Notably:
+
+- **DeepSeek** is operated by DeepSeek (深度求索), headquartered in Hangzhou, China.
+- **Moonshot AI (Kimi)** is operated by Moonshot AI (月之暗面), headquartered in Beijing, China.
+- **DashScope** is operated by Alibaba Cloud, headquartered in Hangzhou, China.
+
+Data sent to these providers is subject to the laws of the People's Republic of China, including the Personal Information Protection Law (PIPL) and the Cybersecurity Law, which may differ significantly from GDPR, CCPA, or other data protection frameworks you are accustomed to.
+
+**You are solely responsible for ensuring that your use of any AI provider complies with applicable data protection laws in your jurisdiction**, including but not limited to the EU General Data Protection Regulation (GDPR), the UK GDPR, the California Consumer Privacy Act (CCPA), and any institutional or organizational data policies that apply to you. If you are subject to regulations that restrict international data transfers, you should only select providers that meet your compliance requirements. We do not make any representations regarding the data protection practices of third-party AI providers.
+
+## 13. Free and Beta Services
 
 Certain features of the Extension, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
 
-## 13. Disclaimer of Warranties
+## 14. Assumption of Risk
 
-THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+You acknowledge that:
+
+1. **AI Outputs**: AI-generated content is inherently unpredictable and may be inaccurate, incomplete, or unsuitable. You assume all risk associated with your reliance on AI-generated outputs, including in academic publications, professional work, or any other context.
+2. **API Costs**: When using your own API keys, you are solely responsible for any charges incurred from third-party AI providers. We have no control over and accept no responsibility for third-party pricing, rate limits, or billing disputes.
+3. **Data Loss**: While the Extension operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Extension.
+
+## 15. Disclaimer of Warranties
+
+THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
 
 We do not warrant that:
 
@@ -93,52 +117,68 @@ We do not warrant that:
 2. The Extension will be uninterrupted, timely, secure, or error-free.
 3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
 4. Any defects in the Extension will be corrected.
+5. The Extension will be compatible with any particular third-party software, hardware, or AI provider.
+6. Third-party AI providers will remain available or maintain their current terms.
 
-## 14. Limitation of Liability
+YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
+
+## 16. Limitation of Liability
 
 TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim.
+WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
 
-## 15. Indemnification
+Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
 
-You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, or (d) Your Content.
+## 17. Indemnification
 
-## 16. Dispute Resolution
+You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+
+## 18. Dispute Resolution
 
 - **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
 - **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
+- **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
+- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Extension must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
 - **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
-## 17. Modifications to the Terms
+## 19. Modifications to the Terms
 
 We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Extension (e.g., via a notification or changelog entry) or by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
 
-## 18. Termination
+## 20. Termination
 
-We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 13, 14, 15, 16, and 19 shall survive termination.
+We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
 
-## 19. Governing Law
+## 21. Governing Law
 
-These Terms shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to conflict of law principles. To the extent litigation is permitted under these Terms, the exclusive venue shall be the state or federal courts located in San Francisco County, California.
+These Terms shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to conflict of law principles and without regard to the United Nations Convention on Contracts for the International Sale of Goods. To the extent litigation is permitted under these Terms, the exclusive venue shall be the state or federal courts located in San Francisco County, California.
 
-## 20. Assignment
+## 22. Assignment
 
-You may not assign or transfer these Terms or any rights hereunder without our prior written consent. We may freely assign these Terms, including to any successor entity formed upon incorporation, without restriction or notice. Any attempted assignment in violation of this section shall be null and void.
+You may not assign or transfer these Terms or any rights hereunder without our prior written consent. We may freely assign these Terms, including to any successor entity formed upon incorporation, merger, acquisition, or reorganization, without restriction or notice. Any attempted assignment in violation of this section shall be null and void.
 
-## 21. Force Majeure
+## 23. Force Majeure
 
-We shall not be liable for any failure or delay in performing our obligations under these Terms where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, acts of government, internet or infrastructure outages, or third-party service disruptions.
+We shall not be liable for any failure or delay in performing our obligations under these Terms where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, acts of government, pandemic, internet or infrastructure outages, third-party service disruptions, or changes to third-party AI provider terms or availability.
 
-## 22. Severability
+## 24. No Third-Party Beneficiaries
+
+These Terms do not confer any rights, remedies, or benefits on any third party. No third party shall have any right to enforce any provision of these Terms.
+
+## 25. Waiver
+
+Our failure to enforce any right or provision of these Terms shall not constitute a waiver of such right or provision. Any waiver of any provision of these Terms will be effective only if in writing and signed by us.
+
+## 26. Severability
 
 If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
 
-## 23. Entire Agreement
+## 27. Entire Agreement
 
 These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and the TeXRA team regarding the Extension and supersede all prior agreements and understandings.
 
-## 24. Contact
+## 28. Contact
 
 If you have questions or concerns about these Terms, please contact us:
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -34,8 +34,8 @@ We reserve all rights not expressly granted in these Terms.
 
 ## 5. User Accounts and API Keys
 
-- **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers.
-- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. Participation in such programs may be subject to additional terms and may be modified or discontinued at any time.
+- **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers. See Section 9 for details on how data is handled in this mode.
+- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. When using this program, requests are routed through a TeXRA-operated relay server (see Section 9 for details). Participation is limited to personal research and academic use, is subject to fair-use limits, and may be modified or discontinued at any time.
 
 ## 6. Acceptable Use
 
@@ -61,17 +61,18 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 
 ## 9. Privacy and Data Handling
 
-- **Local Processing**: API calls to AI providers are made directly from your local VS Code instance. Your document content and API keys are not sent to or stored on TeXRA servers.
-- **Third-Party Providers**: When using third-party AI models, your content is transmitted to the respective provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
-- **Telemetry**: The Extension may collect anonymized usage telemetry (such as feature usage and error reports) to improve the product. You can opt out of telemetry through VS Code's standard telemetry settings.
+- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local VS Code instance to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to us.
+- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
+- **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
+- **Telemetry**: The Extension collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through VS Code's standard telemetry settings.
 
 ## 10. AI and Machine Learning
 
 - **No Model Training on Your Content**: We do not use Your Content to train, fine-tune, or improve any machine learning models. Your Content is processed solely to provide you with the requested AI-assisted features.
 - **Third-Party AI Providers**: Each AI provider has its own data usage policies. Some providers may use API inputs for model improvement unless you opt out. We strongly recommend reviewing the data policies of your chosen provider(s):
-  - [Anthropic Usage Policy](https://www.anthropic.com/policies)
-  - [OpenAI Usage Policies](https://openai.com/policies)
-  - [Google AI Terms](https://ai.google.dev/terms)
+  - [Anthropic Acceptable Use Policy](https://www.anthropic.com/legal/aup)
+  - [OpenAI Usage Policies](https://openai.com/policies/usage-policies)
+  - [Google Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms)
 - **AI Output Disclaimer**: AI-generated content may contain errors, inaccuracies, hallucinations, or biases. You are solely responsible for reviewing, verifying, and validating all AI-generated outputs before use in research, publications, or any other context. AI outputs do not constitute professional, academic, legal, or any other form of advice.
 
 ## 11. Third-Party Services

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -10,22 +10,34 @@
 
 ## 1. Acceptance of Terms
 
-By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+
+These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Extension. References to "TeXRA" refer to the Extension and its associated services, not a corporate entity.
 
 ## 2. Description of Service
 
-TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers—including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini)—to deliver its features. TeXRA is published by TeXRA.ai ("we," "us," or "our").
+TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
 
 ## 3. Eligibility
 
 You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
 
-## 4. User Accounts and API Keys
+## 4. License Grant
+
+Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Extension for your personal or internal business purposes. This license does not include the right to:
+
+1. Modify, adapt, or create derivative works of the Extension.
+2. Distribute, sublicense, lease, lend, or sell the Extension to any third party.
+3. Use the Extension to build a competing product or service.
+
+We reserve all rights not expressly granted in these Terms.
+
+## 5. User Accounts and API Keys
 
 - **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers.
-- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. Participation in such programs may be subject to additional terms.
+- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. Participation in such programs may be subject to additional terms and may be modified or discontinued at any time.
 
-## 5. Acceptable Use
+## 6. Acceptable Use
 
 You agree not to use the Extension to:
 
@@ -36,23 +48,41 @@ You agree not to use the Extension to:
 5. Attempt to reverse-engineer, decompile, or disassemble the Extension beyond what applicable law expressly permits.
 6. Circumvent any access controls, rate limits, or usage restrictions.
 7. Use the Extension for automated bulk processing in a manner that abuses third-party API services.
+8. Misrepresent AI-generated content as solely human-authored in contexts where disclosure is required.
 
-## 6. Intellectual Property
+## 7. Intellectual Property
 
-- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by TeXRA.ai. These Terms do not grant you any rights to use our trademarks, trade names, or branding.
-- **Your Content**: You retain ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
+- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
+- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
 
-## 7. Privacy and Data Handling
+## 8. Feedback
+
+If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Extension ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Extension without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+
+## 9. Privacy and Data Handling
 
 - **Local Processing**: API calls to AI providers are made directly from your local VS Code instance. Your document content and API keys are not sent to or stored on TeXRA servers.
 - **Third-Party Providers**: When using third-party AI models, your content is transmitted to the respective provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
 - **Telemetry**: The Extension may collect anonymized usage telemetry (such as feature usage and error reports) to improve the product. You can opt out of telemetry through VS Code's standard telemetry settings.
 
-## 8. Third-Party Services
+## 10. AI and Machine Learning
 
-The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies.
+- **No Model Training on Your Content**: We do not use Your Content to train, fine-tune, or improve any machine learning models. Your Content is processed solely to provide you with the requested AI-assisted features.
+- **Third-Party AI Providers**: Each AI provider has its own data usage policies. Some providers may use API inputs for model improvement unless you opt out. We strongly recommend reviewing the data policies of your chosen provider(s):
+  - [Anthropic Usage Policy](https://www.anthropic.com/policies)
+  - [OpenAI Usage Policies](https://openai.com/policies)
+  - [Google AI Terms](https://ai.google.dev/terms)
+- **AI Output Disclaimer**: AI-generated content may contain errors, inaccuracies, hallucinations, or biases. You are solely responsible for reviewing, verifying, and validating all AI-generated outputs before use in research, publications, or any other context. AI outputs do not constitute professional, academic, legal, or any other form of advice.
 
-## 9. Disclaimer of Warranties
+## 11. Third-Party Services
+
+The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
+
+## 12. Free and Beta Services
+
+Certain features of the Extension, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
+
+## 13. Disclaimer of Warranties
 
 THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
 
@@ -63,39 +93,51 @@ We do not warrant that:
 3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
 4. Any defects in the Extension will be corrected.
 
-**AI Output Disclaimer**: AI-generated content may contain errors, inaccuracies, or biases. You are solely responsible for reviewing, verifying, and validating all AI-generated outputs before use in research, publications, or any other context.
+## 14. Limitation of Liability
 
-## 10. Limitation of Liability
-
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL TEXRA.AI, ITS OFFICERS, DIRECTORS, EMPLOYEES, OR AGENTS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim.
 
-## 11. Indemnification
+## 15. Indemnification
 
-You agree to indemnify, defend, and hold harmless TeXRA.ai and its affiliates, officers, directors, employees, and agents from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with your use of the Extension, your violation of these Terms, or your infringement of any third-party rights.
+You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, or (d) Your Content.
 
-## 12. Modifications to the Terms
+## 16. Dispute Resolution
 
-We reserve the right to update or modify these Terms at any time. Changes will be indicated by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
+- **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
+- **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
+- **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
-## 13. Termination
+## 17. Modifications to the Terms
 
-We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 6, 9, 10, 11, and 14 shall survive termination.
+We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Extension (e.g., via a notification or changelog entry) or by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
 
-## 14. Governing Law
+## 18. Termination
 
-These Terms shall be governed by and construed in accordance with the laws of the jurisdiction in which TeXRA.ai operates, without regard to conflict of law principles. Any disputes arising under these Terms shall be resolved in the competent courts of that jurisdiction.
+We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 13, 14, 15, 16, and 19 shall survive termination.
 
-## 15. Severability
+## 19. Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to conflict of law principles. To the extent litigation is permitted under these Terms, the exclusive venue shall be the state or federal courts located in San Francisco County, California.
+
+## 20. Assignment
+
+You may not assign or transfer these Terms or any rights hereunder without our prior written consent. We may freely assign these Terms, including to any successor entity formed upon incorporation, without restriction or notice. Any attempted assignment in violation of this section shall be null and void.
+
+## 21. Force Majeure
+
+We shall not be liable for any failure or delay in performing our obligations under these Terms where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, acts of government, internet or infrastructure outages, or third-party service disruptions.
+
+## 22. Severability
 
 If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
 
-## 16. Entire Agreement
+## 23. Entire Agreement
 
-These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and TeXRA.ai regarding the Extension and supersede all prior agreements and understandings.
+These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and the TeXRA team regarding the Extension and supersede all prior agreements and understandings.
 
-## 17. Contact
+## 24. Contact
 
 If you have questions or concerns about these Terms, please contact us:
 

--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -66,7 +66,7 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 - **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
 - **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
-- **Telemetry**: The Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through the applicable platform settings (e.g., VS Code's telemetry settings).
+- **Telemetry**: When you are signed in to TeXRA (e.g., through the Researcher Access Program), the Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. If you are not signed in, no telemetry data is collected or transmitted.
 
 ## 10. AI and Machine Learning
 
@@ -103,7 +103,7 @@ You acknowledge that:
 
 ## 15. Disclaimer of Warranties
 
-THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
+THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
 
 We do not warrant that:
 
@@ -114,11 +114,11 @@ We do not warrant that:
 5. The Service will be compatible with any particular third-party software, hardware, or AI provider.
 6. Third-party AI providers will remain available or maintain their current terms.
 
-YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
+YOU USE THE SERVICE AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
 
 ## 16. Limitation of Liability
 
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE SERVICE, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -174,6 +174,8 @@ const baseConfig = {
       provider: 'local',
     },
     footer: {
+      message:
+        '<a href="/terms">Terms of Service</a> · <a href="/providers">Providers</a>',
       copyright: 'Copyright © 2024-2026 TeXRA Team. All rights reserved.',
     },
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,9 @@
   "version": "0.3.0",
   "main": "index.js",
   "scripts": {
-    "dev": "vitepress dev .",
-    "docs:build": "vitepress build .",
+    "sync-legal": "cp ../TERMS_OF_SERVICE.md terms.md",
+    "dev": "npm run sync-legal && vitepress dev .",
+    "docs:build": "npm run sync-legal && vitepress build .",
     "docs:serve": "vitepress serve .",
     "docs:deploy": "npm run docs:build && gh-pages --cname texra.ai -d .vitepress/dist -m \"Deploy docs [ci skip]\""
   },

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -14,7 +14,6 @@ The following table lists the AI model providers supported by TeXRA, along with 
 | DeepSeek | Hangzhou, China | [Terms](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html) · [Privacy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html) |
 | Moonshot AI (Kimi) | Beijing, China | [Terms](https://platform.moonshot.ai/docs/agreement/modeluse) · [Privacy](https://platform.moonshot.ai/docs/agreement/userprivacy) |
 | DashScope (Alibaba) | Hangzhou, China | [Terms](https://www.alibabacloud.com/help/en/legal/) · [Privacy](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy) |
-| Wolfram | Champaign, IL, USA | [Terms](https://www.wolfram.com/legal/terms/wolfram/) · [Privacy](https://www.wolfram.com/legal/privacy/wolfram/) |
 
 ## Access Modes
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -6,15 +6,15 @@ The following table lists the AI model providers supported by TeXRA, along with 
 
 | Provider | Headquarters | Terms / Privacy |
 |----------|-------------|-----------------|
-| Anthropic (Claude) | San Francisco, CA, USA | [Terms](https://www.anthropic.com/legal/consumer-terms) · [Privacy](https://www.anthropic.com/legal/privacy) · [AUP](https://www.anthropic.com/legal/aup) |
-| OpenAI (GPT) | San Francisco, CA, USA | [Terms](https://openai.com/policies/terms-of-use) · [Privacy](https://openai.com/policies/privacy-policy) · [Usage](https://openai.com/policies/usage-policies) |
+| Anthropic (Claude) | San Francisco, CA, USA | [Terms](https://legal.anthropic.com/) · [Privacy](https://docs.anthropic.com/en/docs/legal-center/privacy) · [AUP](https://www.anthropic.com/legal/aup) |
+| OpenAI (GPT) | San Francisco, CA, USA | [Terms](https://openai.com/policies/row-terms-of-use/) · [Privacy](https://openai.com/policies/row-privacy-policy/) · [Usage](https://openai.com/policies/usage-policies/) |
 | Google (Gemini) | Mountain View, CA, USA | [Terms](https://ai.google.dev/gemini-api/terms) · [Privacy](https://policies.google.com/privacy) |
 | xAI (Grok) | San Francisco, CA, USA | [Terms](https://x.ai/legal/terms-of-service) · [Privacy](https://x.ai/legal/privacy-policy) |
-| OpenRouter | San Francisco, CA, USA | [Terms](https://openrouter.ai/terms) · [Privacy](https://openrouter.ai/privacy) |
-| DeepSeek | Hangzhou, China | [Terms](https://www.deepseek.com/terms_of_use) · [Privacy](https://www.deepseek.com/privacy_policy) |
-| Moonshot AI (Kimi) | Beijing, China | [Terms](https://www.moonshot.cn/user-agreement) · [Privacy](https://www.moonshot.cn/privacy-policy) |
-| DashScope (Alibaba) | Hangzhou, China | [Terms](https://www.alibabacloud.com/help/legal) · [Privacy](https://www.alibabacloud.com/help/legal/privacy-policy) |
-| Wolfram | Champaign, IL, USA | [Terms](https://www.wolfram.com/legal/terms/) · [Privacy](https://www.wolfram.com/legal/privacy/wolfram/) |
+| OpenRouter | New York, NY, USA | [Terms](https://openrouter.ai/terms) · [Privacy](https://openrouter.ai/privacy) |
+| DeepSeek | Hangzhou, China | [Terms](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html) · [Privacy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html) |
+| Moonshot AI (Kimi) | Beijing, China | [Terms](https://platform.moonshot.ai/docs/agreement/modeluse) · [Privacy](https://platform.moonshot.ai/docs/agreement/userprivacy) |
+| DashScope (Alibaba) | Hangzhou, China | [Terms](https://www.alibabacloud.com/help/en/legal/) · [Privacy](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy) |
+| Wolfram | Champaign, IL, USA | [Terms](https://www.wolfram.com/legal/terms/wolfram/) · [Privacy](https://www.wolfram.com/legal/privacy/wolfram/) |
 
 ## Access Modes
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,7 +1,5 @@
 # Supported AI Providers
 
-**TeXRA — AI-Powered LaTeX Research Assistant**
-
 *Last Updated: February 10, 2026*
 
 The following table lists the AI model providers supported by TeXRA, along with their operating headquarters and links to their respective terms and privacy policies. When you select a provider, your content is transmitted to that provider's API endpoints and is subject to their terms.
@@ -27,4 +25,4 @@ The following table lists the AI model providers supported by TeXRA, along with 
 
 You are responsible for selecting providers that comply with the data protection laws applicable to you (e.g., GDPR, UK GDPR, CCPA). Some providers operate in jurisdictions with different data protection standards. Review each provider's policies before use.
 
-See also: [Terms of Service](TERMS_OF_SERVICE.md)
+See also: [Terms of Service](/terms)

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,7 +1,5 @@
 # Terms of Service
 
-**TeXRA — AI-Powered Research Assistant**
-
 *Effective Date: February 9, 2026*
 
 *Last Updated: February 9, 2026*

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -10,27 +10,27 @@
 
 ## 1. Acceptance of Terms
 
-By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+By installing, accessing, or using TeXRA — including the Visual Studio Code extension, any web applications, APIs, desktop or mobile applications, or other software or services we make available now or in the future (collectively, the "Service") — you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install, access, or use the Service.
 
-These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Extension. References to "TeXRA" refer to the Extension and its associated services, not a corporate entity.
+These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Service. References to "TeXRA" refer to the Service and its associated offerings, not a corporate entity.
 
 ## 2. Description of Service
 
-TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
+TeXRA is an AI-powered platform for LaTeX research and writing. The Service currently includes a Visual Studio Code extension and may expand to include web applications, APIs, and other interfaces. The Service connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
 
-We reserve the right to modify, suspend, or discontinue the Extension (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Extension.
+We reserve the right to modify, suspend, or discontinue the Service (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Service.
 
 ## 3. Eligibility
 
-You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
+You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Service. By using TeXRA, you represent that you meet this requirement.
 
 ## 4. License Grant
 
-Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Extension for your personal or internal business purposes. This license does not include the right to:
+Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Service for your personal or internal business purposes. This license does not include the right to:
 
-1. Modify, adapt, or create derivative works of the Extension.
-2. Distribute, sublicense, lease, lend, or sell the Extension to any third party.
-3. Use the Extension to build a competing product or service.
+1. Modify, adapt, or create derivative works of the Service.
+2. Distribute, sublicense, lease, lend, or sell the Service to any third party.
+3. Use the Service to build a competing product or service.
 
 We reserve all rights not expressly granted in these Terms.
 
@@ -41,32 +41,32 @@ We reserve all rights not expressly granted in these Terms.
 
 ## 6. Acceptable Use
 
-You agree not to use the Extension to:
+You agree not to use the Service to:
 
 1. Violate any applicable law, regulation, or third-party rights.
 2. Generate, submit, or distribute content that is unlawful, harmful, threatening, abusive, defamatory, or otherwise objectionable.
 3. Infringe upon intellectual property rights of any party.
-4. Interfere with or disrupt the Extension or any connected services.
-5. Attempt to reverse-engineer, decompile, or disassemble the Extension beyond what applicable law expressly permits.
+4. Interfere with or disrupt the Service or any connected services.
+5. Attempt to reverse-engineer, decompile, or disassemble the Service beyond what applicable law expressly permits.
 6. Circumvent any access controls, rate limits, or usage restrictions.
-7. Use the Extension for automated bulk processing in a manner that abuses third-party API services.
+7. Use the Service for automated bulk processing in a manner that abuses third-party API services.
 8. Misrepresent AI-generated content as solely human-authored in contexts where disclosure is required.
 
 ## 7. Intellectual Property
 
-- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
-- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
+- **Service**: TeXRA is proprietary software. All rights, title, and interest in the Service, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
+- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Service ("Your Content"). We do not claim any ownership rights over Your Content.
 
 ## 8. Feedback
 
-If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Extension ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Extension without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Service without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
 
 ## 9. Privacy and Data Handling
 
-- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local VS Code instance to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to us.
+- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
 - **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
-- **Telemetry**: The Extension collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through VS Code's standard telemetry settings.
+- **Telemetry**: The Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through the applicable platform settings (e.g., VS Code's telemetry settings).
 
 ## 10. AI and Machine Learning
 
@@ -79,11 +79,11 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 
 ## 11. Third-Party Services
 
-The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
+The Service integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
 
 ## 12. International Data Transfers
 
-The Extension supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
+The Service supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
 
 A current list of supported providers and their operating jurisdictions is available at [https://texra.ai/providers](https://texra.ai/providers). This list may be updated from time to time as providers are added or removed.
 
@@ -91,7 +91,7 @@ A current list of supported providers and their operating jurisdictions is avail
 
 ## 13. Free and Beta Services
 
-Certain features of the Extension, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
+Certain features of the Service, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
 
 ## 14. Assumption of Risk
 
@@ -99,7 +99,7 @@ You acknowledge that:
 
 1. **AI Outputs**: AI-generated content is inherently unpredictable and may be inaccurate, incomplete, or unsuitable. You assume all risk associated with your reliance on AI-generated outputs, including in academic publications, professional work, or any other context.
 2. **API Costs**: When using your own API keys, you are solely responsible for any charges incurred from third-party AI providers. We have no control over and accept no responsibility for third-party pricing, rate limits, or billing disputes.
-3. **Data Loss**: While the Extension operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Extension.
+3. **Data Loss**: While the Service operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Service.
 
 ## 15. Disclaimer of Warranties
 
@@ -107,11 +107,11 @@ THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY K
 
 We do not warrant that:
 
-1. The Extension will meet your specific requirements.
-2. The Extension will be uninterrupted, timely, secure, or error-free.
+1. The Service will meet your specific requirements.
+2. The Service will be uninterrupted, timely, secure, or error-free.
 3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
-4. Any defects in the Extension will be corrected.
-5. The Extension will be compatible with any particular third-party software, hardware, or AI provider.
+4. Any defects in the Service will be corrected.
+5. The Service will be compatible with any particular third-party software, hardware, or AI provider.
 6. Third-party AI providers will remain available or maintain their current terms.
 
 YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
@@ -122,27 +122,27 @@ TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA T
 
 WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
 
-Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
+Our total cumulative liability to you for all claims arising from or related to the Service shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Service during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
 
 ## 17. Indemnification
 
-You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Service, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
 
 ## 18. Dispute Resolution
 
 - **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
 - **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
 - **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
-- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Extension must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
+- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Service must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
 - **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
 ## 19. Modifications to the Terms
 
-We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Extension (e.g., via a notification or changelog entry) or by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
+We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Service, our website, or other reasonable means (e.g., via an in-app notification, changelog entry, or email) or by updating the "Last Updated" date at the top of this document. Your continued use of the Service after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
 
 ## 20. Termination
 
-We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
+We may suspend or terminate your access to the Service at any time, with or without cause, and with or without notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
 
 ## 21. Governing Law
 
@@ -170,7 +170,7 @@ If any provision of these Terms is found to be unenforceable or invalid, that pr
 
 ## 27. Entire Agreement
 
-These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and the TeXRA team regarding the Extension and supersede all prior agreements and understandings.
+These Terms, together with any additional terms you agree to when using particular features of the Service, constitute the entire agreement between you and the TeXRA team regarding the Service and supersede all prior agreements and understandings.
 
 ## 28. Contact
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**TeXRA — AI-Powered LaTeX Research Assistant**
+**TeXRA — AI-Powered Research Assistant**
 
 *Effective Date: February 9, 2026*
 
@@ -59,12 +59,12 @@ You agree not to use the Service to:
 
 ## 8. Feedback
 
-If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Service without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+If you voluntarily provide suggestions, ideas, enhancement requests, or other feedback regarding the Service ("Feedback"), we may use that Feedback to improve the Service without any obligation or compensation to you. You are never required to provide Feedback.
 
 ## 9. Privacy and Data Handling
 
 - **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
-- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
+- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not read, analyze, or permanently store Your Content on the relay — it transits our servers solely for the purpose of forwarding the request to the AI provider.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
 - **Telemetry**: When you are signed in to TeXRA (e.g., through the Researcher Access Program), the Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. If you are not signed in, no telemetry data is collected or transmitted.
 
@@ -126,14 +126,12 @@ Our total cumulative liability to you for all claims arising from or related to 
 
 ## 17. Indemnification
 
-You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Service, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+To the extent permitted by applicable law, you agree to hold harmless the TeXRA team and its members from any claims, liabilities, damages, or expenses (including reasonable attorneys' fees) arising from: (a) your violation of these Terms, (b) your infringement of any third-party rights, or (c) your use of the Service in a manner not authorized by these Terms.
 
 ## 18. Dispute Resolution
 
 - **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
-- **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
-- **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
-- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Service must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
+- **Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
 - **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
 
 ## 19. Modifications to the Terms
@@ -142,7 +140,7 @@ We reserve the right to update or modify these Terms at any time. Material chang
 
 ## 20. Termination
 
-We may suspend or terminate your access to the Service at any time, with or without cause, and with or without notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
+We may suspend or terminate your access to the Service if you violate these Terms, or for any other reason with reasonable notice. In urgent circumstances (such as abuse, fraud, or legal requirements), we may act immediately without prior notice. You may stop using the Service at any time by uninstalling it or ceasing to access it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
 
 ## 21. Governing Law
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,181 @@
+# Terms of Service
+
+**TeXRA — AI-Powered LaTeX Research Assistant**
+
+*Effective Date: February 9, 2026*
+
+*Last Updated: February 9, 2026*
+
+---
+
+## 1. Acceptance of Terms
+
+By installing, accessing, or using the TeXRA Visual Studio Code extension ("Extension"), you ("you" or "User") agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not install or use the Extension.
+
+These Terms are entered into between you and the TeXRA team ("we," "us," or "our"), the individuals developing and operating the Extension. References to "TeXRA" refer to the Extension and its associated services, not a corporate entity.
+
+## 2. Description of Service
+
+TeXRA is a VS Code extension that provides AI-powered assistance for LaTeX research and writing. The Extension connects to third-party large language model (LLM) providers — including but not limited to Anthropic (Claude), OpenAI (GPT), and Google (Gemini) — to deliver its features.
+
+We reserve the right to modify, suspend, or discontinue the Extension (or any part of it) at any time, with or without notice. We shall not be liable to you or any third party for any modification, suspension, or discontinuation of the Extension.
+
+## 3. Eligibility
+
+You must be at least 18 years old, or the age of legal majority in your jurisdiction, to use the Extension. By using TeXRA, you represent that you meet this requirement.
+
+## 4. License Grant
+
+Subject to your compliance with these Terms, we grant you a limited, non-exclusive, non-transferable, non-sublicensable, revocable license to install and use the Extension for your personal or internal business purposes. This license does not include the right to:
+
+1. Modify, adapt, or create derivative works of the Extension.
+2. Distribute, sublicense, lease, lend, or sell the Extension to any third party.
+3. Use the Extension to build a competing product or service.
+
+We reserve all rights not expressly granted in these Terms.
+
+## 5. User Accounts and API Keys
+
+- **API Keys**: Certain features require you to provide your own API keys for third-party AI providers. You are solely responsible for obtaining, maintaining, and securing your API keys. API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to TeXRA servers. See Section 9 for details on how data is handled in this mode.
+- **Researcher Access Program**: TeXRA may offer access programs that provide limited access to AI models without requiring personal API keys. When using this program, requests are routed through a TeXRA-operated relay server (see Section 9 for details). Participation is limited to personal research and academic use, is subject to fair-use limits, and may be modified or discontinued at any time.
+
+## 6. Acceptable Use
+
+You agree not to use the Extension to:
+
+1. Violate any applicable law, regulation, or third-party rights.
+2. Generate, submit, or distribute content that is unlawful, harmful, threatening, abusive, defamatory, or otherwise objectionable.
+3. Infringe upon intellectual property rights of any party.
+4. Interfere with or disrupt the Extension or any connected services.
+5. Attempt to reverse-engineer, decompile, or disassemble the Extension beyond what applicable law expressly permits.
+6. Circumvent any access controls, rate limits, or usage restrictions.
+7. Use the Extension for automated bulk processing in a manner that abuses third-party API services.
+8. Misrepresent AI-generated content as solely human-authored in contexts where disclosure is required.
+
+## 7. Intellectual Property
+
+- **Extension**: TeXRA is proprietary software. All rights, title, and interest in the Extension, including its code, design, documentation, and trademarks, are owned by the TeXRA team (and will be assigned to any successor entity upon incorporation). These Terms do not grant you any rights to use our trademarks, trade names, or branding.
+- **Your Content**: You retain full ownership of all LaTeX documents, research materials, and other content you process through the Extension ("Your Content"). We do not claim any ownership rights over Your Content.
+
+## 8. Feedback
+
+If you provide suggestions, ideas, enhancement requests, or other feedback regarding the Extension ("Feedback"), you grant us a worldwide, perpetual, irrevocable, royalty-free license to use, reproduce, modify, and incorporate such Feedback into the Extension without obligation or compensation to you. Feedback is voluntary and provided at your sole discretion.
+
+## 9. Privacy and Data Handling
+
+- **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local VS Code instance to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally using VS Code's built-in Secret Storage and are never transmitted to us.
+- **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
+- **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
+- **Telemetry**: The Extension collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through VS Code's standard telemetry settings.
+
+## 10. AI and Machine Learning
+
+- **No Model Training on Your Content**: We do not use Your Content to train, fine-tune, or improve any machine learning models. Your Content is processed solely to provide you with the requested AI-assisted features.
+- **Third-Party AI Providers**: Each AI provider has its own data usage policies. Some providers may use API inputs for model improvement unless you opt out. We strongly recommend reviewing the data policies of your chosen provider(s):
+  - [Anthropic Acceptable Use Policy](https://www.anthropic.com/legal/aup)
+  - [OpenAI Usage Policies](https://openai.com/policies/usage-policies)
+  - [Google Gemini API Terms of Service](https://ai.google.dev/gemini-api/terms)
+- **AI Output Disclaimer**: AI-generated content may contain errors, inaccuracies, hallucinations, or biases. You are solely responsible for reviewing, verifying, and validating all AI-generated outputs before use in research, publications, or any other context. AI outputs do not constitute professional, academic, legal, or any other form of advice.
+
+## 11. Third-Party Services
+
+The Extension integrates with third-party services, including AI model providers and OpenRouter. We are not responsible for the availability, accuracy, or content of these third-party services. Your use of third-party services is governed by their respective terms and policies. We may add, remove, or change supported third-party integrations at any time.
+
+## 12. International Data Transfers
+
+The Extension supports AI providers headquartered in various jurisdictions worldwide, including providers based outside the European Union and the United States. Some supported providers operate in jurisdictions that may not provide the same level of data protection as your home country or the EU/EEA. By selecting a provider, you acknowledge and consent to your data being transmitted to and processed in the jurisdiction where that provider operates, subject to that jurisdiction's local laws.
+
+A current list of supported providers and their operating jurisdictions is available at [https://texra.ai/providers](https://texra.ai/providers). This list may be updated from time to time as providers are added or removed.
+
+**You are solely responsible for ensuring that your use of any AI provider complies with applicable data protection laws in your jurisdiction**, including but not limited to the EU General Data Protection Regulation (GDPR), the UK GDPR, the California Consumer Privacy Act (CCPA), and any institutional or organizational data policies that apply to you. If you are subject to regulations that restrict international data transfers, you should only select providers that meet your compliance requirements. We do not make any representations regarding the data protection practices of third-party AI providers.
+
+## 13. Free and Beta Services
+
+Certain features of the Extension, including the Researcher Access Program, may be offered free of charge or in beta. These features are provided without any service level commitments and may be modified, suspended, or discontinued at any time without notice. We make no guarantees regarding availability, uptime, or continued support for free or beta features.
+
+## 14. Assumption of Risk
+
+You acknowledge that:
+
+1. **AI Outputs**: AI-generated content is inherently unpredictable and may be inaccurate, incomplete, or unsuitable. You assume all risk associated with your reliance on AI-generated outputs, including in academic publications, professional work, or any other context.
+2. **API Costs**: When using your own API keys, you are solely responsible for any charges incurred from third-party AI providers. We have no control over and accept no responsibility for third-party pricing, rate limits, or billing disputes.
+3. **Data Loss**: While the Extension operates on your local files, you are responsible for maintaining your own backups. We are not liable for any data loss or corruption arising from use of the Extension.
+
+## 15. Disclaimer of Warranties
+
+THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
+
+We do not warrant that:
+
+1. The Extension will meet your specific requirements.
+2. The Extension will be uninterrupted, timely, secure, or error-free.
+3. AI-generated outputs will be accurate, complete, or suitable for any particular purpose.
+4. Any defects in the Extension will be corrected.
+5. The Extension will be compatible with any particular third-party software, hardware, or AI provider.
+6. Third-party AI providers will remain available or maintain their current terms.
+
+YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
+
+## 16. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
+
+Our total cumulative liability to you for all claims arising from or related to the Extension shall not exceed the greater of (a) the amount you have paid to us, if any, for access to the Extension during the twelve (12) months preceding the claim, or (b) fifty US dollars (USD $50).
+
+## 17. Indemnification
+
+You agree to indemnify, defend, and hold harmless the TeXRA team and its members from and against any claims, liabilities, damages, losses, and expenses (including reasonable attorneys' fees) arising out of or in any way connected with: (a) your use of the Extension, (b) your violation of these Terms, (c) your infringement of any third-party rights, (d) Your Content, (e) your selection of and data transfers to third-party AI providers, or (f) any dispute between you and a third-party AI provider.
+
+## 18. Dispute Resolution
+
+- **Informal Resolution**: Before filing any formal legal claim, you agree to first contact us at contact@texra.ai and attempt to resolve the dispute informally for at least thirty (30) days.
+- **Binding Arbitration**: If the dispute cannot be resolved informally, either party may elect to resolve the dispute through binding arbitration administered under the rules of a mutually agreed-upon arbitration body. Arbitration shall be conducted on an individual basis; class arbitrations and class actions are not permitted.
+- **Class Action Waiver**: YOU AGREE THAT ANY DISPUTE RESOLUTION PROCEEDINGS WILL BE CONDUCTED ONLY ON AN INDIVIDUAL BASIS AND NOT IN A CLASS, CONSOLIDATED, OR REPRESENTATIVE ACTION. If for any reason a claim proceeds in court rather than through arbitration, each party waives any right to a jury trial.
+- **Statute of Limitations**: You agree that any claim arising out of or related to these Terms or the Extension must be filed within one (1) year after the cause of action arose, or such claim shall be permanently barred.
+- **Exceptions**: Either party may seek injunctive or other equitable relief in any court of competent jurisdiction to prevent the actual or threatened infringement or misappropriation of intellectual property rights.
+
+## 19. Modifications to the Terms
+
+We reserve the right to update or modify these Terms at any time. Material changes will be communicated through the Extension (e.g., via a notification or changelog entry) or by updating the "Last Updated" date at the top of this document. Your continued use of the Extension after any modifications constitutes acceptance of the revised Terms. We encourage you to review these Terms periodically.
+
+## 20. Termination
+
+We may suspend or terminate your access to the Extension at any time, with or without cause, and with or without notice. You may stop using the Extension at any time by uninstalling it. Upon termination, all rights and licenses granted to you under these Terms will immediately cease. Sections 7, 8, 10, 12, 14, 15, 16, 17, 18, 21, and 22 shall survive termination.
+
+## 21. Governing Law
+
+These Terms shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to conflict of law principles and without regard to the United Nations Convention on Contracts for the International Sale of Goods. To the extent litigation is permitted under these Terms, the exclusive venue shall be the state or federal courts located in San Francisco County, California.
+
+## 22. Assignment
+
+You may not assign or transfer these Terms or any rights hereunder without our prior written consent. We may freely assign these Terms, including to any successor entity formed upon incorporation, merger, acquisition, or reorganization, without restriction or notice. Any attempted assignment in violation of this section shall be null and void.
+
+## 23. Force Majeure
+
+We shall not be liable for any failure or delay in performing our obligations under these Terms where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, acts of government, pandemic, internet or infrastructure outages, third-party service disruptions, or changes to third-party AI provider terms or availability.
+
+## 24. No Third-Party Beneficiaries
+
+These Terms do not confer any rights, remedies, or benefits on any third party. No third party shall have any right to enforce any provision of these Terms.
+
+## 25. Waiver
+
+Our failure to enforce any right or provision of these Terms shall not constitute a waiver of such right or provision. Any waiver of any provision of these Terms will be effective only if in writing and signed by us.
+
+## 26. Severability
+
+If any provision of these Terms is found to be unenforceable or invalid, that provision shall be limited or eliminated to the minimum extent necessary so that these Terms shall otherwise remain in full force and effect.
+
+## 27. Entire Agreement
+
+These Terms, together with any additional terms you agree to when using particular features of the Extension, constitute the entire agreement between you and the TeXRA team regarding the Extension and supersede all prior agreements and understandings.
+
+## 28. Contact
+
+If you have questions or concerns about these Terms, please contact us:
+
+- **Email**: contact@texra.ai
+- **GitHub**: [https://github.com/texra-ai/texra-issues](https://github.com/texra-ai/texra-issues)
+- **Website**: [https://texra.ai](https://texra.ai)

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -66,7 +66,7 @@ If you provide suggestions, ideas, enhancement requests, or other feedback regar
 - **Personal API Keys (Local Processing)**: When you use your own API keys, all calls to AI providers are made directly from your local device to the provider's endpoints. In this mode, your document content is not sent to or routed through TeXRA servers. Your API keys are stored locally (e.g., via VS Code's built-in Secret Storage or equivalent platform-specific secure storage) and are never transmitted to us.
 - **Researcher Access Program (Relay Processing)**: When you use the Researcher Access Program (server-side keys), your requests are routed through a TeXRA-operated relay server (`remote.texra.ai`) before being forwarded to the AI provider. In this mode, your document content temporarily passes through our relay infrastructure in order to authenticate the request. We do not permanently store Your Content on the relay, but you should be aware that it transits our servers.
 - **Third-Party Providers**: In both modes, your content is ultimately transmitted to the respective AI provider's API endpoints. You are responsible for reviewing and accepting the privacy policies and terms of service of your chosen AI provider(s).
-- **Telemetry**: The Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. You can opt out of telemetry through the applicable platform settings (e.g., VS Code's telemetry settings).
+- **Telemetry**: When you are signed in to TeXRA (e.g., through the Researcher Access Program), the Service collects anonymized usage metadata — such as model name, token counts, estimated cost, and response time — to monitor service health and improve the product. Telemetry does not include Your Content. If you are not signed in, no telemetry data is collected or transmitted.
 
 ## 10. AI and Machine Learning
 
@@ -103,7 +103,7 @@ You acknowledge that:
 
 ## 15. Disclaimer of Warranties
 
-THE EXTENSION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
+THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, ACCURACY, AND QUIET ENJOYMENT.
 
 We do not warrant that:
 
@@ -114,11 +114,11 @@ We do not warrant that:
 5. The Service will be compatible with any particular third-party software, hardware, or AI provider.
 6. Third-party AI providers will remain available or maintain their current terms.
 
-YOU USE THE EXTENSION AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
+YOU USE THE SERVICE AT YOUR OWN RISK. THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY, AND EFFORT IS WITH YOU.
 
 ## 16. Limitation of Liability
 
-TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE EXTENSION, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE TEXRA TEAM OR ITS MEMBERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS, DATA, USE, OR GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE SERVICE, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 WITHOUT LIMITING THE FOREGOING, WE SHALL NOT BE LIABLE FOR ANY DAMAGES ARISING FROM: (A) THIRD-PARTY AI PROVIDER OUTAGES, CHANGES IN TERMS, OR DISCONTINUATION OF SERVICES; (B) INACCURATE, MISLEADING, OR HARMFUL AI-GENERATED CONTENT; (C) UNAUTHORIZED ACCESS TO YOUR API KEYS OR CONTENT CAUSED BY YOUR FAILURE TO SECURE YOUR CREDENTIALS; (D) ANY ACTIONS TAKEN BASED ON AI-GENERATED OUTPUTS; OR (E) INTERNATIONAL DATA TRANSFERS TO THIRD-PARTY AI PROVIDERS YOU SELECT.
 


### PR DESCRIPTION
Covers acceptance, acceptable use, IP rights, privacy/data handling,
disclaimers, liability limitations, and contact information.

https://claude.ai/code/session_0128nG5xmADXm9mVw5w6wxsY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a simple docs build step (`cp`) to sync legal content; no runtime or security-sensitive logic is modified.
> 
> **Overview**
> Adds a new `TERMS_OF_SERVICE.md` and publishes it in the VitePress site as `docs/terms.md`, with build/dev scripts updated to sync the legal doc into the docs bundle.
> 
> Introduces a new `docs/providers.md` page listing supported AI providers and adds persistent links to **Terms of Service** and **Providers** in the docs footer; the root `README.md` also links to the Terms and provider list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc44651b86b09d49821507fa9c3e4d3b13588ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->