### PR TITLE
Claude/fix codex cli error 8sz7 d

### DIFF
--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,6 +214,48 @@ function formatCodexError(
 }
 
 // ============================================================================
+// ESM/CJS interop helper
+// ============================================================================
+
+/**
+ * Robustly import the Codex class from @openai/codex-sdk.
+ *
+ * The SDK is ESM-only but the extension is bundled as CJS. In some
+ * Electron/Node.js versions the module namespace object from `import()`
+ * may wrap named exports under a `default` property, causing a bare
+ * `{ Codex }` destructure to yield `undefined` and the subsequent
+ * `new Codex()` to throw "e is not a constructor" (minified name).
+ */
+async function importCodexClass(): Promise<
+  new (options?: Record<string, unknown>) => {
+    startThread(options?: Record<string, unknown>): Thread;
+  }
+> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  // Normal named export
+  if (typeof mod.Codex === 'function') {
+    return mod.Codex as never;
+  }
+
+  // Wrapped under default (some ESM/CJS interop scenarios)
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') {
+    return def.Codex as never;
+  }
+
+  // Default export IS the class (unlikely, but defensive)
+  if (typeof def === 'function') {
+    return def as never;
+  }
+
+  throw new Error(
+    'Failed to import Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,54 +214,6 @@ function formatCodexError(
 }
 
 // ============================================================================
