### PR TITLE
Make Select All / Unselect All per source type (builtin/custom/remote)

### DIFF
--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1172,11 +1172,12 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           ? getWorkflowAgents()
           : getToolUseAgents();
 
+      const sourceAgents = allAgents.filter((e) => e.source === data.source);
       const targetKeys = new Set(
-        allAgents
-          .filter((e) => e.source === data.source)
-          .map((e) => createKey(e.source, e.name)),
+        sourceAgents.map((e) => createKey(e.source, e.name)),
       );
+      // Legacy entries may use plain agent names without source prefix
+      const targetLegacyNames = new Set(sourceAgents.map((e) => e.name));
 
       // Resolve current state: undefined means "all enabled" (never configured)
       const raw = workspaceSM.get<string[]>(stateKey);
@@ -1192,8 +1193,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           ...[...targetKeys].filter((k) => !currentSet.has(k)),
         ];
       } else {
-        // Remove all keys from the target source
-        updated = current.filter((k) => !targetKeys.has(k));
+        // Remove both source:name and legacy plain-name entries for this source
+        updated = current.filter(
+          (k) => !targetKeys.has(k) && !targetLegacyNames.has(k),
+        );
       }
 
       await workspaceSM.update(stateKey, updated);

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1167,17 +1167,33 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           ? WorkspaceStateKey.ENABLED_AGENTS
           : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS;
 
