### PR TITLE
Interleave user messages and groups chronologically in tool-use mode

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -60,10 +60,6 @@ export class ToolUsePrepareNode<C> extends Node<
         },
       );
 
-    if (userRequest) {
-      logger.userMessage(userRequest);
-    }
-
     const systemMessage = systemPrompt
       ? `${systemPrompt}\n${instructionSuffix}`
       : instructionSuffix;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -147,6 +147,28 @@ async function validateAndGetModelConfig(modelName: string): Promise<void> {
   throw new Error(`Model ${modelName} not found in MODEL_CONFIGS`);
 }
 
+/**
+ * Create a "Run:" stage, optionally logging a user instruction first.
+ *
+ * ORDERING INVARIANT: The instruction is emitted BEFORE the stage is created.
+ * At this point no group context exists, so the message gets no groupId and
+ * its timestamp precedes the stage's startTime.  The chronological timeline
+ * therefore renders the instruction *before* the run group.
+ *
+ * Both operations live in one function so the ordering cannot be
+ * accidentally reversed by future edits.
+ */
+async function beginRunStage(
+  agentLogger: AgentLogger,
+  label: string,
+  instruction: string | undefined,
+): Promise<AgentLogStage> {
+  if (instruction) {
+    agentLogger.userMessage(instruction);
+  }
+  return agentLogger.stage(label);
+}
+
 interface ResolveAgentOptions {
   streamTabIdOverride?: StreamTabId;
 }
@@ -211,19 +233,18 @@ async function resolveAgentBase(
     hasMultipleOutputs: useMultipleOutputs,
   });
 
-  // Log the initial user request BEFORE creating the run group so that
-  // the message timestamp precedes the group's startTime. This ensures
-  // the message renders before the group in the chronological timeline.
-  // Skip on resume (streamTabIdOverride) where the message was already logged.
-  if (
+  const toolUseInstruction =
     setting.agentCategory === AgentCategory.ToolUse &&
     config.instruction?.trim() &&
     !options?.streamTabIdOverride
-  ) {
-    agentLogger.userMessage(config.instruction.trim());
-  }
+      ? config.instruction.trim()
+      : undefined;
 
-  const parentStage = await agentLogger.stage(`Run: ${config.agent}`);
+  const parentStage = await beginRunStage(
+    agentLogger,
+    `Run: ${config.agent}`,
+    toolUseInstruction,
+  );
   const storageKey: StorageKey = parentStage.id
     ? normalizeRunId(parentStage.id)
     : (executionId as StorageKey);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -211,6 +211,18 @@ async function resolveAgentBase(
     hasMultipleOutputs: useMultipleOutputs,
   });
 
