### PR TITLE
Fix latexmk ENOENT error by extending process PATH with TeX directories

### DIFF
--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -191,10 +191,17 @@ export async function configureLatexSettings(): Promise<void> {
   // find latexmk, pdflatex, and other TeX binaries.  When VS Code is launched
   // from the macOS Finder or Windows Start Menu it often inherits a minimal
   // PATH that excludes TeX directories, causing "spawn latexmk ENOENT" errors.
-  const extendedPath = extendEnvPath(process.env.PATH);
-  if (extendedPath !== process.env.PATH) {
-    process.env.PATH = extendedPath;
-    logger.info('extension', 'Extended process PATH with TeX directories');
+  try {
+    const extendedPath = extendEnvPath(process.env.PATH);
+    if (extendedPath !== process.env.PATH) {
+      process.env.PATH = extendedPath;
+      logger.info('extension', 'Extended process PATH with TeX directories');
+    }
+  } catch (err) {
+    logger.warn(
+      'extension',
+      `Failed to extend PATH with TeX directories: ${toErrorMessage(err)}`,
+    );
   }
 
   try {

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -16,6 +16,7 @@ import * as logger from '@logger/logUtils';
 import { DEFAULT_MODELS } from '@model/computeModelOptions';
 import { GlobalStorageFS, StorageFS } from '@utils/files';
 import { isConfigExplicitlySet, updateConfig } from '@utils/config';
+import { extendEnvPath } from '@utils/system/platformPaths';
 
 /**
  * Version number for the default model list.
@@ -185,6 +186,17 @@ const GLOBAL_IF_UNSET = {
  * Configure LaTeX-related workspace settings if LaTeX Workshop extension is installed
  */
 export async function configureLatexSettings(): Promise<void> {
+  // Extend process.env.PATH with common TeX installation directories so that
+  // child processes spawned by other extensions (e.g., LaTeX Workshop) can
+  // find latexmk, pdflatex, and other TeX binaries.  When VS Code is launched
+  // from the macOS Finder or Windows Start Menu it often inherits a minimal
+  // PATH that excludes TeX directories, causing "spawn latexmk ENOENT" errors.
+  const extendedPath = extendEnvPath(process.env.PATH);
+  if (extendedPath !== process.env.PATH) {
+    process.env.PATH = extendedPath;
+    logger.info('extension', 'Extended process PATH with TeX directories');
+  }
+
   try {
     const latexWorkshop = vscode.extensions.getExtension(
       'James-Yu.latex-workshop',


### PR DESCRIPTION
When VS Code is launched from macOS Finder or Windows Start Menu, the
extension host inherits a minimal PATH that excludes TeX installation
directories (e.g. /Library/TeX/texbin). This causes LaTeX Workshop to
fail with "spawn latexmk ENOENT" when building.

Extend process.env.PATH at activation time using the existing
extendEnvPath() utility so all child processes (including those spawned
by LaTeX Workshop) can find latexmk, pdflatex, and other TeX binaries.

https://claude.ai/code/session_01U8cCHSC933H8U9pgwYd1ja

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only adjusts the extension host process environment and adds logging; minimal impact outside LaTeX-related workflows.
> 
> **Overview**
> Prevents LaTeX Workshop builds from failing with `spawn latexmk ENOENT` when VS Code is launched with a minimal environment by extending the extension host `process.env.PATH` with common TeX installation directories at the start of `configureLatexSettings()`.
> 
> The PATH update is done via existing `extendEnvPath()` logic, with informational logging when PATH changes and a warning if PATH extension fails, before proceeding with LaTeX Workshop detection/configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c6c5d6e172ab08f710db057bfedce4bad040749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->