### PR TITLE
Leverage SDK features: inline base64 fallback, Google retry config, streaming tool call detection

### DIFF
--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -55,7 +55,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
-import { K_SLICE, getModelRetryMaxAttempts } from '@utils/config';
+import { K_SLICE } from '@utils/config';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
@@ -343,10 +343,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         apiKey: credential,
         httpOptions: {
           baseUrl: baseUrl ?? undefined,
-          // Align SDK-level retries with the user's retry configuration.
-          // The SDK retries transient network errors and 5xx responses automatically.
-          // attempts includes the initial request, so add 1 to the max-retries value.
-          retryOptions: { attempts: getModelRetryMaxAttempts() + 1 },
+          // Disable SDK-level retries so that only the flow-level retry loop
+          // (RetryState.getNodeRetryConfig) manages the user's retry budget.
+          // Without this, transient errors would be retried by BOTH the SDK and
+          // the flow, multiplying the configured attempt count.
+          retryOptions: { attempts: 1 },
         },
       });
     }
@@ -361,7 +362,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         apiKey: credential,
         httpOptions: {
           baseUrl: baseUrl ?? undefined,
-          retryOptions: { attempts: getModelRetryMaxAttempts() + 1 },
+          retryOptions: { attempts: 1 },
         },
       });
     }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -55,7 +55,7 @@ import type { ToolFileAttachment } from '@tools/result';
 import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
-import { K_SLICE } from '@utils/config';
+import { K_SLICE, getModelRetryMaxAttempts } from '@utils/config';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
@@ -343,6 +343,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         apiKey: credential,
         httpOptions: {
           baseUrl: baseUrl ?? undefined,
+          // Align SDK-level retries with the user's retry configuration.
+          // The SDK retries transient network errors and 5xx responses automatically.
+          // attempts includes the initial request, so add 1 to the max-retries value.
+          retryOptions: { attempts: getModelRetryMaxAttempts() + 1 },
         },
       });
     }
