### PR TITLE
Enforce mathematical notation in blueprints, not Lean syntax

### DIFF
--- a/reference-agents/Lean4/leanBlueprint.yaml
+++ b/reference-agents/Lean4/leanBlueprint.yaml
@@ -40,7 +40,7 @@ prompts:
 
     WRITING STYLE
 
-    Write the way a good math textbook does: plain, precise, and readable. A blueprint is read by humans — both mathematicians orienting themselves and formalizers deciding what to work on next.
+    Write the way a published mathematics paper does: plain, precise, and readable. A blueprint is read by humans — both mathematicians orienting themselves and formalizers deciding what to work on next. The LaTeX output must read as standard mathematical prose with no trace of Lean or any programming language.
 
     - State things directly. Avoid filler, hedge words, and unnecessary qualifiers.
     - Each statement should be self-contained: a reader should understand the hypotheses and conclusion without chasing references.
@@ -48,6 +48,37 @@ prompts:
     - Use standard mathematical prose. Use $...$ for math. Keep sentences short.
     - Do not over-format. No bold, no bullet lists, no markdown headings inside the LaTeX content. Just clear paragraphs and standard theorem environments.
     - Always cross-reference by label, never by hardcoded number. Write "Theorem~\ref{thm:main}" not "Theorem 3". This keeps references stable when items are reordered or renumbered.
+
+
+    NOTATION TRANSLATION — LEAN TO MATHEMATICS
+
+    The informal mathematical content in the blueprint (theorem statements, definitions, proof sketches) must use standard mathematical notation as found in published papers and textbooks. Never let Lean syntax, identifiers, or naming conventions leak into the LaTeX prose.
+
+    Translate Lean identifiers into conventional mathematical symbols and language:
+    - Lean CamelCase names become standard notation: GaugeEquiv(A, B) → "$A$ and $B$ are gauge equivalent" or "$A \sim B$"
+    - Lean predicate-style calls become mathematical sentences: SameMPV(A, B) → "$A$ and $B$ have the same monopole-point-value" or whatever the standard terminology is
+    - Lean function application f x y → $f(x, y)$ or the conventional notation for that operation
+    - Lean type constructors become their mathematical counterparts: Fin n → $\{1, \dots, n\}$, List α → sequences, Finset α → finite subsets of $\alpha$
+    - Lean dot notation Nat.add_comm → commutativity of addition (or $m + n = n + m$)
+    - Lean prop connectives: And P Q → $P \land Q$, Or P Q → $P \lor Q$, Not P → $\lnot P$, Iff P Q → $P \iff Q$
+    - Lean quantifiers: ∀ x : α, P x → "for all $x \in \alpha$, $P(x)$" (or the standard way to phrase it)
+    - Lean arrows: α → β → function from $\alpha$ to $\beta$; P → Q (in propositions) → "if $P$ then $Q$" or "$P \implies Q$"
+    - Lean structures and typeclasses: [Group G] → "let $G$ be a group"; [TopologicalSpace X] → "let $X$ be a topological space"
+    - Lean set-builder: {x : α | P x} → $\{x \in \alpha \mid P(x)\}$
+
+    When in doubt, look up how the concept is stated in the relevant mathematical literature (use arxiv_search, web_search) and follow that convention. The \lean{} macro already links to the Lean declaration — the prose itself should be pure mathematics.
+
+    Examples of what NOT to write:
+    - "If SameMPV(A, B) then GaugeEquiv(A, B)" — this is Lean, not math.
+    - "We apply Finset.sum_add_sum to obtain..." — cite by mathematical content, not Lean name.
+    - "Let f : α →ₗ[R] β be a LinearMap" — write "Let $f : V \to W$ be an $R$-linear map."
+
+    Examples of correct mathematical prose:
+    - "If $A$ and $B$ have the same monopole-point-value, then they are gauge equivalent."
+    - "By the additivity of finite sums, we obtain..."
+    - "Let $f \colon V \to W$ be an $R$-linear map."
+
+    The \lean{} macro handles the Lean connection; the English and LaTeX handle the mathematics. Keep these concerns cleanly separated.
 
 
     LEANBLUEPRINT FORMAT
@@ -108,7 +139,7 @@ prompts:
 
     2. Design the dependency DAG. Start from the main theorem(s), work backward. Each node should be one well-defined mathematical fact — not so large it takes weeks, not so small it clutters the graph. Make dependencies explicit and accurate.
 
-    3. Write the content. Statements must be mathematically precise. Proof sketches should outline the strategy clearly enough for a formalizer to follow. Use \lean{} with the actual qualified Lean name when the declaration exists. Only place \leanok when you have verified the Lean declaration exists and compiles.
+    3. Write the content. Statements must be mathematically precise and written in standard mathematical notation — translate all Lean identifiers and type signatures into conventional symbols and prose (see NOTATION TRANSLATION above). Proof sketches should outline the strategy clearly enough for a formalizer to follow. Use \lean{} with the actual qualified Lean name when the declaration exists (this is the only place Lean names belong). Only place \leanok when you have verified the Lean declaration exists and compiles.
 
     4. Before writing any blueprint entry, search for existing formalizations and literature:
        - lean_loogle for type signature search in Mathlib
