### PR TITLE
Add Select All/Unselect All buttons to agent selection panel

### DIFF
--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -334,6 +334,7 @@ export const SETTINGS_VIEW_CMD = {
   GET_AGENT_SELECTION: 'getAgentSelection',
   OPEN_AGENT_YAML: 'openAgentYaml',
   SET_AGENT_ENABLED: 'setAgentEnabled',
+  SET_ALL_AGENTS_ENABLED: 'setAllAgentsEnabled',
   OPEN_AGENT_FOLDER: 'openAgentFolder',
   CREATE_AGENT: 'createAgent',
   // Remote agent auto-show

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -396,6 +396,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenAgentYaml(data),
       [SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED]: (data) =>
         this.handleSetAgentEnabled(data),
+      [SETTINGS_VIEW_COMMANDS.SET_ALL_AGENTS_ENABLED]: (data) =>
+        this.handleSetAllAgentsEnabled(data),
       [SETTINGS_VIEW_COMMANDS.OPEN_AGENT_FOLDER]: (data) =>
         this.handleOpenAgentFolder(data),
       [SETTINGS_VIEW_COMMANDS.CREATE_AGENT]: (data) =>
@@ -1141,6 +1143,41 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         updated = current.filter(
           (entry) => entry !== key && entry !== data.agentName,
         );
+      }
+
+      await workspaceSM.update(stateKey, updated);
+
+      void vscode.commands.executeCommand('texra.refreshAllOptions');
+      await this.withActiveWebview((w) => this.sendAgentSelectionData(w));
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to update agent visibility',
+        error,
+      );
+    }
+  }
+
+  private async handleSetAllAgentsEnabled(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_ALL_AGENTS_ENABLED>,
+  ): Promise<void> {
+    try {
+      const stateKey =
+        data.category === 'workflow'
+          ? WorkspaceStateKey.ENABLED_AGENTS
+          : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS;
+
+      let updated: string[];
+      if (data.enabled) {
+        // Enable all: store all agent keys
+        const allAgents =
+          data.category === 'workflow'
+            ? getWorkflowAgents()
+            : getToolUseAgents();
+        updated = allAgents.map((e) => createKey(e.source, e.name));
+      } else {
+        // Disable all: empty array means "nothing enabled"
+        updated = [];
       }
 
       await workspaceSM.update(stateKey, updated);

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -419,6 +419,10 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED,
   );
 
+  private handleSetAllAgentsEnabled = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_ALL_AGENTS_ENABLED,
+  );
+
   private handleOpenAgentFolder = forwardDetail(
     SETTINGS_VIEW_COMMANDS.OPEN_AGENT_FOLDER,
   );
@@ -577,6 +581,7 @@ export class SettingsApp extends BaseWebviewApp {
               .initialSubTab=${this.agentSubTab}
               @agent-open-yaml=${this.handleOpenAgentYaml}
               @agent-enabled-set=${this.handleSetAgentEnabled}
+              @agent-all-enabled-set=${this.handleSetAllAgentsEnabled}
               @agent-open-folder=${this.handleOpenAgentFolder}
               @agent-auto-show-remote=${this.handleSetAutoShowRemote}
               @agent-create=${this.handleCreateAgent}

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -232,11 +232,34 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-count {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
         padding: var(--spacing-small) var(--spacing-medium);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         border-top: var(--border-thin) solid var(--color-border);
         background: var(--vscode-editor-background);
+      }
+
+      .agent-count-actions {
+        display: flex;
+        gap: var(--spacing-small);
+      }
+
+      .agent-count-link {
+        font-size: var(--font-size-xs);
+        font-family: inherit;
+        color: var(--vscode-textLink-foreground);
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        text-decoration: none;
+      }
+
+      .agent-count-link:hover {
+        text-decoration: underline;
       }
 
       .agent-empty-message {
@@ -353,6 +376,15 @@ export class AgentSelectionPanel extends LitElement {
         agentSource: agent.source,
         category: this.category,
         enabled: !agent.enabled,
+      }),
+    );
+  }
+
+  private handleSetAllEnabled(enabled: boolean): void {
+    this.dispatchEvent(
+      AgentSelectionEvents.setAllEnabled({
+        category: this.category,
+        enabled,
       }),
     );
   }
