### PR TITLE
docs: Update architecture and structure documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ The project has two build systems with different trade-offs:
 
 ## Coding style
 
-- All code in `src/` is written in TypeScript targeting ES2022, except some javascript files in `src/(webview,progressView)/modules/`.
+- All code in `src/` is written in TypeScript targeting ES2022.
 - Use the provided ESLint configuration (`eslint.config.mjs`) and Prettier settings (`.prettierrc`). Run `npm run format` before committing.
 - Prefer `const` and `let` over `var`.
 - Group imports by source and prefix each block with a descriptive comment (e.g., `// Third-party imports`, `// Local imports - component`).
@@ -84,8 +84,7 @@ The project has two build systems with different trade-offs:
   - `frontend/media/` - Image and audio handling
 - `src/common/` holds backend-only helpers (errors, state, files, base webview classes). Import them through the `@common/*` alias for clarity.
   - `common/state/` - State managers including `pendingStateManager`
-  - `common/modules/` - Shared webview modules (`BaseDomHandler`, `domUtils`, `templateUtils`)
-  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), theme handlers
+  - `common/webview/` - Base classes (`BaseViewContentProvider`, `BaseViewMessageHandler`), command constants
 - `src/utils/` is reserved for utilities used by both the extension host and webviews. If a helper is specific to one side, place it under `frontend/` or `common/` instead of `utils/`.
   - `utils/core/` - Async utilities (`debounce`, `withTimeout`, `delay`)
   - `utils/files/` - Filesystem utilities, rules, and vars
@@ -253,8 +252,8 @@ Aim for code that looks like it was designed correctly from the start:
 
 **Agent execution and tool-use**
 
-- Implement new agents against `IAgent` (`src/agent/core/IAgent.ts`) and compose them via the factories in `src/agent/runtime`.
-- Persist interactive runs with `ToolUseSessionManager` (`src/agent/toolUse/ToolUseSessionManager.ts`) and launch/resume executions via `executeAgent` or `runPreparedAgent` (`src/agent/runtime/executeAgent.ts`) so session filters, run directories, and resume actions stay synchronized.
+- Define agents using `AgentDataclass` and `AgentConfig` (`src/agent/core/`) and compose them via the factories in `src/agent/runtime`.
+- Launch and resume executions via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters, run directories, and resume actions stay synchronized.
 - Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/ModelRegistry.ts`.
 
 **PocketFlow architecture**
@@ -276,16 +275,14 @@ See `docs/pocketflow/` for full framework documentation.
 
 **Webviews and UI**
 
-- Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` and `BaseDomHandler` for consistent lifecycle management across views.
-- Register webview message handlers with `registerMessageHandlers` (`src/common/modules/webviewContext.js`). When adding UI managers (e.g., under `src/webview/modules/uiManagers/` or `src/progressView/modules/uiManagers/`), expose their URIs in the relevant content provider and import map.
-- Use codicon-based controls and the shared helpers in `src/common/modules/` (`iconConstants`, `templateUtils`, `domUtils`, `stringUtils`, `pathUtils`, `webviewState`) and `src/common/webview/themeHandlers.js` alongside `src/webview/modules/pasteHandler.js` for consistent interactions.
-- Map every module dependency in the import map, including transitives, and generate URIs via helper methods (`getHistoryViewUri`, `getCommonUri`, etc.). Missing entries will prevent modules from loading in the sandboxed webview.
+- Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
+- Use codicon-based controls and shared utilities from `@utils/text/stringUtils` and `@utils/files/pathUtils` for consistent interactions.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js, `@vscode/codicons`) local to reduce extension size.
 - Keep CSS modular (per-component styles in `src/progressView/styles`, shared tokens in `src/common/styles/common.css`) and use codicon chevrons (e.g., `<i class="codicon codicon-chevron-down"></i>`) for toggle affordances.
 
 **Progress view**
 
