### PR TITLE
Create shared webview storage singleton for progress view

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -14,8 +14,8 @@ import {
   PROGRESS_VIEW_COMMANDS,
 } from '@common/webview/commands';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
-import { postMessage, vscode } from '@shared/vscode';
-import { PersistedState, createWebviewStorage } from '@shared/state';
+import { postMessage } from '@shared/vscode';
+import { PersistedState } from '@shared/state';
 
 // Local imports - shared schemas
 import {
@@ -39,6 +39,7 @@ import { sortStreams, StreamSortSchema } from '@shared/streams/streamSort';
 import { codiconStyles } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view frontend
+import { webviewStorage } from './webviewStorage';
 import {
   createInitialState,
   EMPTY_STREAM_LOGS,
@@ -435,7 +436,7 @@ export class ProgressApp extends ProgressAppBase {
   });
 
   private prefsManager = new PersistedState(
-    createWebviewStorage(vscode),
+    webviewStorage,
     'progressViewPrefs',
     ProgressViewPrefsSchema,
   );

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -30,6 +30,7 @@ import {
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { ProgressEvents } from '../events';
+import { webviewStorage } from '../webviewStorage';
 
 // Local imports - contexts
 import {
@@ -202,8 +203,10 @@ export class BackgroundTasksPanel extends LitElement {
   @property({ attribute: false }) activeSubagents: ActiveChildInfo[] = [];
   @property({ attribute: false }) finishedSubagentCount = 0;
 
-  /** Open state — managed internally. Toggled by user or auto-opened on first active task. */
+  /** Open state — persisted across webview visibility changes. */
   @state() open = false;
+
+  private static readonly STORAGE_KEY = 'backgroundTasks:open';
 
   @consume({ context: processOutputContext, subscribe: true })
   @state()
@@ -216,12 +219,21 @@ export class BackgroundTasksPanel extends LitElement {
   /** Track previous active count to detect 0→N transitions for auto-open. */
   private prevActiveCount = 0;
 
+  constructor() {
+    super();
+    const stored = webviewStorage.get(BackgroundTasksPanel.STORAGE_KEY);
+    if (typeof stored === 'boolean') {
+      this.open = stored;
+    }
+  }
+
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
     const active = this.activeProcesses.length + this.activeSubagents.length;
     // Auto-open when tasks first appear (0 → N), but never force-close
     if (this.prevActiveCount === 0 && active > 0) {
       this.open = true;
+      webviewStorage.set(BackgroundTasksPanel.STORAGE_KEY, true);
     }
     this.prevActiveCount = active;
   }
@@ -385,7 +397,9 @@ export class BackgroundTasksPanel extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+    const next = e.detail?.open ?? this.open;
+    this.open = next;
+    webviewStorage.set(BackgroundTasksPanel.STORAGE_KEY, next);
   }
 
   private navigateToStream(streamId: string): void {

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -30,7 +30,6 @@ import {
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 import { CHEVRON_RIGHT_CLASS } from '@shared/utils/icons';
 import { ProgressEvents } from '../events';
-import { webviewStorage } from '../webviewStorage';
 
 // Local imports - contexts
 import {
@@ -203,10 +202,8 @@ export class BackgroundTasksPanel extends LitElement {
   @property({ attribute: false }) activeSubagents: ActiveChildInfo[] = [];
   @property({ attribute: false }) finishedSubagentCount = 0;
 
-  /** Open state — persisted across webview visibility changes. */
+  /** Open state — auto-expands when active tasks appear, auto-collapses when all finish. */
   @state() open = false;
-
-  private static readonly STORAGE_KEY = 'backgroundTasks:open';
 
   @consume({ context: processOutputContext, subscribe: true })
   @state()
@@ -216,24 +213,17 @@ export class BackgroundTasksPanel extends LitElement {
   @state()
   private descriptions: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
 
-  /** Track previous active count to detect 0→N transitions for auto-open. */
+  /** Track previous active count to detect transitions. */
   private prevActiveCount = 0;
-
-  constructor() {
-    super();
-    const stored = webviewStorage.get(BackgroundTasksPanel.STORAGE_KEY);
-    if (typeof stored === 'boolean') {
-      this.open = stored;
-    }
-  }
 
   protected override willUpdate(changed: PropertyValues): void {
     super.willUpdate(changed);
     const active = this.activeProcesses.length + this.activeSubagents.length;
-    // Auto-open when tasks first appear (0 → N), but never force-close
+    // Auto-open when tasks appear (0 → N), auto-close when all finish (N → 0)
     if (this.prevActiveCount === 0 && active > 0) {
       this.open = true;
-      webviewStorage.set(BackgroundTasksPanel.STORAGE_KEY, true);
+    } else if (this.prevActiveCount > 0 && active === 0) {
+      this.open = false;
     }
     this.prevActiveCount = active;
   }
@@ -397,9 +387,7 @@ export class BackgroundTasksPanel extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    const next = e.detail?.open ?? this.open;
-    this.open = next;
-    webviewStorage.set(BackgroundTasksPanel.STORAGE_KEY, next);
+    this.open = e.detail?.open ?? this.open;
   }
 
   private navigateToStream(streamId: string): void {

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -24,11 +24,12 @@ import './TaskGroupList';
 // Local imports
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import type { LogMessageData, TaskGroup } from '@shared/schemas';
-import { PersistedState, createWebviewStorage } from '@shared/state';
+import { PersistedState } from '@shared/state';
 import { ToggleStateStore } from '@shared/state/ToggleStateStore';
 import { codiconStyles, designTokens } from '@shared/styles';
 import { copyWithFeedback } from '@shared/utils/clipboard';
-import { postMessage, vscode } from '@shared/vscode';
+import { postMessage } from '@shared/vscode';
+import { webviewStorage } from '../webviewStorage';
 
 // Local imports - progress view contexts
 import {
@@ -77,7 +78,7 @@ export class LogList extends LitElement {
 
   /** Per-stream DOM cache: one TaskGroupList per visited stream */
   private streamCache = new Map<string, CachedStream>();
-  private storage = createWebviewStorage(vscode);
+  private storage = webviewStorage;
   private activeStreamId: string | null = null;
   private shouldScrollToBottom = false;
 

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -32,6 +32,7 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
+import { webviewStorage } from '../webviewStorage';
 
 @customElement('plan-view')
 export class PlanView extends LitElement {
@@ -164,12 +165,23 @@ export class PlanView extends LitElement {
 
   @property({ attribute: false }) plan: Plan | null = null;
 
-  /** Open state — managed internally. Auto-opens when plan is updated. */
+  /** Open state — persisted across webview visibility changes. */
   @state() private open = true;
+
+  private static readonly STORAGE_KEY = 'planView:open';
+
+  constructor() {
+    super();
+    const stored = webviewStorage.get(PlanView.STORAGE_KEY);
+    if (typeof stored === 'boolean') {
+      this.open = stored;
+    }
+  }
 
   protected override willUpdate(changed: PropertyValues): void {
     if (changed.has('plan') && this.plan && !this.open) {
       this.open = true;
+      webviewStorage.set(PlanView.STORAGE_KEY, true);
     }
   }
 
@@ -245,6 +257,8 @@ export class PlanView extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+    const next = e.detail?.open ?? this.open;
+    this.open = next;
+    webviewStorage.set(PlanView.STORAGE_KEY, next);
   }
 }

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -32,7 +32,6 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view constants
 import { ELEMENT_IDS } from '../constants';
-import { webviewStorage } from '../webviewStorage';
 
 @customElement('plan-view')
 export class PlanView extends LitElement {
@@ -165,23 +164,16 @@ export class PlanView extends LitElement {
 
   @property({ attribute: false }) plan: Plan | null = null;
 
-  /** Open state — persisted across webview visibility changes. */
+  /** Open state — auto-expands on plan updates, auto-collapses when cleared. */
   @state() private open = true;
 
-  private static readonly STORAGE_KEY = 'planView:open';
-
-  constructor() {
-    super();
-    const stored = webviewStorage.get(PlanView.STORAGE_KEY);
-    if (typeof stored === 'boolean') {
-      this.open = stored;
-    }
-  }
-
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('plan') && this.plan && !this.open) {
-      this.open = true;
-      webviewStorage.set(PlanView.STORAGE_KEY, true);
+    if (changed.has('plan')) {
+      if (this.plan) {
+        this.open = true;
+      } else {
+        this.open = false;
+      }
     }
   }
 
@@ -257,8 +249,6 @@ export class PlanView extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    const next = e.detail?.open ?? this.open;
-    this.open = next;
-    webviewStorage.set(PlanView.STORAGE_KEY, next);
+    this.open = e.detail?.open ?? this.open;
   }
 }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -21,6 +21,7 @@ import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 import { ELEMENT_IDS } from '../constants';
+import { webviewStorage } from '../webviewStorage';
 
 @customElement('todo-list')
 export class TodoList extends LitElement {
@@ -102,12 +103,23 @@ export class TodoList extends LitElement {
 
   @property({ attribute: false }) todos: TodoItem[] = [];
 
-  /** Open state — managed internally. Auto-opens when todos are updated. */
+  /** Open state — persisted across webview visibility changes. */
   @state() private open = true;
+
+  private static readonly STORAGE_KEY = 'todoList:open';
+
+  constructor() {
+    super();
+    const stored = webviewStorage.get(TodoList.STORAGE_KEY);
+    if (typeof stored === 'boolean') {
+      this.open = stored;
+    }
+  }
 
   protected override willUpdate(changed: PropertyValues): void {
     if (changed.has('todos') && this.todos.length > 0 && !this.open) {
       this.open = true;
+      webviewStorage.set(TodoList.STORAGE_KEY, true);
     }
   }
 
@@ -171,6 +183,8 @@ export class TodoList extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    this.open = e.detail?.open ?? this.open;
+    const next = e.detail?.open ?? this.open;
+    this.open = next;
+    webviewStorage.set(TodoList.STORAGE_KEY, next);
   }
 }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -21,7 +21,6 @@ import { TODO_STATUS, STATUS_ICONS, type TodoItem } from '@shared/schemas';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
 import { ELEMENT_IDS } from '../constants';
-import { webviewStorage } from '../webviewStorage';
 
 @customElement('todo-list')
 export class TodoList extends LitElement {
@@ -103,23 +102,16 @@ export class TodoList extends LitElement {
 
   @property({ attribute: false }) todos: TodoItem[] = [];
 
-  /** Open state — persisted across webview visibility changes. */
+  /** Open state — auto-expands on todo updates, auto-collapses when cleared. */
   @state() private open = true;
 
-  private static readonly STORAGE_KEY = 'todoList:open';
-
-  constructor() {
-    super();
-    const stored = webviewStorage.get(TodoList.STORAGE_KEY);
-    if (typeof stored === 'boolean') {
-      this.open = stored;
-    }
-  }
-
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('todos') && this.todos.length > 0 && !this.open) {
-      this.open = true;
-      webviewStorage.set(TodoList.STORAGE_KEY, true);
+    if (changed.has('todos')) {
+      if (this.todos.length > 0) {
+        this.open = true;
+      } else {
+        this.open = false;
+      }
     }
   }
 
@@ -183,8 +175,6 @@ export class TodoList extends LitElement {
   }
 
   private handleCollapsibleToggle(e: CustomEvent<{ open?: boolean }>): void {
-    const next = e.detail?.open ?? this.open;
-    this.open = next;
-    webviewStorage.set(TodoList.STORAGE_KEY, next);
+    this.open = e.detail?.open ?? this.open;
   }
 }

--- a/src/progressView/frontend/webviewStorage.ts
+++ b/src/progressView/frontend/webviewStorage.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared webview storage singleton for the progress view.
+ *
+ * All components in the progress view frontend MUST use this shared instance
+ * rather than calling `createWebviewStorage(vscode)` independently. Multiple
+ * independent instances each maintain their own cache, so writes from one
+ * instance can silently overwrite changes made by another.
+ */
+import { createWebviewStorage } from '@shared/state';
+import { vscode } from '@shared/vscode';
+
+export const webviewStorage = createWebviewStorage(vscode);


### PR DESCRIPTION
## Summary
Introduces a shared webview storage singleton to prevent cache inconsistencies across the progress view frontend. Multiple independent storage instances were silently overwriting each other's changes, so all components now use a centralized instance.

## Key Changes
- **New file**: `src/progressView/frontend/webviewStorage.ts` - Exports a singleton `webviewStorage` instance that all progress view components must use
- **ProgressApp.ts**: Updated to use the shared `webviewStorage` singleton instead of creating its own instance
- **LogList.ts**: Updated to use the shared `webviewStorage` singleton instead of creating its own instance
- **PlanView.ts**: Improved auto-collapse behavior - now collapses when plan is cleared (not just expands when plan is set)
- **TodoList.ts**: Improved auto-collapse behavior - now collapses when todos are cleared (not just expands when todos are added)
- **BackgroundTasksPanel.ts**: Improved auto-collapse behavior - now collapses when all tasks finish (not just expands when tasks appear)

## Implementation Details
- The singleton is created once at module load time and exported for use throughout the progress view
- Updated JSDoc comments to clarify the auto-expand/auto-collapse behavior in affected components
- Refactored conditional logic in `willUpdate` methods for better clarity and symmetry (expand on content, collapse when empty)

https://claude.ai/code/session_016tw7kdPoRbqWTNBJzXYVzq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to progress-view UI state persistence and collapsible panel behavior; main risk is unintended preference/toggle-state regressions due to the storage adapter consolidation.
> 
> **Overview**
> Introduces a **shared `webviewStorage` singleton** for the progress view so all `PersistedState` usage reads/writes through one cached `createWebviewStorage(vscode)` instance, preventing separate caches from overwriting each other.
> 
> Updates `ProgressApp` and `LogList` to use this singleton instead of constructing their own storage adapters.
> 
> Tweaks collapsible UI panels (`BackgroundTasksPanel`, `PlanView`, `TodoList`) to **auto-collapse when their backing data becomes empty** (e.g., tasks finish, plan/todos cleared), not just auto-expand when new data appears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 687b139a41a5fb08b537cce5c1ea8be07dcc1379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->