### PR TITLE
Expand MiKTeX path search across all platforms

### DIFF
--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -56,24 +56,31 @@ Even the best research assistants (human or AI) have off days. This guide helps 
   2. `/usr/local/bin` (Intel Homebrew and general tools)
   3. `/Library/TeX/texbin` (MacTeX symlink)
   4. `/usr/texbin` (legacy MacTeX location)
-  5. Versioned TeX Live directories (e.g., `/usr/local/texlive/2024/bin/universal-darwin`)
-  6. User-specific installations in `~/texlive/*/bin/*` and `~/TinyTeX/bin/*`
+  5. `~/bin` (MiKTeX default symlink target)
+  6. `~/.miktex/texmf/bin` (MiKTeX per-user binaries)
+  7. Versioned TeX Live directories (e.g., `/usr/local/texlive/2024/bin/universal-darwin`)
+  8. User-specific installations in `~/texlive/*/bin/*` and `~/TinyTeX/bin/*`
 
   **Windows:**
   1. `C:\Program Files\MiKTeX\miktex\bin\x64` (64-bit MiKTeX)
   2. `C:\Program Files\MiKTeX\miktex\bin` (32-bit MiKTeX)
   3. `C:\Program Files (x86)\MiKTeX\miktex\bin` (32-bit on 64-bit Windows)
   4. `%LOCALAPPDATA%\Programs\MiKTeX\miktex\bin\x64` (user MiKTeX installation)
-  5. Versioned TeX Live directories (e.g., `C:\texlive\2024\bin\windows`)
-  6. User-specific installations in `%USERPROFILE%\texlive\*\bin\*` and `%USERPROFILE%\TinyTeX\bin\*`
+  5. `%LOCALAPPDATA%\Programs\MiKTeX\miktex\bin` (user MiKTeX, 32-bit)
+  6. `%LOCALAPPDATA%\Programs\MiKTeX 2.9\miktex\bin\x64` (legacy user MiKTeX 2.9)
+  7. `%LOCALAPPDATA%\MiKTeX\miktex\bin\x64` (user MiKTeX without Programs subfolder)
+  8. Versioned TeX Live directories (e.g., `C:\texlive\2024\bin\windows`)
+  9. User-specific installations in `%USERPROFILE%\texlive\*\bin\*` and `%USERPROFILE%\TinyTeX\bin\*`
 
   **Linux:**
   1. `/usr/local/bin`
   2. `/usr/bin`
   3. `/usr/texbin`
   4. `/home/linuxbrew/.linuxbrew/bin` (Linuxbrew)
-  5. Versioned TeX Live directories
-  6. User-specific installations
+  5. `~/bin` (MiKTeX default symlink target)
+  6. `~/.miktex/texmf/bin` (MiKTeX per-user binaries)
+  7. Versioned TeX Live directories
+  8. User-specific installations
 
   **Fallback mechanisms:**
   - If tools aren't found in standard paths, TeXRA searches `texmf-dist/scripts` directories

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -56,8 +56,8 @@ Even the best research assistants (human or AI) have off days. This guide helps 
   2. `/usr/local/bin` (Intel Homebrew and general tools)
   3. `/Library/TeX/texbin` (MacTeX symlink)
   4. `/usr/texbin` (legacy MacTeX location)
-  5. `~/bin` (MiKTeX default symlink target)
-  6. `~/.miktex/texmf/bin` (MiKTeX per-user binaries)
+  5. `/Applications/MiKTeX Console.app/Contents/bin` (MiKTeX app bundle)
+  6. `~/bin` (MiKTeX default symlink target)
   7. Versioned TeX Live directories (e.g., `/usr/local/texlive/2024/bin/universal-darwin`)
   8. User-specific installations in `~/texlive/*/bin/*` and `~/TinyTeX/bin/*`
 
@@ -75,10 +75,10 @@ Even the best research assistants (human or AI) have off days. This guide helps 
   **Linux:**
   1. `/usr/local/bin`
   2. `/usr/bin`
-  3. `/usr/texbin`
-  4. `/home/linuxbrew/.linuxbrew/bin` (Linuxbrew)
-  5. `~/bin` (MiKTeX default symlink target)
-  6. `~/.miktex/texmf/bin` (MiKTeX per-user binaries)
+  3. `/opt/miktex/bin` (MiKTeX installed via APT/AUR)
+  4. `/snap/bin` (Ubuntu snap packages)
+  5. `/home/linuxbrew/.linuxbrew/bin` (Linuxbrew)
+  6. `~/bin` (MiKTeX default symlink target)
   7. Versioned TeX Live directories
   8. User-specific installations
 

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -41,10 +41,18 @@ function getExtraDirs(): string[] {
       '/Library/TeX/texbin',
       '/usr/texbin',
     );
