### PR TITLE
Docs: Refresh guides with new agents, UI updates, and clearer examples

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -124,6 +124,7 @@ const baseConfig = {
             { text: 'LaTeX Tools', link: '/guide/latex-tools' },
             { text: 'File Management', link: '/guide/file-management' },
             { text: 'Multiple Output', link: '/guide/multiple-output' },
+            { text: 'Working with Overleaf', link: '/guide/working-with-overleaf' },
             { text: 'ProgressBoard', link: '/guide/progress-board' },
           ],
         },
@@ -173,7 +174,7 @@ const baseConfig = {
       provider: 'local',
     },
     footer: {
-      copyright: 'Copyright © 2024-present TeXRA Team. All rights reserved.',
+      copyright: 'Copyright © 2024-2026 TeXRA Team. All rights reserved.',
     },
   },
   ignoreDeadLinks: true,

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -1,10 +1,10 @@
 # How TeXRA Agents Work: An Overview
 
-At its core, a TeXRA agent is a recipe for instructing a Large Language Model (LLM) to perform a specific academic research task. This guide provides a high-level overview of how these agents are defined and how they execute your requests.
+Every time you click "Execute" in TeXRA, an **agent** takes your files and instructions, asks an AI model to do the work, and delivers the result. This page explains what happens under the hood—enough to understand the system, customize it, and troubleshoot when things go sideways.
 
 ## Agent Definition Files (`.yaml`)
 
-The core of TeXRA's agent definition lies in a combination of YAML for structure, Jinja2 for templating, and often XML within the prompts for guiding the LLM's output. Each agent's behavior is defined in a `.yaml` file located in the built-in or custom agent directories.
+Each agent is defined in a simple `.yaml` file that tells TeXRA what to say to the AI model and how to handle the response. You can browse these files in the Agent Explorer, or create your own (see [Custom Agents](./custom-agents.md)).
 
 ## Understanding the YAML Structure
 
@@ -57,9 +57,9 @@ sequenceDiagram
 
 **Continuation Handling:** If the LLM response gets cut off due to output token limits before generating the required `endTag`, TeXRA automatically sends a continuation prompt. This prompt asks the model to resume generating exactly where it left off, ensuring complete outputs even for very long tasks. This happens seamlessly within a processing round.
 
-### Prompt Composition and Message Flow
+### What Goes Into the Prompt
 
-TeXRA constructs the conversation by merging your agent's `systemPrompt`, the context-filled `userPrefix`, and the `userRequest`. Depending on settings, the extension may insert additional messages in between—for example the output of `texcount` when you enable **Attach TeX Count**, or encoded images and audio files selected in the file panel. The sequence is not a fixed "system–user–system" pattern: attachments or tool results can be inserted at any point before the LLM generates a single response containing `<scratchpad>` reasoning followed by the XML-wrapped output defined by `settings.documentTag`.
+TeXRA assembles a conversation from your agent's prompts and the content you selected in the UI. If you enabled **Attach TeX Count** or **Attach Diagnostics**, that information is included too. Figures and audio files are sent alongside the text for models that support them. The AI then reasons through the task and produces its output.
 
 **Reflection Rounds (Round 1+):**
 

--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -11,7 +11,7 @@ The core of TeXRA's agent definition lies in a combination of YAML for structure
 These `.yaml` files have two main parts (and thankfully, YAML is usually less prickly than XML or JSON):
 
 1.  **`settings`**: Define general operational parameters. For example:
-    - `agentType`: Is it a complex `CoT` (Chain of Thought) agent that "thinks" step-by-step, a simpler `direct` agent, or a `toolUse` agent designed to call model-integrated tools?
+    - `agentCategory`: Is it a `workflow` agent (structured Chain-of-Thought reasoning with XML-wrapped output) or a `toolUse` agent (interactive conversation that can call tools like file editing, web search, etc.)?
     - `prefills`: Text the agent should automatically start its response with (e.g., `<scratchpad>`).
     - _(Other settings control output format, inheritance, etc. See [Configuration](./configuration.md) and [Custom Agents](./custom-agents.md) for full details)._
 2.  **`prompts`**: Contain text templates that TeXRA fills with your specific context (input files, instructions) to guide the LLM at different stages:

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -46,62 +46,7 @@ and enhance the flow between paragraphs. Maintain all technical content and equa
 Focus especially on the introduction and discussion sections.
 ```
 
-### `polish_cover`
-
-The `polish_cover` agent focuses specifically on improving the style, clarity, and impact of cover letters.
-
-**Purpose:** Enhance the quality and persuasiveness of academic cover letters.
-
-**Best for:**
-
-- Refining draft cover letters for job applications or submissions
-- Ensuring a professional and compelling tone
-
-**Example instruction:**
-
-```
-Polish this cover letter to improve its clarity, flow, and professional tone. Ensure it strongly highlights my qualifications for the [Job Title/Submission Venue]. Make the language concise and impactful.
-```
-
 ## Content Generation & Transformation Agents
-
-### `derive`
-
-The `derive` agent focuses on deriving mathematical equations or logical steps.
-
-**Purpose:** Assist with mathematical derivations and logical reasoning.
-
-**Best for:**
-
-- Filling in intermediate steps in a derivation
-- Checking the logical flow of an argument
-- Deriving equations based on stated principles
-
-**Example instruction:**
-
-```
-Starting from Equation (1) and assuming [state assumptions], derive the expression for [target variable]. Show the key intermediate steps clearly.
-```
-
-### `paper2note`
-
-The `paper2note` agent transforms research papers into comprehensive lecture notes.
-
-**Purpose:** Convert academic papers to educational materials.
-
-**Best for:**
-
-- Creating teaching materials from research papers
-- Converting dense research into student-friendly content
-- Developing study guides for complex topics
-
-**Example instruction:**
-
-```
-Transform this research paper into lecture notes suitable for a graduate-level course.
-Add explanatory text for complex concepts, include discussion questions, and highlight
-key takeaways. Create sections for Introduction, Background, Methods, Results, and Discussion.
-```
 
 ### `paper2slide`
 
@@ -141,23 +86,6 @@ The `paper2poster` agent transforms papers into academic conference posters.
 Convert this paper into an academic poster using the baposter template.
 Include sections for Introduction, Methodology, Results, and Conclusions.
 Highlight key figures and tables. Make it visually appealing with appropriate columns.
-```
-
-### `paper2cover`
-
-The `paper2cover` agent generates a draft cover letter based on the content of a research paper.
-
-**Purpose:** Quickly create a starting point for a submission cover letter.
-
-**Best for:**
-
-- Drafting cover letters for journal submissions
-- Summarizing a paper's contribution for introductory purposes
-
-**Example instruction:**
-
-```
-Generate a draft cover letter for submitting this paper to [Journal Name]. Highlight the main contributions, significance, and suitability for the journal based on the paper's content.
 ```
 
 ## Figure & Media Agents
@@ -218,25 +146,49 @@ The `transcribe_audio` agent converts audio files into text transcripts.
 Transcribe the provided audio file [interview.mp3]. Provide the output as a plain text file with speaker labels if possible.
 ```
 
-## Specialized Agents
+## Presentation & Simplification Agents
 
-### `solve_qi`
+### `presenter`
 
-The `solve_qi` agent attempts to solve quantitative interview (QI) style questions.
+An interactive scientific presentation builder with visual quality assurance. It creates LaTeX Beamer presentations, posters, and visual materials by surveying your codebase, planning slides, and iteratively compiling and inspecting the output PDF.
 
-**Purpose:** Assist with solving quantitative problems, often found in technical interviews.
+**Purpose:** Build publication-ready presentations from research projects.
 
 **Best for:**
 
-- Practicing quantitative interview questions
-- Getting step-by-step solutions for math or logic puzzles
-- Understanding problem-solving approaches for quantitative tasks
+- Conference talks, poster sessions, and seminar presentations
+- Code documentation slides and tutorial materials
+- Generating TikZ diagrams and including computed figures
 
 **Example instruction:**
 
 ```
