### PR TITLE
Refactor agent tooltip handling and remove selection description

### DIFF
--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -8,7 +8,7 @@ import { repeat } from 'lit/directives/repeat.js';
 import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 import { AGENT_DECORATORS, getModelProviderDecorator } from './icons';
 
-function buildAgentTooltip(opt: AgentOptionData): string {
+export function buildAgentTooltip(opt: AgentOptionData): string {
   const { properties } = AGENT_DECORATORS;
   const hints: string[] = [];
 

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -14,6 +14,7 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared schemas and types
 import type { AgentOptionData } from '@shared/schemas';
+import { buildAgentTooltip } from '@shared/commons';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -185,7 +186,6 @@ export class InstructionPanel extends LitElement {
         top: auto;
       }
 
-
       .recording {
         color: var(--vscode-errorForeground);
         animation: pulse 1s infinite;
@@ -210,11 +210,11 @@ export class InstructionPanel extends LitElement {
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
 
-  /** Build a tooltip string for the currently selected agent. */
-  private getAgentTooltip(): string {
+  /** Resolve the AgentOptionData for the currently selected agent. */
+  private getSelectedAgentOption(): AgentOptionData | undefined {
     const session = this.sessionData;
-    if (!session) return '';
-    const options: AgentOptionData[] =
+    if (!session) return undefined;
+    const options =
       session.sessionType === SESSION_TYPES.WORKFLOW
         ? session.workflowAgentOptions
         : session.toolUseAgentOptions;
@@ -222,8 +222,7 @@ export class InstructionPanel extends LitElement {
       session.sessionType === SESSION_TYPES.WORKFLOW
         ? session.workflowAgent
         : session.toolUseAgent;
-    const opt = options.find((o) => o.value === selectedValue);
-    return opt?.description ?? '';
+    return options.find((o) => o.value === selectedValue);
   }
 
   private handleSessionTypeChange(event: Event): void {
@@ -310,12 +309,15 @@ export class InstructionPanel extends LitElement {
     );
   }
 
-
   override render(): TemplateResult | typeof nothing {
     const session = this.sessionData;
     if (!session) {
       return nothing;
     }
+    const selectedAgent = this.getSelectedAgentOption();
+    const agentTooltip = selectedAgent
+      ? buildAgentTooltip(selectedAgent)
+      : '';
     return html`
       <div class="instruction-box">
         <div class="instruction-header">
@@ -442,7 +444,7 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="workflow"
                     aria-label="Workflow agent"
-                    title=${this.getAgentTooltip() || nothing}
+                    title=${agentTooltip || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.WORKFLOW
                       ? 0
                       : -1}
@@ -470,7 +472,7 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="toolUse"
                     aria-label="Tool-use agent"
-                    title=${this.getAgentTooltip() || nothing}
+                    title=${agentTooltip || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.TOOL_USE
                       ? 0
                       : -1}

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -13,7 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared schemas and types
-import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+import type { AgentOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -185,21 +185,6 @@ export class InstructionPanel extends LitElement {
         top: auto;
       }
 
-      .selection-description {
-        font-size: var(--font-size-xs);
-        color: var(--color-text-secondary, var(--vscode-descriptionForeground));
-        line-height: var(--line-height-normal, 1.4);
-        padding-top: var(--spacing-tiny);
-        min-height: 1.2em;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        transition: opacity var(--transition-fast);
-      }
-
-      .selection-description:empty {
-        display: none;
-      }
 
       .recording {
         color: var(--vscode-errorForeground);
@@ -225,8 +210,8 @@ export class InstructionPanel extends LitElement {
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
 
-  /** Build a short description for the currently selected agent. */
-  private getSelectedAgentDescription(): string {
+  /** Build a tooltip string for the currently selected agent. */
+  private getAgentTooltip(): string {
     const session = this.sessionData;
     if (!session) return '';
     const options: AgentOptionData[] =
@@ -239,17 +224,6 @@ export class InstructionPanel extends LitElement {
         : session.toolUseAgent;
     const opt = options.find((o) => o.value === selectedValue);
     return opt?.description ?? '';
-  }
-
-  /** Build a short description for the currently selected model. */
-  private getSelectedModelDescription(): string {
-    const session = this.sessionData;
-    if (!session) return '';
-    const opt = session.modelOptions.find(
-      (o: ModelOptionData) => o.value === session.model,
-    );
-    if (!opt) return '';
-    return opt.hint ?? '';
   }
 
   private handleSessionTypeChange(event: Event): void {
@@ -336,22 +310,6 @@ export class InstructionPanel extends LitElement {
     );
   }
 
-  private renderSelectionDescription(): TemplateResult | typeof nothing {
-    const agentDesc = this.getSelectedAgentDescription();
-    const modelDesc = this.getSelectedModelDescription();
-
-    // Combine: prefer showing both, separated by a dash
-    const parts: string[] = [];
-    if (agentDesc) parts.push(agentDesc);
-    if (modelDesc) parts.push(modelDesc);
-    const text = parts.join(' — ');
-
-    if (!text) return nothing;
-
-    return html`<div class="selection-description" title=${text}>
-      ${text}
-    </div>`;
-  }
 
   override render(): TemplateResult | typeof nothing {
     const session = this.sessionData;
@@ -484,6 +442,7 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="workflow"
                     aria-label="Workflow agent"
+                    title=${this.getAgentTooltip() || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.WORKFLOW
                       ? 0
                       : -1}
@@ -511,6 +470,7 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="toolUse"
                     aria-label="Tool-use agent"
+                    title=${this.getAgentTooltip() || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.TOOL_USE
                       ? 0
                       : -1}
@@ -559,7 +519,6 @@ export class InstructionPanel extends LitElement {
             @click=${this.handleExecute}
           ></vscode-button>
         </div>
-        ${this.renderSelectionDescription()}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
This PR refactors how agent tooltips are displayed in the InstructionPanel component by moving tooltip generation logic to a shared utility function and simplifying the UI rendering.

## Key Changes
- **Exported `buildAgentTooltip` function** from `selectTemplates.ts` to make it reusable across components
- **Removed `renderSelectionDescription()` method** that previously combined agent and model descriptions into a single UI element
- **Removed `.selection-description` CSS styles** that are no longer needed
- **Simplified agent description retrieval** by creating `getSelectedAgentOption()` method that returns the full `AgentOptionData` object instead of just the description string
- **Removed `getSelectedModelDescription()` method** as model descriptions are no longer displayed in this component
- **Added direct tooltip attributes** to agent selection buttons using the shared `buildAgentTooltip()` function

## Implementation Details
- The agent tooltip is now computed once during render and applied directly to the workflow and tool-use agent buttons via the `title` attribute
- This change consolidates tooltip generation logic in a shared utility, reducing duplication and improving maintainability
- The removal of the combined selection description simplifies the UI while maintaining agent information accessibility through button tooltips

https://claude.ai/code/session_01PF5oBAViAHPSYaqmav6agz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that centralizes tooltip text generation and removes the combined agent/model description line; main risk is minor UX regression if users relied on the inline description.
> 
> **Overview**
> **Agent tooltip generation is centralized and reused across components.** `buildAgentTooltip` is now exported from `selectTemplates.ts` (and re-exported via `@shared/commons`) so `InstructionPanel` can compute the tooltip for the currently selected agent.
> 
> **InstructionPanel UI is simplified.** The inline combined agent/model selection description (and its `.selection-description` styling) is removed, and the computed agent tooltip is applied via the `title` attribute on both agent dropdowns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f74d9283001c26b9d715ded4245b2b38f580694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->