-- Extend the existing managers coordinated by `ProgressViewDomHandler` (`src/progressView/modules/domHandlers.js`). `StreamTabs`, `Toolbar`, `UsageSummary`, `UsageGroup`, `TaskGroupManager`, and `LogEntryManager` own their respective UI surfaces—augment them rather than manipulating the DOM directly.
+- Extend the existing Lit components in `src/progressView/frontend/components/` (`StreamTabs`, `LogEntry`, `LogList`, `UsagePanel`, `TaskGroupList`, etc.) and managers in `src/progressView/managers/` (`StreamTabsManager`, `TaskGroupManager`, `UsageStatsManager`, `WebviewUpdater`) — augment them rather than manipulating the DOM directly.
 - Tool-use and workflow sessions surface in separate filters; continue emitting usage, status, and log events through the established progress event commands so filters, counts, and badges update automatically.
 
 **Error handling and types**
@@ -302,13 +299,13 @@ See `docs/pocketflow/` for full framework documentation.
 - Dispose event listeners and watchers when webviews close to prevent leaks.
 - Prefer enums or discriminated unions over bare booleans in configuration objects.
 - Favor debug logs for routine events and reserve info/error levels for notable outcomes.
-- Use the helpers in `src/frontend/ui/messageUtils.ts` for consistent casing and notification primitives shared across the extension.
+- Use the helpers in `src/frontend/ui/dialogs.ts` and `src/frontend/ui/instruction.ts` for consistent notification primitives shared across the extension.
 
 ### Webview Consistency Patterns
 
-- **Base Classes**: All webviews (webview, progressView, settingsView) extend `BaseViewContentProvider`, `BaseViewMessageHandler`, and use DOM managers built on `BaseDomHandler` from `src/common/modules/BaseDomHandler.js` for consistent error handling, logging, and cleanup.
+- **Base Classes**: All webviews (webview, progressView, settingsView) extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `src/common/webview/` for consistent error handling, logging, and cleanup.
 - **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `SettingsViewMessageHandler`, `ProgressViewDomHandler`)
-- **Command Constants**: Define all commands in `src/common/webview/commands.js` and `.ts` - use constants, not string literals
+- **Command Constants**: Define all commands in `src/common/webview/commands.ts` - use constants, not string literals
 - **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
 - **Client-Side State**: Add empty handlers with `/* State saved client-side */` comment for checkbox/toggle operations
 - **Resource Access**: Include all common module paths in `localResourceRoots` to prevent 401 errors
@@ -319,7 +316,7 @@ See `docs/pocketflow/` for full framework documentation.
 
 ### Source Organization
 
-Commands live under `src/commands/` and are grouped by domain. Key folders include `agent/` for agent lifecycle and merge commands, `housekeeping/` for cleanup and packaging, `latex/` for LaTeX document tasks, `wolfram/` for Wolfram Alpha and script utilities, and `system/` for editor helpers along with XML/YAML utilities. This structure keeps each area focused and aligns with the design philosophy of deep modules.
+Commands live under `src/commands/` and are grouped by domain. Key folders include `agent/` for agent lifecycle and merge commands, `housekeeping/` for cleanup and packaging, `latex/` for LaTeX document tasks, `settings/` for settings view commands, and `system/` for editor helpers along with XML/YAML utilities. This structure keeps each area focused and aligns with the design philosophy of deep modules.
 
 ## Design and refactoring
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ Aim for code that looks like it was designed correctly from the start:
 **Configuration, storage, and workspace files**
 
 - Use `getConfig`, `updateConfig`, and `watchConfig` from `@utils/config` to read and react to settings changes.
-- Interact with the filesystem through `@utils/files` helpers (`WorkspaceFS`, `RelativeFS`, `StorageFS`, `GlobalStorageFS`, `AbsoluteFS`). They resolve workspace paths, manage global storage, and expose cleanup helpers like `StorageFS.cleanupOldFiles`.
+- Interact with the filesystem through `@utils/files` helpers (`WorkspaceFS`, `RelativeFS`, `StorageFS`, `GlobalStorageFS`, `AbsoluteFS`). They resolve workspace paths, manage global storage, and expose cleanup helpers like `RelativeFS.cleanupOldFiles`.
 - Generate and resolve pasted-image paths with `@utils/files/pastedImageUtils` so temporary assets map correctly back to storage.
 - Surface files and agent directories through the shared frontend utilities (`fileLister` in `src/frontend/files/fileLister.ts`, `agentDirectories` in `src/frontend/agents/AgentDirectoryManager.ts`) instead of duplicating discovery logic.
 