-Solve the following quantitative interview question, showing your reasoning and steps clearly: [Insert Question Here]
+Create a 15-slide Beamer presentation from this project. Cover motivation, the core
+algorithm, key results, and future work. Use the metropolis theme and include TikZ
+diagrams for the architecture. Compile and verify every slide looks correct.
 ```
+
+### `simplifier`
+
+A code and writing simplification specialist that makes scientific projects clearer and more maintainable while preserving exact correctness.
+
+**Purpose:** Remove duplication, unnecessary abstraction, and prose bloat from code and documents.
+
+**Best for:**
+
+- Refactoring research code for clarity
+- Tightening manuscript prose and cleaning up LLM-generated artifacts
+- Replacing hand-rolled implementations with standard library equivalents
+
+**Example instruction:**
+
+```
+Simplify the numerical solver in solver.py. Look for duplicated loops that could be
+vectorized with NumPy, inline any single-use helper functions, and remove dead code.
+Run the existing tests after each change to verify correctness.
+```
+
+## Specialized Agents
 
 ### `merge`
 

--- a/docs/guide/best-practices.md
+++ b/docs/guide/best-practices.md
@@ -33,9 +33,9 @@ For complex tasks:
 
 Match model capability to task complexity - overpowered models waste money, underpowered ones produce poor results.
 
-- **Simple tasks** (corrections): Use fast, cheap models (`gemini25f-`, `gpt5--`)
+- **Simple tasks** (corrections): Use fast, cheap models (`gemini3f`, `gpt5-`, `haiku35`)
 - **Complex tasks** (transformations): Use powerful models (`opus46`, `gpt52pro`)
-- **Reasoning-heavy**: Use thinking models (`sonnet45T`, `o1`, `deepseekT`)
+- **Reasoning-heavy**: Use thinking models (`sonnet45T`, `opus46T`, `deepseekT`)
 
 See the [AI Models Guide](./models.md) for detailed comparisons.
 
@@ -63,10 +63,11 @@ project/
 
 ### Staged Approach
 
-1. **Drafting**: `txt2tex` to convert to LaTeX
-2. **Development**: `polish` for clarity
-3. **Visualization**: `draw` for figures
-4. **Finalization**: `correct` for proofreading
+1. **Research**: `search` or `research` to find papers and verify ideas
+2. **Writing**: `chat` to draft LaTeX content interactively
+3. **Development**: `polish` for clarity and style
+4. **Visualization**: `draw` for figures, `presenter` for slides
+5. **Finalization**: `correct` for proofreading
 
 ### Quality Assurance
 

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -1,6 +1,6 @@
 # Built-in Agent Reference
 
-TeXRA provides built-in AI agents, each specialized for specific research tasks. Choose from the dropdown menu in the TeXRA UI.
+TeXRA ships with built-in agents for common research tasks—polishing prose, fixing errors, creating figures, converting formats, and more. Pick one from the dropdown in the TeXRA UI and you're ready to go.
 
 ## Quick Reference
 
@@ -33,14 +33,9 @@ For details on the underlying structure and execution flow common to all agents,
 
 ### `chat`
 
-A general-purpose research assistant that can read, write, and edit files in your workspace. It acts as a friendly scientist focused on careful reasoning.
+Your go-to research companion. It can read your project, edit files, run shell commands, and search through your workspace—all in a back-and-forth conversation.
 
-**Capabilities:**
-
-- Read and analyze your documents
-- Edit files with your approval (via VS Code diff view)
-- Run shell commands for compilation or other tasks
-- Search through your project files
+> **User story:** You just got reviewer comments back. Instead of manually hunting through a 40-page paper, you open `chat` and paste the reviewer's feedback: "Address comment 3 about missing error bars in Table 2—add them and update the caption." The agent reads your files, makes the edits, and shows you a diff to approve.
 
 **Best for:** General research assistance, code/LaTeX editing, running compilations
 
@@ -223,14 +218,11 @@ Don't change the technical content or writing style.
 
 ### `polish`
 
-The `polish` agent improves the writing quality of your document while preserving essential technical content and meaning. It focuses on:
+The `polish` agent improves the writing quality of your document while preserving essential technical content and meaning.
 
-- Enhancing clarity and readability
-- Improving sentence structure and paragraph flow
-- Fixing grammatical issues and typos
-- Standardizing formatting and style
+> **User story:** Your draft is technically solid but reads like it was written at 3 AM (because it was). Select `polish`, tell it "Improve clarity for a CVPR audience—keep all equations and citations intact," and in a couple of minutes you'll have a version that reads like it went through a professional copyedit. Review the colour-coded diff to accept or reject each change.
 
-This agent is ideal for refining drafts that are technically sound but need language improvements or polishing before submission.
+This agent is ideal for refining drafts that are technically sound but need language improvements before submission.
 
 #### Example Output
 
@@ -315,9 +307,9 @@ Highlight key figures and tables. Make it visually appealing with appropriate co
 
 ### `draw`
 
-The `draw` agent creates or enhances TikZ figures based on textual descriptions or existing figures.
+Creates or enhances TikZ figures from textual descriptions or existing code.
 
-**Purpose:** Generate visual representations of concepts, systems, or data.
+> **User story:** You need a neural-network architecture diagram for your paper. Describe the layers and connections in the instruction box, and `draw` generates compilable TikZ code.
 
 **Best for:**
 

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -6,19 +6,21 @@ TeXRA provides built-in AI agents, each specialized for specific research tasks.
 
 | Agent              | Type     | Purpose                                 |
 | ------------------ | -------- | --------------------------------------- |
-| `chat`             | Tool-use | General assistance, file editing        |
-| `ask`              | Tool-use | Read-only questions and exploration     |
-| `search`           | Tool-use | Literature discovery, web search        |
-| `research`         | Tool-use | Computational verification with Wolfram |
-| `discuss`          | Tool-use | Academic brainstorming with literature  |
-| `lean`             | Tool-use | Lean 4 proof development                |
-| `correct`          | Workflow | Fix errors without style changes        |
-| `polish`           | Workflow | Improve writing quality                 |
-| `paper2slide`      | Workflow | Convert papers to beamer slides         |
-| `paper2poster`     | Workflow | Create academic posters                 |
-| `draw`             | Workflow | Create/enhance TikZ figures             |
-| `ocr`              | Workflow | Extract text from images/PDFs           |
-| `transcribe_audio` | Workflow | Transcribe audio to text                |
+| `chat`             | Tool-use | General assistance, file editing            |
+| `ask`              | Tool-use | Read-only questions and exploration         |
+| `search`           | Tool-use | Literature discovery, web search            |
+| `research`         | Tool-use | Computational verification with Wolfram     |
+| `discuss`          | Tool-use | Academic brainstorming with literature      |
+| `lean`             | Tool-use | Lean 4 proof development                    |
+| `presenter`        | Tool-use | Interactive presentation builder            |
+| `simplifier`       | Tool-use | Simplify code and LaTeX for clarity         |
+| `correct`          | Workflow | Fix errors without style changes            |
+| `polish`           | Workflow | Improve writing quality                     |
+| `paper2slide`      | Workflow | Convert papers to beamer slides             |
+| `paper2poster`     | Workflow | Create academic posters                     |
+| `draw`             | Workflow | Create/enhance TikZ figures                 |
+| `ocr`              | Workflow | Extract text from images/PDFs               |
+| `transcribe_audio` | Workflow | Transcribe audio to text                    |
 
 ::: warning Important Note
 The underlying prompts and specific behaviors of these built-in agents may change slightly between TeXRA versions as we continue to optimize them. If you require precise, unchanging behavior or wish to heavily customize the process, consider creating a [Custom Agent](./custom-agents.md) based on these examples.
@@ -148,6 +150,52 @@ Interactive Lean 4 proof assistant with VS Code integration.
 ```
 Formalize the proof of the theorem in Proofs/GroupTheory.lean. Start with an
 informal outline, then produce Lean code and iterate until it compiles.
