### PR TITLE
Prioritize user messages in message classification logic

### DIFF
--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -124,7 +124,12 @@ export class AgentLogger {
     options: LogOptions = {},
   ): void {
     logger[level](this.streamId, message, {
-      groupId: options.groupId ?? this.resolveActiveGroupId(),
+      // Distinguish "caller passed explicit groupId" (even if undefined/null)
+      // from "caller didn't specify" (inherit from async context).
+      groupId:
+        'groupId' in options
+          ? (options.groupId ?? undefined)
+          : this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
@@ -283,7 +288,13 @@ export class AgentLogger {
   }
 
   userMessage(message: string, groupId?: string): void {
-    this.info(message, { groupId, messageType: MESSAGE_TYPES.USER_MESSAGE });
+    // User messages are top-level input — never inherit group context.
+    // Pass groupId explicitly (defaults to undefined) to prevent the
+    // log() fallback to resolveActiveGroupId().
+    this.log('info', message, {
+      groupId: groupId ?? undefined,
+      messageType: MESSAGE_TYPES.USER_MESSAGE,
+    });
   }
 
   logToolUse(data: unknown, groupId?: string): void {

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -176,19 +176,23 @@ export class TaskGroupList extends LitElement {
   private appendNewMessages(startIndex: number): void {
     for (let i = startIndex; i < this.messages.length; i++) {
       const msg = this.messages[i];
-      const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
-      if (node) {
-        node.messages = this.insertMessageSorted(node.messages, msg);
-      } else if (msg.messageType === 'userMessage') {
+      if (msg.messageType === 'userMessage') {
+        // User messages always go to the dedicated list regardless of groupId.
+        // See buildGroupTree() for rationale.
         this.cachedUserMessages = this.insertMessageSorted(
           this.cachedUserMessages,
           msg,
         );
       } else {
-        this.cachedOtherUngrouped = this.insertMessageSorted(
-          this.cachedOtherUngrouped,
-          msg,
-        );
+        const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
+        if (node) {
+          node.messages = this.insertMessageSorted(node.messages, msg);
+        } else {
+          this.cachedOtherUngrouped = this.insertMessageSorted(
+            this.cachedOtherUngrouped,
+            msg,
+          );
+        }
       }
     }
   }
@@ -235,6 +239,18 @@ export class TaskGroupList extends LitElement {
 
   /** Replace a single message ref in the cached tree. O(1) node lookup + O(k) findIndex. */
   private replaceSingleMessage(msg: LogMessageData): void {
+    // User messages are always in cachedUserMessages (never in group nodes),
+    // matching the classification order in buildGroupTree/appendNewMessages.
+    if (msg.messageType === 'userMessage') {
+      const idx = this.cachedUserMessages.findIndex((m) => m.id === msg.id);
+      if (idx >= 0) {
+        const updated = [...this.cachedUserMessages];
+        updated[idx] = msg;
+        this.cachedUserMessages = updated;
+      }
+      return;
+    }
+
     // Try group node first (O(1) lookup). A message with groupId may live in
     // cachedOtherUngrouped if the group didn't exist at classification time,
     // so fall through to ungrouped search on miss.
@@ -251,21 +267,12 @@ export class TaskGroupList extends LitElement {
       }
     }
 
-    // Search ungrouped lists
-    if (msg.messageType === 'userMessage') {
-      const idx = this.cachedUserMessages.findIndex((m) => m.id === msg.id);
-      if (idx >= 0) {
-        const updated = [...this.cachedUserMessages];
-        updated[idx] = msg;
-        this.cachedUserMessages = updated;
-      }
-    } else {
-      const idx = this.cachedOtherUngrouped.findIndex((m) => m.id === msg.id);
-      if (idx >= 0) {
-        const updated = [...this.cachedOtherUngrouped];
-        updated[idx] = msg;
-        this.cachedOtherUngrouped = updated;
-      }
+    // Search other ungrouped
+    const idx = this.cachedOtherUngrouped.findIndex((m) => m.id === msg.id);
+    if (idx >= 0) {
+      const updated = [...this.cachedOtherUngrouped];
+      updated[idx] = msg;
+      this.cachedOtherUngrouped = updated;
     }
   }
 
@@ -326,13 +333,16 @@ export class TaskGroupList extends LitElement {
     const otherUngrouped: LogMessageData[] = [];
 
     for (const msg of sortedMessages) {
-      if (msg.groupId && groupMap.has(msg.groupId)) {
+      if (msg.messageType === 'userMessage') {
+        // User messages always go to the dedicated list regardless of groupId.
+        // Follow-ups consumed during a run cycle inherit the run's groupId via
+        // AsyncLocalStorage, but should render in the top-level user section,
+        // not nested among progress entries inside the group.
+        userMessages.push(msg);
+      } else if (msg.groupId && groupMap.has(msg.groupId)) {
         const bucket = messagesByGroup.get(msg.groupId) ?? [];
         bucket.push(msg);
         messagesByGroup.set(msg.groupId, bucket);
-      } else if (msg.messageType === 'userMessage') {
-        // Separate user messages for tool-use ordering (user messages first)
-        userMessages.push(msg);
       } else {
         otherUngrouped.push(msg);
       }


### PR DESCRIPTION
## Summary
Refactored message classification logic to consistently prioritize user messages by checking for `messageType === 'userMessage'` first, before attempting group-based classification. This ensures user messages always go to the dedicated `cachedUserMessages` list regardless of any inherited `groupId`.

## Key Changes
- **appendNewMessages()**: Reordered classification to check message type first, then handle group assignment for non-user messages
- **replaceSingleMessage()**: Moved user message handling to the beginning with early return, simplifying the logic flow and eliminating redundant conditional nesting
- **buildGroupTree()**: Reordered classification to match the priority established in `appendNewMessages()`, ensuring consistency across all message processing paths

## Implementation Details
- User messages are now consistently classified first across all three methods, preventing them from being incorrectly nested in group nodes even if they inherit a `groupId` via AsyncLocalStorage
- The change addresses a specific use case where follow-ups consumed during a run cycle inherit the run's `groupId` but should render in the top-level user section, not nested within progress entries
- Code structure is simplified by using early returns in `replaceSingleMessage()` rather than nested conditionals, improving readability and maintainability

https://claude.ai/code/session_01GmyWDmdnib5NEPQZSF1yCm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized behavior change to logging/classification that mainly affects where user messages render; low risk but could alter grouping expectations if any code relied on inherited `groupId` for user messages.
> 
> **Overview**
> Ensures `userMessage` logs never get nested under a run/group when they accidentally inherit a `groupId` from async context.
> 
> `AgentLogger.log()` now treats an explicitly-provided `groupId` (even `undefined`) as authoritative instead of falling back to `resolveActiveGroupId()`, and `AgentLogger.userMessage()` always logs with an explicit (possibly `undefined`) `groupId` to prevent inheritance. In the progress view, `TaskGroupList` reorders classification/replacement logic so `messageType === 'userMessage'` is handled first in `buildGroupTree()`, `appendNewMessages()`, and `replaceSingleMessage()`, guaranteeing these messages land in `cachedUserMessages` regardless of `groupId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d2d4780fabda66d1fa4f9a3105d79aad44faa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->