### PR TITLE
Add Tool Dashboard tab to Settings view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1059,6 +1059,12 @@
         "icon": "$(symbol-method)"
       },
       {
+        "command": "texra.showTools",
+        "title": "Show Tool Dashboard",
+        "category": "TeXRA",
+        "icon": "$(tools)"
+      },
+      {
         "command": "texra.openSettings",
         "title": "Open TeXRA Settings",
         "category": "TeXRA",

--- a/src/MainViewProvider.ts
+++ b/src/MainViewProvider.ts
@@ -19,9 +19,8 @@ import { consumePendingState } from '@common/state';
 // Local imports - frontend
 import { agentDirectories } from '@frontend/agents';
 import { computeModelOptionsData } from '@model/computeModelOptions';
-import { watchConfig, getConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
+import { watchConfig, DEBOUNCE_OPTIONS_MS } from '@utils/config';
 import { debounce } from '@utils/core';
-import { checkCoreDependencies } from '@utils/system/toolUtils';
 
 // Local file imports
 import { MainViewMessageHandler } from './webview/MainViewMessageHandler';
@@ -196,22 +195,6 @@ export class MainViewProvider
     super.resolveWebviewViewInternal(webviewView);
 
     this.setupInitialState(webviewView);
-
-    // Check for missing core dependencies and display banner if needed
-    const showDependencyReminders = getConfig<boolean>(
-      'texra.ui.showDependencyReminders',
-      true,
-    );
-    if (showDependencyReminders) {
-      checkCoreDependencies(false).then((missingTools) => {
-        if (missingTools.length > 0) {
-          webviewView.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
-            missingTools,
-          });
-        }
-      });
-    }
   }
 
   private async setupInitialState(webviewView: vscode.WebviewView) {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -10,7 +10,6 @@ import {
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 
-import * as vscode from 'vscode';
 import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
 
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
@@ -20,10 +19,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
-import {
-  getUnavailableToolNames,
-  getExcludedToolLabels,
-} from '@tools/toolAvailability';
+import { getUnavailableToolNames } from '@tools/toolAvailability';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
@@ -76,7 +72,6 @@ async function resolveTools(
   options?: { isSubagent?: boolean },
 ): Promise<ToolDefinition[]> {
   const unavailable = await getUnavailableToolNames();
-  const excluded = new Set<string>();
 
   const toolConfigs = Array.isArray(tools) ? tools : [];
   const resolved = toolConfigs
@@ -84,7 +79,6 @@ async function resolveTools(
     .filter((def) => {
       if (options?.isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
       if (unavailable.has(def.name)) {
-        excluded.add(def.name);
         logger.warn(
           `Tool "${def.name}" excluded: external dependency not installed`,
         );
@@ -96,21 +90,6 @@ async function resolveTools(
       }
       return true;
     });
-
-  // Notify the user about excluded external tools
-  if (excluded.size > 0) {
-    const labels = getExcludedToolLabels(excluded);
-    if (labels.length > 0) {
-      const msg = `Some tools were excluded because their dependencies are not installed: ${labels.join(', ')}.`;
-      void vscode.window
-        .showWarningMessage(msg, 'Open Tool Dashboard')
-        .then((action) => {
-          if (action === 'Open Tool Dashboard') {
-            void vscode.commands.executeCommand('texra.showTools');
-          }
-        });
-    }
-  }
 
   if (getToolUseMemoryEnabled() && !resolved.some((d) => d.name === 'memory')) {
     const memoryTool = registry.get('memory');

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -19,7 +19,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
-import { getUnavailableToolNames } from '@tools/toolAvailability';
+import { getUnavailableToolNamesCached } from '@tools/toolAvailability';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
@@ -65,13 +65,13 @@ const DELEGATION_TOOLS = new Set([
   'propose_agent',
 ]);
 
-async function resolveTools(
+function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
   options?: { isSubagent?: boolean },
-): Promise<ToolDefinition[]> {
-  const unavailable = await getUnavailableToolNames();
+): ToolDefinition[] {
+  const unavailable = getUnavailableToolNamesCached();
 
   const toolConfigs = Array.isArray(tools) ? tools : [];
   const resolved = toolConfigs
@@ -110,7 +110,7 @@ export async function runToolUseFlow<C = unknown>(
   const { logger, streamId, executionId, setting, onInterrupt } = input;
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const resolvedTools = await resolveTools(setting.tools, registry, logger, {
+  const resolvedTools = resolveTools(setting.tools, registry, logger, {
     isSubagent: input.isSubagent,
   });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -18,7 +18,7 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common/Ba
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
-import { getDefaultToolRegistry } from '@tools/registry';
+import { DELEGATION_TOOLS, getDefaultToolRegistry } from '@tools/registry';
 import { getUnavailableToolNamesCached } from '@tools/toolAvailability';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
@@ -57,13 +57,6 @@ export interface ToolUseFlowContext {
 }
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
-
-const DELEGATION_TOOLS = new Set([
-  'delegate_workflow',
-  'delegate_agent',
-  'propose_workflow',
-  'propose_agent',
-]);
 
 function resolveTools(
   tools: AgentToolUseSetting['tools'],

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -10,6 +10,7 @@ import {
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 
+import * as vscode from 'vscode';
 import { PersistedFlow, type FlowRecord } from '@agent/node/persisted-flow';
 
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
@@ -19,6 +20,10 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import { getDefaultToolRegistry } from '@tools/registry';
+import {
+  getUnavailableToolNames,
+  getExcludedToolLabels,
+} from '@tools/toolAvailability';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';
 import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
@@ -64,23 +69,49 @@ const DELEGATION_TOOLS = new Set([
   'propose_agent',
 ]);
 
-function resolveTools(
+async function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
   options?: { isSubagent?: boolean },
-): ToolDefinition[] {
+): Promise<ToolDefinition[]> {
+  const unavailable = await getUnavailableToolNames();
+  const excluded = new Set<string>();
+
   const toolConfigs = Array.isArray(tools) ? tools : [];
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
       if (options?.isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
+      if (unavailable.has(def.name)) {
+        excluded.add(def.name);
+        logger.warn(
+          `Tool "${def.name}" excluded: external dependency not installed`,
+        );
+        return false;
+      }
       if (!registry.has(def.name)) {
         logger.warn(`Tool "${def.name}" not found in registry`);
         return false;
       }
       return true;
     });
+
+  // Notify the user about excluded external tools
+  if (excluded.size > 0) {
+    const labels = getExcludedToolLabels(excluded);
+    if (labels.length > 0) {
+      const msg = `Some tools were excluded because their dependencies are not installed: ${labels.join(', ')}.`;
+      void vscode.window
+        .showWarningMessage(msg, 'Open Tool Dashboard')
+        .then((action) => {
+          if (action === 'Open Tool Dashboard') {
+            void vscode.commands.executeCommand('texra.showTools');
+          }
+        });
+    }
+  }
+
   if (getToolUseMemoryEnabled() && !resolved.some((d) => d.name === 'memory')) {
     const memoryTool = registry.get('memory');
     if (memoryTool) {
@@ -100,7 +131,7 @@ export async function runToolUseFlow<C = unknown>(
   const { logger, streamId, executionId, setting, onInterrupt } = input;
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const resolvedTools = resolveTools(setting.tools, registry, logger, {
+  const resolvedTools = await resolveTools(setting.tools, registry, logger, {
     isSubagent: input.isSubagent,
   });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -18,7 +18,8 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common/Ba
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
-import { DELEGATION_TOOLS, getDefaultToolRegistry } from '@tools/registry';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { getDefaultToolRegistry } from '@tools/registry';
 import { getUnavailableToolNamesCached } from '@tools/toolAvailability';
 import { getToolUseMemoryEnabled } from '@utils/config/constants';
 import { ToolUsePrepareNode } from './nodes/ToolUsePrepareNode';

--- a/src/commands/settings/settingsCommands.ts
+++ b/src/commands/settings/settingsCommands.ts
@@ -14,6 +14,7 @@ export const settingsViewCommands = {
   showHistory: 'texra.showAgentHistory',
   showModels: 'texra.showModels',
   showAgents: 'texra.showAgents',
+  showTools: 'texra.showTools',
 } as const;
 
 let settingsViewProvider: SettingsViewProvider | null = null;
@@ -64,6 +65,9 @@ export function registerSettingsViewCommands(
       settingsViewCommands.showAgents,
       (subTab?: AgentCategory) =>
         settingsViewProvider?.showSettingsView(SETTINGS_TAB.AGENTS, subTab),
+    ),
+    vscode.commands.registerCommand(settingsViewCommands.showTools, () =>
+      settingsViewProvider?.showSettingsView(SETTINGS_TAB.TOOLS),
     ),
   );
 }

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -346,6 +346,10 @@ export const SETTINGS_VIEW_CMD = {
   // Multi-Agent commands
   GET_SUPER_YOLO_ENABLED: 'getSuperYoloEnabled',
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
+  // Tool dashboard commands
+  GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
+  OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
+  RECHECK_TOOL_STATUS: 'recheckToolStatus',
 } as const;
 
 // Settings view specific commands (combines Memory, History, and Profile views)
@@ -364,4 +368,5 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_AUTO_SHOW_REMOTE: 'updateAutoShowRemote',
   UPDATE_CUSTOM_AGENT_DIR: 'updateCustomAgentDir',
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
+  UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
 } as const;

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -10,7 +10,7 @@
 // Local imports - shared utilities
 import { isPlainObject } from '@shared/utils/string';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
-import { DELEGATION_TOOLS } from '@tools/registry';
+import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -10,6 +10,8 @@
 // Local imports - shared utilities
 import { isPlainObject } from '@shared/utils/string';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
+import { DELEGATION_TOOLS } from '@tools/registry';
+import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import type { ExecutionsToolInput } from '@tools/ExecutionsTool';
 import type { EditInput } from '@tools/EditTool';
 import type { TextEditorInput } from '@tools/TextEditorTool';
@@ -20,7 +22,6 @@ import type {
   WorkflowAgentInput,
 } from '@tools/WorkflowTool';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 
 // Local imports - Lit template utilities
 import {
@@ -143,14 +144,6 @@ const STATUS_ICONS: Record<string, string> = {
   failed: 'codicon codicon-error',
   in_progress: 'codicon codicon-sync spin',
 };
-
-/** Tools that represent agent delegation (have restorable config). Includes legacy names for historical log entries. */
-const DELEGATION_TOOLS = new Set([
-  'delegate_agent',
-  'delegate_workflow',
-  'propose_agent',
-  'propose_workflow',
-]);
 
 type ToolSectionOptions = {
   toolName?: string;

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -84,6 +84,7 @@ import { getConfig } from '@utils/config/configUtils';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import { loadMemoryItems } from './utils/memoryFileSystem';
+import { buildToolDashboardItems } from './utils/toolDashboardData';
 import type {
   RemoteAgent,
   ProviderKeyStatus,
@@ -399,6 +400,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenAgentFolder(data),
       [SETTINGS_VIEW_COMMANDS.CREATE_AGENT]: (data) =>
         this.handleCreateAgent(data),
+
+      // Tool dashboard handlers
+      [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
+        this.handleGetToolDashboardData(),
+      [SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL]: (data) =>
+        this.handleOpenToolInstallUrl(data),
+      [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
+        this.handleRecheckToolStatus(),
     };
   }
 
@@ -458,6 +467,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.sendAutoShowRemote(webview),
       this.sendCustomAgentDir(webview),
       this.sendSuperYoloEnabled(webview),
+      this.sendToolDashboardData(webview),
     ]);
   }
 
@@ -1219,5 +1229,31 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         error,
       );
     }
+  }
+
+  // ============================================================
+  // Tool dashboard handler implementations
+  // ============================================================
+
+  public async sendToolDashboardData(webview: vscode.Webview): Promise<void> {
+    const items = await buildToolDashboardItems();
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items,
+    });
+  }
+
+  private async handleGetToolDashboardData(): Promise<void> {
+    await this.withActiveWebview((w) => this.sendToolDashboardData(w));
+  }
+
+  private async handleOpenToolInstallUrl(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_TOOL_INSTALL_URL>,
+  ): Promise<void> {
+    await vscode.env.openExternal(vscode.Uri.parse(data.url));
+  }
+
+  private async handleRecheckToolStatus(): Promise<void> {
+    await this.withActiveWebview((w) => this.sendToolDashboardData(w));
   }
 }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -457,6 +457,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
 
   public async sendAllData(webview: vscode.Webview): Promise<void> {
+    // Tool dashboard involves network I/O (Zotero probe, etc.) — fire async
+    // so it doesn't block the initial render. The frontend shows a loading
+    // spinner until data arrives.
+    void this.sendToolDashboardData(webview);
+
     await Promise.all([
       this.sendMemoryData(webview),
       this.sendMemoryEnabled(webview),
@@ -467,7 +472,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.sendAutoShowRemote(webview),
       this.sendCustomAgentDir(webview),
       this.sendSuperYoloEnabled(webview),
-      this.sendToolDashboardData(webview),
     ]);
   }
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -38,8 +38,10 @@ import {
   UpdateAutoShowRemoteMessageSchema,
   UpdateCustomAgentDirMessageSchema,
   UpdateSuperYoloEnabledMessageSchema,
+  UpdateToolDashboardMessageSchema,
   type AgentSelectionItem,
   type NumberVscodeSetting,
+  type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
 import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
 
@@ -59,6 +61,7 @@ import './tabs/HistoryTab';
 import './tabs/ModelsTab';
 import './tabs/AgentsTab';
 import './tabs/MultiAgentTab';
+import './tabs/ToolsTab';
 import type { HistoryTab } from './tabs/HistoryTab';
 
 const HISTORY_ACTION_COMMANDS: Record<string, string> = {
@@ -150,6 +153,9 @@ export class SettingsApp extends BaseWebviewApp {
   @state() private superYoloToggleDisabled = true;
   @state() private reliabilitySettings: NumberVscodeSetting[] = [];
 
+  // Tool dashboard state
+  @state() private toolDashboardItems: ToolDashboardItem[] = [];
+
   protected get readyCommand(): string | null {
     return null;
   }
@@ -166,6 +172,7 @@ export class SettingsApp extends BaseWebviewApp {
     postMessage(SETTINGS_VIEW_COMMANDS.GET_AUTO_SHOW_REMOTE);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_CUSTOM_AGENT_DIR);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED);
+    postMessage(SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA);
   }
 
   private parseMessage<T>(
@@ -276,6 +283,13 @@ export class SettingsApp extends BaseWebviewApp {
         this.superYoloEnabled = data.enabled;
         this.superYoloToggleDisabled = false;
         this.reliabilitySettings = data.reliabilitySettings;
+        return;
+      }
+
+      case SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD: {
+        const data = this.parseMessage(raw, UpdateToolDashboardMessageSchema);
+        if (!data) return;
+        this.toolDashboardItems = data.items;
         return;
       }
 
@@ -427,6 +441,15 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED,
   );
 
+  // Tool dashboard event handlers
+  private handleToolOpenUrl = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL,
+  );
+
+  private handleToolRecheck(): void {
+    postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS);
+  }
+
   private handleOpenVscodeSettings(): void {
     postMessage(SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS);
   }
@@ -495,6 +518,7 @@ export class SettingsApp extends BaseWebviewApp {
           <vscode-tab-header slot="header">Models</vscode-tab-header>
           <vscode-tab-header slot="header">Agents</vscode-tab-header>
           <vscode-tab-header slot="header">Multi-Agent</vscode-tab-header>
+          <vscode-tab-header slot="header">Tools</vscode-tab-header>
 
           <vscode-tab-panel>
             <memory-tab
@@ -567,6 +591,14 @@ export class SettingsApp extends BaseWebviewApp {
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
             ></multi-agent-tab>
+          </vscode-tab-panel>
+
+          <vscode-tab-panel>
+            <tools-tab
+              .items=${this.toolDashboardItems}
+              @tool-open-url=${this.handleToolOpenUrl}
+              @tool-recheck=${this.handleToolRecheck}
+            ></tools-tab>
           </vscode-tab-panel>
         </vscode-tabs>
       </div>

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -155,6 +155,7 @@ export class SettingsApp extends BaseWebviewApp {
 
   // Tool dashboard state
   @state() private toolDashboardItems: ToolDashboardItem[] = [];
+  @state() private toolDashboardLoaded = false;
 
   protected get readyCommand(): string | null {
     return null;
@@ -290,6 +291,7 @@ export class SettingsApp extends BaseWebviewApp {
         const data = this.parseMessage(raw, UpdateToolDashboardMessageSchema);
         if (!data) return;
         this.toolDashboardItems = data.items;
+        this.toolDashboardLoaded = true;
         return;
       }
 
@@ -596,6 +598,7 @@ export class SettingsApp extends BaseWebviewApp {
           <vscode-tab-panel>
             <tools-tab
               .items=${this.toolDashboardItems}
+              .loaded=${this.toolDashboardLoaded}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-recheck=${this.handleToolRecheck}
             ></tools-tab>

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -266,10 +266,12 @@ export class ToolCard extends LitElement {
                   `
                 : nothing}
             </div>
+            ${this.item.configNotes
+              ? html`<div class="tool-config-note">
+                  ${this.item.configNotes}
+                </div>`
+              : nothing}
           `
-        : nothing}
-      ${this.item.configNotes
-        ? html`<div class="tool-config-note">${this.item.configNotes}</div>`
         : nothing}
     `;
   }
@@ -286,7 +288,12 @@ export class ToolCard extends LitElement {
         <div class="tool-description">${this.item.description}</div>
         <div class="tool-ids">
           ${this.item.tools.map(
-            (tool) => html`<span class="tool-id-tag">${tool}</span>`,
+            (tool) =>
+              html`<span
+                class="tool-id-tag"
+                title=${tool.description ?? tool.name}
+                >${tool.name}</span
+              >`,
           )}
         </div>
         ${this.renderGuide()}

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -1,0 +1,302 @@
+/**
+ * ToolCard component - displays a single tool group with status, description,
+ * and optional installation guide.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared schemas
+import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+
+@customElement('tool-card')
+export class ToolCard extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .tool-card {
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius);
+        padding: var(--spacing-medium) var(--spacing-large);
+        margin-bottom: var(--spacing-medium);
+        background: var(
+          --vscode-editor-background,
+          var(--vscode-sideBar-background)
+        );
+        transition: border-color 0.15s ease;
+      }
+
+      .tool-card:hover {
+        border-color: var(--vscode-focusBorder);
+      }
+
+      .tool-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-medium);
+        margin-bottom: var(--spacing-small);
+      }
+
+      .tool-title-group {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        min-width: 0;
+      }
+
+      .tool-name {
+        font-weight: 500;
+        font-size: var(--font-size);
+        color: var(--vscode-foreground);
+        white-space: nowrap;
+      }
+
+      .tool-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 1px var(--spacing-small);
+        font-size: var(--font-size-xs, 11px);
+        border-radius: var(--border-radius);
+        white-space: nowrap;
+        font-weight: 500;
+      }
+
+      .tool-badge--available {
+        color: var(--vscode-testing-iconPassed, #73c991);
+        background: rgba(115, 201, 145, 0.12);
+      }
+
+      .tool-badge--not-found {
+        color: var(--vscode-testing-iconFailed, #f48771);
+        background: rgba(244, 135, 113, 0.12);
+      }
+
+      .tool-badge--unknown {
+        color: var(--color-text-secondary);
+        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+      }
+
+      .tool-description {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        margin-bottom: var(--spacing-small);
+        line-height: 1.4;
+      }
+
+      .tool-ids {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-bottom: var(--spacing-small);
+      }
+
+      .tool-id-tag {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-size: var(--font-size-xs, 11px);
+        padding: 1px 6px;
+        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--color-text-secondary);
+        border-radius: var(--border-radius);
+      }
+
+      .tool-guide-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+        font-size: var(--font-size-sm);
+        font-family: inherit;
+        color: var(--vscode-textLink-foreground, #3794ff);
+        background: none;
+        border: none;
+        cursor: pointer;
+        transition: opacity 0.1s ease;
+      }
+
+      .tool-guide-toggle:hover {
+        opacity: 0.8;
+      }
+
+      .tool-guide {
+        margin-top: var(--spacing-small);
+        padding: var(--spacing-medium);
+        background: var(
+          --vscode-textCodeBlock-background,
+          rgba(128, 128, 128, 0.08)
+        );
+        border-radius: var(--border-radius);
+        font-size: var(--font-size-sm);
+        color: var(--vscode-foreground);
+        line-height: 1.5;
+        white-space: pre-wrap;
+      }
+
+      .tool-guide-actions {
+        display: flex;
+        gap: var(--spacing-small);
+        margin-top: var(--spacing-small);
+      }
+
+      .tool-action-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) var(--spacing-medium);
+        font-size: var(--font-size-sm);
+        font-family: inherit;
+        color: var(--vscode-button-foreground, #fff);
+        background: var(--vscode-button-background, #0e639c);
+        border: none;
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        transition:
+          background 0.1s ease,
+          opacity 0.1s ease;
+      }
+
+      .tool-action-btn:hover {
+        background: var(--vscode-button-hoverBackground, #1177bb);
+      }
+
+      .tool-action-btn--secondary {
+        color: var(--vscode-button-secondaryForeground, #ccc);
+        background: var(
+          --vscode-button-secondaryBackground,
+          rgba(128, 128, 128, 0.2)
+        );
+      }
+
+      .tool-action-btn--secondary:hover {
+        background: var(
+          --vscode-button-secondaryHoverBackground,
+          rgba(128, 128, 128, 0.3)
+        );
+      }
+
+      .tool-config-note {
+        margin-top: var(--spacing-small);
+        font-size: var(--font-size-xs, 11px);
+        color: var(--color-text-secondary);
+        font-style: italic;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) item!: ToolDashboardItem;
+
+  @state() private guideExpanded = false;
+
+  private toggleGuide(): void {
+    this.guideExpanded = !this.guideExpanded;
+  }
+
+  private handleInstallUrl(): void {
+    if (this.item.installUrl) {
+      this.dispatchEvent(
+        new CustomEvent('tool-open-url', {
+          detail: { url: this.item.installUrl },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  private renderBadge(): TemplateResult {
+    const { status } = this.item;
+    const iconClass =
+      status === 'available'
+        ? 'codicon-check'
+        : status === 'not-found'
+          ? 'codicon-warning'
+          : 'codicon-question';
+    const label =
+      status === 'available'
+        ? 'Available'
+        : status === 'not-found'
+          ? 'Not Found'
+          : 'Unknown';
+
+    return html`
+      <span class="tool-badge tool-badge--${status}">
+        <span class="codicon ${iconClass}"></span>
+        ${label}
+      </span>
+    `;
+  }
+
+  private renderGuide(): TemplateResult | typeof nothing {
+    if (!this.item.requiresSetup) return nothing;
+
+    const hasGuide = this.item.installGuide || this.item.installUrl;
+    if (!hasGuide) return nothing;
+
+    return html`
+      <button class="tool-guide-toggle" @click=${this.toggleGuide}>
+        <span
+          class="codicon ${this.guideExpanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}"
+        ></span>
+        Installation Guide
+      </button>
+      ${this.guideExpanded
+        ? html`
+            <div class="tool-guide">${this.item.installGuide}</div>
+            <div class="tool-guide-actions">
+              ${this.item.installUrl
+                ? html`
+                    <button
+                      class="tool-action-btn"
+                      @click=${this.handleInstallUrl}
+                    >
+                      <span class="codicon codicon-link-external"></span>
+                      Open Install Page
+                    </button>
+                  `
+                : nothing}
+            </div>
+          `
+        : nothing}
+      ${this.item.configNotes
+        ? html`<div class="tool-config-note">${this.item.configNotes}</div>`
+        : nothing}
+    `;
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <div class="tool-card">
+        <div class="tool-header">
+          <div class="tool-title-group">
+            <span class="tool-name">${this.item.name}</span>
+            ${this.renderBadge()}
+          </div>
+        </div>
+        <div class="tool-description">${this.item.description}</div>
+        <div class="tool-ids">
+          ${this.item.tools.map(
+            (tool) => html`<span class="tool-id-tag">${tool}</span>`,
+          )}
+        </div>
+        ${this.renderGuide()}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'tool-card': ToolCard;
+  }
+}

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -177,16 +177,6 @@ export class ToolsTab extends LitElement {
   @property({ attribute: false }) items: ToolDashboardItem[] = [];
   @property({ type: Boolean }) loaded = false;
 
-  private handleOpenUrl(event: CustomEvent<{ url: string }>): void {
-    this.dispatchEvent(
-      new CustomEvent('tool-open-url', {
-        detail: event.detail,
-        bubbles: true,
-        composed: true,
-      }),
-    );
-  }
-
   private handleRecheck(): void {
     this.dispatchEvent(
       new CustomEvent('tool-recheck', {
@@ -251,11 +241,7 @@ export class ToolsTab extends LitElement {
         ${repeat(
           items,
           (item) => item.id,
-          (item) =>
-            html`<tool-card
-              .item=${item}
-              @tool-open-url=${this.handleOpenUrl}
-            ></tool-card>`,
+          (item) => html`<tool-card .item=${item}></tool-card>`,
         )}
       </div>
     `;

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -1,0 +1,303 @@
+/**
+ * ToolsTab component - tool dashboard showing all available tools
+ * with their configuration status and installation guides.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared schemas
+import type {
+  ToolDashboardItem,
+  ToolCategory,
+} from '@shared/schemas/settingsViewMessages';
+
+// Local imports - tool card component (side-effect: register)
+import '../components/tools/ToolCard';
+
+/** Display labels for each tool category */
+const CATEGORY_LABELS: Record<ToolCategory, string> = {
+  file: 'File & Shell',
+  latex: 'LaTeX',
+  academic: 'Academic Research',
+  web: 'Web',
+  computation: 'Computation',
+  lean: 'Lean 4',
+  workflow: 'Memory & Workflow',
+};
+
+/** Icons for each tool category */
+const CATEGORY_ICONS: Record<ToolCategory, string> = {
+  file: 'codicon-files',
+  latex: 'codicon-file-code',
+  academic: 'codicon-mortar-board',
+  web: 'codicon-globe',
+  computation: 'codicon-symbol-operator',
+  lean: 'codicon-beaker',
+  workflow: 'codicon-type-hierarchy',
+};
+
+/** Canonical category display order */
+const CATEGORY_ORDER: ToolCategory[] = [
+  'file',
+  'latex',
+  'academic',
+  'web',
+  'computation',
+  'lean',
+  'workflow',
+];
+
+@customElement('tools-tab')
+export class ToolsTab extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .tools-container {
+        max-width: 1000px;
+        margin: 0 auto;
+      }
+
+      .tools-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--spacing-large);
+      }
+
+      .tools-title {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        font-size: var(--font-size-lg, 14px);
+        font-weight: 500;
+        color: var(--vscode-foreground);
+      }
+
+      .tools-summary {
+        display: flex;
+        gap: var(--spacing-large);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+      }
+
+      .tools-summary-stat {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .tools-summary-stat .codicon {
+        font-size: var(--font-size-sm);
+      }
+
+      .tools-stat-available {
+        color: var(--vscode-testing-iconPassed, #73c991);
+      }
+
+      .tools-stat-missing {
+        color: var(--vscode-testing-iconFailed, #f48771);
+      }
+
+      .tools-recheck-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) var(--spacing-small);
+        font-size: var(--font-size-xs);
+        font-family: inherit;
+        color: var(--color-text-secondary);
+        background: none;
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        transition:
+          color 0.1s ease,
+          border-color 0.1s ease;
+      }
+
+      .tools-recheck-btn:hover {
+        color: var(--vscode-foreground);
+        border-color: var(--vscode-focusBorder);
+      }
+
+      .category-section {
+        margin-bottom: var(--spacing-large);
+      }
+
+      .category-header {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding-bottom: var(--spacing-small);
+        margin-bottom: var(--spacing-medium);
+        border-bottom: var(--border-thin) solid var(--color-border);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .category-header .codicon {
+        font-size: var(--font-size);
+      }
+
+      .category-count {
+        font-weight: normal;
+        opacity: var(--opacity-normal);
+      }
+
+      .tools-empty {
+        text-align: center;
+        padding: var(--spacing-large);
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) items: ToolDashboardItem[] = [];
+
+  private handleOpenUrl(event: CustomEvent<{ url: string }>): void {
+    this.dispatchEvent(
+      new CustomEvent('tool-open-url', {
+        detail: event.detail,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private handleRecheck(): void {
+    this.dispatchEvent(
+      new CustomEvent('tool-recheck', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private groupByCategory(): Map<ToolCategory, ToolDashboardItem[]> {
+    const groups = new Map<ToolCategory, ToolDashboardItem[]>();
+    for (const item of this.items) {
+      const existing = groups.get(item.category);
+      if (existing) {
+        existing.push(item);
+      } else {
+        groups.set(item.category, [item]);
+      }
+    }
+    return groups;
+  }
+
+  private renderSummary(): TemplateResult | typeof nothing {
+    if (this.items.length === 0) return nothing;
+
+    const available = this.items.filter(
+      (i) => i.status === 'available',
+    ).length;
+    const missing = this.items.filter(
+      (i) => i.status === 'not-found',
+    ).length;
+
+    return html`
+      <div class="tools-summary">
+        <span class="tools-summary-stat tools-stat-available">
+          <span class="codicon codicon-check"></span>
+          ${available} available
+        </span>
+        ${missing > 0
+          ? html`
+              <span class="tools-summary-stat tools-stat-missing">
+                <span class="codicon codicon-warning"></span>
+                ${missing} need setup
+              </span>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderCategory(
+    category: ToolCategory,
+    items: ToolDashboardItem[],
+  ): TemplateResult {
+    return html`
+      <div class="category-section">
+        <div class="category-header">
+          <span class="codicon ${CATEGORY_ICONS[category]}"></span>
+          ${CATEGORY_LABELS[category]}
+          <span class="category-count">(${items.length})</span>
+        </div>
+        ${repeat(
+          items,
+          (item) => item.id,
+          (item) =>
+            html`<tool-card
+              .item=${item}
+              @tool-open-url=${this.handleOpenUrl}
+            ></tool-card>`,
+        )}
+      </div>
+    `;
+  }
+
+  override render(): TemplateResult {
+    const groups = this.groupByCategory();
+
+    if (this.items.length === 0) {
+      return html`
+        <div class="tools-container">
+          <div class="tools-empty">
+            <span class="codicon codicon-loading codicon-modifier-spin"></span>
+            Loading tool information...
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="tools-container">
+        <div class="tools-header">
+          <div class="tools-title">
+            <span class="codicon codicon-tools"></span>
+            Tool Dashboard
+          </div>
+          <div style="display:flex;align-items:center;gap:var(--spacing-medium)">
+            ${this.renderSummary()}
+            <button
+              class="tools-recheck-btn"
+              @click=${this.handleRecheck}
+              title="Re-check tool availability"
+            >
+              <span class="codicon codicon-refresh"></span>
+              Re-check
+            </button>
+          </div>
+        </div>
+
+        ${CATEGORY_ORDER.filter((cat) => groups.has(cat)).map((cat) =>
+          this.renderCategory(cat, groups.get(cat)!),
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'tools-tab': ToolsTab;
+  }
+}

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -20,29 +20,29 @@ import type {
 // Local imports - tool card component (side-effect: register)
 import '../components/tools/ToolCard';
 
-/** Display labels for each tool category */
-const CATEGORY_LABELS: Record<ToolCategory, string> = {
-  file: 'File & Shell',
-  latex: 'LaTeX',
-  academic: 'Academic Research',
-  web: 'Web',
-  computation: 'Computation',
-  lean: 'Lean 4',
-  workflow: 'Memory & Workflow',
+/** Per-category display metadata. */
+interface CategoryMeta {
+  readonly label: string;
+  readonly icon: string;
+}
+
+/**
+ * Single definition for category display metadata.
+ * Record<ToolCategory, ...> ensures every category has an entry —
+ * adding a new variant to ToolCategorySchema without an entry here
+ * is a compile error.
+ */
+const CATEGORY_META: Record<ToolCategory, CategoryMeta> = {
+  file: { label: 'File & Shell', icon: 'codicon-files' },
+  latex: { label: 'LaTeX', icon: 'codicon-file-code' },
+  academic: { label: 'Academic Research', icon: 'codicon-mortar-board' },
+  web: { label: 'Web', icon: 'codicon-globe' },
+  computation: { label: 'Computation', icon: 'codicon-symbol-operator' },
+  lean: { label: 'Lean 4', icon: 'codicon-beaker' },
+  workflow: { label: 'Memory & Workflow', icon: 'codicon-type-hierarchy' },
 };
 
-/** Icons for each tool category */
-const CATEGORY_ICONS: Record<ToolCategory, string> = {
-  file: 'codicon-files',
-  latex: 'codicon-file-code',
-  academic: 'codicon-mortar-board',
-  web: 'codicon-globe',
-  computation: 'codicon-symbol-operator',
-  lean: 'codicon-beaker',
-  workflow: 'codicon-type-hierarchy',
-};
-
-/** Canonical category display order */
+/** Canonical category display order. */
 const CATEGORY_ORDER: ToolCategory[] = [
   'file',
   'latex',
@@ -234,8 +234,8 @@ export class ToolsTab extends LitElement {
     return html`
       <div class="category-section">
         <div class="category-header">
-          <span class="codicon ${CATEGORY_ICONS[category]}"></span>
-          ${CATEGORY_LABELS[category]}
+          <span class="codicon ${CATEGORY_META[category].icon}"></span>
+          ${CATEGORY_META[category].label}
           <span class="category-count">(${items.length})</span>
         </div>
         ${repeat(

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -165,10 +165,17 @@ export class ToolsTab extends LitElement {
         color: var(--color-text-secondary);
         font-size: var(--font-size-sm);
       }
+
+      .tools-header-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-medium);
+      }
     `,
   ];
 
   @property({ attribute: false }) items: ToolDashboardItem[] = [];
+  @property({ type: Boolean }) loaded = false;
 
   private handleOpenUrl(event: CustomEvent<{ url: string }>): void {
     this.dispatchEvent(
@@ -257,7 +264,7 @@ export class ToolsTab extends LitElement {
   override render(): TemplateResult {
     const groups = this.groupByCategory();
 
-    if (this.items.length === 0) {
+    if (!this.loaded) {
       return html`
         <div class="tools-container">
           <div class="tools-empty">
@@ -275,7 +282,7 @@ export class ToolsTab extends LitElement {
             <span class="codicon codicon-tools"></span>
             Tool Dashboard
           </div>
-          <div style="display:flex;align-items:center;gap:var(--spacing-medium)">
+          <div class="tools-header-actions">
             ${this.renderSummary()}
             <button
               class="tools-recheck-btn"

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -40,6 +40,7 @@ const CATEGORY_META: Record<ToolCategory, CategoryMeta> = {
   computation: { label: 'Computation', icon: 'codicon-symbol-operator' },
   lean: { label: 'Lean 4', icon: 'codicon-beaker' },
   workflow: { label: 'Memory & Workflow', icon: 'codicon-type-hierarchy' },
+  system: { label: 'System Dependencies', icon: 'codicon-gear' },
 };
 
 /** Canonical category display order. */
@@ -51,6 +52,7 @@ const CATEGORY_ORDER: ToolCategory[] = [
   'computation',
   'lean',
   'workflow',
+  'system',
 ];
 
 @customElement('tools-tab')

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -1,27 +1,56 @@
 /**
  * Tool dashboard data builder.
  *
- * Defines static UI metadata for all tool groups and delegates runtime
- * availability checks to {@link @tools/toolAvailability}.
+ * Enriches tool groups with runtime availability and per-tool descriptions
+ * from the registry. External tool UI metadata lives in
+ * {@link @tools/toolAvailability EXTERNAL_TOOL_CHECKS} — no parallel map here.
  */
 
 // Local imports
-import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
-import { runExternalToolChecks } from '@tools/toolAvailability';
+import type {
+  ToolDashboardItem,
+  ToolInfo,
+} from '@shared/schemas/settingsViewMessages';
+import {
+  EXTERNAL_TOOL_CHECKS,
+  runExternalToolChecks,
+} from '@tools/toolAvailability';
+import { getDefaultToolRegistry } from '@tools/registry';
+
+// ============================================================
+// Tool description enrichment
+// ============================================================
+
+/**
+ * Look up per-tool descriptions from the registry.
+ * Falls back to name-only when a tool isn't registered.
+ */
+function enrichTools(toolNames: readonly string[]): ToolInfo[] {
+  const registry = getDefaultToolRegistry();
+  return toolNames.map((name) => {
+    const tool = registry.get(name);
+    return {
+      name,
+      description: tool?.definition.description,
+    };
+  });
+}
 
 // ============================================================
 // Static tool metadata
 // ============================================================
 
 /** Tool groups that are always available (built-in, no external deps). */
-const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
+const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
+  toolNames: readonly string[];
+})[] = [
   {
     id: 'file-ops',
     name: 'File & Shell Operations',
     category: 'file',
     description:
       'Read, write, edit files and run shell commands. Includes glob/grep search and directory listing.',
-    tools: [
+    toolNames: [
       'bash',
       'read_file',
       'write_file',
@@ -39,7 +68,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'latex',
     description:
       'Extract figures, TikZ diagrams, and bibliography entries from LaTeX documents.',
-    tools: ['extract_figures', 'extract_tikz_figures', 'extract_bib_entries'],
+    toolNames: ['extract_figures', 'extract_tikz_figures', 'extract_bib_entries'],
     requiresSetup: false,
   },
   {
@@ -48,7 +77,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'latex',
     description:
       'Report LaTeX compilation errors and warnings from the VS Code Problems panel.',
-    tools: ['diagnostics'],
+    toolNames: ['diagnostics'],
     requiresSetup: false,
   },
   {
@@ -57,7 +86,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'academic',
     description:
       'Search arXiv papers, retrieve metadata, and download LaTeX source packages.',
-    tools: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source'],
+    toolNames: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source'],
     requiresSetup: false,
   },
   {
@@ -66,7 +95,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'academic',
     description:
       'Search Crossref for academic publications by query or resolve DOIs to full metadata.',
-    tools: ['crossref_doi', 'crossref_search'],
+    toolNames: ['crossref_doi', 'crossref_search'],
     requiresSetup: false,
   },
   {
@@ -75,7 +104,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'web',
     description:
       'Search the web via DuckDuckGo Instant Answers and fetch/extract content from URLs.',
-    tools: ['web_search', 'web_fetch'],
+    toolNames: ['web_search', 'web_fetch'],
     requiresSetup: false,
   },
   {
@@ -84,7 +113,7 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     category: 'workflow',
     description:
       'Persistent memory across sessions, task tracking with to-do lists, and delegate work to sub-agents.',
-    tools: [
+    toolNames: [
       'memory',
       'todo_write',
       'delegate_workflow',
@@ -95,90 +124,6 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
     requiresSetup: false,
   },
 ];
-
-/**
- * UI-only metadata for external tool groups.
- * Keyed by group ID (must match {@link EXTERNAL_TOOL_CHECKS} entries).
- */
-const EXTERNAL_TOOL_UI: Record<
-  string,
-  Omit<ToolDashboardItem, 'status' | 'tools'>
-> = {
-  texcount: {
-    id: 'texcount',
-    name: 'TeXcount',
-    category: 'latex',
-    description:
-      'Count words, headers, figures, and other elements in LaTeX documents.',
-    requiresSetup: true,
-    installGuide:
-      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install texcount\n' +
-      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
-      '  Windows: Install via MiKTeX or TeX Live package manager',
-    installUrl: 'https://app.uio.no/ifi/texcount/',
-    configNotes: 'Part of most TeX Live distributions.',
-  },
-  wolfram: {
-    id: 'wolfram',
-    name: 'Wolfram Language',
-    category: 'computation',
-    description:
-      'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
-    requiresSetup: true,
-    installGuide:
-      'Requires WolframScript or the Wolfram Engine.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install wolfram-engine\n' +
-      '  Ubuntu:  sudo apt-get install wolfram-engine\n' +
-      '  Windows: Download from wolfram.com/engine\n\n' +
-      'Free Wolfram Engine licenses are available for development use.',
-    installUrl: 'https://www.wolfram.com/engine/',
-    configNotes:
-      'Requires a free Wolfram Engine license or Mathematica installation.',
-  },
-  zotero: {
-    id: 'zotero',
-    name: 'Zotero Integration',
-    category: 'academic',
-    description:
-      'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
-    requiresSetup: true,
-    installGuide:
-      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
-      'Setup:\n' +
-      '  1. Install Zotero (zotero.org)\n' +
-      '  2. Install Better BibTeX plugin:\n' +
-      '     - Download from retorque.re/zotero-better-bibtex\n' +
-      '     - In Zotero: Tools > Add-ons > Install from File\n' +
-      '  3. Keep Zotero running while using TeXRA\n\n' +
-      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
-      'that TeXRA uses to communicate with your library.',
-    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
-    configNotes:
-      'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
-  },
-  lean4: {
-    id: 'lean4',
-    name: 'Lean 4 Proof Assistant',
-    category: 'lean',
-    description:
-      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
-    requiresSetup: true,
-    installGuide:
-      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
-      'Setup:\n' +
-      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
-      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
-      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
-      'The Lean tools communicate via the Lean Language Server\n' +
-      'provided by the VS Code extension.',
-    installUrl:
-      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
-    configNotes: 'Lean 4 VS Code extension must be installed and active.',
-  },
-};
 
 // ============================================================
 // Public API
@@ -192,20 +137,34 @@ const EXTERNAL_TOOL_UI: Record<
  */
 export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
   // Built-in tools are always available
-  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.map((tool) => ({
-    ...tool,
-    status: 'available' as const,
-  }));
+  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.map(
+    ({ toolNames, ...rest }) => ({
+      ...rest,
+      tools: enrichTools(toolNames),
+      status: 'available' as const,
+    }),
+  );
 
   // Run fresh checks — also updates the availability cache
   const results = await runExternalToolChecks();
 
-  // Merge check results with UI metadata
+  // Merge check results with UI metadata from EXTERNAL_TOOL_CHECKS
   const externalItems: ToolDashboardItem[] = [];
   for (const { id, tools, status } of results) {
-    const ui = EXTERNAL_TOOL_UI[id];
-    if (!ui) continue;
-    externalItems.push({ ...ui, tools: [...tools], status });
+    const def = EXTERNAL_TOOL_CHECKS.find((c) => c.id === id);
+    if (!def) continue;
+    externalItems.push({
+      id: def.id,
+      name: def.name,
+      category: def.category,
+      description: def.description,
+      tools: enrichTools(tools),
+      status,
+      requiresSetup: true,
+      installGuide: def.installGuide,
+      installUrl: def.installUrl,
+      configNotes: def.configNotes,
+    });
   }
 
   return [...builtinItems, ...externalItems];

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -1,0 +1,244 @@
+/**
+ * Tool dashboard data builder.
+ *
+ * Defines static metadata for all tool groups and performs runtime
+ * availability checks for tools that depend on external binaries,
+ * applications, or VS Code extensions.
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import axios from 'axios';
+
+// Local imports
+import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+import { getZoteroPort } from '@tools/zotero/bbtClient';
+import { checkToolInstalled } from '@utils/system/toolUtils';
+
+// ============================================================
+// Static tool metadata
+// ============================================================
+
+/** Tool groups that are always available (built-in, no external deps). */
+const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
+  {
+    id: 'file-ops',
+    name: 'File & Shell Operations',
+    category: 'file',
+    description:
+      'Read, write, edit files and run shell commands. Includes glob/grep search and directory listing.',
+    tools: [
+      'bash',
+      'read_file',
+      'write_file',
+      'edit_file',
+      'glob',
+      'grep',
+      'ls',
+      'apply_path',
+    ],
+    requiresSetup: false,
+  },
+  {
+    id: 'latex-extract',
+    name: 'LaTeX Extraction',
+    category: 'latex',
+    description:
+      'Extract figures, TikZ diagrams, and bibliography entries from LaTeX documents.',
+    tools: ['extract_figures', 'extract_tikz_figures', 'extract_bib_entries'],
+    requiresSetup: false,
+  },
+  {
+    id: 'latex-diagnostics',
+    name: 'LaTeX Diagnostics',
+    category: 'latex',
+    description:
+      'Report LaTeX compilation errors and warnings from the VS Code Problems panel.',
+    tools: ['diagnostics'],
+    requiresSetup: false,
+  },
+  {
+    id: 'arxiv',
+    name: 'ArXiv Search & Download',
+    category: 'academic',
+    description:
+      'Search arXiv papers, retrieve metadata, and download LaTeX source packages.',
+    tools: ['arxiv_search', 'arxiv_metadata', 'download_arxiv_source'],
+    requiresSetup: false,
+  },
+  {
+    id: 'crossref',
+    name: 'Crossref Citation Lookup',
+    category: 'academic',
+    description:
+      'Search Crossref for academic publications by query or resolve DOIs to full metadata.',
+    tools: ['crossref_doi', 'crossref_search'],
+    requiresSetup: false,
+  },
+  {
+    id: 'web',
+    name: 'Web Search & Fetch',
+    category: 'web',
+    description:
+      'Search the web via DuckDuckGo Instant Answers and fetch/extract content from URLs.',
+    tools: ['web_search', 'web_fetch'],
+    requiresSetup: false,
+  },
+  {
+    id: 'memory-workflow',
+    name: 'Memory, Tasks & Delegation',
+    category: 'workflow',
+    description:
+      'Persistent memory across sessions, task tracking with to-do lists, and delegate work to sub-agents.',
+    tools: [
+      'memory',
+      'todo_write',
+      'delegate_workflow',
+      'delegate_agent',
+      'executions',
+      'accept_run_files',
+    ],
+    requiresSetup: false,
+  },
+];
+
+/** Tool groups that require external dependencies. */
+const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
+  check: () => Promise<boolean>;
+})[] = [
+  {
+    id: 'texcount',
+    name: 'TeXcount',
+    category: 'latex',
+    description:
+      'Count words, headers, figures, and other elements in LaTeX documents.',
+    tools: ['texcount'],
+    requiresSetup: true,
+    installGuide:
+      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install texcount\n' +
+      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
+      '  Windows: Install via MiKTeX or TeX Live package manager',
+    installUrl: 'https://app.uio.no/ifi/texcount/',
+    configNotes: 'Part of most TeX Live distributions.',
+    check: () => checkToolInstalled('texcount', false),
+  },
+  {
+    id: 'wolfram',
+    name: 'Wolfram Language',
+    category: 'computation',
+    description:
+      'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
+    tools: ['wolfram'],
+    requiresSetup: true,
+    installGuide:
+      'Requires WolframScript or the Wolfram Engine.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install wolfram-engine\n' +
+      '  Ubuntu:  sudo apt-get install wolfram-engine\n' +
+      '  Windows: Download from wolfram.com/engine\n\n' +
+      'Free Wolfram Engine licenses are available for development use.',
+    installUrl: 'https://www.wolfram.com/engine/',
+    configNotes:
+      'Requires a free Wolfram Engine license or Mathematica installation.',
+    check: () => checkToolInstalled('wolframscript', false),
+  },
+  {
+    id: 'zotero',
+    name: 'Zotero Integration',
+    category: 'academic',
+    description:
+      'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
+    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
+    requiresSetup: true,
+    installGuide:
+      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
+      'Setup:\n' +
+      '  1. Install Zotero (zotero.org)\n' +
+      '  2. Install Better BibTeX plugin:\n' +
+      '     - Download from retorque.re/zotero-better-bibtex\n' +
+      '     - In Zotero: Tools > Add-ons > Install from File\n' +
+      '  3. Keep Zotero running while using TeXRA\n\n' +
+      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
+      'that TeXRA uses to communicate with your library.',
+    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
+    configNotes:
+      'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
+    check: async () => {
+      try {
+        const port = getZoteroPort();
+        await axios.get(`http://localhost:${port}/better-bibtex/json-rpc`, {
+          timeout: 2000,
+        });
+        return true;
+      } catch {
+        // 405 Method Not Allowed means the server is running but expects POST
+        // Any response from the server means Zotero + BBT is available
+        return false;
+      }
+    },
+  },
+  {
+    id: 'lean4',
+    name: 'Lean 4 Proof Assistant',
+    category: 'lean',
+    description:
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
+    tools: [
+      'lean_diagnostics',
+      'lean_file',
+      'lean_project',
+      'lean_inspect',
+      'lean_loogle',
+    ],
+    requiresSetup: true,
+    installGuide:
+      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
+      'Setup:\n' +
+      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
+      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
+      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
+      'The Lean tools communicate via the Lean Language Server\n' +
+      'provided by the VS Code extension.',
+    installUrl:
+      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
+    configNotes: 'Lean 4 VS Code extension must be installed and active.',
+    check: async () => {
+      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
+      return lean4Ext !== undefined;
+    },
+  },
+];
+
+// ============================================================
+// Public API
+// ============================================================
+
+/**
+ * Build the complete tool dashboard items list with runtime availability checks.
+ */
+export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
+  // Built-in tools are always available
+  const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.map((tool) => ({
+    ...tool,
+    status: 'available' as const,
+  }));
+
+  // Check external tools in parallel
+  const externalChecks = await Promise.all(
+    EXTERNAL_TOOLS.map(async ({ check, ...tool }) => {
+      try {
+        const available = await check();
+        return {
+          ...tool,
+          status: available ? ('available' as const) : ('not-found' as const),
+        };
+      } catch {
+        return { ...tool, status: 'unknown' as const };
+      }
+    }),
+  );
+
+  return [...builtinItems, ...externalChecks];
+}

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -1,19 +1,13 @@
 /**
  * Tool dashboard data builder.
  *
- * Defines static metadata for all tool groups and performs runtime
- * availability checks for tools that depend on external binaries,
- * applications, or VS Code extensions.
+ * Defines static UI metadata for all tool groups and delegates runtime
+ * availability checks to {@link @tools/toolAvailability}.
  */
-
-// Third-party imports
-import * as vscode from 'vscode';
-import axios from 'axios';
 
 // Local imports
 import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
-import { getZoteroPort } from '@tools/zotero/bbtClient';
-import { checkToolInstalled } from '@utils/system/toolUtils';
+import { runExternalToolChecks } from '@tools/toolAvailability';
 
 // ============================================================
 // Static tool metadata
@@ -102,17 +96,20 @@ const BUILTIN_TOOLS: Omit<ToolDashboardItem, 'status'>[] = [
   },
 ];
 
-/** Tool groups that require external dependencies. */
-const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
-  check: () => Promise<boolean>;
-})[] = [
-  {
+/**
+ * UI-only metadata for external tool groups.
+ * Keyed by group ID (must match {@link EXTERNAL_TOOL_CHECKS} entries).
+ */
+const EXTERNAL_TOOL_UI: Record<
+  string,
+  Omit<ToolDashboardItem, 'status' | 'tools'>
+> = {
+  texcount: {
     id: 'texcount',
     name: 'TeXcount',
     category: 'latex',
     description:
       'Count words, headers, figures, and other elements in LaTeX documents.',
-    tools: ['texcount'],
     requiresSetup: true,
     installGuide:
       'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
@@ -122,15 +119,13 @@ const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
       '  Windows: Install via MiKTeX or TeX Live package manager',
     installUrl: 'https://app.uio.no/ifi/texcount/',
     configNotes: 'Part of most TeX Live distributions.',
-    check: () => checkToolInstalled('texcount', false),
   },
-  {
+  wolfram: {
     id: 'wolfram',
     name: 'Wolfram Language',
     category: 'computation',
     description:
       'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
-    tools: ['wolfram'],
     requiresSetup: true,
     installGuide:
       'Requires WolframScript or the Wolfram Engine.\n\n' +
@@ -142,15 +137,13 @@ const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
     installUrl: 'https://www.wolfram.com/engine/',
     configNotes:
       'Requires a free Wolfram Engine license or Mathematica installation.',
-    check: () => checkToolInstalled('wolframscript', false),
   },
-  {
+  zotero: {
     id: 'zotero',
     name: 'Zotero Integration',
     category: 'academic',
     description:
       'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
-    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
     requiresSetup: true,
     installGuide:
       'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
@@ -165,33 +158,13 @@ const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
     installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
     configNotes:
       'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
-    check: async () => {
-      try {
-        const port = getZoteroPort();
-        await axios.get(`http://localhost:${port}/better-bibtex/json-rpc`, {
-          timeout: 2000,
-        });
-        return true;
-      } catch {
-        // 405 Method Not Allowed means the server is running but expects POST
-        // Any response from the server means Zotero + BBT is available
-        return false;
-      }
-    },
   },
-  {
+  lean4: {
     id: 'lean4',
     name: 'Lean 4 Proof Assistant',
     category: 'lean',
     description:
       'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
-    tools: [
-      'lean_diagnostics',
-      'lean_file',
-      'lean_project',
-      'lean_inspect',
-      'lean_loogle',
-    ],
     requiresSetup: true,
     installGuide:
       'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
@@ -204,12 +177,8 @@ const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
     configNotes: 'Lean 4 VS Code extension must be installed and active.',
-    check: async () => {
-      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
-      return lean4Ext !== undefined;
-    },
   },
-];
+};
 
 // ============================================================
 // Public API
@@ -217,6 +186,9 @@ const EXTERNAL_TOOLS: (Omit<ToolDashboardItem, 'status'> & {
 
 /**
  * Build the complete tool dashboard items list with runtime availability checks.
+ *
+ * Always runs fresh external checks (and updates the availability cache
+ * in {@link @tools/toolAvailability} as a side effect).
  */
 export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
   // Built-in tools are always available
@@ -225,20 +197,16 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
     status: 'available' as const,
   }));
 
-  // Check external tools in parallel
-  const externalChecks = await Promise.all(
-    EXTERNAL_TOOLS.map(async ({ check, ...tool }) => {
-      try {
-        const available = await check();
-        return {
-          ...tool,
-          status: available ? ('available' as const) : ('not-found' as const),
-        };
-      } catch {
-        return { ...tool, status: 'unknown' as const };
-      }
-    }),
-  );
+  // Run fresh checks — also updates the availability cache
+  const results = await runExternalToolChecks();
 
-  return [...builtinItems, ...externalChecks];
+  // Merge check results with UI metadata
+  const externalItems: ToolDashboardItem[] = [];
+  for (const { id, tools, status } of results) {
+    const ui = EXTERNAL_TOOL_UI[id];
+    if (!ui) continue;
+    externalItems.push({ ...ui, tools: [...tools], status });
+  }
+
+  return [...builtinItems, ...externalItems];
 }

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -15,7 +15,10 @@ import {
   EXTERNAL_TOOL_CHECKS,
   runExternalToolChecks,
 } from '@tools/toolAvailability';
-import { getDefaultToolRegistry } from '@tools/registry';
+import {
+  getDefaultToolRegistry,
+  type RegisteredToolName,
+} from '@tools/registry';
 
 // ============================================================
 // Tool description enrichment
@@ -42,7 +45,7 @@ function enrichTools(toolNames: readonly string[]): ToolInfo[] {
 
 /** Tool groups that are always available (built-in, no external deps). */
 const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
-  toolNames: readonly string[];
+  toolNames: readonly RegisteredToolName[];
 })[] = [
   {
     id: 'file-ops',

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -2,8 +2,8 @@
  * Tool dashboard data builder.
  *
  * Enriches tool groups with runtime availability and per-tool descriptions
- * from the registry. External tool UI metadata lives in
- * {@link @tools/toolAvailability EXTERNAL_TOOL_CHECKS} — no parallel map here.
+ * from the registry. External tool definitions (SSOT) live in
+ * {@link @tools/externalToolDefs}.
  */
 
 // Local imports
@@ -11,10 +11,8 @@ import type {
   ToolDashboardItem,
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
-import {
-  EXTERNAL_TOOL_CHECKS,
-  runExternalToolChecks,
-} from '@tools/toolAvailability';
+import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import { runExternalToolChecks } from '@tools/toolAvailability';
 import {
   getDefaultToolRegistry,
   type RegisteredToolName,
@@ -151,10 +149,10 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
   // Run fresh checks — also updates the availability cache
   const results = await runExternalToolChecks();
 
-  // Merge check results with UI metadata from EXTERNAL_TOOL_CHECKS
+  // Merge check results with UI metadata from EXTERNAL_TOOL_DEFS
   const externalItems: ToolDashboardItem[] = [];
   for (const { id, tools, status } of results) {
-    const def = EXTERNAL_TOOL_CHECKS.find((c) => c.id === id);
+    const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
     if (!def) continue;
     externalItems.push({
       id: def.id,

--- a/src/shared/constants/delegationTools.ts
+++ b/src/shared/constants/delegationTools.ts
@@ -1,0 +1,14 @@
+/**
+ * Tools that delegate work to sub-agents.
+ *
+ * Defined in shared/ so both extension-host code and webview bundles
+ * can import without pulling in tool class constructors.
+ *
+ * Includes legacy aliases for historical log entries.
+ */
+export const DELEGATION_TOOLS: ReadonlySet<string> = new Set([
+  'delegate_workflow',
+  'delegate_agent',
+  'propose_workflow',
+  'propose_agent',
+]);

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -51,6 +51,7 @@ export const SETTINGS_TAB_ORDER = [
   'MODELS',
   'AGENTS',
   'MULTI_AGENT',
+  'TOOLS',
 ] as const;
 
 export type SettingsTabName = (typeof SETTINGS_TAB_ORDER)[number];
@@ -203,6 +204,50 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 >;
 
 // ============================================================
+// Tool dashboard data schemas
+// ============================================================
+
+/** Status of a tool dependency */
+export const ToolStatusSchema = z.enum(['available', 'not-found', 'unknown']);
+export type ToolStatus = z.infer<typeof ToolStatusSchema>;
+
+/** Category for grouping tools in the dashboard */
+export const ToolCategorySchema = z.enum([
+  'file',
+  'latex',
+  'academic',
+  'web',
+  'computation',
+  'lean',
+  'workflow',
+]);
+export type ToolCategory = z.infer<typeof ToolCategorySchema>;
+
+/** Single tool entry in the dashboard */
+export const ToolDashboardItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  category: ToolCategorySchema,
+  description: z.string(),
+  tools: z.array(z.string()),
+  status: ToolStatusSchema,
+  requiresSetup: z.boolean(),
+  installGuide: z.string().optional(),
+  installUrl: z.string().optional(),
+  configNotes: z.string().optional(),
+});
+export type ToolDashboardItem = z.infer<typeof ToolDashboardItemSchema>;
+
+/** Outbound: backend → frontend tool dashboard data */
+export const UpdateToolDashboardMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD),
+  items: z.array(ToolDashboardItemSchema),
+});
+export type UpdateToolDashboardMessage = z.infer<
+  typeof UpdateToolDashboardMessageSchema
+>;
+
+// ============================================================
 // Inbound message schemas (frontend → backend)
 // ============================================================
 
@@ -321,6 +366,20 @@ const SetSuperYoloEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+// Tool dashboard inbound messages
+const GetToolDashboardDataMessageSchema = z.object({
+  command: z.literal(CMD.GET_TOOL_DASHBOARD_DATA),
+});
+
+const OpenToolInstallUrlMessageSchema = z.object({
+  command: z.literal(CMD.OPEN_TOOL_INSTALL_URL),
+  url: z.string().url(),
+});
+
+const RecheckToolStatusMessageSchema = z.object({
+  command: z.literal(CMD.RECHECK_TOOL_STATUS),
+});
+
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
 
@@ -333,6 +392,10 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
   [
     // Navigation messages
     OpenVscodeSettingsMessageSchema,
+    // Tool dashboard messages
+    GetToolDashboardDataMessageSchema,
+    OpenToolInstallUrlMessageSchema,
+    RecheckToolStatusMessageSchema,
     // Memory messages
     GetMemoryDataMessageSchema,
     OpenMemoryFileMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -220,6 +220,7 @@ export const ToolCategorySchema = z.enum([
   'computation',
   'lean',
   'workflow',
+  'system',
 ]);
 export type ToolCategory = z.infer<typeof ToolCategorySchema>;
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -223,13 +223,20 @@ export const ToolCategorySchema = z.enum([
 ]);
 export type ToolCategory = z.infer<typeof ToolCategorySchema>;
 
+/** Individual tool within a group — carries an optional description for tooltips. */
+export const ToolInfoSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+export type ToolInfo = z.infer<typeof ToolInfoSchema>;
+
 /** Single tool entry in the dashboard */
 export const ToolDashboardItemSchema = z.object({
   id: z.string(),
   name: z.string(),
   category: ToolCategorySchema,
   description: z.string(),
-  tools: z.array(z.string()),
+  tools: z.array(ToolInfoSchema),
   status: ToolStatusSchema,
   requiresSetup: z.boolean(),
   installGuide: z.string().optional(),

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -1,0 +1,152 @@
+/**
+ * External tool definitions — single source of truth.
+ *
+ * Each entry co-locates:
+ *   - identity: id, tool names (typed via RegisteredToolName)
+ *   - check function: how to detect availability at runtime
+ *   - dashboard metadata: name, category, description, install guide
+ *
+ * Consumed by:
+ *   - {@link @tools/toolAvailability} — reads id/tools/check for caching
+ *   - {@link @settingsView/utils/toolDashboardData} — reads everything for the UI
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import axios from 'axios';
+
+// Local imports
+import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
+import type { RegisteredToolName } from '@tools/registry';
+import { getZoteroPort } from '@tools/zotero/bbtClient';
+import { checkToolInstalled } from '@utils/system/toolUtils';
+
+// ============================================================
+// Type
+// ============================================================
+
+/** Full definition for an external tool group. */
+export interface ExternalToolDef {
+  /** Unique group identifier (matches ToolDashboardItem.id). */
+  readonly id: string;
+  /** Tool names belonging to this group — must match registry keys. */
+  readonly tools: readonly RegisteredToolName[];
+  /** Returns true if the external dependency is available. */
+  readonly check: () => Promise<boolean>;
+  // Dashboard UI metadata
+  readonly name: string;
+  readonly category: ToolCategory;
+  readonly description: string;
+  readonly installGuide?: string;
+  readonly installUrl?: string;
+  readonly configNotes?: string;
+}
+
+// ============================================================
+// Definitions
+// ============================================================
+
+export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
+  {
+    id: 'texcount',
+    tools: ['texcount'],
+    name: 'TeXcount',
+    category: 'latex',
+    description:
+      'Count words, headers, figures, and other elements in LaTeX documents.',
+    installGuide:
+      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install texcount\n' +
+      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
+      '  Windows: Install via MiKTeX or TeX Live package manager',
+    installUrl: 'https://app.uio.no/ifi/texcount/',
+    configNotes: 'Part of most TeX Live distributions.',
+    check: () => checkToolInstalled('texcount', false),
+  },
+  {
+    id: 'wolfram',
+    tools: ['wolfram'],
+    name: 'Wolfram Language',
+    category: 'computation',
+    description:
+      'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
+    installGuide:
+      'Requires WolframScript or the Wolfram Engine.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install wolfram-engine\n' +
+      '  Ubuntu:  sudo apt-get install wolfram-engine\n' +
+      '  Windows: Download from wolfram.com/engine\n\n' +
+      'Free Wolfram Engine licenses are available for development use.',
+    installUrl: 'https://www.wolfram.com/engine/',
+    configNotes:
+      'Requires a free Wolfram Engine license or Mathematica installation.',
+    check: () => checkToolInstalled('wolframscript', false),
+  },
+  {
+    id: 'zotero',
+    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
+    name: 'Zotero Integration',
+    category: 'academic',
+    description:
+      'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
+    installGuide:
+      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
+      'Setup:\n' +
+      '  1. Install Zotero (zotero.org)\n' +
+      '  2. Install Better BibTeX plugin:\n' +
+      '     - Download from retorque.re/zotero-better-bibtex\n' +
+      '     - In Zotero: Tools > Add-ons > Install from File\n' +
+      '  3. Keep Zotero running while using TeXRA\n\n' +
+      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
+      'that TeXRA uses to communicate with your library.',
+    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
+    configNotes:
+      'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
+    check: async () => {
+      try {
+        const port = getZoteroPort();
+        await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
+          timeout: 2000,
+        });
+        return true;
+      } catch (error: unknown) {
+        // 405 Method Not Allowed means the server is running but expects POST —
+        // any HTTP response from the endpoint means Zotero + BBT is available.
+        if (axios.isAxiosError(error) && error.response?.status === 405) {
+          return true;
+        }
+        return false;
+      }
+    },
+  },
+  {
+    id: 'lean4',
+    tools: [
+      'lean_diagnostics',
+      'lean_file',
+      'lean_project',
+      'lean_inspect',
+      'lean_loogle',
+    ],
+    name: 'Lean 4 Proof Assistant',
+    category: 'lean',
+    description:
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
+    installGuide:
+      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
+      'Setup:\n' +
+      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
+      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
+      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
+      'The Lean tools communicate via the Lean Language Server\n' +
+      'provided by the VS Code extension.',
+    installUrl:
+      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
+    configNotes: 'Lean 4 VS Code extension must be installed and active.',
+    check: async () => {
+      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
+      return lean4Ext !== undefined;
+    },
+  },
+];

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -149,4 +149,67 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       return lean4Ext !== undefined;
     },
   },
+
+  // ── System dependencies (no agent tools gated) ───────────────
+  {
+    id: 'latex-format',
+    tools: [],
+    name: 'LaTeX Formatting (latexindent)',
+    category: 'system',
+    description:
+      'Format and indent LaTeX documents. Requires latexindent and Perl.',
+    installGuide:
+      'latexindent is a Perl script for formatting LaTeX files.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install latexindent\n' +
+      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
+      '  Windows: Install via MiKTeX or TeX Live package manager\n\n' +
+      'Perl is also required:\n' +
+      '  Mac:     brew install perl\n' +
+      '  Ubuntu:  sudo apt-get install perl\n' +
+      '  Windows: Download from strawberryperl.com',
+    installUrl: 'https://github.com/cmhughes/latexindent.pl',
+    configNotes: 'Part of most TeX Live distributions. Requires Perl runtime.',
+    check: async () => {
+      const [hasLatexindent, hasPerl] = await Promise.all([
+        checkToolInstalled('latexindent', false),
+        checkToolInstalled('perl', false),
+      ]);
+      return hasLatexindent && hasPerl;
+    },
+  },
+  {
+    id: 'image-processing',
+    tools: [],
+    name: 'Image Processing (Ghostscript + GM/IM)',
+    category: 'system',
+    description:
+      'Convert PDF pages to PNG images for preview. Requires Ghostscript and either GraphicsMagick or ImageMagick.',
+    installGuide:
+      'Ghostscript converts PDF to raster images; GraphicsMagick or\n' +
+      'ImageMagick handles the final PNG output.\n\n' +
+      'Ghostscript:\n' +
+      '  Mac:     brew install ghostscript\n' +
+      '  Ubuntu:  sudo apt-get install ghostscript\n' +
+      '  Windows: Download from ghostscript.com\n\n' +
+      'GraphicsMagick (recommended):\n' +
+      '  Mac:     brew install graphicsmagick\n' +
+      '  Ubuntu:  sudo apt-get install graphicsmagick\n' +
+      '  Windows: Download from graphicsmagick.org\n\n' +
+      'OR ImageMagick:\n' +
+      '  Mac:     brew install imagemagick\n' +
+      '  Ubuntu:  sudo apt-get install imagemagick\n' +
+      '  Windows: Download from imagemagick.org',
+    installUrl: 'https://ghostscript.com/releases/gsdnld.html',
+    configNotes:
+      'Needs Ghostscript plus either GraphicsMagick or ImageMagick.',
+    check: async () => {
+      const [hasGs, hasGm, hasMagick] = await Promise.all([
+        checkToolInstalled('gs', false),
+        checkToolInstalled('gm', false),
+        checkToolInstalled('magick', false),
+      ]);
+      return hasGs && (hasGm || hasMagick);
+    },
+  },
 ];

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -100,6 +100,19 @@ const DEFAULT_TOOLS = {
 export type RegisteredToolName = keyof typeof DEFAULT_TOOLS;
 
 /**
+ * Tools that delegate work to sub-agents. Shared between:
+ *   - runToolUseFlow (filters these out for subagents to prevent nesting)
+ *   - progressView formatters (renders delegation-specific UI)
+ * Includes legacy aliases for historical log entries.
+ */
+export const DELEGATION_TOOLS: ReadonlySet<string> = new Set<RegisteredToolName>([
+  'delegate_workflow',
+  'delegate_agent',
+  'propose_workflow',
+  'propose_agent',
+]);
+
+/**
  * Get the default tool registry as an IToolRegistry.
  * Uses lazy initialization and singleton pattern.
  */

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,5 +1,5 @@
 // Local imports - core types
-import type { IToolRegistry } from '@agent/core/ToolTypes';
+import type { ITool, IToolRegistry } from '@agent/core/ToolTypes';
 import { MapToolRegistry } from '@agent/core/ToolTypes';
 
 // Local imports - model types
@@ -48,54 +48,64 @@ import { AcceptRunFilesTool } from './AcceptRunFilesTool';
 let defaultRegistryInstance: IToolRegistry | null = null;
 
 /**
+ * Canonical tool map — single source of truth for all registered tools.
+ * `RegisteredToolName` is derived from these keys, so adding/renaming
+ * a tool here automatically propagates to the dashboard and availability
+ * checks at compile time.
+ */
+const DEFAULT_TOOLS = {
+  str_replace_editor: new TextEditorTool(),
+  diagnostics: new DiagnosticsTool(),
+  bash: new BashTool(),
+  read_file: new ReadFileTool(),
+  write_file: new WriteFileTool(),
+  edit_file: new EditFileTool(),
+  apply_path: new ApplyPathTool(),
+  glob: new GlobTool(),
+  grep: new GrepTool(),
+  ls: new LsTool(),
+  download_arxiv_source: new ArxivDownloadTool(),
+  arxiv_metadata: new ArxivMetadataTool(),
+  arxiv_search: new ArxivSearchTool(),
+  extract_figures: new ExtractLatexFiguresTool(),
+  extract_bib_entries: new ExtractBibliographyTool(),
+  extract_tikz_figures: new ExtractTikzFiguresTool(),
+  crossref_doi: new CrossrefDoiTool(),
+  crossref_search: new CrossrefSearchTool(),
+  zotero_add: new ZoteroAddTool(),
+  zotero_search: new ZoteroSearchTool(),
+  zotero_export: new ZoteroExportTool(),
+  wolfram: new WolframTool(),
+  texcount: new TexcountTool(),
+  web_fetch: new WebFetchTool(),
+  web_search: new WebSearchTool(),
+  todo_write: new TodoWriteTool(),
+  memory: new MemoryTool(),
+  lean_diagnostics: new LeanDiagnosticsTool(),
+  lean_file: new LeanFileTool(),
+  lean_project: new LeanProjectTool(),
+  lean_inspect: new LeanInspectTool(),
+  lean_loogle: new LeanLoogleTool(),
+  delegate_workflow: new WorkflowAgentTool(),
+  delegate_agent: new DelegateAgentTool(),
+  executions: new ExecutionsTool(),
+  accept_run_files: new AcceptRunFilesTool(),
+  // Legacy aliases — old agent configs may reference these names
+  propose_workflow: new WorkflowAgentTool(),
+  propose_agent: new DelegateAgentTool(),
+  runs: new ExecutionsTool(),
+} satisfies Record<string, ITool>;
+
+/** Union of all tool names registered in the default registry. */
+export type RegisteredToolName = keyof typeof DEFAULT_TOOLS;
+
+/**
  * Get the default tool registry as an IToolRegistry.
  * Uses lazy initialization and singleton pattern.
  */
 export function getDefaultToolRegistry(): IToolRegistry {
   if (!defaultRegistryInstance) {
-    defaultRegistryInstance = new MapToolRegistry({
-      str_replace_editor: new TextEditorTool(),
-      diagnostics: new DiagnosticsTool(),
-      bash: new BashTool(),
-      read_file: new ReadFileTool(),
-      write_file: new WriteFileTool(),
-      edit_file: new EditFileTool(),
-      apply_path: new ApplyPathTool(),
-      glob: new GlobTool(),
-      grep: new GrepTool(),
-      ls: new LsTool(),
-      download_arxiv_source: new ArxivDownloadTool(),
-      arxiv_metadata: new ArxivMetadataTool(),
-      arxiv_search: new ArxivSearchTool(),
-      extract_figures: new ExtractLatexFiguresTool(),
-      extract_bib_entries: new ExtractBibliographyTool(),
-      extract_tikz_figures: new ExtractTikzFiguresTool(),
-      crossref_doi: new CrossrefDoiTool(),
-      crossref_search: new CrossrefSearchTool(),
-      zotero_add: new ZoteroAddTool(),
-      zotero_search: new ZoteroSearchTool(),
-      zotero_export: new ZoteroExportTool(),
-      wolfram: new WolframTool(),
-      texcount: new TexcountTool(),
-      web_fetch: new WebFetchTool(),
-      web_search: new WebSearchTool(),
-      todo_write: new TodoWriteTool(),
-      memory: new MemoryTool(),
-      // Lean 4 tools (uses VS Code extension)
-      lean_diagnostics: new LeanDiagnosticsTool(),
-      lean_file: new LeanFileTool(),
-      lean_project: new LeanProjectTool(),
-      lean_inspect: new LeanInspectTool(),
-      lean_loogle: new LeanLoogleTool(),
-      delegate_workflow: new WorkflowAgentTool(),
-      delegate_agent: new DelegateAgentTool(),
-      executions: new ExecutionsTool(),
-      accept_run_files: new AcceptRunFilesTool(),
-      // Legacy aliases — old agent configs may reference these names
-      propose_workflow: new WorkflowAgentTool(),
-      propose_agent: new DelegateAgentTool(),
-      runs: new ExecutionsTool(),
-    });
+    defaultRegistryInstance = new MapToolRegistry(DEFAULT_TOOLS);
   }
   return defaultRegistryInstance;
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -48,69 +48,63 @@ import { AcceptRunFilesTool } from './AcceptRunFilesTool';
 let defaultRegistryInstance: IToolRegistry | null = null;
 
 /**
- * Canonical tool map — single source of truth for all registered tools.
- * `RegisteredToolName` is derived from these keys, so adding/renaming
+ * Canonical tool factory — single source of truth for all registered tools.
+ * `RegisteredToolName` is derived from the return-type keys, so adding/renaming
  * a tool here automatically propagates to the dashboard and availability
  * checks at compile time.
+ *
+ * Defined as a function (not a module-scope const) so tool constructors
+ * run lazily on first `getDefaultToolRegistry()` call rather than eagerly
+ * on import. This keeps imports side-effect-free and ensures
+ * `resetDefaultToolRegistry()` creates genuinely fresh instances.
  */
-const DEFAULT_TOOLS = {
-  str_replace_editor: new TextEditorTool(),
-  diagnostics: new DiagnosticsTool(),
-  bash: new BashTool(),
-  read_file: new ReadFileTool(),
-  write_file: new WriteFileTool(),
-  edit_file: new EditFileTool(),
-  apply_path: new ApplyPathTool(),
-  glob: new GlobTool(),
-  grep: new GrepTool(),
-  ls: new LsTool(),
-  download_arxiv_source: new ArxivDownloadTool(),
-  arxiv_metadata: new ArxivMetadataTool(),
-  arxiv_search: new ArxivSearchTool(),
-  extract_figures: new ExtractLatexFiguresTool(),
-  extract_bib_entries: new ExtractBibliographyTool(),
-  extract_tikz_figures: new ExtractTikzFiguresTool(),
-  crossref_doi: new CrossrefDoiTool(),
-  crossref_search: new CrossrefSearchTool(),
-  zotero_add: new ZoteroAddTool(),
-  zotero_search: new ZoteroSearchTool(),
-  zotero_export: new ZoteroExportTool(),
-  wolfram: new WolframTool(),
-  texcount: new TexcountTool(),
-  web_fetch: new WebFetchTool(),
-  web_search: new WebSearchTool(),
-  todo_write: new TodoWriteTool(),
-  memory: new MemoryTool(),
-  lean_diagnostics: new LeanDiagnosticsTool(),
-  lean_file: new LeanFileTool(),
-  lean_project: new LeanProjectTool(),
-  lean_inspect: new LeanInspectTool(),
-  lean_loogle: new LeanLoogleTool(),
-  delegate_workflow: new WorkflowAgentTool(),
-  delegate_agent: new DelegateAgentTool(),
-  executions: new ExecutionsTool(),
-  accept_run_files: new AcceptRunFilesTool(),
-  // Legacy aliases — old agent configs may reference these names
-  propose_workflow: new WorkflowAgentTool(),
-  propose_agent: new DelegateAgentTool(),
-  runs: new ExecutionsTool(),
-} satisfies Record<string, ITool>;
+function createDefaultTools() {
+  return {
+    str_replace_editor: new TextEditorTool(),
+    diagnostics: new DiagnosticsTool(),
+    bash: new BashTool(),
+    read_file: new ReadFileTool(),
+    write_file: new WriteFileTool(),
+    edit_file: new EditFileTool(),
+    apply_path: new ApplyPathTool(),
+    glob: new GlobTool(),
+    grep: new GrepTool(),
+    ls: new LsTool(),
+    download_arxiv_source: new ArxivDownloadTool(),
+    arxiv_metadata: new ArxivMetadataTool(),
+    arxiv_search: new ArxivSearchTool(),
+    extract_figures: new ExtractLatexFiguresTool(),
+    extract_bib_entries: new ExtractBibliographyTool(),
+    extract_tikz_figures: new ExtractTikzFiguresTool(),
+    crossref_doi: new CrossrefDoiTool(),
+    crossref_search: new CrossrefSearchTool(),
+    zotero_add: new ZoteroAddTool(),
+    zotero_search: new ZoteroSearchTool(),
+    zotero_export: new ZoteroExportTool(),
+    wolfram: new WolframTool(),
+    texcount: new TexcountTool(),
+    web_fetch: new WebFetchTool(),
+    web_search: new WebSearchTool(),
+    todo_write: new TodoWriteTool(),
+    memory: new MemoryTool(),
+    lean_diagnostics: new LeanDiagnosticsTool(),
+    lean_file: new LeanFileTool(),
+    lean_project: new LeanProjectTool(),
+    lean_inspect: new LeanInspectTool(),
+    lean_loogle: new LeanLoogleTool(),
+    delegate_workflow: new WorkflowAgentTool(),
+    delegate_agent: new DelegateAgentTool(),
+    executions: new ExecutionsTool(),
+    accept_run_files: new AcceptRunFilesTool(),
+    // Legacy aliases — old agent configs may reference these names
+    propose_workflow: new WorkflowAgentTool(),
+    propose_agent: new DelegateAgentTool(),
+    runs: new ExecutionsTool(),
+  } satisfies Record<string, ITool>;
+}
 
 /** Union of all tool names registered in the default registry. */
-export type RegisteredToolName = keyof typeof DEFAULT_TOOLS;
-
-/**
- * Tools that delegate work to sub-agents. Shared between:
- *   - runToolUseFlow (filters these out for subagents to prevent nesting)
- *   - progressView formatters (renders delegation-specific UI)
- * Includes legacy aliases for historical log entries.
- */
-export const DELEGATION_TOOLS: ReadonlySet<string> = new Set<RegisteredToolName>([
-  'delegate_workflow',
-  'delegate_agent',
-  'propose_workflow',
-  'propose_agent',
-]);
+export type RegisteredToolName = keyof ReturnType<typeof createDefaultTools>;
 
 /**
  * Get the default tool registry as an IToolRegistry.
@@ -118,14 +112,14 @@ export const DELEGATION_TOOLS: ReadonlySet<string> = new Set<RegisteredToolName>
  */
 export function getDefaultToolRegistry(): IToolRegistry {
   if (!defaultRegistryInstance) {
-    defaultRegistryInstance = new MapToolRegistry(DEFAULT_TOOLS);
+    defaultRegistryInstance = new MapToolRegistry(createDefaultTools());
   }
   return defaultRegistryInstance;
 }
 
 /**
  * Reset the default tool registry singleton.
- * @internal For testing only - prevents state leakage between tests.
+ * @internal For testing only - creates fresh tool instances on next access.
  */
 export function resetDefaultToolRegistry(): void {
   defaultRegistryInstance = null;

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -13,6 +13,7 @@ import axios from 'axios';
 
 // Local imports
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
+import type { RegisteredToolName } from '@tools/registry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 
@@ -24,8 +25,8 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 export interface ExternalToolCheck {
   /** Unique group identifier (matches ToolDashboardItem.id). */
   readonly id: string;
-  /** Tool names belonging to this group. */
-  readonly tools: readonly string[];
+  /** Tool names belonging to this group — must match registry keys. */
+  readonly tools: readonly RegisteredToolName[];
   /** Human-readable display name. */
   readonly name: string;
   /** Returns true if the external dependency is available. */

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -63,10 +63,12 @@ export async function runExternalToolChecks(): Promise<
     ),
   );
 
-  // Update cache — last writer wins, which is fine since fresher data is always better
+  // Update cache — only exclude tools whose check definitively failed.
+  // 'unknown' (check threw) is not treated as missing: the tool may still
+  // work fine and will produce a clear error at call time if it doesn't.
   const unavailable = new Set<string>();
   for (const r of results) {
-    if (r.status !== 'available') {
+    if (r.status === 'not-found') {
       r.tools.forEach((t) => unavailable.add(t));
     }
   }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 import axios from 'axios';
 
 // Local imports
+import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 
@@ -19,44 +20,90 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 // Check definitions
 // ============================================================
 
-/** Defines how to check whether an external tool group is available. */
+/** Defines an external tool group: runtime check + dashboard UI metadata. */
 export interface ExternalToolCheck {
   /** Unique group identifier (matches ToolDashboardItem.id). */
   readonly id: string;
   /** Tool names belonging to this group. */
   readonly tools: readonly string[];
-  /** Human-readable group name (for user-facing notifications). */
-  readonly label: string;
+  /** Human-readable display name. */
+  readonly name: string;
   /** Returns true if the external dependency is available. */
   readonly check: () => Promise<boolean>;
+  // Dashboard UI metadata
+  readonly category: ToolCategory;
+  readonly description: string;
+  readonly installGuide?: string;
+  readonly installUrl?: string;
+  readonly configNotes?: string;
 }
 
 /** Result of running a single external tool check. */
 export interface ExternalToolCheckResult {
   readonly id: string;
   readonly tools: readonly string[];
-  readonly label: string;
+  readonly name: string;
   readonly status: 'available' | 'not-found' | 'unknown';
 }
 
-/** All external tool groups and their availability checks. */
+/** All external tool groups — single source of truth for checks and UI metadata. */
 export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
   {
     id: 'texcount',
     tools: ['texcount'],
-    label: 'TeXcount',
+    name: 'TeXcount',
+    category: 'latex',
+    description:
+      'Count words, headers, figures, and other elements in LaTeX documents.',
+    installGuide:
+      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install texcount\n' +
+      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
+      '  Windows: Install via MiKTeX or TeX Live package manager',
+    installUrl: 'https://app.uio.no/ifi/texcount/',
+    configNotes: 'Part of most TeX Live distributions.',
     check: () => checkToolInstalled('texcount', false),
   },
   {
     id: 'wolfram',
     tools: ['wolfram'],
-    label: 'Wolfram Language',
+    name: 'Wolfram Language',
+    category: 'computation',
+    description:
+      'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
+    installGuide:
+      'Requires WolframScript or the Wolfram Engine.\n\n' +
+      'Installation:\n' +
+      '  Mac:     brew install wolfram-engine\n' +
+      '  Ubuntu:  sudo apt-get install wolfram-engine\n' +
+      '  Windows: Download from wolfram.com/engine\n\n' +
+      'Free Wolfram Engine licenses are available for development use.',
+    installUrl: 'https://www.wolfram.com/engine/',
+    configNotes:
+      'Requires a free Wolfram Engine license or Mathematica installation.',
     check: () => checkToolInstalled('wolframscript', false),
   },
   {
     id: 'zotero',
     tools: ['zotero_search', 'zotero_add', 'zotero_export'],
-    label: 'Zotero',
+    name: 'Zotero Integration',
+    category: 'academic',
+    description:
+      'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
+    installGuide:
+      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
+      'Setup:\n' +
+      '  1. Install Zotero (zotero.org)\n' +
+      '  2. Install Better BibTeX plugin:\n' +
+      '     - Download from retorque.re/zotero-better-bibtex\n' +
+      '     - In Zotero: Tools > Add-ons > Install from File\n' +
+      '  3. Keep Zotero running while using TeXRA\n\n' +
+      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
+      'that TeXRA uses to communicate with your library.',
+    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
+    configNotes:
+      'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
     check: async () => {
       try {
         const port = getZoteroPort();
@@ -83,7 +130,21 @@ export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
       'lean_inspect',
       'lean_loogle',
     ],
-    label: 'Lean 4',
+    name: 'Lean 4 Proof Assistant',
+    category: 'lean',
+    description:
+      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
+    installGuide:
+      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
+      'Setup:\n' +
+      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
+      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
+      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
+      'The Lean tools communicate via the Lean Language Server\n' +
+      'provided by the VS Code extension.',
+    installUrl:
+      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
+    configNotes: 'Lean 4 VS Code extension must be installed and active.',
     check: async () => {
       const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
       return lean4Ext !== undefined;
@@ -124,17 +185,17 @@ export async function runExternalToolChecks(): Promise<
 > {
   const results = await Promise.all(
     EXTERNAL_TOOL_CHECKS.map(
-      async ({ id, tools, label, check }): Promise<ExternalToolCheckResult> => {
+      async ({ id, tools, name, check }): Promise<ExternalToolCheckResult> => {
         try {
           const available = await check();
           return {
             id,
             tools,
-            label,
+            name,
             status: available ? 'available' : 'not-found',
           };
         } catch {
-          return { id, tools, label, status: 'unknown' };
+          return { id, tools, name, status: 'unknown' };
         }
       },
     ),

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -107,7 +107,7 @@ export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
     check: async () => {
       try {
         const port = getZoteroPort();
-        await axios.get(`http://localhost:${port}/better-bibtex/json-rpc`, {
+        await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
           timeout: 2000,
         });
         return true;
@@ -211,6 +211,19 @@ export async function runExternalToolChecks(): Promise<
   cached = unavailable;
 
   return results;
+}
+
+/**
+ * Non-blocking cache read — returns cached unavailable tool names if
+ * checks have already completed, or an empty set if the cache isn't
+ * populated yet. Never triggers I/O.
+ *
+ * Used by the agent tool resolver to avoid blocking the first tool-use
+ * flow on network probes. External tools that are actually missing will
+ * fail at call time with a clear error — same as pre-dashboard behavior.
+ */
+export function getUnavailableToolNamesCached(): ReadonlySet<string> {
+  return cached ?? new Set();
 }
 
 /**

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -1,43 +1,22 @@
 /**
  * External tool availability checks with caching.
  *
- * Single source of truth for which external tools are installed.
+ * Pure service — runs checks, manages cache, returns results.
+ * Tool definitions (what to check + UI metadata) live in
+ * {@link @tools/externalToolDefs}.
+ *
  * Used by:
- *   - Tool dashboard (UI) — always runs fresh checks via `runExternalToolChecks()`
- *   - Agent tool resolver — reads cached results via `getUnavailableToolNames()`
+ *   - Tool dashboard (UI) — runs fresh checks via `runExternalToolChecks()`
+ *   - Agent tool resolver — reads cache via `getUnavailableToolNamesCached()`
  */
 
-// Third-party imports
-import * as vscode from 'vscode';
-import axios from 'axios';
-
 // Local imports
-import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
-import { getZoteroPort } from '@tools/zotero/bbtClient';
-import { checkToolInstalled } from '@utils/system/toolUtils';
+import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 
 // ============================================================
-// Check definitions
+// Result type
 // ============================================================
-
-/** Defines an external tool group: runtime check + dashboard UI metadata. */
-export interface ExternalToolCheck {
-  /** Unique group identifier (matches ToolDashboardItem.id). */
-  readonly id: string;
-  /** Tool names belonging to this group — must match registry keys. */
-  readonly tools: readonly RegisteredToolName[];
-  /** Human-readable display name. */
-  readonly name: string;
-  /** Returns true if the external dependency is available. */
-  readonly check: () => Promise<boolean>;
-  // Dashboard UI metadata
-  readonly category: ToolCategory;
-  readonly description: string;
-  readonly installGuide?: string;
-  readonly installUrl?: string;
-  readonly configNotes?: string;
-}
 
 /** Result of running a single external tool check. */
 export interface ExternalToolCheckResult {
@@ -47,119 +26,13 @@ export interface ExternalToolCheckResult {
   readonly status: 'available' | 'not-found' | 'unknown';
 }
 
-/** All external tool groups — single source of truth for checks and UI metadata. */
-export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
-  {
-    id: 'texcount',
-    tools: ['texcount'],
-    name: 'TeXcount',
-    category: 'latex',
-    description:
-      'Count words, headers, figures, and other elements in LaTeX documents.',
-    installGuide:
-      'TeXcount is a Perl script for counting words in LaTeX files.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install texcount\n' +
-      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
-      '  Windows: Install via MiKTeX or TeX Live package manager',
-    installUrl: 'https://app.uio.no/ifi/texcount/',
-    configNotes: 'Part of most TeX Live distributions.',
-    check: () => checkToolInstalled('texcount', false),
-  },
-  {
-    id: 'wolfram',
-    tools: ['wolfram'],
-    name: 'Wolfram Language',
-    category: 'computation',
-    description:
-      'Execute Wolfram Language code for symbolic math, computation, and data analysis.',
-    installGuide:
-      'Requires WolframScript or the Wolfram Engine.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install wolfram-engine\n' +
-      '  Ubuntu:  sudo apt-get install wolfram-engine\n' +
-      '  Windows: Download from wolfram.com/engine\n\n' +
-      'Free Wolfram Engine licenses are available for development use.',
-    installUrl: 'https://www.wolfram.com/engine/',
-    configNotes:
-      'Requires a free Wolfram Engine license or Mathematica installation.',
-    check: () => checkToolInstalled('wolframscript', false),
-  },
-  {
-    id: 'zotero',
-    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
-    name: 'Zotero Integration',
-    category: 'academic',
-    description:
-      'Search, add items to, and export citations from your Zotero library. Requires Better BibTeX plugin.',
-    installGuide:
-      'Requires Zotero with the Better BibTeX plugin installed.\n\n' +
-      'Setup:\n' +
-      '  1. Install Zotero (zotero.org)\n' +
-      '  2. Install Better BibTeX plugin:\n' +
-      '     - Download from retorque.re/zotero-better-bibtex\n' +
-      '     - In Zotero: Tools > Add-ons > Install from File\n' +
-      '  3. Keep Zotero running while using TeXRA\n\n' +
-      'Better BibTeX exposes a JSON-RPC API on localhost:23119\n' +
-      'that TeXRA uses to communicate with your library.',
-    installUrl: 'https://retorque.re/zotero-better-bibtex/installation/',
-    configNotes:
-      'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
-    check: async () => {
-      try {
-        const port = getZoteroPort();
-        await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
-          timeout: 2000,
-        });
-        return true;
-      } catch (error: unknown) {
-        // 405 Method Not Allowed means the server is running but expects POST —
-        // any HTTP response from the endpoint means Zotero + BBT is available.
-        if (axios.isAxiosError(error) && error.response?.status === 405) {
-          return true;
-        }
-        return false;
-      }
-    },
-  },
-  {
-    id: 'lean4',
-    tools: [
-      'lean_diagnostics',
-      'lean_file',
-      'lean_project',
-      'lean_inspect',
-      'lean_loogle',
-    ],
-    name: 'Lean 4 Proof Assistant',
-    category: 'lean',
-    description:
-      'Interact with Lean 4 projects: check diagnostics, inspect terms, search Loogle, and manage files.',
-    installGuide:
-      'Requires the Lean 4 VS Code extension (leanprover.lean4).\n\n' +
-      'Setup:\n' +
-      '  1. Install the "lean4" extension from VS Code Marketplace\n' +
-      '  2. Open a Lean 4 project (with lakefile.lean)\n' +
-      '  3. The extension will auto-install elan and Lean toolchain\n\n' +
-      'The Lean tools communicate via the Lean Language Server\n' +
-      'provided by the VS Code extension.',
-    installUrl:
-      'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
-    configNotes: 'Lean 4 VS Code extension must be installed and active.',
-    check: async () => {
-      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
-      return lean4Ext !== undefined;
-    },
-  },
-];
-
 // ============================================================
 // Check execution + cache
 // ============================================================
 
 /** Fail-closed fallback — if checks cannot run, all external tools are unavailable. */
 const ALL_EXTERNAL_TOOLS: ReadonlySet<string> = new Set(
-  EXTERNAL_TOOL_CHECKS.flatMap((c) => [...c.tools]),
+  EXTERNAL_TOOL_DEFS.flatMap((c) => [...c.tools]),
 );
 
 /** Cached set of unavailable tool names. */
@@ -185,7 +58,7 @@ export async function runExternalToolChecks(): Promise<
   ExternalToolCheckResult[]
 > {
   const results = await Promise.all(
-    EXTERNAL_TOOL_CHECKS.map(
+    EXTERNAL_TOOL_DEFS.map(
       async ({ id, tools, name, check }): Promise<ExternalToolCheckResult> => {
         try {
           const available = await check();

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -42,7 +42,7 @@ export interface ExternalToolCheck {
 /** Result of running a single external tool check. */
 export interface ExternalToolCheckResult {
   readonly id: string;
-  readonly tools: readonly string[];
+  readonly tools: readonly RegisteredToolName[];
   readonly name: string;
   readonly status: 'available' | 'not-found' | 'unknown';
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -1,0 +1,171 @@
+/**
+ * External tool availability checks with caching.
+ *
+ * Single source of truth for which external tools are installed.
+ * Used by:
+ *   - Tool dashboard (UI) — always runs fresh checks via `runExternalToolChecks()`
+ *   - Agent tool resolver — reads cached results via `getUnavailableToolNames()`
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import axios from 'axios';
+
+// Local imports
+import { getZoteroPort } from '@tools/zotero/bbtClient';
+import { checkToolInstalled } from '@utils/system/toolUtils';
+
+// ============================================================
+// Check definitions
+// ============================================================
+
+/** Defines how to check whether an external tool group is available. */
+export interface ExternalToolCheck {
+  /** Unique group identifier (matches ToolDashboardItem.id). */
+  readonly id: string;
+  /** Tool names belonging to this group. */
+  readonly tools: readonly string[];
+  /** Human-readable group name (for user-facing notifications). */
+  readonly label: string;
+  /** Returns true if the external dependency is available. */
+  readonly check: () => Promise<boolean>;
+}
+
+/** Result of running a single external tool check. */
+export interface ExternalToolCheckResult {
+  readonly id: string;
+  readonly tools: readonly string[];
+  readonly label: string;
+  readonly status: 'available' | 'not-found' | 'unknown';
+}
+
+/** All external tool groups and their availability checks. */
+export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
+  {
+    id: 'texcount',
+    tools: ['texcount'],
+    label: 'TeXcount',
+    check: () => checkToolInstalled('texcount', false),
+  },
+  {
+    id: 'wolfram',
+    tools: ['wolfram'],
+    label: 'Wolfram Language',
+    check: () => checkToolInstalled('wolframscript', false),
+  },
+  {
+    id: 'zotero',
+    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
+    label: 'Zotero',
+    check: async () => {
+      try {
+        const port = getZoteroPort();
+        await axios.get(`http://localhost:${port}/better-bibtex/json-rpc`, {
+          timeout: 2000,
+        });
+        return true;
+      } catch (error: unknown) {
+        // 405 Method Not Allowed means the server is running but expects POST —
+        // any HTTP response from the endpoint means Zotero + BBT is available.
+        if (axios.isAxiosError(error) && error.response?.status === 405) {
+          return true;
+        }
+        return false;
+      }
+    },
+  },
+  {
+    id: 'lean4',
+    tools: [
+      'lean_diagnostics',
+      'lean_file',
+      'lean_project',
+      'lean_inspect',
+      'lean_loogle',
+    ],
+    label: 'Lean 4',
+    check: async () => {
+      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
+      return lean4Ext !== undefined;
+    },
+  },
+];
+
+// ============================================================
+// Check execution + cache
+// ============================================================
+
+/** Cached unavailable tool names and their group labels. */
+let cache: { unavailable: Set<string>; labels: string[] } | null = null;
+
+/**
+ * Run all external tool checks in parallel.
+ * Always performs fresh checks and updates the internal cache.
+ *
+ * @returns Per-group results with `available` / `not-found` / `unknown` status.
+ */
+export async function runExternalToolChecks(): Promise<
+  ExternalToolCheckResult[]
+> {
+  const results = await Promise.all(
+    EXTERNAL_TOOL_CHECKS.map(
+      async ({ id, tools, label, check }): Promise<ExternalToolCheckResult> => {
+        try {
+          const available = await check();
+          return {
+            id,
+            tools,
+            label,
+            status: available ? 'available' : 'not-found',
+          };
+        } catch {
+          return { id, tools, label, status: 'unknown' };
+        }
+      },
+    ),
+  );
+
+  // Update cache as a side effect
+  const unavailable = new Set<string>();
+  const labels: string[] = [];
+  for (const r of results) {
+    if (r.status !== 'available') {
+      r.tools.forEach((t) => unavailable.add(t));
+      labels.push(r.label);
+    }
+  }
+  cache = { unavailable, labels };
+
+  return results;
+}
+
+/**
+ * Get the set of external tool names that are currently unavailable.
+ *
+ * Uses the cached result from the most recent `runExternalToolChecks()` call.
+ * If no cached data exists, runs a fresh check first.
+ */
+export async function getUnavailableToolNames(): Promise<ReadonlySet<string>> {
+  if (cache) return cache.unavailable;
+  await runExternalToolChecks();
+  return cache!.unavailable;
+}
+
+/**
+ * Get the human-readable labels of unavailable tool groups that were
+ * actually requested by an agent. Used for user-facing notifications.
+ *
+ * @param excludedToolNames - Tool names that were excluded during resolution.
+ */
+export function getExcludedToolLabels(
+  excludedToolNames: ReadonlySet<string>,
+): string[] {
+  return EXTERNAL_TOOL_CHECKS.filter((c) =>
+    c.tools.some((t) => excludedToolNames.has(t)),
+  ).map((c) => c.label);
+}
+
+/** Clear the cached availability data. Next access will re-check. */
+export function invalidateToolAvailability(): void {
+  cache = null;
+}

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -95,8 +95,11 @@ export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
 // Check execution + cache
 // ============================================================
 
-/** Cached unavailable tool names and their group labels. */
-let cache: { unavailable: Set<string>; labels: string[] } | null = null;
+/** Cached set of unavailable tool names. */
+let cached: ReadonlySet<string> | null = null;
+
+/** In-flight check promise — prevents duplicate concurrent checks. */
+let inflight: Promise<ExternalToolCheckResult[]> | null = null;
 
 /**
  * Run all external tool checks in parallel.
@@ -127,14 +130,13 @@ export async function runExternalToolChecks(): Promise<
 
   // Update cache as a side effect
   const unavailable = new Set<string>();
-  const labels: string[] = [];
   for (const r of results) {
     if (r.status !== 'available') {
       r.tools.forEach((t) => unavailable.add(t));
-      labels.push(r.label);
     }
   }
-  cache = { unavailable, labels };
+  cached = unavailable;
+  inflight = null;
 
   return results;
 }
@@ -142,30 +144,20 @@ export async function runExternalToolChecks(): Promise<
 /**
  * Get the set of external tool names that are currently unavailable.
  *
- * Uses the cached result from the most recent `runExternalToolChecks()` call.
- * If no cached data exists, runs a fresh check first.
+ * Returns cached results when available. Concurrent callers share a
+ * single in-flight check (promise dedup) to avoid duplicate work.
  */
 export async function getUnavailableToolNames(): Promise<ReadonlySet<string>> {
-  if (cache) return cache.unavailable;
-  await runExternalToolChecks();
-  return cache!.unavailable;
-}
-
-/**
- * Get the human-readable labels of unavailable tool groups that were
- * actually requested by an agent. Used for user-facing notifications.
- *
- * @param excludedToolNames - Tool names that were excluded during resolution.
- */
-export function getExcludedToolLabels(
-  excludedToolNames: ReadonlySet<string>,
-): string[] {
-  return EXTERNAL_TOOL_CHECKS.filter((c) =>
-    c.tools.some((t) => excludedToolNames.has(t)),
-  ).map((c) => c.label);
+  if (cached) return cached;
+  if (!inflight) {
+    inflight = runExternalToolChecks();
+  }
+  await inflight;
+  return cached ?? new Set();
 }
 
 /** Clear the cached availability data. Next access will re-check. */
 export function invalidateToolAvailability(): void {
-  cache = null;
+  cached = null;
+  inflight = null;
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -95,15 +95,27 @@ export const EXTERNAL_TOOL_CHECKS: readonly ExternalToolCheck[] = [
 // Check execution + cache
 // ============================================================
 
+/** Fail-closed fallback — if checks cannot run, all external tools are unavailable. */
+const ALL_EXTERNAL_TOOLS: ReadonlySet<string> = new Set(
+  EXTERNAL_TOOL_CHECKS.flatMap((c) => [...c.tools]),
+);
+
 /** Cached set of unavailable tool names. */
 let cached: ReadonlySet<string> | null = null;
 
-/** In-flight check promise — prevents duplicate concurrent checks. */
+/**
+ * In-flight dedup promise, owned exclusively by `getUnavailableToolNames()`.
+ * `runExternalToolChecks()` never touches this — so a direct dashboard call
+ * cannot break the dedup for concurrent agent callers.
+ */
 let inflight: Promise<ExternalToolCheckResult[]> | null = null;
 
 /**
  * Run all external tool checks in parallel.
- * Always performs fresh checks and updates the internal cache.
+ * Always performs fresh checks and updates the availability cache.
+ *
+ * Called directly by the tool dashboard (needs per-group results)
+ * and indirectly by `getUnavailableToolNames()` (needs the cache side-effect).
  *
  * @returns Per-group results with `available` / `not-found` / `unknown` status.
  */
@@ -128,7 +140,7 @@ export async function runExternalToolChecks(): Promise<
     ),
   );
 
-  // Update cache as a side effect
+  // Update cache — last writer wins, which is fine since fresher data is always better
   const unavailable = new Set<string>();
   for (const r of results) {
     if (r.status !== 'available') {
@@ -136,7 +148,6 @@ export async function runExternalToolChecks(): Promise<
     }
   }
   cached = unavailable;
-  inflight = null;
 
   return results;
 }
@@ -146,18 +157,20 @@ export async function runExternalToolChecks(): Promise<
  *
  * Returns cached results when available. Concurrent callers share a
  * single in-flight check (promise dedup) to avoid duplicate work.
+ * Fails closed — if checks cannot complete, all external tools are
+ * treated as unavailable rather than silently enabled.
  */
 export async function getUnavailableToolNames(): Promise<ReadonlySet<string>> {
   if (cached) return cached;
   if (!inflight) {
-    inflight = runExternalToolChecks();
+    inflight = runExternalToolChecks().finally(() => {
+      inflight = null;
+    });
   }
-  await inflight;
-  return cached ?? new Set();
-}
-
-/** Clear the cached availability data. Next access will re-check. */
-export function invalidateToolAvailability(): void {
-  cached = null;
-  inflight = null;
+  try {
+    await inflight;
+  } catch {
+    return ALL_EXTERNAL_TOOLS;
+  }
+  return cached ?? ALL_EXTERNAL_TOOLS;
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -6,7 +6,7 @@
  * {@link @tools/externalToolDefs}.
  *
  * Used by:
- *   - Tool dashboard (UI) — runs fresh checks via `runExternalToolChecks()`
+ *   - Tool dashboard — runs fresh checks via `runExternalToolChecks()`
  *   - Agent tool resolver — reads cache via `getUnavailableToolNamesCached()`
  */
 
@@ -30,27 +30,15 @@ export interface ExternalToolCheckResult {
 // Check execution + cache
 // ============================================================
 
-/** Fail-closed fallback — if checks cannot run, all external tools are unavailable. */
-const ALL_EXTERNAL_TOOLS: ReadonlySet<string> = new Set(
-  EXTERNAL_TOOL_DEFS.flatMap((c) => [...c.tools]),
-);
-
 /** Cached set of unavailable tool names. */
 let cached: ReadonlySet<string> | null = null;
-
-/**
- * In-flight dedup promise, owned exclusively by `getUnavailableToolNames()`.
- * `runExternalToolChecks()` never touches this — so a direct dashboard call
- * cannot break the dedup for concurrent agent callers.
- */
-let inflight: Promise<ExternalToolCheckResult[]> | null = null;
 
 /**
  * Run all external tool checks in parallel.
  * Always performs fresh checks and updates the availability cache.
  *
- * Called directly by the tool dashboard (needs per-group results)
- * and indirectly by `getUnavailableToolNames()` (needs the cache side-effect).
+ * Called by the tool dashboard (needs per-group results).
+ * Also populates the cache read by `getUnavailableToolNamesCached()`.
  *
  * @returns Per-group results with `available` / `not-found` / `unknown` status.
  */
@@ -98,27 +86,4 @@ export async function runExternalToolChecks(): Promise<
  */
 export function getUnavailableToolNamesCached(): ReadonlySet<string> {
   return cached ?? new Set();
-}
-
-/**
- * Get the set of external tool names that are currently unavailable.
- *
- * Returns cached results when available. Concurrent callers share a
- * single in-flight check (promise dedup) to avoid duplicate work.
- * Fails closed — if checks cannot complete, all external tools are
- * treated as unavailable rather than silently enabled.
- */
-export async function getUnavailableToolNames(): Promise<ReadonlySet<string>> {
-  if (cached) return cached;
-  if (!inflight) {
-    inflight = runExternalToolChecks().finally(() => {
-      inflight = null;
-    });
-  }
-  try {
-    await inflight;
-  } catch {
-    return ALL_EXTERNAL_TOOLS;
-  }
-  return cached ?? ALL_EXTERNAL_TOOLS;
 }


### PR DESCRIPTION
Adds a "Tools" tab to the Dashboard/Settings view showing all available
agent tools grouped by category (File, LaTeX, Academic, Web, Computation,
Lean 4, Workflow) with runtime availability detection and installation
guides for external dependencies (TeXcount, Wolfram, Zotero, Lean 4).

https://claude.ai/code/session_01UPz19qYv9bbPTMnEzTzQGh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new runtime dependency probing (including network calls) and changes tool resolution to omit cached-unavailable tools, which could alter tool-use behavior if the cache is stale or checks mis-detect availability.
> 
> **Overview**
> Adds a new **Tools dashboard** tab in the Settings view (and `texra.showTools` command) that lists tool groups by category, shows availability status, and provides install guides/links with a re-check action.
> 
> Introduces an external-dependency checking/caching layer (`externalToolDefs`, `toolAvailability`) and a builder (`toolDashboardData`) that runs runtime probes (e.g., binaries, VS Code extensions, Zotero localhost) and enriches UI data from the tool registry.
> 
> Updates tool-use flow resolution to **filter out tools whose external dependencies are known-missing** (via the availability cache), and centralizes delegation tool names in shared `DELEGATION_TOOLS`. Removes the main-view startup dependency banner check from `MainViewProvider`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f122a4e30d34392fcb4ed2b36b5bf51cc3d629f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->