### PR TITLE
Aggregate per-round usage logs into single database record

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -598,6 +598,7 @@ export async function executeAgent(
             onFollowUpConsumed: () =>
               bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
           });
+          ctx.usageMonitor.flushToBackend();
           return {
             category: 'toolUse' as const,
             status: result.status,
@@ -616,6 +617,7 @@ export async function executeAgent(
           parentStage: ctx.parentStage,
           onRoundCompleted: createRoundProgressCallback(ctx.executionId),
         });
+        ctx.usageMonitor.flushToBackend();
         return {
           category: 'workflow' as const,
           status: result.status,
@@ -672,6 +674,7 @@ export async function executeMergeAgent(
         parentStage: ctx.parentStage,
         onRoundCompleted: createRoundProgressCallback(ctx.executionId),
       });
+      ctx.usageMonitor.flushToBackend();
       return {
         category: 'workflow' as const,
         status: result.status,
@@ -721,6 +724,7 @@ export async function resumeToolUseFromSnapshot(
         undefined,
         setupSession ? (context) => setupSession(context.session) : undefined,
       );
+      ctx.usageMonitor.flushToBackend();
       return {
         category: 'toolUse' as const,
         status: result.status,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -586,45 +586,47 @@ export async function executeAgent(
         logger.info(`Executing ${agentName} with model ${config.model}`);
         const interrupts = createInterruptCallbacks();
 
-        if (setting.agentCategory === AgentCategory.ToolUse) {
-          const result = await runToolUseFlow({
+        try {
+          if (setting.agentCategory === AgentCategory.ToolUse) {
+            const result = await runToolUseFlow({
+              ...ctx,
+              ...interrupts,
+              onRoundFinalized: (run) =>
+                ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+              setting: ctx.setting as AgentToolUseSetting,
+              isSubagent,
+              onBeforeWaiting: options?.onBeforeWaiting,
+              onFollowUpConsumed: () =>
+                bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
+            });
+            return {
+              category: 'toolUse' as const,
+              status: result.status,
+              lastResponse: result.lastResponse,
+              executionId: ctx.executionId,
+              streamId,
+            };
+          }
+
+          const result = await runReflectionFlow({
             ...ctx,
             ...interrupts,
             onRoundFinalized: (run) =>
-              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-            setting: ctx.setting as AgentToolUseSetting,
-            isSubagent,
-            onBeforeWaiting: options?.onBeforeWaiting,
-            onFollowUpConsumed: () =>
-              bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
+              ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+            setting: ctx.setting as AgentWorkflowSetting,
+            parentStage: ctx.parentStage,
+            onRoundCompleted: createRoundProgressCallback(ctx.executionId),
           });
-          ctx.usageMonitor.flushToBackend();
           return {
-            category: 'toolUse' as const,
+            category: 'workflow' as const,
             status: result.status,
-            lastResponse: result.lastResponse,
+            outputs: toOutputSummaries(result.roundOutputs),
             executionId: ctx.executionId,
             streamId,
           };
+        } finally {
+          ctx.usageMonitor.flushToBackend();
         }
-
-        const result = await runReflectionFlow({
-          ...ctx,
-          ...interrupts,
-          onRoundFinalized: (run) =>
-            ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-          setting: ctx.setting as AgentWorkflowSetting,
-          parentStage: ctx.parentStage,
-          onRoundCompleted: createRoundProgressCallback(ctx.executionId),
-        });
-        ctx.usageMonitor.flushToBackend();
-        return {
-          category: 'workflow' as const,
-          status: result.status,
-          outputs: toOutputSummaries(result.roundOutputs),
-          executionId: ctx.executionId,
-          streamId,
-        };
       });
     },
     {
@@ -660,28 +662,31 @@ export async function executeMergeAgent(
       logger.info(`Executing merge with model ${model}`);
 
       const fileService = new TaskRunFileService(executionId);
-      const result = await runReflectionFlow({
-        ...ctx,
-        ...createInterruptCallbacks(),
-        onRoundFinalized: (run) =>
-          ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-        setting: ctx.setting as AgentWorkflowSetting,
-        getOutputFileLocation: createMergeOutputFileLocationGetter(
-          inputFile,
-          editedFile,
-          fileService,
-        ),
-        parentStage: ctx.parentStage,
-        onRoundCompleted: createRoundProgressCallback(ctx.executionId),
-      });
-      ctx.usageMonitor.flushToBackend();
-      return {
-        category: 'workflow' as const,
-        status: result.status,
-        outputs: toOutputSummaries(result.roundOutputs),
-        executionId: ctx.executionId,
-        streamId,
-      };
+      try {
+        const result = await runReflectionFlow({
+          ...ctx,
+          ...createInterruptCallbacks(),
+          onRoundFinalized: (run) =>
+            ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+          setting: ctx.setting as AgentWorkflowSetting,
+          getOutputFileLocation: createMergeOutputFileLocationGetter(
+            inputFile,
+            editedFile,
+            fileService,
+          ),
+          parentStage: ctx.parentStage,
+          onRoundCompleted: createRoundProgressCallback(ctx.executionId),
+        });
+        return {
+          category: 'workflow' as const,
+          status: result.status,
+          outputs: toOutputSummaries(result.roundOutputs),
+          executionId: ctx.executionId,
+          streamId,
+        };
+      } finally {
+        ctx.usageMonitor.flushToBackend();
+      }
     });
   });
 }
