### PR TITLE
Add revised analysis of agent/flow simplification opportunities

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,243 @@
+# Simplify Agent/Flow Architecture — Revised Proposal
+
+## Previous Plan vs Reality
+
+The original plan proposed flattening the CycleNode wrappers into the parent flows
+for ~425 lines saved. After tracing every code path, **Changes 1-3 are NOT feasible
+as proposed.** Here's why, and what IS actually doable.
+
+---
+
+## Why Flattening Doesn't Work
+
+### The Serialization Boundary (the real reason the wrappers exist)
+
+Both parent flows use **persisted flows** (`RoundPersistedFlow` for reflection,
+`PersistedFlow` for tool-use). After every node step, the entire shared state is
+serialized via `structuredClone()` to a KV store (`persisted-flow.ts:86,153`).
+
+The inner cycle flows are **plain `Flow`** instances (not persisted). They hold
+transient, non-serializable state:
+
+**ResponseCycleFlow** (`ResponseCycleFlow.ts:83-88`):
+```typescript
+// CycleTransientFields — explicitly NOT serialized
+interface CycleTransientFields {
+  systemPrompt?: string;
+  responseObject?: unknown;  // Raw provider response — NOT structuredClone-safe
+}
+```
+
+**ToolUseCycleFlow** (`ToolUseCycleFlow.ts:150-158`):
+```typescript
+response: z.unknown().optional(),           // Raw provider response
+toolCalls: z.array(z.unknown()).optional(),  // SdkToolCall[] — class instances
+```
+
+If these fields were on `ReflectionFlowShared` or `ToolUseRunShared`, the
+`structuredClone()` call in `PersistedFlow.serializeShared()` would **throw**
+on non-cloneable provider response objects.
+
+The wrapper nodes (`ResponseCycleNode`, `ToolUseCycleNode`) are **not just
+wrappers** — they are **serialization adapters** that create a transient sandbox
+(`ResponseCycleShared` / `ToolUseCycleShared`) for the cycle to operate in,
+then extract only the serializable results back to the persisted shared state.
+
+### The Service Lifetime Mismatch
+
+`Flow._orchestrate()` (`node/index.ts:274`) calls `current.setServices(this._services)`
+on every node. Services are set once for the entire flow.
+
+The cycle services include per-cycle mutable values:
+- `client: C` — lazily fetched API client (via `buildCycleServices` getter)
+- `round: ConversationRoundStateSnapshot` — mutated during the cycle
+- `workspace: AgentWorkspaceState` — mutated during the cycle
+
+These can't be on the flow-level services (which are set once and shared across
+all round iterations). They need to be created fresh each cycle — which is
+exactly what the wrapper nodes do.
+
+### The Type Parameter Mismatch
+
+All nodes in a single `Flow<S, P, Svc>` must share the same `S` type.
+The inner cycle nodes are typed against `ResponseCycleShared` / `ToolUseCycleShared`.
+The parent flow nodes are typed against `ReflectionFlowShared` / `ToolUseRunShared`.
+These are fundamentally different shapes. Flattening would require retyping all
+inner cycle node classes — 4 classes for response, 4 for tool-use.
+
+---
+
+## What IS Actually Possible
+
+### Change A: Eliminate CycleOutcome double-interpretation (SAVE ~60 lines)
+
+Both wrappers construct an intermediate discriminated union from the cycle's
+mutable shared state, then interpret that union in `post()`.
+
+**ResponseCycleNode** (`ResponseCycleNode.ts:31-34,108-118,150-174`):
+```typescript
+// Current: exec() reads cycleShared → constructs CycleOutcome
+type CycleOutcome =
+  | { outcome: 'completed'; endTurn: boolean }
+  | { outcome: 'cancelled' }
+  | { outcome: 'failed'; error: Error; retryable?: boolean };
+
+// exec() builds it:
+if (cycleShared.lastError) return { outcome: 'failed', ... };
+if (cycleShared.shouldStop && !cycleShared.endTurn) return { outcome: 'cancelled' };
+return { outcome: 'completed', endTurn: cycleShared.endTurn };
+
+// post() interprets it:
+if (execRes.outcome === 'failed') { throw execRes.error; }
+shared.endTurn = execRes.outcome === 'completed' ? execRes.endTurn : false;
+if (execRes.outcome === 'cancelled') { shared.continueRounds = false; }
+```
+
+**Proposed:** Return `cycleShared` directly from `exec()`. In `post()`, read
+the cycle's fields directly. No intermediate enum.
+
+```typescript
+// New: exec() returns cycleShared itself
+async exec(prepRes): Promise<ResponseCycleShared> {
+  // ... same setup ...
+  await flow.run(cycleShared);
+  return cycleShared;
+}
+
+// New: post() reads cycle fields directly
+async post(shared, prepRes, cycleShared): Promise<string | undefined> {
+  if (cycleShared.lastError) {
+    shared.lastError = { message: cycleShared.lastError.message, retryable: ... };
+    throw new Error(cycleShared.lastError.message);
+  }
+  if (cycleShared.shouldStop && !cycleShared.endTurn) {
+    shared.continueRounds = false;
+    return FlowTransition.DEFAULT;
+  }
+  shared.endTurn = cycleShared.endTurn;
+  // ... rest stays same ...
+}
+```
+
+**Lines eliminated per wrapper:**
+- CycleOutcome type definition: 4 lines
+- Outcome construction in exec(): ~10 lines
+- Outcome interpretation switch in post(): ~8 lines
+- Error catch → CycleOutcome conversion: ~10 lines
+- Total: ~32 lines per wrapper
+
+**Savings: ~60 lines** (ResponseCycleNode ~32, ToolUseCycleNode ~28)
+
+### Change B: Extract shared prep pattern (SAVE ~20 lines)
+
+Both `ResponsePrepNode` (`ResponseCycleFlow.ts:120-164`) and `ToolUsePrepNode`
+(`ToolUseCycleFlow.ts:239-300`) share this exact pattern:
+
+```typescript
+// Shared: check interruption (both prep nodes)
+const interrupted = this.services.checkInterruption();
+
+// Shared: handle interruption (both post nodes)
+if (prepRes.interrupted) {
+  shared.shouldStop = true;
+  shared.endTurn = false;
+  return FlowTransition.COMPLETE;
+}
+
+// Shared: reset + debug save (both post nodes, ~12 lines each)
+resetCycleState(shared, [...]);
+await maybeSaveDebugObject({
+  object: shared.messages,
+  objectType: 'messages',
+  context: getDebugContext(this.services, { modelName, isRemote }),
+  fileOptions: { continuationCount: ..., baseName: ... },
+});
+```
+
+**Unique logic that stays:**
+- ResponsePrepNode: derives systemPrompt, checks outputLocation existence
+- ToolUsePrepNode: injects queued follow-ups, resets cycleResponseTimeMs
+
+**Proposed:** Extract `handleCycleInterruption()` (~5 lines) and
+`saveCycleDebugMessages()` (~10 lines) helpers in `CommonCycleTypes.ts`.
+
+**Savings: ~20 lines** (replacing ~12 duplicated lines in each prep node with
+function calls)
+
+### Change C: Simplify buildCycleServices (SAVE ~15 lines)
+
+`buildCycleServices()` (`CycleServices.ts:57-80`) creates a lazy client getter.
+It's only called from the two wrapper nodes with near-identical arguments.
+
+**Proposed:** The wrapper nodes already have access to `this.services.modelHandler`.
+Replace the generic `buildCycleServices()` with inline client creation:
+
+```typescript
+// In ResponseCycleNode.exec():
+const client = await this.services.modelHandler.getClient();
+flow.setServices({
+  ...this.services,
+  client,
+  round: prepRes.round,
+  run: prepRes.run,
+  workspace: prepRes.workspace,
+});
+```
+
+This eliminates:
+- `buildCycleServices()` function (24 lines)
+- `refreshClient` abstraction (unused by cycle nodes after creation)
+
+**Savings: ~15 lines**
+
+---
+
+## Revised Summary
+
+| Change | What | Lines Saved | Risk |
+|---|---|---|---|
+| A | Eliminate CycleOutcome enums | ~60 | Low — mechanical refactor |
+| B | Extract shared prep pattern | ~20 | Low — pure extraction |
+| C | Simplify buildCycleServices | ~15 | Low — inline + delete |
+| **Total** | | **~95** | |
+
+4,293 lines → ~4,198 lines (2.2% reduction)
+
+---
+
+## Honest Assessment
+
+**The agent/flow system does not have a large consolidation opportunity.**
+
+The two-level flow architecture (persisted parent flow + transient inner cycle) exists
+for a real reason: **the serialization boundary**. The wrapper nodes are legitimate
+adapters, not gratuitous indirection. The CLAUDE.md guidance on "Flattening Abstraction
+Layers" applies to wrappers that exist for no reason — these wrappers manage a genuine
+concern (transient vs persisted state).
+
+The two cycle flows (Response: 690 lines, ToolUse: 938 lines) are genuinely different:
+- Response: file writing, LaTeX connectors, text replacement, continuation/prefill
+- ToolUse: tool execution, deduplication, batching, streaming, media
+
+They share ~80 lines of common pattern (already factored into `ModelInvocationNode`
+and `CommonCycleTypes`). Forcing them together would create a god-class.
+
+**Where the real code volume is:**
+| Component | Lines | Justified? |
+|---|---|---|
+| ToolUseDispatchNode (tool execution) | 362 | Yes — real tool dispatch complexity |
+| ResponseProcessNode (response handling) | 252 | Yes — file I/O, replacements, connectors |
+| OutputNode (XML/diff processing) | 275 | Yes — output processing domain logic |
+| RetryState (retry infrastructure) | 357 | Yes — retry + token refresh logic |
+| runReflectionFlow (orchestration) | 324 | Mostly setup — hard to reduce |
+| runToolUseFlow (orchestration) | 212 | Mostly setup — hard to reduce |
+
+These are all doing real, unique work. The ~95 lines of genuine waste (CycleOutcome
+enums, duplicated prep patterns, buildCycleServices indirection) are worth cleaning
+but aren't a "big" win.
+
+## Implementation Order
+
+1. **Change B** (extract prep helpers) — smallest, safest, self-contained
+2. **Change A** (eliminate CycleOutcome) — moderate, touchees only 2 files
+3. **Change C** (simplify buildCycleServices) — cleanup after A

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -28,10 +28,10 @@ interface CyclePrepInput {
   round: ConversationRoundStateSnapshot;
 }
 
