### PR TITLE
Add support for MiniMax and GLM model providers

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -237,6 +237,8 @@ TeXRA also loads environment variables from a `.env` file in your workspace. Def
 - **DeepSeek API Key**: Available from [DeepSeek Platform](https://platform.deepseek.com/api_keys)
 - **Moonshot API Key**: Available from [Moonshot Console](https://platform.moonshot.cn/console)
 - **DashScope API Key**: Available from [DashScope Console](https://dashscope.aliyun.com/api-console/)
+- **MiniMax API Key**: Available from [MiniMax Platform](https://platform.minimax.io/) (international) or [MiniMax China](https://platform.minimaxi.com/) (China region)
+- **GLM API Key**: Available from [Z.AI](https://z.ai/) (international) or [BigModel](https://open.bigmodel.cn/) (China region)
   :::
 
 ## Verifying Installation

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -77,6 +77,7 @@ MiniMax uses interleaved thinking (chain-of-thought woven into responses). API k
 
 - **International**: Get your API key at [platform.minimax.io](https://platform.minimax.io/)
 - **China**: Get your API key at [platform.minimaxi.com](https://platform.minimaxi.com/)
+- **Coding Plan**: MiniMax offers monthly subscription plans ($10/$20/$50/mo) as an alternative to pay-as-you-go. Coding Plan keys are **not interchangeable** with standard API keys — enter your Coding Plan key via "Set API Key" as usual. [Subscribe here](https://platform.minimax.io/subscribe/coding-plan).
 
 ## GLM (Zhipu AI / Z.AI) Models
 
@@ -92,6 +93,7 @@ GLM models support thinking mode (reasoning is shown inline). The API uses a non
 
 - **International (Z.AI)**: Get your API key at [z.ai](https://z.ai/) — endpoint: api.z.ai
 - **China (BigModel)**: Get your API key at [open.bigmodel.cn](https://open.bigmodel.cn/) — endpoint: open.bigmodel.cn (default)
+- **Coding Plan**: GLM offers monthly subscription plans as an alternative to pay-as-you-go, with access to all GLM models. Coding Plan uses a separate endpoint (`/api/coding/paas/v4`). Enable the "Coding Plan" toggle in the Models tab. [Subscribe here](https://z.ai/subscribe).
 
 ## Grok / xAI Models
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -66,6 +66,33 @@ GPT-5 reasoning summaries require account verification. Enable with `texra.model
 | `qwenplus`  | Hybrid thinking, 1M context   | $$   | Medium |
 | `qwenturbo` | Fast with optional thinking   | $    | Fast   |
 
+## MiniMax Models
+
+| Model ID      | Use Case                       | Cost | Speed  |
+| :------------ | :----------------------------- | :--- | :----- |
+| `minimaxM27`  | Flagship with interleaved thinking | $$   | Medium |
+| `minimaxM25`  | Strong all-rounder             | $$   | Medium |
+
+MiniMax uses interleaved thinking (chain-of-thought woven into responses). API keys are region-specific — international keys (api.minimax.io) and China keys (api.minimaxi.com) are not interchangeable. Toggle the region in the Models tab.
+
+- **International**: Get your API key at [platform.minimax.io](https://platform.minimax.io/)
+- **China**: Get your API key at [platform.minimaxi.com](https://platform.minimaxi.com/)
+
+## GLM (Zhipu AI / Z.AI) Models
+
+| Model ID      | Use Case                         | Cost | Speed  |
+| :------------ | :------------------------------- | :--- | :----- |
+| `glm5`        | Flagship open-source model       | $$$  | Medium |
+| `glm5turbo`   | Fast inference, agent-optimized  | $$$  | Medium |
+| `glm47`       | Programming and multi-step reasoning | $$   | Medium |
+| `glm46v`      | Multimodal vision model          | $$   | Medium |
+| `glm45`       | Hybrid reasoning (MoE)           | $$   | Medium |
+
+GLM models support thinking mode (reasoning is shown inline). The API uses a non-standard base path (`/api/paas/v4`), which TeXRA handles automatically.
+
+- **International (Z.AI)**: Get your API key at [z.ai](https://z.ai/) — endpoint: api.z.ai
+- **China (BigModel)**: Get your API key at [open.bigmodel.cn](https://open.bigmodel.cn/) — endpoint: open.bigmodel.cn (default)
+
 ## Grok / xAI Models
 
 | Model ID | Use Case                        | Cost | Speed  |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,6 +1,6 @@
 # Supported AI Providers
 
-_Last Updated: February 10, 2026_
+_Last Updated: March 19, 2026_
 
 The following table lists the AI model providers supported by TeXRA, along with their operating headquarters and links to their respective terms and privacy policies. When you select a provider, your content is transmitted to that provider's API endpoints and is subject to their terms.
 
@@ -14,6 +14,8 @@ The following table lists the AI model providers supported by TeXRA, along with 
 | DeepSeek            | Hangzhou, China        | [Terms](https://cdn.deepseek.com/policies/en-US/deepseek-terms-of-use.html) · [Privacy](https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html)              |
 | Moonshot AI (Kimi)  | Beijing, China         | [Terms](https://platform.moonshot.ai/docs/agreement/modeluse) · [Privacy](https://platform.moonshot.ai/docs/agreement/userprivacy)                                         |
 | DashScope (Alibaba) | Hangzhou, China        | [Terms](https://www.alibabacloud.com/help/en/legal/) · [Privacy](https://www.alibabacloud.com/help/en/legal/latest/alibaba-cloud-international-website-privacy-policy)     |
+| MiniMax             | Beijing, China         | [Terms](https://www.minimax.io/platform/protocol/terms-of-service) · [Privacy](https://www.minimax.io/platform/protocol/privacy-policy)                                    |
+| Zhipu AI (GLM)      | Beijing, China         | [Terms](https://docs.z.ai/legal-agreement/terms-of-use) · [Privacy](https://docs.z.ai/legal-agreement/privacy-policy)                                                     |
 
 ## Access Modes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.38",
         "lit": "^3.3.2",
-        "llm-zoo": "^1.1.4",
+        "llm-zoo": "^1.2.0",
         "mark.js": "^8.11.1",
         "markdown-it": "^14.1.1",
         "markdown-it-texmath": "^1.0.0",
@@ -7735,9 +7735,9 @@
       }
     },
     "node_modules/llm-zoo": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.1.4.tgz",
-      "integrity": "sha512-kd3rM8tHv9AI5oE8t+clKjA/mQ7HfhS82qMF4yJ5qgw8VKMBJrb0YNFVXc9tw6+kLBB7Udz7okKXBLtDIyEhZA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.2.0.tgz",
+      "integrity": "sha512-Bfvgaxv5V9MeDbrYozwczwuTV8K/QaBx1nKGWRPqST7d/NBGFX+trOBqPKwFufZEL5X+rw9oAMPUZ8zQp9ijvQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1416,7 +1416,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.38",
     "lit": "^3.3.2",
-    "llm-zoo": "^1.1.4",
+    "llm-zoo": "^1.2.0",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.1.1",
     "markdown-it-texmath": "^1.0.0",

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -11,6 +11,8 @@ export { ModelHandlerDeepSeek } from './modelHandlerDeepSeek';
 export { ModelHandlerXAI } from './modelHandlerXAI';
 export { ModelHandlerKimi } from './modelHandlerKimi';
 export { ModelHandlerDashScope } from './modelHandlerDashScope';
+export { ModelHandlerMiniMax } from './modelHandlerMiniMax';
+export { ModelHandlerGLM } from './modelHandlerGLM';
 export {
   ModelHandlerOpenRouter,
   ModelHandlerAnthropicViaOpenRouter,

--- a/src/agent/modelHandlers/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/modelHandlerGLM.ts
@@ -4,13 +4,19 @@ import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 /**
- * Handler for GLM (Zhipu AI) models using OpenAI-compatible API.
+ * Handler for GLM (Zhipu AI / Z.AI) models using OpenAI-compatible API.
  *
- * GLM-4.5 supports reasoning mode with reasoning_content in responses.
- * The base OpenAI handler already extracts reasoning_content from deltas.
+ * GLM models (4.5, 4.7, 5) support deep thinking via standard `reasoning_content`
+ * in both streaming deltas and non-streaming responses. Thinking is controlled by
+ * the `thinking` parameter: `{ type: "enabled" | "disabled" }`.
+ *
+ * GLM supports interleaved thinking with tool calls — the model thinks between
+ * tool invocations and after receiving results. Historical `reasoning_content`
+ * must be preserved in tool-use follow-up messages for reasoning coherence.
  *
  * usageProvider and toolCallProvider inherit from base class via config.provider.
  *
+ * @see https://docs.z.ai/guides/capabilities/thinking
  * @see https://open.bigmodel.cn/dev/api
  */
 export class ModelHandlerGLM extends ModelHandlerOpenAI {
@@ -21,7 +27,30 @@ export class ModelHandlerGLM extends ModelHandlerOpenAI {
   }
 
   /**
-   * GLM requires content to be converted to strings.
+   * GLM models require explicit `thinking` parameter to enable/disable reasoning.
+   * Thinking models (e.g. GLM-4.5) need it enabled; non-thinking variants need
+   * it disabled. Models without reasoning support return undefined (no parameter sent).
+   */
+  protected override getThinkingParameter():
+    | { type: 'enabled' | 'disabled' }
+    | undefined {
+    if (this.capabilities.supportsReasoning) {
+      return { type: 'enabled' };
+    }
+    return undefined;
+  }
+
+  /**
+   * GLM thinking models require reasoning_content in tool-use follow-up messages
+   * to maintain reasoning chain coherence across tool calls.
+   */
+  protected override shouldIncludeReasoningInToolCalls(): boolean {
+    return this.capabilities.supportsReasoning;
+  }
+
+  /**
+   * GLM requires content to be converted to strings for non-vision models.
+   * Vision models (GLM-4.5v, GLM-4.6v) use standard OpenAI image_url format.
    */
   protected override getMessageNormalizationOptions():
     | NormalizeOpenAIMessageContentOptions

--- a/src/agent/modelHandlers/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/modelHandlerGLM.ts
@@ -1,0 +1,34 @@
+// Local file imports
+import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
+import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
+
+/**
+ * Handler for GLM (Zhipu AI) models using OpenAI-compatible API.
+ *
+ * GLM-4.5 supports reasoning mode with reasoning_content in responses.
+ * The base OpenAI handler already extracts reasoning_content from deltas.
+ *
+ * usageProvider and toolCallProvider inherit from base class via config.provider.
+ *
+ * @see https://open.bigmodel.cn/dev/api
+ */
+export class ModelHandlerGLM extends ModelHandlerOpenAI {
+  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
+    return this.capabilities.supportsReasoning
+      ? new BaseReasoningStreamAggregator()
+      : null;
+  }
+
+  /**
+   * GLM requires content to be converted to strings.
+   */
+  protected override getMessageNormalizationOptions():
+    | NormalizeOpenAIMessageContentOptions
+    | undefined {
+    if (this.capabilities.supportsVision) {
+      return undefined;
+    }
+    return { convertContentToString: true };
+  }
+}

--- a/src/agent/modelHandlers/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/modelHandlerGLM.ts
@@ -27,17 +27,14 @@ export class ModelHandlerGLM extends ModelHandlerOpenAI {
   }
 
   /**
-   * GLM models require explicit `thinking` parameter to enable/disable reasoning.
-   * Thinking models (e.g. GLM-4.5) need it enabled; non-thinking variants need
-   * it disabled. Models without reasoning support return undefined (no parameter sent).
+   * GLM models require explicit `thinking` parameter to control reasoning.
+   * Thinking models (e.g. GLM-4.5) need it enabled; non-thinking variants
+   * get it explicitly disabled to prevent unexpected reasoning activation.
    */
-  protected override getThinkingParameter():
-    | { type: 'enabled' | 'disabled' }
-    | undefined {
-    if (this.capabilities.supportsReasoning) {
-      return { type: 'enabled' };
-    }
-    return undefined;
+  protected override getThinkingParameter(): { type: 'enabled' | 'disabled' } {
+    return this.capabilities.supportsReasoning
+      ? { type: 'enabled' }
+      : { type: 'disabled' };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/modelHandlerMiniMax.ts
@@ -1,35 +1,34 @@
 // Local file imports
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 /**
  * Handler for MiniMax models using OpenAI-compatible API.
  *
- * MiniMax M-series models support interleaved thinking via reasoning_content
- * in streaming responses. The base OpenAI handler already extracts
- * reasoning_content from deltas and non-streaming responses.
+ * MiniMax M-series are interleaved thinking models. Their reasoning behavior
+ * differs from the standard `reasoning_content` convention used by DeepSeek/GLM:
  *
- * usageProvider and toolCallProvider inherit from base class via config.provider.
+ * - **Streaming**: The `reasoning_content` field in deltas is EMPTY. Thinking is
+ *   embedded in `<think>...</think>` tags within `delta.content`. This is by design:
+ *   the OpenAI ChatCompletion format doesn't natively support thinking pass-back,
+ *   so MiniMax injects thinking into the content field.
+ *
+ * - **Non-streaming**: `reasoning_content` on the message IS populated correctly.
+ *   The base OpenAI handler extracts it automatically.
+ *
+ * - **Tool calls**: The full content (with `<think>` tags) is naturally preserved
+ *   in the assistant message, maintaining the reasoning chain. We do NOT use
+ *   `shouldIncludeReasoningInToolCalls()` since reasoning_content would be empty.
+ *
+ * We intentionally do NOT use BaseReasoningStreamAggregator here — it would look
+ * for `reasoning_content` in streaming deltas and find nothing.
  *
  * @see https://platform.minimax.io/docs/api-reference/text-openai-api
+ * @see https://platform.minimax.io/docs/guides/text-m2-function-call
  */
 export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
-  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    return this.capabilities.supportsReasoning
-      ? new BaseReasoningStreamAggregator()
-      : null;
-  }
-
   /**
-   * MiniMax thinking models require reasoning_content in tool-use follow-up messages.
-   */
-  protected override shouldIncludeReasoningInToolCalls(): boolean {
-    return this.capabilities.supportsReasoning;
-  }
-
-  /**
-   * MiniMax requires content to be converted to strings for non-vision models.
+   * MiniMax requires content to be converted to strings.
    */
   protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
     return { convertContentToString: true };

--- a/src/agent/modelHandlers/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/modelHandlerMiniMax.ts
@@ -1,0 +1,37 @@
+// Local file imports
+import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
+import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
+import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
+
+/**
+ * Handler for MiniMax models using OpenAI-compatible API.
+ *
+ * MiniMax M-series models support interleaved thinking via reasoning_content
+ * in streaming responses. The base OpenAI handler already extracts
+ * reasoning_content from deltas and non-streaming responses.
+ *
+ * usageProvider and toolCallProvider inherit from base class via config.provider.
+ *
+ * @see https://platform.minimax.io/docs/api-reference/text-openai-api
+ */
+export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
+  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
+    return this.capabilities.supportsReasoning
+      ? new BaseReasoningStreamAggregator()
+      : null;
+  }
+
+  /**
+   * MiniMax thinking models require reasoning_content in tool-use follow-up messages.
+   */
+  protected override shouldIncludeReasoningInToolCalls(): boolean {
+    return this.capabilities.supportsReasoning;
+  }
+
+  /**
+   * MiniMax requires content to be converted to strings for non-vision models.
+   */
+  protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
+    return { convertContentToString: true };
+  }
+}

--- a/src/agent/modelHandlers/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/modelHandlerMiniMax.ts
@@ -28,9 +28,15 @@ import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils'
  */
 export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
   /**
-   * MiniMax requires content to be converted to strings.
+   * MiniMax requires content to be converted to strings for non-vision models.
+   * Vision models use standard OpenAI image_url format.
    */
-  protected override getMessageNormalizationOptions(): NormalizeOpenAIMessageContentOptions {
+  protected override getMessageNormalizationOptions():
+    | NormalizeOpenAIMessageContentOptions
+    | undefined {
+    if (this.capabilities.supportsVision) {
+      return undefined;
+    }
     return { convertContentToString: true };
   }
 }

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -4,6 +4,8 @@ import { getConfig } from '@utils/config';
 import {
   getProviderEndpoint,
   getDashScopeUseChina,
+  getMiniMaxUseChina,
+  getGLMUseChina,
 } from '@utils/config/providerConfig';
 
 // NOTE: getProviderEndpoint reads from globalSM (VS Code global state), which is
@@ -44,9 +46,9 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.DEEPSEEK]: 'https://api.deepseek.com',
   [ModelProvider.XAI]: 'https://api.x.ai/v1',
   [ModelProvider.MOONSHOT]: 'https://api.moonshot.cn/v1',
-  [ModelProvider.DASHSCOPE]: null, // Resolved dynamically via getDashScopeBaseUrl()
-  [ModelProvider.MINIMAX]: 'https://api.minimax.io/v1',
-  [ModelProvider.GLM]: 'https://open.bigmodel.cn/api/paas/v4',
+  [ModelProvider.DASHSCOPE]: null, // Resolved dynamically (China/international toggle)
+  [ModelProvider.MINIMAX]: null, // Resolved dynamically (China/international toggle)
+  [ModelProvider.GLM]: null, // Resolved dynamically (China/international toggle)
   [ModelProvider.COPILOT]: null,
   [ModelProvider.OTHERS]: null,
 };
@@ -165,6 +167,24 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
       ? 'dashscope.aliyuncs.com'
       : 'dashscope-intl.aliyuncs.com';
     return `https://${domain}/compatible-mode/v1`;
+  }
+
+  // MiniMax base URL depends on the China/international region toggle
+  // China: api.minimaxi.com (note the extra 'i'), International: api.minimax.io
+  if (config.provider === ModelProvider.MINIMAX) {
+    const domain = getMiniMaxUseChina()
+      ? 'api.minimaxi.com'
+      : 'api.minimax.io';
+    return `https://${domain}/v1`;
+  }
+
+  // GLM base URL depends on the China/international region toggle
+  // China: open.bigmodel.cn, International: api.z.ai
+  if (config.provider === ModelProvider.GLM) {
+    const domain = getGLMUseChina()
+      ? 'open.bigmodel.cn'
+      : 'api.z.ai';
+    return `https://${domain}/api/paas/v4`;
   }
 
   return BASE_URLS[config.provider];

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -6,6 +6,7 @@ import {
   getDashScopeUseChina,
   getMiniMaxUseChina,
   getGLMUseChina,
+  getGLMCodingPlan,
 } from '@utils/config/providerConfig';
 
 // NOTE: getProviderEndpoint reads from globalSM (VS Code global state), which is
@@ -171,6 +172,7 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
 
   // MiniMax base URL depends on the China/international region toggle
   // China: api.minimaxi.com (note the extra 'i'), International: api.minimax.io
+  // Note: Coding Plan uses the same endpoint but requires a separate API key
   if (config.provider === ModelProvider.MINIMAX) {
     const domain = getMiniMaxUseChina()
       ? 'api.minimaxi.com'
@@ -180,11 +182,13 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
 
   // GLM base URL depends on the China/international region toggle
   // China: open.bigmodel.cn, International: api.z.ai
+  // Coding Plan uses /api/coding/paas/v4 path instead of /api/paas/v4
   if (config.provider === ModelProvider.GLM) {
     const domain = getGLMUseChina()
       ? 'open.bigmodel.cn'
       : 'api.z.ai';
-    return `https://${domain}/api/paas/v4`;
+    const path = getGLMCodingPlan() ? '/api/coding/paas/v4' : '/api/paas/v4';
+    return `https://${domain}${path}`;
   }
 
   return BASE_URLS[config.provider];

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -45,6 +45,8 @@ const BASE_URLS: Record<ModelProvider, string | null> = {
   [ModelProvider.XAI]: 'https://api.x.ai/v1',
   [ModelProvider.MOONSHOT]: 'https://api.moonshot.cn/v1',
   [ModelProvider.DASHSCOPE]: null, // Resolved dynamically via getDashScopeBaseUrl()
+  [ModelProvider.MINIMAX]: 'https://api.minimax.io/v1',
+  [ModelProvider.GLM]: 'https://open.bigmodel.cn/api/paas/v4',
   [ModelProvider.COPILOT]: null,
   [ModelProvider.OTHERS]: null,
 };

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -6,6 +6,8 @@ import { ModelHandlerDeepSeek } from '@agent/modelHandlers/modelHandlerDeepSeek'
 import { ModelHandlerXAI } from '@agent/modelHandlers/modelHandlerXAI';
 import { ModelHandlerKimi } from '@agent/modelHandlers/modelHandlerKimi';
 import { ModelHandlerDashScope } from '@agent/modelHandlers/modelHandlerDashScope';
+import { ModelHandlerMiniMax } from '@agent/modelHandlers/modelHandlerMiniMax';
+import { ModelHandlerGLM } from '@agent/modelHandlers/modelHandlerGLM';
 import {
   ModelHandlerOpenRouter,
   ModelHandlerAnthropicViaOpenRouter,
@@ -32,6 +34,8 @@ const PROVIDER_HANDLERS = new Map<
   [ModelProvider.XAI, ModelHandlerXAI],
   [ModelProvider.MOONSHOT, ModelHandlerKimi],
   [ModelProvider.DASHSCOPE, ModelHandlerDashScope],
+  [ModelProvider.MINIMAX, ModelHandlerMiniMax],
+  [ModelProvider.GLM, ModelHandlerGLM],
   [ModelProvider.OTHERS, ModelHandlerOpenRouter],
 ]);
 

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -75,6 +75,9 @@ export enum GlobalStateKey {
   MINIMAX_USE_CHINA = 'texra.minimax.useChina',
   GLM_USE_CHINA = 'texra.glm.useChina',
 
+  // Coding plan settings
+  GLM_CODING_PLAN = 'texra.glm.codingPlan',
+
   // Transport settings
   WEBSOCKET_OPENAI = 'texra.websocket.openai',
 }

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -46,6 +46,8 @@ export enum GlobalStateKey {
   STREAMING_DEEPSEEK = 'texra.streaming.deepseek',
   STREAMING_MOONSHOT = 'texra.streaming.moonshot',
   STREAMING_DASHSCOPE = 'texra.streaming.dashscope',
+  STREAMING_MINIMAX = 'texra.streaming.minimax',
+  STREAMING_GLM = 'texra.streaming.glm',
 
   // LaTeX settings
   LATEX_CONFIG_VERSION = 'texra.latexConfigVersion',
@@ -65,9 +67,13 @@ export enum GlobalStateKey {
   ENDPOINT_XAI = 'texra.endpoint.xai',
   ENDPOINT_MOONSHOT = 'texra.endpoint.moonshot',
   ENDPOINT_DASHSCOPE = 'texra.endpoint.dashscope',
+  ENDPOINT_MINIMAX = 'texra.endpoint.minimax',
+  ENDPOINT_GLM = 'texra.endpoint.glm',
 
   // Region settings
   DASHSCOPE_USE_CHINA = 'texra.dashscope.useChina',
+  MINIMAX_USE_CHINA = 'texra.minimax.useChina',
+  GLM_USE_CHINA = 'texra.glm.useChina',
 
   // Transport settings
   WEBSOCKET_OPENAI = 'texra.websocket.openai',

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -45,6 +45,8 @@ export class SecretManager {
     'deepseek',
     'moonshot',
     'dashscope',
+    'minimax',
+    'glm',
   ] as const;
 
   public static getApiKeySecretName(provider: ApiProvider): string {

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -27,6 +27,8 @@ export const DEFAULT_MODELS = [
   'deepseekT',
   'kimi25T',
   'grok4',
+  'minimaxM27',
+  'glm47',
 ];
 
 /**
@@ -35,7 +37,7 @@ export const DEFAULT_MODELS = [
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 7;
+export const MODEL_LIST_VERSION = 8;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -208,4 +208,22 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       globalStateKey: GlobalStateKey.DASHSCOPE_USE_CHINA,
     },
   ],
+  minimax: [
+    {
+      key: GlobalStateKey.MINIMAX_USE_CHINA,
+      label: 'China Region',
+      description:
+        'Use the China region endpoint (api.minimaxi.com) instead of international (api.minimax.io). API keys are region-specific.',
+      globalStateKey: GlobalStateKey.MINIMAX_USE_CHINA,
+    },
+  ],
+  glm: [
+    {
+      key: GlobalStateKey.GLM_USE_CHINA,
+      label: 'China Region',
+      description:
+        'Use the China region endpoint (open.bigmodel.cn) instead of international (api.z.ai). Enabled by default.',
+      globalStateKey: GlobalStateKey.GLM_USE_CHINA,
+    },
+  ],
 };

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -68,6 +68,18 @@ const PROVIDER_REGISTRY = [
     hasServerKey: true,
     keyUrl: 'https://dashscope.aliyun.com/api-console/',
   },
+  {
+    id: ModelProvider.MINIMAX,
+    displayName: 'MiniMax',
+    hasServerKey: true,
+    keyUrl: 'https://platform.minimax.io/',
+  },
+  {
+    id: ModelProvider.GLM,
+    displayName: 'GLM',
+    hasServerKey: true,
+    keyUrl: 'https://open.bigmodel.cn/',
+  },
 ] as const satisfies readonly ProviderDef[];
 
 /** Providers not in the main registry (no server-side keys, no model selection). */

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -215,7 +215,7 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       description:
         'Use the China region endpoint (api.minimaxi.com) instead of international (api.minimax.io). API keys are region-specific — you must obtain a key from the matching region.',
       warning:
-        'International keys do not work with the China endpoint, and vice versa.',
+        'International keys do not work with the China endpoint, and vice versa. Coding Plan keys are also region-specific.',
       warningUrl: 'https://platform.minimax.io/',
       warningUrlLabel: 'Get API key',
       globalStateKey: GlobalStateKey.MINIMAX_USE_CHINA,
@@ -230,6 +230,15 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       warningUrl: 'https://open.bigmodel.cn/',
       warningUrlLabel: 'BigModel console',
       globalStateKey: GlobalStateKey.GLM_USE_CHINA,
+    },
+    {
+      key: GlobalStateKey.GLM_CODING_PLAN,
+      label: 'Coding Plan',
+      description:
+        'Use a Coding Plan subscription key instead of pay-as-you-go. Routes requests through the coding-specific endpoint with monthly quota limits.',
+      warningUrl: 'https://z.ai/subscribe',
+      warningUrlLabel: 'Subscribe',
+      globalStateKey: GlobalStateKey.GLM_CODING_PLAN,
     },
   ],
 };

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -213,7 +213,11 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       key: GlobalStateKey.MINIMAX_USE_CHINA,
       label: 'China Region',
       description:
-        'Use the China region endpoint (api.minimaxi.com) instead of international (api.minimax.io). API keys are region-specific.',
+        'Use the China region endpoint (api.minimaxi.com) instead of international (api.minimax.io). API keys are region-specific — you must obtain a key from the matching region.',
+      warning:
+        'International keys do not work with the China endpoint, and vice versa.',
+      warningUrl: 'https://platform.minimax.io/',
+      warningUrlLabel: 'Get API key',
       globalStateKey: GlobalStateKey.MINIMAX_USE_CHINA,
     },
   ],
@@ -222,7 +226,9 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       key: GlobalStateKey.GLM_USE_CHINA,
       label: 'China Region',
       description:
-        'Use the China region endpoint (open.bigmodel.cn) instead of international (api.z.ai). Enabled by default.',
+        'Use the China region endpoint (open.bigmodel.cn) instead of international (api.z.ai). Enabled by default. API keys work with either endpoint.',
+      warningUrl: 'https://open.bigmodel.cn/',
+      warningUrlLabel: 'BigModel console',
       globalStateKey: GlobalStateKey.GLM_USE_CHINA,
     },
   ],

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -37,6 +37,7 @@ function buildAnthropicConfig(
 
   return {
     name: 'test-anthropic',
+    label: 'Test Anthropic',
     fullName: 'claude-test',
     shortName: 'claude-test',
     provider: ModelProvider.ANTHROPIC,

--- a/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerGoogleGenAI.test.ts
@@ -80,6 +80,7 @@ function buildGoogleConfig(
 
   return {
     name: 'test-google',
+    label: 'Test Google',
     fullName: 'test-google',
     shortName: 'test-google',
     provider: ModelProvider.GOOGLE,

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAINormalize.test.ts
@@ -116,6 +116,7 @@ function buildConfig(
     },
     openRouterOnly: false,
     ...overrides,
+    label: overrides.label ?? 'Test Model',
   };
 }
 

--- a/src/test/modelHandlers/ModelHandlerGoogle.test.ts
+++ b/src/test/modelHandlers/ModelHandlerGoogle.test.ts
@@ -20,6 +20,7 @@ import type { Content } from '@google/genai';
 describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
   const handler = new ModelHandlerGoogleGenAI({
     name: 'test-google-model',
+    label: 'Test Google Model',
     fullName: 'google/test',
     shortName: 'google/test',
     provider: ModelProvider.GOOGLE,
@@ -70,6 +71,7 @@ describe('ModelHandlerGoogleGenAI.shouldContinue', () => {
 describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
   const handler = new ModelHandlerGoogleGenAI({
     name: 'test-google-model',
+    label: 'Test Google Model',
     fullName: 'google/test',
     shortName: 'google/test',
     provider: ModelProvider.GOOGLE,
@@ -112,6 +114,7 @@ describe('ModelHandlerGoogleGenAI.extractToolUse', () => {
 describe('ModelHandlerGoogleGenAI.createToolUseFollowUpMessages', () => {
   const handler = new ModelHandlerGoogleGenAI({
     name: 'test-google-model',
+    label: 'Test Google Model',
     fullName: 'google/test',
     shortName: 'google/test',
     provider: ModelProvider.GOOGLE,
@@ -158,6 +161,7 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
   it('strips unsupported identifier fields before issuing chat history', async () => {
     const handler = new ModelHandlerGoogleGenAI({
       name: 'test-google-model',
+      label: 'Test Google Model',
       fullName: 'google/test',
       shortName: 'google/test',
       provider: ModelProvider.GOOGLE,
@@ -252,6 +256,7 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
   it('aggregates streamed chunks without relying on SDK response promises', async () => {
     const handler = new ModelHandlerGoogleGenAI({
       name: 'test-google-model',
+      label: 'Test Google Model',
       fullName: 'google/test',
       shortName: 'google/test',
       provider: ModelProvider.GOOGLE,
@@ -350,6 +355,7 @@ describe('ModelHandlerGoogleGenAI.createResponse', () => {
   it('concatenates automaticFunctionCallingHistory across streamed chunks', async () => {
     const handler = new ModelHandlerGoogleGenAI({
       name: 'test-google-model',
+      label: 'Test Google Model',
       fullName: 'google/test',
       shortName: 'google/test',
       provider: ModelProvider.GOOGLE,

--- a/src/test/tools/BashTool.test.ts
+++ b/src/test/tools/BashTool.test.ts
@@ -129,6 +129,7 @@ describe('BashTool', () => {
 
     const config: ModelConfig = {
       name: 'test',
+      label: 'Test',
       fullName: 'test',
       shortName: 'test',
       provider: ModelProvider.OPENAI,

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -18,6 +18,8 @@ const STREAMING_KEY: Record<string, GlobalStateKey> = {
   deepseek: GlobalStateKey.STREAMING_DEEPSEEK,
   moonshot: GlobalStateKey.STREAMING_MOONSHOT,
   dashscope: GlobalStateKey.STREAMING_DASHSCOPE,
+  minimax: GlobalStateKey.STREAMING_MINIMAX,
+  glm: GlobalStateKey.STREAMING_GLM,
 };
 
 /** Map from provider string to GlobalStateKey for per-provider endpoint. */
@@ -29,6 +31,8 @@ const ENDPOINT_KEY: Record<string, GlobalStateKey> = {
   xai: GlobalStateKey.ENDPOINT_XAI,
   moonshot: GlobalStateKey.ENDPOINT_MOONSHOT,
   dashscope: GlobalStateKey.ENDPOINT_DASHSCOPE,
+  minimax: GlobalStateKey.ENDPOINT_MINIMAX,
+  glm: GlobalStateKey.ENDPOINT_GLM,
 };
 
 /** Read the global streaming default. */
@@ -138,6 +142,28 @@ export function getProviderKeyUrl(
     return BAILIAN_KEY_URL;
   }
   return defaultUrl;
+}
+
+// ---------------------------------------------------------------------------
+// MiniMax region setting (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Whether MiniMax is set to use the China region (minimaxi.com). */
+export function getMiniMaxUseChina(): boolean {
+  return (
+    globalSM?.get<boolean>(GlobalStateKey.MINIMAX_USE_CHINA, false) ?? false
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GLM region setting (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Whether GLM is set to use the China region (bigmodel.cn). Defaults to true since bigmodel.cn is the primary platform. */
+export function getGLMUseChina(): boolean {
+  return (
+    globalSM?.get<boolean>(GlobalStateKey.GLM_USE_CHINA, true) ?? true
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -133,13 +133,19 @@ export function getProviderDisplayName(
   return defaultName;
 }
 
-/** Resolve key URL for a provider, accounting for DashScope China region. */
+/** Resolve key URL for a provider, accounting for region toggles. */
 export function getProviderKeyUrl(
   provider: string,
   defaultUrl: string,
 ): string {
   if (provider === 'dashscope' && getDashScopeUseChina()) {
     return BAILIAN_KEY_URL;
+  }
+  if (provider === 'minimax' && getMiniMaxUseChina()) {
+    return 'https://platform.minimaxi.com/';
+  }
+  if (provider === 'glm' && !getGLMUseChina()) {
+    return 'https://z.ai/';
   }
   return defaultUrl;
 }

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -173,6 +173,17 @@ export function getGLMUseChina(): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Coding plan settings (globalSM-backed)
+// ---------------------------------------------------------------------------
+
+/** Whether GLM is set to use Coding Plan (subscription-based API access). */
+export function getGLMCodingPlan(): boolean {
+  return (
+    globalSM?.get<boolean>(GlobalStateKey.GLM_CODING_PLAN, false) ?? false
+  );
+}
+
+// ---------------------------------------------------------------------------
 // WebSocket transport setting (globalSM-backed)
 // ---------------------------------------------------------------------------
 

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -8,7 +8,7 @@
  * - Ultra: All models including premium ($3+/M input)
  */
 
-import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.0.2';
+import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.2.0';
 
 // =============================================================================
 // Types
@@ -108,6 +108,8 @@ const ALL_PROVIDERS = [
   'xai',
   'moonshot',
   'dashscope',
+  'minimax',
+  'glm',
 ] as const;
 
 // =============================================================================


### PR DESCRIPTION
## Summary
This PR adds support for two new AI model providers: MiniMax and GLM (Zhipu AI). Both providers use OpenAI-compatible APIs and support reasoning capabilities through interleaved thinking.

## Key Changes

- **New Model Handlers**: Created `ModelHandlerMiniMax` and `ModelHandlerGLM` classes that extend `ModelHandlerOpenAI` with provider-specific configurations
  - Both handlers support reasoning mode via `BaseReasoningStreamAggregator`
  - MiniMax requires content normalization to strings for non-vision models
  - GLM requires content normalization to strings only for non-vision models
  - Both include reasoning_content in tool-use follow-up messages when reasoning is supported

- **Provider Registration**: Added MiniMax and GLM to the provider registry with appropriate display names and key URLs

- **API Configuration**: Configured base URLs for both providers:
  - MiniMax: `https://api.minimax.io/v1`
  - GLM: `https://open.bigmodel.cn/api/paas/v4`

- **Model Factory Integration**: Registered both handlers in `ModelFactory` for proper instantiation

- **Default Models**: Added `minimaxM27` and `glm47` to the default model list

- **Dependencies**: Updated `llm-zoo` from `^1.1.4` to `^1.2.0` to include model configurations for both providers

- **Test Updates**: Added missing `label` field to model config objects in existing tests to match updated type requirements

## Implementation Details

Both handlers follow the established pattern of extending `ModelHandlerOpenAI` and only override methods where provider-specific behavior is needed. The reasoning support is automatically handled by the base class's existing `reasoning_content` extraction logic, with the handlers simply enabling the streaming aggregator when reasoning capabilities are detected.

https://claude.ai/code/session_01LhiYz2LHkXTiMTwLhonUh5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new model providers and routing/config toggles (region + GLM coding plan), which changes how base URLs, streaming, and key lookup are resolved for some requests. Main risk is misconfiguration leading to failed API calls or unexpected endpoint selection.
> 
> **Overview**
> Adds **MiniMax** and **GLM (Zhipu / Z.AI)** as supported providers end-to-end: new `ModelHandlerMiniMax`/`ModelHandlerGLM`, registration in `ModelFactory`, provider metadata, secret key support, and inclusion in the relay provider allowlist.
> 
> Extends routing/config to support provider-specific base URL resolution, including *region toggles* for MiniMax/GLM and a *GLM Coding Plan* toggle that switches the API path; also adds per-provider streaming/endpoint state keys and bumps default models/version to include `minimaxM27` and `glm47`.
> 
> Updates docs (installation/model tables/provider policies) and bumps `llm-zoo` to `^1.2.0`, with test fixtures updated to include required `label` fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0724f72d3e9b7254433b0620899f9119f504c6fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->