@@ -534,8 +566,30 @@ export class AgentSelectionPanel extends LitElement {
         ${this.renderList()} ${this.renderDetail()}
       </div>
       <div class="agent-count">
-        ${enabledCount}/${this.agents.length}
-        agent${this.agents.length !== 1 ? 's' : ''} visible
+        <span>
+          ${enabledCount}/${this.agents.length}
+          agent${this.agents.length !== 1 ? 's' : ''} visible
+        </span>
+        <span class="agent-count-actions">
+          ${enabledCount < this.agents.length
+            ? html`<button
+                class="agent-count-link"
+                @click=${() => this.handleSetAllEnabled(true)}
+                title="Show all agents in dropdowns"
+              >
+                Select All
+              </button>`
+            : nothing}
+          ${enabledCount > 0
+            ? html`<button
+                class="agent-count-link"
+                @click=${() => this.handleSetAllEnabled(false)}
+                title="Hide all agents from dropdowns"
+              >
+                Unselect All
+              </button>`
+            : nothing}
+        </span>
       </div>
     `;
   }

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -45,6 +45,10 @@ export const AgentSelectionEvents = {
     category: 'workflow' | 'toolUse';
     enabled: boolean;
   }) => createEvent('agent-enabled-set', detail),
+  setAllEnabled: (detail: {
+    category: 'workflow' | 'toolUse';
+    enabled: boolean;
+  }) => createEvent('agent-all-enabled-set', detail),
   openFolder: (detail: {
     folderType: 'custom' | 'builtInWorkflow' | 'builtInToolUse';
   }) => createEvent('agent-open-folder', detail),

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -339,6 +339,12 @@ const SetAgentEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+const SetAllAgentsEnabledMessageSchema = z.object({
+  command: z.literal(CMD.SET_ALL_AGENTS_ENABLED),
+  category: AgentCategorySchema,
+  enabled: z.boolean(),
+});
+
 const OpenAgentFolderMessageSchema = z.object({
   command: z.literal(CMD.OPEN_AGENT_FOLDER),
   folderType: z.enum(['custom', 'builtInWorkflow', 'builtInToolUse']),
@@ -439,6 +445,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetAgentSelectionMessageSchema,
     OpenAgentYamlMessageSchema,
     SetAgentEnabledMessageSchema,
+    SetAllAgentsEnabledMessageSchema,
     OpenAgentFolderMessageSchema,
     CreateAgentMessageSchema,
     // Auto-show remote agents messages


### PR DESCRIPTION
## Summary
This PR adds "Select All" and "Unselect All" action buttons to the agent selection panel footer, allowing users to quickly enable or disable all agents in a category at once.

## Key Changes
- **UI Updates**: Modified the agent count footer section to display action buttons alongside the agent count
  - Added flexbox layout to `.agent-count` for proper spacing
  - Created new `.agent-count-actions` and `.agent-count-link` styles for button styling
  - Conditionally render "Select All" button when not all agents are enabled
  - Conditionally render "Unselect All" button when at least one agent is enabled

- **Event Handling**: Added new event and handler infrastructure
  - Created `setAllEnabled` event in `AgentSelectionEvents`
  - Added `handleSetAllEnabled` method to dispatch the new event
  - Wired up event listener in `SettingsApp` component

- **Backend Processing**: Implemented server-side logic to handle bulk agent enable/disable
  - Added `handleSetAllAgentsEnabled` method in `SettingsViewMessageHandler`
  - Handles both workflow and tool-use agent categories
  - Updates workspace state with all agent keys when enabling, or empty array when disabling
  - Triggers refresh of all options after update

- **Message Schema**: Extended settings view message protocol
  - Added `SET_ALL_AGENTS_ENABLED` command constant
  - Created `SetAllAgentsEnabledMessageSchema` for validation
  - Integrated new message type into inbound message schema

## Implementation Details
- The buttons use the existing link styling (`agent-count-link`) to maintain visual consistency
- Buttons are conditionally rendered based on current state to avoid redundant actions
- The implementation mirrors the existing single-agent enable/disable pattern for consistency
- Both workflow and tool-use agent categories are supported

https://claude.ai/code/session_014CdmXc6afWq3wcJ87HFAWr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to settings UI and workspace-state updates for agent visibility; minimal surface area and no auth/data-processing changes.
> 
> **Overview**
> Adds **Select All / Unselect All** actions to the agent selection panel footer so users can quickly show/hide all agents in a category.
> 
> Introduces a new `SET_ALL_AGENTS_ENABLED` settings-view command and message schema, wires a new `agent-all-enabled-set` frontend event through `SettingsApp`, and implements a backend handler that updates the relevant workspace state (workflow vs tool-use) to either all agent keys or an empty list, then refreshes options and the webview.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8cda0a31a548694c2fb4cab3e31999c410e17d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->