### PR TITLE
fix: add non-null assertions for Array.at(-1) to resolve TS2532 errors

### DIFF
--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -246,7 +246,7 @@ export class TaskGroupList extends LitElement {
   ): void {
     const msgTime = message.timestamp ?? 0;
     const lastTs =
-      target.length > 0 ? (target.at(-1).timestamp ?? 0) : -Infinity;
+      target.length > 0 ? (target.at(-1)!.timestamp ?? 0) : -Infinity;
     if (msgTime >= lastTs) {
       target.push(message);
     } else {
@@ -426,7 +426,7 @@ export class TaskGroupList extends LitElement {
       const entry = { key: m.id, time: m.timestamp ?? 0, msg: m };
       const lastTime =
         this.cachedTimeline.length > 0
-          ? this.cachedTimeline.at(-1).time
+          ? this.cachedTimeline.at(-1)!.time
           : -Infinity;
       if (entry.time >= lastTime) {
         this.cachedTimeline.push(entry);


### PR DESCRIPTION
The array length is checked before accessing .at(-1), so the result
is guaranteed to be defined. Added non-null assertions to satisfy
the TypeScript compiler.

https://claude.ai/code/session_01QXtA2NAtXwTmUH2NBF7bAr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that preserves runtime behavior; risk is limited to potential oversight if an array could be mutated between the length check and `.at(-1)` access (unlikely in this synchronous code).
> 
> **Overview**
> Resolves TypeScript `TS2532` errors in `TaskGroupList.ts` by adding non-null assertions (`!`) to `Array.at(-1)` results after explicit length checks.
> 
> This keeps the existing append-vs-insert logic unchanged while making the compiler aware the last element is defined when the array is non-empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39c0f0f661aed3dd406e3e42e075f273d5729843. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->