+```
+
+## Presentation & Simplification Agents
+
+### `presenter`
+
+An interactive scientific presentation builder with visual quality assurance. It creates LaTeX Beamer presentations, posters, and visual materials by surveying your codebase, planning slides, and iteratively compiling and inspecting the output PDF.
+
+**Capabilities:**
+
+- Build Beamer presentations, posters, and tutorial materials from your research
+- Survey your project with `glob`/`grep` to extract key algorithms, results, and figures
+- Generate and include TikZ diagrams, matplotlib plots, and Wolfram-generated figures
+- Compile LaTeX and visually inspect every slide of the output PDF to fix layout issues
+- Search arXiv and the web for supporting references
+
+**Best for:** Conference talks, poster sessions, seminar presentations, code documentation slides, lightning talks
+
+**Example instruction:**
+
+```
+Create a 15-slide Beamer presentation from this project. Cover motivation, the core
+algorithm, key results, and future work. Use the metropolis theme and include TikZ
+diagrams for the architecture. Compile and verify every slide looks correct.
+```
+
+### `simplifier`
+
+A code and writing simplification specialist that makes scientific projects clearer and more maintainable while preserving exact correctness.
+
+**Capabilities:**
+
+- Remove code duplication across files using systematic search
+- Inline single-use wrappers and collapse unnecessary abstraction layers
+- Replace hand-rolled implementations with standard library equivalents
+- Clean up AI-generated prose bloat (filler phrases, redundant transitions, hedging pileups)
+- Apply language-idiomatic patterns (vectorized NumPy ops, Julia broadcasting, LaTeX `\tikzset`, etc.)
+
+**Best for:** Refactoring research code, tightening manuscript prose, cleaning up LLM-generated artifacts
+
+**Example instruction:**
+
+```
+Simplify the numerical solver in solver.py. Look for duplicated loops that could be
+vectorized with NumPy, inline any single-use helper functions, and remove dead code.
+Run the existing tests after each change to verify correctness.
 ```
 
 ## Correction & Polishing Agents

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -48,13 +48,7 @@ Then update the file with your changes.
 
 ### `ask`
 
-A read-only assistant for exploring your workspace without risk of modifications.
-
-**Capabilities:**
-
-- Read and analyze documents
-- Search through project files
-- Answer questions about your codebase
+A read-only assistant for exploring your workspace. It can answer questions about your project without touching any files—safe to use when you just want to understand what's there.
 
 **Best for:** Quick questions, understanding existing code, safe exploration
 
@@ -68,14 +62,7 @@ What packages does this LaTeX project use? Summarize the document structure.
 
 ### `search`
 
-Specializes in finding academic literature and web content. Read-only - cannot modify your files.
-
-**Capabilities:**
-
-- Search arXiv for preprints and papers
-- Look up publications via Crossref/DOI
-- Fetch and summarize web pages
-- Cross-reference multiple sources
+Finds papers and web content for you. Give it a topic and it comes back with relevant preprints, published articles, and web resources. Read-only—it won't touch your files.
 
 **Best for:** Literature reviews, finding citations, fact-checking
 
@@ -88,14 +75,7 @@ Focus on papers from 2023-2024 that address mathematical equation handling.
 
 ### `research`
 
-Combines file editing with computational verification using Wolfram Language for symbolic mathematics.
-
-**Capabilities:**
-
-- Perform symbolic and numerical calculations
-- Verify mathematical derivations step-by-step
-- Edit files with computational results
-- Track progress on complex tasks
+A hands-on research agent that can edit your files **and** verify mathematics computationally. When you need to check a derivation or run a symbolic calculation alongside your writing, this is the one.
 
 **Best for:** Mathematical derivations, computational verification, multi-step research
 
@@ -108,14 +88,7 @@ Verify each step computationally and update the file with results.
 
 ### `discuss`
 
-An academic discussion partner for brainstorming and exploring research directions. Read-only with literature access.
-
-**Capabilities:**
-
-- Engage in substantive intellectual discourse
-- Find and synthesize relevant literature
-- Offer counterarguments and alternative perspectives
-- Connect ideas across papers
+A brainstorming partner that can pull in relevant literature as you talk. Useful for thinking through research directions, poking holes in methodology, or connecting ideas across papers. Read-only.
 
 **Best for:** Brainstorming, methodology critique, research direction guidance
 
@@ -130,14 +103,7 @@ tradeoffs compared to tree-based approaches? What does the literature say?
 
 ### `lean`
 
-Interactive Lean 4 proof assistant with VS Code integration.
-
-**Capabilities:**
-
-- Get real-time diagnostics and error feedback
-- Inspect proof state and types at any position
-- Search Mathlib for relevant lemmas
-- Build and verify proofs
+Helps you write and debug Lean 4 proofs. It reads compiler diagnostics, inspects proof state, and iterates until the proof compiles.
 
 **Best for:** Formalizing proofs, Lean 4 development, Mathlib projects
 
@@ -152,46 +118,29 @@ informal outline, then produce Lean code and iterate until it compiles.
 
 ### `presenter`
 
-An interactive scientific presentation builder with visual quality assurance. It creates LaTeX Beamer presentations, posters, and visual materials by surveying your codebase, planning slides, and iteratively compiling and inspecting the output PDF.
+Builds conference-ready Beamer presentations, posters, and visual materials from your project. Point it at your paper and it reads through your work, plans the slide structure, generates figures, and compiles the result—checking every slide visually before handing it back to you.
 
-**Capabilities:**
-
-- Build Beamer presentations, posters, and tutorial materials from your research
-- Survey your project with `glob`/`grep` to extract key algorithms, results, and figures
-- Generate and include TikZ diagrams, matplotlib plots, and Wolfram-generated figures
-- Compile LaTeX and visually inspect every slide of the output PDF to fix layout issues
-- Search arXiv and the web for supporting references
-
-**Best for:** Conference talks, poster sessions, seminar presentations, code documentation slides, lightning talks
+**Best for:** Conference talks, poster sessions, seminar presentations, lightning talks
 
 **Example instruction:**
 
 ```
 Create a 15-slide Beamer presentation from this project. Cover motivation, the core
 algorithm, key results, and future work. Use the metropolis theme and include TikZ
-diagrams for the architecture. Compile and verify every slide looks correct.
+diagrams for the architecture.
 ```
 
 ### `simplifier`
 
-A code and writing simplification specialist that makes scientific projects clearer and more maintainable while preserving exact correctness.
+Cuts through complexity in your code and writing. Whether it's duplicated logic across files, overly-abstract wrappers, or LLM-generated filler prose, `simplifier` cleans things up while preserving correctness.
 
-**Capabilities:**
-
-- Remove code duplication across files using systematic search
-- Inline single-use wrappers and collapse unnecessary abstraction layers
-- Replace hand-rolled implementations with standard library equivalents
-- Clean up AI-generated prose bloat (filler phrases, redundant transitions, hedging pileups)
-- Apply language-idiomatic patterns (vectorized NumPy ops, Julia broadcasting, LaTeX `\tikzset`, etc.)
-
-**Best for:** Refactoring research code, tightening manuscript prose, cleaning up LLM-generated artifacts
+**Best for:** Refactoring research code, tightening manuscript prose, cleaning up verbose AI-generated text
 
 **Example instruction:**
 
 ```
-Simplify the numerical solver in solver.py. Look for duplicated loops that could be
-vectorized with NumPy, inline any single-use helper functions, and remove dead code.
-Run the existing tests after each change to verify correctness.
+Simplify the numerical solver in solver.py. Look for duplicated code, inline any
+single-use helper functions, and remove dead code. Run existing tests after each change.
 ```
 
 ## Correction & Polishing Agents
@@ -365,15 +314,9 @@ Transcribe the provided lecture audio file [lecture.mp3]. Provide the output as 
 
 ### `merge`
 
-The `merge` agent intelligently combines changes from an edited document back into a base document.
+Takes an AI-edited document and merges the improvements back into your original, keeping the best of both. It understands context, so it won't blindly overwrite your careful phrasing with generic rewrites.
 
-**Capabilities:**
-
-- Compare an AI-edited file against the original base document
-- Selectively integrate improvements while preserving technical precision
-- Resolve conflicting changes between document versions
-
-**Best for:** Applying AI-suggested edits from `_r0_` or `_r1_` output files, incorporating reviewer suggestions, combining different drafts
+**Best for:** Applying AI-suggested edits from output files, incorporating reviewer suggestions, combining different drafts
 
 **Example instruction:**
 

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -21,6 +21,7 @@ TeXRA provides built-in AI agents, each specialized for specific research tasks.
 | `draw`             | Workflow | Create/enhance TikZ figures                 |
 | `ocr`              | Workflow | Extract text from images/PDFs               |
 | `transcribe_audio` | Workflow | Transcribe audio to text                    |
+| `merge`            | Workflow | Intelligently merge document versions       |
 
 ::: warning Important Note
 The underlying prompts and specific behaviors of these built-in agents may change slightly between TeXRA versions as we continue to optimize them. If you require precise, unchanging behavior or wish to heavily customize the process, consider creating a [Custom Agent](./custom-agents.md) based on these examples.
@@ -367,6 +368,30 @@ The `transcribe_audio` agent converts audio files (like lectures, podcasts, or p
 ```
 Transcribe the provided lecture audio file [lecture.mp3]. Provide the output as plain text, identifying different speakers if possible (e.g., Lecturer, Questioner 1).
 ```
+
+## Merge Agent
+
+### `merge`
+
+The `merge` agent intelligently combines changes from an edited document back into a base document.
+
+**Capabilities:**
+
+- Compare an AI-edited file against the original base document
+- Selectively integrate improvements while preserving technical precision
+- Resolve conflicting changes between document versions
+
+**Best for:** Applying AI-suggested edits from `_r0_` or `_r1_` output files, incorporating reviewer suggestions, combining different drafts
+
+**Example instruction:**
+
+```
+Merge changes from the edited file into the original document. Prioritize substantive
+improvements in clarity while maintaining the original's technical precision.
+Preserve mathematical notation and citations from the original.
+```
+
+See [Intelligent Merge](./intelligent-merge.md) for details on the merge workflow.
 
 ## Next Steps
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -77,6 +77,37 @@ Configure how TeXRA connects to AI model providers:
 
 **Note:** Only the providers marked with ✅ are supported by the proxy. Other providers will use their direct API endpoints even when proxy is enabled.
 
+### Anthropic 1M Context Window
+
+Enable the extended 1M-token context window for Claude Opus 4.6 and Sonnet 4/4.5:
+
+```json
+"texra.model.useAnthropic1MBeta": true
+```
+
+This attaches the `context-1m-2025-08-07` beta header to Anthropic requests. Usage is capped at 200K tokens by the extension.
+
+### Bibliography Settings
+
+Configure the default bibliography file path for Zotero exports and bibliography tools:
+
+```json
+"texra.bib.defaultPath": "${workspaceFolder}/references.bib"
+```
+
+When set, bibliography tools will use this path when no explicit file is provided. Works with Zotero auto-exported `.bib` files.
+
+### Agent Output Storage
+
+Control where agent-generated files are saved:
+
+```json
+"texra.agentOutputs.storageMode": "workspace"
+```
+
+- `workspace`: Write output files beside the source files (default)
+- `taskRunStorage`: Isolate artifacts inside the extension storage
+
 ### Audio Settings
 
 Specify a custom path to the [SoX](http://sox.sourceforge.net/) binary when automatic detection fails:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -4,16 +4,16 @@ TeXRA provides extensive configuration options that allow you to customize its b
 
 ## The TeXRA Dashboard
 
-The **Dashboard** is a unified panel that consolidates several management views into one place. Open it via the Command Palette (`Ctrl+Shift+P`) with **TeXRA: Show Dashboard** (or **TeXRA: Show Agents**, **TeXRA: View Profile**, etc.):
+The **Dashboard** is your one-stop shop for managing everything in TeXRA. Open it from the Command Palette (`Ctrl+Shift+P`) with **TeXRA: Show Dashboard**:
 
-- **Agents tab**: Toggle agent visibility for the current workspace. Agents with a `_multiple.yaml` variant are flagged with a multi-output badge.
-- **Models tab**: A provider-grouped list of all available models with checkboxes to control which appear in the model dropdown. Deprecation toggles and tier availability indicators help you choose. You can also set/remove API keys for each provider inline.
-- **History tab**: Searchable, collapsible list of past agent execution sessions.
-- **Memory tab**: Browse and delete agent memory entries stored across sessions.
-- **Profile tab**: View your account status, access level, and available remote agents.
+- **Agents** - Turn agents on or off for the current workspace. Agents that support multiple output files are marked with a badge.
+- **Models** - Pick which models show up in your dropdown. Models are grouped by provider (Anthropic, OpenAI, Google, etc.) and you can set or remove API keys for each provider right there - no need to hunt through settings.
+- **History** - Search and browse past runs. Handy for finding that polish job you ran last week.
+- **Memory** - See what your tool-use agents have remembered across sessions, and delete entries you no longer need.
+- **Profile** - Check your account, access level, and available remote agents.
 
 ::: tip
-Streaming and endpoint settings (like `useStreaming`, `useOpenAIResponsesAPI`) have been migrated from VS Code settings to the **Settings View** accessible from the Dashboard.
+Streaming and connection settings have moved out of VS Code settings and into the **Settings View**, accessible from the Dashboard.
 :::
 
 ## Accessing Configuration
@@ -42,7 +42,7 @@ default list is maintained in the [Models Guide](./models.md). Override it by
 specifying your own model identifiers:
 
 ```json
