### PR TITLE
Add @openai/codex-sdk as optional external dependency

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -115,6 +115,7 @@ const extensionConfig = {
     'fsevents', // macOS native module
     'bufferutil', // Optional native module
     'utf-8-validate', // Optional native module
+    '@openai/codex-sdk', // Optional runtime dependency — dynamically imported when Codex CLI is installed
   ],
   loader: { '.tex': 'text' },
   plugins: [aliasPlugin, progressPlugin],

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -240,10 +240,8 @@ export class CodexTool extends defineTool({
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    // Dynamic import — variable indirection hides the specifier from webpack
-    // so it doesn't try to bundle/resolve the optional ESM-only package.
-    const codexSdkModule = '@openai/codex-sdk';
-    const { Codex } = await import(/* webpackIgnore: true */ codexSdkModule);
+    // Dynamic import — resolved at runtime, not bundled (see webpack externals)
+    const { Codex } = await import('@openai/codex-sdk');
 
     const codex = new Codex();
     const thread = codex.startThread({

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -11,15 +11,46 @@
 
 // Third-party imports
 import { z } from 'zod';
-import type {
-  ItemCompletedEvent,
-  RunResult,
-  SandboxMode,
-  ThreadItem,
-  Thread,
-  TurnCompletedEvent,
-  TurnFailedEvent,
-} from '@openai/codex-sdk';
+
+// ---------------------------------------------------------------------------
+// Codex SDK types — defined locally to avoid a static import of the optional
+// @openai/codex-sdk package, which is ESM-only and breaks webpack CJS builds.
+// ---------------------------------------------------------------------------
+
+type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+interface ThreadItem {
+  type: string;
+  // file_change items
+  changes: { kind: string; path: string }[];
+  // command_execution items
+  command: string;
+  exit_code: number;
+  // agent_message items
+  text: string;
+}
+
+interface RunResult {
+  items: ThreadItem[];
+  finalResponse: string | null;
+  usage: { input_tokens: number; output_tokens: number } | null;
+}
+
+interface Thread {
+  run(prompt: string): Promise<RunResult>;
+  runStreamed(prompt: string): Promise<{ events: AsyncIterable<CodexEvent> }>;
+}
+
+interface CodexEvent {
+  type: string;
+  item?: ThreadItem;
+  usage?: RunResult['usage'];
+  error?: { message: string };
+}
+
+type ItemCompletedEvent = CodexEvent & { item: ThreadItem };
+type TurnCompletedEvent = CodexEvent & { usage: RunResult['usage'] };
+type TurnFailedEvent = CodexEvent & { error: { message: string } };
 
 // Local imports - agent
 import {
@@ -209,8 +240,10 @@ export class CodexTool extends defineTool({
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    // Dynamic import — avoids hard dependency when CLI is not installed
-    const { Codex } = await import('@openai/codex-sdk');
+    // Dynamic import — variable indirection hides the specifier from webpack
+    // so it doesn't try to bundle/resolve the optional ESM-only package.
+    const codexSdkModule = '@openai/codex-sdk';
+    const { Codex } = await import(/* webpackIgnore: true */ codexSdkModule);
 
     const codex = new Codex();
     const thread = codex.startThread({

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -219,7 +219,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk.',
     check: async () => {
       try {
-        const { Codex } = await import('@openai/codex-sdk');
+        const mod = '@openai/codex-sdk';
+        const { Codex } = await import(/* webpackIgnore: true */ mod);
         // Constructor resolves the binary path — throws if not found
         new Codex();
         return true;
@@ -229,7 +230,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     },
     detailCheck: async () => {
       try {
-        const { Codex } = await import('@openai/codex-sdk');
+        const mod = '@openai/codex-sdk';
+        const { Codex } = await import(/* webpackIgnore: true */ mod);
         new Codex();
         return 'Codex CLI binary found. Ready for SDK use.';
       } catch (err: unknown) {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -219,8 +219,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk.',
     check: async () => {
       try {
-        const mod = '@openai/codex-sdk';
-        const { Codex } = await import(/* webpackIgnore: true */ mod);
+        const { Codex } = await import('@openai/codex-sdk');
         // Constructor resolves the binary path — throws if not found
         new Codex();
         return true;
@@ -230,8 +229,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     },
     detailCheck: async () => {
       try {
-        const mod = '@openai/codex-sdk';
-        const { Codex } = await import(/* webpackIgnore: true */ mod);
+        const { Codex } = await import('@openai/codex-sdk');
         new Codex();
         return 'Codex CLI binary found. Ready for SDK use.';
       } catch (err: unknown) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,6 +130,7 @@ const extensionConfig = {
     'split.js': 'Split',
     '@vscode/codicons': 'commonjs @vscode/codicons',
     vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    '@openai/codex-sdk': 'commonjs @openai/codex-sdk', // optional runtime dependency — dynamically imported when Codex CLI is installed
     // modules added here also need to be added in the .vscodeignore file
   },
   resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,7 +130,7 @@ const extensionConfig = {
     'split.js': 'Split',
     '@vscode/codicons': 'commonjs @vscode/codicons',
     vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
-    '@openai/codex-sdk': 'commonjs @openai/codex-sdk', // optional runtime dependency — dynamically imported when Codex CLI is installed
+    '@openai/codex-sdk': "promise import('@openai/codex-sdk')", // ESM-only — must use import(), not require()
     // modules added here also need to be added in the .vscodeignore file
   },
   resolve: {


### PR DESCRIPTION
## Summary
This PR adds `@openai/codex-sdk` as an optional external dependency to both the esbuild and webpack build configurations, allowing it to be dynamically imported when the Codex CLI is installed.

## Changes
- **esbuild.config.mjs**: Added `@openai/codex-sdk` to the externals list with a comment indicating it's an optional runtime dependency that's dynamically imported when Codex CLI is installed
- **webpack.config.js**: Added `@openai/codex-sdk` to the externals configuration as a CommonJS module, with a matching comment about its optional nature and dynamic import behavior

## Implementation Details
Both build configurations now properly exclude `@openai/codex-sdk` from bundling, treating it as an external dependency. This allows the extension to gracefully handle scenarios where the Codex CLI may or may not be installed, with the SDK being loaded at runtime only when needed.

https://claude.ai/code/session_01JuXDDq7rMiLHHmVJiU1Gm3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes bundling/externals behavior for the extension build; misconfiguration could cause runtime module resolution failures when `@openai/codex-sdk` is absent or when webpack/esbuild handle ESM interop differently.
> 
> **Overview**
> Makes `@openai/codex-sdk` an explicitly *optional* runtime dependency by excluding it from both esbuild and webpack bundles, so it can be loaded only when present.
> 
> Updates `CodexTool` to avoid static type imports from the ESM-only SDK by defining minimal local SDK types, while keeping the runtime `import('@openai/codex-sdk')` path for execution and availability checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c42b85c23217b7b314912001cdcaf99c14cb387. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->