### PR TITLE
Add virtual path support for /memories and /executions in glob/grep

### DIFF
--- a/src/test/tools/virtualPath.test.ts
+++ b/src/test/tools/virtualPath.test.ts
@@ -1,0 +1,169 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { ToolError } from '@tools/result';
+import { StorageFS } from '@utils/files';
+import {
+  tryResolveVirtualPath,
+  translateOutputLine,
+  type VirtualNamespace,
+} from '@tools/virtualPath';
+
+// Stub StorageFS.fullPath to return a predictable absolute path
+// without requiring VS Code extension context initialization.
+const FAKE_STORAGE_BASE = '/fake/storage';
+const originalFullPath = StorageFS.fullPath;
+
+beforeEach(() => {
+  (StorageFS as unknown as Record<string, unknown>).fullPath = (target: string) =>
+    `${FAKE_STORAGE_BASE}/${target}`;
+});
+
+afterEach(() => {
+  (StorageFS as unknown as Record<string, unknown>).fullPath = originalFullPath;
+});
+
+// ============================================================================
+// tryResolveVirtualPath
+// ============================================================================
+
+describe('tryResolveVirtualPath', () => {
+  // --- Namespace matching ---
+
+  it('returns null for non-virtual paths', () => {
+    assert.equal(tryResolveVirtualPath('src/main.ts'), null);
+    assert.equal(tryResolveVirtualPath('/usr/local/bin'), null);
+    assert.equal(tryResolveVirtualPath('.'), null);
+    assert.equal(tryResolveVirtualPath(''), null);
+  });
+
+  it('resolves /memories root', () => {
+    const result = tryResolveVirtualPath('/memories');
+    assert.ok(result);
+    assert.equal(result.absolutePath, `${FAKE_STORAGE_BASE}/memories`);
+    assert.equal(result.namespace.display, '/memories');
+    assert.equal(result.namespace.storage, 'memories');
+  });
+
+  it('resolves /memories with subpath', () => {
+    const result = tryResolveVirtualPath('/memories/notes.md');
+    assert.ok(result);
+    assert.equal(result.absolutePath, `${FAKE_STORAGE_BASE}/memories/notes.md`);
+    assert.equal(result.namespace.display, '/memories');
+  });
+
+  it('resolves /executions root', () => {
+    const result = tryResolveVirtualPath('/executions');
+    assert.ok(result);
+    assert.equal(result.absolutePath, `${FAKE_STORAGE_BASE}/executions`);
+    assert.equal(result.namespace.display, '/executions');
+    assert.equal(result.namespace.storage, 'executions');
+  });
+
+  it('resolves /executions with subpath', () => {
+    const result = tryResolveVirtualPath('/executions/abc123/config.json');
+    assert.ok(result);
+    assert.equal(
+      result.absolutePath,
+      `${FAKE_STORAGE_BASE}/executions/abc123/config.json`,
+    );
+    assert.equal(result.namespace.display, '/executions');
+  });
+
+  // --- Does not match similar-but-wrong prefixes ---
+
+  it('does not match partial prefix like /memoriesextra', () => {
+    assert.equal(tryResolveVirtualPath('/memoriesextra'), null);
+  });
+
+  it('does not match partial prefix like /executionsfoo', () => {
+    assert.equal(tryResolveVirtualPath('/executionsfoo'), null);
+  });
+
+  // --- Path traversal rejection ---
+
+  it('rejects ../ traversal in /memories', () => {
+    assert.throws(
+      () => tryResolveVirtualPath('/memories/../../../etc/passwd'),
+      ToolError,
+    );
+  });
+
+  it('rejects ../ traversal in /executions', () => {
+    assert.throws(
+      () => tryResolveVirtualPath('/executions/../secret'),
+      ToolError,
+    );
+  });
+
+  it('rejects traversal via ./../../esc', () => {
+    assert.throws(
+      () => tryResolveVirtualPath('/memories/./../../foo'),
+      ToolError,
+    );
+  });
+
+  it('allows safe relative segments like /memories/a/b', () => {
+    const result = tryResolveVirtualPath('/memories/a/b');
+    assert.ok(result);
+    assert.equal(result.absolutePath, `${FAKE_STORAGE_BASE}/memories/a/b`);
+  });
+});
+
+// ============================================================================
+// translateOutputLine
+// ============================================================================
+
+describe('translateOutputLine', () => {
+  const ns: VirtualNamespace = {
+    display: '/memories',
+    storage: 'memories',
+  };
+  const absoluteBase = '/fake/storage/memories';
+
+  it('replaces leading absolute path with virtual prefix', () => {
+    const line = `${absoluteBase}/notes.md:10:some content`;
+    assert.equal(
+      translateOutputLine(line, absoluteBase, ns),
+      '/memories/notes.md:10:some content',
+    );
+  });
+
+  it('handles files_with_matches mode (path only, no colon)', () => {
+    const line = `${absoluteBase}/notes.md`;
+    assert.equal(
+      translateOutputLine(line, absoluteBase, ns),
+      '/memories/notes.md',
+    );
+  });
+
+  it('handles count mode output (path:count)', () => {
+    const line = `${absoluteBase}/notes.md:42`;
+    assert.equal(
+      translateOutputLine(line, absoluteBase, ns),
+      '/memories/notes.md:42',
+    );
+  });
+
+  it('handles context lines with - delimiter', () => {
+    const line = `${absoluteBase}/notes.md-11-context line`;
+    assert.equal(
+      translateOutputLine(line, absoluteBase, ns),
+      '/memories/notes.md-11-context line',
+    );
+  });
+
+  it('passes through lines that do not start with base path', () => {
+    assert.equal(translateOutputLine('--', absoluteBase, ns), '--');
+    assert.equal(
+      translateOutputLine('some random line', absoluteBase, ns),
+      'some random line',
+    );
+    assert.equal(translateOutputLine('', absoluteBase, ns), '');
+  });
+
+  it('translates root path exactly', () => {
+    assert.equal(translateOutputLine(absoluteBase, absoluteBase, ns), ns.display);
+  });
+});

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import { glob } from 'glob';
 import { z } from 'zod';
