### PR TITLE
Optimize LaTeX settings detection with caching and timeouts

### DIFF
--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -16,6 +16,8 @@ import {
   SETTINGS_VIEW_CMD,
   type ModelSelectionItem,
   type AgentSelectionItem,
+  type LatexSettingsStatus,
+  DEFAULT_LATEX_SETTINGS_STATUS,
 } from '@shared/schemas/settingsViewMessages';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -323,10 +325,19 @@ function buildAgentSelectionItems(): {
   return { workflow, toolUse };
 }
 
+/** How long cached LaTeX settings remain valid (ms). */
+const LATEX_SETTINGS_CACHE_TTL = 60_000;
+
 export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private readonly handlerRegistry: SettingsViewInboundHandlerRegistry;
+
+  /** Cached LaTeX settings to avoid redundant tool detection on repeat opens. */
+  private latexSettingsCache: {
+    settings: LatexSettingsStatus;
+    timestamp: number;
+  } | null = null;
 
   constructor(_context: vscode.ExtensionContext) {
     super('SettingsView', { trackActiveView: true });
@@ -1791,56 +1802,83 @@ prompts:
   }
 
   public async sendLatexSettingsStatus(webview: vscode.Webview): Promise<void> {
-    const [
-      pdflatexOk,
-      latexmkOk,
-      latexdiffOk,
-      latexindentOk,
-      perlOk,
-      texcountOk,
-      gsOk,
-      gmOk,
-      magickOk,
-    ] = await Promise.all([
-      checkToolInstalled('pdflatex', false),
-      checkToolInstalled('latexmk', false),
-      checkToolInstalled('latexdiff', false),
-      checkToolInstalled('latexindent', false),
-      checkToolInstalled('perl', false),
-      checkToolInstalled('texcount', false),
-      checkToolInstalled('gs', false),
-      checkToolInstalled('gm', false),
-      checkToolInstalled('magick', false),
-    ]);
+    const now = Date.now();
+    if (
+      !this.latexSettingsCache ||
+      now - this.latexSettingsCache.timestamp >= LATEX_SETTINGS_CACHE_TTL
+    ) {
+      this.latexSettingsCache = {
+        settings: await this.detectLatexSettings(),
+        timestamp: now,
+      };
+    }
 
-    const platform = normalizePlatform(process.platform);
-
-    const settings = {
-      outDir: this.isRecommendedValueSet('outDir'),
-      autoRevealExclude: this.isRecommendedValueSet('autoRevealExclude'),
-      texDistributionInstalled: pdflatexOk || latexmkOk,
-      latexWorkshopInstalled: Boolean(
-        vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID),
-      ),
-      latexdiffInstalled: latexdiffOk,
-      latexindentInstalled: latexindentOk && perlOk,
-      texcountInstalled: texcountOk,
-      imageProcessingInstalled: gsOk && (gmOk || magickOk),
-      platform,
-      pdflatexPath: findToolInCommonPaths('pdflatex'),
-      latexmkPath: findToolInCommonPaths('latexmk'),
-      latexdiffPath: findToolInCommonPaths('latexdiff'),
-      latexindentPath: findToolInCommonPaths('latexindent'),
-      texcountPath: findToolInCommonPaths('texcount'),
-      ghostscriptPath: findToolInCommonPaths('gs'),
-      graphicsmagickPath:
-        findToolInCommonPaths('gm') ?? findToolInCommonPaths('magick'),
-      packageManager: detectPackageManager(),
-    };
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
-      settings,
+      settings: this.latexSettingsCache.settings,
     });
