### PR TITLE
Enhance Zotero search with structured fields and code formatting

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -758,8 +758,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             httpResponse?.headers?.get?.('request-id') ??
             httpResponse?.headers?.get?.('x-request-id');
           if (reqId && streamError instanceof Error) {
-            (streamError as Error & { request_id?: string }).request_id =
-              reqId;
+            (streamError as Error & { request_id?: string }).request_id = reqId;
           }
         } catch {
           // Response may not be available (e.g. network error before HTTP response)

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -3,10 +3,7 @@
  * Encapsulates the streaming event handling logic for improved testability and readability.
  */
 // Third-party imports
-import {
-  MESSAGE_TYPES,
-  type StreamDiagnostics,
-} from '@shared/schemas';
+import { MESSAGE_TYPES, type StreamDiagnostics } from '@shared/schemas';
 import {
   extractDomain,
   type WebSearchResult,
@@ -59,11 +56,10 @@ interface AnthropicStreamState {
  * runtime-efficient types (Set, timestamps) that getDiagnostics() converts
  * to the serializable output form.
  */
-interface StreamDiagnosticsState
-  extends Omit<
-    StreamDiagnostics,
-    'blockTypesSeen' | 'elapsedSecs' | 'secsSinceLastEvent' | 'finalized'
-  > {
+interface StreamDiagnosticsState extends Omit<
+  StreamDiagnostics,
+  'blockTypesSeen' | 'elapsedSecs' | 'secsSinceLastEvent' | 'finalized'
+> {
   /** Block types seen during streaming (converted to array in getDiagnostics) */
   blockTypesSeen: Set<string>;
   /** Timestamp when streaming started (converted to elapsedSecs) */

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -18,21 +18,69 @@ import {
   type BbtSearchResultItem,
 } from './bbtClient';
 
-const ZoteroSearchInputSchema = z.strictObject({
-  query: z
-    .string()
-    .min(1)
-    .describe(
-      'Search query - can be citation key, title, author, or year. ' +
-        'Works like the search box in Zotero.',
+/**
+ * Build a human-readable label from whichever search parameters are set.
+ */
+function describeSearch(input: {
+  query?: string | null;
+  title?: string | null;
+  author?: string | null;
+  year?: string | number | null;
+}): string {
+  if (input.query) return input.query;
+  const parts: string[] = [];
+  if (input.title) parts.push(`title="${input.title}"`);
+  if (input.author) parts.push(`author="${input.author}"`);
+  if (input.year) parts.push(`year=${input.year}`);
+  return parts.join(', ');
+}
+
+const ZoteroSearchInputSchema = z
+  .strictObject({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        'Quick search string (searches across title, creators, and year simultaneously). ' +
+          'Best for short queries like a single surname or citekey. ' +
+          'All words must match, so keep it to one or two terms. ' +
+          'Omit this when using the structured title/author/year fields instead.',
+      )
+      .nullish(),
+    title: z
+      .string()
+      .describe(
+        'Search by title (partial match). Use a few distinctive words, not the full title.',
+      )
+      .nullish(),
+    author: z
+      .string()
+      .describe(
+        'Search by author/creator surname (partial match). Use a single surname.',
+      )
+      .nullish(),
+    year: z
+      .union([z.string(), z.number()])
+      .describe('Filter by publication year (exact match).')
+      .nullish(),
+    library: z
+      .string()
+      .describe(
+        'Optional library name to search in. Use "*" to search all libraries.',
+      )
+      .nullish(),
+  })
+  .check(
+    z.check(
+      (val: {
+        query?: string | null;
+        title?: string | null;
+        author?: string | null;
+        year?: string | number | null;
+      }) => !!(val.query || val.title || val.author || val.year),
+      'Provide at least one of: query, title, author, or year.',
     ),
-  library: z
-    .string()
-    .describe(
-      'Optional library name to search in. Use "*" to search all libraries.',
-    )
-    .nullish(),
-});
+  );
 
 export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
 
@@ -78,13 +126,33 @@ export class ZoteroSearchTool extends defineTool({
   name: 'zotero_search',
   description:
     'Search Zotero library by citation key, title, author, or year. ' +
+    'Prefer the structured title/author/year fields over a single query string. ' +
     'Requires Better BibTeX plugin to be installed in Zotero.',
   schema: ZoteroSearchInputSchema,
 }) {
-  protected async execute({ query, library }: ZoteroSearchInput) {
+  protected async execute({
+    query,
+    title,
+    author,
+    year,
+    library,
+  }: ZoteroSearchInput) {
     const port = getZoteroPort();
 
-    const params: unknown[] = [query];
+    // Build search params: use advanced tuple search when structured fields
+    // are provided, otherwise fall back to simple quick-search string.
+    let searchTerms: unknown;
+    if (title || author || year) {
+      const conditions: [string, string, string][] = [];
+      if (title) conditions.push(['title', 'contains', title]);
+      if (author) conditions.push(['creator', 'contains', author]);
+      if (year) conditions.push(['date', 'is', String(year)]);
+      searchTerms = conditions;
+    } else {
+      searchTerms = query!;
+    }
+
+    const params: unknown[] = [searchTerms];
     if (library) {
       params.push(library);
     }
@@ -95,9 +163,11 @@ export class ZoteroSearchTool extends defineTool({
       port,
     );
 
+    const label = describeSearch({ query, title, author, year });
+
     if (!Array.isArray(result) || result.length === 0) {
       return {
-        summary: `No results found for "${query}"`,
+        summary: `No results found for ${label}`,
         output: 'No matching items in Zotero library.',
       };
     }
@@ -106,7 +176,7 @@ export class ZoteroSearchTool extends defineTool({
     const items = result.map((item) => formatSearchResult(item));
 
     return {
-      summary: `Found ${result.length} item${result.length === 1 ? '' : 's'} matching "${query}"`,
+      summary: `Found ${result.length} item${result.length === 1 ? '' : 's'} matching ${label}`,
       output: items.join('\n'),
     };
   }

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -45,8 +45,6 @@ const BaseSearchSchema = z.strictObject({
     .nullish(),
 });
 
-type BaseSearchInput = z.infer<typeof BaseSearchSchema>;
-
 const QueryRequiredSchema = BaseSearchSchema.extend({
   query: z.string().min(1).describe(QUERY_DESCRIPTION),
 });
@@ -76,7 +74,7 @@ export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
  * Build a human-readable label from whichever search parameters are set.
  */
 function describeSearch(
-  input: Pick<BaseSearchInput, 'query' | 'title' | 'author' | 'year'>,
+  input: Pick<ZoteroSearchInput, 'query' | 'title' | 'author' | 'year'>,
 ): string {
   const hasStructuredSearch = !!(input.title || input.author || input.year);
   if (hasStructuredSearch) {

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -18,15 +18,56 @@ import {
   type BbtSearchResultItem,
 } from './bbtClient';
 
+const BaseSearchSchema = z.strictObject({
+  query: z
+    .string()
+    .min(1)
+    .describe(
+      'Quick search string (searches across title, creators, and year simultaneously). ' +
+        'Best for short queries like a single surname or citekey. ' +
+        'All words must match, so keep it to one or two terms. ' +
+        'Omit this when using the structured title/author/year fields instead.',
+    )
+    .nullish(),
+  title: z
+    .string()
+    .describe(
+      'Search by title (partial match). Use a few distinctive words, not the full title.',
+    )
+    .nullish(),
+  author: z
+    .string()
+    .describe(
+      'Search by author/creator surname (partial match). Use a single surname.',
+    )
+    .nullish(),
+  year: z
+    .union([z.string(), z.number()])
+    .describe('Filter by publication year (exact match).')
+    .nullish(),
+  library: z
+    .string()
+    .describe(
+      'Optional library name to search in. Use "*" to search all libraries.',
+    )
+    .nullish(),
+});
+
+type BaseSearchInput = z.infer<typeof BaseSearchSchema>;
+
+const ZoteroSearchInputSchema = BaseSearchSchema.refine(
+  (val) => !!(val.query || val.title || val.author || val.year),
+  'Provide at least one of: query, title, author, or year.',
+);
+
+export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
+
 /**
  * Build a human-readable label from whichever search parameters are set.
  */
-function describeSearch(input: {
-  query?: string | null;
-  title?: string | null;
-  author?: string | null;
-  year?: string | number | null;
-}): string {
+function describeSearch(
+  input: Pick<BaseSearchInput, 'query' | 'title' | 'author' | 'year'>,
+): string {
   if (input.query) return input.query;
   const parts: string[] = [];
   if (input.title) parts.push(`title="${input.title}"`);
@@ -34,55 +75,6 @@ function describeSearch(input: {
   if (input.year) parts.push(`year=${input.year}`);
   return parts.join(', ');
 }
-
-const ZoteroSearchInputSchema = z
-  .strictObject({
-    query: z
-      .string()
-      .min(1)
-      .describe(
-        'Quick search string (searches across title, creators, and year simultaneously). ' +
-          'Best for short queries like a single surname or citekey. ' +
-          'All words must match, so keep it to one or two terms. ' +
-          'Omit this when using the structured title/author/year fields instead.',
-      )
-      .nullish(),
-    title: z
-      .string()
-      .describe(
-        'Search by title (partial match). Use a few distinctive words, not the full title.',
-      )
-      .nullish(),
-    author: z
-      .string()
-      .describe(
-        'Search by author/creator surname (partial match). Use a single surname.',
-      )
-      .nullish(),
-    year: z
-      .union([z.string(), z.number()])
-      .describe('Filter by publication year (exact match).')
-      .nullish(),
-    library: z
-      .string()
-      .describe(
-        'Optional library name to search in. Use "*" to search all libraries.',
-      )
-      .nullish(),
-  })
-  .check(
-    z.check(
-      (val: {
-        query?: string | null;
-        title?: string | null;
-        author?: string | null;
-        year?: string | number | null;
-      }) => !!(val.query || val.title || val.author || val.year),
-      'Provide at least one of: query, title, author, or year.',
-    ),
-  );
-
-export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
 
 /**
  * Format a single search result item for display.

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -18,33 +18,25 @@ import {
   type BbtSearchResultItem,
 } from './bbtClient';
 
+const QUERY_DESCRIPTION =
+  'Quick search string (searches across title, creators, and year simultaneously). ' +
+  'Best for short queries like a single surname or citekey. ' +
+  'All words must match, so keep it to one or two terms. ' +
+  'Omit this when using the structured title/author/year fields instead.';
+
+const TITLE_DESCRIPTION =
+  'Search by title (partial match). Use a few distinctive words, not the full title.';
+
+const AUTHOR_DESCRIPTION =
+  'Search by author/creator surname (partial match). Use a single surname.';
+
+const YEAR_DESCRIPTION = 'Filter by publication year (exact match).';
+
 const BaseSearchSchema = z.strictObject({
-  query: z
-    .string()
-    .min(1)
-    .describe(
-      'Quick search string (searches across title, creators, and year simultaneously). ' +
-        'Best for short queries like a single surname or citekey. ' +
-        'All words must match, so keep it to one or two terms. ' +
-        'Omit this when using the structured title/author/year fields instead.',
-    )
-    .nullish(),
-  title: z
-    .string()
-    .describe(
-      'Search by title (partial match). Use a few distinctive words, not the full title.',
-    )
-    .nullish(),
-  author: z
-    .string()
-    .describe(
-      'Search by author/creator surname (partial match). Use a single surname.',
-    )
-    .nullish(),
-  year: z
-    .union([z.string(), z.number()])
-    .describe('Filter by publication year (exact match).')
-    .nullish(),
+  query: z.string().min(1).describe(QUERY_DESCRIPTION).nullish(),
+  title: z.string().describe(TITLE_DESCRIPTION).nullish(),
+  author: z.string().describe(AUTHOR_DESCRIPTION).nullish(),
+  year: z.union([z.string(), z.number()]).describe(YEAR_DESCRIPTION).nullish(),
   library: z
     .string()
     .describe(
@@ -55,10 +47,28 @@ const BaseSearchSchema = z.strictObject({
 
 type BaseSearchInput = z.infer<typeof BaseSearchSchema>;
 
-const ZoteroSearchInputSchema = BaseSearchSchema.refine(
-  (val) => !!(val.query || val.title || val.author || val.year),
-  'Provide at least one of: query, title, author, or year.',
-);
+const QueryRequiredSchema = BaseSearchSchema.extend({
+  query: z.string().min(1).describe(QUERY_DESCRIPTION),
+});
+
+const TitleRequiredSchema = BaseSearchSchema.extend({
+  title: z.string().min(1).describe(TITLE_DESCRIPTION),
+});
+
+const AuthorRequiredSchema = BaseSearchSchema.extend({
+  author: z.string().min(1).describe(AUTHOR_DESCRIPTION),
+});
+
+const YearRequiredSchema = BaseSearchSchema.extend({
+  year: z.union([z.string(), z.number()]).describe(YEAR_DESCRIPTION),
+});
+
+const ZoteroSearchInputSchema = z.union([
+  QueryRequiredSchema,
+  TitleRequiredSchema,
+  AuthorRequiredSchema,
+  YearRequiredSchema,
+]);
 
 export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
 
@@ -68,12 +78,16 @@ export type ZoteroSearchInput = z.infer<typeof ZoteroSearchInputSchema>;
 function describeSearch(
   input: Pick<BaseSearchInput, 'query' | 'title' | 'author' | 'year'>,
 ): string {
-  if (input.query) return input.query;
-  const parts: string[] = [];
-  if (input.title) parts.push(`title="${input.title}"`);
-  if (input.author) parts.push(`author="${input.author}"`);
-  if (input.year) parts.push(`year=${input.year}`);
-  return parts.join(', ');
+  const hasStructuredSearch = !!(input.title || input.author || input.year);
+  if (hasStructuredSearch) {
+    const parts: string[] = [];
+    if (input.title) parts.push(`title="${input.title}"`);
+    if (input.author) parts.push(`author="${input.author}"`);
+    if (input.year) parts.push(`year=${input.year}`);
+    return parts.join(', ');
+  }
+
+  return input.query ?? 'query';
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR enhances the Zotero search tool with structured search fields (title, author, year) while maintaining backward compatibility with quick search, and applies code formatting improvements across the codebase.

## Key Changes

### Zotero Search Enhancement
- **Structured search fields**: Added `title`, `author`, and `year` as optional search parameters alongside the existing `query` field
- **Flexible search strategy**: Implements intelligent fallback logic—uses advanced tuple-based search when structured fields are provided, otherwise falls back to quick-search string
- **Improved validation**: Added schema refinement to ensure at least one search parameter is provided
- **Better UX**: 
  - Updated descriptions to guide users toward structured fields for better precision
  - Added `describeSearch()` helper function to generate human-readable search labels
  - Updated result summaries to display the actual search parameters used

### Code Formatting
- Reformatted multi-line imports in `AnthropicStreamHandler.ts` for consistency
- Adjusted line breaks in type definitions for better readability
- Minor formatting cleanup in `modelHandlerAnthropic.ts`

## Implementation Details
- The `BaseSearchSchema` is extracted as a reusable base, with `ZoteroSearchInputSchema` adding validation via `.refine()`
- Search conditions are built dynamically as tuples matching the Better BibTeX API format: `[field, operator, value]`
- The `describeSearch()` function handles all combinations of search parameters to provide clear feedback to users

https://claude.ai/code/session_01EfQwdZtqXyo6fkRH5RyFR7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the `zotero_search` tool input schema and changes how Better BibTeX search parameters are constructed, which could alter search behavior or edge-case validation; other edits are formatting-only.
> 
> **Overview**
> Enhances `zotero_search` to accept structured search inputs (`title`, `author`, `year`) in addition to the existing quick `query`, and updates request construction to send Better BibTeX advanced tuple conditions when structured fields are provided (otherwise falling back to the quick-search string).
> 
> Improves tool UX by adding clearer field descriptions and generating result summaries based on the actual search parameters used. Also includes minor formatting-only cleanup in Anthropic streaming-related files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257f9be6bb3b5edc326b12fcf6969abb666da576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->