### PR TITLE
refactor: split RequestPanels and BannerGroup into individual components

### DIFF
--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { MainViewPersistedStateSchema } from '@shared/schemas';
 
 // Local imports - agent
+import { getServerSideKeyService } from '@auth/serverKeys';
 import { refresh, computeAgentOptionsData } from '@agent/index';
 
 // Local imports - common
@@ -21,7 +22,6 @@ import { computeModelOptionsData } from '@model/computeModelOptions';
 import { watchConfig, getConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
 import { checkCoreDependencies } from '@utils/system/toolUtils';
-import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local file imports
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -6,7 +6,6 @@ import {
   type RoundOutput,
   type StorageKey,
 } from '@shared/schemas';
-import { executionToEndStatus } from '@common/constants/streamStatus';
 import { getExecutionStore } from '@agent/storage';
 import {
   createOutputState,
@@ -29,6 +28,7 @@ import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { FlowRecord } from '@agent/node/persisted-flow';
 import { RoundPersistedFlow } from '@agent/node/round-persisted-flow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
+import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { AgentLogStage } from '@logger/AgentLogger';
 import {
   TaskRunFileService,

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -6,6 +6,7 @@ import {
   createToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import { buildCycleServices } from '@agent/core/flows/CycleServices';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { formatProviderHttpError } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -16,7 +17,6 @@ import {
 } from './types';
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import type { TodoItem } from '@shared/schemas';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 
 type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -3,8 +3,8 @@ import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 
-import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import { findLastAssistantText } from './types';
+import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
 
 interface WaitPrepResult {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -3,7 +3,6 @@ import {
   EXECUTION_STATUS,
   type EndGroupStatus,
 } from '@shared/schemas';
-import { executionToEndStatus } from '@common/constants/streamStatus';
 import { getExecutionStore, type ExecutionKVStore } from '@agent/storage';
 import {
   registerInterruptible,
@@ -15,11 +14,12 @@ import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
 
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
-import type { ToolDefinition } from '@model';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
+import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { executionToEndStatus } from '@common/constants/streamStatus';
+import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
-import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -21,17 +21,17 @@ import {
   AgentDefinitionSchema,
 } from '@agent/core/AgentDataclass';
 import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import * as logger from '@logger/logUtils';
-import { AbsoluteFS } from '@utils/files';
-import type { AgentOptionData } from '@shared/schemas';
-
 import {
   GlobalStateKey,
   WorkspaceStateKey,
   globalSM,
   workspaceSM,
 } from '@common/state';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
+import * as logger from '@logger/logUtils';
+import { AbsoluteFS } from '@utils/files';
+import type { AgentOptionData } from '@shared/schemas';
+
 
 const CHANNEL = 'agentRegistry';
 logger.initialize(CHANNEL);

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -10,6 +10,12 @@ import { MAX_TIER } from '@auth/config';
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - agent
+import {
+  type ModelConfig,
+  ModelProvider,
+  type ModelCapabilities,
+  ReasoningEffort,
+} from 'llm-zoo';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory, type AgentSetting } from '@agent/core/AgentDataclass';
 import type {
@@ -27,23 +33,17 @@ import { SecretManager, ApiProvider } from '@frontend/secretManager';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model
-import {
-  type ModelConfig,
-  ModelProvider,
-  type ModelCapabilities,
-  ReasoningEffort,
-} from 'llm-zoo';
 
 // Local imports - tools
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
 import { K_SLICE } from '@utils/config';
+import type { FileLocation } from '@utils/files';
 import {
   getProviderStreaming,
   getGlobalStreaming,
 } from '@utils/config/constants';
-import type { FileLocation } from '@utils/files';
 import { MediaAttachmentProcessor } from './support/MediaAttachmentProcessor';
 import {
   resolveBaseUrl,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -29,6 +29,7 @@ import {
 } from '@google/genai';
 
 // Local imports - agent
+import { ReasoningEffort } from 'llm-zoo';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 // Internal imports
 import { AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
@@ -47,7 +48,6 @@ import {
 } from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 
-import { ReasoningEffort } from 'llm-zoo';
 
 // Internal imports
 import replacementEngine from '@replacement/engine';

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 
 // Third-party imports
 import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
-import type { InputTokenCountParams } from 'openai/resources/responses/input-tokens';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -22,7 +21,6 @@ import {
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
-import type { ModelConfig } from 'llm-zoo';
 import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
 
@@ -63,6 +61,8 @@ import {
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
+import type { ModelConfig } from 'llm-zoo';
+import type { InputTokenCountParams } from 'openai/resources/responses/input-tokens';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';

--- a/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
+++ b/src/agent/modelHandlers/support/MediaAttachmentProcessor.ts
@@ -17,15 +17,15 @@ import {
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Type imports
-import type { ModelCapabilities } from 'llm-zoo';
-
-// Internal imports
 import {
   AbsoluteFS,
   getMimeType,
   getShortDisplayPath,
   type FileLocation,
 } from '@utils/files';
+import type { ModelCapabilities } from 'llm-zoo';
+
+// Internal imports
 
 /**
  * Result of loading a media file.

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -13,10 +13,10 @@ import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { MediaEntry } from '@agent/utils/mediaTypes';
 import type { ToolResultPayload } from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import type { AgentLogger } from '@logger/AgentLogger';
-import type { ModelConfig, ModelCapabilities } from 'llm-zoo';
 import type { ToolDefinition } from '@model';
 import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
+import type { ModelConfig, ModelCapabilities } from 'llm-zoo';
 import type { ProviderMessage } from './ProviderMessage';
 import type { ProviderStopReason } from './StopReasonTypes';
 import type {

--- a/src/agent/output/LatexOutputUtils.ts
+++ b/src/agent/output/LatexOutputUtils.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import { hasExtension } from '@utils/core/pathCore';
 import { WorkspaceFS, type FileLocation } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 import { runLatexFormatter } from '@latex/texFormatter';
 
 interface Logger {

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -1,6 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import yaml from 'yaml';
 
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { SUPABASE_CONFIG } from '@auth/config';
 import {
   AgentSetting,
   AgentPromptSchema,
@@ -20,8 +22,6 @@ import type { AgentLoadOptions } from '@agent/runtime/agentLoad';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { resolveToolDefinitions } from '@tools/registry';
-import { SupabaseClient } from '@auth/SupabaseClient';
-import { SUPABASE_CONFIG } from '@auth/config';
 
 import {
   RemoteAgentListItemSchema,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -6,15 +6,15 @@
  * cascade in getExecutionStatusInfo and handleKill.
  */
 
-import { bus } from '@eventBus/ProgressEventBus';
-import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
   type StreamTabId,
 } from '@shared/schemas';
+import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { formatDuration } from '@utils/core';
+import { bus } from '@eventBus/ProgressEventBus';
 
 // ============================================================================
 // Status types

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,3 +1,4 @@
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
@@ -14,7 +15,6 @@ import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpe
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import * as logger from '@logger/logUtils';
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { getConfig } from '@utils/config';
 
 const CHANNEL = 'ModelFactory';

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -20,9 +20,9 @@ import {
   type AgentSetting,
   type AgentPrompt,
 } from '@agent/core/AgentDataclass';
+import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
-import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import { resolveToolDefinitions } from '@tools/registry';
 
 // Internal imports

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -20,6 +20,7 @@ import {
   getAgent,
   type ResolvedAgent,
 } from '@agent/index';
+import { writeTerminalStatus } from '@agent/storage';
 import type { IModelHandler } from '@agent/modelHandlers/types/IModelHandler';
 import { createMergeOutputFileLocationGetter } from '@agent/utils/outputFileUtils';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
@@ -67,7 +68,6 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { bus } from '@eventBus/ProgressEventBus';
 
-import { writeTerminalStatus } from '@agent/storage';
 import { getRunStorageService } from './RunStorageService';
 import { StreamStatusService } from './StreamStatusService';
 import { createInterruptCallbacks } from './InterruptManager';

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -6,8 +6,6 @@
  */
 
 import { bus } from '@eventBus/ProgressEventBus';
-import type { StreamTabId } from '@shared/schemas';
-
 import {
   type ExecutionHandle,
   AgentExecutionHandle,
@@ -16,6 +14,8 @@ import {
   emitActiveProcessesUpdate,
   interruptActiveChildren as interruptActiveChildrenImpl,
 } from './ExecutionHandle';
+import type { StreamTabId } from '@shared/schemas';
+
 
 export type { ExecutionHandle } from './ExecutionHandle';
 export {

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -9,9 +9,9 @@ import * as path from 'path';
 
 import { isFileNotFoundError } from '@common/errors';
 import { isFile } from '@common/files/fsEntryType';
+import { StorageFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
 
-import { StorageFS } from '@utils/files';
 import type { ExecutionId } from '@shared/schemas';
 
 /**

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getConfig } from '@utils/config';
+import { showSettingsView } from '@commands/settings';
 import { SupabaseClient } from './SupabaseClient';
 import { SupabaseAuthProvider } from './SupabaseAuthProvider';
 import { type OAuthProvider, getExternalAuthCallbackUri } from './config';
 import { AUTH_PROVIDER_ID, AUTH_COMMANDS } from './constants';
-import { showSettingsView } from '@commands/settings';
 
 // Re-export for backwards compatibility
 export { AUTH_COMMANDS } from './constants';

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - agent runtime
+import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
 import { getBaseName, getMultipleName } from '@agent/index';
 import {
   AgentWorkflowSettingSchema,
@@ -20,7 +21,6 @@ import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import { globalSM, GlobalStateKey } from '@common/state';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
-import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core/stringCore';

--- a/src/commands/agent/executeCommand.ts
+++ b/src/commands/agent/executeCommand.ts
@@ -4,8 +4,8 @@ import { ZodError } from 'zod';
 
 // Local imports
 import { AgentConfigSchema } from '@agent/core';
-import { executeAgent } from '@agent/runtime/executeAgent';
 import { registerExecution } from '@agent/storage';
+import { executeAgent } from '@agent/runtime/executeAgent';
 import { formatZodError } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { generateExecutionId } from '@utils/core/executionId';

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -12,7 +12,6 @@ import {
 } from '@common/errors';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import * as logger from '@logger/logUtils';
-import { hasExtension } from '@utils/core/pathCore';
 import { RoundKeySchema } from '@progressView/persistence/schemaUtils';
 import { getConfig } from '@utils/config';
 import {
@@ -23,6 +22,7 @@ import {
   type FileLocation,
 } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
+import { hasExtension } from '@utils/core/pathCore';
 import { LaTeXdiffService, type LaTeXdiffResult } from '@latex/latexdiff';
 import {
   DEFAULT_MATH_MARKUP,

--- a/src/explorer/ExplorerOperations.ts
+++ b/src/explorer/ExplorerOperations.ts
@@ -9,8 +9,8 @@ import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import { agentDirectories, validateYamlAndPromptAdd } from '@frontend/agents';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { hasExtension } from '@utils/core/pathCore';
 import { AbsoluteFS } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 
 // Local file imports
 import { FileItem } from './FileItem';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,12 @@ import dotenv from 'dotenv';
 
 // Local imports - core
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import { initializeServerSideKeyAccess } from '@auth/serverKeys';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import { SupabaseAuthProvider } from '@auth/SupabaseAuthProvider';
+import { SupabaseUriHandler } from '@auth/UriHandler';
+import { isSupabaseConfigured, setRuntimeExtensionId } from '@auth/config';
+import { loadAgents } from '@agent/index';
 import { toErrorMessage } from '@common/errors';
 import { initializeStateManagers } from '@common/state';
 import { isTerminalStatus } from '@common/constants/streamStatus';
@@ -27,12 +33,6 @@ import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
 import { bus } from '@eventBus/ProgressEventBus';
-import { initializeServerSideKeyAccess } from '@auth/serverKeys';
-import { SupabaseClient } from '@auth/SupabaseClient';
-import { SupabaseAuthProvider } from '@auth/SupabaseAuthProvider';
-import { SupabaseUriHandler } from '@auth/UriHandler';
-import { isSupabaseConfigured, setRuntimeExtensionId } from '@auth/config';
-import { loadAgents } from '@agent/index';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';

--- a/src/frontend/agents/register.ts
+++ b/src/frontend/agents/register.ts
@@ -10,8 +10,8 @@ import * as vscode from 'vscode';
 import { AgentCategory, type AgentWorkflowSetting } from '@agent/core';
 import { getBaseName, getMultipleName } from '@agent/index';
 import { isValidAgentYaml } from '@agent/runtime/agentLoad';
-import * as logger from '@logger/logUtils';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
+import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'AgentRegister';
 logger.initialize(CHANNEL);

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -7,9 +7,9 @@ import * as vscode from 'vscode';
 // Local imports - log
 import { showLoggedErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { hasExtension } from '@utils/core/pathCore';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { hasExtension } from '@utils/core/pathCore';
 import { runLatexFormatter } from '@latex/texFormatter';
 
 // Local imports - housekeeping

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -12,13 +12,13 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 
 import { toErrorMessage } from '@common/errors';
 import { AgentLogger } from '@logger/AgentLogger';
-import { hasExtension } from '@utils/core/pathCore';
 import {
   TaskRunFileService,
   flexibleFS,
   pathToLocation,
   type FileLocation,
 } from '@utils/files';
+import { hasExtension } from '@utils/core/pathCore';
 
 // Local file imports
 import { extractFigurePathsFromLatex } from './extractFigure';

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 // Local imports - log
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { hasExtension } from '@utils/core/pathCore';
 import { flexibleFS, pathToLocation } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { runToolWithCheck } from '@utils/system';
+import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);

--- a/src/logger/UsageLogService.ts
+++ b/src/logger/UsageLogService.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'crypto';
 
-import * as logger from '@logger/logUtils';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SUPABASE_CUSTOM_DOMAIN } from '@auth/config';
+import * as logger from '@logger/logUtils';
 
 import { UsageLogResponseSchema } from './UsageLogTypes';
 import type {

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -5,10 +5,10 @@ import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - frontend
+import { GlobalStateKey, globalSM } from '@common/state';
 import { ApiProvider, SecretManager } from '@frontend/secretManager';
 
 // Local imports - state
-import { GlobalStateKey, globalSM } from '@common/state';
 
 // Local imports - shared schemas
 import type { ModelOptionData } from '@shared/schemas';

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -6,7 +6,6 @@ import {
   type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
-import type { AgentProposal } from '@shared/schemas/prompts';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getAgent } from '@agent/index/agentRegistry';
@@ -63,6 +62,7 @@ import {
   buildFileContextFromTaskState,
   polishTextWithAI,
 } from '@utils/text/textEnhancementUtils';
+import type { AgentProposal } from '@shared/schemas/prompts';
 import type { OutputFileInfo, StorageKey, StreamTabId } from '@shared/schemas';
 
 import type { ProgressViewProvider } from './ProgressViewProvider';

--- a/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -1,39 +1,29 @@
 /**
  * Base class for request panels that support rejection feedback.
  *
- * Provides shared feedback state management, reject/feedback rendering,
- * and action emission. ToolEdit, Bash, and Proposal panels extend this.
- * RetryRequestPanel does NOT extend this (no feedback support).
+ * Adds feedback state, reject/feedback rendering, and common keyboard
+ * shortcuts (y/n/escape) on top of BaseRequestPanel.
+ * ToolEdit, Bash, and Proposal panels extend this.
  */
 
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { state } from 'lit/decorators.js';
 
 // Local imports - shared utilities
 import { FEEDBACK_ELIGIBLE_KINDS } from '@shared/utils/uiConstants';
 
-// Local imports - progress view events
-import { ProgressEvents } from '../events';
+// Local imports - base class
+import { BaseRequestPanel } from './BaseRequestPanel';
 
-// Local imports - progress view component types
-import type { PermissionState } from './PermissionCard';
-
-export abstract class BaseFeedbackPanel extends LitElement {
-  @property({ attribute: false }) permission!: PermissionState;
-
+export abstract class BaseFeedbackPanel extends BaseRequestPanel {
   @state() protected showFeedback = false;
 
   // ===========================================================================
   // Keyboard shortcuts (common y/n/escape, subclasses add type-specific keys)
   // ===========================================================================
 
-  /**
-   * Handle keyboard shortcut from container. Returns true if handled.
-   * Common keys (y=approve, n=reject, escape=close feedback) are handled here.
-   * Subclasses override `handleExtraKey()` to add type-specific keys (d, s, etc).
-   */
-  handleKeyboardShortcut(key: string): boolean {
+  override handleKeyboardShortcut(key: string): boolean {
     switch (key) {
       case 'y':
         this.emitAction('approve');
@@ -52,13 +42,13 @@ export abstract class BaseFeedbackPanel extends LitElement {
     }
   }
 
-  /** Override in subclasses to handle type-specific keys. */
+  /** Override in subclasses to handle type-specific keys (d, s, etc). */
   protected handleExtraKey(_key: string): boolean {
     return false;
   }
 
   // ===========================================================================
-  // Feedback handling (shared across ToolEdit, Bash, Proposal)
+  // Feedback handling
   // ===========================================================================
 
   protected handleRejectAction(): void {
@@ -116,25 +106,6 @@ export abstract class BaseFeedbackPanel extends LitElement {
         ></vscode-textarea>
       </div>
     `;
-  }
-
-  // ===========================================================================
-  // Action emission
-  // ===========================================================================
-
-  protected emitAction(
-    action: string,
-    feedback?: string,
-    modelOverride?: string,
-  ): void {
-    this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission: this.permission,
-        action,
-        feedback,
-        modelOverride,
-      }),
-    );
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -24,8 +24,38 @@ export abstract class BaseFeedbackPanel extends LitElement {
 
   @state() protected showFeedback = false;
 
-  /** Subclasses must implement keyboard shortcut handling. */
-  abstract handleKeyboardShortcut(key: string): boolean;
+  // ===========================================================================
+  // Keyboard shortcuts (common y/n/escape, subclasses add type-specific keys)
+  // ===========================================================================
+
+  /**
+   * Handle keyboard shortcut from container. Returns true if handled.
+   * Common keys (y=approve, n=reject, escape=close feedback) are handled here.
+   * Subclasses override `handleExtraKey()` to add type-specific keys (d, s, etc).
+   */
+  handleKeyboardShortcut(key: string): boolean {
+    switch (key) {
+      case 'y':
+        this.emitAction('approve');
+        return true;
+      case 'n':
+        this.handleRejectAction();
+        return true;
+      case 'escape':
+        if (this.showFeedback) {
+          this.showFeedback = false;
+          return true;
+        }
+        return false;
+      default:
+        return this.handleExtraKey(key);
+    }
+  }
+
+  /** Override in subclasses to handle type-specific keys. */
+  protected handleExtraKey(_key: string): boolean {
+    return false;
+  }
 
   // ===========================================================================
   // Feedback handling (shared across ToolEdit, Bash, Proposal)

--- a/src/progressView/frontend/components/BaseFeedbackPanel.ts
+++ b/src/progressView/frontend/components/BaseFeedbackPanel.ts
@@ -1,0 +1,121 @@
+/**
+ * Base class for request panels that support rejection feedback.
+ *
+ * Provides shared feedback state management, reject/feedback rendering,
+ * and action emission. ToolEdit, Bash, and Proposal panels extend this.
+ * RetryRequestPanel does NOT extend this (no feedback support).
+ */
+
+// Third-party imports
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { property, state } from 'lit/decorators.js';
+
+// Local imports - shared utilities
+import { FEEDBACK_ELIGIBLE_KINDS } from '@shared/utils/uiConstants';
+
+// Local imports - progress view events
+import { ProgressEvents } from '../events';
+
+// Local imports - progress view component types
+import type { PermissionState } from './PermissionCard';
+
+export abstract class BaseFeedbackPanel extends LitElement {
+  @property({ attribute: false }) permission!: PermissionState;
+
+  @state() protected showFeedback = false;
+
+  /** Subclasses must implement keyboard shortcut handling. */
+  abstract handleKeyboardShortcut(key: string): boolean;
+
+  // ===========================================================================
+  // Feedback handling (shared across ToolEdit, Bash, Proposal)
+  // ===========================================================================
+
+  protected handleRejectAction(): void {
+    if (!FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind)) {
+      this.emitAction('reject');
+      return;
+    }
+
+    if (!this.showFeedback) {
+      this.showFeedback = true;
+      this.updateComplete.then(() => {
+        const input =
+          this.renderRoot.querySelector<HTMLElement>('[data-feedback-input]');
+        input?.focus();
+      });
+      return;
+    }
+
+    const feedback = this.getFeedbackValue();
+    this.showFeedback = false;
+    this.emitAction('reject', feedback);
+  }
+
+  protected renderRejectButton(rejectTitle: string): TemplateResult {
+    return html`
+      <vscode-toolbar-button
+        icon=${this.showFeedback ? 'check' : 'close'}
+        label=${this.showFeedback ? 'Submit' : 'Reject'}
+        title=${this.showFeedback ? 'Submit rejection (n)' : rejectTitle}
+        @click=${() => this.handleRejectAction()}
+        >${this.showFeedback ? 'Submit' : 'Reject'}</vscode-toolbar-button
+      >
+    `;
+  }
+
+  protected renderFeedbackSection(
+    containerClass: string,
+    inputClass: string,
+    placeholder = 'Why are you rejecting?',
+  ): TemplateResult | typeof nothing {
+    if (
+      !this.showFeedback ||
+      !FEEDBACK_ELIGIBLE_KINDS.has(this.permission.kind)
+    ) {
+      return nothing;
+    }
+
+    return html`
+      <div class=${containerClass}>
+        <vscode-textarea
+          class=${inputClass}
+          placeholder=${placeholder}
+          rows="3"
+          data-feedback-input
+        ></vscode-textarea>
+      </div>
+    `;
+  }
+
+  // ===========================================================================
+  // Action emission
+  // ===========================================================================
+
+  protected emitAction(
+    action: string,
+    feedback?: string,
+    modelOverride?: string,
+  ): void {
+    this.dispatchEvent(
+      ProgressEvents.permissionAction({
+        permission: this.permission,
+        action,
+        feedback,
+        modelOverride,
+      }),
+    );
+  }
+
+  // ===========================================================================
+  // Utilities
+  // ===========================================================================
+
+  private getFeedbackValue(): string | undefined {
+    const input = this.renderRoot.querySelector<HTMLElement>(
+      '[data-feedback-input]',
+    ) as HTMLElement & { value?: string };
+    const trimmed = (input?.value ?? '').trim();
+    return trimmed || undefined;
+  }
+}

--- a/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -1,0 +1,41 @@
+/**
+ * Minimal base class shared by all 4 request panel types.
+ *
+ * Provides the `permission` property, `emitAction()` helper, and the
+ * `handleKeyboardShortcut()` contract that the container delegates to.
+ *
+ * BaseFeedbackPanel extends this to add reject-feedback support.
+ * RetryRequestPanel extends this directly (no feedback).
+ */
+
+// Third-party imports
+import { LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+// Local imports - progress view events
+import { ProgressEvents } from '../events';
+
+// Local imports - progress view component types
+import type { PermissionState } from './PermissionCard';
+
+export abstract class BaseRequestPanel extends LitElement {
+  @property({ attribute: false }) permission!: PermissionState;
+
+  /** Handle keyboard shortcut from container. Returns true if handled. */
+  abstract handleKeyboardShortcut(key: string): boolean;
+
+  protected emitAction(
+    action: string,
+    feedback?: string,
+    modelOverride?: string,
+  ): void {
+    this.dispatchEvent(
+      ProgressEvents.permissionAction({
+        permission: this.permission,
+        action,
+        feedback,
+        modelOverride,
+      }),
+    );
+  }
+}

--- a/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/src/progressView/frontend/components/BashRequestPanel.ts
@@ -1,0 +1,102 @@
+/**
+ * Individual panel component for bash command approval requests.
+ *
+ * Renders a single bash permission with the command block,
+ * approve/reject buttons, and feedback input.
+ *
+ * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
+ */
+
+// Third-party imports
+import { html, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+// Local imports - shared styles
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+
+// Local imports - progress view styles
+import { codeBlockStyles } from '../styles/codeBlockStyles';
+
+// Local imports - progress view formatters
+import { buildCodeBlock } from '../formatters/htmlBuilders';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+// Local imports - shared schemas
+import type { BashPermission } from '@shared/schemas';
+
+@customElement('bash-request-panel')
+export class BashRequestPanel extends BaseFeedbackPanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    codeBlockStyles,
+    requestPanelStyles,
+  ];
+
+  override handleKeyboardShortcut(key: string): boolean {
+    switch (key) {
+      case 'y':
+        this.emitAction('approve');
+        return true;
+      case 'n':
+        this.handleRejectAction();
+        return true;
+      case 'escape':
+        if (this.showFeedback) {
+          this.showFeedback = false;
+          return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  override render(): TemplateResult {
+    const data = this.permission.data as BashPermission;
+
+    return html`
+      <div
+        class=${classMap({
+          'bash-approval-request': true,
+          'bash-approval-request--feedback-active': this.showFeedback,
+        })}
+      >
+        <div class="bash-approval-request__details">
+          <div class="bash-approval-request__command">
+            ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
+          </div>
+        </div>
+        <vscode-toolbar-container class="bash-approval-request__actions">
+          <vscode-toolbar-button
+            icon="check"
+            label="Approve"
+            title="Allow this command to execute (y)"
+            @click=${() => this.emitAction('approve')}
+            >Approve</vscode-toolbar-button
+          >
+          ${this.renderRejectButton('Reject this command (n)')}
+        </vscode-toolbar-container>
+        ${this.renderFeedbackSection(
+          'bash-approval-request__feedback',
+          'bash-approval-request__feedback-input',
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bash-request-panel': BashRequestPanel;
+  }
+}

--- a/src/progressView/frontend/components/BashRequestPanel.ts
+++ b/src/progressView/frontend/components/BashRequestPanel.ts
@@ -42,25 +42,6 @@ export class BashRequestPanel extends BaseFeedbackPanel {
     requestPanelStyles,
   ];
 
-  override handleKeyboardShortcut(key: string): boolean {
-    switch (key) {
-      case 'y':
-        this.emitAction('approve');
-        return true;
-      case 'n':
-        this.handleRejectAction();
-        return true;
-      case 'escape':
-        if (this.showFeedback) {
-          this.showFeedback = false;
-          return true;
-        }
-        return false;
-      default:
-        return false;
-    }
-  }
-
   override render(): TemplateResult {
     const data = this.permission.data as BashPermission;
 

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -1,0 +1,249 @@
+/**
+ * Individual panel component for agent proposal requests.
+ *
+ * Renders a single proposal permission with agent/model details,
+ * workflow file lists, model selection dropdown, approve/reject/setup
+ * buttons, and feedback input.
+ *
+ * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
+ */
+
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+  selectStyles,
+} from '@shared/styles';
+
+// Local imports - shared utils
+import { renderModelOptions } from '@shared/utils/selectTemplates';
+
+// Local imports - shared schemas
+import {
+  AGENT_CATEGORY,
+  type AgentProposalPermission,
+  type WorkflowAgentProposalPermission,
+} from '@shared/schemas';
+import { getProposalFileGroups } from '@shared/schemas/proposalFields';
+
+// Local imports - shared utilities
+import { getBasename } from '@shared/utils/path';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
+import { postMessage } from '@shared/vscode';
+
+// Local imports - webview commands
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+@customElement('proposal-request-panel')
+export class ProposalRequestPanel extends BaseFeedbackPanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    requestPanelStyles,
+    selectStyles,
+  ];
+
+  @state() private selectedModel: string | null = null;
+
+  override handleKeyboardShortcut(key: string): boolean {
+    switch (key) {
+      case 'y':
+        this.emitAction('approve');
+        return true;
+      case 'n':
+        this.handleRejectAction();
+        return true;
+      case 's':
+        this.emitAction('setup');
+        return true;
+      case 'escape':
+        if (this.showFeedback) {
+          this.showFeedback = false;
+          return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  override render(): TemplateResult {
+    const data = this.permission.data as AgentProposalPermission;
+    const modelOptions =
+      this.permission.kind === PERMISSION_KIND.PROPOSAL
+        ? (this.permission.modelOptions ?? [])
+        : [];
+    const isWorkflow = data.agentCategory === AGENT_CATEGORY.WORKFLOW;
+    const categoryLabel = isWorkflow ? 'Workflow' : 'Tool-Use';
+    const currentModel = this.selectedModel ?? data.model;
+    const hasModelOptions = modelOptions.length > 0;
+
+    return html`
+      <div
+        class=${classMap({
+          'workflow-proposal': true,
+          'workflow-proposal--feedback-active': this.showFeedback,
+        })}
+      >
+        <div class="workflow-proposal__details">
+          <div class="workflow-proposal__header-row">
+            <span
+              class=${classMap({
+                'workflow-proposal__category-badge': true,
+                'workflow-proposal__category-badge--workflow': isWorkflow,
+                'workflow-proposal__category-badge--tool-use': !isWorkflow,
+              })}
+            >
+              ${categoryLabel}
+            </span>
+            <span class="workflow-proposal__agent">${data.agent}</span>
+            ${hasModelOptions
+              ? html`
+                  <div class="workflow-proposal__model-select">
+                    <i class="codicon codicon-robot"></i>
+                    <vscode-single-select
+                      class="proposal-model-dropdown"
+                      position="below"
+                      .value=${currentModel}
+                      @change=${this.handleSelectChange}
+                    >
+                      ${renderModelOptions(modelOptions, currentModel)}
+                    </vscode-single-select>
+                  </div>
+                `
+              : html`<span class="workflow-proposal__model"
+                  >${data.model}</span
+                >`}
+          </div>
+          <div class="workflow-proposal__instruction">${data.instruction}</div>
+          ${isWorkflow
+            ? html`<div class="workflow-proposal__files">
+                ${this.renderProposalFiles(
+                  data as WorkflowAgentProposalPermission,
+                )}
+              </div>`
+            : nothing}
+        </div>
+        <vscode-toolbar-container class="workflow-proposal__actions">
+          <vscode-toolbar-button
+            icon="check"
+            label="Approve"
+            title="Approve (y)"
+            @click=${() => this.emitAction('approve')}
+            >Approve</vscode-toolbar-button
+          >
+          ${this.renderRejectButton('Reject (n)')}
+          <vscode-toolbar-button
+            icon="reply"
+            label="Setup"
+            title="Setup (s)"
+            @click=${() => this.emitAction('setup')}
+            >Setup</vscode-toolbar-button
+          >
+        </vscode-toolbar-container>
+        ${this.renderFeedbackSection(
+          'workflow-proposal__feedback',
+          'workflow-proposal__feedback-input',
+        )}
+      </div>
+    `;
+  }
+
+  // ===========================================================================
+  // Proposal-specific rendering
+  // ===========================================================================
+
+  private renderProposalFiles(
+    permission: WorkflowAgentProposalPermission,
+  ): TemplateResult | typeof nothing {
+    return html`${repeat(
+      getProposalFileGroups(permission),
+      ({ label }) => label,
+      ({ label, files }) => this.renderProposalFileList(label, files),
+    )}`;
+  }
+
+  private renderProposalFileList(
+    label: string,
+    files: string[],
+  ): TemplateResult | typeof nothing {
+    if (files.length === 0) return nothing;
+
+    return html`
+      <div
+        class="workflow-proposal__${label.toLowerCase()}-files"
+        @click=${this.handleFileClick}
+      >
+        <span class="workflow-proposal__file-label">${label}:</span>
+        ${repeat(
+          files,
+          (file) => file,
+          (file, i) =>
+            html`${i > 0 ? ', ' : ''}<span
+                class="workflow-proposal__file-name"
+                title=${file}
+                data-file=${file}
+                >${getBasename(file)}</span
+              >`,
+        )}
+      </div>
+    `;
+  }
+
+  // ===========================================================================
+  // Proposal-specific handlers
+  // ===========================================================================
+
+  private handleFileClick = (event: MouseEvent): void => {
+    const target = event.target as HTMLElement;
+    const file = target.dataset?.file;
+    if (file) {
+      postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, { file });
+    }
+  };
+
+  private handleSelectChange = (event: Event): void => {
+    const value = (event.target as HTMLSelectElement).value;
+    if (value) {
+      this.selectedModel = value;
+    }
+  };
+
+  // ===========================================================================
+  // Override emitAction to include model override for approve
+  // ===========================================================================
+
+  protected override emitAction(
+    action: string,
+    feedback?: string,
+  ): void {
+    const modelOverride =
+      action === 'approve' ? this.getModelOverride() : undefined;
+    super.emitAction(action, feedback, modelOverride);
+  }
+
+  private getModelOverride(): string | undefined {
+    const data = this.permission.data as AgentProposalPermission;
+    return this.selectedModel && this.selectedModel !== data.model
+      ? this.selectedModel
+      : undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'proposal-request-panel': ProposalRequestPanel;
+  }
+}

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -57,26 +57,12 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
 
   @state() private selectedModel: string | null = null;
 
-  override handleKeyboardShortcut(key: string): boolean {
-    switch (key) {
-      case 'y':
-        this.emitAction('approve');
-        return true;
-      case 'n':
-        this.handleRejectAction();
-        return true;
-      case 's':
-        this.emitAction('setup');
-        return true;
-      case 'escape':
-        if (this.showFeedback) {
-          this.showFeedback = false;
-          return true;
-        }
-        return false;
-      default:
-        return false;
+  protected override handleExtraKey(key: string): boolean {
+    if (key === 's') {
+      this.emitAction('setup');
+      return true;
     }
+    return false;
   }
 
   override render(): TemplateResult {

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -1,3 +1,12 @@
+/**
+ * Lightweight container for permission request panels.
+ *
+ * Groups permissions by kind and renders section headers with
+ * individual panel components. Manages global keyboard shortcuts
+ * (y=approve, n=reject, d=diff, r=retry, s=setup, Esc=dismiss)
+ * by delegating to the first visible panel.
+ */
+
 // Third-party imports
 import {
   LitElement,
@@ -6,10 +15,8 @@ import {
   type PropertyValues,
   type TemplateResult,
 } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { classMap } from 'lit/directives/class-map.js';
-import { when } from 'lit/directives/when.js';
 
 // Local imports - shared styles
 import {
@@ -17,53 +24,43 @@ import {
   commonViewStyles,
   designTokens,
   requestPanelStyles,
-  selectStyles,
 } from '@shared/styles';
 
-// Local imports - shared utils
-import { renderModelOptions } from '@shared/utils/selectTemplates';
-
-// Local imports - progress view styles
-import { codeBlockStyles } from '../styles/codeBlockStyles';
-
-// Local imports - shared schemas
-import {
-  AGENT_CATEGORY,
-  type AgentProposalPermission,
-  type BashPermission,
-  type ProviderErrorPartial,
-  type RetryPermission,
-  type ToolEditPermission,
-  type WorkflowAgentProposalPermission,
-} from '@shared/schemas';
-import { getProposalFileGroups } from '@shared/schemas/proposalFields';
-
 // Local imports - shared utilities
-import { getBasename } from '@shared/utils/path';
-import {
-  FEEDBACK_ELIGIBLE_KINDS,
-  PERMISSION_KIND,
-} from '@shared/utils/uiConstants';
-import { postMessage } from '@shared/vscode';
-
-// Local imports - webview commands
-import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
-
-// Local imports - progress view events
-import { ProgressEvents } from '../events';
-import { buildCodeBlock } from '../formatters/htmlBuilders';
-import { getComposedPathElement } from '../utils';
+import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view component types
 import type { PermissionState } from './PermissionCard';
 
-type PermissionKey = string;
+// Side-effect imports to register sub-panel custom elements
+import './ToolEditRequestPanel';
+import './BashRequestPanel';
+import './RetryRequestPanel';
+import './ProposalRequestPanel';
+
+// Import sub-panel types for keyboard delegation
+import type { ToolEditRequestPanel } from './ToolEditRequestPanel';
+import type { BashRequestPanel } from './BashRequestPanel';
+import type { RetryRequestPanel } from './RetryRequestPanel';
+import type { ProposalRequestPanel } from './ProposalRequestPanel';
+
+/** Common interface for sub-panels that support keyboard shortcuts */
+type KeyboardPanel =
+  | ToolEditRequestPanel
+  | BashRequestPanel
+  | RetryRequestPanel
+  | ProposalRequestPanel;
+
+/** Selector to find any sub-panel in shadow DOM */
+const PANEL_SELECTOR =
+  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel';
 
 /** Section configuration for rendering permission groups */
 interface SectionConfig {
   cssClass: string;
   icon: string;
   title: string;
+  panelTag: string;
 }
 
 const SECTION_CONFIGS: Record<string, SectionConfig> = {
@@ -71,21 +68,25 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
     cssClass: 'approval-requests',
     icon: 'diff',
     title: 'Tool edit approval',
+    panelTag: 'tool-edit-request-panel',
   },
   bash: {
     cssClass: 'bash-approval-requests',
     icon: 'terminal',
     title: 'Command approval',
+    panelTag: 'bash-request-panel',
   },
   retry: {
     cssClass: 'retry-requests',
     icon: 'refresh',
     title: 'Retry request',
+    panelTag: 'retry-request-panel',
   },
   proposal: {
     cssClass: 'workflow-proposals',
     icon: 'rocket',
     title: 'Agent proposal',
+    panelTag: 'proposal-request-panel',
   },
 };
 
@@ -117,15 +118,10 @@ export class RequestPanels extends LitElement {
     designTokens,
     commonViewStyles,
     codiconIconClasses,
-    codeBlockStyles,
     requestPanelStyles,
-    selectStyles,
   ];
 
   @property({ attribute: false }) permissions: PermissionState[] = [];
-
-  @state() private feedbackOpenKeys: Set<PermissionKey> = new Set();
-  @state() private openDiffMenuKey: PermissionKey | null = null;
 
   /** Memoized permission groups - recomputed in willUpdate() when permissions change */
   private approvalPermissions: PermissionState[] = [];
@@ -133,26 +129,9 @@ export class RequestPanels extends LitElement {
   private retryPermissions: PermissionState[] = [];
   private proposalPermissions: PermissionState[] = [];
 
-  /** Per-proposal selected model overrides (proposalId → model value). */
-  @state() private selectedModels: Map<string, string> = new Map();
-
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    if (!changedProperties.has('permissions')) {
-      return;
-    }
+    if (!changedProperties.has('permissions')) return;
 
-    const activeKeys = new Set(
-      this.permissions.map((permission) => this.getPermissionKey(permission)),
-    );
-    const nextFeedbackKeys = new Set(
-      [...this.feedbackOpenKeys].filter((key) => activeKeys.has(key)),
-    );
-    this.feedbackOpenKeys = nextFeedbackKeys;
-    if (this.openDiffMenuKey && !activeKeys.has(this.openDiffMenuKey)) {
-      this.openDiffMenuKey = null;
-    }
-
-    // Memoize filtered permission groups so render() doesn't re-filter
     this.approvalPermissions = this.permissions.filter(
       (p) => p.kind === PERMISSION_KIND.TOOL_EDIT,
     );
@@ -165,35 +144,14 @@ export class RequestPanels extends LitElement {
     this.proposalPermissions = this.permissions.filter(
       (p) => p.kind === PERMISSION_KIND.PROPOSAL,
     );
-
-    // Clean up selected models for removed proposals
-    const activeProposalIds = new Set(
-      this.proposalPermissions.map(
-        (p) => (p.data as AgentProposalPermission).proposalId,
-      ),
-    );
-    if (this.selectedModels.size > 0) {
-      const nextModels = new Map(
-        [...this.selectedModels].filter(([id]) => activeProposalIds.has(id)),
-      );
-      if (nextModels.size !== this.selectedModels.size) {
-        this.selectedModels = nextModels;
-      }
-    }
   }
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('click', this.handleActionClick);
-    this.addEventListener('keydown', this.handleKeydown);
-    document.addEventListener('click', this.handleOutsideClick, true);
     document.addEventListener('keydown', this.handleGlobalKeydown);
   }
 
   override disconnectedCallback(): void {
-    this.removeEventListener('click', this.handleActionClick);
-    this.removeEventListener('keydown', this.handleKeydown);
-    document.removeEventListener('click', this.handleOutsideClick, true);
     document.removeEventListener('keydown', this.handleGlobalKeydown);
     super.disconnectedCallback();
   }
@@ -202,35 +160,22 @@ export class RequestPanels extends LitElement {
     if (this.permissions.length === 0) return nothing;
 
     return html`
-      ${this.renderSection(
-        SECTION_CONFIGS.approval,
-        this.approvalPermissions,
-        (p) => this.renderToolEditRequest(p),
-      )}
-      ${this.renderSection(SECTION_CONFIGS.bash, this.bashPermissions, (p) =>
-        this.renderBashRequest(p),
-      )}
-      ${this.renderSection(SECTION_CONFIGS.retry, this.retryPermissions, (p) =>
-        this.renderRetryRequest(p),
-      )}
-      ${this.renderSection(
-        SECTION_CONFIGS.proposal,
-        this.proposalPermissions,
-        (p) => this.renderProposalRequest(p),
-      )}
+      ${this.renderSection(SECTION_CONFIGS.approval, this.approvalPermissions)}
+      ${this.renderSection(SECTION_CONFIGS.bash, this.bashPermissions)}
+      ${this.renderSection(SECTION_CONFIGS.retry, this.retryPermissions)}
+      ${this.renderSection(SECTION_CONFIGS.proposal, this.proposalPermissions)}
     `;
   }
 
   // ===========================================================================
-  // Section renderers
+  // Section rendering
   // ===========================================================================
 
   private renderSection(
     config: SectionConfig,
-    prompts: PermissionState[],
-    renderItem: (permission: PermissionState) => TemplateResult,
+    permissions: PermissionState[],
   ): TemplateResult | typeof nothing {
-    if (prompts.length === 0) return nothing;
+    if (permissions.length === 0) return nothing;
 
     return html`
       <section class=${config.cssClass}>
@@ -240,781 +185,82 @@ export class RequestPanels extends LitElement {
         </div>
         <div class="${config.cssClass}__list">
           ${repeat(
-            prompts,
-            (permission) => this.getPermissionKey(permission),
-            renderItem,
+            permissions,
+            (p) => this.getPermissionKey(p),
+            (p) =>
+              this.renderPanel(config.panelTag, p),
           )}
         </div>
       </section>
     `;
   }
 
-  // ===========================================================================
-  // Individual request renderers
-  // ===========================================================================
-
-  private renderToolEditRequest(permission: PermissionState): TemplateResult {
-    const data = permission.data as ToolEditPermission;
-    const key = this.getPermissionKey(permission);
-    const isFeedbackOpen = this.feedbackOpenKeys.has(key);
-    const diffMeta = this.renderToolEditDiffMeta(data);
-
-    return html`
-      <div
-        class=${classMap({
-          'approval-request': true,
-          'approval-request--feedback-active': isFeedbackOpen,
-        })}
-        data-permission-key=${key}
-      >
-        <div class="approval-request__details">
-          <div class="approval-request__path">
-            ${data.relativePath || data.path}
-          </div>
-          <div class="approval-request__meta">
-            ${data.sourceTool ? `Requested by ${data.sourceTool}` : ''}
-            ${data.sourceTool && diffMeta ? html`<span>•</span>` : nothing}
-            ${diffMeta}
-          </div>
-        </div>
-        <vscode-toolbar-container class="approval-request__actions">
-          ${this.renderToolEditDiffActions(permission)}
-          <vscode-toolbar-button
-            icon="check"
-            data-action="approve"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Approve"
-            title="Approve (y)"
-            >Approve</vscode-toolbar-button
-          >
-          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject (n)')}
-        </vscode-toolbar-container>
-        ${this.renderFeedbackSection(
-          permission,
-          'approval-request__feedback',
-          'approval-request__feedback-input',
-          'Why are you rejecting?',
-        )}
-      </div>
-    `;
-  }
-
-  private renderToolEditDiffActions(
+  private renderPanel(
+    tag: string,
     permission: PermissionState,
   ): TemplateResult {
-    const data = permission.data as ToolEditPermission;
-    const key = this.getPermissionKey(permission);
-    const isMenuOpen = this.openDiffMenuKey === key;
-    const showDropdown = Boolean(data.isLatex);
-
-    return html`
-      <div class="diff-dropdown">
-        <vscode-toolbar-button
-          icon="diff"
-          class="diff-main-button"
-          data-action="openDiff"
-          data-permission-kind=${permission.kind}
-          data-permission-id=${this.getPermissionId(permission)}
-          label="Open diff"
-          title="Open diff (d)"
-          >Open diff</vscode-toolbar-button
-        >
-        ${showDropdown
-          ? html`
-              <vscode-toolbar-button
-                class="diff-dropdown-trigger"
-                aria-haspopup="true"
-                aria-expanded=${isMenuOpen ? 'true' : 'false'}
-                label="More diff actions"
-                title="More diff actions"
-                @click=${(event: MouseEvent) => this.toggleDiffMenu(event, key)}
-              >
-                <i class="codicon codicon-chevron-down"></i>
-              </vscode-toolbar-button>
-              <vscode-context-menu
-                class="diff-dropdown-menu"
-                ?show=${isMenuOpen}
-                .data=${[
-                  { label: 'Preview', value: 'previewProposed' },
-                  { label: 'LaTeXdiff', value: 'showLatexdiff' },
-                ]}
-                data-permission-kind=${permission.kind}
-                data-permission-id=${this.getPermissionId(permission)}
-                @vsc-click=${this.handleMenuClick}
-              ></vscode-context-menu>
-            `
-          : nothing}
-      </div>
-    `;
-  }
-
-  private renderBashRequest(permission: PermissionState): TemplateResult {
-    const data = permission.data as BashPermission;
-    const key = this.getPermissionKey(permission);
-    const isFeedbackOpen = this.feedbackOpenKeys.has(key);
-    return html`
-      <div
-        class=${classMap({
-          'bash-approval-request': true,
-          'bash-approval-request--feedback-active': isFeedbackOpen,
-        })}
-        data-permission-key=${key}
-      >
-        <div class="bash-approval-request__details">
-          <div class="bash-approval-request__command">
-            ${buildCodeBlock(data.command ?? '', { language: 'bash' })}
-          </div>
-        </div>
-        <vscode-toolbar-container class="bash-approval-request__actions">
-          <vscode-toolbar-button
-            icon="check"
-            data-action="approve"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Approve"
-            title="Allow this command to execute (y)"
-            >Approve</vscode-toolbar-button
-          >
-          ${this.renderRejectButton(
-            permission,
-            isFeedbackOpen,
-            'Reject this command (n)',
-          )}
-        </vscode-toolbar-container>
-        ${this.renderFeedbackSection(
-          permission,
-          'bash-approval-request__feedback',
-          'bash-approval-request__feedback-input',
-          'Why are you rejecting?',
-        )}
-      </div>
-    `;
-  }
-
-  private renderRetryRequest(permission: PermissionState): TemplateResult {
-    const data = permission.data as RetryPermission;
-    const isRelay = data.errorDetails?.isRelayError === true;
-    const retryable = data.errorDetails?.retryable !== false;
-    const metaParts = [
-      data.model ? `Model: ${data.model}` : null,
-      isRelay ? 'Source: Relay' : null,
-      `Retryable: ${retryable ? 'Yes' : 'No'}`,
-    ].filter(Boolean);
-
-    const detailsText = this.formatRetryDetails(data.errorDetails);
-
-    return html`
-      <div
-        class=${classMap({
-          'retry-request': true,
-          'retry-request--relay': isRelay,
-        })}
-      >
-        <div class="retry-request__details">
-          <div class="retry-request__operation">
-            ${isRelay ? '[Relay] ' : ''}
-            ${data.operation ? `Failed: ${data.operation}` : 'Request failed'}
-          </div>
-          <div class="retry-request__meta">${metaParts.join(' \u2022 ')}</div>
-          ${when(
-            data.errorMessage,
-            () =>
-              html`<div class="retry-request__error">
-                ${data.errorMessage}
-              </div>`,
-          )}
-          ${detailsText
-            ? html`
-                <details class="retry-request__error-details">
-                  <summary class="retry-request__error-summary">
-                    <i class="codicon codicon-chevron-right toggle-icon"></i>
-                    Error details
-                  </summary>
-                  <div class="retry-request__error-body">${detailsText}</div>
-                </details>
-              `
-            : nothing}
-        </div>
-        <vscode-toolbar-container class="retry-request__actions">
-          <vscode-toolbar-button
-            icon="refresh"
-            data-action="retry"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Retry"
-            title="Retry (r)"
-            >Retry</vscode-toolbar-button
-          >
-          <vscode-toolbar-button
-            icon="close"
-            data-action="dismiss"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Dismiss"
-            title="Dismiss (Esc)"
-            >Dismiss</vscode-toolbar-button
-          >
-        </vscode-toolbar-container>
-      </div>
-    `;
-  }
-
-  private renderProposalRequest(permission: PermissionState): TemplateResult {
-    const data = permission.data as AgentProposalPermission;
-    const modelOptions =
-      permission.kind === PERMISSION_KIND.PROPOSAL
-        ? (permission.modelOptions ?? [])
-        : [];
-    const key = this.getPermissionKey(permission);
-    const isFeedbackOpen = this.feedbackOpenKeys.has(key);
-    const isWorkflow = data.agentCategory === AGENT_CATEGORY.WORKFLOW;
-    const categoryLabel = isWorkflow ? 'Workflow' : 'Tool-Use';
-    const selectedModel = this.getSelectedModel(data);
-    const hasModelOptions = modelOptions.length > 0;
-
-    return html`
-      <div
-        class=${classMap({
-          'workflow-proposal': true,
-          'workflow-proposal--feedback-active': isFeedbackOpen,
-        })}
-      >
-        <div class="workflow-proposal__details">
-          <div class="workflow-proposal__header-row">
-            <span
-              class=${classMap({
-                'workflow-proposal__category-badge': true,
-                'workflow-proposal__category-badge--workflow': isWorkflow,
-                'workflow-proposal__category-badge--tool-use': !isWorkflow,
-              })}
-            >
-              ${categoryLabel}
-            </span>
-            <span class="workflow-proposal__agent">${data.agent}</span>
-            ${hasModelOptions
-              ? html`
-                  <div class="workflow-proposal__model-select">
-                    <i class="codicon codicon-robot"></i>
-                    <vscode-single-select
-                      class="proposal-model-dropdown"
-                      position="below"
-                      data-proposal-id=${data.proposalId}
-                      .value=${selectedModel}
-                      @change=${this.handleSelectChange}
-                    >
-                      ${renderModelOptions(modelOptions, selectedModel)}
-                    </vscode-single-select>
-                  </div>
-                `
-              : html`<span class="workflow-proposal__model"
-                  >${data.model}</span
-                >`}
-          </div>
-          <div class="workflow-proposal__instruction">${data.instruction}</div>
-          ${isWorkflow
-            ? html`<div class="workflow-proposal__files">
-                ${this.renderProposalFiles(
-                  data as WorkflowAgentProposalPermission,
-                )}
-              </div>`
-            : nothing}
-        </div>
-        <vscode-toolbar-container class="workflow-proposal__actions">
-          <vscode-toolbar-button
-            icon="check"
-            data-action="approve"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Approve"
-            title="Approve (y)"
-            >Approve</vscode-toolbar-button
-          >
-          ${this.renderRejectButton(permission, isFeedbackOpen, 'Reject (n)')}
-          <vscode-toolbar-button
-            icon="reply"
-            data-action="setup"
-            data-permission-kind=${permission.kind}
-            data-permission-id=${this.getPermissionId(permission)}
-            label="Setup"
-            title="Setup (s)"
-            >Setup</vscode-toolbar-button
-          >
-        </vscode-toolbar-container>
-        ${this.renderFeedbackSection(
-          permission,
-          'workflow-proposal__feedback',
-          'workflow-proposal__feedback-input',
-          'Why are you rejecting?',
-        )}
-      </div>
-    `;
-  }
-
-  private renderProposalFiles(
-    permission: WorkflowAgentProposalPermission,
-  ): TemplateResult | typeof nothing {
-    return html`${repeat(
-      getProposalFileGroups(permission),
-      ({ label }) => label,
-      ({ label, files }) => this.renderProposalFileList(label, files),
-    )}`;
-  }
-
-  private renderProposalFileList(
-    label: string,
-    files: string[],
-  ): TemplateResult | typeof nothing {
-    if (files.length === 0) return nothing;
-
-    return html`
-      <div
-        class="workflow-proposal__${label.toLowerCase()}-files"
-        @click=${this.handleProposalFileClick}
-      >
-        <span class="workflow-proposal__file-label">${label}:</span>
-        ${repeat(
-          files,
-          (file) => file,
-          (file, i) =>
-            html`${i > 0 ? ', ' : ''}<span
-                class="workflow-proposal__file-name"
-                title=${file}
-                data-file=${file}
-                >${getBasename(file)}</span
-              >`,
-        )}
-      </div>
-    `;
-  }
-
-  private handleProposalFileClick = (event: MouseEvent): void => {
-    const target = event.target as HTMLElement;
-    const file = target.dataset?.file;
-    if (file) {
-      this.openFile(file);
+    switch (tag) {
+      case 'tool-edit-request-panel':
+        return html`<tool-edit-request-panel
+          .permission=${permission}
+        ></tool-edit-request-panel>`;
+      case 'bash-request-panel':
+        return html`<bash-request-panel
+          .permission=${permission}
+        ></bash-request-panel>`;
+      case 'retry-request-panel':
+        return html`<retry-request-panel
+          .permission=${permission}
+        ></retry-request-panel>`;
+      case 'proposal-request-panel':
+        return html`<proposal-request-panel
+          .permission=${permission}
+        ></proposal-request-panel>`;
+      default:
+        return html``;
     }
-  };
-
-  private renderFeedbackSection(
-    permission: PermissionState,
-    containerClass: string,
-    inputClass: string,
-    placeholder: string,
-  ): TemplateResult | typeof nothing {
-    const key = this.getPermissionKey(permission);
-    if (
-      !this.feedbackOpenKeys.has(key) ||
-      !FEEDBACK_ELIGIBLE_KINDS.has(permission.kind)
-    ) {
-      return nothing;
-    }
-
-    return html`
-      <div class=${containerClass}>
-        <vscode-textarea
-          class=${inputClass}
-          placeholder=${placeholder}
-          rows="3"
-          data-feedback-for=${key}
-        ></vscode-textarea>
-      </div>
-    `;
-  }
-
-  private renderToolEditDiffMeta(
-    request: ToolEditPermission,
-  ): TemplateResult | typeof nothing {
-    const toCount = (value: number | undefined): number => {
-      if (value === undefined || !Number.isFinite(value)) return 0;
-      return Math.max(0, value);
-    };
-    const added = toCount(request.addedLines);
-    const removed = toCount(request.removedLines);
-    const total = added + removed;
-    const lineLabel = total === 1 ? 'line' : 'lines';
-    const tooltip = this.buildDiffTooltip(added, removed, lineLabel);
-
-    return html`
-      <span class="approval-request__diff" title=${tooltip}>
-        ${when(
-          added > 0,
-          () =>
-            html`<span class="approval-request__diff-added">+${added}</span>`,
-        )}
-        ${when(
-          removed > 0,
-          () =>
-            html`<span class="approval-request__diff-removed"
-              >-${removed}</span
-            >`,
-        )}
-        <span class="approval-request__diff-label">${total} ${lineLabel}</span>
-      </span>
-    `;
   }
 
   // ===========================================================================
-  // Event handlers
+  // Keyboard shortcuts
   // ===========================================================================
-
-  private handleActionClick = (event: MouseEvent): void => {
-    // Use composedPath to get the actual clicked element inside shadow DOM
-    const actionEl = getComposedPathElement<HTMLElement>(
-      event,
-      '[data-action][data-permission-kind][data-permission-id]',
-    );
-    if (!actionEl) return;
-
-    const action = actionEl.dataset.action;
-    const kind = actionEl.dataset.permissionKind as
-      | PermissionState['kind']
-      | undefined;
-    const permissionId = actionEl.dataset.permissionId;
-    if (!action || !kind || !permissionId) return;
-
-    const permission = this.permissions.find(
-      (item) =>
-        item.kind === kind && this.getPermissionId(item) === permissionId,
-    );
-    if (!permission) return;
-
-    const key = this.getPermissionKey(permission);
-    if (action === 'reject' && FEEDBACK_ELIGIBLE_KINDS.has(kind)) {
-      if (!this.feedbackOpenKeys.has(key)) {
-        this.openFeedback(key);
-        return;
-      }
-
-      const feedback = this.getFeedbackValue(key);
-      this.closeFeedback(key);
-      this.emitAction(permission, action, feedback);
-      return;
-    }
-
-    if (action === 'dismiss') {
-      this.emitAction(permission, 'cancel');
-      return;
-    }
-
-    this.emitAction(permission, action);
-  };
-
-  /**
-   * Handle keydown events on focusable elements within the component.
-   * Allows Enter/Space to activate buttons.
-   */
-  private handleKeydown = (event: KeyboardEvent): void => {
-    // Use composedPath to get the actual element inside shadow DOM
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-
-    const actionEl = getComposedPathElement<HTMLElement>(
-      event,
-      '[data-action][data-permission-kind][data-permission-id]',
-    );
-    if (!actionEl) return;
-
-    event.preventDefault();
-    actionEl.click();
-  };
 
   /**
    * Handle global keyboard shortcuts for permission actions.
    * Only active when permissions are visible and no text input is focused.
-   * Shortcuts: y=approve, n=reject, d=diff, r=retry, s=setup, Esc=dismiss
+   * Delegates to the first visible sub-panel's handleKeyboardShortcut().
    */
   private handleGlobalKeydown = (event: KeyboardEvent): void => {
-    // Don't intercept if typing in an input/textarea (handles Shadow DOM)
     if (isTextInput(document.activeElement)) return;
-
-    // Don't intercept if modifier keys are pressed (except shift for some)
     if (event.ctrlKey || event.metaKey || event.altKey) return;
-
-    // Only process if we have permissions
     if (this.permissions.length === 0) return;
 
-    // Get the first permission to act on (most recent/urgent)
-    const firstPermission = this.permissions[0];
-    if (!firstPermission) return;
-
-    this.handleKeyboardShortcut(event, firstPermission);
-  };
-
-  /** Process keyboard shortcuts for permission actions */
-  private handleKeyboardShortcut(
-    event: KeyboardEvent,
-    permission: PermissionState,
-  ): void {
     const key = event.key.toLowerCase();
+    const panel = this.getFirstPanel();
+    if (!panel) return;
 
-    switch (key) {
-      case 'y':
-        event.preventDefault();
-        this.emitAction(permission, 'approve');
-        break;
-
-      case 'n':
-        event.preventDefault();
-        this.handleRejectShortcut(permission);
-        break;
-
-      case 'd':
-        if (permission.kind === PERMISSION_KIND.TOOL_EDIT) {
-          event.preventDefault();
-          this.emitAction(permission, 'openDiff');
-        }
-        break;
-
-      case 'r':
-        if (permission.kind === PERMISSION_KIND.RETRY) {
-          event.preventDefault();
-          this.emitAction(permission, 'retry');
-        }
-        break;
-
-      case 's':
-        if (permission.kind === PERMISSION_KIND.PROPOSAL) {
-          event.preventDefault();
-          this.emitAction(permission, 'setup');
-        }
-        break;
-
-      case 'escape':
-        event.preventDefault();
-        this.handleEscapeShortcut(permission);
-        break;
-    }
-  }
-
-  /** Handle 'n' key for reject with feedback support */
-  private handleRejectShortcut(permission: PermissionState): void {
-    if (!FEEDBACK_ELIGIBLE_KINDS.has(permission.kind)) {
-      this.emitAction(permission, 'reject');
-      return;
-    }
-
-    const permKey = this.getPermissionKey(permission);
-    if (!this.feedbackOpenKeys.has(permKey)) {
-      this.openFeedback(permKey);
-    } else {
-      const feedback = this.getFeedbackValue(permKey);
-      this.closeFeedback(permKey);
-      this.emitAction(permission, 'reject', feedback);
-    }
-  }
-
-  /** Handle Escape key for dismiss/cancel */
-  private handleEscapeShortcut(permission: PermissionState): void {
-    if (permission.kind === PERMISSION_KIND.RETRY) {
-      this.emitAction(permission, 'cancel');
-      return;
-    }
-
-    // Close feedback if open
-    const permKey = this.getPermissionKey(permission);
-    if (this.feedbackOpenKeys.has(permKey)) {
-      this.closeFeedback(permKey);
-    }
-  }
-
-  private handleMenuClick = (event: CustomEvent): void => {
-    const menu = getComposedPathElement<HTMLElement>(
-      event,
-      'vscode-context-menu',
-    );
-    if (!menu) return;
-
-    const kind = menu.dataset.permissionKind as
-      | PermissionState['kind']
-      | undefined;
-    const permissionId = menu.dataset.permissionId;
-    const action = event.detail?.value ?? '';
-    if (!kind || !permissionId || !action) return;
-
-    const permission = this.permissions.find(
-      (item) =>
-        item.kind === kind && this.getPermissionId(item) === permissionId,
-    );
-    if (!permission) return;
-
-    this.openDiffMenuKey = null;
-    this.emitAction(permission, action);
-  };
-
-  private handleOutsideClick = (event: MouseEvent): void => {
-    if (!this.openDiffMenuKey) return;
-
-    const path = event.composedPath?.() ?? [];
-    const clickedInside = path.some(
-      (node) =>
-        node instanceof Element &&
-        (node.classList.contains('diff-dropdown') ||
-          node.classList.contains('diff-dropdown-menu')),
-    );
-    if (!clickedInside) {
-      this.openDiffMenuKey = null;
+    if (panel.handleKeyboardShortcut(key)) {
+      event.preventDefault();
     }
   };
 
-  private toggleDiffMenu(event: MouseEvent, key: PermissionKey): void {
-    event.stopPropagation();
-    this.openDiffMenuKey = this.openDiffMenuKey === key ? null : key;
-  }
-
-  private openFeedback(key: PermissionKey): void {
-    const next = new Set(this.feedbackOpenKeys);
-    next.add(key);
-    this.feedbackOpenKeys = next;
-
-    this.updateComplete.then(() => {
-      const input = this.renderRoot.querySelector<HTMLElement>(
-        `[data-feedback-for="${key}"]`,
-      );
-      input?.focus();
-    });
-  }
-
-  private closeFeedback(key: PermissionKey): void {
-    const next = new Set(this.feedbackOpenKeys);
-    next.delete(key);
-    this.feedbackOpenKeys = next;
-  }
-
-  private getFeedbackValue(key: PermissionKey): string | undefined {
-    const input = this.renderRoot.querySelector<HTMLElement>(
-      `[data-feedback-for="${key}"]`,
-    ) as HTMLElement & { value?: string };
-    const trimmed = (input?.value ?? '').trim();
-    return trimmed || undefined;
-  }
-
-  // ===========================================================================
-  // Shared renderers
-  // ===========================================================================
-
-  private renderRejectButton(
-    permission: PermissionState,
-    isFeedbackOpen: boolean,
-    rejectTitle: string,
-  ): TemplateResult {
-    return html`
-      <vscode-toolbar-button
-        icon=${isFeedbackOpen ? 'check' : 'close'}
-        data-action="reject"
-        data-permission-kind=${permission.kind}
-        data-permission-id=${this.getPermissionId(permission)}
-        label=${isFeedbackOpen ? 'Submit' : 'Reject'}
-        title=${isFeedbackOpen ? 'Submit rejection (n)' : rejectTitle}
-        >${isFeedbackOpen ? 'Submit' : 'Reject'}</vscode-toolbar-button
-      >
-    `;
+  /** Find the first rendered sub-panel element in shadow DOM */
+  private getFirstPanel(): KeyboardPanel | null {
+    return this.renderRoot.querySelector<KeyboardPanel>(PANEL_SELECTOR);
   }
 
   // ===========================================================================
   // Utilities
   // ===========================================================================
 
-  private getPermissionId(permission: PermissionState): string {
-    switch (permission.kind) {
-      case PERMISSION_KIND.RETRY:
-        return permission.data.streamId;
-      case PERMISSION_KIND.PROPOSAL:
-        return permission.data.proposalId;
-      default:
-        return permission.data.requestId;
-    }
-  }
-
-  private getPermissionKey(permission: PermissionState): PermissionKey {
-    return `${permission.kind}:${this.getPermissionId(permission)}`;
-  }
-
-  private openFile(filePath: string): void {
-    postMessage(PROGRESS_VIEW_COMMANDS.OPEN_FILE, { file: filePath });
-  }
-
-  /** Get the selected model for a proposal, falling back to the proposal's original model. */
-  private getSelectedModel(data: AgentProposalPermission): string {
-    return this.selectedModels.get(data.proposalId) ?? data.model;
-  }
-
-  /** Delegated change handler for model dropdowns in proposal cards. */
-  private handleSelectChange = (event: Event): void => {
-    const target = event.target as HTMLElement | null;
-    const proposalId = target?.dataset?.proposalId;
-    if (!proposalId) return;
-    const value = (target as HTMLSelectElement).value;
-    if (!value) return;
-    const next = new Map(this.selectedModels);
-    next.set(proposalId, value);
-    this.selectedModels = next;
-  };
-
-  /** Get the model override for a proposal if different from original. */
-  private getModelOverride(permission: PermissionState): string | undefined {
-    if (permission.kind !== PERMISSION_KIND.PROPOSAL) return undefined;
-    const data = permission.data as AgentProposalPermission;
-    const selected = this.selectedModels.get(data.proposalId);
-    return selected && selected !== data.model ? selected : undefined;
-  }
-
-  private emitAction(
-    permission: PermissionState,
-    action: string,
-    feedback?: string,
-  ): void {
-    const modelOverride =
-      action === 'approve' ? this.getModelOverride(permission) : undefined;
-    this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission,
-        action,
-        feedback,
-        modelOverride,
-      }),
-    );
-  }
-
-  private buildDiffTooltip(
-    added: number,
-    removed: number,
-    lineLabel: string,
-  ): string {
-    if (added === 0 && removed === 0) {
-      return 'No line changes';
-    }
-    const parts: string[] = [];
-    if (added > 0) parts.push(`+${added}`);
-    if (removed > 0) parts.push(`-${removed}`);
-    return `${parts.join(' / ')} ${lineLabel} changed`;
-  }
-
-  private formatRetryDetails(
-    details: ProviderErrorPartial | undefined,
-  ): string | null {
-    if (!details) return null;
-
-    const formatBody = (v: unknown) =>
-      typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v);
-
-    const lines = [
-      details.provider && `provider: ${details.provider}`,
-      details.requestId && `requestId: ${details.requestId}`,
-      details.rawErrorBody != null &&
-        `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
-    ].filter(Boolean);
-
-    const diag = details.streamDiagnostics;
-    if (diag && (diag.eventsProcessed > 0 || diag.messageStartReceived)) {
-      const entries = Object.entries(diag).map(([k, v]) =>
-        k === 'blockTypesSeen'
-          ? `  ${k}: [${(v as string[])?.join(', ') || ''}]`
-          : `  ${k}: ${v ?? 'null'}`,
-      );
-      lines.push('--- Stream Diagnostics ---', ...entries);
-    }
-
-    return lines.length > 0 ? lines.join('\n') : null;
+  private getPermissionKey(permission: PermissionState): string {
+    const id =
+      permission.kind === PERMISSION_KIND.RETRY
+        ? permission.data.streamId
+        : permission.kind === PERMISSION_KIND.PROPOSAL
+          ? permission.data.proposalId
+          : permission.data.requestId;
+    return `${permission.kind}:${id}`;
   }
 }
 

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -4,7 +4,7 @@
  * Groups permissions by kind and renders section headers with
  * individual panel components. Manages global keyboard shortcuts
  * (y=approve, n=reject, d=diff, r=retry, s=setup, Esc=dismiss)
- * by delegating to the first visible panel.
+ * by delegating to the panel matching the newest permission in the queue.
  */
 
 // Third-party imports
@@ -197,7 +197,7 @@ export class RequestPanels extends LitElement {
   /**
    * Handle global keyboard shortcuts for permission actions.
    * Only active when permissions are visible and no text input is focused.
-   * Delegates to the first visible sub-panel's handleKeyboardShortcut().
+   * Delegates to the panel matching the newest permission (permissions[0]).
    */
   private handleGlobalKeydown = (event: KeyboardEvent): void => {
     if (isTextInput(document.activeElement)) return;
@@ -205,7 +205,7 @@ export class RequestPanels extends LitElement {
     if (this.permissions.length === 0) return;
 
     const key = event.key.toLowerCase();
-    const panel = this.getFirstPanel();
+    const panel = this.getNewestPanel();
     if (!panel) return;
 
     if (panel.handleKeyboardShortcut(key)) {
@@ -213,9 +213,22 @@ export class RequestPanels extends LitElement {
     }
   };
 
-  /** Find the first rendered sub-panel element in shadow DOM */
-  private getFirstPanel(): BaseRequestPanel | null {
-    return this.renderRoot.querySelector<BaseRequestPanel>(PANEL_SELECTOR);
+  /**
+   * Find the panel for the newest permission (first in the queue).
+   *
+   * Permissions are prepended so index 0 is always the latest request.
+   * We match by reference rather than querying DOM order, which follows
+   * fixed section ordering (approval → bash → retry → proposal) and
+   * would target the wrong panel when mixed kinds are pending.
+   */
+  private getNewestPanel(): BaseRequestPanel | null {
+    const newest = this.permissions[0];
+    const panels =
+      this.renderRoot.querySelectorAll<BaseRequestPanel>(PANEL_SELECTOR);
+    for (const panel of panels) {
+      if (panel.permission === newest) return panel;
+    }
+    return null;
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -31,25 +31,13 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - progress view component types
 import type { PermissionState } from './PermissionCard';
+import type { BaseRequestPanel } from './BaseRequestPanel';
 
 // Side-effect imports to register sub-panel custom elements
 import './ToolEditRequestPanel';
 import './BashRequestPanel';
 import './RetryRequestPanel';
 import './ProposalRequestPanel';
-
-// Import sub-panel types for keyboard delegation
-import type { ToolEditRequestPanel } from './ToolEditRequestPanel';
-import type { BashRequestPanel } from './BashRequestPanel';
-import type { RetryRequestPanel } from './RetryRequestPanel';
-import type { ProposalRequestPanel } from './ProposalRequestPanel';
-
-/** Common interface for sub-panels that support keyboard shortcuts */
-type KeyboardPanel =
-  | ToolEditRequestPanel
-  | BashRequestPanel
-  | RetryRequestPanel
-  | ProposalRequestPanel;
 
 /** Selector to find any sub-panel in shadow DOM */
 const PANEL_SELECTOR =
@@ -60,7 +48,7 @@ interface SectionConfig {
   cssClass: string;
   icon: string;
   title: string;
-  panelTag: string;
+  renderPanel: (p: PermissionState) => TemplateResult;
 }
 
 const SECTION_CONFIGS: Record<string, SectionConfig> = {
@@ -68,25 +56,33 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
     cssClass: 'approval-requests',
     icon: 'diff',
     title: 'Tool edit approval',
-    panelTag: 'tool-edit-request-panel',
+    renderPanel: (p) =>
+      html`<tool-edit-request-panel
+        .permission=${p}
+      ></tool-edit-request-panel>`,
   },
   bash: {
     cssClass: 'bash-approval-requests',
     icon: 'terminal',
     title: 'Command approval',
-    panelTag: 'bash-request-panel',
+    renderPanel: (p) =>
+      html`<bash-request-panel .permission=${p}></bash-request-panel>`,
   },
   retry: {
     cssClass: 'retry-requests',
     icon: 'refresh',
     title: 'Retry request',
-    panelTag: 'retry-request-panel',
+    renderPanel: (p) =>
+      html`<retry-request-panel .permission=${p}></retry-request-panel>`,
   },
   proposal: {
     cssClass: 'workflow-proposals',
     icon: 'rocket',
     title: 'Agent proposal',
-    panelTag: 'proposal-request-panel',
+    renderPanel: (p) =>
+      html`<proposal-request-panel
+        .permission=${p}
+      ></proposal-request-panel>`,
   },
 };
 
@@ -187,38 +183,11 @@ export class RequestPanels extends LitElement {
           ${repeat(
             permissions,
             (p) => this.getPermissionKey(p),
-            (p) =>
-              this.renderPanel(config.panelTag, p),
+            (p) => config.renderPanel(p),
           )}
         </div>
       </section>
     `;
-  }
-
-  private renderPanel(
-    tag: string,
-    permission: PermissionState,
-  ): TemplateResult {
-    switch (tag) {
-      case 'tool-edit-request-panel':
-        return html`<tool-edit-request-panel
-          .permission=${permission}
-        ></tool-edit-request-panel>`;
-      case 'bash-request-panel':
-        return html`<bash-request-panel
-          .permission=${permission}
-        ></bash-request-panel>`;
-      case 'retry-request-panel':
-        return html`<retry-request-panel
-          .permission=${permission}
-        ></retry-request-panel>`;
-      case 'proposal-request-panel':
-        return html`<proposal-request-panel
-          .permission=${permission}
-        ></proposal-request-panel>`;
-      default:
-        return html``;
-    }
   }
 
   // ===========================================================================
@@ -245,8 +214,8 @@ export class RequestPanels extends LitElement {
   };
 
   /** Find the first rendered sub-panel element in shadow DOM */
-  private getFirstPanel(): KeyboardPanel | null {
-    return this.renderRoot.querySelector<KeyboardPanel>(PANEL_SELECTOR);
+  private getFirstPanel(): BaseRequestPanel | null {
+    return this.renderRoot.querySelector<BaseRequestPanel>(PANEL_SELECTOR);
   }
 
   // ===========================================================================

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -4,12 +4,12 @@
  * Renders a single retry permission with error details,
  * retry/dismiss buttons, and stream diagnostics.
  *
- * Exposes `handleKeyboardShortcut(key)` for container-driven keyboard support.
+ * Extends BaseRequestPanel for shared permission/emit/keyboard contract.
  */
 
 // Third-party imports
-import { LitElement, html, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { when } from 'lit/directives/when.js';
 
@@ -22,16 +22,13 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
-import { ProgressEvents } from '../events';
 import type { ProviderErrorPartial, RetryPermission } from '@shared/schemas';
 
-// Local imports - progress view events
-
-// Local imports - progress view component types
-import type { PermissionState } from './PermissionCard';
+// Local imports - base class
+import { BaseRequestPanel } from './BaseRequestPanel';
 
 @customElement('retry-request-panel')
-export class RetryRequestPanel extends LitElement {
+export class RetryRequestPanel extends BaseRequestPanel {
   static override styles = [
     designTokens,
     commonViewStyles,
@@ -39,10 +36,7 @@ export class RetryRequestPanel extends LitElement {
     requestPanelStyles,
   ];
 
-  @property({ attribute: false }) permission!: PermissionState;
-
-  /** Handle keyboard shortcut from container. Returns true if handled. */
-  handleKeyboardShortcut(key: string): boolean {
+  override handleKeyboardShortcut(key: string): boolean {
     switch (key) {
       case 'r':
         this.emitAction('retry');
@@ -122,15 +116,6 @@ export class RetryRequestPanel extends LitElement {
   // ===========================================================================
   // Utilities
   // ===========================================================================
-
-  private emitAction(action: string): void {
-    this.dispatchEvent(
-      ProgressEvents.permissionAction({
-        permission: this.permission,
-        action,
-      }),
-    );
-  }
 
   private formatRetryDetails(
     details: ProviderErrorPartial | undefined,

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -1,0 +1,169 @@
+/**
+ * Individual panel component for retry requests.
+ *
+ * Renders a single retry permission with error details,
+ * retry/dismiss buttons, and stream diagnostics.
+ *
+ * Exposes `handleKeyboardShortcut(key)` for container-driven keyboard support.
+ */
+
+// Third-party imports
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { when } from 'lit/directives/when.js';
+
+// Local imports - shared styles
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+
+// Local imports - shared schemas
+import { ProgressEvents } from '../events';
+import type { ProviderErrorPartial, RetryPermission } from '@shared/schemas';
+
+// Local imports - progress view events
+
+// Local imports - progress view component types
+import type { PermissionState } from './PermissionCard';
+
+@customElement('retry-request-panel')
+export class RetryRequestPanel extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    requestPanelStyles,
+  ];
+
+  @property({ attribute: false }) permission!: PermissionState;
+
+  /** Handle keyboard shortcut from container. Returns true if handled. */
+  handleKeyboardShortcut(key: string): boolean {
+    switch (key) {
+      case 'r':
+        this.emitAction('retry');
+        return true;
+      case 'escape':
+        this.emitAction('cancel');
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  override render(): TemplateResult {
+    const data = this.permission.data as RetryPermission;
+    const isRelay = data.errorDetails?.isRelayError === true;
+    const retryable = data.errorDetails?.retryable !== false;
+    const metaParts = [
+      data.model ? `Model: ${data.model}` : null,
+      isRelay ? 'Source: Relay' : null,
+      `Retryable: ${retryable ? 'Yes' : 'No'}`,
+    ].filter(Boolean);
+
+    const detailsText = this.formatRetryDetails(data.errorDetails);
+
+    return html`
+      <div
+        class=${classMap({
+          'retry-request': true,
+          'retry-request--relay': isRelay,
+        })}
+      >
+        <div class="retry-request__details">
+          <div class="retry-request__operation">
+            ${isRelay ? '[Relay] ' : ''}
+            ${data.operation ? `Failed: ${data.operation}` : 'Request failed'}
+          </div>
+          <div class="retry-request__meta">${metaParts.join(' \u2022 ')}</div>
+          ${when(
+            data.errorMessage,
+            () =>
+              html`<div class="retry-request__error">
+                ${data.errorMessage}
+              </div>`,
+          )}
+          ${detailsText
+            ? html`
+                <details class="retry-request__error-details">
+                  <summary class="retry-request__error-summary">
+                    <i class="codicon codicon-chevron-right toggle-icon"></i>
+                    Error details
+                  </summary>
+                  <div class="retry-request__error-body">${detailsText}</div>
+                </details>
+              `
+            : nothing}
+        </div>
+        <vscode-toolbar-container class="retry-request__actions">
+          <vscode-toolbar-button
+            icon="refresh"
+            label="Retry"
+            title="Retry (r)"
+            @click=${() => this.emitAction('retry')}
+            >Retry</vscode-toolbar-button
+          >
+          <vscode-toolbar-button
+            icon="close"
+            label="Dismiss"
+            title="Dismiss (Esc)"
+            @click=${() => this.emitAction('cancel')}
+            >Dismiss</vscode-toolbar-button
+          >
+        </vscode-toolbar-container>
+      </div>
+    `;
+  }
+
+  // ===========================================================================
+  // Utilities
+  // ===========================================================================
+
+  private emitAction(action: string): void {
+    this.dispatchEvent(
+      ProgressEvents.permissionAction({
+        permission: this.permission,
+        action,
+      }),
+    );
+  }
+
+  private formatRetryDetails(
+    details: ProviderErrorPartial | undefined,
+  ): string | null {
+    if (!details) return null;
+
+    const formatBody = (v: unknown) =>
+      typeof v === 'object' ? JSON.stringify(v, null, 2) : String(v);
+
+    const lines = [
+      details.provider && `provider: ${details.provider}`,
+      details.requestId && `requestId: ${details.requestId}`,
+      details.rawErrorBody !== undefined &&
+        details.rawErrorBody !== null &&
+        `rawErrorBody: ${formatBody(details.rawErrorBody)}`,
+    ].filter(Boolean);
+
+    const diag = details.streamDiagnostics;
+    if (diag && (diag.eventsProcessed > 0 || diag.messageStartReceived)) {
+      const entries = Object.entries(diag).map(([k, v]) =>
+        k === 'blockTypesSeen'
+          ? `  ${k}: [${(v as string[])?.join(', ') || ''}]`
+          : `  ${k}: ${v ?? 'null'}`,
+      );
+      lines.push('--- Stream Diagnostics ---', ...entries);
+    }
+
+    return lines.length > 0 ? lines.join('\n') : null;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'retry-request-panel': RetryRequestPanel;
+  }
+}

--- a/src/progressView/frontend/components/TaskGroupHeader.ts
+++ b/src/progressView/frontend/components/TaskGroupHeader.ts
@@ -9,6 +9,7 @@ import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - progress view constants
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+import { formatDuration } from '@utils/core';
 import { STREAM_STATUS } from '../constants';
 
 // Local imports - progress view styles
@@ -19,7 +20,6 @@ import {
   getDateTimeFormatter,
   getTimeFormatter,
 } from '../formatters/timestampUtils';
-import { formatDuration } from '@utils/core';
 
 // Local imports - shared schemas
 import type { TaskGroup } from '@shared/schemas';

--- a/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -48,26 +48,12 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
     super.disconnectedCallback();
   }
 
-  override handleKeyboardShortcut(key: string): boolean {
-    switch (key) {
-      case 'y':
-        this.emitAction('approve');
-        return true;
-      case 'n':
-        this.handleRejectAction();
-        return true;
-      case 'd':
-        this.emitAction('openDiff');
-        return true;
-      case 'escape':
-        if (this.showFeedback) {
-          this.showFeedback = false;
-          return true;
-        }
-        return false;
-      default:
-        return false;
+  protected override handleExtraKey(key: string): boolean {
+    if (key === 'd') {
+      this.emitAction('openDiff');
+      return true;
     }
+    return false;
   }
 
   override render(): TemplateResult {

--- a/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -1,0 +1,233 @@
+/**
+ * Individual panel component for tool edit approval requests.
+ *
+ * Renders a single tool edit permission with diff metadata, diff actions
+ * (including LaTeX dropdown), approve/reject buttons, and feedback input.
+ *
+ * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
+ */
+
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { when } from 'lit/directives/when.js';
+
+// Local imports - shared styles
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+// Local imports - shared schemas
+import type { ToolEditPermission } from '@shared/schemas';
+
+@customElement('tool-edit-request-panel')
+export class ToolEditRequestPanel extends BaseFeedbackPanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    requestPanelStyles,
+  ];
+
+  @state() private diffMenuOpen = false;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('click', this.handleOutsideClick, true);
+  }
+
+  override disconnectedCallback(): void {
+    document.removeEventListener('click', this.handleOutsideClick, true);
+    super.disconnectedCallback();
+  }
+
+  override handleKeyboardShortcut(key: string): boolean {
+    switch (key) {
+      case 'y':
+        this.emitAction('approve');
+        return true;
+      case 'n':
+        this.handleRejectAction();
+        return true;
+      case 'd':
+        this.emitAction('openDiff');
+        return true;
+      case 'escape':
+        if (this.showFeedback) {
+          this.showFeedback = false;
+          return true;
+        }
+        return false;
+      default:
+        return false;
+    }
+  }
+
+  override render(): TemplateResult {
+    const data = this.permission.data as ToolEditPermission;
+    const diffMeta = this.renderDiffMeta(data);
+
+    return html`
+      <div
+        class=${classMap({
+          'approval-request': true,
+          'approval-request--feedback-active': this.showFeedback,
+        })}
+      >
+        <div class="approval-request__details">
+          <div class="approval-request__path">
+            ${data.relativePath || data.path}
+          </div>
+          <div class="approval-request__meta">
+            ${data.sourceTool ? `Requested by ${data.sourceTool}` : ''}
+            ${data.sourceTool && diffMeta ? html`<span>•</span>` : nothing}
+            ${diffMeta}
+          </div>
+        </div>
+        <vscode-toolbar-container class="approval-request__actions">
+          ${this.renderDiffActions()}
+          <vscode-toolbar-button
+            icon="check"
+            label="Approve"
+            title="Approve (y)"
+            @click=${() => this.emitAction('approve')}
+            >Approve</vscode-toolbar-button
+          >
+          ${this.renderRejectButton('Reject (n)')}
+        </vscode-toolbar-container>
+        ${this.renderFeedbackSection(
+          'approval-request__feedback',
+          'approval-request__feedback-input',
+        )}
+      </div>
+    `;
+  }
+
+  // ===========================================================================
+  // Diff-specific rendering
+  // ===========================================================================
+
+  private renderDiffActions(): TemplateResult {
+    const data = this.permission.data as ToolEditPermission;
+    const showDropdown = Boolean(data.isLatex);
+
+    return html`
+      <div class="diff-dropdown">
+        <vscode-toolbar-button
+          icon="diff"
+          class="diff-main-button"
+          label="Open diff"
+          title="Open diff (d)"
+          @click=${() => this.emitAction('openDiff')}
+          >Open diff</vscode-toolbar-button
+        >
+        ${showDropdown
+          ? html`
+              <vscode-toolbar-button
+                class="diff-dropdown-trigger"
+                aria-haspopup="true"
+                aria-expanded=${this.diffMenuOpen ? 'true' : 'false'}
+                label="More diff actions"
+                title="More diff actions"
+                @click=${this.toggleDiffMenu}
+              >
+                <i class="codicon codicon-chevron-down"></i>
+              </vscode-toolbar-button>
+              <vscode-context-menu
+                class="diff-dropdown-menu"
+                ?show=${this.diffMenuOpen}
+                .data=${[
+                  { label: 'Preview', value: 'previewProposed' },
+                  { label: 'LaTeXdiff', value: 'showLatexdiff' },
+                ]}
+                @vsc-click=${this.handleMenuClick}
+              ></vscode-context-menu>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderDiffMeta(
+    request: ToolEditPermission,
+  ): TemplateResult | typeof nothing {
+    const toCount = (value: number | undefined): number => {
+      if (value === undefined || !Number.isFinite(value)) return 0;
+      return Math.max(0, value);
+    };
+    const added = toCount(request.addedLines);
+    const removed = toCount(request.removedLines);
+    const total = added + removed;
+    const lineLabel = total === 1 ? 'line' : 'lines';
+
+    const parts: string[] = [];
+    if (added > 0) parts.push(`+${added}`);
+    if (removed > 0) parts.push(`-${removed}`);
+    const tooltip =
+      total === 0
+        ? 'No line changes'
+        : `${parts.join(' / ')} ${lineLabel} changed`;
+
+    return html`
+      <span class="approval-request__diff" title=${tooltip}>
+        ${when(
+          added > 0,
+          () =>
+            html`<span class="approval-request__diff-added">+${added}</span>`,
+        )}
+        ${when(
+          removed > 0,
+          () =>
+            html`<span class="approval-request__diff-removed"
+              >-${removed}</span
+            >`,
+        )}
+        <span class="approval-request__diff-label">${total} ${lineLabel}</span>
+      </span>
+    `;
+  }
+
+  // ===========================================================================
+  // Diff menu handlers
+  // ===========================================================================
+
+  private handleMenuClick = (event: CustomEvent): void => {
+    const action = event.detail?.value ?? '';
+    if (!action) return;
+    this.diffMenuOpen = false;
+    this.emitAction(action);
+  };
+
+  private handleOutsideClick = (event: MouseEvent): void => {
+    if (!this.diffMenuOpen) return;
+
+    const path = event.composedPath?.() ?? [];
+    const clickedInside = path.some(
+      (node) =>
+        node instanceof Element &&
+        (node.classList.contains('diff-dropdown') ||
+          node.classList.contains('diff-dropdown-menu')),
+    );
+    if (!clickedInside) {
+      this.diffMenuOpen = false;
+    }
+  };
+
+  private toggleDiffMenu = (event: MouseEvent): void => {
+    event.stopPropagation();
+    this.diffMenuOpen = !this.diffMenuOpen;
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'tool-edit-request-panel': ToolEditRequestPanel;
+  }
+}

--- a/src/progressView/frontend/components/UsagePanel.ts
+++ b/src/progressView/frontend/components/UsagePanel.ts
@@ -8,13 +8,13 @@ import { designTokens } from '@shared/styles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - shared schemas
-import type { TokenUsageStats } from '@shared/schemas';
 
 // Local imports - progress view formatters
 import { formatTokens } from '../formatters/timestampUtils';
 
 // Local imports - progress view constants and types
 import { ELEMENT_IDS } from '../constants';
+import type { TokenUsageStats } from '@shared/schemas';
 import type { ContextState } from '../store';
 
 @customElement('usage-panel')

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -10,7 +10,6 @@
 // Local imports - shared utilities
 import { isPlainObject } from '@shared/utils/string';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
-import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
 import type { TextEditorInput } from '@tools/TextEditorTool';
@@ -21,6 +20,7 @@ import type {
   WorkflowAgentInput,
 } from '@tools/WorkflowTool';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
+import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 
 // Local imports - Lit template utilities
 import {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -34,21 +34,20 @@ import {
   getToolUseAgents,
   loadAgents,
 } from '@agent/index';
-import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
-import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
-import {
-  BaseViewMessageHandler,
-  SETTINGS_VIEW_COMMANDS,
-} from '@common/webview';
-import { showLoggedErrorMessage } from '@common/errors';
 import {
   listExecutions,
   deleteExecution,
   deleteAllExecutions,
   readConfig,
 } from '@agent/storage';
+import { selectAgentInMainView } from '@agent/remote/remoteAgentUtils';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
+import {
+  BaseViewMessageHandler,
+  SETTINGS_VIEW_COMMANDS,
+} from '@common/webview';
+import { showLoggedErrorMessage } from '@common/errors';
 import {
   GlobalStateKey,
   WorkspaceStateKey,
@@ -56,11 +55,16 @@ import {
   workspaceSM,
 } from '@common/state';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
+import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import {
   DEFAULT_MODELS,
   formatContext,
   formatCost,
 } from '@model/computeModelOptions';
+import {
+  _disableAllProposalBypasses,
+  setToolEditApprovalSessionBypass,
+} from '@tools/approval';
 import { MEMORY_STORAGE_ROOT } from '@tools/memory/constants';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
@@ -78,10 +82,6 @@ import {
 } from '@utils/config/constants';
 import { getConfig } from '@utils/config/configUtils';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
-import {
-  _disableAllProposalBypasses,
-  setToolEditApprovalSessionBypass,
-} from '@tools/approval';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import type {

--- a/src/settingsView/SettingsViewProvider.ts
+++ b/src/settingsView/SettingsViewProvider.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - common webview
+import { type SettingsTab } from '@shared/schemas/settingsViewMessages';
 import { BaseWebviewProvider, SETTINGS_VIEW_COMMANDS } from '@common/webview';
 
 // Local imports - settings view components
@@ -9,7 +10,6 @@ import { SettingsViewContentProvider } from './SettingsViewContentProvider';
 import { SettingsViewMessageHandler } from './SettingsViewMessageHandler';
 
 // Local imports - shared schemas
-import { type SettingsTab } from '@shared/schemas/settingsViewMessages';
 import type { AgentCategory } from '@shared/schemas/agent';
 
 export class SettingsViewProvider

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -6,7 +6,6 @@
 // Third-party imports
 import { html, css, type TemplateResult } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
-import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Local imports - shared webview
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
@@ -49,6 +48,7 @@ import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
 
 // Local imports - settings view styles
 import { settingsViewStyles } from './styles';
+import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Local imports - shared schema types
 import type { AgentCategory } from '@shared/schemas/agent';

--- a/src/settingsView/frontend/tabs/HistoryTab.ts
+++ b/src/settingsView/frontend/tabs/HistoryTab.ts
@@ -16,10 +16,10 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared schemas
+import { HistoryViewState } from '../components/history/state';
 import type { HistoryItem } from '@shared/schemas';
 
 // Local imports - settings view components
-import { HistoryViewState } from '../components/history/state';
 import '../components/history/SearchBar';
 import '../components/history/HistoryList';
 import type { SearchAction } from '../components/history/HistoryList';

--- a/src/settingsView/utils/memoryFileSystem.ts
+++ b/src/settingsView/utils/memoryFileSystem.ts
@@ -8,7 +8,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
 import {
   MEMORY_STORAGE_ROOT,
   MAX_PREVIEW_LINES,
@@ -17,6 +16,7 @@ import {
 } from '@tools/memory/constants';
 import { relativeToDisplayPath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
+import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
 
 /**
  * Builds a preview of content with truncation info.

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -11,11 +11,11 @@ import { themeContext } from '@shared/contexts/themeContext';
 
 // Local imports - webview commands
 import { postMessage } from '@shared/vscode';
+import { installToolbarTooltips } from '@shared/controllers';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 
 // Local imports - shared controllers
-import { installToolbarTooltips } from '@shared/controllers';
 
 /**
  * Base class for Lit-powered webview apps.

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -2,6 +2,12 @@
 import { strict as assert } from 'assert';
 
 // Local imports - agent
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelCapabilities,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 
@@ -9,12 +15,6 @@ import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropi
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model config
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelCapabilities,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
 import * as configModule from '@utils/config';
 import { pathToLocation } from '@utils/files';
 

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -10,6 +10,12 @@ import {
 
 // Local imports - agent
 import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelCapabilities,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+import {
   ModelHandlerGoogleGenAI,
   validateGoogleMessageHistory,
 } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
@@ -19,12 +25,6 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model config
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelCapabilities,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
 import { pathToLocation, type FileLocation } from '@utils/files';
 
 // Type imports

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
@@ -4,6 +4,11 @@ import { strict as assert } from 'assert';
 // (none needed)
 
 // Local imports - agent
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
 import { ModelHandlerDashScope } from '@agent/modelHandlers/modelHandlerDashScope';
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/modelHandlerDeepSeek';
 import { ModelHandlerKimi } from '@agent/modelHandlers/modelHandlerKimi';
@@ -12,11 +17,6 @@ import { ModelHandlerKimi } from '@agent/modelHandlers/modelHandlerKimi';
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - model config
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
 
 type LoggerStub = Partial<AgentLogger> & {
   streamId: string;

--- a/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
+++ b/src/test/agent/modelHandlers/support/MediaAttachmentProcessor.test.ts
@@ -9,6 +9,7 @@ import { strict as assert } from 'assert';
 import { PDFDocument, StandardFonts } from '@cantoo/pdf-lib';
 
 // Local imports - agent
+import { DEFAULT_MODEL_CAPABILITIES, type ModelCapabilities } from 'llm-zoo';
 import {
   MediaAttachmentProcessor,
   type MediaFileResult,
@@ -18,7 +19,6 @@ import {
 import type { AgentLogger } from '@logger/AgentLogger';
 
 // Internal imports
-import { DEFAULT_MODEL_CAPABILITIES, type ModelCapabilities } from 'llm-zoo';
 import { AbsoluteFS, pathToLocation, getShortDisplayPath } from '@utils/files';
 
 interface LoggerStub extends Partial<AgentLogger> {

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -9,10 +9,10 @@ import {
 } from '@google/genai';
 
 // Local imports - agent
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
 import type { AgentSetting } from '@agent/core/AgentDataclass';
 // Internal imports
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
-import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
 
 // Type imports
 import type { Content } from '@google/genai';

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -2,6 +2,11 @@
 import { strict as assert } from 'assert';
 
 // Local imports - agent core
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import { createRunState } from '@agent/core/AgentState';
@@ -22,11 +27,6 @@ import type { ExecResult } from '@agent/types/ResultTypes';
 // Internal imports
 import { MapToolRegistry } from '@agent/core/ToolTypes';
 import { AgentLogger } from '@logger/AgentLogger';
-import {
-  DEFAULT_MODEL_CAPABILITIES,
-  type ModelConfig,
-  ModelProvider,
-} from 'llm-zoo';
 import { BashTool } from '@tools/bash';
 import * as execUtils from '@utils/system/execUtils';
 import type { StreamTabId } from '@shared/schemas';

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 // Local imports - tools
+import { getExecutionStore } from '@agent/storage';
 import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 import {
@@ -39,7 +40,6 @@ import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 
 // Local imports - storage
-import { getExecutionStore } from '@agent/storage';
 
 import type { ExecutionId, FileLocation } from '@shared/schemas';
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -15,6 +15,11 @@ import { z } from 'zod';
 
 // Local imports - agent
 import {
+  EXECUTION_STATUS,
+  ExecutionIdSchema,
+  type ExecutionId,
+} from '@shared/schemas';
+import {
   getExecutionStore,
   type ExecutionListingEntry,
   type ChildRecord,
@@ -46,11 +51,6 @@ import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
-import {
-  EXECUTION_STATUS,
-  ExecutionIdSchema,
-  type ExecutionId,
-} from '@shared/schemas';
 
 // ============================================================================
 // Category-aware field filtering

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -20,6 +20,7 @@ import {
   type ToolUseAgentProposal,
   type StreamTabId,
 } from '@shared/schemas';
+import { getExecutionStore, registerExecution } from '@agent/storage';
 import {
   getAgent,
   getVisibleWorkflowAgents,
@@ -63,7 +64,6 @@ import { defineTool } from '@tools/core/define';
 // Local imports - utils
 import { WorkspaceFS } from '@utils/files';
 import { generateExecutionId } from '@utils/core/executionId';
-import { getExecutionStore, registerExecution } from '@agent/storage';
 
 // ============================================================================
 // Shared utilities

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -7,8 +7,8 @@ import { LsTool } from '@tools/ls';
 import { ToolError, ToolResult } from '@tools/result';
 import { formatToolOutput } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
-import { toPosixPath } from '@utils/core/pathCore';
 import { WorkspaceFS } from '@utils/files';
+import { toPosixPath } from '@utils/core/pathCore';
 import { arxivProcessor } from '@latex/arxivProcessor';
 
 const ArxivDownloadInputSchema = z.strictObject({

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -7,28 +7,27 @@ import * as path from 'path';
 import { z } from 'zod';
 
 // Local imports - agent
-import type { StreamTabId, ExecutionId } from '@shared/schemas';
+import {
+  getExecutionStore,
+  registerExecution,
+  writeTerminalStatus,
+} from '@agent/storage';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
   trackExecution,
   untrackExecution,
   ProcessExecutionHandle,
 } from '@agent/runtime/executionRegistry';
-import {
-  getExecutionStore,
-  registerExecution,
-  writeTerminalStatus,
-} from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
 // Local imports - tools
 import { ToolError, type ToolResult } from '@tools/result';
+import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
 } from '@tools/approval/bashApproval';
-import { formatBashDelivery, formatBashError } from '@tools/subagentResults';
 import { executeCommand, signalProcessGroup } from '@utils/system/execUtils';
 
 // Local imports - utils
@@ -37,6 +36,7 @@ import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 // Local file imports
 import { defineTool } from './core/define';
+import type { StreamTabId, ExecutionId } from '@shared/schemas';
 
 const BASH_TIMEOUT_MS = 120_000; // 120 s
 

--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -3,9 +3,9 @@ import * as os from 'os';
 import * as path from 'path';
 
 // Local imports - utils
-import { toPosixPath } from '@utils/core/pathCore';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
+import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports
 import { createGlobMatcher } from './utils';

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -12,8 +12,8 @@ import {
   pluralize,
 } from '@tools/utils';
 import { getGitignoreMatcher } from '@tools/gitignore';
-import { toPosixPath } from '@utils/core/pathCore';
 import { WorkspaceFS } from '@utils/files';
+import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports
 import { defineTool } from './core/define';

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -16,8 +16,8 @@ import {
   pluralize,
 } from '@tools/utils';
 import { getGitignoreMatcher } from '@tools/gitignore';
-import { toPosixPath } from '@utils/core/pathCore';
 import { WorkspaceFS } from '@utils/files';
+import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports
 import { defineTool } from './core/define';

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { z } from 'zod';
 
 // Local imports - filesystem utilities
+import { formatRelativeTime } from '@shared/utils/string';
 import { StorageFS } from '@utils/files';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 
@@ -23,7 +24,6 @@ import {
   shouldSkipEntry,
 } from './constants';
 import { toDisplayPath, formatSize, displayToStoragePath } from './memoryUtils';
-import { formatRelativeTime } from '@shared/utils/string';
 
 const MemoryToolInputSchema = z.strictObject({
   command: z.enum([

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -12,8 +12,8 @@ import { ToolError, type ToolFileAttachment } from '@tools/result';
 
 // Local imports - core utilities
 import { isNonEmptyString } from '@utils/core';
-import { toPosixPath } from '@utils/core/pathCore';
 import { WorkspaceFS, getMimeType } from '@utils/files';
+import { toPosixPath } from '@utils/core/pathCore';
 
 export interface WorkspacePathResolution {
   relative: string;

--- a/src/tools/zotero/ZoteroAddTool.ts
+++ b/src/tools/zotero/ZoteroAddTool.ts
@@ -23,11 +23,11 @@ import { z } from 'zod';
 
 // Local imports - core
 import { toErrorMessage } from '@common/errors';
-import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
-import { waitForRateLimit } from '@tools/citation/rateLimiter';
 import { ToolError } from '@tools/result';
 import { isTimeoutErrorCode } from '@tools/timeouts';
 import { pluralize } from '@tools/utils';
+import { waitForRateLimit } from '@tools/citation/rateLimiter';
+import { CROSSREF_CONSTANTS, crossrefClient } from '@tools/citation/constants';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - zotero

--- a/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,0 +1,103 @@
+/**
+ * Banner component for missing agent configuration.
+ *
+ * Displays a warning banner when agent configuration is missing,
+ * with actions to edit agents, set directory, or view docs.
+ *
+ * @fires agent-config-action - When edit/dir/docs button is clicked
+ */
+
+// Third-party imports
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared schemas
+
+// Local imports - shared banner styles
+import { warningBannerStyles } from '../styles/warningBannerStyles';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
+import type { AgentConfigBannerState } from '@shared/schemas';
+
+@customElement('agent-config-banner')
+export class AgentConfigBanner extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    warningBannerStyles,
+  ];
+
+  @property({ attribute: false }) state: AgentConfigBannerState = {
+    visible: false,
+  };
+
+  private handleActionClick(event: MouseEvent): void {
+    const button = (event.target as HTMLElement).closest<HTMLElement>(
+      '[data-action]',
+    );
+    const action = button?.dataset.action as
+      | 'edit'
+      | 'dir'
+      | 'docs'
+      | undefined;
+    if (!action) return;
+    this.dispatchEvent(
+      MainViewEvents.agentConfigAction({
+        action,
+        customDirSet: this.state.customDirSet,
+      }),
+    );
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.state.visible) return nothing;
+
+    return html`
+      <div
+        id="agentConfigBanner"
+        class="warning-banner"
+        data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
+      >
+        <span>
+          ${this.state.agentName
+            ? `Agent file for "${this.state.agentName}" is missing.`
+            : 'Agent configuration is missing.'}
+        </span>
+        <div class="actions" @click=${this.handleActionClick}>
+          <vscode-toolbar-button
+            id="agentConfigEditButton"
+            icon="edit"
+            data-action="edit"
+          >
+            Edit Agents
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="agentConfigDirButton"
+            icon="folder"
+            data-action="dir"
+          >
+            ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="agentConfigDocButton"
+            icon="book"
+            data-action="docs"
+          >
+            Docs
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'agent-config-banner': AgentConfigBanner;
+  }
+}

--- a/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/src/webview/frontend/components/AgentConfigBanner.ts
@@ -14,12 +14,10 @@ import { customElement, property } from 'lit/decorators.js';
 // Local imports - shared styles
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
 
-// Local imports - shared schemas
-
 // Local imports - shared banner styles
 import { warningBannerStyles } from '../styles/warningBannerStyles';
 
-// Local imports - main view events
+// Local imports - main view events and schemas
 import { MainViewEvents } from '../events';
 import type { AgentConfigBannerState } from '@shared/schemas';
 

--- a/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,0 +1,89 @@
+/**
+ * Banner component for missing API key notification.
+ *
+ * Displays a warning banner when an API key is missing for a provider,
+ * with actions to set or get the key.
+ *
+ * @fires api-key-action - When set/guide button is clicked
+ */
+
+// Third-party imports
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared schemas
+
+// Local imports - shared banner styles
+import { warningBannerStyles } from '../styles/warningBannerStyles';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
+import type { ApiKeyBannerState } from '@shared/schemas';
+
+@customElement('api-key-banner')
+export class ApiKeyBanner extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    warningBannerStyles,
+  ];
+
+  @property({ attribute: false }) state: ApiKeyBannerState = {
+    visible: false,
+  };
+
+  private handleActionClick(event: MouseEvent): void {
+    const button = (event.target as HTMLElement).closest<HTMLElement>(
+      '[data-action]',
+    );
+    const action = button?.dataset.action as 'set' | 'guide' | undefined;
+    if (!action) return;
+    const provider = this.state.provider ?? '';
+    this.dispatchEvent(MainViewEvents.apiKeyAction({ action, provider }));
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.state.visible) return nothing;
+
+    const provider = this.state.provider ?? '';
+    const providerLabel = provider
+      ? `${provider.charAt(0).toUpperCase()}${provider.slice(1)}`
+      : '';
+
+    return html`
+      <div id="apiKeyBanner" class="warning-banner">
+        <span>
+          ${provider
+            ? html`<strong>${providerLabel}</strong> API key missing.`
+            : 'TeXRA requires an API key to run.'}
+        </span>
+        <div class="actions" @click=${this.handleActionClick}>
+          <vscode-toolbar-button
+            id="apiKeyBannerButton"
+            icon="key"
+            data-action="set"
+          >
+            ${provider ? 'Set Key' : 'Set API Key'}
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="apiKeyGuideButton"
+            icon="book"
+            data-action="guide"
+          >
+            ${provider ? 'Get Key' : 'API Key Guide'}
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'api-key-banner': ApiKeyBanner;
+  }
+}

--- a/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/src/webview/frontend/components/ApiKeyBanner.ts
@@ -14,12 +14,10 @@ import { customElement, property } from 'lit/decorators.js';
 // Local imports - shared styles
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
 
-// Local imports - shared schemas
-
 // Local imports - shared banner styles
 import { warningBannerStyles } from '../styles/warningBannerStyles';
 
-// Local imports - main view events
+// Local imports - main view events and schemas
 import { MainViewEvents } from '../events';
 import type { ApiKeyBannerState } from '@shared/schemas';
 

--- a/src/webview/frontend/components/BannerGroup.ts
+++ b/src/webview/frontend/components/BannerGroup.ts
@@ -1,20 +1,14 @@
 /**
- * BannerGroup component for MainView banners.
+ * Lightweight container for MainView banners.
  *
- * Renders various notification banners (API key, agent config,
- * dependency, getting started, login).
+ * Renders individual banner components (API key, agent config,
+ * dependency, getting started, login) by passing through state
+ * properties. Each banner handles its own rendering and events.
  */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { repeat } from 'lit/directives/repeat.js';
-import { when } from 'lit/directives/when.js';
-
-// Local imports - main view
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
-import { COMMAND_LINKS } from '@shared/utils/uiConstants';
-import { MainViewEvents } from '../events';
 
 // Local imports - shared schemas
 import type {
@@ -23,422 +17,48 @@ import type {
   DependencyBannerState,
 } from '@shared/schemas';
 
+// Side-effect imports to register banner custom elements
+import './ApiKeyBanner';
+import './AgentConfigBanner';
+import './DependencyBanner';
+import './GettingStartedBanner';
+import './LoginBanner';
+
 @customElement('banner-group')
 export class BannerGroup extends LitElement {
-  static override styles = [
-    designTokens,
-    codiconStyles,
-    commonViewStyles,
-    css`
-      :host {
-        display: block;
-      }
+  static override styles = css`
+    :host {
+      display: block;
+    }
+  `;
 
-      .api-key-banner,
-      .agent-config-banner,
-      .dependency-banner,
-      .getting-started-banner {
-        border-radius: var(--border-radius);
-        padding: var(--spacing-small) var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
-      }
-
-      .api-key-banner,
-      .agent-config-banner,
-      .dependency-banner {
-        background-color: var(--vscode-inputValidation-warningBackground);
-        color: var(--vscode-inputValidation-warningForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-warningBorder);
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-
-      .getting-started-banner {
-        background-color: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        line-height: 1.5;
-      }
-
-      .getting-started-banner a {
-        color: var(--color-text-link);
-        text-decoration: none;
-      }
-
-      .getting-started-banner a:hover {
-        text-decoration: underline;
-      }
-
-      .actions {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-small);
-      }
-
-      .dependency-item {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: var(--spacing-small);
-      }
-
-      .missing-tools {
-        display: flex;
-        flex-direction: column;
-        gap: var(--spacing-tiny);
-      }
-
-      .login-banner {
-        background: linear-gradient(
-          135deg,
-          var(--vscode-inputValidation-infoBackground) 0%,
-          color-mix(
-              in srgb,
-              var(--vscode-inputValidation-infoBackground) 80%,
-              var(--vscode-button-background)
-            )
-            100%
-        );
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        border-radius: var(--border-radius);
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: var(--spacing-medium);
-      }
-
-      .login-banner-content {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-medium);
-        flex: 1;
-      }
-
-      .login-banner-icon {
-        font-size: 1.5em;
-        color: var(--vscode-button-background);
-        display: flex;
-        align-items: center;
-      }
-
-      .login-banner-text {
-        display: flex;
-        flex-direction: column;
-        gap: var(--spacing-tiny);
-      }
-
-      .login-banner-title {
-        font-weight: 600;
-        font-size: 1em;
-      }
-
-      .login-banner-description {
-        font-size: var(--font-size-sm);
-        opacity: var(--opacity-normal);
-      }
-
-      .login-banner .actions {
-        flex-shrink: 0;
-      }
-    `,
-  ];
-
-  /** API key banner state */
   @property({ attribute: false }) apiKeyBanner: ApiKeyBannerState = {
     visible: false,
   };
 
-  /** Agent config banner state */
   @property({ attribute: false }) agentConfigBanner: AgentConfigBannerState = {
     visible: false,
   };
 
-  /** Dependency banner state */
   @property({ attribute: false }) dependencyBanner: DependencyBannerState = {
     visible: false,
   };
 
-  /** Getting started banner visibility */
   @property({ attribute: false }) gettingStartedVisible = false;
 
-  /** Login banner visibility */
   @property({ attribute: false }) loginBannerVisible = false;
-
-  private handleApiKeyActionClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-action]',
-    );
-    const action = button?.dataset.action as 'set' | 'guide' | undefined;
-    if (!action) return;
-    const provider = this.apiKeyBanner.provider ?? '';
-    this.dispatchEvent(MainViewEvents.apiKeyAction({ action, provider }));
-  }
-
-  private handleAgentConfigActionClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-action]',
-    );
-    const action = button?.dataset.action as
-      | 'edit'
-      | 'dir'
-      | 'docs'
-      | undefined;
-    if (!action) return;
-    this.dispatchEvent(
-      MainViewEvents.agentConfigAction({
-        action,
-        customDirSet: this.agentConfigBanner.customDirSet,
-      }),
-    );
-  }
-
-  private handleDependencyDismiss(): void {
-    this.dispatchEvent(MainViewEvents.dependencyDismiss());
-  }
-
-  private handleRecheckDependencies(): void {
-    this.dispatchEvent(MainViewEvents.recheckDependencies());
-  }
-
-  private handleInstallClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-tool]',
-    );
-    const tool = button?.dataset.tool;
-    if (tool) {
-      this.dispatchEvent(MainViewEvents.openInstallGuide({ tool }));
-    }
-  }
-
-  private handleSignIn(): void {
-    this.dispatchEvent(MainViewEvents.signIn());
-  }
-
-  private handleDismissLogin(): void {
-    this.dispatchEvent(MainViewEvents.dismissLogin());
-  }
-
-  private getToolLabel(tool: string): string {
-    switch (tool) {
-      case 'gm':
-        return 'GraphicsMagick';
-      case 'magick':
-        return 'ImageMagick';
-      default:
-        return tool;
-    }
-  }
-
-  private renderApiKeyBanner(): TemplateResult | typeof nothing {
-    if (!this.apiKeyBanner.visible) return nothing;
-
-    const provider = this.apiKeyBanner.provider ?? '';
-    const providerLabel = provider
-      ? `${provider.charAt(0).toUpperCase()}${provider.slice(1)}`
-      : '';
-
-    return html`
-      <div id="apiKeyBanner" class="api-key-banner">
-        <span>
-          ${provider
-            ? html`<strong>${providerLabel}</strong> API key missing.`
-            : 'TeXRA requires an API key to run.'}
-        </span>
-        <div class="actions" @click=${this.handleApiKeyActionClick}>
-          <vscode-toolbar-button
-            id="apiKeyBannerButton"
-            icon="key"
-            data-action="set"
-          >
-            ${provider ? 'Set Key' : 'Set API Key'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="apiKeyGuideButton"
-            icon="book"
-            data-action="guide"
-          >
-            ${provider ? 'Get Key' : 'API Key Guide'}
-          </vscode-toolbar-button>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderAgentConfigBanner(): TemplateResult | typeof nothing {
-    if (!this.agentConfigBanner.visible) return nothing;
-
-    return html`
-      <div
-        id="agentConfigBanner"
-        class="agent-config-banner"
-        data-custom-dir-set=${this.agentConfigBanner.customDirSet
-          ? 'true'
-          : 'false'}
-      >
-        <span>
-          ${this.agentConfigBanner.agentName
-            ? `Agent file for "${this.agentConfigBanner.agentName}" is missing.`
-            : 'Agent configuration is missing.'}
-        </span>
-        <div class="actions" @click=${this.handleAgentConfigActionClick}>
-          <vscode-toolbar-button
-            id="agentConfigEditButton"
-            icon="edit"
-            data-action="edit"
-          >
-            Edit Agents
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDirButton"
-            icon="folder"
-            data-action="dir"
-          >
-            ${this.agentConfigBanner.customDirSet
-              ? 'Open Directory'
-              : 'Set Directory'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDocButton"
-            icon="book"
-            data-action="docs"
-          >
-            Docs
-          </vscode-toolbar-button>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderDependencyBanner(): TemplateResult | typeof nothing {
-    if (!this.dependencyBanner.visible) return nothing;
-
-    const missing = this.dependencyBanner.missingTools ?? [];
-    const tools = missing.flatMap((tool) =>
-      tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
-    );
-
-    return html`
-      <div id="dependencyBanner" class="dependency-banner">
-        <span class="missing-tools" @click=${this.handleInstallClick}>
-          ${when(
-            tools.length === 0,
-            () => html`Missing dependencies: none`,
-            () =>
-              repeat(
-                tools,
-                (tool) => tool,
-                (tool) => {
-                  const label = this.getToolLabel(tool);
-                  return html`
-                    <div class="dependency-item">
-                      <span>${label}</span>
-                      <vscode-toolbar-button
-                        class="btn-secondary dependency-install-button"
-                        icon="cloud-download"
-                        data-tool=${tool}
-                      >
-                        Install
-                      </vscode-toolbar-button>
-                    </div>
-                  `;
-                },
-              ),
-          )}
-        </span>
-        <div class="actions">
-          <vscode-toolbar-button
-            id="dependencyRecheckButton"
-            icon="refresh"
-            @click=${this.handleRecheckDependencies}
-          >
-            Re-check
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="dependencyDismissButton"
-            class="btn-secondary"
-            title="Dismiss (can be re-enabled in settings)"
-            icon="close"
-            @click=${this.handleDependencyDismiss}
-          >
-            Dismiss
-          </vscode-toolbar-button>
-        </div>
-      </div>
-    `;
-  }
-
-  private renderGettingStartedBanner(): TemplateResult | typeof nothing {
-    if (!this.gettingStartedVisible) return nothing;
-
-    return html`
-      <div id="gettingStartedBanner" class="getting-started-banner">
-        <span class="getting-started-text">
-          No files found in workspace. Try
-          <a href=${COMMAND_LINKS.GETTING_STARTED}
-            >opening the getting started walkthrough</a
-          >,
-          <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
-            >creating a sample project</a
-          >,
-          <a href=${COMMAND_LINKS.CLONE_OVERLEAF}>cloning an Overleaf project</a
-          >, or
-          <a href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>downloading an arXiv source</a
-          >.
-        </span>
-      </div>
-    `;
-  }
-
-  private renderLoginBanner(): TemplateResult | typeof nothing {
-    if (!this.loginBannerVisible) return nothing;
-
-    return html`
-      <div id="loginBanner" class="login-banner">
-        <div class="login-banner-content">
-          <span class="login-banner-icon"
-            ><i class="codicon codicon-sparkle"></i
-          ></span>
-          <div class="login-banner-text">
-            <span class="login-banner-title">Researcher Access Program</span>
-            <span class="login-banner-description">
-              Sign in to access AI models and remote agents without your own API
-              keys.
-            </span>
-          </div>
-        </div>
-        <div class="actions">
-          <vscode-button
-            id="loginBannerButton"
-            appearance="primary"
-            @click=${this.handleSignIn}
-          >
-            <span slot="start" class="codicon codicon-sign-in"></span>
-            Sign In
-          </vscode-button>
-          <vscode-toolbar-button
-            id="loginBannerDismissButton"
-            icon="close"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss login banner"
-            @click=${this.handleDismissLogin}
-          ></vscode-toolbar-button>
-        </div>
-      </div>
-    `;
-  }
 
   override render(): TemplateResult {
     return html`
-      ${this.renderApiKeyBanner()} ${this.renderAgentConfigBanner()}
-      ${this.renderDependencyBanner()} ${this.renderGettingStartedBanner()}
-      ${this.renderLoginBanner()}
+      <api-key-banner .state=${this.apiKeyBanner}></api-key-banner>
+      <agent-config-banner
+        .state=${this.agentConfigBanner}
+      ></agent-config-banner>
+      <dependency-banner .state=${this.dependencyBanner}></dependency-banner>
+      <getting-started-banner
+        .visible=${this.gettingStartedVisible}
+      ></getting-started-banner>
+      <login-banner .visible=${this.loginBannerVisible}></login-banner>
     `;
   }
 }

--- a/src/webview/frontend/components/DependencyBanner.ts
+++ b/src/webview/frontend/components/DependencyBanner.ts
@@ -18,12 +18,10 @@ import { when } from 'lit/directives/when.js';
 // Local imports - shared styles
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
 
-// Local imports - shared schemas
-
 // Local imports - shared banner styles
 import { warningBannerStyles } from '../styles/warningBannerStyles';
 
-// Local imports - main view events
+// Local imports - main view events and schemas
 import { MainViewEvents } from '../events';
 import type { DependencyBannerState } from '@shared/schemas';
 

--- a/src/webview/frontend/components/DependencyBanner.ts
+++ b/src/webview/frontend/components/DependencyBanner.ts
@@ -1,0 +1,149 @@
+/**
+ * Banner component for missing system dependencies.
+ *
+ * Displays a warning banner listing missing tools with install buttons,
+ * plus recheck and dismiss actions.
+ *
+ * @fires dependency-dismiss - When dismiss button is clicked
+ * @fires recheck-dependencies - When recheck button is clicked
+ * @fires open-install-guide - When install button is clicked for a tool
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { when } from 'lit/directives/when.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared schemas
+
+// Local imports - shared banner styles
+import { warningBannerStyles } from '../styles/warningBannerStyles';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
+import type { DependencyBannerState } from '@shared/schemas';
+
+@customElement('dependency-banner')
+export class DependencyBanner extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    warningBannerStyles,
+    css`
+      .dependency-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-small);
+      }
+
+      .missing-tools {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-tiny);
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) state: DependencyBannerState = {
+    visible: false,
+  };
+
+  private handleDismiss(): void {
+    this.dispatchEvent(MainViewEvents.dependencyDismiss());
+  }
+
+  private handleRecheck(): void {
+    this.dispatchEvent(MainViewEvents.recheckDependencies());
+  }
+
+  private handleInstallClick(event: MouseEvent): void {
+    const button = (event.target as HTMLElement).closest<HTMLElement>(
+      '[data-tool]',
+    );
+    const tool = button?.dataset.tool;
+    if (tool) {
+      this.dispatchEvent(MainViewEvents.openInstallGuide({ tool }));
+    }
+  }
+
+  private getToolLabel(tool: string): string {
+    switch (tool) {
+      case 'gm':
+        return 'GraphicsMagick';
+      case 'magick':
+        return 'ImageMagick';
+      default:
+        return tool;
+    }
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.state.visible) return nothing;
+
+    const missing = this.state.missingTools ?? [];
+    const tools = missing.flatMap((tool) =>
+      tool === 'gm/magick' ? ['gm', 'magick'] : [tool],
+    );
+
+    return html`
+      <div id="dependencyBanner" class="warning-banner">
+        <span class="missing-tools" @click=${this.handleInstallClick}>
+          ${when(
+            tools.length === 0,
+            () => html`Missing dependencies: none`,
+            () =>
+              repeat(
+                tools,
+                (tool) => tool,
+                (tool) => {
+                  const label = this.getToolLabel(tool);
+                  return html`
+                    <div class="dependency-item">
+                      <span>${label}</span>
+                      <vscode-toolbar-button
+                        class="btn-secondary dependency-install-button"
+                        icon="cloud-download"
+                        data-tool=${tool}
+                      >
+                        Install
+                      </vscode-toolbar-button>
+                    </div>
+                  `;
+                },
+              ),
+          )}
+        </span>
+        <div class="actions">
+          <vscode-toolbar-button
+            id="dependencyRecheckButton"
+            icon="refresh"
+            @click=${this.handleRecheck}
+          >
+            Re-check
+          </vscode-toolbar-button>
+          <vscode-toolbar-button
+            id="dependencyDismissButton"
+            class="btn-secondary"
+            title="Dismiss (can be re-enabled in settings)"
+            icon="close"
+            @click=${this.handleDismiss}
+          >
+            Dismiss
+          </vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dependency-banner': DependencyBanner;
+  }
+}

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,0 +1,80 @@
+/**
+ * Banner component for the getting started walkthrough.
+ *
+ * Displays an info banner with links to various getting started
+ * actions when no files are found in the workspace.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared utilities
+import { COMMAND_LINKS } from '@shared/utils/uiConstants';
+
+@customElement('getting-started-banner')
+export class GettingStartedBanner extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .getting-started-banner {
+        border-radius: var(--border-radius);
+        padding: var(--spacing-small) var(--spacing-medium);
+        margin-bottom: var(--spacing-large);
+        background-color: var(--vscode-inputValidation-infoBackground);
+        color: var(--vscode-inputValidation-infoForeground);
+        border: var(--border-thin) solid
+          var(--vscode-inputValidation-infoBorder);
+        line-height: 1.5;
+      }
+
+      .getting-started-banner a {
+        color: var(--color-text-link);
+        text-decoration: none;
+      }
+
+      .getting-started-banner a:hover {
+        text-decoration: underline;
+      }
+    `,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.visible) return nothing;
+
+    return html`
+      <div id="gettingStartedBanner" class="getting-started-banner">
+        <span class="getting-started-text">
+          No files found in workspace. Try
+          <a href=${COMMAND_LINKS.GETTING_STARTED}
+            >opening the getting started walkthrough</a
+          >,
+          <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
+            >creating a sample project</a
+          >,
+          <a href=${COMMAND_LINKS.CLONE_OVERLEAF}>cloning an Overleaf project</a
+          >, or
+          <a href=${COMMAND_LINKS.DOWNLOAD_ARXIV}>downloading an arXiv source</a
+          >.
+        </span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'getting-started-banner': GettingStartedBanner;
+  }
+}

--- a/src/webview/frontend/components/LoginBanner.ts
+++ b/src/webview/frontend/components/LoginBanner.ts
@@ -1,0 +1,150 @@
+/**
+ * Banner component for the Researcher Access Program sign-in.
+ *
+ * Displays an info banner encouraging users to sign in for
+ * access to AI models without their own API keys.
+ *
+ * @fires sign-in - When sign in button is clicked
+ * @fires dismiss-login - When dismiss button is clicked
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
+
+@customElement('login-banner')
+export class LoginBanner extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .login-banner {
+        background: linear-gradient(
+          135deg,
+          var(--vscode-inputValidation-infoBackground) 0%,
+          color-mix(
+              in srgb,
+              var(--vscode-inputValidation-infoBackground) 80%,
+              var(--vscode-button-background)
+            )
+            100%
+        );
+        color: var(--vscode-inputValidation-infoForeground);
+        border: var(--border-thin) solid
+          var(--vscode-inputValidation-infoBorder);
+        border-radius: var(--border-radius);
+        padding: var(--spacing-medium);
+        margin-bottom: var(--spacing-large);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: var(--spacing-medium);
+      }
+
+      .login-banner-content {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-medium);
+        flex: 1;
+      }
+
+      .login-banner-icon {
+        font-size: 1.5em;
+        color: var(--vscode-button-background);
+        display: flex;
+        align-items: center;
+      }
+
+      .login-banner-text {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-tiny);
+      }
+
+      .login-banner-title {
+        font-weight: 600;
+        font-size: 1em;
+      }
+
+      .login-banner-description {
+        font-size: var(--font-size-sm);
+        opacity: var(--opacity-normal);
+      }
+
+      .login-banner .actions {
+        flex-shrink: 0;
+      }
+
+      .actions {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+      }
+    `,
+  ];
+
+  @property({ type: Boolean }) visible = false;
+
+  private handleSignIn(): void {
+    this.dispatchEvent(MainViewEvents.signIn());
+  }
+
+  private handleDismiss(): void {
+    this.dispatchEvent(MainViewEvents.dismissLogin());
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.visible) return nothing;
+
+    return html`
+      <div id="loginBanner" class="login-banner">
+        <div class="login-banner-content">
+          <span class="login-banner-icon"
+            ><i class="codicon codicon-sparkle"></i
+          ></span>
+          <div class="login-banner-text">
+            <span class="login-banner-title">Researcher Access Program</span>
+            <span class="login-banner-description">
+              Sign in to access AI models and remote agents without your own API
+              keys.
+            </span>
+          </div>
+        </div>
+        <div class="actions">
+          <vscode-button
+            id="loginBannerButton"
+            appearance="primary"
+            @click=${this.handleSignIn}
+          >
+            <span slot="start" class="codicon codicon-sign-in"></span>
+            Sign In
+          </vscode-button>
+          <vscode-toolbar-button
+            id="loginBannerDismissButton"
+            icon="close"
+            title="Dismiss (can be re-enabled in settings)"
+            aria-label="Dismiss login banner"
+            @click=${this.handleDismiss}
+          ></vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'login-banner': LoginBanner;
+  }
+}

--- a/src/webview/frontend/styles/warningBannerStyles.ts
+++ b/src/webview/frontend/styles/warningBannerStyles.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared styles for warning-type banners (API key, agent config, dependency).
+ *
+ * Provides the common layout (flex row, warning colors, padding/margin)
+ * and action button container used by all warning banners.
+ */
+
+import { css, type CSSResult } from 'lit';
+
+export const warningBannerStyles: CSSResult = css`
+  :host {
+    display: block;
+  }
+
+  .warning-banner {
+    border-radius: var(--border-radius);
+    padding: var(--spacing-small) var(--spacing-medium);
+    margin-bottom: var(--spacing-large);
+    background-color: var(--vscode-inputValidation-warningBackground);
+    color: var(--vscode-inputValidation-warningForeground);
+    border: var(--border-thin) solid
+      var(--vscode-inputValidation-warningBorder);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+  }
+`;


### PR DESCRIPTION
RequestPanels.ts (1025 → 272 lines): Split 4 distinct panel types into
individual components (ToolEditRequestPanel, BashRequestPanel,
RetryRequestPanel, ProposalRequestPanel) with a BaseFeedbackPanel base
class for shared feedback/reject/emit logic. The container now handles
only permission grouping, section headers, and keyboard shortcut delegation.

BannerGroup.ts (451 → 71 lines): Split 5 banner types into individual
components (ApiKeyBanner, AgentConfigBanner, DependencyBanner,
GettingStartedBanner, LoginBanner) with shared warningBannerStyles.
The container now only passes through state properties.

Each component is independently testable with its own rendering, state,
and event handling. No changes to external interfaces — both
<request-panels> and <banner-group> custom elements remain unchanged.

https://claude.ai/code/session_01QzChKBpfUzUrNgbRtBrkwP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a UI refactor, but it changes event/keyboard-handling paths for approvals and banners; regressions could affect user ability to approve/reject actions or trigger banner commands.
> 
> **Overview**
> Refactors the Progress View permission UI by extracting the monolithic `RequestPanels` implementation into `ToolEditRequestPanel`, `BashRequestPanel`, `RetryRequestPanel`, and `ProposalRequestPanel`, with shared `BaseRequestPanel`/`BaseFeedbackPanel` helpers for action emission, reject-feedback capture, and per-panel keyboard shortcuts. The `request-panels` container is reduced to grouping + rendering sections and now delegates global shortcuts to the *newest* permission’s panel instance.
> 
> Refactors Main View banners by splitting `BannerGroup` into independent banner components (`ApiKeyBanner`, `AgentConfigBanner`, `DependencyBanner`, `GettingStartedBanner`, `LoginBanner`) with shared `warningBannerStyles`; `banner-group` now only passes state through.
> 
> The rest of the diff is largely import reordering/cleanup across runtime/tools/tests (no functional logic changes apparent outside the UI refactor).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 323dcdb42c0592b913207e764fb483bc7852a7d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->