### PR TITLE
Add post-compaction context for active executions

### DIFF
--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -142,11 +142,12 @@ export class ModelInvocationNode<
       if (this._config.getPostCompactionContext) {
         const context = this._config.getPostCompactionContext(this.services);
         if (context) {
-          shared.messages =
-            await this.services.modelHandler.createUserFollowUpMessages(
-              shared.messages,
-              context,
-            );
+          // All handler implementations mutate the array in-place and return
+          // the same reference, so no reassignment of shared.messages is needed.
+          await this.services.modelHandler.createUserFollowUpMessages(
+            shared.messages,
+            context,
+          );
         }
       }
     }

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -25,6 +25,12 @@ export interface ModelInvocationConfig<TShared, TServices> {
   getEndTag?: (services: TServices) => string | undefined;
   getTools?: (services: TServices) => ToolDefinition[] | undefined;
   storeResponse: (shared: TShared, response: unknown) => void;
+  /**
+   * Called after compaction to get additional context (e.g. active executions)
+   * to append to the compacted messages. Returns the context string to inject
+   * as a user follow-up message, or null if no context is needed.
+   */
+  getPostCompactionContext?: (services: TServices) => string | null;
   getDebugSaveOptions?: (
     shared: TShared,
     services: TServices,
@@ -130,6 +136,19 @@ export class ModelInvocationNode<
 
     if (successRes.updatedMessages != null) {
       replaceMessagesInPlace(shared.messages, successRes.updatedMessages);
+
+      // After compaction, inject active execution context so the agent knows
+      // about running subagents/background processes it launched pre-compaction.
+      if (this._config.getPostCompactionContext) {
+        const context = this._config.getPostCompactionContext(this.services);
+        if (context) {
+          shared.messages =
+            await this.services.modelHandler.createUserFollowUpMessages(
+              shared.messages,
+              context,
+            );
+        }
+      }
     }
 
     shared.responseTimeMs = successRes.responseTimeMs;

--- a/src/agent/core/flows/ModelInvocationNode.ts
+++ b/src/agent/core/flows/ModelInvocationNode.ts
@@ -142,12 +142,11 @@ export class ModelInvocationNode<
       if (this._config.getPostCompactionContext) {
         const context = this._config.getPostCompactionContext(this.services);
         if (context) {
-          // All handler implementations mutate the array in-place and return
-          // the same reference, so no reassignment of shared.messages is needed.
-          await this.services.modelHandler.createUserFollowUpMessages(
-            shared.messages,
-            context,
-          );
+          shared.messages =
+            await this.services.modelHandler.createUserFollowUpMessages(
+              shared.messages,
+              context,
+            );
         }
       }
     }

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -21,6 +21,8 @@ import { messageToSkeleton } from '@agent/utils/messageSkeletonUtils';
 import { checkForMassiveRepetition } from '@agent/utils/text/repetitionUtils';
 
 import { isTokenLimitStopReason } from '@agent/modelHandlers/utils/stopReasonUtils';
+import { getActiveChildren } from '@agent/runtime/executionRegistry';
+import { formatPostCompactionContext } from '@tools/subagentResults';
 import { bestConnectionMethod } from '@latex';
 import replacementEngine from '@replacement/engine';
 import { MESSAGE_TYPES, AgentFileLocationSchema } from '@shared/schemas';
@@ -650,6 +652,10 @@ export function createResponseCycleFlow<C>(): Flow<
         : undefined,
     storeResponse: (shared, response) => {
       shared.responseObject = response;
+    },
+    getPostCompactionContext: (services) => {
+      const { subagents, processes } = getActiveChildren(services.streamId);
+      return formatPostCompactionContext(subagents, processes);
     },
     getDebugSaveOptions: (shared, services) => ({
       context: {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -50,6 +50,8 @@ import { isNonEmptyString } from '@utils/core';
 import { formatContent } from '@utils/text/xmlUtils';
 
 // Local file imports
+import { getActiveChildren } from '@agent/runtime/executionRegistry';
+import { formatPostCompactionContext } from '@tools/subagentResults';
 import { FlowTransition } from './FlowTransitions';
 import { ModelInvocationNode } from './ModelInvocationNode';
 import type { CycleParams, ToolUseCycleServices } from './CycleServices';
@@ -905,6 +907,10 @@ export function createToolUseCycleFlow<C>(): Flow<
     streaming: true,
     storeResponse: (shared, response) => {
       shared.response = response;
+    },
+    getPostCompactionContext: (services) => {
+      const { subagents, processes } = getActiveChildren(services.streamId);
+      return formatPostCompactionContext(subagents, processes);
     },
     getDebugSaveOptions: (shared, services) => ({
       context: {

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -190,7 +190,7 @@ export function interruptActiveChildren(
 }
 
 /** Collect {executionId, agentName} for handles matching a class under a parent stream. */
-function collectChildSummary(
+export function collectChildSummary(
   parentStreamId: StreamTabId,
   handles: Iterable<ExecutionHandle>,
   ctor: new (...args: any[]) => ExecutionHandle,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -8,7 +8,7 @@
 import * as fs from 'fs';
 
 import { bus } from '@eventBus/ProgressEventBus';
-import type { StreamTabId } from '@shared/schemas';
+import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 import {
   type ExecutionHandle,
   AgentExecutionHandle,
@@ -222,8 +222,8 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
 
 /** Get active subagent and process children for a parent stream. */
 export function getActiveChildren(parentStreamId: StreamTabId): {
-  subagents: import('@shared/schemas').ActiveChildInfo[];
-  processes: import('@shared/schemas').ActiveChildInfo[];
+  subagents: ActiveChildInfo[];
+  processes: ActiveChildInfo[];
 } {
   return {
     subagents: collectChildSummary(

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -13,6 +13,7 @@ import {
   type ExecutionHandle,
   AgentExecutionHandle,
   ProcessExecutionHandle,
+  collectChildSummary,
   emitActiveSubagentsUpdate,
   emitActiveProcessesUpdate,
   interruptActiveChildren as interruptActiveChildrenImpl,
@@ -217,6 +218,25 @@ export function waitForAnyExecutionChange(
  */
 export function interruptActiveChildren(parentStreamId: StreamTabId): void {
   interruptActiveChildrenImpl(parentStreamId, registry.values());
+}
+
+/** Get active subagent and process children for a parent stream. */
+export function getActiveChildren(parentStreamId: StreamTabId): {
+  subagents: import('@shared/schemas').ActiveChildInfo[];
+  processes: import('@shared/schemas').ActiveChildInfo[];
+} {
+  return {
+    subagents: collectChildSummary(
+      parentStreamId,
+      registry.values(),
+      AgentExecutionHandle,
+    ),
+    processes: collectChildSummary(
+      parentStreamId,
+      registry.values(),
+      ProcessExecutionHandle,
+    ),
+  };
 }
 
 // ============================================================================

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -13,7 +13,7 @@ import type {
   OutputFileSummary,
 } from '@agent/runtime/AgentFlowResult';
 import type { ExecResult } from '@agent/types/ResultTypes';
-import type { SubagentProgressUpdate } from '@shared/schemas';
+import type { ActiveChildInfo, SubagentProgressUpdate } from '@shared/schemas';
 import { formatDuration } from '@utils/core';
 
 // ============================================================================
@@ -243,14 +243,6 @@ export function formatBashError(
 // Post-compaction execution context
 // ============================================================================
 
-/** Minimal execution info needed for post-compaction context formatting. */
-export interface ActiveExecutionSummary {
-  executionId: string;
-  agentName: string;
-  status?: string;
-  elapsed?: string | null;
-}
-
 /**
  * Format active execution state as context for the agent after compaction.
  * Returns null if there are no active children to report.
@@ -262,8 +254,8 @@ export interface ActiveExecutionSummary {
  * - Understand that pending results may arrive as follow-up messages
  */
 export function formatPostCompactionContext(
-  subagents: ActiveExecutionSummary[],
-  processes: ActiveExecutionSummary[],
+  subagents: ActiveChildInfo[],
+  processes: ActiveChildInfo[],
 ): string | null {
   if (subagents.length === 0 && processes.length === 0) {
     return null;

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -280,15 +280,15 @@ export function formatPostCompactionContext(
   }
 
   if (processes.length > 0) {
-    lines.push(`<active-processes count="${processes.length}">`);
+    lines.push(`<active-background-bash count="${processes.length}">`);
     for (const proc of processes) {
       const elapsedAttr =
         proc.elapsed ? ` elapsed="${escapeAttr(proc.elapsed)}"` : '';
       lines.push(
-        `  <process id="${escapeAttr(proc.executionId)}" command="${escapeAttr(proc.agentName)}"${elapsedAttr} />`,
+        `  <background-bash id="${escapeAttr(proc.executionId)}" command="${escapeAttr(proc.agentName)}"${elapsedAttr} />`,
       );
     }
-    lines.push('</active-processes>');
+    lines.push('</active-background-bash>');
   }
 
   lines.push('</post-compaction-context>');

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -239,6 +239,70 @@ export function formatBashError(
   ].join('\n');
 }
 
+// ============================================================================
+// Post-compaction execution context
+// ============================================================================
+
+/** Minimal execution info needed for post-compaction context formatting. */
+export interface ActiveExecutionSummary {
+  executionId: string;
+  agentName: string;
+  status?: string;
+  elapsed?: string | null;
+}
+
+/**
+ * Format active execution state as context for the agent after compaction.
+ * Returns null if there are no active children to report.
+ *
+ * This helps the agent understand what subagents and background processes
+ * are still running after context was compressed, so it can:
+ * - Avoid launching duplicate subagents
+ * - Know which execution IDs to check on
+ * - Understand that pending results may arrive as follow-up messages
+ */
+export function formatPostCompactionContext(
+  subagents: ActiveExecutionSummary[],
+  processes: ActiveExecutionSummary[],
+): string | null {
+  if (subagents.length === 0 && processes.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [
+    '<post-compaction-context>',
+    '<note>Your conversation context was compacted (summarized) to free up space. The following executions were launched before compaction and may still be active. Their results will be delivered as follow-up messages when they complete. Use the executions tool to check on their status or read their results.</note>',
+  ];
+
+  if (subagents.length > 0) {
+    lines.push(`<active-subagents count="${subagents.length}">`);
+    for (const sa of subagents) {
+      const statusAttr = sa.status ? ` status="${escapeAttr(sa.status)}"` : '';
+      const elapsedAttr =
+        sa.elapsed ? ` elapsed="${escapeAttr(sa.elapsed)}"` : '';
+      lines.push(
+        `  <subagent id="${escapeAttr(sa.executionId)}" agent="${escapeAttr(sa.agentName)}"${statusAttr}${elapsedAttr} />`,
+      );
+    }
+    lines.push('</active-subagents>');
+  }
+
+  if (processes.length > 0) {
+    lines.push(`<active-processes count="${processes.length}">`);
+    for (const proc of processes) {
+      const elapsedAttr =
+        proc.elapsed ? ` elapsed="${escapeAttr(proc.elapsed)}"` : '';
+      lines.push(
+        `  <process id="${escapeAttr(proc.executionId)}" command="${escapeAttr(proc.agentName)}"${elapsedAttr} />`,
+      );
+    }
+    lines.push('</active-processes>');
+  }
+
+  lines.push('</post-compaction-context>');
+  return lines.join('\n');
+}
+
 function lastNLines(text: string, n: number): string {
   const lines = text.split('\n');
   return lines.length <= n ? text : lines.slice(-n).join('\n');


### PR DESCRIPTION
## Summary
When conversation context is compacted (summarized) to free up space, the agent loses awareness of subagents and background processes that were launched before compaction. This PR adds functionality to inform the agent about active executions after compaction, so it can avoid launching duplicates and understand that results may arrive as follow-up messages.

## Key Changes

- **New `formatPostCompactionContext()` function** in `subagentResults.ts`: Formats active subagent and process information as XML context for the agent after compaction. Returns null if there are no active children to report.

- **New `getActiveChildren()` export** in `executionRegistry.ts`: Retrieves active subagent and process children for a given parent stream by collecting summaries from the execution registry.

- **Enhanced `ModelInvocationNode`** in `ModelInvocationNode.ts`: Added optional `getPostCompactionContext` callback to the config. After message compaction, if this callback is provided and returns context, it's injected as a user follow-up message to inform the agent about active executions.

- **Integration in response cycles**: Both `ResponseCycleFlow.ts` and `ToolUseCycleFlow.ts` now implement the `getPostCompactionContext` callback to automatically provide active execution context after compaction.

- **Exported `collectChildSummary()`** in `ExecutionHandle.ts`: Made the internal helper function public to support the new `getActiveChildren()` functionality.

- **Type imports**: Added `ActiveChildInfo` type import where needed to support the new functionality.

## Implementation Details

The post-compaction context is formatted as XML with:
- A note explaining that context was compacted and results will arrive as follow-up messages
- Active subagents section with execution ID, agent name, status, and elapsed time
- Active processes section with execution ID, command, and elapsed time
- Proper XML attribute escaping for all values

This allows the agent to maintain awareness of in-flight executions across context boundaries and make informed decisions about launching new work.

https://claude.ai/code/session_0144ccpFQN38rF1b243CcgqW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core model-invocation flow and message mutation after compaction; mistakes could inject incorrect context or subtly alter conversation state across response/tool-use cycles.
> 
> **Overview**
> After message compaction, the agent now injects a follow-up user message describing any still-active subagents/background bash executions so it doesn’t lose awareness and re-launch duplicates.
> 
> This adds an optional `getPostCompactionContext` hook to `ModelInvocationNode`, wires it into both `ResponseCycleFlow` and `ToolUseCycleFlow`, exposes `collectChildSummary` and introduces `getActiveChildren` in `executionRegistry`, and adds `formatPostCompactionContext()` to serialize active execution info into XML.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d22f230bd4db1cf22c8a6f275c84e0c0baeef20d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->