### PR TITLE
Inline trivial wrapper functions across codebase

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -644,7 +644,7 @@ export function isRemoteAgent(identifier: string | undefined): boolean {
  * Get visible agents for a category (filtered and deduplicated).
  * No default → undefined means "never configured" (show all).
  */
-function getVisibleAgents(category: 'workflow' | 'toolUse'): AgentEntry[] {
+export function getVisibleAgents(category: 'workflow' | 'toolUse'): AgentEntry[] {
   const isToolUse = category === 'toolUse';
   const entries = isToolUse ? getToolUseAgents() : getWorkflowAgents();
   const stateKey = isToolUse
@@ -654,15 +654,6 @@ function getVisibleAgents(category: 'workflow' | 'toolUse'): AgentEntry[] {
   return deduplicateByName(filterVisible(entries, raw));
 }
 
-/** Get visible workflow agents for the main webview dropdown. */
-export function getVisibleWorkflowAgents(): AgentEntry[] {
-  return getVisibleAgents('workflow');
-}
-
-/** Get visible tool-use agents for the main webview dropdown. */
-export function getVisibleToolUseAgents(): AgentEntry[] {
-  return getVisibleAgents('toolUse');
-}
 
 /**
  * Deduplicate agents by name, keeping only the highest priority source.
@@ -767,11 +758,11 @@ export async function computeAgentOptionsData(): Promise<AgentOptionsDataPayload
 
   return {
     workflow: sortAgentEntries(
-      getVisibleWorkflowAgents(),
+      getVisibleAgents('workflow'),
       DEFAULT_WORKFLOW_AGENT,
     ).map(entryToOptionData),
     toolUse: sortAgentEntries(
-      getVisibleToolUseAgents(),
+      getVisibleAgents('toolUse'),
       DEFAULT_TOOL_USE_AGENT,
     ).map(entryToOptionData),
   };

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -29,8 +29,7 @@ export {
   // Source helpers
   isRemoteAgent,
   // Visible agents (for dropdowns and tools)
-  getVisibleWorkflowAgents,
-  getVisibleToolUseAgents,
+  getVisibleAgents,
   // Description update (for remote agent loading)
   updateAgentDescription,
 } from './agentRegistry';

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -73,7 +73,6 @@ import {
 } from './utils/toolAttachmentUtils';
 import {
   computeCachePercentage,
-  nonZeroOrUndefined,
 } from './utils/usageNormalization';
 
 // Type imports
@@ -1719,15 +1718,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'anthropic',
-      cachedInputTokens: nonZeroOrUndefined(usageTotals.cacheReadTokens),
-      cacheCreationTokens: nonZeroOrUndefined(usageTotals.cacheCreationTokens),
+      cachedInputTokens: usageTotals.cacheReadTokens || undefined,
+      cacheCreationTokens: usageTotals.cacheCreationTokens || undefined,
       percentageCached: computeCachePercentage(
         usageTotals.cacheReadTokens + usageTotals.cacheCreationTokens,
         totalInput,
       ),
-      serverToolRequests: nonZeroOrUndefined(
-        rawUsage.server_tool_use?.web_search_requests,
-      ),
+      serverToolRequests:
+        rawUsage.server_tool_use?.web_search_requests || undefined,
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -63,7 +63,6 @@ import { K_SLICE } from '@utils/config';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import {
   computeCachePercentage,
-  nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 import { TOOL_USE_SAFETY_BUFFER } from './contextManagementConstants';
@@ -987,10 +986,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'google',
-      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      cachedInputTokens: cachedTokens || undefined,
       percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens: nonZeroOrUndefined(reasoningTokens),
-      toolUsePromptTokens: nonZeroOrUndefined(rawUsage.toolUsePromptTokenCount),
+      reasoningTokens: reasoningTokens || undefined,
+      toolUsePromptTokens: rawUsage.toolUsePromptTokenCount || undefined,
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -47,7 +47,6 @@ import { flexibleFS } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
 import {
   computeCachePercentage,
-  nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
@@ -979,11 +978,10 @@ export class ModelHandlerOpenAI<
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: this.usageProvider,
-      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      cachedInputTokens: cachedTokens || undefined,
       percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens: nonZeroOrUndefined(
-        rawUsage.completion_tokens_details?.reasoning_tokens,
-      ),
+      reasoningTokens:
+        rawUsage.completion_tokens_details?.reasoning_tokens || undefined,
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -33,7 +33,6 @@ import { flexibleFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import {
   computeCachePercentage,
-  nonZeroOrUndefined,
 } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 
@@ -1664,11 +1663,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       cost: this.computePrice(rawUsage),
       responseTimeMs,
       provider: 'openai-response',
-      cachedInputTokens: nonZeroOrUndefined(cachedTokens),
+      cachedInputTokens: cachedTokens || undefined,
       percentageCached: computeCachePercentage(cachedTokens, inputTokens),
-      reasoningTokens: nonZeroOrUndefined(
-        rawUsage.output_tokens_details?.reasoning_tokens,
-      ),
+      reasoningTokens:
+        rawUsage.output_tokens_details?.reasoning_tokens || undefined,
       _native: rawUsage,
     };
   }

--- a/src/agent/modelHandlers/utils/usageNormalization.ts
+++ b/src/agent/modelHandlers/utils/usageNormalization.ts
@@ -21,16 +21,3 @@ export function computeCachePercentage(
   if (totalInputTokens <= 0 || cachedTokens <= 0) return undefined;
   return (cachedTokens / totalInputTokens) * 100;
 }
-
-/**
- * Convert a numeric value to undefined if zero/falsy.
- * Used to avoid storing 0 values in optional fields.
- *
- * @param value - Numeric value to convert
- * @returns The value if truthy, undefined otherwise
- */
-export function nonZeroOrUndefined(
-  value: number | undefined,
-): number | undefined {
-  return value || undefined;
-}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -4,8 +4,7 @@ import * as path from 'path';
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import {
-  getVisibleWorkflowAgents,
-  getVisibleToolUseAgents,
+  getVisibleAgents,
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 // Internal imports
@@ -114,8 +113,8 @@ function getBasicVars(
       })
       .join('\n');
 
-  const workflowAgentsList = formatAgentList(getVisibleWorkflowAgents());
-  const toolUseAgentsList = formatToolUseAgentList(getVisibleToolUseAgents());
+  const workflowAgentsList = formatAgentList(getVisibleAgents('workflow'));
+  const toolUseAgentsList = formatToolUseAgentList(getVisibleAgents('toolUse'));
 
   // Get default bib path from settings (empty string if not configured)
   const defaultBibPath = getConfig<string>('texra.bib.defaultPath', '');

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -54,7 +54,6 @@ export { ArxivSourceProcessor, arxivProcessor } from './arxivProcessor';
 
 export { compileLatex2Pdf } from './texTools';
 export {
-  formatTeXCountStats,
   getTeXCount,
   getTeXCountStats,
   type TexcountMode,

--- a/src/latex/texcount.ts
+++ b/src/latex/texcount.ts
@@ -293,20 +293,12 @@ export async function getTeXCount(
   }
 }
 
-/**
- * Run texcount on LaTeX files and return formatted statistics with XML-style tags
- * @param filePaths Single file path or array of file paths
- * @param channel The channel to use for logging
- * @returns Promise<string | null> String containing formatted texcount statistics with XML tags, or null if an error occurred
- */
-export function formatTeXCountStats(texcountOutput: string): string {
-  return `TeX Count Statistics:<texcount>\n${texcountOutput}\n</texcount>\n\n`;
-}
-
 export async function getTeXCountStats(
   filePaths: string | string[],
   channel: string = CHANNEL,
 ): Promise<string | null> {
   const { output } = await getTeXCount(filePaths, { channel });
-  return output ? formatTeXCountStats(output) : null;
+  return output
+    ? `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`
+    : null;
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -125,14 +125,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
       // Stream management
       [PROGRESS_VIEW_COMMANDS.SWITCH_STREAM]: (data) =>
-        this.handleSwitchStream(data),
+        this.provider.setActiveStream(data.stream),
       [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
         this.handleDeleteStream(data),
       [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
-      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (data) =>
-        this.handleStopStream(data),
-      [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: (data) =>
-        this.handleCompactResponse(data),
+      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: async (data) =>
+        vscode.commands.executeCommand('texra.stopAgent', data.stream),
+      [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) =>
+        vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
       // Actions
       [PROGRESS_VIEW_COMMANDS.RESUME]: (data) => this.handleResume(data),
@@ -226,14 +226,15 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.GET_FOLLOWUP_OPTIONS]: (data) =>
         this.handleGetFollowupOptions(data),
       [PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP]: (data) =>
-        this.handleSetupFollowup(data),
+        this.processFollowup(data, false),
       [PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP]: (data) =>
-        this.handleRunFollowup(data),
+        this.processFollowup(data, true),
 
       // File operations
-      [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: (data) => this.handleOpenFile(data),
-      [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: (data) =>
-        this.handleOpenFileCompile(data),
+      [PROGRESS_VIEW_COMMANDS.OPEN_FILE]: async (data) =>
+        vscode.commands.executeCommand('texra.openFile', data.file, data.line),
+      [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: async (data) =>
+        vscode.commands.executeCommand('texra.openFileCompile', data.file),
       [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (data) =>
         this.handleCompareOriginal(data),
       [PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS]: (data) =>
@@ -243,7 +244,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (data) => this.handleMergeFile(data),
       [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]: (data) =>
         this.handleLatexdiffFile(data),
-      [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: (data) => this.handleOpenLabel(data),
+      [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: async (data) =>
+        vscode.commands.executeCommand('texra.openLabel', data.label),
     };
   }
 
@@ -300,12 +302,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // Stream management handlers
   // ============================================================
 
-  private handleSwitchStream(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.SWITCH_STREAM>,
-  ): void {
-    this.provider.setActiveStream(data.stream);
-  }
-
   private async handleDeleteStream(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.DELETE_STREAM>,
   ): Promise<void> {
@@ -351,18 +347,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     await this.provider.state.clearAll();
     // Force rebuild since we deleted all streams
     this.provider.updateWebview({ forceRebuild: true });
-  }
-
-  private async handleStopStream(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.STOP_STREAM>,
-  ): Promise<void> {
-    await vscode.commands.executeCommand('texra.stopAgent', data.stream);
-  }
-
-  private async handleCompactResponse(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE>,
-  ): Promise<void> {
-    await vscode.commands.executeCommand('texra.compactResponse', data.stream);
   }
 
   // ============================================================
@@ -717,22 +701,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // File operation handlers
   // ============================================================
 
-  private async handleOpenFile(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.OPEN_FILE>,
-  ): Promise<void> {
-    await vscode.commands.executeCommand(
-      'texra.openFile',
-      data.file,
-      data.line,
-    );
-  }
-
-  private async handleOpenFileCompile(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE>,
-  ): Promise<void> {
-    await vscode.commands.executeCommand('texra.openFileCompile', data.file);
-  }
-
   private async handleCompareOriginal(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL>,
   ): Promise<void> {
@@ -897,12 +865,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleOpenLabel(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.OPEN_LABEL>,
-  ): Promise<void> {
-    await vscode.commands.executeCommand('texra.openLabel', data.label);
-  }
-
   // ============================================================
   // Followup task handlers
   // ============================================================
@@ -931,18 +893,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         `Failed to get followup options: ${toErrorMessage(error)}`,
       );
     }
-  }
-
-  private async handleSetupFollowup(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.SETUP_FOLLOWUP>,
-  ): Promise<void> {
-    await this.processFollowup(data, false);
-  }
-
-  private async handleRunFollowup(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RUN_FOLLOWUP>,
-  ): Promise<void> {
-    await this.processFollowup(data, true);
   }
 
   // ============================================================

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -309,7 +309,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Memory handlers
       [SETTINGS_VIEW_COMMANDS.GET_MEMORY_DATA]: () =>
-        this.handleGetMemoryData(),
+        this.withActiveWebview((w) => this.sendMemoryData(w)),
       [SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FILE]: (data) =>
         this.handleOpenMemoryFile(data),
       [SETTINGS_VIEW_COMMANDS.OPEN_MEMORY_FOLDER]: () =>
@@ -317,13 +317,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.DELETE_MEMORY]: (data) =>
         this.handleDeleteMemory(data),
       [SETTINGS_VIEW_COMMANDS.GET_MEMORY_ENABLED]: () =>
-        this.handleGetMemoryEnabled(),
+        this.withActiveWebview((w) => this.sendMemoryEnabled(w)),
       [SETTINGS_VIEW_COMMANDS.SET_MEMORY_ENABLED]: (data) =>
         this.handleSetMemoryEnabled(data),
 
       // History handlers
       [SETTINGS_VIEW_COMMANDS.GET_HISTORY_DATA]: () =>
-        this.handleGetHistoryData(),
+        this.withActiveWebview((w) => this.sendHistoryData(w)),
       [SETTINGS_VIEW_COMMANDS.RERUN_AGENT]: (data) =>
         this.handleRerunAgent(data),
       [SETTINGS_VIEW_COMMANDS.RESTORE_AGENT]: (data) =>
@@ -334,11 +334,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Profile handlers
       [SETTINGS_VIEW_COMMANDS.GET_PROFILE_DATA]: () =>
-        this.handleGetProfileData(),
+        this.withActiveWebview((w) => this.sendProfileData(w)),
       [SETTINGS_VIEW_COMMANDS.SELECT_AGENT]: (data) =>
         this.handleSelectAgent(data),
-      [SETTINGS_VIEW_COMMANDS.SIGN_IN]: () => this.handleSignIn(),
-      [SETTINGS_VIEW_COMMANDS.SIGN_OUT]: () => this.handleSignOut(),
+      [SETTINGS_VIEW_COMMANDS.SIGN_IN]: async () =>
+        vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN),
+      [SETTINGS_VIEW_COMMANDS.SIGN_OUT]: async () =>
+        vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_OUT),
       [SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE]: (data) =>
         this.handleSetApiAccessMode(data),
       [SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY]: (data) =>
@@ -360,7 +362,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Model selection handlers
       [SETTINGS_VIEW_COMMANDS.GET_MODEL_SELECTION]: () =>
-        this.handleGetModelSelection(),
+        this.withActiveWebview((w) => this.sendModelSelectionData(w)),
       [SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED]: (data) =>
         this.handleSetModelEnabled(data),
       [SETTINGS_VIEW_COMMANDS.SET_POLISH_MODEL]: (data) =>
@@ -368,13 +370,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Auto-show remote agents handlers
       [SETTINGS_VIEW_COMMANDS.GET_AUTO_SHOW_REMOTE]: () =>
-        this.handleGetAutoShowRemote(),
+        this.withActiveWebview((w) => this.sendAutoShowRemote(w)),
       [SETTINGS_VIEW_COMMANDS.SET_AUTO_SHOW_REMOTE]: (data) =>
         this.handleSetAutoShowRemote(data),
 
       // Custom agent directory handlers
       [SETTINGS_VIEW_COMMANDS.GET_CUSTOM_AGENT_DIR]: () =>
-        this.handleGetCustomAgentDir(),
+        this.withActiveWebview((w) => this.sendCustomAgentDir(w)),
       [SETTINGS_VIEW_COMMANDS.SET_CUSTOM_AGENT_DIR]: () =>
         this.handleSetCustomAgentDir(),
       [SETTINGS_VIEW_COMMANDS.RESET_CUSTOM_AGENT_DIR]: () =>
@@ -382,13 +384,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Super YOLO handlers
       [SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED]: () =>
-        this.handleGetSuperYoloEnabled(),
+        this.withActiveWebview((w) => this.sendSuperYoloEnabled(w)),
       [SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED]: (data) =>
         this.handleSetSuperYoloEnabled(data),
 
       // Agent selection handlers
       [SETTINGS_VIEW_COMMANDS.GET_AGENT_SELECTION]: () =>
-        this.handleGetAgentSelection(),
+        this.withActiveWebview((w) => this.sendAgentSelectionData(w)),
       [SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML]: (data) =>
         this.handleOpenAgentYaml(data),
       [SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED]: (data) =>
@@ -617,10 +619,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private async handleGetAutoShowRemote(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendAutoShowRemote(w));
-  }
-
   private async handleSetAutoShowRemote(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_AUTO_SHOW_REMOTE>,
   ): Promise<void> {
@@ -642,10 +640,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       enabled,
       reliabilitySettings: getReliabilitySettings(),
     });
-  }
-
-  private async handleGetSuperYoloEnabled(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
   }
 
   private async handleSetSuperYoloEnabled(
@@ -684,10 +678,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
   // Memory handler implementations
   // ============================================================
-
-  private async handleGetMemoryData(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendMemoryData(w));
-  }
 
   private async handleOpenMemoryFile(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_MEMORY_FILE>,
@@ -754,10 +744,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     }
   }
 
-  private async handleGetMemoryEnabled(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendMemoryEnabled(w));
-  }
-
   private async handleSetMemoryEnabled(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MEMORY_ENABLED>,
   ): Promise<void> {
@@ -768,10 +754,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
   // History handler implementations
   // ============================================================
-
-  private async handleGetHistoryData(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendHistoryData(w));
-  }
 
   private async handleRerunAgent(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.RERUN_AGENT>,
@@ -869,10 +851,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Profile handler implementations
   // ============================================================
 
-  private async handleGetProfileData(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendProfileData(w));
-  }
-
   private async handleSelectAgent(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SELECT_AGENT>,
   ): Promise<void> {
@@ -880,14 +858,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       showSuccessMessage: true,
       copyToClipboardOnFailure: false,
     });
