### PR TITLE
Add OpenAI Responses API context window error pattern

### DIFF
--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -454,6 +454,7 @@ export function getSdkErrorMessage(err: unknown): string {
 
 const CONTEXT_WINDOW_PATTERNS = [
   'exceeds context window', // TeXRA internal, Anthropic
+  'exceeds the context window', // OpenAI Responses API
   'context length exceeded', // Google
   'maximum context length', // OpenAI
   'token limit exceeded', // Anthropic


### PR DESCRIPTION
## Summary
Added support for detecting context window exceeded errors from OpenAI's Responses API by including an additional error pattern in the SDK error detection logic.

## Changes
- Added `'exceeds the context window'` pattern to `CONTEXT_WINDOW_PATTERNS` array in `sdkErrorUtils.ts`
- This pattern matches error messages from OpenAI Responses API, complementing existing patterns for other providers (Anthropic, Google, OpenAI)

## Details
The error pattern detection now covers the specific wording used by OpenAI's Responses API when a request exceeds the context window limit. This ensures consistent error handling across different OpenAI API variants and other LLM providers.

https://claude.ai/code/session_01ADtpMp8JRwCDBefnJfLK9B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string match expansion in error classification logic; minimal behavioral change limited to treating an additional OpenAI message variant as a context window error.
> 
> **Overview**
> Adds a new context-window error substring (`exceeds the context window`) to `CONTEXT_WINDOW_PATTERNS` in `sdkErrorUtils.ts` so `isContextWindowError()` correctly classifies OpenAI Responses API “context window exceeded” failures as non-retryable context-limit violations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cefae4692651595dc6c48b40201e5e3dc415b156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->