### PR TITLE
Move progress board from bottom panel to sidebar with responsive layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1174,15 +1174,14 @@
           "id": "texra",
           "title": "TeXRA",
           "icon": "resources/logo-128x128.svg"
-        }
-      ],
-      "panel": [
+        },
         {
           "id": "texra-panel",
           "title": "TeXRA ProgressBoard",
           "icon": "$(server-process)"
         }
-      ]
+      ],
+      "panel": []
     },
     "views": {
       "texra": [

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -100,9 +100,9 @@ async function handleCompare(
     const editedFileName = path.basename(editedLocation.absolutePath);
     const title = `Compare: ${editedFileName} ↔ ${baseFileName}`;
 
-    // If the ProgressBoard lives in the secondary sidebar, close the bottom
-    // panel to give the diff view more space. If the view is in the panel
-    // already, leave it open.
+    // If the ProgressBoard lives in a sidebar (primary or secondary),
+    // close the bottom panel to give the diff view more space.
+    // If the view is in the panel itself, leave it open.
     const contextKeyCommandId = 'vscode.getContextKeyValue';
     try {
       const location: string | undefined = await vscode.commands.executeCommand(
@@ -110,7 +110,7 @@ async function handleCompare(
         'viewContainerLocation:texra-panel',
       );
 
-      if (location === 'secondarySideBar') {
+      if (location !== 'panel') {
         await vscode.commands.executeCommand('workbench.action.closePanel');
       }
     } catch (err) {

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -110,7 +110,7 @@ async function handleCompare(
         'viewContainerLocation:texra-panel',
       );
 
-      if (location !== 'panel') {
+      if (location === 'sidebar' || location === 'secondarySideBar') {
         await vscode.commands.executeCommand('workbench.action.closePanel');
       }
     } catch (err) {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -286,6 +286,9 @@ export class ProgressViewProvider
       webviewView.onDidChangeVisibility(() => {
         if (webviewView.visible) {
           this.updateWebview();
+          // Re-detect sidebar side — visibility changes fire when the view
+          // is dragged between primary sidebar, secondary sidebar, or panel.
+          this.sendSidebarPosition();
         }
       }),
       webviewView.onDidDispose(this.cleanupView.bind(this)),
@@ -373,16 +376,37 @@ export class ProgressViewProvider
   }
 
   /**
-   * Read the primary sidebar location from VS Code settings.
-   * The progress view is registered in the primary sidebar activity bar,
-   * so this determines which side the stream tabs panel appears on.
+   * Determine which physical side of the screen the progress view is on.
+   *
+   * Queries the `viewContainerLocation:texra-panel` context key to find the
+   * actual container ('sidebar' = primary, 'secondarySideBar' = secondary),
+   * then combines with `workbench.sideBar.location` to compute the physical
+   * side.  Falls back to the config-only approach if the context key command
+   * is unavailable (older VS Code versions).
    */
-  private getSidebarPosition(): 'left' | 'right' {
-    return (
-      vscode.workspace
+  private async detectViewSide(): Promise<'left' | 'right'> {
+    const primarySide =
+      (vscode.workspace
         .getConfiguration('workbench')
-        .get<string>('sideBar.location') ?? 'left'
-    ) as 'left' | 'right';
+        .get<string>('sideBar.location') ?? 'left') as 'left' | 'right';
+
+    try {
+      const location: string | undefined =
+        await vscode.commands.executeCommand(
+          'vscode.getContextKeyValue',
+          'viewContainerLocation:texra-panel',
+        );
+
+      if (location === 'secondarySideBar') {
+        // Secondary sidebar is always opposite the primary
+        return primarySide === 'left' ? 'right' : 'left';
+      }
+    } catch {
+      // Context key command not available — fall through to default
+    }
+
+    // Primary sidebar (default) or panel — use the config value
+    return primarySide;
   }
 
   /**
@@ -390,16 +414,17 @@ export class ProgressViewProvider
    * (stream tabs on the editor-adjacent side).
    */
   private sendSidebarPosition(): void {
-    const position = this.getSidebarPosition();
-    for (const webview of [
-      this._view?.webview,
-      this._panelView?.webview,
-    ]) {
-      webview?.postMessage({
-        command: 'updateSidebarPosition',
-        position,
-      });
-    }
+    void this.detectViewSide().then((position) => {
+      for (const webview of [
+        this._view?.webview,
+        this._panelView?.webview,
+      ]) {
+        webview?.postMessage({
+          command: 'updateSidebarPosition',
+          position,
+        });
+      }
+    });
   }
 
   public getPendingAgentProposal(

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -289,6 +289,11 @@ export class ProgressViewProvider
         }
       }),
       webviewView.onDidDispose(this.cleanupView.bind(this)),
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration('workbench.sideBar.location')) {
+          this.sendSidebarPosition();
+        }
+      }),
     );
 
     this.updateWebview();
@@ -349,6 +354,7 @@ export class ProgressViewProvider
 
     this._pendingUpdateOptions = null;
     this.updateWebview({ forceRebuild: true });
+    this.sendSidebarPosition();
     this.replayPendingPrompts();
   }
 