@@ -357,6 +361,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         apiKey: credential,
         httpOptions: {
           baseUrl: baseUrl ?? undefined,
+          retryOptions: { attempts: getModelRetryMaxAttempts() + 1 },
         },
       });
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2297,14 +2297,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } else if (attachments.length > 0 && this.canProcessToolResultAttachments) {
       // Inline base64 fallback: when file uploads are unavailable (e.g. OpenRouter)
       // but the model supports visual content, embed images/PDFs directly.
-      const inlineParts = await this.buildInlineAttachmentParts(attachments);
+      const { parts: inlineParts, inlined, skipped } =
+        await this.buildInlineAttachmentParts(attachments);
       if (inlineParts.length > 0) {
-        // Rebuild text with 'included-inline' variant so the model doesn't get
-        // a misleading "use read_file" hint alongside the actual inline content.
-        const inlineSummary = formatAttachmentSummary(
-          attachments,
-          'included-inline',
-        );
+        // Build summary that accurately reflects which attachments were inlined
+        // vs. skipped, so the model only gets a read_file hint for skipped ones.
+        const summaryParts: string[] = [];
+        if (inlined.length > 0) {
+          summaryParts.push(
+            formatAttachmentSummary(inlined, 'included-inline'),
+          );
+        }
+        if (skipped.length > 0) {
+          summaryParts.push(formatAttachmentSummary(skipped, 'metadata-only'));
+        }
+        const inlineSummary = summaryParts.join('\n');
         finalResult.attachmentSummary = inlineSummary;
         combinedText = formatToolResultAsText(result, inlineSummary);
         outputPayload = [
@@ -2392,16 +2399,25 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    */
   private async buildInlineAttachmentParts(
     attachments: ToolFileAttachment[],
-  ): Promise<ResponseFunctionCallOutputItemList> {
+  ): Promise<{
+    parts: ResponseFunctionCallOutputItemList;
+    inlined: ToolFileAttachment[];
+    skipped: ToolFileAttachment[];
+  }> {
     const MAX_INLINE_BYTES = 20 * 1024 * 1024; // 20 MiB cap per attachment
     const parts: ResponseFunctionCallOutputItemList = [];
+    const inlined: ToolFileAttachment[] = [];
+    const skipped: ToolFileAttachment[] = [];
 
     for (const attachment of attachments) {
       const mimeType = attachment.mimeType ?? 'application/octet-stream';
       const isImage = mimeType.startsWith('image/');
       const isPdf = mimeType === 'application/pdf';
 
-      if (!isImage && !isPdf) continue;
+      if (!isImage && !isPdf) {
+        skipped.push(attachment);
+        continue;
+      }
 
       let buffer: Buffer | undefined;
       try {
@@ -2410,6 +2426,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           this.logger.debug(
             `Skipping inline attachment ${attachment.path ?? 'attachment'}: ${buffer.length} bytes exceeds limit`,
           );
+          skipped.push(attachment);
           continue;
         }
 
@@ -2429,14 +2446,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
               : 'attachment.pdf';
           parts.push({
             type: 'input_file',
-            file_data: base64,
+            file_data: `data:application/pdf;base64,${base64}`,
             filename,
           });
         }
+        inlined.push(attachment);
       } catch (err) {
         this.logger.debug(
           `Unable to inline attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
         );
+        skipped.push(attachment);
       } finally {
         if (buffer) {
           buffer.fill(0);
@@ -2445,7 +2464,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
     }
 
-    return parts;
+    return { parts, inlined, skipped };
   }
 
   async createUserFollowUpMessages(

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1342,6 +1342,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           hasThinkingContent: false,
         };
 
+        /** Finalize and reset the thinking stream if it has content. */
+        const rotateThinkingStream = (): void => {
+          if (!state.hasThinkingContent) return;
+          state.thinkingStream.finalize();
+          state.hasThinkingContent = false;
+          state.thinkingStream = this.createThinkingStream();
+        };
+
         for await (const event of stream) {
           if (this.isReasoningDeltaEvent(event)) {
             state.thinkingStream.append(event.delta);
@@ -1351,20 +1359,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           } else if (this.isWebSearchInProgressEvent(event)) {
             // Web search starting - finalize current thinking stream
             // Don't emit placeholder here - wait for output_item.done with full data
-            if (state.hasThinkingContent) {
-              state.thinkingStream.finalize();
-              state.hasThinkingContent = false;
-              // Create new thinking stream for potential continuation after search
-              state.thinkingStream = this.createThinkingStream();
-            }
+            rotateThinkingStream();
           } else if (this.isFunctionCallArgumentsDoneEvent(event)) {
             // Function call arguments complete - finalize streams since no more
             // text/thinking deltas will arrive after tool calls begin.
-            if (state.hasThinkingContent) {
-              state.thinkingStream.finalize();
-              state.hasThinkingContent = false;
-              state.thinkingStream = this.createThinkingStream();
-            }
+            rotateThinkingStream();
             this.logger.debug(
               `Tool call ready during streaming: ${event.name}`,
             );
@@ -1377,11 +1376,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
               hasOpenAIWebSearchData(item)
             ) {
               // Finalize thinking if we have content (in case in_progress didn't fire)
-              if (state.hasThinkingContent) {
-                state.thinkingStream.finalize();
-                state.hasThinkingContent = false;
-                state.thinkingStream = this.createThinkingStream();
-              }
+              rotateThinkingStream();
               this.emitOpenAIWebSearch(item);
               state.emittedWebSearchIds.add(item.id);
             }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2268,7 +2268,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     // Build tool result as plain text - JSON wastes tokens
-    const combinedText = formatToolResultAsText(
+    let combinedText = formatToolResultAsText(
       result,
       finalResult.attachmentSummary,
     );
@@ -2299,6 +2299,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // but the model supports visual content, embed images/PDFs directly.
       const inlineParts = await this.buildInlineAttachmentParts(attachments);
       if (inlineParts.length > 0) {
+        // Rebuild text with 'included-inline' variant so the model doesn't get
+        // a misleading "use read_file" hint alongside the actual inline content.
+        const inlineSummary = formatAttachmentSummary(
+          attachments,
+          'included-inline',
+        );
+        finalResult.attachmentSummary = inlineSummary;
+        combinedText = formatToolResultAsText(result, inlineSummary);
         outputPayload = [
           { type: 'input_text', text: combinedText },
           ...inlineParts,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -97,6 +97,7 @@ import type {
   ResponseReasoningSummaryTextDeltaEvent,
   ResponseOutputItemDoneEvent,
   ResponseWebSearchCallInProgressEvent,
+  ResponseFunctionCallArgumentsDoneEvent,
 } from 'openai/resources/responses/responses';
 
 interface UploadedOpenAIResponseAttachment {
@@ -1356,6 +1357,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
               // Create new thinking stream for potential continuation after search
               state.thinkingStream = this.createThinkingStream();
             }
+          } else if (this.isFunctionCallArgumentsDoneEvent(event)) {
+            // Function call arguments complete - finalize streams since no more
+            // text/thinking deltas will arrive after tool calls begin.
+            if (state.hasThinkingContent) {
+              state.thinkingStream.finalize();
+              state.hasThinkingContent = false;
+              state.thinkingStream = this.createThinkingStream();
+            }
+            this.logger.debug(
+              `Tool call ready during streaming: ${event.name}`,
+            );
           } else if (this.isOutputItemDoneEvent(event)) {
             // When output item is done, we can get the full web search data
             const item = event.item;
@@ -2287,6 +2299,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       outputPayload = parts;
+    } else if (
+      attachments.length > 0 &&
+      this.canProcessToolResultAttachments
+    ) {
+      // Inline base64 fallback: when file uploads are unavailable (e.g. OpenRouter)
+      // but the model supports visual content, embed images/PDFs directly.
+      const inlineParts = await this.buildInlineAttachmentParts(attachments);
+      if (inlineParts.length > 0) {
+        outputPayload = [
+          { type: 'input_text', text: combinedText },
+          ...inlineParts,
+        ];
+      } else {
+        outputPayload = combinedText;
+      }
     } else {
       outputPayload = combinedText;
     }
@@ -2356,6 +2383,69 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     return uploaded;
+  }
+
+  /**
+   * Build inline base64 content parts for tool attachments when file uploads
+   * are unavailable (e.g., OpenRouter routing). Images use data URI in
+   * `image_url`; PDFs use `file_data`. Non-visual attachments are skipped.
+   */
+  private async buildInlineAttachmentParts(
+    attachments: ToolFileAttachment[],
+  ): Promise<ResponseFunctionCallOutputItemList> {
+    const MAX_INLINE_BYTES = 20 * 1024 * 1024; // 20 MiB cap per attachment
+    const parts: ResponseFunctionCallOutputItemList = [];
+
+    for (const attachment of attachments) {
+      const mimeType = attachment.mimeType ?? 'application/octet-stream';
+      const isImage = mimeType.startsWith('image/');
+      const isPdf = mimeType === 'application/pdf';
+
+      if (!isImage && !isPdf) continue;
+
+      let buffer: Buffer | undefined;
+      try {
+        buffer = await loadAttachmentBuffer(attachment);
+        if (buffer.length > MAX_INLINE_BYTES) {
+          this.logger.debug(
+            `Skipping inline attachment ${attachment.path ?? 'attachment'}: ${buffer.length} bytes exceeds limit`,
+          );
+          continue;
+        }
+
+        const base64 = buffer.toString('base64');
+
+        if (isImage) {
+          parts.push({
+            type: 'input_image',
+            detail: 'auto',
+            image_url: `data:${mimeType};base64,${base64}`,
+          });
+        } else {
+          // PDF
+          const filename =
+            typeof attachment.path === 'string' && attachment.path.length > 0
+              ? path.basename(attachment.path)
+              : 'attachment.pdf';
+          parts.push({
+            type: 'input_file',
+            file_data: base64,
+            filename,
+          });
+        }
+      } catch (err) {
+        this.logger.debug(
+          `Unable to inline attachment ${attachment.path ?? 'attachment'}: ${getSdkErrorMessage(err)}`,
+        );
+      } finally {
+        if (buffer) {
+          buffer.fill(0);
+          buffer = undefined;
+        }
+      }
+    }
+
+    return parts;
   }
 
   async createUserFollowUpMessages(
@@ -2477,6 +2567,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     event: ResponseStreamEvent,
   ): event is ResponseOutputItemDoneEvent {
     return event.type === 'response.output_item.done';
+  }
+
+  /** Type guard for function call arguments done events. */
+  private isFunctionCallArgumentsDoneEvent(
+    event: ResponseStreamEvent,
+  ): event is ResponseFunctionCallArgumentsDoneEvent {
+    return event.type === 'response.function_call_arguments.done';
   }
 
   /** Type guard for web search output items. */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2294,10 +2294,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       outputPayload = parts;
-    } else if (
-      attachments.length > 0 &&
-      this.canProcessToolResultAttachments
-    ) {
+    } else if (attachments.length > 0 && this.canProcessToolResultAttachments) {
       // Inline base64 fallback: when file uploads are unavailable (e.g. OpenRouter)
       // but the model supports visual content, embed images/PDFs directly.
       const inlineParts = await this.buildInlineAttachmentParts(attachments);


### PR DESCRIPTION
- OpenAI Response: Add inline base64 fallback for tool attachments when file
  uploads are unavailable (e.g. OpenRouter routing). Images use data URI in
  image_url; PDFs use file_data. Previously these fell back to text-only
  metadata, preventing the model from seeing visual content.

- Google GenAI: Explicitly configure httpOptions.retryOptions.attempts to
  align SDK-level HTTP retries with the user's retry configuration instead
  of relying on the SDK's undocumented default.

- OpenAI Response: Process ResponseFunctionCallArgumentsDoneEvent during
  streaming to finalize thinking streams early and log tool call names.
  Uses the new `name` field (SDK v6.18.0+) for direct access without
  needing to track call-to-name mappings from earlier events.

https://claude.ai/code/session_01SzteH2sG5bZVDCQU5KZ3DD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes provider request/streaming behavior and attachment payload construction, which can affect reliability, token usage, and proxy/provider compatibility (especially with large base64 inlining).
> 
> **Overview**
> Improves provider SDK integration by **disabling Google GenAI SDK HTTP retries** (`retryOptions.attempts: 1`) so only the flow-level retry loop consumes the configured retry budget.
> 
> Enhances OpenAI Responses streaming by handling `response.function_call_arguments.done` to finalize/rotate the “thinking” stream before tool execution and log tool call readiness.
> 
> Adds an OpenAI tool-result attachment fallback: when file uploads aren’t possible, **inline images/PDFs as base64** (`input_image` data URIs / `input_file.file_data`) with a 20MiB per-attachment cap and an updated attachment summary that distinguishes *included inline* vs *metadata-only*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19b07631162774148244da9e93e834f7da12d996. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->