### PR TITLE
Add prompt caching support for system prompts and tools in Anthropic

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -37,6 +37,9 @@ import {
   attachStreamDiagnostics,
 } from '@common/errors/sdkErrorUtils';
 
+// Local imports - model
+import type { ToolDefinition } from '@model';
+
 // Local imports - replacement
 import replacementEngine from '@replacement/engine';
 
@@ -261,6 +264,25 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /** Tracks PDF page counts for files uploaded to the Anthropic Files API. */
   private uploadedPdfPageCounts = new Map<string, number>();
+
+  /**
+   * Cached system prompt for API-level cache stability. Once the system prompt
+   * is resolved and wrapped as TextBlockParam[], we reuse the same object across
+   * API calls within this handler's lifetime. This guarantees byte-identical
+   * prefixes across requests, maximizing prompt cache hit rates even if the
+   * upstream regenerates the string (with identical content) each cycle.
+   */
+  private cachedSystemPromptBlocks?: BetaTextBlockParam[];
+  private cachedSystemPromptSource?: string;
+
+  /**
+   * Cached tool definitions for API-level cache stability. Tools are converted
+   * once via toAnthropicTools() and reused across cycles. Since tool definitions
+   * don't change within a session, this avoids redundant conversion and ensures
+   * the tools prefix is byte-identical across API calls.
+   */
+  private cachedToolBlocks?: BetaToolUnion[];
+  private cachedToolFingerprint?: string;
 
   /** Sum of all tracked PDF page counts across uploaded files. */
   private getTrackedPdfPageCount(): number {
@@ -505,13 +527,28 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return systemPrompt;
     }
 
-    return [
+    // Reuse cached blocks when the source string is identical across cycles.
+    // The upstream regenerates the system prompt every cycle (template + rules),
+    // but the content is stable within a session. Returning the same object
+    // guarantees byte-identical prefixes for Anthropic's prompt cache.
+    if (
+      this.cachedSystemPromptSource === systemPrompt &&
+      this.cachedSystemPromptBlocks
+    ) {
+      return this.cachedSystemPromptBlocks;
+    }
+
+    const blocks: BetaTextBlockParam[] = [
       {
         type: 'text' as const,
         text: systemPrompt,
         cache_control: EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral,
       },
     ];
+
+    this.cachedSystemPromptSource = systemPrompt;
+    this.cachedSystemPromptBlocks = blocks;
+    return blocks;
   }
 
   /**
@@ -531,6 +568,31 @@ export class ModelHandlerAnthropic extends ModelHandler<
       (lastTool as { cache_control?: BetaCacheControlEphemeral }).cache_control =
         EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral;
     }
+  }
+
+  /**
+   * Returns cached Anthropic tool definitions, converting and applying cache
+   * control only when the tool set changes. Uses a lightweight fingerprint
+   * (tool names joined) to detect changes — safe because tool definitions
+   * don't change within a session.
+   */
+  private getOrBuildCachedTools(
+    tools: ToolDefinition[],
+  ): BetaToolUnion[] {
+    const fingerprint = tools.map((t) => t.name).join(',');
+
+    if (this.cachedToolFingerprint === fingerprint && this.cachedToolBlocks) {
+      return this.cachedToolBlocks;
+    }
+
+    const converted = toAnthropicTools(tools, {
+      supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
+    });
+    this.applyCacheControlToLastTool(converted);
+
+    this.cachedToolFingerprint = fingerprint;
+    this.cachedToolBlocks = converted;
+    return converted;
   }
 
   async getClient(): Promise<Anthropic> {
@@ -688,10 +750,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
     };
 
     if (tools && tools.length > 0) {
-      options.tools = toAnthropicTools(tools, {
-        supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
-      });
-      this.applyCacheControlToLastTool(options.tools);
+      options.tools = this.getOrBuildCachedTools(tools);
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       // Models using adaptive thinking get interleaved thinking automatically.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -86,6 +86,7 @@ import type {
 } from './types/IModelHandler';
 import type { AnthropicBeta } from '@anthropic-ai/sdk/resources/beta/beta';
 import type {
+  BetaCacheControlEphemeral,
   BetaContentBlock,
   BetaContentBlockParam,
   BetaCompactionBlock,
@@ -96,7 +97,9 @@ import type {
   BetaOutputConfig,
   BetaRedactedThinkingBlock,
   BetaRequestDocumentBlock,
+  BetaTextBlockParam,
   BetaThinkingBlock,
+  BetaToolUnion,
   BetaUsage,
   MessageCountTokensParams,
   MessageCreateParams,
@@ -489,6 +492,47 @@ export class ModelHandlerAnthropic extends ModelHandler<
     }
   }
 
