### PR TITLE
Preserve todos and plan in post-compaction context

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -648,7 +648,12 @@ export function createResponseCycleFlow<C>(): Flow<
     },
     getPostCompactionContext: (services) => {
       const { subagents, processes } = getActiveChildren(services.streamId);
-      return formatPostCompactionContext(subagents, processes);
+      return formatPostCompactionContext(
+        subagents,
+        processes,
+        services.workspace.todos.todos,
+        services.workspace.plan.plan,
+      );
     },
     getDebugSaveOptions: (shared, services) => ({
       context: {

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -913,7 +913,12 @@ export function createToolUseCycleFlow<C>(): Flow<
     },
     getPostCompactionContext: (services) => {
       const { subagents, processes } = getActiveChildren(services.streamId);
-      return formatPostCompactionContext(subagents, processes);
+      return formatPostCompactionContext(
+        subagents,
+        processes,
+        services.workspace.todos.todos,
+        services.workspace.plan.plan,
+      );
     },
     getDebugSaveOptions: (shared, services) => ({
       context: {

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -17,7 +17,12 @@ import type {
   OutputFileSummary,
 } from '@agent/runtime/AgentFlowResult';
 import type { ExecResult } from '@agent/types/ResultTypes';
-import type { ActiveChildInfo, SubagentProgressUpdate } from '@shared/schemas';
+import type {
+  ActiveChildInfo,
+  SubagentProgressUpdate,
+  TodoItem,
+  Plan,
+} from '@shared/schemas';
 import type { ExecutionId } from '@shared/schemas';
 import { TODO_STATUS } from '@shared/schemas/todo';
 import { formatDuration } from '@utils/core';
@@ -449,14 +454,20 @@ export function formatBashError(
 export function formatPostCompactionContext(
   subagents: ActiveChildInfo[],
   processes: ActiveChildInfo[],
+  todos?: TodoItem[],
+  plan?: Plan | null,
 ): string | null {
-  if (subagents.length === 0 && processes.length === 0) {
+  const hasChildren = subagents.length > 0 || processes.length > 0;
+  const hasTodos = todos != null && todos.length > 0;
+  const hasPlan = plan != null;
+
+  if (!hasChildren && !hasTodos && !hasPlan) {
     return null;
   }
 
   const lines: string[] = [
     '<post-compaction-context>',
-    '<note>Your conversation context was compacted (summarized) to free up space. The following executions were launched before compaction and may still be active. Their results will be delivered as follow-up messages when they complete. Use the executions tool to check on their status or read their results.</note>',
+    '<note>Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction.</note>',
   ];
 
   if (subagents.length > 0) {
@@ -486,8 +497,51 @@ export function formatPostCompactionContext(
     lines.push('</active-background-bash>');
   }
 
+  if (hasTodos) {
+    lines.push(...formatTodoContext(todos));
+  }
+
+  if (hasPlan) {
+    lines.push(...formatPlanContext(plan));
+  }
+
   lines.push('</post-compaction-context>');
   return lines.join('\n');
+}
+
+/**
+ * Format todo items as XML lines for post-compaction context.
+ */
+function formatTodoContext(todos: TodoItem[]): string[] {
+  const lines: string[] = [`<current-todos count="${todos.length}">`];
+  for (const todo of todos) {
+    lines.push(
+      `  <todo status="${escapeAttr(todo.status)}">${escapeText(todo.content)}</todo>`,
+    );
+  }
+  lines.push('</current-todos>');
+  return lines;
+}
+
+/**
+ * Format plan as XML lines for post-compaction context.
+ */
+function formatPlanContext(plan: Plan): string[] {
+  const lines: string[] = [
+    `<current-plan summary="${escapeAttr(plan.summary)}">`,
+  ];
+  for (let i = 0; i < plan.steps.length; i++) {
+    const step = plan.steps[i]!;
+    const filesAttr =
+      step.files.length > 0
+        ? ` files="${escapeAttr(step.files.join(', '))}"`
+        : '';
+    lines.push(
+      `  <step index="${i + 1}" status="${escapeAttr(step.status)}" title="${escapeAttr(step.title)}"${filesAttr}>${escapeText(step.description)}</step>`,
+    );
+  }
+  lines.push('</current-plan>');
+  return lines;
 }
 
 function lastNLines(text: string, n: number): string {

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -465,10 +465,14 @@ export function formatPostCompactionContext(
     return null;
   }
 
-  const lines: string[] = [
-    '<post-compaction-context>',
-    '<note>Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction. Any active executions listed below may still be running and their results will be delivered as follow-up messages when they complete.</note>',
-  ];
+  let note =
+    'Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction.';
+  if (hasChildren) {
+    note +=
+      ' Any active executions listed below may still be running and their results will be delivered as follow-up messages when they complete.';
+  }
+
+  const lines: string[] = ['<post-compaction-context>', `<note>${note}</note>`];
 
   if (subagents.length > 0) {
     lines.push(`<active-subagents count="${subagents.length}">`);

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -467,7 +467,7 @@ export function formatPostCompactionContext(
 
   const lines: string[] = [
     '<post-compaction-context>',
-    '<note>Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction.</note>',
+    '<note>Your conversation context was compacted (summarized) to free up space. The following state was preserved from before compaction. Any active executions listed below may still be running and their results will be delivered as follow-up messages when they complete.</note>',
   ];
 
   if (subagents.length > 0) {
@@ -516,7 +516,7 @@ function formatTodoContext(todos: TodoItem[]): string[] {
   const lines: string[] = [`<current-todos count="${todos.length}">`];
   for (const todo of todos) {
     lines.push(
-      `  <todo status="${escapeAttr(todo.status)}">${escapeText(todo.content)}</todo>`,
+      `  <todo status="${escapeAttr(todo.status)}" activeForm="${escapeAttr(todo.activeForm)}">${escapeText(todo.content)}</todo>`,
     );
   }
   lines.push('</current-todos>');


### PR DESCRIPTION
## Summary
Enhanced the post-compaction context preservation to include todo items and plan information alongside active executions. This ensures that when conversation context is compacted, users retain visibility into their current todos and plan state.

## Key Changes
- **Updated `formatPostCompactionContext` function** to accept optional `todos` and `plan` parameters and include them in the formatted output
- **Added `formatTodoContext` helper** to format todo items as XML with status and activeForm attributes
- **Added `formatPlanContext` helper** to format plan steps as XML with index, status, title, description, and associated files
- **Updated note text** in post-compaction context to reflect that multiple types of state are preserved, not just active executions
- **Updated call sites** in `ResponseCycleFlow.ts` and `ToolUseCycleFlow.ts` to pass todos and plan data to `formatPostCompactionContext`
- **Added type imports** for `TodoItem` and `Plan` from shared schemas

## Implementation Details
- The function now checks for the presence of todos, plan, and active children before deciding whether to return null
- Both new formatting helpers use `escapeAttr` and `escapeText` utilities to safely handle special characters in XML output
- Plan steps are indexed starting from 1 for better readability
- Files associated with plan steps are only included in the XML attribute if the array is non-empty

https://claude.ai/code/session_019VAPo7xPPk2rnUGYPypWdm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what state is re-injected into model context after compaction, which can affect model behavior and token usage. Logic is localized to XML formatting and two call sites, with low risk of broader side effects.
> 
> **Overview**
> Expands the post-compaction XML context to preserve *workspace state* beyond active executions: current todos and the current plan (including step metadata and optional file lists).
> 
> Updates `formatPostCompactionContext` to accept optional `todos`/`plan`, emit new `<current-todos>` and `<current-plan>` sections, adjust the note text, and return `null` only when there’s no children/todos/plan to include; `ResponseCycleFlow` and `ToolUseCycleFlow` now pass these values through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e45fdfb9246449f0b0e3e346e8ea9951a2402de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->