### PR TITLE
Add AI-generated session descriptions for tool-use executions

### DIFF
--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -16,7 +16,11 @@
  * ```
  */
 
-import { EXECUTION_STATUS, type ExecutionStatus } from '@shared/schemas';
+import {
+  EXECUTION_STATUS,
+  type ExecutionStatus,
+  type RetryErrorInfo,
+} from '@shared/schemas';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { AgentLogStage } from '@logger/AgentLogger';
 
@@ -43,7 +47,7 @@ export interface RoundAwareState {
   continueRounds: boolean;
 
   /** Set by nodes when execution fails. Skips round completion callbacks. */
-  lastError?: { message: string; retryable: boolean } | undefined;
+  lastError?: RetryErrorInfo;
 }
 
 // ============================================================================
@@ -200,6 +204,7 @@ export class RoundPersistedFlow<
    */
   private shouldContinueNextRound(shared: S): boolean {
     return (
+      !shared.lastError &&
       !this.callbacks.checkInterruption?.() &&
       shared.continueRounds &&
       !isRoundAtOrBeyondLimit(shared.currentRound + 1, shared.totalRounds)

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -78,6 +78,7 @@ import {
   AgentExecutionHandle,
 } from './executionRegistry';
 import type { AgentFlowResult, OutputFileSummary } from './AgentFlowResult';
+import { generateSessionDescription } from './sessionDescription';
 
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
@@ -342,6 +343,12 @@ async function runFlowWithLifecycle(
     const result = await runner();
     options?.onCompleted?.(result);
     await writeTerminalStatus(ctx.executionId, result.status).catch(() => {});
+
+    // Fire-and-forget: generate AI session description for completed tool-use sessions
+    if (category === 'toolUse' && result.status !== 'error') {
+      generateSessionDescription(ctx.executionId, ctx.config).catch(() => {});
+    }
+
     untrackExecution(ctx.executionId);
     ctx.parentStage.end(result.status);
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -344,8 +344,9 @@ async function runFlowWithLifecycle(
     options?.onCompleted?.(result);
     await writeTerminalStatus(ctx.executionId, result.status).catch(() => {});
 
-    // Fire-and-forget: generate AI session description for completed tool-use sessions
-    if (category === 'toolUse' && result.status !== 'error') {
+    // Fire-and-forget: generate AI session description for completed tool-use sessions.
+    // Note: 'stopped' means successfully completed; user-cancellation maps to 'error'.
+    if (category === 'toolUse' && result.status === END_GROUP_STATUS.STOPPED) {
       generateSessionDescription(ctx.executionId, ctx.config).catch(() => {});
     }
 

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared helper model resolution and handler creation.
+ *
+ * Used by session description generation, instruction polishing, and
+ * AI-assisted agent creation — all lightweight, non-streaming one-shot
+ * LLM calls that share the same configured "helper model" setting.
+ */
+
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+import type { ModelHandler } from '@agent/modelHandlers';
+import { createModelHandler } from '@agent/runtime/ModelFactory';
+import { GlobalStateKey, globalSM } from '@common/state';
+import { isNonEmptyString } from '@utils/core';
+
+/**
+ * A ready-to-use helper model handler + client pair.
+ */
+export interface HelperModelKit {
+  handler: ModelHandler;
+  client: unknown;
+  modelName: string;
+}
+
+/**
+ * Resolve the configured helper model, create a non-streaming handler,
+ * and obtain a client.
+ *
+ * Returns `undefined` when the configured model name is not found in
+ * MODEL_CONFIGS (caller decides how to surface the error).
+ * Throws if the model is valid but handler/client creation fails.
+ */
+export async function createHelperModelKit(): Promise<
+  HelperModelKit | undefined
+> {
+  const configuredModel = globalSM.get<string>(
+    GlobalStateKey.HELPER_MODEL,
+    DEFAULT_HELPER_MODEL,
+  );
+  const modelName = isNonEmptyString(configuredModel)
+    ? configuredModel.trim()
+    : DEFAULT_HELPER_MODEL;
+
+  const modelConfig = MODEL_CONFIGS[modelName];
+  if (!modelConfig) {
+    return undefined;
+  }
+
+  const handler = createModelHandler(modelConfig);
+  handler.setOutputStreaming(false);
+  handler.setProgressViewEnabled(false);
+
+  const client = await handler.getClient();
+  return { handler, client, modelName };
+}

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -1,0 +1,109 @@
+/**
+ * Session description generation.
+ *
+ * After a tool-use session completes, generates a short AI summary describing
+ * what the session aimed to accomplish. The description is persisted on the
+ * execution metadata so that future agents and the history view can quickly
+ * understand what each session did.
+ */
+
+import { MODEL_CONFIGS } from 'llm-zoo';
+
+import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { getAgent } from '@agent/index';
+import { createModelHandler } from '@agent/runtime/ModelFactory';
+import { writeSessionDescription } from '@agent/storage';
+import { GlobalStateKey, globalSM } from '@common/state';
+import * as logger from '@logger/logUtils';
+import { isNonEmptyString } from '@utils/core';
+
+import type { ExecutionId } from '@shared/schemas';
+
+const CHANNEL = 'SessionDescription';
+
+const SYSTEM_PROMPT = `You generate concise session descriptions for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write 1-2 sentences summarizing what this session aimed to accomplish. Be specific and informative. Do not include meta-commentary — just the summary. Write in past tense (e.g. "Reviewed the introduction for...").`;
+
+/**
+ * Build a user prompt for session description generation.
+ */
+function buildUserPrompt(
+  agentName: string,
+  agentDescription: string | undefined,
+  instruction: string,
+): string {
+  const parts = [`Agent: ${agentName}`];
+  if (agentDescription) {
+    parts.push(`Agent purpose: ${agentDescription}`);
+  }
+  parts.push(`User instruction: ${instruction}`);
+  return parts.join('\n');
+}
+
+/**
+ * Generate and persist a session description for a completed execution.
+ *
+ * Runs fire-and-forget — never throws. Uses the configured polish model
+ * for a one-shot, non-streaming call.
+ */
+export async function generateSessionDescription(
+  executionId: ExecutionId,
+  config: AgentConfig,
+): Promise<void> {
+  try {
+    const instruction = config.instruction?.trim();
+    if (!instruction) return;
+
+    const agentEntry = getAgent(config.agent, true);
+    const agentDescription = agentEntry?.description;
+
+    const configuredModel = globalSM.get<string>(
+      GlobalStateKey.POLISH_MODEL,
+      DEFAULT_POLISH_MODEL,
+    );
+    const modelName = isNonEmptyString(configuredModel)
+      ? configuredModel.trim()
+      : DEFAULT_POLISH_MODEL;
+    const modelConfig = MODEL_CONFIGS[modelName];
+    if (!modelConfig) {
+      logger.warn(
+        CHANNEL,
+        `Unknown model "${modelName}" for session description`,
+      );
+      return;
+    }
+
+    const handler = createModelHandler(modelConfig);
+    handler.setOutputStreaming(false);
+    handler.setProgressViewEnabled(false);
+
+    const client = await handler.getClient();
+    const userPrompt = buildUserPrompt(
+      config.agent,
+      agentDescription,
+      instruction,
+    );
+    const messages = await handler.initializeMessages(
+      '',
+      userPrompt,
+      undefined,
+      SYSTEM_PROMPT,
+    );
+    const result = await handler.createResponse({
+      client,
+      messages,
+      temperature: 0,
+    });
+    const { text } = handler.extractResponse(result.response, '');
+
+    if (isNonEmptyString(text)) {
+      const description = text.trim();
+      await writeSessionDescription(executionId, description);
+      logger.info(CHANNEL, `Generated session description for ${executionId}`);
+    }
+  } catch (err) {
+    logger.warn(CHANNEL, `Failed to generate session description`, {
+      data: err,
+    });
+  }
+}

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -7,14 +7,10 @@
  * understand what each session did.
  */
 
-import { MODEL_CONFIGS } from 'llm-zoo';
-
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
-import type { AgentConfig } from '@agent/core/AgentConfig';
 import { getAgent } from '@agent/index';
-import { createModelHandler } from '@agent/runtime/ModelFactory';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { createHelperModelKit } from '@agent/runtime/helperModel';
 import { writeSessionDescription } from '@agent/storage';
-import { GlobalStateKey, globalSM } from '@common/state';
 import * as logger from '@logger/logUtils';
 import { isNonEmptyString } from '@utils/core';
 
@@ -57,27 +53,13 @@ export async function generateSessionDescription(
     const agentEntry = getAgent(config.agent, true);
     const agentDescription = agentEntry?.description;
 
-    const configuredModel = globalSM.get<string>(
-      GlobalStateKey.HELPER_MODEL,
-      DEFAULT_HELPER_MODEL,
-    );
-    const modelName = isNonEmptyString(configuredModel)
-      ? configuredModel.trim()
-      : DEFAULT_HELPER_MODEL;
-    const modelConfig = MODEL_CONFIGS[modelName];
-    if (!modelConfig) {
-      logger.warn(
-        CHANNEL,
-        `Unknown model "${modelName}" for session description`,
-      );
+    const kit = await createHelperModelKit();
+    if (!kit) {
+      logger.warn(CHANNEL, 'Helper model not available for session description');
       return;
     }
 
-    const handler = createModelHandler(modelConfig);
-    handler.setOutputStreaming(false);
-    handler.setProgressViewEnabled(false);
-
-    const client = await handler.getClient();
+    const { handler, client } = kit;
     const userPrompt = buildUserPrompt(
       config.agent,
       agentDescription,
@@ -93,11 +75,13 @@ export async function generateSessionDescription(
       client,
       messages,
       temperature: 0,
+      systemPrompt: SYSTEM_PROMPT,
     });
     const { text } = handler.extractResponse(result.response, '');
 
     if (isNonEmptyString(text)) {
-      const description = text.trim();
+      // Collapse newlines to prevent corrupting line-based tool output.
+      const description = text.trim().replaceAll(/\s*\n\s*/g, ' ');
       await writeSessionDescription(executionId, description);
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -9,7 +9,7 @@
 
 import { MODEL_CONFIGS } from 'llm-zoo';
 
-import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { getAgent } from '@agent/index';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
@@ -43,7 +43,7 @@ function buildUserPrompt(
 /**
  * Generate and persist a session description for a completed execution.
  *
- * Runs fire-and-forget — never throws. Uses the configured polish model
+ * Runs fire-and-forget — never throws. Uses the configured helper model
  * for a one-shot, non-streaming call.
  */
 export async function generateSessionDescription(
@@ -58,12 +58,12 @@ export async function generateSessionDescription(
     const agentDescription = agentEntry?.description;
 
     const configuredModel = globalSM.get<string>(
-      GlobalStateKey.POLISH_MODEL,
-      DEFAULT_POLISH_MODEL,
+      GlobalStateKey.HELPER_MODEL,
+      DEFAULT_HELPER_MODEL,
     );
     const modelName = isNonEmptyString(configuredModel)
       ? configuredModel.trim()
-      : DEFAULT_POLISH_MODEL;
+      : DEFAULT_HELPER_MODEL;
     const modelConfig = MODEL_CONFIGS[modelName];
     if (!modelConfig) {
       logger.warn(

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -28,6 +28,8 @@ export interface ExecutionMeta {
   terminalStatus?: string;
   /** Runtime category override (e.g. 'process' for background bash). */
   category?: string;
+  /** AI-generated summary of what the session aimed to accomplish. */
+  description?: string;
 }
 
 /** Shape of a persisted todo item from tool-use flow state. */

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -68,3 +68,22 @@ export async function writeTerminalStatus(
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
   }
 }
+
+/**
+ * Persist an AI-generated session description on an existing execution's metadata.
+ * Never throws — description is supplementary data.
+ */
+export async function writeSessionDescription(
+  executionId: ExecutionId,
+  description: string,
+): Promise<void> {
+  try {
+    const store = getExecutionStore(executionId);
+    const existing = await store.read<ExecutionMeta>('meta');
+    if (!existing) return;
+    await store.write('meta', { ...existing, description });
+    invalidateListingCache();
+  } catch {
+    // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
+  }
+}

--- a/src/agent/storage/executionListing.ts
+++ b/src/agent/storage/executionListing.ts
@@ -42,6 +42,8 @@ export interface ExecutionListingEntry {
   agentConfig: AgentConfig | null;
   category?: string;
   terminalStatus?: string;
+  /** AI-generated summary of what the session aimed to accomplish. */
+  description?: string;
 }
 
 // ============================================================================
@@ -128,6 +130,7 @@ export async function listExecutions(): Promise<ExecutionListingEntry[]> {
           agentConfig: cfg ?? null,
           category: meta.category ?? cfg?.agentCategory,
           terminalStatus: meta.terminalStatus,
+          description: meta.description,
         };
       } catch (error) {
         logger.warn(CHANNEL, `Skipping corrupt execution ${id}`, {

--- a/src/agent/storage/index.ts
+++ b/src/agent/storage/index.ts
@@ -15,7 +15,11 @@ export {
   detectWaitingStreams,
   hasPersistedFlowRecord,
 } from './detectWaitingStreams';
-export { registerExecution, writeTerminalStatus } from './executionLifecycle';
+export {
+  registerExecution,
+  writeTerminalStatus,
+  writeSessionDescription,
+} from './executionLifecycle';
 export {
   type ExecutionListingEntry,
   listExecutions,

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -6,20 +6,17 @@ import * as vscode from 'vscode';
 import * as nunjucks from 'nunjucks';
 import * as yaml from 'yaml';
 import { z } from 'zod';
-import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - agent runtime
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { getBaseName, getMultipleName } from '@agent/index';
 import {
   AgentWorkflowSettingSchema,
   AgentToolUseSettingSchema,
   AgentPromptSchema,
 } from '@agent/core/AgentDataclass';
-import { createModelHandler } from '@agent/runtime/ModelFactory';
+import { createHelperModelKit } from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
-import { globalSM, GlobalStateKey } from '@common/state';
 import { agentDirectories, promptToAddAgentToConfig } from '@frontend/agents';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
@@ -346,24 +343,12 @@ async function tryAIGeneration(
   vars: Record<string, string>,
 ): Promise<string | undefined> {
   try {
-    // Resolve model (reuse the helper model setting)
-    const configuredModel = globalSM.get<string>(
-      GlobalStateKey.HELPER_MODEL,
-      DEFAULT_HELPER_MODEL,
-    );
-    const modelName = isNonEmptyString(configuredModel)
-      ? configuredModel.trim()
-      : DEFAULT_HELPER_MODEL;
-    const modelConfig = MODEL_CONFIGS[modelName];
-    if (!modelConfig) {
-      logger.error(CHANNEL, `Unknown model "${modelName}" for agent creation`);
+    const kit = await createHelperModelKit();
+    if (!kit) {
+      logger.error(CHANNEL, 'Helper model not available for agent creation');
       return undefined;
     }
-
-    const handler = createModelHandler(modelConfig);
-    handler.setOutputStreaming(false);
-    handler.setProgressViewEnabled(false);
-    const client = await handler.getClient();
+    const { handler, client } = kit;
 
     // Build prompts – include RUNTIME_PASSTHROUGH so that template variable
     // references like {{ INPUT_FILE }} in the creator prompts survive Nunjucks
@@ -392,6 +377,7 @@ async function tryAIGeneration(
         client,
         messages,
         temperature: 0,
+        systemPrompt,
       });
       const { text } = handler.extractResponse(result.response, '');
 

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - agent runtime
-import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { getBaseName, getMultipleName } from '@agent/index';
 import {
   AgentWorkflowSettingSchema,
@@ -346,14 +346,14 @@ async function tryAIGeneration(
   vars: Record<string, string>,
 ): Promise<string | undefined> {
   try {
-    // Resolve model (reuse the polish model setting)
+    // Resolve model (reuse the helper model setting)
     const configuredModel = globalSM.get<string>(
-      GlobalStateKey.POLISH_MODEL,
-      DEFAULT_POLISH_MODEL,
+      GlobalStateKey.HELPER_MODEL,
+      DEFAULT_HELPER_MODEL,
     );
     const modelName = isNonEmptyString(configuredModel)
       ? configuredModel.trim()
-      : DEFAULT_POLISH_MODEL;
+      : DEFAULT_HELPER_MODEL;
     const modelConfig = MODEL_CONFIGS[modelName];
     if (!modelConfig) {
       logger.error(CHANNEL, `Unknown model "${modelName}" for agent creation`);

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -29,7 +29,7 @@ export enum GlobalStateKey {
 
   // Model selection settings
   ENABLED_MODELS = 'enabledModels',
-  POLISH_MODEL = 'polishModel',
+  HELPER_MODEL = 'polishModel',
 
   // Streaming settings
   STREAMING_GLOBAL = 'texra.streaming.global',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -329,7 +329,7 @@ export const SETTINGS_VIEW_CMD = {
   // Model selection commands
   GET_MODEL_SELECTION: 'getModelSelection',
   SET_MODEL_ENABLED: 'setModelEnabled',
-  SET_POLISH_MODEL: 'setPolishModel',
+  SET_HELPER_MODEL: 'setPolishModel',
   // Agent selection commands
   GET_AGENT_SELECTION: 'getAgentSelection',
   OPEN_AGENT_YAML: 'openAgentYaml',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -20,7 +20,7 @@ import {
 import {
   PROVIDER_DISPLAY_NAMES,
   MODEL_PROVIDERS_ORDER,
-  DEFAULT_POLISH_MODEL,
+  DEFAULT_HELPER_MODEL,
 } from '@shared/constants/providers';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ULTRA_TIER, MAX_TIER } from '@auth/config';
@@ -368,8 +368,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.withActiveWebview((w) => this.sendModelSelectionData(w)),
       [SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED]: (data) =>
         this.handleSetModelEnabled(data),
-      [SETTINGS_VIEW_COMMANDS.SET_POLISH_MODEL]: (data) =>
-        this.handleSetPolishModel(data),
+      [SETTINGS_VIEW_COMMANDS.SET_HELPER_MODEL]: (data) =>
+        this.handleSetHelperModel(data),
 
       // Custom agent directory handlers
       [SETTINGS_VIEW_COMMANDS.GET_CUSTOM_AGENT_DIR]: () =>
@@ -589,14 +589,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
     const models = buildModelSelectionItems();
-    const polishModel = globalSM.get<string>(
-      GlobalStateKey.POLISH_MODEL,
-      DEFAULT_POLISH_MODEL,
+    const helperModel = globalSM.get<string>(
+      GlobalStateKey.HELPER_MODEL,
+      DEFAULT_HELPER_MODEL,
     );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
       models,
-      polishModel,
+      helperModel,
     });
   }
 
@@ -1032,15 +1032,15 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     await globalSM.update(GlobalStateKey.ENABLED_MODELS, updated);
 
-    // Auto-reset polish model if it was just disabled
+    // Auto-reset helper model if it was just disabled
     if (!data.enabled) {
-      const polishModel = globalSM.get<string>(
-        GlobalStateKey.POLISH_MODEL,
-        DEFAULT_POLISH_MODEL,
+      const helperModel = globalSM.get<string>(
+        GlobalStateKey.HELPER_MODEL,
+        DEFAULT_HELPER_MODEL,
       );
-      if (polishModel === data.modelName) {
-        const newPolish = updated[0] ?? DEFAULT_POLISH_MODEL;
-        await globalSM.update(GlobalStateKey.POLISH_MODEL, newPolish);
+      if (helperModel === data.modelName) {
+        const newHelper = updated[0] ?? DEFAULT_HELPER_MODEL;
+        await globalSM.update(GlobalStateKey.HELPER_MODEL, newHelper);
       }
     }
 
@@ -1048,10 +1048,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview((w) => this.sendModelSelectionData(w));
   }
 
-  private async handleSetPolishModel(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_POLISH_MODEL>,
+  private async handleSetHelperModel(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_HELPER_MODEL>,
   ): Promise<void> {
-    await globalSM.update(GlobalStateKey.POLISH_MODEL, data.modelName);
+    await globalSM.update(GlobalStateKey.HELPER_MODEL, data.modelName);
     await this.withActiveWebview((w) => this.sendModelSelectionData(w));
   }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -504,6 +504,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         id: entry.id,
         timestamp: entry.timestamp,
         agentConfig: entry.agentConfig!,
+        description: entry.description,
       }));
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY,

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -42,7 +42,7 @@ import {
   type NumberVscodeSetting,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
-import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 // Local imports - settings view commands
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
@@ -137,7 +137,7 @@ export class SettingsApp extends BaseWebviewApp {
 
   // Model selection state
   @state() private modelSelectionItems: ModelSelectionItem[] = [];
-  @state() private polishModel = DEFAULT_POLISH_MODEL;
+  @state() private helperModel = DEFAULT_HELPER_MODEL;
 
   // Agent selection state
   @state() private workflowAgents: AgentSelectionItem[] = [];
@@ -245,7 +245,7 @@ export class SettingsApp extends BaseWebviewApp {
         const data = this.parseMessage(raw, UpdateModelSelectionMessageSchema);
         if (!data) return;
         this.modelSelectionItems = data.models;
-        this.polishModel = data.polishModel;
+        this.helperModel = data.helperModel;
         return;
       }
 
@@ -396,8 +396,8 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED,
   );
 
-  private handleSetPolishModel = forwardDetail(
-    SETTINGS_VIEW_COMMANDS.SET_POLISH_MODEL,
+  private handleSetHelperModel = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_HELPER_MODEL,
   );
 
   // Agent selection event handlers
@@ -553,7 +553,7 @@ export class SettingsApp extends BaseWebviewApp {
               .providerKeyStatuses=${this.providerKeyStatuses}
               .globalStreamingDefault=${this.globalStreamingDefault}
               .modelSelectionItems=${this.modelSelectionItems}
-              .polishModel=${this.polishModel}
+              .helperModel=${this.helperModel}
               @profile-api-access-mode=${this.handleApiAccessMode}
               @provider-key-set=${this.handleSetProviderKey}
               @provider-key-remove=${this.handleRemoveProviderKey}
@@ -565,7 +565,7 @@ export class SettingsApp extends BaseWebviewApp {
                 .handleSetProviderVscodeSetting}
               @provider-open-url=${this.handleOpenUrl}
               @model-enabled-set=${this.handleSetModelEnabled}
-              @polish-model-set=${this.handleSetPolishModel}
+              @helper-model-set=${this.handleSetHelperModel}
             ></models-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -218,6 +218,7 @@ export class HistoryItem extends LitElement {
     const instructionText = config.instruction?.trim()
       ? config.instruction
       : null;
+    const descriptionText = this.item.description?.trim() || null;
 
     const extraDetails: Array<TemplateResult> = [];
 
@@ -277,6 +278,9 @@ export class HistoryItem extends LitElement {
             ></vscode-toolbar-button>
           </vscode-toolbar-container>
         </div>
+        ${descriptionText
+          ? html`<div class="history-description">${descriptionText}</div>`
+          : nothing}
         <div class="history-details basic-details">
           <span class="history-label">Category:</span>
           <span class="history-value">

--- a/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -1,6 +1,6 @@
 /**
  * ModelSelectionList component - checkbox list of models grouped by provider.
- * Includes deprecated model toggles and a polish model dropdown.
+ * Includes deprecated model toggles and a helper model dropdown.
  */
 
 // Third-party imports
@@ -35,7 +35,7 @@ export class ModelSelectionList extends LitElement {
   static override styles = [designTokens, codiconStyles, profileViewStyles];
 
   @property({ attribute: false }) models: ModelSelectionItem[] = [];
-  @property({ attribute: false }) polishModel = '';
+  @property({ attribute: false }) helperModel = '';
   @property({ attribute: false }) authenticated = false;
   @property({ attribute: false }) apiAccessMode: 'included' | 'personal' =
     'personal';
@@ -94,10 +94,10 @@ export class ModelSelectionList extends LitElement {
     return this.allowedModels.includes(modelName);
   }
 
-  private handlePolishModelChange(e: Event): void {
+  private handleHelperModelChange(e: Event): void {
     const value = (e.currentTarget as HTMLSelectElement).value;
     this.dispatchEvent(
-      ModelSelectionEvents.setPolishModel({ modelName: value }),
+      ModelSelectionEvents.setHelperModel({ modelName: value }),
     );
   }
 
@@ -191,22 +191,22 @@ export class ModelSelectionList extends LitElement {
     `;
   }
 
