### PR TITLE
Add file read tracking and gating to memory tool operations

### DIFF
--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -78,27 +78,36 @@ export class MemoryTool extends defineTool({
 Paths must start with /memories. Use /memories to list files, /memories/file.md for specific files. "/" alone is invalid.`,
   schema: MemoryToolInputSchema,
 }) {
+  /**
+   * Canonicalize a raw display path so that equivalent spellings
+   * (e.g. `/memories/` vs `/memories`) resolve to the same string.
+   * Round-trips through storage resolution to normalize slashes and segments.
+   */
+  private canonicalize(rawPath: string): string {
+    return toDisplayPath(displayToStoragePath(rawPath));
+  }
+
   protected async execute(input: MemoryToolInput): Promise<ToolResult> {
     switch (input.command) {
       case 'view':
         return this.view(
-          requireField(input.path, 'path', input.command),
+          this.canonicalize(requireField(input.path, 'path', input.command)),
           input.view_range ?? undefined,
         );
       case 'create':
         return this.create(
-          requireField(input.path, 'path', input.command),
+          this.canonicalize(requireField(input.path, 'path', input.command)),
           requireField(input.file_text, 'file_text', input.command),
         );
       case 'str_replace':
         return this.strReplace(
-          requireField(input.path, 'path', input.command),
+          this.canonicalize(requireField(input.path, 'path', input.command)),
           requireField(input.old_str, 'old_str', input.command),
           requireField(input.new_str, 'new_str', input.command),
         );
       case 'insert':
         return this.insert(
-          requireField(input.path, 'path', input.command),
+          this.canonicalize(requireField(input.path, 'path', input.command)),
           requireField(input.insert_line, 'insert_line', input.command),
           requireField(
             input.insert_text ?? input.new_str,
@@ -107,11 +116,17 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
           ),
         );
       case 'delete':
-        return this.delete(requireField(input.path, 'path', input.command));
+        return this.delete(
+          this.canonicalize(requireField(input.path, 'path', input.command)),
+        );
       case 'rename':
         return this.rename(
-          requireField(input.old_path, 'old_path', input.command),
-          requireField(input.new_path, 'new_path', input.command),
+          this.canonicalize(
+            requireField(input.old_path, 'old_path', input.command),
+          ),
+          this.canonicalize(
+            requireField(input.new_path, 'new_path', input.command),
+          ),
         );
       default:
         throw new ToolError(`Unrecognized command: ${input.command}`);
@@ -144,12 +159,15 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
   }
 
   /** Return early result if the file hasn't been viewed yet. */
-  private requireViewBeforeEdit(inputPath: string): ToolResult | undefined {
+  private requireViewBeforeModify(
+    inputPath: string,
+    operation: string = 'editing',
+  ): ToolResult | undefined {
     return (
       requireFileReadForEdit(
         inputPath,
         true,
-        'Edits to memory files require viewing the file first. Please use the view command before editing.',
+        `Modifications to memory files require viewing the file first. Please use the view command before ${operation}.`,
       ) ?? undefined
     );
   }
@@ -197,6 +215,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const stats = await StorageFS.stat(resolvedPath);
     if (stats.type === vscode.FileType.Directory) {
       const listing = await this.buildDirectoryListing(resolvedPath);
+      recordToolFileRead(inputPath);
       return {
         summary: `Listed directory: ${inputPath}`,
         output: [
@@ -267,7 +286,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     await this.requireEditableFile(resolvedPath, inputPath);
 
-    const readGate = this.requireViewBeforeEdit(inputPath);
+    const readGate = this.requireViewBeforeModify(inputPath);
     if (readGate) return readGate;
 
     const { content } = await this.readMemoryFile(resolvedPath);
@@ -313,7 +332,7 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     const resolvedPath = this.resolveMemoryPath(inputPath);
     await this.requireEditableFile(resolvedPath, inputPath);
 
-    const readGate = this.requireViewBeforeEdit(inputPath);
+    const readGate = this.requireViewBeforeModify(inputPath);
     if (readGate) return readGate;
 
     const { content } = await this.readMemoryFile(resolvedPath);
@@ -348,6 +367,9 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
       throw new ToolError(`The path ${inputPath} does not exist.`);
     }
 
+    const readGate = this.requireViewBeforeModify(inputPath, 'deleting');
+    if (readGate) return readGate;
+
     await StorageFS.delete(resolvedPath, { recursive: true });
     return {
       summary: `Deleted: ${inputPath}`,
@@ -366,6 +388,9 @@ Paths must start with /memories. Use /memories to list files, /memories/file.md 
     if (!oldExists) {
       throw new ToolError(`The path ${oldPathInput} does not exist.`);
     }
+
+    const readGate = this.requireViewBeforeModify(oldPathInput, 'renaming');
+    if (readGate) return readGate;
 
     const newExists = await StorageFS.exists(resolvedNewPath);
     if (newExists) {


### PR DESCRIPTION
## Summary
This change adds file read tracking and access gating to the memory tool to ensure users view files before performing destructive operations, improving safety and consistency.

## Key Changes
- **Record file reads on directory listing**: Added `recordToolFileRead()` call when listing directory contents to track access
- **Gate delete operations**: Implemented a read requirement gate for the delete operation that prevents users from deleting memory files without first viewing them, consistent with existing str_replace/insert behavior

## Implementation Details
The delete operation now checks `requireFileReadForEdit()` before allowing deletion, returning an error message if the file hasn't been viewed first. This creates a consistent user experience across all file modification operations and adds a safety mechanism to prevent accidental deletions.

https://claude.ai/code/session_01SGz2PbFs6g1BbH3iteedap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate behavior change to safety checks for destructive operations; low implementation complexity but could block existing workflows if view tracking/canonicalization differs from prior path strings.
> 
> **Overview**
> Adds path canonicalization so equivalent `/memories` spellings are normalized before all operations, making file-read tracking and gating consistent.
> 
> Extends the existing “must view before edit” guard to a generalized `requireViewBeforeModify` and applies it to **delete** and **rename**, and records reads when listing directories so those views satisfy the gate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6765a06c74552ca394762fbeffdfc8d7b7995811. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->