### PR TITLE
Simplify correct_multiple agent prompt to single-pass workflow

### DIFF
--- a/resources/agents/correct_multiple.yaml
+++ b/resources/agents/correct_multiple.yaml
@@ -8,7 +8,6 @@ settings:
   outputExt: tex
   prefills:
     - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -58,75 +57,34 @@ prompts:
     The output files should be in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}.
     {% endif %}
 
-  userRequest:
-    - |
-      In the scratchpad below, brainstorm concrete ways to significantly improve the quality of all latex documents that are directly relevant to the instruction above. Do not consider any other aspects of the papers. Be as concrete as to change what in which section of which paper in what ways. Use the scratchpad as an opportunity to formulate as detailed as possible action plans so that a graduate student can also perform the revisions. In the scratchpad, list the planned changes, the rationale for each change, and the concrete steps to be taken to implement the changes starting from the beginning of each document.
+  userRequest: |
+    In the scratchpad below, brainstorm concrete ways to significantly improve the quality of all latex documents that are directly relevant to the instruction above. Do not consider any other aspects of the papers. Be as concrete as to change what in which section of which paper in what ways. Use the scratchpad as an opportunity to formulate as detailed as possible action plans so that a graduate student can also perform the revisions. In the scratchpad, list the planned changes, the rationale for each change, and the concrete steps to be taken to implement the changes starting from the beginning of each document.
 
-      <scratchpad>
+    <scratchpad>
 
-      1. [Specific improvement 1 addressing the instruction]
-          - Affected documents: [List of documents]
-          - Rationale: [explanation]
-          - Implementation: [Concrete steps]
-      2. [Specific improvement 2 addressing the instruction]
-          - Affected documents: [List of documents]
-          - Rationale: [explanation]
-          - Implementation: [Concrete steps]
-      3. [Specific improvement 3 addressing the instruction]
-          - Affected documents: [List of documents]
-          - Rationale: [explanation]
-          - Implementation: [Concrete steps]
+    1. [Specific improvement 1 addressing the instruction]
+        - Affected documents: [List of documents]
+        - Rationale: [explanation]
+        - Implementation: [Concrete steps]
+    2. [Specific improvement 2 addressing the instruction]
+        - Affected documents: [List of documents]
+        - Rationale: [explanation]
+        - Implementation: [Concrete steps]
+    3. [Specific improvement 3 addressing the instruction]
+        - Affected documents: [List of documents]
+        - Rationale: [explanation]
+        - Implementation: [Concrete steps]
 
-      </scratchpad>
+    </scratchpad>
 
-      Then, following your plan in the scratchpad, please output updated versions of all \LaTeX documents with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
+    Then, following your plan in the scratchpad, please output updated versions of all \LaTeX documents with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
 
-      <latex_documents>
-      <document name="{OUTPUT_FILES_ORDER[0]}">
-      % 1ST_UPDATED_LATEX_DOCUMENT_1 HERE
-      </document>
-      <document name="{OUTPUT_FILES_ORDER[1]}">
-      {{ 1ST_UPDATED_LATEX_DOCUMENT_2 }}
-      </document>
-      ... (repeat for all output files)
-      </latex_documents>
-    - |
-      Now that you have made initial improvements to the papers, please reflect on your changes and consider any additional improvements that could further enhance the quality of the papers while staying focused on the original instruction.
-
-      <scratchpad>
-      % Summary of Previous Changes
-      \begin{enumerate}
-          \item [Summary of major changes made to each paper]
-          \item [Evaluation of the effectiveness of these changes]
-          \item [Identification of any areas that may need further improvement]
-      \end{enumerate}
-
-      % Additional Improvements
-      \begin{enumerate}
-          \item [Additional improvement 1]
-          \begin{itemize}
-              \item Affected documents: [List of documents]
-              \item Rationale: [Brief explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-          
-          \item [Additional improvement 2]
-          \begin{itemize}
-              \item Affected documents: [List of documents]
-              \item Rationale: [Brief explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-          
-          \item [Additional improvement 3]
-          \begin{itemize}
-              \item Affected documents: [List of documents]
-              \item Rationale: [Brief explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-      \end{enumerate}
-      ...
-      </scratchpad>
-
-      Then, output further enhanced and complete versions of all \LaTeX documents in the <latex_documents> tag, incorporating the reflections and additional improvements discussed above. Remember to stay laser-focused on the specific instruction or the additional plan in the scratchpad. Only modify sections explicitly mentioned in the instruction or the additional plan in the scratchpad, unless changes in one section directly necessitate adjustments in another for consistency.
-
-      Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}
+    <latex_documents>
+    <document name="{OUTPUT_FILES_ORDER[0]}">
+    % 1ST_UPDATED_LATEX_DOCUMENT_1 HERE
+    </document>
+    <document name="{OUTPUT_FILES_ORDER[1]}">
+    {{ 1ST_UPDATED_LATEX_DOCUMENT_2 }}
+    </document>
+    ... (repeat for all output files)
+    </latex_documents>


### PR DESCRIPTION
## Summary
Refactored the `correct_multiple.yaml` agent configuration to streamline the LaTeX document correction workflow from a multi-pass iterative approach to a single-pass execution model.

## Key Changes
- **Removed duplicate prefill**: Eliminated redundant `<scratchpad>` entry in the prefills section
- **Consolidated userRequest**: Converted `userRequest` from a multi-item list (2 sequential prompts) into a single unified prompt that:
  - Maintains the initial brainstorming and planning phase in the scratchpad
  - Directly follows with LaTeX document output generation
  - Removes the iterative reflection and refinement loop that was previously the second prompt
- **Simplified workflow**: Eliminated the secondary reflection phase that asked the model to review changes and suggest additional improvements, reducing complexity and API calls

## Implementation Details
The original two-prompt sequence was:
1. Initial brainstorming → LaTeX output generation
2. Reflection on changes → Additional improvements → Enhanced LaTeX output

The new single-prompt approach combines the planning and execution into one cohesive request, removing the iterative refinement cycle while preserving the core functionality of planning improvements and generating corrected LaTeX documents.

https://claude.ai/code/session_01BN1som3w6wn3au4qb5hx9T

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only refactor in an agent YAML with no code execution changes; main risk is behavioral/regression in output quality due to removal of the second refinement pass.
> 
> **Overview**
> Simplifies `correct_multiple.yaml` by removing a duplicated `<scratchpad>` prefill and collapsing the previous two-step `userRequest` (plan+edit, then reflect+refine) into a single unified prompt.
> 
> The new prompt keeps the upfront scratchpad planning but drops the iterative reflection/additional-improvements phase, moving directly from the plan to emitting updated LaTeX documents in the required `<latex_documents>` format/order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 569b8a1c321a1355ac7aeef01a453f453493350c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->