-type CycleOutcome =
-  | { outcome: 'completed'; endTurn: boolean }
-  | { outcome: 'cancelled' }
-  | { outcome: 'failed'; error: Error; retryable?: boolean };
+/** Result from exec: either the cycle's mutable shared state, or a prefill-only completion. */
+type CycleExecResult =
+  | { kind: 'prefill'; endTurn: true }
+  | { kind: 'ran'; cycleShared: ResponseCycleShared };
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
@@ -62,7 +62,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
     };
   }
 
-  async exec(prepRes: CyclePrepInput): Promise<CycleOutcome> {
+  async exec(prepRes: CyclePrepInput): Promise<CycleExecResult> {
     const { shared } = prepRes;
     const context = shared.context!; // Validated in prep()
 
@@ -77,94 +77,99 @@ export class ResponseCycleNode<C = unknown> extends Node<
       );
 
     if (prefillEndsTurn) {
-      return { outcome: 'completed', endTurn: true };
+      return { kind: 'prefill', endTurn: true };
     }
 
+    const cycleShared: ResponseCycleShared = {
+      messages: initializedMessages,
+      outputLocation: prepRes.outputLocation,
+      endTurn: false,
+      shouldStop: false,
+      outputExists: false,
+      systemPrompt: undefined,
+      responseObject: undefined,
+      responseTimeMs: undefined,
+      stopReason: undefined,
+      processedResponse: undefined,
+      lastError: undefined,
+    };
+
+    const flow = createResponseCycleFlow<C>();
+    flow.setServices(
+      await buildCycleServices(this.services, {
+        round: prepRes.round,
+        run: prepRes.run,
+        workspace: prepRes.workspace,
+      }),
+    );
+
     try {
-      const cycleShared: ResponseCycleShared = {
-        messages: initializedMessages,
-        outputLocation: prepRes.outputLocation,
-        endTurn: false,
-        shouldStop: false,
-        outputExists: false,
-        systemPrompt: undefined,
-        responseObject: undefined,
-        responseTimeMs: undefined,
-        stopReason: undefined,
-        processedResponse: undefined,
-        lastError: undefined,
-      };
-
-      const flow = createResponseCycleFlow<C>();
-      flow.setServices(
-        await buildCycleServices(this.services, {
-          round: prepRes.round,
-          run: prepRes.run,
-          workspace: prepRes.workspace,
-        }),
-      );
       await flow.run(cycleShared);
-
-      if (cycleShared.lastError) {
-        return {
-          outcome: 'failed',
-          error: new Error(cycleShared.lastError.message),
-          retryable: cycleShared.lastError.retryable,
-        };
-      }
-      if (cycleShared.shouldStop && !cycleShared.endTurn) {
-        return { outcome: 'cancelled' };
-      }
-      return { outcome: 'completed', endTurn: cycleShared.endTurn };
     } catch (error) {
       recordRound(prepRes.run, prepRes.round);
       if (this.services.onRoundFinalized) {
         await this.services.onRoundFinalized(prepRes.run);
       }
-      const formatted = formatProviderHttpError(error);
-      return {
-        outcome: 'failed',
-        error: error instanceof Error ? error : new Error(String(error)),
-        retryable: formatted.retryable,
-      };
+      throw error;
     }
+
+    return { kind: 'ran', cycleShared };
   }
 
   async execFallback(
-    _prepRes: CyclePrepInput,
+    prepRes: CyclePrepInput,
     error: Error,
-  ): Promise<CycleOutcome> {
+  ): Promise<CycleExecResult> {
+    // Wrap as a cycle shared with the error recorded, so post() handles uniformly
     const formatted = formatProviderHttpError(error);
-    return { outcome: 'failed', error, retryable: formatted.retryable };
+    const cycleShared: ResponseCycleShared = {
+      messages: [],
+      outputLocation: prepRes.outputLocation,
+      endTurn: false,
+      shouldStop: true,
+      outputExists: false,
+      lastError: { message: error.message, retryable: formatted.retryable },
+    };
+    return { kind: 'ran', cycleShared };
   }
 
   async post(
     shared: ReflectionFlowShared,
     prepRes: CyclePrepInput,
-    execRes: CycleOutcome,
+    execRes: CycleExecResult,
   ): Promise<string | undefined> {
     const { logger } = this.services;
 
     shared.outputLocation = prepRes.outputLocation;
 
-    if (execRes.outcome === 'failed') {
-      logger.error(`Response cycle failed: ${execRes.error.message}`);
-      shared.lastError = {
-        message: execRes.error.message,
-        retryable: execRes.retryable ?? false,
-      };
-      throw execRes.error;
+    // Determine endTurn from cycle result
+    const endTurn =
+      execRes.kind === 'prefill' ? true : execRes.cycleShared.endTurn;
+
+    // For ran cycles: check error / cancellation before committing state
+    if (execRes.kind === 'ran') {
+      const { cycleShared } = execRes;
+
+      if (cycleShared.lastError) {
+        logger.error(`Response cycle failed: ${cycleShared.lastError.message}`);
+        shared.lastError = {
+          message: cycleShared.lastError.message,
+          retryable: cycleShared.lastError.retryable ?? false,
+        };
+        throw new Error(cycleShared.lastError.message);
+      }
+
+      if (cycleShared.shouldStop && !cycleShared.endTurn) {
+        logger.debug('Response cycle cancelled by user');
+        shared.endTurn = false;
+        shared.continueRounds = false;
+        shared.lastError = undefined;
+        return FlowTransition.DEFAULT;
+      }
     }
 
-    shared.endTurn = execRes.outcome === 'completed' ? execRes.endTurn : false;
-
-    if (execRes.outcome === 'cancelled') {
-      logger.debug('Response cycle cancelled by user');
-      shared.continueRounds = false;
-      shared.lastError = undefined;
-      return FlowTransition.DEFAULT;
-    }
-
+    // Completed (either prefill or normal cycle)
+    shared.endTurn = endTurn;
     shared.lastError = undefined;
     shared.runStateSnapshot = prepRes.run;
     shared.workspaceSnapshot = prepRes.workspace.toSnapshot();

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -4,6 +4,7 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
   createToolUseCycleShared,
+  type ToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import { buildCycleServices } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
@@ -18,11 +19,10 @@ import {
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import type { TodoItem } from '@shared/schemas';
 
-type ToolUseCycleOutcome =
-  | { outcome: 'completed'; messages: ProviderMessage[] }
-  | { outcome: 'skipped' }
-  | { outcome: 'cancelled' }
-  | { outcome: 'failed'; message: string; retryable?: boolean };
+/** Result from exec: either skipped (resume), or the cycle's mutable shared state. */
+type CycleExecResult =
+  | { kind: 'skipped' }
+  | { kind: 'ran'; cycleShared: ToolUseCycleShared };
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
@@ -43,9 +43,8 @@ export class ToolUseCycleNode<C> extends Node<
     };
   }
 
-  async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { streamId, setting, resolvedTools, modelHandler, config } =
-      this.services;
+  async exec(prepRes: CyclePrepResult): Promise<CycleExecResult> {
+    const { streamId, setting, resolvedTools, config } = this.services;
 
     if (prepRes.shouldSkip) {
       if (prepRes.workspaceState.todos.todos.length > 0) {
@@ -54,7 +53,7 @@ export class ToolUseCycleNode<C> extends Node<
           todos: prepRes.workspaceState.todos.todos,
         });
       }
-      return { outcome: 'skipped' };
+      return { kind: 'skipped' };
     }
 
     const cycleShared = createToolUseCycleShared(
@@ -74,47 +73,38 @@ export class ToolUseCycleNode<C> extends Node<
     );
 
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {
-      bus.emit('updateTodos', {
-        streamId,
-        todos,
-      });
+      bus.emit('updateTodos', { streamId, todos });
     });
 
     try {
       await flow.run(cycleShared);
-
-      if (cycleShared.shouldStop && cycleShared.lastError) {
-        return {
-          outcome: 'failed',
-          message: cycleShared.lastError.message ?? 'Cycle failed',
-          retryable: cycleShared.lastError.retryable,
-        };
-      }
-      if (cycleShared.shouldStop && !cycleShared.endTurn) {
-        return { outcome: 'cancelled' };
-      }
-      return { outcome: 'completed', messages: cycleShared.messages };
     } finally {
       prepRes.workspaceState.todos.clearOnUpdate();
     }