-"texra.models": ["sonnet45T", "gpt51", "gpt5pro"]
+"texra.models": ["sonnet45T", "opus46T", "gemini3p", "gpt52"]
 ```
 
 ### API Provider Settings

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -2,9 +2,23 @@
 
 TeXRA provides extensive configuration options that allow you to customize its behavior to match your workflow (don't worry, the defaults are sensible!). This guide explains the available settings and how to adjust them for optimal performance.
 
+## The TeXRA Dashboard
+
+The **Dashboard** is a unified panel that consolidates several management views into one place. Open it via the Command Palette (`Ctrl+Shift+P`) with **TeXRA: Show Dashboard** (or **TeXRA: Show Agents**, **TeXRA: View Profile**, etc.):
+
+- **Agents tab**: Toggle agent visibility for the current workspace. Agents with a `_multiple.yaml` variant are flagged with a multi-output badge.
+- **Models tab**: A provider-grouped list of all available models with checkboxes to control which appear in the model dropdown. Deprecation toggles and tier availability indicators help you choose. You can also set/remove API keys for each provider inline.
+- **History tab**: Searchable, collapsible list of past agent execution sessions.
+- **Memory tab**: Browse and delete agent memory entries stored across sessions.
+- **Profile tab**: View your account status, access level, and available remote agents.
+
+::: tip
+Streaming and endpoint settings (like `useStreaming`, `useOpenAIResponsesAPI`) have been migrated from VS Code settings to the **Settings View** accessible from the Dashboard.
+:::
+
 ## Accessing Configuration
 
-You can configure TeXRA through VS Code's settings:
+You can also configure TeXRA through VS Code's standard settings:
 
 1. Open VS Code Settings (File > Preferences > Settings or `Ctrl+,`)
 2. Search for "TeXRA" to see all available settings

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -59,9 +59,9 @@ inherits: base # Or polish, correct, etc.
 # Override parent settings here if inheriting.
 settings:
   # Core Behavior
-  agentType: CoT # Type: 'CoT' (Chain of Thought) for complex reasoning with scratchpads, 'direct' for simpler direct output, or 'toolUse' for agents that call model tools.
+  agentCategory: workflow # 'workflow' for structured reasoning with XML-wrapped output, or 'toolUse' for interactive agents that call tools (file editing, web search, etc.)
   temperature: 0.1 # LLM creativity (0.0 = deterministic, >0 = more random). Can be overridden by user settings.
-  isRewrite: true # Boolean: Does the agent primarily rewrite existing content (true) or generate new content (false)? Affects some internal handling.
+  isRewrite: true # Does the agent primarily rewrite existing content (true) or generate new content (false)?
 
   # Output Handling
   documentTag: document # The main XML tag wrapping the agent's final output (required for CoT).
@@ -220,7 +220,7 @@ Example:
 
 ```yaml
 settings:
-  agentType: toolUse
+  agentCategory: toolUse
   tools:
     - str_replace_editor
     - wolfram

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -1,6 +1,8 @@
 # Custom Agents
 
-TeXRA is a VS Code extension that orchestrates AI-driven writing tools using YAML agent files. Each agent follows a chain-of-thought workflow with scratchpad planning and a final XML-wrapped output. This guide focuses on creating those definition (`.yaml`) files so you can tailor TeXRA to your research needs (or make an agent that writes everything in pirate speak—we won't judge).
+Every lab has its own writing style, formatting quirks, and recurring tasks. Maybe your group always needs a "rewrite the abstract for a Nature-style letter" pass, or you want an agent that converts your internal notes into arXiv-ready LaTeX. Custom agents let you encode these workflows once and reuse them with a single click.
+
+This guide walks you through creating your own agent definition files (`.yaml`) so TeXRA does exactly what your research needs—no coding required.
 
 ::: info Agent Fundamentals
 Before creating a custom agent, it's highly recommended to understand the underlying concepts:
@@ -12,16 +14,7 @@ Before creating a custom agent, it's highly recommended to understand the underl
 
 ## Reference Agents
 
-TeXRA ships with a `reference-agents/` folder in the repository root containing example agent definitions you can use as starting points. These include:
-
-- **orchestrator** - Multi-agent workflow coordination with proposal review
-- **enhance** / **criticize** - Content improvement and critique workflows
-- **devise** / **logic** - Problem-solving and logical reasoning
-- **notation** - Mathematical notation standardization
-- **verifyFix** - Verify and fix LaTeX compilation errors
-- **generic** - General-purpose template
-
-Each reference agent also has a `_multiple` variant for multi-file output. Copy any of these into your custom agents directory and modify them to suit your needs.
+TeXRA includes ready-made reference agents you can use as starting points. Think of them as recipes: copy one into your custom agents directory, tweak it, and you have a new agent in minutes. Examples range from content-enhancement workflows to notation standardizers and multi-agent orchestrators. Each also has a `_multiple` variant for multi-file output.
 
 ## Creating a Custom Agent File
 
@@ -178,65 +171,47 @@ userPrefix: |
 - **Start Simple:** Begin with basic settings/prompts and add complexity incrementally.
 - **Test Iteratively:** Test frequently and review logs in the ProgressBoard.
 
-### Runtime XML exports
+### Chaining Agents Together
 
-Reflection-style agents automatically collect a lightweight summary of the XML they generate. The summary is exposed as
-`runtimeXmlExports` on the agent instance so pipeline orchestrators can forward the results to follow-up steps.
+After a workflow agent finishes, TeXRA captures the output so follow-up steps can reuse it without another trip through the file picker. This is how multi-stage pipelines work—for example, an orchestrator agent can run a `polish` step, then automatically hand the result to a `correct` step, all in a single session.
 
-The structure includes three simple fields:
-
-- `tagContents`: a dictionary of detected XML tags. For `<document>` outputs this contains either a single string or an array of strings (when the model generated multiple named documents). A `<scratchpad>` tag is captured when present.
-- `documents`: a list of serialized `<document>` elements suitable for pasting directly into the next prompt.
-- `singleOutputFile`: the processed output path when the agent produced exactly one LaTeX document.
-
-Because this data lives alongside the run state, orchestrators can choose how to apply it—for example, by inserting the serialized documents straight into the next request or by handing off the processed file path to a critique step.
+You don't need to configure this yourself; it happens automatically when an agent definition includes orchestration prompts. See the reference agents for working examples.
 
 ### Tool-Use Agents
 
-Tools live under `src/tools/` and each one defines its input schema with Zod.
-List the desired tools by name in your agent YAML. The registry includes
-workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
-`glob`, `grep`, and `ls` alongside domain-specific helpers such as
-`str_replace_editor`, `wolfram`,
-`web_fetch`, `web_search`, `memory`, `todo_write`, `diagnostics`,
-`extract_figures`, `extract_tikz_figures`, `extract_bib_entries`,
-`arxiv_search`, `arxiv_metadata`, `arxiv_download`,
-`crossref_search`, `crossref_doi`,
-`zotero_search`, `zotero_export`, and `zotero_add`.
+Tool-use agents are interactive: instead of producing a single polished file, they hold a conversation and take actions on your behalf—reading and editing files, searching the web, looking up papers, and more.
 
-> **Tip:** The `read_file` tool returns only the first 2,000 lines of a file (per request) to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 2,000 lines. The tool enforces the same 2,000-line limit on each requested window, prefixes each line with a `cat -n` style line number, reports the specific line range that was returned, and notes when the requested end exceeds the file length so you know the response was clipped. When copying text for `edit_file`, use only the content after the line-number prefix.
+**Typical user story:** You're writing up results for a conference submission and realize you need three new BibTeX entries, a TikZ architecture diagram, and a consistency pass across four `.tex` files. Rather than switching between browser tabs and terminal windows, you open a `chat` agent and describe what you need. The agent reads your project, searches arXiv for the missing references, drafts the TikZ code, and edits the files—all in one session.
 
-For a minimal read-only configuration, see the built-in `ask` agent
-(`resources/tool_use_agents/ask.yaml`), which only grants `read_file`, `glob`,
-`grep`, and `ls` access.
+To create your own tool-use agent, set `agentCategory: toolUse` and list the tools you want to grant. TeXRA provides tools in several categories:
 
-Common workspace helpers:
+| Category           | What it lets the agent do                                    |
+| ------------------ | ------------------------------------------------------------ |
+| **File workspace** | Read, write, edit, search, and list files in your project    |
+| **Shell**          | Run commands (compilation, scripts, etc.)                    |
+| **Web & search**   | Fetch web pages and search the internet                      |
+| **Literature**     | Search arXiv, Crossref, and manage your Zotero library       |
+| **Math**           | Run Wolfram Language computations                            |
+| **Figures**        | Extract and compile figures and TikZ diagrams                |
+| **Memory & tasks** | Remember context across sessions; track multi-step progress  |
 
-- `glob` — Quickly list files matching a pattern, sorted by modification time.
-- `grep` — Run ripgrep searches without leaving the workspace sandbox. By default it returns matching content lines; switch the `output_mode` to `files_with_matches` or `count` to change the response format.
-- `ls` — Inspect directory contents with optional ignore globs.
+For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `chat`, `search`, or `ask`) in the Agent Explorer—their `tools:` array shows exactly which tools are available.
 
