### PR TITLE
Move UI notifications from agent to frontend via event bus

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import * as vscode from 'vscode';
 import { ZodError } from 'zod';
 import { MODEL_CONFIGS } from 'llm-zoo';
 
@@ -423,7 +422,7 @@ async function runFlowWithLifecycle(
       ) {
         showApiKeyErrorNotification();
       } else {
-        vscode.window.showErrorMessage(errorMsg);
+        bus.emit('requestShowError', { message: errorMsg });
       }
     }
 
@@ -431,7 +430,7 @@ async function runFlowWithLifecycle(
   }
 }
 
-async function showAgentNotification(config: AgentConfig): Promise<void> {
+function showAgentNotification(config: AgentConfig): void {
   const inputName = config.inputFile
     ? path.basename(config.inputFile)
     : 'selected input';
@@ -443,18 +442,12 @@ async function showAgentNotification(config: AgentConfig): Promise<void> {
     outputInfo = outputFiles[0] ? `to ${path.basename(outputFiles[0])}` : '';
   }
 
-  const selection = await vscode.window.showInformationMessage(
-    `TeXRA Agent Started: "${config.agent}" is processing ${inputName} with ${config.model} ${outputInfo}. View in ProgressBoard for progress.`,
-    {
-      modal: false,
-      detail:
-        'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-    },
-    'Show ProgressBoard',
-  );
-  if (selection) {
-    await vscode.commands.executeCommand('texra.showProgressView');
-  }
+  bus.emit('requestShowAgentStarted', {
+    agentName: config.agent,
+    modelName: config.model,
+    inputName,
+    outputInfo,
+  });
 }
 
 function showApiKeyErrorNotification(): void {
@@ -511,7 +504,7 @@ async function resolveAndAcquireStream(
   } catch (err) {
     StreamStatusService.releaseIfInitializing(preliminaryStreamId);
     if (!(err instanceof ZodError)) {
-      void vscode.window.showErrorMessage(toErrorMessage(err));
+      bus.emit('requestShowError', { message: toErrorMessage(err) });
     }
     throw err;
   }
@@ -559,7 +552,7 @@ async function prepareAgentUI(
   // the orchestrator's stream is already visible.
   if (!options?.isSubagent) {
     if (!runStorage.isViewVisible()) {
-      await vscode.commands.executeCommand('texra.showProgressView');
+      bus.emit('requestEnsureProgressView', undefined);
     }
     if (!runStorage.isViewVisible()) {
       showAgentNotification(config);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -430,7 +430,7 @@ async function runFlowWithLifecycle(
   }
 }
 
-function showAgentNotification(config: AgentConfig): void {
+function buildFallbackNotification(config: AgentConfig) {
   const inputName = config.inputFile
     ? path.basename(config.inputFile)
     : 'selected input';
@@ -441,13 +441,7 @@ function showAgentNotification(config: AgentConfig): void {
   } else {
     outputInfo = outputFiles[0] ? `to ${path.basename(outputFiles[0])}` : '';
   }
-
-  bus.emit('requestShowAgentStarted', {
-    agentName: config.agent,
-    modelName: config.model,
-    inputName,
-    outputInfo,
-  });
+  return { agentName: config.agent, modelName: config.model, inputName, outputInfo };
 }
 
 function showApiKeyErrorNotification(): void {
@@ -550,13 +544,10 @@ async function prepareAgentUI(
 
   // Subagents don't need to force-open the progress board or show notifications —
   // the orchestrator's stream is already visible.
-  if (!options?.isSubagent) {
-    if (!runStorage.isViewVisible()) {
-      bus.emit('requestEnsureProgressView', undefined);
-    }
-    if (!runStorage.isViewVisible()) {
-      showAgentNotification(config);
-    }
+  if (!options?.isSubagent && !runStorage.isViewVisible()) {
+    bus.emit('requestEnsureProgressView', {
+      fallbackNotification: buildFallbackNotification(config),
+    });
   }
   bus.emit('setTaskState', {
     streamId,

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -127,14 +127,18 @@ export interface ProgressEventPayloads {
   requestShowError: {
     message: string;
   };
-  /** Request the frontend to ensure the progress view is visible. */
-  requestEnsureProgressView: undefined;
-  /** Request the frontend to show an agent-started notification with an option to open the progress board. */
-  requestShowAgentStarted: {
-    agentName: string;
-    modelName: string;
-    inputName: string;
-    outputInfo: string;
+  /**
+   * Request the frontend to ensure the progress view is visible.
+   * If the view cannot be opened and a fallback notification is provided,
+   * show a toast notification as a last resort.
+   */
+  requestEnsureProgressView: {
+    fallbackNotification?: {
+      agentName: string;
+      modelName: string;
+      inputName: string;
+      outputInfo: string;
+    };
   };
 }
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -123,6 +123,19 @@ export interface ProgressEventPayloads {
   showAgentConfigBanner: {
     agentName: string;
   };
+  /** Request the frontend to show an error message via VS Code notification. */
+  requestShowError: {
+    message: string;
+  };
+  /** Request the frontend to ensure the progress view is visible. */
+  requestEnsureProgressView: undefined;
+  /** Request the frontend to show an agent-started notification with an option to open the progress board. */
+  requestShowAgentStarted: {
+    agentName: string;
+    modelName: string;
+    inputName: string;
+    outputInfo: string;
+  };
 }
 
 export type ProgressEvent = keyof ProgressEventPayloads;

--- a/src/frontend/events/agentEventListeners.ts
+++ b/src/frontend/events/agentEventListeners.ts
@@ -61,6 +61,33 @@ async function handleShowAgentConfigBanner(
   });
 }
 
+function handleRequestShowError(
+  payload: ProgressEventPayloads['requestShowError'],
+): void {
+  vscode.window.showErrorMessage(payload.message);
+}
+
+function handleRequestEnsureProgressView(): void {
+  vscode.commands.executeCommand('texra.showProgressView');
+}
+
+async function handleRequestShowAgentStarted(
+  payload: ProgressEventPayloads['requestShowAgentStarted'],
+): Promise<void> {
+  const selection = await vscode.window.showInformationMessage(
+    `TeXRA Agent Started: "${payload.agentName}" is processing ${payload.inputName} with ${payload.modelName} ${payload.outputInfo}. View in ProgressBoard for progress.`,
+    {
+      modal: false,
+      detail:
+        'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+    },
+    'Show ProgressBoard',
+  );
+  if (selection) {
+    await vscode.commands.executeCommand('texra.showProgressView');
+  }
+}
+
 /**
  * Register all agent→frontend event listeners.
  * Returns a Disposable that cleans up all subscriptions.
@@ -74,6 +101,15 @@ export function registerAgentEventListeners(): vscode.Disposable {
   bus.on(
     'showAgentConfigBanner',
     (payload) => void handleShowAgentConfigBanner(payload),
+    { signal },
+  );
+  bus.on('requestShowError', handleRequestShowError, { signal });
+  bus.on('requestEnsureProgressView', handleRequestEnsureProgressView, {
+    signal,
+  });
+  bus.on(
+    'requestShowAgentStarted',
+    (payload) => void handleRequestShowAgentStarted(payload),
     { signal },
   );
 

--- a/src/frontend/events/agentEventListeners.ts
+++ b/src/frontend/events/agentEventListeners.ts
@@ -13,6 +13,7 @@ import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import * as logger from '@logger/logUtils';
+import { getRunStorageService } from '@agent/runtime/RunStorageService';
 import { bus } from '@eventBus/ProgressEventBus';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
@@ -67,24 +68,28 @@ function handleRequestShowError(
   vscode.window.showErrorMessage(payload.message);
 }
 
-function handleRequestEnsureProgressView(): void {
-  vscode.commands.executeCommand('texra.showProgressView');
-}
-
-async function handleRequestShowAgentStarted(
-  payload: ProgressEventPayloads['requestShowAgentStarted'],
+async function handleRequestEnsureProgressView(
+  payload: ProgressEventPayloads['requestEnsureProgressView'],
 ): Promise<void> {
-  const selection = await vscode.window.showInformationMessage(
-    `TeXRA Agent Started: "${payload.agentName}" is processing ${payload.inputName} with ${payload.modelName} ${payload.outputInfo}. View in ProgressBoard for progress.`,
-    {
-      modal: false,
-      detail:
-        'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
-    },
-    'Show ProgressBoard',
-  );
-  if (selection) {
-    await vscode.commands.executeCommand('texra.showProgressView');
+  await vscode.commands.executeCommand('texra.showProgressView');
+
+  // If the view is still not visible after attempting to open it and a
+  // fallback notification was provided, show a toast as a last resort.
+  // This preserves the original two-check semantics that relied on await.
+  const fb = payload.fallbackNotification;
+  if (fb && !getRunStorageService().isViewVisible()) {
+    const selection = await vscode.window.showInformationMessage(
+      `TeXRA Agent Started: "${fb.agentName}" is processing ${fb.inputName} with ${fb.modelName} ${fb.outputInfo}. View in ProgressBoard for progress.`,
+      {
+        modal: false,
+        detail:
+          'TeXRA agents run in the background and their progress can be tracked in the ProgressBoard.',
+      },
+      'Show ProgressBoard',
+    );
+    if (selection) {
+      await vscode.commands.executeCommand('texra.showProgressView');
+    }
   }
 }
 
@@ -104,12 +109,9 @@ export function registerAgentEventListeners(): vscode.Disposable {
     { signal },
   );
   bus.on('requestShowError', handleRequestShowError, { signal });
-  bus.on('requestEnsureProgressView', handleRequestEnsureProgressView, {
-    signal,
-  });
   bus.on(
-    'requestShowAgentStarted',
-    (payload) => void handleRequestShowAgentStarted(payload),
+    'requestEnsureProgressView',
+    (payload) => void handleRequestEnsureProgressView(payload),
     { signal },
   );
 


### PR DESCRIPTION
## Summary
Refactored the agent runtime to emit UI notification requests through the event bus instead of directly calling VS Code APIs. This decouples the agent logic from the frontend framework and centralizes UI handling in the frontend event listeners.

## Key Changes
- **Removed direct VS Code API calls from agent runtime**: Replaced `vscode.window.showErrorMessage()` and `vscode.commands.executeCommand()` calls in `executeAgent.ts` with event bus emissions
- **Added three new event bus handlers in frontend**:
  - `requestShowError`: Displays error messages via VS Code notifications
  - `requestEnsureProgressView`: Ensures the progress view is visible
  - `requestShowAgentStarted`: Shows an information message when an agent starts, with an option to open the progress board
- **Refactored `showAgentNotification()`**: Changed from async function that directly handled UI interactions to a synchronous function that emits a `requestShowAgentStarted` event with agent metadata
- **Removed vscode import**: Eliminated the direct `vscode` dependency from `executeAgent.ts`

## Implementation Details
- All three new event payloads are properly typed in `ProgressEventPayloads` interface
- The `requestShowAgentStarted` event includes agent name, model name, input name, and output info to allow the frontend to construct the full notification message
- Event handlers are registered with proper signal cleanup in the disposable pattern
- The refactoring maintains the same user-facing behavior while improving separation of concerns

https://claude.ai/code/session_01CZWHT2yLSZV3TPMBdQ61Jy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior is largely the same but notification/display timing now depends on event delivery and frontend listener registration; regressions could hide errors or fail to surface ProgressBoard/agent-start feedback.
> 
> **Overview**
> Agent runtime no longer calls VS Code UI APIs directly: `executeAgent.ts` replaces `vscode.window.showErrorMessage` and progress-view opening/“agent started” toasts with `bus.emit` requests.
> 
> `ProgressEventBus` adds typed `requestShowError` and `requestEnsureProgressView` events, and `agentEventListeners.ts` implements the corresponding handlers (show error toast; attempt to open ProgressBoard and, if still hidden, show the fallback “Agent Started” notification with a button to open it).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd0ae99f7291079ed36f55f0a70278bf8e540fe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->