### PR TITLE
Add real-time progress updates from subagents to orchestrator

### DIFF
--- a/docs/analysis-subagent-updates.md
+++ b/docs/analysis-subagent-updates.md
@@ -375,20 +375,119 @@ This creates a **latency floor**: the orchestrator only learns about subagent pr
 | Mechanism | Real-Time? | Data Available | Cost to Orchestrator |
 |-----------|-----------|----------------|---------------------|
 | **FollowUpQueue delivery** | Near-real-time (fires at completion/WAITING) | Final result (XML with outputs or last response) | Zero - delivered automatically as follow-up message |
+| **FollowUpQueue progress** (NEW) | Coalesced (3s debounce) | Todos, round progress, tool count, files changed | Zero - delivered automatically |
 | **`executions` with `action=wait`** | Efficient blocking | Status + progress + todos | One tool call per check (blocks efficiently) |
 | **`executions` with `action=view`** | Snapshot | Status, progress, conversation, todos, files | One tool call per check |
 | **`executions/{id}/conversation`** | Snapshot | Full message history with tool calls | One tool call (can be large) |
 | **`executions/{id}/todos`** | Snapshot | Task checklist | One tool call |
 | **Event bus** | True real-time | Everything | Not available to orchestrator (UI only) |
 
+---
+
+## Implementation: Pushed Progress Updates (NEW)
+
+### What Changed
+
+Subagents now proactively push intermediate progress to the orchestrator via the FollowUpQueue, using a new `onProgress` callback wired through the execution stack.
+
+### Progress Update Types (Typed Internally)
+
+```typescript
+// Discriminated union — typed objects internally, XML at boundary
+type SubagentProgressUpdate =
+  | { kind: 'todos'; todos: TodoItem[] }           // Todo list changed
+  | { kind: 'round'; currentRound: number;          // Workflow round done
+      totalRounds: number }
+  | { kind: 'overview'; toolCallCount: number;       // Activity summary
+      filesChanged: string[] }
+```
+
+### XML Format at Boundary
+
+```xml
+<!-- Todo update -->
+<subagent-progress id="abc123" agent="chat" type="todos"
+    completed="2" active="1" pending="3">
+  [x] Read the input file
+  [x] Identify citation errors
+  [>] Fix citations on slide 3
+  [ ] Fix citations on slide 7
+  [ ] Verify bibliography consistency
+  [ ] Final review
+</subagent-progress>
+
+<!-- Round completion (workflow) -->
+<subagent-progress id="def456" agent="correct" type="round"
+    current="2" total="5" />
+
+<!-- Overview (tool-use) -->
+<subagent-progress id="abc123" agent="chat" type="overview"
+    tool-calls="7" files-changed="slides/talk.tex, refs.bib" />
+```
+
+### Coalescing
+
+To avoid flooding the orchestrator when rapid changes occur (e.g., 5 todo updates in 1 second), updates are coalesced with a 3-second debounce timer per update kind:
+
+```
+                    Subagent emits updates
+                    ──────────────────────
+t=0s   onProgress({kind:'todos', ...})   → buffered
+t=0.5s onProgress({kind:'todos', ...})   → replaces previous
+t=1s   onProgress({kind:'overview', ...}) → buffered (different kind)
+t=3s   ─── timer fires ───────────────── → flush both to FollowUpQueue
+t=3.2s onProgress({kind:'todos', ...})   → buffered (new timer)
+t=6.2s ─── timer fires ───────────────── → flush
+```
+
+When the final result is delivered (`onBeforeWaiting` / `onCompleted`), any buffered progress is flushed immediately before the result message.
+
+### Wiring Diagram
+
+```
+executeSubagent() ─── onProgress callback (with coalescing) ──┐
+        │                                                       │
+        ▼                                                       │
+executeAgent(options: { onProgress })                           │
+        │                                                       │
+        ├── Tool-Use path:                                      │
+        │   runToolUseFlow(input: { onProgress })               │
+        │     → ToolUseServices.onProgress                      │
+        │       → ToolUseCycleNode.exec():                      │
+        │           todos.setOnUpdate() → onProgress({todos})   │
+        │       → ToolUseCycleNode.post():                      │
+        │           onProgress({overview: toolCalls, files})     │
+        │                                                       │
+        └── Workflow path:                                      │
+            createRoundProgressCallback(id, onProgress)         │
+              → onRoundCompleted → onProgress({round})          │
+                                                                │
+                      formatSubagentProgress() ◄────────────────┘
+                              │
+                              ▼
+                  ToolUseFollowUpQueue.enqueue()
+                              │
+                              ▼
+                    Orchestrator receives as
+                    user-role follow-up message
+```
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `src/tools/subagentResults.ts` | New `SubagentProgressUpdate` types + `formatSubagentProgress()` |
+| `src/tools/WorkflowTool.ts` | Coalescing `onProgress` callback in `executeSubagent()` |
+| `src/agent/runtime/executeAgent.ts` | `onProgress` in `ExecuteAgentOptions`, wired to both paths |
+| `src/agent/implementations/flows/tooluse/ToolUseServices.ts` | `onProgress` field on services interface |
+| `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` | `onProgress` on `RunToolUseFlowInput` |
+| `src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts` | Emit todos + overview via `onProgress` |
+
 ### Key Insight
 
-The orchestrator **can** get intermediate updates by polling the `executions` endpoints (especially `conversation` and `todos`), but it must actively choose to do so. The system is designed for an **async fire-and-forget** pattern where the orchestrator launches subagents and receives results via the FollowUpQueue. The `executions` tool exists as an **escape hatch** for when the orchestrator needs to check on long-running subagents, but it's not the primary communication channel.
+The `executions` tool endpoints remain useful for deep inspection (full conversation, file contents, killing stuck processes), but the orchestrator no longer needs to spend tool calls just to learn that progress happened. The primary communication path is now:
 
-The hint is right in the `executeSubagent()` return message (WorkflowTool.ts:170):
-```
-"To check intermediate progress: executions tool with
- path=/executions/${executionId} and action=wait"
-```
-
-This tells the model it *can* poll, but the default expectation is that results arrive automatically.
+1. **Launch** → immediate "Launched async" response
+2. **Progress** → automatic `<subagent-progress>` messages via FollowUpQueue (NEW)
+3. **Result** → automatic `<subagent-result>` message via FollowUpQueue (existing)
+4. **Deep inspection** → `executions` tool (escape hatch, unchanged)

--- a/docs/analysis-subagent-updates.md
+++ b/docs/analysis-subagent-updates.md
@@ -2,7 +2,7 @@
 
 ## Short Answer
 
-**Yes, but with important caveats.** The orchestrator *can* query running subagents via the `executions` tool endpoints, but it **doesn't receive streaming mid-execution updates automatically**. The system provides two distinct update channels:
+**Yes, but with important caveats.** The orchestrator _can_ query running subagents via the `executions` tool endpoints, but it **doesn't receive streaming mid-execution updates automatically**. The system provides two distinct update channels:
 
 1. **Active polling** via the `executions` tool (status, progress, todos, conversation)
 2. **Passive delivery** via the FollowUpQueue (final or near-final results only)
@@ -100,21 +100,21 @@ The orchestrator has access to the `executions` tool, which provides a REST-like
 
 **Actions available:**
 
-| Action | Behavior |
-|--------|----------|
-| `view` | Returns data immediately (snapshot of current state) |
+| Action | Behavior                                               |
+| ------ | ------------------------------------------------------ |
+| `view` | Returns data immediately (snapshot of current state)   |
 | `wait` | Blocks until a status change occurs, then returns data |
-| `kill` | Terminates the running execution |
+| `kill` | Terminates the running execution                       |
 
 **What the orchestrator CAN see while a subagent is running:**
 
-| Endpoint | Live Data? | Details |
-|----------|-----------|---------|
-| Summary (`/executions/{id}`) | Yes | Status (RUNNING/WAITING/etc), elapsed time, round progress (`round 2/5`) |
-| Conversation | Yes | Full message history including tool calls and results, updated after each model turn |
-| Todos | Yes | Task list items with status (pending/in_progress/completed) |
-| Files | Partial | Only available after rounds complete (workflow agents write per-round) |
-| Report | No | Only written on completion or when `onBeforeWaiting` fires |
+| Endpoint                     | Live Data? | Details                                                                              |
+| ---------------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| Summary (`/executions/{id}`) | Yes        | Status (RUNNING/WAITING/etc), elapsed time, round progress (`round 2/5`)             |
+| Conversation                 | Yes        | Full message history including tool calls and results, updated after each model turn |
+| Todos                        | Yes        | Task list items with status (pending/in_progress/completed)                          |
+| Files                        | Partial    | Only available after rounds complete (workflow agents write per-round)               |
+| Report                       | No         | Only written on completion or when `onBeforeWaiting` fires                           |
 
 **The `wait` action** is the efficient polling mechanism:
 
