### PR TITLE
Add leanSimplifier and leanSearch agents to remote agents

### DIFF
--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -292,6 +292,34 @@ ON CONFLICT (name) DO UPDATE SET
   agent_category = EXCLUDED.agent_category,
   tools          = EXCLUDED.tools;
 
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'leanSimplifier',
+  'Simplifies Lean 4 proofs and code to Mathlib-quality standards — clear, general, and ready to upstream.',
+  'tool_use/leanSimplifier.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
+  'leanSearch',
+  'Lean 4 and Mathlib research assistant — finds lemmas, explores APIs, and answers formalization questions.',
+  'tool_use/leanSearch.yaml',
+  ARRAY['researcher'],
+  'toolUse',
+  ARRAY['todo_write', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'web_search', 'web_fetch', 'arxiv_search', 'arxiv_metadata', 'download_arxiv_source']
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
 -- =============================================================================
 -- VERIFY
 -- =============================================================================


### PR DESCRIPTION
## Summary
This PR adds two new Lean 4-focused agents to the remote agents database: `leanSimplifier` and `leanSearch`. These agents extend the platform's capabilities for Lean proof development and mathematical library research.

## Key Changes
- **leanSimplifier agent**: A new agent that simplifies Lean 4 proofs and code to Mathlib-quality standards. It has access to file manipulation, bash execution, and Lean-specific diagnostic tools.
- **leanSearch agent**: A new research assistant agent for Lean 4 and Mathlib that helps find lemmas, explore APIs, and answer formalization questions. It includes additional web search and arXiv capabilities alongside Lean tools.

Both agents are:
- Configured with `researcher` visibility level
- Categorized as `toolUse` agents
- Set up with appropriate tool access including Lean diagnostics, file operations, and search capabilities
- Configured to use upsert semantics (INSERT ... ON CONFLICT) to allow for future updates

## Implementation Details
- Both agents follow the existing remote_agents table schema
- Storage paths reference YAML configuration files in the `tool_use/` directory
- leanSearch includes extended research tools (web_search, web_fetch, arxiv_search, arxiv_metadata, download_arxiv_source) in addition to the core Lean tools
- Both use the standard conflict resolution pattern to update existing entries if re-run

https://claude.ai/code/session_01FNXWJNox4QDQZRT6wqYJ4N

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a documentation/ops SQL sync script to insert two new agent definitions; no runtime code paths are modified.
> 
> **Overview**
> Adds two new `toolUse` remote agents to the Supabase sync script: `leanSimplifier` (Lean 4 proof/code simplification) and `leanSearch` (Lean/Mathlib research assistant). Both are upserted in `docs/supabase/SYNC_REFERENCE_AGENTS.sql` with `researcher` visibility and Lean-specific tool permissions, with `leanSearch` also granted web/arXiv search tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd4ba1cef4c3079fd7e5fe74efddfea8fb464277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->