### PR TITLE
Refactor selection descriptions to use native tooltips

### DIFF
--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -13,7 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared schemas and types
-import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
+import type { AgentOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -185,22 +185,6 @@ export class InstructionPanel extends LitElement {
         top: auto;
       }
 
-      .selection-description {
-        font-size: var(--font-size-xs);
-        color: var(--color-text-secondary, var(--vscode-descriptionForeground));
-        line-height: var(--line-height-normal, 1.4);
-        padding-top: var(--spacing-tiny);
-        min-height: 1.2em;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        transition: opacity var(--transition-fast);
-      }
-
-      .selection-description:empty {
-        display: none;
-      }
-
       .recording {
         color: var(--vscode-errorForeground);
         animation: pulse 1s infinite;
@@ -225,31 +209,12 @@ export class InstructionPanel extends LitElement {
   @query('#instruction')
   private instructionTextarea?: HTMLElement;
 
-  /** Build a short description for the currently selected agent. */
-  private getSelectedAgentDescription(): string {
-    const session = this.sessionData;
-    if (!session) return '';
-    const options: AgentOptionData[] =
-      session.sessionType === SESSION_TYPES.WORKFLOW
-        ? session.workflowAgentOptions
-        : session.toolUseAgentOptions;
-    const selectedValue =
-      session.sessionType === SESSION_TYPES.WORKFLOW
-        ? session.workflowAgent
-        : session.toolUseAgent;
-    const opt = options.find((o) => o.value === selectedValue);
-    return opt?.description ?? '';
-  }
-
-  /** Build a short description for the currently selected model. */
-  private getSelectedModelDescription(): string {
-    const session = this.sessionData;
-    if (!session) return '';
-    const opt = session.modelOptions.find(
-      (o: ModelOptionData) => o.value === session.model,
-    );
-    if (!opt) return '';
-    return opt.hint ?? '';
+  /** Get the tooltip for an agent dropdown based on the selected agent's description. */
+  private getAgentTooltip(
+    options: AgentOptionData[],
+    selectedValue: string,
+  ): string {
+    return options.find((o) => o.value === selectedValue)?.description ?? '';
   }
 
   private handleSessionTypeChange(event: Event): void {
@@ -334,23 +299,6 @@ export class InstructionPanel extends LitElement {
         text: 'Choose the AI model used by the selected agent.',
       }),
     );
-  }
-
-  private renderSelectionDescription(): TemplateResult | typeof nothing {
-    const agentDesc = this.getSelectedAgentDescription();
-    const modelDesc = this.getSelectedModelDescription();
-
-    // Combine: prefer showing both, separated by a dash
-    const parts: string[] = [];
-    if (agentDesc) parts.push(agentDesc);
-    if (modelDesc) parts.push(modelDesc);
-    const text = parts.join(' — ');
-
-    if (!text) return nothing;
-
-    return html`<div class="selection-description" title=${text}>
-      ${text}
-    </div>`;
   }
 
   override render(): TemplateResult | typeof nothing {
@@ -484,6 +432,10 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="workflow"
                     aria-label="Workflow agent"
+                    title=${this.getAgentTooltip(
+                      session.workflowAgentOptions,
+                      session.workflowAgent,
+                    ) || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.WORKFLOW
                       ? 0
                       : -1}
@@ -511,6 +463,10 @@ export class InstructionPanel extends LitElement {
                     })}
                     data-session-type="toolUse"
                     aria-label="Tool-use agent"
+                    title=${this.getAgentTooltip(
+                      session.toolUseAgentOptions,
+                      session.toolUseAgent,
+                    ) || nothing}
                     tabindex=${session.sessionType === SESSION_TYPES.TOOL_USE
                       ? 0
                       : -1}
@@ -559,7 +515,6 @@ export class InstructionPanel extends LitElement {
             @click=${this.handleExecute}
           ></vscode-button>
         </div>
-        ${this.renderSelectionDescription()}
       </div>
     `;
   }

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -13,7 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 // Local imports - shared schemas and types
-import type { AgentOptionData } from '@shared/schemas';
+import type { AgentOptionData, ModelOptionData } from '@shared/schemas';
 
 // Local imports - shared styles
 import { designTokens } from '@shared/styles';
@@ -215,6 +215,14 @@ export class InstructionPanel extends LitElement {
     selectedValue: string,
   ): string {
     return options.find((o) => o.value === selectedValue)?.description ?? '';
+  }
+
+  /** Get the tooltip for the model dropdown based on the selected model's hint. */
+  private getModelTooltip(
+    options: ModelOptionData[],
+    selectedValue: string,
+  ): string {
+    return options.find((o) => o.value === selectedValue)?.hint ?? '';
   }
 
   private handleSessionTypeChange(event: Event): void {
@@ -499,6 +507,10 @@ export class InstructionPanel extends LitElement {
                 id="model"
                 position="above"
                 aria-label="Model"
+                title=${this.getModelTooltip(
+                  session.modelOptions,
+                  session.model,
+                ) || nothing}
                 .value=${session.model}
                 @focus=${this.handleModelFocus}
                 @change=${this.handleModelChange}


### PR DESCRIPTION
## Summary
Refactored the InstructionPanel component to display agent descriptions via native HTML `title` attributes instead of a separate rendered description element. This simplifies the UI while maintaining the same information accessibility.

## Key Changes
- Removed the `.selection-description` CSS class and associated styling
- Removed the `renderSelectionDescription()` method that combined agent and model descriptions
- Removed `getSelectedAgentDescription()` and `getSelectedModelDescription()` methods
- Added new `getAgentTooltip()` helper method that extracts agent descriptions from options
- Updated both workflow and tool-use agent dropdowns to use `title` attribute with agent descriptions via `getAgentTooltip()`
- Removed the rendered description element from the template
- Removed unused `ModelOptionData` import

## Implementation Details
The refactoring moves from displaying descriptions in a dedicated UI element to using native browser tooltips on the dropdown elements themselves. The `getAgentTooltip()` method is a more focused utility that retrieves the description for a specific agent option, replacing the previous session-aware methods. This approach reduces DOM complexity while preserving user access to agent descriptions through standard tooltip behavior.

https://claude.ai/code/session_011brPapevKrn6EJ6yPj3Dqp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor limited to `InstructionPanel` presentation; main behavioral change is removal of the inline description element in favor of `title` tooltips.
> 
> **Overview**
> Refactors `InstructionPanel` to stop rendering the inline `.selection-description` text under the selectors and instead surface agent/model descriptions via native `title` tooltips on the `vscode-single-select` dropdowns.
> 
> Replaces the session-aware description builders with small helper lookups (`getAgentTooltip`, `getModelTooltip`) and removes the associated CSS and render method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73b72d7ecba5d557b89a05a0ec5f03314317206c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->