@@ -136,6 +136,7 @@ Orchestrator                          ExecutionRegistry
 ```
 
 The `wait` action resolves on **any** of these events:
+
 - Stream status change (RUNNING → WAITING, RUNNING → STOPPED, etc.)
 - Round progress update (`updateExecutionProgress`)
 - Execution kill
@@ -196,6 +197,7 @@ This is the **primary result delivery mechanism**. Results are pushed to the orc
 ### No Streaming of Intermediate Work
 
 The orchestrator does **not** receive real-time streaming of:
+
 - Model token generation in progress
 - Individual tool call results as they happen
 - Partial document rewrites mid-round
@@ -372,15 +374,15 @@ This creates a **latency floor**: the orchestrator only learns about subagent pr
 
 ## Summary: Update Mechanisms Ranked by Usefulness
 
-| Mechanism | Real-Time? | Data Available | Cost to Orchestrator |
-|-----------|-----------|----------------|---------------------|
-| **FollowUpQueue delivery** | Near-real-time (fires at completion/WAITING) | Final result (XML with outputs or last response) | Zero - delivered automatically as follow-up message |
-| **FollowUpQueue progress** (NEW) | Coalesced (3s debounce) | Todos, round progress, tool count, files changed | Zero - delivered automatically |
-| **`executions` with `action=wait`** | Efficient blocking | Status + progress + todos | One tool call per check (blocks efficiently) |
-| **`executions` with `action=view`** | Snapshot | Status, progress, conversation, todos, files | One tool call per check |
-| **`executions/{id}/conversation`** | Snapshot | Full message history with tool calls | One tool call (can be large) |
-| **`executions/{id}/todos`** | Snapshot | Task checklist | One tool call |
-| **Event bus** | True real-time | Everything | Not available to orchestrator (UI only) |
+| Mechanism                           | Real-Time?                                   | Data Available                                   | Cost to Orchestrator                                |
+| ----------------------------------- | -------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| **FollowUpQueue delivery**          | Near-real-time (fires at completion/WAITING) | Final result (XML with outputs or last response) | Zero - delivered automatically as follow-up message |
+| **FollowUpQueue progress** (NEW)    | Coalesced (3s debounce)                      | Todos, round progress, tool count, files changed | Zero - delivered automatically                      |
+| **`executions` with `action=wait`** | Efficient blocking                           | Status + progress + todos                        | One tool call per check (blocks efficiently)        |
+| **`executions` with `action=view`** | Snapshot                                     | Status, progress, conversation, todos, files     | One tool call per check                             |
+| **`executions/{id}/conversation`**  | Snapshot                                     | Full message history with tool calls             | One tool call (can be large)                        |
+| **`executions/{id}/todos`**         | Snapshot                                     | Task checklist                                   | One tool call                                       |
+| **Event bus**                       | True real-time                               | Everything                                       | Not available to orchestrator (UI only)             |
 
 ---
 
@@ -395,11 +397,17 @@ Subagents now proactively push intermediate progress to the orchestrator via the
 ```typescript
 // Discriminated union — typed objects internally, XML at boundary
 type SubagentProgressUpdate =
