### PR TITLE
Add stream diagnostics for Anthropic message lifecycle events

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -747,6 +747,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const isUsingRelay = this.shouldUseServerSideKeys();
         const diagnostics = streamHandler.getDiagnostics();
 
+        // Try to extract Anthropic request ID from stream response headers
+        try {
+          const response = await (
+            stream as unknown as { response: Promise<Response> }
+          ).response;
+          diagnostics.anthropicRequestId =
+            response?.headers?.get?.('x-request-id') ?? null;
+        } catch {
+          // Response may not be available (e.g. network error before HTTP response)
+        }
+
         this.logger.error(
           `Stream failed: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
           {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -751,10 +751,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // detectRequestId() (in sdkErrorUtils) picks it up via the existing
         // ProviderError.requestId path — no duplicate field needed.
         try {
-          const response = await (
+          const httpResponse = await (
             stream as unknown as { response: Promise<Response> }
           ).response;
-          const reqId = response?.headers?.get?.('x-request-id');
+          const reqId =
+            httpResponse?.headers?.get?.('request-id') ??
+            httpResponse?.headers?.get?.('x-request-id');
           if (reqId && streamError instanceof Error) {
             (streamError as Error & { request_id?: string }).request_id =
               reqId;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -747,13 +747,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const isUsingRelay = this.shouldUseServerSideKeys();
         const diagnostics = streamHandler.getDiagnostics();
 
-        // Try to extract Anthropic request ID from stream response headers
+        // Enrich error with request ID from stream response headers so
+        // detectRequestId() (in sdkErrorUtils) picks it up via the existing
+        // ProviderError.requestId path — no duplicate field needed.
         try {
           const response = await (
             stream as unknown as { response: Promise<Response> }
           ).response;
-          diagnostics.anthropicRequestId =
-            response?.headers?.get?.('x-request-id') ?? null;
+          const reqId = response?.headers?.get?.('x-request-id');
+          if (reqId && streamError instanceof Error) {
+            (streamError as Error & { request_id?: string }).request_id =
+              reqId;
+          }
         } catch {
           // Response may not be available (e.g. network error before HTTP response)
         }

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -76,6 +76,14 @@ const StreamDiagnosticsStateSchema = z.object({
   startTime: z.number(),
   /** Timestamp of last event received */
   lastEventTime: z.number(),
+  /** Whether message_start event was received */
+  messageStartReceived: z.boolean(),
+  /** Whether message_stop event was received */
+  messageStopReceived: z.boolean(),
+  /** Stop reason from message_delta event */
+  stopReason: z.string().nullable(),
+  /** Anthropic message ID from message_start */
+  anthropicMessageId: z.string().nullable(),
 });
 
 type StreamDiagnosticsState = z.infer<typeof StreamDiagnosticsStateSchema>;
@@ -130,6 +138,10 @@ export class AnthropicStreamHandler {
     lastEventType: null,
     startTime: Date.now(),
     lastEventTime: Date.now(),
+    messageStartReceived: false,
+    messageStopReceived: false,
+    stopReason: null,
+    anthropicMessageId: null,
   };
 
   constructor(
@@ -172,6 +184,12 @@ export class AnthropicStreamHandler {
         (now - this.diagnostics.lastEventTime) / 1000,
       ),
       finalized: this.state.finalized,
+      messageStartReceived: this.diagnostics.messageStartReceived,
+      messageStopReceived: this.diagnostics.messageStopReceived,
+      stopReason: this.diagnostics.stopReason,
+      anthropicMessageId: this.diagnostics.anthropicMessageId,
+      // anthropicRequestId is set externally by the model handler from response headers
+      anthropicRequestId: null,
     };
   }
 
@@ -213,6 +231,18 @@ export class AnthropicStreamHandler {
     this.diagnostics.lastEventTime = Date.now();
 
     switch (event.type) {
+      case 'message_start':
+        this.diagnostics.messageStartReceived = true;
+        this.diagnostics.anthropicMessageId =
+          (event.message as { id?: string })?.id ?? null;
+        break;
+      case 'message_delta':
+        this.diagnostics.stopReason =
+          (event.delta as { stop_reason?: string | null })?.stop_reason ?? null;
+        break;
+      case 'message_stop':
+        this.diagnostics.messageStopReceived = true;
+        break;
       case 'content_block_start':
         this.handleBlockStart(event);
         break;

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -3,10 +3,8 @@
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
 // Third-party imports
-import { z } from 'zod';
 import {
   MESSAGE_TYPES,
-  StreamDiagnosticsSchema,
   type StreamDiagnostics,
 } from '@shared/schemas';
 import {
@@ -56,37 +54,23 @@ interface AnthropicStreamState {
 }
 
 /**
- * Schema for internal mutable state during streaming.
- * Uses Set/timestamp fields for efficient tracking during stream processing.
+ * Internal mutable state during streaming.
+ * Shares counter/flag fields with {@link StreamDiagnostics} but uses
+ * runtime-efficient types (Set, timestamps) that getDiagnostics() converts
+ * to the serializable output form.
  */
-const StreamDiagnosticsStateSchema = z.object({
-  /** Characters of thinking content received */
-  thinkingChars: z.number(),
-  /** Characters of text content received */
-  textChars: z.number(),
-  /** Characters of tool input JSON received */
-  toolInputChars: z.number(),
-  /** Total events processed */
-  eventsProcessed: z.number(),
-  /** Last event type (e.g., 'content_block_delta') */
-  lastEventType: z.string().nullable(),
-  /** Block types seen during streaming */
-  blockTypesSeen: z.instanceof(Set<string>),
-  /** Timestamp when streaming started */
-  startTime: z.number(),
-  /** Timestamp of last event received */
-  lastEventTime: z.number(),
-  /** Whether message_start event was received */
-  messageStartReceived: z.boolean(),
-  /** Whether message_stop event was received */
-  messageStopReceived: z.boolean(),
-  /** Stop reason from message_delta event */
-  stopReason: z.string().nullable(),
-  /** Anthropic message ID from message_start */
-  anthropicMessageId: z.string().nullable(),
-});
-
-type StreamDiagnosticsState = z.infer<typeof StreamDiagnosticsStateSchema>;
+interface StreamDiagnosticsState
+  extends Omit<
+    StreamDiagnostics,
+    'blockTypesSeen' | 'elapsedSecs' | 'secsSinceLastEvent' | 'finalized'
+  > {
+  /** Block types seen during streaming (converted to array in getDiagnostics) */
+  blockTypesSeen: Set<string>;
+  /** Timestamp when streaming started (converted to elapsedSecs) */
+  startTime: number;
+  /** Timestamp of last event received (converted to secsSinceLastEvent) */
+  lastEventTime: number;
+}
 
 /**
  * Configuration for the stream handler.

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -188,8 +188,6 @@ export class AnthropicStreamHandler {
       messageStopReceived: this.diagnostics.messageStopReceived,
       stopReason: this.diagnostics.stopReason,
       anthropicMessageId: this.diagnostics.anthropicMessageId,
-      // anthropicRequestId is set externally by the model handler from response headers
-      anthropicRequestId: null,
     };
   }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -286,8 +286,10 @@ function detectRequestId(err: unknown): string | undefined {
     return candidate.requestId;
   }
 
-  // Try headers (Anthropic stores request ID here)
-  const headerValue = candidate.headers?.get?.('x-request-id');
+  // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
+  const headerValue =
+    candidate.headers?.get?.('request-id') ??
+    candidate.headers?.get?.('x-request-id');
   if (headerValue) {
     return headerValue;
   }

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1047,14 +1047,21 @@ export class RequestPanels extends LitElement {
     if (details.streamDiagnostics) {
       const diag = details.streamDiagnostics;
       lines.push('--- Stream Diagnostics ---');
+      lines.push(`  messageStartReceived: ${diag.messageStartReceived}`);
+      lines.push(`  messageStopReceived: ${diag.messageStopReceived}`);
+      lines.push(`  stopReason: ${diag.stopReason ?? 'null'}`);
+      lines.push(`  anthropicMessageId: ${diag.anthropicMessageId ?? 'null'}`);
+      lines.push(
+        `  anthropicRequestId: ${diag.anthropicRequestId ?? 'null'}`,
+      );
+      lines.push(`  eventsProcessed: ${diag.eventsProcessed}`);
+      lines.push(`  lastEventType: ${diag.lastEventType ?? 'null'}`);
       lines.push(`  thinkingChars: ${diag.thinkingChars}`);
       lines.push(`  textChars: ${diag.textChars}`);
       lines.push(`  toolInputChars: ${diag.toolInputChars}`);
       lines.push(
         `  blockTypesSeen: [${diag.blockTypesSeen?.join(', ') || ''}]`,
       );
-      lines.push(`  eventsProcessed: ${diag.eventsProcessed}`);
-      lines.push(`  lastEventType: ${diag.lastEventType ?? 'null'}`);
       lines.push(`  elapsedSecs: ${diag.elapsedSecs}`);
       lines.push(`  secsSinceLastEvent: ${diag.secsSinceLastEvent}`);
       lines.push(`  finalized: ${diag.finalized}`);

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1051,9 +1051,6 @@ export class RequestPanels extends LitElement {
       lines.push(`  messageStopReceived: ${diag.messageStopReceived}`);
       lines.push(`  stopReason: ${diag.stopReason ?? 'null'}`);
       lines.push(`  anthropicMessageId: ${diag.anthropicMessageId ?? 'null'}`);
-      lines.push(
-        `  anthropicRequestId: ${diag.anthropicRequestId ?? 'null'}`,
-      );
       lines.push(`  eventsProcessed: ${diag.eventsProcessed}`);
       lines.push(`  lastEventType: ${diag.lastEventType ?? 'null'}`);
       lines.push(`  thinkingChars: ${diag.thinkingChars}`);

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -19,8 +19,6 @@ export const StreamDiagnosticsSchema = z.object({
   stopReason: z.string().nullable().prefault(null),
   /** Anthropic message ID from message_start (e.g. 'msg_01XFD...') */
   anthropicMessageId: z.string().nullable().prefault(null),
-  /** Anthropic request ID from response headers (x-request-id) */
-  anthropicRequestId: z.string().nullable().prefault(null),
 });
 
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -11,6 +11,16 @@ export const StreamDiagnosticsSchema = z.object({
   elapsedSecs: z.number().prefault(0),
   secsSinceLastEvent: z.number().prefault(0),
   finalized: z.boolean().prefault(false),
+  /** Whether a message_start event was received from the API */
+  messageStartReceived: z.boolean().prefault(false),
+  /** Whether a message_stop event was received from the API */
+  messageStopReceived: z.boolean().prefault(false),
+  /** Stop reason from message_delta (e.g. 'end_turn', 'tool_use', 'max_tokens') */
+  stopReason: z.string().nullable().prefault(null),
+  /** Anthropic message ID from message_start (e.g. 'msg_01XFD...') */
+  anthropicMessageId: z.string().nullable().prefault(null),
+  /** Anthropic request ID from response headers (x-request-id) */
+  anthropicRequestId: z.string().nullable().prefault(null),
 });
 
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;


### PR DESCRIPTION
## Summary
Enhanced stream diagnostics tracking for Anthropic API responses to capture message lifecycle events and improve error debugging. This includes tracking whether message_start/message_stop events were received, capturing the stop reason, and extracting the Anthropic message ID from the stream response.

## Key Changes

- **modelHandlerAnthropic.ts**: Added logic to extract the request ID from stream response headers and attach it to stream errors for better error tracking and debugging
- **AnthropicStreamHandler.ts**: Extended diagnostics state to track:
  - `messageStartReceived`: Whether the message_start event was received
  - `messageStopReceived`: Whether the message_stop event was received
  - `stopReason`: The stop reason from message_delta events (e.g., 'end_turn', 'tool_use', 'max_tokens')
  - `anthropicMessageId`: The Anthropic message ID extracted from message_start event
- **RequestPanels.ts**: Updated the stream diagnostics display to show the new fields in a logical order (lifecycle events first, then content metrics)
- **errors.ts**: Added the new diagnostic fields to the shared StreamDiagnosticsSchema with proper documentation

## Implementation Details

- The request ID extraction is wrapped in a try-catch to handle cases where the response may not be available (e.g., network errors before HTTP response)
- All new diagnostic fields use nullable/optional types with sensible defaults to maintain backward compatibility
- The diagnostics are captured during stream event processing, allowing visibility into the complete message lifecycle

https://claude.ai/code/session_012tzMggxbRXABKdtdxH8CwD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only changes plus request-id extraction from headers; low risk aside from potential edge cases when the stream response object is unavailable or SDK header names differ.
> 
> **Overview**
> Improves Anthropic streaming error debugging by **capturing message lifecycle diagnostics** (`message_start`/`message_stop` seen, `stopReason`, and Anthropic `message.id`) and surfacing them via the shared `StreamDiagnostics` schema and progress-view retry details.
> 
> When a stream fails, the Anthropic handler now **extracts the HTTP request id** from stream response headers (`request-id`/`x-request-id`) and attaches it to the thrown error so existing request-id detection and logging/UI can correlate failures more reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08b90b05bf3c84c5c9db50ca66e871bc06b9fb24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->