### PR TITLE
Generate session descriptions at instruction time and show in stream tabs

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -359,12 +359,6 @@ async function runFlowWithLifecycle(
     options?.onCompleted?.(result);
     await writeTerminalStatus(ctx.executionId, result.status).catch(() => {});
 
-    // Fire-and-forget: generate AI session description for completed tool-use sessions.
-    // Note: 'stopped' means successfully completed; user-cancellation maps to 'error'.
-    if (category === 'toolUse' && result.status === END_GROUP_STATUS.STOPPED) {
-      generateSessionDescription(ctx.executionId, ctx.config).catch(() => {});
-    }
-
     untrackExecution(ctx.executionId);
     ctx.parentStage.end(result.status);
 
@@ -536,6 +530,14 @@ export async function executeAgent(
   const ctx = await resolveAndAcquireStream(configPayload, executionId);
   const { setting, streamId, config } = ctx;
   const agentName = config.agent;
+
+  // Fire-and-forget: generate AI session description from the user's instruction.
+  // Triggered at the start so cancelled/errored sessions still get descriptions.
+  if (setting.agentCategory === AgentCategory.ToolUse) {
+    generateSessionDescription(ctx.executionId, streamId, config).catch(
+      () => {},
+    );
+  }
 
   options?.onStreamResolved?.(streamId);
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -534,7 +534,9 @@ export async function executeAgent(
   // Fire-and-forget: generate AI session description from the user's instruction.
   // Triggered at the start so cancelled/errored sessions still get descriptions.
   if (setting.agentCategory === AgentCategory.ToolUse) {
-    generateSessionDescription(ctx.executionId, streamId, config);
+    generateSessionDescription(ctx.executionId, streamId, config).catch(
+      () => {},
+    );
   }
 
   options?.onStreamResolved?.(streamId);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -531,15 +531,18 @@ export async function executeAgent(
   const { setting, streamId, config } = ctx;
   const agentName = config.agent;
 
-  // Fire-and-forget: generate AI session description from the user's instruction.
-  // Triggered at the start so cancelled/errored sessions still get descriptions.
-  generateSessionDescription(ctx.executionId, streamId, config).catch(
-    () => {},
-  );
-
   options?.onStreamResolved?.(streamId);
 
   const isSubagent = options?.isSubagent;
+
+  // Fire-and-forget: generate AI session description from the user's instruction.
+  // Triggered at the start so cancelled/errored sessions still get descriptions.
+  // Skipped for subagents to avoid unnecessary LLM calls in multi-agent pipelines.
+  if (!isSubagent) {
+    generateSessionDescription(ctx.executionId, streamId, config).catch(
+      () => {},
+    );
+  }
   const category =
     setting.agentCategory === AgentCategory.ToolUse
       ? ('toolUse' as const)

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -534,9 +534,7 @@ export async function executeAgent(
   // Fire-and-forget: generate AI session description from the user's instruction.
   // Triggered at the start so cancelled/errored sessions still get descriptions.
   if (setting.agentCategory === AgentCategory.ToolUse) {
-    generateSessionDescription(ctx.executionId, streamId, config).catch(
-      () => {},
-    );
+    generateSessionDescription(ctx.executionId, streamId, config);
   }
 
   options?.onStreamResolved?.(streamId);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -533,11 +533,9 @@ export async function executeAgent(
 
   // Fire-and-forget: generate AI session description from the user's instruction.
   // Triggered at the start so cancelled/errored sessions still get descriptions.
-  if (setting.agentCategory === AgentCategory.ToolUse) {
-    generateSessionDescription(ctx.executionId, streamId, config).catch(
-      () => {},
-    );
-  }
+  generateSessionDescription(ctx.executionId, streamId, config).catch(
+    () => {},
+  );
 
   options?.onStreamResolved?.(streamId);
 

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -28,11 +28,11 @@ function buildUserPrompt(
   agentDescription: string | undefined,
   instruction: string,
 ): string {
-  const parts = [`Agent: ${agentName}`];
+  const parts = [`<agent>${agentName}</agent>`];
   if (agentDescription) {
-    parts.push(`Agent purpose: ${agentDescription}`);
+    parts.push(`<agent-purpose>${agentDescription}</agent-purpose>`);
   }
-  parts.push(`User instruction: ${instruction}`);
+  parts.push(`<instruction>${instruction}</instruction>`);
   return parts.join('\n');
 }
 

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -1,23 +1,24 @@
 /**
  * Session description generation.
  *
- * After a tool-use session completes, generates a short AI summary describing
- * what the session aimed to accomplish. The description is persisted on the
- * execution metadata so that future agents and the history view can quickly
- * understand what each session did.
+ * When a tool-use session starts, generates a short AI summary describing
+ * what the session aims to accomplish. The description is persisted on the
+ * execution metadata and pushed to the progress view so that the stream tab,
+ * history view, and future agents can quickly understand each session.
  */
 
 import { getAgent } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { createHelperModelKit } from '@agent/runtime/helperModel';
+import { bus } from '@eventBus/ProgressEventBus';
 import * as logger from '@logger/logUtils';
-import type { ExecutionId } from '@shared/schemas';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
 
 const CHANNEL = 'SessionDescription';
 
-const SYSTEM_PROMPT = `You generate concise session descriptions for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write 1-2 sentences summarizing what this session aimed to accomplish. Be specific and informative. Do not include meta-commentary — just the summary. Write in past tense (e.g. "Reviewed the introduction for...").`;
+const SYSTEM_PROMPT = `You generate concise session descriptions for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write 1-2 sentences summarizing what this session aims to accomplish. Be specific and informative. Do not include meta-commentary — just the summary. Write in present tense (e.g. "Reviews the introduction for...").`;
 
 /**
  * Build a user prompt for session description generation.
@@ -36,13 +37,16 @@ function buildUserPrompt(
 }
 
 /**
- * Generate and persist a session description for a completed execution.
+ * Generate and persist a session description from the user's instruction.
  *
- * Runs fire-and-forget — never throws. Uses the configured helper model
- * for a one-shot, non-streaming call.
+ * Called fire-and-forget at the start of a tool-use session — never throws.
+ * Uses the configured helper model for a one-shot, non-streaming call.
+ * On success, persists the description to execution metadata and emits
+ * an `updateStreamDescription` event so the progress view can display it.
  */
 export async function generateSessionDescription(
   executionId: ExecutionId,
+  streamId: StreamTabId,
   config: AgentConfig,
 ): Promise<void> {
   try {
@@ -85,6 +89,7 @@ export async function generateSessionDescription(
       // Collapse newlines to prevent corrupting line-based tool output.
       const description = text.trim().replaceAll(/\s*\n\s*/g, ' ');
       await writeSessionDescription(executionId, description);
+      bus.emit('updateStreamDescription', { streamId, description });
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }
   } catch (err) {

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -13,6 +13,43 @@ import type { ExecutionId } from '@shared/schemas';
 import { type ExecutionMeta, getExecutionStore } from './ExecutionKVStore';
 import { invalidateListingCache } from './executionListing';
 
+// ---------------------------------------------------------------------------
+// Per-execution write queue — serializes read-modify-write cycles on meta
+// so that concurrent writeTerminalStatus / writeSessionDescription calls
+// never race and silently drop each other's fields.
+// ---------------------------------------------------------------------------
+
+const metaWriteQueues = new Map<ExecutionId, Promise<void>>();
+
+/**
+ * Enqueue a read-modify-write operation on an execution's metadata.
+ * Operations for the same executionId are serialized; different IDs run
+ * independently. The queue entry is cleaned up when the chain settles.
+ */
+function enqueueMetaUpdate(
+  executionId: ExecutionId,
+  updater: (existing: ExecutionMeta) => Partial<ExecutionMeta>,
+): Promise<void> {
+  const prev = metaWriteQueues.get(executionId) ?? Promise.resolve();
+  const next = prev.then(async () => {
+    const store = getExecutionStore(executionId);
+    const existing = await store.readMeta();
+    if (!existing) return;
+    await store.writeMeta({ ...existing, ...updater(existing) });
+    invalidateListingCache();
+  });
+  // Swallow errors in the chain so subsequent enqueued ops still run.
+  const safe = next.catch(() => {});
+  metaWriteQueues.set(executionId, safe);
+  // Clean up when chain settles to avoid unbounded growth.
+  safe.then(() => {
+    if (metaWriteQueues.get(executionId) === safe) {
+      metaWriteQueues.delete(executionId);
+    }
+  });
+  return next;
+}
+
 /**
  * Register a new execution: persist config, metadata, and parent linkage.
  * Awaits all writes before returning, then invalidates the listing cache.
@@ -50,7 +87,8 @@ export async function registerExecution(
 
 /**
  * Persist a terminal status on an existing execution's metadata.
- * Reads the current meta, merges `terminalStatus`, and writes back.
+ * Serialized with other meta updates for the same execution to prevent
+ * read-modify-write races (e.g. with writeSessionDescription).
  * Never throws — storage failures are swallowed so callers' lifecycle
  * logic (untrackExecution, follow-up delivery) always runs.
  */
@@ -59,11 +97,7 @@ export async function writeTerminalStatus(
   status: string,
 ): Promise<void> {
   try {
-    const store = getExecutionStore(executionId);
-    const existing = await store.readMeta();
-    if (!existing) return;
-    await store.writeMeta({ ...existing, terminalStatus: status });
-    invalidateListingCache();
+    await enqueueMetaUpdate(executionId, () => ({ terminalStatus: status }));
   } catch {
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
   }
@@ -71,6 +105,8 @@ export async function writeTerminalStatus(
 
 /**
  * Persist an AI-generated session description on an existing execution's metadata.
+ * Serialized with other meta updates for the same execution to prevent
+ * read-modify-write races (e.g. with writeTerminalStatus).
  * Never throws — description is supplementary data.
  */
 export async function writeSessionDescription(
@@ -78,11 +114,7 @@ export async function writeSessionDescription(
   description: string,
 ): Promise<void> {
   try {
-    const store = getExecutionStore(executionId);
-    const existing = await store.readMeta();
-    if (!existing) return;
-    await store.writeMeta({ ...existing, description });
-    invalidateListingCache();
+    await enqueueMetaUpdate(executionId, () => ({ description }));
   } catch {
     // Non-critical bookkeeping — don't let I/O errors disrupt execution lifecycle.
   }

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -21,6 +21,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   SET_ACTIVE_STREAM: 'setActiveStream',
   UPDATE_CONVERSATION_PROGRESS: 'updateConversationProgress',
   UPDATE_STREAM_BADGES: 'updateStreamBadges',
+  UPDATE_STREAM_DESCRIPTION: 'updateStreamDescription',
   UPDATE_PROCESS_OUTPUT: 'updateProcessOutput',
   UPDATE_PARENT_STREAM: 'updateParentStream',
   UPDATE_FILES: 'updateFiles',

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -102,6 +102,10 @@ export interface ProgressEventPayloads {
     stdout: string;
     stderr: string;
   };
+  updateStreamDescription: {
+    streamId: StreamTabId;
+    description: string;
+  };
   setParentStream: {
     childStreamId: StreamTabId;
     parentStreamId: StreamTabId;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -119,6 +119,12 @@ export class ProgressEventHandler {
             );
           }
         },
+        updateStreamDescription: (_, { streamId, description }) => {
+          this.state.setDescription(streamId, description);
+          if (this.webviewUpdater.isAvailable()) {
+            this.webviewUpdater.updateStreamDescription(streamId, description);
+          }
+        },
         setParentStream: (_, { childStreamId, parentStreamId }) => {
           this.state.meta.setParentStream(childStreamId, parentStreamId);
           if (this.webviewUpdater.isAvailable()) {

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -112,6 +112,25 @@ import './components/ContextManagement';
 // Local imports - progress view component types
 import type { PermissionState } from './components/PermissionCard';
 
+// ---------------------------------------------------------------------------
+// Collection equality helpers — avoid allocating temporary arrays in
+// Signal.Computed evaluations that run on every state change.
+// ---------------------------------------------------------------------------
+
+function mapsEqual<K, V>(a: Map<K, V>, b: Map<K, V>): boolean {
+  for (const [k, v] of a) {
+    if (b.get(k) !== v) return false;
+  }
+  return true;
+}
+
+function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  for (const v of a) {
+    if (!b.has(v)) return false;
+  }
+  return true;
+}
+
 // Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
 // Safe because ProgressApp implements all abstract members below.
 const ProgressAppBase = SignalWatcher(
@@ -226,7 +245,7 @@ export class ProgressApp extends ProgressAppBase {
     // so a new Set with identical contents would still propagate.
     if (
       ids.size === this._prevApprovalIds.size &&
-      [...ids].every((id) => this._prevApprovalIds.has(id))
+      setsEqual(ids, this._prevApprovalIds)
     ) {
       return this._prevApprovalIds;
     }
@@ -286,9 +305,7 @@ export class ProgressApp extends ProgressAppBase {
     // so a new Map with identical contents would still propagate.
     if (
       map.size === this._prevDescriptions.size &&
-      [...map].every(
-        ([k, v]) => this._prevDescriptions.get(k) === v,
-      )
+      mapsEqual(map, this._prevDescriptions)
     ) {
       return this._prevDescriptions;
     }

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -118,6 +118,7 @@ import type { PermissionState } from './components/PermissionCard';
 // ---------------------------------------------------------------------------
 
 function mapsEqual<K, V>(a: Map<K, V>, b: Map<K, V>): boolean {
+  if (a.size !== b.size) return false;
   for (const [k, v] of a) {
     if (b.get(k) !== v) return false;
   }
@@ -125,6 +126,7 @@ function mapsEqual<K, V>(a: Map<K, V>, b: Map<K, V>): boolean {
 }
 
 function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) return false;
   for (const v of a) {
     if (!b.has(v)) return false;
   }
@@ -243,10 +245,7 @@ export class ProgressApp extends ProgressAppBase {
     }
     // Return stable reference when unchanged — Signal.Computed uses Object.is(),
     // so a new Set with identical contents would still propagate.
-    if (
-      ids.size === this._prevApprovalIds.size &&
-      setsEqual(ids, this._prevApprovalIds)
-    ) {
+    if (setsEqual(ids, this._prevApprovalIds)) {
       return this._prevApprovalIds;
     }
     this._prevApprovalIds = ids;
@@ -303,10 +302,7 @@ export class ProgressApp extends ProgressAppBase {
     }
     // Return stable reference when unchanged — Signal.Computed uses Object.is(),
     // so a new Map with identical contents would still propagate.
-    if (
-      map.size === this._prevDescriptions.size &&
-      mapsEqual(map, this._prevDescriptions)
-    ) {
+    if (mapsEqual(map, this._prevDescriptions)) {
       return this._prevDescriptions;
     }
     this._prevDescriptions = map;

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -274,6 +274,28 @@ export class ProgressApp extends ProgressAppBase {
 
   // --- Derived computeds: only re-evaluate when selector inputs propagate ---
 
+  /** streamId → description extracted from streamById (for context consumers). */
+  private _prevDescriptions: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
+  private descriptions$ = new Signal.Computed((): StreamDescriptionMap => {
+    const streamById = this.streamById$.get();
+    const map: StreamDescriptionMap = new Map();
+    for (const [id, info] of streamById) {
+      if (info.description) map.set(id, info.description);
+    }
+    // Return stable reference when unchanged — Signal.Computed uses Object.is(),
+    // so a new Map with identical contents would still propagate.
+    if (
+      map.size === this._prevDescriptions.size &&
+      [...map].every(
+        ([k, v]) => this._prevDescriptions.get(k) === v,
+      )
+    ) {
+      return this._prevDescriptions;
+    }
+    this._prevDescriptions = map;
+    return map;
+  });
+
   /**
    * Filtered + sorted stream list.
    * Uses fine-grained selectors so log appends (which only change streamLogs$)
@@ -319,16 +341,6 @@ export class ProgressApp extends ProgressAppBase {
   // These return stable Map entry values (via Mutative structural sharing).
   // When stream B's state changes, activeStreamState$ still returns stream A's
   // state (same reference) → Object.is() passes → no downstream propagation.
-
-  /** streamId → description extracted from streamById (for context consumers). */
-  private descriptions$ = new Signal.Computed((): StreamDescriptionMap => {
-    const streamById = this.streamById$.get();
-    const map: StreamDescriptionMap = new Map();
-    for (const [id, info] of streamById) {
-      if (info.description) map.set(id, info.description);
-    }
-    return map;
-  });
 
   /** Only changes when active stream switches or stream list changes. */
   private activeStreamInfo$ = new Signal.Computed(() => {

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -83,15 +83,18 @@ import {
 
 // Local imports - progress view contexts
 import {
+  EMPTY_DESCRIPTIONS,
   EMPTY_LOG_CONTEXT,
   EMPTY_PROCESS_OUTPUTS,
   EMPTY_STREAM_CONTEXT,
   permissionsContext,
   processOutputContext,
+  streamDescriptionsContext,
   streamLogContext,
   streamStateContext,
   type ProcessOutputMap,
   type StreamContextValue,
+  type StreamDescriptionMap,
   type StreamLogContextValue,
 } from './contexts/streamContexts';
 import type { FrontendEventHandlerContext } from './eventHandlers';
@@ -252,6 +255,10 @@ export class ProgressApp extends ProgressAppBase {
   @state()
   private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
 
+  @provide({ context: streamDescriptionsContext })
+  @state()
+  private descriptionsContextValue: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
+
   // --- Selector computeds: extract fields, auto-memoized by Object.is ---
   private streamById$ = select(this.appState, (s) => s.streamById);
   private streamFilter$ = select(this.appState, (s) => s.streamFilter);
@@ -312,6 +319,16 @@ export class ProgressApp extends ProgressAppBase {
   // These return stable Map entry values (via Mutative structural sharing).
   // When stream B's state changes, activeStreamState$ still returns stream A's
   // state (same reference) → Object.is() passes → no downstream propagation.
+
+  /** streamId → description extracted from streamById (for context consumers). */
+  private descriptions$ = new Signal.Computed((): StreamDescriptionMap => {
+    const streamById = this.streamById$.get();
+    const map: StreamDescriptionMap = new Map();
+    for (const [id, info] of streamById) {
+      if (info.description) map.set(id, info.description);
+    }
+    return map;
+  });
 
   /** Only changes when active stream switches or stream list changes. */
   private activeStreamInfo$ = new Signal.Computed(() => {
@@ -454,6 +471,7 @@ export class ProgressApp extends ProgressAppBase {
     this.streamLogContextValue = this.logContext$.get();
     this.permissionsContextValue = this.permissions$.get();
     this.processOutputContextValue = this.activeProcessOutputs$.get();
+    this.descriptionsContextValue = this.descriptions$.get();
   }
 
   render(): TemplateResult {

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -29,9 +29,12 @@ import { ProgressEvents } from '../events';
 
 // Local imports - contexts
 import {
+  EMPTY_DESCRIPTIONS,
   EMPTY_PROCESS_OUTPUTS,
   processOutputContext,
+  streamDescriptionsContext,
   type ProcessOutputMap,
+  type StreamDescriptionMap,
 } from '../contexts/streamContexts';
 
 // Side-effect imports - sibling components
@@ -102,6 +105,16 @@ export class BackgroundTasksPanel extends LitElement {
 
       .task-name--clickable:hover {
         text-decoration-color: var(--vscode-foreground);
+      }
+
+      .task-description {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 100%;
+        padding-left: calc(var(--font-size-sm) + var(--spacing-small));
       }
 
       .task-elapsed {
@@ -191,6 +204,10 @@ export class BackgroundTasksPanel extends LitElement {
   @consume({ context: processOutputContext, subscribe: true })
   @state()
   private processOutputs: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
+
+  @consume({ context: streamDescriptionsContext, subscribe: true })
+  @state()
+  private descriptions: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
 
   /** Track previous active count to detect 0→N transitions for auto-open. */
   private prevActiveCount = 0;
@@ -285,6 +302,8 @@ export class BackgroundTasksPanel extends LitElement {
     const hasStdout = Boolean(entry?.stdout);
     const hasStderr = Boolean(entry?.stderr);
     const isClickable = kind === 'subagent' && Boolean(child.childStreamId);
+    const description =
+      child.childStreamId ? this.descriptions.get(child.childStreamId) : undefined;
 
     return html`
       <div class="task-item">
@@ -331,6 +350,9 @@ export class BackgroundTasksPanel extends LitElement {
             >${isWaiting(child) ? 'waiting' : 'running'}</span
           >
         </div>
+        ${description
+          ? html`<div class="task-description" title=${description}>${description}</div>`
+          : nothing}
         ${hasStdout
           ? this.renderOutputStream('stdout', entry!.stdout)
           : nothing}

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -37,11 +37,15 @@ function buildTooltip(
   ]
     .filter(Boolean)
     .join(' • ');
-  if (!lastTimestamp) return mainLine;
-  const lastSeen = formatRelativeTime(lastTimestamp);
-  return lastSeen && mainLine
-    ? `${mainLine}\nLast activity ${lastSeen}`
-    : mainLine;
+  const parts = [mainLine];
+  if (info.description) {
+    parts.push(info.description);
+  }
+  if (lastTimestamp) {
+    const lastSeen = formatRelativeTime(lastTimestamp);
+    if (lastSeen) parts.push(`Last activity ${lastSeen}`);
+  }
+  return parts.join('\n');
 }
 
 // =============================================================================
@@ -142,6 +146,16 @@ export class StreamTab extends LitElement {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+      }
+
+      .tab-description {
+        font-size: var(--font-size-sm);
+        color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+        opacity: 0.8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 100%;
       }
 
       .tab-meta {
@@ -263,6 +277,9 @@ export class StreamTab extends LitElement {
           ${this.compact
             ? nothing
             : html`
+                ${stream.description
+                  ? html`<div class="tab-description">${stream.description}</div>`
+                  : nothing}
                 <div class="tab-meta">
                   <span class="last-active"
                     >${this.lastTimestamp

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -67,6 +67,7 @@ export class StreamTab extends LitElement {
     css`
       :host {
         display: block;
+        container-type: inline-size;
       }
 
       .tab-container {
@@ -156,6 +157,14 @@ export class StreamTab extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         width: 100%;
+        display: none;
+      }
+
+      /* Only show description when the tab has enough horizontal space */
+      @container (min-width: 200px) {
+        .tab-description {
+          display: block;
+        }
       }
 
       .tab-meta {

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -88,3 +88,15 @@ export const EMPTY_PROCESS_OUTPUTS: ProcessOutputMap = new Map();
 export const processOutputContext = createContext<ProcessOutputMap>(
   'progress-process-outputs',
 );
+
+/**
+ * Descriptions context: streamId → AI-generated session description.
+ * Consumed by BackgroundTasksPanel to label subagent entries.
+ */
+export type StreamDescriptionMap = Map<string, string>;
+
+export const EMPTY_DESCRIPTIONS: StreamDescriptionMap = new Map();
+
+export const streamDescriptionsContext = createContext<StreamDescriptionMap>(
+  'progress-stream-descriptions',
+);

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -8,7 +8,12 @@
 import { createContext } from '@lit/context';
 
 // Local imports - progress view
-import type { LogMessageData, StreamTabInfo, TaskGroup } from '@shared/schemas';
+import type {
+  LogMessageData,
+  StreamTabId,
+  StreamTabInfo,
+  TaskGroup,
+} from '@shared/schemas';
 import type { FollowupOptionsState, StreamState } from '../store';
 
 // Local imports - progress view components
@@ -93,7 +98,7 @@ export const processOutputContext = createContext<ProcessOutputMap>(
  * Descriptions context: streamId → AI-generated session description.
  * Consumed by BackgroundTasksPanel to label subagent entries.
  */
-export type StreamDescriptionMap = Map<string, string>;
+export type StreamDescriptionMap = Map<StreamTabId, string>;
 
 export const EMPTY_DESCRIPTIONS: StreamDescriptionMap = new Map();
 

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -1,6 +1,6 @@
 /**
- * Stream metadata handlers: UPDATE_STREAM_STATUS, UPDATE_CONVERSATION_PROGRESS,
- * UPDATE_STREAM_BADGES, UPDATE_PROCESS_OUTPUT.
+ * Stream metadata handlers: UPDATE_STREAM_STATUS, UPDATE_STREAM_DESCRIPTION,
+ * UPDATE_CONVERSATION_PROGRESS, UPDATE_STREAM_BADGES, UPDATE_PROCESS_OUTPUT.
  */
 
 import { create } from 'mutative';
@@ -78,6 +78,17 @@ export const streamMetaHandlers: HandlerRegistry = {
 
       return create(prev, (draft) => {
         draft.streamStates.set(stream, updatedState);
+      });
+    });
+  },
+
+  [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION]: (data, ctx) => {
+    const { stream, description } = data;
+    ctx.setState((prev) => {
+      const info = prev.streamById.get(stream);
+      if (!info) return prev;
+      return create(prev, (draft) => {
+        draft.streamById.set(stream, { ...info, description });
       });
     });
   },

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -88,7 +88,8 @@ export const streamMetaHandlers: HandlerRegistry = {
       const info = prev.streamById.get(stream);
       if (!info) return prev;
       return create(prev, (draft) => {
-        draft.streamById.set(stream, { ...info, description });
+        const draftInfo = draft.streamById.get(stream);
+        if (draftInfo) draftInfo.description = description;
       });
     });
   },

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -21,6 +21,7 @@ export class StreamMetaManager {
   private executionIds = new Map<StreamTabId, ExecutionId>();
   private activeRunIds = new Map<StreamTabId, StorageKey | null>();
   private parentStreamIds = new Map<StreamTabId, StreamTabId>();
+  private descriptions = new Map<StreamTabId, string>();
   private loaded = false;
   private readonly logger: AgentLogger;
   private readonly pendingWrites = new Map<StreamTabId, Promise<void>>();
@@ -74,6 +75,17 @@ export class StreamMetaManager {
     this.save(child);
   }
 
+  // -- Descriptions -----------------------------------------------------------
+
+  getDescription(stream: StreamTabId): string | undefined {
+    return this.descriptions.get(stream);
+  }
+
+  setDescription(stream: StreamTabId, description: string): void {
+    this.descriptions.set(stream, description);
+    this.save(stream);
+  }
+
   // -- Queries ----------------------------------------------------------------
 
   /** Return stream IDs with active tool-use sessions. */
@@ -93,6 +105,7 @@ export class StreamMetaManager {
     this.executionIds.delete(stream);
     this.activeRunIds.delete(stream);
     this.parentStreamIds.delete(stream);
+    this.descriptions.delete(stream);
     this.pendingWrites.delete(stream);
   }
 
@@ -102,6 +115,7 @@ export class StreamMetaManager {
     this.executionIds.clear();
     this.activeRunIds.clear();
     this.parentStreamIds.clear();
+    this.descriptions.clear();
     this.pendingWrites.clear();
   }
 
@@ -146,6 +160,10 @@ export class StreamMetaManager {
 
       if (meta.parentStreamId) {
         this.parentStreamIds.set(streamId, meta.parentStreamId as StreamTabId);
+      }
+
+      if (meta.description) {
+        this.descriptions.set(streamId, meta.description);
       }
     }
 
@@ -196,6 +214,9 @@ export class StreamMetaManager {
 
     const parentStreamId = this.parentStreamIds.get(stream);
     if (parentStreamId) meta.parentStreamId = parentStreamId;
+
+    const description = this.descriptions.get(stream);
+    if (description) meta.description = description;
 
     return meta;
   }

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -1,3 +1,4 @@
+import { getExecutionStore } from '@agent/storage';
 import { normalizeRunId } from '@common/constants/runIds';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -81,9 +82,10 @@ export class StreamMetaManager {
     return this.descriptions.get(stream);
   }
 
+  /** Cache description in memory (for live sessions). Not persisted to
+   *  StreamTabMeta — ExecutionMeta is the single source of truth on disk. */
   setDescription(stream: StreamTabId, description: string): void {
     this.descriptions.set(stream, description);
-    this.save(stream);
   }
 
   // -- Queries ----------------------------------------------------------------
@@ -161,17 +163,39 @@ export class StreamMetaManager {
       if (meta.parentStreamId) {
         this.parentStreamIds.set(streamId, meta.parentStreamId as StreamTabId);
       }
-
-      if (meta.description) {
-        this.descriptions.set(streamId, meta.description);
-      }
     }
+
+    // Hydrate descriptions from ExecutionMeta (the single source of truth).
+    // Runs in parallel for all streams that have an associated executionId.
+    await this.hydrateDescriptions();
 
     this.loaded = true;
 
     this.logger.info(
       `Loaded: ${loadedTasks} task states, ${skippedTasks} skipped, ${this.executionIds.size} execution IDs`,
     );
+  }
+
+  /**
+   * Populate in-memory descriptions from ExecutionMeta for all known streams.
+   * ExecutionMeta.description is the single source of truth on disk.
+   */
+  private async hydrateDescriptions(): Promise<void> {
+    const entries = [...this.executionIds.entries()];
+    if (entries.length === 0) return;
+    const results = await Promise.all(
+      entries.map(async ([streamId, executionId]) => {
+        try {
+          const meta = await getExecutionStore(executionId).readMeta();
+          return { streamId, description: meta?.description };
+        } catch {
+          return { streamId, description: undefined };
+        }
+      }),
+    );
+    for (const { streamId, description } of results) {
+      if (description) this.descriptions.set(streamId, description);
+    }
   }
 
   /** Await all pending disk writes. */
@@ -214,9 +238,6 @@ export class StreamMetaManager {
 
     const parentStreamId = this.parentStreamIds.get(stream);
     if (parentStreamId) meta.parentStreamId = parentStreamId;
-
-    const description = this.descriptions.get(stream);
-    if (description) meta.description = description;
 
     return meta;
   }

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -263,6 +263,14 @@ export class WebviewUpdater {
     });
   }
 
+  updateStreamDescription(stream: StreamTabId, description: string): void {
+    this.sendMessage({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION,
+      stream,
+      description,
+    });
+  }
+
   setActiveStream(activeStream: StreamTabId): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,

--- a/src/progressView/persistence/streamTabSchemas.ts
+++ b/src/progressView/persistence/streamTabSchemas.ts
@@ -36,6 +36,7 @@ export const StreamTabMetaSchema = z.object({
   parentStreamId: z.string().optional(),
   executionId: z.string().optional(),
   taskState: TaskStateSchema.optional(),
+  description: z.string().optional(),
 });
 
 export type StreamTabMeta = z.infer<typeof StreamTabMetaSchema>;

--- a/src/progressView/persistence/streamTabSchemas.ts
+++ b/src/progressView/persistence/streamTabSchemas.ts
@@ -36,7 +36,6 @@ export const StreamTabMetaSchema = z.object({
   parentStreamId: z.string().optional(),
   executionId: z.string().optional(),
   taskState: TaskStateSchema.optional(),
-  description: z.string().optional(),
 });
 
 export type StreamTabMeta = z.infer<typeof StreamTabMetaSchema>;

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
@@ -373,6 +374,8 @@ export class ProgressViewState {
 
     this.logger.info('[Persistence] Managers loaded');
 
+    await this.hydrateDescriptions();
+
     this.validateActiveStream();
     cleanupToolUseAgentRegistry(this.meta);
 
@@ -393,6 +396,41 @@ export class ProgressViewState {
   }
 
   // -- Private helpers --------------------------------------------------------
+
+  /**
+   * Populate ephemeral descriptions from persisted execution metadata.
+   * Runs after meta.load() so that execution IDs are available.
+   */
+  private async hydrateDescriptions(): Promise<void> {
+    const entries: { stream: StreamTabId; executionId: string }[] = [];
+    for (const stream of this.streamLogs.keys()) {
+      const executionId = this.meta.getExecutionId(stream);
+      if (executionId) entries.push({ stream, executionId });
+    }
+    if (entries.length === 0) return;
+
+    const results = await Promise.all(
+      entries.map(async ({ stream, executionId }) => {
+        try {
+          const meta = await getExecutionStore(executionId).readMeta();
+          return meta?.description ? { stream, description: meta.description } : null;
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    let count = 0;
+    for (const result of results) {
+      if (result) {
+        this._descriptions.set(result.stream, result.description);
+        count++;
+      }
+    }
+    if (count > 0) {
+      this.logger.info(`[Persistence] Hydrated ${count} session descriptions`);
+    }
+  }
 
   private async loadManagers(streamIds: StreamTabId[]): Promise<void> {
     await Promise.all([

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -116,6 +116,7 @@ export class ProgressViewState {
   // -- Ephemeral state (session-only, not persisted) --------------------------
   private _streamStates = new Map<StreamTabId, StreamExecutionState>();
   private _sessionState = new Map<StreamTabId, StreamSessionState>();
+  private _descriptions = new Map<StreamTabId, string>();
 
   private readonly storage: MementoStorage;
   private readonly logger: AgentLogger;
@@ -215,6 +216,14 @@ export class ProgressViewState {
     }
   }
 
+  setDescription(stream: StreamTabId, description: string): void {
+    this._descriptions.set(stream, description);
+  }
+
+  getDescription(stream: StreamTabId): string | undefined {
+    return this._descriptions.get(stream);
+  }
+
   setTodos(stream: StreamTabId, todos: TodoItem[]): void {
     this.getOrCreateSession(stream).todos = todos;
   }
@@ -299,6 +308,7 @@ export class ProgressViewState {
     this.runInstructions.evict(stream);
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
+    this._descriptions.delete(stream);
 
     // Delete from disk: stream log file + stream data directory
     const store = getStreamTabStore(stream);
@@ -327,6 +337,7 @@ export class ProgressViewState {
     this.runInstructions.evictAll();
     this._sessionState.clear();
     this._streamStates.clear();
+    this._descriptions.clear();
     this._prefs.reset();
 
     // Delete from disk

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { getExecutionStore } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
@@ -117,7 +116,6 @@ export class ProgressViewState {
   // -- Ephemeral state (session-only, not persisted) --------------------------
   private _streamStates = new Map<StreamTabId, StreamExecutionState>();
   private _sessionState = new Map<StreamTabId, StreamSessionState>();
-  private _descriptions = new Map<StreamTabId, string>();
 
   private readonly storage: MementoStorage;
   private readonly logger: AgentLogger;
@@ -218,11 +216,11 @@ export class ProgressViewState {
   }
 
   setDescription(stream: StreamTabId, description: string): void {
-    this._descriptions.set(stream, description);
+    this.meta.setDescription(stream, description);
   }
 
   getDescription(stream: StreamTabId): string | undefined {
-    return this._descriptions.get(stream);
+    return this.meta.getDescription(stream);
   }
 
   setTodos(stream: StreamTabId, todos: TodoItem[]): void {
@@ -309,7 +307,6 @@ export class ProgressViewState {
     this.runInstructions.evict(stream);
     this._sessionState.delete(stream);
     this._streamStates.delete(stream);
-    this._descriptions.delete(stream);
 
     // Delete from disk: stream log file + stream data directory
     const store = getStreamTabStore(stream);
@@ -338,7 +335,6 @@ export class ProgressViewState {
     this.runInstructions.evictAll();
     this._sessionState.clear();
     this._streamStates.clear();
-    this._descriptions.clear();
     this._prefs.reset();
 
     // Delete from disk
@@ -374,8 +370,6 @@ export class ProgressViewState {
 
     this.logger.info('[Persistence] Managers loaded');
 
-    await this.hydrateDescriptions();
-
     this.validateActiveStream();
     cleanupToolUseAgentRegistry(this.meta);
 
@@ -396,41 +390,6 @@ export class ProgressViewState {
   }
 
   // -- Private helpers --------------------------------------------------------
-
-  /**
-   * Populate ephemeral descriptions from persisted execution metadata.
-   * Runs after meta.load() so that execution IDs are available.
-   */
-  private async hydrateDescriptions(): Promise<void> {
-    const entries: { stream: StreamTabId; executionId: string }[] = [];
-    for (const stream of this.streamLogs.keys()) {
-      const executionId = this.meta.getExecutionId(stream);
-      if (executionId) entries.push({ stream, executionId });
-    }
-    if (entries.length === 0) return;
-
-    const results = await Promise.all(
-      entries.map(async ({ stream, executionId }) => {
-        try {
-          const meta = await getExecutionStore(executionId).readMeta();
-          return meta?.description ? { stream, description: meta.description } : null;
-        } catch {
-          return null;
-        }
-      }),
-    );
-
-    let count = 0;
-    for (const result of results) {
-      if (result) {
-        this._descriptions.set(result.stream, result.description);
-        count++;
-      }
-    }
-    if (count > 0) {
-      this.logger.info(`[Persistence] Hydrated ${count} session descriptions`);
-    }
-  }
 
   private async loadManagers(streamIds: StreamTabId[]): Promise<void> {
     await Promise.all([

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -75,6 +75,7 @@ function buildStreamInfo(
     creationTimestamp,
     executionId: state.meta.getExecutionId(id),
     parentStreamId: state.meta.getParentStreamId(id),
+    description: state.getDescription(id),
   };
 }
 

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -159,6 +159,12 @@ export const UpdateParentStreamMessageSchema = z.object({
   parentStreamId: StreamTabIdSchema.nullish(),
 });
 
+export const UpdateStreamDescriptionMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION),
+  stream: StreamTabIdSchema,
+  description: z.string(),
+});
+
 export const UpdateStreamStatusMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS),
   stream: StreamTabIdSchema,
@@ -360,6 +366,7 @@ export const ProgressViewOutboundMessageSchema = z.discriminatedUnion(
     UpdateStreamBadgesMessageSchema,
     UpdateProcessOutputMessageSchema,
     UpdateParentStreamMessageSchema,
+    UpdateStreamDescriptionMessageSchema,
     UpdateStreamStatusMessageSchema,
     LogDeltaMessageSchema,
     UpdateFilesMessageSchema,

--- a/src/shared/schemas/stream.ts
+++ b/src/shared/schemas/stream.ts
@@ -58,6 +58,8 @@ export const StreamTabInfoSchema = z.object({
   creationTimestamp: z.number(),
   executionId: ExecutionIdSchema.optional(),
   parentStreamId: StreamTabIdSchema.optional(),
+  /** AI-generated summary of what this session aims to accomplish. */
+  description: z.string().optional(),
 });
 export type StreamTabInfo = z.infer<typeof StreamTabInfoSchema>;
 


### PR DESCRIPTION
Move generateSessionDescription from completion (runFlowWithLifecycle) to the
start of executeAgent so descriptions are generated from the first user
instruction. This means cancelled/errored sessions still get descriptions.

- Update prompt to use present tense since generation happens at start
- Add streamId param and emit updateStreamDescription bus event
- Wire description through StreamTabInfo schema, ProgressViewState, and
  WebviewUpdater to the frontend
- Render description in StreamTab component (below title, above meta line)
- Include description in tab tooltip

https://claude.ai/code/session_01JJ6LZE2x6WEGZfuVYGhzj1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches execution metadata writes and adds a new backend→frontend event path; bugs could cause lost meta fields or stale/incorrect stream UI state. Changes are mostly additive and fire-and-forget, limiting impact to supplemental description data.
> 
> **Overview**
> Session descriptions are now generated *at the start* of `executeAgent` (skipped for subagents) instead of on successful completion, so cancelled/errored runs can still get a description.
> 
> `generateSessionDescription` now takes `streamId`, uses a present-tense prompt, and emits a new `updateStreamDescription` bus/webview command; the description is plumbed through schemas/state (`StreamTabInfo.description`) and rendered in stream tab tooltips, the tab body, and the background subagent list.
> 
> Execution meta updates for `terminalStatus` and `description` are serialized via a per-`executionId` write queue to prevent read-modify-write races that could drop fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18e88f85fe859c95f74c6bb95a76e2d68d53ff2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->