### PR TITLE
feat: add plan tool for structured implementation planning

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -312,7 +312,12 @@ export class PlanState {
 
   toSnapshot(): PlanStateSnapshot {
     return {
-      plan: this._plan ? { ...this._plan, steps: [...this._plan.steps] } : null,
+      plan: this._plan
+        ? {
+            ...this._plan,
+            steps: this._plan.steps.map((s) => ({ ...s, files: [...s.files] })),
+          }
+        : null,
     };
   }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import {
   TodoItemSchema,
+  PlanSchema,
   FileLocationSchema,
   type TodoItem,
+  type Plan,
   type FileLocation,
 } from '@shared/schemas';
 import { FlattenedEditRecordSchema } from '@tools/result';
@@ -290,6 +292,75 @@ export class TodoState {
   }
 }
 
+/** Internal schema for plan state snapshot. */
+const PlanStateSnapshotSchema = z.object({
+  plan: PlanSchema.nullable().prefault(null),
+});
+
+type PlanStateSnapshot = z.output<typeof PlanStateSnapshotSchema>;
+
+export class PlanState {
+  private _plan: Plan | null = null;
+  private _onUpdate?: (plan: Plan | null) => void;
+
+  static fromSnapshot(snapshot: unknown): PlanState {
+    const parsed = PlanStateSnapshotSchema.parse(snapshot);
+    const state = new PlanState();
+    state._plan = parsed.plan;
+    return state;
+  }
+
+  toSnapshot(): PlanStateSnapshot {
+    return {
+      plan: this._plan ? { ...this._plan, steps: [...this._plan.steps] } : null,
+    };
+  }
+
+  get plan(): Plan | null {
+    return this._plan;
+  }
+
+  setOnUpdate(callback: (plan: Plan | null) => void): void {
+    this._onUpdate = callback;
+  }
+
+  clearOnUpdate(): void {
+    this._onUpdate = undefined;
+  }
+
+  updatePlan(plan: Plan | null): void {
+    if (this._planEqual(this._plan, plan)) return;
+    this._plan = plan;
+    this._onUpdate?.(plan);
+  }
+
+  private _planEqual(a: Plan | null, b: Plan | null): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (a.summary !== b.summary) return false;
+    if (a.steps.length !== b.steps.length) return false;
+    for (let i = 0; i < a.steps.length; i++) {
+      const ai = a.steps[i],
+        bi = b.steps[i];
+      if (!ai || !bi) return false;
+      if (
+        ai.title !== bi.title ||
+        ai.description !== bi.description ||
+        ai.status !== bi.status ||
+        ai.files.length !== bi.files.length ||
+        ai.files.some((f, j) => f !== bi.files[j])
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  reset(): void {
+    this._plan = null;
+  }
+}
+
 export const AgentWorkspaceStateSnapshotSchema = z.object({
   assembly: ResponseAssemblyStateSchema.prefault({
     lastResponse: '',
@@ -305,6 +376,7 @@ export const AgentWorkspaceStateSnapshotSchema = z.object({
     edits: [],
   }),
   todos: TodoStateSnapshotSchema.prefault({ todos: [] }),
+  plan: PlanStateSnapshotSchema.prefault({ plan: null }),
 });
 
 export type AgentWorkspaceSnapshot = z.output<
@@ -318,6 +390,7 @@ export class AgentWorkspaceState {
   public readonly interactions: FileInteractionState;
   public readonly serverToolContent: ServerToolContentState;
   public readonly todos: TodoState;
+  public readonly plan: PlanState;
 
   private constructor(
     assembly: ResponseAssemblyState,
@@ -326,6 +399,7 @@ export class AgentWorkspaceState {
     interactions: FileInteractionState,
     serverToolContent: ServerToolContentState,
     todos: TodoState,
+    plan: PlanState,
   ) {
     this.assembly = assembly;
     this.media = media;
@@ -333,6 +407,7 @@ export class AgentWorkspaceState {
     this.interactions = interactions;
     this.serverToolContent = serverToolContent;
     this.todos = todos;
+    this.plan = plan;
   }
 
   static create(): AgentWorkspaceState {
@@ -343,6 +418,7 @@ export class AgentWorkspaceState {
       new FileInteractionState(),
       ServerToolContentStateSchema.parse({}),
       new TodoState(),
+      new PlanState(),
     );
   }
 
@@ -364,6 +440,7 @@ export class AgentWorkspaceState {
       FileInteractionState.fromSnapshot(parsed.interactions),
       ServerToolContentStateSchema.parse({}),
       TodoState.fromSnapshot(parsed.todos),
+      PlanState.fromSnapshot(parsed.plan),
     );
   }
 
@@ -383,6 +460,7 @@ export class AgentWorkspaceState {
       },
       interactions: this.interactions.toSnapshot(),
       todos: this.todos.toSnapshot(),
+      plan: this.plan.toSnapshot(),
     };
   }
 

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -31,6 +31,7 @@ import {
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type {
   FileInteractionState,
+  PlanState,
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ToolResult } from '@agent/core/ToolTypes';
@@ -608,6 +609,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       this.services,
       workspace.interactions,
       workspace.todos,
+      workspace.plan,
     );
   }
 
@@ -625,6 +627,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
     todoState: TodoState,
+    planState: PlanState,
     onExecutionReady?: () => void,
     onToolOutput?: (chunk: string) => void,
   ): Promise<ToolResult> {
@@ -637,6 +640,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
         {
           tracker,
           todoState,
+          planState,
           streamId: options.logger.streamId,
           executionId: options.executionId,
           toolCallId: call.callId,
@@ -659,6 +663,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
     todoState: TodoState,
+    planState: PlanState,
   ): Promise<ToolExecutionResult> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
@@ -715,6 +720,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       options,
       tracker,
       todoState,
+      planState,
       onExecutionReady,
       onToolOutput,
     );

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -197,7 +197,7 @@ export async function runReflectionFlow<C = unknown>(
     interrupt(): void {
       input.onInterrupt?.();
       retryCoordinator.clearRequest(streamId);
-      planApprovalCoordinator.clearRequest(streamId);
+      planApprovalCoordinator.clearForStream(streamId);
     },
   };
 
@@ -328,7 +328,7 @@ export async function runReflectionFlow<C = unknown>(
     }
 
     retryCoordinator.clearRequest(streamId);
-    planApprovalCoordinator.clearRequest(streamId);
+    planApprovalCoordinator.clearForStream(streamId);
 
     unregisterInterruptible(streamId);
   }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -14,6 +14,7 @@ import {
   type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
+import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { getOutputFileName } from '@agent/utils/outputFileUtils';
 import { createRunState } from '@agent/core/AgentState';
@@ -196,6 +197,7 @@ export async function runReflectionFlow<C = unknown>(
     interrupt(): void {
       input.onInterrupt?.();
       retryCoordinator.clearRequest(streamId);
+      planApprovalCoordinator.clearRequest(streamId);
     },
   };
 
@@ -326,6 +328,7 @@ export async function runReflectionFlow<C = unknown>(
     }
 
     retryCoordinator.clearRequest(streamId);
+    planApprovalCoordinator.clearRequest(streamId);
 
     unregisterInterruptible(streamId);
   }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -52,6 +52,12 @@ export class ToolUseCycleNode<C> extends Node<
           todos: prepRes.workspaceState.todos.todos,
         });
       }
+      if (prepRes.workspaceState.plan.plan) {
+        bus.emit('updatePlan', {
+          streamId,
+          plan: prepRes.workspaceState.plan.plan,
+        });
+      }
       return { outcome: 'skipped' };
     }
 
@@ -85,6 +91,13 @@ export class ToolUseCycleNode<C> extends Node<
       });
       onProgress?.({ kind: 'todos', todos });
     });
+    prepRes.workspaceState.plan.setOnUpdate((plan) => {
+      bus.emit('updatePlan', {
+        streamId,
+        plan,
+      });
+      onProgress?.({ kind: 'plan', plan });
+    });
 
     try {
       await flow.run(cycleShared);
@@ -102,6 +115,7 @@ export class ToolUseCycleNode<C> extends Node<
       return { outcome: 'completed', messages: cycleShared.messages };
     } finally {
       prepRes.workspaceState.todos.clearOnUpdate();
+      prepRes.workspaceState.plan.clearOnUpdate();
     }
   }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -3,6 +3,7 @@ import {
   registerInterruptible,
   unregisterInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
+import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import {
   PersistedFlow,
@@ -139,6 +140,7 @@ export async function runToolUseFlow<C = unknown>(
     interrupt(): void {
       onInterrupt?.();
       retryCoordinator.clearRequest(streamId);
+      planApprovalCoordinator.clearRequest(streamId);
       sessionLifecycle.interrupt();
     },
   };
@@ -226,6 +228,7 @@ export async function runToolUseFlow<C = unknown>(
     }
 
     sessionLifecycle.dispose();
+    planApprovalCoordinator.clearRequest(streamId);
     unregisterInterruptible(streamId);
   }
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -140,7 +140,7 @@ export async function runToolUseFlow<C = unknown>(
     interrupt(): void {
       onInterrupt?.();
       retryCoordinator.clearRequest(streamId);
-      planApprovalCoordinator.clearRequest(streamId);
+      planApprovalCoordinator.clearForStream(streamId);
       sessionLifecycle.interrupt();
     },
   };
@@ -228,7 +228,7 @@ export async function runToolUseFlow<C = unknown>(
     }
 
     sessionLifecycle.dispose();
-    planApprovalCoordinator.clearRequest(streamId);
+    planApprovalCoordinator.clearForStream(streamId);
     unregisterInterruptible(streamId);
   }
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -104,10 +104,10 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
    * Used for cleanup when all streams are deleted.
    */
   clearAll(): void {
-    for (const [streamId, approvalId] of this.streamApprovalMap) {
+    for (const approvalId of this.streamApprovalMap.values()) {
       this.clearRequest(approvalId);
-      this.streamApprovalMap.delete(streamId);
     }
+    this.streamApprovalMap.clear();
   }
 }
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -55,6 +55,9 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     idFieldName: 'approvalId',
   };
 
+  /** Maps streamId → approvalId for stream-based cleanup. */
+  private readonly streamApprovalMap = new Map<string, string>();
+
   protected getDefaultCancelResult(): PlanApprovalResult {
     return { action: 'reject' };
   }
@@ -65,6 +68,9 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     options: PlanApprovalRequestOptions,
   ): Promise<PlanApprovalResult> {
     const { approvalId, plan, timeoutMs } = options;
+
+    // Track stream → approval mapping for cleanup
+    this.streamApprovalMap.set(streamId, approvalId);
 
     // Show progress view to ensure user sees the approval prompt
     void safeExecuteCommand('texra.showProgressView');
@@ -79,6 +85,29 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
       { approvalId, streamId, plan },
       { timeoutMs },
     );
+  }
+
+  /**
+   * Clear any pending plan approval for the given stream.
+   * Used for cleanup when flows are interrupted or streams are deleted.
+   */
+  clearForStream(streamId: string): void {
+    const approvalId = this.streamApprovalMap.get(streamId);
+    if (approvalId) {
+      this.clearRequest(approvalId);
+      this.streamApprovalMap.delete(streamId);
+    }
+  }
+
+  /**
+   * Clear all pending plan approvals.
+   * Used for cleanup when all streams are deleted.
+   */
+  clearAll(): void {
+    for (const [streamId, approvalId] of this.streamApprovalMap) {
+      this.clearRequest(approvalId);
+      this.streamApprovalMap.delete(streamId);
+    }
   }
 }
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -55,8 +55,9 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     idFieldName: 'approvalId',
   };
 
-  /** Maps streamId → approvalId for stream-based cleanup. */
+  /** Bidirectional maps for stream ↔ approval ID lookup. */
   private readonly streamApprovalMap = new Map<string, string>();
+  private readonly approvalStreamMap = new Map<string, string>();
 
   protected getDefaultCancelResult(): PlanApprovalResult {
     return { action: 'reject' };
@@ -69,8 +70,9 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
   ): Promise<PlanApprovalResult> {
     const { approvalId, plan, timeoutMs } = options;
 
-    // Track stream → approval mapping for cleanup
+    // Track bidirectional mapping for cleanup
     this.streamApprovalMap.set(streamId, approvalId);
+    this.approvalStreamMap.set(approvalId, streamId);
 
     // Show progress view to ensure user sees the approval prompt
     void safeExecuteCommand('texra.showProgressView');
@@ -87,6 +89,19 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     );
   }
 
