### PR TITLE
Add user-configurable reasoning level overrides for AI models

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -484,9 +484,9 @@ export abstract class ModelHandler<
       return null;
     }
 
-    if (reasoningEffort === ReasoningEffort.NONE) {
-      return null;
-    }
+    // NONE is a deliberate user choice ("minimize reasoning"), not "no preference".
+    // Providers map it to their minimum effort level (e.g. Anthropic → 'low').
+    // Returning null here would silently fall back to high/default effort.
 
     const isGpt5 = this.config.name.startsWith('gpt5');
     if (

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -345,6 +345,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
       case 'medium':
         return 'medium';
       case 'low':
+      case 'none':
+        // Anthropic doesn't support fully disabling thinking; 'low' is the minimum.
         return 'low';
       default:
         return 'high';

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -196,9 +196,11 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           this.logger.warn(
             "Gemini 3 models can't fully disable thinking. Using thinking_level 'LOW'.",
           );
-          return ThinkingLevel.LOW;
         }
-        return undefined;
+        // Use LOW as the minimum supported level across all thinking models.
+        // Returning undefined would omit thinkingLevel entirely, making the
+        // API fall back to its default (medium/high) — defeating the user's intent.
+        return ThinkingLevel.LOW;
 
       case ReasoningEffort.LOW:
         return ThinkingLevel.LOW;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -179,8 +179,10 @@ export class ModelHandlerOpenAI<
 
     const reasoningEffort = this.getEffectiveReasoningEffort();
     if (this.capabilities.supportsReasoning && reasoningEffort) {
+      // OpenAI doesn't support 'none'; clamp to 'low' (the minimum).
+      const effective = reasoningEffort === 'none' ? 'low' : reasoningEffort;
       baseParams.reasoning_effort = this.validateReasoningEffort(
-        reasoningEffort,
+        effective,
       ) as ChatCompletionRequestBase['reasoning_effort'];
     }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1135,9 +1135,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Build shared params used by both token counting and API call
 
-    const reasoningEffort = this.capabilities.supportsReasoning
+    // OpenAI Responses API doesn't support 'none'; clamp to 'low'.
+    const rawEffort = this.capabilities.supportsReasoning
       ? this.getEffectiveReasoningEffort()
       : undefined;
+    const reasoningEffort =
+      rawEffort === 'none' ? ('low' as const) : rawEffort;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const baseParams = {

--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -133,11 +133,14 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
         this.capabilities.supportsReasoningEffort &&
         this.capabilities.reasoningEffort
       ) {
-        // O1-style models with effort levels
+        // O1-style models with effort levels.
+        // OpenRouter doesn't support 'none'; clamp to 'low'.
+        const effort =
+          this.capabilities.reasoningEffort === 'none'
+            ? 'low'
+            : this.capabilities.reasoningEffort;
         kwargs.reasoning = {
-          effort: this.validateReasoningEffort(
-            this.capabilities.reasoningEffort,
-          ),
+          effort: this.validateReasoningEffort(effort),
         };
         kwargs.include_reasoning = true;
       } else {

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -35,8 +35,11 @@ const PROVIDER_HANDLERS = new Map<
   [ModelProvider.OTHERS, ModelHandlerOpenRouter],
 ]);
 
