### PR TITLE
Add editor type tracking to usage logs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,8 @@ export async function activate(context: vscode.ExtensionContext) {
           typeof context.extension.packageJSON?.version === 'string'
             ? context.extension.packageJSON.version
             : undefined;
-        UsageLogService.initialize({}, extensionVersion);
+        const editorType = vscode.env.appName || undefined;
+        UsageLogService.initialize({}, extensionVersion, editorType);
         // Add safety net disposable in case deactivate() isn't called
         context.subscriptions.push({
           dispose: () => void UsageLogService.dispose(),

--- a/src/logger/UsageLogService.ts
+++ b/src/logger/UsageLogService.ts
@@ -36,13 +36,16 @@ class UsageLogServiceImpl {
   private isFlushing = false;
   private config: UsageLogConfig = DEFAULT_CONFIG;
   private extensionVersion: string | undefined;
+  private editorType: string | undefined;
 
   initialize(
     config?: Partial<UsageLogConfig>,
     extensionVersion?: string,
+    editorType?: string,
   ): void {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.extensionVersion = extensionVersion;
+    this.editorType = editorType;
     this.startFlushTimer();
 
     logger.debug(
@@ -63,6 +66,7 @@ class UsageLogServiceImpl {
       ...entry,
       timestamp: new Date().toISOString(),
       extensionVersion: this.extensionVersion,
+      editorType: this.editorType,
     });
     logger.debug(
       CHANNEL,

--- a/src/logger/UsageLogService.ts
+++ b/src/logger/UsageLogService.ts
@@ -54,7 +54,7 @@ class UsageLogServiceImpl {
     );
   }
 
-  log(entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion'>): void {
+  log(entry: Omit<UsageLogEntry, 'timestamp' | 'extensionVersion' | 'editorType'>): void {
     if (!this.config.enabled) return;
 
     if (this.queue.length >= MAX_QUEUE_SIZE) {

--- a/src/logger/UsageLogTypes.ts
+++ b/src/logger/UsageLogTypes.ts
@@ -32,6 +32,7 @@ export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
 ).extend({
   timestamp: z.iso.datetime(),
   extensionVersion: z.string().optional(),
+  editorType: z.string().optional(),
 });
 
 export type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -43,6 +43,7 @@ interface UsageLogEntry {
   usedRelay?: boolean;
   streamId?: string;
   extensionVersion?: string;
+  editorType?: string;
 }
 
 // =============================================================================
@@ -123,6 +124,8 @@ function validateEntry(entry: unknown): UsageLogEntry | null {
     streamId: typeof e.streamId === 'string' ? e.streamId : undefined,
     extensionVersion:
       typeof e.extensionVersion === 'string' ? e.extensionVersion : undefined,
+    editorType:
+      typeof e.editorType === 'string' ? e.editorType : undefined,
   };
 }
 
@@ -264,6 +267,7 @@ Deno.serve(async (req: Request) => {
       used_relay: entry.usedRelay,
       stream_id: entry.streamId,
       extension_version: entry.extensionVersion,
+      editor_type: entry.editorType,
       batch_id: batch.batchId,
     }));
 

--- a/supabase/migrations/20260214_add_editor_type_to_usage_logs.sql
+++ b/supabase/migrations/20260214_add_editor_type_to_usage_logs.sql
@@ -1,0 +1,7 @@
+-- Migration: Add editor_type column to usage_logs
+--
+-- Tracks which editor the extension is running in (e.g., "Visual Studio Code", "Cursor", "Windsurf").
+
+ALTER TABLE public.usage_logs ADD COLUMN IF NOT EXISTS editor_type TEXT;
+
+COMMENT ON COLUMN public.usage_logs.editor_type IS 'Editor application name (e.g., Visual Studio Code, Cursor)';


### PR DESCRIPTION
## Summary
This PR adds editor type information to usage log entries, allowing better tracking of which editor (VS Code, VS, etc.) is using the extension.

## Key Changes
- **UsageLogService**: Added `editorType` field to track the editor application name
  - Added `editorType` as an optional private property
  - Updated `initialize()` method to accept and store `editorType` parameter
  - Included `editorType` in logged entries alongside existing metadata

- **Extension activation**: Capture and pass editor type during initialization
  - Extract editor type from `vscode.env.appName` during extension activation
  - Pass `editorType` to `UsageLogService.initialize()`

- **UsageLogTypes**: Extended schema to support the new field
  - Added `editorType: z.string().optional()` to `UsageLogEntrySchema`

## Implementation Details
The editor type is captured from the VS Code API (`vscode.env.appName`) at extension activation time and propagated through the usage logging system. This allows usage analytics to differentiate between different editor environments where the extension is installed.

https://claude.ai/code/session_014AWHSvTWVr4Zrhh1smQW4g

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive analytics change (new optional field + DB column) with minimal behavior impact; main risk is mismatched schema/migration deployment causing dropped/ignored values.
> 
> **Overview**
> Adds editor-type tracking to usage analytics by capturing `vscode.env.appName` at activation and passing it into `UsageLogService`, which now includes `editorType` on each queued usage entry.
> 
> Updates the shared usage log schema and the Supabase `log-usage` edge function to validate and persist the new field, plus a DB migration adding `usage_logs.editor_type`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce389cb90b8ee45481812e2614f253573c31d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->