### PR TITLE
Use VS Code terminal theme colors in terminal output

### DIFF
--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -11,6 +11,26 @@ const DEFAULT_THEME = {
   fontFamily: 'monospace',
 } as const;
 
+/** VS Code terminal ANSI color CSS variables mapped to xterm.js theme keys. */
+const ANSI_COLOR_MAP = [
+  ['black', '--vscode-terminal-ansiBlack'],
+  ['red', '--vscode-terminal-ansiRed'],
+  ['green', '--vscode-terminal-ansiGreen'],
+  ['yellow', '--vscode-terminal-ansiYellow'],
+  ['blue', '--vscode-terminal-ansiBlue'],
+  ['magenta', '--vscode-terminal-ansiMagenta'],
+  ['cyan', '--vscode-terminal-ansiCyan'],
+  ['white', '--vscode-terminal-ansiWhite'],
+  ['brightBlack', '--vscode-terminal-ansiBrightBlack'],
+  ['brightRed', '--vscode-terminal-ansiBrightRed'],
+  ['brightGreen', '--vscode-terminal-ansiBrightGreen'],
+  ['brightYellow', '--vscode-terminal-ansiBrightYellow'],
+  ['brightBlue', '--vscode-terminal-ansiBrightBlue'],
+  ['brightMagenta', '--vscode-terminal-ansiBrightMagenta'],
+  ['brightCyan', '--vscode-terminal-ansiBrightCyan'],
+  ['brightWhite', '--vscode-terminal-ansiBrightWhite'],
+] as const;
+
 const MIN_SCROLLBACK = 4_000;
 
 /** Maximum visible rows before terminal scrolls internally. */
@@ -68,6 +88,7 @@ export class TerminalOutput extends LitElement {
       theme: {
         background: resolvedTheme.background,
         foreground: resolvedTheme.foreground,
+        ...resolvedTheme.ansiColors,
       },
     });
 
