### PR TITLE
fix: prevent os.homedir() crash in environments without a home directory

### DIFF
--- a/src/tools/gitignore.ts
+++ b/src/tools/gitignore.ts
@@ -1,11 +1,11 @@
 // Standard library imports
-import * as os from 'os';
 import * as path from 'path';
 
 // Local imports - utils
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { normalizeLineEndings } from '@utils/text/stringUtils';
 import { toPosixPath } from '@utils/core/pathCore';
+import { safeHomedir } from '@utils/system/platformPaths';
 
 // Local file imports
 import { createGlobMatcher } from './utils';
@@ -135,11 +135,11 @@ async function readAbsoluteGitignore(
 }
 
 async function readGlobalGitignore(): Promise<GitignoreSource[]> {
+  const homeDirectory = safeHomedir();
+  if (!homeDirectory) {
+    return [];
+  }
   try {
-    const homeDirectory = os.homedir();
-    if (!homeDirectory) {
-      return [];
-    }
     const source = await readAbsoluteGitignore(
       path.join(homeDirectory, '.gitignore_global'),
     );

--- a/src/utils/files/rulesUtils.ts
+++ b/src/utils/files/rulesUtils.ts
@@ -1,8 +1,8 @@
-import * as os from 'os';
 import * as path from 'path';
 
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import { safeHomedir } from '@utils/system/platformPaths';
 
 import { AbsoluteFS } from './absoluteFS';
 import { WorkspaceFS } from './workspaceFS';
@@ -28,12 +28,15 @@ export async function loadTexraRules(): Promise<string> {
       }
     }
 
-    const homeFile = path.join(os.homedir(), RULES_FILE);
-    if (await AbsoluteFS.exists(homeFile)) {
-      const content = await AbsoluteFS.read(homeFile);
-      if (content.trim()) {
-        logger.debug(CHANNEL, `Loaded home ${RULES_FILE}`);
-        return content.trim();
+    const homeDir = safeHomedir();
+    if (homeDir) {
+      const homeFile = path.join(homeDir, RULES_FILE);
+      if (await AbsoluteFS.exists(homeFile)) {
+        const content = await AbsoluteFS.read(homeFile);
+        if (content.trim()) {
+          logger.debug(CHANNEL, `Loaded home ${RULES_FILE}`);
+          return content.trim();
+        }
       }
     }
   } catch (err) {

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import * as os from 'os';
 import * as path from 'path';
 
 // Third-party imports
@@ -23,6 +24,19 @@ let cachedExtraDirs: string[] | null = null;
 
 const DEFAULT_MSYS_ROOTS = ['C:\\msys64', 'C:\\msys32'];
 const MSYS_SUBDIRS = ['usr\\bin', 'mingw64\\bin', 'mingw32\\bin'];
+
+/**
+ * Safe wrapper around `os.homedir()` that returns `null` instead of throwing.
+ * `os.homedir()` can throw a SystemError (UV_ENOENT) in environments where the
+ * home directory cannot be determined (containers, CI/CD, some remote setups).
+ */
+export function safeHomedir(): string | null {
+  try {
+    return os.homedir() || null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Return common tool directories based on the current platform.


### PR DESCRIPTION
os.homedir() can throw SystemError (UV_ENOENT) in containers, CI/CD,
and remote development environments where the home directory cannot be
determined. Add safeHomedir() wrapper that returns null instead of
throwing, and use it in rulesUtils and gitignore loading.

https://claude.ai/code/session_01WvKrJdgZY22LgHQcCZVMv6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change that only affects optional home-directory file loading; behavior degrades to “no global rules” instead of crashing.
> 
> **Overview**
> Avoids `os.homedir()` crashes in environments without a resolvable home directory by adding `safeHomedir()` in `platformPaths.ts`.
> 
> Updates global ignore/rules loading (`gitignore.ts` and `rulesUtils.ts`) to use `safeHomedir()` and gracefully skip home-directory lookups when unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5880b22facfb48f763af5d4cc94fb2432f8f4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->