### PR TITLE
Add LaTeX settings tab with opt-in config recommendations

### DIFF
--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -43,6 +43,9 @@ export enum GlobalStateKey {
   STREAMING_MOONSHOT = 'texra.streaming.moonshot',
   STREAMING_DASHSCOPE = 'texra.streaming.dashscope',
 
+  // LaTeX settings
+  LATEX_CONFIG_VERSION = 'texra.latexConfigVersion',
+
   // Agent settings (migrated from VS Code config)
   CUSTOM_AGENT_DIR = 'texra.customAgentDir',
   REMOTE_AGENT_META_CACHE = 'texra.remoteAgentMetaCache',

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -355,6 +355,10 @@ export const SETTINGS_VIEW_CMD = {
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
+  // LaTeX settings commands
+  GET_LATEX_SETTINGS_STATUS: 'getLatexSettingsStatus',
+  APPLY_LATEX_SETTINGS: 'applyLatexSettings',
+  INSTALL_LATEX_WORKSHOP: 'installLatexWorkshop',
 } as const;
 
 // Settings view specific commands (combines Memory, History, and Profile views)
@@ -374,4 +378,5 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
   UPDATE_AGENT_MODE_PRESETS: 'updateAgentModePresets',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
+  UPDATE_LATEX_SETTINGS_STATUS: 'updateLatexSettingsStatus',
 } as const;

