### PR TITLE
refactor: classify errors once and carry ProviderError through the en…

### DIFF
--- a/src/agent/core/flows/CommonCycleTypes.ts
+++ b/src/agent/core/flows/CommonCycleTypes.ts
@@ -2,7 +2,7 @@
 
 import { z } from 'zod';
 
-import { RetryErrorInfoSchema } from '@shared/schemas';
+import { ProviderErrorSchema } from '@shared/schemas';
 import {
   ProviderMessageSchema,
   type ProviderMessage,
@@ -19,7 +19,7 @@ export const BaseCycleFieldsSchema = z.object({
   endTurn: z.boolean(),
   responseTimeMs: z.number().optional(),
   stopReason: z.string().nullish(),
-  lastError: RetryErrorInfoSchema.optional(),
+  lastError: ProviderErrorSchema.optional(),
 });
 
 export type BaseCycleFields = z.infer<typeof BaseCycleFieldsSchema>;

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -109,9 +109,9 @@ export class ModelInvocationNode<
 
   async execFallback(
     _prepRes: BaseInvocationPrepResult,
-    error: Error,
+    classified: unknown,
   ): Promise<InvocationResult<BaseInvocationSuccessData>> {
-    return this.getFallbackResult(error);
+    return this.getFallbackResult(classified);
   }
 
   async post(

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -4,7 +4,7 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import {
   MESSAGE_TYPES,
   STREAM_STATUS,
-  type RetryErrorInfo,
+  type ProviderError,
 } from '@shared/schemas';
 import { Node, type NonIterableObject } from '@agent/node';
 import {
@@ -22,7 +22,7 @@ import {
 const BACKGROUND_MODE_MIN_RETRIES = 3;
 
 export interface RetryState {
-  lastError?: RetryErrorInfo;
+  lastError?: ProviderError;
 }
 
 /** Returns maxRetries (1 initial + N auto-retries) and wait (seconds between retries). */
@@ -44,7 +44,7 @@ interface ManualRetryPromptResult {
 /** success: model response | failed: retries exhausted | cancelled: user cancelled | skipped: shouldStop was true */
 export type InvocationResult<TSuccess> =
   | ({ kind: 'success' } & TSuccess)
-  | { kind: 'failed'; message: string; retryable?: boolean }
+  | { kind: 'failed'; error: ProviderError }
   | { kind: 'cancelled' }
   | { kind: 'skipped' };
 
@@ -199,10 +199,19 @@ export abstract class RetryableInvocationNode<
     }
   }
 
+  /**
+   * Classify raw thrown errors into ProviderError once.
+   * All downstream hooks (shouldAutoRetry, retryPrompt, execFallback)
+   * receive this classified result — no redundant formatProviderHttpError calls.
+   */
+  classifyError(raw: unknown): ProviderError {
+    return formatProviderHttpError(raw);
+  }
+
   /** Auth/permission errors (401, 403) skip auto-retries — they need human attention. */
-  shouldAutoRetry(error: Error): boolean {
-    const formatted = formatProviderHttpError(error);
-    const code = formatted.statusCode;
+  shouldAutoRetry(classified: unknown): boolean {
+    const error = classified as ProviderError;
+    const code = error.statusCode;
     return code !== 401 && code !== 403;
   }
 
@@ -223,7 +232,8 @@ export abstract class RetryableInvocationNode<
     return super._exec(prepRes);
   }
 
-  async retryPrompt(_prepRes: unknown, error: Error): Promise<boolean> {
+  async retryPrompt(_prepRes: unknown, classified: unknown): Promise<boolean> {
+    const error = classified as ProviderError;
     const result = await this.handleManualRetryPrompt(error);
 
     if (result.userCancelled) {
@@ -233,8 +243,7 @@ export abstract class RetryableInvocationNode<
     if (result.shouldRetry) {
       this._persistent401Error = null;
       this._hasAttemptedTokenRefresh = false;
-      const formatted = formatProviderHttpError(error);
-      if (formatted.isRelayError && formatted.statusCode === 401) {
+      if (error.isRelayError && error.statusCode === 401) {
         await tryRefreshClient(
           this.services.refreshClient,
           this.services.logger,
@@ -247,27 +256,26 @@ export abstract class RetryableInvocationNode<
   }
 
   protected async handleManualRetryPrompt(
-    error: Error,
+    error: ProviderError,
   ): Promise<ManualRetryPromptResult> {
     const { streamId, logger } = this.services;
     const operationName = this.getOperationName();
-    const formatted = formatProviderHttpError(error);
 
-    if (!formatted.retryable) {
+    if (!error.retryable) {
       return { shouldRetry: false, userCancelled: false };
     }
 
     logger.logErrorData(
-      `${operationName} failed: ${formatted.message}`,
-      formatted,
+      `${operationName} failed: ${error.message}`,
+      error,
     );
 
     StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
     const result: RetryResult = await retryCoordinator.waitForRetry(streamId, {
       operation: operationName,
-      errorMessage: formatted.message,
+      errorMessage: error.message,
       logger,
-      errorDetails: formatted,
+      errorDetails: error,
     });
 
     if (result.action === 'retry') {
@@ -286,25 +294,24 @@ export abstract class RetryableInvocationNode<
   }
 
   protected getFallbackResult(
-    error: Error,
+    classified: unknown,
   ):
     | { kind: 'cancelled' }
-    | { kind: 'failed'; message: string; retryable?: boolean } {
+    | { kind: 'failed'; error: ProviderError } {
     if (this._userCancelled) {
       return { kind: 'cancelled' };
     }
 
-    const formatted = formatProviderHttpError(error);
-    if (!formatted.retryable) {
+    const error = classified as ProviderError;
+    if (!error.retryable) {
       this.services.logger.logErrorData(
-        `${this.getOperationName()} failed (not retryable): ${formatted.message}`,
-        formatted,
+        `${this.getOperationName()} failed (not retryable): ${error.message}`,
+        error,
       );
     }
     return {
       kind: 'failed',
-      message: formatted.message,
-      retryable: formatted.retryable,
+      error,
     };
   }
 }
@@ -339,10 +346,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
   }
 
   if (result.kind === 'failed') {
-    retryState.lastError = {
-      message: result.message,
-      retryable: result.retryable ?? false,
-    };
+    retryState.lastError = result.error;
     state.shouldStop = true;
     state.endTurn = false;
     return null;
@@ -353,6 +357,7 @@ export function handleInvocationResult<T extends { response: unknown }>(
     retryState.lastError = {
       message: EMPTY_RESPONSE_ERROR_MESSAGE,
       retryable: false,
+      isRelayError: false,
     };
     state.shouldStop = true;
     state.endTurn = false;

--- a/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionFlowState.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import {
   AgentFileLocationSchema,
-  RetryErrorInfoSchema,
+  ProviderErrorSchema,
   RoundOutputSchema,
 } from '@shared/schemas';
 import {
@@ -40,7 +40,7 @@ export const ReflectionFlowStateSchema = z.object({
   endTurn: z.boolean(),
 
   /** Distinguishes failure from cancellation during resume. */
-  lastError: RetryErrorInfoSchema.optional(),
+  lastError: ProviderErrorSchema.optional(),
 });
 
 export type ReflectionFlowState = z.infer<typeof ReflectionFlowStateSchema>;

--- a/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/ResponseCycleNode.ts
@@ -12,6 +12,7 @@ import type {
 } from '@agent/core/AgentState';
 import { buildCycleServices } from '@agent/core/flows/CycleServices';
 import { formatProviderHttpError } from '@common/errors';
+import type { ProviderError } from '@shared/schemas';
 import type { AgentFileLocation } from '@utils/files';
 
 import type { ReflectionFlowShared } from '../ReflectionFlowState';
@@ -31,7 +32,7 @@ interface CyclePrepInput {
 type CycleOutcome =
   | { outcome: 'completed'; endTurn: boolean }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; error: Error; retryable?: boolean };
+  | { outcome: 'failed'; error: ProviderError };
 
 export class ResponseCycleNode<C = unknown> extends Node<
   ReflectionFlowShared,
@@ -102,8 +103,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
       if (cycleShared.lastError) {
         return {
           outcome: 'failed',
-          error: new Error(cycleShared.lastError.message),
-          retryable: cycleShared.lastError.retryable,
+          error: cycleShared.lastError,
         };
       }
       if (cycleShared.shouldStop && !cycleShared.endTurn) {
@@ -115,21 +115,18 @@ export class ResponseCycleNode<C = unknown> extends Node<
       if (this.services.onRoundFinalized) {
         await this.services.onRoundFinalized(prepRes.run);
       }
-      const formatted = formatProviderHttpError(error);
       return {
         outcome: 'failed',
-        error: error instanceof Error ? error : new Error(String(error)),
-        retryable: formatted.retryable,
+        error: formatProviderHttpError(error),
       };
     }
   }
 
   async execFallback(
     _prepRes: CyclePrepInput,
-    error: Error,
+    error: unknown,
   ): Promise<CycleOutcome> {
-    const formatted = formatProviderHttpError(error);
-    return { outcome: 'failed', error, retryable: formatted.retryable };
+    return { outcome: 'failed', error: formatProviderHttpError(error) };
   }
 
   async post(
@@ -143,10 +140,7 @@ export class ResponseCycleNode<C = unknown> extends Node<
 
     if (execRes.outcome === 'failed') {
       logger.error(`Response cycle failed: ${execRes.error.message}`);
-      shared.lastError = {
-        message: execRes.error.message,
-        retryable: execRes.retryable ?? false,
-      };
+      shared.lastError = execRes.error;
       shared.continueRounds = false;
       shared.endTurn = false;
       return FlowTransition.FINALIZE;

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -28,6 +28,7 @@ import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import type { FlowRecord } from '@agent/node/persisted-flow';
 import { RoundPersistedFlow } from '@agent/node/round-persisted-flow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
+import { AgentFlowError } from '@common/errors';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { AgentLogStage } from '@logger/AgentLogger';
 import {
@@ -302,7 +303,9 @@ export async function runReflectionFlow<C = unknown>(
       status = END_GROUP_STATUS.ERROR;
       // Re-throw after state persistence (handled in finally) so
       // runFlowWithLifecycle logs the error and shows the user notification.
-      throw new Error(shared.lastError.message);
+      // AgentFlowError preserves the full ProviderError (status code,
+      // request ID, provider, etc.) instead of discarding it.
+      throw new AgentFlowError(shared.lastError);
     } else {
       status = executionToEndStatus(flowStatus) as EndGroupStatus;
     }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -9,6 +9,7 @@ import { buildCycleServices } from '@agent/core/flows/CycleServices';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { formatProviderHttpError } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
+import type { ProviderError, TodoItem } from '@shared/schemas';
 
 import {
   type ToolUseRunShared,
@@ -16,13 +17,12 @@ import {
   assertPreparedShared,
 } from './types';
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
-import type { TodoItem } from '@shared/schemas';
 
 type ToolUseCycleOutcome =
   | { outcome: 'completed'; messages: ProviderMessage[] }
   | { outcome: 'skipped' }
   | { outcome: 'cancelled' }
-  | { outcome: 'failed'; message: string; retryable?: boolean };
+  | { outcome: 'failed'; error: ProviderError };
 
 export class ToolUseCycleNode<C> extends Node<
   ToolUseRunShared,
@@ -88,8 +88,7 @@ export class ToolUseCycleNode<C> extends Node<
       if (cycleShared.shouldStop && cycleShared.lastError) {
         return {
           outcome: 'failed',
-          message: cycleShared.lastError.message,
-          retryable: cycleShared.lastError.retryable,
+          error: cycleShared.lastError,
         };
       }
       if (cycleShared.shouldStop && !cycleShared.endTurn) {
@@ -103,13 +102,11 @@ export class ToolUseCycleNode<C> extends Node<
 
   async execFallback(
     _prepRes: CyclePrepResult,
-    error: Error,
+    error: unknown,
   ): Promise<ToolUseCycleOutcome> {
-    const formatted = formatProviderHttpError(error);
     return {
       outcome: 'failed',
-      message: error.message,
-      retryable: formatted.retryable,
+      error: formatProviderHttpError(error),
     };
   }
 
@@ -149,10 +146,7 @@ export class ToolUseCycleNode<C> extends Node<
         return FlowTransition.DEFAULT;
 
       case 'failed':
-        shared.lastError = {
-          message: execRes.message,
-          retryable: execRes.retryable ?? false,
-        };
+        shared.lastError = execRes.error;
         return FlowTransition.FINALIZE;
 
       case 'cancelled':

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -7,7 +7,7 @@ import type {
 } from '@agent/core/AgentWorkspaceState';
 import type { UserVariableChannels } from '@agent/core/AgentCycleOptions';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import type { RetryErrorInfo } from '@shared/schemas';
+import type { ProviderError } from '@shared/schemas';
 
 export interface StateSlicesSnapshot {
   runStateSnapshot: AgentRunStateSnapshot;
@@ -21,7 +21,7 @@ export interface ToolUseRunShared {
   stateSlices: StateSlicesSnapshot | null;
   userCancelledRetry?: boolean;
   /** Distinguishes failure from cancellation during resume. */
-  lastError?: RetryErrorInfo;
+  lastError?: ProviderError;
 }
 
 interface NodeResultStateBase {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -16,6 +16,7 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
+import { AgentFlowError } from '@common/errors';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
@@ -196,7 +197,9 @@ export async function runToolUseFlow<C = unknown>(
       status = END_GROUP_STATUS.ERROR;
       // Re-throw after state persistence (handled in finally) so
       // runFlowWithLifecycle logs the error and shows the user notification.
-      throw new Error(shared.lastError.message);
+      // AgentFlowError preserves the full ProviderError (status code,
+      // request ID, provider, etc.) instead of discarding it.
+      throw new AgentFlowError(shared.lastError);
     } else {
       const execStatus = input.checkInterruption()
         ? EXECUTION_STATUS.INTERRUPTED

--- a/src/agent/node/index.ts
+++ b/src/agent/node/index.ts
@@ -119,8 +119,19 @@ class Node<
     this.maxRetries = maxRetries;
     this.wait = wait;
   }
-  async execFallback(prepRes: unknown, error: Error): Promise<unknown> {
-    throw error;
+  async execFallback(prepRes: unknown, error: unknown): Promise<unknown> {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+  /**
+   * Hook to classify a raw thrown error into a structured form.
+   * Called once per catch; the result is threaded to shouldAutoRetry,
+   * retryPrompt, and execFallback — avoiding repeated classification.
+   *
+   * Default: wraps in Error if needed (identity for Error instances).
+   * Override to return richer error types (e.g., ProviderError).
+   */
+  classifyError(raw: unknown): unknown {
+    return raw instanceof Error ? raw : new Error(String(raw));
   }
   /**
    * Hook called when all auto-retries are exhausted.
@@ -138,14 +149,14 @@ class Node<
    * @example
    * ```typescript
    * class MyNode extends Node<S, P> {
-   *   async retryPrompt(prepRes: unknown, error: Error): Promise<boolean> {
-   *     const result = await showRetryDialog(error.message);
+   *   async retryPrompt(prepRes: unknown, error: unknown): Promise<boolean> {
+   *     const result = await showRetryDialog(String(error));
    *     return result === 'retry';
    *   }
    * }
    * ```
    */
-  async retryPrompt(_prepRes: unknown, _error: Error): Promise<boolean> {
+  async retryPrompt(_prepRes: unknown, _error: unknown): Promise<boolean> {
     return false;
   }
   /**
@@ -155,7 +166,7 @@ class Node<
    *
    * Default: true (all errors are auto-retried).
    */
-  shouldAutoRetry(_error: Error): boolean {
+  shouldAutoRetry(_error: unknown): boolean {
     return true;
   }
   /**
@@ -195,34 +206,39 @@ class Node<
         // Check abort at start of each retry for responsive cancellation
         // This ensures we don't attempt exec when the user has already cancelled
         if (this.signal?.aborted) {
-          const cancelError = new Error('Operation cancelled by user');
-          return await this.execFallback(prepRes, cancelError);
+          return await this.execFallback(
+            prepRes,
+            this.classifyError(new Error('Operation cancelled by user')),
+          );
         }
         try {
           return await this.exec(prepRes);
         } catch (e) {
+          // Classify once — all downstream hooks receive the classified error
+          const classified = this.classifyError(e);
+
           // If abort signal is set and aborted, skip retries and go to fallback
           // This prevents unnecessary retries when the user intentionally cancelled
           const isAborted = this.signal?.aborted;
           const isLastAutoRetry = this.currentRetry === effectiveMaxRetries - 1;
-          const skipAutoRetry = !this.shouldAutoRetry(e as Error);
+          const skipAutoRetry = !this.shouldAutoRetry(classified);
 
           if (isLastAutoRetry || isAborted || skipAutoRetry) {
             // Auto-retries exhausted - try manual retry (unless aborted)
             if (!isAborted) {
-              const shouldRetry = await this.retryPrompt(prepRes, e as Error);
+              const shouldRetry = await this.retryPrompt(prepRes, classified);
               if (shouldRetry) {
                 manualRetryCount++;
                 break; // Break inner loop to restart auto-retries
               }
             }
-            return await this.execFallback(prepRes, e as Error);
+            return await this.execFallback(prepRes, classified);
           }
           if (this.wait > 0) {
             await delay(this.wait * 1000);
             // Check abort after delay to exit quickly if cancelled during wait
             if (this.signal?.aborted) {
-              return await this.execFallback(prepRes, e as Error);
+              return await this.execFallback(prepRes, classified);
             }
           }
         }

--- a/src/agent/node/round-persisted-flow.ts
+++ b/src/agent/node/round-persisted-flow.ts
@@ -19,7 +19,7 @@
 import {
   EXECUTION_STATUS,
   type ExecutionStatus,
-  type RetryErrorInfo,
+  type ProviderError,
 } from '@shared/schemas';
 import type { ExecutionKVStore } from '@agent/storage';
 import type { AgentLogStage } from '@logger/AgentLogger';
@@ -47,7 +47,7 @@ export interface RoundAwareState {
   continueRounds: boolean;
 
   /** Set by nodes when execution fails. Skips round completion callbacks. */
-  lastError?: RetryErrorInfo;
+  lastError?: ProviderError;
 }
 
 // ============================================================================

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -53,7 +53,11 @@ import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { normalizeRunId } from '@common/constants/runIds';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
+import {
+  getSdkErrorMessage,
+  formatProviderHttpError,
+} from '@common/errors/sdkErrorUtils';
+import { AgentFlowError } from '@common/errors/AgentFlowError';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import {
@@ -411,7 +415,15 @@ async function runFlowWithLifecycle(
   } catch (err) {
     await writeTerminalStatus(ctx.executionId, 'error').catch(() => {});
     untrackExecution(ctx.executionId);
-    const errorMsg = `Error executing agent ${agentName}: ${getSdkErrorMessage(err)}`;
+
+    // Extract structured error info — AgentFlowError carries the full
+    // ProviderError; for other errors, classify on the spot.
+    const providerError =
+      err instanceof AgentFlowError
+        ? err.providerError
+        : formatProviderHttpError(err);
+
+    const errorMsg = `Error executing agent ${agentName}: ${providerError.message}`;
 
     // Log error BEFORE ending the group so it gets the correct groupId
     await ctx.logger.logError(errorMsg, err, {
@@ -424,18 +436,20 @@ async function runFlowWithLifecycle(
     // Subagents propagate errors to the orchestrator via FollowUpQueue —
     // don't show VS Code popups that would confuse the user.
     if (!options?.isSubagent) {
-      const msg = toErrorMessage(err);
-      if (
-        msg.includes('Missing API key') ||
-        msg.includes('API key not found')
-      ) {
+      // Use typed status code detection instead of string matching.
+      // 401 from provider APIs indicates missing/invalid API keys.
+      if (providerError.statusCode === 401) {
         await showApiKeyErrorNotification();
       } else {
         vscode.window.showErrorMessage(errorMsg);
       }
     }
 
-    throw new Error(errorMsg);
+    // Preserve the typed error for upstream consumers
+    if (err instanceof AgentFlowError) {
+      throw err;
+    }
+    throw new AgentFlowError(providerError);
   }
 }
 

--- a/src/common/errors/AgentFlowError.ts
+++ b/src/common/errors/AgentFlowError.ts
@@ -1,0 +1,16 @@
+import type { ProviderError } from '@shared/schemas';
+
+/**
+ * Error thrown when an agent flow fails due to a provider error.
+ *
+ * Carries the full ProviderError (status code, request ID, provider,
+ * relay flag, stream diagnostics) through the call stack, eliminating
+ * the information loss that occurs when re-wrapping as `new Error(message)`.
+ */
+export class AgentFlowError extends Error {
+  override readonly name = 'AgentFlowError';
+
+  constructor(readonly providerError: ProviderError) {
+    super(providerError.message);
+  }
+}

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -21,3 +21,6 @@ export {
 // These SDK utilities are exposed in the barrel because they have broad usage
 // across the codebase (model handlers, runtime, UI layers).
 export { formatProviderHttpError, getSdkErrorMessage } from './sdkErrorUtils';
+
+// Typed error for agent flow failures — carries full ProviderError through the stack.
+export { AgentFlowError } from './AgentFlowError';

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -24,7 +24,7 @@ export const StreamDiagnosticsSchema = z.object({
 export type StreamDiagnostics = z.infer<typeof StreamDiagnosticsSchema>;
 
 /** Core error details from a provider/SDK */
-const ProviderErrorSchema = z.object({
+export const ProviderErrorSchema = z.object({
   message: z.string(),
   statusCode: z.int().optional(),
   statusText: z.string().optional(),


### PR DESCRIPTION
…tire flow

Replace the pattern where `formatProviderHttpError()` was called 5+ times on the same raw error (in withAbortController, shouldAutoRetry, retryPrompt, getFallbackResult, and cycle nodes), with a classify-once architecture:

- Add `classifyError()` hook to Node base class, called once in `_exec()` catch block. The classified result threads through shouldAutoRetry, retryPrompt, and execFallback — no redundant classification.

- RetryableInvocationNode overrides `classifyError()` to call `formatProviderHttpError()` once, returning a full `ProviderError`.

- Change `InvocationResult.failed` from `{ message, retryable? }` to `{ error: ProviderError }` — preserving status codes, request IDs, provider info, relay flags, and stream diagnostics.

- Change `lastError` on all shared state types (BaseCycleFields, ReflectionFlowState, ToolUseRunShared, RoundAwareState) from `RetryErrorInfo { message, retryable }` to full `ProviderError`.

- Introduce `AgentFlowError` — a typed Error subclass carrying `ProviderError` — thrown by flow runners instead of `new Error(shared.lastError.message)`.

- Update `runFlowWithLifecycle` to use typed error detection (`providerError.statusCode === 401`) instead of string matching (`msg.includes('Missing API key')`).

https://claude.ai/code/session_01QUf8RSriJcegoxrEEhtwaX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution/retry plumbing and changes error shapes/types across multiple flows, which could affect retry behavior, persistence/resume parsing, and user-facing error handling if any call sites still assume the old `{message, retryable}` format.
> 
> **Overview**
> Refactors agent flow error handling to **classify thrown provider/SDK errors once** (via a new `Node.classifyError()` hook) and thread the classified result through retry logic (`shouldAutoRetry`, `retryPrompt`, `execFallback`) instead of repeatedly calling `formatProviderHttpError()`.
> 
> Switches flow/shared-state error tracking from minimal `RetryErrorInfo` to full `ProviderError` (schemas + `lastError` across cycle, reflection, tool-use, and round-persisted flows), updates failure result shapes to carry `{ error: ProviderError }`, and introduces `AgentFlowError` so flow runners and `executeAgent` can preserve structured error metadata and use typed status-code checks (e.g. `401` API key prompt) rather than string matching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e60a109629d409cd74b985ae7fd07ada9b075d15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->