### PR TITLE
Add plan tool to agent configurations and tool groups

### DIFF
--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -11,6 +11,7 @@ settings:
     - accept_run_files
     # Project management
     - todo_write
+    - plan
     # File operations
     - read_file
     - write_file
@@ -32,7 +33,7 @@ prompts:
 
     Delegate to lean for hands-on proof work: writing new proofs and definitions, fixing compilation errors or sorry placeholders, refactoring Lean code. Delegate to leanSearch when you need to check whether Mathlib already has something, find the right lemma or tactic for a goal, explore how Mathlib formalizes a concept, or do literature search on arXiv and Zulip. Delegate to leanSimplifier for quality cleanup: refactoring to Mathlib style, enforcing naming conventions, generalizing with typeclasses, removing duplication via @[to_additive], and preparing code for upstream contribution. Delegate to leanBlueprint for creating or syncing LeanBlueprint documents, converting informal math into formalization roadmaps, and tracking formalized vs pending results. Use research, chat, or review for non-Lean tasks.
 
-    Delegate liberally — long proofs, multi-file refactors, and research belong to specialists. Parallelize independent lemmas by delegating them simultaneously. Always search Mathlib before delegating proof work (use lean_loogle yourself for simple lookups, or delegate to leanSearch for deeper research) to prevent duplicate effort.
+    Delegate liberally — long proofs, multi-file refactors, and research belong to specialists. Parallelize independent lemmas by delegating them simultaneously. Always search Mathlib before delegating proof work (use lean_loogle yourself for simple lookups, or delegate to leanSearch for deeper research) to prevent duplicate effort. Use the plan tool to present a structured implementation plan before starting complex multi-step tasks—it outlines your strategy with numbered steps, descriptions, and affected files, pausing for user approval before you begin. Use todo_write for granular execution tracking as you work through each step.
 
     Lean 4 projects use lakefile.lean (or lakefile.toml) for configuration. Key paths to know: lakefile.lean for project config and dependencies, .lake/packages/ for downloaded dependencies after lake build or lake exe cache get, blueprint/ for LeanBlueprint files if present, and lake-manifest.json for pinned dependency versions.
 

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -10,6 +10,7 @@ settings:
     - executions
     - accept_run_files
     - todo_write
+    - plan
     - read_file
     - write_file
     - edit_file
@@ -63,7 +64,7 @@ prompts:
 
     Git workflow: If working in a git repository, use git throughout. Check git log for recent work and README/TODO files to understand project goals. Commit at meaningful checkpoints with descriptive messages—don't let work accumulate uncommitted. Use git status and git diff to review state before and after agent runs. When setting up a new repo, ensure a proper .gitignore is in place (for LaTeX: *.aux, *.log, *.synctex.gz, *.fls, *.fdb_latexmk, *.bbl, *.blg, *.out, *.toc, *.lof, *.lot, *.nav, *.snm, *.vrb, *.run.xml, *.bcf, *-blx.bib, *.pdf unless tracked intentionally, plus editor temporaries and OS files).
 
-    Subagents run asynchronously and deliver results automatically as follow-up messages when they finish—you do not need to poll. To check intermediate progress before delivery (e.g., which round a workflow is on), use action=wait on the executions tool: path=/executions/{id} waits for a specific subagent; path=/executions with action=wait waits for whichever subagent changes next (useful when multiple are running in parallel). Use /executions/{id}/files/{path} to review output files before accepting. Use accept_run_files to accept workflow results by copying generated files to their original workspace paths. Use todo_write to track progress and break complex requests into smaller tasks.
+    Subagents run asynchronously and deliver results automatically as follow-up messages when they finish—you do not need to poll. To check intermediate progress before delivery (e.g., which round a workflow is on), use action=wait on the executions tool: path=/executions/{id} waits for a specific subagent; path=/executions with action=wait waits for whichever subagent changes next (useful when multiple are running in parallel). Use /executions/{id}/files/{path} to review output files before accepting. Use accept_run_files to accept workflow results by copying generated files to their original workspace paths. Use the plan tool to present a structured implementation plan before starting complex multi-step tasks—it outlines your strategy with numbered steps, descriptions, and affected files, pausing for user approval before you begin. Use todo_write for granular execution tracking as you work through each step.
 
     After context compaction, subagent and background process reports remain accessible via /executions/{id}/report. Use /executions/current to see your own execution summary including a list of child executions you launched, or /executions/current/children for a dedicated listing. This lets you rediscover subagent execution IDs even after compaction.
 

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -222,8 +222,8 @@ const TOOL_GROUPS: Record<string, ToolGroup> = {
   },
   Utility: {
     description: 'Memory, todo tracking, and diagnostics',
-    tools: ['memory', 'todo_write', 'diagnostics'],
-    keywords: ['memory', 'todo', 'diagnostic', 'track'],
+    tools: ['memory', 'todo_write', 'plan', 'diagnostics'],
+    keywords: ['memory', 'todo', 'plan', 'diagnostic', 'track'],
   },
 };
 

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -121,6 +121,7 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
     toolNames: [
       'memory',
       'todo_write',
+      'plan',
       'delegate_workflow',
       'delegate_agent',
       'executions',


### PR DESCRIPTION
## Summary
This PR introduces the `plan` tool across agent configurations and tool dashboards. The plan tool enables agents to present structured implementation plans before starting complex multi-step tasks, with numbered steps, descriptions, and affected files, pausing for user approval before execution.

## Key Changes
- **Tool Group Registration**: Added `plan` to the Utility tool group in `agentCreatorCommands.ts` alongside memory, todo_write, and diagnostics, with corresponding keyword updates
- **Agent Configurations**: Enabled the `plan` tool in both the Lean4 orchestrator and main orchestrator agent configurations
- **Tool Dashboard**: Added `plan` to the builtin tools list in the tool dashboard data
- **Documentation Updates**: Enhanced orchestrator prompts to document the plan tool's usage pattern:
  - Use `plan` to present structured implementation plans before complex multi-step tasks
  - Use `todo_write` for granular execution tracking as work progresses through each step
  - This guidance appears in both Lean4 and main orchestrator configurations

## Implementation Details
The plan tool integrates into the existing agent workflow by providing a planning phase that precedes execution, allowing users to review and approve strategies before agents begin work. This complements the existing `todo_write` tool for tracking progress during execution.

https://claude.ai/code/session_01FnroRuzQbrCUZNSF7sszVP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/UI wiring change that only exposes the existing `plan` tool in agent templates and the tool dashboard; no core execution logic is modified.
> 
> **Overview**
> Adds the `plan` tool to the default tool lists for both the main `orchestrator` and `Lean4/leanOrchestrator` reference agents, and updates their prompts to instruct using `plan` for multi-step work before execution.
> 
> Registers `plan` as part of the `Utility` tool group in `agentCreatorCommands.ts` (including keyword matching), and includes `plan` in the built-in “Memory, Tasks & Delegation” tool dashboard group so it appears in the settings UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78e91ecd303a1f7b27ff9ec8d712a7301e498d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->