+  /**
+   * Converts a system prompt string to a TextBlockParam array with cache control.
+   * When prompt caching is supported, the system prompt is wrapped as a content block
+   * with cache_control so it gets independently cached across API calls. This avoids
+   * re-processing the system prompt on every request when only messages change.
+   */
+  private buildCachedSystemPrompt(
+    systemPrompt: string | undefined,
+  ): string | BetaTextBlockParam[] | undefined {
+    if (!systemPrompt || !this.capabilities.supportsPromptCaching) {
+      return systemPrompt;
+    }
+
+    return [
+      {
+        type: 'text' as const,
+        text: systemPrompt,
+        cache_control: EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral,
+      },
+    ];
+  }
+
+  /**
+   * Applies cache control to the last tool definition so that all tool definitions
+   * are cached as a single prefix. Tools rarely change between requests, making them
+   * ideal candidates for caching independently from messages.
+   */
+  private applyCacheControlToLastTool(
+    tools: BetaToolUnion[] | undefined,
+  ): void {
+    if (!tools || tools.length === 0 || !this.capabilities.supportsPromptCaching) {
+      return;
+    }
+
+    const lastTool = tools.at(-1);
+    if (lastTool) {
+      (lastTool as { cache_control?: BetaCacheControlEphemeral }).cache_control =
+        EPHEMERAL_CACHE_CONTROL as BetaCacheControlEphemeral;
+    }
+  }
+
   async getClient(): Promise<Anthropic> {
     const credential = await this.getApiKey();
     const baseUrl = this.getBaseUrl();
@@ -607,7 +651,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaActive =
       effectiveContextWindow > this.config.contextWindow;
 
-    this.enforceCacheControlLimit(messages);
+    // Count cache breakpoint slots reserved for system prompt and tool definitions.
+    // The Anthropic API allows max 4 breakpoints; these reduce the budget for messages.
+    const reservedCacheSlots =
+      (systemPrompt && this.capabilities.supportsPromptCaching ? 1 : 0) +
+      (tools && tools.length > 0 && this.capabilities.supportsPromptCaching
+        ? 1
+        : 0);
+    this.enforceCacheControlLimit(messages, reservedCacheSlots);
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -625,13 +676,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       messages,
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
-      system: systemPrompt,
+      system: this.buildCachedSystemPrompt(systemPrompt),
     };
 
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools, {
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
       });
+      this.applyCacheControlToLastTool(options.tools);
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       // Models using adaptive thinking get interleaved thinking automatically.
@@ -970,7 +1022,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
   }
 
