### PR TITLE
Add support for Google GenAI, OpenAI Response API, and OpenAI Chat Completions

### DIFF
--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -275,7 +275,11 @@ function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
       b.type === 'image_url'
     ) {
       parts.push({ type: 'attachment', attachmentType: 'image' });
-    } else if (b.type === 'document' || b.type === 'input_file') {
+    } else if (
+      b.type === 'document' ||
+      b.type === 'input_file' ||
+      b.type === 'file'
+    ) {
       parts.push({ type: 'attachment', attachmentType: 'document' });
     }
   }

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -328,8 +328,11 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         input: JSON.stringify(block.input ?? {}, null, 2),
       };
 
-    // Anthropic: tool_result blocks (from Google conversion or nested)
+    // Tool result blocks: Anthropic tool_result + server-side code execution results
     case 'tool_result':
+    case 'code_execution_tool_result':
+    case 'bash_code_execution_tool_result':
+    case 'text_editor_code_execution_tool_result':
       return {
         kind: 'tool-result',
         text:
@@ -362,18 +365,6 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         url: block.url,
         title: block.title,
         content: block.page_content,
-      };
-
-    // Anthropic: server-side code execution results
-    case 'code_execution_tool_result':
-    case 'bash_code_execution_tool_result':
-    case 'text_editor_code_execution_tool_result':
-      return {
-        kind: 'tool-result',
-        text:
-          typeof block.content === 'string'
-            ? block.content
-            : JSON.stringify(block.content ?? '', null, 2),
       };
 
     default:

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -56,6 +56,10 @@ const ConversationMessageSchema = z.looseObject({
   content: z
     .union([z.string(), z.array(ContentBlockSchema), z.unknown()])
     .optional(),
+  // Google GenAI uses `parts` instead of `content`
+  parts: z.array(z.unknown()).optional(),
+  // OpenAI Chat Completions: tool_calls on assistant messages
+  tool_calls: z.array(z.unknown()).optional(),
 });
 type ConversationMessage = z.infer<typeof ConversationMessageSchema>;
 