@@ -254,13 +254,13 @@ Aim for code that looks like it was designed correctly from the start:
 
 - Define agents using `AgentDataclass` and `AgentConfig` (`src/agent/core/`) and compose them via the factories in `src/agent/runtime`.
 - Launch and resume executions via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters, run directories, and resume actions stay synchronized.
-- Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/ModelRegistry.ts`.
+- Add new model handlers under `src/agent/modelHandlers/`, export them through the index, and register capabilities/pricing in `src/model/computeModelOptions.ts`.
 
 **PocketFlow architecture**
 
 Agent flows follow the PocketFlow pattern in `src/agent/implementations/flows/`:
 
-- **Flow types**: `ReflectionFlow` for multi-round reflection agents, `ToolUseRunFlow` for tool-use agents
+- **Flow types**: `runReflectionFlow` for multi-round reflection agents, `runToolUseFlow` for tool-use agents
 - **Services** are immutable dependencies injected via `flow.setServices()`. Nodes access them via `this.services`. Define service interfaces in flow-specific files (e.g., `ReflectionServices`, `ToolUseServices`) extending `BaseFlowContextInit` with convenience accessors (`logger`, `context`) defined inline.
 - **Shared store** contains only mutable state (memories). Nodes read/write via `prep()` and `post()` methods.
 - **Flow transitions** - use named constants instead of magic values:
@@ -278,7 +278,7 @@ See `docs/pocketflow/` for full framework documentation.
 - Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
 - Use codicon-based controls and shared utilities from `@utils/text/stringUtils` and `@utils/files/pathUtils` for consistent interactions.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js, `@vscode/codicons`) local to reduce extension size.
-- Keep CSS modular (per-component styles in `src/progressView/styles`, shared tokens in `src/common/styles/common.css`) and use codicon chevrons (e.g., `<i class="codicon codicon-chevron-down"></i>`) for toggle affordances.
+- Keep CSS modular (per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `src/common/styles/common.css`) and use codicon chevrons (e.g., `<i class="codicon codicon-chevron-down"></i>`) for toggle affordances.
 
 **Progress view**
 
@@ -288,7 +288,7 @@ See `docs/pocketflow/` for full framework documentation.
 **Error handling and types**
 
 - Format and surface errors through `logErrorMessage`, `showLoggedErrorMessage`, and `showLoggedMessageWithDocs` in `src/common/errors/errorHandlingUtils.ts` for consistent telemetry and documentation links.
-- Keep shared type definitions colocated with their domains (`src/agent/types`, `src/logger/types`) and derive runtime-safe interfaces with `zod` plus `z.infer`.
+- Keep shared type definitions colocated with their domains (e.g., `src/agent/types`) and derive runtime-safe interfaces with `zod` plus `z.infer`.
 
 **Miscellaneous**
 
@@ -304,7 +304,7 @@ See `docs/pocketflow/` for full framework documentation.
 ### Webview Consistency Patterns
 
 - **Base Classes**: All webviews (webview, progressView, settingsView) extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `src/common/webview/` for consistent error handling, logging, and cleanup.
-- **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `SettingsViewMessageHandler`, `ProgressViewDomHandler`)
+- **Naming Convention**: Follow `[Domain]View[Component]` pattern (e.g., `MainViewContentProvider`, `SettingsViewMessageHandler`, `ProgressViewContentProvider`)
 - **Command Constants**: Define all commands in `src/common/webview/commands.ts` - use constants, not string literals
 - **Message Handlers**: Delegate to domain-specific manager classes (FileManager, SettingsManager, etc.) for separation of concerns
 - **Client-Side State**: Add empty handlers with `/* State saved client-side */` comment for checkbox/toggle operations
@@ -312,7 +312,7 @@ See `docs/pocketflow/` for full framework documentation.
 - **Module Structure**: Keep UI managers focused on a single responsibility
 - **Trust Dependencies**: Use APIs as documented. When behavior is unclear, check the source in `node_modules/` first. Add a workaround only for a documented quirk, with a comment explaining it
 - **Dropdown Menus**: Should close when clicking outside, not just on toggle
-- **CSS Organization**: Keep per-component styles in view-specific `styles/` directories, shared tokens in `src/common/styles/common.css`
+- **CSS Organization**: Keep per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `src/common/styles/common.css`
 
 ### Source Organization
 
@@ -334,7 +334,7 @@ adding new code or refactoring existing modules:
   addresses them. Favor deep modules with minimal, clear APIs.
 - Most importantly, ideally, when you have finished with each change, the system will have the structure it would have had if you had designed it from the start with that change in mind.
 - When your refactoring include a large number of renames, use search tools to make sure you are not missing any files or paths where changes need to be made.
-- **Share instances via constructors**: When managers share state, pass the shared dependency through the constructor (e.g., `new UsageGroup(this.usageSummary)`). This keeps state consistent and dependencies explicit.
+- **Share instances via constructors**: When managers share state, pass the shared dependency through the constructor. This keeps state consistent and dependencies explicit.
 
 ## Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,47 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.35.10] - 2026-02-09
-
-### Features
-
-- Added **Agents tab** to Settings View with split-panel agent browser, keyboard navigation, and folder open buttons.
-- Added **model dropdown** to agent proposal UI in progress view.
-- Added **sync/async mode badges** on agent proposals with setup button in log entry banner.
-- Added **manual compact response button** for tool-use agents.
-- Added **memory tool UI** in progress view with specialized display for memory operations.
-- Context-aware **"New Agent" button** that creates matching agent type (workflow or tool-use).
-- Agent and model buttons in main view now **open settings view tabs** directly.
-- **Migrated agent settings** from VS Code config to state managers in Settings View.
-- Added **remote agent tool persistence** across sessions with orchestrator visibility.
-- Added **reference YAML files** for presenter, search, and simplifier agents.
-- Added **execution status** to runs tool and orchestrator badge in UI.
-- Implemented **subagent output capture** for tool-use agents.
-- Added **reject-with-feedback** to bash command approval prompts.
-- Added **timeout display** next to elapsed timer for bash tool.
-- Added **proactive relay token refresh** before each model invocation for improved session continuity.
-
-### Bug Fixes
-
-- Fixed **context window overflow** from accumulated reasoning tokens in response chaining.
-- Fixed **Windows path compatibility** issues (backslash-to-slash normalization, path separator boundary checks).
-- Fixed **path traversal** vulnerability via backslash-to-slash conversion in locatePath.
-- Fixed **ghost proposal race** between async model options load and proposal resolution.
-- Fixed **Lean 4 syntax highlighting** using third-party highlightjs-lean.
-- Fixed **agent creator prompts** for robust YAML generation with Nunjucks templating.
-- Fixed **stream tab delete button** clipped at narrow panel widths.
-- Fixed **background mode retries** for tool-use cycle.
-- Fixed **bash tool timeout** not killing entire process group for shell commands.
-- Fixed Anthropic **cache invalidation** from userInstruction and thinking budget changes.
-
-### Improvements
-
-- Major **agent execution lifecycle refactoring** reducing abstraction overhead (~223 net lines removed).
-- Consolidated **model invocation nodes** (merged ResponseModelInvocationNode and ToolUseCallNode into ModelInvocationNode).
-- Optimized **progress view Lit components** to reduce unnecessary re-renders.
-- Consolidated **path resolution** into WorkspaceFS.locatePath() and WorkspaceFS.relativePath().
-- Updated dependencies to latest versions.
-
 ## [0.35.9] - 2026-02-06
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.10] - 2026-02-09
+
+### Features
+
+- Added **Agents tab** to Settings View with split-panel agent browser, keyboard navigation, and folder open buttons.
+- Added **model dropdown** to agent proposal UI in progress view.
+- Added **sync/async mode badges** on agent proposals with setup button in log entry banner.
+- Added **manual compact response button** for tool-use agents.
+- Added **memory tool UI** in progress view with specialized display for memory operations.
+- Context-aware **"New Agent" button** that creates matching agent type (workflow or tool-use).
+- Agent and model buttons in main view now **open settings view tabs** directly.
+- **Migrated agent settings** from VS Code config to state managers in Settings View.
+- Added **remote agent tool persistence** across sessions with orchestrator visibility.
+- Added **reference YAML files** for presenter, search, and simplifier agents.
+- Added **execution status** to runs tool and orchestrator badge in UI.
+- Implemented **subagent output capture** for tool-use agents.
+- Added **reject-with-feedback** to bash command approval prompts.
+- Added **timeout display** next to elapsed timer for bash tool.
+- Added **proactive relay token refresh** before each model invocation for improved session continuity.
+
+### Bug Fixes
+
+- Fixed **context window overflow** from accumulated reasoning tokens in response chaining.
+- Fixed **Windows path compatibility** issues (backslash-to-slash normalization, path separator boundary checks).
+- Fixed **path traversal** vulnerability via backslash-to-slash conversion in locatePath.
+- Fixed **ghost proposal race** between async model options load and proposal resolution.
+- Fixed **Lean 4 syntax highlighting** using third-party highlightjs-lean.
+- Fixed **agent creator prompts** for robust YAML generation with Nunjucks templating.
+- Fixed **stream tab delete button** clipped at narrow panel widths.
+- Fixed **background mode retries** for tool-use cycle.
+- Fixed **bash tool timeout** not killing entire process group for shell commands.
+- Fixed Anthropic **cache invalidation** from userInstruction and thinking budget changes.
+
+### Improvements
+
+- Major **agent execution lifecycle refactoring** reducing abstraction overhead (~223 net lines removed).
+- Consolidated **model invocation nodes** (merged ResponseModelInvocationNode and ToolUseCallNode into ModelInvocationNode).
+- Optimized **progress view Lit components** to reduce unnecessary re-renders.
+- Consolidated **path resolution** into WorkspaceFS.locatePath() and WorkspaceFS.relativePath().
+- Updated dependencies to latest versions.
+
 ## [0.35.9] - 2026-02-06
 
 ### Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,12 @@ Key directories in `src/`:
 - `latex/` - LaTeX processing (formatting, diff, TikZ, PDF)
 - `webview/` - Main agent interaction interface
 - `progressView/` - Task tracking board
-- `historyView/` - Execution history browser
-- `profileView/` - Agent profile/settings view
+- `settingsView/` - Unified settings webview (History, Memory, Models, Agents tabs)
+- `shared/` - Shared schemas and message handlers across webviews
 - `explorer/` - VS Code file explorer integration
+- `auth/` - Authentication logic
+- `housekeeping/` - Cleanup and packing operations
+- `types/` - Shared type definitions
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules
@@ -118,9 +121,9 @@ Key documentation in `docs/`:
 - `housekeeping/` - Cleanup, packing, and utilities
 - `latex/` - LaTeX operations (diff, figures, etc.)
 - `progress/` - Progress board management
-- `system/` - Help, settings, tests, XML/YAML utilities, editor commands
+- `settings/` - Settings view commands
+- `system/` - Help, tests, XML/YAML utilities, editor commands
 - `tests/` - Test commands
-- `wolfram/` - Wolfram Alpha queries and script utilities
 
 ### Schema and Type Guidelines
 
@@ -255,7 +258,8 @@ Common aliases (full list in `tsconfig.json`):
 
 - `@agent/*`, `@commands/*`, `@common/*`, `@frontend/*`, `@utils/*`
 - `@model/*`, `@latex/*`, `@logger/*`, `@tools/*`, `@webview/*`
-- `@progressView/*`, `@historyView/*`, `@eventBus/*`, `@replacement/*`
+- `@progressView/*`, `@settingsView/*`, `@shared/*`, `@eventBus/*`
+- `@replacement/*`, `@housekeeping/*`, `@auth/*`, `@types/*`
 
 ## Adding New Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Common aliases (full list in `tsconfig.json`):
 
 1. Create file in appropriate `src/commands/` subdirectory
 2. Export command function following existing patterns
-3. Register in `src/commands/index.ts`
+3. Register in `src/commands.ts`
 
 ### New Agent
 
@@ -277,8 +277,7 @@ Common aliases (full list in `tsconfig.json`):
 ### New Model Provider
 
 1. Create handler in `src/agent/modelHandlers/`
-2. Add provider config in `src/model/providers/`
-3. Register in `src/model/ModelRegistry.ts`
+2. Register capabilities and pricing in `src/model/computeModelOptions.ts`
 
 ## Release Process
 


### PR DESCRIPTION
## Summary
This PR updates the AGENTS.md and CLAUDE.md documentation to reflect the current codebase architecture and remove references to outdated or refactored components.

## Key Changes

### AGENTS.md
- **Coding style**: Removed exception for JavaScript files in webview modules; all `src/` code is now TypeScript targeting ES2022
- **Directory structure**: 
  - Removed `common/modules/` from documentation (shared webview modules consolidated)
  - Updated `common/webview/` description to reference command constants instead of theme handlers
- **Agent execution**: Updated to reference `AgentDataclass` and `AgentConfig` instead of `IAgent`; removed `ToolUseSessionManager` reference; updated model registry path to `computeModelOptions.ts`
- **PocketFlow**: Changed flow type names from class-based (`ReflectionFlow`, `ToolUseRunFlow`) to function-based (`runReflectionFlow`, `runToolUseFlow`)
- **Webviews and UI**:
  - Removed `BaseDomHandler` from base classes; simplified to `BaseViewContentProvider` and `BaseViewMessageHandler`
  - Removed references to `src/common/modules/` helpers; updated to use `@utils/text/stringUtils` and `@utils/files/pathUtils`
  - Removed import map and URI generation details
  - Updated CSS organization to use TypeScript in view directories instead of separate `styles/` folders
- **Progress view**: Updated to reference Lit components and managers in new structure instead of DOM handlers
- **Error handling**: Removed `src/logger/types` from type definition examples
- **UI helpers**: Updated path from `messageUtils.ts` to `dialogs.ts` and `instruction.ts`
- **Webview consistency**: Removed `BaseDomHandler` references; updated command constants location to `commands.ts`; updated CSS organization guidance
- **Commands**: Removed `wolfram/` folder reference; added `settings/` folder

### CLAUDE.md
- **Directory structure**: 
  - Replaced `historyView/` and `profileView/` with unified `settingsView/`
  - Added `shared/`, `auth/`, `housekeeping/`, and `types/` directories
- **Commands structure**: Updated to reference `settings/` instead of `wolfram/`; removed `wolfram/` folder entirely
- **Path aliases**: Updated to include new aliases (`@settingsView/*`, `@shared/*`, `@housekeeping/*`, `@auth/*`, `@types/*`); removed `@historyView/*`
- **New command registration**: Updated to reference `src/commands.ts` instead of `src/commands/index.ts`
- **New model provider**: Simplified to remove `src/model/providers/` reference; register directly in `computeModelOptions.ts`

## Implementation Details
These changes reflect a significant refactoring of the codebase:
- Migration from class-based to function-based PocketFlow patterns
- Consolidation of webview modules and removal of DOM handler abstraction layer
- Unification of separate view files (history, profile) into a single settings view
- Reorganization of command structure with new `settings/` domain
- Simplification of model provider registration

https://claude.ai/code/session_01XZqZjRBf5DKK9M1c2CSh48

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that realign references to current directories, APIs, and conventions; no runtime behavior changes.
> 
> **Overview**
> Updates `AGENTS.md` and `CLAUDE.md` to match the current repository structure and refactors, removing outdated references and renaming concepts to the new sources of truth.
> 
> Key doc changes include: clarifying that all `src/` code is TypeScript; updating filesystem cleanup, agent definitions/execution, PocketFlow flow naming, and model capability registration references; revising webview/progress-view guidance to reflect the newer component/manager organization and command constants location; and refreshing the documented directory/alias/command layout (e.g., `settingsView`, `shared`, `auth`, `housekeeping`, `types`, and `settings/` commands).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65671c17e8e3cd033dab03e90961a49deffbb317. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->