### PR TITLE
Handle retryable Anthropic error types in raw error bodies

### DIFF
--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -387,16 +387,10 @@ function isRelayError(rawErrorBody: unknown): boolean {
   return isObject(nested) && '_relay' in nested;
 }
 
-function determineRetryable(statusCode?: number, rawErrorBody?: unknown): boolean {
-  if (isRelayError(rawErrorBody)) {
-    return true;
-  }
-  return isRetryableStatusCode(statusCode);
-}
-
 export function formatProviderHttpError(err: unknown): ProviderError {
   const rawErrorBody = detectRawErrorBody(err);
   const streamDiagnostics = detectStreamDiagnostics(err);
+  const isRelay = isRelayError(rawErrorBody);
 
   // Handle DOMException AbortError (from AbortController.abort())
   if (err instanceof DOMException && err.name === 'AbortError') {
@@ -409,56 +403,40 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     };
   }
 
+  // Try matching a known SDK error type (connection, abort, HTTP errors)
   const sdkMatch = matchSdkError(err, rawErrorBody);
   if (sdkMatch) {
-    const isRelay = isRelayError(rawErrorBody);
-    const retryable =
-      determineRetryable(sdkMatch.statusCode, rawErrorBody) ||
-      sdkMatch.retryable;
     return {
       ...sdkMatch,
-      retryable,
+      retryable: isRelay || sdkMatch.retryable,
       isRelayError: isRelay,
       rawErrorBody,
       streamDiagnostics,
     };
   }
 
-  // Fallback for unrecognized errors
-  const statusCode = detectStatusCode(err);
+  // Unrecognized error — extract what we can
+  const statusCode =
+    detectStatusCode(err) ?? inferStatusCodeFromBody(rawErrorBody);
   const statusText = detectStatusText(err, statusCode);
   const provider = detectProvider(err);
   const requestId = detectRequestId(err);
-  const isRelay = isRelayError(rawErrorBody);
-
   const fallbackMessage = statusCode
     ? safeGetReasonPhrase(statusCode)
     : undefined;
   const finalMessage =
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
+  const retryable = isRelay || isRetryableStatusCode(statusCode);
+  const message = statusCode
+    ? `${statusText ? `HTTP ${statusCode} ${statusText}` : `HTTP ${statusCode}`} – ${finalMessage}`
+    : finalMessage;
 