-  | { kind: 'todos'; todos: TodoItem[] }           // Todo list changed
-  | { kind: 'round'; currentRound: number;          // Workflow round done
-      totalRounds: number }
-  | { kind: 'overview'; toolCallCount: number;       // Activity summary
-      filesChanged: string[] }
+  | { kind: 'todos'; todos: TodoItem[] } // Todo list changed
+  | {
+      kind: 'round';
+      currentRound: number; // Workflow round done
+      totalRounds: number;
+    }
+  | {
+      kind: 'overview';
+      toolCallCount: number; // Activity summary
+      filesChanged: string[];
+    };
 ```
 
 ### XML Format at Boundary
@@ -474,14 +482,14 @@ executeAgent(options: { onProgress })                           │
 
 ### Files Modified
 
-| File | Change |
-|------|--------|
-| `src/tools/subagentResults.ts` | New `SubagentProgressUpdate` types + `formatSubagentProgress()` |
-| `src/tools/WorkflowTool.ts` | Coalescing `onProgress` callback in `executeSubagent()` |
-| `src/agent/runtime/executeAgent.ts` | `onProgress` in `ExecuteAgentOptions`, wired to both paths |
-| `src/agent/implementations/flows/tooluse/ToolUseServices.ts` | `onProgress` field on services interface |
-| `src/agent/implementations/flows/tooluse/runToolUseFlow.ts` | `onProgress` on `RunToolUseFlowInput` |
-| `src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts` | Emit todos + overview via `onProgress` |
+| File                                                                | Change                                                          |
+| ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `src/tools/subagentResults.ts`                                      | New `SubagentProgressUpdate` types + `formatSubagentProgress()` |
+| `src/tools/WorkflowTool.ts`                                         | Coalescing `onProgress` callback in `executeSubagent()`         |
+| `src/agent/runtime/executeAgent.ts`                                 | `onProgress` in `ExecuteAgentOptions`, wired to both paths      |
+| `src/agent/implementations/flows/tooluse/ToolUseServices.ts`        | `onProgress` field on services interface                        |
+| `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`         | `onProgress` on `RunToolUseFlowInput`                           |
+| `src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts` | Emit todos + overview via `onProgress`                          |
 
 ### Key Insight
 

--- a/docs/analysis-subagent-updates.md
+++ b/docs/analysis-subagent-updates.md
@@ -1,0 +1,394 @@
+# Analysis: Can the Orchestrator Get Real-Time Updates from Subagents?
+
+## Short Answer
+
+**Yes, but with important caveats.** The orchestrator *can* query running subagents via the `executions` tool endpoints, but it **doesn't receive streaming mid-execution updates automatically**. The system provides two distinct update channels:
+
+1. **Active polling** via the `executions` tool (status, progress, todos, conversation)
+2. **Passive delivery** via the FollowUpQueue (final or near-final results only)
+
+The gap: there is **no push-based streaming of intermediate work** from subagent to orchestrator during execution. The orchestrator either polls or waits for completion.
+
+---
+
+## Architecture Diagram
+
+```
+                         ORCHESTRATOR (tool-use agent, streamId: A)
+                         ════════════════════════════════════════
+                              │                          ▲
+                              │ delegate_workflow /       │ Result delivered via
+                              │ delegate_agent           │ ToolUseFollowUpQueue.enqueue()
+                              │                          │
+                              ▼                          │
+                    ┌─────────────────────┐              │
+                    │  executeSubagent()  │              │
+                    │                     │              │
+                    │  1. generateId()    │              │
+                    │  2. registerExec()  │              │
+                    │  3. executeAgent()  │──────────────┤
+                    │     with callbacks: │              │
+                    │     - onBeforeWait  │──┐           │
+                    │     - onCompleted   │──┤           │
+                    │     - onStreamRes   │  │           │
+                    └─────────────────────┘  │           │
+                              │              │           │
+                    Returns immediately:     │           │
+                    "Launched async"          │           │
+                              │              │           │
+                              ▼              │           │
+              ┌───────────────────────────┐  │           │
+              │  SUBAGENT (streamId: B)   │  │           │
+              │  ═══════════════════════  │  │           │
+              │                           │  │           │
+              │  ┌─────────────────────┐  │  │           │
+              │  │ Tool-Use Flow:      │  │  │           │
+              │  │                     │  │  │           │
+              │  │  PrepareNode        │  │  │           │
+              │  │    ↓                │  │  │           │
+              │  │  CycleNode ←──┐    │  │  │           │
+              │  │    │ (model   │    │  │  │           │
+              │  │    │  call,   │    │  │  │           │
+              │  │    │  tools)  │    │  │  │           │
+              │  │    ↓          │    │  │  │           │
+              │  │  WaitNode ────┘    │  │  │           │
+              │  │    │               │  │  │           │
+              │  │    │ onBeforeWait  │──┘  │           │
+              │  │    │ fires HERE ───────────► enqueue()
+              │  │    │               │      │           │
+              │  │    ▼               │      │           │
+              │  │  WAITING status    │      │           │
+              │  └─────────────────────┘      │           │
+              │                           │  │           │
+              │  ┌─────────────────────┐  │  │           │
+              │  │ Workflow Flow:      │  │  │           │
+              │  │                     │  │  │           │
+              │  │  PrepareContext     │  │  │           │
+              │  │    ↓               │  │  │           │
+              │  │  TeXCount          │  │  │           │
+              │  │    ↓               │  │  │           │
+              │  │  MediaExtraction   │  │  │           │
+              │  │    ↓               │  │  │           │
+              │  │  ResponseCycle     │  │  │           │
+              │  │    ↓               │  │  │           │
+              │  │  OutputNode        │  │  │           │
+              │  │    │               │  │  │           │
+              │  │    │ onCompleted   │──┘  │           │
+              │  │    │ fires HERE ───────────► enqueue()
+              │  └─────────────────────┘      │
+              └───────────────────────────┘
+```
+
+---
+
+## The Two Update Channels in Detail
+
+### Channel 1: Active Polling via `executions` Tool
+
+The orchestrator has access to the `executions` tool, which provides a REST-like virtual filesystem for querying subagent state:
+
+```
+/executions/{id}              → Summary: status, agent, model, progress, todos
+/executions/{id}/config       → Agent configuration JSON
+/executions/{id}/conversation → Full message history (tool-use subagents)
+/executions/{id}/todos        → Task checklist (tool-use subagents)
+/executions/{id}/report       → Persisted result report
+/executions/{id}/children     → Child execution listing
+/executions/{id}/files        → Generated output files (workflow subagents)
+/executions/{id}/files/{path} → Read specific output file content
+```
+
+**Actions available:**
+
+| Action | Behavior |
+|--------|----------|
+| `view` | Returns data immediately (snapshot of current state) |
+| `wait` | Blocks until a status change occurs, then returns data |
+| `kill` | Terminates the running execution |
+
+**What the orchestrator CAN see while a subagent is running:**
+
+| Endpoint | Live Data? | Details |
+|----------|-----------|---------|
+| Summary (`/executions/{id}`) | Yes | Status (RUNNING/WAITING/etc), elapsed time, round progress (`round 2/5`) |
+| Conversation | Yes | Full message history including tool calls and results, updated after each model turn |
+| Todos | Yes | Task list items with status (pending/in_progress/completed) |
+| Files | Partial | Only available after rounds complete (workflow agents write per-round) |
+| Report | No | Only written on completion or when `onBeforeWaiting` fires |
+
+**The `wait` action** is the efficient polling mechanism:
+
+```
+Orchestrator                          ExecutionRegistry
+    │                                       │
+    │  executions(path=/executions/{id},     │
+    │             action=wait,               │
+    │             timeout=300)               │
+    │ ─────────────────────────────────────► │
+    │                                       │  Registers changeCallback
+    │              (blocks)                  │
+    │                                       │  ◄── status transition
+    │                                       │      (RUNNING→WAITING)
+    │                                       │      OR progress update
+    │                                       │      OR untrack (complete)
+    │  ◄───────────────────────────────────  │
+    │  Returns current summary              │
+```
+
+The `wait` action resolves on **any** of these events:
+- Stream status change (RUNNING → WAITING, RUNNING → STOPPED, etc.)
+- Round progress update (`updateExecutionProgress`)
+- Execution kill
+- Execution completion (untrack)
+- Timeout
+
+### Channel 2: Passive Delivery via FollowUpQueue
+
+This is the **primary result delivery mechanism**. Results are pushed to the orchestrator's `ToolUseFollowUpQueue` as XML-formatted messages.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    DELIVERY TIMING                            │
+├──────────────┬──────────────────┬────────────────────────────┤
+│ Subagent     │ Trigger          │ Mechanism                  │
+│ Category     │                  │                            │
+├──────────────┼──────────────────┼────────────────────────────┤
+│ Tool-use     │ Enters WAITING   │ onBeforeWaiting callback   │
+│              │ state (done with │ fires BEFORE the agent     │
+│              │ autonomous work) │ actually enters WAITING    │
+├──────────────┼──────────────────┼────────────────────────────┤
+│ Workflow     │ Flow completes   │ onCompleted callback fires │
+│              │ (all rounds      │ after runner() promise     │
+│              │ finished)        │ resolves                   │
+├──────────────┼──────────────────┼────────────────────────────┤
+│ Either       │ Promise rejects  │ .catch() formats error     │
+│ (on error)   │                  │ and enqueues               │
+└──────────────┴──────────────────┴────────────────────────────┘
+```
+
+**Deduplication guard:** A `hasDelivered` boolean ensures only one delivery per subagent. If `onBeforeWaiting` already fired, `onCompleted` becomes a no-op.
+
+**Delivery format (XML injected as user message):**
+
+```xml
+<!-- Tool-use subagent result -->
+<subagent-result id="abc123" agent="chat" category="toolUse" status="stopped">
+  <response>Here is what I found about the citation errors...</response>
+</subagent-result>
+
+<!-- Workflow subagent result -->
+<subagent-result id="def456" agent="correct" category="workflow" status="completed">
+  <output-files>
+    <file path="paper_corrected.tex" location="runStorage" added="12" removed="8" />
+  </output-files>
+</subagent-result>
+
+<!-- Error -->
+<subagent-error id="ghi789" agent="polish">
+  <message>Model rate limit exceeded</message>
+</subagent-error>
+```
+
+---
+
+## The Gap: What the Orchestrator CANNOT See
+
+### No Streaming of Intermediate Work
+
+The orchestrator does **not** receive real-time streaming of:
+- Model token generation in progress
+- Individual tool call results as they happen
+- Partial document rewrites mid-round
+
+The event bus (`ProgressEventBus`) streams these to the **UI/webview** but not back to the orchestrator agent's conversation context.
+
+```
+                    Event Bus (ProgressEventBus)
+                    ════════════════════════════
+                              │
+              ┌───────────────┼───────────────┐
+              │               │               │
+              ▼               ▼               ▼
+        Webview UI      Progress Board    Log Panel
+        (real-time      (task groups,     (tool calls,
+         status)         subagent          model
+                         badges)           responses)
+
+              ▲               ▲               ▲
+              │               │               │
+     updateStreamStatus  updateActive     addLogMessage
+     updateTodos         Subagents        updateLogMessage
+     updateQueued        setParentStream
+     FollowUps
+```
+
+The event bus is **frontend-facing only**. The orchestrator agent has no event bus subscription mechanism.
+
+### Polling Tax
+
+To get intermediate updates, the orchestrator must **actively spend a tool call** on the `executions` tool. Each query consumes a model turn. The `wait` action mitigates this by blocking until something changes, but the orchestrator still needs to:
+
+1. Decide to check on the subagent
+2. Issue a tool call (`executions` with `action=wait`)
+3. Process the response
+4. Decide whether to check again
+
+This creates a **latency floor**: the orchestrator only learns about subagent progress when it chooses to look.
+
+---
+
+## Complete Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                        USER INTERACTION LAYER                           │
+│  ┌──────────┐  ┌──────────────┐  ┌─────────────┐  ┌────────────────┐  │
+│  │ Webview   │  │ Progress     │  │ Log Panel   │  │ Subagent       │  │
+│  │ (chat UI) │  │ Board        │  │             │  │ Badges         │  │
+│  └─────▲─────┘  └──────▲───────┘  └──────▲──────┘  └──────▲─────────┘  │
+│        │               │                │               │              │
+│        │     WebviewUpdater.postMessage()│               │              │
+│        └───────────────┴────────────────┴───────────────┘              │
+│                                  ▲                                      │
+│                     ProgressEventHandler                                │
+│                     (subscribes to all events)                          │
+└─────────────────────────────────┬───────────────────────────────────────┘
+                                  │
+                        ProgressEventBus (pub-sub)
+                                  │
+          ┌───────────────────────┼────────────────────────┐
+          │                       │                        │
+   updateActiveSubagents    updateStreamStatus        addLogMessage
+   setParentStream          updateQueuedFollowUps     updateLogMessage
+          │                       │                        │
+          │                       │                        │
+┌─────────┴───────────────────────┴────────────────────────┴──────────────┐
+│                        EXECUTION REGISTRY                               │
+│                                                                         │
+│  registry: Map<executionId, ExecutionHandle>                            │
+│  changeCallbacks: Map<executionId, callbacks[]>                         │
+│                                                                         │
+│  ┌──────────────────────┐      ┌──────────────────────┐                 │
+│  │ AgentExecutionHandle │      │ AgentExecutionHandle │                 │
+│  │ id: exec1            │      │ id: exec2            │                 │
+│  │ parent: stream-A     │      │ parent: stream-A     │                 │
+│  │ child:  stream-A     │      │ child:  stream-B     │ ◄── subagent   │
+│  │ agent:  "orchestrator"│      │ agent:  "correct"    │                 │
+│  │ category: toolUse    │      │ category: workflow   │                 │
+│  │ progress: n/a        │      │ progress: 2/5        │                 │
+│  └──────────────────────┘      └──────────────────────┘                 │
+│                                         │                               │
+│               trackExecution()  ←───────┘                               │
+│               untrackExecution() ───────► notifyWaiters()               │
+│               updateExecutionProgress() ─► notifyWaiters()              │
+└─────────────────────────────────────────────────────────────────────────┘
+          │                                         ▲
+          │                                         │
+          │  Orchestrator queries via                │  Subagent updates
+          │  `executions` tool                      │  via runtime
+          │                                         │
+          ▼                                         │
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     ORCHESTRATOR AGENT (stream-A)                        │
+│                                                                         │
+│  Tool-Use Flow Loop:                                                    │
+│                                                                         │
+│  ┌─────────────┐    ┌──────────────────┐    ┌───────────────────┐       │
+│  │ PrepareNode │───►│  CycleNode       │───►│  WaitNode         │       │
+│  └─────────────┘    │                  │    │                   │       │
+│                     │  Model call ──►  │    │  Fires            │       │
+│                     │  Tool calls:     │    │  onBeforeWaiting  │       │
+│                     │  - delegate_*    │    │  if subagent mode │       │
+│                     │  - executions    │    │                   │       │
+│                     │  - accept_files  │    │  Waits on         │       │
+│                     │                  │    │  FollowUpQueue    │       │
+│                     └────────▲─────────┘    └─────────┬─────────┘       │
+│                              │                        │                 │
+│                              │    ┌───────────────────┘                 │
+│                              │    │                                     │
+│                              │    ▼                                     │
+│                     ┌──────────────────────┐                            │
+│                     │ ToolUseFollowUpQueue │                            │
+│                     │ (stream-A)           │                            │
+│                     │                      │                            │
+│                     │  Queued messages:     │                            │
+│                     │  - subagent results  │ ◄─── enqueue() from        │
+│                     │  - bash bg results   │      onBeforeWaiting /     │
+│                     │  - user follow-ups   │      onCompleted /         │
+│                     │                      │      catch()               │
+│                     └──────────────────────┘                            │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+          │
+          │  executeAgent(isSubagent: true)
+          ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     SUBAGENT (stream-B)                                  │
+│                                                                         │
+│  ┌─ Workflow Agent ──────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  Round 1/5          Round 2/5          ...          Round 5/5     │  │
+│  │  ┌──────────────┐  ┌──────────────┐               ┌────────────┐ │  │
+│  │  │PrepareContext │  │PrepareContext │               │OutputNode  │ │  │
+│  │  │TeXCount      │  │TeXCount      │               │            │ │  │
+│  │  │MediaExtract  │  │ResponseCycle │               │  Writes:   │ │  │
+│  │  │ResponseCycle │  │OutputNode    │               │  - files   │ │  │
+│  │  │OutputNode    │  │              │               │  - report  │ │  │
+│  │  └──────────────┘  └──────────────┘               └────────────┘ │  │
+│  │         │                  │                             │        │  │
+│  │  updateExecution    updateExecution               onCompleted()  │  │
+│  │  Progress(1/5)      Progress(2/5)                fires ─────────────► Queue
+│  │                                                                    │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+│  ┌─ Tool-Use Agent ──────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  CycleNode ──► CycleNode ──► CycleNode ──► WaitNode              │  │
+│  │  (model call)  (model call)  (model call)  │                      │  │
+│  │  (tool exec)   (tool exec)   (end turn)    │                      │  │
+│  │                                             │                      │  │
+│  │                                      onBeforeWaiting()            │  │
+│  │                                      fires ───────────────────────────► Queue
+│  │                                             │                      │  │
+│  │                                      WAITING status               │  │
+│  │                                                                    │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+│  Persistent KV Store (per execution):                                   │
+│  ┌────────────────────────────────────────────┐                         │
+│  │ meta.json           - agent, model, status │                         │
+│  │ config.json         - full agent config    │                         │
+│  │ conversation.json   - message history      │ ◄── readable via       │
+│  │ todos.json          - task checklist       │     executions tool     │
+│  │ report.json         - result summary       │                         │
+│  │ flow_{id}           - persisted flow state │                         │
+│  │ child-{id}.json     - child records        │                         │
+│  └────────────────────────────────────────────┘                         │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Summary: Update Mechanisms Ranked by Usefulness
+
+| Mechanism | Real-Time? | Data Available | Cost to Orchestrator |
+|-----------|-----------|----------------|---------------------|
+| **FollowUpQueue delivery** | Near-real-time (fires at completion/WAITING) | Final result (XML with outputs or last response) | Zero - delivered automatically as follow-up message |
+| **`executions` with `action=wait`** | Efficient blocking | Status + progress + todos | One tool call per check (blocks efficiently) |
+| **`executions` with `action=view`** | Snapshot | Status, progress, conversation, todos, files | One tool call per check |
+| **`executions/{id}/conversation`** | Snapshot | Full message history with tool calls | One tool call (can be large) |
+| **`executions/{id}/todos`** | Snapshot | Task checklist | One tool call |
+| **Event bus** | True real-time | Everything | Not available to orchestrator (UI only) |
+
+### Key Insight
+
+The orchestrator **can** get intermediate updates by polling the `executions` endpoints (especially `conversation` and `todos`), but it must actively choose to do so. The system is designed for an **async fire-and-forget** pattern where the orchestrator launches subagents and receives results via the FollowUpQueue. The `executions` tool exists as an **escape hatch** for when the orchestrator needs to check on long-running subagents, but it's not the primary communication channel.
+
+The hint is right in the `executeSubagent()` return message (WorkflowTool.ts:170):
+```
+"To check intermediate progress: executions tool with
+ path=/executions/${executionId} and action=wait"
+```
+
+This tells the model it *can* poll, but the default expectation is that results arrive automatically.

