### PR TITLE
Add markdown rendering support to memory item previews

### DIFF
--- a/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -8,7 +8,6 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, queryAll } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import MarkdownIt from 'markdown-it';
 import Mark from 'mark.js';
 
 // Local imports - shared
@@ -22,27 +21,13 @@ import {
 } from '@shared/styles';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
-import { highlightCode } from '@shared/highlighting/highlightCode';
+import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 
 // Local imports - history view styles
 import { historyViewStyles } from './styles';
 
 // Local imports - history view events
 import { HistoryViewEvents } from './events';
-
-/** Lazy-initialized lightweight markdown renderer (no LaTeX/KaTeX). */
-let md: MarkdownIt | null = null;
-const getMd = (): MarkdownIt => {
-  if (!md) {
-    md = new MarkdownIt({
-      breaks: false,
-      linkify: true,
-      html: false,
-      highlight: highlightCode,
-    });
-  }
-  return md;
-};
 
 type ConfigValue = string | number | boolean | string[] | null | undefined;
 
@@ -102,7 +87,7 @@ export class HistoryItem extends LitElement {
   private renderMarkdown(text: string): string {
     if (text !== this.cachedInstructionSource) {
       this.cachedInstructionSource = text;
-      this.cachedInstructionHtml = getMd().render(text);
+      this.cachedInstructionHtml = getLightweightMd().render(text);
     }
     return this.cachedInstructionHtml;
   }

--- a/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -4,9 +4,8 @@
 
 // Third-party imports
 import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import MarkdownIt from 'markdown-it';
 
 // Local imports - shared styles
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
@@ -17,24 +16,10 @@ import {
   formatLineCount,
   formatUpdatedDate,
 } from '@shared/utils/string';
-import { highlightCode } from '@shared/highlighting/highlightCode';
+import { getLightweightMd } from '@shared/highlighting/lightweightMd';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
-
-/** Lazy-initialized lightweight markdown renderer (no LaTeX/KaTeX). */
-let md: MarkdownIt | null = null;
-const getMd = (): MarkdownIt => {
-  if (!md) {
-    md = new MarkdownIt({
-      breaks: false,
-      linkify: true,
-      html: false,
-      highlight: highlightCode,
-    });
-  }
-  return md;
-};
 
 @customElement('memory-item')
 export class MemoryItem extends LitElement {
@@ -79,6 +64,9 @@ export class MemoryItem extends LitElement {
 
   @property({ attribute: false }) item?: MemoryViewItem;
 
+  /** Tracks whether the collapsible has been opened at least once to defer markdown rendering. */
+  @state() private contentsOpened = false;
+
   /** Cached markdown render to avoid re-parsing on every Lit update cycle. */
   private cachedPreviewSource: string | null = null;
   private cachedPreviewHtml = '';
@@ -86,7 +74,7 @@ export class MemoryItem extends LitElement {
   private renderMarkdown(text: string): string {
     if (text !== this.cachedPreviewSource) {
       this.cachedPreviewSource = text;
-      this.cachedPreviewHtml = getMd().render(text);
+      this.cachedPreviewHtml = getLightweightMd().render(text);
     }
     return this.cachedPreviewHtml;
   }
@@ -118,6 +106,12 @@ export class MemoryItem extends LitElement {
       this.dispatchEvent(
         MemoryViewEvents.pinItem({ storagePath: this.item.storagePath }),
       );
+    }
+  }
+
+  private handleContentsToggle(event: CustomEvent<{ open?: boolean }>): void {
+    if (event.detail?.open) {
+      this.contentsOpened = true;
     }
   }
 
@@ -175,14 +169,20 @@ export class MemoryItem extends LitElement {
         <div class="text-secondary memory-meta">
           ${this.renderMeta(this.item)}
         </div>
-        <vscode-collapsible class="collapsible" heading="Contents">
-          <div class="memory-preview">
-            ${previewText
-              ? html`<div class="markdown-content">
-                  ${unsafeHTML(this.renderMarkdown(previewText))}
-                </div>`
-              : html`<em class="text-secondary">This note is empty.</em>`}
-          </div>
+        <vscode-collapsible
+          class="collapsible"
+          heading="Contents"
+          @vsc-collapsible-toggle=${this.handleContentsToggle}
+        >
+          ${this.contentsOpened
+            ? html`<div class="memory-preview">
+                ${previewText
+                  ? html`<div class="markdown-content">
+                      ${unsafeHTML(this.renderMarkdown(previewText))}
+                    </div>`
+                  : html`<em class="text-secondary">This note is empty.</em>`}
+              </div>`
+            : nothing}
         </vscode-collapsible>
       </div>
     `;

--- a/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -5,18 +5,36 @@
 // Third-party imports
 import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import MarkdownIt from 'markdown-it';
 
 // Local imports - shared styles
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { markdownStyles } from '@shared/styles/markdownStyles';
 import type { MemoryViewItem } from '@shared/schemas';
 import {
   formatBytes,
   formatLineCount,
   formatUpdatedDate,
 } from '@shared/utils/string';
+import { highlightCode } from '@shared/highlighting/highlightCode';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
+
+/** Lazy-initialized lightweight markdown renderer (no LaTeX/KaTeX). */
+let md: MarkdownIt | null = null;
+const getMd = (): MarkdownIt => {
+  if (!md) {
+    md = new MarkdownIt({
+      breaks: false,
+      linkify: true,
+      html: false,
+      highlight: highlightCode,
+    });
+  }
+  return md;
+};
 
 @customElement('memory-item')
 export class MemoryItem extends LitElement {
@@ -24,6 +42,7 @@ export class MemoryItem extends LitElement {
     designTokens,
     codiconStyles,
     commonViewStyles,
+    markdownStyles,
     css`
       :host {
         display: block;
@@ -42,12 +61,8 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-preview {
-        font-family: var(--vscode-editor-font-family), monospace;
         font-size: var(--font-size-sm);
         line-height: var(--line-height-normal);
-        white-space: pre-wrap;
-        word-wrap: break-word;
-        background-color: var(--vscode-editor-inactiveSelectionBackground);
         padding: var(--spacing-medium);
         border-radius: var(--border-radius);
         margin: 0;
@@ -63,6 +78,18 @@ export class MemoryItem extends LitElement {
   ];
 
   @property({ attribute: false }) item?: MemoryViewItem;
+
+  /** Cached markdown render to avoid re-parsing on every Lit update cycle. */
+  private cachedPreviewSource: string | null = null;
+  private cachedPreviewHtml = '';
+
+  private renderMarkdown(text: string): string {
+    if (text !== this.cachedPreviewSource) {
+      this.cachedPreviewSource = text;
+      this.cachedPreviewHtml = getMd().render(text);
+    }
+    return this.cachedPreviewHtml;
+  }
 
   private handleOpen(): void {
     if (!this.item) return;
@@ -113,9 +140,7 @@ export class MemoryItem extends LitElement {
       return nothing;
     }
 
-    const previewText = this.item.preview?.trim()
-      ? this.item.preview
-      : 'This note is empty.';
+    const previewText = this.item.preview?.trim() ? this.item.preview : null;
 
     return html`
       <div class="list-item memory-item ${this.item.pinned ? 'pinned' : ''}">
@@ -151,7 +176,13 @@ export class MemoryItem extends LitElement {
           ${this.renderMeta(this.item)}
         </div>
         <vscode-collapsible class="collapsible" heading="Contents">
-          <pre class="memory-preview">${previewText}</pre>
+          <div class="memory-preview">
+            ${previewText
+              ? html`<div class="markdown-content">
+                  ${unsafeHTML(this.renderMarkdown(previewText))}
+                </div>`
+              : html`<em class="text-secondary">This note is empty.</em>`}
+          </div>
         </vscode-collapsible>
       </div>
     `;

--- a/src/shared/highlighting/lightweightMd.ts
+++ b/src/shared/highlighting/lightweightMd.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared lightweight markdown renderer (no LaTeX/KaTeX).
+ * Used by settings-view components that need simple markdown rendering
+ * with code highlighting.
+ */
+
+import MarkdownIt from 'markdown-it';
+
+import { highlightCode } from './highlightCode';
+
+let md: MarkdownIt | null = null;
+
+/** Returns a shared, lazily-initialized MarkdownIt instance. */
+export const getLightweightMd = (): MarkdownIt => {
+  if (!md) {
+    md = new MarkdownIt({
+      breaks: false,
+      linkify: true,
+      html: false,
+      highlight: highlightCode,
+    });
+  }
+  return md;
+};


### PR DESCRIPTION
## Summary
Enhanced the memory item preview display to render markdown content with syntax highlighting instead of displaying raw text in a preformatted block.

## Key Changes
- **Markdown rendering**: Integrated `markdown-it` library with a lazy-initialized singleton instance to parse and render memory preview text as HTML
- **Syntax highlighting**: Connected the markdown renderer to the existing `highlightCode` utility for code block syntax highlighting
- **Styling updates**: 
  - Replaced hardcoded monospace/preformatted styles with shared `markdownStyles`
  - Changed preview container from `<pre>` to `<div>` to support styled markdown output
- **Caching optimization**: Implemented preview HTML caching to avoid re-parsing markdown on every Lit update cycle
- **Empty state handling**: Improved empty note display with styled italic text instead of placeholder text in the markdown

## Implementation Details
- The markdown renderer is configured with `breaks: false`, `linkify: true`, `html: false` for safe rendering
- Caching compares the source text to detect changes and only re-renders when necessary
- Uses `unsafeHTML` directive to safely render the sanitized markdown output (HTML is disabled in the renderer)
- Maintains backward compatibility with existing memory item functionality

https://claude.ai/code/session_01ASYNisvsZyvw2w27yddNKi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects how text is rendered; main risk is display regressions or unexpected markdown rendering despite `html: false` and existing code highlighting.
> 
> **Overview**
> Adds markdown rendering to `memory-item` contents, replacing the raw `<pre>` preview with styled HTML output (via `unsafeHTML`) and a clearer empty-state message; rendering is deferred until the collapsible is opened and cached to avoid repeated parsing.
> 
> Extracts the previously inline `HistoryItem` markdown-it setup into a shared `getLightweightMd()` helper (`lightweightMd.ts`) so both history instructions and memory previews use the same lightweight markdown + `highlightCode` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1db3cc60a9da988bc7f0576e02995d2466c4c85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->