### PR TITLE
Add zotero_collections tool to list Zotero collections

### DIFF
--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -142,7 +142,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   },
   {
     id: 'zotero',
-    tools: ['zotero_search', 'zotero_add', 'zotero_export'],
+    tools: ['zotero_collections', 'zotero_search', 'zotero_add', 'zotero_export'],
     name: 'Zotero Integration',
     category: 'academic',
     description:

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -33,7 +33,12 @@ import { CrossrefDoiTool, CrossrefSearchTool } from './citation';
 import { PlanTool } from './plan';
 import { TodoWriteTool } from './todo';
 import { MemoryTool } from './memory';
-import { ZoteroAddTool, ZoteroSearchTool, ZoteroExportTool } from './zotero';
+import {
+  ZoteroAddTool,
+  ZoteroCollectionsTool,
+  ZoteroSearchTool,
+  ZoteroExportTool,
+} from './zotero';
 import { CodexTool } from './codex';
 import {
   LeanDiagnosticsTool,
@@ -85,6 +90,7 @@ function createDefaultTools() {
     crossref_doi: new CrossrefDoiTool(),
     crossref_search: new CrossrefSearchTool(),
     zotero_add: new ZoteroAddTool(),
+    zotero_collections: new ZoteroCollectionsTool(),
     zotero_search: new ZoteroSearchTool(),
     zotero_export: new ZoteroExportTool(),
     wolfram: new WolframTool(),

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -1,0 +1,207 @@
+/**
+ * List Zotero collections via Better BibTeX JSON-RPC API.
+ *
+ * Returns the collection tree with keys so the agent can pass
+ * a collection key to `zotero_add`. Does one thing: queries
+ * the collection hierarchy. No paper searching, no side effects.
+ *
+ * Requires the Better BibTeX plugin to be installed in Zotero.
+ * See: https://retorque.re/zotero-better-bibtex/exporting/json-rpc/
+ */
+
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports - core
+import { defineTool } from '@tools/core/define';
+
+// Local imports - zotero
+import {
+  callBetterBibTeX,
+  getZoteroPort,
+  type BbtCollection,
+  type BbtLibrary,
+} from './bbtClient';
+
+const ZoteroCollectionsInputSchema = z.strictObject({
+  query: z
+    .string()
+    .describe(
+      'Optional name to filter collections (case-insensitive partial match).',
+    )
+    .nullish(),
+  library: z
+    .string()
+    .describe(
+      'Optional library name to list collections from. Omit for all libraries.',
+    )
+    .nullish(),
+});
+
+type ZoteroCollectionsInput = z.infer<typeof ZoteroCollectionsInputSchema>;
+
+/**
+ * Build a tree from a flat list of collections using parentCollection references.
+ * Returns root-level collections with children nested.
+ */
+interface CollectionNode {
+  key: string;
+  name: string;
+  children: CollectionNode[];
+}
+
+function buildTree(collections: BbtCollection[]): CollectionNode[] {
+  const nodeMap = new Map<string, CollectionNode>();
+  const roots: CollectionNode[] = [];
+
+  // Create all nodes
+  for (const c of collections) {
+    nodeMap.set(c.key, { key: c.key, name: c.name, children: [] });
+  }
+
+  // Link children to parents
+  for (const c of collections) {
+    const node = nodeMap.get(c.key)!;
+    if (c.parentCollection && typeof c.parentCollection === 'string') {
+      const parent = nodeMap.get(c.parentCollection);
+      if (parent) {
+        parent.children.push(node);
+        continue;
+      }
+    }
+    roots.push(node);
+  }
+
+  return roots;
+}
+
+/**
+ * Format a collection tree as indented text with keys.
+ */
+function formatTree(nodes: CollectionNode[], indent: number = 0): string[] {
+  const lines: string[] = [];
+  const prefix = '  '.repeat(indent);
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const isLast = i === nodes.length - 1;
+    const connector = indent === 0 ? '' : isLast ? '└── ' : '├── ';
+    const childPrefix = indent === 0 ? '' : isLast ? '    ' : '│   ';
+
+    lines.push(`${prefix}${connector}${node.name}/ [${node.key}]`);
+
+    if (node.children.length > 0) {
+      const childLines = formatTree(
+        node.children,
+        0, // reset indent — we handle prefix manually
+      );
+      for (const line of childLines) {
+        lines.push(`${prefix}${childPrefix}${line}`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Filter tree nodes by query, keeping ancestors of matching nodes.
+ */
+function filterTree(
+  nodes: CollectionNode[],
+  query: string,
+): CollectionNode[] {
+  const lowerQuery = query.toLowerCase();
+
+  function matches(node: CollectionNode): CollectionNode | null {
+    const nameMatches = node.name.toLowerCase().includes(lowerQuery);
+    const filteredChildren = node.children
+      .map((child) => matches(child))
+      .filter((c): c is CollectionNode => c !== null);
+
+    if (nameMatches || filteredChildren.length > 0) {
+      return { key: node.key, name: node.name, children: filteredChildren };
+    }
+    return null;
+  }
+
+  return nodes
+    .map((n) => matches(n))
+    .filter((n): n is CollectionNode => n !== null);
+}
+
+export class ZoteroCollectionsTool extends defineTool({
+  name: 'zotero_collections',
+  description:
+    'List Zotero collections with their keys. ' +
+    'Use this to discover collection keys before adding items with zotero_add. ' +
+    'Optionally filter by name or library. ' +
+    'Requires Better BibTeX plugin to be installed in Zotero.',
+  schema: ZoteroCollectionsInputSchema,
+}) {
+  protected async execute({ query, library }: ZoteroCollectionsInput) {
+    const port = getZoteroPort();
+
+    const libraries = await callBetterBibTeX<BbtLibrary[]>(
+      'user.groups',
+      [true],
+      port,
+    );
+
+    if (!Array.isArray(libraries) || libraries.length === 0) {
+      return {
+        summary: 'No libraries found in Zotero.',
+        output: 'No libraries found. Is Zotero running with items in your library?',
+      };
+    }
+
+    // Filter by library name if specified
+    const targetLibraries = library
+      ? libraries.filter(
+          (lib) => lib.name.toLowerCase() === library.toLowerCase(),
+        )
+      : libraries;
+
+    if (targetLibraries.length === 0) {
+      const available = libraries.map((lib) => lib.name).join(', ');
+      return {
+        summary: `Library "${library}" not found.`,
+        output: `Library "${library}" not found. Available libraries: ${available}`,
+      };
+    }
+
+    const outputParts: string[] = [];
+    let totalCollections = 0;
+
+    for (const lib of targetLibraries) {
+      const collections = lib.collections ?? [];
+      if (collections.length === 0) continue;
+
+      let tree = buildTree(collections);
+
+      if (query) {
+        tree = filterTree(tree, query);
+      }
+
+      if (tree.length === 0) continue;
+
+      totalCollections += collections.length;
+      outputParts.push(`Library: ${lib.name}`);
+      outputParts.push(...formatTree(tree, 1));
+    }
+
+    if (outputParts.length === 0) {
+      const context = query ? ` matching "${query}"` : '';
+      return {
+        summary: `No collections found${context}.`,
+        output: `No collections found${context}.`,
+      };
+    }
+
+    const context = query ? ` matching "${query}"` : '';
+    return {
+      summary: `Found ${totalCollections} collection${totalCollections === 1 ? '' : 's'}${context} across ${targetLibraries.length} ${targetLibraries.length === 1 ? 'library' : 'libraries'}.`,
+      output: outputParts.join('\n'),
+    };
+  }
+}

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -89,28 +89,43 @@ function buildTree(collections: BbtCollection[]): CollectionNode[] {
 }
 
 /**
- * Format a collection tree as indented text with keys.
+ * Count all nodes in a collection tree (including nested children).
  */
-function formatTree(nodes: CollectionNode[], indent: number = 0): string[] {
+function countNodes(nodes: CollectionNode[]): number {
+  let count = 0;
+  for (const node of nodes) {
+    count += 1 + countNodes(node.children);
+  }
+  return count;
+}
+
+/**
+ * Format a collection tree as indented text with keys.
+ * Uses prefix-passing to correctly indent arbitrarily deep trees.
+ */
+function formatTree(
+  nodes: CollectionNode[],
+  indent: number = 0,
+  parentPrefix: string = '',
+): string[] {
   const lines: string[] = [];
-  const prefix = '  '.repeat(indent);
+  const basePrefix = indent > 0 ? parentPrefix : '  '.repeat(indent);
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     const isLast = i === nodes.length - 1;
     const connector = indent === 0 ? '' : isLast ? '└── ' : '├── ';
-    const childPrefix = indent === 0 ? '' : isLast ? '    ' : '│   ';
+    const childContinuation = indent === 0 ? '' : isLast ? '    ' : '│   ';
 
-    lines.push(`${prefix}${connector}${node.name}/ [${node.key}]`);
+    lines.push(`${basePrefix}${connector}${node.name}/ [${node.key}]`);
 
     if (node.children.length > 0) {
       const childLines = formatTree(
         node.children,
-        0, // reset indent — we handle prefix manually
+        1,
+        `${basePrefix}${childContinuation}`,
       );
-      for (const line of childLines) {
-        lines.push(`${prefix}${childPrefix}${line}`);
-      }
+      lines.push(...childLines);
     }
   }
 
@@ -247,6 +262,7 @@ export class ZoteroCollectionsTool extends defineTool({
 
     const outputParts: string[] = [];
     let totalCollections = 0;
+    let librariesWithResults = 0;
 
     for (const lib of targetLibraries) {
       const collections = lib.collections ?? [];
@@ -260,7 +276,8 @@ export class ZoteroCollectionsTool extends defineTool({
 
       if (tree.length === 0) continue;
 
-      totalCollections += collections.length;
+      totalCollections += countNodes(tree);
+      librariesWithResults++;
       outputParts.push(`Library: ${lib.name}`);
       outputParts.push(...formatTree(tree, 1));
     }
@@ -275,7 +292,7 @@ export class ZoteroCollectionsTool extends defineTool({
 
     const context = query ? ` matching "${query}"` : '';
     return {
-      summary: `Found ${totalCollections} collection${totalCollections === 1 ? '' : 's'}${context} across ${targetLibraries.length} ${targetLibraries.length === 1 ? 'library' : 'libraries'}.`,
+      summary: `Found ${totalCollections} collection${totalCollections === 1 ? '' : 's'}${context} across ${librariesWithResults} ${librariesWithResults === 1 ? 'library' : 'libraries'}.`,
       output: outputParts.join('\n'),
     };
   }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -1,9 +1,10 @@
 /**
  * List Zotero collections via Better BibTeX JSON-RPC API.
  *
- * Returns the collection tree with keys so the agent can pass
- * a collection key to `zotero_add`. Does one thing: queries
- * the collection hierarchy. No paper searching, no side effects.
+ * Two modes:
+ * - **Tree mode** (default): list the full collection hierarchy via `user.groups`
+ * - **Lookup mode** (citekeys provided): show which collections contain specific
+ *   papers via `item.collections`
  *
  * Requires the Better BibTeX plugin to be installed in Zotero.
  * See: https://retorque.re/zotero-better-bibtex/exporting/json-rpc/
@@ -20,6 +21,7 @@ import {
   callBetterBibTeX,
   getZoteroPort,
   type BbtCollection,
+  type BbtCollectionChain,
   type BbtLibrary,
 } from './bbtClient';
 
@@ -27,13 +29,24 @@ const ZoteroCollectionsInputSchema = z.strictObject({
   query: z
     .string()
     .describe(
-      'Optional name to filter collections (case-insensitive partial match).',
+      'Optional name to filter collections (case-insensitive partial match). ' +
+        'Only used in tree mode (when citekeys is not provided).',
     )
     .nullish(),
   library: z
     .string()
     .describe(
-      'Optional library name to list collections from. Omit for all libraries.',
+      'Optional library name to list collections from. Omit for all libraries. ' +
+        'Only used in tree mode (when citekeys is not provided).',
+    )
+    .nullish(),
+  citekeys: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Look up which collections contain these citation keys. ' +
+        'Returns the full collection path for each citekey. ' +
+        'When provided, query and library are ignored.',
     )
     .nullish(),
 });
@@ -130,18 +143,79 @@ function filterTree(
     .filter((n): n is CollectionNode => n !== null);
 }
 
+/**
+ * Flatten a nested parent chain into a breadcrumb path.
+ * e.g. { name: "ML", parentCollection: { name: "Research", parentCollection: false } }
+ *  → "Research / ML"
+ */
+function collectionPath(chain: BbtCollectionChain): string {
+  const parts: string[] = [];
+  let current: BbtCollectionChain | false | undefined = chain;
+  while (current && current !== false) {
+    parts.unshift(`${current.name} [${current.key}]`);
+    current = current.parentCollection;
+  }
+  return parts.join(' / ');
+}
+
 export class ZoteroCollectionsTool extends defineTool({
   name: 'zotero_collections',
   description:
-    'List Zotero collections with their keys. ' +
-    'Use this to discover collection keys before adding items with zotero_add. ' +
-    'Optionally filter by name or library. ' +
+    'List Zotero collections with their keys, or look up which collections contain specific citation keys. ' +
+    'Use this to discover collection keys before adding items with zotero_add, ' +
+    'or to find out where a paper is filed. ' +
     'Requires Better BibTeX plugin to be installed in Zotero.',
   schema: ZoteroCollectionsInputSchema,
 }) {
-  protected async execute({ query, library }: ZoteroCollectionsInput) {
+  protected async execute({
+    query,
+    library,
+    citekeys,
+  }: ZoteroCollectionsInput) {
     const port = getZoteroPort();
 
+    // ── Lookup mode: which collections contain these citekeys? ──
+    if (citekeys?.length) {
+      return this.executeLookup(citekeys, port);
+    }
+
+    // ── Tree mode: list the collection hierarchy ──
+    return this.executeTree(query, library, port);
+  }
+
+  private async executeLookup(citekeys: string[], port: number) {
+    const result = await callBetterBibTeX<
+      Record<string, BbtCollectionChain[]>
+    >('item.collections', [citekeys, true], port);
+
+    const lines: string[] = [];
+    let found = 0;
+
+    for (const key of citekeys) {
+      const collections = result[key];
+      if (!collections || collections.length === 0) {
+        lines.push(`[${key}] — not in any collection`);
+        continue;
+      }
+      found++;
+      const paths = collections.map((c) => collectionPath(c));
+      lines.push(`[${key}]`);
+      for (const path of paths) {
+        lines.push(`  ${path}`);
+      }
+    }
+
+    return {
+      summary: `Found collection info for ${found} of ${citekeys.length} citekey${citekeys.length === 1 ? '' : 's'}.`,
+      output: lines.join('\n'),
+    };
+  }
+
+  private async executeTree(
+    query: string | null | undefined,
+    library: string | null | undefined,
+    port: number,
+  ) {
     const libraries = await callBetterBibTeX<BbtLibrary[]>(
       'user.groups',
       [true],
@@ -151,7 +225,8 @@ export class ZoteroCollectionsTool extends defineTool({
     if (!Array.isArray(libraries) || libraries.length === 0) {
       return {
         summary: 'No libraries found in Zotero.',
-        output: 'No libraries found. Is Zotero running with items in your library?',
+        output:
+          'No libraries found. Is Zotero running with items in your library?',
       };
     }
 

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -1,10 +1,9 @@
 /**
  * List Zotero collections via Better BibTeX JSON-RPC API.
  *
- * Two modes:
- * - **Tree mode** (default): list the full collection hierarchy via `user.groups`
- * - **Lookup mode** (citekeys provided): show which collections contain specific
- *   papers via `item.collections`
+ * Returns the collection tree with keys so the agent can pass
+ * a collection key to `zotero_add`. Does one thing: queries
+ * the collection hierarchy. No paper searching, no side effects.
  *
  * Requires the Better BibTeX plugin to be installed in Zotero.
  * See: https://retorque.re/zotero-better-bibtex/exporting/json-rpc/
@@ -21,7 +20,6 @@ import {
   callBetterBibTeX,
   getZoteroPort,
   type BbtCollection,
-  type BbtCollectionChain,
   type BbtLibrary,
 } from './bbtClient';
 
@@ -29,24 +27,13 @@ const ZoteroCollectionsInputSchema = z.strictObject({
   query: z
     .string()
     .describe(
-      'Optional name to filter collections (case-insensitive partial match). ' +
-        'Only used in tree mode (when citekeys is not provided).',
+      'Optional name to filter collections (case-insensitive partial match).',
     )
     .nullish(),
   library: z
     .string()
     .describe(
-      'Optional library name to list collections from. Omit for all libraries. ' +
-        'Only used in tree mode (when citekeys is not provided).',
-    )
-    .nullish(),
-  citekeys: z
-    .array(z.string())
-    .min(1)
-    .describe(
-      'Look up which collections contain these citation keys. ' +
-        'Returns the full collection path for each citekey. ' +
-        'When provided, query and library are ignored.',
+      'Optional library name to list collections from. Omit for all libraries.',
     )
     .nullish(),
 });
@@ -170,79 +157,18 @@ function filterTree(nodes: CollectionNode[], query: string): FilterResult {
   return { tree, matchCount };
 }
 
-/**
- * Flatten a nested parent chain into a breadcrumb path.
- * e.g. { name: "ML", parentCollection: { name: "Research", parentCollection: false } }
- *  → "Research / ML"
- */
-function collectionPath(chain: BbtCollectionChain): string {
-  const parts: string[] = [];
-  let current: BbtCollectionChain | false | undefined = chain;
-  while (current && current !== false) {
-    parts.unshift(`${current.name} [${current.key}]`);
-    current = current.parentCollection;
-  }
-  return parts.join(' / ');
-}
-
 export class ZoteroCollectionsTool extends defineTool({
   name: 'zotero_collections',
   description:
-    'List Zotero collections with their keys, or look up which collections contain specific citation keys. ' +
-    'Use this to discover collection keys before adding items with zotero_add, ' +
-    'or to find out where a paper is filed. ' +
+    'List Zotero collections (folders) with their keys. ' +
+    'Use this to discover collection keys before adding items with zotero_add. ' +
+    'To see which collections a paper belongs to, use zotero_search with include_collections instead. ' +
     'Requires Better BibTeX plugin to be installed in Zotero.',
   schema: ZoteroCollectionsInputSchema,
 }) {
-  protected async execute({
-    query,
-    library,
-    citekeys,
-  }: ZoteroCollectionsInput) {
+  protected async execute({ query, library }: ZoteroCollectionsInput) {
     const port = getZoteroPort();
 
-    // ── Lookup mode: which collections contain these citekeys? ──
-    if (citekeys?.length) {
-      return this.executeLookup(citekeys, port);
-    }
-
-    // ── Tree mode: list the collection hierarchy ──
-    return this.executeTree(query, library, port);
-  }
-
-  private async executeLookup(citekeys: string[], port: number) {
-    const result = await callBetterBibTeX<
-      Record<string, BbtCollectionChain[]>
-    >('item.collections', [citekeys, true], port);
-
-    const lines: string[] = [];
-    let found = 0;
-
-    for (const key of citekeys) {
-      const collections = result[key];
-      if (!collections || collections.length === 0) {
-        lines.push(`[${key}] — not in any collection`);
-        continue;
-      }
-      found++;
-      const paths = collections.map((c) => collectionPath(c));
-      lines.push(`[${key}]`);
-      for (const path of paths) {
-        lines.push(`  ${path}`);
-      }
-    }
-
-    return {
-      summary: `Found collection info for ${found} of ${citekeys.length} citekey${citekeys.length === 1 ? '' : 's'}.`,
-      output: lines.join('\n'),
-    };
-  }
-
-  private async executeTree(
-    query: string | null | undefined,
-    library: string | null | undefined,
-    port: number,
-  ) {
     const libraries = await callBetterBibTeX<BbtLibrary[]>(
       'user.groups',
       [true],

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -133,19 +133,29 @@ function formatTree(
 }
 
 /**
- * Filter tree nodes by query, keeping ancestors of matching nodes.
+ * Result of filtering a tree: the pruned tree plus how many nodes
+ * actually matched by name (excluding ancestors kept only for context).
  */
-function filterTree(
-  nodes: CollectionNode[],
-  query: string,
-): CollectionNode[] {
-  const lowerQuery = query.toLowerCase();
+interface FilterResult {
+  tree: CollectionNode[];
+  matchCount: number;
+}
 
-  function matches(node: CollectionNode): CollectionNode | null {
+/**
+ * Filter tree nodes by query, keeping ancestors of matching nodes.
+ * Returns both the filtered tree and the count of actual name-matches.
+ */
+function filterTree(nodes: CollectionNode[], query: string): FilterResult {
+  const lowerQuery = query.toLowerCase();
+  let matchCount = 0;
+
+  function visit(node: CollectionNode): CollectionNode | null {
     const nameMatches = node.name.toLowerCase().includes(lowerQuery);
     const filteredChildren = node.children
-      .map((child) => matches(child))
+      .map((child) => visit(child))
       .filter((c): c is CollectionNode => c !== null);
+
+    if (nameMatches) matchCount++;
 
     if (nameMatches || filteredChildren.length > 0) {
       return { key: node.key, name: node.name, children: filteredChildren };
@@ -153,9 +163,11 @@ function filterTree(
     return null;
   }
 
-  return nodes
-    .map((n) => matches(n))
+  const tree = nodes
+    .map((n) => visit(n))
     .filter((n): n is CollectionNode => n !== null);
+
+  return { tree, matchCount };
 }
 
 /**
@@ -268,18 +280,24 @@ export class ZoteroCollectionsTool extends defineTool({
       const collections = lib.collections ?? [];
       if (collections.length === 0) continue;
 
-      let tree = buildTree(collections);
+      const fullTree = buildTree(collections);
 
       if (query) {
-        tree = filterTree(tree, query);
+        const { tree, matchCount } = filterTree(fullTree, query);
+        if (tree.length === 0) continue;
+
+        totalCollections += matchCount;
+        librariesWithResults++;
+        outputParts.push(`Library: ${lib.name}`);
+        outputParts.push(...formatTree(tree, 1));
+      } else {
+        if (fullTree.length === 0) continue;
+
+        totalCollections += countNodes(fullTree);
+        librariesWithResults++;
+        outputParts.push(`Library: ${lib.name}`);
+        outputParts.push(...formatTree(fullTree, 1));
       }
-
-      if (tree.length === 0) continue;
-
-      totalCollections += countNodes(tree);
-      librariesWithResults++;
-      outputParts.push(`Library: ${lib.name}`);
-      outputParts.push(...formatTree(tree, 1));
     }
 
     if (outputParts.length === 0) {

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -15,6 +15,7 @@ import { defineTool } from '@tools/core/define';
 import {
   callBetterBibTeX,
   getZoteroPort,
+  type BbtCollectionChain,
   type BbtSearchResultItem,
 } from './bbtClient';
 
@@ -45,6 +46,13 @@ const ZoteroSearchInputSchema = z
       .string()
       .describe(
         'Optional library name to search in. Use "*" to search all libraries.',
+      )
+      .nullish(),
+    include_collections: z
+      .boolean()
+      .describe(
+        'When true, each result includes the Zotero collections (folders) it belongs to, ' +
+          'shown as breadcrumb paths. Useful for understanding how the library is organized.',
       )
       .nullish(),
   })
@@ -106,6 +114,19 @@ function formatSearchResult(item: BbtSearchResultItem): string {
   return `[${citekey}] ${title}${creatorPart}${yearPart} [${type}]`;
 }
 
+/**
+ * Flatten a nested parent chain into a breadcrumb path.
+ */
+function collectionPath(chain: BbtCollectionChain): string {
+  const parts: string[] = [];
+  let current: BbtCollectionChain | false | undefined = chain;
+  while (current && current !== false) {
+    parts.unshift(current.name);
+    current = current.parentCollection;
+  }
+  return parts.join(' / ');
+}
+
 export class ZoteroSearchTool extends defineTool({
   name: 'zotero_search',
   description:
@@ -120,6 +141,7 @@ export class ZoteroSearchTool extends defineTool({
     author,
     year,
     library,
+    include_collections,
   }: ZoteroSearchInput) {
     const port = getZoteroPort();
 
@@ -151,12 +173,41 @@ export class ZoteroSearchTool extends defineTool({
       };
     }
 
+    // Optionally fetch collection membership for each result
+    const collectionMap = include_collections
+      ? await this.fetchCollections(
+          result.map((r) => r.citekey).filter(Boolean),
+          port,
+        )
+      : null;
+
     // Format results
-    const items = result.map((item) => formatSearchResult(item));
+    const items = result.map((item) => {
+      const base = formatSearchResult(item);
+      if (!collectionMap) return base;
+
+      const chains = collectionMap[item.citekey];
+      if (!chains || chains.length === 0) return base;
+
+      const paths = chains.map((c) => collectionPath(c));
+      return `${base}\n  Filed in: ${paths.join(', ')}`;
+    });
 
     return {
       summary: `Found ${result.length} item${result.length === 1 ? '' : 's'} matching ${label}`,
       output: items.join('\n'),
     };
+  }
+
+  private async fetchCollections(
+    citekeys: string[],
+    port: number,
+  ): Promise<Record<string, BbtCollectionChain[]>> {
+    if (citekeys.length === 0) return {};
+    return callBetterBibTeX<Record<string, BbtCollectionChain[]>>(
+      'item.collections',
+      [citekeys, true],
+      port,
+    );
   }
 }

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -173,10 +173,9 @@ export class ZoteroSearchTool extends defineTool({
       };
     }
 
-    // Optionally fetch collection membership for each result
     const collectionMap = include_collections
       ? await this.fetchCollections(
-          result.map((r) => r.citekey).filter(Boolean),
+          result.map((r) => r.citekey),
           port,
         )
       : null;

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -69,6 +69,24 @@ export interface CslDate {
 }
 
 /**
+ * Zotero collection metadata returned by `user.groups(true)`.
+ */
+export interface BbtCollection {
+  key: string;
+  name: string;
+  parentCollection?: string | false;
+}
+
+/**
+ * Library (group) entry returned by `user.groups`.
+ */
+export interface BbtLibrary {
+  id: number;
+  name: string;
+  collections?: BbtCollection[];
+}
+
+/**
  * CSL JSON item returned by Better BibTeX item.search.
  *
  * This is standard CSL JSON (from Zotero.Utilities.Item.itemToCSLJSON)

--- a/src/tools/zotero/bbtClient.ts
+++ b/src/tools/zotero/bbtClient.ts
@@ -87,6 +87,17 @@ export interface BbtLibrary {
 }
 
 /**
+ * Collection with nested parent chain, returned by `item.collections(citekeys, true)`.
+ * When `includeParents` is true, `parentCollection` is recursively expanded
+ * into a full object instead of a key string.
+ */
+export interface BbtCollectionChain {
+  key: string;
+  name: string;
+  parentCollection?: BbtCollectionChain | false;
+}
+
+/**
  * CSL JSON item returned by Better BibTeX item.search.
  *
  * This is standard CSL JSON (from Zotero.Utilities.Item.itemToCSLJSON)

--- a/src/tools/zotero/index.ts
+++ b/src/tools/zotero/index.ts
@@ -1,3 +1,4 @@
 export { ZoteroAddTool } from './ZoteroAddTool';
+export { ZoteroCollectionsTool } from './ZoteroCollectionsTool';
 export { ZoteroSearchTool } from './ZoteroSearchTool';
 export { ZoteroExportTool } from './ZoteroExportTool';


### PR DESCRIPTION
## Summary
This PR adds a new `zotero_collections` tool that allows agents to discover and list Zotero collections with their keys. This tool is essential for agents to identify the correct collection key before adding items to Zotero using the existing `zotero_add` tool.

## Key Changes
- **New Tool**: Added `ZoteroCollectionsTool` class that queries the Better BibTeX JSON-RPC API to retrieve and display the collection hierarchy
- **Collection Tree Building**: Implemented tree-building logic to organize flat collection lists into a hierarchical structure based on parent-child relationships
- **Filtering & Formatting**: Added support for filtering collections by name (case-insensitive partial match) and formatting output as an indented tree with collection keys
- **Library Support**: Tool can optionally filter results by library name, or display collections from all libraries
- **Type Definitions**: Added `BbtCollection` and `BbtLibrary` interfaces to `bbtClient.ts` to support the new functionality
- **Tool Registration**: Registered the new tool in the tool registry and external tool definitions

## Notable Implementation Details
- The tool uses a two-pass tree-building algorithm: first creating all nodes, then linking children to parents based on `parentCollection` references
- Collection filtering preserves ancestor nodes of matching collections, maintaining the tree structure context
- Output formatting uses ASCII tree characters (├──, └──, │) for visual hierarchy at root level, with proper indentation for nested collections
- The tool returns both a summary (count of collections found) and formatted output showing the collection tree with keys for agent reference
- Requires the Better BibTeX plugin to be installed in Zotero, consistent with other Zotero tools

https://claude.ai/code/session_01Y3Dr282LkK9yXoLY91hntZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Zotero JSON-RPC integration surface (`zotero_collections`) and extends `zotero_search` output when `include_collections` is enabled, which could affect agents relying on prior output formatting or expose new failure modes if the Better BibTeX API responses differ from expectations.
> 
> **Overview**
> Adds a new `zotero_collections` tool that queries Better BibTeX (`user.groups(true)`) to list Zotero libraries’ collection hierarchies, with optional filtering by library name and case-insensitive collection name query, and outputs an indented tree including collection keys for use with `zotero_add`.
> 
> Extends `zotero_search` with an `include_collections` flag that fetches each item’s collection breadcrumb paths via `item.collections(..., true)` and appends them to the formatted search results.
> 
> Registers the new tool across the system (tool registry, `src/tools/zotero/index.ts`, and external tool definitions) and adds the needed Better BibTeX response types (`BbtCollection`, `BbtLibrary`, `BbtCollectionChain`) to `bbtClient.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f74e179833c8bb6789d50e8d6d3b5d600ddcf311. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->