### PR TITLE
Remove Wolfram provider and add DashScope China region support

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -237,7 +237,6 @@ TeXRA also loads environment variables from a `.env` file in your workspace. Def
 - **DeepSeek API Key**: Available from [DeepSeek Platform](https://platform.deepseek.com/api_keys)
 - **Moonshot API Key**: Available from [Moonshot Console](https://platform.moonshot.cn/console)
 - **DashScope API Key**: Available from [DashScope Console](https://dashscope.aliyun.com/api-console/)
-- **Wolfram LLM API Key**: Available from [Wolfram LLM App](https://llm-api.wolframalpha.com/)
   :::
 
 ## Verifying Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,9 +1847,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1867,9 +1864,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1887,9 +1881,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1907,9 +1898,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1927,9 +1915,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,9 +1932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7603,9 +7585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7627,9 +7606,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7651,9 +7627,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7675,9 +7648,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -1,7 +1,10 @@
 import { ModelProvider } from 'llm-zoo';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { getConfig } from '@utils/config';
-import { getProviderEndpoint } from '@utils/config/providerConfig';
+import {
+  getProviderEndpoint,
+  getDashScopeUseChina,
+} from '@utils/config/providerConfig';
 
 // NOTE: getProviderEndpoint reads from globalSM (VS Code global state), which is
 // where the Settings dashboard writes custom endpoints. The legacy settings.json
@@ -41,8 +44,7 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.DEEPSEEK]: 'https://api.deepseek.com',
   [ModelProvider.XAI]: 'https://api.x.ai/v1',
   [ModelProvider.MOONSHOT]: 'https://api.moonshot.cn/v1',
-  [ModelProvider.DASHSCOPE]:
-    'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  [ModelProvider.DASHSCOPE]: null, // Resolved dynamically via getDashScopeBaseUrl()
   [ModelProvider.COPILOT]: null,
   [ModelProvider.OTHERS]: null,
 };
@@ -153,6 +155,14 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
       `Using custom base URL for ${config.provider}: ${customUrl}`,
     );
     return `https://${normalizeUrl(customUrl)}`;
+  }
+
+  // DashScope base URL depends on the China/international region toggle
+  if (config.provider === ModelProvider.DASHSCOPE) {
+    const domain = getDashScopeUseChina()
+      ? 'dashscope.aliyuncs.com'
+      : 'dashscope-intl.aliyuncs.com';
+    return `https://${domain}/compatible-mode/v1`;
   }
 
   return BASE_URLS[config.provider];

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -65,6 +65,9 @@ export enum GlobalStateKey {
   ENDPOINT_MOONSHOT = 'texra.endpoint.moonshot',
   ENDPOINT_DASHSCOPE = 'texra.endpoint.dashscope',
 
+  // Region settings
+  DASHSCOPE_USE_CHINA = 'texra.dashscope.useChina',
+
   // Transport settings
   WEBSOCKET_OPENAI = 'texra.websocket.openai',
 }

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -45,7 +45,6 @@ export class SecretManager {
     'deepseek',
     'moonshot',
     'dashscope',
-    'wolframllmapp',
   ] as const;
 
   public static getApiKeySecretName(provider: ApiProvider): string {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -97,6 +97,7 @@ import {
   getProviderEndpoint,
   setProviderEndpoint,
   supportsCustomEndpoint,
+  getDashScopeUseChina,
 } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
 import { loadMemoryItems } from './utils/memoryFileSystem';
@@ -186,11 +187,19 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
         status = 'not-set';
       }
 