-Example:
+Example skeleton:
 
 ```yaml
 settings:
   agentCategory: toolUse
   tools:
-    - str_replace_editor
-    - wolfram
-    - glob
-    - grep
-    - ls
-    - bash
     - read_file
     - write_file
     - edit_file
-    - web_fetch
+    - glob
+    - grep
     - web_search
 ```
 
-The ProgressBoard shows the JSON passed to each tool along with the tool's
-response.
+The ProgressBoard logs every tool call and its result, so you can always see what the agent is doing.
 
 ### Example: Multiple Output Agent
 
@@ -286,8 +261,6 @@ for more details.
 
 ### Strict XML Extraction
 
-TeXRA's `XmlOutputManager` parses the `<latex_document>` or `<latex_documents>` blocks in the AI output.
-It requires properly closed tags and, for multiple outputs, each `<document>` must include a `name` attribute that matches a filename from the UI.
-If tags are mismatched or a filename is wrong, extraction fails and no files are saved.
+TeXRA expects the model's output to use properly closed XML tags. For agents producing multiple files, each `<document>` block must include a `name` attribute matching one of the filenames from the UI. If tags are mismatched or a filename doesn't match, extraction fails and no files are saved—check the ProgressBoard logs for details.
 
-For more complex examples and advanced configuration options like `requiredFiles` and `filePatternsContain`, examine the source `.yaml` files of the [Built-in Agents](./built-in-agents.md).
+For more examples and advanced options, browse the built-in agent definitions through the [Agent Explorer](./agent-explorer.md).

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -10,6 +10,19 @@ Before creating a custom agent, it's highly recommended to understand the underl
 - **Agent Explorer**: Learn how to browse and manage agent files using the [Agent Explorer](./agent-explorer.md) view in the TeXRA sidebar.
   :::
 
+## Reference Agents
+
+TeXRA ships with a `reference-agents/` folder in the repository root containing example agent definitions you can use as starting points. These include:
+
+- **orchestrator** - Multi-agent workflow coordination with proposal review
+- **enhance** / **criticize** - Content improvement and critique workflows
+- **devise** / **logic** - Problem-solving and logical reasoning
+- **notation** - Mathematical notation standardization
+- **verifyFix** - Verify and fix LaTeX compilation errors
+- **generic** - General-purpose template
+
+Each reference agent also has a `_multiple` variant for multi-file output. Copy any of these into your custom agents directory and modify them to suit your needs.
+
 ## Creating a Custom Agent File
 
 Follow these steps to create a new custom agent:
@@ -185,7 +198,11 @@ List the desired tools by name in your agent YAML. The registry includes
 workspace utilities like `bash`, `read_file`, `write_file`, `edit_file`,
 `glob`, `grep`, and `ls` alongside domain-specific helpers such as
 `str_replace_editor`, `wolfram`,
-`web_fetch`, and `web_search`.
+`web_fetch`, `web_search`, `memory`, `todo_write`, `diagnostics`,
+`extract_figures`, `extract_tikz_figures`, `extract_bib_entries`,
+`arxiv_search`, `arxiv_metadata`, `arxiv_download`,
+`crossref_search`, `crossref_doi`,
+`zotero_search`, `zotero_export`, and `zotero_add`.
 
 > **Tip:** The `read_file` tool returns only the first 2,000 lines of a file (per request) to prevent massive responses from overwhelming the progress log. Provide an optional `range` object (for example, `{"start": 401, "end": 450}`) to page through a file beyond the first 2,000 lines. The tool enforces the same 2,000-line limit on each requested window, prefixes each line with a `cat -n` style line number, reports the specific line range that was returned, and notes when the requested end exceeds the file length so you know the response was clipped. When copying text for `edit_file`, use only the content after the line-number prefix.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -38,7 +38,7 @@ You can also install TeXRA directly in your preferred editor using protocol-base
 ### From VSIX File
 
 1. Open VS Code
-2. Obtain the newest release (`.vsix` file, e.g., `texra-0.28.0.vsix`)
+2. Obtain the newest release (`.vsix` file, e.g., `texra-0.35.10.vsix`)
 3. Find the `.vsix` file in the VS Code file explorer
 4. Right-click on the `.vsix` file
 5. From the context menu, select "Install Extension VSIX"
@@ -172,10 +172,10 @@ TeXRA requires API keys to access language models. Here's how to set them up:
 1. Open VS Code with TeXRA installed
 2. Click on the TeXRA icon in the Activity Bar
 3. Click "Set API Key" in the TeXRA panel
-4. Select the provider (OpenAI or Anthropic)
+4. Select the provider (e.g., Anthropic, OpenAI, Google)
 5. Enter your API key when prompted
 
-Alternatively, you can access the extension settings (including API key setup) by clicking the gear icon (<i class="codicon codicon-gear"></i>) in the TeXRA webview panel.
+You can also manage API keys from the **Models tab** in the TeXRA Dashboard, which provides inline set/remove controls for each provider.
 
 TeXRA also loads environment variables from a `.env` file in your workspace. Define variables like `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` in this file to avoid entering keys manually.
 
@@ -211,7 +211,7 @@ If any component is missing, TeXRA will typically show an error message indicati
 ### Common Installation Issues
 
 1. **Extension Not Loading**:
-   - Check VS Code's minimum version requirement (1.94.2+)
+   - Check VS Code's minimum version requirement (1.99+)
    - Look for errors in the Output panel (select "TeXRA" in the dropdown)
    - Try reinstalling the extension
 

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -66,7 +66,7 @@ TeXRA extracts and processes figures for AI analysis.
 
 The `extract_figures` tool finds figure references (`\includegraphics`) and returns the images as attachments, allowing the LLM to "see" your figures.
 