-// ESM/CJS interop helper
-// ============================================================================
-
-/**
- * Robustly import the Codex class from @openai/codex-sdk.
- *
- * The SDK is ESM-only but the extension is bundled as CJS. In some
- * Electron/Node.js versions the module namespace object from `import()`
- * may wrap named exports under a `default` property, causing a bare
- * `{ Codex }` destructure to yield `undefined` and the subsequent
- * `new Codex()` to throw "e is not a constructor" (minified name).
- */
-async function importCodexClass(): Promise<
-  new (options?: Record<string, unknown>) => {
-    startThread(options?: Record<string, unknown>): Thread;
-  }
-> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
-
-  // Normal named export
-  if (typeof mod.Codex === 'function') {
-    console.log('[Codex] Imported via named export (mod.Codex)');
-    return mod.Codex as never;
-  }
-
-  // Wrapped under default (some ESM/CJS interop scenarios)
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
-    return def.Codex as never;
-  }
-
-  // Default export IS the class (unlikely, but defensive)
-  if (typeof def === 'function') {
-    console.log('[Codex] Imported via default export (mod.default)');
-    return def as never;
-  }
-
-  console.log(
-    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-  throw new Error(
-    'Failed to import Codex class from @openai/codex-sdk. ' +
-      `Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-}
-
-// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -235,20 +235,26 @@ async function importCodexClass(): Promise<
 
   // Normal named export
   if (typeof mod.Codex === 'function') {
+    console.log('[Codex] Imported via named export (mod.Codex)');
     return mod.Codex as never;
   }
 
   // Wrapped under default (some ESM/CJS interop scenarios)
   const def = mod.default as Record<string, unknown> | undefined;
   if (def && typeof def.Codex === 'function') {
+    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
     return def.Codex as never;
   }
 
   // Default export IS the class (unlikely, but defensive)
   if (typeof def === 'function') {
+    console.log('[Codex] Imported via default export (mod.default)');
     return def as never;
   }
 
+  console.log(
+    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
   throw new Error(
     'Failed to import Codex class from @openai/codex-sdk. ' +
       `Module keys: [${Object.keys(mod).join(', ')}]`,

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -133,15 +133,20 @@ function findCodexBinaryPathUncached(): string | undefined {
   try {
     const whichCmd =
       process.platform === 'win32' ? 'where codex' : 'which codex';
-    const codexOnPath = execSync(whichCmd, {
+    const pathHits = execSync(whichCmd, {
       encoding: 'utf8',
       timeout: 5000,
     })
       .trim()
-      .split(/\r?\n/)[0]; // `where` on Windows returns \r\n-separated paths
+      .split(/\r?\n/);
 
-    if (codexOnPath && existsSync(codexOnPath)) {
-      return codexOnPath;
+    // On Windows, skip .cmd/.ps1 shims (npm wrappers) — the SDK spawns
+    // the binary directly without shell:true, so shims aren't executable.
+    for (const hit of pathHits) {
+      const p = hit.trim();
+      if (!p) continue;
+      if (process.platform === 'win32' && /\.(cmd|ps1)$/i.test(p)) continue;
+      if (existsSync(p)) return p;
     }
   } catch {
     // codex not on PATH

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -38,22 +38,36 @@ export async function importCodexClass(): Promise<CodexConstructor> {
     throw err;
   }
 
-  // Normal named export
-  if (typeof mod.Codex === 'function') {
-    return mod.Codex as CodexConstructor;
+  // Probe all possible export shapes — Electron's ESM/CJS interop may
+  // wrap named exports under `default`, sometimes double-nested.
+  const candidates: unknown[] = [
+    mod.Codex,                                              // named export
+    (mod.default as Record<string, unknown> | undefined)?.Codex,  // default.Codex
+    mod.default,                                            // default IS the class
+  ];
+
+  // Double-nested: mod.default.default.Codex or mod.default.default
+  const innerDefault = (mod.default as Record<string, unknown> | undefined)?.default;
+  if (innerDefault && typeof innerDefault === 'object') {
+    candidates.push((innerDefault as Record<string, unknown>).Codex);
+  }
+  candidates.push(innerDefault);
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'function') {
+      return candidate as CodexConstructor;
+    }
   }
 
-  // Wrapped under default (some ESM/CJS interop scenarios)
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    return def.Codex as CodexConstructor;
-  }
-  if (typeof def === 'function') {
-    return def as unknown as CodexConstructor;
-  }
-
+  // Build a diagnostic message showing what we actually got
+  const defType = typeof mod.default;
+  const defKeys = mod.default && typeof mod.default === 'object'
+    ? Object.keys(mod.default as Record<string, unknown>).join(', ')
+    : defType;
   throw new Error(
-    `Failed to resolve Codex class from @openai/codex-sdk. Module keys: [${Object.keys(mod).join(', ')}]`,
+    'Failed to resolve Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}], ` +
+      `default type: ${defType}, default keys: [${defKeys}]`,
   );
 }
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -220,7 +220,14 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
-    check: async () => findCodexBinaryPath() != null,
+    check: async () => {
+      try {
+        await importCodexClass();
+        return findCodexBinaryPath() != null;
+      } catch {
+        return false;
+      }
+    },
     detailCheck: async () => {
       // Step 1: Can we import the SDK?
       try {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -213,6 +213,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       'Install the Codex CLI (choose one):\n\n' +
       '  npm install -g @openai/codex\n' +
       '  brew install codex          (macOS)\n\n' +
+      'On Windows, use WSL or the Codex app.\n' +
+      'See: https://developers.openai.com/codex/cli\n\n' +
       'Authentication (choose one):\n' +
       '  • codex login        — sign in with ChatGPT account (recommended)\n' +
       '  • OPENAI_API_KEY     — environment variable with API key',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the Codex SDK is dynamically imported and how the Codex binary is resolved on PATH (especially on Windows), which could affect tool availability detection at runtime.
> 
> **Overview**
> Improves robustness of `importCodexClass()` by probing multiple ESM/CJS export shapes (including double-nested `default`) and emitting more detailed diagnostics when resolution fails.
> 
> Updates Codex CLI discovery to handle multiple PATH hits and, on Windows, ignore `.cmd`/`.ps1` npm shim entries so the SDK can spawn a real executable. The Codex external tool availability check now requires both a successful SDK import and a resolvable native binary, and the install guide adds Windows guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03a62e70bc6b7a6fb3162820be489a07bdc27e22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->