-  if (!statusCode) {
-    // Unrecognized errors without status codes are likely network errors - retry
-    return {
-      message: finalMessage,
-      provider,
-      retryable: true,
-      isRelayError: isRelay,
-      requestId,
-      rawErrorBody,
-      streamDiagnostics,
-    };
-  }
-
-  const prefix = statusText
-    ? `HTTP ${statusCode} ${statusText}`
-    : `HTTP ${statusCode}`;
   return {
-    message: `${prefix} – ${finalMessage}`,
+    message,
     statusCode,
     statusText,
     provider,
-    retryable: determineRetryable(statusCode, rawErrorBody),
+    retryable,
     isRelayError: isRelay,
     requestId,
     rawErrorBody,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -337,6 +337,35 @@ function detectStreamDiagnostics(err: unknown): StreamDiagnostics | undefined {
 const ANTHROPIC_OVERLOADED_ERROR = 'overloaded_error';
 const ANTHROPIC_TIMEOUT_ERROR = 'timeout_error';
 
+/**
+ * Anthropic error types that indicate transient server-side issues.
+ * Checked against the raw error body when SDK class detection fails
+ * (e.g., streaming SSE errors that produce generic APIError instances
+ * without a proper HTTP status code).
+ */
+const RETRYABLE_ANTHROPIC_ERROR_TYPES = new Set([
+  'api_error', // 500 Internal Server Error
+  'overloaded_error', // 529 Overloaded
+]);
+
+/**
+ * Checks if the raw error body contains a known retryable Anthropic error type.
+ * Handles both direct body (`{ type: "api_error" }`) and nested body
+ * (`{ error: { type: "api_error" } }`) to cover different SDK extraction paths.
+ */
+function isRetryableAnthropicErrorType(rawErrorBody: unknown): boolean {
+  if (!isObject(rawErrorBody)) {
+    return false;
+  }
+  const body = rawErrorBody as { type?: unknown; error?: { type?: unknown } };
+  const errorType =
+    (isString(body.type) ? body.type : undefined) ??
+    (isObject(body.error) && isString(body.error.type)
+      ? body.error.type
+      : undefined);
+  return typeof errorType === 'string' && RETRYABLE_ANTHROPIC_ERROR_TYPES.has(errorType);
+}
+
 function isRelayError(rawErrorBody: unknown): boolean {
   if (!isObject(rawErrorBody)) {
     return false;
@@ -369,6 +398,14 @@ function determineRetryable(
       return true;
     }
   }
+
+  // Check raw error body for retryable Anthropic error types (api_error = 500,
+  // overloaded_error = 529). This catches cases where the SDK produces a generic
+  // APIError without a proper HTTP status code (e.g., streaming SSE errors).
+  if (isRetryableAnthropicErrorType(rawErrorBody)) {
+    return true;
+  }
+
   return isRetryableStatusCode(statusCode);
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -131,7 +131,10 @@ function isRetryableStatusCode(statusCode?: number): boolean {
 type SdkMatchResult = Omit<ProviderError, 'isRelayError' | 'rawErrorBody'>;
 
 /** Match known SDK error types and return structured error details. */
-function matchSdkError(err: unknown): SdkMatchResult | undefined {
+function matchSdkError(
+  err: unknown,
+  rawErrorBody: unknown,
+): SdkMatchResult | undefined {
   const entry = SDK_ERRORS.find(({ ctor }) => err instanceof ctor);
   if (!entry) {
     return undefined;
@@ -150,8 +153,11 @@ function matchSdkError(err: unknown): SdkMatchResult | undefined {
     };
   }
 
-  // HTTP errors - detect status code and build formatted message
-  const statusCode = detectStatusCode(err) ?? entry.fallbackStatusCode;
+  // HTTP errors - detect status code from error object, SDK class, or error body
+  const statusCode =
+    detectStatusCode(err) ??
+    entry.fallbackStatusCode ??
+    inferStatusCodeFromBody(rawErrorBody);
   const statusText = detectStatusText(err, statusCode);
   const fallbackMessage = statusCode
     ? safeGetReasonPhrase(statusCode)
@@ -334,28 +340,30 @@ function detectStreamDiagnostics(err: unknown): StreamDiagnostics | undefined {
   return undefined;
 }
 
-const ANTHROPIC_OVERLOADED_ERROR = 'overloaded_error';
-const ANTHROPIC_TIMEOUT_ERROR = 'timeout_error';
+/**
+ * Maps Anthropic error type strings to their corresponding HTTP status codes.
+ * Used to recover the status code when SDK error objects lose it
+ * (e.g., streaming SSE errors that produce generic APIError instances).
+ */
+const ANTHROPIC_ERROR_TYPE_TO_STATUS: Record<string, number> = {
+  invalid_request_error: StatusCodes.BAD_REQUEST, // 400
+  authentication_error: StatusCodes.UNAUTHORIZED, // 401
+  permission_error: StatusCodes.FORBIDDEN, // 403
+  not_found_error: StatusCodes.NOT_FOUND, // 404
+  request_too_large: StatusCodes.REQUEST_TOO_LONG, // 413
+  rate_limit_error: StatusCodes.TOO_MANY_REQUESTS, // 429
+  api_error: StatusCodes.INTERNAL_SERVER_ERROR, // 500
+  timeout_error: StatusCodes.REQUEST_TIMEOUT, // 408
+  overloaded_error: 529,
+};
 
 /**
- * Anthropic error types that indicate transient server-side issues.
- * Checked against the raw error body when SDK class detection fails
- * (e.g., streaming SSE errors that produce generic APIError instances
- * without a proper HTTP status code).
+ * Infers an HTTP status code from the Anthropic error type in the raw error body.
+ * Handles both `{ type: "api_error" }` and `{ error: { type: "api_error" } }`.
  */
-const RETRYABLE_ANTHROPIC_ERROR_TYPES = new Set([
-  'api_error', // 500 Internal Server Error
-  'overloaded_error', // 529 Overloaded
-]);
-
-/**
- * Checks if the raw error body contains a known retryable Anthropic error type.
- * Handles both direct body (`{ type: "api_error" }`) and nested body
- * (`{ error: { type: "api_error" } }`) to cover different SDK extraction paths.
- */
-function isRetryableAnthropicErrorType(rawErrorBody: unknown): boolean {
+function inferStatusCodeFromBody(rawErrorBody: unknown): number | undefined {
   if (!isObject(rawErrorBody)) {
-    return false;
+    return undefined;
   }
   const body = rawErrorBody as { type?: unknown; error?: { type?: unknown } };
   const errorType =
@@ -363,7 +371,7 @@ function isRetryableAnthropicErrorType(rawErrorBody: unknown): boolean {
     (isObject(body.error) && isString(body.error.type)
       ? body.error.type
       : undefined);
-  return typeof errorType === 'string' && RETRYABLE_ANTHROPIC_ERROR_TYPES.has(errorType);
+  return errorType ? ANTHROPIC_ERROR_TYPE_TO_STATUS[errorType] : undefined;
 }
 
 function isRelayError(rawErrorBody: unknown): boolean {
@@ -379,33 +387,10 @@ function isRelayError(rawErrorBody: unknown): boolean {
   return isObject(nested) && '_relay' in nested;
 }
 
-function determineRetryable(
-  err: unknown,
-  statusCode?: number,
-  rawErrorBody?: unknown,
-): boolean {
+function determineRetryable(statusCode?: number, rawErrorBody?: unknown): boolean {
   if (isRelayError(rawErrorBody)) {
     return true;
   }
-
-  if (err instanceof Error) {
-    const msg = err.message;
-    // Anthropic: overloaded_error and timeout_error should be retryable
-    if (
-      msg.includes(ANTHROPIC_OVERLOADED_ERROR) ||
-      msg.includes(ANTHROPIC_TIMEOUT_ERROR)
-    ) {
-      return true;
-    }
-  }
-
-  // Check raw error body for retryable Anthropic error types (api_error = 500,
-  // overloaded_error = 529). This catches cases where the SDK produces a generic
-  // APIError without a proper HTTP status code (e.g., streaming SSE errors).
-  if (isRetryableAnthropicErrorType(rawErrorBody)) {
-    return true;
-  }
-
   return isRetryableStatusCode(statusCode);
 }
 
@@ -424,11 +409,11 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     };
   }
 
-  const sdkMatch = matchSdkError(err);
+  const sdkMatch = matchSdkError(err, rawErrorBody);
   if (sdkMatch) {
     const isRelay = isRelayError(rawErrorBody);
     const retryable =
-      determineRetryable(err, sdkMatch.statusCode, rawErrorBody) ||
+      determineRetryable(sdkMatch.statusCode, rawErrorBody) ||
       sdkMatch.retryable;
     return {
       ...sdkMatch,
@@ -473,7 +458,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     statusCode,
     statusText,
     provider,
-    retryable: determineRetryable(err, statusCode, rawErrorBody),
+    retryable: determineRetryable(statusCode, rawErrorBody),
     isRelayError: isRelay,
     requestId,
     rawErrorBody,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -359,18 +359,26 @@ const ANTHROPIC_ERROR_TYPE_TO_STATUS: Record<string, number> = {
 
 /**
  * Infers an HTTP status code from the Anthropic error type in the raw error body.
- * Handles both `{ type: "api_error" }` and `{ error: { type: "api_error" } }`.
+ * Handles both the envelope format `{ type: "error", error: { type: "api_error" } }`
+ * and the direct format `{ type: "api_error" }`.
+ *
+ * The nested path is checked first because Anthropic's canonical envelope uses
+ * `type: "error"` at the top level (not a real error type), with the actual
+ * error classification in `error.type`.
  */
 function inferStatusCodeFromBody(rawErrorBody: unknown): number | undefined {
   if (!isObject(rawErrorBody)) {
     return undefined;
   }
   const body = rawErrorBody as { type?: unknown; error?: { type?: unknown } };
-  const errorType =
-    (isString(body.type) ? body.type : undefined) ??
-    (isObject(body.error) && isString(body.error.type)
+  // Nested first: { type: "error", error: { type: "api_error" } }
+  const nestedType =
+    isObject(body.error) && isString(body.error.type)
       ? body.error.type
-      : undefined);
+      : undefined;
+  // Direct fallback: { type: "api_error" }
+  const directType = isString(body.type) ? body.type : undefined;
+  const errorType = nestedType ?? directType;
   return errorType ? ANTHROPIC_ERROR_TYPE_TO_STATUS[errorType] : undefined;
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -159,11 +159,18 @@ function matchSdkError(
     };
   }
 
-  // HTTP errors - detect status code from error object, SDK class, or error body
+  // HTTP errors - detect status code from error object, SDK class, or error body.
+  // If detectStatusCode returns a non-error code (< 400), it's likely misleading
+  // (e.g., SSE connection status 200 while the actual error is in the body),
+  // so prefer the body-inferred status code in that case.
+  const rawStatusCode = detectStatusCode(err);
   const statusCode =
-    detectStatusCode(err) ??
+    (rawStatusCode !== undefined && rawStatusCode >= 400
+      ? rawStatusCode
+      : undefined) ??
     entry.fallbackStatusCode ??
-    inferStatusCodeFromBody(rawErrorBody);
+    inferStatusCodeFromBody(rawErrorBody) ??
+    rawStatusCode;
   const statusText = detectStatusText(err, statusCode);
   const fallbackMessage = statusCode
     ? safeGetReasonPhrase(statusCode)
@@ -440,7 +447,10 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     : undefined;
   const finalMessage =
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
-  const retryable = isRelay || isRetryableStatusCode(statusCode);
+  // No status code on an unrecognized error likely means a network-level failure
+  // (DNS, proxy, TLS, etc.) — treat as retryable for safety.
+  const retryable =
+    isRelay || (statusCode ? isRetryableStatusCode(statusCode) : true);
 
   let message = finalMessage;
   if (statusCode) {

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -122,9 +122,15 @@ const SDK_ERRORS: SdkErrorEntry[] = [
   { ctor: GoogleGenAIApiError },
 ];
 
-/** All 4xx/5xx are retryable (auto-retries skipped for 401/403 via shouldAutoRetry). */
+/** Server errors (5xx), rate limits (429), and request timeouts (408) are retryable
+ *  — these are transient. Other client errors (4xx) are deterministic. */
 function isRetryableStatusCode(statusCode?: number): boolean {
-  return statusCode !== undefined && statusCode >= 400;
+  if (statusCode === undefined) return false;
+  if (statusCode >= 500) return true;
+  return (
+    statusCode === StatusCodes.TOO_MANY_REQUESTS ||
+    statusCode === StatusCodes.REQUEST_TIMEOUT
+  );
 }
 
 /** Partial result before relay detection (isRelayError/rawErrorBody added later). */
@@ -435,9 +441,14 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   const finalMessage =
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
   const retryable = isRelay || isRetryableStatusCode(statusCode);
-  const message = statusCode
-    ? `${statusText ? `HTTP ${statusCode} ${statusText}` : `HTTP ${statusCode}`} – ${finalMessage}`
-    : finalMessage;
+
+  let message = finalMessage;
+  if (statusCode) {
+    const prefix = statusText
+      ? `HTTP ${statusCode} ${statusText}`
+      : `HTTP ${statusCode}`;
+    message = `${prefix} – ${finalMessage}`;
+  }
 
   return {
     message,


### PR DESCRIPTION
## Summary
This change improves error handling for Anthropic API errors by detecting retryable error types directly from raw error response bodies. This is particularly important for streaming SSE errors that may produce generic `APIError` instances without proper HTTP status codes.

## Key Changes
- Added `RETRYABLE_ANTHROPIC_ERROR_TYPES` constant to identify transient server-side errors (`api_error` for 500 errors and `overloaded_error` for 529 errors)
- Implemented `isRetryableAnthropicErrorType()` function to check raw error bodies for retryable error types, handling both direct (`{ type: "api_error" }`) and nested (`{ error: { type: "api_error" } }`) body structures
- Updated `determineRetryable()` to check for retryable Anthropic error types before falling back to status code checks

## Implementation Details
- The new function gracefully handles different error body structures that can result from various SDK extraction paths
- This provides a fallback mechanism for cases where HTTP status codes are unavailable or unreliable (e.g., streaming errors)
- The check is performed after existing retry logic but before the final status code check, ensuring comprehensive error classification

https://claude.ai/code/session_01Cxmigf1C2psLwKvn64oubf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core provider error classification and retryability rules (notably no longer treating all 4xx as retryable), which can alter retry behavior and user-visible failures/timeouts if misclassified.
> 
> **Overview**
> Improves provider HTTP error formatting by **inferring missing/misleading Anthropic status codes from the raw error body**, including streaming/SSE cases where the SDK may surface a generic `APIError` with an incorrect/non-error status.
> 
> Tightens retry semantics to treat **only transient conditions** as retryable (5xx, 429, 408, plus relay errors), removes the previous Anthropic message-substring retry hack, and updates fallback handling so unknown errors without a status code are treated as network failures and retried.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1cf363689a869af758f30cd9e873a80518363b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->