### PR TITLE
Remove schema duplication in settingsViewMessages.ts

### DIFF
--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -11,6 +11,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 import { HISTORY_VIEW_COMMANDS } from '@common/webview/commands';
+import { commandOnly } from './messageFactories';
 
 import { AgentCategorySchema } from './agent';
 
@@ -67,28 +68,28 @@ export const HistoryIdMessageSchema = z.object({
 });
 export type HistoryIdMessage = z.infer<typeof HistoryIdMessageSchema>;
 
-const GetHistoryDataMessageSchema = z.object({
-  command: z.literal(HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA),
-});
+export const GetHistoryDataMessageSchema = commandOnly(
+  HISTORY_VIEW_COMMANDS.GET_HISTORY_DATA,
+);
 
-const RerunAgentMessageSchema = z.object({
+export const RerunAgentMessageSchema = z.object({
   command: z.literal(HISTORY_VIEW_COMMANDS.RERUN_AGENT),
   historyId: z.string().min(1),
 });
 
-const RestoreAgentMessageSchema = z.object({
+export const RestoreAgentMessageSchema = z.object({
   command: z.literal(HISTORY_VIEW_COMMANDS.RESTORE_AGENT),
   historyId: z.string().min(1),
 });
 
-const DeleteAgentMessageSchema = z.object({
+export const DeleteAgentMessageSchema = z.object({
   command: z.literal(HISTORY_VIEW_COMMANDS.DELETE_AGENT),
   historyId: z.string().min(1),
 });
 
-const ClearHistoryMessageSchema = z.object({
-  command: z.literal(HISTORY_VIEW_COMMANDS.CLEAR_HISTORY),
-});
+export const ClearHistoryMessageSchema = commandOnly(
+  HISTORY_VIEW_COMMANDS.CLEAR_HISTORY,
+);
 
 // ============================================================
 // Discriminated union of all inbound messages

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -12,6 +12,12 @@ import {
 } from '@shared/utils/dispatcher';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { UIFileFieldsSchema } from './fileFields';
+import {
+  commandOnly,
+  withFilesArray,
+  withNotifyWhenEmpty,
+  withOptionalFilePath,
+} from './messageFactories';
 import { ToolConfigFieldsSchema } from './toolConfig';
 
 // ============================================================
@@ -659,20 +665,7 @@ export type LatexdiffvcOperationMessage = z.infer<
 // Inbound Message Schemas (frontend -> backend)
 // ============================================================
 
-const commandOnly = <T extends string>(command: T) =>
-  z.object({ command: z.literal(command) });
-
-const withOptionalFilePath = <T extends string>(command: T) =>
-  z.object({ command: z.literal(command), filePath: z.string().optional() });
-
-const withFilesArray = <T extends string>(command: T) =>
-  z.object({ command: z.literal(command), files: z.array(z.string()) });
-
-const withNotifyWhenEmpty = <T extends string>(command: T) =>
-  z.object({
-    command: z.literal(command),
-    notifyWhenEmpty: z.boolean().nullish(),
-  });
+// Factory functions imported from ./messageFactories
 
 const CommonMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.WEBVIEW_READY),

--- a/src/shared/schemas/memoryViewMessages.ts
+++ b/src/shared/schemas/memoryViewMessages.ts
@@ -11,6 +11,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 import { MEMORY_VIEW_COMMANDS } from '@common/webview/commands';
+import { commandOnly } from './messageFactories';
 
 // ============================================================
 // Data schemas
@@ -76,30 +77,30 @@ export const MemoryEnabledMessageSchema = z.object({
 export type MemoryEnabledMessage = z.infer<typeof MemoryEnabledMessageSchema>;
 
 // Inbound messages with command literals
-const GetMemoryDataMessageSchema = z.object({
-  command: z.literal(MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA),
-});
+export const GetMemoryDataMessageSchema = commandOnly(
+  MEMORY_VIEW_COMMANDS.GET_MEMORY_DATA,
+);
 
-const OpenMemoryFileMessageSchema = z.object({
+export const OpenMemoryFileMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FILE),
   storagePath: z.string().min(1),
 });
 
-const OpenMemoryFolderMessageSchema = z.object({
-  command: z.literal(MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER),
-});
+export const OpenMemoryFolderMessageSchema = commandOnly(
+  MEMORY_VIEW_COMMANDS.OPEN_MEMORY_FOLDER,
+);
 
-const DeleteMemoryMessageSchema = z.object({
+export const DeleteMemoryMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.DELETE_MEMORY),
   storagePath: z.string().min(1),
   displayPath: z.string().min(1),
 });
 
-const GetMemoryEnabledMessageSchema = z.object({
-  command: z.literal(MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED),
-});
+export const GetMemoryEnabledMessageSchema = commandOnly(
+  MEMORY_VIEW_COMMANDS.GET_MEMORY_ENABLED,
+);
 
-const SetMemoryEnabledMessageSchema = z.object({
+export const SetMemoryEnabledMessageSchema = z.object({
   command: z.literal(MEMORY_VIEW_COMMANDS.SET_MEMORY_ENABLED),
   enabled: z.boolean(),
 });

--- a/src/shared/schemas/messageFactories.ts
+++ b/src/shared/schemas/messageFactories.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared factory functions for constructing message schemas.
+ *
+ * These helpers reduce boilerplate when defining inbound (frontend → backend)
+ * message schemas across views. Each factory produces a Zod object schema
+ * with a `command` literal discriminator plus optional payload fields.
+ */
+import { z } from 'zod';
+
+/** Schema with only a `command` literal (no payload). */
+export const commandOnly = <T extends string>(command: T) =>
+  z.object({ command: z.literal(command) });
+
+/** Schema with `command` + optional `filePath`. */
+export const withOptionalFilePath = <T extends string>(command: T) =>
+  z.object({ command: z.literal(command), filePath: z.string().optional() });
+
+/** Schema with `command` + required `files` string array. */
+export const withFilesArray = <T extends string>(command: T) =>
+  z.object({ command: z.literal(command), files: z.array(z.string()) });
+
+/** Schema with `command` + optional `notifyWhenEmpty` boolean. */
+export const withNotifyWhenEmpty = <T extends string>(command: T) =>
+  z.object({
+    command: z.literal(command),
+    notifyWhenEmpty: z.boolean().nullish(),
+  });

--- a/src/shared/schemas/profileViewMessages.ts
+++ b/src/shared/schemas/profileViewMessages.ts
@@ -11,6 +11,7 @@ import {
   type HandlerRegistry,
 } from '@shared/utils/dispatcher';
 import { PROFILE_VIEW_COMMANDS } from '@common/webview/commands';
+import { commandOnly } from './messageFactories';
 
 // ============================================================
 // Data schemas
@@ -115,23 +116,20 @@ export type SetApiAccessModeMessage = z.infer<
 >;
 
 // Inbound messages with command literals
-const GetProfileDataMessageSchema = z.object({
-  command: z.literal(PROFILE_VIEW_COMMANDS.GET_PROFILE_DATA),
-});
+export const GetProfileDataMessageSchema = commandOnly(
+  PROFILE_VIEW_COMMANDS.GET_PROFILE_DATA,
+);
 
-const SelectAgentInboundMessageSchema = SelectAgentMessageSchema.extend({
-  command: z.literal(PROFILE_VIEW_COMMANDS.SELECT_AGENT),
-});
+export const SelectAgentInboundMessageSchema =
+  SelectAgentMessageSchema.extend({
+    command: z.literal(PROFILE_VIEW_COMMANDS.SELECT_AGENT),
+  });
 
-const SignInMessageSchema = z.object({
-  command: z.literal(PROFILE_VIEW_COMMANDS.SIGN_IN),
-});
+export const SignInMessageSchema = commandOnly(PROFILE_VIEW_COMMANDS.SIGN_IN);
 
-const SignOutMessageSchema = z.object({
-  command: z.literal(PROFILE_VIEW_COMMANDS.SIGN_OUT),
-});
+export const SignOutMessageSchema = commandOnly(PROFILE_VIEW_COMMANDS.SIGN_OUT);
 
-const SetApiAccessModeInboundMessageSchema =
+export const SetApiAccessModeInboundMessageSchema =
   SetApiAccessModeMessageSchema.extend({
     command: z.literal(PROFILE_VIEW_COMMANDS.SET_API_ACCESS_MODE),
   });

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -18,7 +18,30 @@ import {
   SETTINGS_VIEW_COMMANDS,
 } from '@common/webview/commands';
 import { AgentCategorySchema, AgentSourceSchema } from './agent';
-import { NumberVscodeSettingSchema } from './profileViewMessages';
+import {
+  DeleteMemoryMessageSchema,
+  GetMemoryDataMessageSchema,
+  GetMemoryEnabledMessageSchema,
+  OpenMemoryFileMessageSchema,
+  OpenMemoryFolderMessageSchema,
+  SetMemoryEnabledMessageSchema,
+} from './memoryViewMessages';
+import {
+  ClearHistoryMessageSchema,
+  DeleteAgentMessageSchema,
+  GetHistoryDataMessageSchema,
+  RerunAgentMessageSchema,
+  RestoreAgentMessageSchema,
+} from './historyViewMessages';
+import { commandOnly } from './messageFactories';
+import {
+  GetProfileDataMessageSchema,
+  NumberVscodeSettingSchema,
+  SelectAgentInboundMessageSchema,
+  SetApiAccessModeInboundMessageSchema,
+  SignInMessageSchema,
+  SignOutMessageSchema,
+} from './profileViewMessages';
 export { SETTINGS_VIEW_CMD };
 
 /** Tab name order - single source of truth for tab indices */
@@ -183,82 +206,11 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 // Inbound message schemas (frontend → backend)
 // ============================================================
 
-// Memory inbound messages
-const GetMemoryDataMessageSchema = z.object({
-  command: z.literal(CMD.GET_MEMORY_DATA),
-});
+// Memory, History, and Profile inbound schemas are imported from their
+// respective modules (memoryViewMessages, historyViewMessages, profileViewMessages)
+// to avoid duplicating definitions. The command literal strings are identical.
 
-const OpenMemoryFileMessageSchema = z.object({
-  command: z.literal(CMD.OPEN_MEMORY_FILE),
-  storagePath: z.string().min(1),
-});
-
-const OpenMemoryFolderMessageSchema = z.object({
-  command: z.literal(CMD.OPEN_MEMORY_FOLDER),
-});
-
-const DeleteMemoryMessageSchema = z.object({
-  command: z.literal(CMD.DELETE_MEMORY),
-  storagePath: z.string().min(1),
-  displayPath: z.string().min(1),
-});
-
-const GetMemoryEnabledMessageSchema = z.object({
-  command: z.literal(CMD.GET_MEMORY_ENABLED),
-});
-
-const SetMemoryEnabledMessageSchema = z.object({
-  command: z.literal(CMD.SET_MEMORY_ENABLED),
-  enabled: z.boolean(),
-});
-
-// History inbound messages
-const GetHistoryDataMessageSchema = z.object({
-  command: z.literal(CMD.GET_HISTORY_DATA),
-});
-
-const RerunAgentMessageSchema = z.object({
-  command: z.literal(CMD.RERUN_AGENT),
-  historyId: z.string().min(1),
-});
-
-const RestoreAgentMessageSchema = z.object({
-  command: z.literal(CMD.RESTORE_AGENT),
-  historyId: z.string().min(1),
-});
-
-const DeleteAgentMessageSchema = z.object({
-  command: z.literal(CMD.DELETE_AGENT),
-  historyId: z.string().min(1),
-});
-
-const ClearHistoryMessageSchema = z.object({
-  command: z.literal(CMD.CLEAR_HISTORY),
-});
-
-// Profile inbound messages
-const GetProfileDataMessageSchema = z.object({
-  command: z.literal(CMD.GET_PROFILE_DATA),
-});
-
-const SelectAgentInboundMessageSchema = z.object({
-  command: z.literal(CMD.SELECT_AGENT),
-  agentName: z.string().min(1),
-});
-
-const SignInMessageSchema = z.object({
-  command: z.literal(CMD.SIGN_IN),
-});
-
-const SignOutMessageSchema = z.object({
-  command: z.literal(CMD.SIGN_OUT),
-});
-
-const SetApiAccessModeInboundMessageSchema = z.object({
-  command: z.literal(CMD.SET_API_ACCESS_MODE),
-  mode: z.enum(['included', 'personal']),
-});
-
+// Provider key inbound messages (settings-only)
 const SetProviderKeyMessageSchema = z.object({
   command: z.literal(CMD.SET_PROVIDER_KEY),
   provider: z.string().min(1),
@@ -303,9 +255,7 @@ const OpenExternalUrlMessageSchema = z.object({
 });
 
 // Model selection inbound messages
-const GetModelSelectionMessageSchema = z.object({
-  command: z.literal(CMD.GET_MODEL_SELECTION),
-});
+const GetModelSelectionMessageSchema = commandOnly(CMD.GET_MODEL_SELECTION);
 
 const SetModelEnabledMessageSchema = z.object({
   command: z.literal(CMD.SET_MODEL_ENABLED),
@@ -319,9 +269,7 @@ const SetPolishModelMessageSchema = z.object({
 });
 
 // Agent selection inbound messages
-const GetAgentSelectionMessageSchema = z.object({
-  command: z.literal(CMD.GET_AGENT_SELECTION),
-});
+const GetAgentSelectionMessageSchema = commandOnly(CMD.GET_AGENT_SELECTION);
 
 const OpenAgentYamlMessageSchema = z.object({
   command: z.literal(CMD.OPEN_AGENT_YAML),
@@ -349,9 +297,7 @@ const CreateAgentMessageSchema = z.object({
 });
 
 // Auto-show remote agents inbound messages
-const GetAutoShowRemoteMessageSchema = z.object({
-  command: z.literal(CMD.GET_AUTO_SHOW_REMOTE),
-});
+const GetAutoShowRemoteMessageSchema = commandOnly(CMD.GET_AUTO_SHOW_REMOTE);
 
 const SetAutoShowRemoteMessageSchema = z.object({
   command: z.literal(CMD.SET_AUTO_SHOW_REMOTE),
@@ -359,22 +305,16 @@ const SetAutoShowRemoteMessageSchema = z.object({
 });
 
 // Custom agent directory inbound messages
-const GetCustomAgentDirMessageSchema = z.object({
-  command: z.literal(CMD.GET_CUSTOM_AGENT_DIR),
-});
-
-const SetCustomAgentDirMessageSchema = z.object({
-  command: z.literal(CMD.SET_CUSTOM_AGENT_DIR),
-});
-
-const ResetCustomAgentDirMessageSchema = z.object({
-  command: z.literal(CMD.RESET_CUSTOM_AGENT_DIR),
-});
+const GetCustomAgentDirMessageSchema = commandOnly(CMD.GET_CUSTOM_AGENT_DIR);
+const SetCustomAgentDirMessageSchema = commandOnly(CMD.SET_CUSTOM_AGENT_DIR);
+const ResetCustomAgentDirMessageSchema = commandOnly(
+  CMD.RESET_CUSTOM_AGENT_DIR,
+);
 
 // Super YOLO inbound messages
-const GetSuperYoloEnabledMessageSchema = z.object({
-  command: z.literal(CMD.GET_SUPER_YOLO_ENABLED),
-});
+const GetSuperYoloEnabledMessageSchema = commandOnly(
+  CMD.GET_SUPER_YOLO_ENABLED,
+);
 
 const SetSuperYoloEnabledMessageSchema = z.object({
   command: z.literal(CMD.SET_SUPER_YOLO_ENABLED),
@@ -382,9 +322,7 @@ const SetSuperYoloEnabledMessageSchema = z.object({
 });
 
 // Navigation inbound messages
-const OpenVscodeSettingsMessageSchema = z.object({
-  command: z.literal(CMD.OPEN_VSCODE_SETTINGS),
-});
+const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
 
 // ============================================================
 // Discriminated union of all inbound messages


### PR DESCRIPTION
settingsViewMessages.ts redefined 16 inbound message schemas that were
identical to those in memoryViewMessages.ts, historyViewMessages.ts, and
profileViewMessages.ts. Every schema change had to be synced in two places.

- Export inbound schemas from sub-view files so they can be reused
- Import them in settingsViewMessages.ts instead of redefining locally
- Extract commandOnly/withFilesArray/etc. factories from mainView.ts into
  shared messageFactories.ts for reuse across all schema files
- Use commandOnly() in sub-view files and settingsViewMessages.ts to
  reduce boilerplate for command-only message schemas

Net reduction: ~70 lines removed across schema files.

https://claude.ai/code/session_01DEx6iZxwggmNuRCrn92Zxk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to schema definitions and imports/exports with no behavioral intent; risk is limited to potential type/schema mismatches if any command literal diverges or a schema was subtly different before.
> 
> **Overview**
> Removes duplicated inbound message schema definitions from `settingsViewMessages.ts` by importing the equivalent schemas from `memoryViewMessages.ts`, `historyViewMessages.ts`, and `profileViewMessages.ts` (and exporting those inbound schemas from the sub-view modules).
> 
> Extracts shared Zod schema helpers (`commandOnly`, `withOptionalFilePath`, `withFilesArray`, `withNotifyWhenEmpty`) into a new `messageFactories.ts`, updates `mainView.ts` to consume them, and converts command-only inbound schemas in the sub-view modules and settings view to use `commandOnly()` to reduce boilerplate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80ee2f11a5cafd5aecb2385bd96a64bf84c01d12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->