### PR TITLE
Preserve focus when opening diff documents

### DIFF
--- a/src/frontend/ui/diffView.ts
+++ b/src/frontend/ui/diffView.ts
@@ -37,6 +37,7 @@ function refreshDiff(): void {
     diffInfo.left,
     diffInfo.right,
     diffInfo.title,
+    { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
   );
   logger.debug(CHANNEL, 'Refreshed diff view');
 }

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -446,6 +446,7 @@ async function nativeRequestApproval(
       originalUri,
       proposedUri,
       title,
+      { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
     );
 
     await revealFirstChange(proposedUri, originalContent, proposedContent);
@@ -681,6 +682,7 @@ export async function handleProgressViewToolEditApprovalAction(
         entry.originalUri,
         entry.proposedUri,
         entry.title,
+        { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
       );
       await revealFirstChange(
         entry.proposedUri,


### PR DESCRIPTION
## Summary
Updated diff document opening calls to preserve focus on the current editor, preventing the view from automatically switching to newly opened diff documents.

## Key Changes
- Added `{ preserveFocus: true }` option to all `showTextDocument()` calls in the diff viewing workflow
- Applied to three locations:
  - `nativeRequestApproval()` in toolEditApproval.ts
  - `handleProgressViewToolEditApprovalAction()` in toolEditApproval.ts
  - `refreshDiff()` in diffView.ts

## Implementation Details
The `preserveFocus: true` option is passed as a `vscode.TextDocumentShowOptions` parameter to `showTextDocument()` calls. This ensures that when diff documents are opened programmatically, the focus remains on the user's current editor rather than automatically switching to the newly opened document, providing a better user experience during approval workflows.

https://claude.ai/code/session_01N6N9YKhm7V31H71mriAsXQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5cc1c7fb9cc2034f442978ff37132fe749e92e9c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->