### PR TITLE
Migrate custom endpoint config to globalSM (dashboard settings)

### DIFF
--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,6 +1,7 @@
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { ModelProvider } from 'llm-zoo';
 import { getConfig } from '@utils/config';
+import { getProviderEndpoint } from '@utils/config/providerConfig';
 
 const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
 
@@ -152,15 +153,18 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
   if (useOpenRouter) return 'https://openrouter.ai/api/v1';
 
   // Per-provider custom base URL override (all providers except OpenRouter)
+  // Check both the dashboard settings (globalSM) and workspace config (settings.json)
+  const dashboardEndpoint = getProviderEndpoint(config.provider);
   const endpointKey = ENDPOINT_CONFIG_KEYS[config.provider];
-  if (endpointKey) {
-    const customUrl = getConfig<string>(endpointKey, '').trim();
-    if (customUrl) {
-      config.logger?.debug(
-        `Using custom base URL for ${config.provider}: ${customUrl}`,
-      );
-      return `https://${normalizeUrl(customUrl)}`;
-    }
+  const workspaceEndpoint = endpointKey
+    ? getConfig<string>(endpointKey, '').trim()
+    : '';
+  const customUrl = dashboardEndpoint || workspaceEndpoint;
+  if (customUrl) {
+    config.logger?.debug(
+      `Using custom base URL for ${config.provider}: ${customUrl}`,
+    );
+    return `https://${normalizeUrl(customUrl)}`;
   }
 
   return BASE_URLS[config.provider];

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -3,6 +3,10 @@ import { ModelProvider } from 'llm-zoo';
 import { getConfig } from '@utils/config';
 import { getProviderEndpoint } from '@utils/config/providerConfig';
 
+// NOTE: getProviderEndpoint reads from globalSM (VS Code global state), which is
+// where the Settings dashboard writes custom endpoints. The legacy settings.json
+// keys (texra.model.baseUrl*) are no longer read — globalSM is the single source.
+
 const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
 
 /**
@@ -28,17 +32,6 @@ const PROXY_PATHS: Partial<Record<ModelProvider, string>> = {
   [ModelProvider.OPENAI]: 'openai/v1',
   [ModelProvider.ANTHROPIC]: 'anthropic',
   [ModelProvider.XAI]: 'xai',
-};
-
-/** Per-provider custom endpoint config keys. OpenRouter/Copilot/Others have no custom endpoint. */
-const ENDPOINT_CONFIG_KEYS: Partial<Record<ModelProvider, string>> = {
-  [ModelProvider.OPENAI]: 'texra.model.baseUrlOpenai',
-  [ModelProvider.ANTHROPIC]: 'texra.model.baseUrlAnthropic',
-  [ModelProvider.GOOGLE]: 'texra.model.baseUrlGoogle',
-  [ModelProvider.DEEPSEEK]: 'texra.model.baseUrlDeepSeek',
-  [ModelProvider.XAI]: 'texra.model.baseUrlXai',
-  [ModelProvider.MOONSHOT]: 'texra.model.baseUrlMoonshot',
-  [ModelProvider.DASHSCOPE]: 'texra.model.baseUrlDashscope',
 };
 
 const BASE_URLS: Record<ModelProvider, string | null> = {
@@ -88,7 +81,8 @@ export function shouldUseOpenRouter(config: {
  * 2. Server-side keys relay (experimental, for Ultra users)
  * 3. Improved connection proxy (proxy.texra.ai)
  * 4. OpenRouter
- * 5. Provider default URLs
+ * 5. Per-provider custom endpoint (dashboard settings)
+ * 6. Provider default URLs
  *
  * Note: Server-side keys and proxy.texra.ai are MUTUALLY EXCLUSIVE.
  * When server-side keys are enabled, the relay handles everything
@@ -152,14 +146,8 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
 
   if (useOpenRouter) return 'https://openrouter.ai/api/v1';
 
-  // Per-provider custom base URL override (all providers except OpenRouter)
-  // Check both the dashboard settings (globalSM) and workspace config (settings.json)
-  const dashboardEndpoint = getProviderEndpoint(config.provider);
-  const endpointKey = ENDPOINT_CONFIG_KEYS[config.provider];
-  const workspaceEndpoint = endpointKey
-    ? getConfig<string>(endpointKey, '').trim()
-    : '';
-  const customUrl = dashboardEndpoint || workspaceEndpoint;
+  // Per-provider custom endpoint from dashboard settings (globalSM)
+  const customUrl = getProviderEndpoint(config.provider);
   if (customUrl) {
     config.logger?.debug(
       `Using custom base URL for ${config.provider}: ${customUrl}`,


### PR DESCRIPTION
## Summary
Migrated per-provider custom endpoint configuration from legacy `settings.json` keys to the new globalSM (VS Code global state) storage, which is the single source of truth for Settings dashboard configurations.

## Key Changes
- Removed `ENDPOINT_CONFIG_KEYS` constant that mapped providers to legacy `texra.model.baseUrl*` settings.json keys
- Replaced direct `getConfig()` calls with new `getProviderEndpoint()` utility that reads from globalSM
- Updated resolution priority documentation to reflect the new endpoint source (step 5 is now dashboard settings via globalSM)
- Added explanatory comment clarifying that globalSM is the single source for custom endpoints and legacy settings.json keys are no longer read

## Implementation Details
- The `getProviderEndpoint()` function abstracts away the globalSM storage mechanism, providing a cleaner interface for retrieving custom endpoints
- The resolution order remains unchanged; custom endpoints are still checked after OpenRouter but before provider defaults
- This change ensures consistency between the Settings dashboard UI and the actual endpoint resolution logic

https://claude.ai/code/session_01TE3v8DPUxmTNijCHqCW5eB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API base URLs are resolved for multiple providers; misconfigured or missing global state values could alter routing and break provider connectivity.
> 
> **Overview**
> `resolveBaseUrl` now reads per-provider custom endpoints via `getProviderEndpoint()` (backed by `globalSM`/Settings dashboard) and removes the legacy `texra.model.baseUrl*` `settings.json` key mapping.
> 
> Updates the documented base-URL resolution priority to place dashboard-configured endpoints after OpenRouter and before provider defaults, with a comment clarifying `globalSM` as the single source of truth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cca97e134578a9da0da10e5eda3571533fa8b36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->