### PR TITLE
Add copy-to-clipboard button to user messages

### DIFF
--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -101,7 +101,6 @@ export class UserMessage extends LitElement {
 
   private copyController = new CopyButtonController(this, {
     defaultTitle: 'Copy message',
-    successTitle: 'Copied!',
   });
 
   override render(): TemplateResult {

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -7,10 +7,14 @@
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles/litStyles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
+
+// Local imports - controllers
+import { CopyButtonController } from '@shared/controllers';
 
 // Local imports - formatter helpers
 import { formatTimestamp } from '../formatters/timestampUtils';
@@ -48,6 +52,26 @@ export class UserMessage extends LitElement {
         color: var(--vscode-descriptionForeground);
       }
 
+      .user-message-header-left {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-tiny);
+        flex: 1;
+      }
+
+      .user-message-copy {
+        opacity: 0;
+        transition: opacity 0.15s ease;
+      }
+
+      .user-message:hover .user-message-copy {
+        opacity: 1;
+      }
+
+      .user-message-copy.copy-success {
+        opacity: 1;
+      }
+
       .user-message-icon {
         font-size: var(--font-size-xs);
       }
@@ -75,19 +99,37 @@ export class UserMessage extends LitElement {
   /** Message timestamp (Unix ms) */
   @property({ attribute: false }) timestamp = 0;
 
+  private copyController = new CopyButtonController(this, {
+    defaultTitle: 'Copy message',
+    successTitle: 'Copied!',
+  });
+
   override render(): TemplateResult {
     const { timeDisplay, tooltipTimestamp } = formatTimestamp(
       new Date(this.timestamp),
     );
+    const copyState = this.copyController.state;
 
     return html`
       <div class="user-message-container">
         <div class="user-message">
           <div class="user-message-header">
-            <i class="codicon codicon-comment user-message-icon"></i>
-            <span class="user-message-timestamp" title=${tooltipTimestamp}
-              >${timeDisplay}</span
-            >
+            <span class="user-message-header-left">
+              <i class="codicon codicon-comment user-message-icon"></i>
+              <span class="user-message-timestamp" title=${tooltipTimestamp}
+                >${timeDisplay}</span
+              >
+            </span>
+            <vscode-toolbar-button
+              class=${classMap({
+                'user-message-copy': true,
+                [copyState.successClass]: copyState.copied,
+              })}
+              icon="copy"
+              title=${copyState.title}
+              aria-label=${copyState.ariaLabel}
+              @click=${() => this.copyController.copy(this.text)}
+            ></vscode-toolbar-button>
           </div>
           <div
             class="user-message-content"


### PR DESCRIPTION
## Summary
Added a copy-to-clipboard button to the UserMessage component that allows users to quickly copy message text. The button appears on hover and provides visual feedback when the copy action succeeds.

## Key Changes
- Imported `classMap` directive from Lit for dynamic class binding
- Imported `CopyButtonController` to handle copy functionality and state management
- Added CSS styles for the new copy button:
  - `.user-message-header-left`: Flexbox container for icon and timestamp
  - `.user-message-copy`: Button styling with opacity transition on hover
  - `.user-message-copy.copy-success`: Success state styling
- Initialized `CopyButtonController` with custom titles for default and success states
- Restructured the message header to wrap icon and timestamp in a flex container
- Added a `vscode-toolbar-button` with copy icon that:
  - Dynamically applies classes based on copy state
  - Displays appropriate title and aria-label
  - Triggers copy action on click with the message text

## Implementation Details
- The copy button uses the existing `CopyButtonController` for consistent copy behavior across the application
- Button visibility is controlled via CSS opacity transitions (hidden by default, visible on hover)
- Success state is indicated by the `copy-success` class which keeps the button visible and likely changes its appearance
- The header layout was refactored to use flexbox for better alignment of the icon, timestamp, and new copy button

https://claude.ai/code/session_01YEf9QaVgHdwH8XJvR3trs3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change adding clipboard copy interaction to `UserMessage`; main risk is minor layout/styling or clipboard behavior regressions.
> 
> **Overview**
> Adds a copy-to-clipboard button to `UserMessage` so users can copy message text directly from the message header.
> 
> The header layout is adjusted to accommodate the new action, and hover/success-state styling is added (via `classMap` + `CopyButtonController`) to show the button on hover and keep it visible briefly after a successful copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f06ab5bb6f1fe12fbe9ad796b1b4027281b4753. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->