### PR TITLE
Claude/add websocket OpenAI support n7 yaz

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,12 +107,6 @@
             "description": "Enable background mode for OpenAI Responses API to handle long-running generations (>10mins) more reliably by preventing request timeouts. Adds polling overhead.",
             "scope": "resource"
           },
-          "texra.model.useWebSocket": {
-            "type": "boolean",
-            "default": false,
-            "description": "Use WebSocket transport for OpenAI Responses API. Reduces latency in tool-heavy workflows (~40% faster with 20+ tool calls) by maintaining a persistent connection. Incompatible with OpenRouter.",
-            "scope": "resource"
-          },
           "texra.model.openaiParallelToolCalls": {
             "type": "boolean",
             "default": false,

--- a/package.json
+++ b/package.json
@@ -107,6 +107,12 @@
             "description": "Enable background mode for OpenAI Responses API to handle long-running generations (>10mins) more reliably by preventing request timeouts. Adds polling overhead.",
             "scope": "resource"
           },
+          "texra.model.useWebSocket": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use WebSocket transport for OpenAI Responses API. Reduces latency in tool-heavy workflows (~40% faster with 20+ tool calls) by maintaining a persistent connection. Incompatible with OpenRouter.",
+            "scope": "resource"
+          },
           "texra.model.openaiParallelToolCalls": {
             "type": "boolean",
             "default": false,

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -935,4 +935,12 @@ export abstract class ModelHandler<
   get supportsTokenCounting(): boolean {
     return false;
   }
+
+  /**
+   * Release any resources held by the handler.
+   * Override in subclasses that hold long-lived resources (e.g., WebSocket connections).
+   */
+  dispose(): void {
+    // No-op by default
+  }
 }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -478,6 +478,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (settled) return;
         settled = true;
         cleanup();
+        // Invalidate the connection on error events (e.g., websocket_connection_limit_reached).
+        // The server may close the socket after sending the error, but the close event
+        // fires after this handler and would be a no-op (settled=true).
+        this.closeWebSocket();
         reject(error);
       };
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -414,7 +414,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     ws: ResponsesWS,
     params: ResponseCreateParamsBase,
     signal?: AbortSignal,
