### PR TITLE
Fix latexdiff-vc path handling for git repositories

### DIFF
--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -8,6 +8,7 @@ import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { flexibleFS, pathToLocation, type FileLocation } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { executeCommand } from '@utils/system';
 import { runLatexFormatter } from './texFormatter';
 import { generateDiffFileName } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
@@ -174,13 +175,20 @@ export class LaTeXdiffService {
         path.basename(diffFileName),
       );
 
-      // Run from the file's directory with just the filename.
-      // Absolute paths break latexdiff-vc --git temp path construction.
-      await this.commandExecutor.executeDiffVc(
-        path.basename(inputFile),
-        commitHash,
-        { mathMarkup, cwd: path.dirname(inputFile) },
-      );
+      // latexdiff-vc --git runs `git show <commit>:<file>`, which expects
+      // a path relative to the repo root. Absolute paths break its temp
+      // path construction. Resolve via git rev-parse to get the repo root.
+      const fileDir = path.dirname(inputFile);
+      const gitRoot = await this.getGitRoot(fileDir);
+      const cwd = gitRoot ?? fileDir;
+      const filePath = gitRoot
+        ? path.relative(gitRoot, inputFile)
+        : path.basename(inputFile);
+
+      await this.commandExecutor.executeDiffVc(filePath, commitHash, {
+        mathMarkup,
+        cwd,
+      });
       await this.fileProcessor.processDiffFile(pathToLocation(outputPath));
 
       return {
@@ -351,6 +359,18 @@ export class LaTeXdiffService {
       }
     }
     return true;
