### PR TITLE
Hydrate bypass state on tab switch for correct toggle display

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -17,8 +17,6 @@ import {
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
-import { isApprovalBypassedForStream } from '@tools/approval/toolEditApproval';
-import { isProposalBypassedForStream } from '@tools/approval/proposalApproval';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 import { ProgressEventHandler } from './events/ProgressEventHandler';
@@ -312,10 +310,6 @@ export class ProgressViewProvider
     }
 
     this._pendingUpdateOptions = null;
-
-    if (this.canSendToWebview()) {
-      this.sendBypassStates(activeStream);
-    }
   }
 
   public markWebviewReady(
@@ -373,18 +367,6 @@ export class ProgressViewProvider
     return this.isActivePlacementReady() && this.webviewUpdater.isAvailable();
   }
 
-  private sendBypassStates(streamId: StreamTabId): void {
-    this.webviewUpdater.updateBypassState(
-      streamId,
-      'toolEdit',
-      isApprovalBypassedForStream(streamId),
-    );
-    this.webviewUpdater.updateBypassState(
-      streamId,
-      'superYolo',
-      isProposalBypassedForStream(streamId),
-    );
-  }
 
   public async cleanupTasksAfterRestart(
     waitingStreams?: Set<StreamTabId>,
@@ -433,8 +415,7 @@ export class ProgressViewProvider
     if (!this.canSendToWebview()) return;
 
     this.webviewUpdater.setActiveStream(streamId);
-    this.sendBypassStates(streamId);
-    // Hydrate content (logs, todos, follow-ups, instruction) + active-state metadata
+    // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata
     this.eventHandler.syncStreamContent(streamId, { includeActiveState: true });
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -27,6 +27,11 @@ import {
 import { bus } from '@eventBus/ProgressEventBus';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
+import {
+  isApprovalBypassedForStream,
+  isProposalBypassedForStream,
+} from '@tools/approval';
+
 import { registerHandlers } from './registerHandlers';
 import { registerUIEvents, type UICallbacks } from './UIEvents';
 import type { EventHandlerContext } from './EventHandlerContext';
@@ -521,6 +526,10 @@ export class ProgressEventHandler {
       parentStreamId = this.state.meta.getParentStreamId(stream);
     }
 
+    // Always include toggle bypass state so buttons render correctly on tab switch.
+    const toolEditBypass = isApprovalBypassedForStream(stream);
+    const superYoloBypass = isProposalBypassedForStream(stream);
+
     this.webviewUpdater.sendSyncStreamContent({
       stream,
       action: 'render',
@@ -533,6 +542,8 @@ export class ProgressEventHandler {
       conversationProgress,
       badges,
       parentStreamId,
+      toolEditBypass,
+      superYoloBypass,
     });
 
     return activeRunId;

--- a/src/progressView/frontend/slices/syncSlice.ts
+++ b/src/progressView/frontend/slices/syncSlice.ts
@@ -63,6 +63,15 @@ export const syncHandlers: HandlerRegistry = {
             if (data.todos) d.todos = data.todos;
             if (data.queuedFollowUps) d.queuedFollowUps = data.queuedFollowUps;
           }
+
+          // Hydrate toggle bypass state on tab switch
+          if (isToolUseState(prev)) {
+            const d = draft as ToolUseStreamState;
+            if (data.toolEditBypass !== undefined)
+              d.toolEditBypass = data.toolEditBypass;
+            if (data.superYoloBypass !== undefined)
+              d.superYoloBypass = data.superYoloBypass;
+          }
           if (isWorkflowState(prev) && hasInstruction) {
             const d = draft as WorkflowStreamState;
             if (data.instruction && data.runId) {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -74,6 +74,9 @@ export interface SyncStreamContentPayload {
     finishedProcessCount: StreamExecutionState['finishedProcessCount'];
   };
   parentStreamId?: StreamTabId;
+  /** Toggle bypass state (hydrated on tab switch so toggles display correctly). */
+  toolEditBypass?: boolean;
+  superYoloBypass?: boolean;
 }
 
 /**

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -321,6 +321,9 @@ export const SyncStreamContentMessageSchema = z.object({
     })
     .optional(),
   parentStreamId: StreamTabIdSchema.optional(),
+  // Toggle bypass state (hydrated on tab switch so toggles display correctly)
+  toolEditBypass: z.boolean().optional(),
+  superYoloBypass: z.boolean().optional(),
 });
 
 export const ProgressSetThemeMessageSchema = z.object({


### PR DESCRIPTION
## Summary
Refactored bypass state management to ensure toggle buttons display correctly when switching between stream tabs. Previously, bypass state was sent separately after stream content sync, which could cause UI inconsistencies. Now bypass state is included as part of the stream content sync payload.

## Key Changes
- **Removed separate bypass state sending**: Deleted `sendBypassStates()` method from `ProgressViewProvider` that was called after stream updates
- **Moved bypass state to content sync**: Integrated `toolEditBypass` and `superYoloBypass` into the `syncStreamContent()` payload in `ProgressEventHandler`
- **Updated imports**: Moved approval bypass check imports from `ProgressViewProvider` to `ProgressEventHandler` where they're now used
- **Extended sync payload schema**: Added optional `toolEditBypass` and `superYoloBypass` fields to `SyncStreamContentPayload` interface and Zod schema
- **Updated frontend state hydration**: Modified `syncSlice.ts` to hydrate bypass state from sync payload when switching tabs

## Implementation Details
- Bypass state is now always included in the sync stream content message, ensuring it's available when the tab switches
- The frontend properly hydrates these values into the Redux state so toggle buttons render with the correct state
- This eliminates a race condition where bypass state might not be sent before the UI needs to render the toggles

https://claude.ai/code/session_01LPXqNS6sW7aMUx6FKqMyKT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to progress-view messaging/state hydration; main risk is a UI regression if the new optional fields are missing or mis-typed, but it doesn’t affect security or data integrity.
> 
> **Overview**
> Fixes tab-switch UI inconsistencies by **moving bypass toggle hydration into the `SYNC_STREAM_CONTENT` payload** instead of sending separate `UPDATE_BYPASS` messages.
> 
> Backend: `ProgressViewProvider` drops the `sendBypassStates()` helper and no longer pushes bypass state separately; `ProgressEventHandler.syncStreamContent()` now always includes `toolEditBypass`/`superYoloBypass` (with imports consolidated under `@tools/approval`). Frontend/schema: `SyncStreamContentPayload` and its Zod schema gain optional bypass fields, and `syncSlice` hydrates them into `ToolUseStreamState` on tab switch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4ed63fdea080de1696eb7dede21205defb11b26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->