-  private enforceCacheControlLimit(messages: MessageParam[]): void {
+  /**
+   * Enforces the Anthropic API limit of MAX_CACHE_CONTROLLED_BLOCKS (4) cache breakpoints
+   * across the entire request. The reservedSlots parameter accounts for breakpoints
+   * already used by system prompt and tool definitions, reducing the budget available
+   * for message-level cache markers.
+   */
+  private enforceCacheControlLimit(
+    messages: MessageParam[],
+    reservedSlots = 0,
+  ): void {
     if (!this.capabilities.supportsPromptCaching) {
       return;
     }
@@ -1003,10 +1064,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    // Remove excess cache control markers, keeping only the last MAX_CACHE_CONTROLLED_BLOCKS
+    // Reduce the available budget by slots reserved for system prompt and tool breakpoints
+    const availableSlots = Math.max(
+      0,
+      MAX_CACHE_CONTROLLED_BLOCKS - reservedSlots,
+    );
     const excess = Math.max(
       0,
-      cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS,
+      cacheControlledBlocks.length - availableSlots,
     );
     for (let idx = 0; idx < excess; idx += 1) {
       delete cacheControlledBlocks[idx].cache_control;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -651,13 +651,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaActive =
       effectiveContextWindow > this.config.contextWindow;
 
-    // Count cache breakpoint slots reserved for system prompt and tool definitions.
-    // The Anthropic API allows max 4 breakpoints; these reduce the budget for messages.
-    const reservedCacheSlots =
-      (systemPrompt && this.capabilities.supportsPromptCaching ? 1 : 0) +
-      (tools && tools.length > 0 && this.capabilities.supportsPromptCaching
-        ? 1
-        : 0);
+    // Count cache breakpoint slots reserved outside of messages.
+    // The Anthropic API allows max 4 breakpoints total. We reserve slots for:
+    // - System prompt (1 explicit breakpoint)
+    // - Last tool definition (1 explicit breakpoint)
+    // - Top-level automatic caching (1 slot for the conversation tail)
+    // This leaves the remaining budget for message-level markers (e.g. compaction blocks).
+    const reservedCacheSlots = this.capabilities.supportsPromptCaching
+      ? (systemPrompt ? 1 : 0) + (tools && tools.length > 0 ? 1 : 0) + 1
+      : 0;
     this.enforceCacheControlLimit(messages, reservedCacheSlots);
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
@@ -677,6 +679,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
       system: this.buildCachedSystemPrompt(systemPrompt),
+      // Automatic caching: the API applies a cache breakpoint to the last
+      // cacheable block, so the growing conversation tail is always cached.
+      // This complements the explicit breakpoints on tools and system prompt.
+      ...(this.capabilities.supportsPromptCaching && {
+        cache_control: EPHEMERAL_CACHE_CONTROL,
+      }),
     };
 
     if (tools && tools.length > 0) {

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -543,6 +543,64 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('sends automatic cache_control and cached system prompt in API request', async () => {
+    const handler = createAnthropicHandler();
+    stubHandlerForTest(handler);
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-test',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    await handler.createResponse({
+      client,
+      messages,
+      temperature: 0,
+      systemPrompt: 'You are a helpful assistant.',
+    });
+
+    const options = messageOptions[0] ?? {};
+
+    // Verify top-level automatic caching
+    assert.deepEqual(
+      options.cache_control,
+      { type: 'ephemeral' },
+      'should include top-level cache_control for automatic caching',
+    );
+
+    // Verify system prompt is sent as TextBlockParam[] with cache_control
+    assert.ok(
+      Array.isArray(options.system),
+      'system prompt should be an array of TextBlockParam',
+    );
+    assert.equal(options.system.length, 1);
+    assert.equal(options.system[0].type, 'text');
+    assert.equal(options.system[0].text, 'You are a helpful assistant.');
+    assert.deepEqual(options.system[0].cache_control, { type: 'ephemeral' });
+  });
+
   it('trims follow-up text and rejects empty follow-ups', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages('prefix', 'request');

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -601,6 +601,114 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.deepEqual(options.system[0].cache_control, { type: 'ephemeral' });
   });
 
