### PR TITLE
Release v0.36.4: Reasoning overrides, BYOK analytics, and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 - **Inline base64 fallback for tool attachments** — images and PDFs from tool results are now embedded inline when routed through providers (e.g., OpenRouter) that lack file-upload support, so the model can see visual content.
-- **Lean blueprint notation** — the leanBlueprint agent now translates Lean syntax into standard mathematical notation in informal text, keeping Lean identifiers only inside `\lean{}` macros.
+- **Clearer delegation feedback** — the orchestrator now receives more accurate status signals, rejection details, and approval metadata when delegating to subagents, improving multi-agent coordination.
 
 ## [0.36.3] - 2026-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.36.4] - 2026-03-02
+
+### Features
+
+- **Reasoning level overrides** — configure the reasoning effort (Low / Medium / High) per model in the Models settings tab, overriding each provider's default.
+- **GPT-5.3 Codex** — added OpenAI's GPT-5.3-Codex (`gpt53codex`) to the default model list.
+- **BYOK spending analytics** — new database views for tracking Bring-Your-Own-Key spending by model, day, and month alongside existing relay usage.
+
+### Bug Fixes
+
+- Fixed **truncated Anthropic responses** — relay proxy timeouts during extended thinking could silently cut off output; now detected and retried automatically.
+- Fixed **image uploads rejected** when the configured resize dimension exceeded 8000 px — the limit is now capped to stay within API bounds.
+- Fixed **approval panel disappearing** when opening a diff preview — "Open Diff", "Preview Proposed", and "Show LaTeXDiff" no longer dismiss the approve/reject buttons.
+- Fixed **approval panel disappearing** when an orchestrator launches a new subagent — the view now stays on the current stream until the user responds to a pending approval.
+- Fixed **subagent instruction panel** not appearing — `activeRunId` is now set immediately when an agent starts so instructions are persisted before the first event.
+- Fixed **Google GenAI retry multiplication** — SDK-level retries are now disabled so the application's retry loop respects the user's configured retry count instead of multiplying it.
+
+### Improvements
+
+- **Inline base64 fallback for tool attachments** — images and PDFs from tool results are now embedded inline when routed through providers (e.g., OpenRouter) that lack file-upload support, so the model can see visual content.
+- **Lean blueprint notation** — the leanBlueprint agent now translates Lean syntax into standard mathematical notation in informal text, keeping Lean identifiers only inside `\lean{}` macros.
+- Consolidated CSS magic numbers into design tokens.
+- Decoupled agent core from frontend and broke circular dependency chains.
+- Updated dependencies.
+
 ## [0.36.3] - 2026-02-23
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,18 @@ All notable changes to this project will be documented in this file.
 
 - **Reasoning level overrides** — configure the reasoning effort (Low / Medium / High) per model in the Models settings tab, overriding each provider's default.
 - **GPT-5.3 Codex** — added OpenAI's GPT-5.3-Codex (`gpt53codex`) to the default model list.
-- **BYOK spending analytics** — new database views for tracking Bring-Your-Own-Key spending by model, day, and month alongside existing relay usage.
 
 ### Bug Fixes
 
-- Fixed **truncated Anthropic responses** — relay proxy timeouts during extended thinking could silently cut off output; now detected and retried automatically.
+- Fixed **incomplete Anthropic responses** not being detected — truncated streams are now caught and retried automatically.
 - Fixed **image uploads rejected** when the configured resize dimension exceeded 8000 px — the limit is now capped to stay within API bounds.
-- Fixed **approval panel disappearing** when opening a diff preview — "Open Diff", "Preview Proposed", and "Show LaTeXDiff" no longer dismiss the approve/reject buttons.
-- Fixed **approval panel disappearing** when an orchestrator launches a new subagent — the view now stays on the current stream until the user responds to a pending approval.
-- Fixed **subagent instruction panel** not appearing — `activeRunId` is now set immediately when an agent starts so instructions are persisted before the first event.
-- Fixed **Google GenAI retry multiplication** — SDK-level retries are now disabled so the application's retry loop respects the user's configured retry count instead of multiplying it.
+- Fixed **approval and instruction panels** disappearing or not appearing in the progress board — diff previews, subagent launches, and stream switches no longer dismiss pending approvals or drop instruction data.
+- Fixed **Google GenAI retry multiplication** — the configured retry count is now respected instead of being silently multiplied.
 
 ### Improvements
 
 - **Inline base64 fallback for tool attachments** — images and PDFs from tool results are now embedded inline when routed through providers (e.g., OpenRouter) that lack file-upload support, so the model can see visual content.
 - **Lean blueprint notation** — the leanBlueprint agent now translates Lean syntax into standard mathematical notation in informal text, keeping Lean identifiers only inside `\lean{}` macros.
-- Consolidated CSS magic numbers into design tokens.
-- Decoupled agent core from frontend and broke circular dependency chains.
-- Updated dependencies.
 
 ## [0.36.3] - 2026-02-23
 


### PR DESCRIPTION
## Summary

This release introduces reasoning level configuration per model, adds GPT-5.3 Codex support, and includes several critical bug fixes for response truncation, image uploads, and UI state management.

## Key Changes

**Features:**
- Added per-model reasoning level overrides (Low/Medium/High) in Models settings, allowing fine-grained control over reasoning effort independent of provider defaults
- Integrated OpenAI's GPT-5.3-Codex (`gpt53codex`) into the default model list
- Implemented new database views for BYOK spending analytics, enabling tracking by model, day, and month alongside relay usage

**Bug Fixes:**
- Fixed truncated Anthropic responses caused by relay proxy timeouts during extended thinking—now automatically detected and retried
- Corrected image upload rejection when resize dimensions exceeded 8000 px; limit now properly capped to API bounds
- Resolved approval panel disappearing when opening diff previews—"Open Diff", "Preview Proposed", and "Show LaTeXDiff" actions no longer dismiss approval buttons
- Fixed approval panel disappearing when orchestrator launches subagents—view now persists on current stream until user responds to pending approval
- Corrected subagent instruction panel not appearing—`activeRunId` now set immediately on agent start for proper instruction persistence
- Fixed Google GenAI retry multiplication by disabling SDK-level retries, allowing application retry loop to respect user configuration

**Improvements:**
- Added inline base64 fallback for tool attachments, embedding images and PDFs when routed through providers lacking file-upload support (e.g., OpenRouter)
- Enhanced leanBlueprint agent to translate Lean syntax into standard mathematical notation in informal text, preserving Lean identifiers only in `\lean{}` macros
- Consolidated CSS magic numbers into design tokens for improved maintainability
- Decoupled agent core from frontend and resolved circular dependency chains
- Updated dependencies

https://claude.ai/code/session_019WgiJYzPi2kaA8hn19Dn5S

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates `CHANGELOG.md` and does not modify runtime code paths.
> 
> **Overview**
> Adds the `0.36.4` release entry to `CHANGELOG.md`, documenting new per-model reasoning level overrides and the addition of `gpt53codex`.
> 
> Notes fixes for truncated Anthropic streams, oversized image-resize upload rejections, progress-board approval/instruction panel persistence issues, and Google GenAI retry count handling, plus improvements like inline base64 fallbacks for tool-result attachments and clearer subagent delegation feedback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 366c614d9aa5eabb0eda559fe97b331e684096be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->