### PR TITLE
Switch Anthropic handler to top-level automatic prompt caching

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -580,7 +580,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     if (supportsCache) {
       reservedCacheSlots += 1; // top-level automatic caching
       if (systemPrompt) reservedCacheSlots += 1; // system prompt breakpoint
-      if (tools?.length) reservedCacheSlots += 1; // last tool breakpoint
     }
     this.enforceCacheControlLimit(messages, reservedCacheSlots);
 
@@ -628,14 +627,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         supportsNativeWebFetch: this.capabilities.supportsNativeWebSearch,
         useDynamicFiltering: getAnthropicDynamicFiltering(),
       });
-
-      // Place an explicit cache breakpoint on the last tool definition so all
-      // tools are independently cached (tools rarely change between requests).
-      if (supportsCache && options.tools.length > 0) {
-        const lastTool = options.tools.at(-1)!;
-        (lastTool as { cache_control?: typeof EPHEMERAL_CACHE_CONTROL }).cache_control =
-          EPHEMERAL_CACHE_CONTROL;
-      }
 
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -224,7 +224,10 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
-const MAX_CACHE_CONTROLLED_BLOCKS = 4;
+// Anthropic allows up to 4 cache breakpoints total. Top-level automatic caching
+// uses 1 slot, so explicit block-level breakpoints (e.g. compaction blocks) are
+// limited to 3.
+const MAX_CACHE_CONTROLLED_BLOCKS = 3;
 
 const isCacheControlEligibleBlock = (
   block: CacheControlInspectableBlock,
@@ -249,7 +252,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
   Anthropic,
   BetaMessage
 > {
-  private cacheControlledBlock?: CacheControlEligibleBlock;
 
   /** Flag to force compaction on the next API call, set by requestCompaction(). */
   private compactionRequested = false;
@@ -376,24 +378,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return true;
   }
 
-  /**
-   * Sets or clears the cache control target block.
-   * Pass a block to set it as the cache target, or undefined/null to clear.
-   */
-  private updateCacheControlTarget(
-    block: CacheControlEligibleBlock | null | undefined,
-  ): void {
-    // Clear existing cache_control if switching to different block
-    if (this.cacheControlledBlock && this.cacheControlledBlock !== block) {
-      delete this.cacheControlledBlock.cache_control;
-    }
-
-    if (block && this.capabilities.supportsPromptCaching) {
-      block.cache_control = EPHEMERAL_CACHE_CONTROL;
-    }
-
-    this.cacheControlledBlock = block ?? undefined;
-  }
 
   /** Ensures a beta flag is included in options, initializing the array if needed. */
   private ensureBeta(options: MessageCreateParams, beta: AnthropicBeta): void {
@@ -469,23 +453,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     } satisfies BetaContextManagementConfig;
   }
 
-  private assignCacheControlToLatest(
-    content: (ContentBlockParam | ContentBlock)[] | undefined,
-  ): void {
-    if (!this.capabilities.supportsPromptCaching) {
-      return;
-    }
-
-    const target = content?.findLast(isCacheControlEligibleBlock);
-    if (target) {
-      this.updateCacheControlTarget(target);
-    } else if (content?.length) {
-      this.logger.debug(
-        'No eligible content block available for Anthropic cache control marker',
-      );
-      this.updateCacheControlTarget(undefined);
-    }
-  }
 
   async getClient(): Promise<Anthropic> {
     const credential = await this.getApiKey();
@@ -624,6 +591,12 @@ export class ModelHandlerAnthropic extends ModelHandler<
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
       system: systemPrompt,
+      // Top-level automatic caching: the API automatically applies a cache
+      // breakpoint to the last cacheable block, moving it forward as conversations
+      // grow. This replaces manual per-block cache_control assignment.
+      ...(this.capabilities.supportsPromptCaching && {
+        cache_control: EPHEMERAL_CACHE_CONTROL,
+      }),
     };
 
     if (tools?.length) {
@@ -1034,10 +1007,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     for (let idx = 0; idx < excess; idx += 1) {
       delete cacheControlledBlocks[idx].cache_control;
     }
-
-    this.cacheControlledBlock = cacheControlledBlocks.findLast(
-      isCacheControlEligibleBlock,
-    );
   }
 
   private async replaceDocumentDataWithUploads(
@@ -1333,8 +1302,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       throw new Error(errMsg);
     }
 
