### PR TITLE
Always show agent section headers in selection panel

### DIFF
--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -263,11 +263,6 @@ export class AgentSelectionPanel extends LitElement {
         background: var(--vscode-editor-background);
       }
 
-      .agent-count-actions {
-        display: flex;
-        gap: var(--spacing-small);
-      }
-
       .agent-count-link {
         font-size: var(--font-size-xs);
         font-family: inherit;
@@ -575,9 +570,6 @@ export class AgentSelectionPanel extends LitElement {
       groups.has(s),
     );
 
-    // If only one source, don't show section headers
-    const showHeaders = orderedSources.length > 1;
-
     return html`
       <div
         class="agent-list-pane"
@@ -589,34 +581,31 @@ export class AgentSelectionPanel extends LitElement {
           const agents = groups.get(source)!;
           const enabledInGroup = agents.filter((a) => a.enabled).length;
           return html`
-            ${showHeaders
-              ? html`<div class="agent-list-section-header">
-                  <span>${SOURCE_DISPLAY_NAMES[source] ?? source}</span>
-                  <span class="agent-list-section-actions">
-                    ${enabledInGroup < agents.length
-                      ? html`<button
-                          class="agent-count-link"
-                          @click=${() => this.handleSetAllEnabled(source, true)}
-                          title="Show all ${SOURCE_DISPLAY_NAMES[source] ??
-                          source} agents"
-                        >
-                          All
-                        </button>`
-                      : nothing}
-                    ${enabledInGroup > 0
-                      ? html`<button
-                          class="agent-count-link"
-                          @click=${() =>
-                            this.handleSetAllEnabled(source, false)}
-                          title="Hide all ${SOURCE_DISPLAY_NAMES[source] ??
-                          source} agents"
-                        >
-                          None
-                        </button>`
-                      : nothing}
-                  </span>
-                </div>`
-              : nothing}
+            <div class="agent-list-section-header">
+              <span>${SOURCE_DISPLAY_NAMES[source] ?? source}</span>
+              <span class="agent-list-section-actions">
+                ${enabledInGroup < agents.length
+                  ? html`<button
+                      class="agent-count-link"
+                      @click=${() => this.handleSetAllEnabled(source, true)}
+                      title="Show all ${SOURCE_DISPLAY_NAMES[source] ??
+                      source} agents"
+                    >
+                      All
+                    </button>`
+                  : nothing}
+                ${enabledInGroup > 0
+                  ? html`<button
+                      class="agent-count-link"
+                      @click=${() => this.handleSetAllEnabled(source, false)}
+                      title="Hide all ${SOURCE_DISPLAY_NAMES[source] ??
+                      source} agents"
+                    >
+                      None
+                    </button>`
+                  : nothing}
+              </span>
+            </div>
             ${agents.map((a) => this.renderListItem(a))}
           `;
         })}


### PR DESCRIPTION
## Summary
Removed the conditional logic that hid section headers when only a single agent source was present. Section headers are now always displayed regardless of the number of sources.

## Key Changes
- Removed the `showHeaders` variable that determined header visibility based on source count
- Removed the unused `.agent-count-actions` CSS class
- Simplified the template rendering by unconditionally rendering `agent-list-section-header` divs for each source group
- Maintained all existing functionality for the "All" and "None" action buttons within headers

## Implementation Details
The change simplifies the component's rendering logic by eliminating a conditional check. Section headers now consistently display the source name and enable/disable action buttons for all agent sources, improving UI consistency and predictability.

https://claude.ai/code/session_0134X84xpVQ8RtfmkQYsVRnw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering change limited to the agent selection panel; minimal behavioral risk beyond minor layout/scroll differences from always-present sticky headers.
> 
> **Overview**
> Agent selection list section headers are now **always shown**, removing the conditional behavior that hid headers when only a single agent source was present.
> 
> This also removes the unused `.agent-count-actions` styling while keeping the existing per-section `All`/`None` enable/disable buttons intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a3cce66dd3f6f054671a8a3bcb97a63675f3df4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->