+      // DashScope display name and key URL switch based on China region setting
+      let displayName = PROVIDER_DISPLAY_NAMES[provider];
+      let keyUrl = PROVIDER_URLS[provider];
+      if (provider === 'dashscope' && getDashScopeUseChina()) {
+        displayName = 'Bailian';
+        keyUrl = 'https://bailian.console.aliyun.com/';
+      }
+
       return {
         provider,
-        displayName: PROVIDER_DISPLAY_NAMES[provider],
+        displayName,
         status,
-        keyUrl: PROVIDER_URLS[provider],
+        keyUrl,
         streaming: getProviderStreaming(provider),
         customEndpoint: getProviderEndpoint(provider),
         supportsCustomEndpoint: supportsCustomEndpoint(provider),

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1078,7 +1078,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_PROVIDER_KEY_URL>,
   ): Promise<void> {
     const provider = data.provider as ApiProvider;
-    const url = PROVIDER_URLS[provider];
+    let url = PROVIDER_URLS[provider];
+    if (provider === 'dashscope' && getDashScopeUseChina()) {
+      url = 'https://bailian.console.aliyun.com/';
+    }
     if (url) {
       await vscode.env.openExternal(vscode.Uri.parse(url));
     }

--- a/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -24,9 +24,6 @@ const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
   'not-set': 'Not Set',
 };
 
