### PR TITLE
Update web tool descriptions to reflect native provider support

### DIFF
--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -108,7 +108,7 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
     name: 'Web Search & Fetch',
     category: 'web',
     description:
-      'Search the web via DuckDuckGo Instant Answers and fetch/extract content from URLs.',
+      'Search the web and fetch/extract content from URLs. Uses native provider tools when available, with DuckDuckGo Instant Answers as fallback.',
     toolNames: ['web_search', 'web_fetch'],
     requiresSetup: false,
   },

--- a/src/tools/web/WebFetchTool.ts
+++ b/src/tools/web/WebFetchTool.ts
@@ -39,7 +39,7 @@ const PRIVATE_IPV6_PREFIXES = ['fc', 'fd', 'fe80'];
 export class WebFetchTool extends defineTool({
   name: 'web_fetch',
   description:
-    'Retrieve the HTML at a given URL, convert it to Markdown, and return the cleaned text. Include an optional prompt to explain what context you need so the fetched content can be interpreted correctly.',
+    'Fetch content from a URL and return it as clean text. Uses the native provider fetch tool when available; falls back to fetching HTML and converting to Markdown locally. Include an optional prompt to explain what context you need so the fetched content can be interpreted correctly.',
   schema: WebFetchInputSchema,
 }) {
   private readonly turndown: TurndownService;

--- a/src/tools/web/WebSearchTool.ts
+++ b/src/tools/web/WebSearchTool.ts
@@ -39,7 +39,8 @@ interface DuckDuckGoResponse {
 
 export class WebSearchTool extends defineTool({
   name: 'web_search',
-  description: 'Search the web and return top results',
+  description:
+    'Search the web and return top results. Uses the native provider search tool when available; falls back to DuckDuckGo Instant Answers API.',
   schema: WebSearchInputSchema,
 }) {
   protected async execute(input: WebSearchInput): Promise<ToolResult> {


### PR DESCRIPTION
## Summary
Updated descriptions for web search and fetch tools to clarify that they now support native provider implementations when available, with fallback to existing APIs (DuckDuckGo and local HTML-to-Markdown conversion).

## Changes
- **WebSearchTool**: Updated description to indicate native provider search tool support with DuckDuckGo Instant Answers as fallback
- **WebFetchTool**: Updated description to clarify native provider fetch tool support with local HTML-to-Markdown conversion as fallback
- **Tool Dashboard**: Updated the "Web Search & Fetch" category description to reflect the new native provider capabilities and fallback behavior

## Details
These description updates improve clarity for users about the tool's behavior and capabilities. The changes indicate that the tools now intelligently use native provider implementations when available (likely for better performance or integration), while maintaining backward compatibility through fallback mechanisms to the existing DuckDuckGo and local processing implementations.

https://claude.ai/code/session_01CRs8x3FNTfpNpNnFHDMQ4y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to user-facing `description` strings for the web tools and dashboard, with no behavioral or API logic modifications.
> 
> **Overview**
> Updates the user-facing descriptions for `web_search` and `web_fetch` to state they use native provider implementations when available and fall back to DuckDuckGo Instant Answers / local HTML-to-Markdown conversion.
> 
> Aligns the Tool Dashboard’s “Web Search & Fetch” group description with this native-provider-first behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c921b46a0e657ba7ad442dbadcab422b3feec803. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->