### PR TITLE
Fix wait endpoint blocking on subagents that already finished

### DIFF
--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -159,9 +159,9 @@ function getExecutionStatusInfo(
  * Returns true when:
  * - The handle is gone (execution already untracked / completed), OR
  * - The stream left all ACTIVE_STATUSES, OR
- * - The execution is a *subagent* in WAITING (job done, result already
- *   delivered via onBeforeWaiting — distinct from a non-subagent WAITING
- *   for human input, which should still block).
+ * - The execution is a *tool-use subagent* in WAITING (job done, result
+ *   already delivered via onBeforeWaiting). Workflow subagents in WAITING
+ *   may still be awaiting retry/user action and should keep blocking.
  *
  * One getHandle + one getStatus per call — no redundant lookups.
  */
@@ -172,11 +172,13 @@ function shouldSkipWait(executionId: string): boolean {
   const { status } = handle.getStatus();
   if (!ACTIVE_STATUSES.has(status)) return true;
 
-  // Subagent in WAITING = job delivered, don't block.
+  // Tool-use subagent in WAITING = job delivered via onBeforeWaiting, don't block.
+  // Workflow subagent in WAITING = may be waiting for retry/user action, keep blocking.
   // Non-subagent WAITING = human input needed, keep blocking.
   if (
     status === STREAM_STATUS.WAITING &&
     handle instanceof AgentExecutionHandle &&
+    handle.category === 'toolUse' &&
     handle.parentStreamId !== handle.childStreamId
   ) {
     return true;

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -154,17 +154,35 @@ function getExecutionStatusInfo(
 }
 
 /**
- * Check if an execution is a subagent that has already entered WAITING.
- * A subagent in WAITING has completed its job and delivered results via
- * onBeforeWaiting — blocking on it would cause unnecessary delay.
- * This is distinct from a non-subagent in WAITING, which is waiting for
- * human input and should still be treated as active.
+ * Single-pass check: should the wait endpoint skip blocking on this execution?
+ *
+ * Returns true when:
+ * - The handle is gone (execution already untracked / completed), OR
+ * - The stream left all ACTIVE_STATUSES, OR
+ * - The execution is a *subagent* in WAITING (job done, result already
+ *   delivered via onBeforeWaiting — distinct from a non-subagent WAITING
+ *   for human input, which should still block).
+ *
+ * One getHandle + one getStatus per call — no redundant lookups.
  */
-function isSubagentDoneWaiting(executionId: string): boolean {
+function shouldSkipWait(executionId: string): boolean {
   const handle = getHandle(executionId);
-  if (!(handle instanceof AgentExecutionHandle)) return false;
-  if (handle.parentStreamId === handle.childStreamId) return false;
-  return handle.getStatus().status === STREAM_STATUS.WAITING;
+  if (!handle) return true;
+
+  const { status } = handle.getStatus();
+  if (!ACTIVE_STATUSES.has(status)) return true;
+
+  // Subagent in WAITING = job delivered, don't block.
+  // Non-subagent WAITING = human input needed, keep blocking.
+  if (
+    status === STREAM_STATUS.WAITING &&
+    handle instanceof AgentExecutionHandle &&
+    handle.parentStreamId !== handle.childStreamId
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 /** Format round progress as a display line, or empty string if unavailable. */
@@ -344,24 +362,17 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     const activeIds = getActiveExecutionIds();
     if (activeIds.length === 0) return;
 
-    // Exclude subagents that have already finished (WAITING status) —
-    // they delivered their result and won't change further.
-    const pendingIds = activeIds.filter((id) => !isSubagentDoneWaiting(id));
+    // Exclude executions that are already effectively done
+    // (completed, inactive, or subagent-WAITING with result delivered).
+    const pendingIds = activeIds.filter((id) => !shouldSkipWait(id));
     if (pendingIds.length === 0) return;
 
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
     // Register callback before re-checking to close the race window
     const waitPromise = waitForAnyExecutionChange(pendingIds, ac.signal);
-    // If all watched executions completed or entered subagent-WAITING
-    // between filtering and callback registration, abort immediately.
-    if (
-      pendingIds.every(
-        (id) => !getHandle(id) || isSubagentDoneWaiting(id),
-      )
-    ) {
-      ac.abort();
-    }
+    // Re-check after registration: if all resolved in the gap, abort.
+    if (pendingIds.every(shouldSkipWait)) ac.abort();
     await waitPromise;
     clearTimeout(timer);
   }
@@ -371,28 +382,14 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     executionId: ExecutionId,
     timeout: number,
   ): Promise<void> {
-    const info = getExecutionStatusInfo(executionId);
-    if (!ACTIVE_STATUSES.has(info.status)) return;
-
-    // A subagent in WAITING has already finished and delivered its result
-    // via onBeforeWaiting — don't block waiting for a follow-up that the
-    // caller won't send. This is distinct from a non-subagent WAITING for
-    // human input, which should still be treated as active.
-    if (isSubagentDoneWaiting(executionId)) return;
+    if (shouldSkipWait(executionId)) return;
 
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
     // Register callback before re-checking to close the race window
     const waitPromise = waitForExecutionChange(executionId, ac.signal);
-    // If execution completed or entered subagent-WAITING between status
-    // check and callback registration, abort immediately.
-    const rechecked = getExecutionStatusInfo(executionId);
-    if (
-      !ACTIVE_STATUSES.has(rechecked.status) ||
-      isSubagentDoneWaiting(executionId)
-    ) {
-      ac.abort();
-    }
+    // Re-check after registration: if state changed in the gap, abort.
+    if (shouldSkipWait(executionId)) ac.abort();
     await waitPromise;
     clearTimeout(timer);
   }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -365,7 +365,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     if (activeIds.length === 0) return;
 
     // Exclude executions that are already effectively done
-    // (completed, inactive, or subagent-WAITING with result delivered).
+    // (completed, inactive, or tool-use subagent WAITING with result delivered).
     const pendingIds = activeIds.filter((id) => !shouldSkipWait(id));
     if (pendingIds.length === 0) return;
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -173,7 +173,9 @@ function shouldSkipWait(executionId: string): boolean {
   if (!ACTIVE_STATUSES.has(status)) return true;
 
   // Tool-use subagent in WAITING = job delivered via onBeforeWaiting, don't block.
-  // Workflow subagent in WAITING = may be waiting for retry/user action, keep blocking.
+  // Workflow subagent in WAITING = may be waiting for retry/user action. Blocking
+  // isn't very useful (only the user can unblock it), but the subagent is still
+  // technically active so we don't skip — avoids misreporting it as done.
   // Non-subagent WAITING = human input needed, keep blocking.
   if (
     status === STREAM_STATUS.WAITING &&

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -31,6 +31,7 @@ import {
   type ExecutionHandle,
   type ExecutionStatusInfo,
   ACTIVE_STATUSES,
+  AgentExecutionHandle,
   getHandle,
   getActiveExecutionIds,
   waitForExecutionChange,
@@ -43,6 +44,7 @@ import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
+import { STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
 
@@ -149,6 +151,20 @@ function getExecutionStatusInfo(
     status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,
     elapsed: null,
   };
+}
+
+/**
+ * Check if an execution is a subagent that has already entered WAITING.
+ * A subagent in WAITING has completed its job and delivered results via
+ * onBeforeWaiting — blocking on it would cause unnecessary delay.
+ * This is distinct from a non-subagent in WAITING, which is waiting for
+ * human input and should still be treated as active.
+ */
+function isSubagentDoneWaiting(executionId: string): boolean {
+  const handle = getHandle(executionId);
+  if (!(handle instanceof AgentExecutionHandle)) return false;
+  if (handle.parentStreamId === handle.childStreamId) return false;
+  return handle.getStatus().status === STREAM_STATUS.WAITING;
 }
 
 /** Format round progress as a display line, or empty string if unavailable. */
@@ -328,15 +344,22 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     const activeIds = getActiveExecutionIds();
     if (activeIds.length === 0) return;
 
+    // Exclude subagents that have already finished (WAITING status) —
+    // they delivered their result and won't change further.
+    const pendingIds = activeIds.filter((id) => !isSubagentDoneWaiting(id));
+    if (pendingIds.length === 0) return;
+
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
     // Register callback before re-checking to close the race window
-    const waitPromise = waitForAnyExecutionChange(activeIds, ac.signal);
-    // If all originally watched executions completed between
-    // getActiveExecutionIds() and callback registration, abort immediately
-    // so we don't block until timeout. Check the original IDs, not the
-    // global set (new executions starting shouldn't prevent abort).
-    if (activeIds.every((id) => !getHandle(id))) {
+    const waitPromise = waitForAnyExecutionChange(pendingIds, ac.signal);
+    // If all watched executions completed or entered subagent-WAITING
+    // between filtering and callback registration, abort immediately.
+    if (
+      pendingIds.every(
+        (id) => !getHandle(id) || isSubagentDoneWaiting(id),
+      )
+    ) {
       ac.abort();
     }
     await waitPromise;
@@ -351,14 +374,23 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     const info = getExecutionStatusInfo(executionId);
     if (!ACTIVE_STATUSES.has(info.status)) return;
 
+    // A subagent in WAITING has already finished and delivered its result
+    // via onBeforeWaiting — don't block waiting for a follow-up that the
+    // caller won't send. This is distinct from a non-subagent WAITING for
+    // human input, which should still be treated as active.
+    if (isSubagentDoneWaiting(executionId)) return;
+
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
     // Register callback before re-checking to close the race window
     const waitPromise = waitForExecutionChange(executionId, ac.signal);
-    // If execution completed between status check and callback registration,
-    // abort immediately so we don't block until timeout.
+    // If execution completed or entered subagent-WAITING between status
+    // check and callback registration, abort immediately.
     const rechecked = getExecutionStatusInfo(executionId);
-    if (!ACTIVE_STATUSES.has(rechecked.status)) {
+    if (
+      !ACTIVE_STATUSES.has(rechecked.status) ||
+      isSubagentDoneWaiting(executionId)
+    ) {
       ac.abort();
     }
     await waitPromise;


### PR DESCRIPTION
When a tool-use subagent completes its job and enters WAITING status,
it has already delivered its result via onBeforeWaiting. The wait
endpoint was treating WAITING as an active status and blocking until
timeout, even though the subagent won't change further.

Add isSubagentDoneWaiting() to distinguish subagent WAITING (job done,
result delivered) from non-subagent WAITING (awaiting human input).
Both waitForChange and waitForAnyChange now return immediately when
all monitored executions are subagents in this state.

https://claude.ai/code/session_01C8VHHuKUqGkSsfmMLmZFca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to execution waiting logic; main risk is incorrectly classifying an execution as skippable and returning early.
> 
> **Overview**
> Prevents the `executions` tool’s `wait` action from blocking until timeout when a *tool-use subagent* transitions to `WAITING` after delivering its result.
> 
> Adds a single-pass `shouldSkipWait` predicate (using `AgentExecutionHandle` and `STREAM_STATUS.WAITING`) and applies it to both `waitForChange` and `waitForAnyChange`, filtering out executions that are inactive/completed or effectively done and tightening the post-registration race recheck logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8cad146209f68d22fc9720e1ee2929da3cc2bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->