### PR TITLE
Export proposalFields schema from shared schemas index

### DIFF
--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -5,6 +5,7 @@ export * from './storage';
 export * from './identifiers';
 export * from './agent';
 export * from './fileFields';
+export * from './proposalFields';
 export * from './toolConfig';
 export * from './errors';
 export * from './usage';


### PR DESCRIPTION
## Summary
Added export of the `proposalFields` schema module to the shared schemas barrel export file, making it available for import from the main schemas index.

## Changes
- Added `export * from './proposalFields'` to `src/shared/schemas/index.ts`

## Details
This change exposes the proposalFields schema definitions through the shared schemas public API, allowing other modules to import proposal field schemas directly from `src/shared/schemas` rather than requiring a direct import from the proposalFields module.

https://claude.ai/code/session_019sMtC9Lo47iFp61dhKhT5b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line barrel export change; low risk aside from potential name collisions or minor bundle/typing surface changes.
> 
> **Overview**
> Exposes `proposalFields` (including `BaseProposalFieldsSchema`, `WorkflowSpecificFieldsSchema`, and `getProposalFileGroups`) via the shared schemas barrel export `src/shared/schemas/index.ts`, enabling consumers to import these symbols from `@shared/schemas` instead of a direct `@shared/schemas/proposalFields` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a335425d5078f939278d35f04c215912fab4d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->