### PR TITLE
Remove ProgressBoard mention from orchestrator agent prompt

### DIFF
--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -23,7 +23,7 @@ prompts:
   systemPrompt: |
     You are an AI scientist assistant that stewards the long-term development of LaTeX research projects. Think beyond individual tasks—consider whether the project structure scales, conventions stay consistent, and accumulated work builds toward a coherent whole. Maintain modular folder organization: keep sources, figures, bibliography, and build artifacts in separate directories so the project stays navigable as it grows. Proactively propose cleanup when you see duplicated logic, dead code, or inconsistent patterns. Every change should leave the project in a better structural state, not just fulfill the immediate request.
 
-    You delegate work through proposals on the ProgressBoard. Users can approve, reject with feedback, or edit before running. Delegated agents run in isolated sessions without access to your conversation, so instructions must be completely self-contained—write as you would to a colleague who knows nothing about the current situation. Use \ref{} labels instead of hardcoded section numbers (e.g., "strengthen the bound in \ref{thm:main}" not "strengthen Theorem 3").
+    You delegate work by creating proposals via the delegation tools. Users can approve, reject with feedback, or edit proposals before running. Delegated agents run in isolated sessions without access to your conversation, so instructions must be completely self-contained—write as you would to a colleague who knows nothing about the current situation. Use \ref{} labels instead of hardcoded section numbers (e.g., "strengthen the bound in \ref{thm:main}" not "strengthen Theorem 3").
 
     Self-contained instruction examples:
 

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -89,8 +89,8 @@ export class AcceptRunFilesTool extends defineTool({
   description: `Accept output files from a completed run into the workspace.
 
 Locates output files in run storage or the workspace (depending on storage
-mode) and writes them to the workspace. Each file is shown to the user for
-review before writing.
+mode) and writes them to the workspace. Each file goes through an approval
+step before writing and may be rejected.
 
 Parameters map directly to subagent-result delivery attributes:
   execution_id ← <subagent-result id="...">

--- a/src/tools/WorkflowTool.ts
+++ b/src/tools/WorkflowTool.ts
@@ -215,7 +215,7 @@ function proposalResultToToolResult(
       return {
         summary: `User opened '${agentName}' for editing`,
         output:
-          'Proposal opened in main view for editing. User will run manually.',
+          'Proposal opened for editing. The user will run it manually when ready.',
       };
     case 'approve':
       return null;
@@ -273,7 +273,7 @@ const WorkflowAgentInputSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Model short name (e.g., opus46T, sonnet45T, gpt52, gemini3p). Defaults to the current model if omitted. User can change via dropdown.',
+      'Model short name (e.g., opus46T, sonnet45T, gpt52, gemini3p). Defaults to the current model if omitted.',
     ),
   instruction: z.string().describe('Plain prose instruction for the agent'),
   inputFile: z.string().describe('Primary input file to process (required)'),
@@ -442,7 +442,7 @@ const DelegateAgentInputSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Model short name (e.g., opus46T, sonnet45T, gpt52, gemini3p). Defaults to the current model if omitted. User can change via dropdown.',
+      'Model short name (e.g., opus46T, sonnet45T, gpt52, gemini3p). Defaults to the current model if omitted.',
     ),
   instruction: z
     .string()

--- a/src/tools/lean/LspTools.ts
+++ b/src/tools/lean/LspTools.ts
@@ -156,10 +156,9 @@ export type LeanInspectInput = z.infer<typeof LeanInspectInputSchema>;
 const NO_DIAGNOSTICS_HELP = `No errors, warnings, or hints for this file.
 
 If you expected errors:
-1. Check the Lean 4 output panel (import/dependency errors appear there)
+1. Import/dependency errors may not surface as diagnostics — check imports manually
 2. Make sure the file is saved
-3. Try \`lean_file\` with command "restart" to refresh the Lean server
-4. Verify the Lean 4 extension is active (look for goal state in the infoview)`;
+3. Try \`lean_file\` with command "restart" to refresh the Lean server`;
 
 /** Navigate editor to first error location if present. */
 async function navigateToFirstError(
@@ -190,9 +189,7 @@ Returns diagnostics from the Lean 4 VS Code extension including:
 
 Tips:
 - If diagnostics seem stale, use lean_file with command "restart" to refresh the Lean server
-- Import/dependency errors may only appear in the Lean 4 output panel
-
-Requires: Lean 4 VS Code extension installed and active.`,
+- Import/dependency errors may not surface as diagnostics — check imports manually`,
   schema: LeanDiagnosticsInputSchema,
 }) {
   protected async execute(input: LeanDiagnosticsInput): Promise<ToolResult> {


### PR DESCRIPTION
The agent cannot see or interact with the ProgressBoard UI, so
referencing it in the system prompt is misleading. Rephrased to
describe delegation in terms of tools the agent actually uses.

https://claude.ai/code/session_019v7sEKQSJ43pAJy4xhShUh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only/documentation changes to agent prompts and tool descriptions; no behavior or data-flow logic is modified.
> 
> **Overview**
> Clarifies the `orchestrator` system prompt to describe delegation in terms of the `delegate_*` tools (not the ProgressBoard UI), emphasizing that proposals can be approved, rejected with feedback, or edited before running.
> 
> Updates tool-facing copy: `accept_run_files` now describes an explicit per-file approval/rejection step, `delegate_*` schema descriptions remove UI-specific model-selection wording, and Lean’s `lean_diagnostics` help text is tightened to better set expectations around missing import/dependency diagnostics and recommended recovery steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be6d96b1a14709da9e1fb6c399708fce9c4efe9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->