### PR TITLE
Add orchestrator kill toggle to Multi-Agent settings

### DIFF
--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -20,6 +20,7 @@ export enum WorkspaceStateKey {
   ENABLED_TOOL_USE_AGENTS = 'texra.enabledToolUseAgents',
   PARENT_STREAM_IDS = 'texra.parentStreamIds',
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
+  ALLOW_ORCHESTRATOR_KILL = 'texra.allowOrchestratorKill',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 }
 

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -347,6 +347,7 @@ export const SETTINGS_VIEW_CMD = {
   // Multi-Agent commands
   GET_SUPER_YOLO_ENABLED: 'getSuperYoloEnabled',
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
+  SET_ALLOW_ORCHESTRATOR_KILL: 'setAllowOrchestratorKill',
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',
   DELETE_AGENT_MODE_PRESET: 'deleteAgentModePreset',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -396,6 +396,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.withActiveWebview((w) => this.sendSuperYoloEnabled(w)),
       [SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED]: (data) =>
         this.handleSetSuperYoloEnabled(data),
+      [SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL]: (data) =>
+        this.handleSetAllowOrchestratorKill(data),
 
       // Agent selection handlers
       [SETTINGS_VIEW_COMMANDS.GET_AGENT_SELECTION]: () =>
@@ -655,10 +657,15 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       WorkspaceStateKey.SUPER_YOLO_ENABLED,
       false,
     );
+    const allowOrchestratorKill = workspaceSM.get<boolean>(
+      WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+      true,
+    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
       enabled,
       reliabilitySettings: getReliabilitySettings(),
+      allowOrchestratorKill,
     });
   }
 
@@ -682,6 +689,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     void vscode.window.showInformationMessage(
       `Super YOLO mode ${data.enabled ? 'enabled' : 'disabled'}`,
     );
+  }
+
+  private async handleSetAllowOrchestratorKill(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_ALLOW_ORCHESTRATOR_KILL>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+      data.enabled,
+    );
+    await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
   }
 
   // ============================================================

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -155,6 +155,7 @@ export class SettingsApp extends BaseWebviewApp {
   @state() private superYoloEnabled = false;
   @state() private superYoloToggleDisabled = true;
   @state() private reliabilitySettings: NumberVscodeSetting[] = [];
+  @state() private allowOrchestratorKill = true;
 
   // Tool dashboard state
   @state() private toolDashboardItems: ToolDashboardItem[] = [];
@@ -280,6 +281,7 @@ export class SettingsApp extends BaseWebviewApp {
         this.superYoloEnabled = data.enabled;
         this.superYoloToggleDisabled = false;
         this.reliabilitySettings = data.reliabilitySettings;
+        this.allowOrchestratorKill = data.allowOrchestratorKill;
         return;
       }
 
@@ -461,6 +463,10 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED,
   );
 
+  private handleAllowOrchestratorKillToggle = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL,
+  );
+
   private handleApplyAgentModePreset = forwardDetail(
     SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
   );
@@ -624,7 +630,10 @@ export class SettingsApp extends BaseWebviewApp {
               .toggleDisabled=${this.superYoloToggleDisabled}
               .reliabilitySettings=${this.reliabilitySettings}
               .customPresets=${this.customPresets}
+              .allowOrchestratorKill=${this.allowOrchestratorKill}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
+              @allow-orchestrator-kill-toggle=${this
+                .handleAllowOrchestratorKillToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -188,6 +188,7 @@ export class MultiAgentTab extends LitElement {
 
   @property({ attribute: false }) superYoloEnabled = false;
   @property({ attribute: false }) toggleDisabled = true;
+  @property({ attribute: false }) allowOrchestratorKill = true;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
@@ -197,6 +198,15 @@ export class MultiAgentTab extends LitElement {
     const target = event.target as HTMLInputElement | null;
     this.dispatchEvent(
       createEvent('super-yolo-toggle', { enabled: Boolean(target?.checked) }),
+    );
+  }
+
+  private handleKillToggle(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.dispatchEvent(
+      createEvent('allow-orchestrator-kill-toggle', {
+        enabled: Boolean(target?.checked),
+      }),
     );
   }
 
@@ -324,6 +334,20 @@ export class MultiAgentTab extends LitElement {
             When enabled, allows per-stream auto-approval of agent delegation
             proposals. Use the rocket button in the progress view toolbar to
             activate Super YOLO for individual streams.
+          </p>
+        </div>
+
+        <div class="setting-block">
+          <vscode-checkbox
+            ?checked=${this.allowOrchestratorKill}
+            @change=${this.handleKillToggle}
+          >
+            Allow orchestrator to kill subagents
+          </vscode-checkbox>
+          <p class="text-secondary setting-description">
+            When enabled, the orchestrator can terminate running subagents via
+            the kill action. Disable to prevent premature termination of
+            long-running tasks.
           </p>
         </div>
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -187,7 +187,7 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED),
   enabled: z.boolean(),
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
-  allowOrchestratorKill: z.boolean(),
+  allowOrchestratorKill: z.boolean().prefault(true),
 });
 export type UpdateSuperYoloEnabledMessage = z.infer<
   typeof UpdateSuperYoloEnabledMessageSchema

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -187,6 +187,7 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED),
   enabled: z.boolean(),
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
+  allowOrchestratorKill: z.boolean(),
 });
 export type UpdateSuperYoloEnabledMessage = z.infer<
   typeof UpdateSuperYoloEnabledMessageSchema
