### PR TITLE
Claude/collapsible background tasks sk lb1

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -207,10 +207,12 @@ function collectChildSummary(
     ) {
       continue;
     }
+    const statusInfo = handle.getStatus();
     result.push({
       executionId: handle.executionId,
       agentName: handle.agentName,
-      status: handle.getStatus().status,
+      status: statusInfo.status,
+      elapsed: statusInfo.elapsed ?? null,
       ...(handle instanceof AgentExecutionHandle
         ? { childStreamId: handle.childStreamId }
         : {}),

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -210,6 +210,7 @@ function collectChildSummary(
     result.push({
       executionId: handle.executionId,
       agentName: handle.agentName,
+      status: handle.getStatus().status,
       ...(handle instanceof AgentExecutionHandle
         ? { childStreamId: handle.childStreamId }
         : {}),

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -210,6 +210,9 @@ function collectChildSummary(
     result.push({
       executionId: handle.executionId,
       agentName: handle.agentName,
+      ...(handle instanceof AgentExecutionHandle
+        ? { childStreamId: handle.childStreamId }
+        : {}),
     });
   }
   return result;

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -28,7 +28,7 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 
 // Local imports - types
-import type { ActiveChildInfo } from '@shared/schemas';
+import { STREAM_STATUS, type ActiveChildInfo } from '@shared/schemas';
 
 // Local imports - events
 import { ProgressEvents } from '../events';
@@ -110,13 +110,20 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-status {
-        --_tint: var(--color-warning, var(--vscode-charts-orange));
         flex-shrink: 0;
         font-size: var(--font-size-xs, 10px);
         padding: 1px var(--spacing-small);
         border-radius: var(--border-radius-small);
         color: var(--_tint);
         background: color-mix(in srgb, var(--_tint) 12%, transparent);
+      }
+
+      .task-status--running {
+        --_tint: var(--color-warning, var(--vscode-charts-orange));
+      }
+
+      .task-status--waiting {
+        --_tint: var(--color-text-secondary);
       }
 
       .section-label {
@@ -200,7 +207,7 @@ export class BackgroundTasksPanel extends LitElement {
     const finished = this.finishedProcessCount + this.finishedSubagentCount;
     if (active + finished === 0) return nothing;
 
-    const title = this.buildTitle(active, finished);
+    const title = this.buildTitle(finished);
 
     return html`
       <vscode-collapsible
@@ -217,13 +224,18 @@ export class BackgroundTasksPanel extends LitElement {
     `;
   }
 
-  private buildTitle(active: number, finished: number): string {
-    const parts = ['Background Tasks'];
-    if (active > 0) parts.push(`${active} running`);
-    if (finished > 0) parts.push(`${finished} done`);
-    return parts.length > 1
-      ? `${parts[0]} (${parts.slice(1).join(', ')})`
-      : parts[0];
+  private buildTitle(finished: number): string {
+    const all = [...this.activeProcesses, ...this.activeSubagents];
+    const running = all.filter((c) => !isWaiting(c)).length;
+    const waiting = all.filter((c) => isWaiting(c)).length;
+
+    const segments: string[] = [];
+    if (running > 0) segments.push(`${running} running`);
+    if (waiting > 0) segments.push(`${waiting} waiting`);
+    if (finished > 0) segments.push(`${finished} done`);
+    return segments.length > 0
+      ? `Background Tasks (${segments.join(', ')})`
+      : 'Background Tasks';
   }
 
   private renderSection(
@@ -311,7 +323,14 @@ export class BackgroundTasksPanel extends LitElement {
               : nothing}
             >${child.agentName}</span
           >
-          <span class="task-status task-status--running">running</span>
+          <span
+            class=${classMap({
+              'task-status': true,
+              'task-status--running': !isWaiting(child),
+              'task-status--waiting': isWaiting(child),
+            })}
+            >${isWaiting(child) ? 'waiting' : 'running'}</span
+          >
         </div>
         ${hasStdout
           ? this.renderOutputStream('stdout', entry!.stdout)
@@ -357,6 +376,11 @@ export function toggleBackgroundTasksPanel(
   if (!panel) return;
   panel.open = !panel.open;
   panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+/** Check if a child is in a waiting/idle state rather than actively processing. */
+function isWaiting(child: ActiveChildInfo): boolean {
+  return child.status === STREAM_STATUS.WAITING || child.status === STREAM_STATUS.READY;
 }
 
 declare global {

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -109,6 +109,12 @@ export class BackgroundTasksPanel extends LitElement {
         text-decoration-color: var(--vscode-foreground);
       }
 
+      .task-elapsed {
+        flex-shrink: 0;
+        font-size: var(--font-size-xs, 10px);
+        color: var(--color-text-secondary);
+      }
+
       .task-status {
         flex-shrink: 0;
         font-size: var(--font-size-xs, 10px);
@@ -321,6 +327,9 @@ export class BackgroundTasksPanel extends LitElement {
               : nothing}
             >${child.agentName}</span
           >
+          ${child.elapsed
+            ? html`<span class="task-elapsed">(${child.elapsed})</span>`
+            : nothing}
           <span
             class=${classMap({
               'task-status': true,

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -207,12 +207,10 @@ export class BackgroundTasksPanel extends LitElement {
     const finished = this.finishedProcessCount + this.finishedSubagentCount;
     if (active + finished === 0) return nothing;
 
-    const title = this.buildTitle(finished);
-
     return html`
       <vscode-collapsible
         class="panel-collapsible"
-        title=${title}
+        title="Background Tasks"
         ?open=${this.open}
         @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
       >
@@ -222,20 +220,6 @@ export class BackgroundTasksPanel extends LitElement {
         </div>
       </vscode-collapsible>
     `;
-  }
-
-  private buildTitle(finished: number): string {
-    const all = [...this.activeProcesses, ...this.activeSubagents];
-    const running = all.filter((c) => !isWaiting(c)).length;
-    const waiting = all.filter((c) => isWaiting(c)).length;
-
-    const segments: string[] = [];
-    if (running > 0) segments.push(`${running} running`);
-    if (waiting > 0) segments.push(`${waiting} waiting`);
-    if (finished > 0) segments.push(`${finished} done`);
-    return segments.length > 0
-      ? `Background Tasks (${segments.join(', ')})`
-      : 'Background Tasks';
   }
 
   private renderSection(

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -1,9 +1,9 @@
 /**
  * Collapsible panel for displaying background tasks (processes and subagents).
  *
- * Shows a summary badge in the collapsed header and a list of active/finished
- * tasks when expanded. Each active task has a collapsible real-time terminal
- * output section powered by the existing TerminalOutput (xterm.js) component.
+ * Uses `<vscode-collapsible>` for consistent styling with other panels (Todos,
+ * Files, etc.). Each active subagent is clickable to navigate to its stream tab.
+ * Processes don't have their own tab so they are not clickable.
  */
 
 // Third-party imports
@@ -30,6 +30,9 @@ import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 // Local imports - types
 import type { ActiveChildInfo } from '@shared/schemas';
 
+// Local imports - events
+import { ProgressEvents } from '../events';
+
 // Local imports - contexts
 import {
   EMPTY_PROCESS_OUTPUTS,
@@ -55,46 +58,10 @@ export class BackgroundTasksPanel extends LitElement {
         display: none;
       }
 
-      details.panel-root {
-        border-top: var(--border-thin) solid var(--color-border);
-      }
-
-      summary {
-        padding: var(--spacing-small) var(--spacing-medium);
-      }
-
-      .panel-title {
-        font-weight: var(--font-weight-medium);
-        font-size: var(--font-size-sm);
-        color: var(--color-text-secondary);
-      }
-
-      .badge-count {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-tiny);
-        margin-left: var(--spacing-small);
-        padding: 1px var(--spacing-small);
-        font-size: var(--font-size-xs, 10px);
-        font-weight: var(--font-weight-semibold);
-        border-radius: var(--border-radius-small);
-        white-space: nowrap;
-        color: var(--_tint);
-        background: color-mix(in srgb, var(--_tint) 12%, transparent);
-      }
-
-      .badge-count--active {
-        --_tint: var(--color-warning, var(--vscode-charts-orange));
-      }
-
-      .badge-count--done {
-        --_tint: var(--color-text-secondary);
-      }
-
       .task-list {
-        list-style: none;
-        margin: 0;
-        padding: 0 var(--spacing-medium) var(--spacing-small);
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-tiny);
       }
 
       .task-item {
@@ -129,6 +96,17 @@ export class BackgroundTasksPanel extends LitElement {
         text-overflow: ellipsis;
         white-space: nowrap;
         color: var(--vscode-foreground);
+      }
+
+      .task-name--clickable {
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-color: transparent;
+        transition: text-decoration-color 0.15s ease;
+      }
+
+      .task-name--clickable:hover {
+        text-decoration-color: var(--vscode-foreground);
       }
 
       .task-status {
@@ -222,29 +200,30 @@ export class BackgroundTasksPanel extends LitElement {
     const finished = this.finishedProcessCount + this.finishedSubagentCount;
     if (active + finished === 0) return nothing;
 
+    const title = this.buildTitle(active, finished);
+
     return html`
-      <details class="panel-root" ?open=${this.open} @toggle=${this.handleToggle}>
-        <summary class="details-summary">
-          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
-          <i class="codicon codicon-terminal panel-icon"></i>
-          <span class="panel-title">Background Tasks</span>
-          ${active > 0
-            ? html`<span class="badge-count badge-count--active"
-                >${active} running</span
-              >`
-            : nothing}
-          ${finished > 0
-            ? html`<span class="badge-count badge-count--done"
-                >${finished} done</span
-              >`
-            : nothing}
-        </summary>
+      <vscode-collapsible
+        class="panel-collapsible"
+        title=${title}
+        ?open=${this.open}
+        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
+      >
         <div class="task-list">
           ${this.renderSection(this.activeProcesses, this.finishedProcessCount, 'process')}
           ${this.renderSection(this.activeSubagents, this.finishedSubagentCount, 'subagent')}
         </div>
-      </details>
+      </vscode-collapsible>
     `;
+  }
+
+  private buildTitle(active: number, finished: number): string {
+    const parts = ['Background Tasks'];
+    if (active > 0) parts.push(`${active} running`);
+    if (finished > 0) parts.push(`${finished} done`);
+    return parts.length > 1
+      ? `${parts[0]} (${parts.slice(1).join(', ')})`
+      : parts[0];
   }
 
   private renderSection(
@@ -295,6 +274,7 @@ export class BackgroundTasksPanel extends LitElement {
     const entry = this.processOutputs.get(child.executionId);
     const hasStdout = Boolean(entry?.stdout);
     const hasStderr = Boolean(entry?.stderr);
+    const isClickable = kind === 'subagent' && Boolean(child.childStreamId);
 
     return html`
       <div class="task-item">
@@ -308,7 +288,27 @@ export class BackgroundTasksPanel extends LitElement {
               'task-icon--subagent': kind === 'subagent',
             })}
           ></i>
-          <span class="task-name" title=${child.agentName}
+          <span
+            class=${classMap({
+              'task-name': true,
+              'task-name--clickable': isClickable,
+            })}
+            title=${isClickable
+              ? `Go to ${child.agentName}`
+              : child.agentName}
+            role=${isClickable ? 'link' : 'text'}
+            tabindex=${isClickable ? '0' : '-1'}
+            @click=${isClickable
+              ? () => this.navigateToStream(child.childStreamId!)
+              : nothing}
+            @keydown=${isClickable
+              ? (e: KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.navigateToStream(child.childStreamId!);
+                  }
+                }
+              : nothing}
             >${child.agentName}</span
           >
           <span class="task-status task-status--running">running</span>
@@ -340,10 +340,12 @@ export class BackgroundTasksPanel extends LitElement {
     `;
   }
 
-  private handleToggle(e: ToggleEvent): void {
-    // Only react to the outer panel-root toggle, not bubbled inner <details>
-    if (e.target !== e.currentTarget) return;
-    this.open = (e.currentTarget as HTMLDetailsElement).open;
+  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
+    this.open = e.detail?.open ?? this.open;
+  }
+
+  private navigateToStream(streamId: string): void {
+    this.dispatchEvent(ProgressEvents.streamSwitch({ streamId }));
   }
 }
 

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -136,6 +136,17 @@ export class BackgroundTasksPanel extends LitElement {
         color: var(--color-text-secondary);
         text-transform: uppercase;
         letter-spacing: 0.05em;
+        cursor: pointer;
+        list-style: none;
+        user-select: none;
+      }
+
+      .section-label::-webkit-details-marker {
+        display: none;
+      }
+
+      .section-label:hover {
+        color: var(--vscode-foreground);
       }
 
       .section-label .codicon {
@@ -236,28 +247,31 @@ export class BackgroundTasksPanel extends LitElement {
     const label = kind === 'process' ? 'Processes' : 'Subagents';
 
     return html`
-      <div class="section-label">
-        <i class="codicon ${icon}"></i>
-        <span
-          >${label}${hasActive
-            ? html` &middot; ${active.length} active`
-            : nothing}${hasFinished
-            ? html` &middot; ${finishedCount} done`
-            : nothing}</span
-        >
-      </div>
-      ${hasActive
-        ? repeat(
-            active,
-            (c) => c.executionId,
-            (c) => this.renderTaskItem(c, kind),
-          )
-        : nothing}
-      ${!hasActive && hasFinished
-        ? html`<div class="empty-message">
-            All ${finishedCount} ${label.toLowerCase()} completed
-          </div>`
-        : nothing}
+      <details open>
+        <summary class="section-label">
+          <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
+          <i class="codicon ${icon}"></i>
+          <span
+            >${label}${hasActive
+              ? html` &middot; ${active.length} active`
+              : nothing}${hasFinished
+              ? html` &middot; ${finishedCount} done`
+              : nothing}</span
+          >
+        </summary>
+        ${hasActive
+          ? repeat(
+              active,
+              (c) => c.executionId,
+              (c) => this.renderTaskItem(c, kind),
+            )
+          : nothing}
+        ${!hasActive && hasFinished
+          ? html`<div class="empty-message">
+              All ${finishedCount} ${label.toLowerCase()} completed
+            </div>`
+          : nothing}
+      </details>
     `;
   }
 

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -575,13 +575,21 @@ export class StreamHeader extends LitElement {
 
   /** Render a child-count badge (subagents or processes). */
   private renderChildBadge(
-    active: { agentName: string }[],
+    active: { agentName: string; status?: string }[],
     finishedCount: number,
     icon: string,
     cssClass: string,
   ): TemplateResult | typeof nothing {
     const total = active.length + finishedCount;
     if (total === 0) return nothing;
+    const running = active.filter(
+      (c) => c.status !== STREAM_STATUS.WAITING && c.status !== STREAM_STATUS.READY,
+    ).length;
+    const waiting = active.length - running;
+    const segments: string[] = [];
+    if (running > 0) segments.push(`${running} running`);
+    if (waiting > 0) segments.push(`${waiting} waiting`);
+    if (finishedCount > 0) segments.push(`${finishedCount} done`);
     return html`<span
       class="child-badge child-badge--clickable ${cssClass}"
       role="button"
@@ -591,11 +599,7 @@ export class StreamHeader extends LitElement {
       @keydown=${this.handleBadgeKeydown}
     >
       <i class="codicon codicon-${icon}"></i>
-      ${active.length > 0
-        ? html`${active.length} running`
-        : nothing}${active.length > 0 && finishedCount > 0
-        ? html`, `
-        : nothing}${finishedCount > 0 ? html`${finishedCount} done` : nothing}
+      ${segments.join(', ')}
     </span>`;
   }
 

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -102,27 +102,28 @@ export const streamMetaHandlers: HandlerRegistry = {
         : combined;
     };
     ctx.setState((prev) => {
-      // Prune stale entries opportunistically — this is the only handler
-      // that fires for non-active streams, so it's the only chance to clean up.
-      const streamState = prev.streamStates.get(stream);
-      const activeIds = new Set(
-        (streamState?.activeProcesses ?? []).map(
-          (p: { executionId: string }) => p.executionId,
-        ),
-      );
+      // Only prune stale entries when this stream is active — badge data
+      // (activeProcesses) is only refreshed for the active stream, so for
+      // inactive streams the set would be stale and we'd incorrectly delete
+      // output for still-running sibling processes. For inactive streams,
+      // pruning is handled by UPDATE_STREAM_BADGES when the user switches back.
+      const isActiveStream = prev.activeStreamId === stream;
       return create(prev, (draft) => {
         let streamOutputs = draft.processOutputs.get(stream);
         if (!streamOutputs) {
           streamOutputs = new Map();
           draft.processOutputs.set(stream, streamOutputs);
         }
-        // Prune entries for finished processes — but never prune the
-        // incoming executionId, which we're about to update. The activeIds
-        // set can be stale for non-active streams (badge updates only fire
-        // for the active stream), so pruning the current ID would discard
-        // accumulated output and keep only the latest delta.
-        for (const id of [...streamOutputs.keys()]) {
-          if (id !== executionId && !activeIds.has(id)) streamOutputs.delete(id);
+        if (isActiveStream) {
+          const streamState = prev.streamStates.get(stream);
+          const activeIds = new Set(
+            (streamState?.activeProcesses ?? []).map(
+              (p: { executionId: string }) => p.executionId,
+            ),
+          );
+          for (const id of [...streamOutputs.keys()]) {
+            if (id !== executionId && !activeIds.has(id)) streamOutputs.delete(id);
+          }
         }
         const existing = streamOutputs.get(executionId) ?? {
           stdout: '',

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -32,6 +32,8 @@ export type FollowupMode = z.infer<typeof FollowupModeSchema>;
 export const ActiveChildInfoSchema = z.object({
   executionId: z.string(),
   agentName: z.string(),
+  /** Stream tab ID for subagents (they have their own tab). Absent for processes. */
+  childStreamId: z.string().optional(),
 });
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -34,6 +34,8 @@ export const ActiveChildInfoSchema = z.object({
   agentName: z.string(),
   /** Stream tab ID for subagents (they have their own tab). Absent for processes. */
   childStreamId: z.string().optional(),
+  /** Current execution status (e.g. "running", "waiting"). Defaults to "running". */
+  status: z.string().optional(),
 });
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -36,6 +36,8 @@ export const ActiveChildInfoSchema = z.object({
   childStreamId: z.string().optional(),
   /** Current execution status (e.g. "running", "waiting"). Defaults to "running". */
   status: z.string().optional(),
+  /** Formatted elapsed time (e.g. "1m 23s"). */
+  elapsed: z.string().nullable().optional(),
 });
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared `ActiveChildInfo` schema and multiple progress-view components; regressions could affect task badge counts, navigation, or process output retention across streams. Changes are UI/state focused and not security-sensitive.
> 
> **Overview**
> **Background task badges now carry richer runtime info.** Backend `ExecutionHandle.collectChildSummary()` includes each child’s `status`, formatted `elapsed`, and (for subagents) `childStreamId`, and `ActiveChildInfo` is expanded accordingly.
> 
> **Progress UI behavior is updated to use that data.** The Background Tasks panel is rebuilt on `<vscode-collapsible>`, shows `running` vs `waiting` (READY/WAITING) plus optional elapsed time, and makes subagent names keyboard/click navigable to their stream. Stream header badges now display segmented counts (e.g. `X running, Y waiting, Z done`).
> 
> **Process output pruning is safer.** `UPDATE_PROCESS_OUTPUT` only prunes stale output entries when the stream is active, avoiding accidental deletion for still-running processes on inactive streams (pruning is deferred to `UPDATE_STREAM_BADGES`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11389de6ede817bbb06f85ebf654b997e31a3641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->