### PR TITLE
Skip arXiv download if source already exists locally

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -197,106 +197,111 @@ export class ArxivSourceProcessor {
 
     // Create project directory for the arXiv paper (sanitize ID to avoid path issues)
     const paperDirRelative = id.replaceAll('/', '_');
+    const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
-    // Skip download if source already exists (directory has files beyond the staging dir)
+    // Check if source was already downloaded successfully.
+    // A completed download has content files and no leftover 'download' staging dir.
+    // A leftover staging dir indicates a previous incomplete download that should be retried.
+    let needsDownload = true;
     if (await WorkspaceFS.exists(paperDirRelative)) {
       const entries = await WorkspaceFS.readDir(paperDirRelative);
       const hasContent = entries.some(([name]) => name !== 'download');
-      if (hasContent) {
-        const existingPath = WorkspaceFS.fullPath(paperDirRelative);
+      const hasStaging = entries.some(([name]) => name === 'download');
+      if (hasContent && !hasStaging) {
+        needsDownload = false;
         logger.info(
           this.channel,
-          `arXiv source already exists at: ${existingPath}`,
+          `arXiv source already exists at: ${paperDirFull}`,
         );
-        return existingPath;
       }
     }
 
-    await WorkspaceFS.ensureDir(paperDirRelative);
+    if (needsDownload) {
+      await WorkspaceFS.ensureDir(paperDirRelative);
 
-    // Create temporary download subdirectory for staging the archive
-    const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
-    const downloadDirRelative = path.join(paperDirRelative, 'download');
-    await WorkspaceFS.ensureDir(downloadDirRelative);
+      // Create temporary download subdirectory for staging the archive
+      const downloadDirRelative = path.join(paperDirRelative, 'download');
+      await WorkspaceFS.ensureDir(downloadDirRelative);
 
-    const downloadDirFull = path.join(paperDirFull, 'download');
-    const downloadBasePath = path.join(downloadDirFull, 'source');
+      const downloadDirFull = path.join(paperDirFull, 'download');
+      const downloadBasePath = path.join(downloadDirFull, 'source');
 
-    if (progressCallback) {
-      progressCallback(`Downloading arXiv source for ${id}...`, 20);
-    }
-
-    const downloadUrl = `https://arxiv.org/src/${id}`;
-    const downloadedPath = await this.downloadFile(
-      downloadUrl,
-      downloadBasePath,
-    );
-
-    const isArchive =
-      downloadedPath.endsWith('.tar') ||
-      downloadedPath.endsWith('.tar.gz') ||
-      downloadedPath.endsWith('.tgz');
-
-    // Detect gzip-compressed single files (.gz but not .tar.gz/.tgz)
-    const isGzipOnly = !isArchive && downloadedPath.endsWith('.gz');
-
-    if (isArchive) {
       if (progressCallback) {
-        progressCallback('Extracting source files...', 60);
+        progressCallback(`Downloading arXiv source for ${id}...`, 20);
       }
 
-      const extractResult = await this.extractTarFile(
-        downloadedPath,
-        paperDirFull,
-        { timeout: 30000 },
+      const downloadUrl = `https://arxiv.org/src/${id}`;
+      const downloadedPath = await this.downloadFile(
+        downloadUrl,
+        downloadBasePath,
       );
 
-      if (!extractResult.success) {
-        throw new Error(
-          `Failed to extract arXiv source: ${extractResult.error}`,
-        );
-      }
+      const isArchive =
+        downloadedPath.endsWith('.tar') ||
+        downloadedPath.endsWith('.tar.gz') ||
+        downloadedPath.endsWith('.tgz');
 
-      if (progressCallback) {
-        progressCallback('Cleaning up...', 80);
-      }
+      // Detect gzip-compressed single files (.gz but not .tar.gz/.tgz)
+      const isGzipOnly = !isArchive && downloadedPath.endsWith('.gz');
 
-      // Remove the downloaded archive file
-      await AbsoluteFS.delete(downloadedPath);
-    } else {
-      // For gzip-compressed single files, decompress first
-      let sourceFilePath = downloadedPath;
-      if (isGzipOnly) {
+      if (isArchive) {
         if (progressCallback) {
-          progressCallback('Decompressing source file...', 60);
+          progressCallback('Extracting source files...', 60);
         }
-        const decompressedPath = downloadedPath.replace(/\.gz$/, '');
-        await pipeline(
-          AbsoluteFS.createReadStream(downloadedPath),
-          createGunzip(),
-          AbsoluteFS.createWriteStream(decompressedPath),
+
+        const extractResult = await this.extractTarFile(
+          downloadedPath,
+          paperDirFull,
+          { timeout: 30000 },
         );
+
+        if (!extractResult.success) {
+          throw new Error(
+            `Failed to extract arXiv source: ${extractResult.error}`,
+          );
+        }
+
+        if (progressCallback) {
+          progressCallback('Cleaning up...', 80);
+        }
+
+        // Remove the downloaded archive file
         await AbsoluteFS.delete(downloadedPath);
-        sourceFilePath = decompressedPath;
+      } else {
+        // For gzip-compressed single files, decompress first
+        let sourceFilePath = downloadedPath;
+        if (isGzipOnly) {
+          if (progressCallback) {
+            progressCallback('Decompressing source file...', 60);
+          }
+          const decompressedPath = downloadedPath.replace(/\.gz$/, '');
+          await pipeline(
+            AbsoluteFS.createReadStream(downloadedPath),
+            createGunzip(),
+            AbsoluteFS.createWriteStream(decompressedPath),
+          );
+          await AbsoluteFS.delete(downloadedPath);
+          sourceFilePath = decompressedPath;
+        }
+
+        // Rename to main.tex and move to paper root
+        const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
+        // Use forward slashes to match WorkspaceFS.relativePath() convention
+        const targetRel = [paperDirRelative, 'main.tex'].join('/');
+        if (downloadedRel !== targetRel) {
+          await WorkspaceFS.rename(downloadedRel, targetRel);
+        }
       }
 
-      // Rename to main.tex and move to paper root
-      const downloadedRel = WorkspaceFS.relativePath(sourceFilePath);
-      // Use forward slashes to match WorkspaceFS.relativePath() convention
-      const targetRel = [paperDirRelative, 'main.tex'].join('/');
-      if (downloadedRel !== targetRel) {
-        await WorkspaceFS.rename(downloadedRel, targetRel);
+      // Remove the temporary download directory (files are now in paper root)
+      try {
+        await AbsoluteFS.delete(downloadDirFull, { recursive: true });
+      } catch (err) {
+        logger.debug(
+          this.channel,
+          `Could not remove download directory: ${toErrorMessage(err)}`,
+        );
       }
-    }
-
-    // Remove the temporary download directory (files are now in paper root)
-    try {
-      await AbsoluteFS.delete(downloadDirFull, { recursive: true });
-    } catch (err) {
-      logger.debug(
-        this.channel,
-        `Could not remove download directory: ${toErrorMessage(err)}`,
-      );
     }
 
     if (autoIndent) {

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -200,14 +200,13 @@ export class ArxivSourceProcessor {
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.
-    // A completed download has content files and no leftover 'download' staging dir.
-    // A leftover staging dir indicates a previous incomplete download that should be retried.
+    // A .tex file in the paper directory is a reliable signal that extraction completed,
+    // regardless of whether the staging 'download' dir was cleaned up afterwards.
     let needsDownload = true;
     if (await WorkspaceFS.exists(paperDirRelative)) {
       const entries = await WorkspaceFS.readDir(paperDirRelative);
-      const hasContent = entries.some(([name]) => name !== 'download');
-      const hasStaging = entries.some(([name]) => name === 'download');
-      if (hasContent && !hasStaging) {
+      const hasTexFiles = entries.some(([name]) => name.endsWith('.tex'));
+      if (hasTexFiles) {
         needsDownload = false;
         logger.info(
           this.channel,

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -197,6 +197,21 @@ export class ArxivSourceProcessor {
 
     // Create project directory for the arXiv paper (sanitize ID to avoid path issues)
     const paperDirRelative = id.replaceAll('/', '_');
+
+    // Skip download if source already exists (directory has files beyond the staging dir)
+    if (await WorkspaceFS.exists(paperDirRelative)) {
+      const entries = await WorkspaceFS.readDir(paperDirRelative);
+      const hasContent = entries.some(([name]) => name !== 'download');
+      if (hasContent) {
+        const existingPath = WorkspaceFS.fullPath(paperDirRelative);
+        logger.info(
+          this.channel,
+          `arXiv source already exists at: ${existingPath}`,
+        );
+        return existingPath;
+      }
+    }
+
     await WorkspaceFS.ensureDir(paperDirRelative);
 
     // Create temporary download subdirectory for staging the archive

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -93,7 +93,7 @@ describe('ArxivDownloadTool', () => {
     assert.strictEqual(validateCalls, 1);
     assert.strictEqual(receivedId, '2401.12345v2');
     assert.strictEqual(receivedAutoIndent, false);
-    assert.strictEqual(result.summary, 'Downloaded arXiv source to sample');
+    assert.strictEqual(result.summary, 'arXiv source available at sample');
     assert.ok(result.output?.includes('Listing for sample'));
     assert.ok(result.output?.includes('file main.tex'));
   });

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -63,7 +63,7 @@ export class ArxivDownloadTool extends defineTool({
       listingOutput = `Failed to list directory: ${toErrorMessage(err)}`;
     }
 
-    const summary = `Downloaded arXiv source to ${displayPath}`;
+    const summary = `arXiv source available at ${displayPath}`;
     const output = [
       summary,
       '',


### PR DESCRIPTION
## Summary
This PR adds logic to skip downloading arXiv sources when they already exist locally, improving efficiency and preventing redundant downloads.

## Key Changes
- **ArxivSourceProcessor**: Added a check before downloading to detect if the paper directory already exists with content (files other than the staging `download` directory). If content exists, the method returns the existing path without re-downloading.
- **User-facing messaging**: Updated summary messages from "Downloaded arXiv source to..." to "arXiv source available at..." to accurately reflect that the source may have been retrieved from cache rather than freshly downloaded.
- **Test updates**: Updated test assertion to match the new summary message format.

## Implementation Details
The existence check examines the target directory and looks for any entries besides the `download` staging directory. This allows the processor to distinguish between:
- A fresh directory that needs population
- An already-populated directory that can be reused

This optimization reduces unnecessary network requests and processing time when the same arXiv paper is accessed multiple times.

https://claude.ai/code/session_01XUj8fJEyrk866rwcJd823X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a simple existence check to bypass network/download work and only changes messaging/tests; minimal impact outside arXiv source retrieval behavior.
> 
> **Overview**
> Avoids redundant arXiv source downloads by short-circuiting `ArxivSourceProcessor.downloadSource()` when the target paper directory already contains extracted `.tex` files.
> 
> Updates user-facing output from the `download_arxiv_source` tool to say "arXiv source available at ..." (instead of implying a fresh download), and adjusts the associated unit test expectation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2080fd7ecd6282dc8401e3d4ce930dede59c919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->