@@ -393,6 +394,12 @@ const SetSuperYoloEnabledMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+// Allow orchestrator kill inbound message
+const SetAllowOrchestratorKillMessageSchema = z.object({
+  command: z.literal(CMD.SET_ALLOW_ORCHESTRATOR_KILL),
+  enabled: z.boolean(),
+});
+
 // Agent mode preset inbound messages
 const GetAgentModePresetsMessageSchema = commandOnly(
   CMD.GET_AGENT_MODE_PRESETS,
@@ -488,6 +495,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     // Super YOLO messages
     GetSuperYoloEnabledMessageSchema,
     SetSuperYoloEnabledMessageSchema,
+    SetAllowOrchestratorKillMessageSchema,
     // Agent mode preset messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -41,6 +41,7 @@ import {
 import { ProcessExecutionHandle } from '@agent/runtime/ExecutionHandle';
 
 // Local imports - utils
+import { WorkspaceStateKey, workspaceSM } from '@common/state';
 import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
@@ -557,6 +558,16 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
   }
 
   private handleKill(executionId: ExecutionId): ToolResult {
+    if (
+      !workspaceSM.get<boolean>(WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL, true)
+    ) {
+      return {
+        output:
+          'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
+        isError: true,
+      };
+    }
+
     const ctx = getCurrentToolFileInteractionContext();
     const callerStreamId = ctx?.streamId;
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -558,16 +558,6 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
   }
 
   private handleKill(executionId: ExecutionId): ToolResult {
-    if (
-      !workspaceSM.get<boolean>(WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL, true)
-    ) {
-      return {
-        output:
-          'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
-        isError: true,
-      };
-    }
-
     const ctx = getCurrentToolFileInteractionContext();
     const callerStreamId = ctx?.streamId;
 
@@ -590,6 +580,18 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     if (!callerStreamId || target.parentStreamId !== callerStreamId) {
       return {
         output: `Cannot kill execution ${executionId}: not a child of this session.`,
+        isError: true,
+      };
+    }
+
+    // Only block subagent kills when the toggle is disabled; process kills are always allowed.
+    if (
+      target instanceof AgentExecutionHandle &&
+      !workspaceSM.get<boolean>(WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL, true)
+    ) {
+      return {
+        output:
+          'Killing subagents is disabled. Enable it in Settings > Multi-Agent.',
         isError: true,
       };
     }


### PR DESCRIPTION
## Summary
- Adds a workspace-level "Allow orchestrator to kill subagents" checkbox to Settings > Multi-Agent tab (default: enabled)
- When disabled, `ExecutionsTool.handleKill()` returns an error instead of terminating the subagent
- Piggybacks on the existing `UpdateSuperYoloEnabled` outbound message to avoid a new command pair

## Test plan
- [ ] Open Settings > Multi-Agent tab and verify the new checkbox appears below Super YOLO
- [ ] Uncheck the toggle, then trigger a kill action from the orchestrator — confirm it returns an error message
- [ ] Re-enable the toggle and confirm kill works normally
- [ ] Verify the setting persists across extension reloads (workspace state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior of the execution-termination path based on a new persisted setting; incorrect wiring/defaults could unintentionally block or allow subagent termination.
> 
> **Overview**
> Adds a new workspace-level setting, **“Allow orchestrator to kill subagents”**, surfaced as a checkbox in the Settings `Multi-Agent` tab and persisted via `WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL`.
> 
> Wires the new toggle through the settings webview command/schema plumbing (including `UpdateSuperYoloEnabled` payload) and enforces it in `ExecutionsTool.handleKill()` by blocking termination of `AgentExecutionHandle` subagents (while still allowing process execution kills) when disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b505ab8d0517c785b967801ad0c53f6050895c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->