+  }
+
+  /** Run all tool checks and build the LaTeX settings status object.
+   *  Returns defaults on failure so the webview spinner always dismisses. */
+  private async detectLatexSettings(): Promise<LatexSettingsStatus> {
+    try {
+      const [
+        pdflatexOk,
+        latexmkOk,
+        latexdiffOk,
+        latexindentOk,
+        perlOk,
+        texcountOk,
+        gsOk,
+        gmOk,
+        magickOk,
+      ] = await Promise.all([
+        checkToolInstalled('pdflatex', false),
+        checkToolInstalled('latexmk', false),
+        checkToolInstalled('latexdiff', false),
+        checkToolInstalled('latexindent', false),
+        checkToolInstalled('perl', false),
+        checkToolInstalled('texcount', false),
+        checkToolInstalled('gs', false),
+        checkToolInstalled('gm', false),
+        checkToolInstalled('magick', false),
+      ]);
+
+      const platform = normalizePlatform(process.platform);
+
+      return {
+        outDir: this.isRecommendedValueSet('outDir'),
+        autoRevealExclude: this.isRecommendedValueSet('autoRevealExclude'),
+        texDistributionInstalled: pdflatexOk || latexmkOk,
+        latexWorkshopInstalled: Boolean(
+          vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID),
+        ),
+        latexdiffInstalled: latexdiffOk,
+        latexindentInstalled: latexindentOk && perlOk,
+        texcountInstalled: texcountOk,
+        imageProcessingInstalled: gsOk && (gmOk || magickOk),
+        platform,
+        pdflatexPath: findToolInCommonPaths('pdflatex'),
+        latexmkPath: findToolInCommonPaths('latexmk'),
+        latexdiffPath: findToolInCommonPaths('latexdiff'),
+        latexindentPath: findToolInCommonPaths('latexindent'),
+        texcountPath: findToolInCommonPaths('texcount'),
+        ghostscriptPath: findToolInCommonPaths('gs'),
+        graphicsmagickPath:
+          findToolInCommonPaths('gm') ?? findToolInCommonPaths('magick'),
+        packageManager: detectPackageManager(),
+      };
+    } catch (err) {
+      this.logger.error(
+        this.channel,
+        `LaTeX settings detection failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return {
+        ...DEFAULT_LATEX_SETTINGS_STATUS,
+        platform: normalizePlatform(process.platform),
+      };
+    }
   }
 
   /** Install a VS Code extension and refresh the given view data. */

--- a/src/utils/system/platformPaths.ts
+++ b/src/utils/system/platformPaths.ts
@@ -245,11 +245,24 @@ function isPathSafe(filepath: string): boolean {
   return !normalized.includes('..');
 }
 
+const findToolCache = new Map<string, string>();
+
 /**
  * Locate a tool in the common directories.
  * Performs basic security validation on tool names.
+ * Found paths are cached for the session; misses are always re-checked
+ * so that tools installed mid-session are picked up without a reload.
  */
 export function findToolInCommonPaths(tool: string): string | null {
+  const cached = findToolCache.get(tool);
+  if (cached !== undefined) return cached;
+
+  const result = findToolInCommonPathsUncached(tool);
+  if (result !== null) findToolCache.set(tool, result);
+  return result;
+}
+
+function findToolInCommonPathsUncached(tool: string): string | null {
   // Basic security validation
   if (!isPathSafe(tool)) {
     logger.warn(CHANNEL, `Unsafe tool name rejected: ${tool}`);

--- a/src/utils/system/toolUtils.ts
+++ b/src/utils/system/toolUtils.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 // Third-party imports
-import { execaSync } from 'execa';
+import { execa, execaSync } from 'execa';
 import { parse as shellParse } from 'shell-quote';
 import * as vscode from 'vscode';
 
@@ -195,6 +195,7 @@ export async function checkToolInstalled(
     const execOptions = {
       env: { ...process.env, PATH: extendedPath },
       reject: false,
+      timeout: 5000,
     };
 
     // Log PATH info once (not per-command)
@@ -208,8 +209,10 @@ export async function checkToolInstalled(
     const hasVersionOutput = (result: { stdout?: string; stderr?: string }) =>
       result.stdout?.match(/\d+\.\d+/) || result.stderr?.match(/\d+\.\d+/);
 
-    // Helper function to execute a command with fallback
-    const executeWithFallback = (cmd: string, args: string[]): boolean => {
+    const executeWithFallback = async (
+      cmd: string,
+      args: string[],
+    ): Promise<boolean> => {
       logger.debug(
         CHANNEL,
         `Checking tool '${cmd}' with args [${args.join(', ')}]`,
@@ -217,7 +220,7 @@ export async function checkToolInstalled(
 
       let result;
       try {
-        result = execaSync(cmd, args, execOptions);
+        result = await execa(cmd, args, execOptions);
       } catch (execErr) {
         logger.info(
           CHANNEL,
@@ -255,8 +258,8 @@ export async function checkToolInstalled(
         );
         try {
           result = needsPerl
-            ? execaSync('perl', [fallback, ...args], execOptions)
-            : execaSync(fallback, args, execOptions);
+            ? await execa('perl', [fallback, ...args], execOptions)
+            : await execa(fallback, args, execOptions);
         } catch (fallbackErr) {
           logger.info(
             CHANNEL,
@@ -300,7 +303,7 @@ export async function checkToolInstalled(
       for (const cmd of command) {
         const parsed = parseCommand(cmd);
         if (!parsed) continue;
-        if (executeWithFallback(parsed.cmdName, parsed.args)) {
+        if (await executeWithFallback(parsed.cmdName, parsed.args)) {
           isInstalled = true;
           break;
         }
@@ -311,7 +314,7 @@ export async function checkToolInstalled(
       if (!parsed) {
         throw new Error('Invalid command: no executable found');
       }
-      isInstalled = executeWithFallback(parsed.cmdName, parsed.args);
+      isInstalled = await executeWithFallback(parsed.cmdName, parsed.args);
     }
 
     if (!isInstalled && showError) {
@@ -444,7 +447,11 @@ export async function checkCoreDependencies(
  * Detect the first available package manager on the system.
  * Returns 'brew', 'apt', 'scoop', or null if none found.
  */
+let cachedPackageManager: 'brew' | 'apt' | 'scoop' | undefined;
+
 export function detectPackageManager(): 'brew' | 'apt' | 'scoop' | null {
+  if (cachedPackageManager !== undefined) return cachedPackageManager;
+
   const extendedPath = extendEnvPath();
   const execOptions = {
     env: { ...process.env, PATH: extendedPath },
@@ -478,6 +485,7 @@ export function detectPackageManager(): 'brew' | 'apt' | 'scoop' | null {
       const result = execaSync(name, args, execOptions);
       if (result.exitCode === 0) {
         logger.debug(CHANNEL, `Package manager detected: ${name}`);
+        cachedPackageManager = name;
         return name;
       }
     } catch {


### PR DESCRIPTION
## Summary
This PR improves the performance and reliability of LaTeX settings detection by introducing caching mechanisms and adding timeout protection to tool detection processes.

## Key Changes

- **LaTeX Settings Caching**: Added a 60-second cache for LaTeX settings status to avoid redundant tool detection when the settings view is opened multiple times. The cache is stored in `SettingsViewMessageHandler` and automatically invalidated after the TTL expires.

- **Async Tool Detection with Timeouts**: Converted `checkToolInstalled()` to use async execution (`execa` instead of `execaSync`) with a 5-second timeout per tool check. This prevents the extension from hanging if a tool command becomes unresponsive.

- **Error Handling**: Wrapped LaTeX settings detection in a try-catch block to ensure the webview always receives a response (with default values on failure) and the loading spinner is properly dismissed even when tool detection fails.

- **Package Manager Detection Caching**: Added caching for `detectPackageManager()` results using a sentinel value pattern, since package managers don't change during a session.

- **Tool Path Caching**: Implemented session-level caching for `findToolInCommonPaths()` results using a Map, eliminating redundant filesystem lookups for the same tools.

## Implementation Details

- The LaTeX settings cache uses a timestamp-based TTL approach (`LATEX_SETTINGS_CACHE_TTL = 60_000` ms)
- Tool detection now uses `execa` with `timeout: 5000` to prevent indefinite hangs
- Default LaTeX settings are provided via `DEFAULT_LATEX_SETTINGS_STATUS` when detection fails
- All caching mechanisms are session-scoped and don't persist across extension restarts

https://claude.ai/code/session_019nUVbRoNjAFoZWSdpguhVF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared system-level tool detection used in multiple features; async execution with timeouts and caching could introduce subtle behavior differences or stale results during a session.
> 
> **Overview**
> Improves LaTeX settings status loading by adding a 60s in-memory cache in `SettingsViewMessageHandler`, factoring detection into `detectLatexSettings()`, and guaranteeing the webview receives defaults on detection errors.
> 
> Makes tool detection more resilient by switching `checkToolInstalled()` to async `execa` with a 5s timeout, and adds session-level caching for `findToolInCommonPaths()` (cache hits only) and `detectPackageManager()` to reduce repeated filesystem/process probes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05c1110a046fede23a657ea65aba876e03b8e5c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->