### PR TITLE
Add background tasks panel with real-time process output streaming

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -252,6 +252,8 @@ function reconcileOutputPoller(): void {
 /** Schedule the next poll cycle (serialized — next poll waits for current to finish). */
 function schedulePoll(): void {
   outputPollTimer = setTimeout(async () => {
+    // Clear stale timer ID so reconcileOutputPoller sees !outputPollTimer
+    outputPollTimer = null;
     if (pollInFlight) {
       schedulePoll();
       return;

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -231,14 +231,19 @@ const outputOffsets = new Map<
 let outputPollTimer: ReturnType<typeof setTimeout> | null = null;
 let pollInFlight = false;
 
+/** Check whether any tracked execution is a process handle. */
+function hasActiveProcesses(): boolean {
+  for (const h of registry.values()) {
+    if (h instanceof ProcessExecutionHandle) return true;
+  }
+  return false;
+}
+
 /** Start polling if there are active process handles; stop if none remain. */
 function reconcileOutputPoller(): void {
-  const hasProcesses = [...registry.values()].some(
-    (h) => h instanceof ProcessExecutionHandle,
-  );
-  if (hasProcesses && !outputPollTimer) {
+  if (hasActiveProcesses() && !outputPollTimer) {
     schedulePoll();
-  } else if (!hasProcesses && outputPollTimer) {
+  } else if (!hasActiveProcesses() && outputPollTimer) {
     clearTimeout(outputPollTimer);
     outputPollTimer = null;
   }
@@ -256,12 +261,7 @@ function schedulePoll(): void {
       await pollProcessOutputs();
     } finally {
       pollInFlight = false;
-      // Continue polling if processes remain
-      if ([...registry.values()].some((h) => h instanceof ProcessExecutionHandle)) {
-        schedulePoll();
-      } else {
-        outputPollTimer = null;
-      }
+      reconcileOutputPoller();
     }
   }, OUTPUT_POLL_INTERVAL_MS);
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -84,21 +84,25 @@ export function untrackExecution(executionId: string): void {
     emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
   }
 
-  // Emit process badge update on removal and flush final output
+  // Emit process badge update on removal and flush final output.
+  // The final read must complete before the badge update, because the
+  // badge handler prunes output entries for processes no longer active.
   if (handle instanceof ProcessExecutionHandle) {
-    // Final poll to capture any remaining output, then clean up offset
+    const finalize = (): void => {
+      outputOffsets.delete(executionId);
+      emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
+      reconcileOutputPoller();
+    };
     if (handle.outputPaths) {
       void readIncremental(
         executionId,
         handle.parentStreamId,
         handle.outputPaths.stdout,
         handle.outputPaths.stderr,
-      ).finally(() => outputOffsets.delete(executionId));
+      ).finally(finalize);
     } else {
-      outputOffsets.delete(executionId);
+      finalize();
     }
-    emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
-    reconcileOutputPoller();
   }
 }
 
@@ -291,6 +295,34 @@ async function pollProcessOutputs(): Promise<void> {
 /** Max bytes to read per file per poll — prevents huge allocations from chatty processes. */
 const MAX_READ_PER_POLL = 128 * 1024;
 
+/**
+ * Find the last byte index that ends a complete UTF-8 character.
+ * If the buffer ends mid-character, those trailing bytes are excluded
+ * so the next read starts at the right boundary.
+ */
+function lastCompleteUtf8(buf: Buffer, bytesRead: number): number {
+  if (bytesRead === 0) return 0;
+  // Walk backward (max 3 bytes — longest UTF-8 lead) looking for
+  // a continuation byte (10xxxxxx). If we find a lead byte, check
+  // whether the sequence is complete.
+  for (let i = bytesRead - 1; i >= Math.max(0, bytesRead - 3); i--) {
+    const b = buf[i];
+    // ASCII or single-byte — always complete
+    if (b < 0x80) return bytesRead;
+    // Continuation byte (10xxxxxx) — keep scanning for the lead
+    if ((b & 0xc0) === 0x80) continue;
+    // Lead byte — determine expected sequence length
+    let seqLen: number;
+    if ((b & 0xe0) === 0xc0) seqLen = 2;
+    else if ((b & 0xf0) === 0xe0) seqLen = 3;
+    else if ((b & 0xf8) === 0xf0) seqLen = 4;
+    else return bytesRead; // Invalid lead — let toString handle it
+    // Complete if all bytes of the sequence were read
+    return i + seqLen <= bytesRead ? bytesRead : i;
+  }
+  return bytesRead;
+}
+
 /** Read only the new bytes from a file starting at byteOffset (capped per poll). */
 async function readTail(
   path: string,
@@ -303,7 +335,9 @@ async function readTail(
     const toRead = Math.min(size - byteOffset, MAX_READ_PER_POLL);
     const buf = Buffer.alloc(toRead);
     const { bytesRead } = await fh.read(buf, 0, toRead, byteOffset);
-    return { text: buf.toString('utf-8', 0, bytesRead), newOffset: byteOffset + bytesRead };
+    // Avoid splitting multi-byte UTF-8 characters at the read boundary
+    const safeEnd = lastCompleteUtf8(buf, bytesRead);
+    return { text: buf.toString('utf-8', 0, safeEnd), newOffset: byteOffset + safeEnd };
   } finally {
     await fh.close();
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -288,7 +288,10 @@ async function pollProcessOutputs(): Promise<void> {
   await Promise.all(reads);
 }
 
-/** Read only the new bytes from a file starting at byteOffset. */
+/** Max bytes to read per file per poll — prevents huge allocations from chatty processes. */
+const MAX_READ_PER_POLL = 128 * 1024;
+
+/** Read only the new bytes from a file starting at byteOffset (capped per poll). */
 async function readTail(
   path: string,
   byteOffset: number,
@@ -297,8 +300,9 @@ async function readTail(
   try {
     const { size } = await fh.stat();
     if (size <= byteOffset) return { text: '', newOffset: byteOffset };
-    const buf = Buffer.alloc(size - byteOffset);
-    const { bytesRead } = await fh.read(buf, 0, buf.length, byteOffset);
+    const toRead = Math.min(size - byteOffset, MAX_READ_PER_POLL);
+    const buf = Buffer.alloc(toRead);
+    const { bytesRead } = await fh.read(buf, 0, toRead, byteOffset);
     return { text: buf.toString('utf-8', 0, bytesRead), newOffset: byteOffset + bytesRead };
   } finally {
     await fh.close();
@@ -327,7 +331,8 @@ async function readIncremental(
     bus.emit('updateProcessOutput', {
       parentStreamId,
       executionId,
-      output: out.text + err.text,
+      stdout: out.text,
+      stderr: err.text,
     });
   } catch {
     // File may have been deleted between check and read — ignore

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -5,6 +5,8 @@
  * change notification, and subagent lineage tracking in a single module.
  */
 
+import * as fs from 'fs';
+
 import { bus } from '@eventBus/ProgressEventBus';
 import type { StreamTabId } from '@shared/schemas';
 import {
@@ -64,6 +66,7 @@ export function trackExecution(handle: ExecutionHandle): void {
   // Emit process badge update for background bash processes
   if (handle instanceof ProcessExecutionHandle) {
     emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
+    reconcileOutputPoller();
   }
 }
 
@@ -81,9 +84,20 @@ export function untrackExecution(executionId: string): void {
     emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
   }
 
-  // Emit process badge update on removal
+  // Emit process badge update on removal and flush final output
   if (handle instanceof ProcessExecutionHandle) {
+    // Final poll to capture any remaining output before cleanup
+    if (handle.outputPaths) {
+      void readIncremental(
+        executionId,
+        handle.parentStreamId,
+        handle.outputPaths.stdout,
+        handle.outputPaths.stderr,
+      );
+    }
+    outputOffsets.delete(executionId);
     emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
+    reconcileOutputPoller();
   }
 }
 
@@ -198,6 +212,77 @@ export function waitForAnyExecutionChange(
  */
 export function interruptActiveChildren(parentStreamId: StreamTabId): void {
   interruptActiveChildrenImpl(parentStreamId, registry.values());
+}
+
+// ============================================================================
+// Process output polling
+// ============================================================================
+
+/** Interval at which temp files are read and pushed to the progress UI. */
+const OUTPUT_POLL_INTERVAL_MS = 500;
+
+/** Tracks how many bytes have already been sent per executionId. */
+const outputOffsets = new Map<string, number>();
+
+let outputPollTimer: ReturnType<typeof setInterval> | null = null;
+
+/** Start polling if there are active process handles; stop if none remain. */
+function reconcileOutputPoller(): void {
+  const hasProcesses = [...registry.values()].some(
+    (h) => h instanceof ProcessExecutionHandle,
+  );
+  if (hasProcesses && !outputPollTimer) {
+    outputPollTimer = setInterval(pollProcessOutputs, OUTPUT_POLL_INTERVAL_MS);
+  } else if (!hasProcesses && outputPollTimer) {
+    clearInterval(outputPollTimer);
+    outputPollTimer = null;
+  }
+}
+
+/** Read incremental output from temp files and emit to progress UI. */
+function pollProcessOutputs(): void {
+  for (const handle of registry.values()) {
+    if (!(handle instanceof ProcessExecutionHandle)) continue;
+    if (!handle.outputPaths) continue;
+
+    const { executionId, parentStreamId } = handle;
+
+    // Read both stdout and stderr, concatenated (stderr after stdout)
+    void readIncremental(
+      executionId,
+      parentStreamId,
+      handle.outputPaths.stdout,
+      handle.outputPaths.stderr,
+    );
+  }
+}
+
+async function readIncremental(
+  executionId: string,
+  parentStreamId: StreamTabId,
+  stdoutPath: string,
+  stderrPath: string,
+): Promise<void> {
+  try {
+    const [stdout, stderr] = await Promise.all([
+      fs.promises.readFile(stdoutPath, 'utf-8').catch(() => ''),
+      fs.promises.readFile(stderrPath, 'utf-8').catch(() => ''),
+    ]);
+    const full = stdout + stderr;
+    const offset = outputOffsets.get(executionId) ?? 0;
+    if (full.length <= offset) return;
+
+    const delta = full.slice(offset);
+    outputOffsets.set(executionId, full.length);
+
+    bus.emit('updateProcessOutput', {
+      parentStreamId,
+      executionId,
+      output: delta,
+    });
+  } catch {
+    // File may have been deleted between check and read — ignore
+  }
 }
 
 // ============================================================================

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -343,12 +343,18 @@ async function readTail(
   }
 }
 
+/** Guards against concurrent readIncremental calls for the same executionId. */
+const readingInProgress = new Set<string>();
+
 async function readIncremental(
   executionId: string,
   parentStreamId: StreamTabId,
   stdoutPath: string,
   stderrPath: string,
 ): Promise<void> {
+  // Skip if another read (poll or final flush) is already in flight.
+  if (readingInProgress.has(executionId)) return;
+  readingInProgress.add(executionId);
   try {
     const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
     const [out, err] = await Promise.all([
@@ -370,6 +376,8 @@ async function readIncremental(
     });
   } catch {
     // File may have been deleted between check and read — ignore
+  } finally {
+    readingInProgress.delete(executionId);
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -241,9 +241,10 @@ function hasActiveProcesses(): boolean {
 
 /** Start polling if there are active process handles; stop if none remain. */
 function reconcileOutputPoller(): void {
-  if (hasActiveProcesses() && !outputPollTimer) {
+  const active = hasActiveProcesses();
+  if (active && !outputPollTimer) {
     schedulePoll();
-  } else if (!hasActiveProcesses() && outputPollTimer) {
+  } else if (!active && outputPollTimer) {
     clearTimeout(outputPollTimer);
     outputPollTimer = null;
   }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -222,7 +222,7 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
 /** Interval at which temp files are read and pushed to the progress UI. */
 const OUTPUT_POLL_INTERVAL_MS = 500;
 
-/** Tracks how many characters have already been sent per executionId per stream. */
+/** Tracks byte offsets already sent per executionId per stream. */
 const outputOffsets = new Map<
   string,
   { stdout: number; stderr: number }
@@ -288,6 +288,23 @@ async function pollProcessOutputs(): Promise<void> {
   await Promise.all(reads);
 }
 
+/** Read only the new bytes from a file starting at byteOffset. */
+async function readTail(
+  path: string,
+  byteOffset: number,
+): Promise<{ text: string; newOffset: number }> {
+  const fh = await fs.promises.open(path, 'r');
+  try {
+    const { size } = await fh.stat();
+    if (size <= byteOffset) return { text: '', newOffset: byteOffset };
+    const buf = Buffer.alloc(size - byteOffset);
+    const { bytesRead } = await fh.read(buf, 0, buf.length, byteOffset);
+    return { text: buf.toString('utf-8', 0, bytesRead), newOffset: byteOffset + bytesRead };
+  } finally {
+    await fh.close();
+  }
+}
+
 async function readIncremental(
   executionId: string,
   parentStreamId: StreamTabId,
@@ -295,24 +312,22 @@ async function readIncremental(
   stderrPath: string,
 ): Promise<void> {
   try {
-    const [stdout, stderr] = await Promise.all([
-      fs.promises.readFile(stdoutPath, 'utf-8').catch(() => ''),
-      fs.promises.readFile(stderrPath, 'utf-8').catch(() => ''),
-    ]);
     const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
-    const stdoutDelta = stdout.slice(prev.stdout);
-    const stderrDelta = stderr.slice(prev.stderr);
-    if (!stdoutDelta && !stderrDelta) return;
+    const [out, err] = await Promise.all([
+      readTail(stdoutPath, prev.stdout).catch(() => ({ text: '', newOffset: prev.stdout })),
+      readTail(stderrPath, prev.stderr).catch(() => ({ text: '', newOffset: prev.stderr })),
+    ]);
+    if (!out.text && !err.text) return;
 
     outputOffsets.set(executionId, {
-      stdout: stdout.length,
-      stderr: stderr.length,
+      stdout: out.newOffset,
+      stderr: err.newOffset,
     });
 
     bus.emit('updateProcessOutput', {
       parentStreamId,
       executionId,
-      output: stdoutDelta + stderrDelta,
+      output: out.text + err.text,
     });
   } catch {
     // File may have been deleted between check and read — ignore

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -343,8 +343,11 @@ async function readTail(
   }
 }
 
-/** Guards against concurrent readIncremental calls for the same executionId. */
-const readingInProgress = new Set<string>();
+/**
+ * Tracks in-flight reads per executionId so concurrent calls can await
+ * rather than silently skipping (which would lose tail output on final flush).
+ */
+const readingInProgress = new Map<string, Promise<void>>();
 
 async function readIncremental(
   executionId: string,
@@ -352,32 +355,46 @@ async function readIncremental(
   stdoutPath: string,
   stderrPath: string,
 ): Promise<void> {
-  // Skip if another read (poll or final flush) is already in flight.
-  if (readingInProgress.has(executionId)) return;
-  readingInProgress.add(executionId);
+  // If another read is in flight, wait for it then read again —
+  // the final flush must not be skipped or it loses tail output.
+  const inflight = readingInProgress.get(executionId);
+  if (inflight) {
+    await inflight;
+  }
+
+  const work = (async () => {
+    try {
+      const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
+      const [out, err] = await Promise.all([
+        readTail(stdoutPath, prev.stdout).catch(() => ({ text: '', newOffset: prev.stdout })),
+        readTail(stderrPath, prev.stderr).catch(() => ({ text: '', newOffset: prev.stderr })),
+      ]);
+      if (!out.text && !err.text) return;
+
+      outputOffsets.set(executionId, {
+        stdout: out.newOffset,
+        stderr: err.newOffset,
+      });
+
+      bus.emit('updateProcessOutput', {
+        parentStreamId,
+        executionId,
+        stdout: out.text,
+        stderr: err.text,
+      });
+    } catch {
+      // File may have been deleted between check and read — ignore
+    }
+  })();
+
+  readingInProgress.set(executionId, work);
   try {
-    const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
-    const [out, err] = await Promise.all([
-      readTail(stdoutPath, prev.stdout).catch(() => ({ text: '', newOffset: prev.stdout })),
-      readTail(stderrPath, prev.stderr).catch(() => ({ text: '', newOffset: prev.stderr })),
-    ]);
-    if (!out.text && !err.text) return;
-
-    outputOffsets.set(executionId, {
-      stdout: out.newOffset,
-      stderr: err.newOffset,
-    });
-
-    bus.emit('updateProcessOutput', {
-      parentStreamId,
-      executionId,
-      stdout: out.text,
-      stderr: err.text,
-    });
-  } catch {
-    // File may have been deleted between check and read — ignore
+    await work;
   } finally {
-    readingInProgress.delete(executionId);
+    // Only clear if we're still the latest — another call may have replaced us
+    if (readingInProgress.get(executionId) === work) {
+      readingInProgress.delete(executionId);
+    }
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -86,16 +86,17 @@ export function untrackExecution(executionId: string): void {
 
   // Emit process badge update on removal and flush final output
   if (handle instanceof ProcessExecutionHandle) {
-    // Final poll to capture any remaining output before cleanup
+    // Final poll to capture any remaining output, then clean up offset
     if (handle.outputPaths) {
       void readIncremental(
         executionId,
         handle.parentStreamId,
         handle.outputPaths.stdout,
         handle.outputPaths.stderr,
-      );
+      ).finally(() => outputOffsets.delete(executionId));
+    } else {
+      outputOffsets.delete(executionId);
     }
-    outputOffsets.delete(executionId);
     emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
     reconcileOutputPoller();
   }
@@ -221,10 +222,14 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
 /** Interval at which temp files are read and pushed to the progress UI. */
 const OUTPUT_POLL_INTERVAL_MS = 500;
 
-/** Tracks how many bytes have already been sent per executionId. */
-const outputOffsets = new Map<string, number>();
+/** Tracks how many characters have already been sent per executionId per stream. */
+const outputOffsets = new Map<
+  string,
+  { stdout: number; stderr: number }
+>();
 
-let outputPollTimer: ReturnType<typeof setInterval> | null = null;
+let outputPollTimer: ReturnType<typeof setTimeout> | null = null;
+let pollInFlight = false;
 
 /** Start polling if there are active process handles; stop if none remain. */
 function reconcileOutputPoller(): void {
@@ -232,29 +237,52 @@ function reconcileOutputPoller(): void {
     (h) => h instanceof ProcessExecutionHandle,
   );
   if (hasProcesses && !outputPollTimer) {
-    outputPollTimer = setInterval(pollProcessOutputs, OUTPUT_POLL_INTERVAL_MS);
+    schedulePoll();
   } else if (!hasProcesses && outputPollTimer) {
-    clearInterval(outputPollTimer);
+    clearTimeout(outputPollTimer);
     outputPollTimer = null;
   }
 }
 
+/** Schedule the next poll cycle (serialized — next poll waits for current to finish). */
+function schedulePoll(): void {
+  outputPollTimer = setTimeout(async () => {
+    if (pollInFlight) {
+      schedulePoll();
+      return;
+    }
+    pollInFlight = true;
+    try {
+      await pollProcessOutputs();
+    } finally {
+      pollInFlight = false;
+      // Continue polling if processes remain
+      if ([...registry.values()].some((h) => h instanceof ProcessExecutionHandle)) {
+        schedulePoll();
+      } else {
+        outputPollTimer = null;
+      }
+    }
+  }, OUTPUT_POLL_INTERVAL_MS);
+}
+
 /** Read incremental output from temp files and emit to progress UI. */
-function pollProcessOutputs(): void {
+async function pollProcessOutputs(): Promise<void> {
+  const reads: Promise<void>[] = [];
   for (const handle of registry.values()) {
     if (!(handle instanceof ProcessExecutionHandle)) continue;
     if (!handle.outputPaths) continue;
 
-    const { executionId, parentStreamId } = handle;
-
-    // Read both stdout and stderr, concatenated (stderr after stdout)
-    void readIncremental(
-      executionId,
-      parentStreamId,
-      handle.outputPaths.stdout,
-      handle.outputPaths.stderr,
+    reads.push(
+      readIncremental(
+        handle.executionId,
+        handle.parentStreamId,
+        handle.outputPaths.stdout,
+        handle.outputPaths.stderr,
+      ),
     );
   }
+  await Promise.all(reads);
 }
 
 async function readIncremental(
@@ -268,17 +296,20 @@ async function readIncremental(
       fs.promises.readFile(stdoutPath, 'utf-8').catch(() => ''),
       fs.promises.readFile(stderrPath, 'utf-8').catch(() => ''),
     ]);
-    const full = stdout + stderr;
-    const offset = outputOffsets.get(executionId) ?? 0;
-    if (full.length <= offset) return;
+    const prev = outputOffsets.get(executionId) ?? { stdout: 0, stderr: 0 };
+    const stdoutDelta = stdout.slice(prev.stdout);
+    const stderrDelta = stderr.slice(prev.stderr);
+    if (!stdoutDelta && !stderrDelta) return;
 
-    const delta = full.slice(offset);
-    outputOffsets.set(executionId, full.length);
+    outputOffsets.set(executionId, {
+      stdout: stdout.length,
+      stderr: stderr.length,
+    });
 
     bus.emit('updateProcessOutput', {
       parentStreamId,
       executionId,
-      output: delta,
+      output: stdoutDelta + stderrDelta,
     });
   } catch {
     // File may have been deleted between check and read — ignore

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -34,6 +34,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SET_ACTIVE_STREAM: 'setActiveStream',
   UPDATE_CONVERSATION_PROGRESS: 'updateConversationProgress',
   UPDATE_STREAM_BADGES: 'updateStreamBadges',
+  UPDATE_PROCESS_OUTPUT: 'updateProcessOutput',
   UPDATE_PARENT_STREAM: 'updateParentStream',
   UPDATE_FILES: 'updateFiles',
   UPDATE_MISSING_OUTPUTS: 'updateMissingOutputs',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -99,7 +99,8 @@ export interface ProgressEventPayloads {
   updateProcessOutput: {
     parentStreamId: StreamTabId;
     executionId: ExecutionId;
-    output: string;
+    stdout: string;
+    stderr: string;
   };
   setParentStream: {
     childStreamId: StreamTabId;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -96,6 +96,11 @@ export interface ProgressEventPayloads {
     parentStreamId: StreamTabId;
     processes: ActiveChildInfo[];
   };
+  updateProcessOutput: {
+    parentStreamId: StreamTabId;
+    executionId: ExecutionId;
+    output: string;
+  };
   setParentStream: {
     childStreamId: StreamTabId;
     parentStreamId: StreamTabId;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -114,7 +114,8 @@ export class ProgressEventHandler {
             this.webviewUpdater.updateProcessOutput(
               data.parentStreamId,
               data.executionId,
-              data.output,
+              data.stdout,
+              data.stderr,
             );
           }
         },

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -107,6 +107,15 @@ export class ProgressEventHandler {
             countField: 'finishedProcessCount',
             next: data.processes,
           }),
+        updateProcessOutput: (_, data) => {
+          this.sendIfActive(data.parentStreamId, () =>
+            this.webviewUpdater.updateProcessOutput(
+              data.parentStreamId,
+              data.executionId,
+              data.output,
+            ),
+          );
+        },
         setParentStream: (_, { childStreamId, parentStreamId }) => {
           this.state.meta.setParentStream(childStreamId, parentStreamId);
           if (this.webviewUpdater.isAvailable()) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -108,13 +108,15 @@ export class ProgressEventHandler {
             next: data.processes,
           }),
         updateProcessOutput: (_, data) => {
-          this.sendIfActive(data.parentStreamId, () =>
+          // Always send — output accumulates in frontend state per-stream,
+          // so it must not be dropped when the stream is inactive.
+          if (this.webviewUpdater.isAvailable()) {
             this.webviewUpdater.updateProcessOutput(
               data.parentStreamId,
               data.executionId,
               data.output,
-            ),
-          );
+            );
+          }
         },
         setParentStream: (_, { childStreamId, parentStreamId }) => {
           this.state.meta.setParentStream(childStreamId, parentStreamId);

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -84,10 +84,13 @@ import { dispatchMessage } from './messageDispatcher';
 // Local imports - progress view contexts
 import {
   EMPTY_LOG_CONTEXT,
+  EMPTY_PROCESS_OUTPUTS,
   EMPTY_STREAM_CONTEXT,
   permissionsContext,
+  processOutputContext,
   streamLogContext,
   streamStateContext,
+  type ProcessOutputMap,
   type StreamContextValue,
   type StreamLogContextValue,
 } from './contexts/streamContexts';
@@ -249,6 +252,10 @@ export class ProgressApp extends ProgressAppBase {
   @state()
   private permissionsContextValue: PermissionState[] = [];
 
+  @provide({ context: processOutputContext })
+  @state()
+  private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
+
   // Container ref for accessing child component methods (FollowUpInput)
   private toolUseContentRef = createRef<ToolUseStreamContent>();
 
@@ -262,6 +269,10 @@ export class ProgressApp extends ProgressAppBase {
   private followupOptions$ = select(
     this.appState,
     (s) => s.followupOptionsByStream,
+  );
+  private processOutputs$ = select(
+    this.appState,
+    (s) => s.processOutputs,
   );
 
   // --- Derived computeds: only re-evaluate when selector inputs propagate ---
@@ -337,6 +348,13 @@ export class ProgressApp extends ProgressAppBase {
     const info = this.activeStreamInfo$.get();
     if (!info) return EMPTY_STREAM_LOGS;
     return this.streamLogs$.get().get(info.name) ?? EMPTY_STREAM_LOGS;
+  });
+
+  /** Only changes when the ACTIVE stream's process outputs change. */
+  private activeProcessOutputs$ = new Signal.Computed((): ProcessOutputMap => {
+    const info = this.activeStreamInfo$.get();
+    if (!info) return EMPTY_PROCESS_OUTPUTS;
+    return this.processOutputs$.get().get(info.name) ?? EMPTY_PROCESS_OUTPUTS;
   });
 
   // --- Leaf selectors for logContext$ ---
@@ -445,6 +463,7 @@ export class ProgressApp extends ProgressAppBase {
     this.streamContextValue = this.streamContext$.get();
     this.streamLogContextValue = this.logContext$.get();
     this.permissionsContextValue = this.permissions$.get();
+    this.processOutputContextValue = this.activeProcessOutputs$.get();
   }
 
   render(): TemplateResult {

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -341,7 +341,9 @@ export class BackgroundTasksPanel extends LitElement {
   }
 
   private handleToggle(e: ToggleEvent): void {
-    this.open = (e.target as HTMLDetailsElement).open;
+    // Only react to the outer panel-root toggle, not bubbled inner <details>
+    if (e.target !== e.currentTarget) return;
+    this.open = (e.currentTarget as HTMLDetailsElement).open;
   }
 }
 

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -7,7 +7,14 @@
  */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { consume } from '@lit/context';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
@@ -148,11 +155,6 @@ export class BackgroundTasksPanel extends LitElement {
         );
       }
 
-      .task-status--done {
-        color: var(--color-success);
-        background: color-mix(in srgb, var(--color-success) 12%, transparent);
-      }
-
       .section-label {
         display: flex;
         align-items: center;
@@ -207,11 +209,26 @@ export class BackgroundTasksPanel extends LitElement {
   @property({ attribute: false }) finishedProcessCount = 0;
   @property({ attribute: false }) activeSubagents: ActiveChildInfo[] = [];
   @property({ attribute: false }) finishedSubagentCount = 0;
-  @property({ type: Boolean }) open = false;
+
+  /** Open state — managed internally. Toggled by user or auto-opened on first active task. */
+  @state() open = false;
 
   @consume({ context: processOutputContext, subscribe: true })
   @state()
   private processOutputs: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
+
+  /** Track previous active count to detect 0→N transitions for auto-open. */
+  private prevActiveCount = 0;
+
+  protected override willUpdate(changed: PropertyValues): void {
+    super.willUpdate(changed);
+    const active = this.activeProcesses.length + this.activeSubagents.length;
+    // Auto-open when tasks first appear (0 → N), but never force-close
+    if (this.prevActiveCount === 0 && active > 0) {
+      this.open = true;
+    }
+    this.prevActiveCount = active;
+  }
 
   /** Total number of background tasks (active + finished). */
   private get totalTasks(): number {
@@ -243,7 +260,8 @@ export class BackgroundTasksPanel extends LitElement {
           ${this.renderSummaryBadges()}
         </summary>
         <div class="task-list">
-          ${this.renderProcessSection()} ${this.renderSubagentSection()}
+          ${this.renderSection(this.activeProcesses, this.finishedProcessCount, 'process')}
+          ${this.renderSection(this.activeSubagents, this.finishedSubagentCount, 'subagent')}
         </div>
       </details>
     `;
@@ -268,63 +286,40 @@ export class BackgroundTasksPanel extends LitElement {
     return parts.length > 0 ? html`${parts}` : nothing;
   }
 
-  private renderProcessSection(): TemplateResult | typeof nothing {
-    const hasActive = this.activeProcesses.length > 0;
-    const hasFinished = this.finishedProcessCount > 0;
+  private renderSection(
+    active: ActiveChildInfo[],
+    finishedCount: number,
+    kind: 'process' | 'subagent',
+  ): TemplateResult | typeof nothing {
+    const hasActive = active.length > 0;
+    const hasFinished = finishedCount > 0;
     if (!hasActive && !hasFinished) return nothing;
+
+    const icon =
+      kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
+    const label = kind === 'process' ? 'Processes' : 'Subagents';
 
     return html`
       <div class="section-label">
-        <i class="codicon codicon-terminal"></i>
+        <i class="codicon ${icon}"></i>
         <span
-          >Processes${hasActive
-            ? html` &middot; ${this.activeProcesses.length} active`
+          >${label}${hasActive
+            ? html` &middot; ${active.length} active`
             : nothing}${hasFinished
-            ? html` &middot; ${this.finishedProcessCount} done`
+            ? html` &middot; ${finishedCount} done`
             : nothing}</span
         >
       </div>
       ${hasActive
         ? repeat(
-            this.activeProcesses,
-            (p) => p.executionId,
-            (p) => this.renderTaskItem(p, 'process', true),
+            active,
+            (c) => c.executionId,
+            (c) => this.renderTaskItem(c, kind),
           )
         : nothing}
       ${!hasActive && hasFinished
         ? html`<div class="empty-message">
-            All ${this.finishedProcessCount} processes completed
-          </div>`
-        : nothing}
-    `;
-  }
-
-  private renderSubagentSection(): TemplateResult | typeof nothing {
-    const hasActive = this.activeSubagents.length > 0;
-    const hasFinished = this.finishedSubagentCount > 0;
-    if (!hasActive && !hasFinished) return nothing;
-
-    return html`
-      <div class="section-label">
-        <i class="codicon codicon-server-process"></i>
-        <span
-          >Subagents${hasActive
-            ? html` &middot; ${this.activeSubagents.length} active`
-            : nothing}${hasFinished
-            ? html` &middot; ${this.finishedSubagentCount} done`
-            : nothing}</span
-        >
-      </div>
-      ${hasActive
-        ? repeat(
-            this.activeSubagents,
-            (s) => s.executionId,
-            (s) => this.renderTaskItem(s, 'subagent', true),
-          )
-        : nothing}
-      ${!hasActive && hasFinished
-        ? html`<div class="empty-message">
-            All ${this.finishedSubagentCount} subagents completed
+            All ${finishedCount} ${label.toLowerCase()} completed
           </div>`
         : nothing}
     `;
@@ -333,7 +328,6 @@ export class BackgroundTasksPanel extends LitElement {
   private renderTaskItem(
     child: ActiveChildInfo,
     kind: 'process' | 'subagent',
-    isRunning: boolean,
   ): TemplateResult {
     const icon =
       kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
@@ -355,14 +349,7 @@ export class BackgroundTasksPanel extends LitElement {
           <span class="task-name" title=${child.agentName}
             >${child.agentName}</span
           >
-          <span
-            class=${classMap({
-              'task-status': true,
-              'task-status--running': isRunning,
-              'task-status--done': !isRunning,
-            })}
-            >${isRunning ? 'running' : 'done'}</span
-          >
+          <span class="task-status task-status--running">running</span>
         </div>
         ${hasOutput
           ? html`
@@ -384,6 +371,16 @@ export class BackgroundTasksPanel extends LitElement {
   private handleToggle(e: ToggleEvent): void {
     this.open = (e.target as HTMLDetailsElement).open;
   }
+}
+
+/** Toggle open state and scroll into view. Shared by ToolUseStreamContent and WorkflowStreamContent. */
+export function toggleBackgroundTasksPanel(
+  panelRef: { value: BackgroundTasksPanel | undefined },
+): void {
+  const panel = panelRef.value;
+  if (!panel) return;
+  panel.open = !panel.open;
+  panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
 
 declare global {

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -2,12 +2,14 @@
  * Collapsible panel for displaying background tasks (processes and subagents).
  *
  * Shows a summary badge in the collapsed header and a list of active/finished
- * tasks when expanded, similar to the ContextManagement pattern.
+ * tasks when expanded. Each active task has a collapsible real-time terminal
+ * output section powered by the existing TerminalOutput (xterm.js) component.
  */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -20,6 +22,16 @@ import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 
 // Local imports - types
 import type { ActiveChildInfo } from '@shared/schemas';
+
+// Local imports - contexts
+import {
+  EMPTY_PROCESS_OUTPUTS,
+  processOutputContext,
+  type ProcessOutputMap,
+} from '../contexts/streamContexts';
+
+// Side-effect imports - sibling components
+import './TerminalOutput';
 
 @customElement('background-tasks-panel')
 export class BackgroundTasksPanel extends LitElement {
@@ -36,7 +48,7 @@ export class BackgroundTasksPanel extends LitElement {
         display: none;
       }
 
-      details {
+      details.panel-root {
         border-top: var(--border-thin) solid var(--color-border);
       }
 
@@ -87,6 +99,10 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-item {
+        margin-bottom: var(--spacing-tiny);
+      }
+
+      .task-header {
         display: flex;
         align-items: center;
         gap: var(--spacing-small);
@@ -159,6 +175,31 @@ export class BackgroundTasksPanel extends LitElement {
         color: var(--color-text-secondary);
         font-style: italic;
       }
+
+      /* Collapsible output per task */
+      details.task-output {
+        margin-left: calc(var(--spacing-small) + var(--font-size-sm));
+      }
+
+      details.task-output > summary {
+        padding: 2px 0;
+        font-size: var(--font-size-xs, 10px);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+      }
+
+      details.task-output > summary:hover {
+        color: var(--vscode-foreground);
+      }
+
+      .output-container {
+        margin-top: var(--spacing-tiny);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius-small);
+        overflow: hidden;
+      }
     `,
   ];
 
@@ -167,6 +208,10 @@ export class BackgroundTasksPanel extends LitElement {
   @property({ attribute: false }) activeSubagents: ActiveChildInfo[] = [];
   @property({ attribute: false }) finishedSubagentCount = 0;
   @property({ type: Boolean }) open = false;
+
+  @consume({ context: processOutputContext, subscribe: true })
+  @state()
+  private processOutputs: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
 
   /** Total number of background tasks (active + finished). */
   private get totalTasks(): number {
@@ -190,7 +235,7 @@ export class BackgroundTasksPanel extends LitElement {
     if (this.totalTasks === 0) return nothing;
 
     return html`
-      <details ?open=${this.open} @toggle=${this.handleToggle}>
+      <details class="panel-root" ?open=${this.open} @toggle=${this.handleToggle}>
         <summary class="details-summary">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-terminal panel-icon"></i>
@@ -292,28 +337,46 @@ export class BackgroundTasksPanel extends LitElement {
   ): TemplateResult {
     const icon =
       kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
+    const output = this.processOutputs.get(child.executionId) ?? '';
+    const hasOutput = output.length > 0;
+
     return html`
       <div class="task-item">
-        <i
-          class=${classMap({
-            codicon: true,
-            [icon]: true,
-            'task-icon': true,
-            'task-icon--process': kind === 'process',
-            'task-icon--subagent': kind === 'subagent',
-          })}
-        ></i>
-        <span class="task-name" title=${child.agentName}
-          >${child.agentName}</span
-        >
-        <span
-          class=${classMap({
-            'task-status': true,
-            'task-status--running': isRunning,
-            'task-status--done': !isRunning,
-          })}
-          >${isRunning ? 'running' : 'done'}</span
-        >
+        <div class="task-header">
+          <i
+            class=${classMap({
+              codicon: true,
+              [icon]: true,
+              'task-icon': true,
+              'task-icon--process': kind === 'process',
+              'task-icon--subagent': kind === 'subagent',
+            })}
+          ></i>
+          <span class="task-name" title=${child.agentName}
+            >${child.agentName}</span
+          >
+          <span
+            class=${classMap({
+              'task-status': true,
+              'task-status--running': isRunning,
+              'task-status--done': !isRunning,
+            })}
+            >${isRunning ? 'running' : 'done'}</span
+          >
+        </div>
+        ${hasOutput
+          ? html`
+              <details class="task-output" open>
+                <summary>
+                  <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+                  Output
+                </summary>
+                <div class="output-container">
+                  <terminal-output .text=${output}></terminal-output>
+                </div>
+              </details>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -1,0 +1,330 @@
+/**
+ * Collapsible panel for displaying background tasks (processes and subagents).
+ *
+ * Shows a summary badge in the collapsed header and a list of active/finished
+ * tasks when expanded, similar to the ContextManagement pattern.
+ */
+
+// Third-party imports
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { codiconIconClasses } from '@shared/styles/codiconStyles';
+
+// Local imports - shared utilities
+import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
+
+// Local imports - types
+import type { ActiveChildInfo } from '@shared/schemas';
+
+@customElement('background-tasks-panel')
+export class BackgroundTasksPanel extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    css`
+      :host {
+        display: block;
+      }
+
+      :host([hidden]) {
+        display: none;
+      }
+
+      details {
+        border-top: var(--border-thin) solid var(--color-border);
+      }
+
+      summary {
+        padding: var(--spacing-small) var(--spacing-medium);
+      }
+
+      .panel-title {
+        font-weight: var(--font-weight-medium);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+      }
+
+      .badge-count {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-tiny);
+        margin-left: var(--spacing-small);
+        padding: 1px var(--spacing-small);
+        font-size: var(--font-size-xs, 10px);
+        font-weight: var(--font-weight-semibold);
+        border-radius: var(--border-radius-small);
+        white-space: nowrap;
+      }
+
+      .badge-count--active {
+        color: var(--color-warning, var(--vscode-charts-orange));
+        background: color-mix(
+          in srgb,
+          var(--color-warning, var(--vscode-charts-orange)) 12%,
+          transparent
+        );
+      }
+
+      .badge-count--done {
+        color: var(--color-text-secondary);
+        background: color-mix(
+          in srgb,
+          var(--color-text-secondary) 12%,
+          transparent
+        );
+      }
+
+      .task-list {
+        list-style: none;
+        margin: 0;
+        padding: 0 var(--spacing-medium) var(--spacing-small);
+      }
+
+      .task-item {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+        font-size: var(--font-size-sm);
+      }
+
+      .task-icon {
+        flex-shrink: 0;
+        font-size: var(--font-size-sm);
+      }
+
+      .task-icon--process {
+        color: var(--color-warning, var(--vscode-charts-orange));
+      }
+
+      .task-icon--subagent {
+        color: var(--color-info, var(--vscode-charts-blue));
+      }
+
+      .task-name {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--vscode-foreground);
+      }
+
+      .task-status {
+        flex-shrink: 0;
+        font-size: var(--font-size-xs, 10px);
+        padding: 1px var(--spacing-small);
+        border-radius: var(--border-radius-small);
+      }
+
+      .task-status--running {
+        color: var(--color-warning, var(--vscode-charts-orange));
+        background: color-mix(
+          in srgb,
+          var(--color-warning, var(--vscode-charts-orange)) 12%,
+          transparent
+        );
+      }
+
+      .task-status--done {
+        color: var(--color-success);
+        background: color-mix(in srgb, var(--color-success) 12%, transparent);
+      }
+
+      .section-label {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--spacing-small) 0 var(--spacing-tiny);
+        font-size: var(--font-size-xs, 10px);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .section-label .codicon {
+        font-size: var(--font-size-xs, 10px);
+      }
+
+      .empty-message {
+        padding: var(--spacing-small) 0;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        font-style: italic;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) activeProcesses: ActiveChildInfo[] = [];
+  @property({ attribute: false }) finishedProcessCount = 0;
+  @property({ attribute: false }) activeSubagents: ActiveChildInfo[] = [];
+  @property({ attribute: false }) finishedSubagentCount = 0;
+  @property({ type: Boolean }) open = false;
+
+  /** Total number of background tasks (active + finished). */
+  private get totalTasks(): number {
+    return (
+      this.activeProcesses.length +
+      this.finishedProcessCount +
+      this.activeSubagents.length +
+      this.finishedSubagentCount
+    );
+  }
+
+  private get totalActive(): number {
+    return this.activeProcesses.length + this.activeSubagents.length;
+  }
+
+  private get totalFinished(): number {
+    return this.finishedProcessCount + this.finishedSubagentCount;
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (this.totalTasks === 0) return nothing;
+
+    return html`
+      <details ?open=${this.open} @toggle=${this.handleToggle}>
+        <summary class="details-summary">
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          <i class="codicon codicon-terminal panel-icon"></i>
+          <span class="panel-title">Background Tasks</span>
+          ${this.renderSummaryBadges()}
+        </summary>
+        <div class="task-list">
+          ${this.renderProcessSection()} ${this.renderSubagentSection()}
+        </div>
+      </details>
+    `;
+  }
+
+  private renderSummaryBadges(): TemplateResult | typeof nothing {
+    const parts: TemplateResult[] = [];
+    if (this.totalActive > 0) {
+      parts.push(
+        html`<span class="badge-count badge-count--active"
+          >${this.totalActive} running</span
+        >`,
+      );
+    }
+    if (this.totalFinished > 0) {
+      parts.push(
+        html`<span class="badge-count badge-count--done"
+          >${this.totalFinished} done</span
+        >`,
+      );
+    }
+    return parts.length > 0 ? html`${parts}` : nothing;
+  }
+
+  private renderProcessSection(): TemplateResult | typeof nothing {
+    const hasActive = this.activeProcesses.length > 0;
+    const hasFinished = this.finishedProcessCount > 0;
+    if (!hasActive && !hasFinished) return nothing;
+
+    return html`
+      <div class="section-label">
+        <i class="codicon codicon-terminal"></i>
+        <span
+          >Processes${hasActive
+            ? html` &middot; ${this.activeProcesses.length} active`
+            : nothing}${hasFinished
+            ? html` &middot; ${this.finishedProcessCount} done`
+            : nothing}</span
+        >
+      </div>
+      ${hasActive
+        ? repeat(
+            this.activeProcesses,
+            (p) => p.executionId,
+            (p) => this.renderTaskItem(p, 'process', true),
+          )
+        : nothing}
+      ${!hasActive && hasFinished
+        ? html`<div class="empty-message">
+            All ${this.finishedProcessCount} processes completed
+          </div>`
+        : nothing}
+    `;
+  }
+
+  private renderSubagentSection(): TemplateResult | typeof nothing {
+    const hasActive = this.activeSubagents.length > 0;
+    const hasFinished = this.finishedSubagentCount > 0;
+    if (!hasActive && !hasFinished) return nothing;
+
+    return html`
+      <div class="section-label">
+        <i class="codicon codicon-server-process"></i>
+        <span
+          >Subagents${hasActive
+            ? html` &middot; ${this.activeSubagents.length} active`
+            : nothing}${hasFinished
+            ? html` &middot; ${this.finishedSubagentCount} done`
+            : nothing}</span
+        >
+      </div>
+      ${hasActive
+        ? repeat(
+            this.activeSubagents,
+            (s) => s.executionId,
+            (s) => this.renderTaskItem(s, 'subagent', true),
+          )
+        : nothing}
+      ${!hasActive && hasFinished
+        ? html`<div class="empty-message">
+            All ${this.finishedSubagentCount} subagents completed
+          </div>`
+        : nothing}
+    `;
+  }
+
+  private renderTaskItem(
+    child: ActiveChildInfo,
+    kind: 'process' | 'subagent',
+    isRunning: boolean,
+  ): TemplateResult {
+    const icon =
+      kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
+    return html`
+      <div class="task-item">
+        <i
+          class=${classMap({
+            codicon: true,
+            [icon]: true,
+            'task-icon': true,
+            'task-icon--process': kind === 'process',
+            'task-icon--subagent': kind === 'subagent',
+          })}
+        ></i>
+        <span class="task-name" title=${child.agentName}
+          >${child.agentName}</span
+        >
+        <span
+          class=${classMap({
+            'task-status': true,
+            'task-status--running': isRunning,
+            'task-status--done': !isRunning,
+          })}
+          >${isRunning ? 'running' : 'done'}</span
+        >
+      </div>
+    `;
+  }
+
+  private handleToggle(e: ToggleEvent): void {
+    this.open = (e.target as HTMLDetailsElement).open;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'background-tasks-panel': BackgroundTasksPanel;
+  }
+}

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -79,24 +79,16 @@ export class BackgroundTasksPanel extends LitElement {
         font-weight: var(--font-weight-semibold);
         border-radius: var(--border-radius-small);
         white-space: nowrap;
+        color: var(--_tint);
+        background: color-mix(in srgb, var(--_tint) 12%, transparent);
       }
 
       .badge-count--active {
-        color: var(--color-warning, var(--vscode-charts-orange));
-        background: color-mix(
-          in srgb,
-          var(--color-warning, var(--vscode-charts-orange)) 12%,
-          transparent
-        );
+        --_tint: var(--color-warning, var(--vscode-charts-orange));
       }
 
       .badge-count--done {
-        color: var(--color-text-secondary);
-        background: color-mix(
-          in srgb,
-          var(--color-text-secondary) 12%,
-          transparent
-        );
+        --_tint: var(--color-text-secondary);
       }
 
       .task-list {
@@ -140,19 +132,13 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-status {
+        --_tint: var(--color-warning, var(--vscode-charts-orange));
         flex-shrink: 0;
         font-size: var(--font-size-xs, 10px);
         padding: 1px var(--spacing-small);
         border-radius: var(--border-radius-small);
-      }
-
-      .task-status--running {
-        color: var(--color-warning, var(--vscode-charts-orange));
-        background: color-mix(
-          in srgb,
-          var(--color-warning, var(--vscode-charts-orange)) 12%,
-          transparent
-        );
+        color: var(--_tint);
+        background: color-mix(in srgb, var(--_tint) 12%, transparent);
       }
 
       .section-label {
@@ -230,26 +216,11 @@ export class BackgroundTasksPanel extends LitElement {
     this.prevActiveCount = active;
   }
 
-  /** Total number of background tasks (active + finished). */
-  private get totalTasks(): number {
-    return (
-      this.activeProcesses.length +
-      this.finishedProcessCount +
-      this.activeSubagents.length +
-      this.finishedSubagentCount
-    );
-  }
-
-  private get totalActive(): number {
-    return this.activeProcesses.length + this.activeSubagents.length;
-  }
-
-  private get totalFinished(): number {
-    return this.finishedProcessCount + this.finishedSubagentCount;
-  }
-
   override render(): TemplateResult | typeof nothing {
-    if (this.totalTasks === 0) return nothing;
+    const active =
+      this.activeProcesses.length + this.activeSubagents.length;
+    const finished = this.finishedProcessCount + this.finishedSubagentCount;
+    if (active + finished === 0) return nothing;
 
     return html`
       <details class="panel-root" ?open=${this.open} @toggle=${this.handleToggle}>
@@ -257,7 +228,16 @@ export class BackgroundTasksPanel extends LitElement {
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon codicon-terminal panel-icon"></i>
           <span class="panel-title">Background Tasks</span>
-          ${this.renderSummaryBadges()}
+          ${active > 0
+            ? html`<span class="badge-count badge-count--active"
+                >${active} running</span
+              >`
+            : nothing}
+          ${finished > 0
+            ? html`<span class="badge-count badge-count--done"
+                >${finished} done</span
+              >`
+            : nothing}
         </summary>
         <div class="task-list">
           ${this.renderSection(this.activeProcesses, this.finishedProcessCount, 'process')}
@@ -265,25 +245,6 @@ export class BackgroundTasksPanel extends LitElement {
         </div>
       </details>
     `;
-  }
-
-  private renderSummaryBadges(): TemplateResult | typeof nothing {
-    const parts: TemplateResult[] = [];
-    if (this.totalActive > 0) {
-      parts.push(
-        html`<span class="badge-count badge-count--active"
-          >${this.totalActive} running</span
-        >`,
-      );
-    }
-    if (this.totalFinished > 0) {
-      parts.push(
-        html`<span class="badge-count badge-count--done"
-          >${this.totalFinished} done</span
-        >`,
-      );
-    }
-    return parts.length > 0 ? html`${parts}` : nothing;
   }
 
   private renderSection(

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -292,8 +292,9 @@ export class BackgroundTasksPanel extends LitElement {
   ): TemplateResult {
     const icon =
       kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
-    const output = this.processOutputs.get(child.executionId) ?? '';
-    const hasOutput = output.length > 0;
+    const entry = this.processOutputs.get(child.executionId);
+    const hasStdout = Boolean(entry?.stdout);
+    const hasStderr = Boolean(entry?.stderr);
 
     return html`
       <div class="task-item">
@@ -312,20 +313,30 @@ export class BackgroundTasksPanel extends LitElement {
           >
           <span class="task-status task-status--running">running</span>
         </div>
-        ${hasOutput
-          ? html`
-              <details class="task-output" open>
-                <summary>
-                  <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-                  Output
-                </summary>
-                <div class="output-container">
-                  <terminal-output .text=${output}></terminal-output>
-                </div>
-              </details>
-            `
+        ${hasStdout
+          ? this.renderOutputStream('stdout', entry!.stdout)
+          : nothing}
+        ${hasStderr
+          ? this.renderOutputStream('stderr', entry!.stderr)
           : nothing}
       </div>
+    `;
+  }
+
+  private renderOutputStream(
+    label: string,
+    text: string,
+  ): TemplateResult {
+    return html`
+      <details class="task-output" open>
+        <summary>
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          ${label}
+        </summary>
+        <div class="output-container">
+          <terminal-output .text=${text}></terminal-output>
+        </div>
+      </details>
     `;
   }
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -349,6 +349,24 @@ export class StreamHeader extends LitElement {
         white-space: nowrap;
       }
 
+      .child-badge--clickable {
+        cursor: pointer;
+        transition:
+          background-color var(--transition-fast),
+          box-shadow var(--transition-fast);
+      }
+
+      .child-badge--clickable:hover {
+        background: color-mix(in srgb, var(--_badge-color) 22%, transparent);
+        box-shadow: 0 0 4px
+          color-mix(in srgb, var(--_badge-color) 30%, transparent);
+      }
+
+      .child-badge--clickable:focus-visible {
+        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline-offset: 1px;
+      }
+
       .child-badge .codicon {
         font-size: var(--font-size-xs, 10px);
       }
@@ -565,8 +583,12 @@ export class StreamHeader extends LitElement {
     const total = active.length + finishedCount;
     if (total === 0) return nothing;
     return html`<span
-      class="child-badge ${cssClass}"
-      title=${active.map((s) => s.agentName).join(', ')}
+      class="child-badge child-badge--clickable ${cssClass}"
+      role="button"
+      tabindex="0"
+      title="Click to show background tasks — ${active.map((s) => s.agentName).join(', ')}"
+      @click=${this.handleBadgeClick}
+      @keydown=${this.handleBadgeKeydown}
     >
       <i class="codicon codicon-${icon}"></i>
       ${active.length > 0
@@ -619,5 +641,17 @@ export class StreamHeader extends LitElement {
 
   private handleRunSelected(event: CustomEvent) {
     this.dispatchEvent(ProgressEvents.runSelected(event.detail));
+  }
+
+  private handleBadgeClick(e: MouseEvent): void {
+    e.stopPropagation();
+    this.dispatchEvent(ProgressEvents.backgroundTasksToggle());
+  }
+
+  private handleBadgeKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.dispatchEvent(ProgressEvents.backgroundTasksToggle());
+    }
   }
 }

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -30,6 +30,7 @@ import type { ToolUseStreamState } from '../store';
 
 // Local imports - types
 import type { PermissionState } from './PermissionCard';
+import type { BackgroundTasksPanel } from './BackgroundTasksPanel';
 import type { FollowUpInput } from './FollowUpInput';
 
 // Side-effect imports - sibling components
@@ -39,6 +40,7 @@ import './TodoList';
 import './TaskGroupList';
 import './LogList';
 import './UsagePanel';
+import './BackgroundTasksPanel';
 import './FollowUpInput';
 
 @customElement('tool-use-stream-content')
@@ -62,6 +64,7 @@ export class ToolUseStreamContent extends LitElement {
   private filteredPermissions: PermissionState[] = [];
   private runGroups: RunGroup[] = [];
 
+  private backgroundTasksRef: Ref<BackgroundTasksPanel> = createRef();
   private followUpRef: Ref<FollowUpInput> = createRef();
 
   protected override willUpdate(changedProperties: PropertyValues): void {
@@ -103,11 +106,22 @@ export class ToolUseStreamContent extends LitElement {
         .runs=${this.runGroups}
         .yoloActive=${Boolean(currentState.toolEditBypass)}
         .superYoloActive=${Boolean(currentState.superYoloBypass)}
+        @background-tasks-toggle=${this.handleBackgroundTasksToggle}
       ></stream-header>
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
 
       <todo-list .todos=${currentState.todos}></todo-list>
+
+      <background-tasks-panel
+        ${ref(this.backgroundTasksRef)}
+        .activeProcesses=${currentState.activeProcesses}
+        .finishedProcessCount=${currentState.finishedProcessCount}
+        .activeSubagents=${currentState.activeSubagents}
+        .finishedSubagentCount=${currentState.finishedSubagentCount}
+        .open=${currentState.activeProcesses.length > 0 ||
+        currentState.activeSubagents.length > 0}
+      ></background-tasks-panel>
 
       <log-list></log-list>
 
@@ -138,5 +152,12 @@ export class ToolUseStreamContent extends LitElement {
 
   private handleFocusComplete(): void {
     this.dispatchEvent(ProgressEvents.followupFocusComplete());
+  }
+
+  private handleBackgroundTasksToggle(): void {
+    const panel = this.backgroundTasksRef.value;
+    if (!panel) return;
+    panel.open = !panel.open;
+    panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 }

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -30,7 +30,10 @@ import type { ToolUseStreamState } from '../store';
 
 // Local imports - types
 import type { PermissionState } from './PermissionCard';
-import type { BackgroundTasksPanel } from './BackgroundTasksPanel';
+import {
+  type BackgroundTasksPanel,
+  toggleBackgroundTasksPanel,
+} from './BackgroundTasksPanel';
 import type { FollowUpInput } from './FollowUpInput';
 
 // Side-effect imports - sibling components
@@ -119,8 +122,6 @@ export class ToolUseStreamContent extends LitElement {
         .finishedProcessCount=${currentState.finishedProcessCount}
         .activeSubagents=${currentState.activeSubagents}
         .finishedSubagentCount=${currentState.finishedSubagentCount}
-        .open=${currentState.activeProcesses.length > 0 ||
-        currentState.activeSubagents.length > 0}
       ></background-tasks-panel>
 
       <log-list></log-list>
@@ -155,9 +156,6 @@ export class ToolUseStreamContent extends LitElement {
   }
 
   private handleBackgroundTasksToggle(): void {
-    const panel = this.backgroundTasksRef.value;
-    if (!panel) return;
-    panel.open = !panel.open;
-    panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    toggleBackgroundTasksPanel(this.backgroundTasksRef);
   }
 }

--- a/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -34,7 +34,10 @@ import {
 import type { FollowupOptionsState, WorkflowStreamState } from '../store';
 
 // Local imports - types
-import type { BackgroundTasksPanel } from './BackgroundTasksPanel';
+import {
+  type BackgroundTasksPanel,
+  toggleBackgroundTasksPanel,
+} from './BackgroundTasksPanel';
 import type { PermissionState } from './PermissionCard';
 
 // Side-effect imports - sibling components
@@ -157,8 +160,6 @@ export class WorkflowStreamContent extends LitElement {
         .finishedProcessCount=${state.finishedProcessCount}
         .activeSubagents=${state.activeSubagents}
         .finishedSubagentCount=${state.finishedSubagentCount}
-        .open=${state.activeProcesses.length > 0 ||
-        state.activeSubagents.length > 0}
       ></background-tasks-panel>
 
       <log-list></log-list>
@@ -182,9 +183,6 @@ export class WorkflowStreamContent extends LitElement {
   }
 
   private handleBackgroundTasksToggle(): void {
-    const panel = this.backgroundTasksRef.value;
-    if (!panel) return;
-    panel.open = !panel.open;
-    panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    toggleBackgroundTasksPanel(this.backgroundTasksRef);
   }
 }

--- a/src/progressView/frontend/components/WorkflowStreamContent.ts
+++ b/src/progressView/frontend/components/WorkflowStreamContent.ts
@@ -11,6 +11,7 @@ import {
 } from 'lit';
 import { consume } from '@lit/context';
 import { customElement, state } from 'lit/decorators.js';
+import { createRef, ref, type Ref } from 'lit/directives/ref.js';
 
 // Local imports - progress view
 import type {
@@ -33,6 +34,7 @@ import {
 import type { FollowupOptionsState, WorkflowStreamState } from '../store';
 
 // Local imports - types
+import type { BackgroundTasksPanel } from './BackgroundTasksPanel';
 import type { PermissionState } from './PermissionCard';
 
 // Side-effect imports - sibling components
@@ -43,6 +45,7 @@ import './LogList';
 import './UsagePanel';
 import './FileList';
 import './FollowupSection';
+import './BackgroundTasksPanel';
 import './RequestPanels';
 
 /** Derived values for the currently selected run. */
@@ -80,6 +83,7 @@ export class WorkflowStreamContent extends LitElement {
   // Not @state(): always derived from streamContext/permissionContext (avoids double-render).
   private runGroups: RunGroup[] = [];
   private runValues: RunDerivedValues = EMPTY_RUN_VALUES;
+  private backgroundTasksRef: Ref<BackgroundTasksPanel> = createRef();
   private filteredPermissions: PermissionState[] = [];
 
   protected override willUpdate(changedProperties: PropertyValues): void {
@@ -140,11 +144,22 @@ export class WorkflowStreamContent extends LitElement {
         .runId=${runId}
         .runs=${this.runGroups}
         .yoloActive=${false}
+        @background-tasks-toggle=${this.handleBackgroundTasksToggle}
       ></stream-header>
 
       <instruction-panel .instruction=${instruction}></instruction-panel>
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
+
+      <background-tasks-panel
+        ${ref(this.backgroundTasksRef)}
+        .activeProcesses=${state.activeProcesses}
+        .finishedProcessCount=${state.finishedProcessCount}
+        .activeSubagents=${state.activeSubagents}
+        .finishedSubagentCount=${state.finishedSubagentCount}
+        .open=${state.activeProcesses.length > 0 ||
+        state.activeSubagents.length > 0}
+      ></background-tasks-panel>
 
       <log-list></log-list>
 
@@ -164,5 +179,12 @@ export class WorkflowStreamContent extends LitElement {
         .streamModel=${streamInfo.model ?? null}
       ></followup-section>
     `;
+  }
+
+  private handleBackgroundTasksToggle(): void {
+    const panel = this.backgroundTasksRef.value;
+    if (!panel) return;
+    panel.open = !panel.open;
+    panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 }

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -72,3 +72,16 @@ export const streamLogContext = createContext<StreamLogContextValue>(
 export const permissionsContext = createContext<PermissionState[]>(
   'progress-permissions',
 );
+
+/**
+ * Separate context for background process outputs — changes on every output chunk.
+ * Only consumed by BackgroundTasksPanel, avoiding re-renders of other components.
+ * Keyed by executionId → accumulated output text.
+ */
+export type ProcessOutputMap = Map<string, string>;
+
+export const EMPTY_PROCESS_OUTPUTS: ProcessOutputMap = new Map();
+
+export const processOutputContext = createContext<ProcessOutputMap>(
+  'progress-process-outputs',
+);

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -76,9 +76,14 @@ export const permissionsContext = createContext<PermissionState[]>(
 /**
  * Separate context for background process outputs — changes on every output chunk.
  * Only consumed by BackgroundTasksPanel, avoiding re-renders of other components.
- * Keyed by executionId → accumulated output text.
+ * Keyed by executionId → accumulated stdout/stderr.
  */
-export type ProcessOutputMap = Map<string, string>;
+export interface ProcessOutputEntry {
+  stdout: string;
+  stderr: string;
+}
+
+export type ProcessOutputMap = Map<string, ProcessOutputEntry>;
 
 export const EMPTY_PROCESS_OUTPUTS: ProcessOutputMap = new Map();
 

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -90,6 +90,7 @@ export function handleStreamDelete(
     create(prev, (draft) => {
       draft.streamStates.delete(streamId);
       draft.streamLogs.delete(streamId);
+      draft.processOutputs.delete(streamId);
       draft.streamById.delete(streamId);
       if (draft.activeStreamId === streamId) {
         draft.activeStreamId = firstStreamId(draft.streamById);

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -122,4 +122,7 @@ export const ProgressEvents = {
 
   followupFocusComplete: () =>
     createEvent('followup-focus-complete', undefined),
+
+  backgroundTasksToggle: () =>
+    createEvent('background-tasks-toggle', undefined),
 } as const;

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -178,6 +178,7 @@ export const streamLifecycleHandlers: HandlerRegistry = {
         draft.streamById = new Map();
         draft.streamStates = new Map();
         draft.streamLogs = new Map();
+        draft.processOutputs = new Map();
         draft.activeStreamId = null;
         draft.followupOptionsByStream = new Map();
       }),

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -81,6 +81,7 @@ function updateStreamInfo(
       if (!newStreamById.has(key)) {
         draft.streamStates.delete(key);
         draft.streamLogs.delete(key);
+        draft.processOutputs.delete(key);
       }
     }
 
@@ -154,6 +155,7 @@ export const streamLifecycleHandlers: HandlerRegistry = {
       create(prev, (draft) => {
         draft.streamStates.delete(streamId);
         draft.streamLogs.delete(streamId);
+        draft.processOutputs.delete(streamId);
         draft.streamById.delete(streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -9,7 +9,34 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { STREAM_STATUS } from '@shared/schemas';
 
 import { getStreamState, isToolUseState } from '../store';
-import type { HandlerRegistry } from '../messageDispatcher';
+import type {
+  HandlerRegistry,
+  MessageHandlerContext,
+} from '../messageDispatcher';
+
+/** Remove output entries for processes no longer in the active list. */
+function pruneStaleOutputs(
+  ctx: MessageHandlerContext,
+  stream: string,
+  activeIds: Set<string>,
+): void {
+  ctx.setState((prev) => {
+    const streamOutputs = prev.processOutputs.get(stream);
+    if (!streamOutputs) return prev;
+    let hasStale = false;
+    for (const id of streamOutputs.keys()) {
+      if (!activeIds.has(id)) { hasStale = true; break; }
+    }
+    if (!hasStale) return prev;
+    return create(prev, (draft) => {
+      const outputs = draft.processOutputs.get(stream);
+      if (!outputs) return;
+      for (const id of [...outputs.keys()]) {
+        if (!activeIds.has(id)) outputs.delete(id);
+      }
+    });
+  });
+}
 
 export const streamMetaHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS]: (data, ctx) => {
@@ -57,29 +84,15 @@ export const streamMetaHandlers: HandlerRegistry = {
         draft.finishedProcessCount = data.finishedProcessCount;
       }),
     );
-    // Prune output entries for processes no longer active to free memory.
-    const activeIds = new Set(data.activeProcesses.map((p: { executionId: string }) => p.executionId));
-    ctx.setState((prev) => {
-      const streamOutputs = prev.processOutputs.get(data.stream);
-      if (!streamOutputs) return prev;
-      let pruned = false;
-      for (const id of streamOutputs.keys()) {
-        if (!activeIds.has(id)) { pruned = true; break; }
-      }
-      if (!pruned) return prev;
-      return create(prev, (draft) => {
-        const outputs = draft.processOutputs.get(data.stream);
-        if (!outputs) return;
-        for (const id of [...outputs.keys()]) {
-          if (!activeIds.has(id)) outputs.delete(id);
-        }
-      });
-    });
+    pruneStaleOutputs(
+      ctx,
+      data.stream,
+      new Set(data.activeProcesses.map((p: { executionId: string }) => p.executionId)),
+    );
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data, ctx) => {
     const { stream, executionId, stdout, stderr } = data;
-    // Cap each stream at 100KB to prevent unbounded memory growth.
     const MAX_OUTPUT = 100_000;
     const cap = (prev: string, delta: string): string => {
       if (!delta) return prev;
@@ -88,12 +101,24 @@ export const streamMetaHandlers: HandlerRegistry = {
         ? combined.slice(combined.length - MAX_OUTPUT)
         : combined;
     };
-    ctx.setState((prev) =>
-      create(prev, (draft) => {
+    ctx.setState((prev) => {
+      // Prune stale entries opportunistically — this is the only handler
+      // that fires for non-active streams, so it's the only chance to clean up.
+      const streamState = prev.streamStates.get(stream);
+      const activeIds = new Set(
+        (streamState?.activeProcesses ?? []).map(
+          (p: { executionId: string }) => p.executionId,
+        ),
+      );
+      return create(prev, (draft) => {
         let streamOutputs = draft.processOutputs.get(stream);
         if (!streamOutputs) {
           streamOutputs = new Map();
           draft.processOutputs.set(stream, streamOutputs);
+        }
+        // Prune entries for finished processes
+        for (const id of [...streamOutputs.keys()]) {
+          if (!activeIds.has(id)) streamOutputs.delete(id);
         }
         const existing = streamOutputs.get(executionId) ?? {
           stdout: '',
@@ -103,7 +128,7 @@ export const streamMetaHandlers: HandlerRegistry = {
           stdout: cap(existing.stdout, stdout),
           stderr: cap(existing.stderr, stderr),
         });
-      }),
-    );
+      });
+    });
   },
 };

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -69,7 +69,16 @@ export const streamMetaHandlers: HandlerRegistry = {
           draft.processOutputs.set(stream, streamOutputs);
         }
         const existing = streamOutputs.get(executionId) ?? '';
-        streamOutputs.set(executionId, existing + output);
+        const combined = existing + output;
+        // Cap at 100KB to prevent unbounded memory growth from chatty processes.
+        // Keep the tail so the user sees the most recent output.
+        const MAX_OUTPUT = 100_000;
+        streamOutputs.set(
+          executionId,
+          combined.length > MAX_OUTPUT
+            ? combined.slice(combined.length - MAX_OUTPUT)
+            : combined,
+        );
       }),
     );
   },

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -57,28 +57,52 @@ export const streamMetaHandlers: HandlerRegistry = {
         draft.finishedProcessCount = data.finishedProcessCount;
       }),
     );
+    // Prune output entries for processes no longer active to free memory.
+    const activeIds = new Set(data.activeProcesses.map((p: { executionId: string }) => p.executionId));
+    ctx.setState((prev) => {
+      const streamOutputs = prev.processOutputs.get(data.stream);
+      if (!streamOutputs) return prev;
+      let pruned = false;
+      for (const id of streamOutputs.keys()) {
+        if (!activeIds.has(id)) { pruned = true; break; }
+      }
+      if (!pruned) return prev;
+      return create(prev, (draft) => {
+        const outputs = draft.processOutputs.get(data.stream);
+        if (!outputs) return;
+        for (const id of [...outputs.keys()]) {
+          if (!activeIds.has(id)) outputs.delete(id);
+        }
+      });
+    });
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data, ctx) => {
-    const { stream, executionId, output } = data;
+    const { stream, executionId, stdout, stderr } = data;
+    // Cap each stream at 100KB to prevent unbounded memory growth.
+    const MAX_OUTPUT = 100_000;
+    const cap = (prev: string, delta: string): string => {
+      if (!delta) return prev;
+      const combined = prev + delta;
+      return combined.length > MAX_OUTPUT
+        ? combined.slice(combined.length - MAX_OUTPUT)
+        : combined;
+    };
     ctx.setState((prev) =>
       create(prev, (draft) => {
         let streamOutputs = draft.processOutputs.get(stream);
         if (!streamOutputs) {
-          streamOutputs = new Map<string, string>();
+          streamOutputs = new Map();
           draft.processOutputs.set(stream, streamOutputs);
         }
-        const existing = streamOutputs.get(executionId) ?? '';
-        const combined = existing + output;
-        // Cap at 100KB to prevent unbounded memory growth from chatty processes.
-        // Keep the tail so the user sees the most recent output.
-        const MAX_OUTPUT = 100_000;
-        streamOutputs.set(
-          executionId,
-          combined.length > MAX_OUTPUT
-            ? combined.slice(combined.length - MAX_OUTPUT)
-            : combined,
-        );
+        const existing = streamOutputs.get(executionId) ?? {
+          stdout: '',
+          stderr: '',
+        };
+        streamOutputs.set(executionId, {
+          stdout: cap(existing.stdout, stdout),
+          stderr: cap(existing.stderr, stderr),
+        });
       }),
     );
   },

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -116,9 +116,13 @@ export const streamMetaHandlers: HandlerRegistry = {
           streamOutputs = new Map();
           draft.processOutputs.set(stream, streamOutputs);
         }
-        // Prune entries for finished processes
+        // Prune entries for finished processes — but never prune the
+        // incoming executionId, which we're about to update. The activeIds
+        // set can be stale for non-active streams (badge updates only fire
+        // for the active stream), so pruning the current ID would discard
+        // accumulated output and keep only the latest delta.
         for (const id of [...streamOutputs.keys()]) {
-          if (!activeIds.has(id)) streamOutputs.delete(id);
+          if (id !== executionId && !activeIds.has(id)) streamOutputs.delete(id);
         }
         const existing = streamOutputs.get(executionId) ?? {
           stdout: '',

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -1,6 +1,6 @@
 /**
  * Stream metadata handlers: UPDATE_STREAM_STATUS, UPDATE_CONVERSATION_PROGRESS,
- * UPDATE_STREAM_BADGES.
+ * UPDATE_STREAM_BADGES, UPDATE_PROCESS_OUTPUT.
  */
 
 import { create } from 'mutative';
@@ -55,6 +55,21 @@ export const streamMetaHandlers: HandlerRegistry = {
         draft.finishedSubagentCount = data.finishedSubagentCount;
         draft.activeProcesses = data.activeProcesses;
         draft.finishedProcessCount = data.finishedProcessCount;
+      }),
+    );
+  },
+
+  [PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT]: (data, ctx) => {
+    const { stream, executionId, output } = data;
+    ctx.setState((prev) =>
+      create(prev, (draft) => {
+        let streamOutputs = draft.processOutputs.get(stream);
+        if (!streamOutputs) {
+          streamOutputs = new Map<string, string>();
+          draft.processOutputs.set(stream, streamOutputs);
+        }
+        const existing = streamOutputs.get(executionId) ?? '';
+        streamOutputs.set(executionId, existing + output);
       }),
     );
   },

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -12,6 +12,7 @@ import {
   type StreamTabId,
 } from '@shared/schemas';
 import type { StreamSort } from '@shared/streams/streamSort';
+import type { ProcessOutputMap } from './contexts/streamContexts';
 
 // Re-export schema types for components (single source of truth)
 export {
@@ -66,8 +67,8 @@ export interface ProgressState {
   streamLogs: Map<StreamTabId, StreamLogs>;
   followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
   /** Background process outputs per stream — separated so output appends don't trigger meta context updates.
-   *  Outer key: streamId, inner key: executionId → accumulated output text. */
-  processOutputs: Map<StreamTabId, Map<string, string>>;
+   *  Outer key: streamId, inner key: executionId → { stdout, stderr }. */
+  processOutputs: Map<StreamTabId, ProcessOutputMap>;
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -65,6 +65,9 @@ export interface ProgressState {
   /** Log messages per stream — separated so log appends don't trigger meta context updates */
   streamLogs: Map<StreamTabId, StreamLogs>;
   followupOptionsByStream: Map<StreamTabId, FollowupOptionsState>;
+  /** Background process outputs per stream — separated so output appends don't trigger meta context updates.
+   *  Outer key: streamId, inner key: executionId → accumulated output text. */
+  processOutputs: Map<StreamTabId, Map<string, string>>;
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */
@@ -83,6 +86,7 @@ export function createInitialState(): ProgressState {
     streamStates: new Map(),
     streamLogs: new Map(),
     followupOptionsByStream: new Map(),
+    processOutputs: new Map(),
   };
 }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -314,6 +314,19 @@ export class WebviewUpdater {
     });
   }
 
+  updateProcessOutput(
+    stream: StreamTabId,
+    executionId: string,
+    output: string,
+  ): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
+      stream,
+      executionId,
+      output,
+    });
+  }
+
   updateParentStream(
     stream: StreamTabId,
     parentStreamId: StreamTabId | undefined,

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -317,13 +317,15 @@ export class WebviewUpdater {
   updateProcessOutput(
     stream: StreamTabId,
     executionId: string,
-    output: string,
+    stdout: string,
+    stderr: string,
   ): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
       stream,
       executionId,
-      output,
+      stdout,
+      stderr,
     });
   }
 

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -147,6 +147,13 @@ export const UpdateStreamBadgesMessageSchema = z.object({
   finishedProcessCount: z.number(),
 });
 
+export const UpdateProcessOutputMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT),
+  stream: StreamTabIdSchema,
+  executionId: z.string(),
+  output: z.string(),
+});
+
 export const UpdateParentStreamMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM),
   stream: StreamTabIdSchema,
@@ -352,6 +359,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     SetActiveStreamMessageSchema,
     UpdateConversationProgressMessageSchema,
     UpdateStreamBadgesMessageSchema,
+    UpdateProcessOutputMessageSchema,
     UpdateParentStreamMessageSchema,
     UpdateStreamStatusMessageSchema,
     LogDeltaMessageSchema,

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -151,7 +151,8 @@ export const UpdateProcessOutputMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT),
   stream: StreamTabIdSchema,
   executionId: z.string(),
-  output: z.string(),
+  stdout: z.string(),
+  stderr: z.string(),
 });
 
 export const UpdateParentStreamMessageSchema = z.object({

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -21,9 +21,6 @@ import {
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
-// Local imports - event bus
-import { bus } from '@eventBus/ProgressEventBus';
-
 // Local imports - tools
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
@@ -173,43 +170,14 @@ export class BashTool extends defineTool({
 
     let pid: number | undefined;
     const startedAt = Date.now();
-
-    // Throttled output emitter: buffer chunks and flush to event bus periodically
-    const OUTPUT_FLUSH_INTERVAL_MS = 300;
-    let outputBuffer = '';
-    let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    const flushOutput = (): void => {
-      flushTimer = null;
-      if (outputBuffer.length > 0) {
-        bus.emit('updateProcessOutput', {
-          parentStreamId,
-          executionId,
-          output: outputBuffer,
-        });
-        outputBuffer = '';
-      }
-    };
-    const appendOutput = (chunk: string): void => {
-      outputBuffer += chunk;
-      if (!flushTimer) {
-        flushTimer = setTimeout(flushOutput, OUTPUT_FLUSH_INTERVAL_MS);
-      }
-    };
-
     const promise = executeCommand(command, {
       timeout: timeoutMs,
       buffer: false, // Output is streamed to disk; don't buffer in memory
       onPid: (p) => {
         pid = p;
       },
-      onStdout: (chunk) => {
-        stdoutStream.write(chunk);
-        appendOutput(chunk);
-      },
-      onStderr: (chunk) => {
-        stderrStream.write(chunk);
-        appendOutput(chunk);
-      },
+      onStdout: (chunk) => stdoutStream.write(chunk),
+      onStderr: (chunk) => stderrStream.write(chunk),
     });
 
     const kill = (): boolean => {
@@ -252,9 +220,6 @@ export class BashTool extends defineTool({
     trackExecution(handle);
 
     const cleanupTempFiles = (): void => {
-      // Flush any remaining buffered output before cleanup
-      if (flushTimer) clearTimeout(flushTimer);
-      flushOutput();
       stdoutStream.end();
       stderrStream.end();
       handle.outputPaths = undefined;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -21,6 +21,9 @@ import {
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
+// Local imports - event bus
+import { bus } from '@eventBus/ProgressEventBus';
+
 // Local imports - tools
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
@@ -170,14 +173,43 @@ export class BashTool extends defineTool({
 
     let pid: number | undefined;
     const startedAt = Date.now();
+
+    // Throttled output emitter: buffer chunks and flush to event bus periodically
+    const OUTPUT_FLUSH_INTERVAL_MS = 300;
+    let outputBuffer = '';
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const flushOutput = (): void => {
+      flushTimer = null;
+      if (outputBuffer.length > 0) {
+        bus.emit('updateProcessOutput', {
+          parentStreamId,
+          executionId,
+          output: outputBuffer,
+        });
+        outputBuffer = '';
+      }
+    };
+    const appendOutput = (chunk: string): void => {
+      outputBuffer += chunk;
+      if (!flushTimer) {
+        flushTimer = setTimeout(flushOutput, OUTPUT_FLUSH_INTERVAL_MS);
+      }
+    };
+
     const promise = executeCommand(command, {
       timeout: timeoutMs,
       buffer: false, // Output is streamed to disk; don't buffer in memory
       onPid: (p) => {
         pid = p;
       },
-      onStdout: (chunk) => stdoutStream.write(chunk),
-      onStderr: (chunk) => stderrStream.write(chunk),
+      onStdout: (chunk) => {
+        stdoutStream.write(chunk);
+        appendOutput(chunk);
+      },
+      onStderr: (chunk) => {
+        stderrStream.write(chunk);
+        appendOutput(chunk);
+      },
     });
 
     const kill = (): boolean => {
@@ -220,6 +252,9 @@ export class BashTool extends defineTool({
     trackExecution(handle);
 
     const cleanupTempFiles = (): void => {
+      // Flush any remaining buffered output before cleanup
+      if (flushTimer) clearTimeout(flushTimer);
+      flushOutput();
       stdoutStream.end();
       stderrStream.end();
       handle.outputPaths = undefined;


### PR DESCRIPTION
## Summary
This PR adds a collapsible "Background Tasks" panel to the progress view that displays active and finished processes/subagents with real-time terminal output streaming. The panel integrates with the existing execution registry to poll process output files and stream incremental updates to the UI.

## Key Changes

### New Components
- **BackgroundTasksPanel** (`src/progressView/frontend/components/BackgroundTasksPanel.ts`): A new collapsible panel component that displays:
  - Summary badges showing counts of running/completed tasks
  - Separate sections for processes and subagents
  - Per-task collapsible output sections powered by the existing TerminalOutput component
  - Real-time output streaming via context subscription

### Process Output Polling
- **executionRegistry.ts**: Added incremental file polling system:
  - `reconcileOutputPoller()`: Manages a polling interval that starts when processes are tracked and stops when none remain
  - `pollProcessOutputs()`: Reads stdout/stderr from temp files at 500ms intervals
  - `readIncremental()`: Tracks byte offsets to emit only new output deltas
  - Captures final output on process cleanup before removal

### Context & State Management
- **streamContexts.ts**: New `processOutputContext` for background process outputs (separate from log context to avoid unnecessary re-renders)
- **store.ts**: Added `processOutputs` state as `Map<StreamTabId, Map<executionId, output>>`
- **streamMetaSlice.ts**: Handler for `UPDATE_PROCESS_OUTPUT` command that accumulates output per execution

### UI Integration
- **StreamHeader.ts**: Made child badges (process/subagent counts) clickable with keyboard support to toggle the background tasks panel
- **WorkflowStreamContent.ts** & **ToolUseStreamContent.ts**: Integrated BackgroundTasksPanel with refs for programmatic control
- **ProgressApp.ts**: Provides `processOutputContext` to the component tree

### Event & Message Infrastructure
- **ProgressEventBus.ts**: Added `updateProcessOutput` event payload
- **WebviewUpdater.ts**: New `updateProcessOutput()` method to send output updates to webview
- **ProgressEventHandler.ts**: Handler for routing process output events
- **progressViewCommands.ts**: New `UPDATE_PROCESS_OUTPUT` command
- **progressView.ts**: Schema validation for output update messages
- **events.ts**: New `backgroundTasksToggle` event for panel visibility control

### Cleanup
- **streamLifecycleSlice.ts** & **eventHandlers.ts**: Clean up process outputs when streams are deleted

## Implementation Details
- Output polling uses incremental reads with byte offset tracking to minimize data transfer
- Both stdout and stderr are concatenated in the UI (stderr appended after stdout)
- The polling interval is dynamically managed—only active when processes exist
- Final output is captured on process removal to ensure no data loss
- The separate `processOutputContext` prevents unnecessary re-renders of other components on every output chunk

https://claude.ai/code/session_01FVBUT3G8LtkiRm6nUeJNa8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces continuous file polling and new cross-layer event/message paths; bugs could impact performance (polling/allocations) or drop/misassociate process output, but it avoids auth/data-sensitive areas.
> 
> **Overview**
> Adds a new **collapsible `BackgroundTasksPanel`** to the progress view that lists active/finished subagents and background processes and shows per-process terminal output in-line.
> 
> Implements incremental **process output streaming** by polling process temp files in `executionRegistry` (offset-tracked, UTF-8 boundary safe, size-capped), emitting a new `updateProcessOutput` event/message, and ensuring a final flush happens *before* process badge removal so output isn’t lost.
> 
> Extends frontend state and messaging (`UPDATE_PROCESS_OUTPUT`, schemas, `WebviewUpdater`, handlers) with a dedicated `processOutputContext` + `processOutputs` store branch to accumulate/cap output and prune stale entries, and makes header child-count badges clickable/keyboard-accessible to toggle the panel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05773893d6c64d73ce5f8a2dc5cee441fce31a43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->