-  private renderPolishModelDropdown(): TemplateResult {
+  private renderHelperModelDropdown(): TemplateResult {
     const enabledModels = this.models.filter((m) => m.enabled);
 
     return html`
-      <div class="polish-model-row">
-        <label>Polish model:</label>
+      <div class="helper-model-row">
+        <label>Helper model:</label>
         <vscode-single-select
-          class="polish-model-select"
-          .value=${this.polishModel}
-          @change=${this.handlePolishModelChange}
+          class="helper-model-select"
+          .value=${this.helperModel}
+          @change=${this.handleHelperModelChange}
         >
           ${enabledModels.map(
             (m) =>
               html`<vscode-option
                 value=${m.name}
-                ?selected=${m.name === this.polishModel}
+                ?selected=${m.name === this.helperModel}
               >
                 ${m.name}
               </vscode-option>`,
@@ -225,7 +225,7 @@ export class ModelSelectionList extends LitElement {
         <p class="model-selection-description">
           Select which models appear in the dropdown.
         </p>
-        ${this.renderPolishModelDropdown()}
+        ${this.renderHelperModelDropdown()}
         ${groups.map((g) => this.renderProviderGroup(g))}
       </div>
     `;

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -10,8 +10,8 @@ export const ProfileViewEvents = {
 export const ModelSelectionEvents = {
   setModelEnabled: (detail: { modelName: string; enabled: boolean }) =>
     createEvent('model-enabled-set', detail),
-  setPolishModel: (detail: { modelName: string }) =>
-    createEvent('polish-model-set', detail),
+  setHelperModel: (detail: { modelName: string }) =>
+    createEvent('helper-model-set', detail),
 } as const;
 
 export const ProviderKeyEvents = {

--- a/src/settingsView/frontend/components/profile/styles.ts
+++ b/src/settingsView/frontend/components/profile/styles.ts
@@ -379,20 +379,20 @@ export const profileViewStyles: CSSResult = css`
     margin-bottom: var(--spacing-medium);
   }
 
-  .polish-model-row {
+  .helper-model-row {
     display: flex;
     align-items: center;
     gap: var(--spacing-medium);
     margin-bottom: var(--spacing-large);
   }
 
-  .polish-model-row label {
+  .helper-model-row label {
     font-weight: 500;
     color: var(--vscode-foreground);
     white-space: nowrap;
   }
 
-  .polish-model-select {
+  .helper-model-select {
     flex: 1;
     max-width: 300px;
   }

--- a/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -44,7 +44,7 @@ export class ModelsTab extends LitElement {
   @property({ attribute: false }) globalStreamingDefault = true;
   @property({ attribute: false }) modelSelectionItems: ModelSelectionItem[] =
     [];
-  @property({ attribute: false }) polishModel = '';
+  @property({ attribute: false }) helperModel = '';
 
   override render(): TemplateResult {
     const apiAccessSection = this.authenticated
@@ -58,7 +58,7 @@ export class ModelsTab extends LitElement {
         ${apiAccessSection}
         <model-selection-list
           .models=${this.modelSelectionItems}
-          .polishModel=${this.polishModel}
+          .helperModel=${this.helperModel}
           .authenticated=${this.authenticated}
           .apiAccessMode=${this.apiAccessMode}
           .allowedModels=${this.allowedModels}

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -26,5 +26,5 @@ export const MODEL_PROVIDERS_ORDER: ModelProvider[] = [
   ModelProvider.DASHSCOPE,
 ];
 
-/** Default model used for instruction polishing. */
-export const DEFAULT_POLISH_MODEL = 'sonnet45';
+/** Default model used for auxiliary/helper tasks (polishing, agent creation, session descriptions). */
+export const DEFAULT_HELPER_MODEL = 'sonnet45';

--- a/src/shared/schemas/historyViewMessages.ts
+++ b/src/shared/schemas/historyViewMessages.ts
@@ -40,6 +40,8 @@ export const HistoryItemSchema = z.object({
   id: z.string(),
   timestamp: z.string(),
   agentConfig: AgentConfigSummarySchema,
+  /** AI-generated summary of what the session aimed to accomplish. */
+  description: z.string().optional(),
 });
 export type HistoryItem = z.infer<typeof HistoryItemSchema>;
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -157,7 +157,7 @@ export type ModelSelectionItem = z.infer<typeof ModelSelectionItemSchema>;
 export const UpdateModelSelectionMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION),
   models: z.array(ModelSelectionItemSchema),
-  polishModel: z.string(),
+  helperModel: z.string(),
 });
 export type UpdateModelSelectionMessage = z.infer<
   typeof UpdateModelSelectionMessageSchema
@@ -304,8 +304,8 @@ const SetModelEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
-const SetPolishModelMessageSchema = z.object({
-  command: z.literal(CMD.SET_POLISH_MODEL),
+const SetHelperModelMessageSchema = z.object({
+  command: z.literal(CMD.SET_HELPER_MODEL),
   modelName: z.string().min(1),
 });
 
@@ -439,7 +439,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     // Model selection messages
     GetModelSelectionMessageSchema,
     SetModelEnabledMessageSchema,
-    SetPolishModelMessageSchema,
+    SetHelperModelMessageSchema,
     // Agent selection messages
     GetAgentSelectionMessageSchema,
     OpenAgentYamlMessageSchema,

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -98,6 +98,14 @@ export const historyListStyles: CSSResult = css`
     margin-bottom: var(--spacing-small);
   }
 
+  .history-description {
+    font-size: var(--font-size-sm);
+    color: var(--vscode-descriptionForeground);
+    font-style: italic;
+    margin-top: var(--spacing-small);
+    line-height: 1.4;
+  }
+
   .config-section {
     display: flex;
     flex-direction: column;

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -72,8 +72,9 @@ const WORKFLOW_ONLY_FIELDS = new Set([
 const TOOL_USE_ONLY_FIELDS = new Set(['toolConfig']);
 
 /** Return paths available for a given agent category. */
-function getAvailablePaths(category?: string): string[] {
-  const common = ['config', 'report', 'children'];
+function getAvailablePaths(category?: string, hasChildren?: boolean): string[] {
+  const common = ['config', 'report'];
+  if (hasChildren) common.push('children');
   switch (category) {
     case 'toolUse':
       return [...common, 'conversation', 'todos'];
@@ -453,7 +454,10 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
         lines.push('', ...formatTodoSection(todos));
       }
 
-      const runningPaths = getAvailablePaths(handle.category);
+      const runningPaths = getAvailablePaths(
+        handle.category,
+        children.length > 0,
+      );
       lines.push(
         '',
         `Available paths: ${runningPaths.map((p) => `/executions/${executionId}/${p}`).join(', ')}`,
@@ -512,7 +516,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       lines.push('', 'Result:', report);
     }
 
-    const completedPaths = getAvailablePaths(category);
+    const completedPaths = getAvailablePaths(category, children.length > 0);
     lines.push(
       '',
       `Available paths: ${completedPaths.map((p) => `/executions/${executionId}/${p}`).join(', ')}`,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -209,7 +209,8 @@ function formatListingLine(entry: ExecutionListingEntry): string {
   const parentSuffix = entry.parentExecutionId
     ? `  parent=${entry.parentExecutionId}`
     : '';
-  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}`;
+  const descSuffix = entry.description ? `  — ${entry.description}` : '';
+  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
 }
 
 const TODO_ICON: Record<string, string> = {
@@ -446,7 +447,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       const progressLine = formatProgressLine(handle);
       if (progressLine) lines.push(progressLine);
 
-      this.appendChildren(lines, children);
+      await this.appendChildren(lines, children);
 
       if (todos.length > 0) {
         lines.push('', ...formatTodoSection(todos));
@@ -493,11 +494,15 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       `Status: ${formatStatusInfo(info)}`,
     ];
 
+    if (meta?.description) {
+      lines.push(`Description: ${meta.description}`);
+    }
+
     if (meta?.parentExecutionId) {
       lines.push(`Parent: ${meta.parentExecutionId}`);
     }
 
-    this.appendChildren(lines, children);
+    await this.appendChildren(lines, children);
 
     if (todos.length > 0) {
       lines.push('', ...formatTodoSection(todos));
@@ -517,14 +522,26 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
   }
 
   /** Append formatted child entries to output lines. */
-  private appendChildren(lines: string[], children: ChildRecord[]): void {
+  private async appendChildren(
+    lines: string[],
+    children: ChildRecord[],
+  ): Promise<void> {
     if (children.length === 0) return;
     lines.push('', `Children (${children.length}):`);
-    for (const child of children) {
-      const childInfo = getExecutionStatusInfo(child.id);
+    const metas = await Promise.all(
+      children.map((c) => getExecutionStore(c.id).readMeta()),
+    );
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      const childMeta = metas[i];
+      const childInfo = getExecutionStatusInfo(
+        child.id,
+        childMeta?.terminalStatus,
+      );
       const ts = child.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+      const desc = childMeta?.description ? `  — ${childMeta.description}` : '';
       lines.push(
-        `  ${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(childInfo)}]`,
+        `  ${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(childInfo)}]${desc}`,
       );
     }
   }
@@ -606,10 +623,15 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       };
     }
 
-    const lines = children.map((child) => {
-      const info = getExecutionStatusInfo(child.id);
+    const metas = await Promise.all(
+      children.map((c) => getExecutionStore(c.id).readMeta()),
+    );
+    const lines = children.map((child, i) => {
+      const childMeta = metas[i];
+      const info = getExecutionStatusInfo(child.id, childMeta?.terminalStatus);
       const ts = child.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
-      return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]`;
+      const desc = childMeta?.description ? `  — ${childMeta.description}` : '';
+      return `${child.id}  ${ts}  ${child.agent}  [${formatStatusInfo(info)}]${desc}`;
     });
 
     return {

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -1,17 +1,11 @@
 // Third-party imports
 import * as vscode from 'vscode';
-import { MODEL_CONFIGS } from 'llm-zoo';
-
-// Local imports - shared constants
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 // Local imports - agent
-import { createModelHandler } from '@agent/runtime/ModelFactory';
-import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
+import { createHelperModelKit } from '@agent/runtime/helperModel';
 
 // Local imports - common
 import { getSdkErrorMessage } from '@common/errors';
-import { GlobalStateKey, globalSM } from '@common/state';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -204,57 +198,32 @@ ${text}`;
         responseText += chunk;
       }
     } else {
-      const configuredModel = globalSM.get<string>(
-        GlobalStateKey.HELPER_MODEL,
-        DEFAULT_HELPER_MODEL,
-      );
-      const modelName = isNonEmptyString(configuredModel)
-        ? configuredModel.trim()
-        : DEFAULT_HELPER_MODEL;
-      const modelConfig = MODEL_CONFIGS[modelName];
-
-      if (!modelConfig) {
-        return {
-          success: false,
-          text,
-          error: `Unsupported helper model "${modelName}". Update the helper model in Settings > Models to match a valid model name.`,
-        };
-      }
-
-      let handler: ModelHandler;
+      let kit;
       try {
-        handler = createModelHandler(modelConfig);
+        kit = await createHelperModelKit();
       } catch (error) {
         logger.error(
           CHANNEL,
-          `Failed to create model handler: ${getSdkErrorMessage(error)}`,
+          `Failed to initialize helper model: ${getSdkErrorMessage(error)}`,
         );
         return {
           success: false,
           text,
           error:
-            'Unable to initialize the instruction polishing model. Please verify your model settings.',
+            'Unable to initialize the instruction polishing model. Please check your API key and model settings.',
         };
       }
 
-      handler.setOutputStreaming(false);
-      handler.setProgressViewEnabled(false);
-
-      let client: unknown;
-      try {
-        client = await handler.getClient();
-      } catch (error) {
-        logger.error(
-          CHANNEL,
-          `Failed to initialize model client: ${getSdkErrorMessage(error)}`,
-        );
+      if (!kit) {
         return {
           success: false,
           text,
           error:
-            'Unable to initialize the instruction polishing model. Please check your API key and network settings.',
+            'Unsupported helper model. Update the helper model in Settings > Models to match a valid model name.',
         };
       }
+
+      const { handler, client } = kit;
 
       let messages;
       try {

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
 // Local imports - shared constants
-import { DEFAULT_POLISH_MODEL } from '@shared/constants/providers';
+import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 // Local imports - agent
 import { createModelHandler } from '@agent/runtime/ModelFactory';
@@ -205,19 +205,19 @@ ${text}`;
       }
     } else {
       const configuredModel = globalSM.get<string>(
-        GlobalStateKey.POLISH_MODEL,
-        DEFAULT_POLISH_MODEL,
+        GlobalStateKey.HELPER_MODEL,
+        DEFAULT_HELPER_MODEL,
       );
       const modelName = isNonEmptyString(configuredModel)
         ? configuredModel.trim()
-        : DEFAULT_POLISH_MODEL;
+        : DEFAULT_HELPER_MODEL;
       const modelConfig = MODEL_CONFIGS[modelName];
 
       if (!modelConfig) {
         return {
           success: false,
           text,
-          error: `Unsupported instruction polishing model "${modelName}". Update the polish model in Settings > Models to match a valid model name.`,
+          error: `Unsupported helper model "${modelName}". Update the helper model in Settings > Models to match a valid model name.`,
         };
       }
 


### PR DESCRIPTION
## Summary
This PR adds automatic generation and persistence of AI-generated session descriptions for completed tool-use executions. After a session finishes successfully, a concise summary is generated describing what the session aimed to accomplish, then displayed in the history view.

## Key Changes
- **New session description generation module** (`sessionDescription.ts`): Implements fire-and-forget generation of 1-2 sentence summaries using the configured polish model, with a system prompt that ensures past-tense, specific, and informative descriptions
- **Storage layer updates**: Added `writeSessionDescription()` function to persist descriptions in execution metadata, and updated `ExecutionMeta` interface to include optional `description` field
- **Execution lifecycle integration**: Integrated description generation into `executeAgent.ts` to trigger automatically after successful tool-use sessions complete
- **History view display**: Updated `HistoryItem` component to render the description with styled formatting (italic, smaller font, muted color)
- **Schema updates**: Extended `ExecutionListingEntry`, `HistoryItem`, and related schemas to include the optional description field
- **Message handler**: Updated `SettingsViewMessageHandler` to include descriptions when sending history items to the frontend

## Implementation Details
- Generation is non-blocking (fire-and-forget) and never throws, ensuring it doesn't disrupt execution lifecycle
- Uses the configured polish model with temperature=0 for deterministic output
- Gracefully handles missing agent descriptions and unknown models with warning logs
- Description is only generated for successful tool-use sessions (skips error cases)
- All storage operations are wrapped in try-catch to prevent I/O errors from affecting the execution flow

https://claude.ai/code/session_01ExKWfy5HUo1obUMierPxjy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new LLM calls and persistence into the execution lifecycle and expands stored metadata, which could affect performance, cost, or history/tool outputs if misconfigured or if helper-model resolution fails.
> 
> **Overview**
> Adds **AI-generated session descriptions** for completed `toolUse` executions: on successful completion, a fire-and-forget helper-model call produces a 1–2 sentence summary and persists it to execution metadata.
> 
> Extends execution storage/listing/schemas to carry an optional `description`, surfaces it in the Settings History UI and `executions` tool output (including child listings), and factors shared one-shot LLM setup into `createHelperModelKit()` while renaming the user-facing “polish model” setting to a generalized **helper model** used by polishing, agent creation, and session descriptions.
> 
> Also tightens round-loop termination by preventing `RoundPersistedFlow` from continuing to the next round when `lastError` is set, and standardizes `lastError` typing to `RetryErrorInfo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69cef3a1a391e834bb537b3e647e9262433ae13c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->