@@ -196,6 +200,13 @@ function latexListing(text: string): string {
 // ============================================================
 
 function extractBlocks(msg: ConversationMessage): ContentBlock[] {
+  // Google GenAI: field-based Parts → type-based ContentBlocks
+  if (Array.isArray(msg.parts)) {
+    return (msg.parts as Record<string, unknown>[]).flatMap(
+      googlePartToBlocks,
+    );
+  }
+
   if (typeof msg.content === 'string') {
     return [{ type: 'text', text: msg.content }];
   }
@@ -208,13 +219,61 @@ function extractBlocks(msg: ConversationMessage): ContentBlock[] {
   return [];
 }
 
+/** Convert a Google GenAI Part (field-based discrimination) to type-based ContentBlock(s). */
+function googlePartToBlocks(
+  part: Record<string, unknown>,
+): ContentBlock[] {
+  if (typeof part.text === 'string') {
+    return [{ type: 'text', text: part.text }];
+  }
+  if (typeof part.thought === 'string') {
+    return [{ type: 'thinking', thinking: part.thought }];
+  }
+  if (part.functionCall && typeof part.functionCall === 'object') {
+    const fc = part.functionCall as { name?: string; args?: unknown };
+    return [
+      {
+        type: 'tool_use',
+        name: fc.name ?? 'unknown',
+        input: fc.args ?? {},
+      },
+    ];
+  }
+  if (part.functionResponse && typeof part.functionResponse === 'object') {
+    const fr = part.functionResponse as {
+      name?: string;
+      response?: unknown;
+    };
+    return [
+      {
+        type: 'tool_result',
+        content:
+          typeof fr.response === 'string'
+            ? fr.response
+            : JSON.stringify(fr.response ?? '', null, 2),
+      },
+    ];
+  }
+  if (part.inlineData && typeof part.inlineData === 'object') {
+    const data = part.inlineData as { mimeType?: string };
+    return [
+      { type: data.mimeType?.startsWith('image/') ? 'image' : 'document' },
+    ];
+  }
+  return [];
+}
+
 function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
   const parts: UserPart[] = [];
   for (const b of blocks) {
     // Anthropic: 'text', OpenAI Response API: 'input_text'
     if ((b.type === 'text' || b.type === 'input_text') && b.text) {
       parts.push({ type: 'text', text: b.text });
-    } else if (b.type === 'image' || b.type === 'input_image') {
+    } else if (
+      b.type === 'image' ||
+      b.type === 'input_image' ||
+      b.type === 'image_url'
+    ) {
       parts.push({ type: 'attachment', attachmentType: 'image' });
     } else if (b.type === 'document' || b.type === 'input_file') {
       parts.push({ type: 'attachment', attachmentType: 'document' });
@@ -239,6 +298,7 @@ function extractToolResultText(block: ContentBlock): string | undefined {
 function assistantBlockToNode(block: ContentBlock): ExportNode | null {
   switch (block.type) {
     case 'thinking':
+    case 'redacted_thinking':
       return null;
 
     // Anthropic: 'text', OpenAI Response API: 'output_text'
@@ -253,6 +313,16 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         kind: 'tool-call',
         name: block.name ?? 'unknown',
         input: JSON.stringify(block.input ?? {}, null, 2),
+      };
+
+    // Anthropic: tool_result blocks (from Google conversion or nested)
+    case 'tool_result':
+      return {
+        kind: 'tool-result',
+        text:
+          typeof block.content === 'string'
+            ? block.content
+            : JSON.stringify(block.content ?? '', null, 2),
       };
 
     case 'server_tool_use':
@@ -279,6 +349,18 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
         url: block.url,
         title: block.title,
         content: block.page_content,
+      };
+
+    // Anthropic: server-side code execution results
+    case 'code_execution_tool_result':
+    case 'bash_code_execution_tool_result':
+    case 'text_editor_code_execution_tool_result':
+      return {
+        kind: 'tool-result',
+        text:
+          typeof block.content === 'string'
+            ? block.content
+            : JSON.stringify(block.content ?? '', null, 2),
       };
 
     default:
@@ -334,13 +416,31 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
       continue;
     }
 
-    if (role === 'assistant') {
+    // Google GenAI uses 'model' role instead of 'assistant'
+    if (role === 'assistant' || role === 'model') {
       lastAssistantHadToolUse = false;
       for (const block of blocks) {
         const node = assistantBlockToNode(block);
         if (node) {
           if (node.kind === 'tool-call') lastAssistantHadToolUse = true;
           nodes.push(node);
+        }
+      }
+
+      // OpenAI Chat Completions: tool_calls array on assistant messages
+      if (Array.isArray(msg.tool_calls)) {
+        for (const tc of msg.tool_calls as Record<string, unknown>[]) {
+          const fn = tc.function as
+            | { name?: string; arguments?: string }
+            | undefined;
+          if (fn) {
+            nodes.push({
+              kind: 'tool-call',
+              name: fn.name ?? 'unknown',
+              input: fn.arguments ?? '{}',
+            });
+            lastAssistantHadToolUse = true;
+          }
         }
       }
       continue;

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -223,11 +223,13 @@ function extractBlocks(msg: ConversationMessage): ContentBlock[] {
 function googlePartToBlocks(
   part: Record<string, unknown>,
 ): ContentBlock[] {
+  // Google GenAI: thought is a boolean flag; the actual text is in part.text.
+  // Must check before the plain text branch to avoid exposing thinking as assistant text.
+  if (part.thought === true && typeof part.text === 'string') {
+    return [{ type: 'thinking', thinking: part.text }];
+  }
   if (typeof part.text === 'string') {
     return [{ type: 'text', text: part.text }];
-  }
-  if (typeof part.thought === 'string') {
-    return [{ type: 'thinking', thinking: part.thought }];
   }
   if (part.functionCall && typeof part.functionCall === 'object') {
     const fc = part.functionCall as { name?: string; args?: unknown };
@@ -256,6 +258,13 @@ function googlePartToBlocks(
   }
   if (part.inlineData && typeof part.inlineData === 'object') {
     const data = part.inlineData as { mimeType?: string };
+    return [
+      { type: data.mimeType?.startsWith('image/') ? 'image' : 'document' },
+    ];
+  }
+  // Google GenAI: URI-based file data (uploaded files over the inline threshold)
+  if (part.fileData && typeof part.fileData === 'object') {
+    const data = part.fileData as { mimeType?: string };
     return [
       { type: data.mimeType?.startsWith('image/') ? 'image' : 'document' },
     ];
@@ -391,13 +400,30 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
       continue;
     }
 
-    // OpenAI Response API: top-level function_call_output items
+    // OpenAI Response API: top-level function_call_output items.
+    // output can be a string OR an array of input_text/input_file/input_image parts.
     if (item.type === 'function_call_output') {
-      const output =
-        typeof item.output === 'string'
-          ? item.output
-          : JSON.stringify(item.output ?? '', null, 2);
-      nodes.push({ kind: 'tool-result', text: output });
+      if (Array.isArray(item.output)) {
+        const textParts: string[] = [];
+        for (const part of item.output as Record<string, unknown>[]) {
+          if (part.type === 'input_text' && typeof part.text === 'string') {
+            textParts.push(part.text);
+          } else if (part.type === 'input_image') {
+            textParts.push('[image attachment]');
+          } else if (part.type === 'input_file') {
+            textParts.push('[file attachment]');
+          }
+        }
+        if (textParts.length) {
+          nodes.push({ kind: 'tool-result', text: textParts.join('\n') });
+        }
+      } else {
+        const output =
+          typeof item.output === 'string'
+            ? item.output
+            : JSON.stringify(item.output ?? '', null, 2);
+        nodes.push({ kind: 'tool-result', text: output });
+      }
       lastAssistantHadToolUse = false;
       continue;
     }

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -20,7 +20,8 @@ import latexPreamble from '../../../resources/templates/chatExport.tex';
 // Input schemas (single source of truth)
 // ============================================================
 
-/** Loose schema for API content blocks — accepts many optional fields. */
+/** Loose schema for API content blocks — accepts many optional fields.
+ *  Covers Anthropic, OpenAI Chat Completions, and OpenAI Response API formats. */
 const ContentBlockSchema = z.looseObject({
   type: z.string(),
   text: z.string().optional(),
@@ -44,6 +45,9 @@ const ContentBlockSchema = z.looseObject({
   url: z.string().optional(),
   title: z.string().optional(),
   page_content: z.string().optional(),
+  // OpenAI Response API fields
+  arguments: z.string().optional(),
+  output: z.string().optional(),
 });
 type ContentBlock = z.infer<typeof ContentBlockSchema>;
 
@@ -207,11 +211,12 @@ function extractBlocks(msg: ConversationMessage): ContentBlock[] {
 function blocksToUserParts(blocks: ContentBlock[]): UserPart[] {
   const parts: UserPart[] = [];
   for (const b of blocks) {
-    if (b.type === 'text' && b.text) {
+    // Anthropic: 'text', OpenAI Response API: 'input_text'
+    if ((b.type === 'text' || b.type === 'input_text') && b.text) {
       parts.push({ type: 'text', text: b.text });
-    } else if (b.type === 'image') {
+    } else if (b.type === 'image' || b.type === 'input_image') {
       parts.push({ type: 'attachment', attachmentType: 'image' });
-    } else if (b.type === 'document') {
+    } else if (b.type === 'document' || b.type === 'input_file') {
       parts.push({ type: 'attachment', attachmentType: 'document' });
     }
   }
@@ -224,7 +229,8 @@ function extractToolResultText(block: ContentBlock): string | undefined {
       ? block.content
       : JSON.stringify(block.content, null, 2);
   }
-  if (block.type === 'text' && block.text) {
+  // Anthropic: 'text', OpenAI Response API: 'input_text'
+  if ((block.type === 'text' || block.type === 'input_text') && block.text) {
     return block.text;
   }
   return undefined;
@@ -235,7 +241,9 @@ function assistantBlockToNode(block: ContentBlock): ExportNode | null {
     case 'thinking':
       return null;
 
+    // Anthropic: 'text', OpenAI Response API: 'output_text'
     case 'text':
+    case 'output_text':
       return block.text?.trim()
         ? { kind: 'assistant-text', text: block.text }
         : null;
@@ -283,7 +291,32 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
   let lastAssistantHadToolUse = false;
 
   for (const raw of messages) {
-    const msg = raw as ConversationMessage;
+    const item = raw as Record<string, unknown>;
+
+    // OpenAI Response API: top-level function_call items (not wrapped in a message)
+    if (item.type === 'function_call') {
+      const name = typeof item.name === 'string' ? item.name : 'unknown';
+      const args =
+        typeof item.arguments === 'string'
+          ? item.arguments
+          : JSON.stringify(item.arguments ?? {}, null, 2);
+      nodes.push({ kind: 'tool-call', name, input: args });
+      lastAssistantHadToolUse = true;
+      continue;
+    }
+
+    // OpenAI Response API: top-level function_call_output items
+    if (item.type === 'function_call_output') {
+      const output =
+        typeof item.output === 'string'
+          ? item.output
+          : JSON.stringify(item.output ?? '', null, 2);
+      nodes.push({ kind: 'tool-result', text: output });
+      lastAssistantHadToolUse = false;
+      continue;
+    }
+
+    const msg = item as ConversationMessage;
     const role = msg.role ?? 'unknown';
     const blocks = extractBlocks(msg);
 
@@ -313,7 +346,7 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
       continue;
     }
 
-    // OpenAI tool role
+    // OpenAI Chat Completions tool role
     if (role === 'tool') {
       const text =
         typeof msg.content === 'string'

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -483,6 +483,7 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
           ? msg.content
           : JSON.stringify(msg.content, null, 2);
       nodes.push({ kind: 'tool-result', text });
+      lastAssistantHadToolUse = false;
     }
   }
 


### PR DESCRIPTION
## Summary
Extended the chat export formatter to support multiple AI API formats beyond Anthropic, including Google GenAI, OpenAI Response API, and OpenAI Chat Completions. This enables proper parsing and normalization of conversation exports from these different API providers.

## Key Changes

- **Schema Updates**: Extended `ContentBlockSchema` and `ConversationMessageSchema` to accept fields from Google GenAI (`parts`), OpenAI Response API (`arguments`, `output`), and OpenAI Chat Completions (`tool_calls`)

- **Google GenAI Support**: Added `googlePartToBlocks()` function to convert Google's field-based Part discrimination (text, thought, functionCall, functionResponse, inlineData) to the normalized type-based ContentBlock format

- **OpenAI Response API Support**: Added handling for top-level `function_call` and `function_call_output` items in message normalization, which are not wrapped in message objects like other APIs

- **OpenAI Chat Completions Support**: Added processing of `tool_calls` array on assistant messages, extracting function name and arguments for proper tool-call representation

- **Block Type Normalization**: Updated `blocksToUserParts()` and `extractToolResultText()` to recognize multiple type variants across APIs:
  - Text types: `text`, `input_text`, `output_text`
  - Image types: `image`, `input_image`, `image_url`
  - Document types: `document`, `input_file`, `file`

- **Assistant Role Handling**: Added support for Google GenAI's `model` role in addition to `assistant` role

- **Tool Result Handling**: Added support for Anthropic's code execution tool results (`code_execution_tool_result`, `bash_code_execution_tool_result`, `text_editor_code_execution_tool_result`) and generic `tool_result` blocks

- **Documentation**: Added inline comments clarifying which API formats use which fields and types

## Implementation Details
The changes maintain backward compatibility with existing Anthropic format support while gracefully handling the different structural approaches of other APIs. Google GenAI's parts-based format is converted to the internal ContentBlock representation early in the pipeline, while OpenAI's top-level function items are handled specially during message normalization.

https://claude.ai/code/session_01RB1wf714n2oF6Mtc2m47N1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parsing/normalization logic for chat exports; malformed or unhandled provider-specific shapes could change how tool calls/results and attachments are rendered.
> 
> **Overview**
> Extends `chatExportFormatter` message normalization to accept and correctly export conversations from **Google GenAI**, **OpenAI Response API**, and **OpenAI Chat Completions** in addition to the existing format.
> 
> This broadens the accepted input schemas (`parts`, `tool_calls`, Response API `function_call`/`function_call_output`) and adds conversion/normalization logic (including Google Part→block mapping, additional block type aliases for text/attachments, and more tool-result variants) so tool calls/results and roles like `model` render consistently in Markdown/LaTeX exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c7bdbb078342b12bb2a4d35b464e18db5973528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->