-/** Map user-facing reasoning level strings to the ReasoningEffort enum. */
-const LEVEL_TO_EFFORT: Record<string, ReasoningEffort> = {
+/**
+ * Single source of truth: user-facing reasoning level strings → ReasoningEffort enum.
+ * The reverse mapping (for the settings UI) is derived from this in SettingsViewMessageHandler.
+ */
+export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
   none: ReasoningEffort.NONE,
   low: ReasoningEffort.LOW,
   medium: ReasoningEffort.MEDIUM,
@@ -44,28 +47,29 @@ const LEVEL_TO_EFFORT: Record<string, ReasoningEffort> = {
 };
 
 /**
- * Apply the user's reasoning level override to a handler's capabilities.
- * Only applies if the model supports configurable reasoning effort and the
- * user has set an override for this model.
+ * Apply the user's reasoning level override to a handler, returning it for chaining.
+ * Only mutates capabilities when the model supports configurable effort and the
+ * user has set an override.
  */
-function applyReasoningLevelOverride(handler: ModelHandler): void {
-  if (!handler.capabilities.supportsReasoningEffort) return;
+function withReasoningOverride<T extends ModelHandler>(handler: T): T {
+  if (!handler.capabilities.supportsReasoningEffort) return handler;
 
   const overrides = globalSM.get<Record<string, string>>(
     GlobalStateKey.REASONING_LEVELS,
     {},
   );
   const level = overrides[handler.config.name];
-  if (!level) return;
+  if (!level) return handler;
 
   const effort = LEVEL_TO_EFFORT[level];
-  if (effort === undefined) return;
+  if (effort === undefined) return handler;
 
   logger.debug(
     CHANNEL,
     `Applying reasoning level override for ${handler.config.name}: ${level}`,
   );
   handler.capabilities.reasoningEffort = effort;
+  return handler;
 }
 
 /** Check if OpenAI Responses API should be used for this config. */
@@ -95,36 +99,34 @@ function shouldUseResponsesAPI(
 export function createModelHandler(config: ModelConfig): ModelHandler {
   const useOpenRouter = getConfig<boolean>('texra.model.useOpenRouter', false);
 
-  let handler: ModelHandler;
-
   // OpenAI Responses API (required or optional)
   if (shouldUseResponsesAPI(config, useOpenRouter)) {
     logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
-    handler = new ModelHandlerOpenAIResponse(config);
-  } else if (config.openRouterOnly || useOpenRouter) {
-    // Route through OpenRouter if configured
+    return withReasoningOverride(new ModelHandlerOpenAIResponse(config));
+  }
+
+  // Route through OpenRouter if configured
+  if (config.openRouterOnly || useOpenRouter) {
     const openrouterFullName =
       config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
     if (config.provider === ModelProvider.ANTHROPIC) {
-      handler = new ModelHandlerAnthropicViaOpenRouter({
-        ...config,
-        openrouterFullName,
-      });
-    } else {
-      handler = new ModelHandlerOpenRouter({ ...config, openrouterFullName });
+      return withReasoningOverride(
+        new ModelHandlerAnthropicViaOpenRouter({
+          ...config,
+          openrouterFullName,
+        }),
+      );
     }
-  } else {
-    // Direct provider handler
-    const HandlerClass = PROVIDER_HANDLERS.get(config.provider);
-    if (!HandlerClass) {
-      throw new Error(`Unsupported model provider: ${config.provider}`);
-    }
-    logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
-    handler = new HandlerClass(config);
+    return withReasoningOverride(
+      new ModelHandlerOpenRouter({ ...config, openrouterFullName }),
+    );
   }
 
-  // Apply user reasoning level override (if configured for this model)
-  applyReasoningLevelOverride(handler);
-
-  return handler;
+  // Direct provider handler
+  const HandlerClass = PROVIDER_HANDLERS.get(config.provider);
+  if (!HandlerClass) {
+    throw new Error(`Unsupported model provider: ${config.provider}`);
+  }
+  logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
+  return withReasoningOverride(new HandlerClass(config));
 }

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,4 +1,4 @@
-import { ModelProvider, type ModelConfig } from 'llm-zoo';
+import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
@@ -14,6 +14,7 @@ import { ModelHandlerOpenAI } from '@agent/modelHandlers/modelHandlerOpenAI';
 import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
 
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { GlobalStateKey, globalSM } from '@common/state';
 import * as logger from '@logger/logUtils';
 import { getConfig } from '@utils/config';
 
@@ -33,6 +34,39 @@ const PROVIDER_HANDLERS = new Map<
   [ModelProvider.DASHSCOPE, ModelHandlerDashScope],
   [ModelProvider.OTHERS, ModelHandlerOpenRouter],
 ]);
+
+/** Map user-facing reasoning level strings to the ReasoningEffort enum. */
+const LEVEL_TO_EFFORT: Record<string, ReasoningEffort> = {
+  none: ReasoningEffort.NONE,
+  low: ReasoningEffort.LOW,
+  medium: ReasoningEffort.MEDIUM,
+  high: ReasoningEffort.HIGH,
+};
+
+/**
+ * Apply the user's reasoning level override to a handler's capabilities.
+ * Only applies if the model supports configurable reasoning effort and the
+ * user has set an override for this model.
+ */
+function applyReasoningLevelOverride(handler: ModelHandler): void {
+  if (!handler.capabilities.supportsReasoningEffort) return;
+
+  const overrides = globalSM.get<Record<string, string>>(
+    GlobalStateKey.REASONING_LEVELS,
+    {},
+  );
+  const level = overrides[handler.config.name];
+  if (!level) return;
+
+  const effort = LEVEL_TO_EFFORT[level];
+  if (effort === undefined) return;
+
+  logger.debug(
+    CHANNEL,
+    `Applying reasoning level override for ${handler.config.name}: ${level}`,
+  );
+  handler.capabilities.reasoningEffort = effort;
+}
 
 /** Check if OpenAI Responses API should be used for this config. */
 function shouldUseResponsesAPI(
@@ -56,34 +90,41 @@ function shouldUseResponsesAPI(
 
 /**
  * Creates a model handler instance based on provider and routing configuration.
+ * Applies user reasoning level overrides when the model supports configurable effort.
  */
 export function createModelHandler(config: ModelConfig): ModelHandler {
   const useOpenRouter = getConfig<boolean>('texra.model.useOpenRouter', false);
 
+  let handler: ModelHandler;
+
   // OpenAI Responses API (required or optional)
   if (shouldUseResponsesAPI(config, useOpenRouter)) {
     logger.debug(CHANNEL, 'Using OpenAI Responses API Handler');
-    return new ModelHandlerOpenAIResponse(config);
-  }
-
-  // Route through OpenRouter if configured
-  if (config.openRouterOnly || useOpenRouter) {
+    handler = new ModelHandlerOpenAIResponse(config);
+  } else if (config.openRouterOnly || useOpenRouter) {
+    // Route through OpenRouter if configured
     const openrouterFullName =
       config.openrouterFullName ?? `${config.provider}/${config.fullName}`;
     if (config.provider === ModelProvider.ANTHROPIC) {
-      return new ModelHandlerAnthropicViaOpenRouter({
+      handler = new ModelHandlerAnthropicViaOpenRouter({
         ...config,
         openrouterFullName,
       });
+    } else {
+      handler = new ModelHandlerOpenRouter({ ...config, openrouterFullName });
     }
-    return new ModelHandlerOpenRouter({ ...config, openrouterFullName });
+  } else {
+    // Direct provider handler
+    const HandlerClass = PROVIDER_HANDLERS.get(config.provider);
+    if (!HandlerClass) {
+      throw new Error(`Unsupported model provider: ${config.provider}`);
+    }
+    logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
+    handler = new HandlerClass(config);
   }
 
-  // Direct provider handler
-  const HandlerClass = PROVIDER_HANDLERS.get(config.provider);
-  if (!HandlerClass) {
-    throw new Error(`Unsupported model provider: ${config.provider}`);
-  }
-  logger.debug(CHANNEL, `Using Handler: ${HandlerClass.name}`);
-  return new HandlerClass(config);
+  // Apply user reasoning level override (if configured for this model)
+  applyReasoningLevelOverride(handler);
+
+  return handler;
 }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -33,6 +33,7 @@ export enum GlobalStateKey {
   // Model selection settings
   ENABLED_MODELS = 'enabledModels',
   HELPER_MODEL = 'polishModel',
+  REASONING_LEVELS = 'texra.reasoningLevels',
 
   // Streaming settings
   STREAMING_GLOBAL = 'texra.streaming.global',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -43,6 +43,7 @@ export const SETTINGS_VIEW_CMD = {
   GET_MODEL_SELECTION: 'getModelSelection',
   SET_MODEL_ENABLED: 'setModelEnabled',
   SET_HELPER_MODEL: 'setPolishModel',
+  SET_MODEL_REASONING_LEVEL: 'setModelReasoningLevel',
   // Agent selection commands
   GET_AGENT_SELECTION: 'getAgentSelection',
   OPEN_AGENT_YAML: 'openAgentYaml',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -9,7 +9,7 @@
  * - LatexSettingsHandlers: LaTeX tool detection and recommended settings
  */
 import * as vscode from 'vscode';
-import { MODELS, MODEL_CONFIGS, ReasoningEffort } from 'llm-zoo';
+import { MODELS, MODEL_CONFIGS, type ReasoningEffort } from 'llm-zoo';
 
 // Shared schemas and dispatchers
 import {
@@ -17,7 +17,9 @@ import {
   type SettingsViewInboundHandlerRegistry,
   type SettingsViewInboundMessage,
   SETTINGS_VIEW_CMD,
+  ReasoningLevelSchema,
   type ModelSelectionItem,
+  type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
 import {
   PROVIDER_DISPLAY_NAMES,
@@ -40,6 +42,7 @@ import {
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
 import { getHelperModelName } from '@agent/runtime/helperModel';
+import { LEVEL_TO_EFFORT } from '@agent/runtime/ModelFactory';
 import {
   BaseViewMessageHandler,
   SETTINGS_VIEW_COMMANDS,
@@ -190,17 +193,20 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
 
 const modelProvidersSet = new Set<string>(MODEL_PROVIDERS_ORDER);
 
-/** Map ReasoningEffort enum values to the ReasoningLevel schema values used in the UI. */
-const REASONING_EFFORT_TO_LEVEL: Record<string, ModelSelectionItem['defaultReasoningLevel']> = {
-  [ReasoningEffort.NONE]: 'none',
-  [ReasoningEffort.LOW]: 'low',
-  [ReasoningEffort.MEDIUM]: 'medium',
-  [ReasoningEffort.HIGH]: 'high',
-  [ReasoningEffort.XHIGH]: 'high', // xhigh shown as high in UI (tier-gated at runtime)
-};
+/**
+ * Reverse of LEVEL_TO_EFFORT: maps ReasoningEffort enum values → UI level strings.
+ * Derived from the canonical map in ModelFactory so there's one source of truth.
+ * Efforts not in LEVEL_TO_EFFORT (e.g. XHIGH) intentionally have no entry —
+ * the UI will show a plain "Default" label instead of lying about the level.
+ */
+const EFFORT_TO_LEVEL = new Map<ReasoningEffort, ReasoningLevel>(
+  Object.entries(LEVEL_TO_EFFORT).map(
+    ([level, effort]) => [effort, level as ReasoningLevel] as const,
+  ),
+);
 
 /** Read persisted reasoning level overrides from global state. */
-export function getReasoningLevelOverrides(): Record<string, string> {
+function getReasoningLevelOverrides(): Record<string, string> {
   return globalSM.get<Record<string, string>>(GlobalStateKey.REASONING_LEVELS, {});
 }
 
@@ -228,10 +234,16 @@ function buildModelSelectionItems(): ModelSelectionItem[] {
 
     if (supportsReasoningEffort) {
       item.supportsReasoningLevel = true;
-      item.defaultReasoningLevel = REASONING_EFFORT_TO_LEVEL[reasoningEffort] ?? 'high';
-      const override = reasoningOverrides[name];
-      if (override) {
-        item.reasoningLevel = override as ModelSelectionItem['reasoningLevel'];
+      // Only set defaultReasoningLevel when the effort has a UI-level equivalent.
+      // XHIGH and unknown efforts get no label — the UI shows plain "Default".
+      const defaultLevel = EFFORT_TO_LEVEL.get(reasoningEffort);
+      if (defaultLevel) {
+        item.defaultReasoningLevel = defaultLevel;
+      }
+      // Validate persisted override against the schema instead of blindly casting.
+      const parsed = ReasoningLevelSchema.safeParse(reasoningOverrides[name]);
+      if (parsed.success) {
+        item.reasoningLevel = parsed.data;
       }
     }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -9,7 +9,7 @@
  * - LatexSettingsHandlers: LaTeX tool detection and recommended settings
  */
 import * as vscode from 'vscode';
-import { MODELS, MODEL_CONFIGS } from 'llm-zoo';
+import { MODELS, MODEL_CONFIGS, ReasoningEffort } from 'llm-zoo';
 
 // Shared schemas and dispatchers
 import {
@@ -190,24 +190,52 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
 
 const modelProvidersSet = new Set<string>(MODEL_PROVIDERS_ORDER);
 
+/** Map ReasoningEffort enum values to the ReasoningLevel schema values used in the UI. */
+const REASONING_EFFORT_TO_LEVEL: Record<string, ModelSelectionItem['defaultReasoningLevel']> = {
+  [ReasoningEffort.NONE]: 'none',
+  [ReasoningEffort.LOW]: 'low',
+  [ReasoningEffort.MEDIUM]: 'medium',
+  [ReasoningEffort.HIGH]: 'high',
+  [ReasoningEffort.XHIGH]: 'high', // xhigh shown as high in UI (tier-gated at runtime)
+};
+
+/** Read persisted reasoning level overrides from global state. */
+export function getReasoningLevelOverrides(): Record<string, string> {
+  return globalSM.get<Record<string, string>>(GlobalStateKey.REASONING_LEVELS, {});
+}
+
 function buildModelSelectionItems(): ModelSelectionItem[] {
   const enabledSet = new Set(
     globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS, DEFAULT_MODELS),
   );
+  const reasoningOverrides = getReasoningLevelOverrides();
 
   const items: ModelSelectionItem[] = [];
   for (const name of MODELS) {
     const config = MODEL_CONFIGS[name];
     if (!config || !modelProvidersSet.has(config.provider)) continue;
 
-    items.push({
+    const { supportsReasoningEffort, reasoningEffort } = config.capabilities;
+
+    const item: ModelSelectionItem = {
       name,
       provider: config.provider,
       enabled: enabledSet.has(name),
       deprecated: config.deprecated ?? false,
       contextWindow: formatContext(config.contextWindow),
       cost: formatCost(config.inputPrice, config.outputPrice),
-    });
+    };
+
+    if (supportsReasoningEffort) {
+      item.supportsReasoningLevel = true;
+      item.defaultReasoningLevel = REASONING_EFFORT_TO_LEVEL[reasoningEffort] ?? 'high';
+      const override = reasoningOverrides[name];
+      if (override) {
+        item.reasoningLevel = override as ModelSelectionItem['reasoningLevel'];
+      }
+    }
+
+    items.push(item);
   }
 
   return items.sort((a, b) => a.name.localeCompare(b.name));
@@ -305,6 +333,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleSetModelEnabled(data),
       [SETTINGS_VIEW_COMMANDS.SET_HELPER_MODEL]: (data) =>
         this.handleSetHelperModel(data),
+      [SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL]: (data) =>
+        this.handleSetModelReasoningLevel(data),
 
       // Super YOLO handlers
       [SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED]: () =>
@@ -1002,6 +1032,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_HELPER_MODEL>,
   ): Promise<void> {
     await globalSM.update(GlobalStateKey.HELPER_MODEL, data.modelName);
+    await this.withActiveWebview((w) => this.sendModelSelectionData(w));
+  }
+
+  private async handleSetModelReasoningLevel(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MODEL_REASONING_LEVEL>,
+  ): Promise<void> {
+    const overrides = getReasoningLevelOverrides();
+
+    if (data.level) {
+      overrides[data.modelName] = data.level;
+    } else {
+      delete overrides[data.modelName];
+    }
+
+    await globalSM.update(GlobalStateKey.REASONING_LEVELS, overrides);
     await this.withActiveWebview((w) => this.sendModelSelectionData(w));
   }
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -457,6 +457,10 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.SET_HELPER_MODEL,
   );
 
+  private handleSetReasoningLevel = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_MODEL_REASONING_LEVEL,
+  );
+
   // Agent selection event handlers
   private handleOpenAgentYaml = forwardDetail(
     SETTINGS_VIEW_COMMANDS.OPEN_AGENT_YAML,
@@ -678,6 +682,7 @@ export class SettingsApp extends SettingsAppBase {
               @provider-open-url=${this.handleOpenUrl}
               @model-enabled-set=${this.handleSetModelEnabled}
               @helper-model-set=${this.handleSetHelperModel}
+              @model-reasoning-level-set=${this.handleSetReasoningLevel}
             ></models-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -21,9 +21,10 @@ import { profileViewStyles } from './styles';
 import { ModelSelectionEvents } from './events';
 
 // Local imports - shared schemas
-import type {
-  ModelSelectionItem,
-  ReasoningLevel,
+import {
+  ReasoningLevelSchema,
+  type ModelSelectionItem,
+  type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
 
 /** Display labels for reasoning level options. */
@@ -34,7 +35,7 @@ const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
   high: 'High',
 };
 
-const REASONING_LEVELS: ReasoningLevel[] = ['none', 'low', 'medium', 'high'];
+const REASONING_LEVELS = ReasoningLevelSchema.options;
 
 interface ProviderGroup {
   provider: string;

--- a/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -21,7 +21,20 @@ import { profileViewStyles } from './styles';
 import { ModelSelectionEvents } from './events';
 
 // Local imports - shared schemas
-import type { ModelSelectionItem } from '@shared/schemas/settingsViewMessages';
+import type {
+  ModelSelectionItem,
+  ReasoningLevel,
+} from '@shared/schemas/settingsViewMessages';
+
+/** Display labels for reasoning level options. */
+const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
+  none: 'None',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+};
+
+const REASONING_LEVELS: ReasoningLevel[] = ['none', 'low', 'medium', 'high'];
 
 interface ProviderGroup {
   provider: string;
@@ -101,6 +114,48 @@ export class ModelSelectionList extends LitElement {
     );
   }
 
+  private handleReasoningLevelChange(modelName: string, e: Event): void {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+    this.dispatchEvent(
+      ModelSelectionEvents.setReasoningLevel({
+        modelName,
+        level: value === '' ? null : value,
+      }),
+    );
+  }
+
+  private renderReasoningDropdown(model: ModelSelectionItem): TemplateResult {
+    if (!model.supportsReasoningLevel) return html`${nothing}`;
+
+    const currentValue = model.reasoningLevel ?? '';
+    const defaultLabel = model.defaultReasoningLevel
+      ? `Default (${REASONING_LEVEL_LABELS[model.defaultReasoningLevel]})`
+      : 'Default';
+
+    return html`
+      <vscode-single-select
+        class="reasoning-level-select"
+        .value=${currentValue}
+        title="Reasoning level"
+        @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
+      >
+        <vscode-option value="" ?selected=${currentValue === ''}>
+          ${defaultLabel}
+        </vscode-option>
+        ${REASONING_LEVELS.map(
+          (level) => html`
+            <vscode-option
+              value=${level}
+              ?selected=${currentValue === level}
+            >
+              ${REASONING_LEVEL_LABELS[level]}
+            </vscode-option>
+          `,
+        )}
+      </vscode-single-select>
+    `;
+  }
+
   private renderModelRow(model: ModelSelectionItem): TemplateResult {
     const available = this.isRelayAvailable(model.name);
     const unavailableClass = !available ? ' model-row--unavailable' : '';
@@ -127,6 +182,7 @@ export class ModelSelectionList extends LitElement {
               ></span>`
             : nothing}
         </vscode-checkbox>
+        ${this.renderReasoningDropdown(model)}
         <span class="model-metadata">
           ${model.contextWindow
             ? html`<span>${model.contextWindow}</span>`

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -12,6 +12,8 @@ export const ModelSelectionEvents = {
     createEvent('model-enabled-set', detail),
   setHelperModel: (detail: { modelName: string }) =>
     createEvent('helper-model-set', detail),
+  setReasoningLevel: (detail: { modelName: string; level: string | null }) =>
+    createEvent('model-reasoning-level-set', detail),
 } as const;
 
 export const ProviderKeyEvents = {

--- a/src/settingsView/frontend/components/profile/styles.ts
+++ b/src/settingsView/frontend/components/profile/styles.ts
@@ -496,6 +496,12 @@ export const profileViewStyles: CSSResult = css`
     margin-left: auto;
   }
 
+  .reasoning-level-select {
+    flex-shrink: 0;
+    max-width: 160px;
+    font-size: var(--font-size-xs);
+  }
+
   .deprecated-toggle {
     display: flex;
     align-items: center;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -145,6 +145,15 @@ export type UpdateAgentSelectionMessage = z.infer<
 // Model selection data schema
 // ============================================================
 
+/** Reasoning effort levels that a user can select. */
+export const ReasoningLevelSchema = z.enum([
+  'none',
+  'low',
+  'medium',
+  'high',
+]);
+export type ReasoningLevel = z.infer<typeof ReasoningLevelSchema>;
+
 export const ModelSelectionItemSchema = z.object({
   name: z.string(),
   provider: z.string(),
@@ -152,6 +161,12 @@ export const ModelSelectionItemSchema = z.object({
   deprecated: z.boolean(),
   contextWindow: z.string().optional(),
   cost: z.string().optional(),
+  /** Whether this model supports user-configurable reasoning effort. */
+  supportsReasoningLevel: z.boolean().optional(),
+  /** The model's default reasoning level from its static config. */
+  defaultReasoningLevel: ReasoningLevelSchema.optional(),
+  /** The user's chosen reasoning level override (undefined = use default). */
+  reasoningLevel: ReasoningLevelSchema.optional(),
 });
 export type ModelSelectionItem = z.infer<typeof ModelSelectionItemSchema>;
 
@@ -384,6 +399,13 @@ const SetHelperModelMessageSchema = z.object({
   modelName: z.string().min(1),
 });
 
+const SetModelReasoningLevelMessageSchema = z.object({
+  command: z.literal(CMD.SET_MODEL_REASONING_LEVEL),
+  modelName: z.string().min(1),
+  /** The reasoning level to set, or undefined/null to reset to model default. */
+  level: ReasoningLevelSchema.nullable(),
+});
+
 // Agent selection inbound messages
 const GetAgentSelectionMessageSchema = commandOnly(CMD.GET_AGENT_SELECTION);
 
@@ -566,6 +588,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetModelSelectionMessageSchema,
     SetModelEnabledMessageSchema,
     SetHelperModelMessageSchema,
+    SetModelReasoningLevelMessageSchema,
     // Agent selection messages
     GetAgentSelectionMessageSchema,
     OpenAgentYamlMessageSchema,


### PR DESCRIPTION
## Summary
This PR adds support for users to override the reasoning effort level for AI models that support configurable reasoning. Users can now select from predefined reasoning levels (None, Low, Medium, High) in the settings UI, with these preferences persisted and applied at runtime.

## Key Changes

- **Runtime Model Handler Updates** (`ModelFactory.ts`):
  - Added `applyReasoningLevelOverride()` function to apply user-selected reasoning levels to model handlers
  - Modified `createModelHandler()` to apply reasoning level overrides after handler instantiation
  - Added mapping between user-facing level strings and `ReasoningEffort` enum values

- **Settings View Backend** (`SettingsViewMessageHandler.ts`):
  - Added `handleSetModelReasoningLevel()` to persist reasoning level overrides to global state
  - Added `getReasoningLevelOverrides()` to retrieve persisted overrides
  - Enhanced `buildModelSelectionItems()` to include reasoning level support information and current overrides for each model
  - Added mapping from `ReasoningEffort` enum to UI-friendly `ReasoningLevel` schema values

- **Settings View Frontend** (`ModelSelectionList.ts`):
  - Added `renderReasoningDropdown()` to display reasoning level selector for supported models
  - Added `handleReasoningLevelChange()` to dispatch reasoning level change events
  - Integrated reasoning level dropdown into model row rendering

- **Schema & Events**:
  - Added `ReasoningLevel` schema type with values: 'none', 'low', 'medium', 'high'
  - Extended `ModelSelectionItem` schema with `supportsReasoningLevel`, `defaultReasoningLevel`, and `reasoningLevel` fields
  - Added `SET_MODEL_REASONING_LEVEL` command and message schema
  - Added `setReasoningLevel()` event creator to `ModelSelectionEvents`

- **State Management**:
  - Added `REASONING_LEVELS` global state key to persist user overrides

- **Styling** (`styles.ts`):
  - Added CSS for `.reasoning-level-select` dropdown with appropriate sizing and font

## Implementation Details

- Reasoning level overrides are stored as a map of model names to level strings in global state
- The UI displays the model's default reasoning level when no override is set
- Only models with `supportsReasoningEffort` capability show the reasoning level selector
- The `xhigh` reasoning effort tier is mapped to `high` in the UI (tier-gating handled at runtime)
- Changes are persisted immediately and reflected across all views

https://claude.ai/code/session_01UMujBqHopfd5R2bTbVAgeD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how reasoning/thinking parameters are computed and sent to multiple providers (OpenAI, OpenRouter, Google, Anthropic), which can alter model behavior and cost; mis-mapping could cause unexpected defaults or API validation errors.
> 
> **Overview**
> Users can now override a model’s reasoning effort (*None/Low/Medium/High*) from the Settings model list; overrides are persisted in global state (`GlobalStateKey.REASONING_LEVELS`) and applied at handler creation via `ModelFactory.withReasoningOverride`.
> 
> Provider request building is updated to treat `ReasoningEffort.NONE` as an explicit “minimum reasoning” choice: `ModelHandler.getEffectiveReasoningEffort` no longer converts NONE to `null`, and each provider clamps/ maps `none` to its minimum supported setting (Anthropic → `low`, Google thinking → `LOW`, OpenAI/OpenAI Responses/OpenRouter → `low`) to avoid silent fallback to higher default reasoning.
> 
> Settings messaging/schemas are extended with `ReasoningLevelSchema`, new `SET_MODEL_REASONING_LEVEL` command, and extra fields on `ModelSelectionItem` so the UI can show a reasoning dropdown only for models that support configurable effort (including a “Default (X)” label when the default maps cleanly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d615858665bde2b72adab909a123d19ad71303a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->