### PR TITLE
Add resume_subagent tool for iterative subagent refinement

### DIFF
--- a/docs/design/bidirectional-followups.md
+++ b/docs/design/bidirectional-followups.md
@@ -1,33 +1,62 @@
-# Bidirectional Follow-ups (Future Work)
+# Bidirectional Follow-ups
 
 ## Current State
 
-The FollowUpQueue is unidirectional: subagents deliver results to the orchestrator via `ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg)`. Once delivered, the subagent either exits or enters WAITING state.
+The FollowUpQueue supports bidirectional message flow between orchestrators and subagents:
 
-The `onBeforeWaiting` callback infrastructure already exists — tool-use subagents fire this callback before entering WAITING, allowing the orchestrator to receive interim results without waiting for the flow to fully exit.
+- **Subagent → Orchestrator**: Results delivered via `ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg)` through `onBeforeWaiting` callback (tool-use) or `onCompleted` callback (workflow).
+- **Orchestrator → Subagent**: Follow-up instructions sent via the `resume_subagent` tool, which routes through `sendSubagentFollowUp()` and triggers auto-resume of WAITING sessions.
 
-## Vision
+## Architecture
 
-Enable the orchestrator to send follow-up instructions to a subagent that has reported back and is in WAITING state. This would allow iterative refinement without re-launching:
+### Orchestrator → Subagent Flow
 
-1. Subagent completes initial work, delivers result via FollowUpQueue
-2. Subagent enters WAITING state (flow paused, resources retained)
-3. Orchestrator reviews result, decides refinement is needed
-4. Orchestrator sends follow-up instruction to the waiting subagent
-5. Subagent resumes with the new instruction, produces refined result
+```
+1. Orchestrator calls resume_subagent(execution_id, instruction)
+2. ResumeSubagentTool resolves execution_id → AgentExecutionHandle → childStreamId
+3. sendSubagentFollowUp() routes the instruction to the child stream:
+   a. Active session → direct append via session.appendFollowUp()
+   b. WAITING session → queue + auto-resume via tryAutoResumeSubagent()
+   c. RESUMING session → queue (processed when resume completes)
+4. Subagent resumes from persisted state with new instruction as user message
+5. Subagent delivers refined result via onBeforeWaiting → orchestrator's FollowUpQueue
+```
 
-## Key Questions
+### Key Design Decisions
 
-- **Message format**: How should the orchestrator's follow-up instruction be structured? Plain text? Structured payload with context about what to refine?
-- **Queueing semantics**: Should the subagent's FollowUpQueue be bidirectional, or should a separate channel exist for orchestrator-to-subagent messages?
-- **Resume mechanism**: How does the waiting subagent consume the follow-up? The current FollowUpQueue is consumed during the tool-use cycle — a reverse queue would need to inject into the subagent's conversation as a user message.
-- **Timeout and cleanup**: How long should a subagent remain in WAITING? What happens if the orchestrator never sends a follow-up?
-- **Nesting depth**: Should bidirectional follow-ups be limited to one level, or can a subagent itself delegate and wait?
+- **Message format**: Plain text instructions. The subagent sees the follow-up as a standard user message in its conversation, maintaining simplicity and compatibility with the existing tool-use cycle.
+- **Queueing semantics**: Reuses the existing `FollowUpQueue` (same channel for both user and orchestrator messages). No separate bidirectional channel needed — the subagent's WaitNode already consumes follow-ups generically.
+- **Resume mechanism**: Follow-ups are injected via `sendFollowUp()` which queues to the child stream's `FollowUpQueue`. For WAITING sessions, `tryAutoResumeSubagent()` retrieves the session snapshot and triggers `texra.resumeAgent` to restart the persisted flow.
+- **Nesting depth**: `resume_subagent` is included in `DELEGATION_TOOLS` and filtered out for subagents (`isSubagent: true`), preventing infinite delegation chains.
 
-## Dependencies
+### Components
 
