### PR TITLE
Unify todo and plan tools into single task tracking system

### DIFF
--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -3,10 +3,8 @@ import { z } from 'zod';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import {
   TodoItemSchema,
-  PlanSchema,
   FileLocationSchema,
   type TodoItem,
-  type Plan,
   type FileLocation,
 } from '@shared/schemas';
 import { FlattenedEditRecordSchema } from '@tools/result';
@@ -230,33 +228,61 @@ const ServerToolContentStateSchema = z.object({
 
 type ServerToolContentState = z.output<typeof ServerToolContentStateSchema>;
 
-/** Internal schema for todo state snapshot. */
-const TodoStateSnapshotSchema = z.object({
+/** Callback shape for task state updates. */
+export interface TaskStateUpdate {
+  todos: TodoItem[];
+  summary: string | null;
+}
+
+/** Internal schema for task state snapshot (unified todo + plan). */
+const TaskStateSnapshotSchema = z.object({
   todos: z.array(TodoItemSchema).prefault([]),
+  summary: z.string().nullable().prefault(null),
 });
 
-type TodoStateSnapshot = z.output<typeof TodoStateSnapshotSchema>;
+type TaskStateSnapshot = z.output<typeof TaskStateSnapshotSchema>;
 
-export class TodoState {
+/**
+ * Unified task tracking state.
+ *
+ * Manages both lightweight todos and richer plan-style items in a single list.
+ * The optional `summary` provides a high-level overview (previously Plan.summary).
+ *
+ * Exposes `TodoState` and `PlanState` facades for backward compatibility
+ * during the migration period.
+ */
+export class TaskState {
   private _todos: TodoItem[] = [];
-  private _onUpdate?: (todos: TodoItem[]) => void;
+  private _summary: string | null = null;
+  private _onUpdate?: (update: TaskStateUpdate) => void;
 
-  static fromSnapshot(snapshot: unknown): TodoState {
-    const parsed = TodoStateSnapshotSchema.parse(snapshot);
-    const state = new TodoState();
+  static fromSnapshot(snapshot: unknown): TaskState {
+    const parsed = TaskStateSnapshotSchema.parse(snapshot);
+    const state = new TaskState();
     state._todos = [...parsed.todos];
+    state._summary = parsed.summary;
     return state;
   }
 
-  toSnapshot(): TodoStateSnapshot {
-    return { todos: [...this._todos] };
+  toSnapshot(): TaskStateSnapshot {
+    return {
+      todos: this._todos.map((t) => ({
+        ...t,
+        files: t.files ? [...t.files] : undefined,
+      })),
+      summary: this._summary,
+    };
   }
 
   get todos(): TodoItem[] {
     return this._todos;
   }
 
-  setOnUpdate(callback: (todos: TodoItem[]) => void): void {
+  get summary(): string | null {
+    return this._summary;
+  }
+
+  setOnUpdate(callback: (update: TaskStateUpdate) => void): void {
     this._onUpdate = callback;
   }
 
@@ -264,10 +290,24 @@ export class TodoState {
     this._onUpdate = undefined;
   }
 
-  updateTodos(todos: TodoItem[]): void {
-    if (this._todosEqual(this._todos, todos)) return;
+  updateTodos(todos: TodoItem[], summary?: string | null): void {
+    const newSummary = summary !== undefined ? summary : this._summary;
+    if (
+      this._todosEqual(this._todos, todos) &&
+      this._summary === newSummary
+    ) {
+      return;
+    }
     this._todos = todos;
-    this._onUpdate?.(todos);
+    this._summary = newSummary;
+    this._onUpdate?.({ todos: this._todos, summary: this._summary });
+  }
+
+  /** Clear the summary without changing todos. */
+  clearSummary(): void {
+    if (this._summary === null) return;
+    this._summary = null;
+    this._onUpdate?.({ todos: this._todos, summary: null });
   }
 
   private _todosEqual(a: TodoItem[], b: TodoItem[]): boolean {
@@ -275,96 +315,46 @@ export class TodoState {
     for (let i = 0; i < a.length; i++) {
       const ai = a[i],
         bi = b[i];
-      if (!ai || !bi) return false; // Guard against sparse arrays
+      if (!ai || !bi) return false;
       if (
         ai.content !== bi.content ||
         ai.status !== bi.status ||
-        ai.activeForm !== bi.activeForm
+        ai.activeForm !== bi.activeForm ||
+        ai.description !== bi.description ||
+        !this._arraysEqual(ai.files, bi.files)
       ) {
         return false;
       }
     }
     return true;
+  }
+
+  private _arraysEqual(
+    a: string[] | undefined,
+    b: string[] | undefined,
+  ): boolean {
+    if (a === b) return true;
+    if (!a || !b) return a === b;
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
   }
 
   reset(): void {
     this._todos = [];
+    this._summary = null;
   }
 }
 
-/** Internal schema for plan state snapshot. */
-const PlanStateSnapshotSchema = z.object({
-  plan: PlanSchema.nullable().prefault(null),
-});
+/**
+ * @deprecated Use TaskState directly. Kept for backward compatibility.
+ */
+export type TodoState = TaskState;
+export const TodoState = TaskState;
 
-type PlanStateSnapshot = z.output<typeof PlanStateSnapshotSchema>;
-
-export class PlanState {
-  private _plan: Plan | null = null;
-  private _onUpdate?: (plan: Plan | null) => void;
-
-  static fromSnapshot(snapshot: unknown): PlanState {
-    const parsed = PlanStateSnapshotSchema.parse(snapshot);
-    const state = new PlanState();
-    state._plan = parsed.plan;
-    return state;
-  }
-
-  toSnapshot(): PlanStateSnapshot {
-    return {
-      plan: this._plan
-        ? {
-            ...this._plan,
-            steps: this._plan.steps.map((s) => ({ ...s, files: [...s.files] })),
-          }
-        : null,
-    };
-  }
-
-  get plan(): Plan | null {
-    return this._plan;
-  }
-
-  setOnUpdate(callback: (plan: Plan | null) => void): void {
-    this._onUpdate = callback;
-  }
-
-  clearOnUpdate(): void {
-    this._onUpdate = undefined;
-  }
-
-  updatePlan(plan: Plan | null): void {
-    if (this._planEqual(this._plan, plan)) return;
-    this._plan = plan;
-    this._onUpdate?.(plan);
-  }
-
-  private _planEqual(a: Plan | null, b: Plan | null): boolean {
-    if (a === b) return true;
-    if (!a || !b) return false;
-    if (a.summary !== b.summary) return false;
-    if (a.steps.length !== b.steps.length) return false;
-    for (let i = 0; i < a.steps.length; i++) {
-      const ai = a.steps[i],
-        bi = b.steps[i];
-      if (!ai || !bi) return false;
-      if (
-        ai.title !== bi.title ||
-        ai.description !== bi.description ||
-        ai.status !== bi.status ||
-        ai.files.length !== bi.files.length ||
-        ai.files.some((f, j) => f !== bi.files[j])
-      ) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  reset(): void {
-    this._plan = null;
-  }
-}
+/**
+ * @deprecated Use TaskState directly. Kept for backward compatibility.
+ */
+export type PlanState = TaskState;
 
 export const AgentWorkspaceStateSnapshotSchema = z.object({
   assembly: ResponseAssemblyStateSchema.prefault({
@@ -380,8 +370,7 @@ export const AgentWorkspaceStateSnapshotSchema = z.object({
     readFiles: [],
     edits: [],
   }),
-  todos: TodoStateSnapshotSchema.prefault({ todos: [] }),
-  plan: PlanStateSnapshotSchema.prefault({ plan: null }),
+  tasks: TaskStateSnapshotSchema.prefault({ todos: [], summary: null }),
 });
 
 export type AgentWorkspaceSnapshot = z.output<
@@ -394,8 +383,7 @@ export class AgentWorkspaceState {
   public readonly reasoning: ReasoningCacheState;
   public readonly interactions: FileInteractionState;
   public readonly serverToolContent: ServerToolContentState;
-  public readonly todos: TodoState;
-  public readonly plan: PlanState;
+  public readonly tasks: TaskState;
 
   private constructor(
     assembly: ResponseAssemblyState,
@@ -403,16 +391,14 @@ export class AgentWorkspaceState {
     reasoning: ReasoningCacheState,
     interactions: FileInteractionState,
     serverToolContent: ServerToolContentState,
-    todos: TodoState,
-    plan: PlanState,
+    tasks: TaskState,
   ) {
     this.assembly = assembly;
     this.media = media;
     this.reasoning = reasoning;
     this.interactions = interactions;
     this.serverToolContent = serverToolContent;
-    this.todos = todos;
-    this.plan = plan;
+    this.tasks = tasks;
   }
 
   static create(): AgentWorkspaceState {
@@ -422,8 +408,7 @@ export class AgentWorkspaceState {
       ReasoningCacheStateSchema.parse({}),
       new FileInteractionState(),
       ServerToolContentStateSchema.parse({}),
-      new TodoState(),
-      new PlanState(),
+      new TaskState(),
     );
   }
 
@@ -444,8 +429,7 @@ export class AgentWorkspaceState {
       parsed.reasoning,
       FileInteractionState.fromSnapshot(parsed.interactions),
       ServerToolContentStateSchema.parse({}),
-      TodoState.fromSnapshot(parsed.todos),
-      PlanState.fromSnapshot(parsed.plan),
+      TaskState.fromSnapshot(parsed.tasks),
     );
   }
 
@@ -464,8 +448,7 @@ export class AgentWorkspaceState {
         thinkingBlocks: [...this.reasoning.thinkingBlocks],
       },
       interactions: this.interactions.toSnapshot(),
-      todos: this.todos.toSnapshot(),
-      plan: this.plan.toSnapshot(),
+      tasks: this.tasks.toSnapshot(),
     };
   }
 

--- a/src/agent/core/AgentWorkspaceState.ts
+++ b/src/agent/core/AgentWorkspaceState.ts
@@ -3,10 +3,12 @@ import { z } from 'zod';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import {
   TodoItemSchema,
+  PlanSchema,
   FileLocationSchema,
   type TodoItem,
   type FileLocation,
 } from '@shared/schemas';
+import { planToTodos } from '@shared/schemas/plan';
 import { FlattenedEditRecordSchema } from '@tools/result';
 import { pathToLocation } from '@utils/files';
 
@@ -330,8 +332,8 @@ export class TaskState {
   }
 
   private _arraysEqual(
-    a: string[] | undefined,
-    b: string[] | undefined,
+    a: string[] | null | undefined,
+    b: string[] | null | undefined,
   ): boolean {
     if (a === b) return true;
     if (!a || !b) return a === b;
@@ -356,22 +358,74 @@ export const TodoState = TaskState;
  */
 export type PlanState = TaskState;
 
-export const AgentWorkspaceStateSnapshotSchema = z.object({
-  assembly: ResponseAssemblyStateSchema.prefault({
-    lastResponse: '',
-    accumulatedOutput: '',
-  }),
-  media: MediaAttachmentStateSnapshotSchema.prefault({ files: [] }),
-  reasoning: ReasoningCacheStateSchema.prefault({
-    thinkingBlocks: [],
-    thinkingAdded: false,
-  }),
-  interactions: FileInteractionStateSnapshotSchema.prefault({
-    readFiles: [],
-    edits: [],
-  }),
-  tasks: TaskStateSnapshotSchema.prefault({ todos: [], summary: null }),
+/**
+ * Legacy snapshot schema for pre-unification snapshots that stored
+ * `todos` and `plan` as separate top-level keys.
+ */
+const LegacyTodoSnapshotSchema = z.object({
+  todos: z.array(TodoItemSchema).prefault([]),
 });
+const LegacyPlanSnapshotSchema = z.object({
+  plan: PlanSchema.nullable().prefault(null),
+});
+
+/**
+ * Migrates legacy `todos`/`plan` snapshot fields into the unified `tasks` shape.
+ * If a legacy `plan` is present, its steps are converted to todo items and
+ * merged (plan items take precedence since they carry richer metadata).
+ */
+function migrateLegacyTaskState(raw: Record<string, unknown>): TaskStateSnapshot {
+  const legacyTodos = LegacyTodoSnapshotSchema.parse(raw.todos ?? {});
+  const legacyPlan = LegacyPlanSnapshotSchema.parse(raw.plan ?? {});
+
+  if (legacyPlan.plan) {
+    const { summary, todos } = planToTodos(legacyPlan.plan);
+    return { todos, summary };
+  }
+
+  return { todos: legacyTodos.todos, summary: null };
+}
+
+export const AgentWorkspaceStateSnapshotSchema = z
+  .object({
+    assembly: ResponseAssemblyStateSchema.prefault({
+      lastResponse: '',
+      accumulatedOutput: '',
+    }),
+    media: MediaAttachmentStateSnapshotSchema.prefault({ files: [] }),
+    reasoning: ReasoningCacheStateSchema.prefault({
+      thinkingBlocks: [],
+      thinkingAdded: false,
+    }),
+    interactions: FileInteractionStateSnapshotSchema.prefault({
+      readFiles: [],
+      edits: [],
+    }),
+    tasks: TaskStateSnapshotSchema.prefault({ todos: [], summary: null }),
+    // Legacy fields — kept for migration (passthrough only)
+    todos: z.unknown().optional(),
+    plan: z.unknown().optional(),
+  })
+  .transform((parsed) => {
+    // If the new `tasks` field has data, use it as-is (new format).
+    // If it's empty/default but legacy fields exist, migrate them.
+    const hasNewTasks = parsed.tasks.todos.length > 0 || parsed.tasks.summary !== null;
+    const hasLegacyData =
+      parsed.todos !== undefined || parsed.plan !== undefined;
+
+    const tasks =
+      !hasNewTasks && hasLegacyData
+        ? migrateLegacyTaskState(parsed as Record<string, unknown>)
+        : parsed.tasks;
+
+    return {
+      assembly: parsed.assembly,
+      media: parsed.media,
+      reasoning: parsed.reasoning,
+      interactions: parsed.interactions,
+      tasks,
+    };
+  });
 
 export type AgentWorkspaceSnapshot = z.output<
   typeof AgentWorkspaceStateSnapshotSchema

--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -651,8 +651,8 @@ export function createResponseCycleFlow<C>(): Flow<
       return formatPostCompactionContext(
         subagents,
         processes,
-        services.workspace.todos.todos,
-        services.workspace.plan.plan,
+        services.workspace.tasks.todos,
+        services.workspace.tasks.summary,
       );
     },
     getDebugSaveOptions: (shared, services) => ({

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -31,8 +31,7 @@ import {
 import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import type {
   FileInteractionState,
-  PlanState,
-  TodoState,
+  TaskState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ToolResult } from '@agent/core/ToolTypes';
 import { toErrorMessage } from '@common/errors';
@@ -608,8 +607,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       call,
       this.services,
       workspace.interactions,
-      workspace.todos,
-      workspace.plan,
+      workspace.tasks,
     );
   }
 
@@ -626,8 +624,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     parsedInput: unknown,
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
-    todoState: TodoState,
-    planState: PlanState,
+    taskState: TaskState,
     onExecutionReady?: () => void,
     onToolOutput?: (chunk: string) => void,
   ): Promise<ToolResult> {
@@ -639,8 +636,9 @@ class ToolUseDispatchNode<C> extends BatchNode<
       return await withToolFileInteractionContext(
         {
           tracker,
-          todoState,
-          planState,
+          taskState,
+          todoState: taskState,
+          planState: taskState,
           streamId: options.logger.streamId,
           executionId: options.executionId,
           toolCallId: call.callId,
@@ -662,8 +660,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     call: SdkToolCall,
     options: ToolUseCycleServices<C>,
     tracker: FileInteractionState,
-    todoState: TodoState,
-    planState: PlanState,
+    taskState: TaskState,
   ): Promise<ToolExecutionResult> {
     const parsedInput = parseToolInput(call.input, call.callId, options.logger);
     const tool = options.toolRegistry.get(call.name);
@@ -719,8 +716,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
       parsedInput,
       options,
       tracker,
-      todoState,
-      planState,
+      taskState,
       onExecutionReady,
       onToolOutput,
     );
@@ -916,8 +912,8 @@ export function createToolUseCycleFlow<C>(): Flow<
       return formatPostCompactionContext(
         subagents,
         processes,
-        services.workspace.todos.todos,
-        services.workspace.plan.plan,
+        services.workspace.tasks.todos,
+        services.workspace.tasks.summary,
       );
     },
     getDebugSaveOptions: (shared, services) => ({

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -46,16 +46,12 @@ export class ToolUseCycleNode<C> extends Node<
       this.services;
 
     if (prepRes.shouldSkip) {
-      if (prepRes.workspaceState.todos.todos.length) {
+      const { tasks } = prepRes.workspaceState;
+      if (tasks.todos.length) {
         bus.emit('updateTodos', {
           streamId,
-          todos: prepRes.workspaceState.todos.todos,
-        });
-      }
-      if (prepRes.workspaceState.plan.plan) {
-        bus.emit('updatePlan', {
-          streamId,
-          plan: prepRes.workspaceState.plan.plan,
+          todos: tasks.todos,
+          summary: tasks.summary,
         });
       }
       return { outcome: 'skipped' };
@@ -86,24 +82,18 @@ export class ToolUseCycleNode<C> extends Node<
     const { onProgress, persistTodos } = this.services;
     // Serialize writes so rapid updates don't persist out of order
     let todoPersistChain = Promise.resolve();
-    prepRes.workspaceState.todos.setOnUpdate((todos) => {
+    prepRes.workspaceState.tasks.setOnUpdate(({ todos, summary }) => {
       bus.emit('updateTodos', {
         streamId,
         todos,
+        summary,
       });
       if (persistTodos) {
         todoPersistChain = todoPersistChain
           .then(() => persistTodos(todos))
           .catch(() => {});
       }
-      onProgress?.({ kind: 'todos', todos });
-    });
-    prepRes.workspaceState.plan.setOnUpdate((plan) => {
-      bus.emit('updatePlan', {
-        streamId,
-        plan,
-      });
-      onProgress?.({ kind: 'plan', plan });
+      onProgress?.({ kind: 'todos', todos, summary });
     });
 
     try {
@@ -121,8 +111,7 @@ export class ToolUseCycleNode<C> extends Node<
       }
       return { outcome: 'completed', messages: cycleShared.messages };
     } finally {
-      prepRes.workspaceState.todos.clearOnUpdate();
-      prepRes.workspaceState.plan.clearOnUpdate();
+      prepRes.workspaceState.tasks.clearOnUpdate();
       // Drain in-flight persist writes before returning so they don't
       // race with the projection's writeTodos after this node completes.
       await todoPersistChain;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -192,7 +192,7 @@ export async function runToolUseFlow<C = unknown>(
     >(prepareNode, kv);
     pf.setServices(services);
     pf.setProjection(async (s, store) => {
-      const todos = s.stateSlices?.workspaceSnapshot?.todos?.todos;
+      const todos = s.stateSlices?.workspaceSnapshot?.tasks?.todos;
       if (Array.isArray(todos) && todos.length) await store.writeTodos(todos);
       if (s.messages.length) await store.writeConversation(s.messages);
     });

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -1,8 +1,7 @@
 // Type imports
 import type {
   FileInteractionState,
-  PlanState,
-  TodoState,
+  TaskState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
@@ -15,10 +14,12 @@ export interface ToolFileInteractionContext {
   /** Agent name of the parent agent (e.g. "orchestrator", "search-agent"). */
   agentName?: string;
   tracker: FileInteractionState;
-  /** Todo state for managing task lists. Optional for backward compatibility. */
-  todoState?: TodoState;
-  /** Plan state for managing implementation plans. Optional for backward compatibility. */
-  planState?: PlanState;
+  /** Unified task state for managing todos and plans. */
+  taskState?: TaskState;
+  /** @deprecated Use taskState. Alias for backward compatibility. */
+  todoState?: TaskState;
+  /** @deprecated Use taskState. Alias for backward compatibility. */
+  planState?: TaskState;
   /** Called by tools with approval flows to trigger in-progress log after approval. */
   onExecutionReady?: () => void;
   /** Called by tools to push partial output for live streaming to the UI. */

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -17,7 +17,6 @@ import type {
   StreamTabId,
   TokenUsageStats,
   ToolEditPermission,
-  UpdatePlanPayload,
   UpdateTodosPayload,
 } from '@shared/schemas';
 
@@ -87,7 +86,6 @@ export interface ProgressEventPayloads {
   showPlanApproval: PlanApprovalPermission;
   resolvePlanApproval: { approvalId: string };
   updateTodos: UpdateTodosPayload;
-  updatePlan: UpdatePlanPayload;
   updateConversationProgress: {
     streamId: StreamTabId;
     progress: ConversationProgress;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -208,10 +208,19 @@ export class ProgressEventHandler {
         updateTodos: (ctx, { streamId, todos, summary }) => {
           ctx.state.setTodos(streamId, todos);
           ctx.state.setTodoSummary(streamId, summary ?? null);
-          // Always send when webview is available (not just active stream),
-          // since plan approval may trigger a stream switch right after.
-          if (this.webviewUpdater.isAvailable()) {
-            ctx.webviewUpdater.updateTodos(streamId, todos, summary ?? null);
+          // Plan updates (summary present) must always reach the webview
+          // because PlanApprovalCoordinator switches to this stream right
+          // after emitting. Regular todo updates use the active-stream
+          // guard to avoid unnecessary messages for non-visible streams.
+          const hasSummary = summary != null;
+          if (hasSummary) {
+            if (this.webviewUpdater.isAvailable()) {
+              ctx.webviewUpdater.updateTodos(streamId, todos, summary ?? null);
+            }
+          } else {
+            this.sendIfActive(streamId, () =>
+              ctx.webviewUpdater.updateTodos(streamId, todos, null),
+            );
           }
         },
         // Follow-up events

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -204,23 +204,14 @@ export class ProgressEventHandler {
             );
           }
         },
-        // Todo events
-        updateTodos: (ctx, { streamId, todos }) => {
+        // Task tracking events (unified todos + plan)
+        updateTodos: (ctx, { streamId, todos, summary }) => {
           ctx.state.setTodos(streamId, todos);
-          this.sendIfActive(streamId, () =>
-            ctx.webviewUpdater.updateTodos(streamId, todos),
-          );
-        },
-        // Plan events — always send when webview is available, not just
-        // when the stream is active. During initial plan creation the
-        // PlanApprovalCoordinator switches to this stream right after,
-        // but the stream may not be active yet at the time of this event.
-        // Unlike high-frequency log events, plan updates are rare and
-        // critical for the approval UX.
-        updatePlan: (ctx, { streamId, plan }) => {
-          ctx.state.setPlan(streamId, plan);
+          ctx.state.setTodoSummary(streamId, summary ?? null);
+          // Always send when webview is available (not just active stream),
+          // since plan approval may trigger a stream switch right after.
           if (this.webviewUpdater.isAvailable()) {
-            ctx.webviewUpdater.updatePlan(streamId, plan);
+            ctx.webviewUpdater.updateTodos(streamId, todos, summary ?? null);
           }
         },
         // Follow-up events
@@ -514,7 +505,7 @@ export class ProgressEventHandler {
         action: 'clear',
         activeRunId: null,
         todos: [],
-        plan: null,
+        todoSummary: null,
         queuedFollowUps: [],
         instruction: null,
       });
@@ -525,6 +516,7 @@ export class ProgressEventHandler {
 
     const { extras, activeRunId } = this.prepareStreamSyncExtras(stream);
     const todos = this.state.getTodos(stream);
+    const todoSummary = this.state.getTodoSummary(stream);
     const plan = this.state.getPlan(stream);
     const queuedFollowUps = ToolUseFollowUpQueue.getAll(stream);
 
@@ -567,6 +559,7 @@ export class ProgressEventHandler {
       action: 'render',
       ...extras,
       todos,
+      todoSummary,
       plan,
       queuedFollowUps,
       instruction,

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -43,6 +43,19 @@ export class TodoList extends LitElement {
         border-bottom: var(--border-thin) solid var(--color-border);
       }
 
+      .todo-collapsible::part(body) {
+        max-height: var(--height-xlarge);
+        overflow-y: auto;
+      }
+
+      .todo-summary {
+        font-size: var(--font-size);
+        line-height: var(--line-height-normal);
+        color: var(--color-text-secondary);
+        margin-bottom: var(--spacing-small);
+        padding: var(--spacing-tiny) 0;
+      }
+
       .todo-list {
         display: flex;
         flex-direction: column;
@@ -58,6 +71,16 @@ export class TodoList extends LitElement {
         line-height: var(--line-height-normal);
       }
 
+      .todo-item__number {
+        flex-shrink: 0;
+        font-size: var(--font-size-sm);
+        min-width: 1.4em;
+        text-align: right;
+        color: var(--color-text-secondary);
+        line-height: var(--line-height-normal);
+        margin-top: var(--border-thin);
+      }
+
       .todo-item__icon {
         flex-shrink: 0;
         font-size: var(--font-size-icon-sm);
@@ -65,9 +88,36 @@ export class TodoList extends LitElement {
         margin-top: var(--border-thin);
       }
 
-      .todo-item__content {
+      .todo-item__body {
         flex: 1;
+        min-width: 0;
+      }
+
+      .todo-item__content {
         word-break: break-word;
+      }
+
+      .todo-item__description {
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+        margin-top: var(--spacing-tiny);
+        word-break: break-word;
+      }
+
+      .todo-item__files {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--spacing-tiny);
+        margin-top: var(--spacing-small);
+      }
+
+      .todo-item__file {
+        font-size: var(--font-size-sm);
+        color: var(--vscode-textLink-foreground);
+        background: var(--vscode-badge-background);
+        padding: var(--border-thin) var(--spacing-medium);
+        border-radius: var(--border-radius);
+        font-family: var(--vscode-editor-font-family, monospace);
       }
 
       .todo-item--pending {
@@ -86,6 +136,10 @@ export class TodoList extends LitElement {
         color: var(--vscode-progressBar-background);
       }
 
+      .todo-item--in-progress .todo-item__content {
+        color: var(--vscode-progressBar-background);
+      }
+
       .todo-item--completed {
         opacity: var(--opacity-disabled);
       }
@@ -101,9 +155,15 @@ export class TodoList extends LitElement {
   ];
 
   @property({ attribute: false }) todos: TodoItem[] = [];
+  @property({ attribute: false }) summary: string | null = null;
 
   /** Open state — auto-expands on todo updates, auto-collapses when cleared. */
   @state() private open = true;
+
+  /** Whether any item has rich metadata (description or files). */
+  private get isRichMode(): boolean {
+    return this.todos.some((t) => t.description || (t.files && t.files.length > 0));
+  }
 
   protected override willUpdate(changed: PropertyValues): void {
     if (changed.has('todos')) {
@@ -124,31 +184,38 @@ export class TodoList extends LitElement {
       (t) => t.status === TODO_STATUS.COMPLETED,
     ).length;
     const total = this.todos.length;
+    const title = this.summary ? `Plan (${completed}/${total})` : `Todos (${completed}/${total})`;
 
     return html`
       <vscode-collapsible
         id=${ELEMENT_IDS.TODO_LIST_CONTAINER}
         class="todo-collapsible panel-collapsible"
-        title=${`Todos (${completed}/${total})`}
+        title=${title}
         ?open=${this.open}
         @vsc-collapsible-toggle=${this.handleCollapsibleToggle}
       >
+        ${this.summary
+          ? html`<div class="todo-summary">${this.summary}</div>`
+          : nothing}
         <div id=${ELEMENT_IDS.TODO_LIST} class="todo-list">
           ${repeat(
             this.todos,
             (_todo, index) => index,
-            (todo) => this.renderTodo(todo),
+            (todo, index) => this.renderTodo(todo, index),
           )}
         </div>
       </vscode-collapsible>
     `;
   }
 
-  private renderTodo(todo: TodoItem): TemplateResult {
+  private renderTodo(todo: TodoItem, index: number): TemplateResult {
     const status = todo.status ?? TODO_STATUS.PENDING;
     const isInProgress = status === TODO_STATUS.IN_PROGRESS;
     const icon = STATUS_ICONS[status] ?? STATUS_ICONS[TODO_STATUS.PENDING];
-    const content = isInProgress
+    const isRich = this.isRichMode;
+
+    // In simple mode, show activeForm when in progress
+    const displayContent = isInProgress && !isRich
       ? (todo.activeForm ?? todo.content)
       : todo.content;
 
@@ -161,6 +228,9 @@ export class TodoList extends LitElement {
           'todo-item--completed': status === TODO_STATUS.COMPLETED,
         })}
       >
+        ${isRich
+          ? html`<span class="todo-item__number">${index + 1}.</span>`
+          : nothing}
         <i
           class=${classMap({
             codicon: true,
@@ -169,7 +239,22 @@ export class TodoList extends LitElement {
             spin: isInProgress,
           })}
         ></i>
-        <span class="todo-item__content">${content}</span>
+        <div class="todo-item__body">
+          <div class="todo-item__content">${displayContent}</div>
+          ${todo.description
+            ? html`<div class="todo-item__description">${todo.description}</div>`
+            : nothing}
+          ${todo.files && todo.files.length > 0
+            ? html`
+                <div class="todo-item__files">
+                  ${todo.files.map(
+                    (file) =>
+                      html`<span class="todo-item__file">${file}</span>`,
+                  )}
+                </div>
+              `
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -106,7 +106,10 @@ export class ToolUseStreamContent extends LitElement {
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
 
-      <todo-list .todos=${currentState.todos}></todo-list>
+      <todo-list
+        .todos=${currentState.todos}
+        .summary=${currentState.todoSummary ?? null}
+      ></todo-list>
 
       <plan-view .plan=${currentState.plan}></plan-view>
 

--- a/src/progressView/frontend/slices/syncSlice.ts
+++ b/src/progressView/frontend/slices/syncSlice.ts
@@ -63,6 +63,8 @@ export const syncHandlers: HandlerRegistry = {
           if (isToolUseState(prev) && hasTaskData) {
             const d = draft as ToolUseStreamState;
             if (data.todos) d.todos = data.todos;
+            if (data.todoSummary !== undefined)
+              d.todoSummary = data.todoSummary;
             if (data.plan !== undefined) d.plan = data.plan;
             if (data.queuedFollowUps) d.queuedFollowUps = data.queuedFollowUps;
           }

--- a/src/progressView/frontend/slices/taskSlice.ts
+++ b/src/progressView/frontend/slices/taskSlice.ts
@@ -1,5 +1,5 @@
 /**
- * Task handlers: UPDATE_TODOS, UPDATE_PLAN.
+ * Task handlers: UPDATE_TODOS (unified todo + plan tracking).
  */
 
 import { create } from 'mutative';
@@ -14,9 +14,13 @@ export const taskHandlers: HandlerRegistry = {
     updateToolUseState(ctx, data.stream, (prev) =>
       create(prev, (draft) => {
         draft.todos = data.todos;
+        if (data.summary !== undefined) {
+          draft.todoSummary = data.summary;
+        }
       }),
     );
   },
+  // Keep UPDATE_PLAN handler for backward compatibility during migration
   [PROGRESS_VIEW_COMMANDS.UPDATE_PLAN]: (data, ctx) => {
     updateToolUseState(ctx, data.stream, (prev) =>
       create(prev, (draft) => {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -15,6 +15,7 @@ import type {
   InstructionUpdate,
   OutputFileInfo,
   PermissionPayload,
+  Plan,
   ProgressPermissionKind,
   ProgressViewPlacement,
   ProgressViewOutboundMessage,
@@ -22,7 +23,6 @@ import type {
   StreamStatus,
   StreamTabId,
   StreamTabInfo,
-  Plan,
   TodoItem,
   TokenUsageStats,
   StorageKey,
@@ -62,7 +62,8 @@ export interface SyncStreamContentPayload {
   runMissingOutputs?: Record<string, { [key: number]: string[] }>;
   contextState?: ContextState;
   todos: TodoItem[];
-  plan: Plan | null;
+  todoSummary?: string | null;
+  plan?: Plan | null;
   queuedFollowUps: string[];
   instruction: InstructionUpdate | null;
   agentCategory?: string;
@@ -341,19 +342,16 @@ export class WebviewUpdater {
     });
   }
 
-  updateTodos(stream: StreamTabId, todos: TodoItem[]): void {
+  updateTodos(
+    stream: StreamTabId,
+    todos: TodoItem[],
+    summary?: string | null,
+  ): void {
     this.sendMessage({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
       stream,
       todos,
-    });
-  }
-
-  updatePlan(stream: StreamTabId, plan: Plan | null): void {
-    this.sendMessage({
-      command: PROGRESS_VIEW_COMMANDS.UPDATE_PLAN,
-      stream,
-      plan,
+      summary: summary ?? null,
     });
   }
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -51,6 +51,8 @@ export type StreamHints = z.infer<typeof StreamHintsSchema>;
 const StreamSessionStateSchema = z.object({
   hints: StreamHintsSchema.prefault({}),
   todos: z.array(TodoItemSchema).prefault([]),
+  todoSummary: z.string().nullable().prefault(null),
+  /** @deprecated Use todos + todoSummary instead. */
   plan: PlanSchema.nullable().prefault(null),
   contextState: ContextStateDataSchema.nullable().prefault(null),
 });
@@ -234,10 +236,20 @@ export class ProgressViewState {
     return this._sessionState.get(stream)?.todos ?? [];
   }
 
+  setTodoSummary(stream: StreamTabId, summary: string | null): void {
+    this.getOrCreateSession(stream).todoSummary = summary;
+  }
+
+  getTodoSummary(stream: StreamTabId): string | null {
+    return this._sessionState.get(stream)?.todoSummary ?? null;
+  }
+
+  /** @deprecated Use setTodos + setTodoSummary. */
   setPlan(stream: StreamTabId, plan: Plan | null): void {
     this.getOrCreateSession(stream).plan = plan;
   }
 
+  /** @deprecated Use getTodos + getTodoSummary. */
   getPlan(stream: StreamTabId): Plan | null {
     return this._sessionState.get(stream)?.plan ?? null;
   }

--- a/src/shared/schemas/plan.ts
+++ b/src/shared/schemas/plan.ts
@@ -1,8 +1,21 @@
+/**
+ * Plan schemas — derived from the unified TodoItem schema.
+ *
+ * A "plan" is a todo list with a summary and richer item metadata.
+ * These schemas exist for backward compatibility and for the plan
+ * approval flow. Internally, plans are stored as todo items with
+ * optional description/files fields.
+ */
+
 import { z } from 'zod';
 
 import { StreamTabIdSchema } from './identifiers';
-import { TodoStatusSchema } from './todo';
+import { TodoItemSchema, TodoStatusSchema } from './todo';
 
+/**
+ * PlanStep is a TodoItem that requires description and files.
+ * Used by the plan approval flow and legacy API surfaces.
+ */
 export const PlanStepSchema = z.strictObject({
   title: z.string().min(1).describe('Short title for this step'),
   description: z
@@ -28,6 +41,23 @@ export const PlanSchema = z.strictObject({
     .describe('Ordered list of implementation steps'),
 });
 export type Plan = z.infer<typeof PlanSchema>;
+
+/** Convert a Plan into the unified todo format (summary + TodoItem[]). */
+export function planToTodos(plan: Plan): {
+  summary: string;
+  todos: z.infer<typeof TodoItemSchema>[];
+} {
+  return {
+    summary: plan.summary,
+    todos: plan.steps.map((step) => ({
+      content: step.title,
+      status: step.status,
+      activeForm: step.title,
+      description: step.description,
+      files: step.files.length > 0 ? step.files : undefined,
+    })),
+  };
+}
 
 export const UpdatePlanPayloadSchema = z.strictObject({
   streamId: StreamTabIdSchema,

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -210,6 +210,7 @@ export const UpdateTodosMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.UPDATE_TODOS),
   stream: StreamTabIdSchema,
   todos: z.array(TodoItemSchema),
+  summary: z.string().nullable().optional(),
 });
 
 export const UpdatePlanMessageSchema = z.object({
@@ -337,6 +338,7 @@ export const SyncStreamContentMessageSchema = z.object({
     .optional(),
   contextState: ContextStateSchema.optional(),
   todos: z.array(TodoItemSchema).optional(),
+  todoSummary: z.string().nullable().optional(),
   plan: PlanSchema.nullable().optional(),
   queuedFollowUps: z.array(z.string()).optional(),
   instruction: InstructionUpdateSchema.nullable().optional(),

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -106,6 +106,9 @@ export const ToolUseStreamStateSchema = BaseStreamStateSchema.extend({
   kind: z.literal(AGENT_CATEGORY.TOOL_USE),
   // Frontend-owned fields updated by targeted progress-view messages
   todos: z.array(TodoItemSchema).prefault([]),
+  /** Optional high-level summary for the todo list (e.g., plan overview). */
+  todoSummary: z.string().nullable().prefault(null),
+  /** @deprecated Kept for backward compatibility during migration. Use todos + todoSummary instead. */
   plan: PlanSchema.nullable().prefault(null),
   queuedFollowUps: z.array(z.string()).prefault([]),
   toolEditBypass: z.boolean().optional(),

--- a/src/shared/schemas/subagentProgress.ts
+++ b/src/shared/schemas/subagentProgress.ts
@@ -10,10 +10,11 @@
 import type { Plan } from './plan';
 import type { TodoItem } from './todo';
 
-/** Todo state changed in a tool-use subagent. */
+/** Task state changed in a tool-use subagent (covers both todos and plans). */
 export interface TodoProgressUpdate {
   readonly kind: 'todos';
   readonly todos: TodoItem[];
+  readonly summary?: string | null;
 }
 
 /** Workflow round completed. */
@@ -31,7 +32,10 @@ export interface OverviewProgressUpdate {
   readonly cost?: number;
 }
 
-/** Plan state changed in a tool-use subagent. */
+/**
+ * @deprecated Use TodoProgressUpdate with summary instead.
+ * Kept for backward compatibility during migration.
+ */
 export interface PlanProgressUpdate {
   readonly kind: 'plan';
   readonly plan: Plan | null;

--- a/src/shared/schemas/todo.ts
+++ b/src/shared/schemas/todo.ts
@@ -23,9 +23,9 @@ export const TodoItemSchema = z.strictObject({
     .min(1)
     .describe('Present continuous form for display during execution'),
   /** Optional detailed description (used for plan-style items). */
-  description: z.string().optional(),
+  description: z.string().nullish(),
   /** Optional list of files involved (used for plan-style items). */
-  files: z.array(z.string()).optional(),
+  files: z.array(z.string()).nullish(),
 });
 export type TodoItem = z.infer<typeof TodoItemSchema>;
 

--- a/src/shared/schemas/todo.ts
+++ b/src/shared/schemas/todo.ts
@@ -22,11 +22,17 @@ export const TodoItemSchema = z.strictObject({
     .string()
     .min(1)
     .describe('Present continuous form for display during execution'),
+  /** Optional detailed description (used for plan-style items). */
+  description: z.string().optional(),
+  /** Optional list of files involved (used for plan-style items). */
+  files: z.array(z.string()).optional(),
 });
 export type TodoItem = z.infer<typeof TodoItemSchema>;
 
 export const UpdateTodosPayloadSchema = z.strictObject({
   streamId: StreamTabIdSchema,
   todos: z.array(TodoItemSchema),
+  /** Optional high-level summary of the task list (replaces Plan.summary). */
+  summary: z.string().nullable().optional(),
 });
 export type UpdateTodosPayload = z.infer<typeof UpdateTodosPayloadSchema>;

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -9,14 +9,8 @@
 import { z } from 'zod';
 
 // Local imports
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
-import {
-  PlanSchema,
-  planToTodos,
-  STATUS_DISPLAY,
-  countByStatus,
-} from '@shared/schemas';
+import { PlanSchema, planToTodos } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 import { TodoWriteTool } from '@tools/todo/TodoTool';

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -1,71 +1,36 @@
 /**
- * Plan tool for creating structured implementation plans during tool-use agent sessions.
+ * Plan tool — thin wrapper that converts Plan input into unified todo format.
  *
- * Unlike todo_write (which tracks execution progress), this tool lets the agent
- * outline an implementation strategy with numbered steps, descriptions, and file
- * references — giving the user visibility into the agent's approach before and
- * during execution.
- *
- * When a new plan is created (all steps pending), the tool pauses execution and
- * waits for user approval before returning. Progress updates (steps already
- * in_progress or completed) are applied immediately without approval.
+ * @deprecated Use todo_write with summary + description + files instead.
+ * This tool is kept for backward compatibility with existing agent prompts.
  */
 
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - tools
-import { PlanState } from '@agent/core/AgentWorkspaceState';
-import {
-  planApprovalCoordinator,
-  type PlanApprovalResult,
-} from '@agent/runtime/PlanApprovalCoordinator';
+// Local imports
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
-  TODO_STATUS,
-  STATUS_DISPLAY,
   PlanSchema,
+  planToTodos,
+  STATUS_DISPLAY,
   countByStatus,
-  type Plan,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
+import { TodoWriteTool } from '@tools/todo/TodoTool';
 
 const logger = new AgentLogger('PlanTool');
 
-/** Counter for generating unique approval IDs */
-let approvalCounter = 0;
-
-/**
- * Schema for the plan tool input.
- * Uses PlanSchema from shared schemas as single source of truth.
- */
 const PlanToolInputSchema = z.strictObject({
-  /** The implementation plan */
   plan: PlanSchema.describe('The structured implementation plan'),
 });
 
 export type PlanToolInput = z.infer<typeof PlanToolInputSchema>;
 
 /**
- * Tool for creating structured implementation plans during agent sessions.
- *
- * Use this tool to:
- * - Outline a strategy before implementing complex changes
- * - Show users the planned approach with steps, descriptions, and files
- * - Track which plan steps are being worked on or completed
- *
- * Each step has:
- * - title: Short name for the step
- * - description: What the step involves
- * - status: pending | in_progress | completed
- * - files: Optional list of files involved
- *
- * When you create a NEW plan (all steps pending), execution pauses until the
- * user approves. If the user rejects, you will receive their feedback and
- * should revise your approach accordingly. Progress updates (updating step
- * statuses on an existing plan) are applied immediately.
+ * @deprecated Use todo_write with summary, description, and files fields instead.
  */
 export class PlanTool extends defineTool({
   name: 'plan',
@@ -98,133 +63,11 @@ Best practices:
 - Include file paths to help the user understand the scope`,
   schema: PlanToolInputSchema,
 }) {
+  private todoTool = new TodoWriteTool();
+
   protected async execute(input: PlanToolInput): Promise<ToolResult> {
-    const context = getCurrentToolFileInteractionContext();
-
-    if (!context?.planState) {
-      logger.warn(
-        'plan called without planState in context — plan will not persist or display in UI',
-      );
-      return {
-        summary: 'Created plan (no active session)',
-        output: this.formatPlan(input.plan),
-        diagnostics: {
-          warning: 'No active plan context — plan may not persist',
-        },
-      };
-    }
-
-    // Determine if this is a new plan (all steps pending) vs. a progress update
-    const isNewPlan = input.plan.steps.every(
-      (s) => s.status === TODO_STATUS.PENDING,
-    );
-
-    // Show the plan in the UI immediately
-    context.planState.updatePlan(input.plan);
-
-    if (isNewPlan) {
-      if (!context.streamId) {
-        logger.warn(
-          'New plan created without streamId — skipping approval gate',
-        );
-      } else {
-        return this.requestApproval(
-          input.plan,
-          context.streamId,
-          context.planState,
-        );
-      }
-    }
-
-    return this.buildProgressResult(input.plan);
-  }
-
-  /**
-   * Request user approval for a new plan. Pauses execution until approved/rejected.
-   */
-  private async requestApproval(
-    plan: Plan,
-    streamId: string,
-    planState: PlanState,
-  ): Promise<ToolResult> {
-    const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
-
-    logger.info(`Requesting approval for plan: ${plan.summary}`);
-
-    const result: PlanApprovalResult =
-      await planApprovalCoordinator.waitForApproval(streamId, {
-        approvalId,
-        plan,
-      });
-
-    if (result.action === 'approve') {
-      logger.info('Plan approved by user');
-      return {
-        summary: 'Plan approved — proceed with implementation',
-        output:
-          'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
-      };
-    }
-
-    // Rejected or timed out — clear the plan from UI
-    planState.updatePlan(null);
-
-    if (result.action === 'timeout') {
-      logger.warn('Plan approval timed out');
-      return {
-        summary: 'Plan approval timed out',
-        output:
-          'The plan approval request timed out before the user responded. Please try again or proceed without a plan.',
-        isError: true,
-      };
-    }
-
-    const feedback = result.feedback;
-    const feedbackNote = feedback
-      ? `\nUser feedback: ${feedback}`
-      : '\nNo specific feedback was provided.';
-
-    logger.info(`Plan rejected by user${feedback ? `: ${feedback}` : ''}`);
-
-    return {
-      summary: 'Plan rejected — revise approach',
-      output: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
-      isError: true,
-      ...(feedback ? { userInstruction: feedback } : {}),
-    };
-  }
-
-  /**
-   * Build result for a progress update (no approval needed).
-   */
-  private buildProgressResult(plan: Plan): ToolResult {
-    const { completed, inProgress, pending } = countByStatus(plan.steps);
-
-    const summary = `Plan updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`;
-
-    return {
-      summary,
-      output: 'OK',
-    };
-  }
-
-  /**
-   * Format the plan for display in the tool output (fallback when no UI context).
-   */
-  private formatPlan(plan: Plan): string {
-    const lines: string[] = [`Plan: ${plan.summary}`, ''];
-
-    for (let i = 0; i < plan.steps.length; i++) {
-      const step = plan.steps[i];
-      if (!step) continue;
-      const { icon, label } = STATUS_DISPLAY[step.status];
-      lines.push(`${i + 1}. ${icon} [${label}] ${step.title}`);
-      lines.push(`   ${step.description}`);
-      if (step.files.length > 0) {
-        lines.push(`   Files: ${step.files.join(', ')}`);
-      }
-    }
-
-    return lines.join('\n');
+    // Convert plan to unified todo format and delegate
+    const { summary, todos } = planToTodos(input.plan);
+    return this.todoTool.call({ todos, summary });
   }
 }

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -449,13 +449,12 @@ export function formatPostCompactionContext(
   subagents: ActiveChildInfo[],
   processes: ActiveChildInfo[],
   todos?: TodoItem[],
-  plan?: Plan | null,
+  summary?: string | null,
 ): string | null {
   const hasChildren = subagents.length > 0 || processes.length > 0;
   const hasTodos = todos != null && todos.length > 0;
-  const hasPlan = plan != null;
 
-  if (!hasChildren && !hasTodos && !hasPlan) {
+  if (!hasChildren && !hasTodos) {
     return null;
   }
 
@@ -496,11 +495,7 @@ export function formatPostCompactionContext(
   }
 
   if (hasTodos) {
-    lines.push(...formatTodoContext(todos));
-  }
-
-  if (hasPlan) {
-    lines.push(...formatPlanContext(plan));
+    lines.push(...formatTodoContext(todos, summary));
   }
 
   lines.push('</post-compaction-context>');
@@ -509,36 +504,29 @@ export function formatPostCompactionContext(
 
 /**
  * Format todo items as XML lines for post-compaction context.
+ * Includes optional summary and rich item metadata (description, files).
  */
-function formatTodoContext(todos: TodoItem[]): string[] {
-  const lines: string[] = [`<current-todos count="${todos.length}">`];
+function formatTodoContext(
+  todos: TodoItem[],
+  summary?: string | null,
+): string[] {
+  const summaryAttr = summary ? ` summary="${escapeAttr(summary)}"` : '';
+  const lines: string[] = [
+    `<current-todos count="${todos.length}"${summaryAttr}>`,
+  ];
   for (const todo of todos) {
+    const filesAttr =
+      todo.files && todo.files.length > 0
+        ? ` files="${escapeAttr(todo.files.join(', '))}"`
+        : '';
+    const descAttr = todo.description
+      ? ` description="${escapeAttr(todo.description)}"`
+      : '';
     lines.push(
-      `  <todo status="${escapeAttr(todo.status)}" activeForm="${escapeAttr(todo.activeForm)}">${escapeText(todo.content)}</todo>`,
+      `  <todo status="${escapeAttr(todo.status)}" activeForm="${escapeAttr(todo.activeForm)}"${descAttr}${filesAttr}>${escapeText(todo.content)}</todo>`,
     );
   }
   lines.push('</current-todos>');
-  return lines;
-}
-
-/**
- * Format plan as XML lines for post-compaction context.
- */
-function formatPlanContext(plan: Plan): string[] {
-  const lines: string[] = [
-    `<current-plan summary="${escapeAttr(plan.summary)}">`,
-  ];
-  for (let i = 0; i < plan.steps.length; i++) {
-    const step = plan.steps[i]!;
-    const filesAttr =
-      step.files.length > 0
-        ? ` files="${escapeAttr(step.files.join(', '))}"`
-        : '';
-    lines.push(
-      `  <step index="${i + 1}" status="${escapeAttr(step.status)}" title="${escapeAttr(step.title)}"${filesAttr}>${escapeText(step.description)}</step>`,
-    );
-  }
-  lines.push('</current-plan>');
   return lines;
 }
 

--- a/src/tools/todo/TodoTool.ts
+++ b/src/tools/todo/TodoTool.ts
@@ -1,22 +1,32 @@
 /**
- * Todo tool for managing task lists during tool-use agent sessions.
+ * Unified task tracking tool for managing todo lists and implementation plans.
  *
- * This tool allows agents to create and manage structured task lists,
- * helping track progress on complex multi-step tasks and showing
- * the user visibility into the agent's progress.
+ * This tool consolidates the previous separate `todo_write` and `plan` tools
+ * into a single tool that supports both lightweight task tracking and rich
+ * implementation plans with descriptions, file references, and approval flows.
+ *
+ * When a `summary` is provided and all items are `pending`, the tool pauses
+ * execution and waits for user approval before returning (plan mode).
  */
 
 // Third-party imports
 import { z } from 'zod';
 
 // Local imports - tools
+import { TaskState } from '@agent/core/AgentWorkspaceState';
+import {
+  planApprovalCoordinator,
+  type PlanApprovalResult,
+} from '@agent/runtime/PlanApprovalCoordinator';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { AgentLogger } from '@logger/AgentLogger';
 import {
   TODO_STATUS,
   STATUS_DISPLAY,
   TodoItemSchema,
+  PlanSchema,
   countByStatus,
+  planToTodos,
   type TodoItem,
 } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
@@ -26,31 +36,64 @@ const logger = new AgentLogger('TodoWriteTool');
 
 /**
  * Schema for the todo_write tool input.
- * Uses TodoItemSchema from eventBus/schemas as single source of truth.
+ * Supports both simple todos and rich plan-style items.
  */
 const TodoWriteInputSchema = z.strictObject({
   /** The complete updated todo list */
   todos: z
     .array(TodoItemSchema)
     .describe('The updated todo list with all current tasks'),
+  /** Optional high-level summary (triggers plan approval when all items are pending) */
+  summary: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Brief overview of the task list. When provided with all-pending items, triggers plan approval.',
+    ),
 });
 
 export type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>;
 
+/** Counter for generating unique approval IDs */
+let approvalCounter = 0;
+
 /**
- * Tool for managing task lists during agent sessions.
+ * Unified tool for managing task lists and implementation plans.
  *
  * Use this tool to:
  * - Plan complex multi-step tasks by creating a todo list
  * - Track progress by updating task statuses
  * - Show users visibility into what the agent is working on
+ * - Create implementation plans with descriptions and file references
+ *
+ * Task states:
+ * - pending: Task not yet started
+ * - in_progress: Currently working on (limit to ONE at a time)
+ * - completed: Task finished successfully
+ *
+ * Each task needs two forms:
+ * - content: Imperative form describing what to do (e.g., "Run tests")
+ * - activeForm: Present continuous form for display (e.g., "Running tests")
+ *
+ * Optional rich fields for plan-style items:
+ * - description: Detailed explanation of what the step involves
+ * - files: List of files that will be created or modified
+ *
+ * Plan mode:
+ * When you provide a `summary` and all items are "pending", this creates a
+ * plan that is presented to the user for approval. Execution pauses until
+ * they approve or reject. Progress updates (items already in_progress or
+ * completed) are applied immediately.
  *
  * Best practices:
- * - Use for tasks requiring 3+ distinct steps
- * - Mark tasks as in_progress BEFORE starting work
- * - Mark tasks as completed IMMEDIATELY after finishing
+ * - Create todos BEFORE starting complex work
+ * - Mark task as in_progress BEFORE beginning it
+ * - Mark task as completed IMMEDIATELY after finishing
+ * - Break large tasks into smaller, specific steps
+ * - Remove tasks that are no longer relevant
+ * - Use summary + description + files for implementation plans
  * - Keep only ONE task as in_progress at a time
- * - Remove tasks that become irrelevant
  */
 export class TodoWriteTool extends defineTool({
   name: 'todo_write',
@@ -60,6 +103,7 @@ Use this tool to:
 - Plan multi-step tasks by breaking them into actionable items
 - Track progress by updating task statuses (pending → in_progress → completed)
 - Give users visibility into what you're working on
+- Create implementation plans with descriptions and file references
 
 Task states:
 - pending: Task not yet started
@@ -70,61 +114,169 @@ Each task needs two forms:
 - content: Imperative form describing what to do (e.g., "Run tests")
 - activeForm: Present continuous form for display (e.g., "Running tests")
 
+Optional fields for richer plan-style items:
+- description: Detailed explanation of what the step involves
+- files: List of files that will be created or modified
+
+Plan mode:
+When you set a "summary" and all items are "pending", a plan is presented
+to the user for approval. Execution pauses until they approve or reject.
+If rejected, you receive their feedback and should revise. Progress updates
+(marking items in_progress or completed) are applied immediately.
+
 Best practices:
 - Create todos BEFORE starting complex work
 - Mark task as in_progress BEFORE beginning it
 - Mark task as completed IMMEDIATELY after finishing
 - Break large tasks into smaller, specific steps
-- Remove tasks that are no longer relevant`,
+- Remove tasks that are no longer relevant
+- Use summary + description + files for implementation plans`,
   schema: TodoWriteInputSchema,
 }) {
   protected async execute(input: TodoWriteInput): Promise<ToolResult> {
     const context = getCurrentToolFileInteractionContext();
+    const taskState = context?.taskState ?? context?.todoState;
 
-    if (!context?.todoState) {
-      // No context available - log warning and still format output
+    if (!taskState) {
       logger.warn(
-        'todo_write called without todoState in context - todos will not persist or display in UI',
+        'todo_write called without taskState in context - todos will not persist or display in UI',
       );
       return {
         summary: 'Updated todo list (no active session)',
-        output: this.formatTodoList(input.todos),
+        output: this.formatTodoList(input.todos, input.summary),
         diagnostics: {
           warning: 'No active todo context - todos may not persist',
         },
       };
     }
 
-    // Update the todos in workspace state
-    // This triggers the onUpdate callback which emits events to the UI
-    context.todoState.updateTodos(input.todos);
+    const summary = input.summary ?? null;
+    const isNewPlan =
+      summary !== null &&
+      input.todos.length > 0 &&
+      input.todos.every((t) => t.status === TODO_STATUS.PENDING);
+
+    // Update state immediately (shows in UI)
+    taskState.updateTodos(input.todos, summary);
+
+    if (isNewPlan && context?.streamId) {
+      return this.requestApproval(
+        input.todos,
+        summary!,
+        context.streamId,
+        taskState,
+      );
+    }
 
     const { completed, inProgress, pending } = countByStatus(input.todos);
-
-    const summary = `Todo list updated: ${completed} completed, ${inProgress} in progress, ${pending} pending`;
-
-    // Return minimal output - the UI already shows the input, no need to repeat the list
+    const summaryText = summary ? `Plan: ${summary} — ` : '';
     return {
-      summary,
+      summary: `${summaryText}${completed} completed, ${inProgress} in progress, ${pending} pending`,
       output: 'OK',
     };
   }
 
   /**
-   * Format the todo list for display in the tool output.
+   * Request user approval for a new plan. Pauses execution until approved/rejected.
    */
-  private formatTodoList(todos: TodoItem[]): string {
+  private async requestApproval(
+    todos: TodoItem[],
+    summary: string,
+    streamId: string,
+    taskState: TaskState,
+  ): Promise<ToolResult> {
+    const approvalId = `plan-${Date.now().toString(36)}-${++approvalCounter}`;
+
+    logger.info(`Requesting approval for plan: ${summary}`);
+
+    // Build Plan object for the approval flow
+    const plan = {
+      summary,
+      steps: todos.map((t) => ({
+        title: t.content,
+        description: t.description ?? t.content,
+        status: t.status,
+        files: t.files ?? [],
+      })),
+    };
+    // Validate with PlanSchema
+    PlanSchema.parse(plan);
+
+    const result: PlanApprovalResult =
+      await planApprovalCoordinator.waitForApproval(streamId, {
+        approvalId,
+        plan,
+      });
+
+    if (result.action === 'approve') {
+      logger.info('Plan approved by user');
+      return {
+        summary: 'Plan approved — proceed with implementation',
+        output:
+          'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
+      };
+    }
+
+    // Rejected or timed out — clear the plan from UI
+    taskState.updateTodos([], null);
+
+    if (result.action === 'timeout') {
+      logger.warn('Plan approval timed out');
+      return {
+        summary: 'Plan approval timed out',
+        output:
+          'The plan approval request timed out before the user responded. Please try again or proceed without a plan.',
+        isError: true,
+      };
+    }
+
+    const feedback = result.feedback;
+    const feedbackNote = feedback
+      ? `\nUser feedback: ${feedback}`
+      : '\nNo specific feedback was provided.';
+
+    logger.info(`Plan rejected by user${feedback ? `: ${feedback}` : ''}`);
+
+    return {
+      summary: 'Plan rejected — revise approach',
+      output: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
+      isError: true,
+      ...(feedback ? { userInstruction: feedback } : {}),
+    };
+  }
+
+  /**
+   * Format the todo list for display in the tool output (fallback when no UI context).
+   */
+  private formatTodoList(
+    todos: TodoItem[],
+    summary?: string | null,
+  ): string {
     if (todos.length === 0) {
       return 'Todo list is empty.';
     }
 
-    const lines: string[] = ['Current todo list:', ''];
+    const lines: string[] = [];
+    if (summary) {
+      lines.push(`Plan: ${summary}`, '');
+    } else {
+      lines.push('Current todo list:', '');
+    }
 
     for (let i = 0; i < todos.length; i++) {
       const todo = todos[i];
       const { icon, label } = STATUS_DISPLAY[todo.status];
       lines.push(`${i + 1}. ${icon} [${label}] ${todo.content}`);
-      if (todo.status === TODO_STATUS.IN_PROGRESS) {
+      if (todo.description) {
+        lines.push(`   ${todo.description}`);
+      }
+      if (todo.files && todo.files.length > 0) {
+        lines.push(`   Files: ${todo.files.join(', ')}`);
+      }
+      if (
+        todo.status === TODO_STATUS.IN_PROGRESS &&
+        !todo.description
+      ) {
         lines.push(`   → ${todo.activeForm}...`);
       }
     }


### PR DESCRIPTION
## Summary

Consolidates the separate `todo_write` and `plan` tools into a unified task tracking system. The `plan` tool now delegates to `todo_write`, which supports both lightweight task lists and rich implementation plans with descriptions, file references, and approval flows.

## Key Changes

- **Unified TaskState**: Replaced separate `TodoState` and `PlanState` classes with a single `TaskState` that manages both todos and an optional summary. Maintains backward compatibility through type aliases.

- **Enhanced todo_write tool**: 
  - Added optional `summary` field to trigger plan approval when all items are pending
  - Added support for `description` and `files` fields on todo items for richer metadata
  - Integrated plan approval flow directly into the tool
  - Improved documentation with plan mode behavior and best practices

- **Simplified plan tool**: Now a thin wrapper that converts `Plan` input to unified todo format via new `planToTodos()` helper function, delegating to `todo_write`.

- **Updated UI components**:
  - `TodoList` now displays summary, descriptions, and file references
  - Added rich mode detection to show numbered items and metadata when present
  - Improved styling for descriptions and file badges

- **Unified event system**: 
  - Consolidated `updateTodos` and `updatePlan` events into single `updateTodos` event with optional summary
  - Updated `ProgressEventHandler` to handle unified task state
  - Removed separate plan event handling

- **Context and state management**:
  - `ToolFileInteractionContext` now provides single `taskState` instead of separate `todoState`/`planState`
  - Updated all tool dispatch and execution paths to use unified state
  - Maintained backward compatibility aliases for migration period

- **Post-compaction context**: Updated `formatPostCompactionContext()` to include todo summary and rich item metadata (description, files) in a single XML structure.

## Implementation Details

- Plan approval flow remains unchanged but is now triggered from `todo_write` when `summary` is provided with all-pending items
- Backward compatibility maintained through type aliases and dual property exposure in context
- `planToTodos()` conversion preserves all step information (title→content, description, files, status)
- Task state updates trigger callbacks with both todos and summary for consistent UI synchronization

https://claude.ai/code/session_01N4gEs4nAXETwmxTBgQUTQx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool-use state serialization/migration, tool approval gating, and progress-view messaging; mistakes could break persistence or the plan-approval UX across runs.
> 
> **Overview**
> Unifies todo + plan tracking into a single `TaskState` stored on the workspace as `tasks` (todos + optional `summary`), including snapshot migration from legacy `todos`/`plan` fields and updated post-compaction context formatting.
> 
> Moves plan-approval behavior into `todo_write`: it now accepts optional `summary` plus richer per-item metadata (`description`, `files`) and triggers approval when `summary` is set and all items are `pending`; the legacy `plan` tool is reduced to a wrapper that converts a `Plan` to the unified todo format.
> 
> Updates progress-view plumbing and UI to carry/display `todoSummary` via `updateTodos` (deprecating `updatePlan` usage), and enhances `TodoList` rendering to show summary, descriptions, and file badges with a richer layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afac8bc6e27a7f8f9445818d5dc223ca9fa1649f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->