### PR TITLE
Remove duplicate operations and redundant iterations

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -731,9 +731,6 @@ class ToolUseDispatchNode<C> extends BatchNode<
       source: 'tool',
       sourceDisplay: 'Tool use',
     }));
-    if (editedFiles.length > 0) {
-      extracted.sanitizedResult.editedFiles = editedFiles;
-    }
 
     return {
       call,
@@ -753,10 +750,17 @@ class ToolUseDispatchNode<C> extends BatchNode<
     const { call, result, parsedInput, extracted, editedFiles, logRef } =
       execResult;
 
+    // Spread sanitizedResult so editedFiles in the log don't leak into
+    // extracted.sanitizedResult (which is reused for model messages in post).
+    const logOutput =
+      editedFiles.length > 0
+        ? { ...extracted.sanitizedResult, editedFiles }
+        : extracted.sanitizedResult;
+
     const toolUseLog = {
       toolName: call.name,
       input: parsedInput ?? call.raw,
-      output: extracted.sanitizedResult,
+      output: logOutput,
       ...(editedFiles.length > 0 && { files: editedFiles }),
       isError: Boolean(result.isError),
     };

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -504,7 +504,6 @@ interface ToolExecutionResult {
   parsedInput: unknown;
   /** Pre-extracted attachments and sanitized result (avoids re-extraction in post). */
   extracted: ExtractedToolAttachments;
-  sanitizedOutput: Record<string, unknown>;
   editedFiles: Array<{
     path: string;
     ok: boolean;
@@ -584,21 +583,13 @@ class ToolUseDispatchNode<C> extends BatchNode<
     // Skip duplicate parallel calls — return a synthetic error result so
     // the model is informed and can retry sequentially if needed.
     if (this._duplicateCallIds.has(call.callId)) {
-      const errorResult = {
-        error: DUPLICATE_CALL_ERROR,
-        isError: true as const,
-      };
       return {
         call,
-        result: errorResult,
+        result: { error: DUPLICATE_CALL_ERROR, isError: true as const },
         parsedInput: call.input,
         extracted: {
           sanitizedResult: { error: DUPLICATE_CALL_ERROR, isError: true },
           attachments: [],
-        },
-        sanitizedOutput: {
-          error: DUPLICATE_CALL_ERROR,
-          isError: true,
         },
         editedFiles: [],
         logRef: {
@@ -734,7 +725,6 @@ class ToolUseDispatchNode<C> extends BatchNode<
     }
 
     const extracted = extractToolAttachments(result);
-    const sanitizedOutput = extracted.sanitizedResult;
     const editedFiles = trackedEdits.edits.map((entry) => ({
       path: entry.path,
       ok: true,
@@ -742,7 +732,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       sourceDisplay: 'Tool use',
     }));
     if (editedFiles.length > 0) {
-      sanitizedOutput.editedFiles = editedFiles;
+      extracted.sanitizedResult.editedFiles = editedFiles;
     }
 
     return {
@@ -750,7 +740,6 @@ class ToolUseDispatchNode<C> extends BatchNode<
       result,
       parsedInput,
       extracted,
-      sanitizedOutput,
       editedFiles,
       logRef,
     };
@@ -761,13 +750,13 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleServices<C>,
     workspace: ToolUseCycleServices<C>['workspace'],
   ): Promise<void> {
-    const { call, result, parsedInput, sanitizedOutput, editedFiles, logRef } =
+    const { call, result, parsedInput, extracted, editedFiles, logRef } =
       execResult;
 
     const toolUseLog = {
       toolName: call.name,
       input: parsedInput ?? call.raw,
-      output: sanitizedOutput,
+      output: extracted.sanitizedResult,
       ...(editedFiles.length > 0 && { files: editedFiles }),
       isError: Boolean(result.isError),
     };

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -588,7 +588,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
         result: { error: DUPLICATE_CALL_ERROR, isError: true as const },
         parsedInput: call.input,
         extracted: {
-          sanitizedResult: { error: DUPLICATE_CALL_ERROR, isError: true },
+          sanitizedResult: { error: DUPLICATE_CALL_ERROR },
           attachments: [],
         },
         editedFiles: [],

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -24,7 +24,10 @@ import {
 import { maybeSaveDebugObject } from '@agent/utils/debugMessageSaver';
 
 // Internal imports - use core ToolTypes as single source of truth
-import { extractToolAttachments } from '@agent/modelHandlers/utils/toolAttachmentUtils';
+import {
+  extractToolAttachments,
+  type ExtractedToolAttachments,
+} from '@agent/modelHandlers/utils/toolAttachmentUtils';
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type {
   FileInteractionState,
@@ -499,6 +502,8 @@ interface ToolExecutionResult {
   call: SdkToolCall;
   result: ToolResult;
   parsedInput: unknown;
+  /** Pre-extracted attachments and sanitized result (avoids re-extraction in post). */
+  extracted: ExtractedToolAttachments;
   sanitizedOutput: Record<string, unknown>;
   editedFiles: Array<{
     path: string;
@@ -579,13 +584,18 @@ class ToolUseDispatchNode<C> extends BatchNode<
     // Skip duplicate parallel calls — return a synthetic error result so
     // the model is informed and can retry sequentially if needed.
     if (this._duplicateCallIds.has(call.callId)) {
+      const errorResult = {
+        error: DUPLICATE_CALL_ERROR,
+        isError: true as const,
+      };
       return {
         call,
-        result: {
-          error: DUPLICATE_CALL_ERROR,
-          isError: true,
-        },
+        result: errorResult,
         parsedInput: call.input,
+        extracted: {
+          sanitizedResult: { error: DUPLICATE_CALL_ERROR, isError: true },
+          attachments: [],
+        },
         sanitizedOutput: {
           error: DUPLICATE_CALL_ERROR,
           isError: true,
@@ -723,7 +733,8 @@ class ToolUseDispatchNode<C> extends BatchNode<
       result.lineChanges = trackedEdits.lineChanges;
     }
 
-    const sanitizedOutput = extractToolAttachments(result).sanitizedResult;
+    const extracted = extractToolAttachments(result);
+    const sanitizedOutput = extracted.sanitizedResult;
     const editedFiles = trackedEdits.edits.map((entry) => ({
       path: entry.path,
       ok: true,
@@ -738,6 +749,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       call,
       result,
       parsedInput,
+      extracted,
       sanitizedOutput,
       editedFiles,
       logRef,
@@ -824,9 +836,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       await this.logAndProcessMediaFiles(execResult, services, workspace);
     }
 
-    const extracted = completedResults.map((er) =>
-      extractToolAttachments(er.result),
-    );
+    const extracted = completedResults.map((er) => er.extracted);
     const calls = completedResults.map((er) => er.call);
 
     // For Google/DeepSeek/Kimi handlers with multiple parallel calls, batch all tool calls

--- a/src/agent/output/FileLineageCalculator.ts
+++ b/src/agent/output/FileLineageCalculator.ts
@@ -31,7 +31,23 @@ function invertMapping(
 
 /** Calculates file lineage and mappings between base files and round outputs. */
 export class FileLineageCalculator {
-  constructor(private readonly baseFiles: FileLocation[]) {}
+  /** Pre-computed base file names to avoid repeated path parsing. */
+  private readonly baseEntries: ReadonlyArray<{
+    loc: FileLocation;
+    baseName: string;
+    baseNameNoExt: string;
+  }>;
+
+  constructor(private readonly baseFiles: FileLocation[]) {
+    this.baseEntries = baseFiles.map((baseLoc) => {
+      const baseName = path.basename(
+        baseLoc.kind !== 'external'
+          ? baseLoc.relativePath
+          : baseLoc.absolutePath,
+      );
+      return { loc: baseLoc, baseName, baseNameNoExt: path.parse(baseName).name };
+    });
+  }
 
   calculateMapping(
     currentOutputs: OutputFileInfo[],
@@ -92,16 +108,6 @@ export class FileLineageCalculator {
   findMatchingBaseFile(source: string): FileLocation | undefined {
     const sourceNoExt = path.parse(source).name;
 
-    // Pre-compute path parsing once per base file instead of per matcher
-    const indexed = this.baseFiles.map((baseLoc) => {
-      const baseName = path.basename(
-        baseLoc.kind !== 'external'
-          ? baseLoc.relativePath
-          : baseLoc.absolutePath,
-      );
-      return { baseLoc, baseName, baseNameNoExt: path.parse(baseName).name };
-    });
-
     const matchers = [
       (b: string, bNoExt: string) => b === source,
       (b: string, bNoExt: string) => bNoExt === sourceNoExt,
@@ -110,9 +116,9 @@ export class FileLineageCalculator {
     ];
 
     for (const match of matchers) {
-      for (const { baseLoc, baseName, baseNameNoExt } of indexed) {
+      for (const { loc, baseName, baseNameNoExt } of this.baseEntries) {
         if (match(baseName, baseNameNoExt)) {
-          return baseLoc;
+          return loc;
         }
       }
     }

--- a/src/agent/output/FileLineageCalculator.ts
+++ b/src/agent/output/FileLineageCalculator.ts
@@ -92,6 +92,16 @@ export class FileLineageCalculator {
   findMatchingBaseFile(source: string): FileLocation | undefined {
     const sourceNoExt = path.parse(source).name;
 
+    // Pre-compute path parsing once per base file instead of per matcher
+    const indexed = this.baseFiles.map((baseLoc) => {
+      const baseName = path.basename(
+        baseLoc.kind !== 'external'
+          ? baseLoc.relativePath
+          : baseLoc.absolutePath,
+      );
+      return { baseLoc, baseName, baseNameNoExt: path.parse(baseName).name };
+    });
+
     const matchers = [
       (b: string, bNoExt: string) => b === source,
       (b: string, bNoExt: string) => bNoExt === sourceNoExt,
@@ -100,13 +110,7 @@ export class FileLineageCalculator {
     ];
 
     for (const match of matchers) {
-      for (const baseLoc of this.baseFiles) {
-        const baseName = path.basename(
-          baseLoc.kind !== 'external'
-            ? baseLoc.relativePath
-            : baseLoc.absolutePath,
-        );
-        const baseNameNoExt = path.parse(baseName).name;
+      for (const { baseLoc, baseName, baseNameNoExt } of indexed) {
         if (match(baseName, baseNameNoExt)) {
           return baseLoc;
         }

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -7,10 +7,7 @@ import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
-import replacementEngine, {
-  applyReplacements,
-  getReplacementsByCategory,
-} from '@replacement/engine';
+import replacementEngine, { applyReplacements } from '@replacement/engine';
 import { FENCED_LATEX_BLOCK_REPLACEMENTS } from '@replacement/rulesRegex';
 import type { OutputFileInfo } from '@shared/schemas';
 import {
@@ -59,19 +56,10 @@ export class XmlOutputManager {
   ) {}
 
   async processXmlContent(content: string): Promise<string> {
+    // applyNonRegex already applies all enabled non-regex categories
+    // (including latex_xml and scratchpad_xml), so no need to re-apply them.
     content = replacementEngine.applyNonRegex(content);
     content = applyReplacements(content, FENCED_LATEX_BLOCK_REPLACEMENTS);
-
-    const latexXmlReplacements = getReplacementsByCategory('latex_xml');
-    if (latexXmlReplacements) {
-      content = applyReplacements(content, latexXmlReplacements);
-    }
-
-    const scratchpadXmlReplacements =
-      getReplacementsByCategory('scratchpad_xml');
-    if (scratchpadXmlReplacements) {
-      content = applyReplacements(content, scratchpadXmlReplacements);
-    }
 
     return content;
   }
@@ -99,7 +87,7 @@ export class XmlOutputManager {
     outputLocation: FileLocation,
     documentTag: string,
     thinkingTag: string = 'scratchpad',
-  ): Promise<FileLocation> {
+  ): Promise<{ location: FileLocation; sourceName: string }> {
     const { name } = path.parse(outputLocation.absolutePath);
     const outputDir = getFileDirectory(outputLocation);
     const texRelativePath = outputDir
@@ -109,6 +97,8 @@ export class XmlOutputManager {
     const texLocation = this.fileService.createLocation(texRelativePath);
 
     let outputContent = await AbsoluteFS.read(outputLocation.absolutePath);
+    const sourceName =
+      outputContent.match(DOCUMENT_NAME_REGEX)?.[1]?.trim() ?? '';
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = addCdataToTags(outputContent, tagsToWrap);
 
@@ -120,7 +110,7 @@ export class XmlOutputManager {
         this.logger.logInternal(`Recovered ${documentTag} ${suffix}`);
       }
       await AbsoluteFS.write(texLocation.absolutePath, regexResult.content);
-      return texLocation;
+      return { location: texLocation, sourceName };
     }
     this.logger.debugInternal(
       `No ${documentTag} found in output file using fallback method`,
@@ -132,7 +122,7 @@ export class XmlOutputManager {
     const latexDocument = extractContentFromXMLbyTag(root, documentTag);
     if (latexDocument) {
       await AbsoluteFS.write(texLocation.absolutePath, latexDocument);
-      return texLocation;
+      return { location: texLocation, sourceName };
     }
     throw new Error(
       `Failed to extract <${documentTag}> from ${path.basename(outputLocation.absolutePath)}`,
@@ -270,18 +260,15 @@ export class XmlOutputManager {
       `Splitting scratchpad output XML: ${outputLocation.absolutePath}`,
     );
 
-    const processedTexLocation = await this.splitScratchpadOutputXml(
+    const { location, sourceName } = await this.splitScratchpadOutputXml(
       outputLocation,
       this.agentSetting.documentTag,
     );
 
-    const xmlContent = await AbsoluteFS.read(outputLocation.absolutePath);
-    const original = xmlContent.match(DOCUMENT_NAME_REGEX)?.[1]?.trim() ?? '';
-
     return {
-      source: original || this.agentConfig.inputFile,
+      source: sourceName || this.agentConfig.inputFile,
       round,
-      location: processedTexLocation,
+      location,
       lineage: null,
       diff: null,
     };

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -292,30 +292,18 @@ export class ProgressApp extends ProgressAppBase {
     () => new Map(this.filteredStreams$.get().map((s) => [s.name, s])),
   );
 
-  /** Status string per stream tab. */
-  private statusById$ = combine(
+  /** Status and timestamp per stream tab (single pass over filtered streams). */
+  private statusAndTimestampById$ = combine(
     [this.streamStates$, this.filteredStreams$] as const,
     (states, streams) => {
-      const map = new Map<StreamTabId, string>();
+      const statusMap = new Map<StreamTabId, string>();
+      const timestampMap = new Map<StreamTabId, number | undefined>();
       for (const stream of streams) {
-        map.set(
-          stream.name,
-          states.get(stream.name)?.status ?? STREAM_STATUS.READY,
-        );
+        const state = states.get(stream.name);
+        statusMap.set(stream.name, state?.status ?? STREAM_STATUS.READY);
+        timestampMap.set(stream.name, state?.lastTimestamp);
       }
-      return map;
-    },
-  );
-
-  /** Last timestamp per stream tab. */
-  private timestampById$ = combine(
-    [this.streamStates$, this.filteredStreams$] as const,
-    (states, streams) => {
-      const map = new Map<StreamTabId, number | undefined>();
-      for (const stream of streams) {
-        map.set(stream.name, states.get(stream.name)?.lastTimestamp);
-      }
-      return map;
+      return { statusMap, timestampMap };
     },
   );
 
@@ -521,8 +509,8 @@ export class ProgressApp extends ProgressAppBase {
               .activeStreamId=${this.activeStreamId$.get()}
               .filter=${this.streamFilter$.get()}
               .sort=${this.streamSort$.get()}
-              .streamStatusById=${this.statusById$.get()}
-              .streamLastTimestampById=${this.timestampById$.get()}
+              .streamStatusById=${this.statusAndTimestampById$.get().statusMap}
+              .streamLastTimestampById=${this.statusAndTimestampById$.get().timestampMap}
               .pendingApprovalStreamIds=${this.pendingApprovalIds$.get()}
               @stream-switch=${this.onStreamSwitch}
               @stream-delete=${this.onStreamDelete}

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -217,18 +217,6 @@ export function getAllReplacementsRegex(): ReplacementCategory[] {
 }
 
 /**
- * Get replacement patterns for a specific category.
- */
-export function getReplacementsByCategory(
-  categoryName: string,
-): ReplacementCategory | undefined {
-  return (
-    NON_REGEX_CATEGORIES.find((c) => c.name === categoryName) ??
-    REGEX_CATEGORIES.find((c) => c.name === categoryName)
-  );
-}
-
-/**
  * Apply replacements to text, handling both regex and non-regex patterns.
  */
 export function applyReplacements(

--- a/src/replacement/engine.ts
+++ b/src/replacement/engine.ts
@@ -152,8 +152,9 @@ export function getAllReplacements(): ReplacementCategory {
   const customReplacements = getConfig('texra.latex.customReplacements', {});
 
   // Filter predefined categories based on user configuration
+  const enabledSet = new Set(enabledCategoryNames);
   const enabledCategories = NON_REGEX_CATEGORIES.filter((category) =>
-    enabledCategoryNames.includes(category.name),
+    enabledSet.has(category.name),
   );
 
   // Combine patterns from all enabled categories with custom replacements taking precedence
@@ -194,8 +195,9 @@ export function getAllReplacementsRegex(): ReplacementCategory[] {
     {},
   );
 
+  const enabledSet = new Set(enabledCategoryNames);
   const enabledCategories = REGEX_CATEGORIES.filter((category) =>
-    enabledCategoryNames.includes(category.name),
+    enabledSet.has(category.name),
   );
 
   if (Object.keys(customReplacements).length === 0) {

--- a/src/replacement/maxRules.ts
+++ b/src/replacement/maxRules.ts
@@ -232,7 +232,8 @@ export const MAX_AUTO_REPLACEMENTS: ReplacementCategory = {
     // Greek Letters (Bold)
     // Generate patterns for bold Greek letters with \b prefix
     // prettier-ignore
-    const commonGreekLetters = GREEK_LETTERS.filter((letter) => ['alpha', 'beta', 'gamma', 'epsilon', 'eta', 'theta', 'mu', 'nu', 'omega', 'phi', 'sigma', 'xi', 'zeta'].includes(letter));
+    const commonGreekSet = new Set(['alpha', 'beta', 'gamma', 'epsilon', 'eta', 'theta', 'mu', 'nu', 'omega', 'phi', 'sigma', 'xi', 'zeta']);
+    const commonGreekLetters = GREEK_LETTERS.filter((letter) => commonGreekSet.has(letter));
 
     // prettier-ignore
     const greekBoldLetters = [...commonGreekLetters, 'chi', 'pi', 'varphi', 'Sigma', 'lambda', 'Gamma', 'Lambda'];

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -213,11 +213,13 @@ export class AgentHandlers {
         data.category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
 
       const sourceAgents = allAgents.filter((e) => e.source === data.source);
-      const targetKeys = new Set(
-        sourceAgents.map((e) => createKey(e.source, e.name)),
-      );
+      const targetKeys = new Set<string>();
       // Legacy entries may use plain agent names without source prefix
-      const targetLegacyNames = new Set(sourceAgents.map((e) => e.name));
+      const targetLegacyNames = new Set<string>();
+      for (const e of sourceAgents) {
+        targetKeys.add(createKey(e.source, e.name));
+        targetLegacyNames.add(e.name);
+      }
 
       // Resolve current state: undefined means "all enabled" (never configured)
       const raw = workspaceSM.get<string[]>(stateKey);


### PR DESCRIPTION
- FileLineageCalculator: pre-compute baseName/baseNameNoExt once instead
  of re-parsing paths up to 4x per base file in findMatchingBaseFile
- ProgressApp: merge statusById$ and timestampById$ into a single
  combined signal that iterates filtered streams once instead of twice
- maxRules: use Set for Greek letter lookup instead of array .includes()
- agentHandlers: build targetKeys and targetLegacyNames in a single loop
  instead of two separate .map() calls
- engine: convert enabledCategoryNames to Set before .filter() in both
  getAllReplacements and getAllReplacementsRegex

https://claude.ai/code/session_01W2DNBWfPi4KayDCQAZxdCD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily performance refactors with minimal behavioral change, though subtle differences could surface if any removed duplicate replacement application or tool-result logging payload mutation was relied on.
> 
> **Overview**
> Reduces repeated work across the agent runtime and UI by **caching or consolidating derived data** instead of recomputing it multiple times.
> 
> In `ToolUseCycleFlow`, tool results now carry precomputed `extractToolAttachments` output through execution and logging to avoid re-extraction and to prevent `editedFiles` from mutating the payload reused for follow-up messages.
> 
> Several hot paths are optimized by collapsing multiple passes into one or switching lookups to `Set` membership: `FileLineageCalculator` precomputes base file name variants, `ProgressApp` combines per-stream status/timestamp maps into one computed, replacement engine category filtering uses `Set`, `maxRules` uses a `Set` for Greek-letter selection, and `agentHandlers` builds key/name sets in a single loop. `XmlOutputManager` also stops re-applying XML replacement categories now covered by `applyNonRegex`, and `getReplacementsByCategory` is removed from `replacement/engine`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea196cdce50e37b8bca1359c4ce082c452143e17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->