### PR TITLE
Collapse background tasks panel by default and propagate approval bypass to subagents

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -138,6 +138,8 @@ async function beginRunStage(
 
 interface ResolveAgentOptions {
   streamTabIdOverride?: StreamTabId;
+  /** Fires after streamId is assigned but before setActiveStream is emitted. */
+  onBeforeActivation?: (streamId: StreamTabId) => void;
 }
 
 async function resolveAgentBase(
@@ -192,6 +194,8 @@ async function resolveAgentBase(
   );
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
+
+  options?.onBeforeActivation?.(streamId);
 
   bus.emit('setActiveStream', {
     streamId,
@@ -452,12 +456,14 @@ async function resolveAndAcquireStream(
   options?: {
     streamTabIdOverride?: StreamTabId;
     taskType?: string;
+    onBeforeActivation?: (streamId: StreamTabId) => void;
   },
 ): Promise<ResolvedAgentBase> {
   if (options?.streamTabIdOverride) {
     // Direct resolution with known stream ID (e.g., resume from snapshot)
     return resolveAgentBase(configPayload, executionId, {
       streamTabIdOverride: options.streamTabIdOverride,
+      onBeforeActivation: options?.onBeforeActivation,
     });
   }
 
@@ -479,7 +485,9 @@ async function resolveAndAcquireStream(
 
   let ctx: ResolvedAgentBase;
   try {
-    ctx = await resolveAgentBase(configPayload, executionId);
+    ctx = await resolveAgentBase(configPayload, executionId, {
+      onBeforeActivation: options?.onBeforeActivation,
+    });
   } catch (err) {
     StreamStatusService.releaseIfInitializing(preliminaryStreamId);
     if (!(err instanceof ZodError)) {
@@ -516,7 +524,7 @@ export interface ExecuteAgentOptions {
   isSubagent?: boolean;
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
-  /** Fires early with the real streamId, before flow execution starts. */
+  /** Fires with the real streamId before the stream is activated (before UI sync). */
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
   onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
@@ -531,11 +539,11 @@ export async function executeAgent(
   executionId?: ExecutionId,
   options?: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
-  const ctx = await resolveAndAcquireStream(configPayload, executionId);
+  const ctx = await resolveAndAcquireStream(configPayload, executionId, {
+    onBeforeActivation: options?.onStreamResolved,
+  });
   const { setting, streamId, config } = ctx;
   const agentName = config.agent;
-
-  options?.onStreamResolved?.(streamId);
 
   const isSubagent = options?.isSubagent;
 

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -268,7 +268,7 @@ export class BackgroundTasksPanel extends LitElement {
     const label = kind === 'process' ? 'Processes' : 'Subagents';
 
     return html`
-      <details open>
+      <details>
         <summary class="section-label">
           <i class="${CHEVRON_RIGHT_CLASS} toggle-icon"></i>
           <i class="codicon ${icon}"></i>

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -31,7 +31,6 @@ export class TodoList extends LitElement {
     css`
       :host {
         display: block;
-        margin: var(--spacing-small) 0;
       }
 
       :host([hidden]) {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -56,6 +56,7 @@ import type { ToolResult } from '@tools/result';
 import {
   isSuperYoloFeatureEnabled,
   isProposalBypassedForStream,
+  isApprovalBypassedForStream,
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import {
@@ -356,6 +357,7 @@ async function proposeAndExecute(
     }),
   };
   return executeSubagent(toConfigPayload(effective), agentName, streamId, {
+    enableYoloOnChild: isApprovalBypassedForStream(streamId),
     approvalMeta,
   });
 }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -176,7 +176,11 @@ async function executeSubagent(
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       if (options?.enableYoloOnChild) {
-        setToolEditApprovalSessionBypass(resolvedStreamId, true);
+        // Silent: fires before stream activation so the UI notification would
+        // be dropped. The subsequent SYNC_STREAM_CONTENT reads from the map.
+        setToolEditApprovalSessionBypass(resolvedStreamId, true, {
+          silent: true,
+        });
       }
     },
     onProgress,

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -85,12 +85,21 @@ function notifyBypassState(streamId: StreamTabId): void {
   });
 }
 
+/**
+ * Set YOLO bypass state for a stream.
+ * @param silent - Skip UI notification. Use when the bypass is set before
+ *   the stream is activated (the subsequent SYNC_STREAM_CONTENT will carry
+ *   the correct state from isApprovalBypassedForStream).
+ */
 export function setToolEditApprovalSessionBypass(
   streamId: StreamTabId,
   enabled: boolean,
+  options?: { silent?: boolean },
 ): void {
   bypassedByStream.set(streamId, enabled);
-  notifyBypassState(streamId);
+  if (!options?.silent) {
+    notifyBypassState(streamId);
+  }
 }
 
 export function toggleToolEditApprovalSessionBypass(


### PR DESCRIPTION
## Summary
This PR makes two improvements to the background tasks panel and subagent delegation:
1. Changes the default state of the background tasks panel from expanded to collapsed
2. Propagates the approval bypass setting to child subagents during delegation

## Key Changes
- **BackgroundTasksPanel.ts**: Removed the `open` attribute from the `<details>` element, causing the Processes/Subagents section to be collapsed by default instead of expanded
- **DelegationTools.ts**: 
  - Added import for `isApprovalBypassedForStream` function
  - Pass `enableYoloOnChild` flag to `executeSubagent()` based on whether approval bypass is enabled for the current stream, ensuring child subagents inherit the parent's approval bypass setting

## Implementation Details
The approval bypass propagation ensures consistent behavior across nested subagent calls - if a parent stream has approval bypass enabled, child subagents will also operate with the same bypass setting rather than requiring separate approval.

https://claude.ai/code/session_017mL3p8ctaz2riSxwcM65Ti

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent stream activation timing and approval-bypass propagation, which can affect UI synchronization and tool-edit approval behavior across delegated runs; UI-only collapses are low risk but the lifecycle callback change is moderately sensitive.
> 
> **Overview**
> Makes the Background Tasks panel’s Processes/Subagents sections start *collapsed by default* (no longer rendered with `open`).
> 
> Updates agent startup to expose a new pre-activation hook (`onBeforeActivation`) and wires `executeAgent`’s `onStreamResolved` to fire **before** `setActiveStream`, enabling callers to mutate per-stream state ahead of initial UI sync.
> 
> Propagates per-stream tool-edit approval (YOLO) bypass to delegated subagents: `DelegationTools` now enables bypass for child streams when the parent stream is bypassed, and `setToolEditApprovalSessionBypass` gains a `silent` option to suppress premature UI notifications during early activation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1281b4a21ebbdadcbd00a72dd0c02f7b2ba100d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->