### PR TITLE
Fix ESM/CJS interop issues with @openai/codex-sdk import

### DIFF
--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -213,6 +213,48 @@ function formatCodexError(
 }
 
 // ============================================================================
+// ESM/CJS interop helper
+// ============================================================================
+
+/**
+ * Robustly import the Codex class from @openai/codex-sdk.
+ *
+ * The SDK is ESM-only but the extension is bundled as CJS. In some
+ * Electron/Node.js versions the module namespace object from `import()`
+ * may wrap named exports under a `default` property, causing a bare
+ * `{ Codex }` destructure to yield `undefined` and the subsequent
+ * `new Codex()` to throw "e is not a constructor" (minified name).
+ */
+async function importCodexClass(): Promise<
+  new (options?: Record<string, unknown>) => {
+    startThread(options?: Record<string, unknown>): Thread;
+  }
+> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  // Normal named export
+  if (typeof mod.Codex === 'function') {
+    return mod.Codex as never;
+  }
+
+  // Wrapped under default (some ESM/CJS interop scenarios)
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') {
+    return def.Codex as never;
+  }
+
+  // Default export IS the class (unlikely, but defensive)
+  if (typeof def === 'function') {
+    return def as never;
+  }
+
+  throw new Error(
+    'Failed to import Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 
@@ -222,7 +264,7 @@ export class CodexTool extends defineTool({
     'Spin off an OpenAI Codex agent to perform code analysis, generation, or research in a sandboxed environment. ' +
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +
     'Requires the Codex CLI to be installed (`npm install -g @openai/codex`). ' +
-    'Auth is handled by the CLI itself (`codex login` or OPENAI_API_KEY env var).',
+    'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var.',
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
@@ -241,7 +283,7 @@ export class CodexTool extends defineTool({
     ctx?.onExecutionReady?.();
 
     // Dynamic import — resolved at runtime, not bundled (see webpack externals)
-    const { Codex } = await import('@openai/codex-sdk');
+    const Codex = await importCodexClass();
 
     const codex = new Codex();
     const thread = codex.startThread({

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -234,20 +234,26 @@ async function importCodexClass(): Promise<
 
   // Normal named export
   if (typeof mod.Codex === 'function') {
+    console.log('[Codex] Imported via named export (mod.Codex)');
     return mod.Codex as never;
   }
 
   // Wrapped under default (some ESM/CJS interop scenarios)
   const def = mod.default as Record<string, unknown> | undefined;
   if (def && typeof def.Codex === 'function') {
+    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
     return def.Codex as never;
   }
 
   // Default export IS the class (unlikely, but defensive)
   if (typeof def === 'function') {
+    console.log('[Codex] Imported via default export (mod.default)');
     return def as never;
   }
 
+  console.log(
+    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
   throw new Error(
     'Failed to import Codex class from @openai/codex-sdk. ' +
       `Module keys: [${Object.keys(mod).join(', ')}]`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -82,6 +82,7 @@ import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { importCodexClass } from './codexImport';
 
 // ============================================================================
 // Schema
@@ -210,54 +211,6 @@ function formatCodexError(
     `<message>${escapeText(message)}</message>`,
     '</codex-error>',
   ].join('\n');
-}
-
-// ============================================================================
-// ESM/CJS interop helper
-// ============================================================================
-
-/**
- * Robustly import the Codex class from @openai/codex-sdk.
- *
- * The SDK is ESM-only but the extension is bundled as CJS. In some
- * Electron/Node.js versions the module namespace object from `import()`
- * may wrap named exports under a `default` property, causing a bare
- * `{ Codex }` destructure to yield `undefined` and the subsequent
- * `new Codex()` to throw "e is not a constructor" (minified name).
- */
-async function importCodexClass(): Promise<
-  new (options?: Record<string, unknown>) => {
-    startThread(options?: Record<string, unknown>): Thread;
-  }
-> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
-
-  // Normal named export
-  if (typeof mod.Codex === 'function') {
-    console.log('[Codex] Imported via named export (mod.Codex)');
-    return mod.Codex as never;
-  }
-
-  // Wrapped under default (some ESM/CJS interop scenarios)
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
-    return def.Codex as never;
-  }
-
-  // Default export IS the class (unlikely, but defensive)
-  if (typeof def === 'function') {
-    console.log('[Codex] Imported via default export (mod.default)');
-    return def as never;
-  }
-
-  console.log(
-    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-  throw new Error(
-    'Failed to import Codex class from @openai/codex-sdk. ' +
-      `Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
 }
 
 // ============================================================================

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -1,0 +1,45 @@
+/**
+ * Robust ESM/CJS interop helper for importing the Codex class from
+ * @openai/codex-sdk.
+ *
+ * The SDK is ESM-only but the extension is bundled as CJS. In some
+ * Electron/Node.js versions the module namespace object from `import()`
+ * wraps named exports under a `default` property, causing a bare
+ * `{ Codex }` destructure to yield `undefined` and the subsequent
+ * `new Codex()` to throw "e is not a constructor" (minified name).
+ *
+ * This helper probes multiple export shapes so it works regardless of
+ * the runtime's interop behavior.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CodexConstructor = new (options?: any) => any;
+
+export async function importCodexClass(): Promise<CodexConstructor> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  // Normal named export
+  if (typeof mod.Codex === 'function') {
+    console.log('[Codex] Imported via named export (mod.Codex)');
+    return mod.Codex as CodexConstructor;
+  }
+
+  // Wrapped under default (some ESM/CJS interop scenarios)
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') {
+    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
+    return def.Codex as CodexConstructor;
+  }
+
+  // Default export IS the class (unlikely, but defensive)
+  if (typeof def === 'function') {
+    console.log('[Codex] Imported via default export (mod.default)');
+    return def as unknown as CodexConstructor;
+  }
+
+  const keys = Object.keys(mod).join(', ');
+  console.log(`[Codex] Import failed. Module keys: [${keys}]`);
+  throw new Error(
+    `Failed to import Codex class from @openai/codex-sdk. Module keys: [${keys}]`,
+  );
+}

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -19,41 +19,9 @@ import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
+import { importCodexClass } from '@tools/codexImport';
 
 const LEAN4_EXT_ID = 'leanprover.lean4';
-
-/**
- * Robustly import the Codex constructor from the ESM-only @openai/codex-sdk.
- *
- * In some Electron/Node.js versions, dynamic `import()` of ESM modules from
- * CJS bundles wraps named exports under `default`, so `{ Codex }` destructuring
- * yields `undefined` and `new Codex()` throws "e is not a constructor".
- */
-async function importCodexClassForCheck(): Promise<new () => unknown> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
-
-  if (typeof mod.Codex === 'function') {
-    console.log('[Codex check] Imported via named export (mod.Codex)');
-    return mod.Codex as never;
-  }
-
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    console.log('[Codex check] Imported via default wrapper (mod.default.Codex)');
-    return def.Codex as never;
-  }
-  if (typeof def === 'function') {
-    console.log('[Codex check] Imported via default export (mod.default)');
-    return def as never;
-  }
-
-  console.log(
-    `[Codex check] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-  throw new Error(
-    `Failed to import Codex class. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-}
 
 /**
  * Pluggable check for VS Code extension availability.
@@ -255,7 +223,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
     check: async () => {
       try {
-        const Codex = await importCodexClassForCheck();
+        const Codex = await importCodexClass();
         // Constructor resolves the binary path — throws if not found
         new Codex();
         return true;
@@ -265,7 +233,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     },
     detailCheck: async () => {
       try {
-        const Codex = await importCodexClassForCheck();
+        const Codex = await importCodexClass();
         new Codex();
         return 'Codex CLI binary found. Ready for SDK use.';
       } catch (err: unknown) {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -32,12 +32,24 @@ const LEAN4_EXT_ID = 'leanprover.lean4';
 async function importCodexClassForCheck(): Promise<new () => unknown> {
   const mod: Record<string, unknown> = await import('@openai/codex-sdk');
 
-  if (typeof mod.Codex === 'function') return mod.Codex as never;
+  if (typeof mod.Codex === 'function') {
+    console.log('[Codex check] Imported via named export (mod.Codex)');
+    return mod.Codex as never;
+  }
 
   const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') return def.Codex as never;
-  if (typeof def === 'function') return def as never;
+  if (def && typeof def.Codex === 'function') {
+    console.log('[Codex check] Imported via default wrapper (mod.default.Codex)');
+    return def.Codex as never;
+  }
+  if (typeof def === 'function') {
+    console.log('[Codex check] Imported via default export (mod.default)');
+    return def as never;
+  }
 
+  console.log(
+    `[Codex check] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
   throw new Error(
     `Failed to import Codex class. Module keys: [${Object.keys(mod).join(', ')}]`,
   );

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -23,6 +23,27 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 const LEAN4_EXT_ID = 'leanprover.lean4';
 
 /**
+ * Robustly import the Codex constructor from the ESM-only @openai/codex-sdk.
+ *
+ * In some Electron/Node.js versions, dynamic `import()` of ESM modules from
+ * CJS bundles wraps named exports under `default`, so `{ Codex }` destructuring
+ * yields `undefined` and `new Codex()` throws "e is not a constructor".
+ */
+async function importCodexClassForCheck(): Promise<new () => unknown> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  if (typeof mod.Codex === 'function') return mod.Codex as never;
+
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') return def.Codex as never;
+  if (typeof def === 'function') return def as never;
+
+  throw new Error(
+    `Failed to import Codex class. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
+}
+
+/**
  * Pluggable check for VS Code extension availability.
  * Set by the extension host at activation; defaults to false (not available).
  */
@@ -212,14 +233,17 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Install the Codex CLI via npm:\n\n' +
       '  npm install -g @openai/codex\n\n' +
       'The CLI includes platform-specific binaries that the SDK\n' +
-      'spawns as a child process. An OpenAI API key is required\n' +
-      'and can be set via OPENAI_API_KEY environment variable.',
+      'spawns as a child process.\n\n' +
+      'Authentication (choose one):\n' +
+      '  • codex login        — OAuth sign-in (recommended)\n' +
+      '  • OPENAI_API_KEY     — environment variable with API key',
     installUrl: 'https://github.com/openai/codex',
     configNotes:
-      'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk.',
+      'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
+      'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
     check: async () => {
       try {
-        const { Codex } = await import('@openai/codex-sdk');
+        const Codex = await importCodexClassForCheck();
         // Constructor resolves the binary path — throws if not found
         new Codex();
         return true;
@@ -229,7 +253,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     },
     detailCheck: async () => {
       try {
-        const { Codex } = await import('@openai/codex-sdk');
+        const Codex = await importCodexClassForCheck();
         new Codex();
         return 'Codex CLI binary found. Ready for SDK use.';
       } catch (err: unknown) {
@@ -239,6 +263,9 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
         }
         if (msg.includes('Unsupported platform')) {
           return `Platform not supported: ${msg}`;
+        }
+        if (msg.includes('not a constructor') || msg.includes('Failed to import')) {
+          return 'Codex SDK import failed — ESM/CJS interop issue. Try reinstalling: npm install @openai/codex-sdk';
         }
         return `Codex CLI check failed: ${msg}`;
       }


### PR DESCRIPTION
## Summary
Fixes runtime errors when importing the Codex class from the ESM-only `@openai/codex-sdk` package in CJS-bundled environments. In some Electron/Node.js versions, dynamic `import()` wraps named exports under a `default` property, causing destructuring to fail with "e is not a constructor" errors.

## Key Changes
- **Added robust import helper functions** (`importCodexClass()` and `importCodexClassForCheck()`) that handle multiple ESM/CJS interop scenarios:
  - Normal named export (`mod.Codex`)
  - Wrapped under default (`mod.default.Codex`)
  - Default export as the class itself
  - Provides detailed error messages with module keys for debugging

- **Updated CodexTool** to use the new import helper instead of direct destructuring

- **Updated externalToolDefs** to use the import helper in both `check()` and `detailCheck()` functions, with improved error detection for import failures

- **Improved user-facing documentation**:
  - Clarified authentication options (OAuth via `codex login` recommended vs. `OPENAI_API_KEY` env var)
  - Enhanced installation and configuration notes with clearer formatting
  - Added specific error message for ESM/CJS interop failures with remediation steps

## Implementation Details
The helper functions defensively check multiple export patterns and throw descriptive errors that include the actual module keys found, making it easier to diagnose import issues in different runtime environments.

https://claude.ai/code/session_01HTxbB48zoUynGpHHKW6HUs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the Codex SDK is dynamically imported and how tool availability checks behave, which can affect whether the `codex` tool runs or is detected at runtime across Electron/Node versions.
> 
> **Overview**
> Fixes Codex SDK runtime import failures by routing all `@openai/codex-sdk` loading through a new `importCodexClass()` helper that tolerates multiple ESM/CJS interop export shapes, and updates `CodexTool` plus the external dependency `check()`/`detailCheck()` to use it.
> 
> Also refreshes the Codex tool/installer messaging to explicitly document OAuth via `codex login` vs `OPENAI_API_KEY`, and adds a targeted `detailCheck` hint when the import fails ("not a constructor" / "Failed to import").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a96b090a450e947c09aae60b0ef80a80a5ad98e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->