### PR TITLE
Clean up diff files after accepting run output files

### DIFF
--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -32,9 +32,6 @@ import {
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 
-// Local imports - common
-import { isFileNotFoundError } from '@common/errors';
-
 // Local imports - utils
 import {
   StorageFS,
@@ -89,11 +86,16 @@ export type AcceptRunFilesInput = z.infer<typeof AcceptRunFilesInputSchema>;
 
 export class AcceptRunFilesTool extends defineTool({
   name: 'accept_run_files',
-  description: `Accept output files from a completed run into the workspace.
+  description: `Accept output files from a completed workflow run into the workspace.
+
+Use this tool ONLY for workflow subagent results (category="workflow").
+Do NOT use it for tool-use subagent results — those produce text responses,
+not output files.
 
 Locates output files in run storage or the workspace (depending on storage
 mode) and writes them to the workspace. Each file goes through an approval
-step before writing and may be rejected.
+step before writing and may be rejected. Associated diff files (e.g.
+paper_r0_gemini_diff.tex) are automatically cleaned up from the workspace.
 
 Parameters map directly to subagent-result delivery attributes:
   execution_id ← <subagent-result id="...">
@@ -301,10 +303,8 @@ Call:
         try {
           await WorkspaceFS.delete(loc.relativePath);
           return loc.relativePath;
-        } catch (err) {
-          if (!isFileNotFoundError(err)) {
-            // Silently ignore not-found; other errors (e.g. locked) are also non-fatal
-          }
+        } catch {
+          // Non-fatal: file may not exist or may be locked
           return null;
         }
       }),

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -32,6 +32,9 @@ import {
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 
+// Local imports - common
+import { isFileNotFoundError } from '@common/errors';
+
 // Local imports - utils
 import {
   StorageFS,
@@ -174,6 +177,7 @@ Call:
     // Phase 2: Request approval and write each file
     const results: string[] = [];
     const edits: ToolResult['edits'] = [];
+    const acceptedPaths: string[] = [];
     let rejected = 0;
     const rejectionMessages: string[] = [];
 
@@ -209,6 +213,7 @@ Call:
         lineChanges: approval.lineChanges,
         startLine: approval.startLine,
       });
+      acceptedPaths.push(entry.path);
     }
 
     // Single rejection → return rejection result
@@ -221,12 +226,6 @@ Call:
     }
 
     // Phase 3: Clean up diff files from workspace for accepted files
-    const acceptedPaths: string[] = [];
-    for (let i = 0; i < prepared.length; i++) {
-      if (!results[i].startsWith('rejected')) {
-        acceptedPaths.push(prepared[i].path);
-      }
-    }
     const cleaned = await this.cleanupDiffFiles(acceptedPaths);
     for (const f of cleaned) {
       results.push(`cleaned: ${f}`);
@@ -289,24 +288,28 @@ Call:
    * Diff files follow the pattern `{baseName}_diff{ext}` (e.g. `paper_r0_gemini_diff.tex`).
    */
   private async cleanupDiffFiles(acceptedPaths: string[]): Promise<string[]> {
-    const deleted: string[] = [];
+    const results = await Promise.all(
+      acceptedPaths.map(async (filePath) => {
+        const { name, ext } = path.parse(filePath);
+        const diffPath = `${name}_diff${ext}`;
+        const dir = path.dirname(filePath);
+        const fullDiffPath = dir === '.' ? diffPath : `${dir}/${diffPath}`;
 
-    for (const filePath of acceptedPaths) {
-      const ext = path.extname(filePath);
-      const baseName = filePath.slice(0, -ext.length);
-      const diffPath = `${baseName}_diff${ext}`;
+        const loc = WorkspaceFS.locatePath(fullDiffPath);
+        if (loc.kind === 'external') return null;
 
-      const loc = WorkspaceFS.locatePath(diffPath);
-      if (loc.kind !== 'external' && (await WorkspaceFS.exists(loc.relativePath))) {
         try {
           await WorkspaceFS.delete(loc.relativePath);
-          deleted.push(loc.relativePath);
-        } catch {
-          // Silently ignore deletion failures (e.g. file locked)
+          return loc.relativePath;
+        } catch (err) {
+          if (!isFileNotFoundError(err)) {
+            // Silently ignore not-found; other errors (e.g. locked) are also non-fatal
+          }
+          return null;
         }
-      }
-    }
+      }),
+    );
 
-    return deleted;
+    return results.filter((f): f is string => f !== null);
   }
 }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -11,6 +11,9 @@
  * panel as write_file), so the user can review, edit, or reject each file.
  */
 
+// Standard library imports
+import * as path from 'path';
+
 // Third-party imports
 import { z } from 'zod';
 
@@ -217,6 +220,18 @@ Call:
       );
     }
 
+    // Phase 3: Clean up diff files from workspace for accepted files
+    const acceptedPaths: string[] = [];
+    for (let i = 0; i < prepared.length; i++) {
+      if (!results[i].startsWith('rejected')) {
+        acceptedPaths.push(prepared[i].path);
+      }
+    }
+    const cleaned = await this.cleanupDiffFiles(acceptedPaths);
+    for (const f of cleaned) {
+      results.push(`cleaned: ${f}`);
+    }
+
     const accepted = files.length - rejected;
     const summary = `Accepted ${accepted}/${files.length} file${files.length > 1 ? 's' : ''} from run ${executionId}`;
     return {
@@ -267,5 +282,31 @@ Call:
       `File not found in run storage or workspace: ${runPath}. ` +
         `Use executions tool with path /executions/${executionId}/files to list available files.`,
     );
