### PR TITLE
Handle tool use and reflection errors gracefully without throwing

### DIFF
--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -153,7 +153,8 @@ export class ResponseCycleNode<C = unknown> extends Node<
         message: execRes.error.message,
         retryable: execRes.retryable ?? false,
       };
-      throw execRes.error;
+      shared.continueRounds = false;
+      return FlowTransition.FINALIZE;
     }
 
     shared.endTurn = execRes.outcome === 'completed' ? execRes.endTurn : false;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -300,6 +300,9 @@ export async function runReflectionFlow<C = unknown>(
 
     if (shared?.lastError) {
       status = END_GROUP_STATUS.ERROR;
+      // Re-throw after state persistence so runFlowWithLifecycle logs
+      // the error and shows the user notification.
+      throw new Error(shared.lastError.message);
     } else {
       status = executionToEndStatus(flowStatus) as EndGroupStatus;
     }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -298,7 +298,11 @@ export async function runReflectionFlow<C = unknown>(
       );
     }
 
-    status = executionToEndStatus(flowStatus) as EndGroupStatus;
+    if (shared?.lastError) {
+      status = END_GROUP_STATUS.ERROR;
+    } else {
+      status = executionToEndStatus(flowStatus) as EndGroupStatus;
+    }
   } catch (error) {
     status = END_GROUP_STATUS.ERROR;
     throw error;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -139,7 +139,7 @@ export class ToolUseCycleNode<C> extends Node<
           message: execRes.message,
           retryable: execRes.retryable ?? false,
         };