@@ -133,7 +164,7 @@ prompts:
 
     3. Check each \leanok. Use lean_diagnostics and lean_inspect to confirm the declaration compiles without sorry. If a proof was reverted to sorry, remove \leanok. If a previously unformalized item now has a clean proof, add \leanok.
 
-    4. Check statement consistency. Use lean_inspect hover to get the Lean type signature and compare it to the LaTeX statement. Watch for: changed hypotheses, swapped quantifier order, different bounds (< vs <=), renamed variables, added or removed typeclass assumptions.
+    4. Check statement consistency. Use lean_inspect hover to get the Lean type signature and compare it to the LaTeX statement. Translate the Lean type into standard mathematical notation before comparing — the LaTeX statement should never mirror Lean syntax. Watch for: changed hypotheses, swapped quantifier order, different bounds (< vs <=), renamed variables, added or removed typeclass assumptions. When updating statements, always express them in conventional mathematical language.
 
     5. Check \uses{} accuracy. When Lean declarations change their dependencies (using different lemmas, importing different modules), the blueprint \uses{} should reflect this. Spurious dependencies hide parallelism; missing ones produce a wrong graph.
 
@@ -149,7 +180,7 @@ prompts:
        - Cross-check against the source paper or textbook (use arxiv_search, download_arxiv_source, web_search). If the blueprint cites an external result (e.g. "by \ref{thm:ruzsa-covering} which follows [AuthorName, Theorem 3.2]"), verify that the cited result actually says what the blueprint claims.
        - Verify that proof sketches are actually valid strategies. A sketch that says "by induction on n" should make sense for the stated result. A sketch citing \ref{lem:foo} should actually use what lem:foo provides.
        - Check for circular dependencies in the mathematical argument, not just in the \uses{} graph. If lemma A's proof sketch relies on lemma B, and B's sketch relies on A, that's a real problem.
-       - When the blueprint makes a claim about what Mathlib contains (e.g. "this follows from Mathlib's Nat.add_comm"), verify it with lean_loogle or grep.
+       - When the blueprint makes a claim about what Mathlib contains, verify it with lean_loogle or grep. Reference such results by their mathematical content ("by commutativity of addition"), not by Lean identifier ("by Nat.add_comm"). The \lean{} macro is the only place for Lean names.
        - Flag any statement where the informal claim and the Lean type genuinely disagree in mathematical content — not just notation differences, but actual logical mismatches.
 
     Report what you find clearly: what's in sync, what's drifted, what's mathematically suspect, and what you changed.


### PR DESCRIPTION
## Summary
This PR strengthens the leanBlueprint.yaml guidelines to enforce that blueprint prose must use standard mathematical notation and language, never Lean syntax or identifiers. The changes clarify the separation of concerns: Lean names belong only in `\lean{}` macros, while the mathematical content must be expressed in conventional notation as found in published papers and textbooks.

## Key Changes

- **Updated writing style guidance**: Changed the reference from "good math textbook" to "published mathematics paper" and explicitly added that LaTeX output must contain "no trace of Lean or any programming language"

- **Added comprehensive NOTATION TRANSLATION section**: New detailed guidelines for translating Lean constructs to mathematical notation:
  - CamelCase identifiers → standard mathematical language or symbols
  - Lean predicates → mathematical sentences
  - Type constructors (Fin, List, Finset) → their mathematical counterparts
  - Logical connectives and quantifiers → standard mathematical symbols
  - Structures and typeclasses → mathematical phrasing
  - Set-builder notation and function arrows → conventional mathematical notation

- **Provided concrete examples**: Added both negative examples (what NOT to write) and positive examples of correct mathematical prose to make the standard unambiguous

- **Reinforced in workflow steps**: Updated the "Write the content" step (step 3) to explicitly require translating Lean identifiers into conventional symbols and prose, with a cross-reference to the new NOTATION TRANSLATION section

- **Clarified statement consistency checks**: Updated the verification step to emphasize that LaTeX statements should never mirror Lean syntax, and that statements must be expressed in conventional mathematical language when updated

- **Refined Mathlib reference guidance**: Changed the guidance to reference results by mathematical content rather than Lean identifiers, with the clarification that `\lean{}` macros are the only place for Lean names

## Rationale
These changes ensure that blueprints serve their dual audience (mathematicians and formalizers) effectively by maintaining a clear boundary: the blueprint's prose is pure mathematics, while the `\lean{}` macro handles the connection to formal code. This improves readability for mathematicians and prevents Lean implementation details from obscuring the mathematical content.

https://claude.ai/code/session_01NFrLDCQKn9YdqudRjX89rN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust authoring guidance; no runtime behavior or code paths are modified.
> 
> **Overview**
> Updates the `leanBlueprint.yaml` system prompt to **strictly require pure mathematical prose** in blueprint LaTeX, explicitly forbidding Lean syntax/identifiers outside of `\lean{}`.
> 
> Adds a detailed *Lean-to-math notation translation* section with concrete do/don’t examples, and reinforces this rule in the “writing new blueprints” and “syncing existing blueprints” workflows (including guidance to reference Mathlib results by mathematical content rather than Lean names).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5c420b4283fbc0c1a8ed32838c6dab2b47317a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->