### PR TITLE
Fix duplicate permissions when replaying pending prompts

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -403,6 +403,7 @@ export class ProgressViewProvider
   }
 
   public async showInSidebar(options?: { inPlace?: boolean }): Promise<void> {
+    const placementChanged = this._activePlacement !== 'sidebar';
     this._activePlacement = 'sidebar';
 
     if (this._mainViewProvider) {
@@ -418,7 +419,10 @@ export class ProgressViewProvider
 
     if (this.isActivePlacementReady()) {
       this.syncFullView({ forceRebuild: true });
-      this.replayPendingPrompts();
+      // Only replay permissions when switching from editor → sidebar.
+      // If already on sidebar, the webview already has the correct permissions;
+      // replaying would cause duplicates.
+      if (placementChanged) this.replayPendingPrompts();
     }
   }
 
@@ -443,11 +447,12 @@ export class ProgressViewProvider
 
   public async popOutToEditor(): Promise<void> {
     if (this._panelView) {
+      const placementChanged = this._activePlacement !== 'editor';
       this._activePlacement = 'editor';
       await this.restoreSidebarToLauncher();
       this.revealEditorPanel();
       this.syncFullView({ forceRebuild: true });
-      this.replayPendingPrompts();
+      if (placementChanged) this.replayPendingPrompts();
       return;
     }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -64,6 +64,8 @@ export class ProgressViewProvider
   private _panelView?: vscode.WebviewPanel;
   private _panelDisposables: vscode.Disposable[] = [];
   private _activePlacement: ProgressViewPlacement = 'sidebar';
+  /** Set by disposePanelResources so showInSidebar knows replay is needed. */
+  private _panelJustDisposed = false;
   private _pendingUpdateOptions: { forceRebuild: boolean } | null = null;
   private readonly logger: AgentLogger;
 
@@ -306,6 +308,7 @@ export class ProgressViewProvider
     }
 
     this._pendingUpdateOptions = null;
+    this._panelJustDisposed = false;
     this.syncFullView({ forceRebuild: true });
     this.replayPendingPrompts();
   }
@@ -403,7 +406,12 @@ export class ProgressViewProvider
   }
 
   public async showInSidebar(options?: { inPlace?: boolean }): Promise<void> {
-    const placementChanged = this._activePlacement !== 'sidebar';
+    // disposePanelResources resets _activePlacement to 'sidebar' before we
+    // get here, so also check the _panelJustDisposed flag to detect a real
+    // editor → sidebar transition that needs permission replay.
+    const placementChanged =
+      this._activePlacement !== 'sidebar' || this._panelJustDisposed;
+    this._panelJustDisposed = false;
     this._activePlacement = 'sidebar';
 
     if (this._mainViewProvider) {
@@ -550,6 +558,7 @@ export class ProgressViewProvider
     this._panelReady = false;
     if (this._activePlacement === 'editor') {
       this._activePlacement = 'sidebar';
+      this._panelJustDisposed = true;
     }
     if (disposeView) {
       panelView?.dispose();

--- a/src/progressView/frontend/slices/permissionSlice.ts
+++ b/src/progressView/frontend/slices/permissionSlice.ts
@@ -116,11 +116,25 @@ export const permissionHandlers: HandlerRegistry = {
         });
       } else {
         // Prepend newest permissions so keyboard shortcuts target the latest request.
+        // Deduplicate by requestId to prevent duplicate UI when replay() re-sends
+        // pending items (e.g., on view visibility change).
         const entry = {
           kind: permission.kind,
           data: permission.data,
         } as PermissionState;
-        ctx.setPermissions([entry, ...ctx.getPermissions()]);
+        const idField =
+          permission.kind === PERMISSION_KIND.RETRY ? 'streamId' : 'requestId';
+        const id = (permission.data as Record<string, unknown>)[idField];
+        const existing = ctx.getPermissions();
+        const alreadyPresent =
+          id != null &&
+          existing.some(
+            (p) =>
+              p.kind === permission.kind &&
+              (p.data as Record<string, unknown>)[idField] === id,
+          );
+        if (alreadyPresent) return;
+        ctx.setPermissions([entry, ...existing]);
       }
       return;
     }


### PR DESCRIPTION
## Summary
This PR fixes an issue where permission prompts were being duplicated in the UI when the progress view changed placement (e.g., sidebar to editor or vice versa). The root cause was that `replayPendingPrompts()` was being called unconditionally, re-sending permissions that were already present in the webview.

## Key Changes

- **Permission deduplication in `permissionSlice.ts`**: Added logic to detect and skip duplicate permissions based on `requestId` (or `streamId` for retry permissions). This prevents the same permission from being added multiple times when `replay()` re-sends pending items.

- **Conditional replay in `ProgressViewProvider.ts`**: Modified `showInSidebar()` and `popOutToEditor()` to only call `replayPendingPrompts()` when the placement actually changes. If the view is already in the target placement, replaying is skipped since the webview already has the correct permissions.

## Implementation Details

- The deduplication check compares both the permission kind and the relevant ID field (`requestId` or `streamId`) to identify duplicates
- Placement change detection uses a boolean flag that captures the previous `_activePlacement` before updating it
- This approach handles both the deduplication at the slice level and prevents unnecessary replays at the provider level, providing defense-in-depth against duplicates

https://claude.ai/code/session_017hMNFrcCyerh1o5pmi6GGM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when pending permission prompts are replayed and adds frontend deduplication; mistakes could cause missing or duplicated approval requests in the UI when switching between sidebar and editor.
> 
> **Overview**
> Fixes duplicate permission prompts when the progress view moves between *sidebar* and *editor*.
> 
> `ProgressViewProvider` now only calls `replayPendingPrompts()` when the placement actually changes (including the editor panel being disposed via a new `_panelJustDisposed` flag), avoiding re-sending already-present prompts.
> 
> The frontend `permissionSlice` adds defensive deduplication for non-proposal permissions by skipping inserts when a permission with the same kind and `requestId` (or `streamId` for retry) already exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e2f765188d0c9c0e27b68385a4ca0c02cd7332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->