+    // MiKTeX on macOS: default symlink target for executables
+    const macHome = process.env.HOME;
+    if (macHome) {
+      dirs.push(path.join(macHome, 'bin'));
+      dirs.push(path.join(macHome, '.miktex', 'texmf', 'bin'));
+    }
   } else if (platform === 'win32') {
     dirs.push(
       'C:\\Program Files\\MiKTeX\\miktex\\bin\\x64',
       'C:\\Program Files\\MiKTeX\\miktex\\bin',
+      'C:\\Program Files\\MiKTeX 2.9\\miktex\\bin\\x64',
+      'C:\\Program Files\\MiKTeX 2.9\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX\\miktex\\bin',
       'C:\\Program Files (x86)\\MiKTeX 2.9\\miktex\\bin',
       'C:\\Program Files\\gs\\gs9.56.1\\bin',
@@ -54,10 +62,22 @@ function getExtraDirs(): string[] {
       'C:\\Program Files (x86)\\gs\\gs9.55.0\\bin',
       'C:\\Program Files (x86)\\gs\\gs9.54.0\\bin',
     );
-    const localAppData = process.env.LOCALAPPDATA;
+    const localAppData =
+      process.env.LOCALAPPDATA ||
+      (process.env.USERPROFILE
+        ? path.join(process.env.USERPROFILE, 'AppData', 'Local')
+        : null);
     if (localAppData) {
       dirs.push(
+        // Modern MiKTeX per-user install
         path.join(localAppData, 'Programs', 'MiKTeX', 'miktex', 'bin', 'x64'),
+        path.join(localAppData, 'Programs', 'MiKTeX', 'miktex', 'bin'),
+        // Legacy MiKTeX 2.9 per-user install
+        path.join(localAppData, 'Programs', 'MiKTeX 2.9', 'miktex', 'bin', 'x64'),
+        path.join(localAppData, 'Programs', 'MiKTeX 2.9', 'miktex', 'bin'),
+        // MiKTeX installed directly under LOCALAPPDATA (without Programs)
+        path.join(localAppData, 'MiKTeX', 'miktex', 'bin', 'x64'),
+        path.join(localAppData, 'MiKTeX', 'miktex', 'bin'),
       );
     }
 
@@ -103,6 +123,12 @@ function getExtraDirs(): string[] {
       '/snap/bin', // Ubuntu snap packages
       '/home/linuxbrew/.linuxbrew/bin',
     );
+    // MiKTeX on Linux: per-user binary and symlink directories
+    const linuxHome = process.env.HOME;
+    if (linuxHome) {
+      dirs.push(path.join(linuxHome, 'bin'));
+      dirs.push(path.join(linuxHome, '.miktex', 'texmf', 'bin'));
+    }
   }
 
   const texDistPatterns =

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -41,7 +41,10 @@ function getExtraDirs(): string[] {
       '/Library/TeX/texbin',
       '/usr/texbin',
     );
-    // MiKTeX on macOS: default symlink target for executables
+    // MiKTeX on macOS: app bundle and default symlink targets
+    dirs.push(
+      '/Applications/MiKTeX Console.app/Contents/bin',
+    );
     const macHome = process.env.HOME;
     if (macHome) {
       dirs.push(path.join(macHome, 'bin'));
@@ -120,6 +123,7 @@ function getExtraDirs(): string[] {
     dirs.push(
       '/usr/local/bin',
       '/usr/bin',
+      '/opt/miktex/bin', // MiKTeX installed via APT/AUR
       '/snap/bin', // Ubuntu snap packages
       '/home/linuxbrew/.linuxbrew/bin',
     );

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -48,7 +48,6 @@ function getExtraDirs(): string[] {
     const macHome = process.env.HOME;
     if (macHome) {
       dirs.push(path.join(macHome, 'bin'));
-      dirs.push(path.join(macHome, '.miktex', 'texmf', 'bin'));
     }
   } else if (platform === 'win32') {
     dirs.push(
@@ -127,11 +126,10 @@ function getExtraDirs(): string[] {
       '/snap/bin', // Ubuntu snap packages
       '/home/linuxbrew/.linuxbrew/bin',
     );
-    // MiKTeX on Linux: per-user binary and symlink directories
+    // MiKTeX on Linux: per-user symlink directory for private installs
     const linuxHome = process.env.HOME;
     if (linuxHome) {
       dirs.push(path.join(linuxHome, 'bin'));
-      dirs.push(path.join(linuxHome, '.miktex', 'texmf', 'bin'));
     }
   }
 


### PR DESCRIPTION
Previously only searched a limited set of Windows MiKTeX paths and had
no MiKTeX-specific paths for macOS or Linux. Users with per-user MiKTeX
installs could fail to find tools like pdflatex and latexdiff.

Windows additions:
- LOCALAPPDATA fallback via USERPROFILE when env var is missing
- Per-user paths without x64 suffix (32-bit installs)
- Legacy MiKTeX 2.9 paths (both system-wide and per-user)
- LOCALAPPDATA\MiKTeX (without Programs subfolder)

macOS/Linux additions:
- ~/bin (MiKTeX default symlink target for executables)
- ~/.miktex/texmf/bin (MiKTeX per-user binary directory)

https://claude.ai/code/session_01XKrKEV2xu1tfWxi52F2qnS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to local executable discovery/search paths and documentation; main risk is unintended precedence/selection of a different TeX tool binary on some systems.
> 
> **Overview**
> TeXRA’s common-path tool discovery now searches a broader set of MiKTeX install locations across all platforms to reduce “missing tool” failures (e.g., `pdflatex`, `latexdiff`).
> 
> On Windows, it adds additional system-wide and per-user MiKTeX (including legacy 2.9 and 32-bit) directories and falls back to deriving `%LOCALAPPDATA%` from `%USERPROFILE%` when needed; on macOS/Linux it adds MiKTeX-specific locations like the macOS MiKTeX app bundle and `~/bin`, plus `/opt/miktex/bin` on Linux. The troubleshooting docs are updated to reflect the new search order and paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f52dcb92056f3459e465379e664b20a77768d594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->