### PR TITLE
fix: hide internal template files from presenter agent file list UI

### DIFF
--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -84,9 +84,12 @@ export async function buildUserVars(
     ...getToolFlags(agentConfig, agentSetting, agentPrompt),
   };
 
-  // Emit aggregated file list if any files were loaded
-  if (allLoadedFiles.length > 0) {
-    logger.fileList(allLoadedFiles);
+  // Emit aggregated file list if any non-internal files were loaded.
+  // Internal-only files (e.g. requiredFilesInternal templates) are loaded
+  // for prompt variable substitution but shouldn't appear in the UI.
+  const visibleFiles = allLoadedFiles.filter((f) => !f.internal);
+  if (visibleFiles.length > 0) {
+    logger.fileList(visibleFiles);
   }
 
   return userVars;


### PR DESCRIPTION
requiredFilesInternal files (e.g. template_slide.tex) were showing as
"Files (1/1 loaded)" in the UI for tool-use agents like the presenter.
These internal templates are loaded for prompt variable substitution but
should not appear in the user-facing file list since they are not
user-provided files.

https://claude.ai/code/session_01K1axUELxLFSBNqtQV9pmSe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to file-list logging that only affects UI presentation and not file loading or prompt variable generation.
> 
> **Overview**
> Filters `buildUserVars` aggregated `allLoadedFiles` before logging, so only non-`internal` loaded files are emitted via `logger.fileList`.
> 
> This prevents `requiredFilesInternal` template files (used for prompt variable substitution) from appearing in the user-facing file list UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc918dcbbe4e1599afc477f0363e2bf7d34acaee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->