-  }
-
-  private async handleSignIn(): Promise<void> {
-    await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
-  }
-
-  private async handleSignOut(): Promise<void> {
-    await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_OUT);
   }
 
   private async handleSetApiAccessMode(
@@ -1039,10 +1009,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Model selection handler implementations
   // ============================================================
 
-  private async handleGetModelSelection(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendModelSelectionData(w));
-  }
-
   private async handleSetModelEnabled(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MODEL_ENABLED>,
   ): Promise<void> {
@@ -1088,10 +1054,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
   // Agent selection handler implementations
   // ============================================================
-
-  private async handleGetAgentSelection(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendAgentSelectionData(w));
-  }
 
   private async handleOpenAgentYaml(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_AGENT_YAML>,
@@ -1216,10 +1178,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
   // Custom agent directory handler implementations
   // ============================================================
-
-  private async handleGetCustomAgentDir(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendCustomAgentDir(w));
-  }
 
   /** Refresh agent dir + selection after a directory change. */
   private async refreshAgentDirUI(): Promise<void> {

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -22,8 +22,7 @@ import {
 } from '@shared/schemas';
 import {
   getAgent,
-  getVisibleWorkflowAgents,
-  getVisibleToolUseAgents,
+  getVisibleAgents,
 } from '@agent/index/agentRegistry';
 import {
   AgentConfigSchema,
@@ -339,7 +338,7 @@ export class WorkflowAgentTool extends defineTool({
     () => `Delegate a task to a workflow agent for document processing.
 
 Available agents:
-${formatAgentList(getVisibleWorkflowAgents())}
+${formatAgentList(getVisibleAgents('workflow'))}
 
 Available models: ${getVisibleModels().join(', ')}
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
@@ -351,7 +350,7 @@ Example: agent=correct, inputFile=paper.tex, instruction="This research paper pr
     // Validate agent exists and is a workflow agent
     const agentEntry = getAgent(input.agent);
     if (!agentEntry) {
-      const available = getVisibleWorkflowAgents()
+      const available = getVisibleAgents('workflow')
         .map((a) => a.name)
         .join(', ');
       throw new Error(
@@ -462,7 +461,7 @@ export class DelegateAgentTool extends defineTool({
     () => `Delegate a task to a tool-use agent for exploration or research.
 
 Available agents:
-${formatAgentList(getVisibleToolUseAgents())}
+${formatAgentList(getVisibleAgents('toolUse'))}
 
 Available models: ${getVisibleModels().join(', ')}
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
@@ -474,7 +473,7 @@ Example: agent=search, instruction="The paper at paper.tex proposes a new attent
     // Validate agent exists and is a tool-use agent
     const agentEntry = getAgent(input.agent);
     if (!agentEntry) {
-      const available = getVisibleToolUseAgents()
+      const available = getVisibleAgents('toolUse')
         .map((a) => a.name)
         .join(', ');
       throw new Error(

--- a/src/tools/lean/VscodeIntegration.ts
+++ b/src/tools/lean/VscodeIntegration.ts
@@ -158,13 +158,6 @@ export async function promptLean4ExtensionInstall(): Promise<void> {
 }
 
 /**
- * Check if Lean 4 extension is installed.
- */
-export function isLean4ExtensionInstalled(): boolean {
-  return vscode.extensions.getExtension(LEAN4_EXTENSION_ID) !== undefined;
-}
-
-/**
  * Get the Lean 4 extension's client provider.
  * Returns null if the extension is not installed or not ready.
  * Prompts user to install the extension if not found.

--- a/src/tools/texcount/TexcountTool.ts
+++ b/src/tools/texcount/TexcountTool.ts
@@ -4,11 +4,7 @@ import { z } from 'zod';
 // Local imports - latex utilities
 import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
-import {
-  formatTeXCountStats,
-  getTeXCount,
-  type TexcountMode,
-} from '@latex/texcount';
+import { getTeXCount, type TexcountMode } from '@latex/texcount';
 
 // Local imports - tool core
 
@@ -29,7 +25,7 @@ function toFileArray(files: TexcountInput['files']): string[] {
 
 function formatOutput(output: string, format: TexcountInput['format']): string {
   if (format === 'stats') {
-    return formatTeXCountStats(output);
+    return `TeX Count Statistics:<texcount>\n${output}\n</texcount>\n\n`;
   }
   return output;
 }


### PR DESCRIPTION
Eliminate ~30 trivial wrapper functions that just delegated to another
function, reducing indirection without changing behavior.

- Export getVisibleAgents() directly, remove getVisibleWorkflowAgents/
  getVisibleToolUseAgents one-liner wrappers (agentRegistry, WorkflowTool,
  userVars)
- Inline 11 handleGet* wrappers in SettingsViewMessageHandler into the
  handler registry (handleGetMemoryData, handleGetProfileData,
  handleSignIn/Out, etc.)
- Inline 8 handler wrappers in ProgressViewMessageHandler into the
  handler registry (handleStopStream, handleOpenFile, handleOpenLabel,
  etc.)
- Inline nonZeroOrUndefined() → `value || undefined` at all 10 call
  sites across 4 model handlers, delete the function
- Remove dead isLean4ExtensionInstalled export (exported, never imported)
- Inline formatTeXCountStats template string at its 2 call sites, delete
  the function

https://claude.ai/code/session_01QQ93qm8C64SsAMYtbn3sEh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactoring that removes thin wrappers and re-routes handlers without changing underlying behavior. Main risk is minor regression from mismatched command wiring or signature assumptions in webview message handlers.
> 
> **Overview**
> Reduces indirection by removing a set of trivial one-line wrapper functions and inlining their call-through logic at the call sites.
> 
> This **consolidates agent visibility lookups** into a single exported `getVisibleAgents(category)` API (replacing `getVisibleWorkflowAgents`/`getVisibleToolUseAgents`) and updates dropdown/tool/user-var code paths to use it.
> 
> It also **simplifies webview message dispatch** by wiring several Progress/Settings view commands directly to `vscode.commands.executeCommand(...)` or existing `send*`/`processFollowup` methods, deleting now-redundant `handleGet*`/`handleOpen*`/`handleStop*` wrappers. Separately, it removes `nonZeroOrUndefined` and `formatTeXCountStats` by inlining `value || undefined` and the texcount formatting template, and drops an unused `isLean4ExtensionInstalled` export.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a4cd2b07d5f9178c33dfe3d297fa7a8fb19d5d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->