-/** Providers that have no per-provider streaming config (Wolfram uses a different protocol). */
-const NO_STREAMING_PROVIDERS = new Set(['wolframllmapp']);
-
 @customElement('provider-key-list')
 export class ProviderKeyList extends LitElement {
   static override styles = [
@@ -43,12 +40,9 @@ export class ProviderKeyList extends LitElement {
 
   @state() private expandedProvider: string | null = null;
 
-  private hasSettings(entry: ProviderKeyStatus): boolean {
-    return (
-      !NO_STREAMING_PROVIDERS.has(entry.provider) ||
-      entry.supportsCustomEndpoint ||
-      entry.vscodeSettings.length > 0
-    );
+  /** All providers have at least a streaming toggle, so settings are always available. */
+  private hasSettings(_entry: ProviderKeyStatus): boolean {
+    return true;
   }
 
   private toggleExpanded(provider: string): void {
@@ -91,10 +85,7 @@ export class ProviderKeyList extends LitElement {
   }
 
   private renderDetailRow(entry: ProviderKeyStatus): TemplateResult {
-    const hasStreaming = !NO_STREAMING_PROVIDERS.has(entry.provider);
-
-    const streamingToggle = hasStreaming
-      ? html`
+    const streamingToggle = html`
           <div class="provider-setting">
             <vscode-checkbox
               ?checked=${entry.streaming}
@@ -111,8 +102,7 @@ export class ProviderKeyList extends LitElement {
               Streaming
             </vscode-checkbox>
           </div>
-        `
-      : nothing;
+        `;
 
     const endpointInput = entry.supportsCustomEndpoint
       ? html`

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -194,4 +194,13 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
         'Enable the 1M-token context window for Claude Opus 4.6, Sonnet 4.6, and Sonnet 4 (usage capped at 200K by extension).',
     },
   ],
+  dashscope: [
+    {
+      key: GlobalStateKey.DASHSCOPE_USE_CHINA,
+      label: 'China Region (Bailian)',
+      description:
+        'Use the China region endpoint (dashscope.aliyuncs.com) instead of international (dashscope-intl.aliyuncs.com). Provider displays as "Bailian".',
+      globalStateKey: GlobalStateKey.DASHSCOPE_USE_CHINA,
+    },
+  ],
 };

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -73,7 +73,6 @@ const PROVIDER_REGISTRY = [
 /** Providers not in the main registry (no server-side keys, no model selection). */
 const EXTRA_DISPLAY_NAMES: Record<string, string> = {
   openRouter: 'OpenRouter',
-  wolframllmapp: 'Wolfram',
   [ModelProvider.COPILOT]: 'Copilot',
   [ModelProvider.OTHERS]: 'Others',
 };
@@ -116,7 +115,6 @@ export const PROVIDER_URLS: Record<string, string> = {
     PROVIDER_REGISTRY.filter((p) => p.keyUrl).map((p) => [p.id, p.keyUrl!]),
   ),
   openRouter: 'https://openrouter.ai/keys',
-  wolframllmapp: 'https://llm-api.wolframalpha.com/',
 };
 
 /** Default model used for auxiliary/helper tasks (polishing, agent creation, merge, session descriptions). */

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -64,7 +64,7 @@ const PROVIDER_REGISTRY = [
   },
   {
     id: ModelProvider.DASHSCOPE,
-    displayName: 'DashScope',
+    displayName: 'Qwen',
     hasServerKey: true,
     keyUrl: 'https://dashscope.aliyun.com/api-console/',
   },
@@ -199,7 +199,7 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       key: GlobalStateKey.DASHSCOPE_USE_CHINA,
       label: 'China Region (Bailian)',
       description:
-        'Use the China region endpoint (dashscope.aliyuncs.com) instead of international (dashscope-intl.aliyuncs.com). Provider displays as "Bailian".',
+        'Use the China region endpoint (dashscope.aliyuncs.com) instead of international (dashscope-intl.aliyuncs.com). Display name switches to "Bailian".',
       globalStateKey: GlobalStateKey.DASHSCOPE_USE_CHINA,
     },
   ],

--- a/src/shared/utils/icons.ts
+++ b/src/shared/utils/icons.ts
@@ -43,7 +43,7 @@ const MODEL_PROVIDER_DECORATORS: Record<string, ProviderDecorator> = {
   },
   dashscope: {
     unicode: '\u2604', // ☄ - Comet (Alibaba Cloud)
-    label: 'DashScope',
+    label: 'Qwen',
     hint: 'Alibaba Cloud Qwen models',
   },
   copilot: {

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -105,6 +105,17 @@ export async function setAnthropicDynamicFiltering(
 }
 
 // ---------------------------------------------------------------------------
+// DashScope region setting (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Whether DashScope is set to use the China (Bailian) region. */
+export function getDashScopeUseChina(): boolean {
+  return (
+    globalSM?.get<boolean>(GlobalStateKey.DASHSCOPE_USE_CHINA, false) ?? false
+  );
+}
+
+// ---------------------------------------------------------------------------
 // WebSocket transport setting (globalSM-backed)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
This PR removes support for the Wolfram LLM provider and adds dynamic region configuration for DashScope, allowing users to switch between China (Bailian) and international endpoints.

## Key Changes

- **Removed Wolfram provider support**: Deleted all references to `wolframllmapp` from the codebase, including display names, API URLs, and secret manager configuration
- **Simplified provider settings logic**: Removed the `NO_STREAMING_PROVIDERS` constant and the conditional logic in `ProviderKeyList` since all providers now support streaming toggles
- **Added DashScope region toggle**: Implemented a new `DASHSCOPE_USE_CHINA` global state setting that allows users to switch between:
  - China region: `dashscope.aliyuncs.com` (displays as "Bailian")
  - International region: `dashscope-intl.aliyuncs.com` (displays as "DashScope")
- **Dynamic base URL resolution**: Updated `ProxyConfigResolver` to resolve DashScope's base URL dynamically based on the region setting instead of using a static URL
- **Settings UI integration**: Added a new provider-specific setting in the settings view to control the DashScope region preference
- **Updated documentation**: Removed Wolfram API key reference from installation guide

## Implementation Details

- The DashScope region setting is persisted in VS Code's global state via `GlobalStateKey.DASHSCOPE_USE_CHINA`
- The `getDashScopeUseChina()` function provides a centralized way to check the region preference across the codebase
- The settings view now dynamically updates the display name and key URL for DashScope based on the region setting
- All streaming toggle logic is now unconditional, simplifying the provider detail rendering

https://claude.ai/code/session_01HDLbWAhPF7NhKRLSTDw61Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes provider routing and settings UI for DashScope, which can affect API request destinations; the Wolfram removal is low risk but may break any users relying on that provider.
> 
> **Overview**
> **Removes the Wolfram LLM provider** across docs, UI constants, and secret-key handling, including deleting `wolframllmapp` from provider lists/URLs.
> 
> **Adds DashScope China region support** via a new global state flag `GlobalStateKey.DASHSCOPE_USE_CHINA`, surfaced as a provider-specific setting in the dashboard; DashScope now resolves its base URL dynamically between China and international endpoints, and the settings UI adapts the provider display name/key URL (e.g., “Bailian” when China is enabled).
> 
> Also updates DashScope branding in shared display constants/icons (e.g., shown as “Qwen”), and includes a `package-lock.json` metadata refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64ab2f686eb1cedbf0cfd54fe8b42b08cf7815ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->