-    this.updateCacheControlTarget(undefined);
-
     // Create content list for the user message
     const userMessageContent: ContentBlockParam[] = [];
 
@@ -1368,8 +1335,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const messages: MessageParam[] = [
       { role: 'user', content: userMessageContent },
     ];
-
-    this.assignCacheControlToLatest(userMessageContent);
 
     return messages;
   }
@@ -1419,8 +1384,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     messages.push({ role: 'user', content: roundContent });
 
-    this.assignCacheControlToLatest(roundContent);
-
     return messages;
   }
 
@@ -1439,8 +1402,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       { type: 'text', text: trimmedMessage, citations: null },
     ];
     messages.push({ role: 'user', content });
-
-    this.assignCacheControlToLatest(content);
 
     return messages;
   }
@@ -1619,8 +1580,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       { type: 'text', text: userMessageContinuation },
     ];
     messages.push({ role: 'user', content });
-
-    this.assignCacheControlToLatest(content);
   }
 
   /** Initializes output file and handles prefill content, returning [isComplete, updatedMessages]. */
@@ -1686,7 +1645,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         content: [{ type: 'text', text: fileContent }],
       });
 
-      this.updateCacheControlTarget(undefined);
       return [true, messages];
     }
 
@@ -1702,8 +1660,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       `Using existing content as prefill: ${outputLocation.absolutePath}`,
     );
     messages.push({ role: 'assistant', content });
-
-    this.assignCacheControlToLatest(content);
 
     if (!this.capabilities.supportsAssistantPrefill) {
       // For models that don't support assistant prefill, we need to:
@@ -1877,9 +1833,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         ];
       }
 
-      this.assignCacheControlToLatest(
-        lastMessage.content as (ContentBlockParam | ContentBlock)[],
-      );
     }
   }
 
@@ -1925,7 +1878,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           type: 'text',
           text: bestConnector + newResponse,
         } as ContentBlockParam);
-        this.assignCacheControlToLatest(secondLastMessage.content);
       }
 
       messages.pop();
@@ -1955,7 +1907,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
       text: workspaceState.assembly.accumulatedOutput,
     } as ContentBlockParam);
 
-    this.assignCacheControlToLatest(content);
     messages.push({ role: 'assistant', content });
   }
 
@@ -2385,13 +2336,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         },
       ],
     };
-
-    const toolResultBlock = Array.isArray(resultMsg.content)
-      ? resultMsg.content.at(-1)
-      : undefined;
-    if (isCacheControlEligibleBlock(toolResultBlock)) {
-      this.updateCacheControlTarget(toolResultBlock);
-    }
 
     return [callMsg, resultMsg];
   }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -210,7 +210,7 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
 };
 
 // Anthropic allows up to 4 cache breakpoint slots total. Top-level automatic
-// caching and the system prompt each use one slot when present.
+// caching uses one slot, and the system prompt uses another when present.
 // enforceCacheControlLimit dynamically computes the remaining slots available
 // for message-level blocks (e.g. compaction blocks).
 const MAX_CACHE_BREAKPOINT_SLOTS = 4;
@@ -550,8 +550,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaActive =
       effectiveContextWindow > this.config.contextWindow;
 
-    // Count cache slots reserved by system prompt, tools, and top-level automatic
-    // caching so enforceCacheControlLimit knows how many remain for message blocks.
+    // Count cache slots reserved by top-level automatic caching and system prompt
+    // so enforceCacheControlLimit knows how many remain for message blocks.
     const supportsCache = this.capabilities.supportsPromptCaching;
     let reservedCacheSlots = 0;
     if (supportsCache) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -224,10 +224,11 @@ const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