+      const allAgents =
+        data.category === 'workflow'
+          ? getWorkflowAgents()
+          : getToolUseAgents();
+
+      const targetKeys = new Set(
+        allAgents
+          .filter((e) => e.source === data.source)
+          .map((e) => createKey(e.source, e.name)),
+      );
+
+      // Resolve current state: undefined means "all enabled" (never configured)
+      const raw = workspaceSM.get<string[]>(stateKey);
+      const current =
+        raw ?? allAgents.map((e) => createKey(e.source, e.name));
+
       let updated: string[];
       if (data.enabled) {
-        // Enable all: store all agent keys
-        const allAgents =
-          data.category === 'workflow'
-            ? getWorkflowAgents()
-            : getToolUseAgents();
-        updated = allAgents.map((e) => createKey(e.source, e.name));
+        // Add all keys from the target source (deduplicated)
+        const currentSet = new Set(current);
+        updated = [
+          ...current,
+          ...[...targetKeys].filter((k) => !currentSet.has(k)),
+        ];
       } else {
-        // Disable all: empty array means "nothing enabled"
-        updated = [];
+        // Remove all keys from the target source
+        updated = current.filter((k) => !targetKeys.has(k));
       }
 
       await workspaceSM.update(stateKey, updated);

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -67,6 +67,7 @@ export class AgentSelectionPanel extends LitElement {
       .agent-list-section-header {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         padding: var(--spacing-small) var(--spacing-medium);
         font-size: var(--font-size-xs);
         font-weight: 600;
@@ -78,6 +79,14 @@ export class AgentSelectionPanel extends LitElement {
         position: sticky;
         top: 0;
         z-index: 1;
+      }
+
+      .agent-list-section-actions {
+        display: flex;
+        gap: var(--spacing-small);
+        text-transform: none;
+        letter-spacing: normal;
+        font-weight: normal;
       }
 
       .agent-list-item {
@@ -380,10 +389,11 @@ export class AgentSelectionPanel extends LitElement {
     );
   }
 
-  private handleSetAllEnabled(enabled: boolean): void {
+  private handleSetAllEnabled(source: string, enabled: boolean): void {
     this.dispatchEvent(
       AgentSelectionEvents.setAllEnabled({
         category: this.category,
+        source,
         enabled,
       }),
     );
@@ -452,10 +462,31 @@ export class AgentSelectionPanel extends LitElement {
       >
         ${orderedSources.map((source) => {
           const agents = groups.get(source)!;
+          const enabledInGroup = agents.filter((a) => a.enabled).length;
           return html`
             ${showHeaders
               ? html`<div class="agent-list-section-header">
-                  ${SOURCE_DISPLAY_NAMES[source] ?? source}
+                  <span>${SOURCE_DISPLAY_NAMES[source] ?? source}</span>
+                  <span class="agent-list-section-actions">
+                    ${enabledInGroup < agents.length
+                      ? html`<button
+                          class="agent-count-link"
+                          @click=${() => this.handleSetAllEnabled(source, true)}
+                          title="Show all ${SOURCE_DISPLAY_NAMES[source] ?? source} agents"
+                        >
+                          All
+                        </button>`
+                      : nothing}
+                    ${enabledInGroup > 0
+                      ? html`<button
+                          class="agent-count-link"
+                          @click=${() => this.handleSetAllEnabled(source, false)}
+                          title="Hide all ${SOURCE_DISPLAY_NAMES[source] ?? source} agents"
+                        >
+                          None
+                        </button>`
+                      : nothing}
+                  </span>
                 </div>`
               : nothing}
             ${agents.map((a) => this.renderListItem(a))}
@@ -560,6 +591,10 @@ export class AgentSelectionPanel extends LitElement {
     }
 
     const enabledCount = this.agents.filter((a) => a.enabled).length;
+    const singleSource =
+      this.groupedSources.size === 1
+        ? [...this.groupedSources.keys()][0]
+        : null;
 
     return html`
       <div class="agent-split-panel">
@@ -570,26 +605,28 @@ export class AgentSelectionPanel extends LitElement {
           ${enabledCount}/${this.agents.length}
           agent${this.agents.length !== 1 ? 's' : ''} visible
         </span>
-        <span class="agent-count-actions">
-          ${enabledCount < this.agents.length
-            ? html`<button
-                class="agent-count-link"
-                @click=${() => this.handleSetAllEnabled(true)}
-                title="Show all agents in dropdowns"
-              >
-                Select All
-              </button>`
-            : nothing}
-          ${enabledCount > 0
-            ? html`<button
-                class="agent-count-link"
-                @click=${() => this.handleSetAllEnabled(false)}
-                title="Hide all agents from dropdowns"
-              >
-                Unselect All
-              </button>`
-            : nothing}
-        </span>
+        ${singleSource
+          ? html`<span class="agent-count-actions">
+              ${enabledCount < this.agents.length
+                ? html`<button
+                    class="agent-count-link"
+                    @click=${() => this.handleSetAllEnabled(singleSource, true)}
+                    title="Show all agents"
+                  >
+                    All
+                  </button>`
+                : nothing}
+              ${enabledCount > 0
+                ? html`<button
+                    class="agent-count-link"
+                    @click=${() => this.handleSetAllEnabled(singleSource, false)}
+                    title="Hide all agents"
+                  >
+                    None
+                  </button>`
+                : nothing}
+            </span>`
+          : nothing}
       </div>
     `;
   }

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -19,7 +19,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { codiconStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared schemas and events
-import { AGENT_SOURCE, type AgentCategory } from '@shared/schemas/agent';
+import {
+  AGENT_SOURCE,
+  type AgentCategory,
+  type AgentSourceType,
+} from '@shared/schemas/agent';
 import { AgentSelectionEvents } from './events';
 import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
 
@@ -283,7 +287,7 @@ export class AgentSelectionPanel extends LitElement {
 
   @state() private selectedKey: string | null = null;
 
-  @state() private groupedSources: Map<string, AgentSelectionItem[]> =
+  @state() private groupedSources: Map<AgentSourceType, AgentSelectionItem[]> =
     new Map();
 
   /** Flat list in visual display order, for keyboard navigation */
@@ -298,7 +302,7 @@ export class AgentSelectionPanel extends LitElement {
 
   protected override willUpdate(changed: PropertyValues): void {
     if (changed.has('agents')) {
-      const groups = new Map<string, AgentSelectionItem[]>();
+      const groups = new Map<AgentSourceType, AgentSelectionItem[]>();
       for (const agent of this.agents) {
         const list = groups.get(agent.source) ?? [];
         list.push(agent);
@@ -389,7 +393,7 @@ export class AgentSelectionPanel extends LitElement {
     );
   }
 
-  private handleSetAllEnabled(source: string, enabled: boolean): void {
+  private handleSetAllEnabled(source: AgentSourceType, enabled: boolean): void {
     this.dispatchEvent(
       AgentSelectionEvents.setAllEnabled({
         category: this.category,

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -47,6 +47,7 @@ export const AgentSelectionEvents = {
   }) => createEvent('agent-enabled-set', detail),
   setAllEnabled: (detail: {
     category: 'workflow' | 'toolUse';
+    source: string;
     enabled: boolean;
   }) => createEvent('agent-all-enabled-set', detail),
   openFolder: (detail: {

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -47,7 +47,7 @@ export const AgentSelectionEvents = {
   }) => createEvent('agent-enabled-set', detail),
   setAllEnabled: (detail: {
     category: 'workflow' | 'toolUse';
-    source: string;
+    source: AgentSourceType;
     enabled: boolean;
   }) => createEvent('agent-all-enabled-set', detail),
   openFolder: (detail: {

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -342,6 +342,7 @@ const SetAgentEnabledMessageSchema = z.object({
 const SetAllAgentsEnabledMessageSchema = z.object({
   command: z.literal(CMD.SET_ALL_AGENTS_ENABLED),
   category: AgentCategorySchema,
+  source: AgentSourceSchema,
   enabled: z.boolean(),
 });
 


### PR DESCRIPTION
Instead of a single global Select All / Unselect All for the entire
agent category, each source group section header (Built-in, Custom,
Remote) now has its own All/None buttons. The backend handler filters
by the specified source, preserving enabled state of agents from other
sources. When only one source exists, the footer retains the buttons.

https://claude.ai/code/session_016raNBd92jQq5fDxLAa7PR4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how enabled-agent workspace state is computed and persisted, which could unintentionally alter agent visibility if edge cases (undefined state, legacy keys, per-source filtering) are mishandled. UI/event contract changes also require frontend/backend schema alignment.
> 
> **Overview**
> Agent visibility bulk actions are now **scoped per agent source** (Built-in/Custom/Remote) instead of a single category-wide Select/Unselect All.
> 
> The frontend adds per-source `All`/`None` controls in each source section header (and only keeps footer controls when a single source exists), and the `SET_ALL_AGENTS_ENABLED` message/event/schema now includes a required `source`.
> 
> Backend handling of `SET_ALL_AGENTS_ENABLED` is updated to only add/remove enabled entries for the specified source while preserving other sources, including cleanup of legacy plain-name entries and correct handling of the “undefined means all enabled” state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7844f155cdc70b06007c0715b568255f288b1e4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->