-        throw new Error(execRes.message);
+        return FlowTransition.FINALIZE;
 
       case 'cancelled':
         shared.userCancelledRetry = true;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -188,6 +188,9 @@ export async function runToolUseFlow<C = unknown>(
 
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
+      // Re-throw after state persistence so runFlowWithLifecycle logs
+      // the error and shows the user notification.
+      throw new Error(shared.lastError.message);
     } else {
       const execStatus = input.checkInterruption()
         ? EXECUTION_STATUS.INTERRUPTED

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -125,7 +125,7 @@ export async function runToolUseFlow<C = unknown>(
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
 
-  const shared: ToolUseRunShared = {
+  let shared: ToolUseRunShared = {
     messages: [],
     shouldSkipCycle: false,
     stateSlices: null,
@@ -169,6 +169,11 @@ export async function runToolUseFlow<C = unknown>(
     >(prepareNode, kv);
     pf.setServices(services);
     await pf.run(shared);
+    // Re-read shared from the flow record — PersistedFlow deep-clones the
+    // initial shared via structuredClone, so nodes mutate the clone, not the
+    // original object.  Without this, reads of lastError, messages, etc. below
+    // would always see the stale initial values.
+    shared = (await pf.getShared()) ?? shared;
 
     // Persist conversation and todos as direct keys before finally deletes the flow record
     const writes: Promise<void>[] = [];

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -181,10 +181,14 @@ export async function runToolUseFlow<C = unknown>(
     }
     await Promise.all(writes);
 
-    const execStatus = input.checkInterruption()
-      ? EXECUTION_STATUS.INTERRUPTED
-      : EXECUTION_STATUS.COMPLETED;
-    status = executionToEndStatus(execStatus) as EndGroupStatus;
+    if (shared.lastError) {
+      status = END_GROUP_STATUS.ERROR;
+    } else {
+      const execStatus = input.checkInterruption()
+        ? EXECUTION_STATUS.INTERRUPTED
+        : EXECUTION_STATUS.COMPLETED;
+      status = executionToEndStatus(execStatus) as EndGroupStatus;
+    }
   } catch (error) {
     status = END_GROUP_STATUS.ERROR;
     throw error;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -264,6 +264,34 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return total;
   }
 
+  /**
+   * Removes entries from uploadedPdfPageCounts whose file IDs are no longer
+   * referenced in the current messages. This keeps the tracked total accurate
+   * after server-side compaction drops old messages.
+   */
+  private pruneTrackedPdfPages(messages: MessageParam[]): void {
+    const liveFileIds = new Set<string>();
+    for (const message of messages) {
+      const contentBlocks = message.content;
+      if (!Array.isArray(contentBlocks)) continue;
+
+      for (const block of this.extractDocumentBlocks(contentBlocks)) {
+        const source = (block as DocumentBlockParam).source as
+          | { type: string; file_id?: string }
+          | undefined;
+        if (source?.type === 'file' && source.file_id) {
+          liveFileIds.add(source.file_id);
+        }
+      }
+    }
+
+    for (const fileId of this.uploadedPdfPageCounts.keys()) {
+      if (!liveFileIds.has(fileId)) {
+        this.uploadedPdfPageCounts.delete(fileId);
+      }
+    }
+  }
+
   private isClaudeOpus46(): boolean {
     return this.config.fullName === OPUS_46_FULLNAME;
   }
@@ -519,6 +547,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
+
+    // Prune tracked PDF page counts for file IDs no longer in messages
+    // (e.g. after server-side compaction drops old messages)
+    if (this.uploadedPdfPageCounts.size > 0) {
+      this.pruneTrackedPdfPages(messages);
+    }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const options: MessageCreateParams = {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -2148,12 +2148,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (pageLimitExceeded.length > 0) {
+      const remaining =
+        ANTHROPIC_MAX_PDF_PAGES - this.getTrackedPdfPageCount();
       const names = pageLimitExceeded
         .map((a) => a.path ?? 'attachment.pdf')
         .join(', ');
       toolResultContent.unshift({
         type: 'text',
-        text: `PDF page limit reached — could not include: ${names}. The conversation has reached the maximum of ${ANTHROPIC_MAX_PDF_PAGES} PDF pages. Tell the user.`,
+        text: `PDF page limit reached — could not include: ${names}. ${remaining} of ${ANTHROPIC_MAX_PDF_PAGES} PDF pages remaining in this conversation. Tell the user.`,
       });
     }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -255,6 +255,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
 
+  /** Sum of all tracked PDF page counts for uploaded files. */
+  private getTrackedPdfPageCount(): number {
+    let total = 0;
+    for (const count of this.uploadedPdfPageCounts.values()) {
+      total += count;
+    }
+    return total;
+  }
+
   private isClaudeOpus46(): boolean {
     return this.config.fullName === OPUS_46_FULLNAME;
   }
@@ -1160,9 +1169,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ): Promise<{
     uploaded: UploadedAnthropicAttachment[];
     unsupported: ToolFileAttachment[];
+    pageLimitExceeded: ToolFileAttachment[];
   }> {
     const uploaded: UploadedAnthropicAttachment[] = [];
     const unsupported: ToolFileAttachment[] = [];
+    const pageLimitExceeded: ToolFileAttachment[] = [];
 
     for (const attachment of attachments) {
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
@@ -1186,6 +1197,25 @@ export class ModelHandlerAnthropic extends ModelHandler<
         continue;
       }
 
+      // Check cumulative PDF page limit before uploading
+      let pdfPageCount = 0;
+      if (isPdf) {
+        pdfPageCount = await this.countPdfPagesFromBuffer(buffer);
+        const currentTotal = this.getTrackedPdfPageCount();
+        if (currentTotal + pdfPageCount > ANTHROPIC_MAX_PDF_PAGES) {
+          this.logger.warn(
+            `PDF page limit reached: ${attachment.path ?? 'attachment.pdf'} has ${pdfPageCount} pages, ` +
+              `but conversation already has ${currentTotal}/${ANTHROPIC_MAX_PDF_PAGES} pages`,
+          );
+          pageLimitExceeded.push(attachment);
+          if (buffer) {
+            buffer.fill(0);
+            buffer = undefined;
+          }
+          continue;
+        }
+      }
+
       try {
         const filename = this.sanitizeFilename(
           attachment.path ??
@@ -1199,6 +1229,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
           file: await toFile(buffer!, filename, { type: mimeType }),
           betas: [FILES_API_BETA],
         });
+
+        if (isPdf && pdfPageCount > 0) {
+          this.uploadedPdfPageCounts.set(uploadedFile.id, pdfPageCount);
+        }
 
         uploaded.push({
           attachment,
@@ -1217,7 +1251,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    return { uploaded, unsupported };
+    return { uploaded, unsupported, pageLimitExceeded };
   }
 
   private sanitizeFilename(filename: string): string {
@@ -2121,6 +2155,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     let uploadedAttachments: UploadedAnthropicAttachment[] = [];
     const unsupportedAttachments: ToolFileAttachment[] = [];
+    const pageLimitAttachments: ToolFileAttachment[] = [];
 
     if (canUploadFiles && attachments.length > 0 && client) {
       const uploadResult = await this.uploadToolAttachments(
@@ -2129,6 +2164,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
       uploadedAttachments = uploadResult.uploaded;
       unsupportedAttachments.push(...uploadResult.unsupported);
+      pageLimitAttachments.push(...uploadResult.pageLimitExceeded);
 
       if (uploadedAttachments.length > 0) {
         // Store uploaded file info with fileId (Anthropic-specific extension)
@@ -2200,6 +2236,20 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (unsupportedAttachments.length > 0) {
       unsupportedNotes.push(...describeAttachments(unsupportedAttachments));
+    }
+
+    if (pageLimitAttachments.length > 0) {
+      const currentTotal = this.getTrackedPdfPageCount();
+      const names = pageLimitAttachments
+        .map((a) => a.path ?? 'attachment.pdf')
+        .join(', ');
+      toolResultContent.unshift({
+        type: 'text',
+        text:
+          `PDF page limit reached: cannot include ${names}. ` +
+          `The conversation already contains ${currentTotal} of the maximum ${ANTHROPIC_MAX_PDF_PAGES} PDF pages allowed per request. ` +
+          `Inform the user and suggest reducing PDF attachments or starting a new conversation.`,
+      });
     }
 
     if (unsupportedNotes.length > 0) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -255,15 +255,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
 
-  /** Sum of all tracked PDF page counts for uploaded files. */
-  private getTrackedPdfPageCount(): number {
-    let total = 0;
-    for (const count of this.uploadedPdfPageCounts.values()) {
-      total += count;
-    }
-    return total;
-  }
-
   private isClaudeOpus46(): boolean {
     return this.config.fullName === OPUS_46_FULLNAME;
   }
@@ -520,9 +511,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
 
-    // Validate PDF page limit before expensive token counting and uploads
+    // Strip old PDF blocks if the conversation exceeds the page limit
     if (documentAnalysis.hasBase64Pdf || documentAnalysis.hasFileSource) {
-      await this.validatePdfPageLimit(messages);
+      await this.enforcePdfPageLimit(messages);
     }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
@@ -978,7 +969,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             file_id: uploadedFile.id,
           } as BetaRequestDocumentBlock['source'];
 
-          // Track page count so validatePdfPageLimit can account for
+          // Track page count so enforcePdfPageLimit can account for
           // this file reference in subsequent rounds
           if (pageCount > 0) {
             this.uploadedPdfPageCounts.set(uploadedFile.id, pageCount);
@@ -1088,56 +1079,146 @@ export class ModelHandlerAnthropic extends ModelHandler<
    * Only messages at or after the last compaction block are counted, because
    * the Anthropic API drops pre-compaction messages server-side.
    */
-  private async validatePdfPageLimit(messages: MessageParam[]): Promise<void> {
+  /**
+   * Enforces the PDF page limit by stripping the oldest PDF document blocks
+   * from the conversation until the total is within ANTHROPIC_MAX_PDF_PAGES.
+   *
+   * Stripped blocks are replaced with text placeholders so the model knows
+   * content was removed. This avoids throwing errors or crashing the agent —
+   * old PDFs are simply evicted to make room for new ones.
+   *
+   * Only messages at or after the last compaction block are counted, because
+   * the Anthropic API drops pre-compaction messages server-side.
+   */
+  private async enforcePdfPageLimit(messages: MessageParam[]): Promise<void> {
     const startIndex = this.findLastCompactionMessageIndex(messages);
+
+    // Collect every PDF block location with its page count (oldest first)
+    interface PdfLocation {
+      /** The array containing the document block (top-level or tool_result content) */
+      container: unknown[];
+      /** Index of the document block within that container */
+      index: number;
+      pageCount: number;
+      title: string;
+      fileId?: string;
+    }
+
+    const locations: PdfLocation[] = [];
     let totalPages = 0;
 
     for (let i = startIndex; i < messages.length; i++) {
-      const message = messages[i];
-      const contentBlocks = message.content;
-      if (!Array.isArray(contentBlocks)) {
-        continue;
-      }
+      const contentBlocks = messages[i].content;
+      if (!Array.isArray(contentBlocks)) continue;
 
-      for (const block of this.extractDocumentBlocks(contentBlocks)) {
-        // Cast to beta source type: upload code stores BetaFileDocumentSource
-        // entries (via Files API) into non-beta message arrays.
-        const source = block.source as BetaRequestDocumentBlock['source'];
+      for (let j = 0; j < contentBlocks.length; j++) {
+        const block = contentBlocks[j];
 
-        if (source.type === 'file') {
-          // PDF previously uploaded to the Files API — use tracked page count
-          const fileId = source.file_id;
-          const tracked = this.uploadedPdfPageCounts.get(fileId);
-          if (tracked !== undefined) {
-            totalPages += tracked;
+        if (block.type === 'document' && (block as DocumentBlockParam).source) {
+          const loc = await this.pdfLocationFromBlock(
+            block as DocumentBlockParam,
+            contentBlocks,
+            j,
+          );
+          if (loc) {
+            locations.push(loc);
+            totalPages += loc.pageCount;
           }
         } else if (
-          source.type === 'base64' &&
-          source.media_type === 'application/pdf' &&
-          source.data
+          block.type === 'tool_result' &&
+          Array.isArray((block as { content?: unknown }).content)
         ) {
-          // Inline base64 PDF — decode and count pages
-          const buffer = Buffer.from(source.data, 'base64');
-          try {
-            totalPages += await this.countPdfPagesFromBuffer(buffer);
-          } finally {
-            buffer.fill(0);
+          const nested = (block as { content: unknown[] }).content;
+          for (let k = 0; k < nested.length; k++) {
+            const n = nested[k] as { type: string; source?: unknown };
+            if (n.type === 'document' && n.source) {
+              const loc = await this.pdfLocationFromBlock(
+                n as DocumentBlockParam,
+                nested,
+                k,
+              );
+              if (loc) {
+                locations.push(loc);
+                totalPages += loc.pageCount;
+              }
+            }
           }
-        }
-
-        if (totalPages > ANTHROPIC_MAX_PDF_PAGES) {
-          const err = new Error(
-            `PDF page limit reached: the conversation contains ${totalPages}+ PDF pages, ` +
-              `but the API allows a maximum of ${ANTHROPIC_MAX_PDF_PAGES} pages per request. ` +
-              `Please compact the conversation, reduce the number of PDF attachments, or start a new conversation.`,
-          );
-          // Attach status 400 so formatProviderHttpError classifies this as
-          // non-retryable (same as the raw API error it replaces).
-          (err as Error & { status: number }).status = 400;
-          throw err;
         }
       }
     }
+
+    if (totalPages <= ANTHROPIC_MAX_PDF_PAGES) return;
+
+    // Strip oldest PDFs until we fit within the limit
+    let pagesToRemove = totalPages - ANTHROPIC_MAX_PDF_PAGES;
+    let strippedCount = 0;
+
+    for (const loc of locations) {
+      if (pagesToRemove <= 0) break;
+
+      loc.container[loc.index] = {
+        type: 'text',
+        text: `[PDF removed: ${loc.title} (${loc.pageCount} page${loc.pageCount === 1 ? '' : 's'}) — exceeded ${ANTHROPIC_MAX_PDF_PAGES}-page conversation limit]`,
+      };
+
+      if (loc.fileId) {
+        this.uploadedPdfPageCounts.delete(loc.fileId);
+      }
+
+      pagesToRemove -= loc.pageCount;
+      strippedCount++;
+    }
+
+    this.logger.warn(
+      `Stripped ${strippedCount} PDF document(s) from conversation to stay within ` +
+        `${ANTHROPIC_MAX_PDF_PAGES}-page limit (was ${totalPages} pages)`,
+    );
+  }
+
+  /**
+   * Extracts page count, title, and file ID from a PDF document block.
+   * Returns null for non-PDF documents or on parse failure.
+   */
+  private async pdfLocationFromBlock(
+    block: DocumentBlockParam,
+    container: unknown[],
+    index: number,
+  ): Promise<{
+    container: unknown[];
+    index: number;
+    pageCount: number;
+    title: string;
+    fileId?: string;
+  } | null> {
+    const source = block.source as BetaRequestDocumentBlock['source'];
+    const title =
+      (block as { title?: string }).title ?? 'document.pdf';
+
+    if (source.type === 'file') {
+      const fileId = source.file_id;
+      const tracked = this.uploadedPdfPageCounts.get(fileId);
+      if (tracked !== undefined) {
+        return { container, index, pageCount: tracked, title, fileId };
+      }
+      // Untracked file reference — can't determine page count, keep it
+      return null;
+    }
+
+    if (
+      source.type === 'base64' &&
+      source.media_type === 'application/pdf' &&
+      source.data
+    ) {
+      const buffer = Buffer.from(source.data, 'base64');
+      try {
+        const pageCount = await this.countPdfPagesFromBuffer(buffer);
+        return { container, index, pageCount, title };
+      } finally {
+        buffer.fill(0);
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -1169,11 +1250,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ): Promise<{
     uploaded: UploadedAnthropicAttachment[];
     unsupported: ToolFileAttachment[];
-    pageLimitExceeded: ToolFileAttachment[];
   }> {
     const uploaded: UploadedAnthropicAttachment[] = [];
     const unsupported: ToolFileAttachment[] = [];
-    const pageLimitExceeded: ToolFileAttachment[] = [];
 
     for (const attachment of attachments) {
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
@@ -1197,25 +1276,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         continue;
       }
 
-      // Check cumulative PDF page limit before uploading
-      let pdfPageCount = 0;
-      if (isPdf) {
-        pdfPageCount = await this.countPdfPagesFromBuffer(buffer);
-        const currentTotal = this.getTrackedPdfPageCount();
-        if (currentTotal + pdfPageCount > ANTHROPIC_MAX_PDF_PAGES) {
-          this.logger.warn(
-            `PDF page limit reached: ${attachment.path ?? 'attachment.pdf'} has ${pdfPageCount} pages, ` +
-              `but conversation already has ${currentTotal}/${ANTHROPIC_MAX_PDF_PAGES} pages`,
-          );
-          pageLimitExceeded.push(attachment);
-          if (buffer) {
-            buffer.fill(0);
-            buffer = undefined;
-          }
-          continue;
-        }
-      }
-
       try {
         const filename = this.sanitizeFilename(
           attachment.path ??
@@ -1223,6 +1283,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
               ? 'document.pdf'
               : `image.${normalized.split('/').pop() ?? 'png'}`),
         );
+
+        // Count PDF pages before upload so enforcePdfPageLimit can track them
+        let pdfPageCount = 0;
+        if (isPdf) {
+          pdfPageCount = await this.countPdfPagesFromBuffer(buffer);
+        }
 
         const base64Data = buffer.toString('base64');
         const uploadedFile = await client.beta.files.upload({
@@ -1251,7 +1317,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    return { uploaded, unsupported, pageLimitExceeded };
+    return { uploaded, unsupported };
   }
 
   private sanitizeFilename(filename: string): string {
@@ -2155,7 +2221,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     let uploadedAttachments: UploadedAnthropicAttachment[] = [];
     const unsupportedAttachments: ToolFileAttachment[] = [];
-    const pageLimitAttachments: ToolFileAttachment[] = [];
 
     if (canUploadFiles && attachments.length > 0 && client) {
       const uploadResult = await this.uploadToolAttachments(
@@ -2164,7 +2229,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
       uploadedAttachments = uploadResult.uploaded;
       unsupportedAttachments.push(...uploadResult.unsupported);
-      pageLimitAttachments.push(...uploadResult.pageLimitExceeded);
 
       if (uploadedAttachments.length > 0) {
         // Store uploaded file info with fileId (Anthropic-specific extension)
@@ -2236,20 +2300,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (unsupportedAttachments.length > 0) {
       unsupportedNotes.push(...describeAttachments(unsupportedAttachments));
-    }
-
-    if (pageLimitAttachments.length > 0) {
-      const currentTotal = this.getTrackedPdfPageCount();
-      const names = pageLimitAttachments
-        .map((a) => a.path ?? 'attachment.pdf')
-        .join(', ');
-      toolResultContent.unshift({
-        type: 'text',
-        text:
-          `PDF page limit reached: cannot include ${names}. ` +
-          `The conversation already contains ${currentTotal} of the maximum ${ANTHROPIC_MAX_PDF_PAGES} PDF pages allowed per request. ` +
-          `Inform the user and suggest compacting the conversation, reducing PDF attachments, or starting a new conversation.`,
-      });
     }
 
     if (unsupportedNotes.length > 0) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1129,7 +1129,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           const err = new Error(
             `PDF page limit reached: the conversation contains ${totalPages}+ PDF pages, ` +
               `but the API allows a maximum of ${ANTHROPIC_MAX_PDF_PAGES} pages per request. ` +
-              `Please reduce the number of PDF attachments or start a new conversation.`,
+              `Please compact the conversation, reduce the number of PDF attachments, or start a new conversation.`,
           );
           // Attach status 400 so formatProviderHttpError classifies this as
           // non-retryable (same as the raw API error it replaces).
@@ -2248,7 +2248,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         text:
           `PDF page limit reached: cannot include ${names}. ` +
           `The conversation already contains ${currentTotal} of the maximum ${ANTHROPIC_MAX_PDF_PAGES} PDF pages allowed per request. ` +
-          `Inform the user and suggest reducing PDF attachments or starting a new conversation.`,
+          `Inform the user and suggest compacting the conversation, reducing PDF attachments, or starting a new conversation.`,
       });
     }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -255,6 +255,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
 
+  /** Sum of all tracked PDF page counts across uploaded files. */
+  private getTrackedPdfPageCount(): number {
+    let total = 0;
+    for (const count of this.uploadedPdfPageCounts.values()) {
+      total += count;
+    }
+    return total;
+  }
+
   private isClaudeOpus46(): boolean {
     return this.config.fullName === OPUS_46_FULLNAME;
   }
@@ -510,11 +519,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
-
-    // Strip old PDF blocks if the conversation exceeds the page limit
-    if (documentAnalysis.hasBase64Pdf || documentAnalysis.hasFileSource) {
-      await this.enforcePdfPageLimit(messages);
-    }
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const options: MessageCreateParams = {
@@ -969,8 +973,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
             file_id: uploadedFile.id,
           } as BetaRequestDocumentBlock['source'];
 
-          // Track page count so enforcePdfPageLimit can account for
-          // this file reference in subsequent rounds
+          // Track page count so uploadToolAttachments can enforce
+          // the PDF page limit in subsequent rounds
           if (pageCount > 0) {
             this.uploadedPdfPageCounts.set(uploadedFile.id, pageCount);
           }
@@ -1072,187 +1076,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
   }
 
   /**
-   * Validates that the total number of PDF pages across all messages does not
-   * exceed the Anthropic API limit. Throws a user-friendly error when the
-   * limit is reached, avoiding the raw HTTP 400 from the API.
-   *
-   * Only messages at or after the last compaction block are counted, because
-   * the Anthropic API drops pre-compaction messages server-side.
-   */
-  /**
-   * Enforces the PDF page limit by stripping the oldest PDF document blocks
-   * from the conversation until the total is within ANTHROPIC_MAX_PDF_PAGES.
-   *
-   * Stripped blocks are replaced with text placeholders so the model knows
-   * content was removed. This avoids throwing errors or crashing the agent —
-   * old PDFs are simply evicted to make room for new ones.
-   *
-   * Only messages at or after the last compaction block are counted, because
-   * the Anthropic API drops pre-compaction messages server-side.
-   */
-  private async enforcePdfPageLimit(messages: MessageParam[]): Promise<void> {
-    const startIndex = this.findLastCompactionMessageIndex(messages);
-
-    // Collect every PDF block location with its page count (oldest first)
-    interface PdfLocation {
-      /** The array containing the document block (top-level or tool_result content) */
-      container: unknown[];
-      /** Index of the document block within that container */
-      index: number;
-      pageCount: number;
-      title: string;
-      fileId?: string;
-    }
-
-    const locations: PdfLocation[] = [];
-    let totalPages = 0;
-
-    for (let i = startIndex; i < messages.length; i++) {
-      const contentBlocks = messages[i].content;
-      if (!Array.isArray(contentBlocks)) continue;
-
-      for (let j = 0; j < contentBlocks.length; j++) {
-        const block = contentBlocks[j];
-
-        if (block.type === 'document' && (block as DocumentBlockParam).source) {
-          const loc = await this.pdfLocationFromBlock(
-            block as DocumentBlockParam,
-            contentBlocks,
-            j,
-          );
-          if (loc) {
-            locations.push(loc);
-            totalPages += loc.pageCount;
-          }
-        } else if (
-          block.type === 'tool_result' &&
-          Array.isArray((block as { content?: unknown }).content)
-        ) {
-          const nested = (block as { content: unknown[] }).content;
-          for (let k = 0; k < nested.length; k++) {
-            const n = nested[k] as { type: string; source?: unknown };
-            if (n.type === 'document' && n.source) {
-              const loc = await this.pdfLocationFromBlock(
-                n as DocumentBlockParam,
-                nested,
-                k,
-              );
-              if (loc) {
-                locations.push(loc);
-                totalPages += loc.pageCount;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (totalPages <= ANTHROPIC_MAX_PDF_PAGES) return;
-
-    // Strip oldest PDFs until we fit within the limit
-    let pagesToRemove = totalPages - ANTHROPIC_MAX_PDF_PAGES;
-    let strippedCount = 0;
-
-    for (const loc of locations) {
-      if (pagesToRemove <= 0) break;
-
-      loc.container[loc.index] = {
-        type: 'text',
-        text: `[PDF removed: ${loc.title} (${loc.pageCount} page${loc.pageCount === 1 ? '' : 's'}) — exceeded ${ANTHROPIC_MAX_PDF_PAGES}-page conversation limit]`,
-      };
-
-      if (loc.fileId) {
-        this.uploadedPdfPageCounts.delete(loc.fileId);
-      }
-
-      pagesToRemove -= loc.pageCount;
-      strippedCount++;
-    }
-
-    this.logger.warn(
-      `Stripped ${strippedCount} PDF document(s) from conversation to stay within ` +
-        `${ANTHROPIC_MAX_PDF_PAGES}-page limit (was ${totalPages} pages)`,
-    );
-  }
-
-  /**
-   * Extracts page count, title, and file ID from a PDF document block.
-   * Returns null for non-PDF documents or on parse failure.
-   */
-  private async pdfLocationFromBlock(
-    block: DocumentBlockParam,
-    container: unknown[],
-    index: number,
-  ): Promise<{
-    container: unknown[];
-    index: number;
-    pageCount: number;
-    title: string;
-    fileId?: string;
-  } | null> {
-    const source = block.source as BetaRequestDocumentBlock['source'];
-    const title =
-      (block as { title?: string }).title ?? 'document.pdf';
-
-    if (source.type === 'file') {
-      const fileId = source.file_id;
-      const tracked = this.uploadedPdfPageCounts.get(fileId);
-      if (tracked !== undefined) {
-        return { container, index, pageCount: tracked, title, fileId };
-      }
-      // Untracked file reference — can't determine page count, keep it
-      return null;
-    }
-
-    if (
-      source.type === 'base64' &&
-      source.media_type === 'application/pdf' &&
-      source.data
-    ) {
-      const buffer = Buffer.from(source.data, 'base64');
-      try {
-        const pageCount = await this.countPdfPagesFromBuffer(buffer);
-        return { container, index, pageCount, title };
-      } finally {
-        buffer.fill(0);
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Finds the index of the last message containing a compaction block.
-   * After server-side compaction, the API drops all messages before the
-   * compaction block, so only messages from this index onwards are relevant
-   * for limit validation.
-   *
-   * Returns 0 when no compaction block is found (count all messages).
-   */
-  private findLastCompactionMessageIndex(messages: MessageParam[]): number {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const contentBlocks = messages[i].content;
-      if (!Array.isArray(contentBlocks)) {
-        continue;
-      }
-      for (const block of contentBlocks) {
-        if ((block as { type: string }).type === 'compaction') {
-          return i;
-        }
-      }
-    }
-    return 0;
-  }
-
   private async uploadToolAttachments(
     client: Anthropic,
     attachments: ToolFileAttachment[],
   ): Promise<{
     uploaded: UploadedAnthropicAttachment[];
     unsupported: ToolFileAttachment[];
+    pageLimitExceeded: ToolFileAttachment[];
   }> {
     const uploaded: UploadedAnthropicAttachment[] = [];
     const unsupported: ToolFileAttachment[] = [];
+    const pageLimitExceeded: ToolFileAttachment[] = [];
 
     for (const attachment of attachments) {
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
@@ -1276,6 +1110,21 @@ export class ModelHandlerAnthropic extends ModelHandler<
         continue;
       }
 
+      // Check PDF page limit before uploading
+      let pdfPageCount = 0;
+      if (isPdf) {
+        pdfPageCount = await this.countPdfPagesFromBuffer(buffer);
+        if (
+          this.getTrackedPdfPageCount() + pdfPageCount >
+          ANTHROPIC_MAX_PDF_PAGES
+        ) {
+          pageLimitExceeded.push(attachment);
+          buffer.fill(0);
+          buffer = undefined;
+          continue;
+        }
+      }
+
       try {
         const filename = this.sanitizeFilename(
           attachment.path ??
@@ -1283,12 +1132,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
               ? 'document.pdf'
               : `image.${normalized.split('/').pop() ?? 'png'}`),
         );
-
-        // Count PDF pages before upload so enforcePdfPageLimit can track them
-        let pdfPageCount = 0;
-        if (isPdf) {
-          pdfPageCount = await this.countPdfPagesFromBuffer(buffer);
-        }
 
         const base64Data = buffer.toString('base64');
         const uploadedFile = await client.beta.files.upload({
@@ -1317,7 +1160,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    return { uploaded, unsupported };
+    return { uploaded, unsupported, pageLimitExceeded };
   }
 
   private sanitizeFilename(filename: string): string {
@@ -2221,6 +2064,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     let uploadedAttachments: UploadedAnthropicAttachment[] = [];
     const unsupportedAttachments: ToolFileAttachment[] = [];
+    const pageLimitExceeded: ToolFileAttachment[] = [];
 
     if (canUploadFiles && attachments.length > 0 && client) {
       const uploadResult = await this.uploadToolAttachments(
@@ -2229,6 +2073,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       );
       uploadedAttachments = uploadResult.uploaded;
       unsupportedAttachments.push(...uploadResult.unsupported);
+      pageLimitExceeded.push(...uploadResult.pageLimitExceeded);
 
       if (uploadedAttachments.length > 0) {
         // Store uploaded file info with fileId (Anthropic-specific extension)
@@ -2300,6 +2145,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (unsupportedAttachments.length > 0) {
       unsupportedNotes.push(...describeAttachments(unsupportedAttachments));
+    }
+
+    if (pageLimitExceeded.length > 0) {
+      const names = pageLimitExceeded
+        .map((a) => a.path ?? 'attachment.pdf')
+        .join(', ');
+      toolResultContent.unshift({
+        type: 'text',
+        text: `PDF page limit reached — could not include: ${names}. The conversation has reached the maximum of ${ANTHROPIC_MAX_PDF_PAGES} PDF pages. Tell the user.`,
+      });
     }
 
     if (unsupportedNotes.length > 0) {

--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -41,6 +41,9 @@ export interface RoundAwareState {
 
   /** Whether to continue to next round (can be set false by nodes) */
   continueRounds: boolean;
+
+  /** Set by nodes when execution fails. Skips round completion callbacks. */
+  lastError?: { message: string; retryable: boolean } | undefined;
 }
 
 // ============================================================================
@@ -151,20 +154,24 @@ export class RoundPersistedFlow<
       }
 
       // Determine final status
-      const interrupted =
-        this.callbacks.checkInterruption?.() || !currentShared.continueRounds;
-      const completedAllRounds = isRoundAtOrBeyondLimit(
-        currentShared.currentRound + 1,
-        currentShared.totalRounds,
-      );
-      if (!completedAllRounds && interrupted) {
-        status = EXECUTION_STATUS.INTERRUPTED;
+      if (currentShared.lastError) {
+        status = EXECUTION_STATUS.ERROR;
       } else {
-        // Only notify round completion if the round actually finished
-        await this.callbacks.onRoundCompleted?.(
-          currentShared.currentRound,
-          currentShared,
+        const interrupted =
+          this.callbacks.checkInterruption?.() ||
+          !currentShared.continueRounds;
+        const completedAllRounds = isRoundAtOrBeyondLimit(
+          currentShared.currentRound + 1,
+          currentShared.totalRounds,
         );
+        if (!completedAllRounds && interrupted) {
+          status = EXECUTION_STATUS.INTERRUPTED;
+        } else {
+          await this.callbacks.onRoundCompleted?.(
+            currentShared.currentRound,
+            currentShared,
+          );
+        }
       }
     } catch (error) {
       status = EXECUTION_STATUS.ERROR;

--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -160,11 +160,7 @@ export class RoundPersistedFlow<
         const interrupted =
           this.callbacks.checkInterruption?.() ||
           !currentShared.continueRounds;
-        const completedAllRounds = isRoundAtOrBeyondLimit(
-          currentShared.currentRound + 1,
-          currentShared.totalRounds,
-        );
-        if (!completedAllRounds && interrupted) {
+        if (interrupted) {
           status = EXECUTION_STATUS.INTERRUPTED;
         } else {
           await this.callbacks.onRoundCompleted?.(

--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -154,20 +154,12 @@ export class RoundPersistedFlow<
       }
 
       // Determine final status
-      if (currentShared.lastError) {
-        status = EXECUTION_STATUS.ERROR;
-      } else {
-        const interrupted =
-          this.callbacks.checkInterruption?.() ||
-          !currentShared.continueRounds;
-        if (interrupted) {
-          status = EXECUTION_STATUS.INTERRUPTED;
-        } else {
-          await this.callbacks.onRoundCompleted?.(
-            currentShared.currentRound,
-            currentShared,
-          );
-        }
+      status = this.resolveTerminalStatus(currentShared);
+      if (status === EXECUTION_STATUS.COMPLETED) {
+        await this.callbacks.onRoundCompleted?.(
+          currentShared.currentRound,
+          currentShared,
+        );
       }
     } catch (error) {
       status = EXECUTION_STATUS.ERROR;
@@ -212,6 +204,24 @@ export class RoundPersistedFlow<
       shared.continueRounds &&
       !isRoundAtOrBeyondLimit(shared.currentRound + 1, shared.totalRounds)
     );
+  }
+
+  /**
+   * Derive terminal ExecutionStatus from shared state after the round loop exits.
+   *
+   * Priority:
+   * 1. lastError → ERROR (node-level failure)
+   * 2. interrupted / !continueRounds → INTERRUPTED (early stop)
+   * 3. otherwise → COMPLETED (all rounds finished normally)
+   */
+  private resolveTerminalStatus(shared: S): ExecutionStatus {
+    if (shared.lastError) {
+      return EXECUTION_STATUS.ERROR;
+    }
+    if (this.callbacks.checkInterruption?.() || !shared.continueRounds) {
+      return EXECUTION_STATUS.INTERRUPTED;
+    }
+    return EXECUTION_STATUS.COMPLETED;
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR improves error handling in the tool use and reflection flows by capturing errors without throwing exceptions, allowing the flows to transition to finalization gracefully instead of interrupting execution.

## Key Changes
- **runToolUseFlow.ts**: Added check for `shared.lastError` to set status to ERROR before attempting to determine execution status. This ensures errors are properly reflected in the final status.
- **ResponseCycleNode.ts**: Changed error handling to set `shared.continueRounds = false` and return `FlowTransition.FINALIZE` instead of throwing the error, allowing the flow to complete gracefully.
- **ToolUseCycleNode.ts**: Changed error handling to return `FlowTransition.FINALIZE` instead of throwing an error, enabling proper flow termination without exception propagation.

## Implementation Details
These changes follow a pattern where errors are captured in the shared state and the flow transitions to finalization rather than throwing exceptions. This allows:
- Errors to be properly tracked and reported through the flow's status mechanism
- Graceful termination of execution cycles
- Better control flow through explicit state transitions instead of exception handling

https://claude.ai/code/session_017iFguNDbqJV75vASbu61RB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches flow termination/status and persistence behavior for tool-use/reflection runs; mistakes could misclassify failures or alter cleanup/resume semantics. Also changes Anthropic attachment handling and PDF limit enforcement, which could affect tool-result fidelity and user messaging.
> 
> **Overview**
> Tool-use and reflection flows now **stop rounds gracefully on node failures**: `ResponseCycleNode`/`ToolUseCycleNode` record `shared.lastError`, set `continueRounds = false` where applicable, and transition to `FINALIZE` instead of throwing mid-flow.
> 
> Both `runReflectionFlow` and `runToolUseFlow` now **persist state first**, then map `shared.lastError` to an `ERROR` end status and rethrow a simplified error so lifecycle code can log/notify consistently; `runToolUseFlow` also re-reads `shared` from `PersistedFlow` to avoid stale state due to `structuredClone`.
> 
> `RoundPersistedFlow` adds `lastError` to its shared-state contract and uses it to resolve terminal status (error vs interruption vs completion) and to avoid firing round-completion callbacks on failed executions.
> 
> Anthropic handler refactors PDF page-limit handling: removes the per-request scan validator, tracks total pages across uploaded file IDs, prunes counts after server-side compaction, enforces the page limit during `uploadToolAttachments`, and surfaces a user-facing note when attachments are skipped due to the limit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3071cee0a1ab69d52dd6a7943d52c5e6efb058f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->