### PR TITLE
Make onBeforeWaiting callback async and fetch execution report

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -18,7 +18,7 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly snapshot: ToolUseSessionSnapshot | null;
   readonly onRoundFinalized: RoundFinalizedCallback;
   readonly onFollowUpConsumed?: () => void;
-  readonly onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  readonly onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
 }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -37,7 +37,7 @@ export class ToolUseWaitNode<C> extends Node<
       return { kind: 'stop' };
     }
 
-    onBeforeWaiting?.(prepRes.lastResponse);
+    await onBeforeWaiting?.(prepRes.lastResponse);
 
     if (!session.hasQueuedFollowUp()) {
       StreamStatusService.set(streamId, STREAM_STATUS.WAITING);

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -44,7 +44,7 @@ export interface RunToolUseFlowInput<
   /** When true, delegation tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
-  onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -566,7 +566,7 @@ export interface ExecuteAgentOptions {
   /** Fires early with the real streamId, before flow execution starts. */
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
-  onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
   /** Fires on meaningful progress: todo changes, round completions, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Fires after flow completes but BEFORE untrackExecution, so follow-ups are enqueued before waiters resolve. */

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -431,9 +431,10 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     if (handle) {
       // Running execution: agent/status from handle, only fetch live data from KV
       const store = getExecutionStore(executionId);
-      const [children, todos] = await Promise.all([
+      const [children, todos, report] = await Promise.all([
         store.readChildren(),
         store.readTodos(),
+        store.readReport(),
       ]);
 
       const info = handle.getStatus();
@@ -452,6 +453,10 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
       if (todos.length > 0) {
         lines.push('', ...formatTodoSection(todos));
+      }
+
+      if (report) {
+        lines.push('', 'Result:', report);
       }
 
       const runningPaths = getAvailablePaths(

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -145,9 +145,8 @@ async function executeSubagent(
       }
     },
     onProgress,
-    onBeforeWaiting: (lastResponse) => {
+    onBeforeWaiting: async (lastResponse) => {
       if (hasDelivered || !childStreamId) return;
-      hasDelivered = true;
       const msg = formatSubagentDelivery(agentName, {
         category: 'toolUse' as const,
         status: 'stopped' as const,
@@ -155,7 +154,15 @@ async function executeSubagent(
         executionId,
         streamId: childStreamId,
       });
-      void getExecutionStore(executionId).write('report', msg);
+      // Best-effort persist — must never block delivery or abort the subagent.
+      try {
+        await getExecutionStore(executionId).write('report', msg);
+      } catch {
+        /* storage failure is non-fatal */
+      }
+      // Mark delivered and enqueue only after the write attempt so that
+      // onCompleted can still act as a fallback if we somehow never reach here.
+      hasDelivered = true;
       ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
     },
     onCompleted: (result) => {


### PR DESCRIPTION
## Summary
This PR makes the `onBeforeWaiting` callback async-capable and updates the execution tool to fetch and display the execution report when viewing running executions.

## Key Changes
- **Made `onBeforeWaiting` callback async**: Updated the callback signature across the tool-use flow to support both synchronous and asynchronous implementations (`void | Promise<void>`). This allows callers to perform async operations before a subagent enters the WAITING state.
  - Updated in `ToolUseServices`, `RunToolUseFlowInput`, and `ExecuteAgentOptions` interfaces
  - Updated `ToolUseWaitNode` to await the callback invocation

- **Updated WorkflowTool subagent delivery**: Changed the `onBeforeWaiting` handler in `executeSubagent` to be async and properly await the report write operation, ensuring the report is persisted before continuing.

- **Enhanced ExecutionsTool status display**: Modified the execution status retrieval to fetch the execution report alongside children and todos, and display it in the status output when available.

## Implementation Details
- The callback is now awaited in `ToolUseWaitNode` before proceeding, ensuring any async operations complete before the subagent enters WAITING state
- The execution report is now fetched in parallel with other execution data using `Promise.all()`
- The report is displayed in the execution status output under a "Result:" section when present

https://claude.ai/code/session_01Vumm6EN9PRWMD7DUNzddti

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral change in the tool-use waiting transition now awaits user-provided callbacks, which could introduce latency or hangs if misused, and adds extra KV reads/writes during subagent delivery and execution summary rendering.
> 
> **Overview**
> Makes the tool-use flow’s `onBeforeWaiting` callback async-capable (`void | Promise<void>`) across `ToolUseServices`, `runToolUseFlow`, and `executeAgent`, and updates `ToolUseWaitNode` to `await` it before entering `WAITING`.
> 
> Improves subagent delivery reliability by persisting the subagent’s formatted result to the execution `report` (best-effort/try-catch) before enqueuing the follow-up message, and enhances the `executions` tool summary for *running* executions to also fetch and display the stored `report` alongside children/todos.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b2dcb57e3eaf34c8ab3bdd589bb30a7225a1ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->