@@ -364,6 +370,36 @@ export class ProgressViewProvider
 
     this.retryRequestHandler.replay();
     this.agentProposalHandler.replay();
+  }
+
+  /**
+   * Read the primary sidebar location from VS Code settings.
+   * The progress view is registered in the primary sidebar activity bar,
+   * so this determines which side the stream tabs panel appears on.
+   */
+  private getSidebarPosition(): 'left' | 'right' {
+    return (
+      vscode.workspace
+        .getConfiguration('workbench')
+        .get<string>('sideBar.location') ?? 'left'
+    ) as 'left' | 'right';
+  }
+
+  /**
+   * Send sidebar position to all webviews so they can orient the layout
+   * (stream tabs on the editor-adjacent side).
+   */
+  private sendSidebarPosition(): void {
+    const position = this.getSidebarPosition();
+    for (const webview of [
+      this._view?.webview,
+      this._panelView?.webview,
+    ]) {
+      webview?.postMessage({
+        command: 'updateSidebarPosition',
+        position,
+      });
+    }
   }
 
   public getPendingAgentProposal(

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -200,7 +200,7 @@ export class ProgressApp extends BaseWebviewApp {
     return html`
       <div class="main-container">
         <vscode-split-layout
-          split="horizontal"
+          split="vertical"
           initial-handle-position="25%"
         >
           <stream-tabs

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -91,6 +91,17 @@ import type { FollowUpInput } from './components/FollowUpInput';
 import type { PermissionState } from './components/PermissionCard';
 import type { ToolUseStreamContent } from './components/ToolUseStreamContent';
 
+/** Type guard for sidebar position messages (not part of the outbound schema). */
+function isSidebarPositionMessage(
+  raw: unknown,
+): raw is { command: 'updateSidebarPosition'; position: 'left' | 'right' } {
+  return (
+    typeof raw === 'object' &&
+    raw !== null &&
+    (raw as Record<string, unknown>).command === 'updateSidebarPosition'
+  );
+}
+
 @customElement('progress-app')
 export class ProgressApp extends BaseWebviewApp {
   static override styles = css`
@@ -133,6 +144,9 @@ export class ProgressApp extends BaseWebviewApp {
 
   @state() private appState: ProgressState;
   @state() private permissions: PermissionState[] = [];
+
+  /** Whether stream tabs render on the right side (true when sidebar is on the left). */
+  @state() private tabsOnRight = true;
 
   @provide({ context: streamStateContext })
   @state()
@@ -201,10 +215,11 @@ export class ProgressApp extends BaseWebviewApp {
       <div class="main-container">
         <vscode-split-layout
           split="vertical"
-          initial-handle-position="25%"
+          initial-handle-position="${this.tabsOnRight ? '75%' : '25%'}"
         >
           <stream-tabs
-            slot="start"
+            slot="${this.tabsOnRight ? 'end' : 'start'}"
+            side="${this.tabsOnRight ? 'right' : 'left'}"
             .streams=${this.cachedFilteredStreams}
             .activeStreamId=${this.appState.activeStreamId}
             .filter=${this.appState.streamFilter}
@@ -217,7 +232,7 @@ export class ProgressApp extends BaseWebviewApp {
           ></stream-tabs>
 
           <div
-            slot="end"
+            slot="${this.tabsOnRight ? 'start' : 'end'}"
             class="content-area"
             @stream-switch=${this.onStreamSwitch}
           >
@@ -271,6 +286,12 @@ export class ProgressApp extends BaseWebviewApp {
   }
 
   protected handleMessage(raw: unknown): void {
+    // Handle sidebar position updates (layout hint, not part of outbound schema)
+    if (isSidebarPositionMessage(raw)) {
+      this.tabsOnRight = raw.position === 'left';
+      return;
+    }
+
     // Schema-driven dispatch - parses once with discriminated union,
     // then routes to typed handler
     dispatchMessage(raw, this.createMessageHandlerContext());

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -93,6 +93,9 @@ import type { ToolUseStreamContent } from './components/ToolUseStreamContent';
 
 @customElement('progress-app')
 export class ProgressApp extends BaseWebviewApp {
+  /** Width threshold below which we switch to vertical (top/bottom) layout. */
+  private static readonly NARROW_THRESHOLD_PX = 500;
+
   static override styles = css`
     :host {
       display: flex;
@@ -133,6 +136,10 @@ export class ProgressApp extends BaseWebviewApp {
   @state() private appState: ProgressState;
   @state() private permissions: PermissionState[] = [];
 
+  /** Whether the container is narrow (sidebar) or wide (panel/editor). */
+  @state() private _isNarrow = false;
+  private _resizeObserver?: ResizeObserver;
+
   @provide({ context: streamStateContext })
   @state()
   private streamContextValue: StreamContextValue = EMPTY_STREAM_CONTEXT;
@@ -172,6 +179,26 @@ export class ProgressApp extends BaseWebviewApp {
     };
   }
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this._resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = entry.contentRect.width;
+        const narrow = width > 0 && width < ProgressApp.NARROW_THRESHOLD_PX;
+        if (narrow !== this._isNarrow) {
+          this._isNarrow = narrow;
+        }
+      }
+    });
+    this._resizeObserver.observe(this);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = undefined;
+  }
+
   protected override get readyCommand(): string | null {
     return PROGRESS_VIEW_COMMANDS.WEBVIEW_READY;
   }
@@ -196,6 +223,42 @@ export class ProgressApp extends BaseWebviewApp {
   }
 
   render(): TemplateResult {
+    const streamTabs = html`
+      <stream-tabs
+        .streams=${this.cachedFilteredStreams}
+        .activeStreamId=${this.appState.activeStreamId}
+        .filter=${this.appState.streamFilter}
+        .sort=${this.appState.streamSort}
+        @stream-switch=${this.onStreamSwitch}
+        @stream-delete=${this.onStreamDelete}
+        @filter-change=${this.onFilterChange}
+        @sort-change=${this.onSortChange}
+        @delete-all=${this.onDeleteAll}
+      ></stream-tabs>
+    `;
+
+    // Narrow view (sidebar): top/bottom split — tabs on top, content below
+    if (this._isNarrow) {
+      return html`
+        <div class="main-container">
+          <vscode-split-layout
+            split="horizontal"
+            initial-handle-position="25%"
+          >
+            <div slot="start">${streamTabs}</div>
+            <div
+              slot="end"
+              class="content-area"
+              @stream-switch=${this.onStreamSwitch}
+            >
+              ${this.renderStreamContent()}
+            </div>
+          </vscode-split-layout>
+        </div>
+      `;
+    }
+
+    // Wide view (panel/editor tab): left/right split — content left, tabs right
     return html`
       <div class="main-container">
         <vscode-split-layout initial-handle-position="80%">
@@ -206,19 +269,7 @@ export class ProgressApp extends BaseWebviewApp {
           >
             ${this.renderStreamContent()}
           </div>
-
-          <stream-tabs
-            slot="end"
-            .streams=${this.cachedFilteredStreams}
-            .activeStreamId=${this.appState.activeStreamId}
-            .filter=${this.appState.streamFilter}
-            .sort=${this.appState.streamSort}
-            @stream-switch=${this.onStreamSwitch}
-            @stream-delete=${this.onStreamDelete}
-            @filter-change=${this.onFilterChange}
-            @sort-change=${this.onSortChange}
-            @delete-all=${this.onDeleteAll}
-          ></stream-tabs>
+          <div slot="end">${streamTabs}</div>
         </vscode-split-layout>
       </div>
     `;

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -112,6 +112,7 @@ export class ProgressApp extends BaseWebviewApp {
       display: flex;
       width: 100%;
       height: 100vh;
+      border: none; /* Remove outer border — redundant inside a sidebar/panel */
     }
 
     .content-area {

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -93,9 +93,6 @@ import type { ToolUseStreamContent } from './components/ToolUseStreamContent';
 
 @customElement('progress-app')
 export class ProgressApp extends BaseWebviewApp {
-  /** Width threshold below which we switch to vertical (top/bottom) layout. */
-  private static readonly NARROW_THRESHOLD_PX = 500;
-
   static override styles = css`
     :host {
       display: flex;
@@ -136,10 +133,6 @@ export class ProgressApp extends BaseWebviewApp {
   @state() private appState: ProgressState;
   @state() private permissions: PermissionState[] = [];
 
-  /** Whether the container is narrow (sidebar) or wide (panel/editor). */
-  @state() private _isNarrow = false;
-  private _resizeObserver?: ResizeObserver;
-
   @provide({ context: streamStateContext })
   @state()
   private streamContextValue: StreamContextValue = EMPTY_STREAM_CONTEXT;
@@ -179,26 +172,6 @@ export class ProgressApp extends BaseWebviewApp {
     };
   }
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-    this._resizeObserver = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const width = entry.contentRect.width;
-        const narrow = width > 0 && width < ProgressApp.NARROW_THRESHOLD_PX;
-        if (narrow !== this._isNarrow) {
-          this._isNarrow = narrow;
-        }
-      }
-    });
-    this._resizeObserver.observe(this);
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._resizeObserver?.disconnect();
-    this._resizeObserver = undefined;
-  }
-
   protected override get readyCommand(): string | null {
     return PROGRESS_VIEW_COMMANDS.WEBVIEW_READY;
   }
@@ -223,53 +196,32 @@ export class ProgressApp extends BaseWebviewApp {
   }
 
   render(): TemplateResult {
-    const streamTabs = html`
-      <stream-tabs
-        .streams=${this.cachedFilteredStreams}
-        .activeStreamId=${this.appState.activeStreamId}
-        .filter=${this.appState.streamFilter}
-        .sort=${this.appState.streamSort}
-        @stream-switch=${this.onStreamSwitch}
-        @stream-delete=${this.onStreamDelete}
-        @filter-change=${this.onFilterChange}
-        @sort-change=${this.onSortChange}
-        @delete-all=${this.onDeleteAll}
-      ></stream-tabs>
-    `;
-
-    // Narrow view (sidebar): top/bottom split — tabs on top, content below
-    if (this._isNarrow) {
-      return html`
-        <div class="main-container">
-          <vscode-split-layout
-            split="horizontal"
-            initial-handle-position="25%"
-          >
-            <div slot="start">${streamTabs}</div>
-            <div
-              slot="end"
-              class="content-area"
-              @stream-switch=${this.onStreamSwitch}
-            >
-              ${this.renderStreamContent()}
-            </div>
-          </vscode-split-layout>
-        </div>
-      `;
-    }
-
-    // Wide view (panel/editor tab): left/right split — content left, tabs right
     return html`
       <div class="main-container">
-        <vscode-split-layout initial-handle-position="80%">
-          <div
+        <vscode-split-layout
+          split="horizontal"
+          initial-handle-position="25%"
+        >
+          <stream-tabs
             slot="start"
+            .streams=${this.cachedFilteredStreams}
+            .activeStreamId=${this.appState.activeStreamId}
+            .filter=${this.appState.streamFilter}
+            .sort=${this.appState.streamSort}
+            @stream-switch=${this.onStreamSwitch}
+            @stream-delete=${this.onStreamDelete}
+            @filter-change=${this.onFilterChange}
+            @sort-change=${this.onSortChange}
+            @delete-all=${this.onDeleteAll}
+          ></stream-tabs>
+
+          <div
+            slot="end"
             class="content-area"
             @stream-switch=${this.onStreamSwitch}
           >
             ${this.renderStreamContent()}
           </div>
-          <div slot="end">${streamTabs}</div>
         </vscode-split-layout>
       </div>
     `;

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -215,7 +215,8 @@ export class ProgressApp extends BaseWebviewApp {
       <div class="main-container">
         <vscode-split-layout
           split="vertical"
-          initial-handle-position="${this.tabsOnRight ? '75%' : '25%'}"
+          initial-handle-position="75%"
+          .handlePosition=${this.tabsOnRight ? '75%' : '25%'}
         >
           <stream-tabs
             slot="${this.tabsOnRight ? 'end' : 'start'}"

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -299,7 +299,7 @@ export class StreamTabs extends LitElement {
         flex: 1;
         min-width: 0;
         font-size: var(--font-size-sm);
-        border-bottom: var(--border-thin) solid var(--color-border);
+        /* No border needed — vscode-split-layout provides the separator */
         height: 100%;
         overflow: visible;
         background-color: var(--background-color);

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -299,7 +299,7 @@ export class StreamTabs extends LitElement {
         flex: 1;
         min-width: 0;
         font-size: var(--font-size-sm);
-        /* No border needed — vscode-split-layout provides the separator */
+        border-right: var(--border-thin) solid var(--color-border);
         height: 100%;
         overflow: visible;
         background-color: var(--background-color);

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -299,10 +299,17 @@ export class StreamTabs extends LitElement {
         flex: 1;
         min-width: 0;
         font-size: var(--font-size-sm);
-        border-right: var(--border-thin) solid var(--color-border);
         height: 100%;
         overflow: visible;
         background-color: var(--background-color);
+      }
+
+      /* Border on the side adjacent to the content area */
+      :host([side='left']) .tabs {
+        border-right: var(--border-thin) solid var(--color-border);
+      }
+      :host([side='right']) .tabs {
+        border-left: var(--border-thin) solid var(--color-border);
       }
 
       .tabs-content {
@@ -351,6 +358,7 @@ export class StreamTabs extends LitElement {
     `,
   ];
 
+  @property({ reflect: true }) side: 'left' | 'right' = 'left';
   @property({ attribute: false }) streams: StreamTabInfo[] = [];
   @property({ attribute: false }) activeStreamId: string | null = null;
   @property({ attribute: false }) filter: StreamFilter = 'all';

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -299,7 +299,7 @@ export class StreamTabs extends LitElement {
         flex: 1;
         min-width: 0;
         font-size: var(--font-size-sm);
-        border-left: var(--border-thin) solid var(--color-border);
+        border-bottom: var(--border-thin) solid var(--color-border);
         height: 100%;
         overflow: visible;
         background-color: var(--background-color);


### PR DESCRIPTION
The progress board was registered as a panel view, placing it in the
bottom panel with terminals/output. This made it very horizontal and
hard to use. Move it to the activity bar (sidebar) and add a
ResizeObserver-based responsive layout: narrow containers (<500px)
use a vertical split (tabs on top, content below) while wide
containers keep the original horizontal split (content left, tabs right).

https://claude.ai/code/session_018iRmaV1KdBgYxxcSEL7sxX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches VS Code view container registration and adds cross-webview messaging based on context keys/config, so regressions could affect view placement or layout orientation across VS Code versions.
> 
> **Overview**
> Moves the ProgressBoard view container from the bottom `panel` into the Activity Bar/sidebar via `package.json`, leaving the contributed `panel` container empty.
> 
> Updates the diff/compare command to close the bottom panel when the ProgressBoard is docked in either the primary or secondary sidebar, maximizing space for diff editors.
> 
> Adds sidebar-side detection in `ProgressViewProvider` (using `viewContainerLocation:texra-panel` plus `workbench.sideBar.location`) and sends `updateSidebarPosition` messages to webviews; the frontend consumes this to flip the split layout so stream tabs render on the editor-adjacent side, with `StreamTabs` updating borders accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dfdc52cbfa7660dc7ca833a443af7bb74770a54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->