### PR TITLE
Add xterm.js display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@supabase/supabase-js": "^2.95.3",
         "@vscode-elements/elements": "^2.5.0",
         "@vscode/codicons": "^0.0.44",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "arxiv-client": "^0.0.9",
         "axios": "^1.13.5",
         "bibtex": "^0.9.0",
@@ -2991,6 +2993,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1361,6 +1361,8 @@
     "@supabase/supabase-js": "^2.95.3",
     "@vscode-elements/elements": "^2.5.0",
     "@vscode/codicons": "^0.0.44",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "arxiv-client": "^0.0.9",
     "axios": "^1.13.5",
     "bibtex": "^0.9.0",

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -44,6 +44,7 @@ export class TerminalOutput extends LitElement {
   private fitAddon: FitAddon | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private writeChain: Promise<void> = Promise.resolve();
+  private detailsElement: HTMLDetailsElement | null = null;
 
   private readonly handleDetailsToggle = (): void => {
     this.refitIfVisible();
@@ -83,10 +84,11 @@ export class TerminalOutput extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    this.closest('details')?.removeEventListener(
+    this.detailsElement?.removeEventListener(
       'toggle',
       this.handleDetailsToggle,
     );
+    this.detailsElement = null;
     window.removeEventListener('resize', this.handleWindowResize);
 
     this.resizeObserver?.disconnect();
@@ -98,10 +100,8 @@ export class TerminalOutput extends LitElement {
   }
 
   private attachResizeHooks(): void {
-    this.closest('details')?.addEventListener(
-      'toggle',
-      this.handleDetailsToggle,
-    );
+    this.detailsElement = this.closest('details');
+    this.detailsElement?.addEventListener('toggle', this.handleDetailsToggle);
     window.addEventListener('resize', this.handleWindowResize);
 
     this.resizeObserver = new ResizeObserver(() => {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -43,8 +43,10 @@ export class TerminalOutput extends LitElement {
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private resizeObserver: ResizeObserver | null = null;
-  private writeChain: Promise<void> = Promise.resolve();
   private detailsElement: HTMLDetailsElement | null = null;
+  private isFlushingText = false;
+  private needsFlush = false;
+  private pendingText = '';
 
   private readonly handleDetailsToggle = (): void => {
     this.refitIfVisible();
@@ -78,6 +80,8 @@ export class TerminalOutput extends LitElement {
 
   override updated(changedProperties: Map<string, unknown>): void {
     if (!changedProperties.has('text')) return;
+    this.pendingText = this.text;
+    this.needsFlush = true;
     this.renderTerminalText();
   }
 
@@ -121,10 +125,19 @@ export class TerminalOutput extends LitElement {
   }
 
   private renderTerminalText(): void {
-    const flushWrite = async (): Promise<void> => {
-      if (!this.terminal) return;
+    if (this.isFlushingText) return;
 
-      const lineCount = this.text.split('\n').length;
+    this.isFlushingText = true;
+    void this.flushTerminalText();
+  }
+
+  private async flushTerminalText(): Promise<void> {
+    while (this.needsFlush) {
+      this.needsFlush = false;
+      if (!this.terminal) continue;
+
+      const text = this.pendingText;
+      const lineCount = text.split('\n').length;
       const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
       if (this.terminal.options.scrollback !== scrollback) {
         this.terminal.options = {
@@ -135,12 +148,15 @@ export class TerminalOutput extends LitElement {
 
       this.terminal.reset();
       await new Promise<void>((resolve) => {
-        this.terminal?.write(this.text, () => resolve());
+        this.terminal?.write(text, () => resolve());
       });
       this.refitIfVisible();
-    };
+    }
 
-    this.writeChain = this.writeChain.then(flushWrite, flushWrite);
+    this.isFlushingText = false;
+    if (this.needsFlush) {
+      this.renderTerminalText();
+    }
   }
 
   private resolveThemeFromCssVars(): {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -136,9 +136,10 @@ export class TerminalOutput extends LitElement {
       while (this.needsFlush) {
         this.needsFlush = false;
         if (!this.terminal) continue;
+        const terminal = this.terminal;
 
         const text = this.pendingText;
-        const activeBuffer = this.terminal.buffer.active;
+        const activeBuffer = terminal.buffer.active;
         const previousBaseY = activeBuffer.baseY;
         const previousViewportY = activeBuffer.viewportY;
         const distanceFromBottom = previousBaseY - previousViewportY;
@@ -146,22 +147,32 @@ export class TerminalOutput extends LitElement {
 
         const lineCount = text.split('\n').length;
         const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
-        if (this.terminal.options.scrollback !== scrollback) {
-          this.terminal.options = {
-            ...this.terminal.options,
+        if (terminal.options.scrollback !== scrollback) {
+          terminal.options = {
+            ...terminal.options,
             scrollback,
           };
         }
 
-        this.terminal.reset();
+        terminal.reset();
         await new Promise<void>((resolve) => {
-          this.terminal?.write(text, () => resolve());
+          let resolved = false;
+          const complete = (): void => {
+            if (resolved) return;
+            resolved = true;
+            resolve();
+          };
+
+          terminal.write(text, complete);
+          setTimeout(complete, 100);
         });
 
+        if (!this.terminal || this.terminal !== terminal) continue;
+
         if (!wasPinnedToBottom) {
-          const nextBaseY = this.terminal.buffer.active.baseY;
+          const nextBaseY = terminal.buffer.active.baseY;
           const targetViewportY = Math.max(0, nextBaseY - distanceFromBottom);
-          this.terminal.scrollToLine(targetViewportY);
+          terminal.scrollToLine(targetViewportY);
         }
 
         this.refitIfVisible();

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -1,14 +1,38 @@
 // Third-party imports
-import { LitElement, html } from 'lit';
+import { LitElement, css, html, unsafeCSS } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
+import xtermStyles from '@xterm/xterm/css/xterm.css?inline';
 
-// Third-party imports - styles
-import '@xterm/xterm/css/xterm.css';
+const DEFAULT_THEME = {
+  background: '#1e1e1e',
+  foreground: '#cccccc',
+  fontFamily: 'monospace',
+} as const;
 
+/**
+ * Read-only terminal renderer for shell output.
+ * Uses xterm.js for ANSI colors/formatting without interactive input.
+ */
 @customElement('terminal-output')
 export class TerminalOutput extends LitElement {
+  static override styles = [
+    css`
+      ${unsafeCSS(xtermStyles)}
+
+      :host {
+        display: block;
+      }
+
+      .terminal-container {
+        min-height: 64px;
+        max-height: var(--height-large);
+        overflow: auto;
+      }
+    `,
+  ];
+
   @property({ type: String }) text = '';
 
   @query('.terminal-container')
@@ -16,48 +40,108 @@ export class TerminalOutput extends LitElement {
 
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
+  private resizeObserver: ResizeObserver | null = null;
 
-  protected override createRenderRoot(): this {
-    return this;
-  }
+  private readonly handleDetailsToggle = (): void => {
+    this.refitIfVisible();
+  };
+
+  private readonly handleWindowResize = (): void => {
+    this.refitIfVisible();
+  };
 
   override firstUpdated(): void {
+    const resolvedTheme = this.resolveThemeFromCssVars();
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
       scrollback: 4_000,
-      fontFamily: 'var(--vscode-editor-font-family, monospace)',
+      fontFamily: resolvedTheme.fontFamily,
       fontSize: 12,
       theme: {
-        background: 'var(--vscode-editor-background, #1e1e1e)',
-        foreground: 'var(--vscode-editor-foreground, #cccccc)',
+        background: resolvedTheme.background,
+        foreground: resolvedTheme.foreground,
       },
     });
+
     this.fitAddon = new FitAddon();
     this.terminal.loadAddon(this.fitAddon);
     this.terminal.open(this.terminalContainer);
-    this.fitAddon.fit();
-    this.renderTerminalText();
+
+    this.attachResizeHooks();
+    this.refitIfVisible();
   }
 
   override updated(changedProperties: Map<string, unknown>): void {
-    if (changedProperties.has('text')) {
-      this.renderTerminalText();
-      this.fitAddon?.fit();
-    }
+    if (!changedProperties.has('text')) return;
+    this.renderTerminalText();
+    this.refitIfVisible();
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
+
+    this.closest('details')?.removeEventListener(
+      'toggle',
+      this.handleDetailsToggle,
+    );
+    window.removeEventListener('resize', this.handleWindowResize);
+
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+
     this.terminal?.dispose();
     this.terminal = null;
     this.fitAddon = null;
+  }
+
+  private attachResizeHooks(): void {
+    this.closest('details')?.addEventListener(
+      'toggle',
+      this.handleDetailsToggle,
+    );
+    window.addEventListener('resize', this.handleWindowResize);
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.refitIfVisible();
+    });
+    this.resizeObserver.observe(this);
+  }
+
+  private refitIfVisible(): void {
+    if (!this.terminal || !this.fitAddon) return;
+    if (this.offsetParent === null) return;
+
+    const { width, height } = this.getBoundingClientRect();
+    if (width === 0 || height === 0) return;
+
+    this.fitAddon.fit();
   }
 
   private renderTerminalText(): void {
     if (!this.terminal) return;
     this.terminal.reset();
     this.terminal.write(this.text);
+  }
+
+  private resolveThemeFromCssVars(): {
+    background: string;
+    foreground: string;
+    fontFamily: string;
+  } {
+    const styles = getComputedStyle(this);
+
+    const background =
+      styles.getPropertyValue('--vscode-editor-background').trim() ||
+      DEFAULT_THEME.background;
+    const foreground =
+      styles.getPropertyValue('--vscode-editor-foreground').trim() ||
+      DEFAULT_THEME.foreground;
+    const fontFamily =
+      styles.getPropertyValue('--vscode-editor-font-family').trim() ||
+      DEFAULT_THEME.fontFamily;
+
+    return { background, foreground, fontFamily };
   }
 
   override render() {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -138,6 +138,12 @@ export class TerminalOutput extends LitElement {
         if (!this.terminal) continue;
 
         const text = this.pendingText;
+        const activeBuffer = this.terminal.buffer.active;
+        const previousBaseY = activeBuffer.baseY;
+        const previousViewportY = activeBuffer.viewportY;
+        const distanceFromBottom = previousBaseY - previousViewportY;
+        const wasPinnedToBottom = distanceFromBottom <= 1;
+
         const lineCount = text.split('\n').length;
         const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
         if (this.terminal.options.scrollback !== scrollback) {
@@ -151,6 +157,13 @@ export class TerminalOutput extends LitElement {
         await new Promise<void>((resolve) => {
           this.terminal?.write(text, () => resolve());
         });
+
+        if (!wasPinnedToBottom) {
+          const nextBaseY = this.terminal.buffer.active.baseY;
+          const targetViewportY = Math.max(0, nextBaseY - distanceFromBottom);
+          this.terminal.scrollToLine(targetViewportY);
+        }
+
         this.refitIfVisible();
       }
     } finally {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -11,6 +11,8 @@ const DEFAULT_THEME = {
   fontFamily: 'monospace',
 } as const;
 
+const MIN_SCROLLBACK = 4_000;
+
 /**
  * Read-only terminal renderer for shell output.
  * Uses xterm.js for ANSI colors/formatting without interactive input.
@@ -41,6 +43,7 @@ export class TerminalOutput extends LitElement {
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private writeChain: Promise<void> = Promise.resolve();
 
   private readonly handleDetailsToggle = (): void => {
     this.refitIfVisible();
@@ -55,7 +58,7 @@ export class TerminalOutput extends LitElement {
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
-      scrollback: 4_000,
+      scrollback: MIN_SCROLLBACK,
       fontFamily: resolvedTheme.fontFamily,
       fontSize: 12,
       theme: {
@@ -75,7 +78,6 @@ export class TerminalOutput extends LitElement {
   override updated(changedProperties: Map<string, unknown>): void {
     if (!changedProperties.has('text')) return;
     this.renderTerminalText();
-    this.refitIfVisible();
   }
 
   override disconnectedCallback(): void {
@@ -119,9 +121,26 @@ export class TerminalOutput extends LitElement {
   }
 
   private renderTerminalText(): void {
-    if (!this.terminal) return;
-    this.terminal.reset();
-    this.terminal.write(this.text);
+    const flushWrite = async (): Promise<void> => {
+      if (!this.terminal) return;
+
+      const lineCount = this.text.split('\n').length;
+      const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
+      if (this.terminal.options.scrollback !== scrollback) {
+        this.terminal.options = {
+          ...this.terminal.options,
+          scrollback,
+        };
+      }
+
+      this.terminal.reset();
+      await new Promise<void>((resolve) => {
+        this.terminal?.write(this.text, () => resolve());
+      });
+      this.refitIfVisible();
+    };
+
+    this.writeChain = this.writeChain.then(flushWrite, flushWrite);
   }
 
   private resolveThemeFromCssVars(): {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -1,0 +1,66 @@
+// Third-party imports
+import { LitElement, html } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal } from '@xterm/xterm';
+
+// Third-party imports - styles
+import '@xterm/xterm/css/xterm.css';
+
+@customElement('terminal-output')
+export class TerminalOutput extends LitElement {
+  @property({ type: String }) text = '';
+
+  @query('.terminal-container')
+  private terminalContainer!: HTMLDivElement;
+
+  private terminal: Terminal | null = null;
+  private fitAddon: FitAddon | null = null;
+
+  protected override createRenderRoot(): this {
+    return this;
+  }
+
+  override firstUpdated(): void {
+    this.terminal = new Terminal({
+      disableStdin: true,
+      convertEol: true,
+      scrollback: 4_000,
+      fontFamily: 'var(--vscode-editor-font-family, monospace)',
+      fontSize: 12,
+      theme: {
+        background: 'var(--vscode-editor-background, #1e1e1e)',
+        foreground: 'var(--vscode-editor-foreground, #cccccc)',
+      },
+    });
+    this.fitAddon = new FitAddon();
+    this.terminal.loadAddon(this.fitAddon);
+    this.terminal.open(this.terminalContainer);
+    this.fitAddon.fit();
+    this.renderTerminalText();
+  }
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('text')) {
+      this.renderTerminalText();
+      this.fitAddon?.fit();
+    }
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.terminal?.dispose();
+    this.terminal = null;
+    this.fitAddon = null;
+  }
+
+  private renderTerminalText(): void {
+    if (!this.terminal) return;
+    this.terminal.reset();
+    this.terminal.write(this.text);
+  }
+
+  override render() {
+    return html`<div class="terminal-container"></div>`;
+  }
+}

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -132,30 +132,32 @@ export class TerminalOutput extends LitElement {
   }
 
   private async flushTerminalText(): Promise<void> {
-    while (this.needsFlush) {
-      this.needsFlush = false;
-      if (!this.terminal) continue;
+    try {
+      while (this.needsFlush) {
+        this.needsFlush = false;
+        if (!this.terminal) continue;
 
-      const text = this.pendingText;
-      const lineCount = text.split('\n').length;
-      const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
-      if (this.terminal.options.scrollback !== scrollback) {
-        this.terminal.options = {
-          ...this.terminal.options,
-          scrollback,
-        };
+        const text = this.pendingText;
+        const lineCount = text.split('\n').length;
+        const scrollback = Math.max(MIN_SCROLLBACK, lineCount);
+        if (this.terminal.options.scrollback !== scrollback) {
+          this.terminal.options = {
+            ...this.terminal.options,
+            scrollback,
+          };
+        }
+
+        this.terminal.reset();
+        await new Promise<void>((resolve) => {
+          this.terminal?.write(text, () => resolve());
+        });
+        this.refitIfVisible();
       }
-
-      this.terminal.reset();
-      await new Promise<void>((resolve) => {
-        this.terminal?.write(text, () => resolve());
-      });
-      this.refitIfVisible();
-    }
-
-    this.isFlushingText = false;
-    if (this.needsFlush) {
-      this.renderTerminalText();
+    } finally {
+      this.isFlushingText = false;
+      if (this.needsFlush) {
+        this.renderTerminalText();
+      }
     }
   }
 

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -61,6 +61,7 @@ import type { WebSearchPayload, LogMessageData } from '@shared/schemas';
 
 // Side-effect import to register <tool-timer> custom element
 import '../../components/ToolTimer';
+import '../../components/TerminalOutput';
 
 /** Default bash tool timeout (matches BASH_TIMEOUT_MS in src/tools/bash.ts). */
 const BASH_DEFAULT_TIMEOUT_MS = 120_000;
@@ -179,6 +180,17 @@ function buildToolSection(
     : wrapInPre(text, extraClass);
 
   return buildToolUseSection(label, content);
+}
+
+/** Build a read-only terminal section for shell output. */
+function buildTerminalSection(label: string, text: string): TemplateResult {
+  return buildToolUseSection(
+    label,
+    html`<terminal-output
+      class="tool-output-terminal"
+      .text=${text}
+    ></terminal-output>`,
+  );
 }
 
 /** Title prefix lookup based on tool state. */
@@ -553,10 +565,12 @@ export function formatToolUseTemplate(
     !isTrivialWriteOutput
   ) {
     sections.push(
-      buildToolSection('Output:', outputText, {
-        toolName,
-        extraClass: 'tool-output-full',
-      }),
+      toolName === 'bash'
+        ? buildTerminalSection('Output:', outputText)
+        : buildToolSection('Output:', outputText, {
+            toolName,
+            extraClass: 'tool-output-full',
+          }),
     );
   }
 

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -144,12 +144,6 @@ export const toolUseStyles = css`
     border: var(--border-thin) solid var(--color-border);
   }
 
-  .tool-output-terminal .terminal-container {
-    min-height: 64px;
-    max-height: var(--height-large);
-    overflow: auto;
-  }
-
   /* Proposal setup link (in summary row and body) */
   .proposal-restore-link {
     color: var(--color-text-link);

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -136,6 +136,20 @@ export const toolUseStyles = css`
     overflow: auto;
   }
 
+  .tool-output-terminal {
+    display: block;
+    border-radius: var(--border-radius-small);
+    overflow: hidden;
+    background: var(--vscode-editor-background, #1e1e1e);
+    border: var(--border-thin) solid var(--color-border);
+  }
+
+  .tool-output-terminal .terminal-container {
+    min-height: 64px;
+    max-height: var(--height-large);
+    overflow: auto;
+  }
+
   /* Proposal setup link (in summary row and body) */
   .proposal-restore-link {
     color: var(--color-text-link);


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995720e7800832496edae900f44fae1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party terminal renderer in the webview and changes how `bash` output is displayed; main risk is UI regressions/performance issues with large outputs and resize/scroll behavior.
> 
> **Overview**
> Updates the ProgressBoard tool log UI to render `bash` tool output in a read-only xterm.js terminal, preserving ANSI colors/formatting instead of showing plain preformatted text.
> 
> Adds a new `TerminalOutput` Lit component that fits/resizes with its container, derives theme colors/fonts from VS Code CSS variables, and manages scrollback/scroll position while updating output. Includes new styling for the terminal wrapper and adds `@xterm/xterm` + `@xterm/addon-fit` dependencies (with lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9096264e5fb94e7d708cea08eaf3f384ba70e902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->