--- a/docs/analysis-subagent-updates.md
+++ b/docs/analysis-subagent-updates.md
@@ -377,7 +377,7 @@ This creates a **latency floor**: the orchestrator only learns about subagent pr
 | Mechanism                           | Real-Time?                                   | Data Available                                   | Cost to Orchestrator                                |
 | ----------------------------------- | -------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
 | **FollowUpQueue delivery**          | Near-real-time (fires at completion/WAITING) | Final result (XML with outputs or last response) | Zero - delivered automatically as follow-up message |
-| **FollowUpQueue progress** (NEW)    | Coalesced (3s debounce)                      | Todos, round progress, tool count, files changed | Zero - delivered automatically                      |
+| **FollowUpQueue progress** (NEW)    | Immediate                                    | Todos, round progress, tool count, files changed | Zero - delivered automatically                      |
 | **`executions` with `action=wait`** | Efficient blocking                           | Status + progress + todos                        | One tool call per check (blocks efficiently)        |
 | **`executions` with `action=view`** | Snapshot                                     | Status, progress, conversation, todos, files     | One tool call per check                             |
 | **`executions/{id}/conversation`**  | Snapshot                                     | Full message history with tool calls             | One tool call (can be large)                        |
@@ -433,27 +433,10 @@ type SubagentProgressUpdate =
     tool-calls="7" files-changed="slides/talk.tex, refs.bib" />
 ```
 
-### Coalescing
-
-To avoid flooding the orchestrator when rapid changes occur (e.g., 5 todo updates in 1 second), updates are coalesced with a 3-second debounce timer per update kind:
-
-```
-                    Subagent emits updates
-                    ──────────────────────
-t=0s   onProgress({kind:'todos', ...})   → buffered
-t=0.5s onProgress({kind:'todos', ...})   → replaces previous
-t=1s   onProgress({kind:'overview', ...}) → buffered (different kind)
-t=3s   ─── timer fires ───────────────── → flush both to FollowUpQueue
-t=3.2s onProgress({kind:'todos', ...})   → buffered (new timer)
-t=6.2s ─── timer fires ───────────────── → flush
-```
-
-When the final result is delivered (`onBeforeWaiting` / `onCompleted`), any buffered progress is flushed immediately before the result message.
-
 ### Wiring Diagram
 
 ```
-executeSubagent() ─── onProgress callback (with coalescing) ──┐
+executeSubagent() ─── onProgress callback ──┐
         │                                                       │
         ▼                                                       │
 executeAgent(options: { onProgress })                           │
@@ -485,7 +468,7 @@ executeAgent(options: { onProgress })                           │
 | File                                                                | Change                                                          |
 | ------------------------------------------------------------------- | --------------------------------------------------------------- |
 | `src/tools/subagentResults.ts`                                      | New `SubagentProgressUpdate` types + `formatSubagentProgress()` |
-| `src/tools/WorkflowTool.ts`                                         | Coalescing `onProgress` callback in `executeSubagent()`         |
+| `src/tools/WorkflowTool.ts`                                         | `onProgress` callback in `executeSubagent()`                    |
 | `src/agent/runtime/executeAgent.ts`                                 | `onProgress` in `ExecuteAgentOptions`, wired to both paths      |
 | `src/agent/implementations/flows/tooluse/ToolUseServices.ts`        | `onProgress` field on services interface                        |
 | `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`         | `onProgress` on `RunToolUseFlowInput`                           |

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -8,7 +8,6 @@ import {
 } from '@shared/schemas';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import { FlattenedEditRecordSchema } from '@tools/result';
-import type { OverviewProgressUpdate } from '@tools/subagentResults';
 import { pathToLocation } from '@utils/files';
 
 /** Schema for thinking blocks (used by model handlers). */
@@ -84,14 +83,9 @@ export class FileInteractionState {
     this._toolCallCount += 1;
   }
 
-  /** Produce an overview progress update from current state. */
-  toOverview(cost?: number): OverviewProgressUpdate {
-    return {
-      kind: 'overview',
-      toolCallCount: this._toolCallCount,
-      filesChanged: [...this.edits.keys()],
-      cost: cost !== undefined && cost > 0 ? cost : undefined,
-    };
+  /** Paths of all files with recorded edits. */
+  get editedFilePaths(): string[] {
+    return [...this.edits.keys()];
   }
 
   recordRead(path: string | undefined | null): void {

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -85,11 +85,19 @@ export class FileInteractionState {
   }
 
   /** Produce an overview progress update from current state. */
-  toOverview(): OverviewProgressUpdate {
+  toOverview(cost?: number): OverviewProgressUpdate {
+    let added = 0;
+    let removed = 0;
+    for (const diff of this.edits.values()) {
+      added += diff.added;
+      removed += diff.removed;
+    }
     return {
       kind: 'overview',
       toolCallCount: this._toolCallCount,
       filesChanged: [...this.edits.keys()],
+      linesChanged: added || removed ? { added, removed } : undefined,
+      cost: cost !== undefined && cost > 0 ? cost : undefined,
     };
   }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/schemas';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import { FlattenedEditRecordSchema } from '@tools/result';
+import type { OverviewProgressUpdate } from '@tools/subagentResults';
 import { pathToLocation } from '@utils/files';
 
 /** Schema for thinking blocks (used by model handlers). */
@@ -81,6 +82,15 @@ export class FileInteractionState {
   /** Record that a tool call was executed. */
   recordToolCall(): void {
     this._toolCallCount += 1;
+  }
+
+  /** Produce an overview progress update from current state. */
+  toOverview(): OverviewProgressUpdate {
+    return {
+      kind: 'overview',
+      toolCallCount: this._toolCallCount,
+      filesChanged: [...this.edits.keys()],
+    };
   }
 
   recordRead(path: string | undefined | null): void {

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -86,17 +86,10 @@ export class FileInteractionState {
 
   /** Produce an overview progress update from current state. */
   toOverview(cost?: number): OverviewProgressUpdate {
-    let added = 0;
-    let removed = 0;
-    for (const diff of this.edits.values()) {
-      added += diff.added;
-      removed += diff.removed;
-    }
     return {
       kind: 'overview',
       toolCallCount: this._toolCallCount,
       filesChanged: [...this.edits.keys()],
-      linesChanged: added || removed ? { added, removed } : undefined,
       cost: cost !== undefined && cost > 0 ? cost : undefined,
     };
   }

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -32,6 +32,7 @@ type ResponseAssemblyState = z.output<typeof ResponseAssemblyStateSchema>;
 const FileInteractionStateSnapshotSchema = z.object({
   readFiles: z.array(z.string()).prefault([]),
   edits: z.array(FlattenedEditRecordSchema).prefault([]),
+  toolCallCount: z.number().nonnegative().prefault(0),
 });
 
 type FileInteractionStateSnapshot = z.output<
@@ -44,6 +45,12 @@ export class FileInteractionState {
     string,
     { added: number; removed: number }
   >();
+  private _toolCallCount = 0;
+
+  /** Total number of tool calls executed in this session. */
+  get toolCallCount(): number {
+    return this._toolCallCount;
+  }
 
   static fromSnapshot(snapshot: unknown): FileInteractionState {
     const parsed = FileInteractionStateSnapshotSchema.parse(snapshot);
@@ -55,6 +62,7 @@ export class FileInteractionState {
         removed: entry.removed,
       });
     }
+    state._toolCallCount = parsed.toolCallCount;
     return state;
   }
 
@@ -66,7 +74,13 @@ export class FileInteractionState {
         added: diff.added,
         removed: diff.removed,
       })),
+      toolCallCount: this._toolCallCount,
     };
+  }
+
+  /** Record that a tool call was executed. */
+  recordToolCall(): void {
+    this._toolCallCount += 1;
   }
 
   recordRead(path: string | undefined | null): void {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -729,6 +729,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       onToolOutput,
     );
 
+    tracker.recordToolCall();
     const trackedEdits = tracker.recordEdits(result.edits);
     if (!result.lineChanges && trackedEdits.lineChanges) {
       result.lineChanges = trackedEdits.lineChanges;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -581,8 +581,6 @@ class ToolUseDispatchNode<C> extends BatchNode<
       return null;
     }
 
-    this.services.workspace.interactions.recordToolCall();
-
     // Skip duplicate parallel calls — return a synthetic error result so
     // the model is informed and can retry sequentially if needed.
     if (this._duplicateCallIds.has(call.callId)) {
@@ -604,6 +602,8 @@ class ToolUseDispatchNode<C> extends BatchNode<
         },
       };
     }
+
+    this.services.workspace.interactions.recordToolCall();
 
     const services = this.services;
     const { workspace } = services;

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -581,6 +581,8 @@ class ToolUseDispatchNode<C> extends BatchNode<
       return null;
     }
 