@@ -201,6 +222,7 @@ export class TerminalOutput extends LitElement {
     background: string;
     foreground: string;
     fontFamily: string;
+    ansiColors: Record<string, string>;
   } {
     const styles = getComputedStyle(this);
 
@@ -214,7 +236,22 @@ export class TerminalOutput extends LitElement {
       styles.getPropertyValue('--vscode-editor-font-family').trim() ||
       DEFAULT_THEME.fontFamily;
 
-    return { background, foreground, fontFamily };
+    const ansiColors: Record<string, string> = {};
+    for (const [key, cssVar] of ANSI_COLOR_MAP) {
+      const value = styles.getPropertyValue(cssVar).trim();
+      if (value) ansiColors[key] = value;
+    }
+
+    // Also resolve cursor and selection colors
+    const cursor =
+      styles.getPropertyValue('--vscode-terminalCursor-foreground').trim();
+    if (cursor) ansiColors['cursor'] = cursor;
+    const selectionBg = styles
+      .getPropertyValue('--vscode-terminal-selectionBackground')
+      .trim();
+    if (selectionBg) ansiColors['selectionBackground'] = selectionBg;
+
+    return { background, foreground, fontFamily, ansiColors };
   }
 
   override render() {

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -78,18 +78,13 @@ export class TerminalOutput extends LitElement {
   };
 
   override firstUpdated(): void {
-    const resolvedTheme = this.resolveThemeFromCssVars();
     this.terminal = new Terminal({
       disableStdin: true,
       convertEol: true,
       scrollback: MIN_SCROLLBACK,
-      fontFamily: resolvedTheme.fontFamily,
+      fontFamily: this.resolveFontFamily(),
       fontSize: 12,
-      theme: {
-        background: resolvedTheme.background,
-        foreground: resolvedTheme.foreground,
-        ...resolvedTheme.ansiColors,
-      },
+      theme: this.resolveThemeFromCssVars(),
     });
 
     this.fitAddon = new FitAddon();
@@ -218,40 +213,42 @@ export class TerminalOutput extends LitElement {
     }
   }
 
-  private resolveThemeFromCssVars(): {
-    background: string;
-    foreground: string;
-    fontFamily: string;
-    ansiColors: Record<string, string>;
-  } {
+  private resolveThemeFromCssVars(): Record<string, string> {
     const styles = getComputedStyle(this);
 
-    const background =
-      styles.getPropertyValue('--vscode-editor-background').trim() ||
-      DEFAULT_THEME.background;
-    const foreground =
-      styles.getPropertyValue('--vscode-editor-foreground').trim() ||
-      DEFAULT_THEME.foreground;
-    const fontFamily =
-      styles.getPropertyValue('--vscode-editor-font-family').trim() ||
-      DEFAULT_THEME.fontFamily;
+    const theme: Record<string, string> = {
+      background:
+        styles.getPropertyValue('--vscode-editor-background').trim() ||
+        DEFAULT_THEME.background,
+      foreground:
+        styles.getPropertyValue('--vscode-editor-foreground').trim() ||
+        DEFAULT_THEME.foreground,
+    };
 
-    const ansiColors: Record<string, string> = {};
     for (const [key, cssVar] of ANSI_COLOR_MAP) {
       const value = styles.getPropertyValue(cssVar).trim();
-      if (value) ansiColors[key] = value;
+      if (value) theme[key] = value;
     }
 
-    // Also resolve cursor and selection colors
-    const cursor =
-      styles.getPropertyValue('--vscode-terminalCursor-foreground').trim();
-    if (cursor) ansiColors['cursor'] = cursor;
+    const cursor = styles
+      .getPropertyValue('--vscode-terminalCursor-foreground')
+      .trim();
+    if (cursor) theme['cursor'] = cursor;
+
     const selectionBg = styles
       .getPropertyValue('--vscode-terminal-selectionBackground')
       .trim();
-    if (selectionBg) ansiColors['selectionBackground'] = selectionBg;
+    if (selectionBg) theme['selectionBackground'] = selectionBg;
 
-    return { background, foreground, fontFamily, ansiColors };
+    return theme;
+  }
+
+  private resolveFontFamily(): string {
+    return (
+      getComputedStyle(this)
+        .getPropertyValue('--vscode-editor-font-family')
+        .trim() || DEFAULT_THEME.fontFamily
+    );
   }
 
   override render() {

--- a/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -17,7 +17,7 @@ export const codeBlockStyles = css`
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-tiny) var(--spacing-small);
-    background-color: var(--vscode-editorGroupHeader-tabsBackground, #252526);
+    background-color: var(--vscode-editorGroupHeader-tabsBackground);
     border-bottom: var(--border-thin) solid var(--color-border);
     font-size: var(--font-size-xs);
   }

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -143,7 +143,7 @@ export const toolUseStyles = css`
     display: block;
     border-radius: var(--border-radius-small);
     overflow: hidden;
-    background: var(--vscode-editor-background, #1e1e1e);
+    background: var(--vscode-editor-background);
     border: var(--border-thin) solid var(--color-border);
   }
 
@@ -195,7 +195,7 @@ export const toolUseStyles = css`
     margin: 0;
     padding: var(--spacing-small);
     border-radius: var(--border-radius-small);
-    background-color: var(--vscode-editor-background, #1e1e1e);
+    background-color: var(--vscode-editor-background);
     white-space: pre-wrap;
     word-break: break-word;
     line-height: var(--line-height-relaxed);


### PR DESCRIPTION
## Summary
This PR updates the terminal output component to respect VS Code's terminal theme colors, including ANSI colors, cursor color, and selection background. It also removes hardcoded fallback colors from CSS variables to ensure consistent theming.

## Key Changes
- Added `ANSI_COLOR_MAP` constant that maps xterm.js theme keys to VS Code terminal ANSI color CSS variables (standard and bright variants)
- Extended `resolveTheme()` method to extract ANSI colors, cursor color, and selection background from computed styles
- Updated terminal theme configuration to include resolved ANSI colors via spread operator
- Removed hardcoded color fallbacks from CSS variables in `toolUseStyles.ts` and `codeBlockStyles.ts` to rely on VS Code's theme system

## Implementation Details
- The `ANSI_COLOR_MAP` provides a complete mapping of all 16 ANSI colors (8 standard + 8 bright variants) to their corresponding VS Code CSS variables
- Color resolution gracefully handles missing values by only including colors that are present in the computed styles
- Cursor and selection background colors are resolved separately and added to the theme configuration
- Removal of hardcoded fallbacks (`#1e1e1e`, `#252526`) ensures the terminal respects the active VS Code theme instead of defaulting to dark theme colors

https://claude.ai/code/session_01CWpTpH3gwF8hYXw7AiKbYU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI theming-only changes that affect terminal/code-block colors; main risk is degraded appearance if expected VS Code CSS variables are unset or differ across hosts.
> 
> **Overview**
> Updates `TerminalOutput` to derive its xterm.js theme from VS Code CSS variables, including full ANSI palette plus cursor and selection colors, and separates font family resolution.
> 
> Removes hardcoded dark-theme fallbacks from `codeBlockStyles` and `toolUseStyles` so backgrounds follow the active VS Code theme variables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3d22bbf5653545ced898bc4f25bfff6dddea6b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->