### PR TITLE
Claude/fix codex cli error 8sz7 d

### DIFF
--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,6 +214,48 @@ function formatCodexError(
 }
 
 // ============================================================================
+// ESM/CJS interop helper
+// ============================================================================
+
+/**
+ * Robustly import the Codex class from @openai/codex-sdk.
+ *
+ * The SDK is ESM-only but the extension is bundled as CJS. In some
+ * Electron/Node.js versions the module namespace object from `import()`
+ * may wrap named exports under a `default` property, causing a bare
+ * `{ Codex }` destructure to yield `undefined` and the subsequent
+ * `new Codex()` to throw "e is not a constructor" (minified name).
+ */
+async function importCodexClass(): Promise<
+  new (options?: Record<string, unknown>) => {
+    startThread(options?: Record<string, unknown>): Thread;
+  }
+> {
+  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
+
+  // Normal named export
+  if (typeof mod.Codex === 'function') {
+    return mod.Codex as never;
+  }
+
+  // Wrapped under default (some ESM/CJS interop scenarios)
+  const def = mod.default as Record<string, unknown> | undefined;
+  if (def && typeof def.Codex === 'function') {
+    return def.Codex as never;
+  }
+
+  // Default export IS the class (unlikely, but defensive)
+  if (typeof def === 'function') {
+    return def as never;
+  }
+
+  throw new Error(
+    'Failed to import Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -214,54 +214,6 @@ function formatCodexError(
 }
 
 // ============================================================================
-// ESM/CJS interop helper
-// ============================================================================
-
-/**
- * Robustly import the Codex class from @openai/codex-sdk.
- *
- * The SDK is ESM-only but the extension is bundled as CJS. In some
- * Electron/Node.js versions the module namespace object from `import()`
- * may wrap named exports under a `default` property, causing a bare
- * `{ Codex }` destructure to yield `undefined` and the subsequent
- * `new Codex()` to throw "e is not a constructor" (minified name).
- */
-async function importCodexClass(): Promise<
-  new (options?: Record<string, unknown>) => {
-    startThread(options?: Record<string, unknown>): Thread;
-  }
-> {
-  const mod: Record<string, unknown> = await import('@openai/codex-sdk');
-
-  // Normal named export
-  if (typeof mod.Codex === 'function') {
-    console.log('[Codex] Imported via named export (mod.Codex)');
-    return mod.Codex as never;
-  }
-
-  // Wrapped under default (some ESM/CJS interop scenarios)
-  const def = mod.default as Record<string, unknown> | undefined;
-  if (def && typeof def.Codex === 'function') {
-    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
-    return def.Codex as never;
-  }
-
-  // Default export IS the class (unlikely, but defensive)
-  if (typeof def === 'function') {
-    console.log('[Codex] Imported via default export (mod.default)');
-    return def as never;
-  }
-
-  console.log(
-    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-  throw new Error(
-    'Failed to import Codex class from @openai/codex-sdk. ' +
-      `Module keys: [${Object.keys(mod).join(', ')}]`,
-  );
-}
-
-// ============================================================================
 // Tool
 // ============================================================================
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -235,20 +235,26 @@ async function importCodexClass(): Promise<
 
   // Normal named export
   if (typeof mod.Codex === 'function') {
+    console.log('[Codex] Imported via named export (mod.Codex)');
     return mod.Codex as never;
   }
 
   // Wrapped under default (some ESM/CJS interop scenarios)
   const def = mod.default as Record<string, unknown> | undefined;
   if (def && typeof def.Codex === 'function') {
+    console.log('[Codex] Imported via default wrapper (mod.default.Codex)');
     return def.Codex as never;
   }
 
   // Default export IS the class (unlikely, but defensive)
   if (typeof def === 'function') {
+    console.log('[Codex] Imported via default export (mod.default)');
     return def as never;
   }
 
+  console.log(
+    `[Codex] Import failed. Module keys: [${Object.keys(mod).join(', ')}]`,
+  );
   throw new Error(
     'Failed to import Codex class from @openai/codex-sdk. ' +
       `Module keys: [${Object.keys(mod).join(', ')}]`,

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -16,6 +16,7 @@ import { execSync } from 'child_process';
 import { createRequire } from 'module';
 import * as path from 'path';
 import { existsSync } from 'fs';
+import { pathToFileURL } from 'url';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CodexConstructor = new (options?: any) => any;
@@ -38,8 +39,44 @@ export async function importCodexClass(): Promise<CodexConstructor> {
     throw err;
   }
 
-  // Probe all possible export shapes — Electron's ESM/CJS interop may
-  // wrap named exports under `default`, sometimes double-nested.
+  const resolved = resolveCodexConstructor(mod);
+  if (resolved) return resolved;
+
+  // When the extension host runs in CJS mode, dynamic import() of an ESM-only
+  // package may lose named exports (only an empty `default` object appears).
+  // Re-import using the resolved file:// URL so Node handles it as true ESM.
+  try {
+    const req = createRequire(__filename);
+    const entryPath = req.resolve('@openai/codex-sdk');
+    const fileUrl = pathToFileURL(entryPath).href;
+    const esmMod = (await import(fileUrl)) as Record<string, unknown>;
+    const esmResolved = resolveCodexConstructor(esmMod);
+    if (esmResolved) return esmResolved;
+  } catch {
+    // Fall through to error below
+  }
+
+  // Build a diagnostic message showing what we actually got
+  const defType = typeof mod.default;
+  const defKeys =
+    mod.default && typeof mod.default === 'object'
+      ? Object.keys(mod.default as Record<string, unknown>).join(', ')
+      : defType;
+  throw new Error(
+    'Failed to resolve Codex class from @openai/codex-sdk. ' +
+      `Module keys: [${Object.keys(mod).join(', ')}], ` +
+      `default type: ${defType}, default keys: [${defKeys}]`,
+  );
+}
+
+/**
+ * Probe all possible export shapes for the Codex constructor.
+ * Electron's ESM/CJS interop may wrap named exports under `default`,
+ * sometimes double-nested.
+ */
+function resolveCodexConstructor(
+  mod: Record<string, unknown>,
+): CodexConstructor | undefined {
   const candidates: unknown[] = [
     mod.Codex, // named export
     (mod.default as Record<string, unknown> | undefined)?.Codex, // default.Codex
@@ -59,18 +96,7 @@ export async function importCodexClass(): Promise<CodexConstructor> {
       return candidate as CodexConstructor;
     }
   }
-
-  // Build a diagnostic message showing what we actually got
-  const defType = typeof mod.default;
-  const defKeys =
-    mod.default && typeof mod.default === 'object'
-      ? Object.keys(mod.default as Record<string, unknown>).join(', ')
-      : defType;
-  throw new Error(
-    'Failed to resolve Codex class from @openai/codex-sdk. ' +
-      `Module keys: [${Object.keys(mod).join(', ')}], ` +
-      `default type: ${defType}, default keys: [${defKeys}]`,
-  );
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -15,7 +15,7 @@
 import { execSync } from 'child_process';
 import { createRequire } from 'module';
 import * as path from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { pathToFileURL } from 'url';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,16 +42,18 @@ export async function importCodexClass(): Promise<CodexConstructor> {
   const resolved = resolveCodexConstructor(mod);
   if (resolved) return resolved;
 
-  // When the extension host runs in CJS mode, dynamic import() of an ESM-only
-  // package may lose named exports (only an empty `default` object appears).
-  // Re-import using the resolved file:// URL so Node handles it as true ESM.
+  // When the extension host runs in CJS mode (Electron), dynamic import() of
+  // an ESM-only package may lose named exports (only an empty `default` object
+  // appears). Locate the package on disk, read its ESM entry point from
+  // package.json, and re-import via file:// URL so Node loads it as true ESM.
   try {
-    const req = createRequire(__filename);
-    const entryPath = req.resolve('@openai/codex-sdk');
-    const fileUrl = pathToFileURL(entryPath).href;
-    const esmMod = (await import(fileUrl)) as Record<string, unknown>;
-    const esmResolved = resolveCodexConstructor(esmMod);
-    if (esmResolved) return esmResolved;
+    const entryFile = resolveEsmEntryPoint('@openai/codex-sdk');
+    if (entryFile) {
+      const fileUrl = pathToFileURL(entryFile).href;
+      const esmMod = (await import(fileUrl)) as Record<string, unknown>;
+      const esmResolved = resolveCodexConstructor(esmMod);
+      if (esmResolved) return esmResolved;
+    }
   } catch {
     // Fall through to error below
   }
@@ -95,6 +97,55 @@ function resolveCodexConstructor(
     if (typeof candidate === 'function') {
       return candidate as CodexConstructor;
     }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// ESM entry-point resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk node_modules directories upward from `__dirname` to find an ESM-only
+ * package and return the absolute path to its ESM entry file.
+ *
+ * We can't use `require.resolve()` because the package exports map has no
+ * `"require"` condition — only `"import"`.  Instead we locate the package
+ * directory manually, read its `package.json`, and extract the entry from
+ * `exports["."].import` (falling back to the `module` field).
+ */
+function resolveEsmEntryPoint(packageName: string): string | undefined {
+  let dir = __dirname;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const pkgJsonPath = path.join(
+      dir,
+      'node_modules',
+      packageName,
+      'package.json',
+    );
+    if (existsSync(pkgJsonPath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+        // Prefer exports["."].import, then top-level "module"
+        const relEntry =
+          (typeof pkg.exports === 'object' &&
+            pkg.exports['.'] &&
+            (typeof pkg.exports['.'] === 'string'
+              ? pkg.exports['.']
+              : pkg.exports['.'].import)) ||
+          pkg.module;
+        if (typeof relEntry === 'string') {
+          const abs = path.resolve(path.dirname(pkgJsonPath), relEntry);
+          if (existsSync(abs)) return abs;
+        }
+      } catch {
+        // Malformed package.json — skip
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
   return undefined;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime module-loading behavior in the extension host (CJS/ESM interop), which could affect how the Codex SDK is resolved and loaded across environments.
> 
> **Overview**
> Fixes Codex SDK loading failures under Electron/CJS by refactoring export-shape probing into `resolveCodexConstructor()` and adding a fallback path that re-imports `@openai/codex-sdk` via its true ESM entry point (resolved from `package.json` and loaded through a `file://` URL).
> 
> Adds `resolveEsmEntryPoint()` to locate the package’s ESM entry (via `exports["."].import` or `module`) by walking up `node_modules`, and enhances error diagnostics when the constructor still can’t be resolved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b248dad7d20d3c06fce0369fda9c5619c30459d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->