+  it('returns same cached system prompt object when source string is identical', () => {
+    const handler = createAnthropicHandler();
+
+    const result1 = (handler as any).buildCachedSystemPrompt(
+      'You are a helpful assistant.',
+    );
+    const result2 = (handler as any).buildCachedSystemPrompt(
+      'You are a helpful assistant.',
+    );
+
+    assert.ok(Array.isArray(result1));
+    assert.strictEqual(
+      result1,
+      result2,
+      'should return the exact same object reference for identical source',
+    );
+  });
+
+  it('rebuilds cached system prompt when source string changes', () => {
+    const handler = createAnthropicHandler();
+
+    const result1 = (handler as any).buildCachedSystemPrompt('prompt A');
+    const result2 = (handler as any).buildCachedSystemPrompt('prompt B');
+
+    assert.ok(Array.isArray(result1));
+    assert.ok(Array.isArray(result2));
+    assert.notStrictEqual(
+      result1,
+      result2,
+      'should return different objects when source changes',
+    );
+    assert.equal(result1[0].text, 'prompt A');
+    assert.equal(result2[0].text, 'prompt B');
+  });
+
+  it('caches converted tool definitions across calls with same tools', () => {
+    const handler = createAnthropicHandler();
+
+    const tools = [
+      {
+        name: 'tool_a',
+        description: 'Tool A',
+        input_schema: { type: 'object' as const, properties: {} },
+      },
+      {
+        name: 'tool_b',
+        description: 'Tool B',
+        input_schema: { type: 'object' as const, properties: {} },
+      },
+    ];
+
+    const result1 = (handler as any).getOrBuildCachedTools(tools);
+    const result2 = (handler as any).getOrBuildCachedTools(tools);
+
+    assert.ok(Array.isArray(result1));
+    assert.strictEqual(
+      result1,
+      result2,
+      'should return the exact same object reference for identical tools',
+    );
+    // Verify cache_control is applied to last tool
+    assert.deepEqual(
+      (result1.at(-1) as any).cache_control,
+      { type: 'ephemeral' },
+      'last tool should have cache control',
+    );
+    assert.equal(
+      (result1[0] as any).cache_control,
+      undefined,
+      'first tool should not have cache control',
+    );
+  });
+
+  it('rebuilds cached tools when tool set changes', () => {
+    const handler = createAnthropicHandler();
+
+    const tools1 = [
+      {
+        name: 'tool_a',
+        description: 'Tool A',
+        input_schema: { type: 'object' as const, properties: {} },
+      },
+    ];
+    const tools2 = [
+      {
+        name: 'tool_a',
+        description: 'Tool A',
+        input_schema: { type: 'object' as const, properties: {} },
+      },
+      {
+        name: 'tool_b',
+        description: 'Tool B',
+        input_schema: { type: 'object' as const, properties: {} },
+      },
+    ];
+
+    const result1 = (handler as any).getOrBuildCachedTools(tools1);
+    const result2 = (handler as any).getOrBuildCachedTools(tools2);
+
+    assert.notStrictEqual(
+      result1,
+      result2,
+      'should return different objects when tools change',
+    );
+    assert.equal(result1.length, 1);
+    assert.equal(result2.length, 2);
+  });
+
   it('trims follow-up text and rejects empty follow-ups', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages('prefix', 'request');

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -437,6 +437,112 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('reduces message cache budget when reservedSlots are provided', () => {
+    const handler = createAnthropicHandler();
+    const messageContent: ContentBlockParam[] = [];
+
+    for (let idx = 0; idx < 4; idx += 1) {
+      messageContent.push({
+        type: 'text',
+        text: `block-${idx}`,
+        citations: null,
+        cache_control: { type: 'ephemeral' },
+      } as ContentBlockParam & { cache_control: { type: 'ephemeral' } });
+    }
+
+    const messages: MessageParam[] = [
+      { role: 'user', content: messageContent },
+    ];
+
+    // Reserve 2 slots for system prompt and tools, leaving 2 for messages
+    (handler as any).enforceCacheControlLimit(messages, 2);
+
+    const cacheControlledBlocks = messageContent.filter(
+      (block) =>
+        'cache_control' in block &&
+        (block as { cache_control?: unknown }).cache_control !== undefined,
+    );
+
+    assert.equal(
+      cacheControlledBlocks.length,
+      2,
+      'only 2 message cache markers should remain when 2 slots are reserved',
+    );
+    assert.deepEqual(
+      cacheControlledBlocks.map((block) => (block as { text?: string }).text),
+      ['block-2', 'block-3'],
+      'the two most recent blocks should retain cache control markers',
+    );
+  });
+
+  it('converts system prompt to TextBlockParam with cache control', () => {
+    const handler = createAnthropicHandler();
+
+    const result = (handler as any).buildCachedSystemPrompt(
+      'You are a helpful assistant.',
+    );
+
+    assert.ok(Array.isArray(result), 'should return an array');
+    assert.equal(result.length, 1, 'should contain a single text block');
+    assert.equal(result[0].type, 'text');
+    assert.equal(result[0].text, 'You are a helpful assistant.');
+    assert.deepEqual(result[0].cache_control, { type: 'ephemeral' });
+  });
+
+  it('returns undefined system prompt as-is when no prompt provided', () => {
+    const handler = createAnthropicHandler();
+
+    const result = (handler as any).buildCachedSystemPrompt(undefined);
+    assert.equal(result, undefined);
+  });
+
+  it('returns system prompt as string when caching is disabled', () => {
+    const handler = createAnthropicHandler({ supportsPromptCaching: false });
+
+    const result = (handler as any).buildCachedSystemPrompt(
+      'You are a helpful assistant.',
+    );
+    assert.equal(result, 'You are a helpful assistant.');
+  });
+
+  it('applies cache control to the last tool definition', () => {
+    const handler = createAnthropicHandler();
+
+    const tools = [
+      { name: 'tool_a', input_schema: { type: 'object', properties: {} } },
+      { name: 'tool_b', input_schema: { type: 'object', properties: {} } },
+    ];
+
+    (handler as any).applyCacheControlToLastTool(tools);
+
+    assert.equal(
+      (tools[0] as any).cache_control,
+      undefined,
+      'first tool should not have cache control',
+    );
+    assert.deepEqual(
+      (tools[1] as any).cache_control,
+      { type: 'ephemeral' },
+      'last tool should have cache control',
+    );
+  });
+
+  it('skips tool cache control when caching is disabled', () => {
+    const handler = createAnthropicHandler({ supportsPromptCaching: false });
+
+    const tools = [
+      { name: 'tool_a', input_schema: { type: 'object', properties: {} } },
+    ];
+
+    (handler as any).applyCacheControlToLastTool(tools);
+
+    assert.equal(
+      (tools[0] as any).cache_control,
+      undefined,
+      'tool should not have cache control when caching disabled',
+    );
+  });
+
   it('trims follow-up text and rejects empty follow-ups', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages('prefix', 'request');


### PR DESCRIPTION
## Summary
This PR implements prompt caching for system prompts and tool definitions in the Anthropic model handler. It optimizes API usage by allowing system prompts and tool definitions to be cached independently across requests, reducing redundant processing when only messages change.

## Key Changes
- **System Prompt Caching**: Added `buildCachedSystemPrompt()` method that wraps system prompts as cached text blocks when prompt caching is supported, enabling independent caching of static system instructions
- **Tool Definition Caching**: Added `applyCacheControlToLastTool()` method that applies cache control markers to the last tool definition, allowing all tools to be cached as a single prefix
- **Cache Budget Management**: Enhanced `enforceCacheControlLimit()` to accept a `reservedSlots` parameter that accounts for cache breakpoints used by system prompts and tools, ensuring the 4-breakpoint API limit is respected across all components
- **Slot Reservation Logic**: Updated the message preparation flow to calculate reserved cache slots based on whether system prompts and tools are present and caching is enabled
- **Comprehensive Tests**: Added 6 new test cases covering cache budget reduction, system prompt conversion, tool cache control application, and behavior when caching is disabled

## Implementation Details
- Cache control markers are only applied when `supportsPromptCaching` capability is enabled
- The implementation respects Anthropic's MAX_CACHE_CONTROLLED_BLOCKS (4) limit by reducing the message-level cache budget based on slots used by system prompts and tools
- System prompts and tools are converted to the appropriate cached block formats only when needed, maintaining backward compatibility when caching is disabled
- The solution maintains the existing behavior of keeping the most recent message cache markers when the budget is exceeded

https://claude.ai/code/session_014GJhfSZ5NpGZVR23rhaKMe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Anthropic request construction path (system/tools/cache_control) and cache-marker budgeting, which can affect request validity and caching behavior across sessions, but is gated behind `supportsPromptCaching` and covered by new tests.
> 
> **Overview**
> Adds explicit prompt-caching support in `ModelHandlerAnthropic` by caching the `system` prompt as a `BetaTextBlockParam[]` with `cache_control`, caching converted tool definitions (and marking the last tool) to create a stable cached prefix across requests, and enabling top-level `cache_control` for automatic caching of the conversation tail.
> 
> Updates cache-breakpoint enforcement to account for cache slots reserved by system prompt/tools/automatic caching (Anthropic’s 4-breakpoint limit) and expands unit tests to cover reserved-slot budgeting, system/tool caching behavior, and request payload changes when caching is enabled/disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19fb87a2c9e29d2897b88e29855f7a016cee40e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->