### PR TITLE
Prevent agent category mismatch when launching agents

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -164,6 +164,23 @@ async function resolveAgentBase(
     resolution.entry.source,
   );
 
+  // Block category mismatch: prevent launching a tool-use agent as a workflow
+  // (or vice versa). The config payload's agentCategory is optional — only
+  // enforce when explicitly provided so that callers who omit it (accepting
+  // whatever the YAML defines) are unaffected.
+  if (
+    configPayload.agentCategory &&
+    configPayload.agentCategory !== setting.agentCategory
+  ) {
+    const suggestion =
+      setting.agentCategory === AgentCategory.ToolUse
+        ? 'delegate_agent'
+        : 'delegate_workflow';
+    throw new Error(
+      `Agent '${fullConfig.agent}' is a ${setting.agentCategory} agent but was launched as ${configPayload.agentCategory}. Use ${suggestion} instead.`,
+    );
+  }
+
   await validateModelExists(fullConfig.model);
 
   const useMultipleOutputs =

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -140,6 +140,8 @@ interface ResolveAgentOptions {
   streamTabIdOverride?: StreamTabId;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
+  /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
+  enforceCategory?: boolean;
 }
 
 async function resolveAgentBase(
@@ -165,10 +167,11 @@ async function resolveAgentBase(
   );
 
   // Block category mismatch: prevent launching a tool-use agent as a workflow
-  // (or vice versa). The config payload's agentCategory is optional — only
-  // enforce when explicitly provided so that callers who omit it (accepting
-  // whatever the YAML defines) are unaffected.
+  // (or vice versa). Only enforced when the caller opts in via enforceCategory,
+  // because many code paths pass pre-parsed configs where agentCategory was
+  // prefaulted to Workflow by the schema (not explicitly chosen by the caller).
   if (
+    options?.enforceCategory &&
     configPayload.agentCategory &&
     configPayload.agentCategory !== setting.agentCategory
   ) {
@@ -474,6 +477,7 @@ async function resolveAndAcquireStream(
     streamTabIdOverride?: StreamTabId;
     taskType?: string;
     onBeforeActivation?: (streamId: StreamTabId) => void;
+    enforceCategory?: boolean;
   },
 ): Promise<ResolvedAgentBase> {
   if (options?.streamTabIdOverride) {
@@ -481,6 +485,7 @@ async function resolveAndAcquireStream(
     return resolveAgentBase(configPayload, executionId, {
       streamTabIdOverride: options.streamTabIdOverride,
       onBeforeActivation: options?.onBeforeActivation,
+      enforceCategory: options?.enforceCategory,
     });
   }
 
@@ -504,6 +509,7 @@ async function resolveAndAcquireStream(
   try {
     ctx = await resolveAgentBase(configPayload, executionId, {
       onBeforeActivation: options?.onBeforeActivation,
+      enforceCategory: options?.enforceCategory,
     });
   } catch (err) {
     StreamStatusService.releaseIfInitializing(preliminaryStreamId);
@@ -539,6 +545,13 @@ async function resolveAndAcquireStream(
 export interface ExecuteAgentOptions {
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
+  /**
+   * When true, enforce that configPayload.agentCategory matches the agent's
+   * YAML-defined category. Callers that explicitly set a category (e.g.
+   * DelegationTools) should opt in; callers that pass pre-parsed configs with
+   * prefaulted defaults (e.g. runExecuteCommand) should leave this off.
+   */
+  enforceCategory?: boolean;
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
   /** Fires with the real streamId before the stream is activated (before UI sync). */
@@ -558,6 +571,7 @@ export async function executeAgent(
 ): Promise<AgentFlowResult> {
   const ctx = await resolveAndAcquireStream(configPayload, executionId, {
     onBeforeActivation: options?.onStreamResolved,
+    enforceCategory: options?.enforceCategory,
   });
   const { setting, streamId, config } = ctx;
   const agentName = config.agent;

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -205,6 +205,7 @@ async function executeSubagent(
 
   const promise = executeAgent(configPayload, executionId, {
     isSubagent: true,
+    enforceCategory: true,
     parentStreamId: orchestratorStreamId,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;


### PR DESCRIPTION
## Summary
Added validation to prevent launching agents with mismatched categories. This ensures that tool-use agents cannot be launched as workflows and vice versa, improving error handling and user guidance.

## Key Changes
- Added category validation in `resolveAgentBase()` that compares the requested `agentCategory` from the config payload against the actual agent's category from the YAML definition
- The validation only enforces when `agentCategory` is explicitly provided in the config payload, allowing callers who omit it to accept whatever category is defined in the YAML
- When a mismatch is detected, throws a descriptive error message that suggests the correct delegation method (`delegate_agent` for tool-use agents, `delegate_workflow` for workflow agents)

## Implementation Details
- The check is placed after agent resolution but before model validation
- The optional nature of `agentCategory` in the config payload is respected, maintaining backward compatibility with existing callers that don't specify it
- Error messages provide actionable guidance by recommending the appropriate delegation method based on the agent's actual category

https://claude.ai/code/session_01BvQtkrwSz2ygX9oFgAL4YD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new runtime validation that can throw and block agent launches for callers opting in (notably delegation), potentially changing execution paths and error handling.
> 
> **Overview**
> Prevents executing an agent under the wrong category by adding an *opt-in* `enforceCategory` check during agent resolution that rejects when `configPayload.agentCategory` conflicts with the agent’s YAML-defined category, with an error suggesting `delegate_agent` vs `delegate_workflow`.
> 
> Threads `enforceCategory` through `resolveAndAcquireStream`/`executeAgent` options, and enables it for subagent launches in `DelegationTools` so delegated executions fail fast on category mismatch rather than running with the wrong flow type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b6e1712fc644d136c4410a114b4a249ebe58a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->