### PR TITLE
Force task-run storage for subagent workflow outputs

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -60,6 +60,8 @@ export interface RunReflectionFlowInput<
   getOutputFileLocation?: (round: number) => AgentFileLocation;
   usageMonitor?: UsageMonitor;
   onRoundCompleted?: (roundIndex: number, totalRounds: number) => void;
+  /** When true, outputs are routed to task-run storage by default. */
+  isSubagent?: boolean;
 }
 
 export interface RunReflectionFlowResult {
@@ -135,7 +137,9 @@ export async function runReflectionFlow<C = unknown>(
   let shared: ReflectionFlowShared | undefined;
   let services: ReflectionServices<C> | undefined;
 
-  const fileService = new TaskRunFileService(executionId);
+  const fileService = new TaskRunFileService(executionId, {
+    forceRunStorage: input.isSubagent,
+  });
 
   const baseFiles: WorkspaceFileLocation[] = (
     config.outputFiles.length > 0 ? config.outputFiles : [config.inputFile]

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -659,6 +659,7 @@ export async function executeAgent(
           setting: ctx.setting as AgentWorkflowSetting,
           parentStage: ctx.parentStage,
           onRoundCompleted,
+          isSubagent,
         });
         return {
           category: 'workflow' as const,

--- a/src/utils/files/taskRunStorage.ts
+++ b/src/utils/files/taskRunStorage.ts
@@ -220,13 +220,24 @@ export class TaskRunFileService {
   private hasPreparedSnapshot = false;
   private readonly mirroredDependencies = new Set<string>();
 
-  constructor(executionId?: ExecutionId) {
+  /**
+   * When true, the service always uses task-run storage regardless of user
+   * config. Set for subagent workflows so their outputs don't overcrowd the
+   * workspace.
+   */
+  private readonly forceRunStorage: boolean;
+
+  constructor(
+    executionId?: ExecutionId,
+    options?: { forceRunStorage?: boolean },
+  ) {
     this.metadata = {
       mode: 'workspace',
       executionId: undefined,
       runDirectory: undefined,
     };
     this.useRunStorage = false;
+    this.forceRunStorage = options?.forceRunStorage ?? false;
     this.updateRunContext(executionId);
   }
 
@@ -236,7 +247,8 @@ export class TaskRunFileService {
       'workspace',
     );
     const shouldUseRunStorage =
-      storageMode === 'taskRunStorage' && Boolean(executionId);
+      (storageMode === 'taskRunStorage' || this.forceRunStorage) &&
+      Boolean(executionId);
 
     const nextMode: 'workspace' | 'taskRunStorage' = shouldUseRunStorage
       ? 'taskRunStorage'


### PR DESCRIPTION
## Summary
This change adds support for forcing task-run storage usage in subagent workflows to prevent their outputs from overcrowding the workspace. A new `forceRunStorage` option is introduced to the `TaskRunFileService` that overrides user configuration when enabled.

## Key Changes
- **TaskRunFileService**: Added `forceRunStorage` boolean option to constructor that forces task-run storage usage regardless of user config settings
- **Storage logic**: Updated `updateRunContext()` to use task-run storage when either the user config specifies it OR `forceRunStorage` is enabled (with a valid executionId)
- **RunReflectionFlow**: Added `isSubagent` input parameter that gets passed to `TaskRunFileService` as the `forceRunStorage` option
- **ExecuteAgent**: Propagated the `isSubagent` flag through to the reflection flow execution

## Implementation Details
- The `forceRunStorage` flag is stored as a private readonly property and checked during storage mode determination
- The logic uses an OR condition: `(storageMode === 'taskRunStorage' || this.forceRunStorage)` to ensure subagent workflows always use task-run storage when they have an executionId
- This prevents subagent outputs from being written to the workspace, keeping the workspace clean while maintaining proper output isolation

https://claude.ai/code/session_015jFmfSfssvGQSByNMXAxmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes output file routing based on a new flag, which could redirect artifacts to a different storage location than users expect if the flag is mis-set.
> 
> **Overview**
> Subagent workflow executions now **force task-run storage** for their output files to avoid cluttering the workspace.
> 
> This introduces a `forceRunStorage` option on `TaskRunFileService` (overriding `texra.agentOutputs.storageMode` when an `executionId` is present) and threads a new `isSubagent` flag from `executeAgent` into `runReflectionFlow`, where it enables the forced storage behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392e197bcd868d79c3fcc0a77f42514f55a6bc84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->