### PR TITLE
fix: honor Anthropic minimum manual compaction trigger

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -344,11 +344,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
       !contextManagementEdits.some((edit) => edit.type === 'compact_20260112')
     ) {
       this.ensureBeta(options, COMPACTION_BETA);
-      // When manually requested, set trigger to 1 to compact on any conversation.
-      // MIN_COMPACTION_TRIGGER_TOKENS is an app-level floor for automatic compaction;
-      // the API itself accepts any positive integer as a trigger value.
+      // Anthropic currently enforces a 50K minimum trigger value for compact_20260112.
+      // Keep manual compaction at that floor so the server accepts the request and
+      // compacts on the next call for any normal conversation.
       const compactionTriggerTokens = forceCompaction
-        ? 1
+        ? MIN_COMPACTION_TRIGGER_TOKENS
         : Math.max(
             MIN_COMPACTION_TRIGGER_TOKENS,
             Math.floor((thresholdPercent / 100) * contextWindow),

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1017,6 +1017,88 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('uses the Anthropic minimum trigger for manual compaction requests', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-6';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+    handler.requestCompaction();
+
+    const loggerStub = {
+      streamId: 'test',
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fileList: () => {},
+      withCurrentGroup: () => undefined,
+      runWithinCurrentGroup: async (fn: () => any) => fn(),
+      runWithGroup: async (_groupId: string | undefined, fn: () => any) => fn(),
+      logContextManagement: () => {},
+    };
+    handler.setLogger(loggerStub as unknown as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-6',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'texra.model.compactionThresholdPercent') return 0;
+        return defaultValue as unknown;
+      };
+
+      await handler.createResponse({ client, messages, temperature: 0 });
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    const options = messageOptions[0] ?? {};
+    const edits = options.context_management?.edits ?? [];
+    const compactionEdit = edits.find(
+      (edit: { type: string }) => edit.type === 'compact_20260112',
+    );
+
+    assert.ok(
+      compactionEdit,
+      'manual request should add compact_20260112 edit',
+    );
+    assert.equal(
+      compactionEdit.trigger?.value,
+      50_000,
+      'manual compaction should honor Anthropic minimum trigger tokens',
+    );
+  });
+
   it('does not add native compaction context edit for non-Opus models', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,


### PR DESCRIPTION
### Motivation

- Fix a runtime failure when requesting Anthropic native compaction which returned `context_management.edits.0.compact_20260112: trigger.value must be at least 50000`.
- Manual compaction previously set `trigger.value = 1`, which is rejected by Anthropic's `compact_20260112` beta and caused user-facing failures when invoking the compact action.

### Description

- Update `src/agent/modelHandlers/modelHandlerAnthropic.ts` to clamp manual compaction triggers to the provider-enforced floor `MIN_COMPACTION_TRIGGER_TOKENS` (50_000) instead of `1` so the server accepts manual compaction requests.
- Add a regression unit test in `src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts` that requests compaction and asserts the emitted `compact_20260112` edit uses `50_000` as the trigger value when automatic compaction is disabled.
- Keep the previous automatic compaction calculation (threshold-based) unchanged and only alter the manual-request branch to honor the Anthropic minimum.

### Testing

- Ran `npm run format` and it completed successfully.
- Ran `npm run compile` and the webpack build completed with a clean build (1 non-blocking warning reported by webpack).
- Ran `npm run lint` and it completed with repository-wide warnings but no lint errors (74 warnings, 0 errors).
- Added a focused unit test covering the manual compaction behavior (`ModelHandlerAnthropic.test.ts`), which is included in the codebase for CI to exercise (no `npm test` run locally per repo guidance).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b7712ece08324960e3c38c1e7d744)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to a single request parameter plus a focused test; low risk aside from potentially altering when manual compaction triggers (now at 50k tokens).
> 
> **Overview**
> Fixes Anthropic native compaction failures by changing *manual* `compact_20260112` requests to use `MIN_COMPACTION_TRIGGER_TOKENS` (50,000) instead of `1`, matching the provider-enforced minimum while leaving threshold-based automatic compaction unchanged.
> 
> Adds a regression unit test ensuring `requestCompaction()` emits a `compact_20260112` edit with `trigger.value = 50_000` when automatic compaction is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc86079de6929a6e8699bde6c86d7a9e7a694192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->