### PR TITLE
Claude/fix codex cli error 8sz7 d

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -37,6 +37,7 @@ CLAUDE.md
 !node_modules/@vscode/codicons/dist/**
 !node_modules/split.js/**
 !node_modules/@vscode-elements/elements/dist/**
+!node_modules/@openai/codex-sdk/**
 
 # Exclude codicon font AFTER negations (loaded via VS Code webview URI, not bundled)
 **/codicon.ttf

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -82,7 +82,7 @@ import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { importCodexClass } from './codexImport';
+import { importCodexClass, findCodexBinaryPath } from './codexImport';
 
 // ============================================================================
 // Schema
@@ -244,7 +244,11 @@ export class CodexTool extends defineTool({
     // Dynamic import — resolved at runtime, not bundled (see webpack externals)
     const Codex = await importCodexClass();
 
-    const codex = new Codex();
+    // The SDK resolves the native binary relative to itself, but we don't
+    // ship the 130 MB platform binaries in the VSIX. Find the binary from
+    // the user's global npm install and pass it via codexPathOverride.
+    const codexPathOverride = findCodexBinaryPath();
+    const codex = new Codex({ codexPathOverride });
     const thread = codex.startThread({
       workingDirectory: input.working_directory,
       sandboxMode: input.sandbox_mode,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,6 +214,48 @@ function formatCodexError(
 }
 
 // ============================================================================
+// ESM/CJS interop helper
+// ============================================================================
+
+/**
+ * Robustly import the Codex class from @openai/codex-sdk.
+ *
+ * The SDK is ESM-only but the extension is bundled as CJS. In some
+ * Electron/Node.js versions the module namespace object from `import()`
+ * may wrap named exports under a `default` property, causing a bare
+ * `{ Codex }` destructure to yield `undefined` and the subsequent
+ * `new Codex()` to throw "e is not a constructor" (minified name).
+ */
+async function importCodexClass(): Promise<
+  new (options?: Record<string, unknown>) => {
+    startThread(options?: Record<string, unknown>): Thread;
+  }
+> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  // Normal named export
+  if (typeof mod.Codex === 'function') {
+    return mod.Codex as never;
+  }
+
+  // Wrapped under default (some ESM/CJS interop scenarios)
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') {
+    return def.Codex as never;
+  }
+
+  // Default export IS the class (unlikely, but defensive)
+  if (typeof def === 'function') {
+    return def as never;
+  }
+
+  throw new Error(
+    'Failed to import Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,54 +214,6 @@ function formatCodexError(
 }
 
 // ============================================================================
-// ESM/CJS interop helper
-// ============================================================================
-
-/**
- * Robustly import the Codex class from @openai/codex-sdk.
- *
- * The SDK is ESM-only but the extension is bundled as CJS. In some
- * Electron/Node.js versions the module namespace object from `import()`
- * may wrap named exports under a `default` property, causing a bare
- * `{ Codex }` destructure to yield `undefined` and the subsequent
- * `new Codex()` to throw "e is not a constructor" (minified name).
- */
-async function importCodexClass(): Promise<
-  new (options?: Record<string, unknown>) => {
-    startThread(options?: Record<string, unknown>): Thread;
-  }
-> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
-
-  // Normal named export
-  if (typeof mod.Codex === 'function') {
-    console.log('[Codex] Imported via named export (mod.Codex)');
-    return mod.Codex as never;
-  }
-
-  // Wrapped under default (some ESM/CJS interop scenarios)
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
-    return def.Codex as never;
-  }
-
-  // Default export IS the class (unlikely, but defensive)
-  if (typeof def === 'function') {
-    console.log('[Codex] Imported via default export (mod.default)');
-    return def as never;
-  }
-
-  console.log(
-    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-  throw new Error(
-    'Failed to import Codex class from @openai/codex-sdk. ' +
-      `Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-}
-
-// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -235,20 +235,26 @@ async function importCodexClass(): Promise<
 
   // Normal named export
   if (typeof mod.Codex === 'function') {
+    console.log('[Codex] Imported via named export (mod.Codex)');
     return mod.Codex as never;
   }
 
   // Wrapped under default (some ESM/CJS interop scenarios)
   const def = mod.default as Record<string, unknown> | undefined;
   if (def && typeof def.Codex === 'function') {
+    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
     return def.Codex as never;
   }
 
   // Default export IS the class (unlikely, but defensive)
   if (typeof def === 'function') {
+    console.log('[Codex] Imported via default export (mod.default)');
     return def as never;
   }
 
+  console.log(
+    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
   throw new Error(
     'Failed to import Codex class from @openai/codex-sdk. ' +
       `Module keys: [${Object.keys(mod).join(', ')}]`,

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -1,45 +1,171 @@
 /**
- * Robust ESM/CJS interop helper for importing the Codex class from
- * @openai/codex-sdk.
+ * Helpers for the Codex tool.
  *
- * The SDK is ESM-only but the extension is bundled as CJS. In some
- * Electron/Node.js versions the module namespace object from `import()`
- * wraps named exports under a `default` property, causing a bare
- * `{ Codex }` destructure to yield `undefined` and the subsequent
- * `new Codex()` to throw "e is not a constructor" (minified name).
+ * 1. `importCodexClass()` — dynamically import the Codex constructor from
+ *    @openai/codex-sdk. Handles ESM/CJS interop edge cases.
  *
- * This helper probes multiple export shapes so it works regardless of
- * the runtime's interop behavior.
+ * 2. `findCodexBinaryPath()` — locate the native Codex CLI binary from a
+ *    global npm install. The SDK bundles its own `findCodexPath()` but it
+ *    resolves `@openai/codex` relative to the SDK itself (inside the VSIX).
+ *    Since we don't ship the 130 MB platform binaries in the VSIX, we probe
+ *    the global npm prefix instead and return the path for `codexPathOverride`.
  */
+
+import { execSync } from 'child_process';
+import { createRequire } from 'module';
+import * as path from 'path';
+import { existsSync } from 'fs';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CodexConstructor = new (options?: any) => any;
 
+// ---------------------------------------------------------------------------
+// SDK import
+// ---------------------------------------------------------------------------
+
 export async function importCodexClass(): Promise<CodexConstructor> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+  let mod: Record<string, unknown>;
+  try {
+    mod = await import('@openai/codex-sdk');
+  } catch (err: unknown) {
+    const code = (err as { code?: string }).code;
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        '@openai/codex-sdk package not found. Install with: npm install -g @openai/codex',
+      );
+    }
+    throw err;
+  }
+
+  console.log(`[Codex] Module keys: [${Object.keys(mod).join(', ')}]`);
 
   // Normal named export
   if (typeof mod.Codex === 'function') {
-    console.log('[Codex] Imported via named export (mod.Codex)');
     return mod.Codex as CodexConstructor;
   }
 
   // Wrapped under default (some ESM/CJS interop scenarios)
   const def = mod.default as Record<string, unknown> | undefined;
   if (def && typeof def.Codex === 'function') {
-    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
     return def.Codex as CodexConstructor;
   }
-
-  // Default export IS the class (unlikely, but defensive)
   if (typeof def === 'function') {
-    console.log('[Codex] Imported via default export (mod.default)');
     return def as unknown as CodexConstructor;
   }
 
-  const keys = Object.keys(mod).join(', ');
-  console.log(`[Codex] Import failed. Module keys: [${keys}]`);
   throw new Error(
-    `Failed to import Codex class from @openai/codex-sdk. Module keys: [${keys}]`,
+    `Failed to resolve Codex class from @openai/codex-sdk. Module keys: [${Object.keys(mod).join(', ')}]`,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Binary resolution from global npm install
+// ---------------------------------------------------------------------------
+
+const PLATFORM_PACKAGE: Record<string, string> = {
+  'linux-x64': '@openai/codex-linux-x64',
+  'linux-arm64': '@openai/codex-linux-arm64',
+  'darwin-x64': '@openai/codex-darwin-x64',
+  'darwin-arm64': '@openai/codex-darwin-arm64',
+  'win32-x64': '@openai/codex-win32-x64',
+  'win32-arm64': '@openai/codex-win32-arm64',
+};
+
+const TARGET_TRIPLE: Record<string, string> = {
+  'linux-x64': 'x86_64-unknown-linux-musl',
+  'linux-arm64': 'aarch64-unknown-linux-musl',
+  'darwin-x64': 'x86_64-apple-darwin',
+  'darwin-arm64': 'aarch64-apple-darwin',
+  'win32-x64': 'x86_64-pc-windows-msvc',
+  'win32-arm64': 'aarch64-pc-windows-msvc',
+};
+
+/**
+ * Attempt to locate the native Codex CLI binary from a global npm install.
+ *
+ * Returns the absolute path to the binary, or `undefined` if not found.
+ * The caller should pass the result as `codexPathOverride` to the Codex
+ * constructor.
+ */
+export function findCodexBinaryPath(): string | undefined {
+  const key = `${process.platform}-${process.arch}`;
+  const platformPkg = PLATFORM_PACKAGE[key];
+  const triple = TARGET_TRIPLE[key];
+  if (!platformPkg || !triple) return undefined;
+
+  const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+
+  // Strategy 1: resolve from global npm prefix
+  try {
+    const prefix = execSync('npm prefix -g', {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+
+    // Global packages live under <prefix>/lib/node_modules on Unix,
+    // <prefix>/node_modules on Windows
+    const roots = [
+      path.join(prefix, 'lib', 'node_modules'),
+      path.join(prefix, 'node_modules'),
+    ];
+
+    for (const root of roots) {
+      const codexPkgDir = path.join(root, '@openai', 'codex');
+      if (!existsSync(codexPkgDir)) continue;
+
+      // Try resolving the platform binary package from the codex package
+      try {
+        const req = createRequire(path.join(codexPkgDir, 'package.json'));
+        const platformPkgJson = req.resolve(`${platformPkg}/package.json`);
+        const vendorRoot = path.join(
+          path.dirname(platformPkgJson),
+          'vendor',
+        );
+        const binary = path.join(vendorRoot, triple, 'codex', binaryName);
+        if (existsSync(binary)) {
+          console.log(`[Codex] Found binary via global npm: ${binary}`);
+          return binary;
+        }
+      } catch {
+        // Platform package not resolvable from this root, try next
+      }
+
+      // Also check if binaries are vendored directly in the codex package
+      const localBinary = path.join(
+        codexPkgDir,
+        'vendor',
+        triple,
+        'codex',
+        binaryName,
+      );
+      if (existsSync(localBinary)) {
+        console.log(
+          `[Codex] Found binary via global npm (local vendor): ${localBinary}`,
+        );
+        return localBinary;
+      }
+    }
+  } catch {
+    // npm prefix -g failed, try other strategies
+  }
+
+  // Strategy 2: resolve from the local project's node_modules
+  // (for development environments where `npm install` was run)
+  try {
+    // Use the bundle's actual path — __filename in the built extension
+    // points to dist/extension.js, which can resolve local node_modules
+    const localReq = createRequire(path.join(__dirname, 'package.json'));
+    const pkgJson = localReq.resolve(`${platformPkg}/package.json`);
+    const vendorRoot = path.join(path.dirname(pkgJson), 'vendor');
+    const binary = path.join(vendorRoot, triple, 'codex', binaryName);
+    if (existsSync(binary)) {
+      console.log(`[Codex] Found binary via local node_modules: ${binary}`);
+      return binary;
+    }
+  } catch {
+    // Not available locally
+  }
+
+  console.log('[Codex] Native binary not found');
+  return undefined;
 }

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -166,6 +166,25 @@ export function findCodexBinaryPath(): string | undefined {
     // Not available locally
   }
 
+  // Strategy 3: Homebrew / PATH-based install (e.g. `brew install codex`)
+  // The `codex` on PATH may be the native binary directly (Homebrew) or a
+  // Node.js wrapper script (npm). We accept it either way — the SDK's
+  // CodexExec spawns it the same regardless.
+  try {
+    const whichCmd = process.platform === 'win32' ? 'where codex' : 'which codex';
+    const codexOnPath = execSync(whichCmd, {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim().split('\n')[0]; // `where` on Windows may return multiple
+
+    if (codexOnPath && existsSync(codexOnPath)) {
+      console.log(`[Codex] Found binary on PATH: ${codexOnPath}`);
+      return codexOnPath;
+    }
+  } catch {
+    // codex not on PATH
+  }
+
   console.log('[Codex] Native binary not found');
   return undefined;
 }

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -95,81 +95,9 @@ export function findCodexBinaryPath(): string | undefined {
 
   const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
 
-  // Strategy 1: resolve from global npm prefix
-  try {
-    const prefix = execSync('npm prefix -g', {
-      encoding: 'utf8',
-      timeout: 5000,
-    }).trim();
-
-    // Global packages live under <prefix>/lib/node_modules on Unix,
-    // <prefix>/node_modules on Windows
-    const roots = [
-      path.join(prefix, 'lib', 'node_modules'),
-      path.join(prefix, 'node_modules'),
-    ];
-
-    for (const root of roots) {
-      const codexPkgDir = path.join(root, '@openai', 'codex');
-      if (!existsSync(codexPkgDir)) continue;
-
-      // Try resolving the platform binary package from the codex package
-      try {
-        const req = createRequire(path.join(codexPkgDir, 'package.json'));
-        const platformPkgJson = req.resolve(`${platformPkg}/package.json`);
-        const vendorRoot = path.join(
-          path.dirname(platformPkgJson),
-          'vendor',
-        );
-        const binary = path.join(vendorRoot, triple, 'codex', binaryName);
-        if (existsSync(binary)) {
-          console.log(`[Codex] Found binary via global npm: ${binary}`);
-          return binary;
-        }
-      } catch {
-        // Platform package not resolvable from this root, try next
-      }
-
-      // Also check if binaries are vendored directly in the codex package
-      const localBinary = path.join(
-        codexPkgDir,
-        'vendor',
-        triple,
-        'codex',
-        binaryName,
-      );
-      if (existsSync(localBinary)) {
-        console.log(
-          `[Codex] Found binary via global npm (local vendor): ${localBinary}`,
-        );
-        return localBinary;
-      }
-    }
-  } catch {
-    // npm prefix -g failed, try other strategies
-  }
-
-  // Strategy 2: resolve from the local project's node_modules
-  // (for development environments where `npm install` was run)
-  try {
-    // Use the bundle's actual path — __filename in the built extension
-    // points to dist/extension.js, which can resolve local node_modules
-    const localReq = createRequire(path.join(__dirname, 'package.json'));
-    const pkgJson = localReq.resolve(`${platformPkg}/package.json`);
-    const vendorRoot = path.join(path.dirname(pkgJson), 'vendor');
-    const binary = path.join(vendorRoot, triple, 'codex', binaryName);
-    if (existsSync(binary)) {
-      console.log(`[Codex] Found binary via local node_modules: ${binary}`);
-      return binary;
-    }
-  } catch {
-    // Not available locally
-  }
-
-  // Strategy 3: Homebrew / PATH-based install (e.g. `brew install codex`)
-  // The `codex` on PATH may be the native binary directly (Homebrew) or a
-  // Node.js wrapper script (npm). We accept it either way — the SDK's
-  // CodexExec spawns it the same regardless.
+  // Strategy 1: PATH lookup (Homebrew, npm global bin, or any install method)
+  // Fastest and most reliable — works for `brew install codex`, npm global,
+  // and any other install that puts `codex` on PATH.
   try {
     const whichCmd = process.platform === 'win32' ? 'where codex' : 'which codex';
     const codexOnPath = execSync(whichCmd, {
@@ -183,6 +111,54 @@ export function findCodexBinaryPath(): string | undefined {
     }
   } catch {
     // codex not on PATH
+  }
+
+  // Strategy 2: resolve from global npm prefix
+  // (covers cases where npm global bin isn't on PATH)
+  try {
+    const prefix = execSync('npm prefix -g', {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+
+    const roots = [
+      path.join(prefix, 'lib', 'node_modules'),
+      path.join(prefix, 'node_modules'),
+    ];
+
+    for (const root of roots) {
+      const codexPkgDir = path.join(root, '@openai', 'codex');
+      if (!existsSync(codexPkgDir)) continue;
+
+      try {
+        const req = createRequire(path.join(codexPkgDir, 'package.json'));
+        const platformPkgJson = req.resolve(`${platformPkg}/package.json`);
+        const vendorRoot = path.join(path.dirname(platformPkgJson), 'vendor');
+        const binary = path.join(vendorRoot, triple, 'codex', binaryName);
+        if (existsSync(binary)) {
+          console.log(`[Codex] Found binary via global npm: ${binary}`);
+          return binary;
+        }
+      } catch {
+        // Platform package not resolvable from this root
+      }
+    }
+  } catch {
+    // npm prefix -g failed
+  }
+
+  // Strategy 3: resolve from local project's node_modules
+  try {
+    const localReq = createRequire(path.join(__dirname, 'package.json'));
+    const pkgJson = localReq.resolve(`${platformPkg}/package.json`);
+    const vendorRoot = path.join(path.dirname(pkgJson), 'vendor');
+    const binary = path.join(vendorRoot, triple, 'codex', binaryName);
+    if (existsSync(binary)) {
+      console.log(`[Codex] Found binary via local node_modules: ${binary}`);
+      return binary;
+    }
+  } catch {
+    // Not available locally
   }
 
   console.log('[Codex] Native binary not found');

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -103,7 +103,7 @@ function findCodexBinaryPathUncached(): string | undefined {
     const codexOnPath = execSync(whichCmd, {
       encoding: 'utf8',
       timeout: 5000,
-    }).trim().split('\n')[0]; // `where` on Windows may return multiple
+    }).trim().split(/\r?\n/)[0]; // `where` on Windows returns \r\n-separated paths
 
     if (codexOnPath && existsSync(codexOnPath)) {
       return codexOnPath;

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -4,11 +4,12 @@
  * 1. `importCodexClass()` — dynamically import the Codex constructor from
  *    @openai/codex-sdk. Handles ESM/CJS interop edge cases.
  *
- * 2. `findCodexBinaryPath()` — locate the native Codex CLI binary from a
- *    global npm install. The SDK bundles its own `findCodexPath()` but it
- *    resolves `@openai/codex` relative to the SDK itself (inside the VSIX).
- *    Since we don't ship the 130 MB platform binaries in the VSIX, we probe
- *    the global npm prefix instead and return the path for `codexPathOverride`.
+ * 2. `findCodexBinaryPath()` — locate the native Codex CLI binary. The SDK
+ *    bundles its own `findCodexPath()` but it resolves `@openai/codex`
+ *    relative to the SDK itself (inside the VSIX). Since we don't ship the
+ *    130 MB platform binaries in the VSIX, we probe PATH, the global npm
+ *    prefix, and local node_modules, then return the path for
+ *    `codexPathOverride`. Results are cached for the session.
  */
 
 import { execSync } from 'child_process';
@@ -37,8 +38,6 @@ export async function importCodexClass(): Promise<CodexConstructor> {
     throw err;
   }
 
-  console.log(`[Codex] Module keys: [${Object.keys(mod).join(', ')}]`);
-
   // Normal named export
   if (typeof mod.Codex === 'function') {
     return mod.Codex as CodexConstructor;
@@ -59,39 +58,40 @@ export async function importCodexClass(): Promise<CodexConstructor> {
 }
 
 // ---------------------------------------------------------------------------
-// Binary resolution from global npm install
+// Binary resolution
 // ---------------------------------------------------------------------------
 
-const PLATFORM_PACKAGE: Record<string, string> = {
-  'linux-x64': '@openai/codex-linux-x64',
-  'linux-arm64': '@openai/codex-linux-arm64',
-  'darwin-x64': '@openai/codex-darwin-x64',
-  'darwin-arm64': '@openai/codex-darwin-arm64',
-  'win32-x64': '@openai/codex-win32-x64',
-  'win32-arm64': '@openai/codex-win32-arm64',
+/** Platform key → npm package name and target triple for the native binary. */
+const PLATFORM_INFO: Record<string, { pkg: string; triple: string }> = {
+  'linux-x64': { pkg: '@openai/codex-linux-x64', triple: 'x86_64-unknown-linux-musl' },
+  'linux-arm64': { pkg: '@openai/codex-linux-arm64', triple: 'aarch64-unknown-linux-musl' },
+  'darwin-x64': { pkg: '@openai/codex-darwin-x64', triple: 'x86_64-apple-darwin' },
+  'darwin-arm64': { pkg: '@openai/codex-darwin-arm64', triple: 'aarch64-apple-darwin' },
+  'win32-x64': { pkg: '@openai/codex-win32-x64', triple: 'x86_64-pc-windows-msvc' },
+  'win32-arm64': { pkg: '@openai/codex-win32-arm64', triple: 'aarch64-pc-windows-msvc' },
 };
 
-const TARGET_TRIPLE: Record<string, string> = {
-  'linux-x64': 'x86_64-unknown-linux-musl',
-  'linux-arm64': 'aarch64-unknown-linux-musl',
-  'darwin-x64': 'x86_64-apple-darwin',
-  'darwin-arm64': 'aarch64-apple-darwin',
-  'win32-x64': 'x86_64-pc-windows-msvc',
-  'win32-arm64': 'aarch64-pc-windows-msvc',
-};
+/** Cached result — found paths are cached; misses are retried. */
+let cachedBinaryPath: string | undefined;
 
 /**
- * Attempt to locate the native Codex CLI binary from a global npm install.
+ * Locate the native Codex CLI binary. Results are cached for the session
+ * (misses are always retried so mid-session installs are picked up).
  *
- * Returns the absolute path to the binary, or `undefined` if not found.
  * The caller should pass the result as `codexPathOverride` to the Codex
  * constructor.
  */
 export function findCodexBinaryPath(): string | undefined {
-  const key = `${process.platform}-${process.arch}`;
-  const platformPkg = PLATFORM_PACKAGE[key];
-  const triple = TARGET_TRIPLE[key];
-  if (!platformPkg || !triple) return undefined;
+  if (cachedBinaryPath !== undefined) return cachedBinaryPath;
+
+  const result = findCodexBinaryPathUncached();
+  if (result) cachedBinaryPath = result;
+  return result;
+}
+
+function findCodexBinaryPathUncached(): string | undefined {
+  const info = PLATFORM_INFO[`${process.platform}-${process.arch}`];
+  if (!info) return undefined;
 
   const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
 
@@ -106,7 +106,6 @@ export function findCodexBinaryPath(): string | undefined {
     }).trim().split('\n')[0]; // `where` on Windows may return multiple
 
     if (codexOnPath && existsSync(codexOnPath)) {
-      console.log(`[Codex] Found binary on PATH: ${codexOnPath}`);
       return codexOnPath;
     }
   } catch {
@@ -132,13 +131,10 @@ export function findCodexBinaryPath(): string | undefined {
 
       try {
         const req = createRequire(path.join(codexPkgDir, 'package.json'));
-        const platformPkgJson = req.resolve(`${platformPkg}/package.json`);
+        const platformPkgJson = req.resolve(`${info.pkg}/package.json`);
         const vendorRoot = path.join(path.dirname(platformPkgJson), 'vendor');
-        const binary = path.join(vendorRoot, triple, 'codex', binaryName);
-        if (existsSync(binary)) {
-          console.log(`[Codex] Found binary via global npm: ${binary}`);
-          return binary;
-        }
+        const binary = path.join(vendorRoot, info.triple, 'codex', binaryName);
+        if (existsSync(binary)) return binary;
       } catch {
         // Platform package not resolvable from this root
       }
@@ -150,17 +146,13 @@ export function findCodexBinaryPath(): string | undefined {
   // Strategy 3: resolve from local project's node_modules
   try {
     const localReq = createRequire(path.join(__dirname, 'package.json'));
-    const pkgJson = localReq.resolve(`${platformPkg}/package.json`);
+    const pkgJson = localReq.resolve(`${info.pkg}/package.json`);
     const vendorRoot = path.join(path.dirname(pkgJson), 'vendor');
-    const binary = path.join(vendorRoot, triple, 'codex', binaryName);
-    if (existsSync(binary)) {
-      console.log(`[Codex] Found binary via local node_modules: ${binary}`);
-      return binary;
-    }
+    const binary = path.join(vendorRoot, info.triple, 'codex', binaryName);
+    if (existsSync(binary)) return binary;
   } catch {
     // Not available locally
   }
 
-  console.log('[Codex] Native binary not found');
   return undefined;
 }

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -19,7 +19,7 @@ import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
-import { importCodexClass } from '@tools/codexImport';
+import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 
 const LEAN4_EXT_ID = 'leanprover.lean4';
 
@@ -210,10 +210,9 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     description:
       'OpenAI Codex agent runtime. Required by the Codex SDK for local code generation and analysis.',
     installGuide:
-      'Install the Codex CLI via npm:\n\n' +
+      'Install the Codex CLI globally:\n\n' +
       '  npm install -g @openai/codex\n\n' +
-      'The CLI includes platform-specific binaries that the SDK\n' +
-      'spawns as a child process.\n\n' +
+      'This installs the SDK and platform-specific CLI binaries.\n\n' +
       'Authentication (choose one):\n' +
       '  • codex login        — OAuth sign-in (recommended)\n' +
       '  • OPENAI_API_KEY     — environment variable with API key',
@@ -223,32 +222,39 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
     check: async () => {
       try {
-        const Codex = await importCodexClass();
-        // Constructor resolves the binary path — throws if not found
-        new Codex();
-        return true;
+        await importCodexClass();
+        const codexPath = findCodexBinaryPath();
+        return codexPath != null;
       } catch {
         return false;
       }
     },
     detailCheck: async () => {
+      // Step 1: Can we import the SDK?
       try {
-        const Codex = await importCodexClass();
-        new Codex();
-        return 'Codex CLI binary found. Ready for SDK use.';
+        await importCodexClass();
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes('Unable to locate')) {
-          return 'Codex CLI binaries not found. Install @openai/codex with optional dependencies.';
+        if (
+          msg.includes('not found') ||
+          msg.includes('MODULE_NOT_FOUND') ||
+          msg.includes('Cannot find package')
+        ) {
+          return '@openai/codex-sdk not found. Install with: npm install -g @openai/codex';
         }
         if (msg.includes('Unsupported platform')) {
           return `Platform not supported: ${msg}`;
         }
-        if (msg.includes('not a constructor') || msg.includes('Failed to import')) {
-          return 'Codex SDK import failed — ESM/CJS interop issue. Try reinstalling: npm install @openai/codex-sdk';
-        }
-        return `Codex CLI check failed: ${msg}`;
+        return `Codex SDK import failed: ${msg}`;
       }
+
+      // Step 2: Can we find the native binary?
+      const codexPath = findCodexBinaryPath();
+      if (!codexPath) {
+        return 'Codex SDK loaded but native binary not found. Install with: npm install -g @openai/codex';
+      }
+
+      return `Codex CLI ready. Binary: ${codexPath}`;
     },
   },
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -210,11 +210,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     description:
       'OpenAI Codex agent runtime. Required by the Codex SDK for local code generation and analysis.',
     installGuide:
-      'Install the Codex CLI globally:\n\n' +
-      '  npm install -g @openai/codex\n\n' +
-      'This installs the SDK and platform-specific CLI binaries.\n\n' +
+      'Install the Codex CLI (choose one):\n\n' +
+      '  npm install -g @openai/codex\n' +
+      '  brew install codex          (macOS)\n\n' +
       'Authentication (choose one):\n' +
-      '  • codex login        — OAuth sign-in (recommended)\n' +
+      '  • codex login        — sign in with ChatGPT account (recommended)\n' +
       '  • OPENAI_API_KEY     — environment variable with API key',
     installUrl: 'https://github.com/openai/codex',
     configNotes:

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -220,15 +220,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
-    check: async () => {
-      try {
-        await importCodexClass();
-        const codexPath = findCodexBinaryPath();
-        return codexPath != null;
-      } catch {
-        return false;
-      }
-    },
+    check: async () => findCodexBinaryPath() != null,
     detailCheck: async () => {
       // Step 1: Can we import the SDK?
       try {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the extension locates and executes the Codex CLI (new path probing via `execSync`) and alters tool availability gating across platforms.
> 
> **Overview**
> Fixes Codex tool startup in the VSIX by **explicitly locating the native `codex` CLI binary** (PATH, global npm prefix, or local `node_modules`) and passing it to the SDK via `codexPathOverride`, instead of relying on the SDK’s bundled binary resolution.
> 
> Improves Codex dependency checks and user messaging by separating **SDK import** vs **native binary presence** in `externalToolDefs`, and updates packaging to include `@openai/codex-sdk` in the VSIX (`.vscodeignore`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ace75952c7c8779e87c52dd9f0e7e4df78c35f35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->