### PR TITLE
Add stateful open/close management to collapsible panels

### DIFF
--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -167,16 +167,9 @@ export class PlanView extends LitElement {
   /** Open state — managed internally. Auto-opens when plan is updated. */
   @state() private open = true;
 
-  /** Snapshot of previous plan for detecting meaningful changes. */
-  private prevPlanJson = '';
-
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('plan') && this.plan) {
-      const json = JSON.stringify(this.plan);
-      if (json !== this.prevPlanJson) {
-        if (!this.open) this.open = true;
-        this.prevPlanJson = json;
-      }
+    if (changed.has('plan') && this.plan && !this.open) {
+      this.open = true;
     }
   }
 

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -4,8 +4,15 @@
  */
 
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -157,6 +164,22 @@ export class PlanView extends LitElement {
 
   @property({ attribute: false }) plan: Plan | null = null;
 
+  /** Open state — managed internally. Auto-opens when plan is updated. */
+  @state() private open = true;
+
+  /** Snapshot of previous plan for detecting meaningful changes. */
+  private prevPlanJson = '';
+
+  protected override willUpdate(changed: PropertyValues): void {
+    if (changed.has('plan') && this.plan) {
+      const json = JSON.stringify(this.plan);
+      if (json !== this.prevPlanJson) {
+        this.open = true;
+        this.prevPlanJson = json;
+      }
+    }
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (!this.plan) {
       return nothing;
@@ -172,7 +195,8 @@ export class PlanView extends LitElement {
         id=${ELEMENT_IDS.PLAN_VIEW_CONTAINER}
         class="plan-collapsible panel-collapsible"
         title=${`Plan (${completed}/${total})`}
-        open
+        ?open=${this.open}
+        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
       >
         <div class="plan-summary">${this.plan.summary}</div>
         <div id=${ELEMENT_IDS.PLAN_VIEW} class="plan-steps">
@@ -225,5 +249,9 @@ export class PlanView extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
+    this.open = e.detail?.open ?? this.open;
   }
 }

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -174,7 +174,7 @@ export class PlanView extends LitElement {
     if (changed.has('plan') && this.plan) {
       const json = JSON.stringify(this.plan);
       if (json !== this.prevPlanJson) {
-        this.open = true;
+        if (!this.open) this.open = true;
         this.prevPlanJson = json;
       }
     }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -105,16 +105,9 @@ export class TodoList extends LitElement {
   /** Open state — managed internally. Auto-opens when todos are updated. */
   @state() private open = true;
 
-  /** Snapshot of previous todos for detecting meaningful changes. */
-  private prevTodosJson = '';
-
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('todos') && this.todos.length > 0) {
-      const json = JSON.stringify(this.todos);
-      if (json !== this.prevTodosJson) {
-        if (!this.open) this.open = true;
-        this.prevTodosJson = json;
-      }
+    if (changed.has('todos') && this.todos.length > 0 && !this.open) {
+      this.open = true;
     }
   }
 

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -112,7 +112,7 @@ export class TodoList extends LitElement {
     if (changed.has('todos') && this.todos.length > 0) {
       const json = JSON.stringify(this.todos);
       if (json !== this.prevTodosJson) {
-        this.open = true;
+        if (!this.open) this.open = true;
         this.prevTodosJson = json;
       }
     }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -1,6 +1,13 @@
 // Third-party imports
-import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -95,6 +102,22 @@ export class TodoList extends LitElement {
 
   @property({ attribute: false }) todos: TodoItem[] = [];
 
+  /** Open state — managed internally. Auto-opens when todos are updated. */
+  @state() private open = true;
+
+  /** Snapshot of previous todos for detecting meaningful changes. */
+  private prevTodosJson = '';
+
+  protected override willUpdate(changed: PropertyValues): void {
+    if (changed.has('todos') && this.todos.length > 0) {
+      const json = JSON.stringify(this.todos);
+      if (json !== this.prevTodosJson) {
+        this.open = true;
+        this.prevTodosJson = json;
+      }
+    }
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (this.todos.length === 0) {
       return nothing;
@@ -110,6 +133,8 @@ export class TodoList extends LitElement {
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
         class="todo-collapsible panel-collapsible"
         title=${`Todos (${completed}/${total})`}
+        ?open=${this.open}
+        @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
       >
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
@@ -150,5 +175,9 @@ export class TodoList extends LitElement {
         <span class="todo-item__content">${content}</span>
       </div>
     `;
+  }
+
+  private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
+    this.open = e.detail?.open ?? this.open;
   }
 }


### PR DESCRIPTION
## Summary
This PR adds internal state management for the open/closed state of collapsible panels in `PlanView` and `TodoList` components. The panels now automatically expand when their content is updated and persist the user's manual toggle state.

## Key Changes
- **Added state management**: Introduced `@state() private open` property to both `PlanView` and `TodoList` components to track the open/closed state internally
- **Auto-expand on content update**: Implemented `willUpdate()` lifecycle hook to automatically open panels when:
  - `PlanView`: The `plan` property is updated with a non-null value
  - `TodoList`: The `todos` array is updated with items
- **Dynamic binding**: Changed from hardcoded `open` attribute to data-bound `?open=${this.open}` to reflect the internal state
- **Toggle event handling**: Added `@vsc-collapsible-toggle` event listener and `handleCollapsibleToggle()` method to capture and persist user interactions with the collapsible toggle
- **Updated imports**: Added `PropertyValues` type and `state` decorator imports to support the new functionality

## Implementation Details
- The `willUpdate()` hook checks if the relevant property has changed before auto-opening, preventing unnecessary state updates
- The toggle event handler safely extracts the `open` state from the custom event detail, with a fallback to the current state
- Both components follow the same pattern for consistency and maintainability

https://claude.ai/code/session_017rJhKqTChrwZcETchsEe4X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts collapsible panel behavior; main risk is minor UX regression if `vsc-collapsible-toggle` event payload differs from expectations.
> 
> **Overview**
> Makes the `PlanView` and `TodoList` `vscode-collapsible` panels stateful instead of always-open by introducing an internal `open` flag.
> 
> Panels now **persist user toggles** via the `@vsc-collapsible-toggle` handler and **auto-expand when their underlying data updates** (`plan` changes or `todos` becomes non-empty) by binding `?open=${this.open}` and using `willUpdate()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6b37d63698c2674b90d1d6c277fc0ad4795b44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->