### PR TITLE
Refine duplicate parallel call error message

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -57,10 +57,8 @@ import type { CycleParams, ToolUseCycleServices } from './CycleServices';
 // ============================================================================
 
 const DUPLICATE_CALL_ERROR =
-  'Duplicate parallel call skipped. This call has the same tool name and arguments ' +
-  'as an earlier call in this batch that was already executed. ' +
-  'If you need to run this tool multiple times with the same arguments, ' +
-  'please call them sequentially in separate responses.';
+  'Duplicate parallel call skipped — same tool name and arguments as an earlier call in this batch. ' +
+  'To run identical calls, invoke them sequentially in separate responses.';
 
 /**
  * Identify duplicate parallel tool calls (same name + identical arguments).


### PR DESCRIPTION
## Summary
Updated the error message for duplicate parallel tool calls to be more concise and clearer in its guidance.

## Changes
- Simplified the `DUPLICATE_CALL_ERROR` message by:
  - Replacing wordy phrasing with more direct language (e.g., "This call has the same" → "same")
  - Using an em dash for better readability
  - Condensing multi-line explanation into two focused lines
  - Clarifying the recommended action ("invoke them sequentially" instead of "call them sequentially")

## Details
The error message now communicates the same information more efficiently while maintaining clarity about what caused the error and how to resolve it. This improves the user experience when encountering duplicate parallel tool calls in the agent's tool use cycle.

https://claude.ai/code/session_01VCAAHT8uBPxb9wJwrdp4sP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change to an error message; no logic, data flow, or security behavior is modified.
> 
> **Overview**
> Refines the user-facing error returned when a duplicate parallel tool call is deduplicated in `ToolUseCycleFlow`, making the message shorter and more direct while keeping the same guidance (rerun identical calls sequentially in separate responses).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b641abe3e6256c6dd41dcda1f4fa51215500bc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->