### PR TITLE
fix: allow unauthenticated users to use personal API keys

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -303,9 +303,9 @@ export abstract class ModelHandler<
     // Prime caches before using sync methods. This ensures that after reload/continue,
     // the tier config and access status are fetched before shouldUseServerSideKeys() is called.
     // Without this, sync methods return false due to empty caches, causing incorrect tier errors.
-    if (useIncludedAccess) {
-      await serverSideKeyService.canUseServerSideKeys();
-    }
+    const hasServerAccess = useIncludedAccess
+      ? await serverSideKeyService.canUseServerSideKeys()
+      : false;
 
     // Use centralized check to ensure consistency with getBaseUrl()
     if (this.shouldUseServerSideKeys()) {
@@ -335,9 +335,11 @@ export abstract class ModelHandler<
       }
     }
 
-    if (useIncludedAccess) {
-      // User selected "Use Included Access" but model is not available for their tier
-      // Don't fall back to personal API keys - throw an error to match dropdown behavior
+    if (useIncludedAccess && hasServerAccess) {
+      // User is authenticated with "Use Included Access" but model is not available for their tier.
+      // Don't fall back to personal API keys - throw an error to match dropdown behavior.
+      // Note: We check hasServerAccess to avoid blocking unauthenticated users who have the
+      // default useIncludedAccess=true setting but should fall through to personal API keys.
       this.logger.debug(
         `Model "${this.config.name}" not available for tier, useIncludedAccess=true`,
       );

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -116,8 +116,11 @@ async function isModelAvailable(
     return true;
   }
 
-  // Fall back to personal API keys (only when not in "Use Included Access" mode)
-  if (!ctx.useIncludedAccess) {
+  // Fall back to personal API keys when:
+  // - User explicitly chose "Use My Own Keys", OR
+  // - User has default "Use Included Access" but isn't actually authenticated with server access
+  //   (avoids showing all models as disabled for unauthenticated users)
+  if (!ctx.useIncludedAccess || !ctx.hasServerAccess) {
     return hasPersonalKeyForModel(config, ctx.hasOpenRouter);
   }
 


### PR DESCRIPTION
The `useIncludedModelAccess` setting defaults to `true`, which caused
`getApiKey()` to throw a tier error for unauthenticated users instead of
falling through to their personal API keys. Now the tier gate also checks
whether the user actually has server-side access before blocking.

https://claude.ai/code/session_01RLsYsztZybio1CuBgtkqby

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized logic change in model availability/key selection; main risk is unintended access-mode fallback behavior for edge cases.
> 
> **Overview**
> Fixes the *"Use Included Access" default* from incorrectly blocking unauthenticated users with tier errors.
> 
> `ModelHandler.getApiKey()` now distinguishes between the setting being enabled and the user actually having server-side access, only enforcing tier gating when authenticated; otherwise it falls through to personal/OpenRouter keys. `computeModelOptionsData()` mirrors this by enabling personal-key availability checks when there’s no server access, preventing all models from appearing disabled for signed-out users.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8db282e8fb5bad698b99a8e3b550c31e462ec7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->