### PR TITLE
Fix approval panel disappearing when opening diff

### DIFF
--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -308,13 +308,17 @@ export function handlePermissionAction(
         action,
         feedback,
       });
-      // Optimistic removal — backend RESOLVE will be a no-op
-      removePrompt(
-        ctx,
-        permission.kind,
-        'requestId',
-        permission.data.requestId,
-      );
+      // Only remove for terminal actions (approve/reject).
+      // Non-terminal actions like openDiff, previewProposed, showLatexdiff
+      // just open editors without settling the approval.
+      if (action === 'approve' || action === 'reject') {
+        removePrompt(
+          ctx,
+          permission.kind,
+          'requestId',
+          permission.data.requestId,
+        );
+      }
       break;
     }
     case PERMISSION_KIND.RETRY:


### PR DESCRIPTION
## Summary

- Fix approval panel in progress view disappearing when clicking "Open diff", "Preview", or "LaTeXdiff" buttons
- Root cause: `removePrompt()` in `handlePermissionAction` was called unconditionally for all tool edit actions, including non-terminal ones that only open editors without settling the approval on the backend
- Guard optimistic removal to only fire for terminal actions (`approve` / `reject`)

## Test plan

- [ ] Open a tool edit approval panel in the progress view
- [ ] Click "Open diff" — approval panel should remain visible
- [ ] Click "Preview" (on LaTeX files) — approval panel should remain visible
- [ ] Click "Approve" or "Reject" — approval panel should still be removed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI state change limited to when prompts are optimistically removed; low risk aside from potentially leaving prompts visible if other terminal actions exist.
> 
> **Overview**
> Fixes a progress view UX bug where tool edit/bash approval prompts were optimistically removed even when the user clicked non-terminal actions (e.g., `openDiff`, `previewProposed`, `showLatexdiff`).
> 
> `handlePermissionAction` now only calls `removePrompt()` for terminal approval actions (`approve`/`reject`), keeping the approval panel visible until the backend actually resolves it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb724ebaba697be4e2e893ff2e6ac4ad642cf1bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->