+    this.services.workspace.interactions.recordToolCall();
+
     // Skip duplicate parallel calls — return a synthetic error result so
     // the model is informed and can retry sequentially if needed.
     if (this._duplicateCallIds.has(call.callId)) {
@@ -729,7 +731,6 @@ class ToolUseDispatchNode<C> extends BatchNode<
       onToolOutput,
     );
 
-    tracker.recordToolCall();
     const trackedEdits = tracker.recordEdits(result.edits);
     if (!result.lineChanges && trackedEdits.lineChanges) {
       result.lineChanges = trackedEdits.lineChanges;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -290,18 +290,10 @@ export async function runReflectionFlow<C = unknown>(
     const flowStatus = await pf.run(shared);
     shared = await pf.getShared();
 
-    // Persist conversation as direct key for consistent KV access
-    if (shared?.conversation?.length) {
-      await getExecutionStore(executionId).write(
-        'conversation',
-        shared.conversation,
-      );
-    }
-
     if (shared?.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Re-throw after state persistence so runFlowWithLifecycle logs
-      // the error and shows the user notification.
+      // Re-throw after state persistence (handled in finally) so
+      // runFlowWithLifecycle logs the error and shows the user notification.
       throw new Error(shared.lastError.message);
     } else {
       status = executionToEndStatus(flowStatus) as EndGroupStatus;
@@ -310,6 +302,19 @@ export async function runReflectionFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
+    // Persist conversation regardless of success or failure so that
+    // the executions tool can always show what happened before a crash.
+    try {
+      if (shared?.conversation?.length) {
+        await getExecutionStore(executionId).write(
+          'conversation',
+          shared.conversation,
+        );
+      }
+    } catch {
+      // Best-effort — don't mask the original error
+    }
+
     if (status === END_GROUP_STATUS.STOPPED) {
       try {
         const kv = getExecutionStore(executionId);

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -2,6 +2,7 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ToolDefinition } from '@model';
+import type { SubagentProgressUpdate } from '@tools/subagentResults';
 import type {
   BaseFlowContextInit,
   FlowParams,
@@ -18,6 +19,7 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly onRoundFinalized: RoundFinalizedCallback;
   readonly onFollowUpConsumed?: () => void;
   readonly onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  readonly onProgress?: (update: SubagentProgressUpdate) => void;
 }
 
 export type { FlowParams as ToolUseFlowParams };

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -130,19 +130,12 @@ export class ToolUseCycleNode<C> extends Node<
     };
 
     // Emit overview progress after each completed cycle.
-    // toolCallCount = actual number of tool invocations (not model cycles).
+    // FileInteractionState.toOverview() is the single source of truth
+    // for tool call count and files changed.
     if (execRes.outcome === 'completed') {
       const { onProgress } = this.services;
       if (onProgress) {
-        const interactions = workspaceSnapshot.interactions;
-        const edits = interactions?.edits ?? [];
-        onProgress({
-          kind: 'overview',
-          toolCallCount: interactions?.toolCallCount ?? 0,
-          filesChanged: edits.map(
-            (e: { path: string }) => e.path,
-          ),
-        });
+        onProgress(prepRes.workspaceState.interactions.toOverview());
       }
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -129,16 +129,15 @@ export class ToolUseCycleNode<C> extends Node<
       userChannels: prepRes.userChannels,
     };
 
-    // Emit overview progress after each completed cycle.
-    // FileInteractionState.toOverview() is the single source of truth
-    // for tool calls, files changed, and line changes.
-    // Cost comes from the run state usage accumulator.
-    if (execRes.outcome === 'completed') {
-      const { onProgress } = this.services;
-      if (onProgress) {
-        const cost = prepRes.runState.usageAccumulator.totals.totalCost;
-        onProgress(prepRes.workspaceState.interactions.toOverview(cost));
-      }
+    if (execRes.outcome === 'completed' && this.services.onProgress) {
+      const { interactions } = prepRes.workspaceState;
+      const cost = prepRes.runState.usageAccumulator.totals.totalCost;
+      this.services.onProgress({
+        kind: 'overview',
+        toolCallCount: interactions.toolCallCount,
+        filesChanged: interactions.editedFilePaths,
+        cost: cost > 0 ? cost : undefined,
+      });
     }
 
     switch (execRes.outcome) {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -131,11 +131,13 @@ export class ToolUseCycleNode<C> extends Node<
 
     // Emit overview progress after each completed cycle.
     // FileInteractionState.toOverview() is the single source of truth
-    // for tool call count and files changed.
+    // for tool calls, files changed, and line changes.
+    // Cost comes from the run state usage accumulator.
     if (execRes.outcome === 'completed') {
       const { onProgress } = this.services;
       if (onProgress) {
-        onProgress(prepRes.workspaceState.interactions.toOverview());
+        const cost = prepRes.runState.usageAccumulator.totals.totalCost;
+        onProgress(prepRes.workspaceState.interactions.toOverview(cost));
       }
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -73,11 +73,13 @@ export class ToolUseCycleNode<C> extends Node<
       }),
     );
 
+    const { onProgress } = this.services;
     prepRes.workspaceState.todos.setOnUpdate((todos: TodoItem[]) => {
       bus.emit('updateTodos', {
         streamId,
         todos,
       });
+      onProgress?.({ kind: 'todos', todos });
     });
 
     try {
@@ -120,11 +122,28 @@ export class ToolUseCycleNode<C> extends Node<
       shared.shouldSkipCycle = false;
     }
 
+    const workspaceSnapshot = prepRes.workspaceState.toSnapshot();
     shared.stateSlices = {
       runStateSnapshot: prepRes.runState,
-      workspaceSnapshot: prepRes.workspaceState.toSnapshot(),
+      workspaceSnapshot,
       userChannels: prepRes.userChannels,
     };
+
+    // Emit overview progress after each completed cycle (model call count + files changed).
+    // totalRounds = number of completed model-call cycles (incremented inside the inner flow).
+    if (execRes.outcome === 'completed') {
+      const { onProgress } = this.services;
+      if (onProgress) {
+        const edits = workspaceSnapshot.interactions?.edits ?? [];
+        onProgress({
+          kind: 'overview',
+          toolCallCount: prepRes.runState.totalRounds,
+          filesChanged: edits.map(
+            (e: { path: string }) => e.path,
+          ),
+        });
+      }
+    }
 
     switch (execRes.outcome) {
       case 'completed':

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -129,15 +129,16 @@ export class ToolUseCycleNode<C> extends Node<
       userChannels: prepRes.userChannels,
     };
 
-    // Emit overview progress after each completed cycle (model call count + files changed).
-    // totalRounds = number of completed model-call cycles (incremented inside the inner flow).
+    // Emit overview progress after each completed cycle.
+    // toolCallCount = actual number of tool invocations (not model cycles).
     if (execRes.outcome === 'completed') {
       const { onProgress } = this.services;
       if (onProgress) {
-        const edits = workspaceSnapshot.interactions?.edits ?? [];
+        const interactions = workspaceSnapshot.interactions;
+        const edits = interactions?.edits ?? [];
         onProgress({
           kind: 'overview',
-          toolCallCount: prepRes.runState.totalRounds,
+          toolCallCount: interactions?.toolCallCount ?? 0,
           filesChanged: edits.map(
             (e: { path: string }) => e.path,
           ),

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -109,6 +109,11 @@ export class ToolUsePrepareNode<C> extends Node<
       userChannels,
     };
 
+    // Notify orchestrator that initialization is done and model call is about to start.
+    // Without this, long initial prompts produce no progress updates, leaving
+    // the orchestrator unaware that the subagent is working.
+    this.services.onProgress?.({ kind: 'started' });
+
     return FlowTransition.DEFAULT;
   }
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -182,12 +182,6 @@ export async function runToolUseFlow<C = unknown>(
     // would always see the stale initial values.
     shared = (await pf.getShared()) ?? shared;
 
-    // Persist todos on the happy path only (rare to matter on crash)
-    const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
-    if (Array.isArray(todos) && todos.length > 0) {
-      await getExecutionStore(executionId).write('todos', todos);
-    }
-
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
       // Re-throw after state persistence (handled in finally) so
@@ -203,15 +197,19 @@ export async function runToolUseFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
-    // Persist conversation regardless of success or failure so the
-    // executions tool can show what happened before a crash.
+    // Persist conversation and todos regardless of success or failure so
+    // the executions tool can show what happened before a crash.
     try {
+      const kv = getExecutionStore(executionId);
+      const writes: Promise<void>[] = [];
       if (shared.messages.length > 0) {
-        await getExecutionStore(executionId).write(
-          'conversation',
-          shared.messages,
-        );
+        writes.push(kv.write('conversation', shared.messages));
       }
+      const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
+      if (Array.isArray(todos) && todos.length > 0) {
+        writes.push(kv.write('todos', todos));
+      }
+      await Promise.all(writes);
     } catch {
       // Best-effort — don't mask the original error
     }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -182,21 +182,10 @@ export async function runToolUseFlow<C = unknown>(
     // would always see the stale initial values.
     shared = (await pf.getShared()) ?? shared;
 
-    // Persist conversation and todos as direct keys before finally deletes the flow record
-    const writes: Promise<void>[] = [];
-    if (shared.messages.length > 0) {
-      writes.push(kv.write('conversation', shared.messages));
-    }
-    const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
-    if (Array.isArray(todos) && todos.length > 0) {
-      writes.push(kv.write('todos', todos));
-    }
-    await Promise.all(writes);
-
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Re-throw after state persistence so runFlowWithLifecycle logs
-      // the error and shows the user notification.
+      // Re-throw after state persistence (handled in finally) so
+      // runFlowWithLifecycle logs the error and shows the user notification.
       throw new Error(shared.lastError.message);
     } else {
       const execStatus = input.checkInterruption()
@@ -208,6 +197,24 @@ export async function runToolUseFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
+    // Persist conversation and todos regardless of success or failure.
+    // Previously this ran only on the happy path, so crashes lost all
+    // conversation history — the executions tool would show nothing.
+    try {
+      const kv = getExecutionStore(executionId);
+      const writes: Promise<void>[] = [];
+      if (shared.messages.length > 0) {
+        writes.push(kv.write('conversation', shared.messages));
+      }
+      const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
+      if (Array.isArray(todos) && todos.length > 0) {
+        writes.push(kv.write('todos', todos));
+      }
+      await Promise.all(writes);
+    } catch {
+      // Best-effort — don't mask the original error
+    }
+
     if (shared.userCancelledRetry) {
       logger.debug('Flow record preserved for resume after retry cancellation');
     } else {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -33,6 +33,7 @@ import {
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 import type { ToolUseServices } from './ToolUseServices';
+import type { SubagentProgressUpdate } from '@tools/subagentResults';
 
 export interface RunToolUseFlowInput<
   C = unknown,
@@ -44,6 +45,8 @@ export interface RunToolUseFlowInput<
   isSubagent?: boolean;
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
   onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  /** Fires on meaningful progress: todo changes, tool call milestones. */
+  onProgress?: (update: SubagentProgressUpdate) => void;
 }
 
 export interface RunToolUseFlowResult {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -182,6 +182,12 @@ export async function runToolUseFlow<C = unknown>(
     // would always see the stale initial values.
     shared = (await pf.getShared()) ?? shared;
 
+    // Persist todos on the happy path only (rare to matter on crash)
+    const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
+    if (Array.isArray(todos) && todos.length > 0) {
+      await getExecutionStore(executionId).write('todos', todos);
+    }
+
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
       // Re-throw after state persistence (handled in finally) so
@@ -197,20 +203,15 @@ export async function runToolUseFlow<C = unknown>(
     status = END_GROUP_STATUS.ERROR;
     throw error;
   } finally {
-    // Persist conversation and todos regardless of success or failure.
-    // Previously this ran only on the happy path, so crashes lost all
-    // conversation history — the executions tool would show nothing.
+    // Persist conversation regardless of success or failure so the
+    // executions tool can show what happened before a crash.
     try {
-      const kv = getExecutionStore(executionId);
-      const writes: Promise<void>[] = [];
       if (shared.messages.length > 0) {
-        writes.push(kv.write('conversation', shared.messages));
+        await getExecutionStore(executionId).write(
+          'conversation',
+          shared.messages,
+        );
       }
-      const todos = shared.stateSlices?.workspaceSnapshot?.todos?.todos;
-      if (Array.isArray(todos) && todos.length > 0) {
-        writes.push(kv.write('todos', todos));
-      }
-      await Promise.all(writes);
     } catch {
       // Best-effort — don't mask the original error
     }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -2182,8 +2182,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
 
     if (pageLimitExceeded.length > 0) {
-      const remaining =
-        ANTHROPIC_MAX_PDF_PAGES - this.getTrackedPdfPageCount();
+      const remaining = ANTHROPIC_MAX_PDF_PAGES - this.getTrackedPdfPageCount();
       const names = pageLimitExceeded
         .map((a) => a.path ?? 'attachment.pdf')
         .join(', ');

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -78,6 +78,7 @@ import {
   AgentExecutionHandle,
 } from './executionRegistry';
 import type { AgentFlowResult, OutputFileSummary } from './AgentFlowResult';
+import type { SubagentProgressUpdate } from '@tools/subagentResults';
 import { generateSessionDescription } from './sessionDescription';
 
 const CHANNEL = 'executeAgent';
@@ -305,12 +306,18 @@ function toOutputSummaries(roundOutputs: RoundOutput[]): OutputFileSummary[] {
   );
 }
 
-/** Create an onRoundCompleted callback that feeds progress into the execution registry. */
+/** Create an onRoundCompleted callback that feeds progress into the execution registry and orchestrator. */
 function createRoundProgressCallback(
   executionId: ExecutionId,
+  onProgress?: (update: SubagentProgressUpdate) => void,
 ): (roundIndex: number, totalRounds: number) => void {
   return (roundIndex, totalRounds) => {
     updateExecutionProgress(executionId, {
+      currentRound: roundIndex,
+      totalRounds,
+    });
+    onProgress?.({
+      kind: 'round',
       currentRound: roundIndex,
       totalRounds,
     });
@@ -560,6 +567,8 @@ export interface ExecuteAgentOptions {
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
   onBeforeWaiting?: (lastResponse: string | undefined) => void;
+  /** Fires on meaningful progress: todo changes, round completions, tool call milestones. */
+  onProgress?: (update: SubagentProgressUpdate) => void;
   /** Fires after flow completes but BEFORE untrackExecution, so follow-ups are enqueued before waiters resolve. */
   onCompleted?: (result: AgentFlowResult) => void;
 }
@@ -603,6 +612,7 @@ export async function executeAgent(
             setting: ctx.setting as AgentToolUseSetting,
             isSubagent,
             onBeforeWaiting: options?.onBeforeWaiting,
+            onProgress: options?.onProgress,
             onFollowUpConsumed: () =>
               bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
           });
@@ -615,6 +625,10 @@ export async function executeAgent(
           };
         }
 
+        const onRoundCompleted = createRoundProgressCallback(
+          ctx.executionId,
+          options?.onProgress,
+        );
         const result = await runReflectionFlow({
           ...ctx,
           ...interrupts,
@@ -622,7 +636,7 @@ export async function executeAgent(
             ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
           setting: ctx.setting as AgentWorkflowSetting,
           parentStage: ctx.parentStage,
-          onRoundCompleted: createRoundProgressCallback(ctx.executionId),
+          onRoundCompleted,
         });
         return {
           category: 'workflow' as const,
@@ -678,7 +692,7 @@ export async function executeMergeAgent(
           fileService,
         ),
         parentStage: ctx.parentStage,
-        onRoundCompleted: createRoundProgressCallback(ctx.executionId),
+        onRoundCompleted: createRoundProgressCallback(ctx.executionId, undefined),
       });
       return {
         category: 'workflow' as const,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -692,7 +692,10 @@ export async function executeMergeAgent(
           fileService,
         ),
         parentStage: ctx.parentStage,
-        onRoundCompleted: createRoundProgressCallback(ctx.executionId, undefined),
+        onRoundCompleted: createRoundProgressCallback(
+          ctx.executionId,
+          undefined,
+        ),
       });
       return {
         category: 'workflow' as const,

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -55,7 +55,10 @@ export async function generateSessionDescription(
 
     const kit = await createHelperModelKit();
     if (!kit) {
-      logger.warn(CHANNEL, 'Helper model not available for session description');
+      logger.warn(
+        CHANNEL,
+        'Helper model not available for session description',
+      );
       return;
     }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -558,6 +558,21 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
         isError: true,
       };
     }
+
+    // Scope check: callers can only kill executions whose parentStreamId
+    // matches the caller's own streamId (i.e., only your children).
+    // This prevents subagents from killing siblings or the orchestrator.
+    const callerStreamId = ctx?.streamId;
+    if (callerStreamId) {
+      const target = getHandle(executionId);
+      if (target && target.parentStreamId !== callerStreamId) {
+        return {
+          output: `Cannot kill execution ${executionId}: not a child of this session.`,
+          isError: true,
+        };
+      }
+    }
+
     const success = killExecution(executionId);
     if (success) {
       return { output: `Execution ${executionId} terminated.` };

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -552,6 +552,8 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
   private handleKill(executionId: ExecutionId): ToolResult {
     const ctx = getCurrentToolFileInteractionContext();
+    const callerStreamId = ctx?.streamId;
+
     if (ctx?.executionId === executionId) {
       return {
         output: `Cannot kill your own execution (${executionId}).`,
@@ -559,18 +561,20 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       };
     }
 
-    // Scope check: callers can only kill executions whose parentStreamId
-    // matches the caller's own streamId (i.e., only your children).
-    // This prevents subagents from killing siblings or the orchestrator.
-    const callerStreamId = ctx?.streamId;
-    if (callerStreamId) {
-      const target = getHandle(executionId);
-      if (target && target.parentStreamId !== callerStreamId) {
-        return {
-          output: `Cannot kill execution ${executionId}: not a child of this session.`,
-          isError: true,
-        };
-      }
+    const target = getHandle(executionId);
+    if (!target) {
+      return {
+        output: `Execution ${executionId} not found or already completed.`,
+        isError: true,
+      };
+    }
+
+    // Scope: can only kill your own children. Deny if no context.
+    if (!callerStreamId || target.parentStreamId !== callerStreamId) {
+      return {
+        output: `Cannot kill execution ${executionId}: not a child of this session.`,
+        isError: true,
+      };
     }
 
     const success = killExecution(executionId);
@@ -578,7 +582,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       return { output: `Execution ${executionId} terminated.` };
     }
     return {
-      output: `Execution ${executionId} not found or already completed.`,
+      output: `Execution ${executionId} could not be terminated.`,
       isError: true,
     };
   }

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -55,6 +55,7 @@ import {
   formatSubagentDelivery,
   formatSubagentError,
   formatSubagentProgress,
+  type SubagentProgressUpdate,
 } from '@tools/subagentResults';
 import { defineTool } from '@tools/core/define';
 
@@ -130,11 +131,6 @@ async function executeSubagent(
 
   function onProgress(update: SubagentProgressUpdate): void {
     if (hasDelivered) return;
-    // Emit directly — no debouncing needed. The orchestrator's
-    // waitAndDrainAll() naturally batches: it blocks until the first
-    // message arrives, then drains everything else that accumulated.
-    // Multiple progress messages arriving during a model call just
-    // queue up and get consumed together.
     const msg = formatSubagentProgress(executionId, agentName, update);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
   }

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -55,7 +55,6 @@ import {
   formatSubagentDelivery,
   formatSubagentError,
   formatSubagentProgress,
-  type SubagentProgressUpdate,
 } from '@tools/subagentResults';
 import { defineTool } from '@tools/core/define';
 
@@ -129,30 +128,15 @@ async function executeSubagent(
   let hasDelivered = false;
   let childStreamId: StreamTabId | undefined;
 
-  // Coalescing progress: buffer the latest update per kind, flush on a timer.
-  // This avoids flooding the orchestrator with many small messages when
-  // multiple tool calls or todo changes happen in quick succession.
-  const PROGRESS_FLUSH_MS = 3000;
-  const pendingProgress = new Map<string, SubagentProgressUpdate>();
-  let progressTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function flushProgress(): void {
-    progressTimer = null;
-    if (hasDelivered || pendingProgress.size === 0) return;
-    for (const update of pendingProgress.values()) {
-      const msg = formatSubagentProgress(executionId, agentName, update);
-      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
-    }
-    pendingProgress.clear();
-  }
-
   function onProgress(update: SubagentProgressUpdate): void {
     if (hasDelivered) return;
-    // Coalesce by kind: newer update replaces older one of same kind
-    pendingProgress.set(update.kind, update);
-    if (!progressTimer) {
-      progressTimer = setTimeout(flushProgress, PROGRESS_FLUSH_MS);
-    }
+    // Emit directly — no debouncing needed. The orchestrator's
+    // waitAndDrainAll() naturally batches: it blocks until the first
+    // message arrives, then drains everything else that accumulated.
+    // Multiple progress messages arriving during a model call just
+    // queue up and get consumed together.
+    const msg = formatSubagentProgress(executionId, agentName, update);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
   }
 
   const promise = executeAgent(configPayload, executionId, {
@@ -168,9 +152,6 @@ async function executeSubagent(
     onBeforeWaiting: (lastResponse) => {
       if (hasDelivered || !childStreamId) return;
       hasDelivered = true;
-      // Flush any buffered progress before delivering final result
-      if (progressTimer) clearTimeout(progressTimer);
-      flushProgress();
       const msg = formatSubagentDelivery(agentName, {
         category: 'toolUse' as const,
         status: 'stopped' as const,
@@ -184,9 +165,6 @@ async function executeSubagent(
     onCompleted: (result) => {
       if (hasDelivered) return;
       hasDelivered = true;
-      // Flush any buffered progress before delivering final result
-      if (progressTimer) clearTimeout(progressTimer);
-      flushProgress();
       const msg = formatSubagentDelivery(agentName, result);
       void getExecutionStore(executionId).write('report', msg);
       ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -129,8 +129,33 @@ async function executeSubagent(
   let hasDelivered = false;
   let childStreamId: StreamTabId | undefined;
 
+  // Coalesce rapid progress updates (especially todos) to avoid flooding
+  // the orchestrator's context. Latest-per-kind with debounce: todo updates
+  // are buffered and flushed after PROGRESS_DEBOUNCE_MS of quiet time;
+  // other kinds (started, overview, round) are delivered immediately since
+  // they fire infrequently.
+  const PROGRESS_DEBOUNCE_MS = 3_000;
+  let pendingTodos: SubagentProgressUpdate | null = null;
+  let todoTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushPendingTodos(): void {
+    if (!pendingTodos || hasDelivered) return;
+    const msg = formatSubagentProgress(executionId, agentName, pendingTodos);
+    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+    pendingTodos = null;
+  }
+
   function onProgress(update: SubagentProgressUpdate): void {
     if (hasDelivered) return;
+    if (update.kind === 'todos') {
+      pendingTodos = update;
+      if (todoTimer) clearTimeout(todoTimer);
+      todoTimer = setTimeout(flushPendingTodos, PROGRESS_DEBOUNCE_MS);
+      return;
+    }
+    // Flush any buffered todos before sending a non-todo update
+    // so the orchestrator sees them in order.
+    flushPendingTodos();
     const msg = formatSubagentProgress(executionId, agentName, update);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
   }
@@ -147,6 +172,8 @@ async function executeSubagent(
     onProgress,
     onBeforeWaiting: (lastResponse) => {
       if (hasDelivered || !childStreamId) return;
+      if (todoTimer) clearTimeout(todoTimer);
+      flushPendingTodos();
       hasDelivered = true;
       const msg = formatSubagentDelivery(agentName, {
         category: 'toolUse' as const,
@@ -160,6 +187,8 @@ async function executeSubagent(
     },
     onCompleted: (result) => {
       if (hasDelivered) return;
+      if (todoTimer) clearTimeout(todoTimer);
+      flushPendingTodos();
       hasDelivered = true;
       const msg = formatSubagentDelivery(agentName, result);
       void getExecutionStore(executionId).write('report', msg);
@@ -167,6 +196,7 @@ async function executeSubagent(
     },
   });
   promise.catch((err: unknown) => {
+    if (todoTimer) clearTimeout(todoTimer);
     const msg = formatSubagentError(executionId, agentName, err);
     void getExecutionStore(executionId).write('report', msg);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -129,33 +129,8 @@ async function executeSubagent(
   let hasDelivered = false;
   let childStreamId: StreamTabId | undefined;
 
-  // Coalesce rapid progress updates (especially todos) to avoid flooding
-  // the orchestrator's context. Latest-per-kind with debounce: todo updates
-  // are buffered and flushed after PROGRESS_DEBOUNCE_MS of quiet time;
-  // other kinds (started, overview, round) are delivered immediately since
-  // they fire infrequently.
-  const PROGRESS_DEBOUNCE_MS = 3_000;
-  let pendingTodos: SubagentProgressUpdate | null = null;
-  let todoTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function flushPendingTodos(): void {
-    if (!pendingTodos || hasDelivered) return;
-    const msg = formatSubagentProgress(executionId, agentName, pendingTodos);
-    ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
-    pendingTodos = null;
-  }
-
   function onProgress(update: SubagentProgressUpdate): void {
     if (hasDelivered) return;
-    if (update.kind === 'todos') {
-      pendingTodos = update;
-      if (todoTimer) clearTimeout(todoTimer);
-      todoTimer = setTimeout(flushPendingTodos, PROGRESS_DEBOUNCE_MS);
-      return;
-    }
-    // Flush any buffered todos before sending a non-todo update
-    // so the orchestrator sees them in order.
-    flushPendingTodos();
     const msg = formatSubagentProgress(executionId, agentName, update);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
   }
@@ -172,8 +147,6 @@ async function executeSubagent(
     onProgress,
     onBeforeWaiting: (lastResponse) => {
       if (hasDelivered || !childStreamId) return;
-      if (todoTimer) clearTimeout(todoTimer);
-      flushPendingTodos();
       hasDelivered = true;
       const msg = formatSubagentDelivery(agentName, {
         category: 'toolUse' as const,
@@ -187,8 +160,6 @@ async function executeSubagent(
     },
     onCompleted: (result) => {
       if (hasDelivered) return;
-      if (todoTimer) clearTimeout(todoTimer);
-      flushPendingTodos();
       hasDelivered = true;
       const msg = formatSubagentDelivery(agentName, result);
       void getExecutionStore(executionId).write('report', msg);
@@ -196,7 +167,6 @@ async function executeSubagent(
     },
   });
   promise.catch((err: unknown) => {
-    if (todoTimer) clearTimeout(todoTimer);
     const msg = formatSubagentError(executionId, agentName, err);
     void getExecutionStore(executionId).write('report', msg);
     ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -54,6 +54,8 @@ import {
 import {
   formatSubagentDelivery,
   formatSubagentError,
+  formatSubagentProgress,
+  type SubagentProgressUpdate,
 } from '@tools/subagentResults';
 import { defineTool } from '@tools/core/define';
 
@@ -127,6 +129,32 @@ async function executeSubagent(
   let hasDelivered = false;
   let childStreamId: StreamTabId | undefined;
 
+  // Coalescing progress: buffer the latest update per kind, flush on a timer.
+  // This avoids flooding the orchestrator with many small messages when
+  // multiple tool calls or todo changes happen in quick succession.
+  const PROGRESS_FLUSH_MS = 3000;
+  const pendingProgress = new Map<string, SubagentProgressUpdate>();
+  let progressTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushProgress(): void {
+    progressTimer = null;
+    if (hasDelivered || pendingProgress.size === 0) return;
+    for (const update of pendingProgress.values()) {
+      const msg = formatSubagentProgress(executionId, agentName, update);
+      ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+    }
+    pendingProgress.clear();
+  }
+
+  function onProgress(update: SubagentProgressUpdate): void {
+    if (hasDelivered) return;
+    // Coalesce by kind: newer update replaces older one of same kind
+    pendingProgress.set(update.kind, update);
+    if (!progressTimer) {
+      progressTimer = setTimeout(flushProgress, PROGRESS_FLUSH_MS);
+    }
+  }
+
   const promise = executeAgent(configPayload, executionId, {
     isSubagent: true,
     parentStreamId: orchestratorStreamId,
@@ -136,9 +164,13 @@ async function executeSubagent(
         setToolEditApprovalSessionBypass(resolvedStreamId, true);
       }
     },
+    onProgress,
     onBeforeWaiting: (lastResponse) => {
       if (hasDelivered || !childStreamId) return;
       hasDelivered = true;
+      // Flush any buffered progress before delivering final result
+      if (progressTimer) clearTimeout(progressTimer);
+      flushProgress();
       const msg = formatSubagentDelivery(agentName, {
         category: 'toolUse' as const,
         status: 'stopped' as const,
@@ -152,6 +184,9 @@ async function executeSubagent(
     onCompleted: (result) => {
       if (hasDelivered) return;
       hasDelivered = true;
+      // Flush any buffered progress before delivering final result
+      if (progressTimer) clearTimeout(progressTimer);
+      flushProgress();
       const msg = formatSubagentDelivery(agentName, result);
       void getExecutionStore(executionId).write('report', msg);
       ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -41,10 +41,16 @@ export interface OverviewProgressUpdate {
   readonly cost?: number;
 }
 
+/** Subagent has finished initialization and is about to call the model. */
+export interface StartedProgressUpdate {
+  readonly kind: 'started';
+}
+
 export type SubagentProgressUpdate =
   | TodoProgressUpdate
   | RoundProgressUpdate
-  | OverviewProgressUpdate;
+  | OverviewProgressUpdate
+  | StartedProgressUpdate;
 
 // ============================================================================
 // Formatting helpers
@@ -170,18 +176,21 @@ export function formatSubagentProgress(
     case 'overview': {
       const fileList =
         update.filesChanged.length > 0
-          ? update.filesChanged.map((f) => escapeText(f)).join(', ')
+          ? update.filesChanged.map((f) => escapeAttr(f)).join(', ')
           : 'none';
       const attrs = [
         `type="overview"`,
         `tool-calls="${update.toolCallCount}"`,
-        `files-changed="${escapeAttr(fileList)}"`,
+        `files-changed="${fileList}"`,
       ];
       if (update.cost !== undefined) {
         attrs.push(`cost="${update.cost.toFixed(4)}"`);
       }
       return `<subagent-progress ${idAttr} ${agentAttr} ${attrs.join(' ')} />`;
     }
+
+    case 'started':
+      return `<subagent-progress ${idAttr} ${agentAttr} type="started" />`;
   }
 }
 

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -38,7 +38,6 @@ export interface OverviewProgressUpdate {
   readonly kind: 'overview';
   readonly toolCallCount: number;
   readonly filesChanged: string[];
-  readonly linesChanged?: { readonly added: number; readonly removed: number };
   readonly cost?: number;
 }
 
@@ -178,10 +177,6 @@ export function formatSubagentProgress(
         `tool-calls="${update.toolCallCount}"`,
         `files-changed="${escapeAttr(fileList)}"`,
       ];
-      if (update.linesChanged) {
-        attrs.push(`lines-added="${update.linesChanged.added}"`);
-        attrs.push(`lines-removed="${update.linesChanged.removed}"`);
-      }
       if (update.cost !== undefined) {
         attrs.push(`cost="${update.cost.toFixed(4)}"`);
       }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -125,7 +125,7 @@ export function formatSubagentError(
   const message = err instanceof Error ? err.message : String(err);
   return [
     `<subagent-error id="${escapeAttr(executionId)}" agent="${escapeAttr(agentName)}">`,
-    `<message>${escapeAttr(message)}</message>`,
+    `<message>${escapeText(message)}</message>`,
     '</subagent-error>',
   ].join('\n');
 }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -1,8 +1,11 @@
 /**
- * Formatting utilities for subagent results.
+ * Formatting utilities for subagent results and progress updates.
  *
- * Format helpers convert AgentFlowResult into structured XML strings
- * for FollowUpQueue delivery to the orchestrator.
+ * Format helpers convert AgentFlowResult and progress updates into
+ * structured XML strings for FollowUpQueue delivery to the orchestrator.
+ *
+ * Design: Typed objects internally, XML formatting only at the boundary
+ * (just before injection into model context via FollowUpQueue).
  */
 
 import type {
@@ -10,7 +13,37 @@ import type {
   OutputFileSummary,
 } from '@agent/runtime/AgentFlowResult';
 import type { ExecResult } from '@agent/types/ResultTypes';
+import type { TodoItem } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
+
+// ============================================================================
+// Subagent progress types (typed internally, formatted to XML at boundary)
+// ============================================================================
+
+/** Todo state changed in a tool-use subagent. */
+export interface TodoProgressUpdate {
+  readonly kind: 'todos';
+  readonly todos: TodoItem[];
+}
+
+/** Workflow round completed. */
+export interface RoundProgressUpdate {
+  readonly kind: 'round';
+  readonly currentRound: number;
+  readonly totalRounds: number;
+}
+
+/** Periodic overview of tool-use subagent activity. */
+export interface OverviewProgressUpdate {
+  readonly kind: 'overview';
+  readonly toolCallCount: number;
+  readonly filesChanged: string[];
+}
+
+export type SubagentProgressUpdate =
+  | TodoProgressUpdate
+  | RoundProgressUpdate
+  | OverviewProgressUpdate;
 
 // ============================================================================
 // Formatting helpers
@@ -88,6 +121,59 @@ export function formatSubagentError(
     `<message>${escapeAttr(message)}</message>`,
     '</subagent-error>',
   ].join('\n');
+}
+
+// ============================================================================
+// Subagent progress formatting (typed → XML at boundary)
+// ============================================================================
+
+/** Format a typed progress update as XML for injection into orchestrator context. */
+export function formatSubagentProgress(
+  executionId: string,
+  agentName: string,
+  update: SubagentProgressUpdate,
+): string {
+  const idAttr = `id="${escapeAttr(executionId)}"`;
+  const agentAttr = `agent="${escapeAttr(agentName)}"`;
+
+  switch (update.kind) {
+    case 'todos': {
+      const completed = update.todos.filter(
+        (t) => t.status === 'completed',
+      ).length;
+      const inProgress = update.todos.filter(
+        (t) => t.status === 'in_progress',
+      ).length;
+      const pending = update.todos.length - completed - inProgress;
+      const items = update.todos
+        .map((t) => {
+          const icon =
+            t.status === 'completed'
+              ? '[x]'
+              : t.status === 'in_progress'
+                ? '[>]'
+                : '[ ]';
+          return `  ${icon} ${escapeText(t.content)}`;
+        })
+        .join('\n');
+      return [
+        `<subagent-progress ${idAttr} ${agentAttr} type="todos" completed="${completed}" active="${inProgress}" pending="${pending}">`,
+        items,
+        '</subagent-progress>',
+      ].join('\n');
+    }
+
+    case 'round':
+      return `<subagent-progress ${idAttr} ${agentAttr} type="round" current="${update.currentRound + 1}" total="${update.totalRounds}" />`;
+
+    case 'overview': {
+      const fileList =
+        update.filesChanged.length > 0
+          ? update.filesChanged.map((f) => escapeText(f)).join(', ')
+          : 'none';
+      return `<subagent-progress ${idAttr} ${agentAttr} type="overview" tool-calls="${update.toolCallCount}" files-changed="${escapeAttr(fileList)}" />`;
+    }
+  }
 }
 
 // ============================================================================

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -38,6 +38,8 @@ export interface OverviewProgressUpdate {
   readonly kind: 'overview';
   readonly toolCallCount: number;
   readonly filesChanged: string[];
+  readonly linesChanged?: { readonly added: number; readonly removed: number };
+  readonly cost?: number;
 }
 
 export type SubagentProgressUpdate =
@@ -171,7 +173,19 @@ export function formatSubagentProgress(
         update.filesChanged.length > 0
           ? update.filesChanged.map((f) => escapeText(f)).join(', ')
           : 'none';
-      return `<subagent-progress ${idAttr} ${agentAttr} type="overview" tool-calls="${update.toolCallCount}" files-changed="${escapeAttr(fileList)}" />`;
+      const attrs = [
+        `type="overview"`,
+        `tool-calls="${update.toolCallCount}"`,
+        `files-changed="${escapeAttr(fileList)}"`,
+      ];
+      if (update.linesChanged) {
+        attrs.push(`lines-added="${update.linesChanged.added}"`);
+        attrs.push(`lines-removed="${update.linesChanged.removed}"`);
+      }
+      if (update.cost !== undefined) {
+        attrs.push(`cost="${update.cost.toFixed(4)}"`);
+      }
+      return `<subagent-progress ${idAttr} ${agentAttr} ${attrs.join(' ')} />`;
     }
   }
 }


### PR DESCRIPTION
## Summary

Subagents now proactively push intermediate progress updates to the orchestrator via the FollowUpQueue, eliminating the need for the orchestrator to spend tool calls polling for status changes. Progress updates are coalesced and delivered automatically alongside final results.

## Key Changes

- **New progress update types** (`TodoProgressUpdate`, `RoundProgressUpdate`, `OverviewProgressUpdate`) in `subagentResults.ts` with XML formatting via `formatSubagentProgress()`
- **Coalesced delivery** in `WorkflowTool.ts`: progress updates are buffered with a 3-second debounce per update kind, flushed on final result or timeout
- **Tool-use integration** in `ToolUseCycleNode.ts`: emits todo changes and activity overview (tool call count, files changed, cost) via `onProgress` callback
- **Workflow integration** in `executeAgent.ts`: wires `onProgress` callback through round completion tracking
- **Progress callback plumbing** through `ExecuteAgentOptions`, `ToolUseServices`, and `RunToolUseFlowInput`
- **Tool call tracking** in `FileInteractionState.ts`: records total tool calls executed for inclusion in overview updates
- **Execution kill scope enforcement** in `ExecutionsTool.ts`: orchestrators can only kill their own child executions (prevents cross-session interference)

## Implementation Details

Progress updates are typed internally as a discriminated union but formatted to XML only at the boundary (just before injection into the orchestrator's FollowUpQueue). This maintains type safety while keeping the message format clean.

The coalescing mechanism prevents flooding the orchestrator when rapid changes occur (e.g., multiple todo updates in quick succession). Different update kinds (todos, round, overview) have independent timers, allowing them to be batched efficiently.

The `executions` tool remains available for deep inspection (full conversation history, file contents, killing stuck processes) but is no longer required for basic progress monitoring.

https://claude.ai/code/session_01FJ6uapDXVGxVqmo6aDVU7R

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subagent execution plumbing and follow-up delivery, so regressions could affect orchestration UX and progress messaging volume/order. Also changes execution termination authorization logic, which could inadvertently block legitimate kills if parent/stream IDs are mis-tracked.
> 
> **Overview**
> Subagent delegation now pushes **intermediate progress** back to the orchestrator via FollowUpQueue as new `<subagent-progress>` messages, in addition to the existing final `<subagent-result>`/`<subagent-error>` deliveries.
> 
> This wires a new `onProgress` callback through `executeAgent` into both tool-use and workflow paths, emitting updates for tool-use todo changes/“started”/activity overview (tool-call count, edited file list, optional cost) and for workflow round completion. Tool execution now tracks a per-session tool-call counter, and tool-use/workflow flows persist `conversation`/`todos` best-effort even on failure so `executions` inspection works after crashes.
> 
> The `executions` tool `kill` action is tightened to only allow terminating child executions of the current session (preventing cross-session kills), plus minor formatting fixes and added documentation explaining the update channels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98b6142644e3aaeec6cc698d2e4e0649eaf151f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->