### PR TITLE
refactor: use native @openrouter/sdk for OpenRouter model handler

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -1,21 +1,15 @@
 // Third-party imports
 import OpenAI from 'openai';
+import { OpenRouter } from '@openrouter/sdk';
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
 
 /**
  * OpenRouter reasoning_details item type.
  *
- * Note: This type is intentionally defined locally rather than imported from
- * `@openrouter/sdk/models` (Schema2 type) because:
- * - The SDK uses ESM subpath exports which require `moduleResolution: "node16"` or higher
- * - This project uses `moduleResolution: "node"` in tsconfig.json
- * - Changing moduleResolution would have broader implications across the codebase
- *
- * The SDK's Schema2 type is equivalent but includes additional optional fields
- * (signature, id, format, index) that we don't need for our use case.
+ * Equivalent to Schema19 in `@openrouter/sdk`, defined locally because
+ * the SDK's subpath exports require `moduleResolution: "node16"` or higher.
  *
  * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- * @see Schema2 in @openrouter/sdk/esm/models/schema2.d.ts for SDK equivalent
  */
 type ReasoningDetailItem =
   | { type: 'reasoning.text'; text?: string | null }
@@ -36,11 +30,132 @@ import type {
 } from './types/IModelHandler';
 import type {
   ChatCompletion,
-  ChatCompletionChunk,
   ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
 
-/** Extract text content from a reasoning detail item by type */
+// ============================================================================
+// Message & Response Conversion (OpenAI ↔ OpenRouter SDK)
+// ============================================================================
+
+/**
+ * Convert OpenAI-format messages (snake_case) to OpenRouter SDK format (camelCase).
+ *
+ * The SDK's Zod schemas validate camelCase fields and remap them to snake_case
+ * for the HTTP request. Passing OpenAI's snake_case directly would cause the
+ * fields to be stripped during validation.
+ *
+ * Fields remapped:
+ * - assistant.tool_calls → toolCalls
+ * - tool.tool_call_id → toolCallId
+ */
+function toOpenRouterMessages(
+  messages: ChatCompletionMessageParam[],
+): unknown[] {
+  return messages.map((msg) => {
+    if (msg.role === 'assistant') {
+      const assistantMsg = msg as unknown as Record<string, unknown>;
+      if (assistantMsg.tool_calls) {
+        const { tool_calls, ...rest } = assistantMsg;
+        return { ...rest, toolCalls: tool_calls };
+      }
+      return msg;
+    }
+    if (msg.role === 'tool') {
+      const toolMsg = msg as unknown as Record<string, unknown>;
+      const { tool_call_id, ...rest } = toolMsg;
+      return { ...rest, toolCallId: tool_call_id };
+    }
+    return msg;
+  });
+}
+
+/**
+ * Convert OpenRouter SDK camelCase usage to OpenAI snake_case format.
+ */
+function toOpenAIUsage(
+  sdkUsage: Record<string, unknown> | undefined,
+): ChatCompletion['usage'] | undefined {
+  if (!sdkUsage) return undefined;
+
+  const usage: Record<string, unknown> = {
+    prompt_tokens: (sdkUsage.promptTokens as number) ?? 0,
+    completion_tokens: (sdkUsage.completionTokens as number) ?? 0,
+    total_tokens: (sdkUsage.totalTokens as number) ?? 0,
+  };
+
+  const completionDetails = sdkUsage.completionTokensDetails as
+    | Record<string, unknown>
+    | undefined;
+  if (completionDetails) {
+    usage.completion_tokens_details = {
+      reasoning_tokens: completionDetails.reasoningTokens ?? undefined,
+    };
+  }
+
+  const promptDetails = sdkUsage.promptTokensDetails as
+    | Record<string, unknown>
+    | undefined;
+  if (promptDetails) {
+    usage.prompt_tokens_details = {
+      cached_tokens: promptDetails.cachedTokens ?? undefined,
+    };
+  }
+
+  return usage as unknown as ChatCompletion['usage'];
+}
+
+/**
+ * Convert an OpenRouter SDK non-streaming response to OpenAI ChatCompletion format.
+ *
+ * The SDK deserializes API responses into camelCase TypeScript objects.
+ * The rest of the handler chain expects OpenAI's snake_case format.
+ */
+function toOpenAIChatCompletion(
+  sdkResponse: Record<string, unknown>,
+): ChatCompletion {
+  const choices = sdkResponse.choices as Array<Record<string, unknown>>;
+
+  return {
+    id: sdkResponse.id as string,
+    object: 'chat.completion',
+    created: sdkResponse.created as number,
+    model: sdkResponse.model as string,
+    choices: (choices ?? []).map((choice) => {
+      const message = choice.message as Record<string, unknown>;
+      const toolCalls = message?.toolCalls as
+        | Array<Record<string, unknown>>
+        | undefined;
+
+      // Build message object imperatively to avoid spread-type issues
+      // with Record<string, unknown> fields
+      const openAIMessage: Record<string, unknown> = {
+        role: 'assistant',
+        content: (message?.content as string) ?? null,
+      };
+      if (toolCalls?.length) openAIMessage.tool_calls = toolCalls;
+      if (message?.reasoning != null)
+        openAIMessage.reasoning = message.reasoning;
+      if (message?.reasoningDetails)
+        openAIMessage.reasoning_details = message.reasoningDetails;
+
+      return {
+        index: (choice.index as number) ?? 0,
+        finish_reason: (choice.finishReason as string) ?? 'stop',
+        message: openAIMessage,
+        logprobs: (choice.logprobs as null) ?? null,
+      };
+    }),
+    usage: toOpenAIUsage(
+      sdkResponse.usage as Record<string, unknown> | undefined,
+    ),
+  } as unknown as ChatCompletion;
+}
+
+// ============================================================================
+// Streaming Aggregator
+// ============================================================================
+
+/** Extract text content from a reasoning detail item by type. */
 function getReasoningItemText(item: ReasoningDetailItem): string | undefined {
   if (item.type === 'reasoning.text') return item.text ?? undefined;
   if (item.type === 'reasoning.summary') return item.summary;
@@ -50,14 +165,12 @@ function getReasoningItemText(item: ReasoningDetailItem): string | undefined {
 
 /**
  * Extracts text content from OpenRouter reasoning_details array.
- * Handles the structured format with type-specific fields.
  * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
  */
-const extractTextFromReasoningDetails = (
+function extractTextFromReasoningDetails(
   details: ReasoningDetailItem[] | unknown,
-): string => {
+): string {
   if (!Array.isArray(details)) {
-    // Fallback: if it's a string, return it directly
     return typeof details === 'string' ? details : '';
   }
 
@@ -68,121 +181,316 @@ const extractTextFromReasoningDetails = (
     .map(getReasoningItemText)
     .filter((text): text is string => !!text)
     .join('');
-};
+}
 
 /**
- * Extracts reasoning delta from streaming chunks for OpenRouter.
- * Handles both:
- * - reasoning_details: array of objects (OpenRouter normalized format)
- * - reasoning_content: string (native DeepSeek/other models)
+ * Accumulates OpenRouter SDK streaming chunks into a final ChatCompletion.
+ *
+ * Replaces the OpenAI SDK's `.finalChatCompletion()` / `.totalUsage()` methods
+ * which are not available on the OpenRouter SDK's EventStream.
  */
-const extractOpenRouterReasoningDelta = (
-  chunk: ChatCompletionChunk,
-): string => {
-  const choice = chunk.choices[0];
-  if (!choice) return '';
+class OpenRouterStreamAggregator {
+  private id = '';
+  private model = '';
+  private created = 0;
+  private content = '';
+  private finishReason: string | null = null;
+  private usage: Record<string, unknown> | null = null;
+  private reasoning = '';
+  private toolCallsMap = new Map<
+    number,
+    {
+      id: string;
+      type: string;
+      function: { name: string; arguments: string };
+    }
+  >();
 
-  const delta = choice.delta as {
-    reasoning_details?: ReasoningDetailItem[] | string;
-    reasoning_content?: string;
-  };
+  /**
+   * Consume a single streaming chunk, extracting content and reasoning deltas.
+   * Returns the deltas for real-time display via thinking/output streams.
+   */
+  consumeChunk(chunk: Record<string, unknown>): {
+    contentDelta: string;
+    reasoningDelta: string;
+  } {
+    if (chunk.id) this.id = chunk.id as string;
+    if (chunk.model) this.model = chunk.model as string;
+    if (chunk.created) this.created = chunk.created as number;
+    if (chunk.usage) this.usage = chunk.usage as Record<string, unknown>;
 
-  // Try reasoning_details first (OpenRouter normalized format)
-  if ('reasoning_details' in delta && delta.reasoning_details) {
-    return extractTextFromReasoningDetails(delta.reasoning_details);
+    const choices = chunk.choices as
+      | Array<Record<string, unknown>>
+      | undefined;
+    const choice = choices?.[0];
+    if (!choice) return { contentDelta: '', reasoningDelta: '' };
+
+    if (choice.finishReason) {
+      this.finishReason = choice.finishReason as string;
+    }
+
+    const delta = choice.delta as Record<string, unknown> | undefined;
+    if (!delta) return { contentDelta: '', reasoningDelta: '' };
+
+    // Content
+    const contentDelta = (delta.content as string) ?? '';
+    if (contentDelta) this.content += contentDelta;
+
+    // Reasoning - try reasoningDetails (structured) then reasoning (string)
+    let reasoningDelta = '';
+    if (delta.reasoningDetails && Array.isArray(delta.reasoningDetails)) {
+      reasoningDelta = extractTextFromReasoningDetails(
+        delta.reasoningDetails as ReasoningDetailItem[],
+      );
+    } else if (delta.reasoning) {
+      reasoningDelta = delta.reasoning as string;
+    }
+    if (reasoningDelta) this.reasoning += reasoningDelta;
+
+    // Accumulate tool calls by index
+    const toolCalls = delta.toolCalls as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (toolCalls) {
+      for (const tc of toolCalls) {
+        const index = (tc.index as number) ?? 0;
+        const fn = tc.function as Record<string, unknown> | undefined;
+        const existing = this.toolCallsMap.get(index);
+
+        if (existing) {
+          if (fn?.arguments) existing.function.arguments += fn.arguments;
+          if (fn?.name) existing.function.name += fn.name;
+        } else {
+          this.toolCallsMap.set(index, {
+            id: (tc.id as string) ?? '',
+            type: (tc.type as string) ?? 'function',
+            function: {
+              name: (fn?.name as string) ?? '',
+              arguments: (fn?.arguments as string) ?? '',
+            },
+          });
+        }
+      }
+    }
+
+    return { contentDelta, reasoningDelta };
   }
 
-  // Fall back to reasoning_content (native format for some models)
-  if ('reasoning_content' in delta && delta.reasoning_content) {
-    return delta.reasoning_content;
-  }
+  /** Build a ChatCompletion from accumulated streaming data. */
+  toChatCompletion(): ChatCompletion {
+    const toolCalls = Array.from(this.toolCallsMap.values());
 
-  return '';
-};
+    return {
+      id: this.id,
+      object: 'chat.completion',
+      created: this.created,
+      model: this.model,
+      choices: [
+        {
+          index: 0,
+          finish_reason: this.finishReason ?? 'stop',
+          message: {
+            role: 'assistant' as const,
+            content: this.content || null,
+            ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+            ...(this.reasoning && { reasoning: this.reasoning }),
+          },
+          logprobs: null,
+        },
+      ],
+      usage: toOpenAIUsage(this.usage ?? undefined),
+    } as ChatCompletion;
+  }
+}
+
+// ============================================================================
+// Hook for injecting parameters the SDK doesn't support yet
+// ============================================================================
 
 /**
- * Handler for models accessed through OpenRouter.
+ * Parameters that OpenRouter's API accepts but the SDK's Zod schemas
+ * strip during validation. Injected via a beforeRequest hook.
+ *
+ * - `include_reasoning`: tells OpenRouter to return reasoning content in the
+ *   response for O1-style models
+ * - `reasoning.enabled`: enables reasoning for DeepSeek V3.2 and similar models
+ */
+interface NonSDKParams {
+  include_reasoning?: boolean;
+  reasoning?: { enabled: boolean };
+}
+
+/**
+ * Creates a beforeRequest hook that injects extra body parameters the SDK
+ * doesn't natively support. Deep-merges nested objects (e.g., reasoning).
+ */
+function createParamInjectionHook(getNonSDKParams: () => NonSDKParams | null) {
+  return {
+    beforeRequest: async (
+      _ctx: unknown,
+      request: Request,
+    ): Promise<Request> => {
+      const extras = getNonSDKParams();
+      if (!extras) return request;
+
+      const cloned = request.clone();
+      const bodyText = await cloned.text();
+      try {
+        const parsed = JSON.parse(bodyText) as Record<string, unknown>;
+        for (const [key, value] of Object.entries(extras)) {
+          // Deep merge for nested objects (e.g., reasoning)
+          if (
+            typeof value === 'object' &&
+            value !== null &&
+            !Array.isArray(value) &&
+            typeof parsed[key] === 'object' &&
+            parsed[key] !== null
+          ) {
+            Object.assign(
+              parsed[key] as Record<string, unknown>,
+              value as Record<string, unknown>,
+            );
+          } else {
+            parsed[key] = value;
+          }
+        }
+        return new Request(request, { body: JSON.stringify(parsed) });
+      } catch {
+        return request;
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+/**
+ * Handler for models accessed through OpenRouter, using the native
+ * `@openrouter/sdk` for API calls.
+ *
+ * Extends ModelHandlerOpenAI to inherit message formatting, tool extraction,
+ * and response processing logic. Overrides `createResponse()` to use the
+ * OpenRouter SDK's `chat.send()` with proper type-safe parameters.
  */
 export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
+  /**
+   * Pending non-SDK parameters to inject via the beforeRequest hook.
+   * Set before each SDK call and consumed (cleared) by the hook.
+   */
+  private pendingNonSDKParams: NonSDKParams | null = null;
+
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'openrouter';
   }
 
-  /** Creates a response using OpenRouter's API with model-specific configuration. */
-  async createResponse(
+  /**
+   * Creates a native OpenRouter SDK client.
+   *
+   * Uses the SDK's built-in configuration for:
+   * - API key authentication
+   * - X-Title header (app identification)
+   * - Base URL (with optional override for proxies/relays)
+   * - A beforeRequest hook to inject parameters the SDK doesn't yet support
+   */
+  private async createNativeClient(): Promise<OpenRouter> {
+    const apiKey = await this.getApiKey();
+    const baseURL = this.getBaseUrl();
+    this.logger.debug(
+      `Creating native OpenRouter SDK client. Base URL: ${baseURL ?? 'default'}`,
+    );
+
+    return new OpenRouter({
+      apiKey,
+      xTitle: 'TeXRA.ai',
+      ...(baseURL && { serverURL: baseURL }),
+      hooks: [
+        createParamInjectionHook(() => {
+          const params = this.pendingNonSDKParams;
+          this.pendingNonSDKParams = null;
+          return params;
+        }),
+      ],
+    });
+  }
+
+  /**
+   * Creates a response using the native OpenRouter SDK.
+   *
+   * Builds SDK-typed request parameters, handles streaming via
+   * OpenRouterStreamAggregator, and converts responses back to
+   * OpenAI ChatCompletion format for the rest of the handler chain.
+   */
+  override async createResponse(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
   ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
-    const { client, messages, temperature, endTag, signal, tools } = options;
-    // Get streaming config
+    const { messages, temperature, endTag, signal, tools } = options;
     const useStreaming = this.getStreamingConfig();
+    const nativeClient = await this.createNativeClient();
 
-    const kwargs: any = {
-      model: this.config.openrouterFullName, // Use OpenRouter model name
-      messages,
-      max_tokens: this.getEffectiveMaxOutputTokens(),
+    // Build SDK request parameters (camelCase for SDK validation)
+    const chatParams: Record<string, unknown> = {
+      model: this.config.openrouterFullName,
+      messages: toOpenRouterMessages(messages),
+      maxTokens: this.getEffectiveMaxOutputTokens(),
       temperature,
-      extra_headers: { 'X-Title': 'TeXRA.ai' },
     };
 
-    // Reasoning parameters vary by model via OpenRouter:
-    // - O1-style models: use reasoning.effort + include_reasoning
-    // - DeepSeek V3.2: use reasoning.enabled (no include_reasoning needed,
-    //   reasoning_details is returned automatically when enabled)
+    // Reasoning parameters - use SDK's `reasoning` field where possible,
+    // inject unsupported params via the beforeRequest hook
     if (this.capabilities.supportsReasoning) {
       if (
         this.capabilities.supportsReasoningEffort &&
         this.capabilities.reasoningEffort
       ) {
-        // O1-style models with effort levels
-        kwargs.reasoning = {
+        // O1-style models: SDK supports reasoning.effort natively
+        chatParams.reasoning = {
           effort: this.validateReasoningEffort(
             this.capabilities.reasoningEffort,
           ),
         };
-        kwargs.include_reasoning = true;
+        // SDK doesn't support include_reasoning yet - inject via hook
+        this.pendingNonSDKParams = { include_reasoning: true };
       } else {
-        // DeepSeek V3.2 and similar models - just enable reasoning
-        kwargs.reasoning = { enabled: true };
+        // DeepSeek V3.2 and similar: SDK doesn't support reasoning.enabled
+        // Send empty reasoning object to SDK, inject enabled via hook
+        chatParams.reasoning = {};
+        this.pendingNonSDKParams = { reasoning: { enabled: true } };
       }
     }
 
     if (tools && tools.length > 0) {
-      kwargs.tools = toOpenAITools(tools);
-      kwargs.tool_choice = 'auto';
+      chatParams.tools = toOpenAITools(tools);
+      chatParams.toolChoice = 'auto';
     }
 
     if (endTag) {
-      kwargs.stop = [endTag];
+      chatParams.stop = [endTag];
     }
 
     if (useStreaming) {
-      kwargs.stream_options = { include_usage: true }; // Assuming OpenRouter passes this through
-      const stream = await client.chat.completions.stream(kwargs, { signal });
+      chatParams.stream = true;
+      chatParams.streamOptions = { includeUsage: true };
+
+      const stream = (await nativeClient.chat.send(
+        { chatGenerationParams: chatParams as any },
+        { signal },
+      )) as unknown as AsyncIterable<Record<string, unknown>>;
+
       const thinking = this.createThinkingStream();
       const output = this.isOutputStreamingEnabled()
         ? this.createOutputStream()
         : undefined;
+      const aggregator = new OpenRouterStreamAggregator();
+
       for await (const chunk of stream) {
-        const reasoningDelta = extractOpenRouterReasoningDelta(chunk);
-        const contentDelta = chunk.choices[0]?.delta?.content ?? '';
+        const { contentDelta, reasoningDelta } = aggregator.consumeChunk(chunk);
         if (reasoningDelta) thinking.append(reasoningDelta);
         if (contentDelta) output?.append(contentDelta);
       }
 
-      // Note that there is no second consumption problem
-      // But i am not sure about openrouter's stream api, whether it works for every model.
-      let response = await stream.finalChatCompletion();
-
-      // Ensure usage is captured - use SDK's totalUsage() as fallback
-      if (!response.usage) {
-        try {
-          const totalUsage = await stream.totalUsage();
-          response = { ...response, usage: totalUsage };
-        } catch (_err) {
-          // totalUsage() may fail if stream ended abnormally
-        }
-      }
-
+      const response = aggregator.toChatCompletion();
       const finalReasoning = this.processThinkingBlock(response);
       thinking.finalize(finalReasoning ?? undefined);
       const finalOutput = response.choices?.[0]?.message?.content ?? '';
@@ -190,7 +498,15 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
       return { response };
     }
 
-    const response = await client.chat.completions.create(kwargs, { signal });
+    // Non-streaming path
+    chatParams.stream = false;
+    const sdkResponse = await nativeClient.chat.send(
+      { chatGenerationParams: chatParams as any },
+      { signal },
+    );
+    const response = toOpenAIChatCompletion(
+      sdkResponse as unknown as Record<string, unknown>,
+    );
     return { response };
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -219,9 +219,7 @@ class OpenRouterStreamAggregator {
     if (chunk.created) this.created = chunk.created as number;
     if (chunk.usage) this.usage = chunk.usage as Record<string, unknown>;
 
-    const choices = chunk.choices as
-      | Array<Record<string, unknown>>
-      | undefined;
+    const choices = chunk.choices as Array<Record<string, unknown>> | undefined;
     const choice = choices?.[0];
     if (!choice) return { contentDelta: '', reasoningDelta: '' };
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -38,6 +38,39 @@ import type {
 // ============================================================================
 
 /**
+ * Remap snake_case keys in a content part to SDK camelCase.
+ *
+ * The SDK's outbound Zod schemas expect camelCase fields and remap them to
+ * snake_case for the HTTP wire format. Passing OpenAI's snake_case directly
+ * causes the SDK to strip the fields during validation.
+ *
+ * Remapped: image_url → imageUrl, input_audio → inputAudio, video_url → videoUrl
+ */
+function toOpenRouterContentPart(
+  part: Record<string, unknown>,
+): Record<string, unknown> {
+  const { image_url, input_audio, video_url, ...rest } = part;
+  const out: Record<string, unknown> = { ...rest };
+  if (image_url !== undefined) out.imageUrl = image_url;
+  if (input_audio !== undefined) out.inputAudio = input_audio;
+  if (video_url !== undefined) out.videoUrl = video_url;
+  return out;
+}
+
+/**
+ * Remap content parts in a message when the content is an array.
+ * Strings are passed through unchanged.
+ */
+function toOpenRouterContent(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  return content.map((part: unknown) =>
+    typeof part === 'object' && part !== null
+      ? toOpenRouterContentPart(part as Record<string, unknown>)
+      : part,
+  );
+}
+
+/**
  * Convert OpenAI-format messages (snake_case) to OpenRouter SDK format (camelCase).
  *
  * The SDK's Zod schemas validate camelCase fields and remap them to snake_case
@@ -47,23 +80,34 @@ import type {
  * Fields remapped:
  * - assistant.tool_calls → toolCalls
  * - tool.tool_call_id → toolCallId
+ * - content part: image_url → imageUrl, input_audio → inputAudio, video_url → videoUrl
  */
 function toOpenRouterMessages(
   messages: ChatCompletionMessageParam[],
 ): unknown[] {
   return messages.map((msg) => {
+    const raw = msg as unknown as Record<string, unknown>;
+
     if (msg.role === 'assistant') {
-      const assistantMsg = msg as unknown as Record<string, unknown>;
-      if (assistantMsg.tool_calls) {
-        const { tool_calls, ...rest } = assistantMsg;
-        return { ...rest, toolCalls: tool_calls };
+      const result: Record<string, unknown> = {
+        ...raw,
+        content: toOpenRouterContent(raw.content),
+      };
+      if (raw.tool_calls) {
+        result.toolCalls = raw.tool_calls;
+        delete result.tool_calls;
       }
-      return msg;
+      return result;
     }
+
     if (msg.role === 'tool') {
-      const toolMsg = msg as unknown as Record<string, unknown>;
-      const { tool_call_id, ...rest } = toolMsg;
+      const { tool_call_id, ...rest } = raw;
       return { ...rest, toolCallId: tool_call_id };
+    }
+
+    // system / user / developer - only need content part remapping
+    if (Array.isArray(raw.content)) {
+      return { ...raw, content: toOpenRouterContent(raw.content) };
     }
     return msg;
   });
@@ -321,21 +365,21 @@ interface NonSDKParams {
 /**
  * Creates a beforeRequest hook that injects extra body parameters the SDK
  * doesn't natively support. Deep-merges nested objects (e.g., reasoning).
+ *
+ * The `nonSDKParams` are captured by reference from the caller, so the
+ * same value is applied on every invocation (including SDK retries).
  */
-function createParamInjectionHook(getNonSDKParams: () => NonSDKParams | null) {
+function createParamInjectionHook(nonSDKParams: NonSDKParams) {
   return {
     beforeRequest: async (
       _ctx: unknown,
       request: Request,
     ): Promise<Request> => {
-      const extras = getNonSDKParams();
-      if (!extras) return request;
-
       const cloned = request.clone();
       const bodyText = await cloned.text();
       try {
         const parsed = JSON.parse(bodyText) as Record<string, unknown>;
-        for (const [key, value] of Object.entries(extras)) {
+        for (const [key, value] of Object.entries(nonSDKParams)) {
           // Deep merge for nested objects (e.g., reasoning)
           if (
             typeof value === 'object' &&
@@ -373,12 +417,6 @@ function createParamInjectionHook(getNonSDKParams: () => NonSDKParams | null) {
  * OpenRouter SDK's `chat.send()` with proper type-safe parameters.
  */
 export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
-  /**
-   * Pending non-SDK parameters to inject via the beforeRequest hook.
-   * Set before each SDK call and consumed (cleared) by the hook.
-   */
-  private pendingNonSDKParams: NonSDKParams | null = null;
-
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'openrouter';
   }
@@ -391,25 +429,26 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
    * - X-Title header (app identification)
    * - Base URL (with optional override for proxies/relays)
    * - A beforeRequest hook to inject parameters the SDK doesn't yet support
+   *
+   * @param nonSDKParams - Extra body parameters to inject via beforeRequest hook.
+   *   Captured by the hook closure so retries re-apply the same values.
    */
-  private async createNativeClient(): Promise<OpenRouter> {
+  private async createNativeClient(
+    nonSDKParams?: NonSDKParams,
+  ): Promise<OpenRouter> {
     const apiKey = await this.getApiKey();
     const baseURL = this.getBaseUrl();
     this.logger.debug(
       `Creating native OpenRouter SDK client. Base URL: ${baseURL ?? 'default'}`,
     );
 
+    const hooks = nonSDKParams ? [createParamInjectionHook(nonSDKParams)] : [];
+
     return new OpenRouter({
       apiKey,
       xTitle: 'TeXRA.ai',
       ...(baseURL && { serverURL: baseURL }),
-      hooks: [
-        createParamInjectionHook(() => {
-          const params = this.pendingNonSDKParams;
-          this.pendingNonSDKParams = null;
-          return params;
-        }),
-      ],
+      hooks,
     });
   }
 
@@ -425,7 +464,6 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
   ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
     const { messages, temperature, endTag, signal, tools } = options;
     const useStreaming = this.getStreamingConfig();
-    const nativeClient = await this.createNativeClient();
 
     // Build SDK request parameters (camelCase for SDK validation)
     const chatParams: Record<string, unknown> = {
@@ -436,7 +474,10 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
     };
 
     // Reasoning parameters - use SDK's `reasoning` field where possible,
-    // inject unsupported params via the beforeRequest hook
+    // inject unsupported params via the beforeRequest hook.
+    // nonSDKParams is computed upfront and captured by the hook closure
+    // so retries re-apply the same values.
+    let nonSDKParams: NonSDKParams | undefined;
     if (this.capabilities.supportsReasoning) {
       if (
         this.capabilities.supportsReasoningEffort &&
@@ -449,14 +490,16 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
           ),
         };
         // SDK doesn't support include_reasoning yet - inject via hook
-        this.pendingNonSDKParams = { include_reasoning: true };
+        nonSDKParams = { include_reasoning: true };
       } else {
         // DeepSeek V3.2 and similar: SDK doesn't support reasoning.enabled
         // Send empty reasoning object to SDK, inject enabled via hook
         chatParams.reasoning = {};
-        this.pendingNonSDKParams = { reasoning: { enabled: true } };
+        nonSDKParams = { reasoning: { enabled: true } };
       }
     }
+
+    const nativeClient = await this.createNativeClient(nonSDKParams);
 
     if (tools && tools.length > 0) {
       chatParams.tools = toOpenAITools(tools);


### PR DESCRIPTION
Replace the OpenAI SDK workaround (new OpenAI with custom baseURL) with
the native OpenRouter SDK's chat.send() API for cleaner integration:

- Use OpenRouter SDK client with native apiKey, xTitle, serverURL config
- Add message conversion layer (OpenAI snake_case ↔ SDK camelCase)
- Add OpenRouterStreamAggregator to replace OpenAI SDK's
  finalChatCompletion()/totalUsage() which aren't available on EventStream
- Add response conversion (SDK camelCase → OpenAI snake_case format)
- Use beforeRequest hook to inject params the SDK doesn't yet support
  (include_reasoning, reasoning.enabled)
- SDK's reasoning.effort param used natively for O1-style models

https://claude.ai/code/session_014JUMtupLpduFP6zSoaEXH3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core request/streaming path for all OpenRouter-backed models, so subtle schema/stream aggregation mismatches could affect tool calls, reasoning visibility, or usage accounting.
> 
> **Overview**
> Switches `ModelHandlerOpenRouter` from using the OpenAI SDK against OpenRouter endpoints to using the native `@openrouter/sdk` `chat.send()` API for both streaming and non-streaming requests.
> 
> Adds explicit OpenAI↔OpenRouter conversion utilities (snake_case↔camelCase for messages/content parts, tool call fields, and usage) and a new `OpenRouterStreamAggregator` to reconstruct a final OpenAI-shaped `ChatCompletion` (including tool calls, reasoning, and usage) from SDK stream chunks.
> 
> Introduces a `beforeRequest` hook to inject OpenRouter body params the SDK currently strips (e.g., `include_reasoning` and `reasoning.enabled`), while using native SDK `reasoning.effort` where supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26791f8f6d2960af1c15156f292559101456fac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->