### PR TITLE
Add agent mode presets to Multi-Agent settings tab

### DIFF
--- a/resources/tool_use_agents/presenter.yaml
+++ b/resources/tool_use_agents/presenter.yaml
@@ -1,0 +1,79 @@
+name: presenter
+description: Creates professional LaTeX Beamer presentations from research papers using tools to analyze content and extract figures.
+
+settings:
+  agentCategory: toolUse
+  requiredFilesInternal:
+    TEMPLATE_SLIDE: template_slide.tex
+  tools:
+    - todo_write
+    - read_file
+    - write_file
+    - edit_file
+    - glob
+    - grep
+    - ls
+    - extract_figures
+    - extract_bib_entries
+    - extract_tikz_figures
+    - texcount
+    - arxiv_search
+    - arxiv_metadata
+    - crossref_search
+    - crossref_doi
+
+prompts:
+  systemPrompt: |
+    You are an expert scientist and scientific presenter. Your task is to create professional LaTeX Beamer presentations based on research papers, tailored for a scientific audience.
+
+    Workflow:
+    (1) Use todo_write to plan the presentation structure (title, sections, key results).
+    (2) Read the source paper and any auxiliary files to understand the full content.
+    (3) Use extract_figures to identify figures, extract_bib_entries for references, and extract_tikz_figures for diagrams.
+    (4) Search the paper with grep for key equations, theorems, and definitions.
+    (5) Write the complete Beamer presentation to the output file.
+    (6) Review the output and use edit_file to refine individual slides.
+
+    Presentation Guidelines:
+    (1) Use LaTeX Beamer syntax and commands correctly.
+    (2) Structure with a clear introduction, body, and conclusion (10-15 slides).
+    (3) Include appropriate equations, figures, and tables from the original paper.
+    (4) Use condensed bullet points — prioritize visual representations and key takeaways over verbose descriptions.
+    (5) Maintain a professional and scientifically rigorous tone with consistent notation.
+    (6) Include slide numbers and end with a conclusion summarizing findings and future work.
+    (7) Cite relevant key papers using \cite{Author2020Title} (author, year, first word of title).
+    (8) Output a complete, self-contained LaTeX file that can be compiled directly.
+
+    LaTeX Best Practices:
+    (1) Use `` and '' instead of "..." for quotes.
+    (2) Follow chktex best practices (no warnings).
+    (3) Use appropriate mathematical environments (equation, align, etc.).
+    (4) Keep mathematical notation consistent throughout.
+    (5) All inline mathematical variables must be enclosed in $...$, not backticks.
+
+    The template structure is available as {{ TEMPLATE_SLIDE }}. Use it as the skeleton for the presentation.
+
+    CRITICAL - File Output Rule: A third-person reader must be able to read any document you output without knowledge of this conversation. No self-referential talk ("I will..."), no meta-commentary to user, no parenthetical asides, no conversation references. Standard academic prose only.
+
+  userPrefix: |
+    Create a LaTeX Beamer presentation based on the following research paper:
+
+    <documents>
+    {{ ALL_AUXILIARYS }}
+    {{ ALL_REFERENCES }}
+    {{ ADDITIONAL_INPUTS }}
+
+    <document name="{{ INPUT_FILE }}">
+    {{ INPUT_CONTENT }}
+    </document>
+    </documents>
+
+  userRequest: |
+    Please create a professional LaTeX Beamer presentation for a scientific audience based on the research paper provided. The presentation should consist of 10-15 slides that effectively communicate the paper's key findings.
+
+    Start by reading the paper carefully, extracting figures and references, then plan the slide structure before writing. After writing the initial version, review it critically and refine.
+
+    {% if INSTRUCTION %}
+    Additional instruction:
+    {{ INSTRUCTION }}
+    {% endif %}

