### PR TITLE
fix(anthropic): honor minimum compaction trigger for manual compaction

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -344,15 +344,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       !contextManagementEdits.some((edit) => edit.type === 'compact_20260112')
     ) {
       this.ensureBeta(options, COMPACTION_BETA);
-      // When manually requested, set trigger to 1 to compact on any conversation.
-      // MIN_COMPACTION_TRIGGER_TOKENS is an app-level floor for automatic compaction;
-      // the API itself accepts any positive integer as a trigger value.
-      const compactionTriggerTokens = forceCompaction
-        ? 1
-        : Math.max(
-            MIN_COMPACTION_TRIGGER_TOKENS,
-            Math.floor((thresholdPercent / 100) * contextWindow),
-          );
+      // Anthropic currently enforces a minimum 50K input-token trigger.
+      // Keep manual compaction compatible by using the same floor.
+      const compactionTriggerTokens = Math.max(
+        MIN_COMPACTION_TRIGGER_TOKENS,
+        forceCompaction
+          ? MIN_COMPACTION_TRIGGER_TOKENS
+          : Math.floor((thresholdPercent / 100) * contextWindow),
+      );
 
       contextManagementEdits.push({
         type: 'compact_20260112',

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1017,6 +1017,87 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('uses Anthropic minimum trigger when compaction is manually requested', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    const loggerStub = {
+      streamId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+      logContextManagement: () => {},
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-6',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'texra.model.compactionThresholdPercent') return 0;
+        return defaultValue as unknown;
+      };
+
+      handler.requestCompaction();
+      await handler.createResponse({ client, messages, temperature: 0 });
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    const options = messageOptions[0] ?? {};
+    const edits = options.context_management?.edits ?? [];
+    const compactionEdit = edits.find(
+      (edit: { type: string }) => edit.type === 'compact_20260112',
+    );
+    assert.ok(
+      compactionEdit,
+      'manual compaction should configure compact_20260112 context edit',
+    );
+    assert.equal(
+      compactionEdit.trigger?.value,
+      50000,
+      'manual compaction should honor Anthropic minimum trigger value',
+    );
+  });
+
   it('does not add native compaction context edit for non-Opus models', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,


### PR DESCRIPTION
### Motivation
- Manual context compaction could request a trigger value of `1`, which conflicts with Anthropic's server requirement (manual compaction caused `compact_20260112: trigger.value must be at least 50000` HTTP 400 failures). 
- Ensure manual compaction remains compatible with Anthropic Opus 4.6 tool-use flows by applying the same minimum trigger floor used for automatic compaction.

### Description
- Update `setupContextManagement` in `src/agent/modelHandlers/modelHandlerAnthropic.ts` so the compaction trigger is computed with `Math.max(MIN_COMPACTION_TRIGGER_TOKENS, ...)`, ensuring manual compaction never sets a trigger below the Anthropic minimum.
- Add a regression test `it('uses Anthropic minimum trigger when compaction is manually requested', ...)` in `src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts` to verify a manual compaction request emits a `compact_20260112` edit with `trigger.value === 50000` when threshold-based compaction is disabled.
- Kept existing behavior for Opus 4.6 tool-use flows and preserved use of the `CONTEXT_MANAGEMENT_BETA` and `COMPACTION_BETA` flags.

### Testing
- Ran `npm run format` and formatting completed successfully.
- Ran `npm run compile:fast` and the extension/webview build completed successfully.
- Ran `npm run lint` which completed successfully with repository warnings (no new lint errors from these changes).
- Ran `npm run typecheck` which failed due to pre-existing repository TypeScript issues unrelated to this change (typecheck errors predate this patch).
- Executed the new unit scenario via `node --test src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts` in this environment which failed to run because Node cannot resolve the project's path aliases (tests should pass under CI or a local test runner that sets up TS path aliases).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b7712ece08324960e3c38c1e7d744)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to compaction trigger calculation plus a unit test; primary risk is altered compaction timing for manual requests but it prevents API 400 failures.
> 
> **Overview**
> Fixes Anthropic Opus 4.6 tool-use manual compaction by ensuring the `compact_20260112` trigger value is never below the provider-enforced 50k-token minimum (instead of previously forcing `1`).
> 
> Adds a regression test asserting that `requestCompaction()` produces a `context_management` compaction edit with `trigger.value === 50000` when threshold-based compaction is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6a5c7db81397da1e09cba2d6bea1378facbb36c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->