### PR TITLE
Prevent event buffer cross-type eviction and add stream cleanup

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -45,7 +45,11 @@ interface SetTaskStatePayload {
   taskState: TaskState;
 }
 
-const MAX_BUFFER_SIZE = 1000;
+/**
+ * Per-event-type buffer limit. Prevents one noisy event type (e.g., addLogMessage)
+ * from evicting critical events of other types during the startup buffering window.
+ */
+const PER_TYPE_BUFFER_LIMIT = 200;
 
 export interface ProgressEventPayloads {
   addLogMessage: { streamId: StreamTabId; logMessage: LogMessageData };
@@ -128,23 +132,49 @@ export interface ProgressEventBusLike {
     event: K,
     payload: ProgressEventPayloads[K],
   ): void;
+  /** Remove all buffered events associated with a specific stream. */
+  clearStream(streamId: string): void;
+  /** Remove all buffered events. */
+  clear(): void;
+}
+
+/**
+ * Check whether a payload is scoped to a specific stream.
+ * Handles all stream-identifying fields used across event payloads.
+ */
+function isStreamPayload(payload: unknown, streamId: string): boolean {
+  if (payload === null || payload === undefined || typeof payload !== 'object') {
+    return false;
+  }
+  const p = payload as Record<string, unknown>;
+  return (
+    p.streamId === streamId ||
+    p.parentStreamId === streamId ||
+    p.childStreamId === streamId
+  );
 }
 
 class ProgressEventBus implements ProgressEventBusLike {
   private emitter = new EventEmitter();
-  private buffer: {
-    event: ProgressEvent;
-    payload: ProgressEventPayloads[ProgressEvent];
-  }[] = [];
+  /** Per-event-type buffer. Replaces the old flat array to prevent cross-type eviction. */
+  private eventStore = new Map<
+    ProgressEvent,
+    ProgressEventPayloads[ProgressEvent][]
+  >();
 
   emit<K extends ProgressEvent>(
     event: K,
     payload: ProgressEventPayloads[K],
   ): void {
     if (this.emitter.listenerCount(event) === 0) {
-      this.buffer.push({ event, payload });
-      if (this.buffer.length > MAX_BUFFER_SIZE) {
-        this.buffer.shift();
+      let entries = this.eventStore.get(event);
+      if (!entries) {
+        entries = [];
+        this.eventStore.set(event, entries);
+      }
+      entries.push(payload);
+      if (entries.length > PER_TYPE_BUFFER_LIMIT) {
+        entries.shift();
       }
     } else {
       this.emitter.emit(event, payload);
@@ -165,18 +195,33 @@ class ProgressEventBus implements ProgressEventBusLike {
     const cleanup = () => this.emitter.off(event, listener);
     options?.signal?.addEventListener('abort', cleanup, { once: true });
 
-    // Replay buffered events for this event type and remove them (single pass)
-    const remaining: typeof this.buffer = [];
-    for (const item of this.buffer) {
-      if (item.event === event) {
-        listener(item.payload as ProgressEventPayloads[K]);
-      } else {
-        remaining.push(item);
+    // Replay buffered events for this event type and remove them
+    const buffered = this.eventStore.get(event);
+    if (buffered?.length) {
+      this.eventStore.delete(event);
+      for (const payload of buffered) {
+        listener(payload as ProgressEventPayloads[K]);
       }
     }
-    this.buffer = remaining;
 
     return cleanup;
+  }
+
+  clearStream(streamId: string): void {
+    for (const [event, entries] of this.eventStore) {
+      const filtered = entries.filter(
+        (payload) => !isStreamPayload(payload, streamId),
+      );
+      if (filtered.length === 0) {
+        this.eventStore.delete(event);
+      } else if (filtered.length < entries.length) {
+        this.eventStore.set(event, filtered);
+      }
+    }
+  }
+
+  clear(): void {
+    this.eventStore.clear();
   }
 }
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -48,8 +48,9 @@ interface SetTaskStatePayload {
 /**
  * Per-event-type buffer limit. Prevents one noisy event type (e.g., addLogMessage)
  * from evicting critical events of other types during the startup buffering window.
+ * Kept at 1000 (same as the previous global limit) so no single type regresses in capacity.
  */
-const PER_TYPE_BUFFER_LIMIT = 200;
+const PER_TYPE_BUFFER_LIMIT = 1000;
 
 export interface ProgressEventPayloads {
   addLogMessage: { streamId: StreamTabId; logMessage: LogMessageData };

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -314,8 +314,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Clear pending task groups, approvals, queued follow-ups, and YOLO state to prevent memory leaks
+    // Clear pending task groups, buffered events, approvals, queued follow-ups, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearPendingTaskGroups(streamId);
+    this.provider.eventHandler.clearBufferedEvents(streamId);
     cleanupApprovalsForStream(streamId);
     ToolUseFollowUpQueue.release(streamId);
     this.clearModelOutputBackups(streamId);
@@ -337,8 +338,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Clear all pending task groups, approvals, queued follow-ups, and YOLO state to prevent memory leaks
+    // Clear all pending task groups, buffered events, approvals, queued follow-ups, and YOLO state to prevent memory leaks
     this.provider.eventHandler.clearAllPendingTaskGroups();
+    this.provider.eventHandler.clearAllBufferedEvents();
     cleanupAllApprovals();
     for (const streamId of this.provider.state.streamTabs.keys()) {
       ToolUseFollowUpQueue.release(streamId);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -650,6 +650,16 @@ export class ProgressEventHandler {
     this.pendingTaskGroups.clear();
   }
 
+  /** Remove buffered events for a deleted stream so they don't replay to the next subscriber. */
+  clearBufferedEvents(streamId: StreamTabId): void {
+    bus.clearStream(streamId);
+  }
+
+  /** Remove all buffered events (e.g., when all streams are deleted). */
+  clearAllBufferedEvents(): void {
+    bus.clear();
+  }
+
   resetRunningTasksToError(waitingStreams?: Set<StreamTabId>): StreamTabId[] {
     const affectedStreams: StreamTabId[] = [];
     const waitingSet = waitingStreams ?? new Set<StreamTabId>();


### PR DESCRIPTION
## Summary
This PR improves the event buffering system in the ProgressEventBus to prevent one noisy event type from evicting critical events of other types, and adds the ability to clear buffered events when streams are deleted.

## Key Changes

- **Per-event-type buffering**: Replaced the flat event buffer array with a `Map<ProgressEvent, payload[]>` structure. This ensures each event type has its own buffer with a limit of 1000 entries, preventing high-volume events (e.g., `addLogMessage`) from evicting important events of other types during the startup buffering window.

- **Stream-scoped event cleanup**: Added `clearStream(streamId)` and `clear()` methods to `ProgressEventBusLike` interface and `ProgressEventBus` class to remove buffered events associated with specific streams or all streams.

- **Helper function for stream identification**: Introduced `isStreamPayload()` utility to check whether an event payload is scoped to a specific stream by examining `streamId`, `parentStreamId`, and `childStreamId` fields.

- **Integration with stream deletion**: Updated `ProgressEventHandler` with `clearBufferedEvents()` and `clearAllBufferedEvents()` methods that delegate to the bus.

- **Memory leak prevention**: Modified `ProgressViewMessageHandler` to call the new cleanup methods when individual streams are deleted or when all streams are cleared, preventing buffered events from replaying to subsequent subscribers.

## Implementation Details

- The per-type buffer limit remains at 1000 (same as the previous global limit) to avoid regressions in individual event type capacity.
- Event replay logic was simplified: instead of filtering a flat array, the code now directly retrieves and deletes the buffered entries for a specific event type.
- Stream cleanup filters entries in-place and removes empty event type entries from the map to maintain a clean state.

https://claude.ai/code/session_0136BLWGhH9gabNrkGJukQZg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core progress event delivery/buffering semantics; mistakes could drop or misorder buffered UI events, though changes are localized and keep prior buffer limits.
> 
> **Overview**
> Updates `ProgressEventBus` to buffer startup events *per event type* (via a `Map` with a per-type limit) so high-volume events can’t evict other event types’ critical buffered events, and simplifies replay to drain only that event’s buffer on first subscription.
> 
> Adds buffered-event cleanup APIs (`clearStream`, `clear`) and wires them into stream deletion flows (`ProgressViewMessageHandler` via `ProgressEventHandler`) so buffered events for removed streams don’t replay later and memory usage doesn’t accumulate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0898502fc701252403f4ccd6adbcd51ea69cd021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->