### PR TITLE
Add run_in_background hint to bash tool timeout message

### DIFF
--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -68,14 +68,19 @@ export class EditFileTool extends defineTool({
     if (occurrences === 0) {
       throw new ToolError(
         `old_str not found in ${targetPath}.\n` +
-          `Copy the text exactly as shown by read_file, but do NOT include the line-number prefix (e.g. "  42\t").\n` +
-          `Common causes: wrong whitespace, stale content (re-read the file), or the text was already changed.`,
+          `To fix:\n` +
+          `- Re-read the file — content may have changed since last read\n` +
+          `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t")\n` +
+          `- Ensure whitespace matches exactly (tabs vs spaces, trailing spaces)`,
       );
     }
 
     if (!replace_all && occurrences > 1) {
       throw new ToolError(
-        `old_str is not unique within ${targetPath}. Include more surrounding context or set replace_all to true.`,
+        `old_str matches ${occurrences} locations in ${targetPath}.\n` +
+          `To fix, either:\n` +
+          `- Include more surrounding context to make old_str unique\n` +
+          `- Set replace_all to true to replace every occurrence: { "replace_all": true }`,
       );
     }
 

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -51,7 +51,8 @@ export class EditFileTool extends defineTool({
 
     if (old_str.length === 0) {
       throw new ToolError(
-        `old_str must not be empty for ${targetPath}. Provide the exact text to replace from read_file output after the line-number prefix.`,
+        `old_str must not be empty for ${targetPath}. ` +
+          `Provide the exact text to replace, copied from read_file output (excluding the line-number prefix).`,
       );
     }
 
@@ -66,7 +67,9 @@ export class EditFileTool extends defineTool({
 
     if (occurrences === 0) {
       throw new ToolError(
-        `The provided old_str was not found in ${targetPath}. Ensure it matches the read_file output exactly after the line-number prefix.`,
+        `old_str not found in ${targetPath}.\n` +
+          `Copy the text exactly as shown by read_file, but do NOT include the line-number prefix (e.g. "  42\t").\n` +
+          `Common causes: wrong whitespace, stale content (re-read the file), or the text was already changed.`,
       );
     }
 

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -70,8 +70,7 @@ export class EditFileTool extends defineTool({
         `old_str not found in ${targetPath}.\n` +
           `To fix:\n` +
           `- Re-read the file — content may have changed since last read\n` +
-          `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t")\n` +
-          `- Ensure whitespace matches exactly (tabs vs spaces, trailing spaces)`,
+          `- Copy text exactly from read_file output, excluding the line-number prefix (e.g. "  42\t"); whitespace must match`,
       );
     }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -297,7 +297,16 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     }
 
     throw new ToolError(
-      `Unknown path: ${input.path}. Valid: /executions/{id}, /executions/{id}/config, /executions/{id}/conversation, /executions/{id}/todos, /executions/{id}/report, /executions/{id}/children, /executions/{id}/output, /executions/{id}/files`,
+      `Unknown path: ${input.path}.\n` +
+        `Valid paths:\n` +
+        `- /executions/{id}              - Summary (status, agent, model)\n` +
+        `- /executions/{id}/config       - Agent configuration\n` +
+        `- /executions/{id}/report       - Result report\n` +
+        `- /executions/{id}/conversation - Message history (subagents)\n` +
+        `- /executions/{id}/todos        - Task list (tool-use subagents)\n` +
+        `- /executions/{id}/children     - Child executions\n` +
+        `- /executions/{id}/output       - stdout/stderr (background processes)\n` +
+        `- /executions/{id}/files        - Generated files (workflows)`,
     );
   }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -24,7 +24,6 @@ import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager
 
 // Local imports - tools
 import { ToolError, type ToolResult } from '@tools/result';
-import { buildTimeoutMessage } from '@tools/timeouts';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -110,13 +109,17 @@ export class BashTool extends defineTool({
     });
 
     if (result.timedOut) {
+      const timeoutSec = timeoutMs / 1000;
+      const maxTimeoutSec = 600_000 / 1000;
       const parts: string[] = [
-        buildTimeoutMessage('Command execution', timeoutMs),
+        `Foreground command timed out after ${timeoutSec}s.`,
       ];
       if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
       if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
       parts.push(
-        `Increase the timeout parameter (max ${600_000}ms) if the command needs more time, or set run_in_background: true to run asynchronously without blocking.`,
+        `To fix, either:\n` +
+          `- Increase the timeout parameter up to ${maxTimeoutSec}s (${600_000}ms): { "timeout": ${600_000} }\n` +
+          `- Set run_in_background: true to execute asynchronously: { "run_in_background": true }`,
       );
       throw new ToolError(parts.join('\n'));
     }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -116,7 +116,7 @@ export class BashTool extends defineTool({
       if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
       if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
       parts.push(
-        'Increase the timeout parameter (in milliseconds) if the command needs more time.',
+        'Increase the timeout parameter (in milliseconds) if the command needs more time, or use run_in_background for long-running commands.',
       );
       throw new ToolError(parts.join('\n'));
     }

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -116,7 +116,7 @@ export class BashTool extends defineTool({
       if (result.stdout) parts.push(`<stdout>${result.stdout}</stdout>`);
       if (result.stderr) parts.push(`<stderr>${result.stderr}</stderr>`);
       parts.push(
-        'Increase the timeout parameter (in milliseconds) if the command needs more time, or use run_in_background for long-running commands.',
+        `Increase the timeout parameter (max ${600_000}ms) if the command needs more time, or set run_in_background: true to run asynchronously without blocking.`,
       );
       throw new ToolError(parts.join('\n'));
     }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -135,8 +135,10 @@ export class GrepTool extends defineTool({
     const exitCode = result.exitCode ?? (result.success ? 0 : 1);
     if (exitCode >= 2) {
       throw new ToolError(
-        `Regex error: ${result.stderr || `exit code ${exitCode}`}. ` +
-          `Check pattern syntax or use literal: true for exact string matching.`,
+        `Regex error: ${result.stderr || `exit code ${exitCode}`}.\n` +
+          `To fix, either:\n` +
+          `- Escape special regex characters in the pattern (e.g. \\., \\(, \\{)\n` +
+          `- Set literal: true for exact string matching: { "literal": true }`,
       );
     }
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -149,7 +149,12 @@ export class GrepTool extends defineTool({
     if (totalCount === 0) {
       return {
         summary: `No matches for "${input.pattern}" in ${display}`,
-        output: `No matches found. Try: broader pattern, -i for case-insensitive, or check path.`,
+        output:
+          `No matches found for "${input.pattern}" in ${display}.\n` +
+          `To fix, try:\n` +
+          `- Broaden the pattern or use a substring\n` +
+          `- Set case-insensitive search: { "-i": true }\n` +
+          `- Search a wider directory (e.g. the workspace root)`,
       };
     }
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -150,11 +150,8 @@ export class GrepTool extends defineTool({
       return {
         summary: `No matches for "${input.pattern}" in ${display}`,
         output:
-          `No matches found for "${input.pattern}" in ${display}.\n` +
-          `To fix, try:\n` +
-          `- Broaden the pattern or use a substring\n` +
-          `- Set case-insensitive search: { "-i": true }\n` +
-          `- Search a wider directory (e.g. the workspace root)`,
+          `No matches found for "${input.pattern}" in ${display}. ` +
+          `Try a broader pattern, { "-i": true } for case-insensitive, or search a wider directory.`,
       };
     }
 

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 
 import { toErrorMessage } from '@common/errors';
 import { ToolResult } from '@tools/result';
-import { isTimeoutErrorCode, buildTimeoutMessage } from '@tools/timeouts';
+import { isTimeoutErrorCode } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const LOOGLE_TIMEOUT_MS = 10_000; // 10 s
@@ -180,10 +180,9 @@ Useful for finding the right lemma when you know roughly what type it should hav
           query,
           result: {
             summary: 'Timeout',
-            output: buildTimeoutMessage(
-              'Loogle API request',
-              LOOGLE_TIMEOUT_MS,
-            ),
+            output:
+              `Loogle API request timed out after ${LOOGLE_TIMEOUT_MS / 1000}s. ` +
+              `The Loogle server may be overloaded. Try again, or simplify the query.`,
             isError: true,
           },
         };

--- a/src/tools/lean/LoogleTool.ts
+++ b/src/tools/lean/LoogleTool.ts
@@ -182,7 +182,8 @@ Useful for finding the right lemma when you know roughly what type it should hav
             summary: 'Timeout',
             output:
               `Loogle API request timed out after ${LOOGLE_TIMEOUT_MS / 1000}s. ` +
-              `The Loogle server may be overloaded. Try again, or simplify the query.`,
+              `The Loogle server may be overloaded. Retry the request. ` +
+              `If it persists, try a simpler type signature or search by name instead.`,
             isError: true,
           },
         };

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -79,8 +79,10 @@ export class LsTool extends defineTool({
     } catch (err) {
       const message = toErrorMessage(err);
       throw new ToolError(
-        `Path not found: ${display} (${message}). ` +
-          `Try: Use glob to search for files, or ls on parent directory.`,
+        `Path not found: ${display} (${message}).\n` +
+          `To fix, either:\n` +
+          `- Use the glob tool to find matching files: { "pattern": "**/<filename>" }\n` +
+          `- List the parent directory to see what exists: { "path": "<parent>" }`,
       );
     }
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
 import { ToolError, ToolResult } from '@tools/result';
-import { isTimeoutErrorCode, buildTimeoutMessage } from '@tools/timeouts';
+import { isTimeoutErrorCode } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 const WEB_FETCH_TIMEOUT_MS = 30_000; // 30 s
@@ -90,7 +90,8 @@ export class WebFetchTool extends defineTool({
       if (axios.isAxiosError(error)) {
         if (isTimeoutErrorCode(error.code)) {
           throw new ToolError(
-            buildTimeoutMessage(`Request to ${url}`, WEB_FETCH_TIMEOUT_MS),
+            `Request to ${url} timed out after ${WEB_FETCH_TIMEOUT_MS / 1000}s. ` +
+              `The server may be slow or unreachable. Try again, or use a different URL.`,
           );
         }
 

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -91,7 +91,7 @@ export class WebFetchTool extends defineTool({
         if (isTimeoutErrorCode(error.code)) {
           throw new ToolError(
             `Request to ${url} timed out after ${WEB_FETCH_TIMEOUT_MS / 1000}s. ` +
-              `The server may be slow or unreachable. Try again, or use a different URL.`,
+              `The remote server did not respond in time. Retry the request, or try a different URL.`,
           );
         }
 

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 
 // Internal imports
 import { ToolResult, ToolError } from '@tools/result';
-import { buildTimeoutMessage } from '@tools/timeouts';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - tools
@@ -48,7 +47,12 @@ export class WolframTool extends defineTool({
     // Build informative error message with all available context
     const parts: string[] = [];
     if (result.timedOut) {
-      parts.push(buildTimeoutMessage('Execution', effectiveTimeout));
+      const timeoutSec = effectiveTimeout / 1000;
+      const maxSec = 600_000 / 1000;
+      parts.push(
+        `Execution timed out after ${timeoutSec}s. ` +
+          `Increase the timeout parameter (up to ${maxSec}s / ${600_000}ms): { "timeout": ${600_000} }`,
+      );
     }
     if (result.exitCode !== null && result.exitCode !== 0) {
       parts.push(`exit code ${result.exitCode}`);

--- a/src/tools/wolfram/WolframTool.ts
+++ b/src/tools/wolfram/WolframTool.ts
@@ -50,8 +50,8 @@ export class WolframTool extends defineTool({
       const timeoutSec = effectiveTimeout / 1000;
       const maxSec = 600_000 / 1000;
       parts.push(
-        `Execution timed out after ${timeoutSec}s. ` +
-          `Increase the timeout parameter (up to ${maxSec}s / ${600_000}ms): { "timeout": ${600_000} }`,
+        `Execution timed out after ${timeoutSec}s.\n` +
+          `To fix: increase the timeout parameter up to ${maxSec}s (${600_000}ms): { "timeout": ${600_000} }`,
       );
     }
     if (result.exitCode !== null && result.exitCode !== 0) {

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -128,8 +128,7 @@ async function checkZoteroRunning(port: number): Promise<void> {
   } catch {
     throw new ToolError(
       `Zotero is not reachable on port ${port}. ` +
-        `Ask the user to start the Zotero desktop app. ` +
-        `If Zotero is already running, the port may be wrong (setting: texra.bib.zoteroPort).`,
+        `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
     );
   }
 }
@@ -164,8 +163,7 @@ async function callZoteroConnector(
         status: 'error',
         message:
           `Zotero Connector request timed out after ${ZOTERO_CONNECTOR_TIMEOUT_MS / 1000}s. ` +
-          `Zotero may be busy indexing or processing. Retry the request. ` +
-          `If it persists, ask the user to check that Zotero is responsive.`,
+          `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
       };
     }
     const message =

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -26,7 +26,7 @@ import { toErrorMessage } from '@common/errors';
 import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
 import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { ToolError } from '@tools/result';
-import { isTimeoutErrorCode, buildTimeoutMessage } from '@tools/timeouts';
+import { isTimeoutErrorCode } from '@tools/timeouts';
 import { pluralize } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
@@ -127,7 +127,9 @@ async function checkZoteroRunning(port: number): Promise<void> {
     }
   } catch {
     throw new ToolError(
-      `Please start Zotero desktop app. The Connector API is not responding on port ${port}.`,
+      `Zotero is not reachable on port ${port}. ` +
+        `Ask the user to start the Zotero desktop app. ` +
+        `If Zotero is already running, the port may be wrong (setting: texra.bib.zoteroPort).`,
     );
   }
 }
@@ -160,10 +162,10 @@ async function callZoteroConnector(
     if (error instanceof AxiosError && isTimeoutErrorCode(error.code)) {
       return {
         status: 'error',
-        message: buildTimeoutMessage(
-          'Zotero Connector request',
-          ZOTERO_CONNECTOR_TIMEOUT_MS,
-        ),
+        message:
+          `Zotero Connector request timed out after ${ZOTERO_CONNECTOR_TIMEOUT_MS / 1000}s. ` +
+          `Zotero may be busy indexing or processing. Retry the request. ` +
+          `If it persists, ask the user to check that Zotero is responsive.`,
       };
     }
     const message =

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -13,7 +13,7 @@ import axios from 'axios';
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
 import { ToolError } from '@tools/result';
-import { isTimeoutErrorCode, buildTimeoutMessage } from '@tools/timeouts';
+import { isTimeoutErrorCode } from '@tools/timeouts';
 import { getConfig } from '@utils/config';
 
 const ZOTERO_BBT_TIMEOUT_MS = 10_000; // 10 s
@@ -179,17 +179,23 @@ export async function callBetterBibTeX<T = unknown>(
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (isTimeoutErrorCode(error.code)) {
-        throw new ToolError(buildTimeoutMessage('Zotero API request', timeout));
+        throw new ToolError(
+          `Zotero API request timed out after ${timeout / 1000}s. ` +
+            `Zotero may be busy indexing or processing. Retry the request. ` +
+            `If it persists, ask the user to check that Zotero is responsive.`,
+        );
       }
       if (error.code === 'ECONNREFUSED') {
         throw new ToolError(
-          'Please start Zotero desktop app. The Connector API is not responding.',
+          `Zotero is not reachable on port ${port}. ` +
+            `Ask the user to start the Zotero desktop app. ` +
+            `If Zotero is already running, the port may be wrong (setting: texra.bib.zoteroPort).`,
         );
       }
       if (error.response?.status === 404) {
         throw new ToolError(
-          'Better BibTeX plugin is not installed. ' +
-            'Install it from https://retorque.re/zotero-better-bibtex/',
+          'Better BibTeX plugin is not installed in Zotero. ' +
+            'Ask the user to install it from https://retorque.re/zotero-better-bibtex/',
         );
       }
     }

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -181,15 +181,13 @@ export async function callBetterBibTeX<T = unknown>(
       if (isTimeoutErrorCode(error.code)) {
         throw new ToolError(
           `Zotero API request timed out after ${timeout / 1000}s. ` +
-            `Zotero may be busy indexing or processing. Retry the request. ` +
-            `If it persists, ask the user to check that Zotero is responsive.`,
+            `Retry the request. If it persists, ask the user to check that Zotero is responsive.`,
         );
       }
       if (error.code === 'ECONNREFUSED') {
         throw new ToolError(
           `Zotero is not reachable on port ${port}. ` +
-            `Ask the user to start the Zotero desktop app. ` +
-            `If Zotero is already running, the port may be wrong (setting: texra.bib.zoteroPort).`,
+            `Ask the user to start Zotero or verify the port (setting: texra.bib.zoteroPort).`,
         );
       }
       if (error.response?.status === 404) {


### PR DESCRIPTION
When a bash command times out in foreground (sync) mode, the error
message now suggests using run_in_background as an alternative to
just increasing the timeout.

https://claude.ai/code/session_019Lswzft4tJdsGSKeLdzGyu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily string/message changes with no behavioral or data-flow changes; low risk aside from potential copy/paste formatting regressions in tool output.
> 
> **Overview**
> Improves user-facing error messages across several tools to be more actionable and consistent, typically switching from single-line errors to multi-line *“To fix”* guidance.
> 
> Notably, `bash` foreground timeouts now suggest either increasing `timeout` (up to 600,000ms) **or** using `run_in_background`; similar timeout/error messaging updates are applied to `web_fetch`, `lean_loogle`, `wolfram`, and Zotero tools, plus clearer guidance for `edit_file`, `ls`, `grep`, and invalid `executions` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebc9c7548db96b9849efa56e1c4f4e147e16614c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->