--- a/resources/tool_use_agents/template_slide.tex
+++ b/resources/tool_use_agents/template_slide.tex
@@ -1,0 +1,39 @@
+\documentclass{beamer}
+
+\usetheme{metropolis}
+
+\setbeamertemplate{navigation symbols}{}
+
+\AtBeginSection[]
+{
+\begin{frame}<beamer>
+\frametitle{Outline}
+\tableofcontents[currentsection]
+\end{frame}
+}
+
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{graphicx}
+\usepackage{physics}
+\usepackage{hyperref}
+\usepackage{natbib}
+
+% Include any other packages needed use \usepackage{...}
+% Include any other external preamble in the paper using \input{...}
+
+% Title information
+\title{Title of the Presentation}
+\author{Authors of the Paper}
+\institute{Institution}
+\date{\today}
+
+\begin{document}
+
+% SLIDE_CONTENT
+
+\begin{frame}[allowframebreaks]{Reference}
+    \bibliography{the bib file used to generate the paper}
+\end{frame}
+
+\end{document}

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -659,7 +659,7 @@ export function getVisibleAgents(
  * Custom agents override built-in agents with the same name.
  * Remote agents use source:name keys to prevent deduplication.
  */
-function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
+export function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
   const byKey = new Map<string, AgentEntry>();
 
   for (const entry of entries) {

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -30,6 +30,8 @@ export {
   isRemoteAgent,
   // Visible agents (for dropdowns and tools)
   getVisibleAgents,
+  // Deduplication
+  deduplicateByName,
   // Description update (for remote agent loading)
   updateAgentDescription,
 } from './agentRegistry';

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -20,6 +20,7 @@ export enum WorkspaceStateKey {
   ENABLED_TOOL_USE_AGENTS = 'texra.enabledToolUseAgents',
   PARENT_STREAM_IDS = 'texra.parentStreamIds',
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
+  CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 }
 
 export enum GlobalStateKey {

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -347,6 +347,7 @@ export const SETTINGS_VIEW_CMD = {
   // Multi-Agent commands
   GET_SUPER_YOLO_ENABLED: 'getSuperYoloEnabled',
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
+  APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -348,6 +348,9 @@ export const SETTINGS_VIEW_CMD = {
   GET_SUPER_YOLO_ENABLED: 'getSuperYoloEnabled',
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
+  SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',
+  DELETE_AGENT_MODE_PRESET: 'deleteAgentModePreset',
+  GET_AGENT_MODE_PRESETS: 'getAgentModePresets',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
@@ -369,5 +372,6 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_AGENT_SELECTION: 'updateAgentSelection',
   UPDATE_CUSTOM_AGENT_DIR: 'updateCustomAgentDir',
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
+  UPDATE_AGENT_MODE_PRESETS: 'updateAgentModePresets',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
 } as const;

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -84,6 +84,7 @@ import {
 import { getConfig } from '@utils/config/configUtils';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
+import { AGENT_MODE_PRESETS } from '@shared/schemas/agentPresets';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import type {
@@ -405,6 +406,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.REVEAL_AGENT_FILE]: (data) =>
         this.handleRevealAgentFile(data),
 
+      // Agent mode preset handlers
+      [SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET]: (data) =>
+        this.handleApplyAgentModePreset(data),
+
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
         this.handleGetToolDashboardData(),
@@ -658,6 +663,59 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     void vscode.window.showInformationMessage(
       `Super YOLO mode ${data.enabled ? 'enabled' : 'disabled'}`,
     );
+  }
+
+  // ============================================================
+  // Agent mode preset handler implementations
+  // ============================================================
+
+  private async handleApplyAgentModePreset(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
+  ): Promise<void> {
+    try {
+      const preset = AGENT_MODE_PRESETS.find((p) => p.id === data.presetId);
+      if (!preset) {
+        await vscode.window.showErrorMessage(
+          `Unknown preset: ${data.presetId}`,
+        );
+        return;
+      }
+
+      await loadAgents();
+
+      // Build enabled keys by matching preset agent names to registered agents.
+      // For each category, find agents whose name matches the preset list and
+      // collect their source:name keys. Agents not in the preset are excluded
+      // (i.e., disabled).
+      const workflowNames = new Set(preset.workflowAgents);
+      const toolUseNames = new Set(preset.toolUseAgents);
+
+      const workflowKeys = getWorkflowAgents()
+        .filter((e) => workflowNames.has(e.name))
+        .map((e) => createKey(e.source, e.name));
+
+      const toolUseKeys = getToolUseAgents()
+        .filter((e) => toolUseNames.has(e.name))
+        .map((e) => createKey(e.source, e.name));
+
+      await workspaceSM.update(WorkspaceStateKey.ENABLED_AGENTS, workflowKeys);
+      await workspaceSM.update(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        toolUseKeys,
+      );
+
+      await this.refreshAfterAgentMutation();
+
+      void vscode.window.showInformationMessage(
+        `Applied "${preset.name}" preset`,
+      );
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to apply agent mode preset',
+        error,
+      );
+    }
   }
 
   // ============================================================

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -31,6 +31,7 @@ import {
   createKey,
   getAgent,
   getAgentsBySource,
+  getVisibleAgents,
   getWorkflowAgents,
   getToolUseAgents,
   loadAgents,
@@ -688,24 +689,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     return parsed.success ? parsed.data : [];
   }
 
-  /**
-   * Resolve enabled agent keys to plain names.
-   * `undefined` enabledKeys means "never configured" → all agents enabled.
-   */
-  private resolveEnabledNames(
-    agents: AgentEntry[],
-    enabledKeys: string[] | undefined,
-  ): string[] {
-    if (enabledKeys === undefined) return agents.map((e) => e.name);
-    return agents
-      .filter(
-        (e) =>
-          enabledKeys.includes(createKey(e.source, e.name)) ||
-          enabledKeys.includes(e.name),
-      )
-      .map((e) => e.name);
-  }
-
   public async sendAgentModePresets(webview: vscode.Webview): Promise<void> {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
@@ -783,14 +766,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       await loadAgents();
 
-      const workflowAgents = this.resolveEnabledNames(
-        getWorkflowAgents(),
-        workspaceSM.get<string[]>(WorkspaceStateKey.ENABLED_AGENTS),
-      );
-      const toolUseAgents = this.resolveEnabledNames(
-        getToolUseAgents(),
-        workspaceSM.get<string[]>(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
-      );
+      const workflowAgents = getVisibleAgents('workflow').map((e) => e.name);
+      const toolUseAgents = getVisibleAgents('toolUse').map((e) => e.name);
 
       const preset: AgentModePreset = {
         id: `custom-${Date.now()}`,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -86,8 +86,10 @@ import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import {
   AGENT_MODE_PRESETS,
+  AgentModePresetSchema,
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
+import { z } from 'zod';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import type {
@@ -679,27 +681,44 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Agent mode preset handler implementations
   // ============================================================
 
+  /** Read and validate custom presets from workspace state. */
+  private getCustomPresets(): AgentModePreset[] {
+    const raw = workspaceSM.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []);
+    const parsed = z.array(AgentModePresetSchema).safeParse(raw);
+    return parsed.success ? parsed.data : [];
+  }
+
+  /**
+   * Resolve enabled agent keys to plain names.
+   * `undefined` enabledKeys means "never configured" → all agents enabled.
+   */
+  private resolveEnabledNames(
+    agents: AgentEntry[],
+    enabledKeys: string[] | undefined,
+  ): string[] {
+    if (enabledKeys === undefined) return agents.map((e) => e.name);
+    return agents
+      .filter(
+        (e) =>
+          enabledKeys.includes(createKey(e.source, e.name)) ||
+          enabledKeys.includes(e.name),
+      )
+      .map((e) => e.name);
+  }
+
   public async sendAgentModePresets(webview: vscode.Webview): Promise<void> {
-    const customPresets = workspaceSM.get<AgentModePreset[]>(
-      WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
-      [],
-    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
-      customPresets: customPresets ?? [],
+      customPresets: this.getCustomPresets(),
     });
   }
 
   /** Find a preset by id across built-in and custom presets. */
   private findPreset(presetId: string): AgentModePreset | undefined {
-    const builtIn = AGENT_MODE_PRESETS.find((p) => p.id === presetId);
-    if (builtIn) return builtIn;
-    const customPresets =
-      workspaceSM.get<AgentModePreset[]>(
-        WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
-        [],
-      ) ?? [];
-    return customPresets.find((p) => p.id === presetId);
+    return (
+      AGENT_MODE_PRESETS.find((p) => p.id === presetId) ??
+      this.getCustomPresets().find((p) => p.id === presetId)
+    );
   }
 
   private async handleApplyAgentModePreset(
@@ -764,37 +783,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       await loadAgents();
 
-      // Snapshot the currently enabled agents as the preset content.
-      const workflowEnabled = workspaceSM.get<string[]>(
-        WorkspaceStateKey.ENABLED_AGENTS,
+      const workflowAgents = this.resolveEnabledNames(
+        getWorkflowAgents(),
+        workspaceSM.get<string[]>(WorkspaceStateKey.ENABLED_AGENTS),
       );
-      const toolUseEnabled = workspaceSM.get<string[]>(
-        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      const toolUseAgents = this.resolveEnabledNames(
+        getToolUseAgents(),
+        workspaceSM.get<string[]>(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
       );
-
-      // Resolve enabled keys to plain agent names.
-      // undefined = "never configured" → all agents enabled.
-      const workflowAgents =
-        workflowEnabled === undefined
-          ? getWorkflowAgents().map((e) => e.name)
-          : getWorkflowAgents()
-              .filter(
-                (e) =>
-                  workflowEnabled.includes(createKey(e.source, e.name)) ||
-                  workflowEnabled.includes(e.name),
-              )
-              .map((e) => e.name);
-
-      const toolUseAgents =
-        toolUseEnabled === undefined
-          ? getToolUseAgents().map((e) => e.name)
-          : getToolUseAgents()
-              .filter(
-                (e) =>
-                  toolUseEnabled.includes(createKey(e.source, e.name)) ||
-                  toolUseEnabled.includes(e.name),
-              )
-              .map((e) => e.name);
 
       const preset: AgentModePreset = {
         id: `custom-${Date.now()}`,
@@ -805,11 +801,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         toolUseAgents,
       };
 
-      const existing =
-        workspaceSM.get<AgentModePreset[]>(
-          WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
-          [],
-        ) ?? [];
+      const existing = this.getCustomPresets();
       await workspaceSM.update(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
         ...existing,
         preset,
@@ -833,20 +825,27 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const existing =
-        workspaceSM.get<AgentModePreset[]>(
-          WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
-          [],
-        ) ?? [];
-      const updated = existing.filter((p) => p.id !== data.presetId);
+      const target = this.getCustomPresets().find(
+        (p) => p.id === data.presetId,
+      );
+      if (!target) return;
+
+      const confirm = await vscode.window.showWarningMessage(
+        `Delete preset "${target.name}"?`,
+        { modal: true },
+        'Delete',
+      );
+      if (confirm !== 'Delete') return;
+
+      const updated = this.getCustomPresets().filter(
+        (p) => p.id !== data.presetId,
+      );
       await workspaceSM.update(
         WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
         updated,
       );
 
       await this.withActiveWebview((w) => this.sendAgentModePresets(w));
-
-      void vscode.window.showInformationMessage('Preset deleted');
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -84,7 +84,10 @@ import {
 import { getConfig } from '@utils/config/configUtils';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
-import { AGENT_MODE_PRESETS } from '@shared/schemas/agentPresets';
+import {
+  AGENT_MODE_PRESETS,
+  type AgentModePreset,
+} from '@shared/schemas/agentPresets';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import type {
@@ -407,8 +410,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleRevealAgentFile(data),
 
       // Agent mode preset handlers
+      [SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS]: () =>
+        this.withActiveWebview((w) => this.sendAgentModePresets(w)),
       [SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET]: (data) =>
         this.handleApplyAgentModePreset(data),
+      [SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET]: (data) =>
+        this.handleSaveAgentModePreset(data),
+      [SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET]: (data) =>
+        this.handleDeleteAgentModePreset(data),
 
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
@@ -480,6 +489,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.sendAgentSelectionData(webview),
       this.sendCustomAgentDir(webview),
       this.sendSuperYoloEnabled(webview),
+      this.sendAgentModePresets(webview),
     ]);
   }
 
@@ -669,11 +679,34 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Agent mode preset handler implementations
   // ============================================================
 
+  public async sendAgentModePresets(webview: vscode.Webview): Promise<void> {
+    const customPresets = workspaceSM.get<AgentModePreset[]>(
+      WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+      [],
+    );
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: customPresets ?? [],
+    });
+  }
+
+  /** Find a preset by id across built-in and custom presets. */
+  private findPreset(presetId: string): AgentModePreset | undefined {
+    const builtIn = AGENT_MODE_PRESETS.find((p) => p.id === presetId);
+    if (builtIn) return builtIn;
+    const customPresets =
+      workspaceSM.get<AgentModePreset[]>(
+        WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+        [],
+      ) ?? [];
+    return customPresets.find((p) => p.id === presetId);
+  }
+
   private async handleApplyAgentModePreset(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const preset = AGENT_MODE_PRESETS.find((p) => p.id === data.presetId);
+      const preset = this.findPreset(data.presetId);
       if (!preset) {
         await vscode.window.showErrorMessage(
           `Unknown preset: ${data.presetId}`,
@@ -713,6 +746,111 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await showLoggedErrorMessage(
         this.channel,
         'Failed to apply agent mode preset',
+        error,
+      );
+    }
+  }
+
+  private async handleSaveAgentModePreset(
+    _data: MessageFor<typeof SETTINGS_VIEW_CMD.SAVE_AGENT_MODE_PRESET>,
+  ): Promise<void> {
+    try {
+      const name = await vscode.window.showInputBox({
+        prompt: 'Name for the new preset',
+        placeHolder: 'e.g. My Research Setup',
+        validateInput: (v) => (v.trim() ? null : 'Name cannot be empty'),
+      });
+      if (!name) return; // cancelled
+
+      await loadAgents();
+
+      // Snapshot the currently enabled agents as the preset content.
+      const workflowEnabled = workspaceSM.get<string[]>(
+        WorkspaceStateKey.ENABLED_AGENTS,
+      );
+      const toolUseEnabled = workspaceSM.get<string[]>(
+        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+      );
+
+      // Resolve enabled keys to plain agent names.
+      // undefined = "never configured" → all agents enabled.
+      const workflowAgents =
+        workflowEnabled === undefined
+          ? getWorkflowAgents().map((e) => e.name)
+          : getWorkflowAgents()
+              .filter(
+                (e) =>
+                  workflowEnabled.includes(createKey(e.source, e.name)) ||
+                  workflowEnabled.includes(e.name),
+              )
+              .map((e) => e.name);
+
+      const toolUseAgents =
+        toolUseEnabled === undefined
+          ? getToolUseAgents().map((e) => e.name)
+          : getToolUseAgents()
+              .filter(
+                (e) =>
+                  toolUseEnabled.includes(createKey(e.source, e.name)) ||
+                  toolUseEnabled.includes(e.name),
+              )
+              .map((e) => e.name);
+
+      const preset: AgentModePreset = {
+        id: `custom-${Date.now()}`,
+        name: name.trim(),
+        description: `Custom preset: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
+        icon: 'codicon-bookmark',
+        workflowAgents,
+        toolUseAgents,
+      };
+
+      const existing =
+        workspaceSM.get<AgentModePreset[]>(
+          WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+          [],
+        ) ?? [];
+      await workspaceSM.update(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+        ...existing,
+        preset,
+      ]);
+
+      await this.withActiveWebview((w) => this.sendAgentModePresets(w));
+
+      void vscode.window.showInformationMessage(
+        `Saved preset "${name.trim()}"`,
+      );
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to save agent mode preset',
+        error,
+      );
+    }
+  }
+
+  private async handleDeleteAgentModePreset(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT_MODE_PRESET>,
+  ): Promise<void> {
+    try {
+      const existing =
+        workspaceSM.get<AgentModePreset[]>(
+          WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+          [],
+        ) ?? [];
+      const updated = existing.filter((p) => p.id !== data.presetId);
+      await workspaceSM.update(
+        WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+        updated,
+      );
+
+      await this.withActiveWebview((w) => this.sendAgentModePresets(w));
+
+      void vscode.window.showInformationMessage('Preset deleted');
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to delete agent mode preset',
         error,
       );
     }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -696,19 +696,25 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  /** Find a preset by id across built-in and custom presets. */
-  private findPreset(presetId: string): AgentModePreset | undefined {
-    return (
-      AGENT_MODE_PRESETS.find((p) => p.id === presetId) ??
-      this.getCustomPresets().find((p) => p.id === presetId)
-    );
+  /** Resolve agent names to source:name keys for the given category. */
+  private resolveAgentKeys(
+    category: 'workflow' | 'toolUse',
+    names: Set<string>,
+  ): string[] {
+    const entries =
+      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
+    return entries
+      .filter((e) => names.has(e.name))
+      .map((e) => createKey(e.source, e.name));
   }
 
   private async handleApplyAgentModePreset(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const preset = this.findPreset(data.presetId);
+      const preset =
+        AGENT_MODE_PRESETS.find((p) => p.id === data.presetId) ??
+        this.getCustomPresets().find((p) => p.id === data.presetId);
       if (!preset) {
         await vscode.window.showErrorMessage(
           `Unknown preset: ${data.presetId}`,
@@ -718,20 +724,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       await loadAgents();
 
-      // Build enabled keys by matching preset agent names to registered agents.
-      // For each category, find agents whose name matches the preset list and
-      // collect their source:name keys. Agents not in the preset are excluded
-      // (i.e., disabled).
-      const workflowNames = new Set(preset.workflowAgents);
-      const toolUseNames = new Set(preset.toolUseAgents);
-
-      const workflowKeys = getWorkflowAgents()
-        .filter((e) => workflowNames.has(e.name))
-        .map((e) => createKey(e.source, e.name));
-
-      const toolUseKeys = getToolUseAgents()
-        .filter((e) => toolUseNames.has(e.name))
-        .map((e) => createKey(e.source, e.name));
+      const workflowKeys = this.resolveAgentKeys(
+        'workflow',
+        new Set(preset.workflowAgents),
+      );
+      const toolUseKeys = this.resolveAgentKeys(
+        'toolUse',
+        new Set(preset.toolUseAgents),
+      );
 
       await workspaceSM.update(WorkspaceStateKey.ENABLED_AGENTS, workflowKeys);
       await workspaceSM.update(
@@ -802,9 +802,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const target = this.getCustomPresets().find(
-        (p) => p.id === data.presetId,
-      );
+      const presets = this.getCustomPresets();
+      const target = presets.find((p) => p.id === data.presetId);
       if (!target) return;
 
       const confirm = await vscode.window.showWarningMessage(
@@ -814,9 +813,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       );
       if (confirm !== 'Delete') return;
 
-      const updated = this.getCustomPresets().filter(
-        (p) => p.id !== data.presetId,
-      );
+      const updated = presets.filter((p) => p.id !== data.presetId);
       await workspaceSM.update(
         WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
         updated,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -29,6 +29,7 @@ import { getServerSideKeyService } from '@auth/serverKeys';
 import {
   type AgentEntry,
   createKey,
+  deduplicateByName,
   getAgent,
   getAgentsBySource,
   getVisibleAgents,
@@ -701,8 +702,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     category: 'workflow' | 'toolUse',
     names: Set<string>,
   ): string[] {
-    const entries =
-      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
+    const entries = deduplicateByName(
+      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents(),
+    );
     return entries
       .filter((e) => names.has(e.name))
       .map((e) => createKey(e.source, e.name));

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -614,6 +614,7 @@ export class SettingsApp extends BaseWebviewApp {
               @agent-delete-custom=${this.handleDeleteCustomAgent}
               @agent-set-custom-dir=${this.handleSetCustomAgentDir}
               @agent-reset-custom-dir=${this.handleResetCustomAgentDir}
+              @save-agent-mode-preset=${this.handleSaveAgentModePreset}
             ></agents-tab>
           </vscode-tab-panel>
 
@@ -626,7 +627,6 @@ export class SettingsApp extends BaseWebviewApp {
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
-              @save-agent-mode-preset=${this.handleSaveAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}
             ></multi-agent-tab>
           </vscode-tab-panel>

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -37,6 +37,7 @@ import {
   UpdateAgentSelectionMessageSchema,
   UpdateCustomAgentDirMessageSchema,
   UpdateSuperYoloEnabledMessageSchema,
+  UpdateAgentModePresetsMessageSchema,
   UpdateToolDashboardMessageSchema,
   type AgentSelectionItem,
   type NumberVscodeSetting,
@@ -53,6 +54,7 @@ import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-t
 
 // Local imports - shared schema types
 import type { AgentCategory } from '@shared/schemas/agent';
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
 
 // Local imports - settings view tabs (side-effect: register)
 import './tabs/MemoryTab';
@@ -146,6 +148,9 @@ export class SettingsApp extends BaseWebviewApp {
   @state() private customAgentDirIsDefault = true;
   @state() private agentSubTab: AgentCategory | undefined;
 
+  // Agent mode presets state
+  @state() private customPresets: AgentModePreset[] = [];
+
   // Super YOLO / reliability state
   @state() private superYoloEnabled = false;
   @state() private superYoloToggleDisabled = true;
@@ -170,6 +175,7 @@ export class SettingsApp extends BaseWebviewApp {
     postMessage(SETTINGS_VIEW_COMMANDS.GET_AGENT_SELECTION);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_CUSTOM_AGENT_DIR);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED);
+    postMessage(SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA);
   }
 
@@ -274,6 +280,16 @@ export class SettingsApp extends BaseWebviewApp {
         this.superYoloEnabled = data.enabled;
         this.superYoloToggleDisabled = false;
         this.reliabilitySettings = data.reliabilitySettings;
+        return;
+      }
+
+      case SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS: {
+        const data = this.parseMessage(
+          raw,
+          UpdateAgentModePresetsMessageSchema,
+        );
+        if (!data) return;
+        this.customPresets = data.customPresets;
         return;
       }
 
@@ -449,6 +465,14 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
   );
 
+  private handleSaveAgentModePreset(): void {
+    postMessage(SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET);
+  }
+
+  private handleDeleteAgentModePreset = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
+  );
+
   // Tool dashboard event handlers
   private handleToolOpenUrl = forwardDetail(
     SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL,
@@ -598,9 +622,12 @@ export class SettingsApp extends BaseWebviewApp {
               .superYoloEnabled=${this.superYoloEnabled}
               .toggleDisabled=${this.superYoloToggleDisabled}
               .reliabilitySettings=${this.reliabilitySettings}
+              .customPresets=${this.customPresets}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
+              @save-agent-mode-preset=${this.handleSaveAgentModePreset}
+              @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}
             ></multi-agent-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -445,6 +445,10 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED,
   );
 
+  private handleApplyAgentModePreset = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+  );
+
   // Tool dashboard event handlers
   private handleToolOpenUrl = forwardDetail(
     SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL,
@@ -596,6 +600,7 @@ export class SettingsApp extends BaseWebviewApp {
               .reliabilitySettings=${this.reliabilitySettings}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
+              @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
             ></multi-agent-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -68,4 +68,5 @@ export const AgentSelectionEvents = {
     agentName: string;
     agentSource: AgentSourceType;
   }) => createEvent('agent-reveal-file', detail),
+  savePreset: () => createEvent('save-agent-mode-preset', undefined),
 } as const;

--- a/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -211,6 +211,10 @@ export class AgentsTab extends LitElement {
     this.dispatchEvent(AgentSelectionEvents.resetCustomDir());
   }
 
+  private handleSavePreset(): void {
+    this.dispatchEvent(AgentSelectionEvents.savePreset());
+  }
+
   override render(): TemplateResult {
     const activeAgents =
       this.activeSubTab === 'workflow'
@@ -248,6 +252,14 @@ export class AgentsTab extends LitElement {
             </button>
           </div>
           <div class="agents-header-actions">
+            <button
+              class="tab-action-btn"
+              @click=${this.handleSavePreset}
+              title="Save current agent configuration as a preset"
+            >
+              <span class="codicon codicon-save"></span>
+              Save Preset
+            </button>
             <button
               class="tab-action-btn"
               @click=${this.handleCreateFromTemplate}

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -50,17 +50,6 @@ export class MultiAgentTab extends LitElement {
         font-size: var(--font-size-small);
       }
 
-      /* Preset section header */
-      .preset-section-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-      }
-
-      .preset-section-header h3 {
-        margin: 0;
-      }
-
       /* Preset cards */
       .preset-grid {
         display: grid;
@@ -297,9 +286,7 @@ export class MultiAgentTab extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="multi-agent-container tab-content-container">
-        <div class="preset-section-header">
-          <h3>Mode Presets</h3>
-        </div>
+        <h3>Mode Presets</h3>
 
         <p class="text-secondary setting-description">
           Apply a preset to quickly configure which agents are enabled for your

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -1,7 +1,8 @@
 /**
  * MultiAgentTab component - multi-agent settings for the settings view.
- * Contains agent mode presets for quick configuration, the Super YOLO toggle
- * for auto-approving agent delegation proposals, and reliability settings.
+ * Contains agent mode presets (built-in + custom) for quick configuration,
+ * the Super YOLO toggle for auto-approving agent delegation proposals,
+ * and reliability settings.
  */
 
 // Third-party imports
@@ -49,6 +50,17 @@ export class MultiAgentTab extends LitElement {
         font-size: var(--font-size-small);
       }
 
+      /* Preset section header */
+      .preset-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .preset-section-header h3 {
+        margin: 0;
+      }
+
       /* Preset cards */
       .preset-grid {
         display: grid;
@@ -57,6 +69,7 @@ export class MultiAgentTab extends LitElement {
       }
 
       .preset-card {
+        position: relative;
         display: flex;
         flex-direction: column;
         gap: var(--spacing-small);
@@ -94,6 +107,11 @@ export class MultiAgentTab extends LitElement {
         font-size: var(--font-size-sm);
         font-weight: 500;
         color: var(--vscode-foreground);
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .preset-card-description {
@@ -117,6 +135,30 @@ export class MultiAgentTab extends LitElement {
         color: var(--color-text-secondary);
         background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
         border-radius: var(--border-radius);
+      }
+
+      .preset-delete-btn {
+        position: absolute;
+        top: var(--spacing-small);
+        right: var(--spacing-small);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 2px;
+        color: var(--color-text-secondary);
+        background: none;
+        border: none;
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        font-size: var(--font-size-sm);
+      }
+
+      .preset-delete-btn:hover {
+        color: var(--vscode-errorForeground);
+      }
+
+      .preset-card:hover .preset-delete-btn {
+        display: inline-flex;
       }
 
       /* Reliability settings */
@@ -155,6 +197,7 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) toggleDisabled = true;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
+  @property({ attribute: false }) customPresets: AgentModePreset[] = [];
 
   private handleToggle(event: Event): void {
     const target = event.target as HTMLInputElement | null;
@@ -167,6 +210,17 @@ export class MultiAgentTab extends LitElement {
     this.dispatchEvent(
       createEvent('apply-agent-mode-preset', { presetId: preset.id }),
     );
+  }
+
+  private handleDeletePreset(event: Event, preset: AgentModePreset): void {
+    event.stopPropagation();
+    this.dispatchEvent(
+      createEvent('delete-agent-mode-preset', { presetId: preset.id }),
+    );
+  }
+
+  private handleSavePreset(): void {
+    this.dispatchEvent(createEvent('save-agent-mode-preset', undefined));
   }
 
   private handleReliabilityChange(
@@ -187,7 +241,10 @@ export class MultiAgentTab extends LitElement {
     );
   }
 
-  private renderPresetCard(preset: AgentModePreset): TemplateResult {
+  private renderPresetCard(
+    preset: AgentModePreset,
+    deletable: boolean,
+  ): TemplateResult {
     const allAgents = [...preset.toolUseAgents, ...preset.workflowAgents];
     return html`
       <div
@@ -205,6 +262,15 @@ export class MultiAgentTab extends LitElement {
             (name) => html`<span class="preset-agent-badge">${name}</span>`,
           )}
         </div>
+        ${deletable
+          ? html`<button
+              class="preset-delete-btn"
+              @click=${(e: Event) => this.handleDeletePreset(e, preset)}
+              title="Delete preset"
+            >
+              <span class="codicon codicon-trash"></span>
+            </button>`
+          : nothing}
       </div>
     `;
   }
@@ -235,7 +301,17 @@ export class MultiAgentTab extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="multi-agent-container tab-content-container">
-        <h3>Mode Presets</h3>
+        <div class="preset-section-header">
+          <h3>Mode Presets</h3>
+          <button
+            class="tab-action-btn"
+            @click=${this.handleSavePreset}
+            title="Save current agent configuration as a preset"
+          >
+            <span class="codicon codicon-save"></span>
+            Save Current
+          </button>
+        </div>
 
         <p class="text-secondary setting-description">
           Apply a preset to quickly configure which agents are enabled for your
@@ -243,7 +319,8 @@ export class MultiAgentTab extends LitElement {
         </p>
 
         <div class="preset-grid">
-          ${AGENT_MODE_PRESETS.map((p) => this.renderPresetCard(p))}
+          ${AGENT_MODE_PRESETS.map((p) => this.renderPresetCard(p, false))}
+          ${this.customPresets.map((p) => this.renderPresetCard(p, true))}
         </div>
 
         <h3>Agent Delegation</h3>

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -1,7 +1,7 @@
 /**
  * MultiAgentTab component - multi-agent settings for the settings view.
- * Contains the Super YOLO toggle for auto-approving agent delegation proposals
- * and reliability settings (compaction threshold, retry config).
+ * Contains agent mode presets for quick configuration, the Super YOLO toggle
+ * for auto-approving agent delegation proposals, and reliability settings.
  */
 
 // Third-party imports
@@ -9,18 +9,23 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { designTokens, commonViewStyles } from '@shared/styles';
+import { codiconStyles, designTokens, commonViewStyles } from '@shared/styles';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
 
 // Local imports - shared schemas
 import type { NumberVscodeSetting } from '@shared/schemas/settingsViewMessages';
+import {
+  AGENT_MODE_PRESETS,
+  type AgentModePreset,
+} from '@shared/schemas/agentPresets';
 
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
   static override styles = [
     designTokens,
+    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -44,6 +49,77 @@ export class MultiAgentTab extends LitElement {
         font-size: var(--font-size-small);
       }
 
+      /* Preset cards */
+      .preset-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: var(--spacing-medium);
+      }
+
+      .preset-card {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-small);
+        padding: var(--spacing-medium);
+        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        transition:
+          border-color 0.15s ease,
+          background-color 0.15s ease;
+      }
+
+      .preset-card:hover {
+        border-color: var(--vscode-focusBorder);
+        background-color: var(
+          --vscode-list-hoverBackground,
+          rgba(128, 128, 128, 0.1)
+        );
+      }
+
+      .preset-card-header {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+      }
+
+      .preset-card-icon {
+        font-size: var(--font-size-lg);
+        color: var(--vscode-focusBorder);
+        flex-shrink: 0;
+      }
+
+      .preset-card-name {
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+        color: var(--vscode-foreground);
+      }
+
+      .preset-card-description {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+        line-height: 1.4;
+        margin: 0;
+      }
+
+      .preset-card-agents {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: var(--spacing-tiny);
+      }
+
+      .preset-agent-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        font-size: 10px;
+        color: var(--color-text-secondary);
+        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+        border-radius: var(--border-radius);
+      }
+
+      /* Reliability settings */
       .reliability-row {
         display: flex;
         align-items: center;
@@ -87,6 +163,12 @@ export class MultiAgentTab extends LitElement {
     );
   }
 
+  private handlePresetClick(preset: AgentModePreset): void {
+    this.dispatchEvent(
+      createEvent('apply-agent-mode-preset', { presetId: preset.id }),
+    );
+  }
+
   private handleReliabilityChange(
     setting: NumberVscodeSetting,
     input: HTMLInputElement,
@@ -103,6 +185,28 @@ export class MultiAgentTab extends LitElement {
     this.dispatchEvent(
       createEvent('reliability-setting-change', { key: setting.key, value }),
     );
+  }
+
+  private renderPresetCard(preset: AgentModePreset): TemplateResult {
+    const allAgents = [...preset.toolUseAgents, ...preset.workflowAgents];
+    return html`
+      <div
+        class="preset-card"
+        @click=${() => this.handlePresetClick(preset)}
+        title="Apply ${preset.name} preset"
+      >
+        <div class="preset-card-header">
+          <span class="codicon ${preset.icon} preset-card-icon"></span>
+          <span class="preset-card-name">${preset.name}</span>
+        </div>
+        <p class="preset-card-description">${preset.description}</p>
+        <div class="preset-card-agents">
+          ${allAgents.map(
+            (name) => html`<span class="preset-agent-badge">${name}</span>`,
+          )}
+        </div>
+      </div>
+    `;
   }
 
   private renderReliabilitySetting(
@@ -131,6 +235,17 @@ export class MultiAgentTab extends LitElement {
   override render(): TemplateResult {
     return html`
       <div class="multi-agent-container tab-content-container">
+        <h3>Mode Presets</h3>
+
+        <p class="text-secondary setting-description">
+          Apply a preset to quickly configure which agents are enabled for your
+          workflow. This updates the Agents tab selection.
+        </p>
+
+        <div class="preset-grid">
+          ${AGENT_MODE_PRESETS.map((p) => this.renderPresetCard(p))}
+        </div>
+
         <h3>Agent Delegation</h3>
 
         <p class="text-secondary setting-description">

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -219,10 +219,6 @@ export class MultiAgentTab extends LitElement {
     );
   }
 
-  private handleSavePreset(): void {
-    this.dispatchEvent(createEvent('save-agent-mode-preset', undefined));
-  }
-
   private handleReliabilityChange(
     setting: NumberVscodeSetting,
     input: HTMLInputElement,
@@ -303,14 +299,6 @@ export class MultiAgentTab extends LitElement {
       <div class="multi-agent-container tab-content-container">
         <div class="preset-section-header">
           <h3>Mode Presets</h3>
-          <button
-            class="tab-action-btn"
-            @click=${this.handleSavePreset}
-            title="Save current agent configuration as a preset"
-          >
-            <span class="codicon codicon-save"></span>
-            Save Current
-          </button>
         </div>
 
         <p class="text-secondary setting-description">

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -53,7 +53,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'Symbolic derivations, mathematical verification, literature discussion, and rigorous manuscript review.',
     icon: 'codicon-symbol-operator',
     workflowAgents: ['correct', 'polish', 'draw'],
-    toolUseAgents: ['research', 'review', 'chat', 'discuss'],
+    toolUseAgents: ['research', 'review', 'chat', 'discuss', 'devise', 'criticize'],
   },
   {
     id: 'mathematician',

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -34,23 +34,16 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     description:
       'Formal proof development with Lean 4, interactive theorem proving, and LaTeX document support.',
     icon: 'codicon-symbol-structure',
-    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
+    workflowAgents: ['correct', 'polish', 'draw'],
     toolUseAgents: ['lean', 'chat', 'review'],
   },
   {
     id: 'computational-physicist',
     name: 'Computational Physicist',
     description:
-      'Numerical computation, Wolfram Language, data analysis, and presentation preparation.',
+      'Numerical computation, Wolfram Language, data analysis, and scientific writing.',
     icon: 'codicon-pulse',
-    workflowAgents: [
-      'correct',
-      'polish',
-      'draw',
-      'merge',
-      'paper2slide',
-      'paper2poster',
-    ],
+    workflowAgents: ['correct', 'polish', 'draw'],
     toolUseAgents: ['research', 'chat', 'review'],
   },
   {
@@ -59,7 +52,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     description:
       'Symbolic derivations, mathematical verification, literature discussion, and rigorous manuscript review.',
     icon: 'codicon-symbol-operator',
-    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
+    workflowAgents: ['correct', 'polish', 'draw'],
     toolUseAgents: ['research', 'review', 'chat', 'discuss'],
   },
   {
@@ -68,7 +61,7 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     description:
       'Formal proofs with Lean 4, symbolic computation, derivation verification, and theorem exploration.',
     icon: 'codicon-symbol-number',
-    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
-    toolUseAgents: ['lean', 'research', 'review', 'chat'],
+    workflowAgents: ['correct', 'polish', 'draw'],
+    toolUseAgents: ['lean', 'leanSearch', 'leanSimplifier', 'research', 'review', 'chat'],
   },
 ];

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -32,14 +32,14 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     id: 'lean-project',
     name: 'Lean Project',
     description:
-      'Formal proof development with Lean 4, interactive theorem proving, and LaTeX document support.',
+      'Formal proof development with Lean 4, theorem search, tactic simplification, and LaTeX document support.',
     icon: 'codicon-symbol-structure',
     workflowAgents: ['correct', 'polish', 'draw'],
-    toolUseAgents: ['lean', 'chat', 'review'],
+    toolUseAgents: ['lean', 'leanSearch', 'leanSimplifier', 'chat', 'review'],
   },
   {
-    id: 'computational-physicist',
-    name: 'Computational Physicist',
+    id: 'computational-scientist',
+    name: 'Computational Scientist',
     description:
       'Numerical computation, Wolfram Language, data analysis, and scientific writing.',
     icon: 'codicon-pulse',
@@ -47,13 +47,13 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     toolUseAgents: ['research', 'chat', 'review'],
   },
   {
-    id: 'analytical-theorist',
-    name: 'Analytical Theorist',
+    id: 'theoretical-physicist',
+    name: 'Theoretical Physicist',
     description:
       'Symbolic derivations, mathematical verification, literature discussion, and rigorous manuscript review.',
     icon: 'codicon-symbol-operator',
     workflowAgents: ['correct', 'polish', 'draw'],
-    toolUseAgents: ['research', 'review', 'chat', 'discuss', 'devise', 'criticize'],
+    toolUseAgents: ['research', 'review', 'chat', 'discuss'],
   },
   {
     id: 'mathematician',

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -1,0 +1,74 @@
+/**
+ * Agent mode presets - predefined collections of enabled agents
+ * for different academic disciplines.
+ *
+ * Each preset specifies which workflow and tool-use agents to enable.
+ * Agent names are plain strings (not source-prefixed keys) so they
+ * match across built-in and custom sources.
+ */
+
+import { z } from 'zod';
+
+/** Schema for a single agent mode preset. */
+export const AgentModePresetSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  icon: z.string(),
+  workflowAgents: z.array(z.string()),
+  toolUseAgents: z.array(z.string()),
+});
+
+export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
+
+/**
+ * Built-in agent mode presets.
+ *
+ * Agent names listed here are matched by name (not source:name key)
+ * so custom agents that override a built-in are included automatically.
+ */
+export const AGENT_MODE_PRESETS: AgentModePreset[] = [
+  {
+    id: 'lean-project',
+    name: 'Lean Project',
+    description:
+      'Formal proof development with Lean 4, interactive theorem proving, and LaTeX document support.',
+    icon: 'codicon-symbol-structure',
+    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
+    toolUseAgents: ['lean', 'chat', 'review'],
+  },
+  {
+    id: 'computational-physicist',
+    name: 'Computational Physicist',
+    description:
+      'Numerical computation, Wolfram Language, data analysis, and presentation preparation.',
+    icon: 'codicon-pulse',
+    workflowAgents: [
+      'correct',
+      'polish',
+      'draw',
+      'merge',
+      'paper2slide',
+      'paper2poster',
+    ],
+    toolUseAgents: ['research', 'chat', 'review'],
+  },
+  {
+    id: 'analytical-theorist',
+    name: 'Analytical Theorist',
+    description:
+      'Symbolic derivations, mathematical verification, literature discussion, and rigorous manuscript review.',
+    icon: 'codicon-symbol-operator',
+    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
+    toolUseAgents: ['research', 'review', 'chat', 'discuss'],
+  },
+  {
+    id: 'mathematician',
+    name: 'Mathematician',
+    description:
+      'Formal proofs with Lean 4, symbolic computation, derivation verification, and theorem exploration.',
+    icon: 'codicon-symbol-number',
+    workflowAgents: ['correct', 'polish', 'draw', 'merge'],
+    toolUseAgents: ['lean', 'research', 'review', 'chat'],
+  },
+];

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -192,6 +192,21 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 >;
 
 // ============================================================
+// Agent mode presets data schema
+// ============================================================
+
+import { AgentModePresetSchema } from './agentPresets';
+
+/** Outbound: backend → frontend agent mode presets (built-in + custom) */
+export const UpdateAgentModePresetsMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS),
+  customPresets: z.array(AgentModePresetSchema),
+});
+export type UpdateAgentModePresetsMessage = z.infer<
+  typeof UpdateAgentModePresetsMessageSchema
+>;
+
+// ============================================================
 // Tool dashboard data schemas
 // ============================================================
 
@@ -380,8 +395,21 @@ const SetSuperYoloEnabledMessageSchema = z.object({
 });
 
 // Agent mode preset inbound messages
+const GetAgentModePresetsMessageSchema = commandOnly(
+  CMD.GET_AGENT_MODE_PRESETS,
+);
+
 const ApplyAgentModePresetMessageSchema = z.object({
   command: z.literal(CMD.APPLY_AGENT_MODE_PRESET),
+  presetId: z.string().min(1),
+});
+
+const SaveAgentModePresetMessageSchema = commandOnly(
+  CMD.SAVE_AGENT_MODE_PRESET,
+);
+
+const DeleteAgentModePresetMessageSchema = z.object({
+  command: z.literal(CMD.DELETE_AGENT_MODE_PRESET),
   presetId: z.string().min(1),
 });
 
@@ -464,7 +492,10 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetSuperYoloEnabledMessageSchema,
     SetSuperYoloEnabledMessageSchema,
     // Agent mode preset messages
+    GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,
+    SaveAgentModePresetMessageSchema,
+    DeleteAgentModePresetMessageSchema,
   ],
 );
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -379,6 +379,12 @@ const SetSuperYoloEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+// Agent mode preset inbound messages
+const ApplyAgentModePresetMessageSchema = z.object({
+  command: z.literal(CMD.APPLY_AGENT_MODE_PRESET),
+  presetId: z.string().min(1),
+});
+
 // Tool dashboard inbound messages
 const GetToolDashboardDataMessageSchema = z.object({
   command: z.literal(CMD.GET_TOOL_DASHBOARD_DATA),
@@ -457,6 +463,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     // Super YOLO messages
     GetSuperYoloEnabledMessageSchema,
     SetSuperYoloEnabledMessageSchema,
+    // Agent mode preset messages
+    ApplyAgentModePresetMessageSchema,
   ],
 );
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -18,6 +18,7 @@ import {
   SETTINGS_VIEW_COMMANDS,
 } from '@common/webview/commands';
 import { AgentCategorySchema, AgentSourceSchema } from './agent';
+import { AgentModePresetSchema } from './agentPresets';
 import {
   DeleteMemoryMessageSchema,
   GetMemoryDataMessageSchema,
@@ -194,8 +195,6 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 // ============================================================
 // Agent mode presets data schema
 // ============================================================
-
-import { AgentModePresetSchema } from './agentPresets';
 
 /** Outbound: backend → frontend agent mode presets (built-in + custom) */
 export const UpdateAgentModePresetsMessageSchema = z.object({


### PR DESCRIPTION
## Summary
This PR adds agent mode presets functionality to the Multi-Agent settings tab, allowing users to quickly apply predefined or custom agent configurations for different academic disciplines.

## Key Changes

- **New Agent Mode Presets Schema** (`src/shared/schemas/agentPresets.ts`)
  - Defined `AgentModePreset` type with id, name, description, icon, and agent lists
  - Created four built-in presets: Lean Project, Computational Physicist, Analytical Theorist, and Mathematician
  - Each preset specifies which workflow and tool-use agents to enable

- **Multi-Agent Tab UI Enhancements** (`src/settingsView/frontend/tabs/MultiAgentTab.ts`)
  - Added preset grid display with clickable preset cards
  - Each card shows preset icon, name, description, and enabled agents as badges
  - Added "Save Current" button to create custom presets from current configuration
  - Custom presets show a delete button on hover
  - Integrated codiconStyles for icon support

- **Backend Preset Handlers** (`src/settingsView/SettingsViewMessageHandler.ts`)
  - Implemented `handleApplyAgentModePreset()` to apply a preset's agent configuration
  - Implemented `handleSaveAgentModePreset()` to save current agent selection as a custom preset
  - Implemented `handleDeleteAgentModePreset()` to remove custom presets
  - Added `sendAgentModePresets()` to send custom presets to frontend
  - Custom presets are persisted in workspace state with validation

- **Frontend State Management** (`src/settingsView/frontend/SettingsApp.ts`)
  - Added `customPresets` state to track user-created presets
  - Added event handlers for apply, save, and delete preset operations
  - Integrated preset data into Multi-Agent tab component

- **Message Schema Updates** (`src/shared/schemas/settingsViewMessages.ts`)
  - Added `UpdateAgentModePresetsMessage` for outbound preset data
  - Added inbound message schemas for preset operations (apply, save, delete, get)

- **Command Definitions** (`src/common/webview/commands.ts`)
  - Added four new commands: `APPLY_AGENT_MODE_PRESET`, `SAVE_AGENT_MODE_PRESET`, `DELETE_AGENT_MODE_PRESET`, `GET_AGENT_MODE_PRESETS`

- **Workspace State** (`src/common/state/stateManager.ts`)
  - Added `CUSTOM_AGENT_PRESETS` key to persist user-created presets

## Implementation Details

- Preset agent names are matched by plain name (not source-prefixed keys) to support custom agents that override built-ins
- Custom presets are validated using Zod schema before storage and retrieval
- Applying a preset updates both workflow and tool-use agent selections in workspace state
- User confirmation is required before deleting custom presets
- Preset cards use VS Code design tokens for consistent styling and theming

https://claude.ai/code/session_016qUXMec2LVL2UUGt3QNzUq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches settings webview messaging and mutates persisted agent enablement state, so bugs could unexpectedly change which agents are enabled or break settings UI interactions; no auth/data-plane logic changes.
> 
> **Overview**
> Adds **agent mode presets** to the Settings view so users can quickly switch enabled workflow/tool-use agents from the Multi-Agent tab, including a set of built-in academic presets and user-created presets.
> 
> Implements end-to-end support: new Zod schema and preset definitions (`agentPresets.ts`), new settings webview commands/messages to get/apply/save/delete presets, backend handlers that persist custom presets in workspace state and update `ENABLED_AGENTS`/`ENABLED_TOOL_USE_AGENTS`, and frontend UI/state to render preset cards and provide save/delete actions.
> 
> Also adds a new built-in tool-use agent `presenter` plus a `template_slide.tex` Beamer template resource, and exports `deduplicateByName` for preset application logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24bd705a5743361553f2a4a17e5141929016b14b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->