### PR TITLE
Align memory tool str_replace with file edit_file operations

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -7,7 +7,7 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
-import { pluralize } from '@tools/utils';
+import { countOccurrences, pluralize } from '@tools/utils';
 import {
   buildApprovalRejectedResult,
   formatUnifiedApprovalUserDiff,
@@ -28,17 +28,6 @@ const EditInputSchema = z.strictObject({
 });
 
 export type EditInput = z.infer<typeof EditInputSchema>;
-
-function countOccurrences(haystack: string, needle: string): number {
-  if (needle.length === 0) return 0;
-  let count = 0;
-  let index = haystack.indexOf(needle);
-  while (index !== -1) {
-    count++;
-    index = haystack.indexOf(needle, index + needle.length);
-  }
-  return count;
-}
 
 export class EditFileTool extends defineTool({
   name: 'edit_file',

--- a/src/tools/fileInteractions.ts
+++ b/src/tools/fileInteractions.ts
@@ -12,6 +12,7 @@ export function recordToolFileRead(path: string): void {
 export function requireFileReadForEdit(
   path: string,
   exists: boolean,
+  errorMessage?: string,
 ): ToolResult | null {
   const context = getCurrentToolFileInteractionContext();
   if (!context || !exists || context.tracker.hasRead(path)) {
@@ -20,6 +21,7 @@ export function requireFileReadForEdit(
   return {
     summary: `Read ${path} before editing`,
     output:
+      errorMessage ??
       'Edits to existing files require a prior read in this session. Please call read_file first.',
     isError: true,
     diagnostics: { reason: 'unread-file', path },

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -49,7 +49,6 @@ const MemoryToolInputSchema = z.strictObject({
     .nullish(),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
-  replace_all: z.boolean().nullish(),
   insert_line: z.int().min(0).nullish(),
   insert_text: z.string().nullish(),
   old_path: z.string().nullish(),
@@ -86,7 +85,6 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
           requireField(input.path, 'path', input.command),
           requireField(input.old_str, 'old_str', input.command),
           requireField(input.new_str, 'new_str', input.command),
-          input.replace_all ?? false,
         );
       case 'insert':
         return this.insert(
@@ -217,7 +215,6 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     inputPath: string,
     oldStr: string,
     newStr: string,
-    replaceAll: boolean,
   ): Promise<ToolResult> {
     if (oldStr.length === 0) {
       throw new ToolError(
@@ -236,34 +233,28 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
       );
     }
 
-    if (!replaceAll && occurrences > 1) {
+    if (occurrences > 1) {
       const lines = content.split('\n');
       const lineNumbers = lines
         .map((line, index) => (line.includes(oldStr) ? index + 1 : -1))
         .filter((n) => n !== -1);
       throw new ToolError(
-        `old_str is not unique within ${inputPath}. Include more surrounding context or set replace_all to true.`,
+        `old_str is not unique within ${inputPath}. Include more surrounding context to make it unique.`,
       );
     }
 
-    // Use split/join for literal replacement
+    // Use indexOf/slice for literal replacement
     // (String.replace has special patterns like $$, $&, $' that corrupt content)
-    let updated: string;
-    if (replaceAll) {
-      updated = content.split(oldStr).join(newStr);
-    } else {
-      const idx = content.indexOf(oldStr);
-      updated =
-        content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
-    }
+    const idx = content.indexOf(oldStr);
+    const updated =
+      content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
     await StorageFS.write(resolvedPath, updated);
 
     const updatedLines = updated.split('\n');
     const numbered = formatLinesWithNumbers(updatedLines);
 
-    const count = replaceAll ? occurrences : 1;
     return {
-      summary: `Replaced ${count} occurrence${count !== 1 ? 's' : ''} in: ${inputPath}`,
+      summary: `Replaced text in: ${inputPath}`,
       output: `The memory file has been edited.\nHere's the content of ${inputPath} with line numbers:\n${numbered.join('\n')}`,
     };
   }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -14,10 +14,10 @@ import { normalizeLineEndings } from '@utils/text/stringUtils';
 import { defineTool } from '../core/define';
 import { ToolError, type ToolResult } from '../result';
 import {
-  countOccurrences,
-  formatLinesWithNumbers,
-  requireField,
-} from '../utils';
+  recordToolFileRead,
+  requireFileReadForEdit,
+} from '../fileInteractions';
+import { formatLinesWithNumbers, requireField } from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
@@ -166,6 +166,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     }
 
     const content = normalizeLineEndings(await StorageFS.read(resolvedPath));
+    recordToolFileRead(inputPath);
     const lines = content.split('\n');
     if (lines.length > 0 && lines.at(-1) === '') {
       lines.pop();
@@ -204,6 +205,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
     await StorageFS.ensureDir(path.dirname(resolvedPath));
     await StorageFS.write(resolvedPath, fileText);
+    recordToolFileRead(inputPath);
 
     return {
       summary: `Created memory file: ${inputPath}`,
@@ -224,6 +226,12 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     await this.requireEditableFile(resolvedPath, inputPath);
+
+    // Gate: require view before edit (matches edit_file behavior)
+    const readGate = requireFileReadForEdit(inputPath, true);
+    if (readGate) {
+      return readGate;
+    }
 
     const content = normalizeLineEndings(await StorageFS.read(resolvedPath));
     const occurrences = content.split(oldStr).length - 1;
@@ -249,6 +257,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const updated =
       content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
     await StorageFS.write(resolvedPath, updated);
+    recordToolFileRead(inputPath);
 
     const updatedLines = updated.split('\n');
     const numbered = formatLinesWithNumbers(updatedLines);
@@ -267,6 +276,12 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     await this.requireEditableFile(resolvedPath, inputPath);
 
+    // Gate: require view before edit (matches edit_file behavior)
+    const readGate = requireFileReadForEdit(inputPath, true);
+    if (readGate) {
+      return readGate;
+    }
+
     const content = normalizeLineEndings(await StorageFS.read(resolvedPath));
     const lines = content.split('\n');
     const totalLines = lines.length;
@@ -284,6 +299,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     ];
 
     await StorageFS.write(resolvedPath, updatedLines.join('\n'));
+    recordToolFileRead(inputPath);
 
     return {
       summary: `Inserted text at line ${insertLine} in: ${inputPath}`,

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -17,7 +17,11 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '../fileInteractions';
-import { formatLinesWithNumbers, requireField } from '../utils';
+import {
+  countOccurrences,
+  formatLinesWithNumbers,
+  requireField,
+} from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
@@ -228,13 +232,17 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     await this.requireEditableFile(resolvedPath, inputPath);
 
     // Gate: require view before edit (matches edit_file behavior)
-    const readGate = requireFileReadForEdit(inputPath, true);
+    const readGate = requireFileReadForEdit(
+      inputPath,
+      true,
+      'Edits to memory files require viewing the file first. Please use the view command before editing.',
+    );
     if (readGate) {
       return readGate;
     }
 
     const content = normalizeLineEndings(await StorageFS.read(resolvedPath));
-    const occurrences = content.split(oldStr).length - 1;
+    const occurrences = countOccurrences(content, oldStr);
     if (occurrences === 0) {
       throw new ToolError(
         `The provided old_str was not found in ${inputPath}. Ensure it matches the file content exactly.`,
@@ -247,7 +255,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
         .map((line, index) => (line.includes(oldStr) ? index + 1 : -1))
         .filter((n) => n !== -1);
       throw new ToolError(
-        `old_str is not unique within ${inputPath}. Include more surrounding context to make it unique.`,
+        `old_str is not unique within ${inputPath} (found in lines ${lineNumbers.join(', ')}). Include more surrounding context to make it unique.`,
       );
     }
 
@@ -277,7 +285,11 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     await this.requireEditableFile(resolvedPath, inputPath);
 
     // Gate: require view before edit (matches edit_file behavior)
-    const readGate = requireFileReadForEdit(inputPath, true);
+    const readGate = requireFileReadForEdit(
+      inputPath,
+      true,
+      'Edits to memory files require viewing the file first. Please use the view command before editing.',
+    );
     if (readGate) {
       return readGate;
     }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -13,7 +13,11 @@ import { normalizeLineEndings } from '@utils/text/stringUtils';
 // Local imports - tool core
 import { defineTool } from '../core/define';
 import { ToolError, type ToolResult } from '../result';
-import { formatLinesWithNumbers, requireField } from '../utils';
+import {
+  countOccurrences,
+  formatLinesWithNumbers,
+  requireField,
+} from '../utils';
 
 // Local imports - shared memory constants and utilities
 import {
@@ -45,6 +49,7 @@ const MemoryToolInputSchema = z.strictObject({
     .nullish(),
   old_str: z.string().nullish(),
   new_str: z.string().nullish(),
+  replace_all: z.boolean().nullish(),
   insert_line: z.int().min(0).nullish(),
   insert_text: z.string().nullish(),
   old_path: z.string().nullish(),
@@ -81,6 +86,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
           requireField(input.path, 'path', input.command),
           requireField(input.old_str, 'old_str', input.command),
           requireField(input.new_str, 'new_str', input.command),
+          input.replace_all ?? false,
         );
       case 'insert':
         return this.insert(
@@ -121,7 +127,9 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const exists = await StorageFS.exists(resolvedPath);
     const isDir = exists && (await StorageFS.isDir(resolvedPath));
     if (!exists || isDir) {
-      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+      throw new ToolError(
+        `The path ${inputPath} does not exist or is a directory.`,
+      );
     }
   }
 
@@ -192,7 +200,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);
     if (exists) {
-      throw new ToolError(`Error: File ${inputPath} already exists`);
+      throw new ToolError(`File ${inputPath} already exists.`);
     }
 
     await StorageFS.ensureDir(MEMORY_STORAGE_ROOT);
@@ -209,7 +217,14 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     inputPath: string,
     oldStr: string,
     newStr: string,
+    replaceAll: boolean,
   ): Promise<ToolResult> {
+    if (oldStr.length === 0) {
+      throw new ToolError(
+        `old_str must not be empty for ${inputPath}. Provide the exact text to replace.`,
+      );
+    }
+
     const resolvedPath = this.resolveMemoryPath(inputPath);
     await this.requireEditableFile(resolvedPath, inputPath);
 
@@ -217,30 +232,38 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const occurrences = content.split(oldStr).length - 1;
     if (occurrences === 0) {
       throw new ToolError(
-        `No replacement was performed, old_str did not appear verbatim in ${inputPath}.`,
+        `The provided old_str was not found in ${inputPath}. Ensure it matches the file content exactly.`,
       );
     }
 
-    if (occurrences > 1) {
+    if (!replaceAll && occurrences > 1) {
       const lines = content.split('\n');
       const lineNumbers = lines
         .map((line, index) => (line.includes(oldStr) ? index + 1 : -1))
         .filter((n) => n !== -1);
       throw new ToolError(
-        `No replacement was performed. Multiple occurrences of old_str in lines: ${lineNumbers.join(
-          ', ',
-        )}. Please ensure it is unique`,
+        `old_str is not unique within ${inputPath}. Include more surrounding context or set replace_all to true.`,
       );
     }
 
-    const updated = content.replace(oldStr, newStr);
+    // Use split/join for literal replacement
+    // (String.replace has special patterns like $$, $&, $' that corrupt content)
+    let updated: string;
+    if (replaceAll) {
+      updated = content.split(oldStr).join(newStr);
+    } else {
+      const idx = content.indexOf(oldStr);
+      updated =
+        content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+    }
     await StorageFS.write(resolvedPath, updated);
 
     const updatedLines = updated.split('\n');
     const numbered = formatLinesWithNumbers(updatedLines);
 
+    const count = replaceAll ? occurrences : 1;
     return {
-      summary: `Replaced text in: ${inputPath}`,
+      summary: `Replaced ${count} occurrence${count !== 1 ? 's' : ''} in: ${inputPath}`,
       output: `The memory file has been edited.\nHere's the content of ${inputPath} with line numbers:\n${numbered.join('\n')}`,
     };
   }
@@ -258,7 +281,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const totalLines = lines.length;
     if (insertLine < 0 || insertLine > totalLines) {
       throw new ToolError(
-        `Error: Invalid \`insert_line\` parameter: ${insertLine}. It should be within the range of lines of the file: [0, ${totalLines}]`,
+        `Invalid \`insert_line\` parameter: ${insertLine}. It should be within the range of lines of the file: [0, ${totalLines}].`,
       );
     }
 
@@ -281,7 +304,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);
     if (!exists) {
-      throw new ToolError(`Error: The path ${inputPath} does not exist`);
+      throw new ToolError(`The path ${inputPath} does not exist.`);
     }
 
     await StorageFS.delete(resolvedPath, { recursive: true });
@@ -300,13 +323,13 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
 
     const oldExists = await StorageFS.exists(resolvedOldPath);
     if (!oldExists) {
-      throw new ToolError(`Error: The path ${oldPathInput} does not exist`);
+      throw new ToolError(`The path ${oldPathInput} does not exist.`);
     }
 
     const newExists = await StorageFS.exists(resolvedNewPath);
     if (newExists) {
       throw new ToolError(
-        `Error: The destination ${newPathInput} already exists`,
+        `The destination ${newPathInput} already exists.`,
       );
     }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -75,6 +75,21 @@ export function createGlobMatcher(pattern: string): (value: string) => boolean {
   return (value: string) => matcher.match(value.replaceAll('\\', '/'));
 }
 
+/**
+ * Count non-overlapping occurrences of `needle` in `haystack`.
+ * Returns 0 for empty needles.
+ */
+export function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count++;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
 /** Default width for line number padding */
 const LINE_NUMBER_WIDTH = 6;
 


### PR DESCRIPTION
- Extract countOccurrences to shared tools/utils.ts (used by both EditTool and MemoryTool)
- Add replace_all parameter to MemoryTool str_replace (matching EditTool)
- Add empty old_str validation to MemoryTool (matching EditTool)
- Use literal split/join replacement instead of String.replace (prevents $$, $& corruption)
- Normalize error messages: remove 'Error: ' prefix, align wording with file tools

https://claude.ai/code/session_016wW25wvengXy2VqnuNeYcV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core behavior of `memory` edits (now requires prior `view`) and alters replacement logic, which may break existing automation or edge cases despite being localized to tool operations.
> 
> **Overview**
> Aligns `memory` file mutations (`str_replace`, `insert`, and post-`create`) with workspace `edit_file` safety by **recording reads** on `view`/`create` and **blocking edits unless the file was viewed in-session**.
> 
> Makes `memory str_replace` safer and more consistent by rejecting empty `old_str`, using shared `countOccurrences` (moved to `tools/utils.ts` and reused by `EditTool`), and switching from `String.replace` to an `indexOf`/`slice` literal replacement to avoid `$`-pattern corruption. Error messages are also normalized, and `requireFileReadForEdit` now supports a caller-provided error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c09808eda97d044ecf69f2cb28366be5afae30f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->