### PR TITLE
fix: add AgentWorkspaceState.emptySnapshot() and fix type errors

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -346,6 +346,15 @@ export class AgentWorkspaceState {
     );
   }
 
+  /**
+   * Create an empty snapshot without instantiating a full class.
+   * Use at initialization sites that only need the serializable shape
+   * (e.g., constructing initial ReflectionFlowShared).
+   */
+  static emptySnapshot(): AgentWorkspaceSnapshot {
+    return AgentWorkspaceStateSnapshotSchema.parse({});
+  }
+
   static fromSnapshot(snapshot: unknown): AgentWorkspaceState {
     const parsed = AgentWorkspaceStateSnapshotSchema.parse(snapshot);
     return new AgentWorkspaceState(

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -229,7 +229,7 @@ export async function runReflectionFlow<C = unknown>(
       shared = {
         currentRound: 0,
         totalRounds,
-        workspaceSnapshot: AgentWorkspaceState.create().toSnapshot(),
+        workspaceSnapshot: AgentWorkspaceState.emptySnapshot(),
         context: null,
         outputLocation: null,
         conversation: [],
@@ -267,7 +267,7 @@ export async function runReflectionFlow<C = unknown>(
           usageMonitor?.setActiveGroupId(stage.id);
         },
         resetForNextRound: (s) => {
-          s.workspaceSnapshot = AgentWorkspaceState.create().toSnapshot();
+          s.workspaceSnapshot = AgentWorkspaceState.emptySnapshot();
         },
         checkInterruption,
         onRoundCompleted: (roundIndex, s) => {

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -128,7 +128,11 @@ async function validateAndGetModelConfig(modelName: string): Promise<void> {
     key: 'modelNotRecognized',
     message: `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
     actions: [
-      { title: 'Model Documentation', command: 'texra.openDoc', args: ['models'] },
+      {
+        title: 'Model Documentation',
+        command: 'texra.openDoc',
+        args: ['models'],
+      },
     ],
     showSuppress: false,
   });
@@ -456,10 +460,15 @@ async function showAgentNotification(config: AgentConfig): Promise<void> {
 function showApiKeyErrorNotification(): void {
   bus.emit('requestShowInstruction', {
     key: 'missingApiKey',
-    message: 'API key not found. Set your API key in the extension settings and run again.',
+    message:
+      'API key not found. Set your API key in the extension settings and run again.',
     actions: [
       { title: 'Set API Key', command: 'texra.setApiKey' },
-      { title: 'Open Settings Guide', command: 'texra.openDoc', args: ['configuration'] },
+      {
+        title: 'Open Settings Guide',
+        command: 'texra.openDoc',
+        args: ['configuration'],
+      },
     ],
     showSuppress: false,
   });

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -274,9 +274,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       withActiveWebview: (fn) => this.withActiveWebview(fn),
     };
 
-    this.agentHandlers = new AgentHandlers(
-      ctx,
-      () => this.refreshAfterAgentMutation(),
+    this.agentHandlers = new AgentHandlers(ctx, () =>
+      this.refreshAfterAgentMutation(),
     );
     this.latexHandlers = new LatexSettingsHandlers(ctx);
 
@@ -383,9 +382,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Custom agent directory
       [SETTINGS_VIEW_COMMANDS.GET_CUSTOM_AGENT_DIR]: () =>
-        this.withActiveWebview((w) =>
-          this.agentHandlers.sendCustomAgentDir(w),
-        ),
+        this.withActiveWebview((w) => this.agentHandlers.sendCustomAgentDir(w)),
       [SETTINGS_VIEW_COMMANDS.SET_CUSTOM_AGENT_DIR]: () =>
         this.agentHandlers.handleSetCustomAgentDir(),
       [SETTINGS_VIEW_COMMANDS.RESET_CUSTOM_AGENT_DIR]: () =>
@@ -812,9 +809,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     try {
       await deleteAllExecutions(new Set(getActiveExecutionIds()));
       await vscode.window.showInformationMessage('Agent history cleared');
-      await this.withActiveWebview((w) =>
-        w.postMessage({ command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED }),
-      );
+      await this.withActiveWebview(async (w) => {
+        await w.postMessage({
+          command: SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED,
+        });
+      });
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,

--- a/src/settingsView/handlers/SettingsHandlerContext.ts
+++ b/src/settingsView/handlers/SettingsHandlerContext.ts
@@ -4,14 +4,16 @@
  * Provides the minimal surface that handler implementations need
  * from the main SettingsViewMessageHandler.
  */
+import type { LogUtilsOptions } from '@logger/logOptions';
+
 import type * as vscode from 'vscode';
 
 export interface SettingsHandlerContext {
   readonly channel: string;
   readonly logger: {
-    warn: (channel: string, msg: string) => void;
-    error: (channel: string, msg: string, data?: unknown) => void;
-    debug: (channel: string, msg: string, data?: { data?: unknown }) => void;
+    warn: (channel: string, msg: string, options?: LogUtilsOptions) => void;
+    error: (channel: string, msg: string, options?: LogUtilsOptions) => void;
+    debug: (channel: string, msg: string, options?: LogUtilsOptions) => void;
   };
   /** Run a callback with the active webview, if available. */
   withActiveWebview: (

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -31,7 +31,12 @@ import {
 } from '@agent/index';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview';
 import { showLoggedErrorMessage } from '@common/errors';
-import { WorkspaceStateKey, GlobalStateKey, workspaceSM, globalSM } from '@common/state';
+import {
+  WorkspaceStateKey,
+  GlobalStateKey,
+  workspaceSM,
+  globalSM,
+} from '@common/state';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import { AbsoluteFS } from '@utils/files';
 

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -152,9 +152,7 @@ export class LatexSettingsHandlers {
         });
       }
 
-      await this.ctx.withActiveWebview((w) =>
-        this.sendLatexSettingsStatus(w),
-      );
+      await this.ctx.withActiveWebview((w) => this.sendLatexSettingsStatus(w));
       const verb = data.reset ? 'reset' : 'applied';
       void vscode.window.showInformationMessage(
         data.field
@@ -205,9 +203,7 @@ export class LatexSettingsHandlers {
   private isRecommendedValueSet(
     field: 'outDir' | 'autoRevealExclude',
   ): boolean {
-    const setting = LATEX_RECOMMENDED_SETTINGS.find(
-      (s) => s.field === field,
-    );
+    const setting = LATEX_RECOMMENDED_SETTINGS.find((s) => s.field === field);
     if (!setting) return false;
     if (!isConfigExplicitlySet(setting.key)) return false;
 


### PR DESCRIPTION
Add emptySnapshot() factory to avoid instantiating a full class just to
immediately serialize it at initialization sites. Fix pre-existing type
errors in SettingsHandlerContext (logger signature mismatch) and
SettingsViewMessageHandler (Thenable<boolean> vs Promise<void>).

https://claude.ai/code/session_01RQJ5rWPbVZQ6sg371BAnCm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to snapshot initialization in the reflection flow and fixing TS type/signature mismatches in settings handlers; primary risk is unintended differences in default snapshot shape or missed call sites.
> 
> **Overview**
> Adds `AgentWorkspaceState.emptySnapshot()` to produce a default `AgentWorkspaceSnapshot` without instantiating `AgentWorkspaceState`, and switches reflection flow initialization/reset to use it instead of `create().toSnapshot()`.
> 
> Fixes settings-view type issues by updating `SettingsHandlerContext` logger method signatures to accept `LogUtilsOptions` and adjusting webview callbacks (notably history clear) to consistently return `Promise<void>`; includes minor formatting-only edits in `executeAgent` notifications and settings handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5efd89230e1c934ae6303afff2078c6fb950f94d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->