-- Requires the ExecutionHandle refactoring (completed) — handles provide the `terminate()` and status introspection needed for lifecycle management of waiting subagents.
-- The `StreamStatusService.shouldPreserveOnCompletion` mechanism already preserves WAITING state, preventing premature cleanup.
+| Component | File | Role |
+|-----------|------|------|
+| `resume_subagent` tool | `src/tools/ResumeSubagentTool.ts` | Tool interface for orchestrators |
+| `sendSubagentFollowUp()` | `src/agent/toolUse/ToolUseFollowUp.ts` | Execution ID → stream routing |
+| `sendFollowUp()` | `src/agent/toolUse/ToolUseFollowUp.ts` | Stream-level follow-up routing |
+| `ToolUseFollowUpQueue` | `src/agent/toolUse/ToolUseFollowUpQueueManager.ts` | Queue management |
+| `ToolUseWaitNode` | `src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts` | Consumes follow-ups |
+
+## Typical Flow
+
+1. Orchestrator launches subagent via `delegate_agent`
+2. Subagent completes initial work, delivers result via FollowUpQueue
+3. Subagent enters WAITING state (flow paused, state persisted)
+4. Orchestrator reviews result, decides refinement is needed
+5. Orchestrator calls `resume_subagent` with execution ID and new instruction
+6. Subagent resumes from snapshot, processes instruction, delivers refined result
+7. Steps 4-6 can repeat for iterative refinement
+
+## Timeout and Cleanup
+
+Subagents remain in WAITING state until:
+- The orchestrator sends a follow-up (via `resume_subagent`)
+- The user manually resumes or stops the session
+- The VS Code window is closed (session state persists on disk via `ExecutionKVStore`)
+
+The `StreamStatusService.shouldPreserveOnCompletion` mechanism prevents premature cleanup of WAITING state.
 
 ## Non-Goals
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -60,6 +60,7 @@ export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
 const DELEGATION_TOOLS = new Set([
   'delegate_workflow',
   'delegate_agent',
+  'resume_subagent',
   'propose_workflow',
   'propose_agent',
 ]);

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -13,9 +13,13 @@
 import { STREAM_STATUS } from '@shared/schemas';
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  getHandle,
+  AgentExecutionHandle,
+} from '@agent/runtime/executionRegistry';
 import { AgentLogger } from '@logger/AgentLogger';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
-import type { StreamTabId } from '@shared/schemas';
+import type { StreamTabId, ExecutionId } from '@shared/schemas';
 
 /**
  * Result of sending a follow-up message to a tool-use session.
@@ -78,4 +82,67 @@ export async function sendFollowUp(
     `No active session for follow-up on stream ${streamId}. Status: ${status ?? 'undefined'}`,
   );
   return { status: 'no_session', streamStatus: status };
+}
+
+// ============================================================================
+// Subagent follow-up (execution ID → child stream routing)
+// ============================================================================
+
+/**
+ * Result of sending a follow-up to a subagent by execution ID.
+ */
+export type SendSubagentFollowUpResult =
+  | { status: 'sent'; streamId: StreamTabId }
+  | { status: 'queued'; reason: 'resuming' | 'waiting'; streamId: StreamTabId }
+  | { status: 'error'; message: string }
+  | {
+      status: 'not_found';
+      reason: 'no_handle' | 'not_agent' | 'not_tool_use';
+    };
+
+/**
+ * Send a follow-up message to a subagent identified by execution ID.
+ *
+ * Resolves the execution ID to its child stream ID via the execution registry,
+ * then delegates to the standard sendFollowUp routing. This enables orchestrators
+ * to send instructions to waiting tool-use subagents for iterative refinement
+ * without re-launching.
+ *
+ * @param executionId - Execution ID of the target subagent
+ * @param text - Follow-up instruction text
+ * @returns Result with routing outcome and resolved stream ID
+ */
+export async function sendSubagentFollowUp(
+  executionId: ExecutionId,
+  text: string,
+): Promise<SendSubagentFollowUpResult> {
+  const handle = getHandle(executionId);
+  if (!handle) {
+    return { status: 'not_found', reason: 'no_handle' };
+  }
+
+  if (!(handle instanceof AgentExecutionHandle)) {
+    return { status: 'not_found', reason: 'not_agent' };
+  }
+
+  if (handle.category !== 'toolUse') {
+    return { status: 'not_found', reason: 'not_tool_use' };
+  }
+
+  const childStreamId = handle.childStreamId;
+  const result = await sendFollowUp(childStreamId, text);
+
+  switch (result.status) {
+    case 'sent':
+      return { status: 'sent', streamId: childStreamId };
+    case 'queued':
+      return { status: 'queued', reason: result.reason, streamId: childStreamId };
+    case 'error':
+      return { status: 'error', message: result.message };
+    case 'no_session':
+      return {
+        status: 'error',
+        message: `Subagent stream has no active session (status: ${result.streamStatus ?? 'unknown'})`,
+      };
+  }
 }