+  }
+
+  private async getGitRoot(cwd: string): Promise<string | null> {
+    try {
+      const result = await executeCommand(
+        ['git', 'rev-parse', '--show-toplevel'],
+        { channel: this.channel, cwd },
+      );
+      return result.success && result.stdout ? result.stdout.trim() : null;
+    } catch {
+      return null;
+    }
   }
 
   private async formatFiles(fileLocations: FileLocation[]): Promise<void> {

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -174,8 +174,14 @@ export class LaTeXdiffService {
         path.basename(diffFileName),
       );
 
-      await this.commandExecutor.executeDiffVc(inputFile, commitHash, {
+      // latexdiff-vc --git expects a relative path from within the repo.
+      // Passing an absolute path causes it to construct broken temp paths.
+      const cwd = path.dirname(inputFile);
+      const relativeFile = path.basename(inputFile);
+
+      await this.commandExecutor.executeDiffVc(relativeFile, commitHash, {
         mathMarkup,
+        cwd,
       });
       await this.fileProcessor.processDiffFile(pathToLocation(outputPath));
 

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -8,6 +8,7 @@ import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { flexibleFS, pathToLocation, type FileLocation } from '@utils/files';
 import { getConfig } from '@utils/config';
+import { executeCommand } from '@utils/system';
 import { runLatexFormatter } from './texFormatter';
 import { generateDiffFileName } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
@@ -174,10 +175,15 @@ export class LaTeXdiffService {
         path.basename(diffFileName),
       );
 
-      // latexdiff-vc --git expects a relative path from within the repo.
-      // Passing an absolute path causes it to construct broken temp paths.
-      const cwd = path.dirname(inputFile);
-      const relativeFile = path.basename(inputFile);
+      // latexdiff-vc --git expects a path relative to the repo root.
+      // Passing an absolute path causes it to construct broken temp paths
+      // (e.g. /tmp/.../latexdiff-vc-abc123//Users/.../main.tex).
+      const fileDir = path.dirname(inputFile);
+      const gitRoot = await this.getGitRoot(fileDir);
+      const cwd = gitRoot ?? fileDir;
+      const relativeFile = gitRoot
+        ? path.relative(gitRoot, inputFile)
+        : path.basename(inputFile);
 
       await this.commandExecutor.executeDiffVc(relativeFile, commitHash, {
         mathMarkup,
@@ -353,6 +359,18 @@ export class LaTeXdiffService {
       }
     }
     return true;
+  }
+
+  private async getGitRoot(cwd: string): Promise<string | null> {
+    try {
+      const result = await executeCommand(
+        ['git', 'rev-parse', '--show-toplevel'],
+        { channel: this.channel, cwd },
+      );
+      return result.success && result.stdout ? result.stdout.trim() : null;
+    } catch {
+      return null;
+    }
   }
 
   private async formatFiles(fileLocations: FileLocation[]): Promise<void> {

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -169,12 +169,6 @@ export class LaTeXdiffService {
         return { success: false, message };
       }
 
-      const diffFileName = inputFile.replace('.tex', `-diff${commitHash}.tex`);
-      const outputPath = path.join(
-        path.dirname(inputFile),
-        path.basename(diffFileName),
-      );
-
       // latexdiff-vc --git runs `git show <commit>:<file>`, which expects
       // a path relative to the repo root. Absolute paths break its temp
       // path construction. Resolve via git rev-parse to get the repo root.
@@ -189,12 +183,18 @@ export class LaTeXdiffService {
         mathMarkup,
         cwd,
       });
+
+      // latexdiff-vc writes output alongside the input, relative to cwd
+      const diffFilePath = filePath.replace('.tex', `-diff${commitHash}.tex`);
+      const outputPath = path.join(cwd, diffFilePath);
       await this.fileProcessor.processDiffFile(pathToLocation(outputPath));
+
+      const diffFileName = path.basename(diffFilePath);
 
       return {
         success: true,
-        diffFileName: path.basename(diffFileName),
-        message: `LaTeXdiff VC completed successfully: ${path.basename(diffFileName)}`,
+        diffFileName,
+        message: `LaTeXdiff VC completed successfully: ${diffFileName}`,
       };
     } catch (err) {
       return this.logDiffError('Error running LaTeX diff VC', err);

--- a/src/latex/latexdiff.ts
+++ b/src/latex/latexdiff.ts
@@ -8,7 +8,6 @@ import * as logger from '@logger/logUtils';
 import { MESSAGE_TYPES } from '@shared/schemas';
 import { flexibleFS, pathToLocation, type FileLocation } from '@utils/files';
 import { getConfig } from '@utils/config';
-import { executeCommand } from '@utils/system';
 import { runLatexFormatter } from './texFormatter';
 import { generateDiffFileName } from './latexdiff/diffFileNameManager';
 import { DiffFileProcessor } from './latexdiff/diffFileProcessor';
@@ -175,20 +174,13 @@ export class LaTeXdiffService {
         path.basename(diffFileName),
       );
 
-      // latexdiff-vc --git expects a path relative to the repo root.
-      // Passing an absolute path causes it to construct broken temp paths
-      // (e.g. /tmp/.../latexdiff-vc-abc123//Users/.../main.tex).
-      const fileDir = path.dirname(inputFile);
-      const gitRoot = await this.getGitRoot(fileDir);
-      const cwd = gitRoot ?? fileDir;
-      const relativeFile = gitRoot
-        ? path.relative(gitRoot, inputFile)
-        : path.basename(inputFile);
-
-      await this.commandExecutor.executeDiffVc(relativeFile, commitHash, {
-        mathMarkup,
-        cwd,
-      });
+      // Run from the file's directory with just the filename.
+      // Absolute paths break latexdiff-vc --git temp path construction.
+      await this.commandExecutor.executeDiffVc(
+        path.basename(inputFile),
+        commitHash,
+        { mathMarkup, cwd: path.dirname(inputFile) },
+      );
       await this.fileProcessor.processDiffFile(pathToLocation(outputPath));
 
       return {
@@ -359,18 +351,6 @@ export class LaTeXdiffService {
       }
     }
     return true;
-  }
-
-  private async getGitRoot(cwd: string): Promise<string | null> {
-    try {
-      const result = await executeCommand(
-        ['git', 'rev-parse', '--show-toplevel'],
-        { channel: this.channel, cwd },
-      );
-      return result.success && result.stdout ? result.stdout.trim() : null;
-    } catch {
-      return null;
-    }
   }
 
   private async formatFiles(fileLocations: FileLocation[]): Promise<void> {


### PR DESCRIPTION
## Summary
Fixed an issue where `latexdiff-vc --git` was receiving absolute paths, causing it to construct broken temporary paths. The command now receives relative paths and is executed from the correct working directory.

## Key Changes
- Modified `executeDiffVc` call to pass a relative file path instead of an absolute path
- Added `cwd` (current working directory) option to execute the command from the repository root
- Extracted the directory and basename from the input file path to construct the relative path

## Implementation Details
The `latexdiff-vc --git` command expects relative paths from within the git repository. By passing an absolute path, the tool was unable to correctly construct temporary file paths during the diff operation. The fix:
1. Extracts the directory path using `path.dirname(inputFile)`
2. Gets the relative filename using `path.basename(inputFile)`
3. Passes the `cwd` option to `executeDiffVc` so the command executes from the correct directory context

This ensures `latexdiff-vc` can properly resolve relative paths and create temporary files in the expected locations.

https://claude.ai/code/session_01JY4vjxHQiR1GN14tEytS5U

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how `latexdiff-vc --git` is invoked by changing working directory and file path handling; risk is moderate because it affects command execution and output file location resolution, which could regress diffs in non-git or nested repo scenarios.
> 
> **Overview**
> Fixes `runDiffVc` so `latexdiff-vc --git` is executed from the repository root (when available) and is given a repo-relative `.tex` path instead of an absolute path.
> 
> Adds a `getGitRoot()` helper (using `git rev-parse --show-toplevel`) and updates diff output path computation to match `latexdiff-vc`’s “output alongside input relative to cwd” behavior, ensuring the generated `*-diff<commit>.tex` is found and post-processed correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a487adae848bac8a7c73b46cb31b08ae2cfca3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->