### PR TITLE
Add scrollable containers to permission and request panel bodies

### DIFF
--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -41,6 +41,8 @@ export const permissionCardStyles: CSSResult = css`
   .permission-body {
     font-size: var(--font-size);
     line-height: var(--line-height-relaxed);
+    max-height: 50vh;
+    overflow-y: auto;
   }
 
   .code-block {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -68,6 +68,8 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: var(--spacing-small);
+    max-height: 50vh;
+    overflow-y: auto;
   }
 
   .approval-request__meta,
@@ -205,11 +207,6 @@ export const requestPanelStyles: CSSResult = css`
 
   .bash-approval-requests__header .codicon {
     color: var(--vscode-terminal-ansiYellow);
-  }
-
-  .bash-approval-request__details {
-    max-height: 50vh;
-    overflow-y: auto;
   }
 
   .bash-approval-request__command {
@@ -456,11 +453,6 @@ export const requestPanelStyles: CSSResult = css`
 
   .plan-approval-requests__header .codicon {
     color: var(--vscode-textLink-foreground);
-  }
-
-  .plan-approval-request__details {
-    max-height: 50vh;
-    overflow-y: auto;
   }
 
   .plan-approval-request__summary {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -207,6 +207,11 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-terminal-ansiYellow);
   }
 
+  .bash-approval-request__details {
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
   .bash-approval-request__command {
     font-family: var(--vscode-editor-font-family);
     font-size: var(--font-size-sm);
@@ -451,6 +456,11 @@ export const requestPanelStyles: CSSResult = css`
 
   .plan-approval-requests__header .codicon {
     color: var(--vscode-textLink-foreground);
+  }
+
+  .plan-approval-request__details {
+    max-height: 50vh;
+    overflow-y: auto;
   }
 
   .plan-approval-request__summary {

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -75,6 +75,7 @@ export const requestPanelStyles: CSSResult = css`
      dropdown that would be clipped by overflow-y: auto). */
   .approval-request__details,
   .bash-approval-request__details,
+  .retry-request__details,
   .plan-approval-request__details {
     max-height: 50vh;
     overflow-y: auto;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -68,6 +68,14 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: var(--spacing-small);
+  }
+
+  /* Scroll constraint for panels with potentially long content.
+     Excluded: workflow-proposal__details (has an absolutely-positioned
+     dropdown that would be clipped by overflow-y: auto). */
+  .approval-request__details,
+  .bash-approval-request__details,
+  .plan-approval-request__details {
     max-height: 50vh;
     overflow-y: auto;
   }


### PR DESCRIPTION
## Summary
Added vertical scrolling capability to two key UI components to improve handling of content overflow and enhance user experience when dealing with large amounts of information.

## Key Changes
- **Permission Card**: Added `max-height: 50vh` and `overflow-y: auto` to `.permission-body` to enable scrolling for permission details that exceed viewport height
- **Request Panel**: Added `max-height: 50vh` and `overflow-y: auto` to the request body container to enable scrolling for approval request content that exceeds viewport height

## Implementation Details
Both changes follow the same pattern:
- Set a maximum height constraint of 50% viewport height (`50vh`)
- Enable vertical scrolling with `overflow-y: auto` to display scrollbars only when content overflows
- This prevents these components from expanding indefinitely and pushing other UI elements off-screen

https://claude.ai/code/session_01TZsMoYYuWLfyZuzRC3A6Ng

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that constrains long content via `max-height`/`overflow-y`, with minor layout/scrollbar behavior changes limited to permission cards and selected request panels.
> 
> **Overview**
> Adds vertical scrolling constraints to long-content areas in the UI.
> 
> `permissionCardStyles` now caps `.permission-body` to `50vh` and enables `overflow-y: auto`. `requestPanelStyles` applies the same `50vh`/scroll treatment to approval/retry/bash/plan request `__details` sections (explicitly excluding `workflow-proposal__details` to avoid clipping its dropdown).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788283e916c2901745427f9a8062522a57ecfc5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->