### PR TITLE
Add web search configuration and pause_turn support for Anthropic

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -15,7 +15,10 @@ import {
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
-import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
+import {
+  ANTHROPIC_STOP,
+  type ProviderStopReason,
+} from '@agent/modelHandlers/types/StopReasonTypes';
 import {
   NormalizedUsageSchema,
   type NormalizedUsage,
@@ -452,6 +455,29 @@ class ToolUseProcessNode<C> extends BaseNode<
     run.totalRounds += 1;
 
     shared.stopReason = execRes.stopReason;
+
+    // Handle pause_turn: the API paused a long-running turn (e.g. during web search).
+    // Send the response back as-is to let the model continue its turn.
+    if (execRes.stopReason === ANTHROPIC_STOP.PAUSE_TURN) {
+      this.services.logger.info(
+        'API paused long-running turn (pause_turn) — resuming',
+      );
+      // Reconstruct the assistant message from the full content blocks
+      // so the API can resume from where it left off.
+      if (execRes.lastAssistantContent?.length) {
+        shared.messages.push({
+          role: 'assistant',
+          content: execRes.lastAssistantContent,
+        } as ProviderMessage);
+      } else if (execRes.text) {
+        shared.messages.push(modelHandler.createAssistantMessage(execRes.text));
+      }
+      workspace.resetServerToolContent();
+      shared.cycleIndex += 1;
+      shared.cycleResponseTimeMs = 0;
+      shared.cycleNormalizedUsage = undefined;
+      return FlowTransition.CONTINUE;
+    }
 
     if (execRes.endTurn) {
       shared.toolCalls = undefined;
@@ -935,6 +961,7 @@ export function createToolUseCycleFlow<C>(): Flow<
   prepNode.next(callNode);
   callNode.next(processNode);
   processNode.next(dispatchNode);
+  processNode.on(FlowTransition.CONTINUE, prepNode); // pause_turn: re-invoke model
   dispatchNode.on(FlowTransition.CONTINUE, prepNode);
 
   return new Flow<ToolUseCycleShared, CycleParams>(prepNode);

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -56,7 +56,7 @@ import {
   TOOL_USE_SAFETY_BUFFER,
 } from './contextManagementConstants';
 import { AnthropicStreamHandler } from './support/AnthropicStreamHandler';
-import { toAnthropicTools } from './toolConversion';
+import { toAnthropicTools, type WebSearchConfig } from './toolConversion';
 import { ANTHROPIC_STOP } from './types/StopReasonTypes';
 import {
   extractAnthropicWebSearchResults,
@@ -252,6 +252,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
   BetaMessage
 > {
   private cacheControlledBlock?: CacheControlEligibleBlock;
+
+  /** Optional web search configuration for domain filtering, max uses, and localization. */
+  webSearchConfig?: WebSearchConfig;
 
   /** Flag to force compaction on the next API call, set by requestCompaction(). */
   private compactionRequested = false;
@@ -631,6 +634,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (tools && tools.length > 0) {
       options.tools = toAnthropicTools(tools, {
         supportsNativeWebSearch: this.capabilities.supportsNativeWebSearch,
+        supportsDynamicFilteringWebSearch:
+          this.capabilities.supportsDynamicFilteringWebSearch,
+        webSearchConfig: this.webSearchConfig,
       });
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
@@ -1957,6 +1963,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
         'Model refused to generate content - stopping generation',
       );
       return false;
+    }
+
+    // pause_turn: the API paused a long-running turn (e.g. during web search).
+    // Always continue to let the model finish its turn.
+    if (stopReason === ANTHROPIC_STOP.PAUSE_TURN) {
+      this.logger.info('Continuing after pause_turn (long-running web search turn)');
+      return true;
     }
 
     // Continue if we hit max tokens OR stop sequence without an end tag

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -38,14 +38,17 @@ function convertToolSchema(
   return (def.parameters ?? null) as Record<string, unknown> | null;
 }
 
-// Map local tool names to Anthropic remote tool types
+// Map local tool names to Anthropic remote tool types (excluding web_search, handled separately)
 const ANTHROPIC_TOOL_TYPE_MAP: Record<string, string> = {
   bash: 'bash_20250124',
   str_replace_editor: 'text_editor_20250429',
   str_replace_based_edit_tool: 'text_editor_20250429',
-  web_search: 'web_search_20250305',
   memory: 'memory_20250818',
 };
+
+/** Web search tool type versions */
+const WEB_SEARCH_BASIC = 'web_search_20250305' as const;
+const WEB_SEARCH_DYNAMIC_FILTERING = 'web_search_20260209' as const;
 
 /**
  * Convert generic ToolDefinition objects to OpenAI ChatCompletionTool format.
@@ -118,11 +121,36 @@ export function toOpenAIResponseTools(
 }
 
 /**
+ * Web search configuration options for Anthropic API.
+ * Controls domain filtering, usage limits, and result localization.
+ */
+export interface WebSearchConfig {
+  /** Only include results from these domains (cannot be used with blockedDomains). */
+  allowedDomains?: string[];
+  /** Never include results from these domains (cannot be used with allowedDomains). */
+  blockedDomains?: string[];
+  /** Maximum number of searches per request. */
+  maxUses?: number;
+  /** User location for localizing search results. */
+  userLocation?: {
+    type: 'approximate';
+    city?: string;
+    region?: string;
+    country?: string;
+    timezone?: string;
+  };
+}
+
+/**
  * Options for Anthropic tool conversion.
  */
-interface AnthropicToolOptions {
+export interface AnthropicToolOptions {
   /** Whether the model supports native web search. Defaults to false. */
   supportsNativeWebSearch?: boolean;
+  /** Whether the model supports dynamic filtering web search (web_search_20260209). Defaults to false. */
+  supportsDynamicFilteringWebSearch?: boolean;
+  /** Web search configuration (domain filtering, max uses, localization). */
+  webSearchConfig?: WebSearchConfig;
 }
 
 /**
@@ -132,12 +160,24 @@ export function toAnthropicTools(
   defs: ToolDefinition[],
   options: AnthropicToolOptions = {},
 ): ToolUnion[] {
-  const { supportsNativeWebSearch = false } = options;
+  const {
+    supportsNativeWebSearch = false,
+    supportsDynamicFilteringWebSearch = false,
+    webSearchConfig,
+  } = options;
 
   return defs.map<ToolUnion>((d) => {
-    // Check for native/server tools
+    // Handle native web search tool with version selection
+    if (d.name === 'web_search' && supportsNativeWebSearch) {
+      return buildAnthropicWebSearchTool(
+        supportsDynamicFilteringWebSearch,
+        webSearchConfig,
+      );
+    }
+
+    // Check for other native/server tools
     const remoteType = ANTHROPIC_TOOL_TYPE_MAP[d.name];
-    if (remoteType && (d.name !== 'web_search' || supportsNativeWebSearch)) {
+    if (remoteType) {
       return { name: d.name, type: remoteType } as ToolUnion;
     }
 
@@ -155,6 +195,41 @@ export function toAnthropicTools(
       ...(params ? { input_schema: params } : {}),
     } as ToolUnion;
   });
+}
+
+/**
+ * Build the Anthropic web search server tool with the appropriate version
+ * and optional configuration (domain filtering, max uses, localization).
+ */
+function buildAnthropicWebSearchTool(
+  supportsDynamicFiltering: boolean,
+  config?: WebSearchConfig,
+): ToolUnion {
+  const toolType = supportsDynamicFiltering
+    ? WEB_SEARCH_DYNAMIC_FILTERING
+    : WEB_SEARCH_BASIC;
+
+  const tool: Record<string, unknown> = {
+    name: 'web_search',
+    type: toolType,
+  };
+
+  if (config) {
+    if (config.allowedDomains && config.allowedDomains.length > 0) {
+      tool.allowed_domains = config.allowedDomains;
+    }
+    if (config.blockedDomains && config.blockedDomains.length > 0) {
+      tool.blocked_domains = config.blockedDomains;
+    }
+    if (config.maxUses !== undefined && config.maxUses !== null) {
+      tool.max_uses = config.maxUses;
+    }
+    if (config.userLocation) {
+      tool.user_location = config.userLocation;
+    }
+  }
+
+  return tool as unknown as ToolUnion;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR enhances web search capabilities for the Anthropic model handler by adding support for domain filtering, usage limits, result localization, and handling of long-running API turns via the `pause_turn` stop reason.

## Key Changes

- **Web Search Configuration**: Introduced `WebSearchConfig` interface to support:
  - Domain filtering (allowedDomains/blockedDomains)
  - Maximum search uses per request
  - User location for result localization (city, region, country, timezone)

- **Web Search Tool Versioning**: 
  - Removed `web_search` from the static tool type map
  - Added support for two web search versions:
    - `web_search_20250305` (basic)
    - `web_search_20260209` (dynamic filtering)
  - New `buildAnthropicWebSearchTool()` function dynamically constructs web search tools with appropriate version and configuration

- **pause_turn Stop Reason Handling**:
  - Added detection and handling of `pause_turn` stop reason in `ToolUseProcessNode`
  - When API pauses a long-running turn (e.g., during web search), the response is sent back to allow the model to resume
  - Updated flow transition to re-invoke the model preparation node on `pause_turn`
  - Added continuation logic in `ModelHandlerAnthropic` to always continue after `pause_turn`

- **API Integration**:
  - Updated `toAnthropicTools()` to accept `supportsDynamicFilteringWebSearch` and `webSearchConfig` options
  - Modified `ModelHandlerAnthropic` to pass web search configuration to tool conversion
  - Added `webSearchConfig` property to model handler for optional configuration

## Implementation Details

- Web search tool building is now conditional based on model capabilities and configuration
- The `pause_turn` handling preserves the assistant's content blocks to allow seamless resumption
- Configuration is optional and only applied when provided, maintaining backward compatibility

https://claude.ai/code/session_01XgEYuq9XoGUu2fiRMo8rCe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control flow for Anthropic tool-use cycles and modifies how `web_search` tools are constructed/sent to the provider, which could affect multi-round continuation and tool invocation behavior.
> 
> **Overview**
> Adds Anthropic `pause_turn` handling to the tool-use cycle: when the API pauses a long-running turn, the flow now preserves the assistant content blocks, resets per-cycle state, and immediately re-invokes the model (new `processNode.on(FlowTransition.CONTINUE, prepNode)` path).
> 
> Extends Anthropic native `web_search` tool support with optional `WebSearchConfig` (allowed/blocked domains, `max_uses`, `user_location`) and tool version selection between `web_search_20250305` and `web_search_20260209`, wiring these options through `ModelHandlerAnthropic` into `toAnthropicTools()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01743ba71baf2d735964056c1158ba913a00766a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->