### PR TITLE
Fix retry/tool-call approval panel disappearing on stream switch

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -154,8 +154,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
         this.handleDeleteStream(data),
       [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
-      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: async (data) =>
-        vscode.commands.executeCommand('texra.stopAgent', data.stream),
+      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: async (data) => {
+        // Clear pending retry requests so the UI panel is dismissed alongside the stop
+        retryCoordinator.clearRequest(data.stream);
+        await vscode.commands.executeCommand('texra.stopAgent', data.stream);
+      },
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) =>
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
@@ -352,8 +355,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Clear pending approvals, queued follow-ups, and YOLO state to prevent memory leaks
+    // Clear pending approvals, retry requests, queued follow-ups, and YOLO state
     cleanupApprovalsForStream(streamId);
+    retryCoordinator.clearRequest(streamId);
     ToolUseFollowUpQueue.release(streamId);
     this.modelOutputBackups.delete(streamId);
     this.provider.webviewBridge.clearStream(streamId);
@@ -394,9 +398,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Clear approvals, queued follow-ups, and YOLO state to prevent memory leaks
+    // Clear approvals, retry requests, queued follow-ups, and YOLO state
     cleanupAllApprovals();
     for (const streamId of this.provider.state.streamLogs.keys()) {
+      retryCoordinator.clearRequest(streamId);
       ToolUseFollowUpQueue.release(streamId);
     }
     this.modelOutputBackups.clear();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -166,6 +166,7 @@ export class ProgressViewProvider
         showAgentProposal: (p) => this.agentProposalHandler.show(p),
         resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
       },
+      (streamId) => this.hasPendingPermissionsForStream(streamId),
     );
 
     this.contentProvider = new ProgressViewContentProvider(context);
