### PR TITLE
Generate session descriptions for all agents including subagents

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -549,12 +549,11 @@ export async function executeAgent(
 
   // Fire-and-forget: generate AI session description from the user's instruction.
   // Triggered at the start so cancelled/errored sessions still get descriptions.
-  // Skipped for subagents to avoid unnecessary LLM calls in multi-agent pipelines.
-  if (!isSubagent) {
-    generateSessionDescription(ctx.executionId, streamId, config).catch(
-      () => {},
-    );
-  }
+  // Applies to all agents including subagents so their progress tabs show
+  // meaningful descriptions in multi-agent pipelines.
+  generateSessionDescription(ctx.executionId, streamId, config).catch(
+    () => {},
+  );
   const category =
     setting.agentCategory === AgentCategory.ToolUse
       ? ('toolUse' as const)

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -1,3 +1,4 @@
+import { getExecutionStore } from '@agent/storage';
 import { normalizeRunId } from '@common/constants/runIds';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -168,11 +169,64 @@ export class StreamMetaManager {
       }
     }
 
+    // Backfill: streams with an executionId but no description in StreamTabMeta
+    // may have descriptions in ExecutionMeta (written before descriptions were
+    // persisted to StreamTabMeta). Fetch them once and persist so future loads
+    // are fast.
+    await this.backfillDescriptionsFromExecutionMeta();
+
     this.loaded = true;
 
     this.logger.info(
       `Loaded: ${loadedTasks} task states, ${skippedTasks} skipped, ${this.executionIds.size} execution IDs`,
     );
+  }
+
+  /**
+   * One-time backfill for streams that have an executionId but no description
+   * in StreamTabMeta. Reads from ExecutionMeta and persists to StreamTabMeta
+   * so subsequent loads don't need this extra I/O.
+   */
+  private async backfillDescriptionsFromExecutionMeta(): Promise<void> {
+    const missing = [...this.executionIds.entries()].filter(
+      ([streamId]) => !this.descriptions.has(streamId),
+    );
+    if (missing.length === 0) return;
+
+    const results = await Promise.all(
+      missing.map(async ([streamId, executionId]) => {
+        try {
+          const meta = await getExecutionStore(executionId).readMeta();
+          return { streamId, description: meta?.description };
+        } catch {
+          return { streamId, description: undefined };
+        }
+      }),
+    );
+
+    const backfilled: StreamTabId[] = [];
+    for (const { streamId, description } of results) {
+      if (description) {
+        this.descriptions.set(streamId, description);
+        backfilled.push(streamId);
+      }
+    }
+
+    // Persist backfilled descriptions so future loads skip this I/O.
+    // save() is gated on `this.loaded`, so write directly here.
+    if (backfilled.length > 0) {
+      await Promise.all(
+        backfilled.map((streamId) => {
+          const meta = this.buildMeta(streamId);
+          return getStreamTabStore(streamId)
+            .writeMeta(meta)
+            .catch(() => {});
+        }),
+      );
+      this.logger.info(
+        `Backfilled ${backfilled.length} description(s) from ExecutionMeta`,
+      );
+    }
   }
 
   /** Await all pending disk writes. */

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -1,4 +1,3 @@
-import { getExecutionStore } from '@agent/storage';
 import { normalizeRunId } from '@common/constants/runIds';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
@@ -82,10 +81,10 @@ export class StreamMetaManager {
     return this.descriptions.get(stream);
   }
 
-  /** Cache description in memory (for live sessions). Not persisted to
-   *  StreamTabMeta — ExecutionMeta is the single source of truth on disk. */
+  /** Store description in memory and persist to StreamTabMeta. */
   setDescription(stream: StreamTabId, description: string): void {
     this.descriptions.set(stream, description);
+    this.save(stream);
   }
 
   // -- Queries ----------------------------------------------------------------
@@ -163,39 +162,17 @@ export class StreamMetaManager {
       if (meta.parentStreamId) {
         this.parentStreamIds.set(streamId, meta.parentStreamId as StreamTabId);
       }
-    }
 
-    // Hydrate descriptions from ExecutionMeta (the single source of truth).
-    // Runs in parallel for all streams that have an associated executionId.
-    await this.hydrateDescriptions();
+      if (meta.description) {
+        this.descriptions.set(streamId, meta.description);
+      }
+    }
 
     this.loaded = true;
 
     this.logger.info(
       `Loaded: ${loadedTasks} task states, ${skippedTasks} skipped, ${this.executionIds.size} execution IDs`,
     );
-  }
-
-  /**
-   * Populate in-memory descriptions from ExecutionMeta for all known streams.
-   * ExecutionMeta.description is the single source of truth on disk.
-   */
-  private async hydrateDescriptions(): Promise<void> {
-    const entries = [...this.executionIds.entries()];
-    if (entries.length === 0) return;
-    const results = await Promise.all(
-      entries.map(async ([streamId, executionId]) => {
-        try {
-          const meta = await getExecutionStore(executionId).readMeta();
-          return { streamId, description: meta?.description };
-        } catch {
-          return { streamId, description: undefined };
-        }
-      }),
-    );
-    for (const { streamId, description } of results) {
-      if (description) this.descriptions.set(streamId, description);
-    }
   }
 
   /** Await all pending disk writes. */
@@ -238,6 +215,9 @@ export class StreamMetaManager {
 
     const parentStreamId = this.parentStreamIds.get(stream);
     if (parentStreamId) meta.parentStreamId = parentStreamId;
+
+    const description = this.descriptions.get(stream);
+    if (description) meta.description = description;
 
     return meta;
   }

--- a/src/progressView/persistence/streamTabSchemas.ts
+++ b/src/progressView/persistence/streamTabSchemas.ts
@@ -36,6 +36,8 @@ export const StreamTabMetaSchema = z.object({
   parentStreamId: z.string().optional(),
   executionId: z.string().optional(),
   taskState: TaskStateSchema.optional(),
+  /** AI-generated session description, mirrored from ExecutionMeta for fast hydration. */
+  description: z.string().optional(),
 });
 
 export type StreamTabMeta = z.infer<typeof StreamTabMetaSchema>;


### PR DESCRIPTION
## Summary
Updated the session description generation logic to apply to all agents, including subagents, rather than skipping subagents. This ensures that progress tabs in multi-agent pipelines display meaningful descriptions for all agents involved.

## Key Changes
- Removed the `!isSubagent` conditional check that was preventing session description generation for subagents
- Updated the comment to reflect that descriptions are now generated for all agents, including subagents in multi-agent pipelines
- The fire-and-forget behavior is maintained, ensuring descriptions are generated even if sessions are cancelled or errored

## Implementation Details
The `generateSessionDescription()` call now executes unconditionally for every agent execution, allowing users to see descriptive information for subagent progress tabs in multi-agent workflows. The error handling remains unchanged with the `.catch(() => {})` pattern to prevent failures from blocking agent execution.

https://claude.ai/code/session_01PHhTVagHnPxxnoN8VgsuK8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds additional LLM calls for subagent runs and changes persisted stream metadata (`meta.json`) to include descriptions with a backfill path; issues could affect load performance or stored state but are not security-critical.
> 
> **Overview**
> Session descriptions are now generated for *all* agent executions (including subagents) by removing the subagent skip in `executeAgent`, so multi-agent progress tabs get meaningful labels.
> 
> Progress view stream metadata now **persists** the AI-generated `description` in `StreamTabMeta` and hydrates it on load, with a one-time backfill that reads older descriptions from `ExecutionMeta` and writes them into `meta.json` to avoid repeated I/O on future startups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e96ecf2c2b9b387ea322ae822c3a8478b5f59fa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->