### PR TITLE
fix: detect truncated Anthropic streams from relay proxy timeout

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -855,8 +855,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // connection mid-thinking, the SDK's for-await loop ends normally and
         // finalMessage() resolves with a partial response (stop_reason: null,
         // no message_stop event). Detect this and throw instead of silently
-        // returning truncated output. Retryability is determined downstream
-        // based on elapsed time (long streams = relay wall clock limit, not transient).
+        // returning truncated output.
         const diagnostics = streamHandler.getDiagnostics();
         if (!diagnostics.messageStopReceived) {
           const truncatedError = new Error(
@@ -864,7 +863,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
               `(${diagnostics.eventsProcessed} events, ` +
               `${diagnostics.thinkingChars} thinking chars, ` +
               `${diagnostics.textChars} text chars). ` +
-              `Likely relay timeout during extended streaming.`,
+              `Stream truncated, likely proxy idle timeout during extended thinking.`,
           );
           attachStreamDiagnostics(truncatedError, diagnostics);
           this.logger.warn(

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -851,6 +851,33 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Note that there is no second consumption problem as per anthropic sdk examples
         response = await stream.finalMessage();
 
+        // Validate stream completeness: when a relay proxy gracefully closes the
+        // connection mid-thinking, the SDK's for-await loop ends normally and
+        // finalMessage() resolves with a partial response (stop_reason: null,
+        // no message_stop event). Detect this and throw a retryable error
+        // instead of silently returning truncated output.
+        if (!streamHandler.getDiagnostics().messageStopReceived) {
+          const diagnostics = streamHandler.getDiagnostics();
+          const truncatedError = new Error(
+            `Stream ended without message_stop after ${diagnostics.elapsedSecs}s ` +
+              `(${diagnostics.eventsProcessed} events, ` +
+              `${diagnostics.thinkingChars} thinking chars, ` +
+              `${diagnostics.textChars} text chars). ` +
+              `Likely relay timeout during extended streaming.`,
+          );
+          attachStreamDiagnostics(truncatedError, diagnostics);
+          this.logger.warn(
+            'Stream truncated: response received without message_stop',
+            {
+              data: {
+                model: this.config.fullName,
+                streamDiagnostics: diagnostics,
+              },
+            },
+          );
+          throw truncatedError;
+        }
+
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } catch (streamError) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -857,8 +857,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // no message_stop event). Detect this and throw instead of silently
         // returning truncated output. Retryability is determined downstream
         // based on elapsed time (long streams = relay wall clock limit, not transient).
-        if (!streamHandler.getDiagnostics().messageStopReceived) {
-          const diagnostics = streamHandler.getDiagnostics();
+        const diagnostics = streamHandler.getDiagnostics();
+        if (!diagnostics.messageStopReceived) {
           const truncatedError = new Error(
             `Stream ended without message_stop after ${diagnostics.elapsedSecs}s ` +
               `(${diagnostics.eventsProcessed} events, ` +

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -854,8 +854,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Validate stream completeness: when a relay proxy gracefully closes the
         // connection mid-thinking, the SDK's for-await loop ends normally and
         // finalMessage() resolves with a partial response (stop_reason: null,
-        // no message_stop event). Detect this and throw a retryable error
-        // instead of silently returning truncated output.
+        // no message_stop event). Detect this and throw instead of silently
+        // returning truncated output. Retryability is determined downstream
+        // based on elapsed time (long streams = relay wall clock limit, not transient).
         if (!streamHandler.getDiagnostics().messageStopReceived) {
           const diagnostics = streamHandler.getDiagnostics();
           const truncatedError = new Error(

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -416,11 +416,20 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
-    // Unrecognized errors without status codes are likely network errors - retry
+    // Unrecognized errors without status codes are likely network errors - retry.
+    // Exception: if stream diagnostics show a long-running stream that received
+    // substantial data before truncation, this is likely a relay wall clock timeout
+    // (Supabase Edge Functions cap at ~400s). Retrying will just burn the same
+    // tokens and hit the same wall, so mark non-retryable.
+    const isLikelyRelayTimeout =
+      streamDiagnostics &&
+      streamDiagnostics.elapsedSecs >= 120 &&
+      streamDiagnostics.eventsProcessed > 0;
+
     return {
       message: finalMessage,
       provider,
-      retryable: true,
+      retryable: !isLikelyRelayTimeout,
       isRelayError: isRelay,
       requestId,
       rawErrorBody,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -416,20 +416,11 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
 
   if (!statusCode) {
-    // Unrecognized errors without status codes are likely network errors - retry.
-    // Exception: if stream diagnostics show a long-running stream that received
-    // substantial data before truncation, this is likely a relay wall clock timeout
-    // (Supabase Edge Functions cap at ~400s). Retrying will just burn the same
-    // tokens and hit the same wall, so mark non-retryable.
-    const isLikelyRelayTimeout =
-      streamDiagnostics &&
-      streamDiagnostics.elapsedSecs >= 120 &&
-      streamDiagnostics.eventsProcessed > 0;
-
+    // Unrecognized errors without status codes are likely network errors - retry
     return {
       message: finalMessage,
       provider,
-      retryable: !isLikelyRelayTimeout,
+      retryable: true,
       isRelayError: isRelay,
       requestId,
       rawErrorBody,

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -87,10 +87,12 @@ const UPSTREAM_TIMEOUT_MS = 390000;
 
 /**
  * Interval for SSE keepalive comments during streaming (30 seconds).
- * Intermediate proxies (Cloudflare, CDN) may drop idle connections after ~100s.
- * Extended thinking can have long pauses between events. Periodic keepalive
- * comments (`: keepalive\n\n`) are ignored by SSE parsers but keep the
- * connection alive through proxy idle timeouts.
+ * Extended thinking emits deltas at a much lower rate than regular text
+ * generation — the model does more computation per token. When the gap
+ * between consecutive SSE events exceeds an intermediate proxy's idle
+ * timeout (Cloudflare ~100s), the proxy drops the connection and truncates
+ * the stream. Periodic keepalive comments (`: keepalive\n\n`) are valid SSE
+ * that parsers ignore, but they keep data flowing to prevent idle drops.
  */
 const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 
@@ -167,10 +169,10 @@ function getProviderConfig(provider: string): ProviderConfig | null {
 
 /**
  * Wraps an SSE response body stream to inject periodic keepalive comments.
- * This prevents intermediate proxies (Cloudflare, load balancers) from dropping
- * idle connections during long AI thinking pauses.
- *
- * SSE keepalive comments (`: keepalive\n\n`) are valid SSE and ignored by parsers.
+ * Extended thinking streams emit deltas at a much lower rate than text
+ * generation, and gaps between events can exceed proxy idle timeouts.
+ * SSE comments (`: keepalive\n\n`) are valid SSE ignored by parsers but
+ * keep data flowing to prevent intermediate proxies from dropping the connection.
  */
 function wrapWithKeepalive(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -744,8 +746,8 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   responseHeaders.set('X-Accel-Buffering', 'no');
 
-  // For SSE streaming responses, inject periodic keepalive comments to prevent
-  // intermediate proxies from dropping idle connections during long thinking pauses.
+  // For SSE streaming responses, inject periodic keepalive comments. Extended
+  // thinking emits deltas at a lower rate; gaps can exceed proxy idle timeouts.
   const contentType = upstreamResponse.headers.get('content-type') ?? '';
   const isSSE = contentType.includes('text/event-stream');
   const responseBody =

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -85,6 +85,15 @@ const RELAY_VERSION = '1.8.2';
 // Upstream request timeout (390s to fit within Supabase's 400s wall clock limit)
 const UPSTREAM_TIMEOUT_MS = 390000;
 
+/**
+ * Interval for SSE keepalive comments during streaming (30 seconds).
+ * Intermediate proxies (Cloudflare, CDN) may drop idle connections after ~100s.
+ * Extended thinking can have long pauses between events. Periodic keepalive
+ * comments (`: keepalive\n\n`) are ignored by SSE parsers but keep the
+ * connection alive through proxy idle timeouts.
+ */
+const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -154,6 +163,46 @@ const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
 
 function getProviderConfig(provider: string): ProviderConfig | null {
   return PROVIDER_CONFIGS[provider as ProviderKey] || null;
+}
+
+/**
+ * Wraps an SSE response body stream to inject periodic keepalive comments.
+ * This prevents intermediate proxies (Cloudflare, load balancers) from dropping
+ * idle connections during long AI thinking pauses.
+ *
+ * SSE keepalive comments (`: keepalive\n\n`) are valid SSE and ignored by parsers.
+ */
+function wrapWithKeepalive(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const keepaliveBytes = encoder.encode(': keepalive\n\n');
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
+  const reader = body.getReader();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      keepaliveTimer = setInterval(() => {
+        try {
+          controller.enqueue(keepaliveBytes);
+        } catch {
+          // Stream already closed — clean up
+          clearInterval(keepaliveTimer);
+        }
+      }, SSE_KEEPALIVE_INTERVAL_MS);
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        clearInterval(keepaliveTimer);
+        controller.close();
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel() {
+      clearInterval(keepaliveTimer);
+      reader.cancel();
+    },
+  });
 }
 
 function getEnabledProviders(): string[] {
@@ -695,7 +744,16 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   responseHeaders.set('X-Accel-Buffering', 'no');
 
-  return new Response(upstreamResponse.body, {
+  // For SSE streaming responses, inject periodic keepalive comments to prevent
+  // intermediate proxies from dropping idle connections during long thinking pauses.
+  const contentType = upstreamResponse.headers.get('content-type') ?? '';
+  const isSSE = contentType.includes('text/event-stream');
+  const responseBody =
+    isSSE && upstreamResponse.body
+      ? wrapWithKeepalive(upstreamResponse.body)
+      : upstreamResponse.body;
+
+  return new Response(responseBody, {
     status: upstreamResponse.status,
     headers: responseHeaders,
   });

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -85,17 +85,6 @@ const RELAY_VERSION = '1.8.2';
 // Upstream request timeout (390s to fit within Supabase's 400s wall clock limit)
 const UPSTREAM_TIMEOUT_MS = 390000;
 
-/**
- * Interval for SSE keepalive comments during streaming (30 seconds).
- * Extended thinking emits deltas at a much lower rate than regular text
- * generation — the model does more computation per token. When the gap
- * between consecutive SSE events exceeds an intermediate proxy's idle
- * timeout (Cloudflare ~100s), the proxy drops the connection and truncates
- * the stream. Periodic keepalive comments (`: keepalive\n\n`) are valid SSE
- * that parsers ignore, but they keep data flowing to prevent idle drops.
- */
-const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
-
 // =============================================================================
 // Types
 // =============================================================================
@@ -165,46 +154,6 @@ const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
 
 function getProviderConfig(provider: string): ProviderConfig | null {
   return PROVIDER_CONFIGS[provider as ProviderKey] || null;
-}
-
-/**
- * Wraps an SSE response body stream to inject periodic keepalive comments.
- * Extended thinking streams emit deltas at a much lower rate than text
- * generation, and gaps between events can exceed proxy idle timeouts.
- * SSE comments (`: keepalive\n\n`) are valid SSE ignored by parsers but
- * keep data flowing to prevent intermediate proxies from dropping the connection.
- */
-function wrapWithKeepalive(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
-  const encoder = new TextEncoder();
-  const keepaliveBytes = encoder.encode(': keepalive\n\n');
-  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
-  const reader = body.getReader();
-
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      keepaliveTimer = setInterval(() => {
-        try {
-          controller.enqueue(keepaliveBytes);
-        } catch {
-          // Stream already closed — clean up
-          clearInterval(keepaliveTimer);
-        }
-      }, SSE_KEEPALIVE_INTERVAL_MS);
-    },
-    async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        clearInterval(keepaliveTimer);
-        controller.close();
-        return;
-      }
-      controller.enqueue(value);
-    },
-    cancel() {
-      clearInterval(keepaliveTimer);
-      reader.cancel();
-    },
-  });
 }
 
 function getEnabledProviders(): string[] {
@@ -746,16 +695,28 @@ app.all('/:provider{[^/]+}/*', async (c) => {
 
   responseHeaders.set('X-Accel-Buffering', 'no');
 
-  // For SSE streaming responses, inject periodic keepalive comments. Extended
-  // thinking emits deltas at a lower rate; gaps can exceed proxy idle timeouts.
-  const contentType = upstreamResponse.headers.get('content-type') ?? '';
-  const isSSE = contentType.includes('text/event-stream');
-  const responseBody =
-    isSSE && upstreamResponse.body
-      ? wrapWithKeepalive(upstreamResponse.body)
-      : upstreamResponse.body;
+  // FUTURE: SSE keepalive injection to prevent proxy idle timeouts.
+  //
+  // Extended thinking emits deltas at a much lower rate than text generation.
+  // Gaps between SSE events can exceed intermediate proxy idle timeouts
+  // (e.g. Cloudflare ~100s), causing the proxy to drop the connection and
+  // truncate the stream. Injecting periodic SSE comments (`: keepalive\n\n`)
+  // would keep data flowing, since parsers ignore comment lines.
+  //
+  // A previous setInterval-based approach was removed because the timer could
+  // fire mid-chunk, injecting `: keepalive\n\n` between two halves of a split
+  // SSE event and corrupting the stream. A safe implementation would need to:
+  //   1. Track whether the last forwarded chunk ended on an event boundary
+  //      (i.e. ended with `\n\n`), and only inject keepalives at clean boundaries.
+  //   2. Or use a pull-based approach that emits a keepalive only when the
+  //      upstream read has been pending longer than the threshold, ensuring
+  //      no interleaving with real data.
+  //
+  // The client-side AnthropicStreamHandler already detects truncated streams
+  // via the `messageStopReceived` diagnostic and throws a retryable error,
+  // so the impact of not having keepalives is a retry, not silent data loss.
 
-  return new Response(responseBody, {
+  return new Response(upstreamResponse.body, {
     status: upstreamResponse.status,
     headers: responseHeaders,
   });


### PR DESCRIPTION
When a relay proxy gracefully closes the connection mid-thinking,
the SDK's for-await loop ends normally and finalMessage() resolves
with a partial response (stop_reason: null, no message_stop event).
Previously this was silently accepted as a valid response.

Now validates that message_stop was received before accepting the
response. If missing, throws a retryable error with diagnostic info
so the retry loop can re-establish the connection.

https://claude.ai/code/session_01Uy8eXnsrk19vWL8ci27EZe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Anthropic streaming success criteria by rejecting responses that end without a `message_stop` event, which may increase retries/errors in previously “successful” but partial streams. Impact is limited to the streaming path and adds diagnostics/logging to aid debugging.
> 
> **Overview**
> Prevents silent partial outputs from Anthropic streaming when a relay/proxy closes the SSE connection mid-response.
> 
> After `stream.finalMessage()`, the client now checks `AnthropicStreamHandler` diagnostics for `messageStopReceived`; if missing, it throws a diagnostics-enriched error (and logs a warning) so the retry loop can re-establish the stream instead of returning truncated text.
> 
> The relay function adds documentation for a *future* safe SSE keepalive approach, but does not change relay behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf0ab8d5ea08314f2d8084159c3cd31cc217b84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->