### PR TITLE
perf: simplify progress view rendering pipeline

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -310,6 +310,8 @@ export class ProgressApp extends BaseWebviewApp {
     if (
       prevLog.logs !== streamLogs.logs ||
       prevLog.taskGroups !== streamState.taskGroups ||
+      prevLog.lastUpdatedLogId !== streamLogs.lastUpdatedLogId ||
+      prevLog.lastUpdatedLogIndex !== streamLogs.lastUpdatedLogIndex ||
       prevLog.runId !== runId ||
       prevLog.isToolUse !== isToolUse ||
       prevLog.hasStreams !== hasStreams ||
@@ -318,6 +320,8 @@ export class ProgressApp extends BaseWebviewApp {
       this.streamLogContextValue = {
         logs: streamLogs.logs,
         taskGroups: streamState.taskGroups,
+        lastUpdatedLogId: streamLogs.lastUpdatedLogId,
+        lastUpdatedLogIndex: streamLogs.lastUpdatedLogIndex,
         runId,
         isToolUse,
         hasStreams,

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -1,9 +1,8 @@
 /**
- * LogList component - declarative log rendering with per-stream DOM caching.
+ * LogList component - declarative log rendering for the active stream.
  *
  * Consumes streamLogContext to get groups, messages, activeRunId, and isToolUse.
- * Renders one TaskGroupList per visited stream, hiding inactive ones with
- * display:none. Tab switching toggles visibility — zero DOM re-creation.
+ * Renders a single TaskGroupList for the active stream only.
  *
  * Handles event delegation for clicks, toggles, and file links.
  *
@@ -14,8 +13,7 @@
 import { LitElement, html, type TemplateResult } from 'lit';
 import { consume } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
-import { createRef, ref, type Ref } from 'lit/directives/ref.js';
-import { repeat } from 'lit/directives/repeat.js';
+import { createRef, ref } from 'lit/directives/ref.js';
 import { z } from 'zod';
 
 // Local imports - side-effect: register component
@@ -60,16 +58,6 @@ const LogListStateSchema = z
   })
   .catch({ groupToggleStates: [] });
 
-/** Cached per-stream data and DOM state */
-interface CachedStream {
-  groups: TaskGroup[];
-  messages: LogMessageData[];
-  activeRunId: string | null;
-  isToolUse: boolean;
-  toggleStates: ToggleStateStore;
-  ref: Ref<TaskGroupList>;
-}
-
 @customElement('log-list')
 export class LogList extends LitElement {
   static override styles = [
@@ -96,6 +84,14 @@ export class LogList extends LitElement {
     return this.streamContext?.runId ?? null;
   }
 
+  private get lastUpdatedLogId(): string | null {
+    return this.streamContext?.lastUpdatedLogId ?? null;
+  }
+
+  private get lastUpdatedLogIndex(): number | null {
+    return this.streamContext?.lastUpdatedLogIndex ?? null;
+  }
+
   private get isToolUse(): boolean {
     return this.streamContext?.isToolUse ?? false;
   }
@@ -104,13 +100,10 @@ export class LogList extends LitElement {
     return this.streamContext?.hasStreams ?? false;
   }
 
-  /** Max cached stream DOM trees. Oldest non-active entries are evicted beyond this. */
-  private static readonly MAX_CACHED_STREAMS = 5;
-
-  /** Per-stream DOM cache: one TaskGroupList per visited stream */
-  private streamCache = new Map<string, CachedStream>();
   private storage = createWebviewStorage(vscode);
   private activeStreamId: string | null = null;
+  private activeToggleStates: ToggleStateStore | null = null;
+  private taskGroupListRef = createRef<TaskGroupList>();
   private shouldScrollToBottom = false;
 
   override connectedCallback(): void {
@@ -130,58 +123,26 @@ export class LogList extends LitElement {
 
     // Detect stream switch
     if (streamId !== this.activeStreamId) {
-      this.activeStreamId = streamId;
-      this.shouldScrollToBottom = true;
-    }
-
-    // All streams removed — drop the entire cache
-    if (!this.hasStreams && this.streamCache.size > 0) {
-      this.streamCache.clear();
-      return;
-    }
-
-    // Update cache for active stream with latest context data
-    if (streamId) {
-      const entry = this.getOrCreateEntry(streamId);
-      entry.groups = this.groups;
-      entry.messages = this.messages;
-      entry.activeRunId = this.activeRunId;
-      entry.isToolUse = this.isToolUse;
-
-      // Evict oldest non-active entries when cache exceeds cap
-      this.evictStaleCacheEntries();
+      this.switchActiveStream(streamId);
     }
   }
 
   override render(): TemplateResult {
-    if (this.streamCache.size === 0 || !this.hasStreams) {
-      return html`<task-group-list
-        .hasStreams=${this.hasStreams}
-      ></task-group-list>`;
-    }
-
-    return html`${repeat(
-      this.streamCache,
-      ([id]) => id,
-      ([id, data]) => html`
-        <task-group-list
-          ${ref(data.ref)}
-          style=${id === this.activeStreamId ? '' : 'display:none'}
-          .groups=${data.groups}
-          .messages=${data.messages}
-          .activeRunId=${data.activeRunId}
-          .isToolUse=${data.isToolUse}
-          .hasStreams=${this.hasStreams}
-          .toggleStates=${data.toggleStates}
-        ></task-group-list>
-      `,
-    )}`;
+    return html`<task-group-list
+      ${ref(this.taskGroupListRef)}
+      .groups=${this.groups}
+      .messages=${this.messages}
+      .lastUpdatedLogId=${this.lastUpdatedLogId}
+      .lastUpdatedLogIndex=${this.lastUpdatedLogIndex}
+      .activeRunId=${this.activeRunId}
+      .isToolUse=${this.isToolUse}
+      .hasStreams=${this.hasStreams}
+      .toggleStates=${this.activeToggleStates}
+    ></task-group-list>`;
   }
 
   override updated(): void {
-    const activeEl = this.activeStreamId
-      ? this.streamCache.get(this.activeStreamId)?.ref.value
-      : undefined;
+    const activeEl = this.taskGroupListRef.value;
 
     if (this.shouldScrollToBottom) {
       // Force scroll to bottom when switching to a different stream tab.
@@ -204,26 +165,16 @@ export class LogList extends LitElement {
   // Private methods
   // ============================================================
 
-  /** Evict oldest non-active cache entries when over the cap */
-  private evictStaleCacheEntries(): void {
-    if (this.streamCache.size <= LogList.MAX_CACHED_STREAMS) return;
-    for (const [id] of this.streamCache) {
-      if (id === this.activeStreamId) continue;
-      this.streamCache.delete(id);
-      if (this.streamCache.size <= LogList.MAX_CACHED_STREAMS) break;
-    }
+  private switchActiveStream(streamId: string | null): void {
+    this.activeStreamId = streamId;
+    this.shouldScrollToBottom = true;
+    this.activeToggleStates = streamId
+      ? this.createToggleStateStore(streamId)
+      : null;
   }
 
-  /** Get or create a cached entry for a stream, loading persisted toggle states */
-  private getOrCreateEntry(streamId: string): CachedStream {
-    let entry = this.streamCache.get(streamId);
-    if (entry) {
-      // Move to end of Map iteration order so LRU eviction works correctly
-      this.streamCache.delete(streamId);
-      this.streamCache.set(streamId, entry);
-      return entry;
-    }
-
+  /** Create toggle state store for active stream from persisted state. */
+  private createToggleStateStore(streamId: string): ToggleStateStore {
     const stateManager = new PersistedState(
       this.storage,
       `logListState:${streamId}`,
@@ -240,17 +191,7 @@ export class LogList extends LitElement {
     if (previous.groupToggleStates.length > 0) {
       toggleStates.load(previous.groupToggleStates);
     }
-
-    entry = {
-      groups: [],
-      messages: [],
-      activeRunId: null,
-      isToolUse: false,
-      toggleStates,
-      ref: createRef<TaskGroupList>(),
-    };
-    this.streamCache.set(streamId, entry);
-    return entry;
+    return toggleStates;
   }
 
   /** Handle click events for file links, copy buttons, etc. */

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -21,10 +21,10 @@ import { STREAM_STATUS } from '@shared/schemas';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { scrollToBottom } from '@shared/utils/dom';
 import { getGettingStartedHtml } from '@shared/utils/uiConstants';
-import { formatDuration } from '@utils/core';
 
 // Local imports - shared styles
 import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+import { formatDuration } from '@utils/core';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS, GROUP_DOM_IDS } from '../constants';
@@ -46,6 +46,10 @@ interface GroupTree {
   children: GroupTree[];
   messages: LogMessageData[];
 }
+
+type ToolUseTimelineItem =
+  | { key: string; time: number; msg: LogMessageData }
+  | { key: string; time: number; tree: GroupTree };
 
 const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
@@ -80,6 +84,10 @@ export class TaskGroupList extends LitElement {
   /** All log messages to render */
   @property({ attribute: false }) messages: LogMessageData[] = [];
 
+  /** Metadata for the latest message update (when provided by stream context). */
+  @property({ attribute: false }) lastUpdatedLogId: string | null = null;
+  @property({ attribute: false }) lastUpdatedLogIndex: number | null = null;
+
   /** Currently visible run ID (null = show all) */
   @property({ attribute: false }) activeRunId: string | null = null;
 
@@ -98,12 +106,21 @@ export class TaskGroupList extends LitElement {
   /** Memoized tree output from buildGroupTree() - recomputed only when inputs change */
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
+  private cachedToolUseTimeline: ToolUseTimelineItem[] = [];
 
   /** O(1) lookup from groupId → tree node. Built during buildGroupTree(). */
   private groupNodeIndex = new Map<string, GroupTree>();
 
   /** Memoized set of root group IDs for isGroupVisible() */
   private cachedRootGroupIds: Set<string> = new Set();
+
+  /** Expanded scopes for "show older entries" progressive rendering. */
+  private expandedMessageScopes = new Set<string>();
+
+  private static readonly DEFAULT_VISIBLE_MESSAGES = 300;
+  private static readonly DEFAULT_VISIBLE_TIMELINE_ITEMS = 500;
+  private static readonly TOOLUSE_TIMELINE_SCOPE = 'tooluse-timeline';
+  private static readonly WORKFLOW_UNGROUPED_SCOPE = 'workflow-ungrouped';
 
   /** Reference to the scroll container */
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
@@ -124,34 +141,65 @@ export class TaskGroupList extends LitElement {
   }
 
   override willUpdate(changedProperties: Map<string, unknown>): void {
+    if (!this.hasStreams && this.expandedMessageScopes.size > 0) {
+      this.expandedMessageScopes.clear();
+    }
+
     if (changedProperties.has('groups')) {
       this.checkForCompletedRuns();
     }
 
     const groupsChanged = changedProperties.has('groups');
     const messagesChanged = changedProperties.has('messages');
+    const modeChanged = changedProperties.has('isToolUse');
+    const prevMessages = messagesChanged
+      ? ((changedProperties.get('messages') as LogMessageData[] | undefined) ??
+        [])
+      : [];
+    const prevCount = prevMessages.length;
 
     if (groupsChanged) {
       // Structural change — always full rebuild
       [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
     } else if (messagesChanged) {
-      // Only messages changed — use Lit's old value to pick incremental path
-      const prevMessages = changedProperties.get('messages') as
-        | LogMessageData[]
-        | undefined;
-      const prevCount = prevMessages?.length ?? 0;
-
-      if (this.messages.length === prevCount && prevMessages) {
+      if (this.messages.length === prevCount) {
         // Same length: text-only update (e.g. streaming UPDATE_LOG).
-        // Propagate fresh message references to cached structures so
-        // render() passes updated objects to repeat()/guard().
-        this.updateCachedMessageRefs(prevMessages);
+        // Prefer direct replacement via provided update index.
+        const updateIndex = this.lastUpdatedLogIndex;
+        const updateId = this.lastUpdatedLogId;
+        const canUseDirectUpdate =
+          updateIndex !== null &&
+          updateIndex >= 0 &&
+          updateIndex < this.messages.length &&
+          this.messages[updateIndex] !== prevMessages[updateIndex] &&
+          (updateId === null || this.messages[updateIndex].id === updateId);
+
+        if (canUseDirectUpdate) {
+          this.replaceSingleMessage(this.messages[updateIndex]);
+        } else {
+          // Fallback for snapshot-style updates that don't provide focused metadata.
+          this.updateCachedMessageRefs(prevMessages);
+        }
       } else if (this.messages.length > prevCount) {
         // Append-only: classify only the new messages incrementally.
         this.appendNewMessages(prevCount);
       } else {
         // Messages shrunk (e.g. clear) — full rebuild
         [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
+      }
+    }
+
+    if (modeChanged) {
+      if (this.isToolUse) {
+        this.rebuildToolUseTimeline();
+      } else {
+        this.cachedToolUseTimeline = [];
+      }
+    } else if (this.isToolUse) {
+      if (groupsChanged || this.messages.length < prevCount) {
+        this.rebuildToolUseTimeline();
+      } else if (messagesChanged && this.messages.length > prevCount) {
+        this.appendNewUngroupedTimelineItems(prevCount);
       }
     }
 
@@ -175,31 +223,39 @@ export class TaskGroupList extends LitElement {
       const msg = this.messages[i];
       const node = msg.groupId ? this.groupNodeIndex.get(msg.groupId) : null;
       if (node) {
-        node.messages = this.insertMessageSorted(node.messages, msg);
+        this.insertMessageSortedInPlace(node.messages, msg);
       } else {
-        this.cachedUngrouped = this.insertMessageSorted(
-          this.cachedUngrouped,
-          msg,
-        );
+        this.insertMessageSortedInPlace(this.cachedUngrouped, msg);
       }
     }
   }
 
-  private insertMessageSorted(
+  private insertMessageSortedInPlace(
     target: LogMessageData[],
     message: LogMessageData,
-  ): LogMessageData[] {
-    const insertIndex = target.findIndex(
-      (entry) => entry.timestamp > message.timestamp,
-    );
-    if (insertIndex < 0) {
-      return [...target, message];
+  ): void {
+    const messageTime = message.timestamp ?? Number.MAX_SAFE_INTEGER;
+    const lastTime = target.at(-1)?.timestamp ?? Number.MAX_SAFE_INTEGER;
+
+    // Common case: append in chronological order.
+    if (target.length === 0 || lastTime <= messageTime) {
+      target.push(message);
+      return;
     }
-    return [
-      ...target.slice(0, insertIndex),
-      message,
-      ...target.slice(insertIndex),
-    ];
+
+    // Out-of-order insert: upper bound by timestamp to preserve stable order.
+    let low = 0;
+    let high = target.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      const midTime = target[mid].timestamp ?? Number.MAX_SAFE_INTEGER;
+      if (midTime <= messageTime) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    target.splice(low, 0, message);
   }
 
   /**
@@ -233,22 +289,219 @@ export class TaskGroupList extends LitElement {
     if (msg.groupId) {
       const node = this.groupNodeIndex.get(msg.groupId);
       if (node) {
-        const idx = node.messages.findIndex((m) => m.id === msg.id);
-        if (idx >= 0) {
-          const updated = [...node.messages];
-          updated[idx] = msg;
-          node.messages = updated;
+        for (let i = node.messages.length - 1; i >= 0; i--) {
+          if (node.messages[i].id !== msg.id) continue;
+          node.messages[i] = msg;
           return;
         }
       }
     }
 
-    const idx = this.cachedUngrouped.findIndex((m) => m.id === msg.id);
-    if (idx >= 0) {
-      const updated = [...this.cachedUngrouped];
-      updated[idx] = msg;
-      this.cachedUngrouped = updated;
+    for (let i = this.cachedUngrouped.length - 1; i >= 0; i--) {
+      if (this.cachedUngrouped[i].id !== msg.id) continue;
+      this.cachedUngrouped[i] = msg;
+      this.replaceTimelineMessageRef(msg);
+      return;
     }
+  }
+
+  private rebuildToolUseTimeline(): void {
+    if (!this.isMessageScopeExpanded(TaskGroupList.TOOLUSE_TIMELINE_SCOPE)) {
+      this.cachedToolUseTimeline = this.buildToolUseTimelineWindow(
+        TaskGroupList.DEFAULT_VISIBLE_TIMELINE_ITEMS,
+      );
+      return;
+    }
+
+    const timeline: ToolUseTimelineItem[] = [];
+
+    for (const message of this.cachedUngrouped) {
+      timeline.push({
+        key: `msg:${message.id}`,
+        time: message.timestamp ?? 0,
+        msg: message,
+      });
+    }
+
+    for (const tree of this.cachedTree) {
+      timeline.push({
+        key: `group:${tree.group.id}`,
+        time: tree.group.startTime ?? 0,
+        tree,
+      });
+    }
+
+    timeline.sort((a, b) => a.time - b.time);
+    this.cachedToolUseTimeline = timeline;
+  }
+
+  private appendNewUngroupedTimelineItems(startIndex: number): void {
+    for (let i = startIndex; i < this.messages.length; i++) {
+      const message = this.messages[i];
+      if (message.groupId && this.groupNodeIndex.has(message.groupId)) {
+        continue;
+      }
+      this.insertTimelineItem({
+        key: `msg:${message.id}`,
+        time: message.timestamp ?? 0,
+        msg: message,
+      });
+    }
+    this.trimToolUseTimelineWindow();
+  }
+
+  private insertTimelineItem(item: ToolUseTimelineItem): void {
+    if (this.cachedToolUseTimeline.length === 0) {
+      this.cachedToolUseTimeline.push(item);
+      return;
+    }
+
+    const last = this.cachedToolUseTimeline.at(-1);
+    if (last && last.time <= item.time) {
+      this.cachedToolUseTimeline.push(item);
+      return;
+    }
+
+    let low = 0;
+    let high = this.cachedToolUseTimeline.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      if (this.cachedToolUseTimeline[mid].time <= item.time) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    this.cachedToolUseTimeline.splice(low, 0, item);
+  }
+
+  private replaceTimelineMessageRef(message: LogMessageData): void {
+    const key = `msg:${message.id}`;
+    const index = this.cachedToolUseTimeline.findIndex(
+      (item) => item.key === key,
+    );
+    if (index < 0) return;
+
+    const item = this.cachedToolUseTimeline[index];
+    if (!('msg' in item)) return;
+
+    const nextTime = message.timestamp ?? 0;
+    if (item.time === nextTime) {
+      item.msg = message;
+      return;
+    }
+
+    this.cachedToolUseTimeline.splice(index, 1);
+    this.insertTimelineItem({ key, time: nextTime, msg: message });
+    this.trimToolUseTimelineWindow();
+  }
+
+  /**
+   * Build a bounded tail window for tool-use timeline by reverse-merging two
+   * sorted sources: ungrouped messages and root groups.
+   */
+  private buildToolUseTimelineWindow(limit: number): ToolUseTimelineItem[] {
+    const items: ToolUseTimelineItem[] = [];
+    let msgIndex = this.cachedUngrouped.length - 1;
+    let groupIndex = this.cachedTree.length - 1;
+
+    while (items.length < limit && (msgIndex >= 0 || groupIndex >= 0)) {
+      const msg = msgIndex >= 0 ? this.cachedUngrouped[msgIndex] : null;
+      const group = groupIndex >= 0 ? this.cachedTree[groupIndex] : null;
+      const msgTime = msg?.timestamp ?? Number.MIN_SAFE_INTEGER;
+      const groupTime = group?.group.startTime ?? Number.MIN_SAFE_INTEGER;
+
+      if (msg && (!group || msgTime >= groupTime)) {
+        items.push({
+          key: `msg:${msg.id}`,
+          time: msgTime,
+          msg,
+        });
+        msgIndex--;
+      } else if (group) {
+        items.push({
+          key: `group:${group.group.id}`,
+          time: groupTime,
+          tree: group,
+        });
+        groupIndex--;
+      } else {
+        break;
+      }
+    }
+
+    items.reverse();
+    return items;
+  }
+
+  private trimToolUseTimelineWindow(): void {
+    if (this.isMessageScopeExpanded(TaskGroupList.TOOLUSE_TIMELINE_SCOPE)) {
+      return;
+    }
+    const overshoot =
+      this.cachedToolUseTimeline.length -
+      TaskGroupList.DEFAULT_VISIBLE_TIMELINE_ITEMS;
+    if (overshoot > 0) {
+      this.cachedToolUseTimeline.splice(0, overshoot);
+    }
+  }
+
+  private isMessageScopeExpanded(scope: string): boolean {
+    return this.expandedMessageScopes.has(scope);
+  }
+
+  private renderMessageList(
+    messages: LogMessageData[],
+    scope: string,
+  ): TemplateResult {
+    const expanded = this.isMessageScopeExpanded(scope);
+    const visibleMessages =
+      !expanded && messages.length > TaskGroupList.DEFAULT_VISIBLE_MESSAGES
+        ? messages.slice(-TaskGroupList.DEFAULT_VISIBLE_MESSAGES)
+        : messages;
+    const hiddenCount = messages.length - visibleMessages.length;
+
+    return html`${this.renderShowOlderControl(scope, hiddenCount)}${repeat(
+      visibleMessages,
+      (m) => m.id,
+      (m) => guard([m], () => formatLogEntry(m)),
+    )}`;
+  }
+
+  private renderShowOlderControl(
+    scope: string,
+    hiddenCount: number,
+  ): TemplateResult | typeof nothing {
+    if (hiddenCount <= 0) return nothing;
+    return html`<div class="log-history-control">
+      <button
+        type="button"
+        class="show-older-logs file-link"
+        data-action="show-older"
+        data-scope=${scope}
+      >
+        Show ${hiddenCount} older ${hiddenCount === 1 ? 'entry' : 'entries'}
+      </button>
+    </div>`;
+  }
+
+  private handleShowOlderClick(event: MouseEvent): void {
+    const target = event
+      .composedPath()
+      .find(
+        (node): node is HTMLElement =>
+          node instanceof HTMLElement && node.dataset.action === 'show-older',
+      );
+    if (!target) return;
+
+    const scope = target.dataset.scope;
+    if (!scope || this.expandedMessageScopes.has(scope)) return;
+
+    this.expandedMessageScopes.add(scope);
+    if (scope === TaskGroupList.TOOLUSE_TIMELINE_SCOPE) {
+      this.rebuildToolUseTimeline();
+    }
+    this.requestUpdate();
   }
 
   /** Play sound when a run group completes */
@@ -440,11 +693,7 @@ export class TaskGroupList extends LitElement {
       return html`
         <div id=${detailsId} class="log-group log-run" data-run-id=${group.id}>
           <div id=${contentId} class="log-group-content">
-            ${repeat(
-              messages,
-              (m) => m.id,
-              (m) => guard([m], () => formatLogEntry(m)),
-            )}
+            ${this.renderMessageList(messages, `group:${group.id}`)}
             ${repeat(
               children,
               (c) => c.group.id,
@@ -477,10 +726,9 @@ export class TaskGroupList extends LitElement {
         </summary>
         <div id=${contentId} class="log-group-content">
           ${expanded
-            ? html`${repeat(
+            ? html`${this.renderMessageList(
                 messages,
-                (m) => m.id,
-                (m) => guard([m], () => formatLogEntry(m)),
+                `group:${group.id}`,
               )}${repeat(
                 children,
                 (c) => c.group.id,
@@ -496,37 +744,40 @@ export class TaskGroupList extends LitElement {
     // Show placeholder only when there are no streams in the current filter
     if (!this.hasStreams) {
       return html`
-        <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
+        <vscode-scrollable
+          id=${ELEMENT_IDS.LOG_CONTENT}
+          class="log-container"
+          @click=${this.handleShowOlderClick}
+        >
           <div class="log-placeholder">${unsafeHTML(PLACEHOLDER_HTML)}</div>
         </vscode-scrollable>
       `;
     }
 
     if (this.isToolUse) {
-      // Tool-use: interleave ungrouped messages (user input, follow-ups, errors)
-      // with groups chronologically so the conversation reads top-to-bottom.
-      const timeline = [
-        ...this.cachedUngrouped.map((m) => ({
-          key: m.id,
-          time: m.timestamp ?? 0,
-          msg: m,
-        })),
-        ...this.cachedTree.map((t) => ({
-          key: t.group.id,
-          time: t.group.startTime ?? 0,
-          tree: t,
-        })),
-      ].sort((a, b) => a.time - b.time);
-
+      const totalTimelineItems =
+        this.cachedUngrouped.length + this.cachedTree.length;
+      const hiddenCount = Math.max(
+        0,
+        totalTimelineItems - this.cachedToolUseTimeline.length,
+      );
       return html`
-        <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
+        <vscode-scrollable
+          id=${ELEMENT_IDS.LOG_CONTENT}
+          class="log-container"
+          @click=${this.handleShowOlderClick}
+        >
+          ${this.renderShowOlderControl(
+            TaskGroupList.TOOLUSE_TIMELINE_SCOPE,
+            hiddenCount,
+          )}
           ${repeat(
-            timeline,
+            this.cachedToolUseTimeline,
             (item) => item.key,
             (item) =>
               'msg' in item
                 ? guard([item.msg], () => formatLogEntry(item.msg))
-                : this.renderGroupNode(item.tree!),
+                : this.renderGroupNode(item.tree),
           )}
         </vscode-scrollable>
       `;
@@ -536,16 +787,19 @@ export class TaskGroupList extends LitElement {
     // Workflow stages are hierarchical (not conversational), so structure-first
     // ordering keeps stage execution visually separate from stray messages.
     return html`
-      <vscode-scrollable id=${ELEMENT_IDS.LOG_CONTENT} class="log-container">
+      <vscode-scrollable
+        id=${ELEMENT_IDS.LOG_CONTENT}
+        class="log-container"
+        @click=${this.handleShowOlderClick}
+      >
         ${repeat(
           this.cachedTree,
           (t) => t.group.id,
           (t) => this.renderGroupNode(t),
         )}
-        ${repeat(
+        ${this.renderMessageList(
           this.cachedUngrouped,
-          (m) => m.id,
-          (m) => guard([m], () => formatLogEntry(m)),
+          TaskGroupList.WORKFLOW_UNGROUPED_SCOPE,
         )}
       </vscode-scrollable>
     `;

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -49,6 +49,8 @@ export const streamStateContext = createContext<StreamContextValue>(
 export interface StreamLogContextValue {
   logs: LogMessageData[];
   taskGroups: TaskGroup[];
+  lastUpdatedLogId: string | null;
+  lastUpdatedLogIndex: number | null;
   runId: string | null;
   isToolUse: boolean;
   hasStreams: boolean;
@@ -59,6 +61,8 @@ export interface StreamLogContextValue {
 export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   logs: [],
   taskGroups: [],
+  lastUpdatedLogId: null,
+  lastUpdatedLogIndex: null,
   runId: null,
   isToolUse: false,
   hasStreams: false,

--- a/src/progressView/frontend/messageDispatcher.ts
+++ b/src/progressView/frontend/messageDispatcher.ts
@@ -63,6 +63,12 @@ export interface MessageHandlerContext extends FrontendEventHandlerContext {
 const pendingLogUpdates = new Map<string, Partial<LogMessageData>>();
 
 /**
+ * Per-stream log ID -> array index lookup.
+ * Avoids O(n) scans on every UPDATE_LOG when streams contain many entries.
+ */
+const logIdIndexByStream = new Map<string, Map<string, number>>();
+
+/**
  * Proposal IDs that were resolved before their SHOW message arrived.
  * When RESOLVE arrives for a proposal not yet in the permission list, we stash the ID.
  * A subsequent SHOW for a stashed ID is dropped instead of creating a ghost permission.
@@ -85,6 +91,30 @@ function clearPendingLogUpdatesForStream(streamId: string): void {
       pendingLogUpdates.delete(key);
     }
   }
+}
+
+function getOrCreateLogIdIndex(streamId: string): Map<string, number> {
+  const existing = logIdIndexByStream.get(streamId);
+  if (existing) return existing;
+  const created = new Map<string, number>();
+  logIdIndexByStream.set(streamId, created);
+  return created;
+}
+
+function clearLogIdIndexForStream(streamId: string): void {
+  logIdIndexByStream.delete(streamId);
+}
+
+function rebuildLogIdIndexForStream(
+  streamId: string,
+  logs: LogMessageData[],
+): void {
+  const index = new Map<string, number>();
+  for (let i = 0; i < logs.length; i++) {
+    const id = logs[i]?.id;
+    if (id) index.set(id, i);
+  }
+  logIdIndexByStream.set(streamId, index);
 }
 
 function addPermission(
@@ -146,6 +176,24 @@ function setActiveStreamRecording(
   }));
 }
 
+function isSameStreamInfo(a: StreamTabInfo, b: StreamTabInfo): boolean {
+  return (
+    a.name === b.name &&
+    a.label === b.label &&
+    a.model === b.model &&
+    a.agent === b.agent &&
+    a.agentCategory === b.agentCategory &&
+    a.hasMultipleOutputs === b.hasMultipleOutputs &&
+    a.isRemote === b.isRemote &&
+    a.lastTimestamp === b.lastTimestamp &&
+    a.inputFile === b.inputFile &&
+    a.creationTimestamp === b.creationTimestamp &&
+    a.status === b.status &&
+    a.executionId === b.executionId &&
+    a.parentStreamId === b.parentStreamId
+  );
+}
+
 function updateStreamInfo(
   state: ProgressState,
   streams: StreamTabInfo[],
@@ -160,16 +208,32 @@ function updateStreamInfo(
       nextStates.delete(key);
       nextLogs.delete(key);
       clearPendingLogUpdatesForStream(key);
+      clearLogIdIndexForStream(key);
     }
   }
 
-  for (const stream of streams) {
+  const previousStreamsById = new Map(
+    state.streams.map((stream) => [stream.name, stream]),
+  );
+  let streamsChanged = streams.length !== state.streams.length;
+  const nextStreams = streams.map((stream, index) => {
+    const previous = previousStreamsById.get(stream.name);
+    const next =
+      previous && isSameStreamInfo(previous, stream) ? previous : stream;
+    if (!streamsChanged && state.streams[index] !== next) {
+      streamsChanged = true;
+    }
+    return next;
+  });
+
+  for (const stream of nextStreams) {
     const backendState = backendStates?.[stream.name];
     if (backendState) {
       const existing = nextStates.get(stream.name);
       // Seed streamLogs from backend state when no frontend logs exist yet
       if (!nextLogs.has(stream.name) && backendState.logs.length > 0) {
         nextLogs.set(stream.name, { logs: backendState.logs });
+        rebuildLogIdIndexForStream(stream.name, backendState.logs);
       }
       // Preserve frontend-owned properties that backend _streamStates never populates:
       // - 'ui': frontend UI state (follow-up text, polish state, etc.)
@@ -201,7 +265,12 @@ function updateStreamInfo(
     }
   }
 
-  return { ...state, streams, streamStates: nextStates, streamLogs: nextLogs };
+  return {
+    ...state,
+    streams: streamsChanged ? nextStreams : state.streams,
+    streamStates: nextStates,
+    streamLogs: nextLogs,
+  };
 }
 
 // ============================================================
@@ -272,6 +341,7 @@ const handlers: HandlerRegistry = {
 
     // Always clear pending log updates for deleted stream, not just active stream
     clearPendingLogUpdatesForStream(streamId);
+    clearLogIdIndexForStream(streamId);
 
     ctx.setState(() => ({
       ...state,
@@ -289,6 +359,7 @@ const handlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: (_data, ctx) => {
     pendingLogUpdates.clear();
+    logIdIndexByStream.clear();
     ctx.setState((prev) => ({
       ...prev,
       streams: [],
@@ -305,6 +376,7 @@ const handlers: HandlerRegistry = {
 
     if (!stream && action === 'clear') {
       pendingLogUpdates.clear();
+      logIdIndexByStream.clear();
       ctx.setState((prev) => ({
         ...prev,
         streamStates: new Map(),
@@ -318,6 +390,7 @@ const handlers: HandlerRegistry = {
     const isClear = action === 'clear';
     if (isClear) {
       clearPendingLogUpdatesForStream(stream);
+      clearLogIdIndexForStream(stream);
     }
 
     // Update meta first — setStreamState creates the streamStates entry if needed,
@@ -389,7 +462,12 @@ const handlers: HandlerRegistry = {
     // Update logs in the separate streamLogs Map (after setStreamState so the entry exists)
     ctx.setStreamLogs(stream, () => ({
       logs: isClear ? [] : messages,
+      lastUpdatedLogId: null,
+      lastUpdatedLogIndex: null,
     }));
+    if (!isClear) {
+      rebuildLogIdIndexForStream(stream, messages);
+    }
   },
 
   // --- Log updates ---
@@ -398,6 +476,8 @@ const handlers: HandlerRegistry = {
   // (content components) skip re-rendering on log-only updates.
 
   [PROGRESS_VIEW_COMMANDS.APPEND_LOG]: (data, ctx) => {
+    if (!ctx.getState().streamStates.has(data.stream)) return;
+
     const logId = data.logMessage.id;
     const pendingUpdate =
       logId && data.stream
@@ -412,21 +492,45 @@ const handlers: HandlerRegistry = {
       pendingLogUpdates.delete(getPendingLogKey(data.stream, logId));
     }
 
+    const logIdIndex = getOrCreateLogIdIndex(data.stream);
     ctx.setStreamLogs(data.stream, (prev) => {
       // Guard: skip if this message is already in the log list (race between
       // UPDATE_LOGS and APPEND_LOG can cause the same entry to arrive twice).
-      if (logId && prev.logs.some((entry) => entry.id === logId)) {
+      if (logId && logIdIndex.has(logId)) {
         return prev;
       }
-      return { logs: [...prev.logs, mergedLogMessage] };
+      const nextIndex = prev.logs.length;
+      if (logId) {
+        logIdIndex.set(logId, nextIndex);
+      }
+      return {
+        logs: [...prev.logs, mergedLogMessage],
+        lastUpdatedLogId: logId ?? null,
+        lastUpdatedLogIndex: nextIndex,
+      };
     });
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_LOG]: (data, ctx) => {
+    if (!ctx.getState().streamStates.has(data.stream)) return;
+
     const logId = data.logMessage.id;
+    const logIdIndex = getOrCreateLogIdIndex(data.stream);
 
     ctx.setStreamLogs(data.stream, (prev) => {
-      const logIndex = prev.logs.findIndex((entry) => entry.id === logId);
+      let logIndex = logId ? (logIdIndex.get(logId) ?? -1) : -1;
+
+      // Recover from stale/missing index (e.g., after backend snapshot sync).
+      if (
+        logIndex < 0 ||
+        logIndex >= prev.logs.length ||
+        (logId && prev.logs[logIndex]?.id !== logId)
+      ) {
+        logIndex = prev.logs.findIndex((entry) => entry.id === logId);
+        if (logId && logIndex >= 0) {
+          logIdIndex.set(logId, logIndex);
+        }
+      }
 
       if (logIndex < 0) {
         // Out-of-order: APPEND hasn't arrived yet, stash for later merge
@@ -443,7 +547,11 @@ const handlers: HandlerRegistry = {
 
       const newLogs = [...prev.logs];
       newLogs[logIndex] = data.logMessage;
-      return { logs: newLogs };
+      return {
+        logs: newLogs,
+        lastUpdatedLogId: logId ?? null,
+        lastUpdatedLogIndex: logIndex,
+      };
     });
   },
 
@@ -457,34 +565,57 @@ const handlers: HandlerRegistry = {
     // Single atomic update: stream state + tab metadata in one setState call,
     // avoiding two Map copies and two Lit re-render triggers.
     ctx.setState((prev) => {
-      const streamInfo = prev.streams.find((s) => s.name === stream);
-      const nextStates = new Map(prev.streamStates);
+      const streamInfoIndex = prev.streams.findIndex((s) => s.name === stream);
+      const streamInfo =
+        streamInfoIndex >= 0 ? prev.streams[streamInfoIndex] : undefined;
 
+      let nextStates = prev.streamStates;
       if (streamInfo) {
         const current = getStreamState(prev, stream, streamInfo.agentCategory);
-        const updatedState =
-          isToolUseState(current) && shouldFocus
-            ? {
-                ...current,
-                status,
-                ui: { ...current.ui, shouldFocusFollowUp: true },
-              }
-            : { ...current, status };
-        nextStates.set(stream, updatedState);
+        let updatedState = current;
+
+        if (isToolUseState(current) && shouldFocus) {
+          if (current.status !== status || !current.ui.shouldFocusFollowUp) {
+            updatedState = {
+              ...current,
+              status,
+              ui: { ...current.ui, shouldFocusFollowUp: true },
+            };
+          }
+        } else if (current.status !== status) {
+          updatedState = { ...current, status };
+        }
+
+        if (updatedState !== current) {
+          nextStates = new Map(prev.streamStates);
+          nextStates.set(stream, updatedState);
+        }
+      }
+
+      let nextStreams = prev.streams;
+      if (streamInfo) {
+        const nextLastTimestamp = lastTimestamp ?? streamInfo.lastTimestamp;
+        if (
+          streamInfo.status !== status ||
+          streamInfo.lastTimestamp !== nextLastTimestamp
+        ) {
+          nextStreams = [...prev.streams];
+          nextStreams[streamInfoIndex] = {
+            ...streamInfo,
+            status,
+            lastTimestamp: nextLastTimestamp,
+          };
+        }
+      }
+
+      if (nextStates === prev.streamStates && nextStreams === prev.streams) {
+        return prev;
       }
 
       return {
         ...prev,
         streamStates: nextStates,
-        streams: prev.streams.map((item) =>
-          item.name === stream
-            ? {
-                ...item,
-                status,
-                lastTimestamp: lastTimestamp ?? item.lastTimestamp,
-              }
-            : item,
-        ),
+        streams: nextStreams,
       };
     });
   },

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -43,9 +43,17 @@ export type FollowupOptionsState = Omit<
  */
 export interface StreamLogs {
   logs: LogMessageData[];
+  /** ID of the most recently updated/appended log entry (if known). */
+  lastUpdatedLogId: string | null;
+  /** Array index of the most recently updated/appended log entry (if known). */
+  lastUpdatedLogIndex: number | null;
 }
 
-export const EMPTY_STREAM_LOGS: StreamLogs = { logs: [] };
+export const EMPTY_STREAM_LOGS: StreamLogs = {
+  logs: [],
+  lastUpdatedLogId: null,
+  lastUpdatedLogIndex: null,
+};
 
 export interface ProgressState {
   activeStreamId: StreamTabId | null;

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -150,6 +150,19 @@ export const logEntryStyles = css`
     font-size: 0.85em;
   }
 
+  .log-history-control {
+    margin: var(--spacing-small) 0;
+  }
+
+  .show-older-logs {
+    border: none;
+    background: none;
+    padding: 0;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
   /* Web search result styles */
   .detail-list {
     list-style: none;


### PR DESCRIPTION
## Summary
- Simplify progress log rendering to a single active stream (`log-list` now renders one `task-group-list`)
- Remove hidden per-stream DOM cache and eviction complexity from `LogList`
- Keep per-stream toggle persistence by reloading persisted toggle state on stream switch
- Preserve bounded history rendering with explicit "Show older" expansion in `TaskGroupList`
- Keep stream tab identity stable and focused log-update metadata flow to reduce unnecessary updates

## Why
The previous implementation had accumulated complexity (multi-stream hidden DOM caches + incremental bookkeeping), which made performance behavior hard to reason about and difficult to improve reliably. This refactor reduces moving parts and makes runtime cost primarily proportional to visible content.

## Validation
- `npm run compile:fast`
- `npm run lint` (existing repo warnings only)

## Changed files
- `src/progressView/frontend/ProgressApp.ts`
- `src/progressView/frontend/components/LogList.ts`
- `src/progressView/frontend/components/TaskGroupList.ts`
- `src/progressView/frontend/contexts/streamContexts.ts`
- `src/progressView/frontend/messageDispatcher.ts`
- `src/progressView/frontend/store.ts`
- `src/progressView/frontend/styles/logEntryStyles.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core log rendering and incremental update paths, so regressions could impact log ordering, missing entries, or scroll/expansion behavior across tool-use and workflow streams.
> 
> **Overview**
> Progress view log rendering is simplified so `log-list` only renders a single `task-group-list` for the active stream, removing the hidden per-stream DOM cache/eviction logic while still reloading per-stream toggle state on stream switches.
> 
> Streaming log updates are optimized end-to-end by adding `lastUpdatedLogId`/`lastUpdatedLogIndex` to `StreamLogs` and `streamLogContext`, maintaining a per-stream logId→index map in `messageDispatcher`, and letting `TaskGroupList` replace/update a single message directly when possible.
> 
> `TaskGroupList` also adds bounded history rendering with per-scope "Show older entries" expansion (including tool-use timelines), and updates styles to support the new history control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17727ff13335154aeed4bab4eb29c0286be85cc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->