### PR TITLE
Add Claude Sonnet 4.6 support with thinking and context compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 - **Guided agent creation wizard** — create new agents by describing what you need; the wizard picks a suitable type, suggests tools, and generates the YAML definition for you.
 - **Agent management in settings** — customize and delete agents directly from the Agents tab; Select All / Unselect All buttons per source type (built-in, custom, remote) for quick toggling.
 - **Beamer theme** — paper2slide now uses the modern metropolis theme.
+- Added **Claude Sonnet 4.6** (thinking and regular) to the default model list, replacing Sonnet 4.5.
+- Enabled **server-side context compaction** for Sonnet 4.6 in tool-use mode (previously Opus 4.6 only).
+- Added Sonnet 4.6 to the **1M context window beta** eligibility list.
 
 ### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.28",
         "lit": "^3.3.2",
-        "llm-zoo": "^1.0.6",
+        "llm-zoo": "^1.0.7",
         "mark.js": "^8.11.1",
         "markdown-it": "^14.1.1",
         "markdown-it-texmath": "^1.0.0",
@@ -7488,9 +7488,9 @@
       }
     },
     "node_modules/llm-zoo": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.0.6.tgz",
-      "integrity": "sha512-nXwcwcAWB9KCo3oMlM1sPA3YMx2A4A9HXZFLy/VLv9nrvi+1bIOddzcC9HR66qPTn1ROC5UDvNm4XuQfMbQuPQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.0.7.tgz",
+      "integrity": "sha512-SK4+jWevYVyZ3NMuRUUvGtkHsJn/8sD+nBxl9KD3zoU9i0irdAi4M/oYfnjF29wx/0A5RyfdA2QEaKpaciEnGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1380,7 +1380,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.28",
     "lit": "^3.3.2",