+  /** Override to clean up stream mapping on normal resolution. */
+  override resolveRequest(
+    id: string,
+    result: PlanApprovalResult,
+  ): boolean {
+    const streamId = this.approvalStreamMap.get(id);
+    if (streamId) {
+      this.streamApprovalMap.delete(streamId);
+      this.approvalStreamMap.delete(id);
+    }
+    return super.resolveRequest(id, result);
+  }
+
   /**
    * Clear any pending plan approval for the given stream.
    * Used for cleanup when flows are interrupted or streams are deleted.
@@ -96,6 +111,7 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     if (approvalId) {
       this.clearRequest(approvalId);
       this.streamApprovalMap.delete(streamId);
+      this.approvalStreamMap.delete(approvalId);
     }
   }
 
@@ -108,6 +124,7 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
       this.clearRequest(approvalId);
     }
     this.streamApprovalMap.clear();
+    this.approvalStreamMap.clear();
   }
 }
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -1,0 +1,90 @@
+/**
+ * Promise-based coordinator for plan approval gates.
+ *
+ * Flow:
+ * 1. PlanTool calls `waitForApproval()` - returns Promise, emits 'showPlanApproval'
+ * 2. User approves/rejects → resolves Promise with corresponding action
+ * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI
+ */
+
+// Local imports
+import { bus } from '@eventBus/ProgressEventBus';
+import { safeExecuteCommand } from '@frontend/system/commandUtils';
+import type { Plan } from '@shared/schemas';
+import {
+  BasePromiseCoordinator,
+  type CoordinatorConfig,
+} from './BasePromiseCoordinator';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Result of a plan approval request. */
+export type PlanApprovalResult =
+  | { action: 'approve' }
+  | { action: 'reject'; feedback?: string }
+  | { action: 'timeout' };
+
+export interface PlanApprovalRequestOptions {
+  approvalId: string;
+  plan: Plan;
+  /** Timeout in milliseconds (default: wait indefinitely) */
+  timeoutMs?: number;
+}
+
+/** Payload for show event */
+interface PlanApprovalShowPayload extends Record<string, unknown> {
+  approvalId: string;
+  streamId: string;
+  plan: Plan;
+}
+
+// ============================================================================
+// Coordinator Implementation
+// ============================================================================
+
+/** Manages pending plan approval requests. */
+class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
+  PlanApprovalResult,
+  PlanApprovalShowPayload
+> {
+  protected readonly config: CoordinatorConfig = {
+    showEventName: 'showPlanApproval',
+    resolveEventName: 'resolvePlanApproval',
+    idFieldName: 'approvalId',
+  };
+
+  protected getDefaultCancelResult(): PlanApprovalResult {
+    return { action: 'reject' };
+  }
+
+  /** Wait for user action on a plan. */
+  waitForApproval(
+    streamId: string,
+    options: PlanApprovalRequestOptions,
+  ): Promise<PlanApprovalResult> {
+    const { approvalId, plan, timeoutMs } = options;
+
+    // Show progress view to ensure user sees the approval prompt
+    void safeExecuteCommand('texra.showProgressView');
+
+    // Activate the stream that needs approval so user sees the prompt immediately
+    if (streamId) {
+      bus.emit('setActiveStream', { streamId });
+    }
+
+    return this.waitForUserAction(
+      approvalId,
+      { approvalId, streamId, plan },
+      { timeoutMs },
+    );
+  }
+}
+
+// ============================================================================
+// Singleton Export
+// ============================================================================
+
+/** Singleton coordinator instance. */
+export const planApprovalCoordinator = new PlanApprovalCoordinatorImpl();

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -1,6 +1,7 @@
 // Type imports
 import type {
   FileInteractionState,
+  PlanState,
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
@@ -16,6 +17,8 @@ export interface ToolFileInteractionContext {
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */
   todoState?: TodoState;
+  /** Plan state for managing implementation plans. Optional for backward compatibility. */
+  planState?: PlanState;
   /** Called by tools with approval flows to trigger in-progress log after approval. */
   onExecutionReady?: () => void;
   /** Called by tools to push partial output for live streaming to the UI. */

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -14,6 +14,7 @@ export const PROGRESS_VIEW_COMMANDS = {
 
   UPDATE_INSTRUCTION: 'updateInstruction',
   UPDATE_TODOS: 'updateTodos',
+  UPDATE_PLAN: 'updatePlan',
   UPDATE_QUEUED_FOLLOW_UPS: 'updateQueuedFollowUps',
   SYNC_STREAM_CONTENT: 'syncStreamContent',
 
@@ -53,6 +54,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   TOGGLE_TOOL_EDIT_APPROVAL_BYPASS: 'toggleToolEditApprovalBypass',
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
+  PLAN_APPROVAL_ACTION: 'planApprovalAction',
   RESTORE_PROPOSAL_CONFIG: 'restoreProposalConfig',
   TOGGLE_SUPER_YOLO_BYPASS: 'toggleSuperYoloBypass',
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -16,6 +16,7 @@ import type {
   StreamTabId,
   TokenUsageStats,
   ToolEditPermission,
+  UpdatePlanPayload,
   UpdateTodosPayload,
 } from '@shared/schemas';
 
@@ -83,6 +84,7 @@ export interface ProgressEventPayloads {
   showAgentProposal: AgentProposalPermission;
   resolveAgentProposal: { proposalId: string };
   updateTodos: UpdateTodosPayload;
+  updatePlan: UpdatePlanPayload;
   updateConversationProgress: {
     streamId: StreamTabId;
     progress: ConversationProgress;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -10,6 +10,7 @@ import type {
   ExecutionId,
   FileLocation,
   OutputFileInfo,
+  PlanApprovalPermission,
   RetryPermission,
   StorageKey,
   StreamStatus,
@@ -83,6 +84,8 @@ export interface ProgressEventPayloads {
   resolveBashPermission: { requestId: string };
   showAgentProposal: AgentProposalPermission;
   resolveAgentProposal: { proposalId: string };
+  showPlanApproval: PlanApprovalPermission;
+  resolvePlanApproval: { approvalId: string };
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
   updateConversationProgress: {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -5,6 +5,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getAgent } from '@agent/index/agentRegistry';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
+import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
@@ -254,6 +255,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         this.handleRestoreProposalConfig(data),
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
         handleProgressViewBashApprovalAction(data),
+      [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: (data) =>
+        this.handlePlanApprovalAction(data),
 
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: async () => {
@@ -563,6 +566,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         break;
       case 'reject':
         proposalCoordinator.resolveRequest(proposalId, {
+          action: 'reject',
+          feedback: data.feedback,
+        });
+        break;
+    }
+  }
+
+  private handlePlanApprovalAction(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
+  ): void {
+    const { approvalId, action } = data;
+    switch (action) {
+      case 'approve':
+        planApprovalCoordinator.resolveRequest(approvalId, {
+          action: 'approve',
+        });
+        break;
+      case 'reject':
+        planApprovalCoordinator.resolveRequest(approvalId, {
           action: 'reject',
           feedback: data.feedback,
         });

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -21,6 +21,7 @@ import type {
   AgentProposalPermission,
   BashPermission,
   ModelOptionData,
+  PlanApprovalPermission,
   ProgressViewPlacement,
   StorageKey,
   StreamTabId,
@@ -88,6 +89,10 @@ export class ProgressViewProvider
     AgentProposalPermission,
     'proposalId'
   >;
+  private readonly planApprovalHandler: ApprovalRequestHandler<
+    PlanApprovalPermission,
+    'approvalId'
+  >;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -136,6 +141,13 @@ export class ProgressViewProvider
       (id) => u.resolvePermission(PERMISSION_KIND.PROPOSAL, id),
       canSend,
     );
+    this.planApprovalHandler = new ApprovalRequestHandler(
+      'approvalId',
+      (p) =>
+        u.showPermission({ kind: PERMISSION_KIND.PLAN_APPROVAL, data: p }),
+      (id) => u.resolvePermission(PERMISSION_KIND.PLAN_APPROVAL, id),
+      canSend,
+    );
 
     this.eventHandler = new ProgressEventHandler(
       this.state,
@@ -158,6 +170,8 @@ export class ProgressViewProvider
         resolveBashPermission: (id) => this.bashApprovalHandler.resolve(id),
         showAgentProposal: (p) => this.agentProposalHandler.show(p),
         resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
+        showPlanApproval: (p) => this.planApprovalHandler.show(p),
+        resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
       },
       (streamId) => this.hasPendingPermissionsForStream(streamId),
     );
@@ -325,6 +339,7 @@ export class ProgressViewProvider
 
     this.retryRequestHandler.replay();
     this.agentProposalHandler.replay();
+    this.planApprovalHandler.replay();
   }
 
   public getPendingAgentProposal(
@@ -342,7 +357,8 @@ export class ProgressViewProvider
       this.retryRequestHandler.hasPendingForStream(streamId) ||
       this.toolEditHandler.hasPendingForStream(streamId) ||
       this.bashApprovalHandler.hasPendingForStream(streamId) ||
-      this.agentProposalHandler.hasPendingForStream(streamId)
+      this.agentProposalHandler.hasPendingForStream(streamId) ||
+      this.planApprovalHandler.hasPendingForStream(streamId)
     );
   }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -211,6 +211,13 @@ export class ProgressEventHandler {
             ctx.webviewUpdater.updateTodos(streamId, todos),
           );
         },
+        // Plan events
+        updatePlan: (ctx, { streamId, plan }) => {
+          ctx.state.setPlan(streamId, plan);
+          this.sendIfActive(streamId, () =>
+            ctx.webviewUpdater.updatePlan(streamId, plan),
+          );
+        },
         // Follow-up events
         updateQueuedFollowUps: (ctx, { streamId }) => {
           this.sendIfActive(streamId, () => {
@@ -502,6 +509,7 @@ export class ProgressEventHandler {
         action: 'clear',
         activeRunId: null,
         todos: [],
+        plan: null,
         queuedFollowUps: [],
         instruction: null,
       });
@@ -512,6 +520,7 @@ export class ProgressEventHandler {
 
     const { extras, activeRunId } = this.prepareStreamSyncExtras(stream);
     const todos = this.state.getTodos(stream);
+    const plan = this.state.getPlan(stream);
     const queuedFollowUps = ToolUseFollowUpQueue.getAll(stream);
 
     let instruction: import('@shared/schemas').InstructionUpdate | null = null;
@@ -553,6 +562,7 @@ export class ProgressEventHandler {
       action: 'render',
       ...extras,
       todos,
+      plan,
       queuedFollowUps,
       instruction,
       agentCategory,

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -40,6 +40,10 @@ export interface UICallbacks {
     payload: ProgressEventPayloads['showAgentProposal'],
   ) => void;
   resolveAgentProposal: (proposalId: string) => void;
+  showPlanApproval: (
+    payload: ProgressEventPayloads['showPlanApproval'],
+  ) => void;
+  resolvePlanApproval: (approvalId: string) => void;
 }
 
 /** Helper to register an event with error handling wrapper. */
@@ -145,6 +149,22 @@ export function registerUIEvents(
     'resolveAgentProposal',
     (p) => callbacks.resolveAgentProposal(p.proposalId),
     'failed to resolve agent proposal',
+    signal,
+  );
+
+  // Plan approval events
+  registerEvent(
+    bus,
+    'showPlanApproval',
+    callbacks.showPlanApproval,
+    'failed to show plan approval',
+    signal,
+  );
+  registerEvent(
+    bus,
+    'resolvePlanApproval',
+    (p) => callbacks.resolvePlanApproval(p.approvalId),
+    'failed to resolve plan approval',
     signal,
   );
 }

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -294,20 +294,20 @@ export class PermissionCard extends LitElement {
 
     return html`
       <p><strong>${plan.summary}</strong></p>
-      <div class="plan-steps-list">
+      <ol class="plan-steps-list">
         ${repeat(
           plan.steps,
-          (_step, i) => i,
-          (step, i) => html`
-            <p>
-              ${i + 1}. ${step.title}
+          (step) => step.title,
+          (step) => html`
+            <li>
+              ${step.title}
               ${step.description
                 ? html`<span class="meta-text"> — ${step.description}</span>`
                 : nothing}
-            </p>
+            </li>
           `,
         )}
-      </div>
+      </ol>
       ${this.renderFeedbackSection()}
     `;
   }

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -297,7 +297,7 @@ export class PermissionCard extends LitElement {
       <ol class="plan-steps-list">
         ${repeat(
           plan.steps,
-          (step) => step.title,
+          (_step, index) => index,
           (step) => html`
             <li>
               ${step.title}

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -12,6 +12,7 @@ import type {
   AgentProposalPermission,
   BashPermission,
   ModelOptionData,
+  PlanApprovalPermission,
   RetryPermission,
   ToolEditPermission,
   WorkflowAgentProposalPermission,
@@ -42,6 +43,10 @@ export type PermissionState =
       kind: typeof PERMISSION_KIND.PROPOSAL;
       data: AgentProposalPermission;
       modelOptions?: ModelOptionData[];
+    }
+  | {
+      kind: typeof PERMISSION_KIND.PLAN_APPROVAL;
+      data: PlanApprovalPermission;
     };
 
 /** Action button configuration */
@@ -62,6 +67,7 @@ const PERMISSION_ICONS: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.BASH]: 'codicon-terminal',
   [PERMISSION_KIND.RETRY]: 'codicon-refresh',
   [PERMISSION_KIND.PROPOSAL]: 'codicon-rocket',
+  [PERMISSION_KIND.PLAN_APPROVAL]: 'codicon-tasklist',
 };
 
 /** Title for each permission type */
@@ -70,6 +76,7 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.BASH]: 'Command approval',
   [PERMISSION_KIND.RETRY]: 'Retry request',
   [PERMISSION_KIND.PROPOSAL]: 'Agent proposal',
+  [PERMISSION_KIND.PLAN_APPROVAL]: 'Plan approval',
 };
 
 /** Primary actions (approve/reject) for each permission type */
@@ -102,6 +109,15 @@ const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
     { action: 'cancel', label: 'Cancel', icon: 'codicon-x', variant: 'reject' },
   ],
   [PERMISSION_KIND.PROPOSAL]: [
+    {
+      action: 'approve',
+      label: 'Approve',
+      icon: 'codicon-check',
+      variant: 'approve',
+    },
+    { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
+  ],
+  [PERMISSION_KIND.PLAN_APPROVAL]: [
     {
       action: 'approve',
       label: 'Approve',
@@ -144,6 +160,7 @@ const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
       variant: 'secondary',
     },
   ],
+  [PERMISSION_KIND.PLAN_APPROVAL]: [],
 };
 
 // =============================================================================
@@ -215,6 +232,8 @@ export class PermissionCard extends LitElement {
         return this.renderRetryBody(this.permission.data);
       case PERMISSION_KIND.PROPOSAL:
         return this.renderProposalBody(this.permission.data);
+      case PERMISSION_KIND.PLAN_APPROVAL:
+        return this.renderPlanApprovalBody(this.permission.data);
       default:
         return nothing;
     }
@@ -264,6 +283,31 @@ export class PermissionCard extends LitElement {
       ${isWorkflow
         ? this.renderWorkflowFiles(data as WorkflowAgentProposalPermission)
         : nothing}
+      ${this.renderFeedbackSection()}
+    `;
+  }
+
+  private renderPlanApprovalBody(
+    data: PlanApprovalPermission,
+  ): TemplateResult {
+    const { plan } = data;
+
+    return html`
+      <p><strong>${plan.summary}</strong></p>
+      <div class="plan-steps-list">
+        ${repeat(
+          plan.steps,
+          (_step, i) => i,
+          (step, i) => html`
+            <p>
+              ${i + 1}. ${step.title}
+              ${step.description
+                ? html`<span class="meta-text"> — ${step.description}</span>`
+                : nothing}
+            </p>
+          `,
+        )}
+      </div>
       ${this.renderFeedbackSection()}
     `;
   }

--- a/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -1,0 +1,110 @@
+/**
+ * Individual panel component for plan approval requests.
+ *
+ * Renders a plan summary, numbered step list with descriptions and
+ * file references, approve/reject buttons, and feedback input.
+ *
+ * Extends BaseFeedbackPanel for shared feedback/reject/emit logic.
+ */
+
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
+
+// Local imports - shared styles
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+
+// Local imports - shared schemas
+import type { PlanApprovalPermission } from '@shared/schemas';
+
+// Local imports - shared utilities
+import { getBasename } from '@shared/utils/path';
+
+// Local imports - base class
+import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+
+@customElement('plan-approval-request-panel')
+export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    requestPanelStyles,
+  ];
+
+  override render(): TemplateResult {
+    const data = this.permission.data as PlanApprovalPermission;
+    const { plan } = data;
+
+    return html`
+      <div
+        class=${classMap({
+          'plan-approval-request': true,
+          'plan-approval-request--feedback-active': this.showFeedback,
+        })}
+      >
+        <div class="plan-approval-request__details">
+          <div class="plan-approval-request__summary">${plan.summary}</div>
+          <ol class="plan-approval-request__steps">
+            ${repeat(
+              plan.steps,
+              (step) => step.title,
+              (step) => html`
+                <li>
+                  <strong>${step.title}</strong>
+                  ${step.description
+                    ? html`<span class="plan-approval-request__step-desc">
+                        — ${step.description}</span
+                      >`
+                    : nothing}
+                  ${step.files.length > 0
+                    ? html`<div class="plan-approval-request__step-files">
+                        ${repeat(
+                          step.files,
+                          (f) => f,
+                          (f, i) =>
+                            html`${i > 0 ? ', ' : ''}<span
+                                class="plan-approval-request__file"
+                                title=${f}
+                                >${getBasename(f)}</span
+                              >`,
+                        )}
+                      </div>`
+                    : nothing}
+                </li>
+              `,
+            )}
+          </ol>
+        </div>
+        <vscode-toolbar-container class="plan-approval-request__actions">
+          <vscode-toolbar-button
+            icon="check"
+            label="Approve"
+            title="Approve this plan (y)"
+            @click=${() => this.emitAction('approve')}
+            >Approve</vscode-toolbar-button
+          >
+          ${this.renderRejectButton('Reject this plan (n)')}
+        </vscode-toolbar-container>
+        ${this.renderFeedbackSection(
+          'plan-approval-request__feedback',
+          'plan-approval-request__feedback-input',
+          'Why are you rejecting this plan?',
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'plan-approval-request-panel': PlanApprovalRequestPanel;
+  }
+}

--- a/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
+++ b/src/progressView/frontend/components/PlanApprovalRequestPanel.ts
@@ -55,7 +55,7 @@ export class PlanApprovalRequestPanel extends BaseFeedbackPanel {
           <ol class="plan-approval-request__steps">
             ${repeat(
               plan.steps,
-              (step) => step.title,
+              (_step, index) => index,
               (step) => html`
                 <li>
                   <strong>${step.title}</strong>

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -15,16 +15,16 @@ import {
   animationStyles,
   commonViewStyles,
 } from '@shared/styles';
-import { PLAN_STEP_STATUS, type Plan, type PlanStep } from '@shared/schemas';
+import { TODO_STATUS, type Plan, type PlanStep } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
 
 const STATUS_ICONS: Record<string, string> = {
-  [PLAN_STEP_STATUS.PENDING]: 'circle-outline',
-  [PLAN_STEP_STATUS.IN_PROGRESS]: 'loading',
-  [PLAN_STEP_STATUS.COMPLETED]: 'pass-filled',
+  [TODO_STATUS.PENDING]: 'circle-outline',
+  [TODO_STATUS.IN_PROGRESS]: 'loading',
+  [TODO_STATUS.COMPLETED]: 'pass-filled',
 };
 
 @customElement('plan-view')
@@ -130,10 +130,6 @@ export class PlanView extends LitElement {
         color: var(--color-text-secondary);
       }
 
-      .plan-step--in-progress {
-        /* No opacity change - active step */
-      }
-
       .plan-step--in-progress .plan-step__icon {
         color: var(--vscode-progressBar-background);
       }
@@ -164,7 +160,7 @@ export class PlanView extends LitElement {
     }
 
     const completed = this.plan.steps.filter(
-      (s) => s.status === PLAN_STEP_STATUS.COMPLETED,
+      (s) => s.status === TODO_STATUS.COMPLETED,
     ).length;
     const total = this.plan.steps.length;
 
@@ -178,7 +174,7 @@ export class PlanView extends LitElement {
         <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
           ${repeat(
             this.plan.steps,
-            (step, index) => `${index}-${step.title}-${step.status}`,
+            (_step, index) => index,
             (step, index) => this.renderStep(step, index),
           )}
         </div>
@@ -187,17 +183,17 @@ export class PlanView extends LitElement {
   }
 
   private renderStep(step: PlanStep, index: number): TemplateResult {
-    const status = step.status ?? PLAN_STEP_STATUS.PENDING;
-    const isInProgress = status === PLAN_STEP_STATUS.IN_PROGRESS;
-    const icon = STATUS_ICONS[status] ?? STATUS_ICONS[PLAN_STEP_STATUS.PENDING];
+    const status = step.status ?? TODO_STATUS.PENDING;
+    const isInProgress = status === TODO_STATUS.IN_PROGRESS;
+    const icon = STATUS_ICONS[status] ?? STATUS_ICONS[TODO_STATUS.PENDING];
 
     return html`
       <div
         class=${classMap({
           'plan-step': true,
-          'plan-step--pending': status === PLAN_STEP_STATUS.PENDING,
-          'plan-step--in-progress': status === PLAN_STEP_STATUS.IN_PROGRESS,
-          'plan-step--completed': status === PLAN_STEP_STATUS.COMPLETED,
+          'plan-step--pending': status === TODO_STATUS.PENDING,
+          'plan-step--in-progress': status === TODO_STATUS.IN_PROGRESS,
+          'plan-step--completed': status === TODO_STATUS.COMPLETED,
         })}
       >
         <span class="plan-step__number">${index + 1}.</span>

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -15,17 +15,11 @@ import {
   animationStyles,
   commonViewStyles,
 } from '@shared/styles';
-import { TODO_STATUS, type Plan, type PlanStep } from '@shared/schemas';
+import { TODO_STATUS, STATUS_ICONS, type Plan, type PlanStep } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
-
-const STATUS_ICONS: Record<string, string> = {
-  [TODO_STATUS.PENDING]: 'circle-outline',
-  [TODO_STATUS.IN_PROGRESS]: 'loading',
-  [TODO_STATUS.COMPLETED]: 'pass-filled',
-};
 
 @customElement('plan-view')
 export class PlanView extends LitElement {
@@ -174,7 +168,7 @@ export class PlanView extends LitElement {
         <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
           ${repeat(
             this.plan.steps,
-            (_step, index) => index,
+            (step) => `${step.title}:${step.status}`,
             (step, index) => this.renderStep(step, index),
           )}
         </div>

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -168,7 +168,7 @@ export class PlanView extends LitElement {
         <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
           ${repeat(
             this.plan.steps,
-            (step) => `${step.title}:${step.status}`,
+            (_step, index) => index,
             (step, index) => this.renderStep(step, index),
           )}
         </div>

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -1,0 +1,229 @@
+/**
+ * PlanView component — renders a structured implementation plan
+ * with numbered steps, descriptions, file references, and status indicators.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+// Local imports - shared styles
+import {
+  designTokens,
+  animationStyles,
+  commonViewStyles,
+} from '@shared/styles';
+import { PLAN_STEP_STATUS, type Plan, type PlanStep } from '@shared/schemas';
+import { codiconIconClasses } from '@shared/styles/codiconStyles';
+
+// Local imports - progress view constants
+import { ELEMENT_IDS } from '../constants';
+
+const STATUS_ICONS: Record<string, string> = {
+  [PLAN_STEP_STATUS.PENDING]: 'circle-outline',
+  [PLAN_STEP_STATUS.IN_PROGRESS]: 'loading',
+  [PLAN_STEP_STATUS.COMPLETED]: 'pass-filled',
+};
+
+@customElement('plan-view')
+export class PlanView extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    animationStyles,
+    css`
+      :host {
+        display: block;
+        margin: var(--spacing-small) 0;
+      }
+
+      :host([hidden]) {
+        display: none;
+      }
+
+      .plan-collapsible {
+        border-bottom: var(--border-thin) solid var(--color-border);
+      }
+
+      .plan-summary {
+        font-size: var(--font-size);
+        line-height: var(--line-height-normal);
+        color: var(--color-text-secondary);
+        margin-bottom: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+      }
+
+      .plan-steps {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-tiny);
+      }
+
+      .plan-step {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+        font-size: var(--font-size);
+        line-height: var(--line-height-normal);
+      }
+
+      .plan-step__number {
+        flex-shrink: 0;
+        font-size: var(--font-size-small);
+        min-width: 1.4em;
+        text-align: right;
+        color: var(--color-text-secondary);
+        line-height: var(--line-height-normal);
+        margin-top: var(--border-thin);
+      }
+
+      .plan-step__icon {
+        flex-shrink: 0;
+        font-size: var(--font-size-icon-sm);
+        line-height: var(--line-height-normal);
+        margin-top: var(--border-thin);
+      }
+
+      .plan-step__body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .plan-step__title {
+        font-weight: var(--font-weight-medium);
+        word-break: break-word;
+      }
+
+      .plan-step__description {
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-small);
+        margin-top: 2px;
+        word-break: break-word;
+      }
+
+      .plan-step__files {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--spacing-tiny);
+        margin-top: 4px;
+      }
+
+      .plan-step__file {
+        font-size: var(--font-size-small);
+        color: var(--vscode-textLink-foreground);
+        background: var(--vscode-badge-background);
+        padding: 1px 6px;
+        border-radius: 3px;
+        font-family: var(--vscode-editor-font-family, monospace);
+      }
+
+      /* Status-specific styles */
+      .plan-step--pending {
+        opacity: var(--opacity-subtle);
+      }
+
+      .plan-step--pending .plan-step__icon {
+        color: var(--color-text-secondary);
+      }
+
+      .plan-step--in-progress {
+        /* No opacity change - active step */
+      }
+
+      .plan-step--in-progress .plan-step__icon {
+        color: var(--vscode-progressBar-background);
+      }
+
+      .plan-step--in-progress .plan-step__title {
+        color: var(--vscode-progressBar-background);
+      }
+
+      .plan-step--completed {
+        opacity: var(--opacity-disabled);
+      }
+
+      .plan-step--completed .plan-step__icon {
+        color: var(--color-success);
+      }
+
+      .plan-step--completed .plan-step__title {
+        text-decoration: line-through var(--color-text-secondary);
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) plan: Plan | null = null;
+
+  override render(): TemplateResult | typeof nothing {
+    if (!this.plan) {
+      return nothing;
+    }
+
+    const completed = this.plan.steps.filter(
+      (s) => s.status === PLAN_STEP_STATUS.COMPLETED,
+    ).length;
+    const total = this.plan.steps.length;
+
+    return html`
+      <vscode-collapsible
+        id=${ELEMENT_IDS.PLAN_VIEW_CONTAINER}
+        class="plan-collapsible panel-collapsible"
+        title=${`Plan (${completed}/${total})`}
+      >
+        <div class="plan-summary">${this.plan.summary}</div>
+        <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
+          ${repeat(
+            this.plan.steps,
+            (step, index) => `${index}-${step.title}-${step.status}`,
+            (step, index) => this.renderStep(step, index),
+          )}
+        </div>
+      </vscode-collapsible>
+    `;
+  }
+
+  private renderStep(step: PlanStep, index: number): TemplateResult {
+    const status = step.status ?? PLAN_STEP_STATUS.PENDING;
+    const isInProgress = status === PLAN_STEP_STATUS.IN_PROGRESS;
+    const icon = STATUS_ICONS[status] ?? STATUS_ICONS[PLAN_STEP_STATUS.PENDING];
+
+    return html`
+      <div
+        class=${classMap({
+          'plan-step': true,
+          'plan-step--pending': status === PLAN_STEP_STATUS.PENDING,
+          'plan-step--in-progress': status === PLAN_STEP_STATUS.IN_PROGRESS,
+          'plan-step--completed': status === PLAN_STEP_STATUS.COMPLETED,
+        })}
+      >
+        <span class="plan-step__number">${index + 1}.</span>
+        <i
+          class=${classMap({
+            codicon: true,
+            [`codicon-${icon}`]: true,
+            'plan-step__icon': true,
+            spin: isInProgress,
+          })}
+        ></i>
+        <div class="plan-step__body">
+          <div class="plan-step__title">${step.title}</div>
+          <div class="plan-step__description">${step.description}</div>
+          ${step.files.length > 0
+            ? html`
+                <div class="plan-step__files">
+                  ${step.files.map(
+                    (file) =>
+                      html`<span class="plan-step__file">${file}</span>`,
+                  )}
+                </div>
+              `
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -242,6 +242,9 @@ export class RequestPanels extends LitElement {
       case PERMISSION_KIND.PROPOSAL:
         id = permission.data.proposalId;
         break;
+      case PERMISSION_KIND.PLAN_APPROVAL:
+        id = permission.data.approvalId;
+        break;
       default:
         id = permission.data.requestId;
         break;

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -38,10 +38,11 @@ import './ToolEditRequestPanel';
 import './BashRequestPanel';
 import './RetryRequestPanel';
 import './ProposalRequestPanel';
+import './PlanApprovalRequestPanel';
 
 /** Selector to find any sub-panel in shadow DOM */
 const PANEL_SELECTOR =
-  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel';
+  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel, plan-approval-request-panel';
 
 /** Section configuration for rendering permission groups */
 interface SectionConfig {
@@ -81,6 +82,15 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
     title: 'Agent proposal',
     renderPanel: (p) =>
       html`<proposal-request-panel .permission=${p}></proposal-request-panel>`,
+  },
+  planApproval: {
+    cssClass: 'plan-approval-requests',
+    icon: 'checklist',
+    title: 'Plan approval',
+    renderPanel: (p) =>
+      html`<plan-approval-request-panel
+        .permission=${p}
+      ></plan-approval-request-panel>`,
   },
 };
 
@@ -122,6 +132,7 @@ export class RequestPanels extends LitElement {
   private bashPermissions: PermissionState[] = [];
   private retryPermissions: PermissionState[] = [];
   private proposalPermissions: PermissionState[] = [];
+  private planApprovalPermissions: PermissionState[] = [];
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('permissions')) return;
@@ -137,6 +148,9 @@ export class RequestPanels extends LitElement {
     );
     this.proposalPermissions = this.permissions.filter(
       (p) => p.kind === PERMISSION_KIND.PROPOSAL,
+    );
+    this.planApprovalPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.PLAN_APPROVAL,
     );
   }
 
@@ -158,6 +172,7 @@ export class RequestPanels extends LitElement {
       ${this.renderSection(SECTION_CONFIGS.bash, this.bashPermissions)}
       ${this.renderSection(SECTION_CONFIGS.retry, this.retryPermissions)}
       ${this.renderSection(SECTION_CONFIGS.proposal, this.proposalPermissions)}
+      ${this.renderSection(SECTION_CONFIGS.planApproval, this.planApprovalPermissions)}
     `;
   }
 

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -10,16 +10,10 @@ import {
   animationStyles,
   commonViewStyles,
 } from '@shared/styles';
-import { TODO_STATUS, type TodoItem } from '@shared/schemas';
+import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 import { ELEMENT_IDS } from '../constants';
-
-const STATUS_ICONS: Record<string, string> = {
-  [TODO_STATUS.PENDING]: 'circle-outline',
-  [TODO_STATUS.IN_PROGRESS]: 'loading',
-  [TODO_STATUS.COMPLETED]: 'pass-filled',
-};
 
 @customElement('todo-list')
 export class TodoList extends LitElement {
@@ -120,7 +114,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (_todo, index) => index,
+            (todo) => `${todo.content}:${todo.status}`,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -120,7 +120,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (todo, index) => `${index}-${todo.content}-${todo.status}`,
+            (_todo, index) => index,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -114,7 +114,7 @@ export class TodoList extends LitElement {
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
-            (todo) => `${todo.content}:${todo.status}`,
+            (_todo, index) => index,
             (todo) => this.renderTodo(todo),
           )}
         </div>

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -34,6 +34,7 @@ import type { PermissionState } from './PermissionCard';
 import './StreamHeader';
 import './RequestPanels';
 import './TodoList';
+import './PlanView';
 import './TaskGroupList';
 import './LogList';
 import './UsagePanel';
@@ -106,6 +107,8 @@ export class ToolUseStreamContent extends LitElement {
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
 
       <todo-list .todos=${currentState.todos}></todo-list>
+
+      <plan-view .plan=${currentState.plan}></plan-view>
 
       <background-tasks-panel
         .activeProcesses=${currentState.activeProcesses}

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -16,6 +16,8 @@ export const ELEMENT_IDS = {
   CONTEXT_STATE: 'contextState',
   TODO_LIST_CONTAINER: 'todoListContainer',
   TODO_LIST: 'todoList',
+  PLAN_VIEW_CONTAINER: 'planViewContainer',
+  PLAN_VIEW: 'planView',
   INSTRUCTION_CONTAINER: 'instructionContainer',
   INSTRUCTION_TEXT: 'instructionText',
   INSTRUCTION_TOGGLE_BTN: 'instructionToggleBtn',

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -351,5 +351,18 @@ export function handlePermissionAction(
         resolvedProposalIds.add(permission.data.proposalId);
       }
       break;
+    case PERMISSION_KIND.PLAN_APPROVAL:
+      postMessage(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION, {
+        approvalId: permission.data.approvalId,
+        action,
+        feedback,
+      });
+      removePrompt(
+        ctx,
+        PERMISSION_KIND.PLAN_APPROVAL,
+        'approvalId',
+        permission.data.approvalId,
+      );
+      break;
   }
 }

--- a/src/progressView/frontend/slices/permissionSlice.ts
+++ b/src/progressView/frontend/slices/permissionSlice.ts
@@ -148,6 +148,9 @@ export const permissionHandlers: HandlerRegistry = {
       case PERMISSION_KIND.RETRY:
         removePrompt(ctx, kind, 'streamId', id);
         break;
+      case PERMISSION_KIND.PLAN_APPROVAL:
+        removePrompt(ctx, kind, 'approvalId', id);
+        break;
       default: {
         const removed = removePrompt(
           ctx,

--- a/src/progressView/frontend/slices/syncSlice.ts
+++ b/src/progressView/frontend/slices/syncSlice.ts
@@ -24,7 +24,9 @@ export const syncHandlers: HandlerRegistry = {
       data.runMissingOutputs !== undefined ||
       data.contextState !== undefined;
     const hasTodos =
-      data.todos !== undefined || data.queuedFollowUps !== undefined;
+      data.todos !== undefined ||
+      data.plan !== undefined ||
+      data.queuedFollowUps !== undefined;
     const hasInstruction = data.instruction !== undefined && !!data.runId;
     const hasMeta =
       data.conversationProgress !== undefined || data.badges !== undefined;
@@ -61,6 +63,7 @@ export const syncHandlers: HandlerRegistry = {
           if (isToolUseState(prev) && hasTodos) {
             const d = draft as ToolUseStreamState;
             if (data.todos) d.todos = data.todos;
+            if (data.plan !== undefined) d.plan = data.plan;
             if (data.queuedFollowUps) d.queuedFollowUps = data.queuedFollowUps;
           }
 

--- a/src/progressView/frontend/slices/syncSlice.ts
+++ b/src/progressView/frontend/slices/syncSlice.ts
@@ -23,7 +23,7 @@ export const syncHandlers: HandlerRegistry = {
       data.runFiles !== undefined ||
       data.runMissingOutputs !== undefined ||
       data.contextState !== undefined;
-    const hasTodos =
+    const hasTaskData =
       data.todos !== undefined ||
       data.plan !== undefined ||
       data.queuedFollowUps !== undefined;
@@ -31,7 +31,7 @@ export const syncHandlers: HandlerRegistry = {
     const hasMeta =
       data.conversationProgress !== undefined || data.badges !== undefined;
 
-    if (hasRunData || hasTodos || hasInstruction || hasMeta) {
+    if (hasRunData || hasTaskData || hasInstruction || hasMeta) {
       ctx.setStreamState(data.stream, (prev) =>
         create(prev, (draft) => {
           if (hasRunData) {
@@ -60,7 +60,7 @@ export const syncHandlers: HandlerRegistry = {
             }
           }
 
-          if (isToolUseState(prev) && hasTodos) {
+          if (isToolUseState(prev) && hasTaskData) {
             const d = draft as ToolUseStreamState;
             if (data.todos) d.todos = data.todos;
             if (data.plan !== undefined) d.plan = data.plan;

--- a/src/progressView/frontend/slices/taskSlice.ts
+++ b/src/progressView/frontend/slices/taskSlice.ts
@@ -1,5 +1,5 @@
 /**
- * Task handlers: UPDATE_TODOS.
+ * Task handlers: UPDATE_TODOS, UPDATE_PLAN.
  */
 
 import { create } from 'mutative';
@@ -14,6 +14,13 @@ export const taskHandlers: HandlerRegistry = {
     updateToolUseState(ctx, data.stream, (prev) =>
       create(prev, (draft) => {
         draft.todos = data.todos;
+      }),
+    );
+  },
+  [PROGRESS_VIEW_COMMANDS.UPDATE_PLAN]: (data, ctx) => {
+    updateToolUseState(ctx, data.stream, (prev) =>
+      create(prev, (draft) => {
+        draft.plan = data.plan;
       }),
     );
   },

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -22,6 +22,7 @@ import type {
   StreamStatus,
   StreamTabId,
   StreamTabInfo,
+  Plan,
   TodoItem,
   TokenUsageStats,
   StorageKey,
@@ -61,6 +62,7 @@ export interface SyncStreamContentPayload {
   runMissingOutputs?: Record<string, { [key: number]: string[] }>;
   contextState?: ContextState;
   todos: TodoItem[];
+  plan: Plan | null;
   queuedFollowUps: string[];
   instruction: InstructionUpdate | null;
   agentCategory?: string;
@@ -344,6 +346,14 @@ export class WebviewUpdater {
       command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
       stream,
       todos,
+    });
+  }
+
+  updatePlan(stream: StreamTabId, plan: Plan | null): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_PLAN,
+      stream,
+      plan,
     });
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -28,6 +28,8 @@ import {
   type ContextStateData,
   type StreamTabId,
   type TodoItem,
+  type Plan,
+  PlanSchema,
 } from '@shared/schemas';
 import {
   PersistedState,
@@ -49,6 +51,7 @@ export type StreamHints = z.infer<typeof StreamHintsSchema>;
 const StreamSessionStateSchema = z.object({
   hints: StreamHintsSchema.prefault({}),
   todos: z.array(TodoItemSchema).prefault([]),
+  plan: PlanSchema.nullable().prefault(null),
   contextState: ContextStateDataSchema.nullable().prefault(null),
 });
 
@@ -229,6 +232,14 @@ export class ProgressViewState {
 
   getTodos(stream: StreamTabId): TodoItem[] {
     return this._sessionState.get(stream)?.todos ?? [];
+  }
+
+  setPlan(stream: StreamTabId, plan: Plan | null): void {
+    this.getOrCreateSession(stream).plan = plan;
+  }
+
+  getPlan(stream: StreamTabId): Plan | null {
+    return this._sessionState.get(stream)?.plan ?? null;
   }
 
   getContextState(stream: StreamTabId): ContextStateData | undefined {

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -19,6 +19,7 @@ export * from './output';
 export * from './log';
 export * from './taskGroup';
 export * from './todo';
+export * from './plan';
 export * from './subagentProgress';
 export * from './prompts';
 export * from './diffResult';

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -19,6 +19,7 @@ export * from './output';
 export * from './log';
 export * from './taskGroup';
 export * from './todo';
+export * from './todoDisplay';
 export * from './plan';
 export * from './subagentProgress';
 export * from './prompts';

--- a/src/shared/schemas/plan.ts
+++ b/src/shared/schemas/plan.ts
@@ -1,19 +1,7 @@
 import { z } from 'zod';
 
 import { StreamTabIdSchema } from './identifiers';
-
-const planStepStatusValues = ['pending', 'in_progress', 'completed'] as const;
-
-export const PLAN_STEP_STATUS = {
-  PENDING: 'pending',
-  IN_PROGRESS: 'in_progress',
-  COMPLETED: 'completed',
-} as const satisfies Record<string, (typeof planStepStatusValues)[number]>;
-
-export const PlanStepStatusSchema = z
-  .enum(planStepStatusValues)
-  .describe('Current status of the plan step');
-export type PlanStepStatus = z.infer<typeof PlanStepStatusSchema>;
+import { TodoStatusSchema } from './todo';
 
 export const PlanStepSchema = z.strictObject({
   title: z.string().min(1).describe('Short title for this step'),
@@ -21,7 +9,7 @@ export const PlanStepSchema = z.strictObject({
     .string()
     .min(1)
     .describe('Detailed description of what this step involves'),
-  status: PlanStepStatusSchema,
+  status: TodoStatusSchema,
   files: z
     .array(z.string())
     .prefault([])

--- a/src/shared/schemas/plan.ts
+++ b/src/shared/schemas/plan.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+import { StreamTabIdSchema } from './identifiers';
+
+const planStepStatusValues = ['pending', 'in_progress', 'completed'] as const;
+
+export const PLAN_STEP_STATUS = {
+  PENDING: 'pending',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+} as const satisfies Record<string, (typeof planStepStatusValues)[number]>;
+
+export const PlanStepStatusSchema = z
+  .enum(planStepStatusValues)
+  .describe('Current status of the plan step');
+export type PlanStepStatus = z.infer<typeof PlanStepStatusSchema>;
+
+export const PlanStepSchema = z.strictObject({
+  title: z.string().min(1).describe('Short title for this step'),
+  description: z
+    .string()
+    .min(1)
+    .describe('Detailed description of what this step involves'),
+  status: PlanStepStatusSchema,
+  files: z
+    .array(z.string())
+    .prefault([])
+    .describe('Files involved in this step'),
+});
+export type PlanStep = z.infer<typeof PlanStepSchema>;
+
+export const PlanSchema = z.strictObject({
+  summary: z
+    .string()
+    .min(1)
+    .describe('Brief overview of the implementation plan'),
+  steps: z
+    .array(PlanStepSchema)
+    .min(1)
+    .describe('Ordered list of implementation steps'),
+});
+export type Plan = z.infer<typeof PlanSchema>;
+
+export const UpdatePlanPayloadSchema = z.strictObject({
+  streamId: StreamTabIdSchema,
+  plan: PlanSchema.nullable(),
+});
+export type UpdatePlanPayload = z.infer<typeof UpdatePlanPayloadSchema>;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -34,6 +34,7 @@ import {
   ConversationProgressSchema,
   StreamMetadataSchema,
 } from './streamState';
+import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
 import { ContextStateSchema, TokenUsageStatsSchema } from './usage';
 
@@ -209,6 +210,12 @@ export const UpdateTodosMessageSchema = z.object({
   todos: z.array(TodoItemSchema),
 });
 
+export const UpdatePlanMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PLAN),
+  stream: StreamTabIdSchema,
+  plan: PlanSchema.nullable(),
+});
+
 export const UpdateRunUsageMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE),
   stream: StreamTabIdSchema,
@@ -318,6 +325,7 @@ export const SyncStreamContentMessageSchema = z.object({
     .optional(),
   contextState: ContextStateSchema.optional(),
   todos: z.array(TodoItemSchema).optional(),
+  plan: PlanSchema.nullable().optional(),
   queuedFollowUps: z.array(z.string()).optional(),
   instruction: InstructionUpdateSchema.nullable().optional(),
   agentCategory: z.string().optional(),
@@ -373,6 +381,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateMissingOutputsMessageSchema,
     UpdateInstructionMessageSchema,
     UpdateTodosMessageSchema,
+    UpdatePlanMessageSchema,
     UpdateRunUsageMessageSchema,
     UpdateQueuedFollowUpsMessageSchema,
     SyncStreamContentMessageSchema,

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -21,6 +21,8 @@ import {
   AgentProposalSchema,
   AgentProposalPermissionSchema,
   BashPermissionSchema,
+  PLAN_APPROVAL_ACTIONS,
+  PlanApprovalPermissionSchema,
   RetryPermissionSchema,
   ToolEditPermissionSchema,
 } from './prompts';
@@ -229,7 +231,13 @@ export const UpdateQueuedFollowUpsMessageSchema = z.object({
   messages: z.array(z.string()),
 });
 
-const PermissionKindSchema = z.enum(['toolEdit', 'bash', 'retry', 'proposal']);
+const PermissionKindSchema = z.enum([
+  'toolEdit',
+  'bash',
+  'retry',
+  'proposal',
+  'planApproval',
+]);
 export type ProgressPermissionKind = z.infer<typeof PermissionKindSchema>;
 
 const PermissionPayloadSchema = z.discriminatedUnion('kind', [
@@ -249,6 +257,10 @@ const PermissionPayloadSchema = z.discriminatedUnion('kind', [
     kind: z.literal('proposal'),
     data: AgentProposalPermissionSchema,
     modelOptionsData: z.array(ModelOptionDataSchema).optional(),
+  }),
+  z.object({
+    kind: z.literal('planApproval'),
+    data: PlanApprovalPermissionSchema,
   }),
 ]);
 export type PermissionPayload = z.infer<typeof PermissionPayloadSchema>;
@@ -602,6 +614,13 @@ const AgentProposalActionMessageSchema = z.object({
   model: z.string().optional(),
 });
 
+const PlanApprovalActionMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION),
+  approvalId: z.string().min(1),
+  action: z.enum(PLAN_APPROVAL_ACTIONS),
+  feedback: z.string().optional(),
+});
+
 const RestoreProposalConfigMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG),
   proposal: AgentProposalSchema,
@@ -706,6 +725,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     ToggleSuperYoloBypassMessageSchema,
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,
+    PlanApprovalActionMessageSchema,
     RestoreProposalConfigMessageSchema,
     ShowInformationMessageSchema,
     OpenProfileMessageSchema,

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { AGENT_CATEGORY } from './agent';
 import { ProviderErrorPartialSchema } from './errors';
 import { StreamTabIdSchema } from './identifiers';
+import { PlanSchema } from './plan';
 import {
   BaseProposalFieldsSchema,
   WorkflowSpecificFieldsSchema,
@@ -101,4 +102,20 @@ export const AgentProposalPermissionSchema = z.discriminatedUnion(
 );
 export type AgentProposalPermission = z.infer<
   typeof AgentProposalPermissionSchema
+>;
+
+// ============================================================================
+// Plan Approval
+// ============================================================================
+
+export const PLAN_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
+export type PlanApprovalAction = (typeof PLAN_APPROVAL_ACTIONS)[number];
+
+export const PlanApprovalPermissionSchema = z.strictObject({
+  approvalId: z.string(),
+  streamId: StreamTabIdSchema,
+  plan: PlanSchema,
+});
+export type PlanApprovalPermission = z.infer<
+  typeof PlanApprovalPermissionSchema
 >;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -8,6 +8,7 @@ import {
 import { OutputFileInfoSchema } from './output';
 import { InstructionUpdateSchema, StreamStatusSchema } from './stream';
 import { TaskGroupSchema } from './taskGroup';
+import { PlanSchema } from './plan';
 import { TodoItemSchema } from './todo';
 import { ContextStateSchema, TokenUsageStatsSchema } from './usage';
 
@@ -105,6 +106,7 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   kind: z.literal(AGENT_CATEGORY.TOOL_USE),
   // Frontend-owned fields updated by targeted progress-view messages
   todos: z.array(TodoItemSchema).prefault([]),
+  plan: PlanSchema.nullable().prefault(null),
   queuedFollowUps: z.array(z.string()).prefault([]),
   toolEditBypass: z.boolean().optional(),
   superYoloBypass: z.boolean().optional(),

--- a/src/shared/schemas/subagentProgress.ts
+++ b/src/shared/schemas/subagentProgress.ts
@@ -7,6 +7,7 @@
  * agent runtime and tools.
  */
 
+import type { Plan } from './plan';
 import type { TodoItem } from './todo';
 
 /** Todo state changed in a tool-use subagent. */
@@ -30,6 +31,12 @@ export interface OverviewProgressUpdate {
   readonly cost?: number;
 }
 
+/** Plan state changed in a tool-use subagent. */
+export interface PlanProgressUpdate {
+  readonly kind: 'plan';
+  readonly plan: Plan | null;
+}
+
 /** Subagent has finished initialization and is about to call the model. */
 export interface StartedProgressUpdate {
   readonly kind: 'started';
@@ -37,6 +44,7 @@ export interface StartedProgressUpdate {
 
 export type SubagentProgressUpdate =
   | TodoProgressUpdate
+  | PlanProgressUpdate
   | RoundProgressUpdate
   | OverviewProgressUpdate
   | StartedProgressUpdate;

--- a/src/shared/schemas/todoDisplay.ts
+++ b/src/shared/schemas/todoDisplay.ts
@@ -1,0 +1,18 @@
+import { TODO_STATUS, type TodoStatus } from './todo';
+
+/** Codicon icon names for each todo/plan step status (used in webview components). */
+export const STATUS_ICONS: Record<TodoStatus, string> = {
+  [TODO_STATUS.PENDING]: 'circle-outline',
+  [TODO_STATUS.IN_PROGRESS]: 'loading',
+  [TODO_STATUS.COMPLETED]: 'pass-filled',
+};
+
+/** Text-based status display for tool output formatting. */
+export const STATUS_DISPLAY: Record<
+  TodoStatus,
+  { icon: string; label: string }
+> = {
+  [TODO_STATUS.PENDING]: { icon: '\u25CB', label: 'PENDING' },
+  [TODO_STATUS.IN_PROGRESS]: { icon: '\u25D0', label: 'IN PROGRESS' },
+  [TODO_STATUS.COMPLETED]: { icon: '\u25CF', label: 'COMPLETED' },
+};

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -160,6 +160,15 @@ export const permissionCardStyles: CSSResult = css`
     border-radius: var(--border-radius-small);
   }
 
+  .plan-steps-list {
+    margin: var(--spacing-small) 0;
+    padding-left: var(--spacing-xlarge);
+  }
+
+  .plan-steps-list li {
+    margin-bottom: var(--spacing-small);
+  }
+
   .feedback-section {
     margin-top: var(--spacing-large);
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -4,7 +4,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-requests,
   .bash-approval-requests,
   .retry-requests,
-  .workflow-proposals {
+  .workflow-proposals,
+  .plan-approval-requests {
     margin: var(--spacing-large) 0;
     padding: var(--spacing-large);
     border-radius: var(--border-radius-large);
@@ -17,7 +18,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-requests__header,
   .bash-approval-requests__header,
   .retry-requests__header,
-  .workflow-proposals__header {
+  .workflow-proposals__header,
+  .plan-approval-requests__header {
     display: flex;
     align-items: center;
     gap: var(--spacing-medium);
@@ -28,7 +30,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-requests__list,
   .bash-approval-requests__list,
   .retry-requests__list,
-  .workflow-proposals__list {
+  .workflow-proposals__list,
+  .plan-approval-requests__list {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-large);
@@ -37,7 +40,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request,
   .bash-approval-request,
   .retry-request,
-  .workflow-proposal {
+  .workflow-proposal,
+  .plan-approval-request {
     display: flex;
     flex-direction: column;
     border-radius: var(--border-radius);
@@ -51,7 +55,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__details,
   .bash-approval-request__details,
   .retry-request__details,
-  .workflow-proposal__details {
+  .workflow-proposal__details,
+  .plan-approval-request__details {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-small);
@@ -70,7 +75,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__actions,
   .bash-approval-request__actions,
   .retry-request__actions,
-  .workflow-proposal__actions {
+  .workflow-proposal__actions,
+  .plan-approval-request__actions {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-small);
@@ -79,7 +85,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__actions::part(container),
   .bash-approval-request__actions::part(container),
   .retry-request__actions::part(container),
-  .workflow-proposal__actions::part(container) {
+  .workflow-proposal__actions::part(container),
+  .plan-approval-request__actions::part(container) {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-small);
@@ -88,14 +95,16 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__actions vscode-toolbar-button,
   .bash-approval-request__actions vscode-toolbar-button,
   .retry-request__actions vscode-toolbar-button,
-  .workflow-proposal__actions vscode-toolbar-button {
+  .workflow-proposal__actions vscode-toolbar-button,
+  .plan-approval-request__actions vscode-toolbar-button {
     min-width: auto;
   }
 
   .approval-request__actions vscode-toolbar-button::part(control),
   .bash-approval-request__actions vscode-toolbar-button::part(control),
   .retry-request__actions vscode-toolbar-button::part(control),
-  .workflow-proposal__actions vscode-toolbar-button::part(control) {
+  .workflow-proposal__actions vscode-toolbar-button::part(control),
+  .plan-approval-request__actions vscode-toolbar-button::part(control) {
     justify-content: flex-start;
     gap: var(--spacing-small);
   }
@@ -103,7 +112,8 @@ export const requestPanelStyles: CSSResult = css`
   /* Shared container chrome — approval, bash, and retry all use the same border/bg */
   .approval-requests,
   .bash-approval-requests,
-  .retry-requests {
+  .retry-requests,
+  .plan-approval-requests {
     border: var(--border-thin) solid var(--vscode-input-border);
     background: var(--vscode-editor-background);
   }
@@ -431,16 +441,57 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-textLink-foreground);
   }
 
-  /* Rejection feedback (shared across approval, bash, proposal) */
+  /* Plan approval requests */
+  .plan-approval-requests__header .codicon {
+    color: var(--vscode-textLink-foreground);
+  }
+
+  .plan-approval-request__summary {
+    font-weight: var(--font-weight-semibold);
+    color: var(--vscode-editor-foreground);
+  }
+
+  .plan-approval-request__steps {
+    margin: var(--spacing-small) 0;
+    padding-left: var(--spacing-xlarge);
+  }
+
+  .plan-approval-request__steps li {
+    margin-bottom: var(--spacing-small);
+  }
+
+  .plan-approval-request__step-desc {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .plan-approval-request__step-files {
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    margin-top: var(--spacing-tiny);
+  }
+
+  .plan-approval-request__file {
+    color: var(--vscode-textLink-foreground);
+  }
+
+  .plan-approval-request__actions vscode-toolbar-button {
+    flex: 1 1 12rem;
+  }
+
+  /* Rejection feedback (shared across approval, bash, proposal, plan-approval) */
   .approval-request__feedback,
   .bash-approval-request__feedback,
-  .workflow-proposal__feedback {
+  .workflow-proposal__feedback,
+  .plan-approval-request__feedback {
     margin-top: var(--spacing-small);
   }
 
   .approval-request__feedback-input,
   .bash-approval-request__feedback-input,
-  .workflow-proposal__feedback-input {
+  .workflow-proposal__feedback-input,
+  .plan-approval-request__feedback-input {
     width: 100%;
   }
 
@@ -452,6 +503,9 @@ export const requestPanelStyles: CSSResult = css`
     vscode-toolbar-button[data-action='reject']::part(control),
   .workflow-proposal--feedback-active
     .workflow-proposal__actions
+    vscode-toolbar-button[data-action='reject']::part(control),
+  .plan-approval-request--feedback-active
+    .plan-approval-request__actions
     vscode-toolbar-button[data-action='reject']::part(control) {
     color: var(--vscode-inputValidation-warningBorder);
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -1,11 +1,35 @@
-import { css, type CSSResult } from 'lit';
+import { css, unsafeCSS, type CSSResult } from 'lit';
+
+/**
+ * Shared selector groups for :is() consolidation.
+ * When adding a new request panel type, add its class names here
+ * and the shared layout rules apply automatically.
+ */
+const CONTAINERS = unsafeCSS(
+  '.approval-requests, .bash-approval-requests, .retry-requests, .workflow-proposals, .plan-approval-requests',
+);
+const HEADERS = unsafeCSS(
+  '.approval-requests__header, .bash-approval-requests__header, .retry-requests__header, .workflow-proposals__header, .plan-approval-requests__header',
+);
+const LISTS = unsafeCSS(
+  '.approval-requests__list, .bash-approval-requests__list, .retry-requests__list, .workflow-proposals__list, .plan-approval-requests__list',
+);
+const ITEMS = unsafeCSS(
+  '.approval-request, .bash-approval-request, .retry-request, .workflow-proposal, .plan-approval-request',
+);
+const DETAILS = unsafeCSS(
+  '.approval-request__details, .bash-approval-request__details, .retry-request__details, .workflow-proposal__details, .plan-approval-request__details',
+);
+const ACTIONS = unsafeCSS(
+  '.approval-request__actions, .bash-approval-request__actions, .retry-request__actions, .workflow-proposal__actions, .plan-approval-request__actions',
+);
 
 export const requestPanelStyles: CSSResult = css`
-  .approval-requests,
-  .bash-approval-requests,
-  .retry-requests,
-  .workflow-proposals,
-  .plan-approval-requests {
+  /* ================================================================
+   * Shared request panel layout (all panel types)
+   * ================================================================ */
+
+  :is(${CONTAINERS}) {
     margin: var(--spacing-large) 0;
     padding: var(--spacing-large);
     border-radius: var(--border-radius-large);
@@ -15,11 +39,7 @@ export const requestPanelStyles: CSSResult = css`
     gap: var(--spacing-large);
   }
 
-  .approval-requests__header,
-  .bash-approval-requests__header,
-  .retry-requests__header,
-  .workflow-proposals__header,
-  .plan-approval-requests__header {
+  :is(${HEADERS}) {
     display: flex;
     align-items: center;
     gap: var(--spacing-medium);
@@ -27,21 +47,13 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-editor-foreground);
   }
 
-  .approval-requests__list,
-  .bash-approval-requests__list,
-  .retry-requests__list,
-  .workflow-proposals__list,
-  .plan-approval-requests__list {
+  :is(${LISTS}) {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-large);
   }
 
-  .approval-request,
-  .bash-approval-request,
-  .retry-request,
-  .workflow-proposal,
-  .plan-approval-request {
+  :is(${ITEMS}) {
     display: flex;
     flex-direction: column;
     border-radius: var(--border-radius);
@@ -52,11 +64,7 @@ export const requestPanelStyles: CSSResult = css`
     position: relative;
   }
 
-  .approval-request__details,
-  .bash-approval-request__details,
-  .retry-request__details,
-  .workflow-proposal__details,
-  .plan-approval-request__details {
+  :is(${DETAILS}) {
     display: flex;
     flex-direction: column;
     gap: var(--spacing-small);
@@ -72,44 +80,28 @@ export const requestPanelStyles: CSSResult = css`
     flex-wrap: wrap;
   }
 
-  .approval-request__actions,
-  .bash-approval-request__actions,
-  .retry-request__actions,
-  .workflow-proposal__actions,
-  .plan-approval-request__actions {
+  :is(${ACTIONS}) {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-small);
   }
 
-  .approval-request__actions::part(container),
-  .bash-approval-request__actions::part(container),
-  .retry-request__actions::part(container),
-  .workflow-proposal__actions::part(container),
-  .plan-approval-request__actions::part(container) {
+  :is(${ACTIONS})::part(container) {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-small);
   }
 
-  .approval-request__actions vscode-toolbar-button,
-  .bash-approval-request__actions vscode-toolbar-button,
-  .retry-request__actions vscode-toolbar-button,
-  .workflow-proposal__actions vscode-toolbar-button,
-  .plan-approval-request__actions vscode-toolbar-button {
+  :is(${ACTIONS}) vscode-toolbar-button {
     min-width: auto;
   }
 
-  .approval-request__actions vscode-toolbar-button::part(control),
-  .bash-approval-request__actions vscode-toolbar-button::part(control),
-  .retry-request__actions vscode-toolbar-button::part(control),
-  .workflow-proposal__actions vscode-toolbar-button::part(control),
-  .plan-approval-request__actions vscode-toolbar-button::part(control) {
+  :is(${ACTIONS}) vscode-toolbar-button::part(control) {
     justify-content: flex-start;
     gap: var(--spacing-small);
   }
 
-  /* Shared container chrome — approval, bash, and retry all use the same border/bg */
+  /* Shared container chrome — approval, bash, retry, and plan use the same border/bg */
   .approval-requests,
   .bash-approval-requests,
   .retry-requests,
@@ -124,7 +116,10 @@ export const requestPanelStyles: CSSResult = css`
     flex: 1 1 12rem;
   }
 
-  /* Approval requests */
+  /* ================================================================
+   * Approval requests (tool edits)
+   * ================================================================ */
+
   .approval-requests__header .codicon {
     color: var(--vscode-editor-foreground);
   }
@@ -204,7 +199,10 @@ export const requestPanelStyles: CSSResult = css`
     transform: rotate(180deg);
   }
 
-  /* Bash approval requests */
+  /* ================================================================
+   * Bash approval requests
+   * ================================================================ */
+
   .bash-approval-requests__header .codicon {
     color: var(--vscode-terminal-ansiYellow);
   }
@@ -223,7 +221,10 @@ export const requestPanelStyles: CSSResult = css`
     word-break: break-word;
   }
 
-  /* Retry requests */
+  /* ================================================================
+   * Retry requests
+   * ================================================================ */
+
   .retry-requests__header .codicon {
     color: var(--color-warning);
   }
@@ -295,7 +296,10 @@ export const requestPanelStyles: CSSResult = css`
     border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
   }
 
-  /* Workflow proposals */
+  /* ================================================================
+   * Workflow proposals
+   * ================================================================ */
+
   .workflow-proposals {
     border: var(--border-thin) solid var(--vscode-inputValidation-infoBorder);
     background: var(--vscode-inputValidation-infoBackground);
@@ -441,7 +445,10 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-textLink-foreground);
   }
 
-  /* Plan approval requests */
+  /* ================================================================
+   * Plan approval requests
+   * ================================================================ */
+
   .plan-approval-requests__header .codicon {
     color: var(--vscode-textLink-foreground);
   }
@@ -480,7 +487,10 @@ export const requestPanelStyles: CSSResult = css`
     flex: 1 1 12rem;
   }
 
-  /* Rejection feedback (shared across approval, bash, proposal, plan-approval) */
+  /* ================================================================
+   * Rejection feedback (shared across panels with feedback support)
+   * ================================================================ */
+
   .approval-request__feedback,
   .bash-approval-request__feedback,
   .workflow-proposal__feedback,

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -11,6 +11,7 @@ export const PERMISSION_KIND = {
   BASH: 'bash',
   RETRY: 'retry',
   PROPOSAL: 'proposal',
+  PLAN_APPROVAL: 'planApproval',
 } as const;
 
 export type PermissionKind =
@@ -21,6 +22,7 @@ export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
   PERMISSION_KIND.TOOL_EDIT,
   PERMISSION_KIND.BASH,
   PERMISSION_KIND.PROPOSAL,
+  PERMISSION_KIND.PLAN_APPROVAL,
 ]);
 
 /** Generates the getting started banner HTML with command links. */

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -8,6 +8,7 @@
  */
 
 // Local file imports - individual approval modules
+import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingBashApprovals,
@@ -27,24 +28,26 @@ import {
 
 /**
  * Clean up all approval state for a deleted stream.
- * Handles pending approvals (tool edits + bash) and YOLO mode state.
+ * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
  */
 export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   _rejectPendingToolEditApprovalsForStream(streamId);
   _rejectPendingBashApprovalsForStream(streamId);
   _clearApprovalBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
+  planApprovalCoordinator.clearForStream(streamId);
 }
 
 /**
  * Clean up all approval state when deleting all streams.
- * Handles pending approvals (tool edits + bash) and YOLO mode state.
+ * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
  */
 export function cleanupAllApprovals(): void {
   _rejectAllPendingToolEditApprovals();
   _rejectAllPendingBashApprovals();
   _clearAllApprovalBypass();
   _clearAllProposalBypass();
+  planApprovalCoordinator.clearAll();
 }
 
 // Re-export commonly used functions from individual modules

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -5,12 +5,20 @@
  * outline an implementation strategy with numbered steps, descriptions, and file
  * references — giving the user visibility into the agent's approach before and
  * during execution.
+ *
+ * When a new plan is created (all steps pending), the tool pauses execution and
+ * waits for user approval before returning. Progress updates (steps already
+ * in_progress or completed) are applied immediately without approval.
  */
 
 // Third-party imports
 import { z } from 'zod';
 
 // Local imports - tools
+import {
+  planApprovalCoordinator,
+  type PlanApprovalResult,
+} from '@agent/runtime/PlanApprovalCoordinator';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -24,6 +32,9 @@ import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
 const logger = new AgentLogger('PlanTool');
+
+/** Counter for generating unique approval IDs */
+let approvalCounter = 0;
 
 /** Configuration for displaying plan step status — icon and label for each status */
 const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {
@@ -56,6 +67,11 @@ export type PlanToolInput = z.infer<typeof PlanToolInputSchema>;
  * - description: What the step involves
  * - status: pending | in_progress | completed
  * - files: Optional list of files involved
+ *
+ * When you create a NEW plan (all steps pending), execution pauses until the
+ * user approves. If the user rejects, you will receive their feedback and
+ * should revise your approach accordingly. Progress updates (updating step
+ * statuses on an existing plan) are applied immediately.
  */
 export class PlanTool extends defineTool({
   name: 'plan',
@@ -66,6 +82,11 @@ Use this tool to:
 - Break down complex tasks into numbered steps with descriptions
 - Show which files will be involved in each step
 - Track progress through the plan as you work
+
+IMPORTANT: When you create a new plan (all steps are "pending"), the plan is
+presented to the user for approval. Execution pauses until they approve or reject.
+If rejected, you receive their feedback and should revise the plan. Progress
+updates (marking steps in_progress or completed) are applied immediately.
 
 Plan structure:
 - summary: Brief overview of the approach (1-3 sentences)
@@ -99,14 +120,73 @@ Best practices:
       };
     }
 
-    // Update the plan in workspace state
-    // This triggers the onUpdate callback which emits events to the UI
+    // Update the plan in workspace state — shows it in the UI immediately
     context.planState.updatePlan(input.plan);
 
+    // Determine if this is a new plan (all steps pending) vs. a progress update
+    const isNewPlan = input.plan.steps.every(
+      (s) => s.status === TODO_STATUS.PENDING,
+    );
+
+    if (isNewPlan && context.streamId) {
+      return this.requestApproval(input.plan, context.streamId);
+    }
+
+    return this.buildProgressResult(input.plan);
+  }
+
+  /**
+   * Request user approval for a new plan. Pauses execution until approved/rejected.
+   */
+  private async requestApproval(
+    plan: Plan,
+    streamId: string,
+  ): Promise<ToolResult> {
+    const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
+
+    logger.info(`Requesting approval for plan: ${plan.summary}`);
+
+    const result: PlanApprovalResult =
+      await planApprovalCoordinator.waitForApproval(streamId, {
+        approvalId,
+        plan,
+      });
+
+    if (result.action === 'approve') {
+      logger.info('Plan approved by user');
+      return {
+        summary: 'Plan approved — proceed with implementation',
+        output:
+          'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
+      };
+    }
+
+    // Rejected or timed out
+    const feedback = 'feedback' in result ? result.feedback : undefined;
+    const feedbackNote = feedback
+      ? `\nUser feedback: ${feedback}`
+      : '\nNo specific feedback was provided.';
+
+    logger.info(
+      `Plan rejected by user${feedback ? `: ${feedback}` : ''}`,
+    );
+
+    return {
+      summary: 'Plan rejected — revise approach',
+      output: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
+      isError: true,
+      ...(feedback ? { userInstruction: feedback } : {}),
+    };
+  }
+
+  /**
+   * Build result for a progress update (no approval needed).
+   */
+  private buildProgressResult(plan: Plan): ToolResult {
     let completedCount = 0;
     let inProgressCount = 0;
     let pendingCount = 0;
-    for (const s of input.plan.steps) {
+    for (const s of plan.steps) {
       if (s.status === TODO_STATUS.COMPLETED) completedCount++;
       else if (s.status === TODO_STATUS.IN_PROGRESS) inProgressCount++;
       else pendingCount++;
@@ -114,7 +194,6 @@ Best practices:
 
     const summary = `Plan updated: ${completedCount} completed, ${inProgressCount} in progress, ${pendingCount} pending`;
 
-    // Return minimal output — the UI already shows the plan
     return {
       summary,
       output: 'OK',

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -121,12 +121,16 @@ Best practices:
     // Show the plan in the UI immediately
     context.planState.updatePlan(input.plan);
 
-    if (isNewPlan && context.streamId) {
-      return this.requestApproval(
-        input.plan,
-        context.streamId,
-        context.planState,
-      );
+    if (isNewPlan) {
+      if (!context.streamId) {
+        logger.warn('New plan created without streamId — skipping approval gate');
+      } else {
+        return this.requestApproval(
+          input.plan,
+          context.streamId,
+          context.planState,
+        );
+      }
     }
 
     return this.buildProgressResult(input.plan);

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -166,7 +166,17 @@ Best practices:
     // Rejected or timed out — clear the plan from UI
     planState.updatePlan(null);
 
-    const feedback = 'feedback' in result ? result.feedback : undefined;
+    if (result.action === 'timeout') {
+      logger.warn('Plan approval timed out');
+      return {
+        summary: 'Plan approval timed out',
+        output:
+          'The plan approval request timed out before the user responded. Please try again or proceed without a plan.',
+        isError: true,
+      };
+    }
+
+    const feedback = result.feedback;
     const feedbackNote = feedback
       ? `\nUser feedback: ${feedback}`
       : '\nNo specific feedback was provided.';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -14,11 +14,11 @@ import { z } from 'zod';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
-  PLAN_STEP_STATUS,
+  TODO_STATUS,
   PlanSchema,
   type Plan,
   type PlanStep,
-  type PlanStepStatus,
+  type TodoStatus,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
@@ -26,12 +26,11 @@ import { defineTool } from '@tools/core/define';
 const logger = new AgentLogger('PlanTool');
 
 /** Configuration for displaying plan step status — icon and label for each status */
-const STATUS_DISPLAY: Record<PlanStepStatus, { icon: string; label: string }> =
-  {
-    [PLAN_STEP_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
-    [PLAN_STEP_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
-    [PLAN_STEP_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
-  };
+const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {
+  [TODO_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
+  [TODO_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
+  [TODO_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
+};
 
 /**
  * Schema for the plan tool input.
@@ -104,15 +103,14 @@ Best practices:
     // This triggers the onUpdate callback which emits events to the UI
     context.planState.updatePlan(input.plan);
 
-    const completedCount = input.plan.steps.filter(
-      (s) => s.status === PLAN_STEP_STATUS.COMPLETED,
-    ).length;
-    const inProgressCount = input.plan.steps.filter(
-      (s) => s.status === PLAN_STEP_STATUS.IN_PROGRESS,
-    ).length;
-    const pendingCount = input.plan.steps.filter(
-      (s) => s.status === PLAN_STEP_STATUS.PENDING,
-    ).length;
+    let completedCount = 0;
+    let inProgressCount = 0;
+    let pendingCount = 0;
+    for (const s of input.plan.steps) {
+      if (s.status === TODO_STATUS.COMPLETED) completedCount++;
+      else if (s.status === TODO_STATUS.IN_PROGRESS) inProgressCount++;
+      else pendingCount++;
+    }
 
     const summary = `Plan updated: ${completedCount} completed, ${inProgressCount} in progress, ${pendingCount} pending`;
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -24,9 +24,9 @@ import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInt
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   TODO_STATUS,
+  STATUS_DISPLAY,
   PlanSchema,
   type Plan,
-  type TodoStatus,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
@@ -35,13 +35,6 @@ const logger = new AgentLogger('PlanTool');
 
 /** Counter for generating unique approval IDs */
 let approvalCounter = 0;
-
-/** Configuration for displaying plan step status — icon and label for each status */
-const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {
-  [TODO_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
-  [TODO_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
-  [TODO_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
-};
 
 /**
  * Schema for the plan tool input.

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -15,6 +15,7 @@
 import { z } from 'zod';
 
 // Local imports - tools
+import { PlanState } from '@agent/core/AgentWorkspaceState';
 import {
   planApprovalCoordinator,
   type PlanApprovalResult,
@@ -119,16 +120,20 @@ Best practices:
       };
     }
 
-    // Update the plan in workspace state — shows it in the UI immediately
-    context.planState.updatePlan(input.plan);
-
     // Determine if this is a new plan (all steps pending) vs. a progress update
     const isNewPlan = input.plan.steps.every(
       (s) => s.status === TODO_STATUS.PENDING,
     );
 
+    // Show the plan in the UI immediately
+    context.planState.updatePlan(input.plan);
+
     if (isNewPlan && context.streamId) {
-      return this.requestApproval(input.plan, context.streamId);
+      return this.requestApproval(
+        input.plan,
+        context.streamId,
+        context.planState,
+      );
     }
 
     return this.buildProgressResult(input.plan);
@@ -140,6 +145,7 @@ Best practices:
   private async requestApproval(
     plan: Plan,
     streamId: string,
+    planState: PlanState,
   ): Promise<ToolResult> {
     const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
 
@@ -160,7 +166,9 @@ Best practices:
       };
     }
 
-    // Rejected or timed out
+    // Rejected or timed out — clear the plan from UI
+    planState.updatePlan(null);
+
     const feedback = 'feedback' in result ? result.feedback : undefined;
     const feedbackNote = feedback
       ? `\nUser feedback: ${feedback}`

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -25,7 +25,6 @@ import {
   TODO_STATUS,
   PlanSchema,
   type Plan,
-  type PlanStep,
   type TodoStatus,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -1,0 +1,145 @@
+/**
+ * Plan tool for creating structured implementation plans during tool-use agent sessions.
+ *
+ * Unlike todo_write (which tracks execution progress), this tool lets the agent
+ * outline an implementation strategy with numbered steps, descriptions, and file
+ * references — giving the user visibility into the agent's approach before and
+ * during execution.
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - tools
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { AgentLogger } from '@logger/AgentLogger';
+import {
+  PLAN_STEP_STATUS,
+  PlanSchema,
+  type Plan,
+  type PlanStep,
+  type PlanStepStatus,
+} from '@shared/schemas';
+import { type ToolResult } from '@tools/result';
+import { defineTool } from '@tools/core/define';
+
+const logger = new AgentLogger('PlanTool');
+
+/** Configuration for displaying plan step status — icon and label for each status */
+const STATUS_DISPLAY: Record<PlanStepStatus, { icon: string; label: string }> =
+  {
+    [PLAN_STEP_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
+    [PLAN_STEP_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
+    [PLAN_STEP_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
+  };
+
+/**
+ * Schema for the plan tool input.
+ * Uses PlanSchema from shared schemas as single source of truth.
+ */
+const PlanToolInputSchema = z.strictObject({
+  /** The implementation plan */
+  plan: PlanSchema.describe('The structured implementation plan'),
+});
+
+export type PlanToolInput = z.infer<typeof PlanToolInputSchema>;
+
+/**
+ * Tool for creating structured implementation plans during agent sessions.
+ *
+ * Use this tool to:
+ * - Outline a strategy before implementing complex changes
+ * - Show users the planned approach with steps, descriptions, and files
+ * - Track which plan steps are being worked on or completed
+ *
+ * Each step has:
+ * - title: Short name for the step
+ * - description: What the step involves
+ * - status: pending | in_progress | completed
+ * - files: Optional list of files involved
+ */
+export class PlanTool extends defineTool({
+  name: 'plan',
+  description: `Create a structured implementation plan to outline your approach before executing.
+
+Use this tool to:
+- Present a clear strategy to the user before making changes
+- Break down complex tasks into numbered steps with descriptions
+- Show which files will be involved in each step
+- Track progress through the plan as you work
+
+Plan structure:
+- summary: Brief overview of the approach (1-3 sentences)
+- steps: Ordered list of implementation steps, each with:
+  - title: Short step name (e.g., "Add authentication middleware")
+  - description: What the step involves and why
+  - status: pending | in_progress | completed
+  - files: List of files that will be created or modified
+
+Best practices:
+- Create the plan BEFORE starting implementation
+- Keep summaries concise — focus on the "why" and high-level "what"
+- Each step should be a distinct, meaningful unit of work
+- Update step statuses as you progress through the plan
+- Include file paths to help the user understand the scope`,
+  schema: PlanToolInputSchema,
+}) {
+  protected async execute(input: PlanToolInput): Promise<ToolResult> {
+    const context = getCurrentToolFileInteractionContext();
+
+    if (!context?.planState) {
+      logger.warn(
+        'plan called without planState in context — plan will not persist or display in UI',
+      );
+      return {
+        summary: 'Created plan (no active session)',
+        output: this.formatPlan(input.plan),
+        diagnostics: {
+          warning: 'No active plan context — plan may not persist',
+        },
+      };
+    }
+
+    // Update the plan in workspace state
+    // This triggers the onUpdate callback which emits events to the UI
+    context.planState.updatePlan(input.plan);
+
+    const completedCount = input.plan.steps.filter(
+      (s) => s.status === PLAN_STEP_STATUS.COMPLETED,
+    ).length;
+    const inProgressCount = input.plan.steps.filter(
+      (s) => s.status === PLAN_STEP_STATUS.IN_PROGRESS,
+    ).length;
+    const pendingCount = input.plan.steps.filter(
+      (s) => s.status === PLAN_STEP_STATUS.PENDING,
+    ).length;
+
+    const summary = `Plan updated: ${completedCount} completed, ${inProgressCount} in progress, ${pendingCount} pending`;
+
+    // Return minimal output — the UI already shows the plan
+    return {
+      summary,
+      output: 'OK',
+    };
+  }
+
+  /**
+   * Format the plan for display in the tool output (fallback when no UI context).
+   */
+  private formatPlan(plan: Plan): string {
+    const lines: string[] = [`Plan: ${plan.summary}`, ''];
+
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      if (!step) continue;
+      const { icon, label } = STATUS_DISPLAY[step.status];
+      lines.push(`${i + 1}. ${icon} [${label}] ${step.title}`);
+      lines.push(`   ${step.description}`);
+      if (step.files.length > 0) {
+        lines.push(`   Files: ${step.files.join(', ')}`);
+      }
+    }
+
+    return lines.join('\n');
+  }
+}

--- a/src/tools/plan/index.ts
+++ b/src/tools/plan/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Plan tool for creating structured implementation plans during tool-use agent sessions.
+ */
+
+export { PlanTool } from './PlanTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -30,6 +30,7 @@ import { WebSearchTool } from './web/WebSearchTool';
 import { WolframTool } from './wolfram';
 import { TexcountTool } from './texcount';
 import { CrossrefDoiTool, CrossrefSearchTool } from './citation';
+import { PlanTool } from './plan';
 import { TodoWriteTool } from './todo';
 import { MemoryTool } from './memory';
 import { ZoteroAddTool, ZoteroSearchTool, ZoteroExportTool } from './zotero';
@@ -90,6 +91,7 @@ function createDefaultTools() {
     web_fetch: new WebFetchTool(),
     web_search: new WebSearchTool(),
     todo_write: new TodoWriteTool(),
+    plan: new PlanTool(),
     memory: new MemoryTool(),
     lean_diagnostics: new LeanDiagnosticsTool(),
     lean_file: new LeanFileTool(),

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -14,6 +14,7 @@ import type {
 } from '@agent/runtime/AgentFlowResult';
 import type { ExecResult } from '@agent/types/ResultTypes';
 import type { ActiveChildInfo, SubagentProgressUpdate } from '@shared/schemas';
+import { TODO_STATUS } from '@shared/schemas/todo';
 import { formatDuration } from '@utils/core';
 
 // ============================================================================
@@ -116,15 +117,15 @@ export function formatSubagentProgress(
   switch (update.kind) {
     case 'todos': {
       const completed = update.todos.filter(
-        (t) => t.status === 'completed',
+        (t) => t.status === TODO_STATUS.COMPLETED,
       ).length;
       const inProgress = update.todos.filter(
-        (t) => t.status === 'in_progress',
+        (t) => t.status === TODO_STATUS.IN_PROGRESS,
       ).length;
       const pending = update.todos.length - completed - inProgress;
       const TODO_PROGRESS_ICON: Record<string, string> = {
-        completed: '[x]',
-        in_progress: '[>]',
+        [TODO_STATUS.COMPLETED]: '[x]',
+        [TODO_STATUS.IN_PROGRESS]: '[>]',
       };
       const items = update.todos
         .map((t) => {
@@ -164,10 +165,10 @@ export function formatSubagentProgress(
       }
       const steps = update.plan.steps;
       const completed = steps.filter(
-        (s) => s.status === 'completed',
+        (s) => s.status === TODO_STATUS.COMPLETED,
       ).length;
       const inProgress = steps.filter(
-        (s) => s.status === 'in_progress',
+        (s) => s.status === TODO_STATUS.IN_PROGRESS,
       ).length;
       const pending = steps.length - completed - inProgress;
       return `<subagent-progress ${idAttr} ${agentAttr} type="plan" steps="${steps.length}" completed="${completed}" active="${inProgress}" pending="${pending}" />`;

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -158,6 +158,21 @@ export function formatSubagentProgress(
       return `<subagent-progress ${idAttr} ${agentAttr} ${attrs.join(' ')} />`;
     }
 
+    case 'plan': {
+      if (!update.plan) {
+        return `<subagent-progress ${idAttr} ${agentAttr} type="plan" status="cleared" />`;
+      }
+      const steps = update.plan.steps;
+      const completed = steps.filter(
+        (s) => s.status === 'completed',
+      ).length;
+      const inProgress = steps.filter(
+        (s) => s.status === 'in_progress',
+      ).length;
+      const pending = steps.length - completed - inProgress;
+      return `<subagent-progress ${idAttr} ${agentAttr} type="plan" steps="${steps.length}" completed="${completed}" active="${inProgress}" pending="${pending}" />`;
+    }
+
     case 'started':
       return `<subagent-progress ${idAttr} ${agentAttr} type="started" />`;
   }

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -14,21 +14,14 @@ import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInt
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   TODO_STATUS,
+  STATUS_DISPLAY,
   TodoItemSchema,
   type TodoItem,
-  type TodoStatus,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
 const logger = new AgentLogger('TodoWriteTool');
-
-/** Configuration for displaying todo status - icon and label for each status */
-const STATUS_DISPLAY: Record<TodoStatus, { icon: string; label: string }> = {
-  [TODO_STATUS.PENDING]: { icon: '○', label: 'PENDING' },
-  [TODO_STATUS.IN_PROGRESS]: { icon: '◐', label: 'IN PROGRESS' },
-  [TODO_STATUS.COMPLETED]: { icon: '●', label: 'COMPLETED' },
-};
 
 /**
  * Schema for the todo_write tool input.

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -105,15 +105,14 @@ Best practices:
     // This triggers the onUpdate callback which emits events to the UI
     context.todoState.updateTodos(input.todos);
 
-    const inProgressCount = input.todos.filter(
-      (t) => t.status === TODO_STATUS.IN_PROGRESS,
-    ).length;
-    const completedCount = input.todos.filter(
-      (t) => t.status === TODO_STATUS.COMPLETED,
-    ).length;
-    const pendingCount = input.todos.filter(
-      (t) => t.status === TODO_STATUS.PENDING,
-    ).length;
+    let completedCount = 0;
+    let inProgressCount = 0;
+    let pendingCount = 0;
+    for (const t of input.todos) {
+      if (t.status === TODO_STATUS.COMPLETED) completedCount++;
+      else if (t.status === TODO_STATUS.IN_PROGRESS) inProgressCount++;
+      else pendingCount++;
+    }
 
     const summary = `Todo list updated: ${completedCount} completed, ${inProgressCount} in progress, ${pendingCount} pending`;
 


### PR DESCRIPTION
Adds a new `plan` tool that lets agents create and display structured
implementation plans, separate from the existing `todo_write` task
tracker. The plan tool follows the same architecture pattern (schema →
tool → state → event bus → webview) and renders in the progress view
with numbered steps, descriptions, file references, and status
indicators.

https://claude.ai/code/session_01FGV43ugYZsHPXVhbBtCbqu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new approval-gated `plan` workflow that pauses execution awaiting user input and threads new state through core flow and progress view messaging, which could impact run lifecycle/cleanup if edge cases are missed.
> 
> **Overview**
> Adds a new structured `plan` capability alongside todos: introduces `PlanSchema`/`PlanState` persisted in `AgentWorkspaceState`, propagated through tool execution context, and emitted to the progress view via a new `updatePlan` event/message.
> 
> Implements a new `plan` tool (`PlanTool`) that updates plan state and, when creating an all-*pending* plan, blocks on a new promise-based `PlanApprovalCoordinator` (approve/reject with optional feedback), with cleanup wired into interruption/stream deletion paths.
> 
> Extends the progress view to render plans and plan-approval prompts (new permission kind, request panel, and `PlanView`), and factors shared todo/plan status display constants into `todoDisplay` (also adjusting some todo rendering keys/formatting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf7f1d76754044e8a7b8fad5d75f0b231de7899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->