--- a/src/common/webview/commands.ts
+++ b/src/common/webview/commands.ts
@@ -354,6 +354,7 @@ export const SETTINGS_VIEW_CMD = {
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
+  INSTALL_TOOL_EXTENSION: 'installToolExtension',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
   // LaTeX settings commands
   GET_LATEX_SETTINGS_STATUS: 'getLatexSettingsStatus',

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -25,6 +25,15 @@ import { extendEnvPath } from '@utils/system/platformPaths';
 const MODEL_LIST_VERSION = 4;
 
 /**
+ * Version number for LaTeX-related VS Code config setup.
+ * Increment this when changing which settings are auto-configured.
+ */
+const LATEX_CONFIG_VERSION = 1;
+
+/** Extension ID for LaTeX Workshop */
+const LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
+
+/**
  * Legacy agent files that should be deleted from GlobalStorage.
  * These agents have moved to remote-only and should not exist locally.
  */
@@ -205,12 +214,19 @@ export async function configureLatexSettings(): Promise<void> {
   }
 
   try {
-    const latexWorkshop = vscode.extensions.getExtension(
-      'James-Yu.latex-workshop',
-    );
+    const latexWorkshop = vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID);
 
     if (!latexWorkshop) {
+      // Prompt has its own suppression — run every activation, not gated by version.
       await promptLatexWorkshopInstall();
+      return;
+    }
+
+    // Only write VS Code config once per version bump
+    const storedVersion = globalSM.get<number>(
+      GlobalStateKey.LATEX_CONFIG_VERSION,
+    );
+    if (storedVersion === LATEX_CONFIG_VERSION) {
       return;
     }
 
@@ -219,39 +235,15 @@ export async function configureLatexSettings(): Promise<void> {
       'LaTeX Workshop extension detected, configuring settings',
     );
 
+    // outDir, explorer.autoRevealExclude, and explorer.autoReveal are now
+    // opt-in recommendations shown in the Settings > LaTeX tab.
     const settings: Array<[string, unknown]> = [
-      // LaTeX Workshop build settings
-      ['latex-workshop.latex.build.fromWorkspaceFolder', true],
-      [
-        'latex-workshop.latex.external.build.args',
-        ['--output-directory=build', '-f', '-pdf'],
-      ],
-      ['latex-workshop.latex.outDir', '%DIR%/build/'],
-      [
-        'latex-workshop.latex.magic.args',
-        [
-          '-synctex=1',
-          '-interaction=nonstopmode',
-          '-file-line-error',
-          '%DOC%',
-          '-pdf',
-          '-f',
-        ],
-      ],
-      ['latex-workshop.formatting.latex', 'latexindent'],
-      // Language-specific editor settings
       [
         '[latex]',
         {
           'editor.wordWrap': 'on',
-          'files.autoSave': 'afterDelay',
-          'intellisense.update.delay': 1000,
         },
       ],
-      ['[yaml]', { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' }],
-      // Explorer settings
-      ['explorer.autoRevealExclude', { 'build/': true }],
-      ['explorer.autoReveal', false],
     ];
 
     for (const [key, value] of settings) {
@@ -267,7 +259,10 @@ export async function configureLatexSettings(): Promise<void> {
       logger.info('extension', 'Activity bar location set to default');
     }
 
-    logger.info('extension', 'LaTeX Workshop settings configured successfully');
+    await globalSM.update(
+      GlobalStateKey.LATEX_CONFIG_VERSION,
+      LATEX_CONFIG_VERSION,
+    );
   } catch (err) {
     logger.error(
       'extension',
@@ -290,7 +285,7 @@ async function promptLatexWorkshopInstall(): Promise<void> {
         callback: () =>
           safeExecuteCommand(
             'workbench.extensions.installExtension',
-            ['James-Yu.latex-workshop'],
+            [LATEX_WORKSHOP_EXT_ID],
             'extension',
           ),
       },

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -8,6 +8,7 @@ import fsExtra from 'fs-extra';
 import * as vscode from 'vscode';
 
 // Local imports
+import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
@@ -29,9 +30,6 @@ const MODEL_LIST_VERSION = 4;
  * Increment this when changing which settings are auto-configured.
  */
 const LATEX_CONFIG_VERSION = 1;
-
-/** Extension ID for LaTeX Workshop */
-const LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
 
 /**
  * Legacy agent files that should be deleted from GlobalStorage.

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -29,7 +29,7 @@ const MODEL_LIST_VERSION = 4;
  * Version number for LaTeX-related VS Code config setup.
  * Increment this when changing which settings are auto-configured.
  */
-const LATEX_CONFIG_VERSION = 1;
+const LATEX_CONFIG_VERSION = 2;
 
 /**
  * Legacy agent files that should be deleted from GlobalStorage.
@@ -233,8 +233,13 @@ export async function configureLatexSettings(): Promise<void> {
       'LaTeX Workshop extension detected, configuring settings',
     );
 
-    // outDir, explorer.autoRevealExclude, and explorer.autoReveal are now
-    // opt-in recommendations shown in the Settings > LaTeX tab.
+    // ── Migration: clean up settings that older TeXRA versions force-wrote ──
+    // These are now either opt-in (LaTeX tab) or left to LaTeX Workshop defaults.
+    if (storedVersion === undefined || storedVersion < 2) {
+      await resetLegacyLatexSettings();
+    }
+
+    // Settings that TeXRA still auto-configures (write-once).
     const settings: Array<[string, unknown]> = [
       [
         '[latex]',
@@ -266,6 +271,76 @@ export async function configureLatexSettings(): Promise<void> {
       'extension',
       `Error configuring LaTeX settings: ${toErrorMessage(err)}`,
     );
+  }
+}
+
+/**
+ * Reset settings that older TeXRA versions (< v0.37) auto-wrote on every activation.
+ * Only resets a setting if its current global value matches what TeXRA set,
+ * so user customizations are preserved.
+ */
+async function resetLegacyLatexSettings(): Promise<void> {
+  const GLOBAL = vscode.ConfigurationTarget.Global;
+  const cfg = vscode.workspace.getConfiguration();
+
+  // Deep equality check for arrays/objects
+  const eq = (a: unknown, b: unknown): boolean =>
+    JSON.stringify(a) === JSON.stringify(b);
+
+  // Simple settings: reset to undefined if value matches what TeXRA wrote.
+  const legacySettings: Array<[string, unknown]> = [
+    ['latex-workshop.latex.build.fromWorkspaceFolder', true],
+    [
+      'latex-workshop.latex.external.build.args',
+      ['--output-directory=build', '-f', '-pdf'],
+    ],
+    [
+      'latex-workshop.latex.magic.args',
+      [
+        '-synctex=1',
+        '-interaction=nonstopmode',
+        '-file-line-error',
+        '%DOC%',
+        '-pdf',
+        '-f',
+      ],
+    ],
+    ['latex-workshop.formatting.latex', 'latexindent'],
+    ['explorer.autoReveal', false],
+  ];
+
+  for (const [key, oldValue] of legacySettings) {
+    const inspection = cfg.inspect(key);
+    if (inspection?.globalValue !== undefined && eq(inspection.globalValue, oldValue)) {
+      await cfg.update(key, undefined, GLOBAL);
+      logger.info('extension', `Reset legacy setting: ${key}`);
+    }
+  }
+
+  // Language-scoped settings: remove only the keys TeXRA added.
+  const legacyLanguageKeys: Array<[string, Record<string, unknown>]> = [
+    ['[latex]', { 'files.autoSave': 'afterDelay', 'intellisense.update.delay': 1000 }],
+    ['[yaml]', { 'editor.wordWrap': 'on', 'files.autoSave': 'afterDelay' }],
+  ];
+
+  for (const [langKey, oldKeys] of legacyLanguageKeys) {
+    const inspection = cfg.inspect<Record<string, unknown>>(langKey);
+    const current = inspection?.globalValue;
+    if (!current || typeof current !== 'object') continue;
+
+    const cleaned = { ...current };
+    let changed = false;
+    for (const [k, v] of Object.entries(oldKeys)) {
+      if (eq(cleaned[k], v)) {
+        delete cleaned[k];
+        changed = true;
+      }
+    }
+    if (changed) {
+      const newValue = Object.keys(cleaned).length > 0 ? cleaned : undefined;
+      await cfg.update(langKey, newValue, GLOBAL);
+      logger.info('extension', `Cleaned legacy keys from ${langKey}`);
+    }
   }
 }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1853,11 +1853,22 @@ prompts:
       for (const { key, value } of targets) {
         let resolvedValue: unknown = data.reset ? undefined : value;
 
-        // Merge object values (e.g. autoRevealExclude) with existing config
-        // to avoid overwriting the user's other entries.
-        if (!data.reset && typeof value === 'object' && value !== null) {
+        if (typeof value === 'object' && value !== null) {
+          const recommended = value as Record<string, unknown>;
           const existing = getConfig<Record<string, unknown>>(key, {});
-          resolvedValue = { ...existing, ...(value as Record<string, unknown>) };
+
+          if (data.reset) {
+            // Remove only the TeXRA-recommended keys, keep the user's other entries.
+            const remaining = { ...existing };
+            for (const k of Object.keys(recommended)) {
+              delete remaining[k];
+            }
+            resolvedValue =
+              Object.keys(remaining).length > 0 ? remaining : undefined;
+          } else {
+            // Merge recommended keys into existing config.
+            resolvedValue = { ...existing, ...recommended };
+          }
         }
 
         await updateConfig(key, resolvedValue, {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -22,6 +22,10 @@ import {
   MODEL_PROVIDERS_ORDER,
   DEFAULT_HELPER_MODEL,
 } from '@shared/constants/providers';
+import {
+  LATEX_WORKSHOP_EXT_ID,
+  normalizePlatform,
+} from '@shared/constants/latex';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ULTRA_TIER, MAX_TIER } from '@auth/config';
 import { AUTH_COMMANDS } from '@auth/constants';
@@ -89,6 +93,7 @@ import {
   updateConfig,
 } from '@utils/config/configUtils';
 import { checkToolInstalled } from '@utils/system/toolUtils';
+import { findToolInCommonPaths } from '@utils/system/platformPaths';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import {
@@ -437,6 +442,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleGetToolDashboardData(),
       [SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL]: (data) =>
         this.handleOpenToolInstallUrl(data),
+      [SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION]: (data) =>
+        this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
         this.handleRecheckToolStatus(),
 
@@ -1711,8 +1718,6 @@ prompts:
   // LaTeX settings handler implementations
   // ============================================================
 
-  private static readonly LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
-
   /** Recommended LaTeX-related VS Code settings and their target values. */
   private static readonly LATEX_RECOMMENDED_SETTINGS: {
     key: string;
@@ -1731,44 +1736,108 @@ prompts:
     },
   ];
 
-  public async sendLatexSettingsStatus(webview: vscode.Webview): Promise<void> {
-    const settings: Record<string, boolean> = {
-      latexWorkshopInstalled: Boolean(
-        vscode.extensions.getExtension(
-          SettingsViewMessageHandler.LATEX_WORKSHOP_EXT_ID,
-        ),
-      ),
-      latexdiffInstalled: await checkToolInstalled('latexdiff', false),
-    };
-    for (const {
-      key,
-      field,
-    } of SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS) {
-      settings[field] = isConfigExplicitlySet(key);
+  /**
+   * Check whether a recommended LaTeX setting's value is active.
+   * For string values: exact match.
+   * For object values: recommended keys are a subset of the current config.
+   */
+  private isRecommendedValueSet(field: 'outDir' | 'autoRevealExclude'): boolean {
+    const setting = SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS.find(
+      (s) => s.field === field,
+    );
+    if (!setting) return false;
+    if (!isConfigExplicitlySet(setting.key)) return false;
+
+    const current = getConfig<unknown>(setting.key);
+    if (typeof setting.value === 'object' && setting.value !== null) {
+      // For object values, check that every recommended key is present
+      if (typeof current !== 'object' || current === null) return false;
+      return Object.entries(setting.value as Record<string, unknown>).every(
+        ([k, v]) => (current as Record<string, unknown>)[k] === v,
+      );
     }
+    return current === setting.value;
+  }
+
+  public async sendLatexSettingsStatus(webview: vscode.Webview): Promise<void> {
+    const [
+      pdflatexOk,
+      latexmkOk,
+      latexdiffOk,
+      latexindentOk,
+      perlOk,
+      texcountOk,
+      gsOk,
+      gmOk,
+      magickOk,
+    ] = await Promise.all([
+      checkToolInstalled('pdflatex', false),
+      checkToolInstalled('latexmk', false),
+      checkToolInstalled('latexdiff', false),
+      checkToolInstalled('latexindent', false),
+      checkToolInstalled('perl', false),
+      checkToolInstalled('texcount', false),
+      checkToolInstalled('gs', false),
+      checkToolInstalled('gm', false),
+      checkToolInstalled('magick', false),
+    ]);
+
+    const platform = normalizePlatform(process.platform);
+
+    const settings = {
+      outDir: this.isRecommendedValueSet('outDir'),
+      autoRevealExclude: this.isRecommendedValueSet('autoRevealExclude'),
+      texDistributionInstalled: pdflatexOk || latexmkOk,
+      latexWorkshopInstalled: Boolean(
+        vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID),
+      ),
+      latexdiffInstalled: latexdiffOk,
+      latexindentInstalled: latexindentOk && perlOk,
+      texcountInstalled: texcountOk,
+      imageProcessingInstalled: gsOk && (gmOk || magickOk),
+      platform,
+      pdflatexPath: findToolInCommonPaths('pdflatex'),
+      latexmkPath: findToolInCommonPaths('latexmk'),
+      latexdiffPath: findToolInCommonPaths('latexdiff'),
+      latexindentPath: findToolInCommonPaths('latexindent'),
+      texcountPath: findToolInCommonPaths('texcount'),
+      ghostscriptPath: findToolInCommonPaths('gs'),
+      graphicsmagickPath:
+        findToolInCommonPaths('gm') ?? findToolInCommonPaths('magick'),
+    };
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
       settings,
     });
   }
 
-  private async handleInstallLatexWorkshop(): Promise<void> {
+  /** Install a VS Code extension and refresh the given view data. */
+  private async installExtension(
+    extensionId: string,
+    refresh: (w: vscode.Webview) => Promise<void>,
+  ): Promise<void> {
     try {
       await vscode.commands.executeCommand(
         'workbench.extensions.installExtension',
-        SettingsViewMessageHandler.LATEX_WORKSHOP_EXT_ID,
+        extensionId,
       );
       void vscode.window.showInformationMessage(
-        'LaTeX Workshop extension installed',
+        `Extension "${extensionId}" installed`,
       );
-      await this.withActiveWebview((w) => this.sendLatexSettingsStatus(w));
+      await this.withActiveWebview(refresh);
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        'Failed to install LaTeX Workshop',
+        `Failed to install extension "${extensionId}"`,
         error,
       );
     }
+  }
+
+  private async handleInstallLatexWorkshop(): Promise<void> {
+    await this.installExtension(LATEX_WORKSHOP_EXT_ID, (w) =>
+      this.sendLatexSettingsStatus(w),
+    );
   }
 
   private async handleApplyLatexSettings(
@@ -1782,22 +1851,32 @@ prompts:
         : SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS;
 
       for (const { key, value } of targets) {
-        await updateConfig(key, value, {
+        let resolvedValue: unknown = data.reset ? undefined : value;
+
+        // Merge object values (e.g. autoRevealExclude) with existing config
+        // to avoid overwriting the user's other entries.
+        if (!data.reset && typeof value === 'object' && value !== null) {
+          const existing = getConfig<Record<string, unknown>>(key, {});
+          resolvedValue = { ...existing, ...(value as Record<string, unknown>) };
+        }
+
+        await updateConfig(key, resolvedValue, {
           target: vscode.ConfigurationTarget.Global,
           prefix: false,
         });
       }
 
       await this.withActiveWebview((w) => this.sendLatexSettingsStatus(w));
+      const verb = data.reset ? 'reset' : 'applied';
       void vscode.window.showInformationMessage(
         data.field
-          ? 'LaTeX setting applied'
-          : 'All recommended LaTeX settings applied',
+          ? `LaTeX setting ${verb}`
+          : `All recommended LaTeX settings ${verb}`,
       );
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        'Failed to apply LaTeX settings',
+        'Failed to update LaTeX settings',
         error,
       );
     }
@@ -1823,6 +1902,14 @@ prompts:
     data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_TOOL_INSTALL_URL>,
   ): Promise<void> {
     await vscode.env.openExternal(vscode.Uri.parse(data.url));
+  }
+
+  private async handleInstallToolExtension(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.INSTALL_TOOL_EXTENSION>,
+  ): Promise<void> {
+    await this.installExtension(data.extensionId, (w) =>
+      this.sendToolDashboardData(w),
+    );
   }
 
   private async handleRecheckToolStatus(): Promise<void> {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1870,8 +1870,14 @@ prompts:
 
         if (typeof value === 'object' && value !== null) {
           const recommended = value as Record<string, unknown>;
-          const existing = getConfig<Record<string, unknown>>(key, {});
-          const remaining = { ...existing };
+          // Read only the user's explicit global entries — not VS Code defaults —
+          // so we don't leak built-in defaults into settings.json.
+          const inspection = vscode.workspace.getConfiguration().inspect(key);
+          const globalObj = (inspection?.globalValue ?? {}) as Record<
+            string,
+            unknown
+          >;
+          const remaining = { ...globalObj };
 
           // Always clean up legacy keys from older TeXRA versions.
           for (const k of legacyKeys ?? []) {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1723,6 +1723,8 @@ prompts:
     key: string;
     value: unknown;
     field: 'outDir' | 'autoRevealExclude';
+    /** Object keys from older TeXRA versions to migrate (remove on apply, clean on reset). */
+    legacyKeys?: string[];
   }[] = [
     {
       key: 'latex-workshop.latex.outDir',
@@ -1733,6 +1735,8 @@ prompts:
       key: 'explorer.autoRevealExclude',
       value: { '**/build/': true },
       field: 'autoRevealExclude',
+      // Old setup.ts wrote { 'build/': true } — migrate to **/build/
+      legacyKeys: ['build/'],
     },
   ];
 
@@ -1741,7 +1745,9 @@ prompts:
    * For string values: exact match.
    * For object values: recommended keys are a subset of the current config.
    */
-  private isRecommendedValueSet(field: 'outDir' | 'autoRevealExclude'): boolean {
+  private isRecommendedValueSet(
+    field: 'outDir' | 'autoRevealExclude',
+  ): boolean {
     const setting = SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS.find(
       (s) => s.field === field,
     );
@@ -1752,9 +1758,18 @@ prompts:
     if (typeof setting.value === 'object' && setting.value !== null) {
       // For object values, check that every recommended key is present
       if (typeof current !== 'object' || current === null) return false;
-      return Object.entries(setting.value as Record<string, unknown>).every(
-        ([k, v]) => (current as Record<string, unknown>)[k] === v,
+      const cur = current as Record<string, unknown>;
+      const rec = setting.value as Record<string, unknown>;
+      const hasRecommended = Object.entries(rec).every(
+        ([k, v]) => cur[k] === v,
       );
+      if (hasRecommended) return true;
+      // Also treat legacy keys as "set" so existing users see the check mark
+      // (they'll get migrated to the new key on next Apply).
+      if (setting.legacyKeys?.length) {
+        return setting.legacyKeys.some((k) => cur[k] !== undefined);
+      }
+      return false;
     }
     return current === setting.value;
   }
@@ -1850,16 +1865,21 @@ prompts:
           )
         : SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS;
 
-      for (const { key, value } of targets) {
+      for (const { key, value, legacyKeys } of targets) {
         let resolvedValue: unknown = data.reset ? undefined : value;
 
         if (typeof value === 'object' && value !== null) {
           const recommended = value as Record<string, unknown>;
           const existing = getConfig<Record<string, unknown>>(key, {});
+          const remaining = { ...existing };
+
+          // Always clean up legacy keys from older TeXRA versions.
+          for (const k of legacyKeys ?? []) {
+            delete remaining[k];
+          }
 
           if (data.reset) {
-            // Remove only the TeXRA-recommended keys, keep the user's other entries.
-            const remaining = { ...existing };
+            // Remove the recommended keys, keep the user's other entries.
             for (const k of Object.keys(recommended)) {
               delete remaining[k];
             }
@@ -1867,7 +1887,7 @@ prompts:
               Object.keys(remaining).length > 0 ? remaining : undefined;
           } else {
             // Merge recommended keys into existing config.
-            resolvedValue = { ...existing, ...recommended };
+            resolvedValue = { ...remaining, ...recommended };
           }
         }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -83,7 +83,12 @@ import {
   setProviderEndpoint,
   supportsCustomEndpoint,
 } from '@utils/config/constants';
-import { getConfig } from '@utils/config/configUtils';
+import {
+  getConfig,
+  isConfigExplicitlySet,
+  updateConfig,
+} from '@utils/config/configUtils';
+import { checkToolInstalled } from '@utils/system/toolUtils';
 import { PROVIDER_URLS } from '@commands/api/apiKeyCommands';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
 import {
@@ -434,6 +439,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleOpenToolInstallUrl(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
         this.handleRecheckToolStatus(),
+
+      // LaTeX settings handlers
+      [SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS]: () =>
+        this.withActiveWebview((w) => this.sendLatexSettingsStatus(w)),
+      [SETTINGS_VIEW_COMMANDS.APPLY_LATEX_SETTINGS]: (data) =>
+        this.handleApplyLatexSettings(data),
+      [SETTINGS_VIEW_COMMANDS.INSTALL_LATEX_WORKSHOP]: () =>
+        this.handleInstallLatexWorkshop(),
     };
   }
 
@@ -498,6 +511,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.sendCustomAgentDir(webview),
       this.sendSuperYoloEnabled(webview),
       this.sendAgentModePresets(webview),
+      this.sendLatexSettingsStatus(webview),
     ]);
   }
 
@@ -1688,6 +1702,102 @@ prompts:
       await showLoggedErrorMessage(
         this.channel,
         'Failed to reset custom agent directory',
+        error,
+      );
+    }
+  }
+
+  // ============================================================
+  // LaTeX settings handler implementations
+  // ============================================================
+
+  private static readonly LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
+
+  /** Recommended LaTeX-related VS Code settings and their target values. */
+  private static readonly LATEX_RECOMMENDED_SETTINGS: {
+    key: string;
+    value: unknown;
+    field: 'outDir' | 'autoRevealExclude';
+  }[] = [
+    {
+      key: 'latex-workshop.latex.outDir',
+      value: '%DIR%/build/',
+      field: 'outDir',
+    },
+    {
+      key: 'explorer.autoRevealExclude',
+      value: { '**/build/': true },
+      field: 'autoRevealExclude',
+    },
+  ];
+
+  public async sendLatexSettingsStatus(webview: vscode.Webview): Promise<void> {
+    const settings: Record<string, boolean> = {
+      latexWorkshopInstalled: Boolean(
+        vscode.extensions.getExtension(
+          SettingsViewMessageHandler.LATEX_WORKSHOP_EXT_ID,
+        ),
+      ),
+      latexdiffInstalled: await checkToolInstalled('latexdiff', false),
+    };
+    for (const {
+      key,
+      field,
+    } of SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS) {
+      settings[field] = isConfigExplicitlySet(key);
+    }
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
+      settings,
+    });
+  }
+
+  private async handleInstallLatexWorkshop(): Promise<void> {
+    try {
+      await vscode.commands.executeCommand(
+        'workbench.extensions.installExtension',
+        SettingsViewMessageHandler.LATEX_WORKSHOP_EXT_ID,
+      );
+      void vscode.window.showInformationMessage(
+        'LaTeX Workshop extension installed',
+      );
+      await this.withActiveWebview((w) => this.sendLatexSettingsStatus(w));
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to install LaTeX Workshop',
+        error,
+      );
+    }
+  }
+
+  private async handleApplyLatexSettings(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.APPLY_LATEX_SETTINGS>,
+  ): Promise<void> {
+    try {
+      const targets = data.field
+        ? SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS.filter(
+            (s) => s.field === data.field,
+          )
+        : SettingsViewMessageHandler.LATEX_RECOMMENDED_SETTINGS;
+
+      for (const { key, value } of targets) {
+        await updateConfig(key, value, {
+          target: vscode.ConfigurationTarget.Global,
+          prefix: false,
+        });
+      }
+
+      await this.withActiveWebview((w) => this.sendLatexSettingsStatus(w));
+      void vscode.window.showInformationMessage(
+        data.field
+          ? 'LaTeX setting applied'
+          : 'All recommended LaTeX settings applied',
+      );
+    } catch (error) {
+      await showLoggedErrorMessage(
+        this.channel,
+        'Failed to apply LaTeX settings',
         error,
       );
     }

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -43,7 +43,7 @@ import {
   type AgentSelectionItem,
   type NumberVscodeSetting,
   type ToolDashboardItem,
-  type LatexSettingsStatus,
+  DEFAULT_LATEX_SETTINGS_STATUS,
 } from '@shared/schemas/settingsViewMessages';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
@@ -164,12 +164,7 @@ export class SettingsApp extends BaseWebviewApp {
   @state() private toolDashboardLoaded = false;
 
   // LaTeX settings state
-  @state() private latexSettingsStatus: LatexSettingsStatus = {
-    outDir: false,
-    autoRevealExclude: false,
-    latexWorkshopInstalled: false,
-    latexdiffInstalled: false,
-  };
+  @state() private latexSettingsStatus = { ...DEFAULT_LATEX_SETTINGS_STATUS };
   @state() private latexSettingsLoaded = false;
 
   protected override get readyCommand(): string | null {
@@ -502,6 +497,10 @@ export class SettingsApp extends BaseWebviewApp {
     SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL,
   );
 
+  private handleToolInstallExtension = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION,
+  );
+
   private handleToolRecheck(): void {
     postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS);
   }
@@ -670,6 +669,7 @@ export class SettingsApp extends BaseWebviewApp {
               .items=${this.toolDashboardItems}
               .loaded=${this.toolDashboardLoaded}
               @tool-open-url=${this.handleToolOpenUrl}
+              @tool-install-extension=${this.handleToolInstallExtension}
               @tool-recheck=${this.handleToolRecheck}
             ></tools-tab>
           </vscode-tab-panel>

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -39,9 +39,11 @@ import {
   UpdateSuperYoloEnabledMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateToolDashboardMessageSchema,
+  UpdateLatexSettingsStatusMessageSchema,
   type AgentSelectionItem,
   type NumberVscodeSetting,
   type ToolDashboardItem,
+  type LatexSettingsStatus,
 } from '@shared/schemas/settingsViewMessages';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
@@ -63,6 +65,7 @@ import './tabs/ModelsTab';
 import './tabs/AgentsTab';
 import './tabs/MultiAgentTab';
 import './tabs/ToolsTab';
+import './tabs/LaTeXTab';
 import type { HistoryTab } from './tabs/HistoryTab';
 
 const HISTORY_ACTION_COMMANDS: Record<string, string> = {
@@ -160,6 +163,15 @@ export class SettingsApp extends BaseWebviewApp {
   @state() private toolDashboardItems: ToolDashboardItem[] = [];
   @state() private toolDashboardLoaded = false;
 
+  // LaTeX settings state
+  @state() private latexSettingsStatus: LatexSettingsStatus = {
+    outDir: false,
+    autoRevealExclude: false,
+    latexWorkshopInstalled: false,
+    latexdiffInstalled: false,
+  };
+  @state() private latexSettingsLoaded = false;
+
   protected override get readyCommand(): string | null {
     return null;
   }
@@ -177,6 +189,7 @@ export class SettingsApp extends BaseWebviewApp {
     postMessage(SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS);
     postMessage(SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA);
+    postMessage(SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS);
   }
 
   private parseMessage<T>(
@@ -298,6 +311,17 @@ export class SettingsApp extends BaseWebviewApp {
         if (!data) return;
         this.toolDashboardItems = data.items;
         this.toolDashboardLoaded = true;
+        return;
+      }
+
+      case SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS: {
+        const data = this.parseMessage(
+          raw,
+          UpdateLatexSettingsStatusMessageSchema,
+        );
+        if (!data) return;
+        this.latexSettingsStatus = data.settings;
+        this.latexSettingsLoaded = true;
         return;
       }
 
@@ -482,6 +506,15 @@ export class SettingsApp extends BaseWebviewApp {
     postMessage(SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS);
   }
 
+  // LaTeX settings event handlers
+  private handleApplyLatexSettings = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.APPLY_LATEX_SETTINGS,
+  );
+
+  private handleInstallLatexWorkshop(): void {
+    postMessage(SETTINGS_VIEW_COMMANDS.INSTALL_LATEX_WORKSHOP);
+  }
+
   private handleOpenVscodeSettings(): void {
     postMessage(SETTINGS_VIEW_COMMANDS.OPEN_VSCODE_SETTINGS);
   }
@@ -551,6 +584,7 @@ export class SettingsApp extends BaseWebviewApp {
           <vscode-tab-header slot="header">Agents</vscode-tab-header>
           <vscode-tab-header slot="header">Multi-Agent</vscode-tab-header>
           <vscode-tab-header slot="header">Tools</vscode-tab-header>
+          <vscode-tab-header slot="header">LaTeX</vscode-tab-header>
 
           <vscode-tab-panel>
             <memory-tab
@@ -638,6 +672,15 @@ export class SettingsApp extends BaseWebviewApp {
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-recheck=${this.handleToolRecheck}
             ></tools-tab>
+          </vscode-tab-panel>
+
+          <vscode-tab-panel>
+            <latex-tab
+              .settings=${this.latexSettingsStatus}
+              .loaded=${this.latexSettingsLoaded}
+              @latex-apply-settings=${this.handleApplyLatexSettings}
+              @latex-install-workshop=${this.handleInstallLatexWorkshop}
+            ></latex-tab>
           </vscode-tab-panel>
         </vscode-tabs>
       </div>

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -214,6 +214,18 @@ export class ToolCard extends LitElement {
     }
   }
 
+  private handleInstallExtension(): void {
+    if (this.item.installExtensionId) {
+      this.dispatchEvent(
+        new CustomEvent('tool-install-extension', {
+          detail: { extensionId: this.item.installExtensionId },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
   private static readonly STATUS_CONFIG: Record<
     string,
     { icon: string; label: string }
@@ -255,10 +267,23 @@ export class ToolCard extends LitElement {
         ? html`
             <div class="tool-guide">${this.item.installGuide}</div>
             <div class="tool-guide-actions">
-              ${this.item.installUrl
+              ${this.item.installExtensionId
                 ? html`
                     <button
                       class="tool-action-btn"
+                      @click=${this.handleInstallExtension}
+                    >
+                      <span class="codicon codicon-cloud-download"></span>
+                      Install Extension
+                    </button>
+                  `
+                : nothing}
+              ${this.item.installUrl
+                ? html`
+                    <button
+                      class="tool-action-btn ${this.item.installExtensionId
+                        ? 'tool-action-btn--secondary'
+                        : ''}"
                       @click=${this.handleInstallUrl}
                     >
                       <span class="codicon codicon-link-external"></span>
@@ -287,6 +312,9 @@ export class ToolCard extends LitElement {
           </div>
         </div>
         <div class="tool-description">${this.item.description}</div>
+        ${this.item.statusDetail
+          ? html`<div class="tool-config-note">${this.item.statusDetail}</div>`
+          : nothing}
         <div class="tool-ids">
           ${this.item.tools.map(
             (tool) =>

--- a/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -5,13 +5,115 @@
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
 import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared schemas
-import type { LatexSettingsStatus } from '@shared/schemas/settingsViewMessages';
+import {
+  DEFAULT_LATEX_SETTINGS_STATUS,
+  type LatexSettingsStatus,
+} from '@shared/schemas/settingsViewMessages';
+
+// Local imports - shared constants
+import {
+  PDFLATEX_INSTALL_GUIDE,
+  LATEXDIFF_INSTALL_GUIDE,
+  LATEXINDENT_INSTALL_GUIDE,
+  TEXCOUNT_INSTALL_GUIDE,
+  IMAGE_PROCESSING_INSTALL_GUIDE,
+  type Platform,
+} from '@shared/constants/latex';
+
+/** Path keys in LatexSettingsStatus for tool paths. */
+type ToolPathKey =
+  | 'pdflatexPath'
+  | 'latexmkPath'
+  | 'latexdiffPath'
+  | 'latexindentPath'
+  | 'texcountPath'
+  | 'ghostscriptPath'
+  | 'graphicsmagickPath';
+
+/** Metadata for a dependency shown in the Dependencies section. */
+interface DependencyInfo {
+  readonly key: keyof LatexSettingsStatus;
+  readonly name: string;
+  readonly installedDesc: string;
+  readonly missingDesc: string;
+  readonly installGuide?: Record<Platform, string>;
+  /** Keys to check for detected tool paths (shown when installed). */
+  readonly pathKeys?: ToolPathKey[];
+  /** If provided, renders an action button when missing (e.g. VS Code install). */
+  readonly actionEvent?: string;
+  readonly actionLabel?: string;
+}
+
+const DEPENDENCIES: DependencyInfo[] = [
+  {
+    key: 'texDistributionInstalled',
+    name: 'TeX Distribution',
+    installedDesc: 'Installed — pdflatex/latexmk detected on PATH.',
+    missingDesc:
+      'Not found — a TeX distribution (TeX Live, MacTeX, or MiKTeX) is required to compile LaTeX documents.',
+    installGuide: PDFLATEX_INSTALL_GUIDE,
+    pathKeys: ['pdflatexPath', 'latexmkPath'],
+  },
+  {
+    key: 'latexWorkshopInstalled',
+    name: 'LaTeX Workshop',
+    installedDesc:
+      'Installed — provides LaTeX compilation, PDF preview, and IntelliSense.',
+    missingDesc:
+      'Not installed — required for LaTeX compilation, PDF preview, and IntelliSense.',
+    actionEvent: 'latex-install-workshop',
+    actionLabel: 'Install',
+  },
+  {
+    key: 'latexdiffInstalled',
+    name: 'latexdiff',
+    installedDesc:
+      'Installed — enables visual comparison of LaTeX document revisions.',
+    missingDesc:
+      'Not found — install via your TeX distribution to enable diff comparisons.',
+    installGuide: LATEXDIFF_INSTALL_GUIDE,
+    pathKeys: ['latexdiffPath'],
+  },
+  {
+    key: 'latexindentInstalled',
+    name: 'latexindent',
+    installedDesc:
+      'Installed — used by agents to clean up formatting after editing your LaTeX source.',
+    missingDesc:
+      'Not found — without it, agents may produce inconsistent indentation ' +
+      'when editing .tex files. Requires Perl.',
+    installGuide: LATEXINDENT_INSTALL_GUIDE,
+    pathKeys: ['latexindentPath'],
+  },
+  {
+    key: 'texcountInstalled',
+    name: 'TeXcount',
+    installedDesc:
+      'Installed — enables word, heading, and figure counting in LaTeX documents.',
+    missingDesc:
+      'Not found — without it, agents cannot count words or structural elements in your .tex files. ' +
+      'Part of most TeX Live distributions.',
+    installGuide: TEXCOUNT_INSTALL_GUIDE,
+    pathKeys: ['texcountPath'],
+  },
+  {
+    key: 'imageProcessingInstalled',
+    name: 'Image Processing',
+    installedDesc:
+      'Installed — Ghostscript + GraphicsMagick/ImageMagick detected for PDF-to-PNG conversion.',
+    missingDesc:
+      'Not found — needed to generate PNG previews of compiled PDF pages. ' +
+      'Requires Ghostscript and either GraphicsMagick or ImageMagick.',
+    installGuide: IMAGE_PROCESSING_INSTALL_GUIDE,
+    pathKeys: ['ghostscriptPath', 'graphicsmagickPath'],
+  },
+];
 
 /** Metadata for each recommended setting. */
 interface SettingInfo {
@@ -76,14 +178,17 @@ export class LaTeXTab extends LitElement {
       }
 
       .dependency-card {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-medium);
         padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
+        margin-bottom: var(--spacing-medium);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--radius-medium);
         background: var(--vscode-editor-background);
+      }
+
+      .dependency-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-medium);
       }
 
       .dependency-icon {
@@ -113,6 +218,46 @@ export class LaTeXTab extends LitElement {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         margin-top: 2px;
+      }
+
+      .dependency-guide-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+        margin-top: var(--spacing-small);
+        font-size: var(--font-size-sm);
+        font-family: inherit;
+        color: var(--vscode-textLink-foreground, #3794ff);
+        background: none;
+        border: none;
+        cursor: pointer;
+        transition: opacity 0.1s ease;
+      }
+
+      .dependency-guide-toggle:hover {
+        opacity: 0.8;
+      }
+
+      .dependency-guide {
+        margin-top: var(--spacing-small);
+        padding: var(--spacing-medium);
+        background: var(
+          --vscode-textCodeBlock-background,
+          rgba(128, 128, 128, 0.08)
+        );
+        border-radius: var(--radius-medium);
+        font-size: var(--font-size-sm);
+        color: var(--vscode-foreground);
+        line-height: 1.5;
+        white-space: pre-wrap;
+      }
+
+      .dependency-path {
+        margin-top: 4px;
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
       }
 
       .section-header {
@@ -206,30 +351,25 @@ export class LaTeXTab extends LitElement {
   ];
 
   @property({ attribute: false })
-  settings: LatexSettingsStatus = {
-    outDir: false,
-    autoRevealExclude: false,
-    latexWorkshopInstalled: false,
-    latexdiffInstalled: false,
-  };
+  settings: LatexSettingsStatus = { ...DEFAULT_LATEX_SETTINGS_STATUS };
 
   @property({ type: Boolean }) loaded = false;
 
-  private handleApply(field?: SettingInfo['key']): void {
+  @state() private expandedGuides = new Set<string>();
+
+  private toggleGuide(key: string): void {
+    const next = new Set(this.expandedGuides);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    this.expandedGuides = next;
+  }
+
+  private handleApply(field?: SettingInfo['key'], reset = false): void {
     this.dispatchEvent(
       new CustomEvent('latex-apply-settings', {
         bubbles: true,
         composed: true,
-        detail: field ? { field } : {},
-      }),
-    );
-  }
-
-  private handleInstallWorkshop(): void {
-    this.dispatchEvent(
-      new CustomEvent('latex-install-workshop', {
-        bubbles: true,
-        composed: true,
+        detail: { ...(field ? { field } : {}), ...(reset ? { reset } : {}) },
       }),
     );
   }
@@ -238,30 +378,77 @@ export class LaTeXTab extends LitElement {
     return this.settings.outDir && this.settings.autoRevealExclude;
   }
 
-  private renderDependencyCard(
-    name: string,
-    installed: boolean,
-    installedDesc: string,
-    missingDesc: string,
-    action?: TemplateResult,
-  ): TemplateResult {
+  /** Collect detected tool paths for a dependency. */
+  private getDetectedPaths(dep: DependencyInfo): string[] {
+    if (!dep.pathKeys) return [];
+    return dep.pathKeys
+      .map((k) => this.settings[k])
+      .filter((v): v is string => v !== null && v !== undefined);
+  }
+
+  private renderDependencyCard(dep: DependencyInfo): TemplateResult {
+    const installed = this.settings[dep.key];
+    const expanded = this.expandedGuides.has(dep.key);
+    const platform = this.settings.platform as Platform;
+    const guideText = dep.installGuide?.[platform] ?? dep.installGuide?.linux;
+    const detectedPaths = installed ? this.getDetectedPaths(dep) : [];
+
     return html`
       <div class="dependency-card">
-        <span
-          class="codicon dependency-icon ${installed
-            ? 'installed codicon-check'
-            : 'missing codicon-warning'}"
-        ></span>
-        <div class="dependency-info">
-          <div class="dependency-name">${name}</div>
-          <div class="dependency-description">
-            ${installed ? installedDesc : missingDesc}
+        <div class="dependency-row">
+          <span
+            class="codicon dependency-icon ${installed
+              ? 'installed codicon-check'
+              : 'missing codicon-warning'}"
+          ></span>
+          <div class="dependency-info">
+            <div class="dependency-name">${dep.name}</div>
+            <div class="dependency-description">
+              ${installed ? dep.installedDesc : dep.missingDesc}
+            </div>
+            ${detectedPaths.map(
+              (p) => html`<div class="dependency-path">${p}</div>`,
+            )}
           </div>
+          ${installed
+            ? html`<span class="setting-badge is-set">Installed</span>`
+            : dep.actionEvent
+              ? html`
+                  <button
+                    class="tab-action-btn"
+                    @click=${() =>
+                      this.dispatchEvent(
+                        new CustomEvent(dep.actionEvent!, {
+                          bubbles: true,
+                          composed: true,
+                        }),
+                      )}
+                    title="${dep.actionLabel ?? 'Install'}"
+                  >
+                    <span class="codicon codicon-cloud-download"></span>
+                    ${dep.actionLabel ?? 'Install'}
+                  </button>
+                `
+              : html`<span class="setting-badge not-set">Not found</span>`}
         </div>
-        ${installed
-          ? html`<span class="setting-badge is-set">Installed</span>`
-          : (action ??
-            html`<span class="setting-badge not-set">Not found</span>`)}
+        ${!installed && guideText
+          ? html`
+              <button
+                class="dependency-guide-toggle"
+                @click=${() => this.toggleGuide(dep.key)}
+              >
+                <span
+                  class="codicon ${expanded
+                    ? 'codicon-chevron-down'
+                    : 'codicon-chevron-right'}"
+                ></span>
+                Installation Guide
+              </button>
+              ${expanded
+                ? html`<div class="dependency-guide">${guideText}</div>`
+                : nothing}
+            `
+          : nothing}
       </div>
     `;
   }
@@ -272,28 +459,7 @@ export class LaTeXTab extends LitElement {
         <span class="codicon codicon-package"></span>
         Dependencies
       </div>
-      ${this.renderDependencyCard(
-        'LaTeX Workshop',
-        this.settings.latexWorkshopInstalled,
-        'Installed — provides LaTeX compilation, PDF preview, and IntelliSense.',
-        'Not installed — required for LaTeX compilation, PDF preview, and IntelliSense.',
-        html`
-          <button
-            class="tab-action-btn"
-            @click=${this.handleInstallWorkshop}
-            title="Install LaTeX Workshop extension"
-          >
-            <span class="codicon codicon-cloud-download"></span>
-            Install
-          </button>
-        `,
-      )}
-      ${this.renderDependencyCard(
-        'latexdiff',
-        this.settings.latexdiffInstalled,
-        'Installed — enables visual comparison of LaTeX document revisions.',
-        'Not found — install via your TeX distribution to enable diff comparisons.',
-      )}
+      ${DEPENDENCIES.map((dep) => this.renderDependencyCard(dep))}
     `;
   }
 
@@ -313,7 +479,16 @@ export class LaTeXTab extends LitElement {
           <div class="setting-description">${info.description}</div>
         </div>
         ${isSet
-          ? html`<span class="setting-badge is-set">Set</span>`
+          ? html`
+              <button
+                class="tab-action-btn"
+                @click=${() => this.handleApply(info.key, true)}
+                title="Reset this setting to default"
+              >
+                <span class="codicon codicon-discard"></span>
+                Reset
+              </button>
+            `
           : html`
               <button
                 class="tab-action-btn"

--- a/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -1,0 +1,389 @@
+/**
+ * LaTeXTab component - shows recommended LaTeX-related VS Code settings
+ * and lets the user apply them with a single click.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared schemas
+import type { LatexSettingsStatus } from '@shared/schemas/settingsViewMessages';
+
+/** Metadata for each recommended setting. */
+interface SettingInfo {
+  readonly key: keyof LatexSettingsStatus;
+  readonly name: string;
+  readonly configKey: string;
+  readonly value: string;
+  readonly description: string;
+}
+
+const RECOMMENDED_SETTINGS: SettingInfo[] = [
+  {
+    key: 'outDir',
+    name: 'LaTeX Output Directory',
+    configKey: 'latex-workshop.latex.outDir',
+    value: '%DIR%/build/',
+    description:
+      'Redirect compilation artifacts to a build/ subfolder, keeping your project root clean.',
+  },
+  {
+    key: 'autoRevealExclude',
+    name: 'Explorer Auto-Reveal Exclude',
+    configKey: 'explorer.autoRevealExclude',
+    value: '{ "**/build/": true }',
+    description:
+      'Prevent the build/ folder from being auto-revealed in the Explorer sidebar.',
+  },
+];
+
+@customElement('latex-tab')
+export class LaTeXTab extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .latex-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: var(--spacing-large);
+      }
+
+      .latex-title {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        font-size: var(--font-size-lg);
+        font-weight: 500;
+        color: var(--vscode-foreground);
+      }
+
+      .latex-description {
+        margin-bottom: var(--spacing-large);
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+        line-height: 1.5;
+      }
+
+      .dependency-card {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-medium);
+        padding: var(--spacing-medium);
+        margin-bottom: var(--spacing-large);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--radius-medium);
+        background: var(--vscode-editor-background);
+      }
+
+      .dependency-icon {
+        flex-shrink: 0;
+        font-size: var(--font-size-lg);
+      }
+
+      .dependency-icon.installed {
+        color: var(--vscode-testing-iconPassed, #73c991);
+      }
+
+      .dependency-icon.missing {
+        color: var(--vscode-testing-iconFailed, #f48771);
+      }
+
+      .dependency-info {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .dependency-name {
+        font-weight: 500;
+        color: var(--vscode-foreground);
+      }
+
+      .dependency-description {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        margin-top: 2px;
+      }
+
+      .section-header {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding-bottom: var(--spacing-small);
+        margin-bottom: var(--spacing-medium);
+        border-bottom: var(--border-thin) solid var(--color-border);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .setting-card {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--spacing-medium);
+        padding: var(--spacing-medium);
+        margin-bottom: var(--spacing-medium);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--radius-medium);
+        background: var(--vscode-editor-background);
+      }
+
+      .setting-status-icon {
+        flex-shrink: 0;
+        margin-top: 2px;
+        font-size: var(--font-size-lg);
+      }
+
+      .setting-status-icon.is-set {
+        color: var(--vscode-testing-iconPassed, #73c991);
+      }
+
+      .setting-status-icon.not-set {
+        color: var(--vscode-testing-iconFailed, #f48771);
+      }
+
+      .setting-info {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .setting-name {
+        font-weight: 500;
+        color: var(--vscode-foreground);
+        margin-bottom: 2px;
+      }
+
+      .setting-config-key {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        margin-bottom: var(--spacing-small);
+      }
+
+      .setting-value {
+        font-family: var(--vscode-editor-font-family, monospace);
+        font-size: var(--font-size-sm);
+        color: var(--vscode-textLink-foreground);
+      }
+
+      .setting-description {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        line-height: 1.4;
+        margin-top: var(--spacing-small);
+      }
+
+      .setting-badge {
+        flex-shrink: 0;
+        font-size: var(--font-size-xs, 11px);
+        padding: 2px 6px;
+        border-radius: var(--radius-small, 3px);
+        font-weight: 500;
+      }
+
+      .setting-badge.is-set {
+        background: var(--vscode-testing-iconPassed, #73c991);
+        color: var(--vscode-editor-background);
+      }
+
+      .setting-badge.not-set {
+        background: var(--vscode-badge-background);
+        color: var(--vscode-badge-foreground);
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  settings: LatexSettingsStatus = {
+    outDir: false,
+    autoRevealExclude: false,
+    latexWorkshopInstalled: false,
+    latexdiffInstalled: false,
+  };
+
+  @property({ type: Boolean }) loaded = false;
+
+  private handleApply(field?: SettingInfo['key']): void {
+    this.dispatchEvent(
+      new CustomEvent('latex-apply-settings', {
+        bubbles: true,
+        composed: true,
+        detail: field ? { field } : {},
+      }),
+    );
+  }
+
+  private handleInstallWorkshop(): void {
+    this.dispatchEvent(
+      new CustomEvent('latex-install-workshop', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private allSettingsSet(): boolean {
+    return this.settings.outDir && this.settings.autoRevealExclude;
+  }
+
+  private renderDependencyCard(
+    name: string,
+    installed: boolean,
+    installedDesc: string,
+    missingDesc: string,
+    action?: TemplateResult,
+  ): TemplateResult {
+    return html`
+      <div class="dependency-card">
+        <span
+          class="codicon dependency-icon ${installed
+            ? 'installed codicon-check'
+            : 'missing codicon-warning'}"
+        ></span>
+        <div class="dependency-info">
+          <div class="dependency-name">${name}</div>
+          <div class="dependency-description">
+            ${installed ? installedDesc : missingDesc}
+          </div>
+        </div>
+        ${installed
+          ? html`<span class="setting-badge is-set">Installed</span>`
+          : (action ??
+            html`<span class="setting-badge not-set">Not found</span>`)}
+      </div>
+    `;
+  }
+
+  private renderDependencies(): TemplateResult {
+    return html`
+      <div class="section-header">
+        <span class="codicon codicon-package"></span>
+        Dependencies
+      </div>
+      ${this.renderDependencyCard(
+        'LaTeX Workshop',
+        this.settings.latexWorkshopInstalled,
+        'Installed — provides LaTeX compilation, PDF preview, and IntelliSense.',
+        'Not installed — required for LaTeX compilation, PDF preview, and IntelliSense.',
+        html`
+          <button
+            class="tab-action-btn"
+            @click=${this.handleInstallWorkshop}
+            title="Install LaTeX Workshop extension"
+          >
+            <span class="codicon codicon-cloud-download"></span>
+            Install
+          </button>
+        `,
+      )}
+      ${this.renderDependencyCard(
+        'latexdiff',
+        this.settings.latexdiffInstalled,
+        'Installed — enables visual comparison of LaTeX document revisions.',
+        'Not found — install via your TeX distribution to enable diff comparisons.',
+      )}
+    `;
+  }
+
+  private renderSettingCard(info: SettingInfo): TemplateResult {
+    const isSet = this.settings[info.key];
+    return html`
+      <div class="setting-card">
+        <span
+          class="codicon setting-status-icon ${isSet
+            ? 'is-set'
+            : 'not-set'} ${isSet ? 'codicon-check' : 'codicon-warning'}"
+        ></span>
+        <div class="setting-info">
+          <div class="setting-name">${info.name}</div>
+          <div class="setting-config-key">${info.configKey}</div>
+          <div class="setting-value">${info.value}</div>
+          <div class="setting-description">${info.description}</div>
+        </div>
+        ${isSet
+          ? html`<span class="setting-badge is-set">Set</span>`
+          : html`
+              <button
+                class="tab-action-btn"
+                @click=${() => this.handleApply(info.key)}
+                title="Apply this setting"
+              >
+                <span class="codicon codicon-check"></span>
+                Apply
+              </button>
+            `}
+      </div>
+    `;
+  }
+
+  override render(): TemplateResult {
+    if (!this.loaded) {
+      return html`
+        <div class="tab-content-container">
+          <div
+            style="text-align:center;padding:var(--spacing-large);color:var(--color-text-secondary)"
+          >
+            <span class="codicon codicon-loading codicon-modifier-spin"></span>
+            Loading LaTeX settings...
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="tab-content-container">
+        <div class="latex-header">
+          <div class="latex-title">
+            <span class="codicon codicon-file-code"></span>
+            LaTeX Settings
+          </div>
+          ${!this.allSettingsSet()
+            ? html`
+                <button
+                  class="tab-action-btn"
+                  @click=${() => this.handleApply()}
+                  title="Apply all recommended settings"
+                >
+                  <span class="codicon codicon-check-all"></span>
+                  Apply All
+                </button>
+              `
+            : nothing}
+        </div>
+
+        ${this.renderDependencies()}
+
+        <div class="section-header" style="margin-top:var(--spacing-large)">
+          <span class="codicon codicon-settings-gear"></span>
+          Recommended Settings
+        </div>
+
+        <div class="latex-description">
+          Agents create temporary files during compilation. The following VS
+          Code settings are recommended to keep your workspace tidy and avoid
+          distracting sidebar activity.
+        </div>
+
+        ${RECOMMENDED_SETTINGS.map((info) => this.renderSettingCard(info))}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'latex-tab': LaTeXTab;
+  }
+}

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -153,11 +153,25 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
   // Run fresh checks — also updates the availability cache
   const results = await runExternalToolChecks();
 
+  // Resolve optional detail checks in parallel
+  const detailResults = await Promise.all(
+    results.map(async ({ id }) => {
+      const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
+      if (!def?.detailCheck) return undefined;
+      try {
+        return await def.detailCheck();
+      } catch {
+        return undefined;
+      }
+    }),
+  );
+
   // Merge check results with UI metadata from EXTERNAL_TOOL_DEFS
   const externalItems: ToolDashboardItem[] = [];
-  for (const { id, tools, status } of results) {
+  for (let i = 0; i < results.length; i++) {
+    const { id, tools, status } = results[i];
     const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
-    if (!def) continue;
+    if (!def || def.hideFromDashboard) continue;
     externalItems.push({
       id: def.id,
       name: def.name,
@@ -168,7 +182,9 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
       requiresSetup: true,
       installGuide: def.installGuide,
       installUrl: def.installUrl,
+      installExtensionId: def.installExtensionId,
       configNotes: def.configNotes,
+      statusDetail: detailResults[i],
     });
   }
 

--- a/src/shared/constants/latex.ts
+++ b/src/shared/constants/latex.ts
@@ -1,0 +1,124 @@
+/** Extension ID for the LaTeX Workshop VS Code extension. */
+export const LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
+
+/** Supported platform keys for install guides. */
+export type Platform = 'darwin' | 'win32' | 'linux';
+
+/**
+ * Per-tool, per-platform install instructions.
+ *
+ * These are the single source of truth consumed by both:
+ *   - `toolUtils.ts` TOOL_CONFIGS (runtime error messages)
+ *   - `LaTeXTab.ts` dependency cards (settings UI)
+ */
+export const PDFLATEX_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install MacTeX (recommended):\n' +
+    '  brew install --cask mactex\n\n' +
+    'Or lightweight alternative:\n' +
+    '  brew install texlive\n\n' +
+    'After installing, restart VS Code so TeXRA can detect\n' +
+    'the new binaries on your PATH.',
+  linux:
+    'Install TeX Live:\n' +
+    '  sudo apt-get install texlive-full\n\n' +
+    'After installing, restart VS Code so TeXRA can detect\n' +
+    'the new binaries on your PATH.',
+  win32:
+    'Install MiKTeX:\n' +
+    '  https://miktex.org/download\n\n' +
+    'Or TeX Live:\n' +
+    '  https://tug.org/texlive/\n\n' +
+    'After installing, restart VS Code so TeXRA can detect\n' +
+    'the new binaries on your PATH.',
+};
+
+export const LATEXDIFF_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install latexdiff:\n' +
+    '  brew install latexdiff\n\n' +
+    'Also included with MacTeX (texlive-extra-utils).',
+  linux:
+    'Install latexdiff:\n' +
+    '  sudo apt-get install latexdiff\n\n' +
+    'Part of most TeX Live distributions (texlive-extra-utils).',
+  win32:
+    'MiKTeX: Open MiKTeX Console → Packages → search "latexdiff" → Install\n\n' +
+    'TeX Live: tlmgr install latexdiff\n\n' +
+    'Part of most TeX Live distributions (texlive-extra-utils).',
+};
+
+export const LATEXINDENT_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install latexindent:\n' +
+    '  brew install latexindent\n\n' +
+    'Also included with MacTeX. Requires Perl (pre-installed on macOS).',
+  linux:
+    'Install latexindent:\n' +
+    '  sudo apt-get install texlive-extra-utils\n\n' +
+    'Requires Perl:\n' +
+    '  sudo apt-get install perl',
+  win32:
+    'MiKTeX: Open MiKTeX Console → Packages → search "latexindent" → Install\n\n' +
+    'TeX Live: tlmgr install latexindent\n\n' +
+    'Also requires Perl (Strawberry Perl recommended):\n' +
+    '  https://strawberryperl.com/',
+};
+
+export const TEXCOUNT_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install TeXcount:\n' +
+    '  brew install texcount\n\n' +
+    'Also included with MacTeX and most TeX Live distributions.',
+  linux:
+    'Install TeXcount:\n' +
+    '  sudo apt-get install texlive-extra-utils\n\n' +
+    'Part of most TeX Live distributions.',
+  win32:
+    'MiKTeX: Open MiKTeX Console → Packages → search "texcount" → Install\n\n' +
+    'TeX Live: tlmgr install texcount\n\n' +
+    'Part of most TeX Live distributions.',
+};
+
+export const IMAGE_PROCESSING_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Ghostscript:\n' +
+    '  brew install ghostscript\n\n' +
+    'GraphicsMagick (recommended):\n' +
+    '  brew install graphicsmagick\n\n' +
+    'Or ImageMagick:\n' +
+    '  brew install imagemagick',
+  linux:
+    'Ghostscript:\n' +
+    '  sudo apt-get install ghostscript\n\n' +
+    'GraphicsMagick (recommended):\n' +
+    '  sudo apt-get install graphicsmagick\n\n' +
+    'Or ImageMagick:\n' +
+    '  sudo apt-get install imagemagick',
+  win32:
+    'Ghostscript:\n' +
+    '  https://ghostscript.com/releases/gsdnld.html\n\n' +
+    'GraphicsMagick (recommended):\n' +
+    '  http://www.graphicsmagick.org/download.html\n\n' +
+    'Or ImageMagick:\n' +
+    '  https://imagemagick.org/script/download.php',
+};
+
+/**
+ * Normalize a raw platform string to one of the three supported values.
+ * Falls back to 'linux' for unrecognized platforms (e.g. 'freebsd').
+ */
+export function normalizePlatform(raw: string): Platform {
+  return raw === 'darwin' || raw === 'win32' ? raw : 'linux';
+}
+
+/**
+ * Select the install guide for the given platform.
+ * Falls back to linux if the platform is unrecognized.
+ */
+export function getInstallGuide(
+  guide: Record<Platform, string>,
+  platform: string,
+): string {
+  return guide[normalizePlatform(platform)] ?? guide.linux;
+}

--- a/src/shared/constants/latex.ts
+++ b/src/shared/constants/latex.ts
@@ -80,6 +80,111 @@ export const TEXCOUNT_INSTALL_GUIDE: Record<Platform, string> = {
     'Part of most TeX Live distributions.',
 };
 
+export const PERL_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Perl is pre-installed on macOS.\n' +
+    'If missing, reinstall via:\n' +
+    '  brew install perl',
+  linux:
+    'Install Perl:\n' +
+    '  sudo apt-get install perl',
+  win32:
+    'Install Strawberry Perl (recommended):\n' +
+    '  https://strawberryperl.com/',
+};
+
+export const GHOSTSCRIPT_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install Ghostscript:\n' +
+    '  brew install ghostscript',
+  linux:
+    'Install Ghostscript:\n' +
+    '  sudo apt-get install ghostscript',
+  win32:
+    'Install Ghostscript:\n' +
+    '  https://ghostscript.com/releases/gsdnld.html',
+};
+
+export const GRAPHICSMAGICK_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install GraphicsMagick:\n' +
+    '  brew install graphicsmagick',
+  linux:
+    'Install GraphicsMagick:\n' +
+    '  sudo apt-get install graphicsmagick',
+  win32:
+    'Install GraphicsMagick:\n' +
+    '  http://www.graphicsmagick.org/download.html',
+};
+
+export const IMAGEMAGICK_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install ImageMagick:\n' +
+    '  brew install imagemagick',
+  linux:
+    'Install ImageMagick:\n' +
+    '  sudo apt-get install imagemagick',
+  win32:
+    'Install ImageMagick:\n' +
+    '  https://imagemagick.org/script/download.php',
+};
+
+export const LATEXMK_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install latexmk:\n' +
+    '  brew install latexmk\n\n' +
+    'Also included with MacTeX.',
+  linux:
+    'Install latexmk:\n' +
+    '  sudo apt-get install latexmk',
+  win32:
+    'MiKTeX: Open MiKTeX Console → Packages → search "latexmk" → Install\n\n' +
+    'TeX Live: tlmgr install latexmk',
+};
+
+export const TEXFMT_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install tex-fmt:\n' +
+    '  brew install tex-fmt\n\n' +
+    'Or via Cargo:\n' +
+    '  cargo install tex-fmt',
+  linux:
+    'Install tex-fmt:\n' +
+    '  apt install tex-fmt\n\n' +
+    'Or via Cargo:\n' +
+    '  cargo install tex-fmt',
+  win32:
+    'Install tex-fmt via Cargo:\n' +
+    '  cargo install tex-fmt',
+};
+
+export const WOLFRAM_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install Wolfram Engine:\n' +
+    '  brew install --cask wolfram-engine\n\n' +
+    'Or download from:\n' +
+    '  https://www.wolfram.com/engine/',
+  linux:
+    'Install Wolfram Engine:\n' +
+    '  https://www.wolfram.com/engine/\n\n' +
+    'Follow the Linux installation guide on the Wolfram site.',
+  win32:
+    'Install Wolfram Engine:\n' +
+    '  https://www.wolfram.com/engine/',
+};
+
+export const PANDOC_INSTALL_GUIDE: Record<Platform, string> = {
+  darwin:
+    'Install pandoc:\n' +
+    '  brew install pandoc',
+  linux:
+    'Install pandoc:\n' +
+    '  sudo apt-get install pandoc',
+  win32:
+    'Install pandoc:\n' +
+    '  https://pandoc.org/installing.html',
+};
+
 export const IMAGE_PROCESSING_INSTALL_GUIDE: Record<Platform, string> = {
   darwin:
     'Ghostscript:\n' +

--- a/src/shared/constants/latex.ts
+++ b/src/shared/constants/latex.ts
@@ -4,14 +4,77 @@ export const LATEX_WORKSHOP_EXT_ID = 'James-Yu.latex-workshop';
 /** Supported platform keys for install guides. */
 export type Platform = 'darwin' | 'win32' | 'linux';
 
-/**
- * Per-tool, per-platform install instructions.
- *
- * These are the single source of truth consumed by both:
- *   - `toolUtils.ts` TOOL_CONFIGS (runtime error messages)
- *   - `LaTeXTab.ts` dependency cards (settings UI)
- */
-export const PDFLATEX_INSTALL_GUIDE: Record<Platform, string> = {
+// ============================================================
+// Install guide builders
+// ============================================================
+
+type Guide = Record<Platform, string>;
+
+/** Tool installable via brew, apt, and a Windows download URL. */
+function brewAptUrl(
+  label: string,
+  brew: string,
+  apt: string,
+  winUrl: string,
+): Guide {
+  return {
+    darwin: `Install ${label}:\n  brew install ${brew}`,
+    linux: `Install ${label}:\n  sudo apt-get install ${apt}`,
+    win32: `Install ${label}:\n  ${winUrl}`,
+  };
+}
+
+/** Append optional notes per-platform. */
+function withNotes(
+  base: Guide,
+  notes: Partial<Guide>,
+): Guide {
+  return {
+    darwin: base.darwin + (notes.darwin ? `\n\n${notes.darwin}` : ''),
+    linux: base.linux + (notes.linux ? `\n\n${notes.linux}` : ''),
+    win32: base.win32 + (notes.win32 ? `\n\n${notes.win32}` : ''),
+  };
+}
+
+/** TeX Live tool: brew + apt on unix, MiKTeX Console + tlmgr on Windows. */
+function texLiveGuide(
+  tool: string,
+  opts: { brew: string; apt: string; notes?: Partial<Guide> },
+): Guide {
+  const base: Guide = {
+    darwin: `Install ${tool}:\n  brew install ${opts.brew}`,
+    linux: `Install ${tool}:\n  sudo apt-get install ${opts.apt}`,
+    win32:
+      `MiKTeX: Open MiKTeX Console → Packages → search "${tool}" → Install\n\n` +
+      `TeX Live: tlmgr install ${tool}`,
+  };
+  return opts.notes ? withNotes(base, opts.notes) : base;
+}
+
+/** Combine multiple guides into a single multi-section guide. */
+function combineGuides(
+  ...sections: Array<[label: string, guide: Guide]>
+): Guide {
+  const platforms: Platform[] = ['darwin', 'linux', 'win32'];
+  return Object.fromEntries(
+    platforms.map((p) => [
+      p,
+      sections.map(([label, g]) => `${label}:\n  ${g[p].split('\n  ')[1]}`).join('\n\n'),
+    ]),
+  ) as Guide;
+}
+
+// ============================================================
+// Per-tool install guides (single source of truth)
+//
+// Consumed by:
+//   - `toolUtils.ts` TOOL_CONFIGS (runtime error messages)
+//   - `LaTeXTab.ts` dependency cards (settings UI)
+// ============================================================
+
+// ── Unique guides (no shared pattern) ──────────────────────
+
+export const PDFLATEX_INSTALL_GUIDE: Guide = {
   darwin:
     'Install MacTeX (recommended):\n' +
     '  brew install --cask mactex\n\n' +
@@ -33,181 +96,109 @@ export const PDFLATEX_INSTALL_GUIDE: Record<Platform, string> = {
     'the new binaries on your PATH.',
 };
 
-export const LATEXDIFF_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install latexdiff:\n' +
-    '  brew install latexdiff\n\n' +
-    'Also included with MacTeX (texlive-extra-utils).',
-  linux:
-    'Install latexdiff:\n' +
-    '  sudo apt-get install latexdiff\n\n' +
-    'Part of most TeX Live distributions (texlive-extra-utils).',
-  win32:
-    'MiKTeX: Open MiKTeX Console → Packages → search "latexdiff" → Install\n\n' +
-    'TeX Live: tlmgr install latexdiff\n\n' +
-    'Part of most TeX Live distributions (texlive-extra-utils).',
-};
-
-export const LATEXINDENT_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install latexindent:\n' +
-    '  brew install latexindent\n\n' +
-    'Also included with MacTeX. Requires Perl (pre-installed on macOS).',
-  linux:
-    'Install latexindent:\n' +
-    '  sudo apt-get install texlive-extra-utils\n\n' +
-    'Requires Perl:\n' +
-    '  sudo apt-get install perl',
-  win32:
-    'MiKTeX: Open MiKTeX Console → Packages → search "latexindent" → Install\n\n' +
-    'TeX Live: tlmgr install latexindent\n\n' +
-    'Also requires Perl (Strawberry Perl recommended):\n' +
-    '  https://strawberryperl.com/',
-};
-
-export const TEXCOUNT_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install TeXcount:\n' +
-    '  brew install texcount\n\n' +
-    'Also included with MacTeX and most TeX Live distributions.',
-  linux:
-    'Install TeXcount:\n' +
-    '  sudo apt-get install texlive-extra-utils\n\n' +
-    'Part of most TeX Live distributions.',
-  win32:
-    'MiKTeX: Open MiKTeX Console → Packages → search "texcount" → Install\n\n' +
-    'TeX Live: tlmgr install texcount\n\n' +
-    'Part of most TeX Live distributions.',
-};
-
-export const PERL_INSTALL_GUIDE: Record<Platform, string> = {
+export const PERL_INSTALL_GUIDE: Guide = {
   darwin:
     'Perl is pre-installed on macOS.\n' +
     'If missing, reinstall via:\n' +
     '  brew install perl',
-  linux:
-    'Install Perl:\n' +
-    '  sudo apt-get install perl',
-  win32:
-    'Install Strawberry Perl (recommended):\n' +
-    '  https://strawberryperl.com/',
+  linux: 'Install Perl:\n  sudo apt-get install perl',
+  win32: 'Install Strawberry Perl (recommended):\n  https://strawberryperl.com/',
 };
 
-export const GHOSTSCRIPT_INSTALL_GUIDE: Record<Platform, string> = {
+export const TEXFMT_INSTALL_GUIDE: Guide = {
   darwin:
-    'Install Ghostscript:\n' +
-    '  brew install ghostscript',
+    'Install tex-fmt:\n  brew install tex-fmt\n\n' +
+    'Or via Cargo:\n  cargo install tex-fmt',
   linux:
-    'Install Ghostscript:\n' +
-    '  sudo apt-get install ghostscript',
-  win32:
-    'Install Ghostscript:\n' +
-    '  https://ghostscript.com/releases/gsdnld.html',
+    'Install tex-fmt:\n  apt install tex-fmt\n\n' +
+    'Or via Cargo:\n  cargo install tex-fmt',
+  win32: 'Install tex-fmt via Cargo:\n  cargo install tex-fmt',
 };
 
-export const GRAPHICSMAGICK_INSTALL_GUIDE: Record<Platform, string> = {
+export const WOLFRAM_INSTALL_GUIDE: Guide = {
   darwin:
-    'Install GraphicsMagick:\n' +
-    '  brew install graphicsmagick',
+    'Install Wolfram Engine:\n  brew install --cask wolfram-engine\n\n' +
+    'Or download from:\n  https://www.wolfram.com/engine/',
   linux:
-    'Install GraphicsMagick:\n' +
-    '  sudo apt-get install graphicsmagick',
-  win32:
-    'Install GraphicsMagick:\n' +
-    '  http://www.graphicsmagick.org/download.html',
-};
-
-export const IMAGEMAGICK_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install ImageMagick:\n' +
-    '  brew install imagemagick',
-  linux:
-    'Install ImageMagick:\n' +
-    '  sudo apt-get install imagemagick',
-  win32:
-    'Install ImageMagick:\n' +
-    '  https://imagemagick.org/script/download.php',
-};
-
-export const LATEXMK_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install latexmk:\n' +
-    '  brew install latexmk\n\n' +
-    'Also included with MacTeX.',
-  linux:
-    'Install latexmk:\n' +
-    '  sudo apt-get install latexmk',
-  win32:
-    'MiKTeX: Open MiKTeX Console → Packages → search "latexmk" → Install\n\n' +
-    'TeX Live: tlmgr install latexmk',
-};
-
-export const TEXFMT_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install tex-fmt:\n' +
-    '  brew install tex-fmt\n\n' +
-    'Or via Cargo:\n' +
-    '  cargo install tex-fmt',
-  linux:
-    'Install tex-fmt:\n' +
-    '  apt install tex-fmt\n\n' +
-    'Or via Cargo:\n' +
-    '  cargo install tex-fmt',
-  win32:
-    'Install tex-fmt via Cargo:\n' +
-    '  cargo install tex-fmt',
-};
-
-export const WOLFRAM_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install Wolfram Engine:\n' +
-    '  brew install --cask wolfram-engine\n\n' +
-    'Or download from:\n' +
-    '  https://www.wolfram.com/engine/',
-  linux:
-    'Install Wolfram Engine:\n' +
-    '  https://www.wolfram.com/engine/\n\n' +
+    'Install Wolfram Engine:\n  https://www.wolfram.com/engine/\n\n' +
     'Follow the Linux installation guide on the Wolfram site.',
-  win32:
-    'Install Wolfram Engine:\n' +
-    '  https://www.wolfram.com/engine/',
+  win32: 'Install Wolfram Engine:\n  https://www.wolfram.com/engine/',
 };
 
-export const PANDOC_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Install pandoc:\n' +
-    '  brew install pandoc',
-  linux:
-    'Install pandoc:\n' +
-    '  sudo apt-get install pandoc',
-  win32:
-    'Install pandoc:\n' +
-    '  https://pandoc.org/installing.html',
-};
+// ── Simple brew / apt / URL tools ──────────────────────────
 
-export const IMAGE_PROCESSING_INSTALL_GUIDE: Record<Platform, string> = {
-  darwin:
-    'Ghostscript:\n' +
-    '  brew install ghostscript\n\n' +
-    'GraphicsMagick (recommended):\n' +
-    '  brew install graphicsmagick\n\n' +
-    'Or ImageMagick:\n' +
-    '  brew install imagemagick',
-  linux:
-    'Ghostscript:\n' +
-    '  sudo apt-get install ghostscript\n\n' +
-    'GraphicsMagick (recommended):\n' +
-    '  sudo apt-get install graphicsmagick\n\n' +
-    'Or ImageMagick:\n' +
-    '  sudo apt-get install imagemagick',
-  win32:
-    'Ghostscript:\n' +
-    '  https://ghostscript.com/releases/gsdnld.html\n\n' +
-    'GraphicsMagick (recommended):\n' +
-    '  http://www.graphicsmagick.org/download.html\n\n' +
-    'Or ImageMagick:\n' +
-    '  https://imagemagick.org/script/download.php',
-};
+export const GHOSTSCRIPT_INSTALL_GUIDE = brewAptUrl(
+  'Ghostscript', 'ghostscript', 'ghostscript',
+  'https://ghostscript.com/releases/gsdnld.html',
+);
+
+export const GRAPHICSMAGICK_INSTALL_GUIDE = brewAptUrl(
+  'GraphicsMagick', 'graphicsmagick', 'graphicsmagick',
+  'http://www.graphicsmagick.org/download.html',
+);
+
+export const IMAGEMAGICK_INSTALL_GUIDE = brewAptUrl(
+  'ImageMagick', 'imagemagick', 'imagemagick',
+  'https://imagemagick.org/script/download.php',
+);
+
+export const PANDOC_INSTALL_GUIDE = brewAptUrl(
+  'pandoc', 'pandoc', 'pandoc',
+  'https://pandoc.org/installing.html',
+);
+
+// ── TeX Live tools (brew + apt + MiKTeX/tlmgr) ────────────
+
+const TEX_EXTRA = 'Part of most TeX Live distributions (texlive-extra-utils).';
+const TEX_DIST = 'Part of most TeX Live distributions.';
+
+export const LATEXDIFF_INSTALL_GUIDE = texLiveGuide('latexdiff', {
+  brew: 'latexdiff',
+  apt: 'latexdiff',
+  notes: {
+    darwin: 'Also included with MacTeX (texlive-extra-utils).',
+    linux: TEX_EXTRA,
+    win32: TEX_EXTRA,
+  },
+});
+
+export const LATEXINDENT_INSTALL_GUIDE = texLiveGuide('latexindent', {
+  brew: 'latexindent',
+  apt: 'texlive-extra-utils',
+  notes: {
+    darwin: 'Also included with MacTeX. Requires Perl (pre-installed on macOS).',
+    linux: 'Requires Perl:\n  sudo apt-get install perl',
+    win32: 'Also requires Perl (Strawberry Perl recommended):\n  https://strawberryperl.com/',
+  },
+});
+
+export const TEXCOUNT_INSTALL_GUIDE = texLiveGuide('texcount', {
+  brew: 'texcount',
+  apt: 'texlive-extra-utils',
+  notes: {
+    darwin: 'Also included with MacTeX and most TeX Live distributions.',
+    linux: TEX_DIST,
+    win32: TEX_DIST,
+  },
+});
+
+export const LATEXMK_INSTALL_GUIDE = texLiveGuide('latexmk', {
+  brew: 'latexmk',
+  apt: 'latexmk',
+  notes: { darwin: 'Also included with MacTeX.' },
+});
+
+// ── Composite guide (image processing bundle) ──────────────
+
+export const IMAGE_PROCESSING_INSTALL_GUIDE = combineGuides(
+  ['Ghostscript', GHOSTSCRIPT_INSTALL_GUIDE],
+  ['GraphicsMagick (recommended)', GRAPHICSMAGICK_INSTALL_GUIDE],
+  ['Or ImageMagick', IMAGEMAGICK_INSTALL_GUIDE],
+);
+
+// ============================================================
+// Utility functions
+// ============================================================
 
 /**
  * Normalize a raw platform string to one of the three supported values.
@@ -222,7 +213,7 @@ export function normalizePlatform(raw: string): Platform {
  * Falls back to linux if the platform is unrecognized.
  */
 export function getInstallGuide(
-  guide: Record<Platform, string>,
+  guide: Guide,
   platform: string,
 ): string {
   return guide[normalizePlatform(platform)] ?? guide.linux;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -245,7 +245,9 @@ export const ToolDashboardItemSchema = z.object({
   requiresSetup: z.boolean(),
   installGuide: z.string().optional(),
   installUrl: z.string().optional(),
+  installExtensionId: z.string().optional(),
   configNotes: z.string().optional(),
+  statusDetail: z.string().optional(),
 });
 export type ToolDashboardItem = z.infer<typeof ToolDashboardItemSchema>;
 
@@ -266,10 +268,42 @@ export type UpdateToolDashboardMessage = z.infer<
 export const LatexSettingsStatusSchema = z.object({
   outDir: z.boolean(),
   autoRevealExclude: z.boolean(),
+  texDistributionInstalled: z.boolean(),
   latexWorkshopInstalled: z.boolean(),
   latexdiffInstalled: z.boolean(),
+  latexindentInstalled: z.boolean(),
+  texcountInstalled: z.boolean(),
+  imageProcessingInstalled: z.boolean(),
+  platform: z.enum(['darwin', 'win32', 'linux']),
+  pdflatexPath: z.string().nullable(),
+  latexmkPath: z.string().nullable(),
+  latexdiffPath: z.string().nullable(),
+  latexindentPath: z.string().nullable(),
+  texcountPath: z.string().nullable(),
+  ghostscriptPath: z.string().nullable(),
+  graphicsmagickPath: z.string().nullable(),
 });
 export type LatexSettingsStatus = z.infer<typeof LatexSettingsStatusSchema>;
+
+/** Shared default — used by SettingsApp and LaTeXTab before backend data arrives. */
+export const DEFAULT_LATEX_SETTINGS_STATUS: LatexSettingsStatus = {
+  outDir: false,
+  autoRevealExclude: false,
+  texDistributionInstalled: false,
+  latexWorkshopInstalled: false,
+  latexdiffInstalled: false,
+  latexindentInstalled: false,
+  texcountInstalled: false,
+  imageProcessingInstalled: false,
+  platform: 'linux',
+  pdflatexPath: null,
+  latexmkPath: null,
+  latexdiffPath: null,
+  latexindentPath: null,
+  texcountPath: null,
+  ghostscriptPath: null,
+  graphicsmagickPath: null,
+};
 
 /** Outbound: backend → frontend LaTeX settings status */
 export const UpdateLatexSettingsStatusMessageSchema = z.object({
@@ -445,6 +479,11 @@ const OpenToolInstallUrlMessageSchema = z.object({
   url: z.url(),
 });
 
+const InstallToolExtensionMessageSchema = z.object({
+  command: z.literal(CMD.INSTALL_TOOL_EXTENSION),
+  extensionId: z.string().min(1),
+});
+
 const RecheckToolStatusMessageSchema = commandOnly(CMD.RECHECK_TOOL_STATUS);
 
 // LaTeX settings inbound messages
@@ -454,6 +493,7 @@ const GetLatexSettingsStatusMessageSchema = commandOnly(
 const ApplyLatexSettingsMessageSchema = z.object({
   command: z.literal(CMD.APPLY_LATEX_SETTINGS),
   field: z.enum(['outDir', 'autoRevealExclude']).optional(),
+  reset: z.boolean().optional(),
 });
 const InstallLatexWorkshopMessageSchema = commandOnly(
   CMD.INSTALL_LATEX_WORKSHOP,
@@ -474,6 +514,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     // Tool dashboard messages
     GetToolDashboardDataMessageSchema,
     OpenToolInstallUrlMessageSchema,
+    InstallToolExtensionMessageSchema,
     RecheckToolStatusMessageSchema,
     // LaTeX settings messages
     GetLatexSettingsStatusMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -53,6 +53,7 @@ export const SETTINGS_TAB_ORDER = [
   'AGENTS',
   'MULTI_AGENT',
   'TOOLS',
+  'LATEX',
 ] as const;
 
 export type SettingsTabName = (typeof SETTINGS_TAB_ORDER)[number];
@@ -258,6 +259,28 @@ export type UpdateToolDashboardMessage = z.infer<
 >;
 
 // ============================================================
+// LaTeX settings data schemas
+// ============================================================
+
+/** Status of each recommended LaTeX-related VS Code setting. */
+export const LatexSettingsStatusSchema = z.object({
+  outDir: z.boolean(),
+  autoRevealExclude: z.boolean(),
+  latexWorkshopInstalled: z.boolean(),
+  latexdiffInstalled: z.boolean(),
+});
+export type LatexSettingsStatus = z.infer<typeof LatexSettingsStatusSchema>;
+
+/** Outbound: backend → frontend LaTeX settings status */
+export const UpdateLatexSettingsStatusMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS),
+  settings: LatexSettingsStatusSchema,
+});
+export type UpdateLatexSettingsStatusMessage = z.infer<
+  typeof UpdateLatexSettingsStatusMessageSchema
+>;
+
+// ============================================================
 // Inbound message schemas (frontend → backend)
 // ============================================================
 
@@ -424,6 +447,18 @@ const OpenToolInstallUrlMessageSchema = z.object({
 
 const RecheckToolStatusMessageSchema = commandOnly(CMD.RECHECK_TOOL_STATUS);
 
+// LaTeX settings inbound messages
+const GetLatexSettingsStatusMessageSchema = commandOnly(
+  CMD.GET_LATEX_SETTINGS_STATUS,
+);
+const ApplyLatexSettingsMessageSchema = z.object({
+  command: z.literal(CMD.APPLY_LATEX_SETTINGS),
+  field: z.enum(['outDir', 'autoRevealExclude']).optional(),
+});
+const InstallLatexWorkshopMessageSchema = commandOnly(
+  CMD.INSTALL_LATEX_WORKSHOP,
+);
+
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
 
@@ -440,6 +475,10 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetToolDashboardDataMessageSchema,
     OpenToolInstallUrlMessageSchema,
     RecheckToolStatusMessageSchema,
+    // LaTeX settings messages
+    GetLatexSettingsStatusMessageSchema,
+    ApplyLatexSettingsMessageSchema,
+    InstallLatexWorkshopMessageSchema,
     // Memory messages
     GetMemoryDataMessageSchema,
     OpenMemoryFileMessageSchema,

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -21,6 +21,8 @@ import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 
+const LEAN4_EXT_ID = 'leanprover.lean4';
+
 // ============================================================
 // Type
 // ============================================================
@@ -185,10 +187,10 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'provided by the VS Code extension.',
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
-    installExtensionId: 'leanprover.lean4',
+    installExtensionId: LEAN4_EXT_ID,
     configNotes: 'Lean 4 VS Code extension must be installed and active.',
     check: async () => {
-      const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
+      const lean4Ext = vscode.extensions.getExtension(LEAN4_EXT_ID);
       return lean4Ext !== undefined;
     },
   },

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -33,13 +33,53 @@ export interface ExternalToolDef {
   readonly tools: readonly RegisteredToolName[];
   /** Returns true if the external dependency is available. */
   readonly check: () => Promise<boolean>;
+  /** Optional detailed status string resolved at check time (shown below description). */
+  readonly detailCheck?: () => Promise<string | undefined>;
   // Dashboard UI metadata
   readonly name: string;
   readonly category: ToolCategory;
   readonly description: string;
   readonly installGuide?: string;
   readonly installUrl?: string;
+  /** VS Code extension ID — when present, the dashboard offers a direct "Install" button. */
+  readonly installExtensionId?: string;
   readonly configNotes?: string;
+  /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
+  readonly hideFromDashboard?: boolean;
+}
+
+// ============================================================
+// Zotero probe helpers
+// ============================================================
+
+/** Probe the Zotero connector endpoint (responds if Zotero is running). */
+async function probeZoteroConnector(port: number): Promise<boolean> {
+  try {
+    await axios.get(`http://127.0.0.1:${port}/connector/ping`, {
+      timeout: 2000,
+    });
+    return true;
+  } catch (error: unknown) {
+    // Any HTTP response means Zotero is running
+    if (axios.isAxiosError(error) && error.response) return true;
+    return false;
+  }
+}
+
+/** Probe the Better BibTeX JSON-RPC endpoint. */
+async function probeZoteroBbt(port: number): Promise<boolean> {
+  try {
+    await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
+      timeout: 2000,
+    });
+    return true;
+  } catch (error: unknown) {
+    // 405 = server running but expects POST — BBT is available
+    if (axios.isAxiosError(error) && error.response?.status === 405) {
+      return true;
+    }
+    return false;
+  }
 }
 
 // ============================================================
@@ -62,6 +102,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  Windows: Install via MiKTeX or TeX Live package manager',
     installUrl: 'https://app.uio.no/ifi/texcount/',
     configNotes: 'Part of most TeX Live distributions.',
+    hideFromDashboard: true, // Shown in LaTeX settings tab instead
     check: () => checkToolInstalled('texcount', false),
   },
   {
@@ -104,20 +145,21 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Zotero must be running with Better BibTeX installed. Port configurable via texra.bib.zoteroPort.',
     check: async () => {
-      try {
-        const port = getZoteroPort();
-        await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
-          timeout: 2000,
-        });
-        return true;
-      } catch (error: unknown) {
-        // 405 Method Not Allowed means the server is running but expects POST —
-        // any HTTP response from the endpoint means Zotero + BBT is available.
-        if (axios.isAxiosError(error) && error.response?.status === 405) {
-          return true;
-        }
-        return false;
+      const port = getZoteroPort();
+      const bbtOk = await probeZoteroBbt(port);
+      return bbtOk;
+    },
+    detailCheck: async () => {
+      const port = getZoteroPort();
+      const zoteroOk = await probeZoteroConnector(port);
+      const bbtOk = await probeZoteroBbt(port);
+      if (zoteroOk && bbtOk) {
+        return `Zotero running on port ${port}, Better BibTeX responding.`;
       }
+      if (zoteroOk && !bbtOk) {
+        return `Zotero detected on port ${port}, but Better BibTeX is not responding. Install the Better BibTeX plugin.`;
+      }
+      return `Zotero not detected on port ${port}. Make sure Zotero is running.`;
     },
   },
   {
@@ -143,6 +185,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'provided by the VS Code extension.',
     installUrl:
       'https://marketplace.visualstudio.com/items?itemName=leanprover.lean4',
+    installExtensionId: 'leanprover.lean4',
     configNotes: 'Lean 4 VS Code extension must be installed and active.',
     check: async () => {
       const lean4Ext = vscode.extensions.getExtension('leanprover.lean4');
@@ -150,65 +193,6 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     },
   },
 
-  // ── System dependencies (no agent tools gated) ───────────────
-  {
-    id: 'latex-format',
-    tools: [],
-    name: 'LaTeX Formatting (latexindent)',
-    category: 'system',
-    description:
-      'Format and indent LaTeX documents. Requires latexindent and Perl.',
-    installGuide:
-      'latexindent is a Perl script for formatting LaTeX files.\n\n' +
-      'Installation:\n' +
-      '  Mac:     brew install latexindent\n' +
-      '  Ubuntu:  sudo apt-get install texlive-extra-utils\n' +
-      '  Windows: Install via MiKTeX or TeX Live package manager\n\n' +
-      'Perl is also required:\n' +
-      '  Mac:     brew install perl\n' +
-      '  Ubuntu:  sudo apt-get install perl\n' +
-      '  Windows: Download from strawberryperl.com',
-    installUrl: 'https://github.com/cmhughes/latexindent.pl',
-    configNotes: 'Part of most TeX Live distributions. Requires Perl runtime.',
-    check: async () => {
-      const [hasLatexindent, hasPerl] = await Promise.all([
-        checkToolInstalled('latexindent', false),
-        checkToolInstalled('perl', false),
-      ]);
-      return hasLatexindent && hasPerl;
-    },
-  },
-  {
-    id: 'image-processing',
-    tools: [],
-    name: 'Image Processing (Ghostscript + GM/IM)',
-    category: 'system',
-    description:
-      'Convert PDF pages to PNG images for preview. Requires Ghostscript and either GraphicsMagick or ImageMagick.',
-    installGuide:
-      'Ghostscript converts PDF to raster images; GraphicsMagick or\n' +
-      'ImageMagick handles the final PNG output.\n\n' +
-      'Ghostscript:\n' +
-      '  Mac:     brew install ghostscript\n' +
-      '  Ubuntu:  sudo apt-get install ghostscript\n' +
-      '  Windows: Download from ghostscript.com\n\n' +
-      'GraphicsMagick (recommended):\n' +
-      '  Mac:     brew install graphicsmagick\n' +
-      '  Ubuntu:  sudo apt-get install graphicsmagick\n' +
-      '  Windows: Download from graphicsmagick.org\n\n' +
-      'OR ImageMagick:\n' +
-      '  Mac:     brew install imagemagick\n' +
-      '  Ubuntu:  sudo apt-get install imagemagick\n' +
-      '  Windows: Download from imagemagick.org',
-    installUrl: 'https://ghostscript.com/releases/gsdnld.html',
-    configNotes: 'Needs Ghostscript plus either GraphicsMagick or ImageMagick.',
-    check: async () => {
-      const [hasGs, hasGm, hasMagick] = await Promise.all([
-        checkToolInstalled('gs', false),
-        checkToolInstalled('gm', false),
-        checkToolInstalled('magick', false),
-      ]);
-      return hasGs && (hasGm || hasMagick);
-    },
-  },
+  // System dependencies (latexindent, image processing) have moved to the
+  // LaTeX settings tab — see LaTeXTab.ts and SettingsViewMessageHandler.ts.
 ];

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -13,6 +13,16 @@ import * as logger from '@logger/logUtils';
 import {
   PDFLATEX_INSTALL_GUIDE,
   LATEXDIFF_INSTALL_GUIDE,
+  LATEXINDENT_INSTALL_GUIDE,
+  TEXCOUNT_INSTALL_GUIDE,
+  PERL_INSTALL_GUIDE,
+  GHOSTSCRIPT_INSTALL_GUIDE,
+  GRAPHICSMAGICK_INSTALL_GUIDE,
+  IMAGEMAGICK_INSTALL_GUIDE,
+  LATEXMK_INSTALL_GUIDE,
+  TEXFMT_INSTALL_GUIDE,
+  WOLFRAM_INSTALL_GUIDE,
+  PANDOC_INSTALL_GUIDE,
   getInstallGuide,
 } from '@shared/constants/latex';
 
@@ -34,72 +44,22 @@ interface ToolConfig {
   openDocsCommand?: string; // Optional command to open documentation
 }
 
-// Installation instructions for LaTeX tools
-function installInstructions(...steps: string[]): string {
-  return 'Installation instructions:\n' + steps.map((s) => `- ${s}`).join('\n');
-}
+// Platform-specific install instructions resolved at module load.
+// All guides are defined in @shared/constants/latex (single source of truth).
+const p = process.platform;
 
-const MIKTEX_OR_TEXLIVE =
-  'Windows: Install through MiKTeX or TeX Live package manager';
-
-const LATEXDIFF_INSTRUCTIONS = getInstallGuide(
-  LATEXDIFF_INSTALL_GUIDE,
-  process.platform,
-);
-const LATEXINDENT_INSTRUCTIONS = installInstructions(
-  'Mac: brew install latexindent',
-  'Ubuntu: sudo apt-get install texlive-extra-utils',
-  MIKTEX_OR_TEXLIVE,
-);
-const TEXFMT_INSTRUCTIONS = installInstructions(
-  'Cargo: cargo install tex-fmt',
-  'Mac: brew install tex-fmt',
-  'Debian: apt install tex-fmt',
-);
-const TEXCOUNT_INSTRUCTIONS = installInstructions(
-  'Mac: brew install texcount',
-  'Ubuntu: sudo apt-get install texlive-extra-utils',
-  MIKTEX_OR_TEXLIVE,
-);
-const PERL_INSTRUCTIONS = installInstructions(
-  'Mac: brew install perl',
-  'Ubuntu: sudo apt-get install perl',
-  'Windows: Download from https://strawberryperl.com/',
-);
-const GHOSTSCRIPT_INSTRUCTIONS = installInstructions(
-  'Mac: brew install ghostscript',
-  'Ubuntu: sudo apt-get install ghostscript',
-  'Windows: Download from https://ghostscript.com/releases/gsdnld.html',
-);
-const GM_INSTRUCTIONS = installInstructions(
-  'Mac: brew install graphicsmagick',
-  'Ubuntu: sudo apt-get install graphicsmagick',
-  'Windows: Download from http://www.graphicsmagick.org/download.html',
-);
-const MAGICK_INSTRUCTIONS = installInstructions(
-  'Mac: brew install imagemagick',
-  'Ubuntu: sudo apt-get install imagemagick',
-  'Windows: Download from https://imagemagick.org/script/download.php',
-);
-const WOLFRAM_INSTRUCTIONS = installInstructions(
-  'Mac: brew install wolfram-engine',
-  'Ubuntu: sudo apt-get install wolfram-engine',
-  'Windows: Download from https://www.wolfram.com/engine/',
-);
-const PANDOC_INSTRUCTIONS = installInstructions(
-  'Mac: brew install pandoc',
-  'Ubuntu: sudo apt-get install pandoc',
-  'Windows: Download from https://pandoc.org/installing.html',
-);
-const PDFLATEX_INSTRUCTIONS = getInstallGuide(
-  PDFLATEX_INSTALL_GUIDE,
-  process.platform,
-);
-const LATEXMK_INSTRUCTIONS = installInstructions(
-  'Mac: brew install latexmk',
-  'Ubuntu: sudo apt-get install latexmk',
-  MIKTEX_OR_TEXLIVE,
-);
+const LATEXDIFF_INSTRUCTIONS = getInstallGuide(LATEXDIFF_INSTALL_GUIDE, p);
+const LATEXINDENT_INSTRUCTIONS = getInstallGuide(LATEXINDENT_INSTALL_GUIDE, p);
+const TEXFMT_INSTRUCTIONS = getInstallGuide(TEXFMT_INSTALL_GUIDE, p);
+const TEXCOUNT_INSTRUCTIONS = getInstallGuide(TEXCOUNT_INSTALL_GUIDE, p);
+const PERL_INSTRUCTIONS = getInstallGuide(PERL_INSTALL_GUIDE, p);
+const GHOSTSCRIPT_INSTRUCTIONS = getInstallGuide(GHOSTSCRIPT_INSTALL_GUIDE, p);
+const GM_INSTRUCTIONS = getInstallGuide(GRAPHICSMAGICK_INSTALL_GUIDE, p);
+const MAGICK_INSTRUCTIONS = getInstallGuide(IMAGEMAGICK_INSTALL_GUIDE, p);
+const WOLFRAM_INSTRUCTIONS = getInstallGuide(WOLFRAM_INSTALL_GUIDE, p);
+const PANDOC_INSTRUCTIONS = getInstallGuide(PANDOC_INSTALL_GUIDE, p);
+const PDFLATEX_INSTRUCTIONS = getInstallGuide(PDFLATEX_INSTALL_GUIDE, p);
+const LATEXMK_INSTRUCTIONS = getInstallGuide(LATEXMK_INSTALL_GUIDE, p);
 
 // All tool configurations in one place
 const TOOL_CONFIGS: Record<string, ToolConfig> = {

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -10,6 +10,11 @@ import * as vscode from 'vscode';
 import type { ExecResult } from '@agent/types/ResultTypes';
 import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
+import {
+  PDFLATEX_INSTALL_GUIDE,
+  LATEXDIFF_INSTALL_GUIDE,
+  getInstallGuide,
+} from '@shared/constants/latex';
 
 // Local file imports
 import {
@@ -37,10 +42,9 @@ function installInstructions(...steps: string[]): string {
 const MIKTEX_OR_TEXLIVE =
   'Windows: Install through MiKTeX or TeX Live package manager';
 
-const LATEXDIFF_INSTRUCTIONS = installInstructions(
-  'Mac: brew install latexdiff',
-  'Ubuntu: sudo apt-get install latexdiff',
-  MIKTEX_OR_TEXLIVE,
+const LATEXDIFF_INSTRUCTIONS = getInstallGuide(
+  LATEXDIFF_INSTALL_GUIDE,
+  process.platform,
 );
 const LATEXINDENT_INSTRUCTIONS = installInstructions(
   'Mac: brew install latexindent',
@@ -87,10 +91,9 @@ const PANDOC_INSTRUCTIONS = installInstructions(
   'Ubuntu: sudo apt-get install pandoc',
   'Windows: Download from https://pandoc.org/installing.html',
 );
-const PDFLATEX_INSTRUCTIONS = installInstructions(
-  'Mac: brew install texlive',
-  'Ubuntu: sudo apt-get install texlive-full',
-  MIKTEX_OR_TEXLIVE,
+const PDFLATEX_INSTRUCTIONS = getInstallGuide(
+  PDFLATEX_INSTALL_GUIDE,
+  process.platform,
 );
 const LATEXMK_INSTRUCTIONS = installInstructions(
   'Mac: brew install latexmk',


### PR DESCRIPTION
## Summary
- Adds a new **LaTeX** tab to the Settings view with opt-in recommended VS Code settings (`outDir`, `autoRevealExclude`) that were previously auto-set on startup
- Each setting can be applied individually or all at once via "Apply All"
- Shows dependency status for **LaTeX Workshop** (with one-click install) and **latexdiff** availability
- Adds a version guard to `configureLatexSettings()` so config writes only run on version bumps

## Test plan
- [ ] Open Settings view → verify "LaTeX" tab appears as the last tab
- [ ] LaTeX tab shows dependency cards for LaTeX Workshop and latexdiff with correct status
- [ ] Click "Install" on LaTeX Workshop card if not installed → extension installs
- [ ] Click individual "Apply" buttons → each setting is applied to VS Code config
- [ ] Click "Apply All" → all recommended settings applied at once
- [ ] Verify `configureLatexSettings()` no longer auto-sets `outDir` or `autoRevealExclude` on startup
- [ ] Verify LaTeX Workshop install prompt still appears on every activation (not gated by version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches extension activation setup and adds new settings/config-migration logic; mistakes could overwrite user VS Code settings or misreport/install dependencies, but changes are localized to settings/tooling UI.
> 
> **Overview**
> Adds a new **LaTeX** tab in the Settings webview that reports LaTeX tool/extension readiness (TeX distribution, LaTeX Workshop with one-click install, `latexdiff`/`latexindent`/`texcount`, Ghostscript + GM/IM) and lets users *apply or reset* recommended VS Code settings (currently `latex-workshop.latex.outDir` and `explorer.autoRevealExclude`) instead of having them auto-set.
> 
> Changes startup behavior in `configureLatexSettings()` to be version-gated via `GlobalStateKey.LATEX_CONFIG_VERSION`, to migrate/clean up legacy auto-written LaTeX settings, and to keep only minimal write-once defaults. The Tools dashboard is also upgraded to support direct VS Code extension installs and optional per-tool `statusDetail` (e.g., richer Zotero status), while moving some LaTeX-related system dependency entries out of the Tools list into the new LaTeX tab and centralizing install-guide strings in `@shared/constants/latex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20dcae9179c85d5279cf41340586f45ed16ae11e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->