-// Anthropic allows up to 4 cache breakpoints total. Top-level automatic caching
-// uses 1 slot, so explicit block-level breakpoints (e.g. compaction blocks) are
-// limited to 3.
-const MAX_CACHE_CONTROLLED_BLOCKS = 3;
+// Anthropic allows up to 4 cache breakpoint slots total. Top-level automatic
+// caching, the system prompt, and the last tool definition each use one slot
+// when present. enforceCacheControlLimit dynamically computes the remaining
+// slots available for message-level blocks (e.g. compaction blocks).
+const MAX_CACHE_BREAKPOINT_SLOTS = 4;
 
 const isCacheControlEligibleBlock = (
   block: CacheControlInspectableBlock,
@@ -572,7 +573,16 @@ export class ModelHandlerAnthropic extends ModelHandler<
     const isAnthropic1MBetaActive =
       effectiveContextWindow > this.config.contextWindow;
 
-    this.enforceCacheControlLimit(messages);
+    // Count cache slots reserved by system prompt, tools, and top-level automatic
+    // caching so enforceCacheControlLimit knows how many remain for message blocks.
+    const supportsCache = this.capabilities.supportsPromptCaching;
+    let reservedCacheSlots = 0;
+    if (supportsCache) {
+      reservedCacheSlots += 1; // top-level automatic caching
+      if (systemPrompt) reservedCacheSlots += 1; // system prompt breakpoint
+      if (tools?.length) reservedCacheSlots += 1; // last tool breakpoint
+    }
+    this.enforceCacheControlLimit(messages, reservedCacheSlots);
 
     const documentAnalysis = this.analyzeDocumentSources(messages);
     let hasFileReference = documentAnalysis.hasFileSource;
@@ -590,11 +600,23 @@ export class ModelHandlerAnthropic extends ModelHandler<
       messages,
       temperature,
       stop_sequences: endTag ? [endTag] : undefined,
-      system: systemPrompt,
+      // Structure system prompt as a block with an explicit cache breakpoint so
+      // it is independently cached even when conversations exceed the 20-block
+      // lookback window.
+      system:
+        systemPrompt && supportsCache
+          ? [
+              {
+                type: 'text' as const,
+                text: systemPrompt,
+                cache_control: EPHEMERAL_CACHE_CONTROL,
+              },
+            ]
+          : systemPrompt,
       // Top-level automatic caching: the API automatically applies a cache
       // breakpoint to the last cacheable block, moving it forward as conversations
       // grow. This replaces manual per-block cache_control assignment.
-      ...(this.capabilities.supportsPromptCaching && {
+      ...(supportsCache && {
         cache_control: EPHEMERAL_CACHE_CONTROL,
       }),
     };
@@ -606,6 +628,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
         supportsNativeWebFetch: this.capabilities.supportsNativeWebSearch,
         useDynamicFiltering: getAnthropicDynamicFiltering(),
       });
+
+      // Place an explicit cache breakpoint on the last tool definition so all
+      // tools are independently cached (tools rarely change between requests).
+      if (supportsCache && options.tools.length > 0) {
+        const lastTool = options.tools.at(-1)!;
+        (lastTool as { cache_control?: typeof EPHEMERAL_CACHE_CONTROL }).cache_control =
+          EPHEMERAL_CACHE_CONTROL;
+      }
+
       (options as MessageCreateParams).tool_choice = { type: 'auto' };
 
       // Models using adaptive thinking get interleaved thinking automatically.
@@ -966,10 +997,25 @@ export class ModelHandlerAnthropic extends ModelHandler<
     );
   }
 