--- a/src/tools/ResumeSubagentTool.ts
+++ b/src/tools/ResumeSubagentTool.ts
@@ -1,0 +1,221 @@
+/**
+ * Tool for sending follow-up instructions to a waiting tool-use subagent.
+ *
+ * Enables the orchestrator to iteratively refine subagent work without
+ * re-launching: the subagent delivers its initial result via onBeforeWaiting,
+ * the orchestrator reviews it, then uses this tool to send further instructions.
+ * The subagent resumes from its persisted state with the new instruction.
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import { z } from 'zod';
+
+// Local imports - agent
+import { STREAM_STATUS, ExecutionIdSchema } from '@shared/schemas';
+import {
+  sendSubagentFollowUp,
+  type SendSubagentFollowUpResult,
+} from '@agent/toolUse/ToolUseFollowUp';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  getHandle,
+  AgentExecutionHandle,
+} from '@agent/runtime/executionRegistry';
+import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
+import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
+import { ResumeAgentResultSchema } from '@commands/agent/resumeCommand';
+
+// Local imports - tools
+import { ToolError, type ToolResult } from '@tools/result';
+import { defineTool } from '@tools/core/define';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+
+const logger = new AgentLogger('ResumeSubagentTool');
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const ResumeSubagentInputSchema = z.strictObject({
+  execution_id: ExecutionIdSchema.describe(
+    'Execution ID of the tool-use subagent to resume. Use /executions to find the ID.',
+  ),
+  instruction: z
+    .string()
+    .describe(
+      'Follow-up instruction for the subagent. Write as a self-contained message—the subagent will see this as a new user message in its conversation.',
+    ),
+});
+
+export type ResumeSubagentInput = z.infer<typeof ResumeSubagentInputSchema>;
+
+// ============================================================================
+// Auto-resume logic (mirrors followUpCommand.tryAutoResume for programmatic use)
+// ============================================================================
+
+/**
+ * Attempt to auto-resume a WAITING tool-use subagent after queuing a follow-up.
+ *
+ * This mirrors the logic in followUpCommand.ts but works without VS Code
+ * command dispatching for the lookup — it resolves the snapshot directly.
+ */
+async function tryAutoResumeSubagent(
+  handle: AgentExecutionHandle,
+): Promise<boolean> {
+  const streamId = handle.childStreamId;
+
+  // Guard against concurrent resume attempts
+  if (StreamStatusService.isActiveOrResuming(streamId)) {
+    logger.debug(
+      `Stream ${streamId} is active/resuming, skipping auto-resume`,
+    );
+    return false;
+  }
+
+  const progressState = ProgressViewProvider.getInstance()?.state;
+  const executionId = progressState?.getExecutionId(streamId);
+  const taskState = progressState?.getTaskState(streamId);
+
+  if (!progressState || !executionId || !taskState) {
+    logger.warn(`Missing state for auto-resume of stream: ${streamId}`);
+    return false;
+  }
+
+  const resumeData = await retrieveSessionResumeData(
+    streamId,
+    executionId,
+    taskState,
+  );
+  if (!resumeData || resumeData.type !== 'toolUse') {
+    logger.warn(`No tool-use resume data for stream: ${streamId}`);
+    return false;
+  }
+
+  logger.info(`Auto-resuming subagent for stream: ${streamId}`);
+  try {
+    const rawResult = await vscode.commands.executeCommand(
+      'texra.resumeAgent',
+      { snapshot: resumeData.snapshot },
+    );
+    const parseResult = ResumeAgentResultSchema.safeParse(rawResult);
+    return parseResult.success && parseResult.data.success;
+  } catch (error) {
+    logger.error(`Failed to auto-resume subagent for stream: ${streamId}`, {
+      data: error,
+    });
+    return false;
+  }
+}
+
+// ============================================================================
+// Tool
+// ============================================================================
+
+export class ResumeSubagentTool extends defineTool({
+  name: 'resume_subagent',
+  description: `Send a follow-up instruction to a waiting tool-use subagent and resume it.
+
+When a tool-use subagent finishes its initial work, it delivers its result and enters a WAITING state. Use this tool to send additional instructions so it continues from where it left off—without re-launching.
+
+Typical flow:
+1. delegate_agent launches a subagent
+2. Subagent delivers result as a follow-up message
+3. You review the result and decide refinement is needed
+4. Use resume_subagent with the subagent's execution ID and new instruction
+5. Subagent resumes and delivers the refined result
+
+The subagent must be in WAITING state (check via executions tool). If the subagent has already exited, use delegate_agent to launch a new one.`,
+  schema: ResumeSubagentInputSchema,
+}) {
+  protected async execute(input: ResumeSubagentInput): Promise<ToolResult> {
+    const { execution_id: executionId, instruction } = input;
+
+    // Validate handle exists and is a tool-use agent
+    const handle = getHandle(executionId);
+    if (!handle) {
+      throw new ToolError(
+        `Execution not found: ${executionId}. The subagent may have already exited. Use delegate_agent to launch a new one.`,
+      );
+    }
+
+    if (!(handle instanceof AgentExecutionHandle)) {
+      throw new ToolError(
+        `Execution ${executionId} is a background process, not an agent. Use resume_subagent only with tool-use subagents.`,
+      );
+    }
+
+    if (handle.category !== 'toolUse') {
+      throw new ToolError(
+        `Execution ${executionId} is a workflow agent ('${handle.agentName}'). resume_subagent only works with tool-use subagents.`,
+      );
+    }
+
+    // Check stream status for clear messaging
+    const streamStatus = StreamStatusService.get(handle.childStreamId);
+    if (
+      streamStatus === STREAM_STATUS.RUNNING ||
+      streamStatus === STREAM_STATUS.RESUMING
+    ) {
+      throw new ToolError(
+        `Subagent '${handle.agentName}' (${executionId}) is currently ${streamStatus}. Wait for it to finish or enter WAITING state before sending a follow-up.`,
+      );
+    }
+
+    // Route the follow-up to the subagent's stream
+    const result: SendSubagentFollowUpResult = await sendSubagentFollowUp(
+      executionId,
+      instruction,
+    );
+
+    switch (result.status) {
+      case 'sent':
+        return {
+          summary: `Follow-up sent to '${handle.agentName}'`,
+          output: `Follow-up delivered to subagent '${handle.agentName}' (${executionId}). The subagent is actively processing.`,
+        };
+
+      case 'queued':
+        if (result.reason === 'waiting') {
+          // Trigger auto-resume for WAITING sessions
+          const resumed = await tryAutoResumeSubagent(handle);
+          if (resumed) {
+            return {
+              summary: `Resumed '${handle.agentName}' with follow-up`,
+              output: [
+                `Subagent '${handle.agentName}' (${executionId}) has been resumed with your follow-up instruction.`,
+                `Result will be delivered automatically as a follow-up message when complete.`,
+              ].join('\n'),
+            };
+          }
+          return {
+            summary: `Follow-up queued for '${handle.agentName}'`,
+            output: [
+              `Follow-up queued for subagent '${handle.agentName}' (${executionId}).`,
+              `Auto-resume failed — the subagent will process the instruction when manually resumed.`,
+            ].join('\n'),
+            isError: true,
+          };
+        }
+        // reason === 'resuming': already being resumed
+        return {
+          summary: `Follow-up queued for '${handle.agentName}' (resuming)`,
+          output: `Subagent '${handle.agentName}' (${executionId}) is currently resuming. Your follow-up has been queued and will be processed after the current resume completes.`,
+        };
+
+      case 'error':
+        return {
+          summary: `Failed to send follow-up to '${handle.agentName}'`,
+          output: `Error sending follow-up to subagent '${handle.agentName}' (${executionId}): ${result.message}`,
+          isError: true,
+        };
+
+      case 'not_found':
+        throw new ToolError(
+          `Could not route follow-up to execution ${executionId}: ${result.reason}`,
+        );
+    }
+  }
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -43,6 +43,7 @@ import {
 import { WorkflowAgentTool, DelegateAgentTool } from './WorkflowTool';
 import { ExecutionsTool } from './ExecutionsTool';
 import { AcceptRunFilesTool } from './AcceptRunFilesTool';
+import { ResumeSubagentTool } from './ResumeSubagentTool';
 
 /** Singleton IToolRegistry instance for the default tools. */
 let defaultRegistryInstance: IToolRegistry | null = null;
@@ -89,6 +90,7 @@ export function getDefaultToolRegistry(): IToolRegistry {
       lean_loogle: new LeanLoogleTool(),
       delegate_workflow: new WorkflowAgentTool(),
       delegate_agent: new DelegateAgentTool(),
+      resume_subagent: new ResumeSubagentTool(),
       executions: new ExecutionsTool(),
       accept_run_files: new AcceptRunFilesTool(),
       // Legacy aliases — old agent configs may reference these names


### PR DESCRIPTION
## Summary

Implements bidirectional follow-up messaging between orchestrators and tool-use subagents, enabling iterative refinement without re-launching. Orchestrators can now send follow-up instructions to waiting subagents via the new `resume_subagent` tool, which automatically resumes WAITING sessions and delivers refined results.

## Key Changes

- **New `ResumeSubagentTool`** (`src/tools/ResumeSubagentTool.ts`): Tool interface allowing orchestrators to send follow-up instructions to subagents by execution ID. Includes:
  - Validation that target is a tool-use subagent (not workflow or background process)
  - Stream status checks to prevent sending to active/resuming sessions
  - Auto-resume logic for WAITING sessions via `tryAutoResumeSubagent()`
  - Clear error messaging for various failure modes

- **New `sendSubagentFollowUp()` function** (`src/agent/toolUse/ToolUseFollowUp.ts`): Execution ID → child stream routing layer that:
  - Resolves execution ID to `AgentExecutionHandle`
  - Validates handle is a tool-use agent
  - Delegates to existing `sendFollowUp()` for stream-level routing
  - Returns structured result with stream ID and routing outcome

- **Tool registration** (`src/tools/registry.ts`): Registers `ResumeSubagentTool` in the tool registry

- **Delegation tools list** (`src/agent/implementations/flows/tooluse/runToolUseFlow.ts`): Adds `resume_subagent` to `DELEGATION_TOOLS` set, making it available to orchestrators but filtered out for subagents (preventing infinite delegation chains)

- **Documentation** (`docs/design/bidirectional-followups.md`): Updated from "Future Work" to completed design, documenting:
  - Bidirectional message flow architecture
  - Component responsibilities and interactions
  - Typical iterative refinement flow
  - Timeout and cleanup semantics

## Implementation Details

- **Message format**: Follow-ups are plain text instructions injected as user messages into the subagent's conversation, maintaining compatibility with existing tool-use cycle
- **Queueing**: Reuses existing `FollowUpQueue` (no separate bidirectional channel needed)
- **Resume mechanism**: For WAITING sessions, retrieves persisted session snapshot and triggers `texra.resumeAgent` command to restart the flow
- **Status handling**: Distinguishes between sent (active session), queued (WAITING/RESUMING), and error states with appropriate messaging

https://claude.ai/code/session_011dMH3ykjqafyuJjuhnPGjd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new orchestration tool that can resume persisted agent sessions and dispatch messages, which could affect execution lifecycle and state if routing/status checks are wrong. Scope is contained to tool-use follow-up/resume paths and adds validations and clear failure modes.
> 
> **Overview**
> Enables iterative refinement of tool-use subagents by introducing a new `resume_subagent` tool that sends a follow-up instruction to a subagent via its execution ID and (when queued for `WAITING`) attempts to auto-resume the persisted session.
> 
> This adds `sendSubagentFollowUp()` to route execution IDs to the subagent’s child stream and reuses existing follow-up queue semantics, registers the new tool in the default registry, and adds `resume_subagent` to the delegation-tool filter to prevent subagents from invoking it. Documentation is updated to reflect the now-implemented bidirectional follow-up architecture and typical flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adac4f07182fdd73e6af0e26721c21fd5cb815c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->