### PR TITLE
Add selection descriptions for agent and model options

### DIFF
--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import { MODEL_CONFIGS, type ModelConfig } from 'llm-zoo';
+import { MODEL_CONFIGS, hint, type ModelConfig } from 'llm-zoo';
 
 // Local imports - auth
 import { getServerSideKeyService } from '@auth/serverKeys';
@@ -151,6 +151,7 @@ async function buildModelOptionData(
     provider: config.provider,
     context: formatContext(config.contextWindow),
     cost: formatCost(config.inputPrice, config.outputPrice),
+    hint: hint(config),
     requiresKey: !available,
     disabled: !available,
   };
@@ -171,6 +172,7 @@ export function buildBasicModelOptionsData(): ModelOptionData[] {
       provider: config.provider,
       context: formatContext(config.contextWindow),
       cost: formatCost(config.inputPrice, config.outputPrice),
+      hint: hint(config),
     };
   });
 }

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -64,6 +64,7 @@ export const ModelOptionDataSchema = z.object({
   provider: z.string().optional(),
   context: z.string().optional(),
   cost: z.string().optional(),
+  hint: z.string().optional(),
   requiresKey: z.boolean().optional(),
   disabled: z.boolean().optional(),
 });

--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -77,8 +77,7 @@ function renderModelOption(
 
   const hints: string[] = [];
   if (decorator.label) hints.push(decorator.label);
-  if (opt.context) hints.push(`Context: ${opt.context}`);
-  if (opt.cost) hints.push(`Cost: ${opt.cost}`);
+  if (opt.hint) hints.push(opt.hint);
   if (opt.requiresKey) hints.push('⚠ API key not configured');
   const tooltip = hints.join(' | ');
 

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -21,7 +21,6 @@ import { commonViewStyles } from '@shared/styles/commonViewStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
 
 // Local imports - shared utils
-import { getModelProviderDecorator } from '@shared/utils/icons';
 import {
   renderAgentOptions,
   renderModelOptions,
@@ -250,14 +249,7 @@ export class InstructionPanel extends LitElement {
       (o: ModelOptionData) => o.value === session.model,
     );
     if (!opt) return '';
-    const parts: string[] = [];
-    if (opt.provider) {
-      const decorator = getModelProviderDecorator(opt.provider);
-      parts.push(decorator.label);
-    }
-    if (opt.context) parts.push(opt.context);
-    if (opt.cost) parts.push(opt.cost);
-    return parts.join(' · ');
+    return opt.hint ?? '';
   }
 
   private handleSessionTypeChange(event: Event): void {

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -12,12 +12,16 @@ import { customElement, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
+// Local imports - shared schemas and types
+import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
 import { commonViewStyles } from '@shared/styles/commonViewStyles';
 import { selectStyles } from '@shared/styles/selectStyles';
 
 // Local imports - shared utils
+import { getModelProviderDecorator } from '@shared/utils/icons';
 import {
   renderAgentOptions,
   renderModelOptions,
@@ -182,6 +186,22 @@ export class InstructionPanel extends LitElement {
         top: auto;
       }
 
+      .selection-description {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary, var(--vscode-descriptionForeground));
+        line-height: var(--line-height-normal, 1.4);
+        padding-top: var(--spacing-tiny);
+        min-height: 1.2em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        transition: opacity var(--transition-fast);
+      }
+
+      .selection-description:empty {
+        display: none;
+      }
+
       .recording {
         color: var(--vscode-errorForeground);
         animation: pulse 1s infinite;
@@ -205,6 +225,40 @@ export class InstructionPanel extends LitElement {
   /** Reference to instruction textarea for paste handling */
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
+
+  /** Build a short description for the currently selected agent. */
+  private getSelectedAgentDescription(): string {
+    const session = this.sessionData;
+    if (!session) return '';
+    const options: AgentOptionData[] =
+      session.sessionType === SESSION_TYPES.WORKFLOW
+        ? session.workflowAgentOptions
+        : session.toolUseAgentOptions;
+    const selectedValue =
+      session.sessionType === SESSION_TYPES.WORKFLOW
+        ? session.workflowAgent
+        : session.toolUseAgent;
+    const opt = options.find((o) => o.value === selectedValue);
+    return opt?.description ?? '';
+  }
+
+  /** Build a short description for the currently selected model. */
+  private getSelectedModelDescription(): string {
+    const session = this.sessionData;
+    if (!session) return '';
+    const opt = session.modelOptions.find(
+      (o: ModelOptionData) => o.value === session.model,
+    );
+    if (!opt) return '';
+    const parts: string[] = [];
+    if (opt.provider) {
+      const decorator = getModelProviderDecorator(opt.provider);
+      parts.push(decorator.label);
+    }
+    if (opt.context) parts.push(opt.context);
+    if (opt.cost) parts.push(opt.cost);
+    return parts.join(' · ');
+  }
 
   private handleSessionTypeChange(event: Event): void {
     const target = event.target as HTMLInputElement | null;
@@ -288,6 +342,23 @@ export class InstructionPanel extends LitElement {
         text: 'Choose the AI model used by the selected agent.',
       }),
     );
+  }
+
+  private renderSelectionDescription(): TemplateResult | typeof nothing {
+    const agentDesc = this.getSelectedAgentDescription();
+    const modelDesc = this.getSelectedModelDescription();
+
+    // Combine: prefer showing both, separated by a dash
+    const parts: string[] = [];
+    if (agentDesc) parts.push(agentDesc);
+    if (modelDesc) parts.push(modelDesc);
+    const text = parts.join(' — ');
+
+    if (!text) return nothing;
+
+    return html`<div class="selection-description" title=${text}>
+      ${text}
+    </div>`;
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -496,6 +567,7 @@ export class InstructionPanel extends LitElement {
             @click=${this.handleExecute}
           ></vscode-button>
         </div>
+        ${this.renderSelectionDescription()}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
This PR adds descriptive text below the agent and model selection controls in the InstructionPanel, providing users with additional context about their current selections.

## Key Changes
- **New styling**: Added `.selection-description` CSS class with appropriate typography, spacing, and overflow handling
- **Agent description method**: Implemented `getSelectedAgentDescription()` to retrieve the description of the currently selected agent based on session type (workflow vs tool-use)
- **Model description method**: Implemented `getSelectedModelDescription()` to build a formatted description combining the model's provider, context window, and cost information
- **Render method**: Added `renderSelectionDescription()` to combine agent and model descriptions and render them as a single descriptive element
- **Template integration**: Integrated the selection description into the main render template, displaying it below the execute button

## Implementation Details
- The model description uses the `getModelProviderDecorator()` utility to fetch provider-specific labels
- Multiple description parts are joined with an em-dash separator (` — `) for clean formatting
- The description element includes a `title` attribute for full text on hover (useful when text is truncated)
- Empty descriptions are hidden via CSS (`:empty` selector) to avoid unnecessary DOM elements
- Descriptions are session-aware and update based on the current session type and selected options

https://claude.ai/code/session_014N8zhdfN8UM6TDHRXNneHo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/schema enhancement that adds optional `hint` metadata to model option payloads and displays selection descriptions in the webview; main risk is minor compatibility issues where older payloads/templates assume different tooltip fields.
> 
> **Overview**
> Adds an optional `hint` field to `ModelOptionData` and populates it from `llm-zoo` when building model option payloads.
> 
> Updates model option rendering to use this `hint` in tooltips, and extends `InstructionPanel` to display a short, combined description under the agent/model selectors (agent `description` + selected model `hint`) with new `.selection-description` styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76b7703075db99762106b03116198cdda01a31ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->