-  private enforceCacheControlLimit(messages: MessageParam[]): void {
+  /**
+   * Enforces the Anthropic cache breakpoint slot limit for message-level blocks.
+   *
+   * @param messages - The conversation messages to enforce limits on
+   * @param reservedSlots - Number of slots already used by system prompt,
+   *   tools, and top-level automatic caching
+   */
+  private enforceCacheControlLimit(
+    messages: MessageParam[],
+    reservedSlots: number,
+  ): void {
     if (!this.capabilities.supportsPromptCaching) {
       return;
     }
+
+    const availableSlots = Math.max(
+      0,
+      MAX_CACHE_BREAKPOINT_SLOTS - reservedSlots,
+    );
 
     const cacheControlledBlocks: Array<
       CacheControlEligibleBlock | CacheControlCompactionBlock
@@ -999,10 +1045,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
     }
 
-    // Remove excess cache control markers, keeping only the last MAX_CACHE_CONTROLLED_BLOCKS
+    // Remove excess cache control markers, keeping only the most recent ones
     const excess = Math.max(
       0,
-      cacheControlledBlocks.length - MAX_CACHE_CONTROLLED_BLOCKS,
+      cacheControlledBlocks.length - availableSlots,
     );
     for (let idx = 0; idx < excess; idx += 1) {
       delete cacheControlledBlocks[idx].cache_control;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -200,46 +200,23 @@ interface ContextManagementSetupOptions {
   thresholdPercent: number;
 }
 
-/**
- * Block types that support cache_control for prompt caching.
- * Uses SDK's ContentBlockParam with Extract to get text and tool_result types.
- */
-type CacheControlEligibleBlock = Extract<
-  ContentBlockParam,
-  { type: 'text' | 'tool_result' }
->;
-
 type CacheControlCompactionBlock = Extract<
   BetaContentBlockParam,
   { type: 'compaction' }
 >;
-
-type CacheControlInspectableBlock =
-  | ContentBlockParam
-  | ContentBlock
-  | BetaContentBlockParam
-  | undefined;
 
 const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
 
 // Anthropic allows up to 4 cache breakpoint slots total. Top-level automatic
-// caching, the system prompt, and the last tool definition each use one slot
-// when present. enforceCacheControlLimit dynamically computes the remaining
-// slots available for message-level blocks (e.g. compaction blocks).
+// caching and the system prompt each use one slot when present.
+// enforceCacheControlLimit dynamically computes the remaining slots available
+// for message-level blocks (e.g. compaction blocks).
 const MAX_CACHE_BREAKPOINT_SLOTS = 4;
 
-const isCacheControlEligibleBlock = (
-  block: CacheControlInspectableBlock,
-): block is CacheControlEligibleBlock => {
-  if (block == null || typeof block !== 'object') return false;
-  const blockType = (block as { type?: string }).type;
-  return blockType === 'text' || blockType === 'tool_result';
-};
-
 const isCompactionCacheControlBlock = (
-  block: CacheControlInspectableBlock,
+  block: ContentBlockParam | ContentBlock | BetaContentBlockParam | undefined,
 ): block is CacheControlCompactionBlock => {
   if (block == null || typeof block !== 'object') return false;
   return (block as { type?: string }).type === 'compaction';
@@ -991,9 +968,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
   /**
    * Enforces the Anthropic cache breakpoint slot limit for message-level blocks.
    *
+   * With top-level automatic caching, only compaction blocks need explicit
+   * cache_control markers in messages. All other block-level markers (including
+   * legacy markers from saved conversations) are stripped. Compaction markers
+   * are then trimmed to fit within the remaining slot budget.
+   *
    * @param messages - The conversation messages to enforce limits on
-   * @param reservedSlots - Number of slots already used by system prompt,
-   *   tools, and top-level automatic caching
+   * @param reservedSlots - Number of slots already used by system prompt
+   *   and top-level automatic caching
    */
   private enforceCacheControlLimit(
     messages: MessageParam[],
@@ -1003,14 +985,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return;
     }
 
-    const availableSlots = Math.max(
-      0,
-      MAX_CACHE_BREAKPOINT_SLOTS - reservedSlots,
-    );
-
-    const cacheControlledBlocks: Array<
-      CacheControlEligibleBlock | CacheControlCompactionBlock
-    > = [];
+    const compactionBlocks: CacheControlCompactionBlock[] = [];
 
     for (const message of messages) {
       const content = message.content;
@@ -1019,30 +994,40 @@ export class ModelHandlerAnthropic extends ModelHandler<
       }
 
       for (const block of content) {
-        // Clear cache_control from ineligible blocks (defensive cleanup)
-        if (
-          !isCacheControlEligibleBlock(block) &&
-          !isCompactionCacheControlBlock(block)
-        ) {
-          if (block && typeof block === 'object' && 'cache_control' in block) {
-            delete (block as { cache_control?: unknown }).cache_control;
+        if (!block || typeof block !== 'object') {
+          continue;
+        }
+
+        // Cast to a broader type that includes compaction blocks (which appear
+        // at runtime via server-side context management but aren't in
+        // ContentBlockParam).
+        const anyBlock = block as ContentBlockParam | BetaContentBlockParam;
+
+        // Compaction blocks keep their markers — track them for slot limiting
+        if (isCompactionCacheControlBlock(anyBlock)) {
+          if (anyBlock.cache_control) {
+            compactionBlocks.push(anyBlock);
           }
           continue;
         }
 
-        if (block.cache_control) {
-          cacheControlledBlocks.push(block);
+        // Strip cache_control from all other blocks (legacy markers from saved
+        // conversations or ineligible block types). Top-level automatic caching
+        // handles the "last block" breakpoint now.
+        if ('cache_control' in block) {
+          delete (block as { cache_control?: unknown }).cache_control;
         }
       }
     }
 
-    // Remove excess cache control markers, keeping only the most recent ones
-    const excess = Math.max(
+    // Trim compaction markers if they exceed the remaining slot budget
+    const availableSlots = Math.max(
       0,
-      cacheControlledBlocks.length - availableSlots,
+      MAX_CACHE_BREAKPOINT_SLOTS - reservedSlots,
     );
+    const excess = Math.max(0, compactionBlocks.length - availableSlots);
     for (let idx = 0; idx < excess; idx += 1) {
-      delete cacheControlledBlocks[idx].cache_control;
+      delete compactionBlocks[idx].cache_control;
     }
   }
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -292,7 +292,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits explicit cache control markers to three blocks (reserving one slot for top-level automatic caching)', () => {
+  it('limits message-level cache markers based on reserved slots', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -309,7 +309,8 @@ describe('ModelHandlerAnthropic message guards', () => {
       { role: 'user', content: messageContent },
     ];
 
-    (handler as any).enforceCacheControlLimit(messages);
+    // Simulate 3 reserved slots (system + tools + automatic = typical case)
+    (handler as any).enforceCacheControlLimit(messages, 3);
 
     const cacheControlledBlocks = messageContent.filter(
       (block) =>
@@ -317,21 +318,15 @@ describe('ModelHandlerAnthropic message guards', () => {
         (block as { cache_control?: unknown }).cache_control !== undefined,
     );
 
-    assert.equal(cacheControlledBlocks.length, 3);
     assert.equal(
-      (messageContent[0] as { cache_control?: unknown }).cache_control,
-      undefined,
-      'the earliest cache markers should be removed',
-    );
-    assert.equal(
-      (messageContent[1] as { cache_control?: unknown }).cache_control,
-      undefined,
-      'the second earliest cache marker should also be removed',
+      cacheControlledBlocks.length,
+      1,
+      'only 1 message-level slot should remain when 3 are reserved',
     );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-2', 'block-3', 'block-4'],
-      'the three most recent blocks should retain cache control markers',
+      ['block-4'],
+      'only the most recent block should retain cache control',
     );
   });
 
@@ -351,7 +346,8 @@ describe('ModelHandlerAnthropic message guards', () => {
       { role: 'assistant', content: messageContent },
     ];
 
-    (handler as any).enforceCacheControlLimit(messages);
+    // 1 reserved slot (automatic only, no system or tools)
+    (handler as any).enforceCacheControlLimit(messages, 1);
 
     const preservedCompaction = (messages[0].content as any[]).find(
       (block) => block.type === 'compaction',

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -216,7 +216,7 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('moves the cache control marker to the newest message block', async () => {
+  it('does not set block-level cache markers on messages (top-level automatic caching handles this)', async () => {
     const handler = createAnthropicHandler();
     const baseMessages = await handler.initializeMessages(
       'prefix',
@@ -224,11 +224,11 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
     const initialContent = baseMessages[0].content as ContentBlockParam[];
     const initialBlock = initialContent.at(-1);
-    const initialMarker = getCacheMarker(initialBlock);
 
-    assert.ok(
-      initialMarker,
-      'expected the initial request to include a cache control marker',
+    assert.equal(
+      getCacheMarker(initialBlock),
+      undefined,
+      'initial message blocks should not include block-level cache markers',
     );
 
     const updated = await handler.createRoundMessages(
@@ -238,67 +238,15 @@ describe('ModelHandlerAnthropic message guards', () => {
     const followUp = updated.at(-1)!;
     const followUpContent = followUp.content as ContentBlockParam[];
     const followUpBlock = followUpContent.at(-1);
-    const followUpMarker = getCacheMarker(followUpBlock);
 
-    assert.ok(
-      followUpMarker,
-      'expected the newest message block to keep the cache marker',
-    );
     assert.equal(
-      getCacheMarker(initialBlock),
+      getCacheMarker(followUpBlock),
       undefined,
-      'previous message should have its cache marker removed',
+      'follow-up message blocks should not include block-level cache markers',
     );
   });
 
-  it('avoids assigning cache control to non-text media blocks', async () => {
-    const handler = new PdfStubAnthropicHandler(
-      buildAnthropicConfig({ supportsVision: true }),
-    );
-
-    handler.setMediaContent([
-      { type: 'text', text: 'Image: diagram.png', citations: null },
-      {
-        type: 'image',
-        source: {
-          type: 'base64',
-          media_type: 'image/png',
-          data: 'ZHVtbXk=',
-        },
-      },
-    ] as ContentBlockParam[]);
-
-    const messages = await handler.initializeMessages('prefix text', '', [
-      pathToLocation('/tmp/diagram.png'),
-    ]);
-
-    const content = messages[0].content as ContentBlockParam[];
-    const finalBlock = content.at(-1);
-    assert.equal(
-      finalBlock?.type,
-      'image',
-      'expected the final block to be an image',
-    );
-    assert.equal(
-      getCacheMarker(finalBlock),
-      undefined,
-      'image block should not carry cache control metadata',
-    );
-
-    const lastTextBlock = [...content]
-      .reverse()
-      .find((block) => block.type === 'text');
-    assert.ok(
-      lastTextBlock,
-      'expected at least one text block in the message content',
-    );
-    assert.ok(
-      getCacheMarker(lastTextBlock),
-      'last eligible text block should include cache control metadata',
-    );
-  });
-
-  it('applies cache control to tool result follow-ups when supported', async () => {
+  it('does not set block-level cache markers on tool result follow-ups', async () => {
     const handler = createAnthropicHandler();
     const call: ToolUseBlock = {
       id: 'tool-call',
@@ -323,20 +271,15 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
 
     const toolResultBlock = (resultMsg.content as ContentBlockParam[])[0];
-    assert.ok(
+    assert.equal(
       getCacheMarker(toolResultBlock),
-      'tool result block should include cache control metadata',
+      undefined,
+      'tool result block should not include block-level cache markers (top-level automatic caching handles this)',
     );
   });
 
   it('skips cache control when prompt caching is disabled', async () => {
     const handler = createAnthropicHandler({ supportsPromptCaching: false });
-    const call: ToolUseBlock = {
-      id: 'tool-call',
-      type: 'tool_use',
-      name: 'demo',
-      input: {},
-    } as ToolUseBlock;
 
     const baseMessages = await handler.initializeMessages('prefix', 'request');
     const initialContent = baseMessages[0].content as ContentBlockParam[];
@@ -347,31 +290,9 @@ describe('ModelHandlerAnthropic message guards', () => {
       undefined,
       'initial message should not include cache metadata when disabled',
     );
-
-    const providerCall = {
-      provider: 'anthropic',
-      callId: call.id,
-      name: call.name,
-      input: call.input,
-      raw: call,
-    } as const;
-
-    const [, resultMsg] = await handler.createToolUseFollowUpMessages(
-      undefined,
-      providerCall,
-      { output: 'ok' },
-      [],
-    );
-
-    const toolResultBlock = (resultMsg.content as ContentBlockParam[])[0];
-    assert.equal(
-      getCacheMarker(toolResultBlock),
-      undefined,
-      'tool result block should remain untouched when caching disabled',
-    );
   });
 
-  it('limits cache control markers to the latest four message blocks', () => {
+  it('limits explicit cache control markers to three blocks (reserving one slot for top-level automatic caching)', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
@@ -396,16 +317,21 @@ describe('ModelHandlerAnthropic message guards', () => {
         (block as { cache_control?: unknown }).cache_control !== undefined,
     );
 
-    assert.equal(cacheControlledBlocks.length, 4);
+    assert.equal(cacheControlledBlocks.length, 3);
     assert.equal(
       (messageContent[0] as { cache_control?: unknown }).cache_control,
       undefined,
       'the earliest cache markers should be removed',
     );
+    assert.equal(
+      (messageContent[1] as { cache_control?: unknown }).cache_control,
+      undefined,
+      'the second earliest cache marker should also be removed',
+    );
     assert.deepEqual(
       cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-1', 'block-2', 'block-3', 'block-4'],
-      'the four most recent blocks should retain cache control markers',
+      ['block-2', 'block-3', 'block-4'],
+      'the three most recent blocks should retain cache control markers',
     );
   });
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -292,10 +292,11 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
-  it('limits message-level cache markers based on reserved slots', () => {
+  it('strips legacy cache markers from non-compaction blocks in restored conversations', () => {
     const handler = createAnthropicHandler();
     const messageContent: ContentBlockParam[] = [];
 
+    // Simulate a saved conversation with old-style cache_control on text blocks
     for (let idx = 0; idx < 5; idx += 1) {
       messageContent.push({
         type: 'text',
@@ -309,36 +310,36 @@ describe('ModelHandlerAnthropic message guards', () => {
       { role: 'user', content: messageContent },
     ];
 
-    // Simulate 3 reserved slots (system + tools + automatic = typical case)
-    (handler as any).enforceCacheControlLimit(messages, 3);
+    (handler as any).enforceCacheControlLimit(messages, 2);
 
-    const cacheControlledBlocks = messageContent.filter(
+    const remaining = messageContent.filter(
       (block) =>
         'cache_control' in block &&
         (block as { cache_control?: unknown }).cache_control !== undefined,
     );
 
     assert.equal(
-      cacheControlledBlocks.length,
-      1,
-      'only 1 message-level slot should remain when 3 are reserved',
-    );
-    assert.deepEqual(
-      cacheControlledBlocks.map((block) => (block as { text?: string }).text),
-      ['block-4'],
-      'only the most recent block should retain cache control',
+      remaining.length,
+      0,
+      'all legacy text block cache markers should be stripped',
     );
   });
 
-  it('preserves compaction cache markers during cache control enforcement', () => {
+  it('preserves compaction cache markers while stripping legacy text markers', () => {
     const handler = createAnthropicHandler();
     const compactionBlock = {
       type: 'compaction',
       content: '<summary>state</summary>',
       cache_control: { type: 'ephemeral' },
     };
+    const legacyTextBlock = {
+      type: 'text',
+      text: 'old-cached-block',
+      citations: null,
+      cache_control: { type: 'ephemeral' },
+    } as ContentBlockParam & { cache_control: { type: 'ephemeral' } };
     const messageContent: ContentBlockParam[] = [
-      { type: 'text', text: 'block-0', citations: null },
+      legacyTextBlock,
       compactionBlock as unknown as ContentBlockParam,
       { type: 'text', text: 'block-1', citations: null },
     ];
@@ -346,16 +347,66 @@ describe('ModelHandlerAnthropic message guards', () => {
       { role: 'assistant', content: messageContent },
     ];
 
-    // 1 reserved slot (automatic only, no system or tools)
-    (handler as any).enforceCacheControlLimit(messages, 1);
+    (handler as any).enforceCacheControlLimit(messages, 2);
 
+    // Legacy text marker stripped
+    assert.equal(
+      (legacyTextBlock as { cache_control?: unknown }).cache_control,
+      undefined,
+      'legacy text cache marker should be stripped',
+    );
+
+    // Compaction marker preserved
     const preservedCompaction = (messages[0].content as any[]).find(
       (block) => block.type === 'compaction',
     );
     assert.deepEqual(
       preservedCompaction?.cache_control,
       { type: 'ephemeral' },
-      'compaction cache marker should remain on replayed assistant content',
+      'compaction cache marker should remain',
+    );
+  });
+
+  it('trims excess compaction markers when they exceed available slots', () => {
+    const handler = createAnthropicHandler();
+    const messageContent = [
+      {
+        type: 'compaction',
+        content: '<summary>old</summary>',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'compaction',
+        content: '<summary>mid</summary>',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'compaction',
+        content: '<summary>new</summary>',
+        cache_control: { type: 'ephemeral' },
+      },
+    ] as unknown as ContentBlockParam[];
+
+    const messages: MessageParam[] = [
+      { role: 'assistant', content: messageContent },
+    ];
+
+    // 2 reserved (system + automatic) → 2 available for compaction
+    (handler as any).enforceCacheControlLimit(messages, 2);
+
+    const withMarkers = (messages[0].content as any[]).filter(
+      (block: any) => block.cache_control,
+    );
+    assert.equal(withMarkers.length, 2, 'only 2 compaction markers should remain');
+    assert.equal(
+      (messageContent[0] as any).cache_control,
+      undefined,
+      'oldest compaction marker should be removed',
+    );
+    assert.deepEqual(
+      (messageContent[2] as any).cache_control,
+      { type: 'ephemeral' },
+      'newest compaction marker should be preserved',
     );
   });
 


### PR DESCRIPTION
Replace manual per-block cache_control assignment with the API's
top-level automatic caching feature. The API automatically applies a
cache breakpoint to the last cacheable block and moves it forward as
conversations grow, eliminating the need for client-side tracking.

- Add cache_control: {type: 'ephemeral'} to the request body when
  supportsPromptCaching is enabled
- Remove assignCacheControlToLatest, updateCacheControlTarget methods
  and cacheControlledBlock instance tracking
- Reduce MAX_CACHE_CONTROLLED_BLOCKS from 4 to 3 (automatic caching
  uses one of the 4 available slots)
- Keep explicit cache_control on compaction blocks (independent breakpoints)
- Update tests to reflect new behavior

https://claude.ai/code/session_016bVztkauYJNyrCpeF6D7Jq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes request payload shape (`cache_control` + system prompt block formatting) and cache breakpoint enforcement, which can impact caching behavior and potentially trigger Anthropic API validation limits.
> 
> **Overview**
> Switches the Anthropic handler from manually tagging the latest message/tool-result block with `cache_control` to using **top-level automatic prompt caching** (`options.cache_control`) when `supportsPromptCaching` is enabled.
> 
> Updates system prompt handling to be sent as a text block with an explicit cache breakpoint, and rewrites cache enforcement to **strip legacy block-level cache markers** from restored conversations while **preserving/limiting compaction block breakpoints** based on remaining slots after accounting for system + automatic caching.
> 
> Refreshes tests to assert the new behavior (no block-level markers on messages/tool results; legacy markers removed; compaction markers preserved and trimmed to available slots).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b015f2581cb35573d8ea039d9912f0b2aecfcb9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->