@@ -353,6 +354,19 @@ export class ProgressViewProvider
     proposalId: string,
   ): AgentProposalPermission | undefined {
     return this.agentProposalHandler.get(proposalId);
+  }
+
+  /**
+   * Check if a stream has any pending approval requests (tool-edit, bash,
+   * retry, or proposal) that require user interaction.
+   */
+  public hasPendingPermissionsForStream(streamId: string): boolean {
+    return (
+      this.retryRequestHandler.hasPendingForStream(streamId) ||
+      this.toolEditHandler.hasPendingForStream(streamId) ||
+      this.bashApprovalHandler.hasPendingForStream(streamId) ||
+      this.agentProposalHandler.hasPendingForStream(streamId)
+    );
   }
 
   private canSendToWebview(): boolean {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -242,8 +242,6 @@ export class ProgressEventHandler {
     if (agentCategory) {
       this.state.getOrCreateStreamState(streamId, agentCategory);
     }
-    this.maybeUpdateFilterForCategory(agentCategory);
-
     // Don't switch away from the current stream if it has pending permissions
     // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
     // interact with the approval panel before losing sight of it.
@@ -251,6 +249,12 @@ export class ProgressEventHandler {
     const shouldSwitch =
       !currentStream || !this.hasPendingPermissions(currentStream);
     if (shouldSwitch) {
+      // Update the category filter only when actually switching. If we change
+      // the filter while suppressing the switch, sendStreamMetadata →
+      // pickValidActiveStream rebuilds the stream list with the new filter,
+      // which may exclude the current stream and override state.activeStream —
+      // completely bypassing the pending-permissions guard.
+      this.maybeUpdateFilterForCategory(agentCategory);
       this.state.activeStream = streamId;
     }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -55,6 +55,7 @@ export class ProgressEventHandler {
     private webviewUpdater: WebviewUpdater,
     private webviewBridge: WebviewBridge,
     private readonly uiCallbacks: UICallbacks,
+    private readonly hasPendingPermissions: (streamId: string) => boolean,
   ) {
     this.logger = new AgentLogger('ProgressEventHandler');
     this.ctx = { state: this.state, webviewUpdater: this.webviewUpdater };
@@ -242,7 +243,16 @@ export class ProgressEventHandler {
       this.state.getOrCreateStreamState(streamId, agentCategory);
     }
     this.maybeUpdateFilterForCategory(agentCategory);
-    this.state.activeStream = streamId;
+
+    // Don't switch away from the current stream if it has pending permissions
+    // (retry, tool-edit, bash approval, or agent proposal) — the user needs to
+    // interact with the approval panel before losing sight of it.
+    const currentStream = this.state.activeStream;
+    const shouldSwitch =
+      !currentStream || !this.hasPendingPermissions(currentStream);
+    if (shouldSwitch) {
+      this.state.activeStream = streamId;
+    }
 
     if (!this.webviewUpdater.isAvailable()) return;
 
@@ -252,14 +262,15 @@ export class ProgressEventHandler {
         this.state,
         StreamStatusService.getAll(),
       );
-    } else {
+    } else if (shouldSwitch) {
       this.webviewUpdater.setActiveStream(streamId);
     }
-    // Known-stream path: include active-stream state in the batch
-    // so we don't need separate progress/badges/parent messages.
+    // Always sync content for the new stream so instruction/badges/parent
+    // info reaches the webview — even when we suppress the view switch.
+    // includeActiveState is only relevant when this IS the active stream.
     this.syncStreamContent(streamId, {
       updateInstruction: true,
-      includeActiveState: wasKnownStream && !filterChanged,
+      includeActiveState: shouldSwitch && wasKnownStream && !filterChanged,
     });
   }
 

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -18,7 +18,10 @@ import { firstStreamId, type ProgressState, type StreamState } from '../store';
 import { clearResolvedProposalIds } from './permissionSlice';
 import { clearCopyContentStore } from '../formatters/copyContentStore';
 import { clearProposalInputStore } from '../formatters/proposalInputStore';
-import { updateParentStreamId } from '../stateUtils';
+import {
+  removePermissionsForStream,
+  updateParentStreamId,
+} from '../stateUtils';
 import type { HandlerRegistry } from '../messageDispatcher';
 
 // ============================================================
@@ -143,6 +146,13 @@ export const streamLifecycleHandlers: HandlerRegistry = {
     clearCopyContentStore();
     clearProposalInputStore();
 
+    // Remove permissions for the deleted stream to prevent orphaned entries
+    const cleaned = removePermissionsForStream(
+      ctx.getPermissions(),
+      streamId,
+    );
+    ctx.setPermissions(cleaned);
+
     ctx.setState((prev) =>
       create(prev, (draft) => {
         draft.streamStates.delete(streamId);
@@ -160,6 +170,10 @@ export const streamLifecycleHandlers: HandlerRegistry = {
     clearResolvedProposalIds();
     clearCopyContentStore();
     clearProposalInputStore();
+
+    // Clear all permissions — no streams means no valid permissions
+    ctx.setPermissions([]);
+
     ctx.setState((prev) =>
       create(prev, (draft) => {
         draft.streamById = new Map();

--- a/src/progressView/frontend/stateUtils.ts
+++ b/src/progressView/frontend/stateUtils.ts
@@ -105,6 +105,20 @@ export function filterPermissionsForStream(
   );
 }
 
+/**
+ * Remove all permissions associated with a specific stream.
+ * Keeps permissions that have no streamId (global) or belong to a different stream.
+ */
+export function removePermissionsForStream(
+  permissions: PermissionState[],
+  streamId: string,
+): PermissionState[] {
+  return permissions.filter(
+    (permission) =>
+      !permission.data.streamId || permission.data.streamId !== streamId,
+  );
+}
+
 // =============================================================================
 // Typed State Updaters
 // =============================================================================

--- a/src/progressView/managers/ApprovalRequestHandler.ts
+++ b/src/progressView/managers/ApprovalRequestHandler.ts
@@ -3,7 +3,7 @@
  * Eliminates duplication across tool edit, bash approval, retry, and proposal handlers.
  */
 export class ApprovalRequestHandler<
-  T extends Record<string, unknown>,
+  T extends { streamId: string },
   K extends keyof T,
 > {
   private readonly pending = new Map<string, T>();
@@ -34,5 +34,13 @@ export class ApprovalRequestHandler<
 
   get(id: string): T | undefined {
     return this.pending.get(id);
+  }
+
+  /** Check if any pending item is associated with the given stream. */
+  hasPendingForStream(streamId: string): boolean {
+    for (const item of this.pending.values()) {
+      if (!item.streamId || item.streamId === streamId) return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
The retry and tool-call approval panels would vanish when the active stream
changed (e.g., another agent started), leaving the user unable to resume the
conversation. Three root causes addressed:

1. Frontend: Backend-initiated stream switches (SET_ACTIVE_STREAM,
   UPDATE_STREAMS) now check if the current stream has pending permissions
   before switching away, keeping the approval panel visible.

2. Frontend: Permissions are cleaned up when streams are deleted
   (DELETE_STREAM removes per-stream permissions, DELETE_ALL clears all),
   preventing orphaned permission entries.

3. Backend: Retry coordinator requests are cleared on stream stop and
   delete (both single and all), preventing dangling retry promises
   that could never be acted on.

https://claude.ai/code/session_01994rwHKh16DrXEjQRX2nTc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active-stream switching and approval/permission cleanup logic in the progress view, which could affect stream selection and prompt visibility across edge cases. No auth/security implications, but UX regressions are possible if pending-permission detection is wrong.
> 
> **Overview**
> Prevents backend-driven stream switches from hiding active approval panels by **suppressing automatic `activeStream` changes** when the current stream has pending permissions (retry/tool-edit/bash/proposal), while still syncing the new stream’s content to the webview.
> 
> Cleans up orphaned prompt state by clearing retry requests on `STOP_STREAM`/stream deletion (single and all) and by removing per-stream (or all) frontend permission entries on `DELETE_STREAM`/`DELETE_ALL`. Adds `ApprovalRequestHandler.hasPendingForStream()` plus a provider-level `hasPendingPermissionsForStream()` helper to support this guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a00149633d779a36dbfb29d852d01bc7cd0d05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->