### PR TITLE
Change paper2slide Beamer theme from Madrid/dolphin to metropolis

### DIFF
--- a/resources/agents/write/paper2slide.yaml
+++ b/resources/agents/write/paper2slide.yaml
@@ -86,12 +86,9 @@ prompts:
       <beamer_presentation>
       \documentclass{beamer}
 
-      \usetheme{Madrid}
-      \usecolortheme{dolphin}
+      \usetheme{metropolis}
 
-      \setbeamertemplate{footline}[page number]
       \setbeamertemplate{navigation symbols}{}
-      \setbeamertemplate{frametitle}[default][center]
 
       \AtBeginSection[]
       {

--- a/resources/agents/write/template_slide.tex
+++ b/resources/agents/write/template_slide.tex
@@ -1,11 +1,8 @@
 \documentclass{beamer}
 
-\usetheme{Madrid}
-\usecolortheme{dolphin}
+\usetheme{metropolis}
 
-\setbeamertemplate{footline}[page number]
 \setbeamertemplate{navigation symbols}{}
-\setbeamertemplate{frametitle}[default][center]
 
 \AtBeginSection[]
 {


### PR DESCRIPTION
The Madrid/dolphin theme is overused and looks generic. Replace it with
the metropolis theme which provides a clean, modern, flat design with
better typography and a built-in progress bar.

Updated both the template file and the inline template in the agent YAML.
Removed the dolphin color theme and frametitle centering overrides that
are unnecessary with metropolis (it handles both natively).

https://claude.ai/code/session_01PUdPnp89crYDP9rgrNYwtA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation styling-only change affecting generated LaTeX output; no runtime logic or data/security impact.
> 
> **Overview**
> Switches the Beamer theme used by the `paper2slide` agent’s inline LaTeX template and the shared `template_slide.tex` from `Madrid` (with `dolphin`) to `metropolis`.
> 
> Removes the custom footline page-number template and frametitle centering override, leaving only navigation symbols disabled for a cleaner default Metropolis layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f759074f681e8a5c2bc49dd2e3795f62ab9c41c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->