-  ): Promise<Response> {
+  ): Promise<{ response: Response; state: StreamingEventState }> {
     // Short-circuit if already aborted before sending the request
     if (signal?.aborted) {
       throw new DOMException('The operation was aborted', 'AbortError');
@@ -422,7 +422,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const state = this.createStreamingEventState();
 
-    return new Promise<Response>((resolve, reject) => {
+    return new Promise<{ response: Response; state: StreamingEventState }>((resolve, reject) => {
       let settled = false;
       // Track the response ID for this request so we only process events
       // belonging to it (important when abort-and-retry reuses the connection).
@@ -480,13 +480,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (settled || !isCurrentResponse(response)) return;
         settled = true;
         cleanup();
-        if (state.hasThinkingContent) {
-          state.thinkingStream.finalize();
-        }
-        const { text: finalText } = this.extractResponse(response, '');
-        if (state.outputStream) state.outputStream.finalize(finalText);
-        this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
-        resolve(response);
+        // Stream finalization is deferred to the caller so that background
+        // polling (if needed) can replace the response before streams close.
+        resolve({ response, state });
       };
 
       const onCompleted = (event: ResponseCompletedEvent): void =>
@@ -1746,7 +1742,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // WebSocket transport: persistent connection for lower-latency tool-use loops
       if (useWebSocket) {
         const ws = await this.getOrCreateWebSocket(client, signal);
-        let response = await this.executeViaWebSocket(ws, params, signal);
+        const wsResult = await this.executeViaWebSocket(ws, params, signal);
+        let response = wsResult.response;
+        const state = wsResult.state;
 
         // Safety net: handle unexpected pending status (shouldn't happen without background mode)
         if (this.isBackgroundPending(response)) {
@@ -1759,6 +1757,15 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
             signal,
           );
         }
+
+        // Finalize streams after background polling so the final text
+        // reflects the completed response, not the pre-poll snapshot.
+        if (state.hasThinkingContent) {
+          state.thinkingStream.finalize();
+        }
+        const { text: finalText } = this.extractResponse(response, '');
+        if (state.outputStream) state.outputStream.finalize(finalText);
+        this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
 
         this.finalizeResponse(
           response,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -250,13 +250,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Whether WebSocket transport is enabled for this handler.
-   * Incompatible with OpenRouter routing (custom base URL not supported by WS)
-   * and background mode (polling-based, doesn't benefit from persistent connection).
+   *
+   * WebSocket transport connects directly to the OpenAI Responses API via the
+   * official SDK and is incompatible with any non-default base URL, including:
+   * - Server-side keys relay (Supabase Edge Function)
+   * - Improved connection proxy (proxy.texra.ai)
+   * - OpenRouter routing
+   * - Custom per-provider or per-model endpoints
+   *
+   * Also incompatible with background mode (polling-based, doesn't benefit
+   * from persistent connection).
    */
   private isWebSocketModeEnabled(): boolean {
     return (
       getConfig<boolean>('texra.model.useWebSocket', false) &&
-      !this.isOpenRouterRoutingEnabled()
+      this.getBaseUrl() === null
     );
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -247,6 +247,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private static readonly WS_MAX_AGE_MS = 55 * 60 * 1000;
   /** Keepalive ping interval to prevent idle timeouts (30 seconds). */
   private static readonly WS_KEEPALIVE_INTERVAL_MS = 30_000;
+  /** WebSocket readyState value for an open connection. */
+  private static readonly WS_OPEN = 1;
 
   /**
    * Whether WebSocket transport is enabled for this handler.
@@ -276,7 +278,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Check if existing connection is still valid
     if (this.wsConnection) {
       const age = Date.now() - this.wsConnectionCreatedAt;
-      const socketReady = this.wsConnection.socket.readyState === 1; // WebSocket.OPEN
+      const socketReady = this.wsConnection.socket.readyState === ModelHandlerOpenAIResponse.WS_OPEN;
       if (age < ModelHandlerOpenAIResponse.WS_MAX_AGE_MS && socketReady) {
         return this.wsConnection;
       }
@@ -292,7 +294,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     // Wait for the socket to open before returning
     await new Promise<void>((resolve, reject) => {
-      if (ws.socket.readyState === 1) {
+      if (ws.socket.readyState === ModelHandlerOpenAIResponse.WS_OPEN) {
         resolve();
         return;
       }
@@ -497,9 +499,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (settled) return;
         settled = true;
         cleanup();
-        // Invalidate the connection so the next call reconnects
-        this.wsConnection = null;
-        this.stopWsKeepalive();
+        this.closeWebSocket();
         reject(
           new Error(
             `WebSocket closed unexpectedly (code: ${code}, reason: ${reason.toString()})`,
@@ -575,7 +575,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.stopWsKeepalive();
     this.wsKeepaliveInterval = setInterval(() => {
       try {
-        if (ws.socket.readyState === 1) {
+        if (ws.socket.readyState === ModelHandlerOpenAIResponse.WS_OPEN) {
           ws.socket.ping();
         }
       } catch {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -274,7 +274,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Get or create a WebSocket connection, reusing an existing one if still valid.
    * Reconnects if the connection is approaching the 60-minute server limit.
    */
-  private async getOrCreateWebSocket(client: OpenAI): Promise<ResponsesWS> {
+  private async getOrCreateWebSocket(
+    client: OpenAI,
+    signal?: AbortSignal,
+  ): Promise<ResponsesWS> {
     // Check if existing connection is still valid
     if (this.wsConnection) {
       const age = Date.now() - this.wsConnectionCreatedAt;
@@ -289,25 +292,45 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.closeWebSocket();
     }
 
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted', 'AbortError');
+    }
+
     this.logger.debug('Opening WebSocket connection to Responses API');
     const ws = new ResponsesWS(client);
 
-    // Wait for the socket to open before returning
+    // Wait for the socket to open, fail on error, or abort on signal.
+    // If the handshake fails or is aborted, close the orphaned socket
+    // to prevent resource leaks (it hasn't been assigned to wsConnection yet).
     await new Promise<void>((resolve, reject) => {
       if (ws.socket.readyState === ModelHandlerOpenAIResponse.WS_OPEN) {
         resolve();
         return;
       }
-      const onOpen = (): void => {
+
+      const cleanup = (): void => {
+        ws.socket.removeListener('open', onOpen);
         ws.socket.removeListener('error', onError);
+        signal?.removeEventListener('abort', onAbort);
+      };
+      const onOpen = (): void => {
+        cleanup();
         resolve();
       };
       const onError = (err: Error): void => {
-        ws.socket.removeListener('open', onOpen);
+        cleanup();
+        try { ws.close(); } catch { /* ignore */ }
         reject(err);
       };
+      const onAbort = (): void => {
+        cleanup();
+        try { ws.close(); } catch { /* ignore */ }
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      };
+
       ws.socket.once('open', onOpen);
       ws.socket.once('error', onError);
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
 
     this.wsConnection = ws;
@@ -544,6 +567,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       } catch (sendError) {
         // If send() throws synchronously, clean up listeners to prevent leaks
         // on the reused WebSocket connection.
+        settled = true;
         cleanup();
         reject(sendError);
       }
@@ -1717,7 +1741,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       // WebSocket transport: persistent connection for lower-latency tool-use loops
       if (useWebSocket) {
-        const ws = await this.getOrCreateWebSocket(client);
+        const ws = await this.getOrCreateWebSocket(client, signal);
         let response = await this.executeViaWebSocket(ws, params, signal);
 
         // Safety net: handle unexpected pending status (shouldn't happen without background mode)

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -459,9 +459,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           return;
         }
 
+        // Discard any events that arrive before response.created identifies
+        // the current request. This guards against out-of-order delivery and
+        // prevents processing stale events on a reused connection.
+        if (!currentResponseId) return;
+
         // Filter events by response ID: skip events from stale responses
         if (
-          currentResponseId &&
           'response_id' in e &&
           typeof (e as Record<string, unknown>).response_id === 'string' &&
           (e as Record<string, unknown>).response_id !== currentResponseId

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -532,6 +532,11 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     });
   }
 
+  /** Release all resources held by this handler (WebSocket, keepalive). */
+  override dispose(): void {
+    this.closeWebSocket();
+  }
+
   /** Close the WebSocket connection and clean up resources. */
   closeWebSocket(): void {
     this.stopWsKeepalive();

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -122,6 +122,12 @@ interface StreamingEventState {
   hasThinkingContent: boolean;
 }
 
+/** Result of executeViaWebSocket: the API response plus streaming state for deferred finalization. */
+interface WebSocketExecutionResult {
+  response: Response;
+  state: StreamingEventState;
+}
+
 /**
  * MIME types that the OpenAI Responses API accepts as `input_file` content.
  * Composed from the shared OFFICE_MIME_TYPES plus PDF.
@@ -399,6 +405,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
+   * Finalize thinking/output streams and emit remaining web searches.
+   * Shared by both WebSocket and HTTP streaming paths after background
+   * polling completes.
+   */
+  private finalizeStreams(response: Response, state: StreamingEventState): void {
+    if (state.hasThinkingContent) {
+      state.thinkingStream.finalize();
+    }
+    const { text: finalText } = this.extractResponse(response, '');
+    if (state.outputStream) state.outputStream.finalize(finalText);
+    this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
+  }
+
+  /**
    * Execute a response request via WebSocket transport.
    * Sends a response.create event and collects streaming events until
    * a terminal event (completed, failed, incomplete) is received.
@@ -412,7 +432,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     ws: ResponsesWS,
     params: ResponseCreateParamsBase,
     signal?: AbortSignal,
-  ): Promise<{ response: Response; state: StreamingEventState }> {
+  ): Promise<WebSocketExecutionResult> {
     // Short-circuit if already aborted before sending the request
     if (signal?.aborted) {
       throw new DOMException('The operation was aborted', 'AbortError');
@@ -420,7 +440,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const state = this.createStreamingEventState();
 
-    return new Promise<{ response: Response; state: StreamingEventState }>((resolve, reject) => {
+    return new Promise<WebSocketExecutionResult>((resolve, reject) => {
       let settled = false;
       // Track the response ID for this request so we only process events
       // belonging to it (important when abort-and-retry reuses the connection).
@@ -1758,12 +1778,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
         // Finalize streams after background polling so the final text
         // reflects the completed response, not the pre-poll snapshot.
-        if (state.hasThinkingContent) {
-          state.thinkingStream.finalize();
-        }
-        const { text: finalText } = this.extractResponse(response, '');
-        if (state.outputStream) state.outputStream.finalize(finalText);
-        this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
+        this.finalizeStreams(response, state);
 
         this.finalizeResponse(
           response,
@@ -1805,15 +1820,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           );
         }
 
-        // Finalize any remaining thinking content (only if there's actual content)
-        if (state.hasThinkingContent) {
-          state.thinkingStream.finalize();
-        }
-        const { text: finalText } = this.extractResponse(response, '');
-        if (state.outputStream) state.outputStream.finalize(finalText);
-
-        // Emit any web searches not yet emitted (fallback for edge cases)
-        this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
+        this.finalizeStreams(response, state);
 
         this.finalizeResponse(
           response,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -542,7 +542,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /** Close the WebSocket connection and clean up resources. */
-  closeWebSocket(): void {
+  private closeWebSocket(): void {
     this.stopWsKeepalive();
     if (this.wsConnection) {
       try {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -529,10 +529,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Build and send the WebSocket client event.
       // ResponsesClientEvent mirrors ResponseCreateParamsBase fields with type: 'response.create'.
       // Transport-specific fields (stream, background) are included but ignored by the server.
-      ws.send({
-        type: 'response.create',
-        ...params,
-      } as ResponsesClientEvent);
+      try {
+        ws.send({
+          type: 'response.create',
+          ...params,
+        } as ResponsesClientEvent);
+      } catch (sendError) {
+        // If send() throws synchronously, clean up listeners to prevent leaks
+        // on the reused WebSocket connection.
+        cleanup();
+        reject(sendError);
+      }
     });
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -413,6 +413,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (settled) return;
         settled = true;
         cleanup();
+        // Close the WebSocket on abort to prevent cross-talk on retry.
+        // The server runs responses sequentially, so after client-side abort
+        // it continues finishing the current response. If we reuse the socket,
+        // the new executeViaWebSocket call's listeners would receive stale
+        // events (including response.created) from the prior response, causing
+        // the new request to resolve with the wrong response.
+        this.closeWebSocket();
         reject(new DOMException('The operation was aborted', 'AbortError'));
       };
       signal?.addEventListener('abort', onAbort, { once: true });

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 
 // Third-party imports
 import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
+import { ResponsesWS } from 'openai/resources/responses/ws';
+import { WebSocketError } from 'openai/resources/responses/internal-base';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
@@ -86,6 +88,11 @@ import type {
   ResponseInputMessageContentList,
   ResponseInputFile,
   ResponseStreamEvent,
+  ResponsesClientEvent,
+  ResponsesServerEvent,
+  ResponseCompletedEvent,
+  ResponseFailedEvent,
+  ResponseIncompleteEvent,
   ResponseStatus,
   ResponseFunctionCallOutputItemList,
   ResponseOutputItem,
@@ -216,6 +223,261 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   /** Clears the pending background response ID. Single point of mutation. */
   private clearPendingBackgroundResponse(): void {
     this.pendingBackgroundResponseId = null;
+  }
+
+  // =========================================================================
+  // WebSocket transport
+  // =========================================================================
+
+  /** WebSocket connection for persistent transport mode. */
+  private wsConnection: ResponsesWS | null = null;
+  /** Timestamp when the WebSocket connection was created (for 60-min limit). */
+  private wsConnectionCreatedAt = 0;
+  /** Keepalive interval for the WebSocket connection. */
+  private wsKeepaliveInterval: ReturnType<typeof setInterval> | null = null;
+  /** Maximum WebSocket connection age before reconnecting (55 min, 5-min buffer before 60-min server limit). */
+  private static readonly WS_MAX_AGE_MS = 55 * 60 * 1000;
+  /** Keepalive ping interval to prevent idle timeouts (30 seconds). */
+  private static readonly WS_KEEPALIVE_INTERVAL_MS = 30_000;
+
+  /**
+   * Whether WebSocket transport is enabled for this handler.
+   * Incompatible with OpenRouter routing (custom base URL not supported by WS)
+   * and background mode (polling-based, doesn't benefit from persistent connection).
+   */
+  private isWebSocketModeEnabled(): boolean {
+    return (
+      getConfig<boolean>('texra.model.useWebSocket', false) &&
+      !this.isOpenRouterRoutingEnabled()
+    );
+  }
+
+  /**
+   * Get or create a WebSocket connection, reusing an existing one if still valid.
+   * Reconnects if the connection is approaching the 60-minute server limit.
+   */
+  private async getOrCreateWebSocket(client: OpenAI): Promise<ResponsesWS> {
+    // Check if existing connection is still valid
+    if (this.wsConnection) {
+      const age = Date.now() - this.wsConnectionCreatedAt;
+      const socketReady = this.wsConnection.socket.readyState === 1; // WebSocket.OPEN
+      if (age < ModelHandlerOpenAIResponse.WS_MAX_AGE_MS && socketReady) {
+        return this.wsConnection;
+      }
+      // Connection expired or closed — reconnect
+      this.logger.debug(
+        `WebSocket connection stale (age: ${Math.round(age / 1000)}s, ready: ${socketReady}) — reconnecting`,
+      );
+      this.closeWebSocket();
+    }
+
+    this.logger.debug('Opening WebSocket connection to Responses API');
+    const ws = new ResponsesWS(client);
+
+    // Wait for the socket to open before returning
+    await new Promise<void>((resolve, reject) => {
+      if (ws.socket.readyState === 1) {
+        resolve();
+        return;
+      }
+      const onOpen = (): void => {
+        ws.socket.removeListener('error', onError);
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        ws.socket.removeListener('open', onOpen);
+        reject(err);
+      };
+      ws.socket.once('open', onOpen);
+      ws.socket.once('error', onError);
+    });
+
+    this.wsConnection = ws;
+    this.wsConnectionCreatedAt = Date.now();
+    this.startWsKeepalive(ws);
+
+    this.logger.debug('WebSocket connection established');
+    return ws;
+  }
+
+  /**
+   * Execute a response request via WebSocket transport.
+   * Sends a response.create event and collects streaming events until
+   * a terminal event (completed, failed, incomplete) is received.
+   */
+  private async executeViaWebSocket(
+    ws: ResponsesWS,
+    params: ResponseCreateParamsBase,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    const state = {
+      thinkingStream: this.createThinkingStream(),
+      outputStream: this.isOutputStreamingEnabled()
+        ? this.createOutputStream()
+        : null,
+      emittedWebSearchIds: new Set<string>(),
+      hasThinkingContent: false,
+    };
+
+    return new Promise<Response>((resolve, reject) => {
+      let settled = false;
+
+      const onAbort = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+
+      // Process streaming events — same logic as the HTTP streaming path.
+      // ResponsesServerEvent and ResponseStreamEvent are the same union type.
+      const onEvent = (event: ResponsesServerEvent): void => {
+        const e = event as ResponseStreamEvent;
+        if (this.isReasoningDeltaEvent(e)) {
+          state.thinkingStream.append(e.delta);
+          state.hasThinkingContent = true;
+        } else if (this.isTextDeltaEvent(e)) {
+          state.outputStream?.append(e.delta);
+        } else if (this.isWebSearchInProgressEvent(e)) {
+          if (state.hasThinkingContent) {
+            state.thinkingStream.finalize();
+            state.hasThinkingContent = false;
+            state.thinkingStream = this.createThinkingStream();
+          }
+        } else if (this.isOutputItemDoneEvent(e)) {
+          const item = e.item;
+          if (
+            this.isWebSearchItem(item) &&
+            !state.emittedWebSearchIds.has(item.id) &&
+            hasOpenAIWebSearchData(item)
+          ) {
+            if (state.hasThinkingContent) {
+              state.thinkingStream.finalize();
+              state.hasThinkingContent = false;
+              state.thinkingStream = this.createThinkingStream();
+            }
+            this.emitOpenAIWebSearch(item);
+            state.emittedWebSearchIds.add(item.id);
+          }
+        }
+      };
+
+      const finalize = (response: Response): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (state.hasThinkingContent) {
+          state.thinkingStream.finalize();
+        }
+        const { text: finalText } = this.extractResponse(response, '');
+        if (state.outputStream) state.outputStream.finalize(finalText);
+        this.emitWebSearchesFromResponse(response, state.emittedWebSearchIds);
+        resolve(response);
+      };
+
+      const onCompleted = (event: ResponseCompletedEvent): void =>
+        finalize(event.response);
+
+      const onFailed = (event: ResponseFailedEvent): void =>
+        finalize(event.response);
+
+      const onIncomplete = (event: ResponseIncompleteEvent): void =>
+        finalize(event.response);
+
+      const onWsError = (error: WebSocketError): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      // Handle unexpected socket close during a request
+      const onSocketClose = (code: number, reason: Buffer): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        // Invalidate the connection so the next call reconnects
+        this.wsConnection = null;
+        this.stopWsKeepalive();
+        reject(
+          new Error(
+            `WebSocket closed unexpectedly (code: ${code}, reason: ${reason.toString()})`,
+          ),
+        );
+      };
+
+      const cleanup = (): void => {
+        signal?.removeEventListener('abort', onAbort);
+        ws.off('event', onEvent);
+        ws.off('response.completed', onCompleted);
+        // Type assertion needed: the EventEmitter generic maps event names to
+        // handler signatures via Extract<ResponsesServerEvent, {type?: EventType}>.
+        // Our handler types are compatible but TS can't prove it through the indirection.
+        ws.off('response.failed', onFailed as Parameters<typeof ws.off>[1]);
+        ws.off(
+          'response.incomplete',
+          onIncomplete as Parameters<typeof ws.off>[1],
+        );
+        ws.off('error', onWsError);
+        ws.socket.off('close', onSocketClose);
+      };
+
+      ws.on('event', onEvent);
+      ws.on('response.completed', onCompleted);
+      ws.on('response.failed', onFailed as Parameters<typeof ws.on>[1]);
+      ws.on(
+        'response.incomplete',
+        onIncomplete as Parameters<typeof ws.on>[1],
+      );
+      ws.on('error', onWsError);
+      ws.socket.on('close', onSocketClose);
+
+      // Build and send the WebSocket client event.
+      // ResponsesClientEvent mirrors ResponseCreateParamsBase fields with type: 'response.create'.
+      // Transport-specific fields (stream, background) are included but ignored by the server.
+      ws.send({
+        type: 'response.create',
+        ...params,
+      } as ResponsesClientEvent);
+    });
+  }
+
+  /** Close the WebSocket connection and clean up resources. */
+  closeWebSocket(): void {
+    this.stopWsKeepalive();
+    if (this.wsConnection) {
+      try {
+        this.wsConnection.close();
+      } catch {
+        // Ignore close errors
+      }
+      this.wsConnection = null;
+      this.wsConnectionCreatedAt = 0;
+      this.logger.debug('WebSocket connection closed');
+    }
+  }
+
+  /** Start keepalive pings on the WebSocket connection. */
+  private startWsKeepalive(ws: ResponsesWS): void {
+    this.stopWsKeepalive();
+    this.wsKeepaliveInterval = setInterval(() => {
+      try {
+        if (ws.socket.readyState === 1) {
+          ws.socket.ping();
+        }
+      } catch {
+        // Ignore ping errors
+      }
+    }, ModelHandlerOpenAIResponse.WS_KEEPALIVE_INTERVAL_MS);
+  }
+
+  /** Stop keepalive pings. */
+  private stopWsKeepalive(): void {
+    if (this.wsKeepaliveInterval) {
+      clearInterval(this.wsKeepaliveInterval);
+      this.wsKeepaliveInterval = null;
+    }
   }
 
   /**
@@ -738,6 +1000,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.previousResponseId = null;
     this.resetConversationState();
     this.clearPendingBackgroundResponse();
+    this.closeWebSocket();
 
     const messages: ResponseInputItem[] = [];
 
@@ -1072,6 +1335,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       backgroundToggleEnabled &&
       this.isBackgroundModeEligible();
     const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
+    const useWebSocket =
+      this.isWebSocketModeEnabled() && !useBackgroundResponses;
 
     if (backgroundToggleEnabled && !useBackgroundResponses) {
       const reason = !this.backgroundModeSupported
@@ -1336,6 +1601,34 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           };
         }
         // Resume failed or response failed remotely - fall through to create new request
+      }
+
+      // WebSocket transport: persistent connection for lower-latency tool-use loops
+      if (useWebSocket) {
+        const ws = await this.getOrCreateWebSocket(client);
+        let response = await this.executeViaWebSocket(ws, params, signal);
+
+        // Safety net: handle unexpected pending status (shouldn't happen without background mode)
+        if (this.isBackgroundPending(response)) {
+          this.logger.warn(
+            `WebSocket response ${response.id} ended with pending status "${response.status}" — polling for completion`,
+          );
+          response = await this.waitForBackgroundCompletion(
+            client,
+            response,
+            signal,
+          );
+        }
+
+        this.finalizeResponse(
+          response,
+          effectiveMessages.length,
+          compactedThisCall,
+        );
+        return {
+          response,
+          updatedMessages: compactedMessages,
+        };
       }
 
       if (useStreaming) {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -113,6 +113,14 @@ interface UploadedOpenAIResponseAttachment {
   isImage: boolean;
 }
 
+/** Shared state for streaming event processing (WebSocket and HTTP paths). */
+interface StreamingEventState {
+  thinkingStream: { append(delta: string): void; finalize(finalText?: string): void };
+  outputStream: { append(delta: string): void; finalize(finalText?: string): void } | null;
+  emittedWebSearchIds: Set<string>;
+  hasThinkingContent: boolean;
+}
+
 /**
  * MIME types that the OpenAI Responses API accepts as `input_file` content.
  * Composed from the shared OFFICE_MIME_TYPES plus PDF.
@@ -301,16 +309,52 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
-   * Execute a response request via WebSocket transport.
-   * Sends a response.create event and collects streaming events until
-   * a terminal event (completed, failed, incomplete) is received.
+   * Process a single streaming event, updating the shared streaming state.
+   * Used by both WebSocket and HTTP streaming paths for consistent behavior.
    */
-  private async executeViaWebSocket(
-    ws: ResponsesWS,
-    params: ResponseCreateParamsBase,
-    signal?: AbortSignal,
-  ): Promise<Response> {
-    const state = {
+  private processStreamingEvent(
+    event: ResponseStreamEvent,
+    state: StreamingEventState,
+  ): void {
+    /** Finalize and reset the thinking stream if it has content. */
+    const rotateThinkingStream = (): void => {
+      if (!state.hasThinkingContent) return;
+      state.thinkingStream.finalize();
+      state.hasThinkingContent = false;
+      state.thinkingStream = this.createThinkingStream();
+    };
+
+    if (this.isReasoningDeltaEvent(event)) {
+      state.thinkingStream.append(event.delta);
+      state.hasThinkingContent = true;
+    } else if (this.isTextDeltaEvent(event)) {
+      state.outputStream?.append(event.delta);
+    } else if (this.isWebSearchInProgressEvent(event)) {
+      rotateThinkingStream();
+    } else if (this.isFunctionCallArgumentsDoneEvent(event)) {
+      // Function call arguments complete - finalize streams since no more
+      // text/thinking deltas will arrive after tool calls begin.
+      rotateThinkingStream();
+      this.logger.debug(
+        `Tool call ready during streaming: ${event.name}`,
+      );
+    } else if (this.isOutputItemDoneEvent(event)) {
+      const item = event.item;
+      if (
+        this.isWebSearchItem(item) &&
+        !state.emittedWebSearchIds.has(item.id) &&
+        hasOpenAIWebSearchData(item)
+      ) {
+        rotateThinkingStream();
+        this.emitOpenAIWebSearch(item);
+        state.emittedWebSearchIds.add(item.id);
+      }
+    }
+  }
+
+  /** Create a fresh streaming event state for a new request. */
+  private createStreamingEventState(): StreamingEventState {
+    return {
       thinkingStream: this.createThinkingStream(),
       outputStream: this.isOutputStreamingEnabled()
         ? this.createOutputStream()
@@ -318,9 +362,37 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       emittedWebSearchIds: new Set<string>(),
       hasThinkingContent: false,
     };
+  }
+
+  /**
+   * Execute a response request via WebSocket transport.
+   * Sends a response.create event and collects streaming events until
+   * a terminal event (completed, failed, incomplete) is received.
+   *
+   * Failed/incomplete responses are thrown as errors so the caller's catch
+   * block can apply recovery logic (e.g., context-window compaction).
+   */
+  private async executeViaWebSocket(
+    ws: ResponsesWS,
+    params: ResponseCreateParamsBase,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    // Short-circuit if already aborted before sending the request
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted', 'AbortError');
+    }
+
+    const state = this.createStreamingEventState();
 
     return new Promise<Response>((resolve, reject) => {
       let settled = false;
+      // Track the response ID for this request so we only process events
+      // belonging to it (important when abort-and-retry reuses the connection)
+      let currentResponseId: string | null = null;
+
+      /** Check whether a terminal event belongs to the current request. */
+      const isCurrentResponse = (response: Response): boolean =>
+        currentResponseId === null || response.id === currentResponseId;
 
       const onAbort = (): void => {
         if (settled) return;
@@ -330,41 +402,31 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       };
       signal?.addEventListener('abort', onAbort, { once: true });
 
-      // Process streaming events — same logic as the HTTP streaming path.
-      // ResponsesServerEvent and ResponseStreamEvent are the same union type.
+      // Process streaming events, filtering by response ID.
       const onEvent = (event: ResponsesServerEvent): void => {
         const e = event as ResponseStreamEvent;
-        if (this.isReasoningDeltaEvent(e)) {
-          state.thinkingStream.append(e.delta);
-          state.hasThinkingContent = true;
-        } else if (this.isTextDeltaEvent(e)) {
-          state.outputStream?.append(e.delta);
-        } else if (this.isWebSearchInProgressEvent(e)) {
-          if (state.hasThinkingContent) {
-            state.thinkingStream.finalize();
-            state.hasThinkingContent = false;
-            state.thinkingStream = this.createThinkingStream();
-          }
-        } else if (this.isOutputItemDoneEvent(e)) {
-          const item = e.item;
-          if (
-            this.isWebSearchItem(item) &&
-            !state.emittedWebSearchIds.has(item.id) &&
-            hasOpenAIWebSearchData(item)
-          ) {
-            if (state.hasThinkingContent) {
-              state.thinkingStream.finalize();
-              state.hasThinkingContent = false;
-              state.thinkingStream = this.createThinkingStream();
-            }
-            this.emitOpenAIWebSearch(item);
-            state.emittedWebSearchIds.add(item.id);
-          }
+
+        // Capture the response ID from the first response.created event
+        if (e.type === 'response.created') {
+          currentResponseId = e.response.id;
+          return;
         }
+
+        // Filter events by response ID: skip events from stale responses
+        if (
+          currentResponseId &&
+          'response_id' in e &&
+          typeof (e as Record<string, unknown>).response_id === 'string' &&
+          (e as Record<string, unknown>).response_id !== currentResponseId
+        ) {
+          return;
+        }
+
+        this.processStreamingEvent(e, state);
       };
 
-      const finalize = (response: Response): void => {
-        if (settled) return;
+      const finalizeSuccess = (response: Response): void => {
+        if (settled || !isCurrentResponse(response)) return;
         settled = true;
         cleanup();
         if (state.hasThinkingContent) {
@@ -377,13 +439,30 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       };
 
       const onCompleted = (event: ResponseCompletedEvent): void =>
-        finalize(event.response);
+        finalizeSuccess(event.response);
 
-      const onFailed = (event: ResponseFailedEvent): void =>
-        finalize(event.response);
+      // Failed/incomplete responses must be rejected (not resolved) so the
+      // caller's catch block can run error recovery (e.g., context-window
+      // compaction or clearing previousResponseId).
+      const onFailed = (event: ResponseFailedEvent): void => {
+        if (settled || !isCurrentResponse(event.response)) return;
+        settled = true;
+        cleanup();
+        const errorMsg =
+          event.response.error?.message ?? 'Response failed without details';
+        reject(new Error(`OpenAI WebSocket response failed: ${errorMsg}`));
+      };
 
-      const onIncomplete = (event: ResponseIncompleteEvent): void =>
-        finalize(event.response);
+      const onIncomplete = (event: ResponseIncompleteEvent): void => {
+        if (settled || !isCurrentResponse(event.response)) return;
+        settled = true;
+        cleanup();
+        const reason =
+          event.response.incomplete_details?.reason ?? 'unknown reason';
+        reject(
+          new Error(`OpenAI WebSocket response incomplete: ${reason}`),
+        );
+      };
 
       const onWsError = (error: WebSocketError): void => {
         if (settled) return;
@@ -1638,54 +1717,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
         // State for handling interleaved thinking and web search
         // GPT can: think → web_search → think more → web_search → text
-        const state = {
-          thinkingStream: this.createThinkingStream(),
-          outputStream: this.isOutputStreamingEnabled()
-            ? this.createOutputStream()
-            : null,
-          emittedWebSearchIds: new Set<string>(),
-          hasThinkingContent: false,
-        };
-
-        /** Finalize and reset the thinking stream if it has content. */
-        const rotateThinkingStream = (): void => {
-          if (!state.hasThinkingContent) return;
-          state.thinkingStream.finalize();
-          state.hasThinkingContent = false;
-          state.thinkingStream = this.createThinkingStream();
-        };
+        const state = this.createStreamingEventState();
 
         for await (const event of stream) {
-          if (this.isReasoningDeltaEvent(event)) {
-            state.thinkingStream.append(event.delta);
-            state.hasThinkingContent = true;
-          } else if (this.isTextDeltaEvent(event)) {
-            state.outputStream?.append(event.delta);
-          } else if (this.isWebSearchInProgressEvent(event)) {
-            // Web search starting - finalize current thinking stream
-            // Don't emit placeholder here - wait for output_item.done with full data
-            rotateThinkingStream();
-          } else if (this.isFunctionCallArgumentsDoneEvent(event)) {
-            // Function call arguments complete - finalize streams since no more
-            // text/thinking deltas will arrive after tool calls begin.
-            rotateThinkingStream();
-            this.logger.debug(
-              `Tool call ready during streaming: ${event.name}`,
-            );
-          } else if (this.isOutputItemDoneEvent(event)) {
-            // When output item is done, we can get the full web search data
-            const item = event.item;
-            if (
-              this.isWebSearchItem(item) &&
-              !state.emittedWebSearchIds.has(item.id) &&
-              hasOpenAIWebSearchData(item)
-            ) {
-              // Finalize thinking if we have content (in case in_progress didn't fire)
-              rotateThinkingStream();
-              this.emitOpenAIWebSearch(item);
-              state.emittedWebSearchIds.add(item.id);
-            }
-          }
+          this.processStreamingEvent(event, state);
         }
 
         let response = await stream.finalResponse();

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -28,6 +28,7 @@ import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
 import { K_SLICE, getConfig } from '@utils/config';
+import { getWebSocketEnabled } from '@utils/config/providerConfig';
 import { delay } from '@utils/core';
 import { flexibleFS, OFFICE_MIME_TYPES } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
@@ -264,10 +265,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * from persistent connection).
    */
   private isWebSocketModeEnabled(): boolean {
-    return (
-      getConfig<boolean>('texra.model.useWebSocket', false) &&
-      this.getBaseUrl() === null
-    );
+    return getWebSocketEnabled() && this.getBaseUrl() === null;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -317,6 +317,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   /**
+   * Finalize and reset the thinking stream if it has content.
+   * Extracted as a method to avoid recreating a closure on every streaming event.
+   */
+  private rotateThinkingStream(state: StreamingEventState): void {
+    if (!state.hasThinkingContent) return;
+    state.thinkingStream.finalize();
+    state.hasThinkingContent = false;
+    state.thinkingStream = this.createThinkingStream();
+  }
+
+  /**
    * Process a single streaming event, updating the shared streaming state.
    * Used by both WebSocket and HTTP streaming paths for consistent behavior.
    */
@@ -324,25 +335,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     event: ResponseStreamEvent,
     state: StreamingEventState,
   ): void {
-    /** Finalize and reset the thinking stream if it has content. */
-    const rotateThinkingStream = (): void => {
-      if (!state.hasThinkingContent) return;
-      state.thinkingStream.finalize();
-      state.hasThinkingContent = false;
-      state.thinkingStream = this.createThinkingStream();
-    };
-
     if (this.isReasoningDeltaEvent(event)) {
       state.thinkingStream.append(event.delta);
       state.hasThinkingContent = true;
     } else if (this.isTextDeltaEvent(event)) {
       state.outputStream?.append(event.delta);
     } else if (this.isWebSearchInProgressEvent(event)) {
-      rotateThinkingStream();
+      this.rotateThinkingStream(state);
     } else if (this.isFunctionCallArgumentsDoneEvent(event)) {
       // Function call arguments complete - finalize streams since no more
       // text/thinking deltas will arrive after tool calls begin.
-      rotateThinkingStream();
+      this.rotateThinkingStream(state);
       this.logger.debug(
         `Tool call ready during streaming: ${event.name}`,
       );
@@ -353,7 +356,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         !state.emittedWebSearchIds.has(item.id) &&
         hasOpenAIWebSearchData(item)
       ) {
-        rotateThinkingStream();
+        this.rotateThinkingStream(state);
         this.emitOpenAIWebSearch(item);
         state.emittedWebSearchIds.add(item.id);
       }
@@ -377,8 +380,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
    * Sends a response.create event and collects streaming events until
    * a terminal event (completed, failed, incomplete) is received.
    *
-   * Failed/incomplete responses are thrown as errors so the caller's catch
-   * block can apply recovery logic (e.g., context-window compaction).
+   * Completed and incomplete responses are resolved so the caller's
+   * `finalizeResponse()` can handle non-completed statuses consistently
+   * with the HTTP streaming path. Failed responses are rejected so the
+   * caller's catch block can apply recovery logic.
    */
   private async executeViaWebSocket(
     ws: ResponsesWS,
@@ -395,12 +400,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return new Promise<Response>((resolve, reject) => {
       let settled = false;
       // Track the response ID for this request so we only process events
-      // belonging to it (important when abort-and-retry reuses the connection)
+      // belonging to it (important when abort-and-retry reuses the connection).
+      // Starts as null — terminal events are ignored until response.created sets it,
+      // preventing stale events from a previous request from being accepted.
       let currentResponseId: string | null = null;
 
       /** Check whether a terminal event belongs to the current request. */
       const isCurrentResponse = (response: Response): boolean =>
-        currentResponseId === null || response.id === currentResponseId;
+        currentResponseId !== null && response.id === currentResponseId;
 
       const onAbort = (): void => {
         if (settled) return;
@@ -449,9 +456,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       const onCompleted = (event: ResponseCompletedEvent): void =>
         finalizeSuccess(event.response);
 
-      // Failed/incomplete responses must be rejected (not resolved) so the
-      // caller's catch block can run error recovery (e.g., context-window
-      // compaction or clearing previousResponseId).
+      // Failed responses must be rejected so the caller's catch block can
+      // run error recovery (e.g., context-window compaction).
       const onFailed = (event: ResponseFailedEvent): void => {
         if (settled || !isCurrentResponse(event.response)) return;
         settled = true;
@@ -461,16 +467,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         reject(new Error(`OpenAI WebSocket response failed: ${errorMsg}`));
       };
 
-      const onIncomplete = (event: ResponseIncompleteEvent): void => {
-        if (settled || !isCurrentResponse(event.response)) return;
-        settled = true;
-        cleanup();
-        const reason =
-          event.response.incomplete_details?.reason ?? 'unknown reason';
-        reject(
-          new Error(`OpenAI WebSocket response incomplete: ${reason}`),
-        );
-      };
+      // Incomplete responses are resolved (not rejected) to match the HTTP
+      // streaming path behavior. The caller's finalizeResponse() handles
+      // non-completed statuses (e.g., max_output_tokens truncation) by
+      // clearing previousResponseId and logging a warning.
+      const onIncomplete = (event: ResponseIncompleteEvent): void =>
+        finalizeSuccess(event.response);
 
       const onWsError = (error: WebSocketError): void => {
         if (settled) return;

--- a/src/agent/modelHandlers/types/IModelHandler.ts
+++ b/src/agent/modelHandlers/types/IModelHandler.ts
@@ -430,4 +430,11 @@ export interface IModelHandler<
     messages: M[],
     mediaFiles: FileLocation[],
   ): Promise<void>;
+
+  /**
+   * Release any resources held by the handler (e.g., WebSocket connections,
+   * keepalive intervals). Called when the handler is no longer needed.
+   * No-op by default.
+   */
+  dispose(): void;
 }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -416,6 +416,10 @@ async function runFlowWithLifecycle(
     }
 
     throw new Error(errorMsg);
+  } finally {
+    // Release long-lived resources (e.g., WebSocket connections, keepalive intervals)
+    // to prevent leaks when handler instances are discarded after execution.
+    ctx.modelHandler.dispose();
   }
 }
 

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -64,6 +64,9 @@ export enum GlobalStateKey {
   ENDPOINT_XAI = 'texra.endpoint.xai',
   ENDPOINT_MOONSHOT = 'texra.endpoint.moonshot',
   ENDPOINT_DASHSCOPE = 'texra.endpoint.dashscope',
+
+  // Transport settings
+  WEBSOCKET_OPENAI = 'texra.websocket.openai',
 }
 
 /** Prefix used for per-instruction suppression flags */

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -154,10 +154,11 @@ const ALLOWED_VSCODE_SETTING_KEYS = new Set([
 function getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {
   const defs = PROVIDER_VSCODE_SETTINGS[provider.toLowerCase()];
   if (!defs) return [];
-  // getConfig reads from VS Code's config API which already knows package.json defaults
   return defs.map((def) => ({
     ...def,
-    value: getConfig<boolean>(def.key, false),
+    value: def.globalStateKey
+      ? (globalSM?.get<boolean>(def.globalStateKey, false) ?? false)
+      : getConfig<boolean>(def.key, false),
   }));
 }
 
@@ -1112,12 +1113,20 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    const config = vscode.workspace.getConfiguration();
-    await config.update(
-      data.key,
-      data.value,
-      vscode.ConfigurationTarget.Global,
-    );
+    // Check if this setting is backed by globalSM instead of VS Code config
+    const def = Object.values(PROVIDER_VSCODE_SETTINGS)
+      .flat()
+      .find((s) => s.key === data.key);
+    if (def?.globalStateKey) {
+      await globalSM?.update(def.globalStateKey, data.value);
+    } else {
+      const config = vscode.workspace.getConfiguration();
+      await config.update(
+        data.key,
+        data.value,
+        vscode.ConfigurationTarget.Global,
+      );
+    }
 
     await this.withActiveWebview(async (w) => {
       await Promise.all([

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 import { ModelProvider } from 'llm-zoo';
 
+import { GlobalStateKey } from '@common/state/stateManager';
+
 // ============================================================================
 // Provider Registry — single source of truth for all provider metadata
 // ============================================================================
@@ -132,6 +134,11 @@ export const ProviderVscodeSettingDefSchema = z.object({
   warning: z.string().optional(),
   warningUrl: z.string().optional(),
   warningUrlLabel: z.string().optional(),
+  /**
+   * When set, the setting is backed by globalSM (extension global state)
+   * instead of VS Code's workspace configuration.
+   */
+  globalStateKey: z.string().optional(),
 });
 
 export type ProviderVscodeSettingDef = z.infer<
@@ -172,6 +179,13 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       label: 'Parallel Tool Calls',
       description:
         'Allow the model to call multiple tools in parallel. Off by default to preserve sequential tool execution.',
+    },
+    {
+      key: GlobalStateKey.WEBSOCKET_OPENAI,
+      label: 'WebSocket Transport',
+      description:
+        'Use a persistent WebSocket connection for lower-latency tool-use loops. Requires direct OpenAI API (not compatible with custom endpoints).',
+      globalStateKey: GlobalStateKey.WEBSOCKET_OPENAI,
     },
   ],
   anthropic: [

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -103,3 +103,12 @@ export async function setAnthropicDynamicFiltering(
 ): Promise<void> {
   await globalSM?.update(GlobalStateKey.ANTHROPIC_DYNAMIC_FILTERING, enabled);
 }
+
+// ---------------------------------------------------------------------------
+// WebSocket transport setting (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Read the WebSocket transport setting for OpenAI. */
+export function getWebSocketEnabled(): boolean {
+  return globalSM?.get<boolean>(GlobalStateKey.WEBSOCKET_OPENAI, false) ?? false;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new WebSocket execution path for OpenAI Responses with persistent connections, event filtering, and keepalive; this changes request/streaming behavior and adds new failure modes around connection lifecycle and abort handling. Also adds a new `dispose()` lifecycle hook that is now called after every agent run, which could surface issues in handlers that need cleanup semantics.
> 
> **Overview**
> Adds an **optional persistent WebSocket transport** for the OpenAI Responses handler, gated by a new `texra.websocket.openai` setting and only used when running against the default OpenAI base URL (no proxy/custom endpoints) and not in background mode.
> 
> Refactors streaming handling to share event-processing/finalization logic across HTTP streaming and WebSocket paths, and adds robust WebSocket lifecycle management (reuse with max-age, keepalive pings, abort/error/close handling, and connection reset on new sessions).
> 
> Introduces a `dispose()` method on `IModelHandler`/`ModelHandler` (no-op by default), implements it in `ModelHandlerOpenAIResponse` to close WebSocket resources, and ensures `executeAgent` always calls `ctx.modelHandler.dispose()` in a `finally` block. Updates settings plumbing to support global-state–backed provider toggles and surfaces the new OpenAI WebSocket toggle in provider settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f21ba0076ae24923d7af55de767d02256d9742c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->