### PR TITLE
Fix: use internal compilation for non-workspace LaTeX files

### DIFF
--- a/src/agent/output/LatexDiffManager.ts
+++ b/src/agent/output/LatexDiffManager.ts
@@ -310,7 +310,6 @@ export class LatexDiffManager {
     await compileLatex2Pdf(diffLocation, {
       channel: this.streamId,
       outputDirectory: buildDir,
-      compiler: 'latexmk',
     });
 
     return diffLocation;

--- a/src/common/schemas.ts
+++ b/src/common/schemas.ts
@@ -31,7 +31,7 @@ export type StreamConfig = z.infer<typeof StreamConfigSchema>;
 export const LaTeXCompileOptionsSchema = z.object({
   channel: z.string().optional(),
   outputDirectory: z.string().optional(),
-  compiler: z.enum(['pdflatex', 'latexmk']).prefault('pdflatex'),
+  compiler: z.enum(['pdflatex', 'latexmk']).prefault('latexmk'),
 });
 
 /** Input type - compiler optional with default applied by schema.parse() */

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -81,7 +81,6 @@ async function openAndBuildLatex(
     const outDir = path.join(path.dirname(uri.fsPath), 'build');
     const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
       outputDirectory: outDir,
-      compiler: 'latexmk',
     });
     if (!ok) {
       logger.warn(CHANNEL, `Internal LaTeX compilation failed for ${uri.fsPath}`);

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import * as vscode from 'vscode';
 
@@ -7,12 +10,15 @@ import { isLatexFile } from '@common/files/fileTypeUtils';
 
 // Local imports - utilities
 import * as logger from '@logger/logUtils';
-import { AbsoluteFS } from '@utils/files';
+import { AbsoluteFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import {
   LATEX_VIEWER_OPEN_DELAY_MS,
   LATEX_VIEWER_REFRESH_DELAY_MS,
 } from '@utils/config';
+
+// Local imports - latex
+import { compileLatex2Pdf } from '@latex/texTools';
 
 const CHANNEL = 'OpenBuildUtils';
 
@@ -39,23 +45,46 @@ export async function openBuildDisplayIfTex(
     return;
   }
 
-  await openAndBuildLatex(uri, options.preserveFocus ?? false);
+  await openAndBuildLatex(uri, fileLocation, options.preserveFocus ?? false);
 }
 
 /**
  * Open LaTeX file, build it, and display PDF viewer.
+ *
+ * Files inside the workspace are compiled via LaTeX Workshop so the user
+ * gets the full editor integration (synctex, diagnostics, etc.).
+ *
+ * Files outside the workspace (e.g. in run-storage) are compiled with the
+ * internal `compileLatex2Pdf` helper which sets TEXINPUTS to include the
+ * workspace root, ensuring project-local .sty / .cls / .bib files are found.
  */
 async function openAndBuildLatex(
   uri: vscode.Uri,
+  fileLocation: FileLocation,
   preserveFocus: boolean,
 ): Promise<void> {
   const doc = await vscode.workspace.openTextDocument(uri);
   await vscode.window.showTextDocument(doc, { preview: true, preserveFocus });
 
-  try {
-    await vscode.commands.executeCommand('latex-workshop.build', uri);
-  } catch (err) {
-    logger.warn(CHANNEL, `LaTeX Workshop build failed: ${toErrorMessage(err)}`);
+  if (fileLocation.kind === 'workspace') {
+    try {
+      await vscode.commands.executeCommand('latex-workshop.build', uri);
+    } catch (err) {
+      logger.warn(
+        CHANNEL,
+        `LaTeX Workshop build failed: ${toErrorMessage(err)}`,
+      );
+    }
+  } else {
+    // Outside workspace — LaTeX Workshop cannot resolve project-local
+    // packages, so compile internally with TEXINPUTS set.
+    const outDir = path.join(path.dirname(uri.fsPath), 'build');
+    const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
+      outputDirectory: outDir,
+    });
+    if (!ok) {
+      logger.warn(CHANNEL, `Internal LaTeX compilation failed for ${uri.fsPath}`);
+    }
   }
 
   scheduleViewerDisplay();

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import * as os from 'os';
 import * as path from 'path';
 
 // Third-party imports
@@ -10,7 +11,6 @@ import { isLatexFile } from '@common/files/fileTypeUtils';
 
 // Local imports - utilities
 import * as logger from '@logger/logUtils';
-import { getConfig } from '@utils/config';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import {
@@ -22,6 +22,56 @@ import {
 import { compileLatex2Pdf } from '@latex/texTools';
 
 const CHANNEL = 'OpenBuildUtils';
+
+/**
+ * Resolve `latex-workshop.latex.outDir` by expanding all LaTeX Workshop
+ * placeholders for the given file.  Longer placeholders are replaced first
+ * so that e.g. `%DOC_EXT%` is not partially consumed by `%DOC%`.
+ *
+ * Falls back to a relative path resolved against the file's directory when the
+ * result is not absolute.
+ */
+function resolveLatexWorkshopOutDir(filePath: string): string {
+  const raw = vscode.workspace
+    .getConfiguration('latex-workshop.latex')
+    .get<string>('outDir', '%DIR%/build');
+
+  const dir = path.dirname(filePath);
+  const normalizedRaw = raw.trim();
+  if (!normalizedRaw) {
+    return path.join(dir, 'build');
+  }
+
+  const docfile = path.basename(filePath, path.extname(filePath));
+  const doc = path.join(dir, docfile);
+  const workspaceFolder =
+    vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? dir;
+  const relativeDir = path.relative(workspaceFolder, dir);
+  const relativeDoc = path.relative(workspaceFolder, doc);
+
+  // Order matters: longer/more-specific placeholders first to avoid partial matches.
+  const replacements: [string, string][] = [
+    ['%DOC_EXT_W32%', filePath.replace(/\//g, '\\')],
+    ['%DOCFILE_EXT%', path.basename(filePath)],
+    ['%DOC_EXT%', filePath],
+    ['%DOCFILE%', docfile],
+    ['%DOC_W32%', doc.replace(/\//g, '\\')],
+    ['%DOC%', doc],
+    ['%DIR_W32%', dir.replace(/\//g, '\\')],
+    ['%DIR%', dir],
+    ['%WORKSPACE_FOLDER%', workspaceFolder],
+    ['%RELATIVE_DIR%', relativeDir],
+    ['%RELATIVE_DOC%', relativeDoc],
+    ['%TMPDIR%', os.tmpdir()],
+  ];
+
+  let resolved = normalizedRaw;
+  for (const [placeholder, value] of replacements) {
+    resolved = resolved.replaceAll(placeholder, value);
+  }
+
+  return path.isAbsolute(resolved) ? resolved : path.resolve(dir, resolved);
+}
 
 /**
  * Open a file, compile if it is TeX, and display the resulting PDF.
@@ -79,9 +129,9 @@ async function openAndBuildLatex(
   } else {
     // Outside workspace — LaTeX Workshop cannot resolve project-local
     // packages, so compile internally with TEXINPUTS set.
-    const outDir = resolveLatexOutDir(uri.fsPath);
+    // Resolve the same outDir that LaTeX Workshop uses so the viewer finds the PDF.
+    const outDir = resolveLatexWorkshopOutDir(uri.fsPath);
     const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
-      compiler: 'latexmk',
       outputDirectory: outDir,
     });
     if (!ok) {
@@ -93,31 +143,6 @@ async function openAndBuildLatex(
   }
 
   scheduleViewerDisplay();
-}
-
-/**
- * Resolves LaTeX Workshop output directory for a given source file path.
- *
- * Mirrors the extension's default (`%DIR%/build/`) while respecting user
- * overrides, so internal compilation and LaTeX Workshop viewer target the
- * same output location.
- */
-function resolveLatexOutDir(latexFilePath: string): string {
-  const fileDir = path.dirname(latexFilePath);
-  const configuredOutDir = getConfig<string>(
-    'latex-workshop.latex.outDir',
-    '%DIR%/build/',
-  );
-
-  const normalizedOutDir = configuredOutDir.trim();
-  if (!normalizedOutDir) {
-    return path.join(fileDir, 'build');
-  }
-
-  const expandedOutDir = normalizedOutDir.replaceAll('%DIR%', fileDir);
-  return path.isAbsolute(expandedOutDir)
-    ? expandedOutDir
-    : path.resolve(fileDir, expandedOutDir);
 }
 
 /**

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -81,6 +81,7 @@ async function openAndBuildLatex(
     const outDir = path.join(path.dirname(uri.fsPath), 'build');
     const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
       outputDirectory: outDir,
+      compiler: 'latexmk',
     });
     if (!ok) {
       logger.warn(CHANNEL, `Internal LaTeX compilation failed for ${uri.fsPath}`);

--- a/src/frontend/latex/openBuild.ts
+++ b/src/frontend/latex/openBuild.ts
@@ -10,6 +10,7 @@ import { isLatexFile } from '@common/files/fileTypeUtils';
 
 // Local imports - utilities
 import * as logger from '@logger/logUtils';
+import { getConfig } from '@utils/config';
 import { AbsoluteFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import {
@@ -78,16 +79,45 @@ async function openAndBuildLatex(
   } else {
     // Outside workspace — LaTeX Workshop cannot resolve project-local
     // packages, so compile internally with TEXINPUTS set.
-    const outDir = path.join(path.dirname(uri.fsPath), 'build');
+    const outDir = resolveLatexOutDir(uri.fsPath);
     const ok = await compileLatex2Pdf(pathToLocation(uri.fsPath), {
+      compiler: 'latexmk',
       outputDirectory: outDir,
     });
     if (!ok) {
-      logger.warn(CHANNEL, `Internal LaTeX compilation failed for ${uri.fsPath}`);
+      logger.warn(
+        CHANNEL,
+        `Internal LaTeX compilation failed for ${uri.fsPath}`,
+      );
     }
   }
 
   scheduleViewerDisplay();
+}
+
+/**
+ * Resolves LaTeX Workshop output directory for a given source file path.
+ *
+ * Mirrors the extension's default (`%DIR%/build/`) while respecting user
+ * overrides, so internal compilation and LaTeX Workshop viewer target the
+ * same output location.
+ */
+function resolveLatexOutDir(latexFilePath: string): string {
+  const fileDir = path.dirname(latexFilePath);
+  const configuredOutDir = getConfig<string>(
+    'latex-workshop.latex.outDir',
+    '%DIR%/build/',
+  );
+
+  const normalizedOutDir = configuredOutDir.trim();
+  if (!normalizedOutDir) {
+    return path.join(fileDir, 'build');
+  }
+
+  const expandedOutDir = normalizedOutDir.replaceAll('%DIR%', fileDir);
+  return path.isAbsolute(expandedOutDir)
+    ? expandedOutDir
+    : path.resolve(fileDir, expandedOutDir);
 }
 
 /**

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -99,7 +99,6 @@ export class LatexMediaManager {
           await flexibleFS.ensureDir(pathToLocation(buildDir));
           const compiled = await compileLatex2Pdf(file, {
             outputDirectory: buildDir,
-            compiler: 'latexmk',
           });
           if (!compiled) {
             return undefined;

--- a/src/latex/TikzPictureManager.ts
+++ b/src/latex/TikzPictureManager.ts
@@ -196,7 +196,7 @@ export class TikzPictureManager {
           suffix,
           channel,
         );
-        await compileLatex2Pdf(texLocation, { channel });
+        await compileLatex2Pdf(texLocation, { channel, compiler: 'pdflatex' });
 
         // Derive PDF location from tex location
         const pdfFilename = path

--- a/src/latex/texTools.ts
+++ b/src/latex/texTools.ts
@@ -98,6 +98,11 @@ export async function compileLatex2Pdf(
         showError: false, // Suppress error for latexmk to try pdflatex as fallback
       });
       if (!result) {
+        logger.warn(
+          channel,
+          'latexmk not found, falling back to single-pass pdflatex — ' +
+            'bibliography, cross-references, and index may be incomplete',
+        );
         result = await runToolWithCheck('pdflatex', pdflatexArgs, {
           channel,
           env,


### PR DESCRIPTION
When openBuildDisplayIfTex is called on files outside the workspace
(e.g. in run-storage for taskRunStorage mode), LaTeX Workshop cannot
resolve project-local .sty/.cls/.bib files because it has no TEXINPUTS
awareness of the workspace root.

Gate the compilation path on FileLocation.kind: workspace files still
use LaTeX Workshop for full editor integration, while non-workspace
files fall back to compileLatex2Pdf which sets TEXINPUTS to include
the workspace root.

https://claude.ai/code/session_01FqX6nRbEhC3VPw9V34tzB6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the LaTeX build pipeline and output directory resolution, which can break PDF generation/viewing if placeholder expansion or compiler selection differs from user setups.
> 
> **Overview**
> Fixes `openBuildDisplayIfTex` so **workspace TeX files** still build via LaTeX Workshop, but **non-workspace files** (e.g. run-storage) are compiled via internal `compileLatex2Pdf`, resolving LaTeX Workshop’s inability to find project-local `.sty/.cls/.bib` dependencies; it also resolves LaTeX Workshop’s `outDir` placeholders to write PDFs where the viewer expects them.
> 
> Changes LaTeX compilation defaults to prefer `latexmk` (removing explicit `compiler: 'latexmk'` call sites), adds a warning+fallback to single-pass `pdflatex` when `latexmk` isn’t installed, and forces `pdflatex` specifically for standalone TikZ compilation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45dca7b72e68bae0e3a709be64e838527905f313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->