### PR TITLE
Fix instruction persistence for subagents by setting activeRunId early

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -541,7 +541,7 @@ async function prepareAgentUI(
   options?: { isSubagent?: boolean },
 ): Promise<void> {
   if (executionId) await ensureRunDir(executionId);
-  const { streamId, config } = ctx;
+  const { streamId, config, storageKey } = ctx;
 
   const runStorage = getRunStorageService();
   StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
@@ -569,6 +569,7 @@ async function prepareAgentUI(
     streamId,
     executionId,
     taskState: agentConfigToTaskState(config),
+    storageKey,
   });
 
   if (config.outputFiles.length > 1 && !config.useMultipleOutputs) {

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -39,6 +39,9 @@ interface SetTaskStatePayload {
   streamId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
+  /** Storage key for this run (root group ID). Allows setting activeRunId early
+   *  so that instruction persistence doesn't require a usage event first. */
+  storageKey?: StorageKey;
 }
 
 const MAX_BUFFER_SIZE = 1000;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -39,9 +39,9 @@ interface SetTaskStatePayload {
   streamId: StreamTabId;
   executionId?: ExecutionId;
   taskState: TaskState;
-  /** Storage key for this run (root group ID). Allows setting activeRunId early
-   *  so that instruction persistence doesn't require a usage event first. */
-  storageKey?: StorageKey;
+  /** Storage key for this run (root group ID). Sets activeRunId so instruction
+   *  persistence works immediately, not after the first usage event. */
+  storageKey: StorageKey;
 }
 
 const MAX_BUFFER_SIZE = 1000;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -165,6 +165,9 @@ export class ProgressEventHandler {
             storageKey,
             usage,
           );
+          // Workflow streams get activeRunId from handleSetTaskState (fires
+          // before any usage event). This guard only triggers for tool-use
+          // streams, which skip the handleSetTaskState instruction block.
           if (!ctx.state.meta.getActiveRunId(streamId)) {
             ctx.state.meta.setActiveRunId(streamId, storageKey);
           }

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -266,7 +266,7 @@ export class ProgressEventHandler {
   private handleSetTaskState(
     data: ProgressEventPayloads['setTaskState'],
   ): void {
-    const { streamId, executionId, taskState } = data;
+    const { streamId, executionId, taskState, storageKey } = data;
     const isActiveStream = this.state.activeStream === streamId;
     const category = taskState.agentConfig.agentCategory;
     const previousFilter = this.state.agentCategoryFilter;
@@ -286,8 +286,23 @@ export class ProgressEventHandler {
       this.state.meta.setExecutionId(streamId, executionId);
     }
 
+    // Set activeRunId early from storageKey so instruction persistence works
+    // immediately — without waiting for the first updateStreamUsage event.
+    // This is critical for subagents launched by orchestrators: by the time
+    // the user switches to the subagent tab, the instruction must already be
+    // persisted with the correct run key.
+    if (storageKey) {
+      this.state.meta.setActiveRunId(streamId, storageKey);
+    }
+
     if (isActiveStream) {
-      this.sendInstructionUpdate(streamId);
+      // Active stream: persist + send instruction to webview
+      this.sendInstructionUpdate(streamId, storageKey ?? undefined);
+    } else if (storageKey) {
+      // Non-active stream: persist instruction so it's available on tab switch.
+      // Without this, subagent instructions are missing when the user clicks
+      // on a subagent tab that wasn't active during setTaskState.
+      this.prepareInstructionUpdate(streamId, storageKey);
     }
 
     if (this.webviewUpdater.isAvailable()) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -286,22 +286,17 @@ export class ProgressEventHandler {
       this.state.meta.setExecutionId(streamId, executionId);
     }
 
-    // Set activeRunId early from storageKey so instruction persistence works
-    // immediately — without waiting for the first updateStreamUsage event.
-    // This is critical for subagents launched by orchestrators: by the time
-    // the user switches to the subagent tab, the instruction must already be
-    // persisted with the correct run key.
-    if (storageKey) {
-      this.state.meta.setActiveRunId(streamId, storageKey);
-    }
+    // Set activeRunId from storageKey (= root group ID) immediately.
+    // Without this, activeRunId only gets set on the first updateStreamUsage
+    // event — long after setTaskState fires. That made sendInstructionUpdate
+    // bail out (no runId), so subagent instructions were never persisted.
+    this.state.meta.setActiveRunId(streamId, storageKey);
 
     if (isActiveStream) {
-      // Active stream: persist + send instruction to webview
-      this.sendInstructionUpdate(streamId, storageKey ?? undefined);
-    } else if (storageKey) {
-      // Non-active stream: persist instruction so it's available on tab switch.
-      // Without this, subagent instructions are missing when the user clicks
-      // on a subagent tab that wasn't active during setTaskState.
+      this.sendInstructionUpdate(streamId, storageKey);
+    } else {
+      // Non-active stream (e.g. subagent while orchestrator is active):
+      // persist instruction so it's available when the user switches tabs.
       this.prepareInstructionUpdate(streamId, storageKey);
     }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -286,18 +286,20 @@ export class ProgressEventHandler {
       this.state.meta.setExecutionId(streamId, executionId);
     }
 
-    // Set activeRunId from storageKey (= root group ID) immediately.
-    // Without this, activeRunId only gets set on the first updateStreamUsage
-    // event — long after setTaskState fires. That made sendInstructionUpdate
-    // bail out (no runId), so subagent instructions were never persisted.
-    this.state.meta.setActiveRunId(streamId, storageKey);
-
-    if (isActiveStream) {
-      this.sendInstructionUpdate(streamId, storageKey);
-    } else {
-      // Non-active stream (e.g. subagent while orchestrator is active):
-      // persist instruction so it's available when the user switches tabs.
-      this.prepareInstructionUpdate(streamId, storageKey);
+    // Instruction panel is only rendered for workflow streams.
+    // Set activeRunId from storageKey (= root group ID) so the instruction
+    // can be persisted immediately — not after the first usage event.
+    // Without this, subagent instructions were never persisted because
+    // sendInstructionUpdate bailed out on a null runId.
+    if (category !== AgentCategory.ToolUse) {
+      this.state.meta.setActiveRunId(streamId, storageKey);
+      if (isActiveStream) {
+        this.sendInstructionUpdate(streamId, storageKey);
+      } else {
+        // Non-active stream (e.g. subagent while orchestrator is active):
+        // persist so the instruction is available when the user switches tabs.
+        this.prepareInstructionUpdate(streamId, storageKey);
+      }
     }
 
     if (this.webviewUpdater.isAvailable()) {


### PR DESCRIPTION
## Summary
This PR fixes a timing issue where subagent instructions were not persisted when users switched to a subagent tab that wasn't active during the initial `setTaskState` event. The fix ensures that `activeRunId` is set immediately from the `storageKey` provided in the event, rather than waiting for a subsequent `updateStreamUsage` event.

## Key Changes
- **ProgressEventHandler**: Modified `handleSetTaskState` to extract and use `storageKey` from the event payload:
  - Sets `activeRunId` early via `setActiveRunId()` to enable immediate instruction persistence
  - For active streams: passes `storageKey` to `sendInstructionUpdate()` for persistence and webview delivery
  - For non-active streams: calls `prepareInstructionUpdate()` to persist instructions so they're available when the user switches tabs

- **executeAgent**: Updated `prepareAgentUI` to extract `storageKey` from context and include it in the `setTaskState` event payload

- **ProgressEventBus**: Extended `SetTaskStatePayload` interface to include optional `storageKey` field with documentation explaining its purpose

## Implementation Details
The fix addresses a critical issue for orchestrator-launched subagents: by the time a user switches to a subagent tab, the instruction must already be persisted with the correct run key. Previously, this persistence depended on the `updateStreamUsage` event arriving first, which could race with user interactions. Now, the storage key is available immediately in `setTaskState`, allowing instruction persistence to happen synchronously for both active and non-active streams.

https://claude.ai/code/session_01L5CicifAb7mcy9yT9E85HW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `setTaskState` event shape and the timing of instruction persistence/active run selection across workflow vs tool-use streams, which could affect progress view state and persistence behavior.
> 
> **Overview**
> Fixes a race where workflow subagent instructions weren’t persisted when the subagent stream wasn’t active at `setTaskState` time.
> 
> `setTaskState` now includes a required `storageKey` (run root ID) emitted from `executeAgent.prepareAgentUI`, and `ProgressEventHandler.handleSetTaskState` uses it to set `activeRunId` and persist/send instructions for both active and non-active workflow streams (while leaving tool-use streams to the existing usage-event fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17536d38eee1cf7e145ca866613117ac0c67ad4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->