### PR TITLE
Add webpack loader support for .tex files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.36.5",
+      "version": "0.36.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,6 +180,10 @@ const extensionConfig = {
         test: /\.node$/,
         use: 'node-loader',
       },
+      {
+        test: /\.tex$/,
+        type: 'asset/source',
+      },
     ],
   },
   devtool: 'nosources-source-map',


### PR DESCRIPTION
## Summary
Added webpack configuration to handle LaTeX (.tex) files as static assets in the build process.

## Changes
- Added a new webpack loader rule for `.tex` files using the `asset/source` type, which treats them as source assets and includes their content as a string in the bundle

## Implementation Details
The new loader rule is configured to:
- Match files with the `.tex` extension
- Use webpack's built-in `asset/source` type to load the file content as a string rather than as a binary asset
- This allows LaTeX files to be imported and used directly within the application code

https://claude.ai/code/session_01XMGzJY96VekrXT6743tdGd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only webpack rule change plus a lockfile version bump; low risk aside from possible bundle-size or import-behavior changes for `.tex` files.
> 
> **Overview**
> Enables importing LaTeX `*.tex` files into the bundle by adding a webpack module rule that treats them as `asset/source` (raw string content).
> 
> Also bumps the project version in `package-lock.json` from `0.36.5` to `0.36.6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 027ee1ee6e210986895f97c1c27e1a55ebe04a0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->