-**Auto-extraction:** Enable "Auto Extract Figures" in the UI to automatically include figures in prompts. See [File Management](./file-management.md#auto-extraction-features).
+**Auto-extraction:** Enable "Auto Extract Figures" in the UI to automatically include figures in prompts. See [Working with Figures](./working-with-figures.md).
 
 ### TikZ Figures
 
@@ -98,8 +98,8 @@ The `wolfram` tool executes Wolfram Language code through `wolframscript`, letti
 
 Control how TeXRA uses tools through the UI:
 
-- **Tool Config Dropdown:** Enable/disable helpers like "Attach TeX Count" or "Attach Diagnostics" for the current run. See [File Management](./file-management.md#tool-config-dropdown).
-- **Auto Extract Dropdown:** Enable/disable automatic extraction of Figures or TikZ Figures. See [File Management](./file-management.md#auto-extraction-features).
+- **Tool Config Dropdown:** Enable/disable helpers like "Attach TeX Count" or "Attach Diagnostics" for the current run. See [Configuration](./configuration.md#agent-execution-settings-webview-interface).
+- **Auto Extract Dropdown:** Enable/disable automatic extraction of Figures or TikZ Figures. See [Working with Figures](./working-with-figures.md).
 
 For detailed tool settings (formatter paths, TikZ processing options, etc.), see the [Configuration guide](./configuration.md).
 

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -1,19 +1,17 @@
 # LaTeX Tools
 
-TeXRA integrates specialized external tools for LaTeX processing.
+TeXRA doesn't just send text to an AI and hope for the best. It plugs into battle-tested LaTeX tools so formatting, diffing, and figure extraction are handled by the right software—not by a language model guessing at syntax.
 
 ## Overview
 
-LaTeX documents require precision in formatting, compilation, and analysis. Rather than relying solely on the LLM, TeXRA leverages dedicated tools for these tasks:
-
-| Tool                      | Purpose                 |
+| What it does              | Tool behind the scenes  |
 | ------------------------- | ----------------------- |
-| `latexindent` / `tex-fmt` | Code formatting         |
-| `latexdiff`               | Version comparison      |
-| `texcount`                | Document statistics     |
-| `extract_figures`         | Figure asset extraction |
-| `extract_tikz_figures`    | TikZ compilation        |
-| `extract_bib_entries`     | Bibliography resolution |
+| Code formatting           | `latexindent` or `tex-fmt` |
+| Version comparison        | `latexdiff`             |
+| Document statistics       | `texcount`              |
+| Figure extraction         | Built-in                |
+| TikZ compilation          | Built-in                |
+| Bibliography resolution   | Built-in                |
 
 ## Formatting Tools
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -61,11 +61,10 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 
 ## Moonshot Kimi Models
 
-| Model ID | Use Case                       | Cost | Speed  |
-| :------- | :----------------------------- | :--- | :----- |
-| `kimi2`  | Agent tasks, 256k context      | $$$  | Medium |
-| `kimi2T` | K2 with thinking mode          | $$   | Medium |
-| `kimit`  | Detailed reasoning with vision | $$$  | Medium |
+| Model ID  | Use Case                    | Cost | Speed  |
+| :-------- | :-------------------------- | :--- | :----- |
+| `kimi25T` | K2.5 with thinking mode     | $$$  | Medium |
+| `kimi25`  | K2.5, agent tasks           | $$$  | Medium |
 
 ## DashScope Qwen Models
 
@@ -85,7 +84,7 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 
 ## Choosing a Model
 
-- **Simple tasks**: Fast, cheap models (`gemini25f-`, `gpt5--`, `haiku35`)
+- **Simple tasks**: Fast, cheap models (`gemini25f-`, `gpt5-`, `haiku35`)
 - **Complex tasks**: Powerful models (`opus46`, `gpt52pro`, `o1`)
 - **Reasoning-heavy**: Thinking models (`sonnet45T`, `deepseekT`, `o3`)
 - **Large documents**: High-context models (`gemini*`, `gpt41`, `gpt5`)

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -54,6 +54,46 @@ The header provides a summary and actions for the selected stream:
   - <i class="codicon codicon-trash"></i> **Clean**: Deletes the output files associated with this stream.
   - <i class="codicon codicon-clear-all"></i> **Erase**: Removes this stream and its log content entirely from the ProgressBoard.
 
+### YOLO Mode
+
+The header includes a **YOLO mode toggle** button for quick access. When YOLO mode is enabled, tool-use agents automatically approve tool calls (file edits, bash commands, etc.) without pausing for your confirmation. This is useful when you trust the agent and want uninterrupted execution.
+
+Toggle it on/off directly from the ProgressBoard header. Use with caution on unfamiliar tasks.
+
+### Context Utilization
+
+During tool-use sessions, the header displays a **context utilization percentage** showing how much of the model's context window has been consumed. This helps you gauge when a conversation is approaching its limits and may need compaction or a fresh session.
+
+### Todo List (Tool-Use Agents)
+
+Tool-use agents can create and manage a **todo list** visible in the ProgressBoard. When an agent uses the `todo_write` tool, the list appears in the content area showing task items with status indicators:
+
+- **Pending**: Task not yet started
+- **In Progress**: Currently being worked on
+- **Completed**: Finished successfully
+
+The todo list gives you visibility into the agent's plan and progress on multi-step tasks.
+
+### Followup Tasks
+
+After a workflow agent completes, you can continue the conversation using the **Followup Task** feature directly in the ProgressBoard:
+
+1. Select a completed workflow stream
+2. Use the followup controls to either:
+   - **Chat** about the results (discuss, ask questions)
+   - **Run another agent** on the output files (e.g., merge multiple outputs)
+3. The followup inherits the context of the previous run
+
+This avoids manually reconfiguring files and agents for iterative workflows.
+
+### Memory View
+
+The ProgressBoard provides access to the **Memory View** for browsing agent memory entries. When the memory tool is enabled (toggle in the toolbar), agents can store and retrieve persistent notes across sessions. The Memory View lets you:
+
+- Browse all saved memory entries
+- Delete individual entries
+- See what context agents have accumulated
+
 ### Log Content
 
 This scrollable area displays the detailed, timestamped logs for the selected agent run.

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -1,6 +1,6 @@
 # ProgressBoard
 
-The ProgressBoard monitors agent execution, displays logs, and manages past runs.
+The ProgressBoard is where you watch agents work and review what they did. Think of it as the flight recorder for every TeXRA run—you can see live progress, re-run a past job, or restore its settings with one click.
 
 ## Accessing the ProgressBoard
 

--- a/docs/guide/progress-board.md
+++ b/docs/guide/progress-board.md
@@ -56,43 +56,28 @@ The header provides a summary and actions for the selected stream:
 
 ### YOLO Mode
 
-The header includes a **YOLO mode toggle** button for quick access. When YOLO mode is enabled, tool-use agents automatically approve tool calls (file edits, bash commands, etc.) without pausing for your confirmation. This is useful when you trust the agent and want uninterrupted execution.
-
-Toggle it on/off directly from the ProgressBoard header. Use with caution on unfamiliar tasks.
+Tired of clicking "Approve" on every file edit? The **YOLO mode** toggle in the header lets tool-use agents run hands-free - they'll edit files, run commands, and search the web without stopping to ask. Great for tasks you trust; just flip it off when you want to review each step.
 
 ### Context Utilization
 
-During tool-use sessions, the header displays a **context utilization percentage** showing how much of the model's context window has been consumed. This helps you gauge when a conversation is approaching its limits and may need compaction or a fresh session.
+A small percentage next to the token count shows how full the model's context window is. When it climbs toward 100%, the conversation may get compacted automatically or you might want to start a fresh session.
 
-### Todo List (Tool-Use Agents)
+### Todo List
 
-Tool-use agents can create and manage a **todo list** visible in the ProgressBoard. When an agent uses the `todo_write` tool, the list appears in the content area showing task items with status indicators:
-
-- **Pending**: Task not yet started
-- **In Progress**: Currently being worked on
-- **Completed**: Finished successfully
-
-The todo list gives you visibility into the agent's plan and progress on multi-step tasks.
+When a tool-use agent tackles a multi-step task, it shows a **live checklist** right in the ProgressBoard. Each item moves from Pending to In Progress to Completed so you always know what the agent is working on and how far along it is.
 
 ### Followup Tasks
 
-After a workflow agent completes, you can continue the conversation using the **Followup Task** feature directly in the ProgressBoard:
+Finished a polish run and want to discuss the results or merge the outputs? Instead of setting everything up again, use the **Followup** controls that appear after a workflow completes:
 
-1. Select a completed workflow stream
-2. Use the followup controls to either:
-   - **Chat** about the results (discuss, ask questions)
-   - **Run another agent** on the output files (e.g., merge multiple outputs)
-3. The followup inherits the context of the previous run
+- **Chat** about what the agent changed
+- **Run another agent** (like `merge`) on the output files
 
-This avoids manually reconfiguring files and agents for iterative workflows.
+The followup picks up right where the previous run left off - no need to re-select files or re-enter your instruction.
 
-### Memory View
+### Memory
 
-The ProgressBoard provides access to the **Memory View** for browsing agent memory entries. When the memory tool is enabled (toggle in the toolbar), agents can store and retrieve persistent notes across sessions. The Memory View lets you:
-
-- Browse all saved memory entries
-- Delete individual entries
-- See what context agents have accumulated
+Tool-use agents can remember things between sessions. When memory is enabled (toggle in the toolbar), agents save useful notes about your project. You can browse and delete these notes from the **Memory** tab in the Dashboard, or by running **TeXRA: Show Memory** from the Command Palette.
 
 ### Log Content
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,15 +1,16 @@
 # Quick Start Guide
 
-This guide will help you get up and running with TeXRA quickly. In just a few minutes, you'll be able to use AI to enhance your academic research in VS Code.
+You have a paper draft and a deadline. Let's get TeXRA working for you in under five minutes.
 
 ## Overview
 
-TeXRA integrates powerful AI capabilities directly into your writing workflow. Here's what you can do:
+TeXRA sits inside VS Code and helps you polish writing, fix errors, create figures, and transform documents—without leaving your editor. Here's the short version:
 
-- Fix grammar and typos in academic documents
-- Improve writing style and clarity
-- Create or enhance technical figures
-- Transform papers into different formats (lecture notes, slides, posters)
+1. Select your file
+2. Pick an agent and model
+3. Write a short instruction
+4. Click Execute
+5. Review the diff
 
 > 💡 **Tip:** Inside VS Code you can open the **Run your first TeXRA workflow** walkthrough from the Get Started page (or by running `TeXRA: Open Getting Started Walkthrough`). It mirrors this guide step-by-step and links directly to the relevant commands.
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -238,13 +238,13 @@ Here are some common tasks you can try with TeXRA:
 ### Fixing Grammar and Typos
 
 - **Agent**: `correct`
-- **Model**: `gemini25p`, `gpt41`, `gpt51`, `gpt5`, or `gpt5pro`
+- **Model**: `gemini3f`, `gemini3p`, `gpt41`, or `sonnet45`
 - **Instruction**: "Fix grammatical errors and typos without changing the content or technical terminology."
 
 ### Converting a Paper to Slides
 
 - **Agent**: `paper2slide`
-- **Model**: `sonnet45T`, `gpt51`, `gpt5`, or `gpt5pro`
+- **Model**: `sonnet45T`, `opus46`, or `gpt52`
 - **Instruction**: "Convert this paper into presentation slides using the beamer template. Create approximately 12-15 slides highlighting the key points, methodology, and results."
 
 ### Improving Writing Style

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -1,19 +1,19 @@
 # Research Tools
 
-The `search`, `discuss`, and `ask` agents can find academic papers and web content for you. Just describe what you're looking for.
+You're deep in a manuscript and realize you need to cite "that attention paper from 2017" but can't remember the exact title. Or you want to verify that an integral in your appendix is correct. Or you need to pull twenty BibTeX entries from your Zotero library into a new project. TeXRA's research agents handle all of this without leaving VS Code.
 
 ## What You Can Do
 
 ### Find Papers
 
-Ask any research agent to search for papers:
+Ask any research agent to search for papers. TeXRA searches **arXiv** (preprints) and **Crossref** (published works) automatically:
 
 ```
 Find recent papers on transformer architectures for document understanding.
 Focus on work from 2023-2024 that handles mathematical equations.
 ```
 
-The agent searches **arXiv** (preprints) and **Crossref** (published works) automatically.
+**User story:** A postdoc is writing a related-work section for a NeurIPS submission. She opens the `search` agent and asks for papers on "efficient self-attention for long documents." In seconds she has a table of relevant arXiv preprints with titles, authors, and abstracts—ready to cite.
 
 ### Look Up Citations
 
@@ -29,7 +29,7 @@ Look up DOI 10.1038/nature12373
 
 ### Download Paper Sources
 
-For deeper analysis, ask to download the LaTeX source:
+For deeper analysis, ask to download the LaTeX source of a paper:
 
 ```
 Download the source files for arxiv:2401.12345 so I can see how they made their figures.
@@ -45,7 +45,7 @@ Find the official PyTorch documentation for attention mechanisms.
 
 ### Manage References with Zotero
 
-If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly:
+If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Just make sure Zotero is running when you use these features.
 
 ```
 Search my Zotero library for papers by Vaswani on attention mechanisms.
@@ -59,10 +59,10 @@ Export the selected Zotero items as a .bib file for my project.
 Add this arXiv paper to my Zotero library.
 ```
 
-The Zotero tools (`zotero_search`, `zotero_export`, `zotero_add`) communicate with Better BibTeX's JSON-RPC interface. Make sure Zotero is running with Better BibTeX installed when using these tools.
+**User story:** A PhD student is collecting references for a thesis chapter. She asks the `search` agent to find key papers on graph neural networks, then says "add these to my Zotero and export them to `references.bib`." The agent handles the lookup, adds entries to her Zotero library, and writes the BibTeX file—all in one conversation.
 
 ::: tip Default Bibliography Path
-Set `texra.bib.defaultPath` in your VS Code settings to specify the default `.bib` file for Zotero exports, so agents know where to save bibliography entries.
+Set `texra.bib.defaultPath` in your VS Code settings to specify where Zotero exports land by default, so agents always know where to save bibliography entries.
 :::
 
 ## Which Agent to Use

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -43,10 +43,33 @@ For documentation, project pages, or general info:
 Find the official PyTorch documentation for attention mechanisms.
 ```
 
+### Manage References with Zotero
+
+If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly:
+
+```
+Search my Zotero library for papers by Vaswani on attention mechanisms.
+```
+
+```
+Export the selected Zotero items as a .bib file for my project.
+```
+
+```
+Add this arXiv paper to my Zotero library.
+```
+
+The Zotero tools (`zotero_search`, `zotero_export`, `zotero_add`) communicate with Better BibTeX's JSON-RPC interface. Make sure Zotero is running with Better BibTeX installed when using these tools.
+
+::: tip Default Bibliography Path
+Set `texra.bib.defaultPath` in your VS Code settings to specify the default `.bib` file for Zotero exports, so agents know where to save bibliography entries.
+:::
+
 ## Which Agent to Use
 
-| Agent     | Best for                                                  |
-| --------- | --------------------------------------------------------- |
-| `search`  | Finding papers, literature reviews, fact-checking         |
-| `discuss` | Brainstorming research directions with literature context |
-| `ask`     | Quick lookups about your documents and related work       |
+| Agent      | Best for                                                  |
+| ---------- | --------------------------------------------------------- |
+| `search`   | Finding papers, literature reviews, fact-checking         |
+| `research` | Computational verification with Wolfram and literature    |
+| `discuss`  | Brainstorming research directions with literature context |
+| `ask`      | Quick lookups about your documents and related work       |

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,10 +70,10 @@ hero:
 
 AI scientists need more than a chat window. TeXRA keeps research grounded in reproducible workflows and transparent reasoning:
 
-- **Reliable scientific loops** – capture every run with logs, diffs, and audit trails so collaborators can verify changes.
-- **Specialized agent roster** – summon correction, polishing, figure generation, and document transformation agents tuned for LaTeX-heavy projects.
-- **Integrated verification tools** – trigger `latexdiff`, `texcount`, compilation checks, and custom scripts directly from the agent run.
-- **Context you control** – work across multi-file projects, reference libraries, and datasets without losing track of provenance.
+- **Reliable scientific loops** – every run is captured with logs, diffs, and audit trails so you and your collaborators can verify changes.
+- **Two kinds of agents** – use workflow agents (`polish`, `correct`, `draw`) for structured tasks, or chat with tool-use agents (`chat`, `search`, `research`) that can edit files, search literature, and run computations interactively.
+- **Integrated verification tools** – trigger `latexdiff`, `texcount`, Wolfram, and compilation checks directly from the agent run.
+- **Literature at your fingertips** – search arXiv, Crossref, and your Zotero library without leaving VS Code.
 
 ## Key Capabilities
 
@@ -127,6 +127,22 @@ AI scientists need more than a chat window. TeXRA keeps research grounded in rep
     <p>Leverage vision-capable models to analyze images, figures, and PDFs directly within your workflow.</p>
     <div class="feature-example">
       <code>&lt;figure.png&gt; + "Write caption"</code> &#8594; <code>\caption{...}</code>
+    </div>
+  </div>
+
+  <div class="feature-item">
+    <h3>💬 Interactive Tool-Use Agents</h3>
+    <p>Chat with AI agents that can read and edit your files, run shell commands, search the web, and manage your Zotero library - all in one conversation.</p>
+    <div class="feature-example">
+      <code>"Find papers on attention mechanisms and add them to my .bib"</code>
+    </div>
+  </div>
+
+  <div class="feature-item">
+    <h3>🔍 Research & Literature Tools</h3>
+    <p>Search arXiv and Crossref, download paper sources, verify computations with Wolfram, and manage references through Zotero - without leaving VS Code.</p>
+    <div class="feature-example">
+      <code>"Search Zotero for Vaswani"</code> &#8594; BibTeX entries exported
     </div>
   </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,9 +71,17 @@ hero:
 AI scientists need more than a chat window. TeXRA keeps research grounded in reproducible workflows and transparent reasoning:
 
 - **Reliable scientific loops** – every run is captured with logs, diffs, and audit trails so you and your collaborators can verify changes.
-- **Two kinds of agents** – use workflow agents (`polish`, `correct`, `draw`) for structured tasks, or chat with tool-use agents (`chat`, `search`, `research`) that can edit files, search literature, and run computations interactively.
-- **Integrated verification tools** – trigger `latexdiff`, `texcount`, Wolfram, and compilation checks directly from the agent run.
+- **Two kinds of agents** – use workflow agents (`polish`, `correct`, `draw`) for structured tasks, or chat with interactive agents (`chat`, `search`, `research`) that can edit files, search literature, and run computations.
+- **Integrated verification tools** – generate visual diffs, count words, verify math with Wolfram, and check compilation directly from the agent run.
 - **Literature at your fingertips** – search arXiv, Crossref, and your Zotero library without leaving VS Code.
+
+### Real-World Examples
+
+> **Deadline crunch.** A PhD student has 48 hours to polish a 30-page thesis chapter. She selects the chapter, picks the `polish` agent, and writes: "Improve clarity and flow for a machine-learning audience. Keep all math intact." Two minutes later she's reviewing a colour-coded diff of every change.
+
+> **Conference talk.** A postdoc needs slides for a workshop next week. He opens the `presenter` agent, points it at his paper, and asks for a 15-slide Beamer deck with TikZ diagrams. The agent reads his codebase, drafts slides, compiles them, and visually checks every page.
+
+> **Literature sweep.** A new collaborator joins the project and needs to get up to speed. She opens the `search` agent and asks: "Find the five most-cited papers on physics-informed neural networks from 2022-2024." In seconds she has titles, abstracts, and BibTeX entries.
 
 ## Key Capabilities
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ AI scientists need more than a chat window. TeXRA keeps research grounded in rep
 
   <div class="feature-item">
     <h3>🔄 Document Transformation</h3>
-    <p>Effortlessly convert papers into slides (`paper2slide`), lecture notes (`paper2note`), posters (`paper2poster`), or even draft cover letters (`paper2cover`).</p>
+    <p>Effortlessly convert papers into slides (<code>paper2slide</code>), posters (<code>paper2poster</code>), or build interactive presentations with the <code>presenter</code> agent.</p>
     <div class="feature-example">
       <code>Paper Abstract</code> &#8594; `Beamer Slides Outline`
     </div>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra-docs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra-docs",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@vscode/codicons": "^0.0.36",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "texra-docs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "scripts": {
     "dev": "vitepress dev .",

--- a/docs/pocketflow/utility_function/viz.md
+++ b/docs/pocketflow/utility_function/viz.md
@@ -75,11 +75,11 @@ If you prefer a custom lightweight implementation, this code recursively travers
 ```typescript
 import { BaseNode, Flow } from '../src/index';
 
-type NodeIds = Map&lt;BaseNode, string&gt;;
+type NodeIds = Map<BaseNode, string>;
 
 function buildMermaid(start: BaseNode): string {
   const ids: NodeIds = new Map();
-  const visited: Set&lt;BaseNode&gt; = new Set();
+  const visited: Set<BaseNode> = new Set();
   const lines: string[] = ['graph LR'];
   let ctr = 1;
 

--- a/docs/pocketflow/utility_function/viz.md
+++ b/docs/pocketflow/utility_function/viz.md
@@ -72,16 +72,14 @@ mermaid.render('diagram-id', diagramDefinition, (svgCode) => {
 
 If you prefer a custom lightweight implementation, this code recursively traverses the nested graph, assigns unique IDs to each node, and treats Flow nodes as subgraphs to generate Mermaid syntax for a hierarchical visualization:
 
-{% raw %}
-
 ```typescript
 import { BaseNode, Flow } from '../src/index';
 
-type NodeIds = Map<BaseNode, string>;
+type NodeIds = Map&lt;BaseNode, string&gt;;
 
 function buildMermaid(start: BaseNode): string {
   const ids: NodeIds = new Map();
-  const visited: Set<BaseNode> = new Set();
+  const visited: Set&lt;BaseNode&gt; = new Set();
   const lines: string[] = ['graph LR'];
   let ctr = 1;
 
@@ -154,8 +152,6 @@ function buildMermaid(start: BaseNode): string {
   return lines.join('\n');
 }
 ```
-
-{% endraw %}
 
 For example, suppose we have a complex Flow for data science:
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -10,7 +10,7 @@ A specialized AI assistant in TeXRA that performs a specific type of task, such 
 
 ### Workflow Agent
 
-An agent that takes your files and instruction, sends them through one or more structured rounds to an AI model, and produces output files (e.g., a polished `.tex` file). Workflow agents use XML-wrapped output and can include scratchpad reasoning. Examples: `correct`, `polish`, `draw`, `paper2slide`.
+An agent that takes your files and instruction, sends them through one or more structured rounds to an AI model, and produces output files (e.g., a polished `.tex` file). Examples: `correct`, `polish`, `draw`, `paper2slide`.
 
 ### Tool-Use Agent
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -8,13 +8,29 @@ This glossary provides definitions for technical terms used throughout the TeXRA
 
 A specialized AI assistant in TeXRA that performs a specific type of task, such as correcting errors, polishing writing, or creating figures. Each agent has custom prompts and settings optimized for its purpose.
 
-### Chain of Thought (CoT)
+### Workflow Agent
 
-An agent type in TeXRA that uses structured XML output with scratchpad thinking for complex reasoning. CoT agents can show their work and reasoning process.
+An agent that takes your files and instruction, sends them through one or more structured rounds to an AI model, and produces output files (e.g., a polished `.tex` file). Workflow agents use XML-wrapped output and can include scratchpad reasoning. Examples: `correct`, `polish`, `draw`, `paper2slide`.
 
-### Direct Agent
+### Tool-Use Agent
 
-An agent type in TeXRA that provides simpler, more straightforward output without intermediate reasoning steps. Direct agents are optimized for less complex tasks.
+An interactive agent that can read files, edit code, run commands, search the web, and more - all in a back-and-forth conversation. You chat with it and it takes actions on your behalf. Examples: `chat`, `search`, `research`, `presenter`.
+
+### Dashboard
+
+The unified management panel in TeXRA where you can browse agents, toggle models, manage API keys, view execution history, and access memory. Open it from the Command Palette with **TeXRA: Show Dashboard**.
+
+### YOLO Mode
+
+A mode that lets tool-use agents run without pausing for your approval on each action (file edits, bash commands, etc.). Toggled from the ProgressBoard header. Handy when you trust the agent, but use with care.
+
+### Remote Agent
+
+A cloud-hosted agent maintained by the TeXRA team that loads on demand. Remote agents are marked with a cloud icon in the agent dropdown and require signing in to access.
+
+### Memory
+
+A persistent store that tool-use agents can write to and read from across sessions. Agents use memory to remember project context, preferences, or notes from earlier conversations. Browseable from the Dashboard's Memory tab.
 
 ### Intelligent Merge
 
@@ -44,7 +60,7 @@ A process where the AI reviews and improves its own work, leading to higher qual
 
 ### LLM (Large Language Model)
 
-An AI system trained on vast amounts of text data, capable of understanding and generating human-like text. Examples include Claude, GPT-4, and Gemini.
+An AI system trained on vast amounts of text data, capable of understanding and generating human-like text. Examples include Claude (Anthropic), GPT-5 (OpenAI), and Gemini (Google).
 
 ### Token
 


### PR DESCRIPTION
## Summary

This PR refreshes the TeXRA documentation to reflect recent product changes, including new agents (`presenter`, `simplifier`), updated UI components (Dashboard, ProgressBoard enhancements), and clearer, more user-focused writing throughout.

## Key Changes

### New Agents & Features
- Added `presenter` and `simplifier` agents to built-in agent reference and guides
- Documented new Dashboard interface for managing agents, models, API keys, history, and memory
- Added ProgressBoard enhancements: YOLO mode, context utilization, todo lists, followup tasks, and memory management
- Updated agent architecture docs to reflect `agentCategory` (workflow/toolUse) terminology replacing `agentType`

### Documentation Improvements
- Rewrote agent-architecture.md with clearer, more accessible explanations of how agents work
- Simplified agents.md by removing outdated agents (`polish_cover`, `derive`, `paper2note`, `paper2cover`, `solve_qi`) and reorganizing remaining agents
- Enhanced built-in-agents.md with user stories and clearer capability descriptions
- Improved custom-agents.md with better tool-use agent guidance and removed overly technical XML export details
- Added new guide stub for "Working with Overleaf" (config only)

### Configuration & Setup
- Updated configuration.md with Dashboard-first approach and new settings (Anthropic 1M context, bibliography paths, agent output storage)
- Clarified API key setup to reference Dashboard Models tab
- Updated model examples throughout (e.g., `gemini3f`, `opus46T`, `gpt52`)
- Updated VS Code minimum version requirement to 1.99+

### Content Reorganization
- Moved figure extraction details to working-with-figures.md references
- Reorganized agents.md to group by function (Content Generation, Presentation & Simplification, Specialized)
- Added Merge Agent section to built-in-agents.md with dedicated documentation
- Updated research-tools.md with Zotero integration details and user stories

### Tone & Accessibility
- Replaced technical jargon with user-focused language throughout
- Added "user story" examples to help readers understand practical use cases
- Simplified explanations of complex concepts (XML extraction, tool-use agents, prompt composition)
- Updated copyright year to 2024-2026

## Notable Details

- Removed references to deprecated agents and outdated terminology
- Maintained backward compatibility notes where relevant
- Ensured all model IDs and examples reflect current offerings
- Preserved technical depth in custom-agents.md while improving clarity for beginners

https://claude.ai/code/session_0113wGdK4MeaE6HhVyd1ftFS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (content, navigation, and package version metadata) with no runtime/product code changes; main risk is stale/incorrect guidance or broken links.
> 
> **Overview**
> Documentation is refreshed to reflect current TeXRA UX and capabilities: updated terminology around agent execution (e.g., `agentCategory` workflow vs tool-use), expanded explanations of prompt/round flow, and more user-focused examples across key guides.
> 
> Adds/spotlights new agents and workflows (`presenter`, `simplifier`, and clearer `merge` guidance), updates best-practice staged workflows, and modernizes model recommendations/IDs (including Kimi updates). Configuration and setup docs are updated to be Dashboard-first and include new settings like Anthropic 1M beta, default bibliography path, and output storage mode; ProgressBoard docs now cover YOLO mode, context utilization, todo/followup tasks, and memory.
> 
> Site/docs plumbing is adjusted with a new sidebar entry for `Working with Overleaf`, updated copyright years, and a docs package version bump (`0.2.0` → `0.3.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e271db06c3c87b6fa2a034e31f3991de1f454e17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->