### PR TITLE
Add gpt53codex to default model list

### DIFF
--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -23,7 +23,7 @@ import { extendEnvPath } from '@utils/system/platformPaths';
  * Version number for the default model list.
  * Increment this when adding new models to force existing users to get the updated defaults.
  */
-const MODEL_LIST_VERSION = 5;
+const MODEL_LIST_VERSION = 6;
 
 /**
  * Version number for LaTeX-related VS Code config setup.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -22,6 +22,7 @@ export const DEFAULT_MODELS = [
   'opus46T',
   'gpt52',
   'gpt52pro',
+  'gpt53codex',
   'gpt41',
   'deepseekT',
   'kimi25T',


### PR DESCRIPTION
## Summary
This PR adds support for a new GPT model (`gpt53codex`) to the application's default model list and increments the model list version to ensure existing users receive the updated defaults.

## Key Changes
- Incremented `MODEL_LIST_VERSION` from 5 to 6 in `src/frontend/setup.ts` to trigger model list updates for existing users
- Added `'gpt53codex'` to the `DEFAULT_MODELS` array in `src/model/computeModelOptions.ts`

## Implementation Details
The new model is inserted in the default models list between `gpt52pro` and `gpt41`, maintaining the existing model ordering convention. The version bump ensures that users with cached model configurations will receive the updated list on their next application startup.

https://claude.ai/code/session_01DPWjMCdTvYEXojuGzb179L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new default model entry and bumps the model list version to trigger refresh for existing users, without changing selection/availability logic.
> 
> **Overview**
> Adds `gpt53codex` to `DEFAULT_MODELS` so it appears in the default visible model list.
> 
> Bumps `MODEL_LIST_VERSION` from `5` to `6` to force a one-time refresh/merge of new defaults into existing users' stored enabled models.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ac085cbd0511646388c725abf7679de4b458d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->