@@ -710,28 +715,31 @@ export async function resumeToolUseFromSnapshot(
     async () => {
       StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
 
-      const result = await runToolUseFlow(
-        {
-          ...ctx,
-          ...createInterruptCallbacks(),
-          onRoundFinalized: (run) =>
-            ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-          setting: setting as AgentToolUseSetting,
-          resumeSnapshot: snapshot,
-          onFollowUpConsumed: () =>
-            bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
-        },
-        undefined,
-        setupSession ? (context) => setupSession(context.session) : undefined,
-      );
-      ctx.usageMonitor.flushToBackend();
-      return {
-        category: 'toolUse' as const,
-        status: result.status,
-        lastResponse: result.lastResponse,
-        executionId: ctx.executionId,
-        streamId,
-      };
+      try {
+        const result = await runToolUseFlow(
+          {
+            ...ctx,
+            ...createInterruptCallbacks(),
+            onRoundFinalized: (run) =>
+              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+            setting: setting as AgentToolUseSetting,
+            resumeSnapshot: snapshot,
+            onFollowUpConsumed: () =>
+              bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
+          },
+          undefined,
+          setupSession ? (context) => setupSession(context.session) : undefined,
+        );
+        return {
+          category: 'toolUse' as const,
+          status: result.status,
+          lastResponse: result.lastResponse,
+          executionId: ctx.executionId,
+          streamId,
+        };
+      } finally {
+        ctx.usageMonitor.flushToBackend();
+      }
     },
     { category: 'toolUse' },
   );

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -10,6 +10,7 @@ import {
   UsageLogService,
   type AgentLogger,
   type AgentUsageReporter,
+  type UsageLogRound,
 } from '@logger/index';
 import type { ModelCapabilities, ModelConfig } from 'llm-zoo';
 import type {
@@ -81,6 +82,15 @@ export class UsageMonitor {
    * rather than the parent stage.
    */
   private activeGroupId: string | undefined;
+
+  /**
+   * Accumulated per-round usage snapshots.
+   * Instead of logging each round to the backend individually, we collect
+   * snapshots and flush once when the agent execution completes.
+   * This reduces N database rows per tool-use run down to 1.
+   */
+  private accumulatedRounds: UsageLogRound[] = [];
+  private accumulatedResponseTimeMs = 0;
 
   constructor(
     private readonly modelInfo: UsageMonitorModelInfo,
@@ -159,18 +169,56 @@ export class UsageMonitor {
         this.activeGroupId,
       );
 
-      // Log to backend for analytics (non-blocking, fire-and-forget)
-      this.logToBackend(stateGlobal.totalResponseTimeMs, {
+      // Accumulate per-round snapshot (flushed once at end of agent execution)
+      this.accumulatedRounds.push({
         inputTokens: roundInputTokens,
         outputTokens: roundOutputTokens,
         cachedInputTokens: roundCacheReadTokens,
         cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         cost: roundCost,
+        responseTimeMs: stateGlobal.totalResponseTimeMs,
       });
+      this.accumulatedResponseTimeMs = stateGlobal.totalResponseTimeMs;
     } catch (error) {
       logger.error(`Error printing ${runKind} statistics: ${error}`);
     }
+  }
+
+  /**
+   * Flush accumulated usage to backend as a single aggregated record.
+   * Call this once after the agent flow completes (not per-round).
+   * Produces one DB row with summed totals and a `rounds` JSONB array
+   * preserving per-cycle granularity.
+   */
+  flushToBackend(): void {
+    if (this.accumulatedRounds.length === 0) return;
+
+    const rounds = this.accumulatedRounds;
+    this.accumulatedRounds = [];
+
+    const totals = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
+      cacheCreationInputTokens: 0,
+      reasoningTokens: 0,
+      cost: 0,
+    };
+
+    for (const r of rounds) {
+      totals.inputTokens += r.inputTokens;
+      totals.outputTokens += r.outputTokens;
+      totals.cachedInputTokens += r.cachedInputTokens ?? 0;
+      totals.cacheCreationInputTokens += r.cacheCreationInputTokens ?? 0;
+      totals.reasoningTokens += r.reasoningTokens ?? 0;
+      totals.cost += r.cost;
+    }
+
+    this.logToBackend(this.accumulatedResponseTimeMs, totals, {
+      roundCount: rounds.length,
+      rounds,
+    });
   }
 
   /**
@@ -205,6 +253,10 @@ export class UsageMonitor {
       reasoningTokens?: number;
       cost: number;
     },
+    aggregation?: {
+      roundCount: number;
+      rounds: UsageLogRound[];
+    },
   ): void {
     try {
       const { config } = this.modelInfo;
@@ -231,6 +283,8 @@ export class UsageMonitor {
           config.name,
         ),
         streamId: this.context.streamId,
+        roundCount: aggregation?.roundCount,
+        rounds: aggregation?.rounds,
       });
     } catch (error) {
       this.context.logger.debug(`Backend usage logging failed: ${error}`);

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -198,7 +198,9 @@ export class UsageMonitor {
     if (this.accumulatedRounds.length === 0) return;
 
     const rounds = this.accumulatedRounds;
+    const totalResponseTimeMs = this.accumulatedResponseTimeMs;
     this.accumulatedRounds = [];
+    this.accumulatedResponseTimeMs = 0;
 
     const totals = {
       inputTokens: 0,
@@ -218,7 +220,7 @@ export class UsageMonitor {
       totals.cost += r.cost;
     }
 
-    this.logToBackend(this.accumulatedResponseTimeMs, totals, {
+    this.logToBackend(totalResponseTimeMs, totals, {
       roundCount: rounds.length,
       rounds,
     });

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -170,6 +170,9 @@ export class UsageMonitor {
       );
 
       // Accumulate per-round snapshot (flushed once at end of agent execution)
+      // Store per-round delta time, not cumulative total
+      const roundResponseTimeMs =
+        stateGlobal.totalResponseTimeMs - this.accumulatedResponseTimeMs;
       this.accumulatedRounds.push({
         inputTokens: roundInputTokens,
         outputTokens: roundOutputTokens,
@@ -177,7 +180,7 @@ export class UsageMonitor {
         cacheCreationInputTokens: roundCacheCreationTokens,
         reasoningTokens: roundReasoningTokens,
         cost: roundCost,
-        responseTimeMs: stateGlobal.totalResponseTimeMs,
+        responseTimeMs: roundResponseTimeMs,
       });
       this.accumulatedResponseTimeMs = stateGlobal.totalResponseTimeMs;
     } catch (error) {

--- a/src/logger/UsageLogTypes.ts
+++ b/src/logger/UsageLogTypes.ts
@@ -27,11 +27,17 @@ export const UsageLogStatsSchema = z.object({
 
 export type UsageLogStats = z.infer<typeof UsageLogStatsSchema>;
 
+export const UsageLogRoundSchema = UsageLogStatsSchema;
+
+export type UsageLogRound = z.infer<typeof UsageLogRoundSchema>;
+
 export const UsageLogEntrySchema = UsageLogMetadataSchema.extend(
   UsageLogStatsSchema.shape,
 ).extend({
   timestamp: z.iso.datetime(),
   extensionVersion: z.string().optional(),
+  roundCount: z.int().nonnegative().optional(),
+  rounds: z.array(UsageLogRoundSchema).optional(),
 });
 
 export type UsageLogEntry = z.infer<typeof UsageLogEntrySchema>;

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -8,3 +8,4 @@ export {
   type TaskState,
 } from './TaskState';
 export { UsageLogService } from './UsageLogService';
+export type { UsageLogRound } from './UsageLogTypes';

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -21,7 +21,7 @@ import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 // Constants
 // =============================================================================
 
-const LOG_USAGE_VERSION = '1.0.2';
+const LOG_USAGE_VERSION = '1.1.0';
 
 // =============================================================================
 // Types
@@ -43,6 +43,8 @@ interface UsageLogEntry {
   usedRelay?: boolean;
   streamId?: string;
   extensionVersion?: string;
+  roundCount?: number;
+  rounds?: Record<string, unknown>[];
 }
 
 // =============================================================================
@@ -123,6 +125,11 @@ function validateEntry(entry: unknown): UsageLogEntry | null {
     streamId: typeof e.streamId === 'string' ? e.streamId : undefined,
     extensionVersion:
       typeof e.extensionVersion === 'string' ? e.extensionVersion : undefined,
+    roundCount:
+      typeof e.roundCount === 'number' && e.roundCount >= 0
+        ? e.roundCount
+        : undefined,
+    rounds: Array.isArray(e.rounds) ? e.rounds : undefined,
   };
 }
 
@@ -265,6 +272,8 @@ Deno.serve(async (req: Request) => {
       stream_id: entry.streamId,
       extension_version: entry.extensionVersion,
       batch_id: batch.batchId,
+      round_count: entry.roundCount,
+      rounds: entry.rounds,
     }));
 
     const { error: insertError } = await adminClient

--- a/supabase/migrations/20260214_add_rounds_to_usage_logs.sql
+++ b/supabase/migrations/20260214_add_rounds_to_usage_logs.sql
@@ -1,0 +1,14 @@
+-- Migration: Add round-level aggregation columns to usage_logs
+--
+-- Previously, tool-use agents created one row per cycle iteration (N rows per run).
+-- Now the client aggregates all cycles into a single row with summed totals.
+-- The per-cycle breakdown is preserved in a JSONB `rounds` column.
+
+-- Number of model invocation cycles in this agent run
+ALTER TABLE public.usage_logs ADD COLUMN round_count INTEGER;
+
+-- Per-cycle usage breakdown (array of {inputTokens, outputTokens, cost, ...})
+ALTER TABLE public.usage_logs ADD COLUMN rounds JSONB;
+
+COMMENT ON COLUMN public.usage_logs.round_count IS 'Number of model invocation rounds in this agent run';
+COMMENT ON COLUMN public.usage_logs.rounds IS 'Per-round usage breakdown as JSONB array (preserves cycle-level granularity)';


### PR DESCRIPTION
## Summary
This PR changes how agent execution usage is logged to the backend. Instead of creating one database row per tool-use cycle, the system now accumulates per-round usage snapshots and flushes them as a single aggregated record when agent execution completes. This reduces database writes from N rows per run to 1 row, while preserving per-cycle granularity in a JSONB `rounds` array.

## Key Changes

- **UsageMonitor refactoring**: 
  - Added `accumulatedRounds` array to collect per-round usage snapshots during execution
  - Modified `printStatistics()` to accumulate round data instead of immediately logging to backend
  - Added new `flushToBackend()` method that aggregates accumulated rounds and sends a single request with summed totals and per-round breakdown

- **Database schema migration**:
  - Added `round_count` column to track number of invocation cycles per run
  - Added `rounds` JSONB column to store per-cycle usage breakdown (preserves granularity while reducing row count)

- **Backend logging updates**:
  - Updated `logToBackend()` signature to accept optional aggregation metadata
  - Modified Supabase function to handle and persist `roundCount` and `rounds` fields
  - Incremented LOG_USAGE_VERSION to 1.1.0

- **Type definitions**:
  - Added `UsageLogRound` type (mirrors `UsageLogStats` structure)
  - Extended `UsageLogEntry` schema with optional `roundCount` and `rounds` fields

- **Agent execution integration**:
  - Added `flushToBackend()` calls at completion of tool-use, workflow, and merge agent executions
  - Ensures accumulated usage is persisted once per agent run, not per cycle

## Implementation Details

- Per-round response time is calculated as delta from cumulative total, not absolute value
- Aggregation happens transparently—callers don't need to change how they use UsageMonitor
- The `rounds` array preserves cycle-level detail for analytics while the summed `totals` provide quick aggregates
- All new fields are optional to maintain backward compatibility

https://claude.ai/code/session_01LMZmV27D8evHqrhWkJAvnc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches usage analytics, edge-function ingestion, and a DB migration; incorrect flushing/aggregation could drop or skew usage data across runs, but changes are isolated from auth and core execution logic.
> 
> **Overview**
> **Usage logging is now aggregated per agent execution** instead of writing one backend `usage_logs` row per round/cycle. `UsageMonitor` now accumulates per-round usage snapshots (including per-round response-time deltas) and flushes a single summed record with a `roundCount` and `rounds` breakdown when the flow completes.
> 
> Agent runners (`executeAgent`, `executeMergeAgent`, `resumeToolUseFromSnapshot`) wrap execution in `try/finally` to always call `usageMonitor.flushToBackend()`. The logging schema/transport is extended end-to-end: `UsageLogEntry` adds optional `roundCount`/`rounds`, the Supabase `log-usage` function accepts/persists them (bumping version to `1.1.0`), and a migration adds `round_count` (INT) and `rounds` (JSONB) columns to `usage_logs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e0e05e564d30a77c077a10787137ee0fe53d40c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->