+  }
+
+  /**
+   * Remove diff files from the workspace that correspond to accepted output files.
+   * Diff files follow the pattern `{baseName}_diff{ext}` (e.g. `paper_r0_gemini_diff.tex`).
+   */
+  private async cleanupDiffFiles(acceptedPaths: string[]): Promise<string[]> {
+    const deleted: string[] = [];
+
+    for (const filePath of acceptedPaths) {
+      const ext = path.extname(filePath);
+      const baseName = filePath.slice(0, -ext.length);
+      const diffPath = `${baseName}_diff${ext}`;
+
+      const loc = WorkspaceFS.locatePath(diffPath);
+      if (loc.kind !== 'external' && (await WorkspaceFS.exists(loc.relativePath))) {
+        try {
+          await WorkspaceFS.delete(loc.relativePath);
+          deleted.push(loc.relativePath);
+        } catch {
+          // Silently ignore deletion failures (e.g. file locked)
+        }
+      }
+    }
+
+    return deleted;
   }
 }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 
 // Local imports - shared
 import { getExecutionStore } from '@agent/storage';
+import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 // Local imports - tools
@@ -94,8 +95,7 @@ not output files.
 
 Locates output files in run storage or the workspace (depending on storage
 mode) and writes them to the workspace. Each file goes through an approval
-step before writing and may be rejected. Associated diff files (e.g.
-paper_r0_gemini_diff.tex) are automatically cleaned up from the workspace.
+step before writing and may be rejected.
 
 Parameters map directly to subagent-result delivery attributes:
   execution_id ← <subagent-result id="...">
@@ -179,7 +179,7 @@ Call:
     // Phase 2: Request approval and write each file
     const results: string[] = [];
     const edits: ToolResult['edits'] = [];
-    const acceptedPaths: string[] = [];
+    const acceptedEntries: { outputPath: string; originalPath: string }[] = [];
     let rejected = 0;
     const rejectionMessages: string[] = [];
 
@@ -215,7 +215,7 @@ Call:
         lineChanges: approval.lineChanges,
         startLine: approval.startLine,
       });
-      acceptedPaths.push(entry.path);
+      acceptedEntries.push({ outputPath: entry.path, originalPath: entry.original });
     }
 
     // Single rejection → return rejection result
@@ -228,7 +228,7 @@ Call:
     }
 
     // Phase 3: Clean up diff files from workspace for accepted files
-    const cleaned = await this.cleanupDiffFiles(acceptedPaths);
+    const cleaned = await this.cleanupDiffFiles(acceptedEntries);
     for (const f of cleaned) {
       results.push(`cleaned: ${f}`);
     }
@@ -287,15 +287,20 @@ Call:
 
   /**
    * Remove diff files from the workspace that correspond to accepted output files.
-   * Diff files follow the pattern `{baseName}_diff{ext}` (e.g. `paper_r0_gemini_diff.tex`).
+   * Uses generateDiffFileName (the same logic that creates diff files) to derive names.
    */
-  private async cleanupDiffFiles(acceptedPaths: string[]): Promise<string[]> {
+  private async cleanupDiffFiles(
+    entries: { outputPath: string; originalPath: string }[],
+  ): Promise<string[]> {
     const results = await Promise.all(
-      acceptedPaths.map(async (filePath) => {
-        const { name, ext } = path.parse(filePath);
-        const diffPath = `${name}_diff${ext}`;
-        const dir = path.dirname(filePath);
-        const fullDiffPath = dir === '.' ? diffPath : `${dir}/${diffPath}`;
+      entries.map(async ({ outputPath, originalPath }) => {
+        const diffFileName = generateDiffFileName(
+          originalPath,
+          outputPath,
+          '_diff',
+        );
+        const dir = path.dirname(originalPath);
+        const fullDiffPath = dir === '.' ? diffFileName : `${dir}/${diffFileName}`;
 
         const loc = WorkspaceFS.locatePath(fullDiffPath);
         if (loc.kind === 'external') return null;


### PR DESCRIPTION
## Summary
Add automatic cleanup of diff files from the workspace when output files are accepted through the AcceptRunFilesTool. This prevents accumulation of temporary diff files that were used for review purposes.

## Key Changes
- Import `path` module for file path manipulation
- Add Phase 3 cleanup logic to the file acceptance workflow that:
  - Identifies which files were accepted (non-rejected)
  - Calls new `cleanupDiffFiles()` method to remove corresponding diff files
  - Reports cleaned files in the results summary
- Implement `cleanupDiffFiles()` private method that:
  - Constructs diff file paths using the pattern `{baseName}_diff{ext}` (e.g., `paper_r0_gemini_diff.tex`)
  - Checks if diff files exist in the workspace
  - Safely deletes them with silent failure handling for locked or inaccessible files
  - Returns list of successfully deleted files

## Implementation Details
- Diff file cleanup is integrated into the existing file acceptance workflow as a final phase
- The method gracefully handles edge cases where diff files may not exist or cannot be deleted
- Deletion failures are silently ignored to prevent blocking the overall acceptance operation
- Results include cleaned file paths for user visibility

https://claude.ai/code/session_01LrA4dsNGi5rVNr1mk1UaXb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `AcceptRunFilesTool` and only attempt to delete derived diff artifacts after successful accepts, with failures treated as non-fatal.
> 
> **Overview**
> **Automatically cleans up diff artifacts after accepting workflow output files.** `AcceptRunFilesTool` now tracks which files were accepted and, after writing them, derives the corresponding latexdiff filename via `generateDiffFileName` and deletes it from the workspace.
> 
> The tool’s description is tightened to clarify it should only be used for workflow subagent results, and acceptance output now reports any diff files that were successfully cleaned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1805c56a7de588b24a3b3b6eca915a6bc8599a17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->