### PR TITLE
Persist todos to execution store for orchestrator access

### DIFF
--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -2,7 +2,7 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ToolDefinition } from '@model';
-import type { SubagentProgressUpdate } from '@shared/schemas';
+import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type {
   BaseFlowContextInit,
   FlowParams,
@@ -22,6 +22,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
     lastResponse: string | undefined,
   ) => void | Promise<void>;
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
+  /** Persist todos to the execution KV store. Injected by runToolUseFlow. */
+  readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
   /** True when this agent was launched as a subagent by an orchestrator. */
   readonly isSubagent?: boolean;
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -6,7 +6,6 @@ import {
   createToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
-import { getExecutionStore } from '@agent/storage';
 import { formatProviderHttpError } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -84,15 +83,19 @@ export class ToolUseCycleNode<C> extends Node<
       agentName: config.agent,
     });
 
-    const { onProgress, executionId } = this.services;
-    const kvStore = getExecutionStore(executionId);
+    const { onProgress, persistTodos } = this.services;
+    // Serialize writes so rapid updates don't persist out of order
+    let todoPersistChain = Promise.resolve();
     prepRes.workspaceState.todos.setOnUpdate((todos) => {
       bus.emit('updateTodos', {
         streamId,
         todos,
       });
-      // Persist immediately so the orchestrator can read via /executions/{id}/todos
-      kvStore.writeTodos(todos).catch(() => {});
+      if (persistTodos) {
+        todoPersistChain = todoPersistChain
+          .then(() => persistTodos(todos))
+          .catch(() => {});
+      }
       onProgress?.({ kind: 'todos', todos });
     });
     prepRes.workspaceState.plan.setOnUpdate((plan) => {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -123,6 +123,9 @@ export class ToolUseCycleNode<C> extends Node<
     } finally {
       prepRes.workspaceState.todos.clearOnUpdate();
       prepRes.workspaceState.plan.clearOnUpdate();
+      // Drain in-flight persist writes before returning so they don't
+      // race with the projection's writeTodos after this node completes.
+      await todoPersistChain;
     }
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -6,6 +6,7 @@ import {
   createToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
+import { getExecutionStore } from '@agent/storage';
 import { formatProviderHttpError } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 
@@ -83,12 +84,15 @@ export class ToolUseCycleNode<C> extends Node<
       agentName: config.agent,
     });
 
-    const { onProgress } = this.services;
+    const { onProgress, executionId } = this.services;
+    const kvStore = getExecutionStore(executionId);
     prepRes.workspaceState.todos.setOnUpdate((todos) => {
       bus.emit('updateTodos', {
         streamId,
         todos,
       });
+      // Persist immediately so the orchestrator can read via /executions/{id}/todos
+      kvStore.writeTodos(todos).catch(() => {});
       onProgress?.({ kind: 'todos', todos });
     });
     prepRes.workspaceState.plan.setOnUpdate((plan) => {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -125,6 +125,8 @@ export async function runToolUseFlow<C = unknown>(
     isSubagent: input.isSubagent,
   });
 
+  const kv = getExecutionStore(executionId);
+
   const services: ToolUseServices<C> = {
     ...input,
     session: sessionLifecycle,
@@ -132,6 +134,7 @@ export async function runToolUseFlow<C = unknown>(
     toolRegistry: registry,
     snapshot: input.resumeSnapshot ?? null,
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
+    persistTodos: (todos) => kv.writeTodos(todos),
   };
 
   const flowContext: ToolUseFlowContext = {
@@ -152,8 +155,6 @@ export async function runToolUseFlow<C = unknown>(
     shouldSkipCycle: false,
     stateSlices: null,
   };
-
-  const kv = getExecutionStore(executionId);
 
   try {
     registerInterruptible(streamId, flowContext);


### PR DESCRIPTION
## Summary
Added persistence of todos to the execution store when they are updated during tool use cycles, enabling the orchestrator to read the current todos state via the `/executions/{id}/todos` endpoint.

## Key Changes
- Imported `getExecutionStore` from the storage module
- Extracted `executionId` from services to access the execution store
- Added immediate persistence of todos updates to the key-value store with error suppression to prevent blocking the main flow

## Implementation Details
- The todos are now written to the execution store whenever they are updated via the `setOnUpdate` callback
- Error handling is implemented with a catch-all that silently fails (`.catch(() => {})`) to ensure persistence doesn't block the agent's execution flow
- This allows external systems (like the orchestrator) to query the current todos state at any time during execution

https://claude.ai/code/session_01CQJbGqoBqjrtGmyejCbzyw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persistence side effects on every todo update during tool-use cycles; while errors are suppressed, ordering/draining logic could still impact timing and completion behavior under heavy update rates.
> 
> **Overview**
> **Persists in-progress todos to execution storage** so external callers (e.g., orchestrators) can read the latest state during execution.
> 
> `runToolUseFlow` now injects a `persistTodos` service wired to `getExecutionStore(executionId).writeTodos`, and `ToolUseCycleNode` calls it on each todo update, serializing writes and draining the chain on exit to avoid racing the flow projection’s final `writeTodos`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c3a4e04a94cd5f6adb82a7c1343364e9c952553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->