+
+    return { kind: 'ran', cycleShared };
   }
 
   async execFallback(
     _prepRes: CyclePrepResult,
     error: Error,
-  ): Promise<ToolUseCycleOutcome> {
+  ): Promise<CycleExecResult> {
     const formatted = formatProviderHttpError(error);
-    return {
-      outcome: 'failed',
-      message: error.message,
-      retryable: formatted.retryable,
+    const cycleShared: ToolUseCycleShared = {
+      messages: [],
+      endTurn: false,
+      shouldStop: true,
+      cycleIndex: 0,
+      cycleResponseTimeMs: 0,
+      lastError: { message: error.message, retryable: formatted.retryable },
     };
+    return { kind: 'ran', cycleShared };
   }
 
   async post(
     shared: ToolUseRunShared,
     prepRes: CyclePrepResult,
-    execRes: ToolUseCycleOutcome,
+    execRes: CycleExecResult,
   ): Promise<string | undefined> {
     if (prepRes.shouldSkip) {
       shared.shouldSkipCycle = false;
@@ -126,24 +116,29 @@ export class ToolUseCycleNode<C> extends Node<
       userChannels: prepRes.userChannels,
     };
 
-    switch (execRes.outcome) {
-      case 'completed':
-        shared.messages = execRes.messages;
-        return FlowTransition.DEFAULT;
-
-      case 'skipped':
-        return FlowTransition.DEFAULT;
-
-      case 'failed':
-        shared.lastError = {
-          message: execRes.message,
-          retryable: execRes.retryable ?? false,
-        };
-        throw new Error(execRes.message);
-
-      case 'cancelled':
-        shared.userCancelledRetry = true;
-        return FlowTransition.FINALIZE;
+    if (execRes.kind === 'skipped') {
+      return FlowTransition.DEFAULT;
     }
+
+    const { cycleShared } = execRes;
+
+    // Failed — propagate error
+    if (cycleShared.shouldStop && cycleShared.lastError) {
+      shared.lastError = {
+        message: cycleShared.lastError.message ?? 'Cycle failed',
+        retryable: cycleShared.lastError.retryable ?? false,
+      };
+      throw new Error(shared.lastError.message);
+    }
+
+    // Cancelled — signal finalization
+    if (cycleShared.shouldStop && !cycleShared.endTurn) {
+      shared.userCancelledRetry = true;
+      return FlowTransition.FINALIZE;
+    }
+
+    // Completed — update messages
+    shared.messages = cycleShared.messages;
+    return FlowTransition.DEFAULT;
   }
 }


### PR DESCRIPTION
Detailed investigation of the agent/flow architecture found that the
original plan to flatten CycleNode wrappers (~425 lines) is blocked by
three hard constraints: serialization boundary (structuredClone on
persisted flows), service lifetime mismatch, and type parameter lock-in.

Revised plan identifies ~95 lines of genuine cleanup: eliminating
CycleOutcome double-interpretation, extracting shared prep patterns,
and simplifying buildCycleServices.

https://claude.ai/code/session_017FoUXxxDvKM77iAJrSwFFx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent execution nodes for reflection/tool-use cycles by changing how errors/cancellation are surfaced and how end-of-turn is computed; behavior should remain equivalent but regressions would affect run control flow and retries.
> 
> **Overview**
> Adds `plan.md` documenting constraints that block flattening cycle wrappers (serialization boundary, service lifetime, and typing) and proposes smaller cleanups.
> 
> Refactors `ResponseCycleNode` and `ToolUseCycleNode` to remove `*CycleOutcome` unions and double-interpretation: `exec()` now returns either a small `{kind: ...}` marker (`prefill`/`skipped`) or the cycle’s mutable shared state, while `post()` derives `endTurn`, cancellation, and error propagation directly from the returned `cycleShared`. Error formatting is moved into `execFallback()` (and `ResponseCycleNode.exec()` now rethrows rather than converting exceptions into an outcome).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4109c24236052501757ce37cf33132930695348b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->