-    "llm-zoo": "^1.0.6",
+    "llm-zoo": "^1.0.7",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.1.1",
     "markdown-it-texmath": "^1.0.0",

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -328,10 +328,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
-  private isClaudeSonnet46(): boolean {
-    return this.config.fullName === SONNET_46_FULLNAME;
-  }
-
   /** Whether this model supports Anthropic's native server-side context compaction. */
   private isCompactionEligibleModel(): boolean {
     return this.isClaudeOpus46() || this.isClaudeSonnet46();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -328,8 +328,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
+  private isClaudeSonnet46(): boolean {
+    return this.config.fullName === SONNET_46_FULLNAME;
+  }
+
+  /** Whether this model supports Anthropic's native server-side context compaction. */
+  private isCompactionEligibleModel(): boolean {
+    return this.isClaudeOpus46() || this.isClaudeSonnet46();
+  }
+
   override get supportsManualCompaction(): boolean {
-    return this.isClaudeOpus46() && this.isToolUseMode();
+    return this.isCompactionEligibleModel() && this.isToolUseMode();
   }
 
   override requestCompaction(): void {
@@ -385,7 +394,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return;
     }
 
-    if (!this.isClaudeOpus46()) {
+    if (!this.isCompactionEligibleModel()) {
       return;
     }
 
@@ -575,6 +584,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaEligibleModel =
       this.config.fullName === 'claude-sonnet-4-20250514' ||
       this.config.fullName === 'claude-sonnet-4-5' ||
+      this.config.fullName === SONNET_46_FULLNAME ||
       this.config.fullName === OPUS_46_FULLNAME;
     const isAnthropic1MBetaActive =
       useAnthropic1MBeta && isAnthropic1MBetaEligibleModel;

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -22,7 +22,7 @@ import { extendEnvPath } from '@utils/system/platformPaths';
  * Version number for the default model list.
  * Increment this when adding new models to force existing users to get the updated defaults.
  */
-const MODEL_LIST_VERSION = 3;
+const MODEL_LIST_VERSION = 4;
 
 /**
  * Legacy agent files that should be deleted from GlobalStorage.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { MODEL_CONFIGS, type ModelConfig, type ModelCapabilities } from 'llm-zoo';
+import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
 
 // Local imports - auth
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -10,40 +10,6 @@ import { ApiProvider, SecretManager } from '@frontend/secretManager';
 
 // Local imports - shared schemas
 import type { ModelOptionData } from '@shared/schemas';
-
-/**
- * Register Sonnet 4.6 models in MODEL_CONFIGS.
- * These are added here until the llm-zoo package includes them natively.
- */
-const SONNET_46_CAPABILITIES: ModelCapabilities = {
-  ...MODEL_CONFIGS['sonnet45T'].capabilities,
-};
-
-MODEL_CONFIGS['sonnet46T'] = {
-  name: 'sonnet46T',
-  fullName: 'claude-sonnet-4-6',
-  openrouterFullName: 'anthropic/claude-sonnet-4.6:thinking',
-  provider: 'anthropic',
-  maxOutputTokens: 64_000,
-  contextWindow: 200_000,
-  inputPrice: 3,
-  outputPrice: 15,
-  capabilities: { ...SONNET_46_CAPABILITIES, supportsReasoning: true, supportsInterleavedThinking: true, supportsAssistantPrefill: false },
-  openRouterOnly: false,
-} as ModelConfig;
-
-MODEL_CONFIGS['sonnet46'] = {
-  name: 'sonnet46',
-  fullName: 'claude-sonnet-4-6',
-  openrouterFullName: 'anthropic/claude-sonnet-4.6',
-  provider: 'anthropic',
-  maxOutputTokens: 64_000,
-  contextWindow: 200_000,
-  inputPrice: 3,
-  outputPrice: 15,
-  capabilities: { ...SONNET_46_CAPABILITIES, supportsReasoning: false, supportsInterleavedThinking: false, supportsAssistantPrefill: true },
-  openRouterOnly: false,
-} as ModelConfig;
 
 /**
  * Default models that should be present in every user's model list.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
+import { MODEL_CONFIGS, type ModelConfig, type ModelCapabilities } from 'llm-zoo';
 
 // Local imports - auth
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -12,13 +12,47 @@ import { ApiProvider, SecretManager } from '@frontend/secretManager';
 import type { ModelOptionData } from '@shared/schemas';
 
 /**
+ * Register Sonnet 4.6 models in MODEL_CONFIGS.
+ * These are added here until the llm-zoo package includes them natively.
+ */
+const SONNET_46_CAPABILITIES: ModelCapabilities = {
+  ...MODEL_CONFIGS['sonnet45T'].capabilities,
+};
+
+MODEL_CONFIGS['sonnet46T'] = {
+  name: 'sonnet46T',
+  fullName: 'claude-sonnet-4-6',
+  openrouterFullName: 'anthropic/claude-sonnet-4.6:thinking',
+  provider: 'anthropic',
+  maxOutputTokens: 64_000,
+  contextWindow: 200_000,
+  inputPrice: 3,
+  outputPrice: 15,
+  capabilities: { ...SONNET_46_CAPABILITIES, supportsReasoning: true, supportsInterleavedThinking: true, supportsAssistantPrefill: false },
+  openRouterOnly: false,
+} as ModelConfig;
+
+MODEL_CONFIGS['sonnet46'] = {
+  name: 'sonnet46',
+  fullName: 'claude-sonnet-4-6',
+  openrouterFullName: 'anthropic/claude-sonnet-4.6',
+  provider: 'anthropic',
+  maxOutputTokens: 64_000,
+  contextWindow: 200_000,
+  inputPrice: 3,
+  outputPrice: 15,
+  capabilities: { ...SONNET_46_CAPABILITIES, supportsReasoning: false, supportsInterleavedThinking: false, supportsAssistantPrefill: true },
+  openRouterOnly: false,
+} as ModelConfig;
+
+/**
  * Default models that should be present in every user's model list.
  * Update this list and increment MODEL_LIST_VERSION in setup.ts when adding new models.
  */
 export const DEFAULT_MODELS = [
   'gemini3p',
   'gemini3f',
-  'sonnet45T',
+  'sonnet46T',
   'opus46T',
   'gpt52',
   'gpt52pro',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -143,7 +143,7 @@ const PROVIDER_VSCODE_SETTINGS: Record<
       key: 'texra.model.useAnthropic1MBeta',
       label: '1M Context Window Beta',
       description:
-        'Enable the 1M-token context window for Claude Opus 4.6 and Sonnet 4 (usage capped at 200K by extension).',
+        'Enable the 1M-token context window for Claude Opus 4.6, Sonnet 4.6, and Sonnet 4 (usage capped at 200K by extension).',
     },
   ],
 };


### PR DESCRIPTION
- Register sonnet46T/sonnet46 model configs and replace sonnet45T in defaults
- Enable server-side context compaction for Sonnet 4.6 (previously Opus 4.6 only)
- Add fixed thinking budget for Sonnet 4.6 tool-use mode (cache stability)
- Add Sonnet 4.6 to 1M context window beta eligibility
- Skip interleaved-thinking beta header for Sonnet 4.6 (like Opus 4.6)
- Increment MODEL_LIST_VERSION to push updated defaults to users

https://claude.ai/code/session_01CpZWXRpgoPnmLudiBZ68uB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider-specific request/compaction gating and default model rollout, which can affect runtime behavior and token/context handling for Anthropic users.
> 
> **Overview**
> Adds `Claude Sonnet 4.6` to the shipped default model set (replacing `Sonnet 4.5`) and bumps `MODEL_LIST_VERSION` so existing installs pick up the new defaults.
> 
> Extends Anthropic server-side context management to treat Sonnet 4.6 as compaction-eligible (previously only Opus 4.6), and includes Sonnet 4.6 in the `texra.model.useAnthropic1MBeta` 1M-context eligibility list and related settings UI copy.
> 
> Updates dependencies via `llm-zoo` `^1.0.6` → `^1.0.7`, and documents the Sonnet 4.6 additions in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b2b8775346c5b6b55b16346c0b5f22e85d12aa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->