+  // Log the initial user request BEFORE creating the run group so that
+  // the message timestamp precedes the group's startTime. This ensures
+  // the message renders before the group in the chronological timeline.
+  // Skip on resume (streamTabIdOverride) where the message was already logged.
+  if (
+    setting.agentCategory === AgentCategory.ToolUse &&
+    config.instruction?.trim() &&
+    !options?.streamTabIdOverride
+  ) {
+    agentLogger.userMessage(config.instruction.trim());
+  }
+
   const parentStage = await agentLogger.stage(`Run: ${config.agent}`);
   const storageKey: StorageKey = parentStage.id
     ? normalizeRunId(parentStage.id)

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -124,12 +124,7 @@ export class AgentLogger {
     options: LogOptions = {},
   ): void {
     logger[level](this.streamId, message, {
-      // Distinguish "caller passed explicit groupId" (even if undefined/null)
-      // from "caller didn't specify" (inherit from async context).
-      groupId:
-        'groupId' in options
-          ? (options.groupId ?? undefined)
-          : this.resolveActiveGroupId(),
+      groupId: options.groupId ?? this.resolveActiveGroupId(),
       messageType: options.messageType,
       isAgent: this.isAgentLogger,
       data: options.data,
@@ -287,12 +282,8 @@ export class AgentLogger {
     );
   }
 
-  userMessage(message: string, groupId?: string): void {
-    // User messages are top-level input — never inherit group context.
-    // Pass groupId explicitly (defaults to undefined) to prevent the
-    // log() fallback to resolveActiveGroupId().
+  userMessage(message: string): void {
     this.log('info', message, {
-      groupId: groupId ?? undefined,
       messageType: MESSAGE_TYPES.USER_MESSAGE,
     });
   }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -494,15 +494,21 @@ export class ProgressEventHandler {
     // Legacy fallback: old tool-use sessions saved before beginRunStage()
     // started emitting logger.userMessage() won't have a userMessage log entry.
     // Synthesise one from runInstructions so the instruction still renders.
-    // Check ALL messages (not just [0]) to avoid duplicates with data from
-    // intermediate versions that logged userMessage inside the group context.
+    // Scope the check to the active run's instruction text so follow-up
+    // userMessages from other turns don't suppress the fallback.
     if (
       activeRunId &&
-      this.getStreamCategory(stream) === AgentCategory.ToolUse &&
-      !messages.some((m) => m.messageType === 'userMessage')
+      this.getStreamCategory(stream) === AgentCategory.ToolUse
     ) {
       const instructionText = runInstructions[activeRunId]?.text?.trim();
-      if (instructionText) {
+      if (
+        instructionText &&
+        !messages.some(
+          (m) =>
+            m.messageType === 'userMessage' &&
+            m.text?.trim() === instructionText,
+        )
+      ) {
         messages = [
           {
             id: `tool-use-instruction:${activeRunId}`,

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -494,10 +494,12 @@ export class ProgressEventHandler {
     // Legacy fallback: old tool-use sessions saved before beginRunStage()
     // started emitting logger.userMessage() won't have a userMessage log entry.
     // Synthesise one from runInstructions so the instruction still renders.
+    // Check ALL messages (not just [0]) to avoid duplicates with data from
+    // intermediate versions that logged userMessage inside the group context.
     if (
       activeRunId &&
       this.getStreamCategory(stream) === AgentCategory.ToolUse &&
-      messages[0]?.messageType !== 'userMessage'
+      !messages.some((m) => m.messageType === 'userMessage')
     ) {
       const instructionText = runInstructions[activeRunId]?.text?.trim();
       if (instructionText) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -491,7 +491,7 @@ export class ProgressEventHandler {
       this.state.getRunInstructions(stream).entries(),
     );
 
-    // Legacy fallback: old tool-use sessions saved before ToolUsePrepareNode
+    // Legacy fallback: old tool-use sessions saved before beginRunStage()
     // started emitting logger.userMessage() won't have a userMessage log entry.
     // Synthesise one from runInstructions so the instruction still renders.
     if (

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -47,11 +47,6 @@ interface GroupTree {
   messages: LogMessageData[];
 }
 
-/** Union type for chronologically merged user messages and group trees */
-type TimelineItem =
-  | { key: string; time: number; kind: 'message'; message: LogMessageData }
-  | { key: string; time: number; kind: 'group'; tree: GroupTree };
-
 const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
@@ -102,8 +97,7 @@ export class TaskGroupList extends LitElement {
 
   /** Memoized tree output from buildGroupTree() - recomputed only when inputs change */
   private cachedTree: GroupTree[] = [];
-  private cachedUserMessages: LogMessageData[] = [];
-  private cachedOtherUngrouped: LogMessageData[] = [];
+  private cachedUngrouped: LogMessageData[] = [];
 
   /** O(1) lookup from groupId → tree node. Built during buildGroupTree(). */
   private groupNodeIndex = new Map<string, GroupTree>();
@@ -139,8 +133,7 @@ export class TaskGroupList extends LitElement {
 
     if (groupsChanged) {
       // Structural change — always full rebuild
-      [this.cachedTree, this.cachedUserMessages, this.cachedOtherUngrouped] =
-        this.buildGroupTree();
+      [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
     } else if (messagesChanged) {
       // Only messages changed — use Lit's old value to pick incremental path
       const prevMessages = changedProperties.get('messages') as
@@ -158,8 +151,7 @@ export class TaskGroupList extends LitElement {
         this.appendNewMessages(prevCount);
       } else {
         // Messages shrunk (e.g. clear) — full rebuild
-        [this.cachedTree, this.cachedUserMessages, this.cachedOtherUngrouped] =
-          this.buildGroupTree();
+        [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
       }
     }
 
@@ -181,23 +173,14 @@ export class TaskGroupList extends LitElement {
   private appendNewMessages(startIndex: number): void {
     for (let i = startIndex; i < this.messages.length; i++) {
       const msg = this.messages[i];
-      if (msg.messageType === 'userMessage') {
-        // User messages always go to the dedicated list regardless of groupId.
-        // See buildGroupTree() for rationale.
-        this.cachedUserMessages = this.insertMessageSorted(
-          this.cachedUserMessages,
+      const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
+      if (node) {
+        node.messages = this.insertMessageSorted(node.messages, msg);
+      } else {
+        this.cachedUngrouped = this.insertMessageSorted(
+          this.cachedUngrouped,
           msg,
         );
-      } else {
-        const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
-        if (node) {
-          node.messages = this.insertMessageSorted(node.messages, msg);
-        } else {
-          this.cachedOtherUngrouped = this.insertMessageSorted(
-            this.cachedOtherUngrouped,
-            msg,
-          );
-        }
       }
     }
   }
@@ -244,20 +227,8 @@ export class TaskGroupList extends LitElement {
 
   /** Replace a single message ref in the cached tree. O(1) node lookup + O(k) findIndex. */
   private replaceSingleMessage(msg: LogMessageData): void {
-    // User messages are always in cachedUserMessages (never in group nodes),
-    // matching the classification order in buildGroupTree/appendNewMessages.
-    if (msg.messageType === 'userMessage') {
-      const idx = this.cachedUserMessages.findIndex((m) => m.id === msg.id);
-      if (idx >= 0) {
-        const updated = [...this.cachedUserMessages];
-        updated[idx] = msg;
-        this.cachedUserMessages = updated;
-      }
-      return;
-    }
-
     // Try group node first (O(1) lookup). A message with groupId may live in
-    // cachedOtherUngrouped if the group didn't exist at classification time,
+    // cachedUngrouped if the group didn't exist at classification time,
     // so fall through to ungrouped search on miss.
     if (msg.groupId) {
       const node = this.groupNodeIndex.get(msg.groupId);
@@ -272,12 +243,11 @@ export class TaskGroupList extends LitElement {
       }
     }
 
-    // Search other ungrouped
-    const idx = this.cachedOtherUngrouped.findIndex((m) => m.id === msg.id);
+    const idx = this.cachedUngrouped.findIndex((m) => m.id === msg.id);
     if (idx >= 0) {
-      const updated = [...this.cachedOtherUngrouped];
+      const updated = [...this.cachedUngrouped];
       updated[idx] = msg;
-      this.cachedOtherUngrouped = updated;
+      this.cachedUngrouped = updated;
     }
   }
 
@@ -303,13 +273,11 @@ export class TaskGroupList extends LitElement {
 
   /**
    * Build hierarchical tree from flat groups array.
-   * Returns [tree, userMessages, otherUngrouped] tuple.
-   *
-   * User messages are separated from other ungrouped messages to support
-   * the tool-use rendering order: user messages first, then groups, then
-   * other ungrouped messages (preserving chronological order for errors).
+   * Returns [tree, ungrouped] tuple. Messages are classified purely by
+   * groupId — the backend (AgentLogger) is responsible for ensuring user
+   * messages don't inherit run-group IDs via AsyncLocalStorage.
    */
-  private buildGroupTree(): [GroupTree[], LogMessageData[], LogMessageData[]] {
+  private buildGroupTree(): [GroupTree[], LogMessageData[]] {
     const groupMap = new Map<string, TaskGroup>();
     const childrenMap = new Map<string, TaskGroup[]>();
 
@@ -323,7 +291,7 @@ export class TaskGroupList extends LitElement {
       }
     }
 
-    // Sort messages by timestamp and index by groupId
+    // Sort messages by timestamp and classify by groupId
     const messageOrder = new Map(
       this.messages.map((message, index) => [message.id, index]),
     );
@@ -334,22 +302,15 @@ export class TaskGroupList extends LitElement {
       return (messageOrder.get(a.id) ?? 0) - (messageOrder.get(b.id) ?? 0);
     });
     const messagesByGroup = new Map<string, LogMessageData[]>();
-    const userMessages: LogMessageData[] = [];
-    const otherUngrouped: LogMessageData[] = [];
+    const ungrouped: LogMessageData[] = [];
 
     for (const msg of sortedMessages) {
-      if (msg.messageType === 'userMessage') {
-        // User messages always go to the dedicated list regardless of groupId.
-        // Follow-ups consumed during a run cycle inherit the run's groupId via
-        // AsyncLocalStorage, but should render in the top-level user section,
-        // not nested among progress entries inside the group.
-        userMessages.push(msg);
-      } else if (msg.groupId && groupMap.has(msg.groupId)) {
+      if (msg.groupId && groupMap.has(msg.groupId)) {
         const bucket = messagesByGroup.get(msg.groupId) ?? [];
         bucket.push(msg);
         messagesByGroup.set(msg.groupId, bucket);
       } else {
-        otherUngrouped.push(msg);
+        ungrouped.push(msg);
       }
     }
 
@@ -382,7 +343,7 @@ export class TaskGroupList extends LitElement {
       })
       .map(buildNode);
 
-    return [tree, userMessages, otherUngrouped];
+    return [tree, ungrouped];
   }
 
   /** Check if a root group should be visible */
@@ -435,61 +396,6 @@ export class TaskGroupList extends LitElement {
     }
     // Re-render to add/remove children from the DOM (lazy collapsed groups)
     this.requestUpdate();
-  }
-
-  /**
-   * Merge user messages and group trees into chronological order.
-   * Both inputs are already sorted, so this is an O(n+m) merge.
-   * User messages with equal timestamps sort before groups (user sends, then agent starts).
-   */
-  private mergeTimelineItems(): TimelineItem[] {
-    const items: TimelineItem[] = [];
-    let mi = 0;
-    let gi = 0;
-    const messages = this.cachedUserMessages;
-    const groups = this.cachedTree;
-
-    while (mi < messages.length && gi < groups.length) {
-      const mTime = messages[mi].timestamp ?? 0;
-      const gTime = groups[gi].group.startTime ?? 0;
-      if (mTime <= gTime) {
-        items.push({
-          key: messages[mi].id,
-          time: mTime,
-          kind: 'message',
-          message: messages[mi],
-        });
-        mi++;
-      } else {
-        items.push({
-          key: groups[gi].group.id,
-          time: gTime,
-          kind: 'group',
-          tree: groups[gi],
-        });
-        gi++;
-      }
-    }
-    while (mi < messages.length) {
-      items.push({
-        key: messages[mi].id,
-        time: messages[mi].timestamp ?? 0,
-        kind: 'message',
-        message: messages[mi],
-      });
-      mi++;
-    }
-    while (gi < groups.length) {
-      items.push({
-        key: groups[gi].group.id,
-        time: groups[gi].group.startTime ?? 0,
-        kind: 'group',
-        tree: groups[gi],
-      });
-      gi++;
-    }
-
-    return items;
   }
 
   /** Render ungrouped messages as log entries with guard() for change detection */
@@ -607,19 +513,31 @@ export class TaskGroupList extends LitElement {
     }
 
     if (this.isToolUse) {
-      // Tool-use: interleave user messages and groups chronologically,
-      // then render other ungrouped messages (errors etc) at the end
+      // Tool-use: interleave ungrouped messages (user input, errors, etc.)
+      // with groups chronologically so the conversation reads top-to-bottom.
+      const timeline = [
+        ...this.cachedUngrouped.map((m) => ({
+          key: m.id,
+          time: m.timestamp ?? 0,
+          msg: m,
+        })),
+        ...this.cachedTree.map((t) => ({
+          key: t.group.id,
+          time: t.group.startTime ?? 0,
+          tree: t,
+        })),
+      ].sort((a, b) => a.time - b.time);
+
       return html`
         <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
           ${repeat(
-            this.mergeTimelineItems(),
+            timeline,
             (item) => item.key,
             (item) =>
-              item.kind === 'message'
-                ? guard([item.message], () => formatLogEntry(item.message))
-                : this.renderGroupNode(item.tree),
+              'msg' in item
+                ? guard([item.msg], () => formatLogEntry(item.msg))
+                : this.renderGroupNode(item.tree!),
           )}
-          ${this.renderUngroupedMessages(this.cachedOtherUngrouped)}
         </vscode-scrollable>
       `;
     }
@@ -632,10 +550,7 @@ export class TaskGroupList extends LitElement {
           (t) => t.group.id,
           (t) => this.renderGroupNode(t),
         )}
-        ${this.renderUngroupedMessages([
-          ...this.cachedUserMessages,
-          ...this.cachedOtherUngrouped,
-        ])}
+        ${this.renderUngroupedMessages(this.cachedUngrouped)}
       </vscode-scrollable>
     `;
   }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -274,8 +274,8 @@ export class TaskGroupList extends LitElement {
   /**
    * Build hierarchical tree from flat groups array.
    * Returns [tree, ungrouped] tuple. Messages are classified purely by
-   * groupId — the backend (AgentLogger) is responsible for ensuring user
-   * messages don't inherit run-group IDs via AsyncLocalStorage.
+   * groupId — initial user messages have no groupId (logged before the
+   * run stage via beginRunStage), while follow-ups inherit their group.
    */
   private buildGroupTree(): [GroupTree[], LogMessageData[]] {
     const groupMap = new Map<string, TaskGroup>();

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -502,30 +502,50 @@ export class TaskGroupList extends LitElement {
       `;
     }
 
-    // Interleave ungrouped messages with groups chronologically.
-    // isGroupVisible() inside renderGroupNode() handles per-mode filtering.
-    const timeline = [
-      ...this.cachedUngrouped.map((m) => ({
-        key: m.id,
-        time: m.timestamp ?? 0,
-        msg: m,
-      })),
-      ...this.cachedTree.map((t) => ({
-        key: t.group.id,
-        time: t.group.startTime ?? 0,
-        tree: t,
-      })),
-    ].sort((a, b) => a.time - b.time);
+    if (this.isToolUse) {
+      // Tool-use: interleave ungrouped messages (user input, follow-ups, errors)
+      // with groups chronologically so the conversation reads top-to-bottom.
+      const timeline = [
+        ...this.cachedUngrouped.map((m) => ({
+          key: m.id,
+          time: m.timestamp ?? 0,
+          msg: m,
+        })),
+        ...this.cachedTree.map((t) => ({
+          key: t.group.id,
+          time: t.group.startTime ?? 0,
+          tree: t,
+        })),
+      ].sort((a, b) => a.time - b.time);
 
+      return html`
+        <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
+          ${repeat(
+            timeline,
+            (item) => item.key,
+            (item) =>
+              'msg' in item
+                ? guard([item.msg], () => formatLogEntry(item.msg))
+                : this.renderGroupNode(item.tree!),
+          )}
+        </vscode-scrollable>
+      `;
+    }
+
+    // Workflow: groups first, then ungrouped messages.
+    // Workflow stages are hierarchical (not conversational), so structure-first
+    // ordering keeps stage execution visually separate from stray messages.
     return html`
       <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
         ${repeat(
-          timeline,
-          (item) => item.key,
-          (item) =>
-            'msg' in item
-              ? guard([item.msg], () => formatLogEntry(item.msg))
-              : this.renderGroupNode(item.tree!),
+          this.cachedTree,
+          (t) => t.group.id,
+          (t) => this.renderGroupNode(t),
+        )}
+        ${repeat(
+          this.cachedUngrouped,
+          (m) => m.id,
+          (m) => guard([m], () => formatLogEntry(m)),
         )}
       </vscode-scrollable>
     `;

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -47,6 +47,11 @@ interface GroupTree {
   messages: LogMessageData[];
 }
 
+/** Union type for chronologically merged user messages and group trees */
+type TimelineItem =
+  | { key: string; time: number; kind: 'message'; message: LogMessageData }
+  | { key: string; time: number; kind: 'group'; tree: GroupTree };
+
 const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
@@ -432,6 +437,61 @@ export class TaskGroupList extends LitElement {
     this.requestUpdate();
   }
 
+  /**
+   * Merge user messages and group trees into chronological order.
+   * Both inputs are already sorted, so this is an O(n+m) merge.
+   * User messages with equal timestamps sort before groups (user sends, then agent starts).
+   */
+  private mergeTimelineItems(): TimelineItem[] {
+    const items: TimelineItem[] = [];
+    let mi = 0;
+    let gi = 0;
+    const messages = this.cachedUserMessages;
+    const groups = this.cachedTree;
+
+    while (mi < messages.length && gi < groups.length) {
+      const mTime = messages[mi].timestamp ?? 0;
+      const gTime = groups[gi].group.startTime ?? 0;
+      if (mTime <= gTime) {
+        items.push({
+          key: messages[mi].id,
+          time: mTime,
+          kind: 'message',
+          message: messages[mi],
+        });
+        mi++;
+      } else {
+        items.push({
+          key: groups[gi].group.id,
+          time: gTime,
+          kind: 'group',
+          tree: groups[gi],
+        });
+        gi++;
+      }
+    }
+    while (mi < messages.length) {
+      items.push({
+        key: messages[mi].id,
+        time: messages[mi].timestamp ?? 0,
+        kind: 'message',
+        message: messages[mi],
+      });
+      mi++;
+    }
+    while (gi < groups.length) {
+      items.push({
+        key: groups[gi].group.id,
+        time: groups[gi].group.startTime ?? 0,
+        kind: 'group',
+        tree: groups[gi],
+      });
+      gi++;
+    }
+
+    return items;
+  }
+
   /** Render ungrouped messages as log entries with guard() for change detection */
   private renderUngroupedMessages(messages: LogMessageData[]) {
     if (messages.length === 0) return nothing;
@@ -546,21 +606,36 @@ export class TaskGroupList extends LitElement {
       `;
     }
 
-    // Tool-use: user messages first, then tree, then other ungrouped (errors etc)
-    // Workflow: tree first, then all ungrouped messages
-    const [ungroupedBefore, ungroupedAfter] = this.isToolUse
-      ? [this.cachedUserMessages, this.cachedOtherUngrouped]
-      : [[], [...this.cachedUserMessages, ...this.cachedOtherUngrouped]];
+    if (this.isToolUse) {
+      // Tool-use: interleave user messages and groups chronologically,
+      // then render other ungrouped messages (errors etc) at the end
+      return html`
+        <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
+          ${repeat(
+            this.mergeTimelineItems(),
+            (item) => item.key,
+            (item) =>
+              item.kind === 'message'
+                ? guard([item.message], () => formatLogEntry(item.message))
+                : this.renderGroupNode(item.tree),
+          )}
+          ${this.renderUngroupedMessages(this.cachedOtherUngrouped)}
+        </vscode-scrollable>
+      `;
+    }
 
+    // Workflow: tree first, then all ungrouped messages
     return html`
       <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
-        ${this.renderUngroupedMessages(ungroupedBefore)}
         ${repeat(
           this.cachedTree,
           (t) => t.group.id,
           (t) => this.renderGroupNode(t),
         )}
-        ${this.renderUngroupedMessages(ungroupedAfter)}
+        ${this.renderUngroupedMessages([
+          ...this.cachedUserMessages,
+          ...this.cachedOtherUngrouped,
+        ])}
       </vscode-scrollable>
     `;
   }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -398,16 +398,6 @@ export class TaskGroupList extends LitElement {
     this.requestUpdate();
   }
 
-  /** Render ungrouped messages as log entries with guard() for change detection */
-  private renderUngroupedMessages(messages: LogMessageData[]) {
-    if (messages.length === 0) return nothing;
-    return repeat(
-      messages,
-      (m) => m.id,
-      (m) => guard([m], () => formatLogEntry(m)),
-    );
-  }
-
   /** Render child group header inline (only called for non-root groups) */
   private renderGroupHeader(group: TaskGroup): TemplateResult {
     const formattedStartTime = getTimeFormatter().format(
@@ -512,45 +502,31 @@ export class TaskGroupList extends LitElement {
       `;
     }
 
-    if (this.isToolUse) {
-      // Tool-use: interleave ungrouped messages (user input, errors, etc.)
-      // with groups chronologically so the conversation reads top-to-bottom.
-      const timeline = [
-        ...this.cachedUngrouped.map((m) => ({
-          key: m.id,
-          time: m.timestamp ?? 0,
-          msg: m,
-        })),
-        ...this.cachedTree.map((t) => ({
-          key: t.group.id,
-          time: t.group.startTime ?? 0,
-          tree: t,
-        })),
-      ].sort((a, b) => a.time - b.time);
+    // Interleave ungrouped messages with groups chronologically.
+    // isGroupVisible() inside renderGroupNode() handles per-mode filtering.
+    const timeline = [
+      ...this.cachedUngrouped.map((m) => ({
+        key: m.id,
+        time: m.timestamp ?? 0,
+        msg: m,
+      })),
+      ...this.cachedTree.map((t) => ({
+        key: t.group.id,
+        time: t.group.startTime ?? 0,
+        tree: t,
+      })),
+    ].sort((a, b) => a.time - b.time);
 
-      return html`
-        <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
-          ${repeat(
-            timeline,
-            (item) => item.key,
-            (item) =>
-              'msg' in item
-                ? guard([item.msg], () => formatLogEntry(item.msg))
-                : this.renderGroupNode(item.tree!),
-          )}
-        </vscode-scrollable>
-      `;
-    }
-
-    // Workflow: tree first, then all ungrouped messages
     return html`
       <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
         ${repeat(
-          this.cachedTree,
-          (t) => t.group.id,
-          (t) => this.renderGroupNode(t),
+          timeline,
+          (item) => item.key,
+          (item) =>
+            'msg' in item
+              ? guard([item.msg], () => formatLogEntry(item.msg))
+              : this.renderGroupNode(item.tree!),
         )}
-        ${this.renderUngroupedMessages(this.cachedUngrouped)}
       </vscode-scrollable>
     `;
   }


### PR DESCRIPTION
## Summary
This PR refactors the rendering logic in TaskGroupList to display user messages and task groups in chronological order when in tool-use mode, rather than showing all user messages before all groups.

## Key Changes
- Added `TimelineItem` union type to represent either a user message or group tree with timing information
- Implemented `mergeTimelineItems()` method that performs an O(n+m) merge of two pre-sorted arrays (user messages and groups) into chronological order
- Updated the render logic to use the merged timeline for tool-use mode, while preserving the original behavior (groups first, then messages) for workflow mode
- User messages with equal timestamps sort before groups, reflecting the semantic ordering (user sends message, then agent starts processing)

## Implementation Details
- The merge algorithm takes advantage of both input arrays being pre-sorted, avoiding the need for a full sort
- Each timeline item includes a `key` field for efficient change detection with Lit's `repeat()` directive
- The `kind` field disambiguates between message and group items for conditional rendering
- Tool-use mode now interleaves messages and groups chronologically, then appends other ungrouped messages (errors, etc.) at the end
- Workflow mode behavior remains unchanged: groups first, followed by all ungrouped messages

https://claude.ai/code/session_01GxxkB6HTGPHqKeKdhPpUNK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core logging/groupId behavior and progress UI ordering for tool-use sessions, which could affect message grouping/timeline rendering across runs.
> 
> **Overview**
> Improves tool-use progress rendering by ensuring the initial instruction is logged as an ungrouped `userMessage` *before* the `Run:` stage starts, so it can be interleaved chronologically with run groups.
> 
> Refactors `TaskGroupList` to classify messages purely by `groupId` and, in tool-use mode, render a single timestamp-sorted timeline that mixes ungrouped messages and run groups; workflow mode keeps structure-first ordering. Updates the progress view legacy fallback to only synthesize the instruction message when the active run’s instruction text is not already present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6ec487d8adbb59b8f5c35e7d30a52e633f1ace. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->