@@ -12,11 +15,12 @@ import {
   pluralize,
 } from '@tools/utils';
 import { getGitignoreMatcher } from '@tools/gitignore';
-import { WorkspaceFS } from '@utils/files';
+import { StorageFS, WorkspaceFS } from '@utils/files';
 import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { tryResolveVirtualPath } from './virtualPath';
 
 const GlobInputSchema = z.strictObject({
   pattern: z.string().min(1, 'pattern is required'),
@@ -33,17 +37,33 @@ interface GlobMatchInfo {
 export class GlobTool extends defineTool({
   name: 'glob',
   description:
-    'Find files matching glob patterns (e.g., "**/*.tex", "src/**/*.ts"). Returns paths sorted by modification time.',
+    'Find files matching glob patterns (e.g., "**/*.tex", "src/**/*.ts"). Returns paths sorted by modification time. ' +
+    'Also supports virtual storage paths: use "/memories" to search memory files, "/executions" to search execution data.',
   schema: GlobInputSchema,
 }) {
   protected async execute(input: GlobInput): Promise<ToolResult> {
-    const { path, display } = resolveAndFormat(input.path ?? undefined);
+    const inputPath = input.path ?? undefined;
+
+    const virtual = inputPath ? tryResolveVirtualPath(inputPath) : null;
+    if (virtual) {
+      return this.executeVirtual(input, inputPath!, virtual);
+    }
+
+    return this.executeWorkspace(input, inputPath);
+  }
+
+  /** Glob workspace files (original behavior). */
+  private async executeWorkspace(
+    input: GlobInput,
+    inputPath: string | undefined,
+  ): Promise<ToolResult> {
+    const { path: resolvedPath, display } = resolveAndFormat(inputPath);
     const gitignore = await getGitignoreMatcher();
 
     let matches: string[];
     try {
       matches = await glob(input.pattern, {
-        cwd: path.absolute,
+        cwd: resolvedPath.absolute,
         dot: true,
         nodir: false,
         absolute: false,
@@ -56,12 +76,11 @@ export class GlobTool extends defineTool({
       );
     }
 
-    // Process matches in parallel for better performance
     const statPromises = matches.map(
       async (match): Promise<GlobMatchInfo | null> => {
         let resolved;
         try {
-          resolved = joinWorkspaceRelativePath(path.relative, match);
+          resolved = joinWorkspaceRelativePath(resolvedPath.relative, match);
         } catch (err) {
           throw new ToolError(
             `Match resolved outside the workspace: ${match} (${toErrorMessage(err)})`,
@@ -84,6 +103,61 @@ export class GlobTool extends defineTool({
       (item): item is GlobMatchInfo => item !== null,
     );
 
+    return this.formatMatches(input, display, decorated);
+  }
+
+  /** Glob virtual storage paths (/memories, /executions). */
+  private async executeVirtual(
+    input: GlobInput,
+    virtualPath: string,
+    resolved: {
+      absolutePath: string;
+      namespace: { display: string; storage: string };
+    },
+  ): Promise<ToolResult> {
+    const { absolutePath, namespace } = resolved;
+
+    const exists = await StorageFS.exists(namespace.storage);
+    if (!exists) {
+      return {
+        summary: `No data found at ${virtualPath}`,
+        output: `The ${namespace.display} directory does not exist yet.`,
+      };
+    }
+
+    let matches: string[];
+    try {
+      matches = await glob(input.pattern, {
+        cwd: absolutePath,
+        dot: true,
+        nodir: false,
+        absolute: false,
+        follow: false,
+      });
+    } catch (err) {
+      throw new ToolError(
+        `Glob pattern error: ${toErrorMessage(err)}. ` +
+          `Check syntax: use ** for recursive, * for single level. Example: "**/*.json"`,
+      );
+    }
+
+    const statPromises = matches.map(async (match): Promise<GlobMatchInfo> => {
+      const storagePath = path.join(namespace.storage, match);
+      const stat = await StorageFS.stat(storagePath).catch(() => null);
+      const displayPath = `${namespace.display}/${toPosixPath(match)}`;
+      return { relativePath: displayPath, mtime: stat?.mtime ?? 0 };
+    });
+
+    const decorated = await Promise.all(statPromises);
+    return this.formatMatches(input, virtualPath, decorated);
+  }
+
+  /** Shared formatting for glob matches. */
+  private formatMatches(
+    input: GlobInput,
+    display: string,
+    decorated: GlobMatchInfo[],
+  ): ToolResult {
     const sorted = decorated.sort((a, b) => {
       if (b.mtime !== a.mtime) {
         return b.mtime - a.mtime;

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -20,7 +20,10 @@ import { toPosixPath } from '@utils/core/pathCore';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { tryResolveVirtualPath } from './virtualPath';
+import {
+  tryResolveVirtualPath,
+  type VirtualPathResolution,
+} from './virtualPath';
 
 const GlobInputSchema = z.strictObject({
   pattern: z.string().min(1, 'pattern is required'),
@@ -45,8 +48,8 @@ export class GlobTool extends defineTool({
     const inputPath = input.path ?? undefined;
 
     const virtual = inputPath ? tryResolveVirtualPath(inputPath) : null;
-    if (virtual) {
-      return this.executeVirtual(input, inputPath!, virtual);
+    if (inputPath && virtual) {
+      return this.executeVirtual(input, inputPath, virtual);
     }
 
     return this.executeWorkspace(input, inputPath);
@@ -110,10 +113,7 @@ export class GlobTool extends defineTool({
   private async executeVirtual(
     input: GlobInput,
     virtualPath: string,
-    resolved: {
-      absolutePath: string;
-      namespace: { display: string; storage: string };
-    },
+    resolved: VirtualPathResolution,
   ): Promise<ToolResult> {
     const { absolutePath, namespace } = resolved;
 
@@ -158,7 +158,7 @@ export class GlobTool extends defineTool({
     display: string,
     decorated: GlobMatchInfo[],
   ): ToolResult {
-    const sorted = decorated.sort((a, b) => {
+    const sorted = decorated.toSorted((a, b) => {
       if (b.mtime !== a.mtime) {
         return b.mtime - a.mtime;
       }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,10 +1,8 @@
-// Standard library imports
-import * as path from 'path';
-
 // Third-party imports
 import { z } from 'zod';
 
 // Local imports - tools
+import type { ExecResult } from '@agent/types/ResultTypes';
 import { ToolError, ToolResult } from '@tools/result';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat } from '@tools/utils';
@@ -13,7 +11,7 @@ import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './memory/constants';
+import { tryResolveVirtualPath, translateOutputLine } from './virtualPath';
 
 const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 
@@ -71,63 +69,6 @@ export type GrepInput = z.infer<typeof GrepInputSchema>;
 
 const CHANNEL = 'GrepTool';
 
-// ============================================================================
-// Virtual storage path support (/memories, /executions)
-// ============================================================================
-
-const EXECUTIONS_STORAGE_ROOT = 'executions';
-const EXECUTIONS_DISPLAY_ROOT = '/executions';
-
-/** Supported virtual namespace definitions. */
-const VIRTUAL_NAMESPACES = [
-  { display: MEMORY_DISPLAY_ROOT, storage: MEMORY_STORAGE_ROOT },
-  { display: EXECUTIONS_DISPLAY_ROOT, storage: EXECUTIONS_STORAGE_ROOT },
-] as const;
-
-type VirtualNamespace = (typeof VIRTUAL_NAMESPACES)[number];
-
-/** Result of resolving a virtual path to a physical storage path. */
-interface VirtualPathResolution {
-  absolutePath: string;
-  namespace: VirtualNamespace;
-}
-
-/**
- * Check if a path is a virtual storage path (/memories or /executions).
- */
-function isVirtualPath(inputPath: string): boolean {
-  return VIRTUAL_NAMESPACES.some(
-    (ns) => inputPath === ns.display || inputPath.startsWith(`${ns.display}/`),
-  );
-}
-
-/**
- * Resolve a virtual display path to a physical absolute path.
- * @throws ToolError if path doesn't match any known virtual namespace
- */
-function resolveVirtualPath(displayPath: string): VirtualPathResolution {
-  for (const ns of VIRTUAL_NAMESPACES) {
-    if (
-      displayPath === ns.display ||
-      displayPath.startsWith(`${ns.display}/`)
-    ) {
-      const suffix =
-        displayPath === ns.display
-          ? ''
-          : displayPath.slice(`${ns.display}/`.length);
-      const storagePath = suffix ? path.join(ns.storage, suffix) : ns.storage;
-      return {
-        absolutePath: StorageFS.fullPath(storagePath),
-        namespace: ns,
-      };
-    }
-  }
-
-  throw new ToolError(
-    `Virtual path must start with /memories or /executions. Got: "${displayPath}".`,
-  );
-}
-
 export function buildArguments(
   input: GrepInput,
   outputMode: OutputMode,
@@ -176,8 +117,9 @@ export class GrepTool extends defineTool({
     const inputPath = input.path ?? undefined;
 
     // Route virtual storage paths through StorageFS instead of workspace
-    if (inputPath && isVirtualPath(inputPath)) {
-      return this.executeVirtual(input, inputPath, outputMode);
+    const virtual = inputPath ? tryResolveVirtualPath(inputPath) : null;
+    if (virtual) {
+      return this.executeVirtual(input, inputPath!, outputMode, virtual);
     }
 
     return this.executeWorkspace(input, inputPath, outputMode);
@@ -218,10 +160,13 @@ export class GrepTool extends defineTool({
     input: GrepInput,
     virtualPath: string,
     outputMode: OutputMode,
+    resolved: {
+      absolutePath: string;
+      namespace: { display: string; storage: string };
+    },
   ): Promise<ToolResult> {
-    const { absolutePath, namespace } = resolveVirtualPath(virtualPath);
+    const { absolutePath, namespace } = resolved;
 
-    // Check if storage directory exists
     const exists = await StorageFS.exists(namespace.storage);
     if (!exists) {
       return {
@@ -231,7 +176,6 @@ export class GrepTool extends defineTool({
     }
 
     const args = buildArguments(input, outputMode);
-    // No gitignore for storage paths — these are internal data files
     const command = ['rg', ...args, input.pattern, absolutePath];
 
     const result = await executeCommand(command, {
@@ -239,9 +183,13 @@ export class GrepTool extends defineTool({
       truncate: false,
     });
 
-    // Translate physical paths back to virtual display paths in output
+    // Translate physical paths to virtual display paths line-by-line
+    // (only replaces the leading path prefix, never content after it)
     if (result.stdout) {
-      result.stdout = result.stdout.replaceAll(absolutePath, namespace.display);
+      result.stdout = result.stdout
+        .split('\n')
+        .map((line) => translateOutputLine(line, absolutePath, namespace))
+        .join('\n');
     }
 
     return this.formatResult(result, input, virtualPath);
@@ -249,12 +197,7 @@ export class GrepTool extends defineTool({
 
   /** Shared formatting for rg results (workspace and virtual). */
   private formatResult(
-    result: {
-      exitCode?: number;
-      success?: boolean;
-      stdout?: string | null;
-      stderr?: string | null;
-    },
+    result: ExecResult,
     input: GrepInput,
     display: string,
   ): ToolResult {

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { ExecResult } from '@agent/types/ResultTypes';
 import { ToolError, ToolResult } from '@tools/result';
 import { getGitignoreMatcher } from '@tools/gitignore';
-import { resolveAndFormat } from '@tools/utils';
+import { resolveAndFormat, formatToolOutput, pluralize } from '@tools/utils';
 import { StorageFS } from '@utils/files';
 import { executeCommand } from '@utils/system/execUtils';
 
@@ -233,18 +233,17 @@ export class GrepTool extends defineTool({
     const paginatedLines = allLines.slice(offset, end);
     const returnedCount = paginatedLines.length;
 
-    const summary = `Found ${returnedCount} of ${totalCount} matches for "${input.pattern}" in ${display}`;
+    const header = `Found ${totalCount} ${pluralize(totalCount, 'match', 'matches')} for "${input.pattern}" in ${display}`;
+    let output = formatToolOutput(header, paginatedLines);
+
     const hasMore = returnedCount < totalCount;
-
-    const toolResult: ToolResult = {
-      summary,
-      output: paginatedLines.join('\n'),
-    };
-
     if (hasMore) {
-      toolResult.instruction = `Showing ${returnedCount} of ${totalCount} results. Use offset=${offset + returnedCount} to see more.`;
+      output += `\n\n(Showing ${returnedCount} of ${totalCount}. Use offset=${offset + returnedCount} to see more.)`;
     }
 
-    return toolResult;
+    return {
+      summary: `Found ${returnedCount} of ${totalCount} matches for "${input.pattern}" in ${display}`,
+      output,
+    };
   }
 }

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -11,7 +11,11 @@ import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { tryResolveVirtualPath, translateOutputLine } from './virtualPath';
+import {
+  tryResolveVirtualPath,
+  translateOutputLine,
+  type VirtualPathResolution,
+} from './virtualPath';
 
 const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 
@@ -118,8 +122,8 @@ export class GrepTool extends defineTool({
 
     // Route virtual storage paths through StorageFS instead of workspace
     const virtual = inputPath ? tryResolveVirtualPath(inputPath) : null;
-    if (virtual) {
-      return this.executeVirtual(input, inputPath!, outputMode, virtual);
+    if (inputPath && virtual) {
+      return this.executeVirtual(input, inputPath, outputMode, virtual);
     }
 
     return this.executeWorkspace(input, inputPath, outputMode);
@@ -160,10 +164,7 @@ export class GrepTool extends defineTool({
     input: GrepInput,
     virtualPath: string,
     outputMode: OutputMode,
-    resolved: {
-      absolutePath: string;
-      namespace: { display: string; storage: string };
-    },
+    resolved: VirtualPathResolution,
   ): Promise<ToolResult> {
     const { absolutePath, namespace } = resolved;
 

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -1,3 +1,6 @@
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import { z } from 'zod';
 
@@ -5,10 +8,12 @@ import { z } from 'zod';
 import { ToolError, ToolResult } from '@tools/result';
 import { getGitignoreMatcher } from '@tools/gitignore';
 import { resolveAndFormat } from '@tools/utils';
+import { StorageFS } from '@utils/files';
 import { executeCommand } from '@utils/system/execUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './memory/constants';
 
 const OUTPUT_MODES = ['content', 'files_with_matches', 'count'] as const;
 
@@ -66,6 +71,63 @@ export type GrepInput = z.infer<typeof GrepInputSchema>;
 
 const CHANNEL = 'GrepTool';
 
+// ============================================================================
+// Virtual storage path support (/memories, /executions)
+// ============================================================================
+
+const EXECUTIONS_STORAGE_ROOT = 'executions';
+const EXECUTIONS_DISPLAY_ROOT = '/executions';
+
+/** Supported virtual namespace definitions. */
+const VIRTUAL_NAMESPACES = [
+  { display: MEMORY_DISPLAY_ROOT, storage: MEMORY_STORAGE_ROOT },
+  { display: EXECUTIONS_DISPLAY_ROOT, storage: EXECUTIONS_STORAGE_ROOT },
+] as const;
+
+type VirtualNamespace = (typeof VIRTUAL_NAMESPACES)[number];
+
+/** Result of resolving a virtual path to a physical storage path. */
+interface VirtualPathResolution {
+  absolutePath: string;
+  namespace: VirtualNamespace;
+}
+
+/**
+ * Check if a path is a virtual storage path (/memories or /executions).
+ */
+function isVirtualPath(inputPath: string): boolean {
+  return VIRTUAL_NAMESPACES.some(
+    (ns) => inputPath === ns.display || inputPath.startsWith(`${ns.display}/`),
+  );
+}
+
+/**
+ * Resolve a virtual display path to a physical absolute path.
+ * @throws ToolError if path doesn't match any known virtual namespace
+ */
+function resolveVirtualPath(displayPath: string): VirtualPathResolution {
+  for (const ns of VIRTUAL_NAMESPACES) {
+    if (
+      displayPath === ns.display ||
+      displayPath.startsWith(`${ns.display}/`)
+    ) {
+      const suffix =
+        displayPath === ns.display
+          ? ''
+          : displayPath.slice(`${ns.display}/`.length);
+      const storagePath = suffix ? path.join(ns.storage, suffix) : ns.storage;
+      return {
+        absolutePath: StorageFS.fullPath(storagePath),
+        namespace: ns,
+      };
+    }
+  }
+
+  throw new ToolError(
+    `Virtual path must start with /memories or /executions. Got: "${displayPath}".`,
+  );
+}
+
 export function buildArguments(
   input: GrepInput,
   outputMode: OutputMode,
@@ -105,12 +167,29 @@ export function buildArguments(
 export class GrepTool extends defineTool({
   name: 'grep',
   description:
-    'Search file contents using regex patterns. output_mode must be "content", "files_with_matches", or "count" (NOT "context"). To show surrounding lines, use -C with output_mode "content".',
+    'Search file contents using regex patterns. output_mode must be "content", "files_with_matches", or "count" (NOT "context"). To show surrounding lines, use -C with output_mode "content". ' +
+    'Also supports virtual storage paths: use "/memories" to search memory files, "/executions" to search execution history (conversations, configs, reports).',
   schema: GrepInputSchema,
 }) {
   protected async execute(input: GrepInput): Promise<ToolResult> {
     const { output_mode: outputMode } = input;
-    const { path, display } = resolveAndFormat(input.path ?? undefined);
+    const inputPath = input.path ?? undefined;
+
+    // Route virtual storage paths through StorageFS instead of workspace
+    if (inputPath && isVirtualPath(inputPath)) {
+      return this.executeVirtual(input, inputPath, outputMode);
+    }
+
+    return this.executeWorkspace(input, inputPath, outputMode);
+  }
+
+  /** Search workspace files (original behavior). */
+  private async executeWorkspace(
+    input: GrepInput,
+    inputPath: string | undefined,
+    outputMode: OutputMode,
+  ): Promise<ToolResult> {
+    const { path: resolvedPath, display } = resolveAndFormat(inputPath);
     const gitignore = await getGitignoreMatcher();
     const args = buildArguments(input, outputMode);
     const ignoreArgs = gitignore.ignoreFiles.flatMap((ignoreFile) => [
@@ -123,7 +202,7 @@ export class GrepTool extends defineTool({
       ...args,
       ...ignoreArgs,
       input.pattern,
-      path.relative,
+      resolvedPath.relative,
     ];
 
     const result = await executeCommand(command, {
@@ -131,6 +210,54 @@ export class GrepTool extends defineTool({
       truncate: false,
     });
 
+    return this.formatResult(result, input, display);
+  }
+
+  /** Search virtual storage paths (/memories, /executions). */
+  private async executeVirtual(
+    input: GrepInput,
+    virtualPath: string,
+    outputMode: OutputMode,
+  ): Promise<ToolResult> {
+    const { absolutePath, namespace } = resolveVirtualPath(virtualPath);
+
+    // Check if storage directory exists
+    const exists = await StorageFS.exists(namespace.storage);
+    if (!exists) {
+      return {
+        summary: `No data found at ${virtualPath}`,
+        output: `The ${namespace.display} directory does not exist yet. No data to search.`,
+      };
+    }
+
+    const args = buildArguments(input, outputMode);
+    // No gitignore for storage paths — these are internal data files
+    const command = ['rg', ...args, input.pattern, absolutePath];
+
+    const result = await executeCommand(command, {
+      channel: CHANNEL,
+      truncate: false,
+    });
+
+    // Translate physical paths back to virtual display paths in output
+    if (result.stdout) {
+      result.stdout = result.stdout.replaceAll(absolutePath, namespace.display);
+    }
+
+    return this.formatResult(result, input, virtualPath);
+  }
+
+  /** Shared formatting for rg results (workspace and virtual). */
+  private formatResult(
+    result: {
+      exitCode?: number;
+      success?: boolean;
+      stdout?: string | null;
+      stderr?: string | null;
+    },
+    input: GrepInput,
+    display: string,
+  ): ToolResult {
     // ripgrep exit codes: 0 = matches found, 1 = no matches, 2+ = error
     const exitCode = result.exitCode ?? (result.success ? 0 : 1);
     if (exitCode >= 2) {

--- a/src/tools/virtualPath.ts
+++ b/src/tools/virtualPath.ts
@@ -1,0 +1,103 @@
+/**
+ * Virtual path resolution for storage namespaces (/memories, /executions).
+ *
+ * Translates virtual display paths to physical StorageFS paths and back,
+ * with traversal validation. Used by grep and glob to search storage.
+ */
+
+// Standard library imports
+import * as path from 'path';
+
+// Local imports
+import { StorageFS } from '@utils/files';
+
+// Local file imports
+import { ToolError } from './result';
+import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './memory/constants';
+
+/** Storage directory for execution data (canonical source: ExecutionKVStore). */
+const EXECUTIONS_STORAGE_ROOT = 'executions';
+const EXECUTIONS_DISPLAY_ROOT = '/executions';
+
+/** A virtual namespace mapping display prefix to storage directory. */
+export interface VirtualNamespace {
+  readonly display: string;
+  readonly storage: string;
+}
+
+/** All supported virtual namespaces. */
+const VIRTUAL_NAMESPACES: readonly VirtualNamespace[] = [
+  { display: MEMORY_DISPLAY_ROOT, storage: MEMORY_STORAGE_ROOT },
+  { display: EXECUTIONS_DISPLAY_ROOT, storage: EXECUTIONS_STORAGE_ROOT },
+];
+
+/** Result of resolving a virtual path. */
+export interface VirtualPathResolution {
+  /** Absolute filesystem path to search. */
+  absolutePath: string;
+  /** The namespace this path belongs to. */
+  namespace: VirtualNamespace;
+}
+
+/**
+ * Try to resolve a virtual display path. Returns null if the path
+ * doesn't match any virtual namespace (i.e. it's a normal workspace path).
+ *
+ * @throws ToolError on path traversal attempts (../)
+ */
+export function tryResolveVirtualPath(
+  displayPath: string,
+): VirtualPathResolution | null {
+  for (const ns of VIRTUAL_NAMESPACES) {
+    if (
+      displayPath === ns.display ||
+      displayPath.startsWith(`${ns.display}/`)
+    ) {
+      const suffix =
+        displayPath === ns.display
+          ? ''
+          : displayPath.slice(`${ns.display}/`.length);
+
+      // Validate against path traversal
+      if (suffix) {
+        const resolved = path.resolve(ns.storage, suffix);
+        const base = path.resolve(ns.storage);
+        const relative = path.relative(base, resolved);
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
+          throw new ToolError(
+            `Invalid path "${displayPath}": path traversal is not allowed.`,
+          );
+        }
+      }
+
+      const storagePath = suffix ? path.join(ns.storage, suffix) : ns.storage;
+      return {
+        absolutePath: StorageFS.fullPath(storagePath),
+        namespace: ns,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Translate a physical absolute path back to a virtual display path.
+ * Only translates the path prefix; content after the path is preserved.
+ *
+ * For rg output lines like `/abs/path/memories/file.md:10:content`,
+ * replaces only the leading path portion up to the first `:` (or the
+ * entire line for files_with_matches mode).
+ */
+export function translateOutputLine(
+  line: string,
+  absoluteBase: string,
+  namespace: VirtualNamespace,
+): string {
+  if (!line.startsWith(absoluteBase)) return line;
+
+  // Replace the absolute base with the virtual prefix.
+  // This is safe because we only match lines that start with the base path,
+  // so we're guaranteed to be replacing the file path portion, not content.
+  return namespace.display + line.slice(absoluteBase.length);
+}

--- a/src/tools/virtualPath.ts
+++ b/src/tools/virtualPath.ts
@@ -9,14 +9,13 @@
 import * as path from 'path';
 
 // Local imports
+import { EXECUTIONS_DIR } from '@agent/storage/ExecutionKVStore';
 import { StorageFS } from '@utils/files';
 
 // Local file imports
 import { ToolError } from './result';
 import { MEMORY_DISPLAY_ROOT, MEMORY_STORAGE_ROOT } from './memory/constants';
 
-/** Storage directory for execution data (canonical source: ExecutionKVStore). */
-const EXECUTIONS_STORAGE_ROOT = 'executions';
 const EXECUTIONS_DISPLAY_ROOT = '/executions';
 
 /** A virtual namespace mapping display prefix to storage directory. */
@@ -28,7 +27,7 @@ export interface VirtualNamespace {
 /** All supported virtual namespaces. */
 const VIRTUAL_NAMESPACES: readonly VirtualNamespace[] = [
   { display: MEMORY_DISPLAY_ROOT, storage: MEMORY_STORAGE_ROOT },
-  { display: EXECUTIONS_DISPLAY_ROOT, storage: EXECUTIONS_STORAGE_ROOT },
+  { display: EXECUTIONS_DISPLAY_ROOT, storage: EXECUTIONS_DIR },
 ];
 
 /** Result of resolving a virtual path. */
@@ -83,11 +82,10 @@ export function tryResolveVirtualPath(
 
 /**
  * Translate a physical absolute path back to a virtual display path.
- * Only translates the path prefix; content after the path is preserved.
  *
- * For rg output lines like `/abs/path/memories/file.md:10:content`,
- * replaces only the leading path portion up to the first `:` (or the
- * entire line for files_with_matches mode).
+ * Replaces the leading `absoluteBase` prefix with the namespace's virtual
+ * display prefix. Everything after the base path (colons, line numbers,
+ * matched content) is preserved as-is.
  */
 export function translateOutputLine(
   line: string,


### PR DESCRIPTION
## Summary
Extends glob and grep tools to support searching virtual storage namespaces (`/memories` and `/executions`) in addition to workspace paths. This allows users to search memory files and execution history using the same familiar glob and grep interfaces.

## Key Changes

- **New `virtualPath.ts` module**: Provides virtual path resolution utilities
  - `tryResolveVirtualPath()`: Translates virtual display paths (e.g., `/memories/file.md`) to physical StorageFS paths with path traversal validation
  - `translateOutputLine()`: Converts physical absolute paths back to virtual display paths in tool output
  - Defines `VirtualNamespace` interface for mapping display prefixes to storage directories

- **Enhanced glob tool**:
  - Detects virtual paths and routes them through `executeVirtual()` method
  - Uses StorageFS for virtual path operations instead of WorkspaceFS
  - Maintains original workspace behavior via `executeWorkspace()` method
  - Updated tool description to document `/memories` and `/executions` support

- **Enhanced grep tool**:
  - Similar virtual path detection and routing as glob
  - Translates ripgrep output paths from physical to virtual display format line-by-line
  - Preserves content after path prefix (handles both `content` and `files_with_matches` modes)
  - Updated tool description to document virtual storage search capability

## Implementation Details

- Virtual namespace mapping is centralized in `virtualPath.ts` and reused by both tools
- Path traversal attempts (e.g., `../`) are validated and rejected with `ToolError`
- Output translation only replaces the leading path prefix, never content after it, ensuring grep output integrity
- Both tools gracefully handle missing virtual directories with informative messages
- Shared formatting logic reduces code duplication between workspace and virtual execution paths

https://claude.ai/code/session_01PJfvBmiCGD6ZhvcuR72H8n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new routing and filesystem access paths for `glob`/`grep` and introduces path translation logic; while guarded by traversal checks, it changes behavior for inputs under `/memories` and `/executions` and could affect search results/output formatting.
> 
> **Overview**
> Adds **virtual storage namespace** support to `glob` and `grep`, allowing users to search `/memories` and `/executions` in addition to workspace paths.
> 
> Introduces `virtualPath.ts` to resolve virtual display paths to `StorageFS` locations (with path-traversal rejection) and to translate ripgrep output paths back to virtual prefixes. `glob` and `grep` now route virtual paths through new virtual execution branches (including “directory missing” handling) while preserving existing workspace behavior, and `grep`’s output formatting is refactored to a shared formatter with consistent headers/pagination messaging.
> 
> Adds unit tests for `tryResolveVirtualPath` and `translateOutputLine`, including namespace matching and traversal edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d953b956392674ea4636cd9a045762a6039989a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->