### PR TITLE
Extract shared file view formatting into reusable utility

### DIFF
--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -881,6 +881,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       path: displayPath,
       lines,
       viewRange,
+      maxLines: Infinity,
     });
   }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -48,9 +48,8 @@ import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { ToolError, type ToolResult } from './result';
-import { READ_FILE_MAX_LINES } from './ReadTool';
 import { defineTool } from './core/define';
-import { formatLinesWithNumbers } from './utils';
+import { formatFileView } from './utils';
 
 // ============================================================================
 // Category-aware field filtering
@@ -881,48 +880,14 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     const requestedEnd = viewRange?.[1] ?? totalLines;
     const startIndex = Math.min(Math.max(requestedStart - 1, 0), totalLines);
     const endIndex = Math.min(requestedEnd, totalLines);
-    const selected = lines.slice(startIndex, endIndex);
-    const truncated = selected.length > READ_FILE_MAX_LINES;
-    const visibleLines = truncated
-      ? selected.slice(0, READ_FILE_MAX_LINES)
-      : selected;
-    const visibleCount = visibleLines.length;
 
-    const segments: string[] = [];
-    if (visibleLines.length > 0) {
-      segments.push(
-        formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
-      );
-    }
-    if (truncated) {
-      segments.push(
-        `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
-      );
-    }
-
-    // Build summary matching read_file format
-    let summary: string;
-    if (visibleCount === 0) {
-      const reason =
-        totalLines === 0 ? 'file is empty' : 'no lines in requested range';
-      summary = `Read ${displayPath} (${reason})`;
-    } else {
-      const startLine = startIndex + 1;
-      const endLine = startIndex + visibleCount;
-      const isFullRead =
-        !viewRange && startLine === 1 && endLine === totalLines;
-      if (isFullRead) {
-        summary = `Read ${displayPath}`;
-      } else {
-        const rangeLabel =
-          startLine === endLine
-            ? `line ${startLine}`
-            : `lines ${startLine}-${endLine}`;
-        summary = `Read ${rangeLabel} of ${displayPath}`;
-      }
-    }
-
-    return { summary, output: segments.join('\n') };
+    return formatFileView({
+      path: displayPath,
+      lines,
+      startIndex,
+      endIndex,
+      rangeProvided: viewRange != null,
+    });
   }
 
   private formatSize(bytes: number): string {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -47,9 +47,10 @@ import {
 import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
+import { splitContentLines } from '@utils/text/stringUtils';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
-import { formatFileView } from './utils';
+import { formatFileView, resolveViewRange } from './utils';
 
 // ============================================================================
 // Category-aware field filtering
@@ -873,13 +874,8 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     }
 
     const content = await StorageFS.read(fullPath);
-    const lines = content.split('\n');
-    const totalLines = lines.length;
-
-    const requestedStart = viewRange?.[0] ?? 1;
-    const requestedEnd = viewRange?.[1] ?? totalLines;
-    const startIndex = Math.min(Math.max(requestedStart - 1, 0), totalLines);
-    const endIndex = Math.min(requestedEnd, totalLines);
+    const lines = splitContentLines(content);
+    const { startIndex, endIndex } = resolveViewRange(viewRange, lines.length);
 
     return formatFileView({
       path: displayPath,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -48,7 +48,9 @@ import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { ToolError, type ToolResult } from './result';
+import { READ_FILE_MAX_LINES } from './ReadTool';
 import { defineTool } from './core/define';
+import { formatLinesWithNumbers } from './utils';
 
 // ============================================================================
 // Category-aware field filtering
@@ -858,27 +860,69 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     filePath: string,
     viewRange?: number[],
   ): Promise<ToolResult> {
+    const displayPath = `/executions/${executionId}/files/${filePath}`;
     const fullPath = await resolveStoragePath(executionId, filePath);
     if (!fullPath) {
-      throw new ToolError(
-        `File not found: /executions/${executionId}/files/${filePath}`,
-      );
+      throw new ToolError(`File not found: ${displayPath}`);
     }
 
     const stats = await StorageFS.stat(fullPath);
     if (isDirectory(stats.type)) {
       throw new ToolError(
-        `Path is a directory: /executions/${executionId}/files/${filePath}. Use without trailing path to list.`,
+        `Path is a directory: ${displayPath}. Use without trailing path to list.`,
       );
     }
 
     const content = await StorageFS.read(fullPath);
-    const output = this.applyViewRange(
-      `File: /executions/${executionId}/files/${filePath}\n\n${content}`,
-      viewRange,
-    );
+    const lines = content.split('\n');
+    const totalLines = lines.length;
 
-    return { output };
+    const requestedStart = viewRange?.[0] ?? 1;
+    const requestedEnd = viewRange?.[1] ?? totalLines;
+    const startIndex = Math.min(Math.max(requestedStart - 1, 0), totalLines);
+    const endIndex = Math.min(requestedEnd, totalLines);
+    const selected = lines.slice(startIndex, endIndex);
+    const truncated = selected.length > READ_FILE_MAX_LINES;
+    const visibleLines = truncated
+      ? selected.slice(0, READ_FILE_MAX_LINES)
+      : selected;
+    const visibleCount = visibleLines.length;
+
+    const segments: string[] = [];
+    if (visibleLines.length > 0) {
+      segments.push(
+        formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
+      );
+    }
+    if (truncated) {
+      segments.push(
+        `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
+      );
+    }
+
+    // Build summary matching read_file format
+    let summary: string;
+    if (visibleCount === 0) {
+      const reason =
+        totalLines === 0 ? 'file is empty' : 'no lines in requested range';
+      summary = `Read ${displayPath} (${reason})`;
+    } else {
+      const startLine = startIndex + 1;
+      const endLine = startIndex + visibleCount;
+      const isFullRead =
+        !viewRange && startLine === 1 && endLine === totalLines;
+      if (isFullRead) {
+        summary = `Read ${displayPath}`;
+      } else {
+        const rangeLabel =
+          startLine === endLine
+            ? `line ${startLine}`
+            : `lines ${startLine}-${endLine}`;
+        summary = `Read ${rangeLabel} of ${displayPath}`;
+      }
+    }
+
+    return { summary, output: segments.join('\n') };
   }
 
   private formatSize(bytes: number): string {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -875,13 +875,13 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     const content = await StorageFS.read(fullPath);
     const lines = splitContentLines(content);
-    const { startIndex, endIndex } = resolveViewRange(viewRange, lines.length);
+    const { startLine, endLine } = resolveViewRange(viewRange, lines.length);
 
     return formatFileView({
       path: displayPath,
       lines,
-      startIndex,
-      endIndex,
+      startLine,
+      endLine,
       rangeProvided: viewRange != null,
     });
   }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -330,7 +330,8 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       return this.readFile(
         executionId,
         rest.join('/'),
-        input.view_range ?? undefined,
+        // Schema enforces length 2; cast since Zod infers number[]
+        input.view_range as [number, number] | undefined,
       );
     }
 
@@ -858,7 +859,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
   private async readFile(
     executionId: ExecutionId,
     filePath: string,
-    viewRange?: number[],
+    viewRange?: [number, number],
   ): Promise<ToolResult> {
     const displayPath = `/executions/${executionId}/files/${filePath}`;
     const fullPath = await resolveStoragePath(executionId, filePath);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -50,7 +50,7 @@ import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
-import { formatFileView, resolveViewRange } from './utils';
+import { formatFileView } from './utils';
 
 // ============================================================================
 // Category-aware field filtering
@@ -875,14 +875,11 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     const content = await StorageFS.read(fullPath);
     const lines = splitContentLines(content);
-    const { startLine, endLine } = resolveViewRange(viewRange, lines.length);
 
     return formatFileView({
       path: displayPath,
       lines,
-      startLine,
-      endLine,
-      rangeProvided: viewRange != null,
+      viewRange,
     });
   }
 

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -96,16 +96,12 @@ export class ReadFileTool extends defineTool({
       ? ` (requested end ${requestedEndLine} exceeds file length ${totalLines})`
       : '';
 
-    const result = formatFileView({
+    return formatFileView({
       path: input.path,
       lines,
-      startLine,
-      endLine,
-      rangeProvided: Boolean(input.range),
+      viewRange: input.range ? [startLine, endLine] : null,
       summarySuffix: suffix,
     });
-
-    return result;
   }
 
   private computeRequestedEndLine(

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -6,7 +6,11 @@ import { z } from 'zod';
 
 // Local imports - tools
 import type { ToolResult } from '@tools/result';
-import { buildFileAttachment, formatLinesWithNumbers } from '@tools/utils';
+import {
+  buildFileAttachment,
+  formatFileView,
+  READ_FILE_MAX_LINES,
+} from '@tools/utils';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import {
   WorkspaceFS,
@@ -19,7 +23,8 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from './core/define';
 
-export const READ_FILE_MAX_LINES = 2000;
+// Re-export so existing consumers can keep importing from here.
+export { READ_FILE_MAX_LINES } from '@tools/utils';
 
 /**
  * Schema for range parameter with preprocessing to handle array format.
@@ -53,18 +58,6 @@ const ReadInputSchema = z.strictObject({
 
 export type ReadInput = z.infer<typeof ReadInputSchema>;
 
-interface BuildSummaryParams {
-  path: string;
-  totalLines: number;
-  visibleCount: number;
-  actualStartLine: number | null;
-  actualEndLine: number | null;
-  requestedEndLine: number;
-  truncated: boolean;
-  rangeProvided: boolean;
-  rangeEndExceeded: boolean;
-}
-
 export class ReadFileTool extends defineTool({
   name: 'read_file',
   description:
@@ -83,7 +76,6 @@ export class ReadFileTool extends defineTool({
     recordToolFileRead(input.path);
 
     const totalLines = lines.length;
-
     const requestedStartLine = input.range?.start ?? 1;
     const requestedEndLine = this.computeRequestedEndLine(
       input.range,
@@ -93,93 +85,29 @@ export class ReadFileTool extends defineTool({
 
     // Convert the requested 1-based range into zero-based indices and clamp them to the
     // available file length so callers can safely request windows beyond the file bounds.
-    // If startIndex >= totalLines, slice will return empty array (which is correct behavior).
     const startIndex = Math.min(requestedStartLine - 1, totalLines);
-    const endIndexExclusive = Math.min(
+    const endIndex = Math.min(
       Math.max(requestedEndLine, requestedStartLine),
       totalLines,
     );
 
-    const selectedLines = lines.slice(startIndex, endIndexExclusive);
-    const truncated = selectedLines.length > READ_FILE_MAX_LINES;
-    const visibleLines = truncated
-      ? selectedLines.slice(0, READ_FILE_MAX_LINES)
-      : selectedLines;
-    const visibleCount = visibleLines.length;
+    // Append a range-exceeded warning when the caller asked beyond EOF
+    const rangeEndExceeded =
+      input.range?.end != null && input.range.end > totalLines;
+    const suffix = rangeEndExceeded
+      ? ` (requested end ${requestedEndLine} exceeds file length ${totalLines})`
+      : '';
 
-    const segments: string[] = [];
-    if (visibleLines.length > 0) {
-      const numberedLines = formatLinesWithNumbers(
-        visibleLines,
-        startIndex + 1,
-      );
-      segments.push(numberedLines.join('\n'));
-    }
-    if (truncated) {
-      segments.push(
-        `...(truncated, ${selectedLines.length - READ_FILE_MAX_LINES} more lines)`,
-      );
-    }
-
-    const actualStartLine = visibleCount > 0 ? startIndex + 1 : null;
-    const actualEndLine = visibleCount > 0 ? startIndex + visibleCount : null;
-
-    const summary = this.buildSummary({
+    const result = formatFileView({
       path: input.path,
-      totalLines,
-      visibleCount,
-      actualStartLine,
-      actualEndLine,
-      requestedEndLine,
-      truncated,
+      lines,
+      startIndex,
+      endIndex,
       rangeProvided: Boolean(input.range),
-
-      rangeEndExceeded:
-        input.range?.end != null && input.range.end > totalLines,
+      summarySuffix: suffix,
     });
 
-    return {
-      summary,
-      output: segments.join('\n'),
-    };
-  }
-
-  private buildSummary({
-    path: filePath,
-    totalLines,
-    visibleCount,
-    actualStartLine,
-    actualEndLine,
-    requestedEndLine,
-    truncated,
-    rangeProvided,
-    rangeEndExceeded,
-  }: BuildSummaryParams): string {
-    if (visibleCount === 0) {
-      const reason =
-        totalLines === 0 ? 'file is empty' : 'no lines in requested range';
-      return `Read ${filePath} (${reason})`;
-    }
-
-    const startLine = actualStartLine ?? 1;
-    const endLine = actualEndLine ?? startLine + visibleCount - 1;
-    const isFullRead =
-      !rangeProvided && !truncated && startLine === 1 && endLine === totalLines;
-
-    if (isFullRead) {
-      return `Read ${filePath}`;
-    }
-
-    const rangeLabel =
-      startLine === endLine
-        ? `line ${startLine}`
-        : `lines ${startLine}-${endLine}`;
-    const base = `Read ${rangeLabel} of ${filePath}`;
-
-    if (rangeEndExceeded) {
-      return `${base} (requested end ${requestedEndLine} exceeds file length ${totalLines})`;
-    }
-    return base;
+    return result;
   }
 
   private computeRequestedEndLine(

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -23,8 +23,6 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from './core/define';
 
-// Re-export so existing consumers can keep importing from here.
-export { READ_FILE_MAX_LINES } from '@tools/utils';
 
 /**
  * Schema for range parameter with preprocessing to handle array format.

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -81,10 +81,10 @@ export class ReadFileTool extends defineTool({
       totalLines,
     );
 
-    // Convert the requested 1-based range into zero-based indices and clamp them to the
-    // available file length so callers can safely request windows beyond the file bounds.
-    const startIndex = Math.min(requestedStartLine - 1, totalLines);
-    const endIndex = Math.min(
+    // Clamp the 1-based range to the file bounds so callers can safely
+    // request windows beyond the file length.
+    const startLine = Math.min(requestedStartLine, totalLines + 1);
+    const endLine = Math.min(
       Math.max(requestedEndLine, requestedStartLine),
       totalLines,
     );
@@ -99,8 +99,8 @@ export class ReadFileTool extends defineTool({
     const result = formatFileView({
       path: input.path,
       lines,
-      startIndex,
-      endIndex,
+      startLine,
+      endLine,
       rangeProvided: Boolean(input.range),
       summarySuffix: suffix,
     });

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -234,22 +234,26 @@ export class TextEditorTool extends defineTool({
 
         const [startLine, endLine] = viewRange;
 
-        if (startLine < 1 || startLine > totalLines) {
-          throw new ToolError(
-            `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its first element \`${startLine}\` should be within the range of lines of the file: [1, ${totalLines}]`,
-          );
-        }
-
-        if (endLine !== -1) {
-          if (endLine > totalLines) {
+        // Only validate bounds when the file is non-empty; empty files
+        // skip validation and formatFileView returns "file is empty".
+        if (totalLines > 0) {
+          if (startLine < 1 || startLine > totalLines) {
             throw new ToolError(
-              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${totalLines}\``,
+              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its first element \`${startLine}\` should be within the range of lines of the file: [1, ${totalLines}]`,
             );
           }
-          if (endLine < startLine) {
-            throw new ToolError(
-              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be larger or equal than its first \`${startLine}\``,
-            );
+
+          if (endLine !== -1) {
+            if (endLine > totalLines) {
+              throw new ToolError(
+                `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${totalLines}\``,
+              );
+            }
+            if (endLine < startLine) {
+              throw new ToolError(
+                `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be larger or equal than its first \`${startLine}\``,
+              );
+            }
           }
         }
 
@@ -263,6 +267,7 @@ export class TextEditorTool extends defineTool({
         path: filePath,
         lines,
         viewRange: viewRange ? [viewStartLine, viewEndLine] : null,
+        maxLines: Infinity,
       });
     } catch (error) {
       rethrowWithContext(error, `Error viewing ${filePath}`);
@@ -606,6 +611,6 @@ export class TextEditorTool extends defineTool({
 
   private makeOutput(content: string, initLine: number = 1): string {
     const lines = splitContentLines(content);
-    return formatLinesWithNumbers(lines, initLine).join('\n') + '\n';
+    return '\n' + formatLinesWithNumbers(lines, initLine).join('\n') + '\n';
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -25,9 +25,8 @@ import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import { READ_FILE_MAX_LINES } from './ReadTool';
 import { ToolResult, ToolError } from './result';
-import { formatLinesWithNumbers, requireField } from './utils';
+import { formatFileView, formatLinesWithNumbers, requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
@@ -258,76 +257,18 @@ export class TextEditorTool extends defineTool({
         endIndex = endLine === -1 ? totalLines : endLine;
       }
 
-      const selected = lines.slice(startIndex, endIndex);
-      const truncated = selected.length > READ_FILE_MAX_LINES;
-      const visibleLines = truncated
-        ? selected.slice(0, READ_FILE_MAX_LINES)
-        : selected;
-      const visibleCount = visibleLines.length;
-
       recordToolFileRead(filePath);
 
-      const segments: string[] = [];
-      if (visibleLines.length > 0) {
-        segments.push(
-          formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
-        );
-      }
-      if (truncated) {
-        segments.push(
-          `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
-        );
-      }
-
-      const summary = this.buildViewSummary(filePath, {
-        totalLines,
-        visibleCount,
-        actualStartLine: visibleCount > 0 ? startIndex + 1 : null,
-        actualEndLine: visibleCount > 0 ? startIndex + visibleCount : null,
+      return formatFileView({
+        path: filePath,
+        lines,
+        startIndex,
+        endIndex,
         rangeProvided: viewRange != null,
       });
-
-      return {
-        summary,
-        output: segments.join('\n'),
-      };
     } catch (error) {
       rethrowWithContext(error, `Error viewing ${filePath}`);
     }
-  }
-
-  /** Build a summary string matching read_file's format. */
-  private buildViewSummary(
-    filePath: string,
-    params: {
-      totalLines: number;
-      visibleCount: number;
-      actualStartLine: number | null;
-      actualEndLine: number | null;
-      rangeProvided: boolean;
-    },
-  ): string {
-    const { totalLines, visibleCount, actualStartLine, actualEndLine, rangeProvided } = params;
-
-    if (visibleCount === 0) {
-      const reason = totalLines === 0 ? 'file is empty' : 'no lines in requested range';
-      return `Read ${filePath} (${reason})`;
-    }
-
-    const startLine = actualStartLine ?? 1;
-    const endLine = actualEndLine ?? startLine + visibleCount - 1;
-    const isFullRead =
-      !rangeProvided && startLine === 1 && endLine === totalLines;
-
-    if (isFullRead) {
-      return `Read ${filePath}`;
-    }
-
-    const rangeLabel =
-      startLine === endLine
-        ? `line ${startLine}`
-        : `lines ${startLine}-${endLine}`;
-    return `Read ${rangeLabel} of ${filePath}`;
   }
 
   private async create(filePath: string, content: string): Promise<ToolResult> {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -262,9 +262,7 @@ export class TextEditorTool extends defineTool({
       return formatFileView({
         path: filePath,
         lines,
-        startLine: viewStartLine,
-        endLine: viewEndLine,
-        rangeProvided: viewRange != null,
+        viewRange: viewRange ? [viewStartLine, viewEndLine] : null,
       });
     } catch (error) {
       rethrowWithContext(error, `Error viewing ${filePath}`);

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -416,11 +416,7 @@ export class TextEditorTool extends defineTool({
         appliedContent,
       );
       const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(
-        snippet,
-        `a snippet of ${filePath}`,
-        startLine,
-      );
+      const snippetOutput = this.makeOutput(snippet, startLine);
       const reviewMessage =
         'Review the changes and make sure they are as expected. Edit the file again if necessary.';
       const baseMsg = `${successIntro} ${snippetOutput}${reviewMessage}`;
@@ -518,11 +514,7 @@ export class TextEditorTool extends defineTool({
       );
 
       const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(
-        snippetText,
-        'a snippet of the edited file',
-        startLine,
-      );
+      const snippetOutput = this.makeOutput(snippetText, startLine);
       const reviewNote =
         'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
       const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
@@ -591,7 +583,7 @@ export class TextEditorTool extends defineTool({
         previousContent,
         appliedContent,
       );
-      const baseOutput = `Last edit to ${filePath} undone successfully. ${this.makeOutput(appliedContent, filePath)}`;
+      const baseOutput = `Last edit to ${filePath} undone successfully. ${this.makeOutput(appliedContent)}`;
       const output = userDiffNote
         ? `${baseOutput}\n${userDiffNote}`
         : baseOutput;
@@ -614,12 +606,8 @@ export class TextEditorTool extends defineTool({
     this.fileHistory.get(filePath)!.push(content);
   }
 
-  private makeOutput(
-    content: string,
-    _fileDescriptor: string,
-    initLine: number = 1,
-  ): string {
-    const lines = content.split('\n');
+  private makeOutput(content: string, initLine: number = 1): string {
+    const lines = splitContentLines(content);
     return formatLinesWithNumbers(lines, initLine).join('\n') + '\n';
   }
 }

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -218,8 +218,8 @@ export class TextEditorTool extends defineTool({
       const lines = splitContentLines(fileContent);
       const totalLines = lines.length;
 
-      let startIndex = 0;
-      let endIndex = totalLines;
+      let viewStartLine = 1;
+      let viewEndLine = totalLines;
 
       if (viewRange) {
         if (
@@ -253,8 +253,8 @@ export class TextEditorTool extends defineTool({
           }
         }
 
-        startIndex = startLine - 1;
-        endIndex = endLine === -1 ? totalLines : endLine;
+        viewStartLine = startLine;
+        viewEndLine = endLine === -1 ? totalLines : endLine;
       }
 
       recordToolFileRead(filePath);
@@ -262,8 +262,8 @@ export class TextEditorTool extends defineTool({
       return formatFileView({
         path: filePath,
         lines,
-        startIndex,
-        endIndex,
+        startLine: viewStartLine,
+        endLine: viewEndLine,
         rangeProvided: viewRange != null,
       });
     } catch (error) {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -21,11 +21,13 @@ import {
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
 import { WorkspaceFS, AbsoluteFS } from '@utils/files';
+import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { READ_FILE_MAX_LINES } from './ReadTool';
 import { ToolResult, ToolError } from './result';
-import { requireField } from './utils';
+import { formatLinesWithNumbers, requireField } from './utils';
 
 // Constants
 const CHANNEL = 'TextEditorTool';
@@ -204,17 +206,21 @@ export class TextEditorTool extends defineTool({
           .join('\n');
 
         return {
-          summary: `View directory ${filePath}`,
-          output: `Here's the files and directories in ${filePath}:\n${formattedContents}`,
+          summary: `Listed directory: ${filePath}`,
+          output: formattedContents,
         };
       }
 
       // Expand tabs to 4 spaces for consistent display
-      let fileContent = (await WorkspaceFS.read(filePath)).replaceAll(
+      const fileContent = (await WorkspaceFS.read(filePath)).replaceAll(
         '\t',
         '    ',
       );
-      let initLine = 1;
+      const lines = splitContentLines(fileContent);
+      const totalLines = lines.length;
+
+      let startIndex = 0;
+      let endIndex = totalLines;
 
       if (viewRange) {
         if (
@@ -227,20 +233,18 @@ export class TextEditorTool extends defineTool({
           );
         }
 
-        const fileLines = fileContent.split('\n');
-        const numLines = fileLines.length;
         const [startLine, endLine] = viewRange;
 
-        if (startLine < 1 || startLine > numLines) {
+        if (startLine < 1 || startLine > totalLines) {
           throw new ToolError(
-            `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its first element \`${startLine}\` should be within the range of lines of the file: [1, ${numLines}]`,
+            `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its first element \`${startLine}\` should be within the range of lines of the file: [1, ${totalLines}]`,
           );
         }
 
         if (endLine !== -1) {
-          if (endLine > numLines) {
+          if (endLine > totalLines) {
             throw new ToolError(
-              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${numLines}\``,
+              `Invalid \`view_range\`: [${startLine}, ${endLine}]. Its second element \`${endLine}\` should be smaller than the number of lines in the file: \`${totalLines}\``,
             );
           }
           if (endLine < startLine) {
@@ -250,28 +254,80 @@ export class TextEditorTool extends defineTool({
           }
         }
 
-        initLine = startLine;
-        const sliceEnd = endLine === -1 ? undefined : endLine;
-        fileContent = fileLines.slice(startLine - 1, sliceEnd).join('\n');
+        startIndex = startLine - 1;
+        endIndex = endLine === -1 ? totalLines : endLine;
       }
+
+      const selected = lines.slice(startIndex, endIndex);
+      const truncated = selected.length > READ_FILE_MAX_LINES;
+      const visibleLines = truncated
+        ? selected.slice(0, READ_FILE_MAX_LINES)
+        : selected;
+      const visibleCount = visibleLines.length;
 
       recordToolFileRead(filePath);
 
-      let summary: string;
-      if (viewRange) {
-        const endLabel = viewRange[1] === -1 ? 'end' : String(viewRange[1]);
-        summary = `View ${filePath} (${viewRange[0]}-${endLabel})`;
-      } else {
-        summary = `View ${filePath}`;
+      const segments: string[] = [];
+      if (visibleLines.length > 0) {
+        segments.push(
+          formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
+        );
       }
+      if (truncated) {
+        segments.push(
+          `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
+        );
+      }
+
+      const summary = this.buildViewSummary(filePath, {
+        totalLines,
+        visibleCount,
+        actualStartLine: visibleCount > 0 ? startIndex + 1 : null,
+        actualEndLine: visibleCount > 0 ? startIndex + visibleCount : null,
+        rangeProvided: viewRange != null,
+      });
 
       return {
         summary,
-        output: this.makeOutput(fileContent, filePath, initLine),
+        output: segments.join('\n'),
       };
     } catch (error) {
       rethrowWithContext(error, `Error viewing ${filePath}`);
     }
+  }
+
+  /** Build a summary string matching read_file's format. */
+  private buildViewSummary(
+    filePath: string,
+    params: {
+      totalLines: number;
+      visibleCount: number;
+      actualStartLine: number | null;
+      actualEndLine: number | null;
+      rangeProvided: boolean;
+    },
+  ): string {
+    const { totalLines, visibleCount, actualStartLine, actualEndLine, rangeProvided } = params;
+
+    if (visibleCount === 0) {
+      const reason = totalLines === 0 ? 'file is empty' : 'no lines in requested range';
+      return `Read ${filePath} (${reason})`;
+    }
+
+    const startLine = actualStartLine ?? 1;
+    const endLine = actualEndLine ?? startLine + visibleCount - 1;
+    const isFullRead =
+      !rangeProvided && startLine === 1 && endLine === totalLines;
+
+    if (isFullRead) {
+      return `Read ${filePath}`;
+    }
+
+    const rangeLabel =
+      startLine === endLine
+        ? `line ${startLine}`
+        : `lines ${startLine}-${endLine}`;
+    return `Read ${rangeLabel} of ${filePath}`;
   }
 
   private async create(filePath: string, content: string): Promise<ToolResult> {
@@ -619,17 +675,10 @@ export class TextEditorTool extends defineTool({
 
   private makeOutput(
     content: string,
-    fileDescriptor: string,
+    _fileDescriptor: string,
     initLine: number = 1,
   ): string {
-    const numberedLines = content
-      .split('\n')
-      .map((line, index) => {
-        const lineNum = index + initLine;
-        return `${lineNum.toString().padStart(6)}\t${line}`;
-      })
-      .join('\n');
-
-    return `Here's the result of running \`cat -n\` on ${fileDescriptor}:\n${numberedLines}\n`;
+    const lines = content.split('\n');
+    return formatLinesWithNumbers(lines, initLine).join('\n') + '\n';
   }
 }

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -254,7 +254,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const { startIndex, endIndex } = resolveViewRange(viewRange, lines.length);
+    const { startLine, endLine } = resolveViewRange(viewRange, lines.length);
 
     // Build metadata suffix for the summary
     const metaParts: string[] = [];
@@ -268,8 +268,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     return formatFileView({
       path: inputPath,
       lines,
-      startIndex,
-      endIndex,
+      startLine,
+      endLine,
       rangeProvided: viewRange != null,
       summarySuffix,
     });

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -101,7 +101,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       case 'view':
         return this.view(
           this.canonicalize(requireField(input.path, 'path', input.command)),
-          input.view_range ?? undefined,
+          // Schema enforces length 2; cast since Zod infers number[]
+          input.view_range as [number, number] | undefined,
         );
       case 'create':
         return this.create(
@@ -211,7 +212,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
   private async view(
     inputPath: string,
-    viewRange?: number[],
+    viewRange?: [number, number],
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -23,6 +23,7 @@ import {
   formatFileView,
   formatLinesWithNumbers,
   requireField,
+  resolveViewRange,
 } from '../utils';
 
 // Local imports - shared memory constants and utilities
@@ -253,10 +254,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const totalLines = lines.length;
-    const [start, end] = viewRange ?? [1, totalLines];
-    const startIndex = Math.min(Math.max(start - 1, 0), totalLines);
-    const endIndex = Math.min(end, totalLines);
+    const { startIndex, endIndex } = resolveViewRange(viewRange, lines.length);
 
     // Build metadata suffix for the summary
     const metaParts: string[] = [];

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -14,6 +14,7 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local imports - tool core
 import { defineTool } from '../core/define';
 import { ToolError, type ToolResult } from '../result';
+import { READ_FILE_MAX_LINES } from '../ReadTool';
 import {
   recordToolFileRead,
   requireFileReadForEdit,
@@ -252,25 +253,84 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const [start, end] = viewRange ?? [1, lines.length];
-    const startIndex = Math.max(start - 1, 0);
-    const endIndex = Math.min(end, lines.length);
+    const totalLines = lines.length;
+    const [start, end] = viewRange ?? [1, totalLines];
+    const startIndex = Math.min(Math.max(start - 1, 0), totalLines);
+    const endIndex = Math.min(end, totalLines);
     const selected = lines.slice(startIndex, endIndex);
-    const numbered = formatLinesWithNumbers(selected, startIndex + 1);
+    const truncated = selected.length > READ_FILE_MAX_LINES;
+    const visibleLines = truncated
+      ? selected.slice(0, READ_FILE_MAX_LINES)
+      : selected;
+    const visibleCount = visibleLines.length;
 
+    const segments: string[] = [];
+    if (visibleLines.length > 0) {
+      segments.push(
+        formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
+      );
+    }
+    if (truncated) {
+      segments.push(
+        `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
+      );
+    }
+
+    const summary = this.buildViewSummary(inputPath, meta, {
+      totalLines,
+      visibleCount,
+      actualStartLine: visibleCount > 0 ? startIndex + 1 : null,
+      actualEndLine: visibleCount > 0 ? startIndex + visibleCount : null,
+      rangeProvided: viewRange != null,
+    });
+
+    return {
+      summary,
+      output: segments.join('\n'),
+    };
+  }
+
+  /** Build a summary string matching read_file's format, with optional memory metadata. */
+  private buildViewSummary(
+    inputPath: string,
+    meta: MemoryFileMeta | null,
+    params: {
+      totalLines: number;
+      visibleCount: number;
+      actualStartLine: number | null;
+      actualEndLine: number | null;
+      rangeProvided: boolean;
+    },
+  ): string {
+    const { totalLines, visibleCount, actualStartLine, actualEndLine, rangeProvided } = params;
+
+    // Build metadata suffix
     const metaParts: string[] = [];
     if (meta) {
       metaParts.push(`last modified by: ${formatAttribution(meta)}`);
-      if (meta.pinned) metaParts.push('[pinned]');
+      if (meta.pinned) metaParts.push('pinned');
     }
-    const header = metaParts.length
-      ? `Here's the content of ${inputPath} (${metaParts.join(', ')}) with line numbers:`
-      : `Here's the content of ${inputPath} with line numbers:`;
+    const metaSuffix = metaParts.length > 0 ? ` (${metaParts.join(', ')})` : '';
 
-    return {
-      summary: `Viewed file: ${inputPath}`,
-      output: [header, ...numbered].join('\n'),
-    };
+    if (visibleCount === 0) {
+      const reason = totalLines === 0 ? 'file is empty' : 'no lines in requested range';
+      return `Read ${inputPath} (${reason})${metaSuffix}`;
+    }
+
+    const startLine = actualStartLine ?? 1;
+    const endLine = actualEndLine ?? startLine + visibleCount - 1;
+    const isFullRead =
+      !rangeProvided && startLine === 1 && endLine === totalLines;
+
+    if (isFullRead) {
+      return `Read ${inputPath}${metaSuffix}`;
+    }
+
+    const rangeLabel =
+      startLine === endLine
+        ? `line ${startLine}`
+        : `lines ${startLine}-${endLine}`;
+    return `Read ${rangeLabel} of ${inputPath}${metaSuffix}`;
   }
 
   private async create(
@@ -342,7 +402,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     return {
       summary: `Replaced text in: ${inputPath}`,
-      output: `The memory file has been edited.\nHere's the content of ${inputPath} with line numbers:\n${numbered.join('\n')}`,
+      output: `The file has been edited.\n${numbered.join('\n')}`,
     };
   }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -14,13 +14,13 @@ import { splitContentLines } from '@utils/text/stringUtils';
 // Local imports - tool core
 import { defineTool } from '../core/define';
 import { ToolError, type ToolResult } from '../result';
-import { READ_FILE_MAX_LINES } from '../ReadTool';
 import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '../fileInteractions';
 import {
   countOccurrences,
+  formatFileView,
   formatLinesWithNumbers,
   requireField,
 } from '../utils';
@@ -257,80 +257,24 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     const [start, end] = viewRange ?? [1, totalLines];
     const startIndex = Math.min(Math.max(start - 1, 0), totalLines);
     const endIndex = Math.min(end, totalLines);
-    const selected = lines.slice(startIndex, endIndex);
-    const truncated = selected.length > READ_FILE_MAX_LINES;
-    const visibleLines = truncated
-      ? selected.slice(0, READ_FILE_MAX_LINES)
-      : selected;
-    const visibleCount = visibleLines.length;
 
-    const segments: string[] = [];
-    if (visibleLines.length > 0) {
-      segments.push(
-        formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
-      );
-    }
-    if (truncated) {
-      segments.push(
-        `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
-      );
-    }
-
-    const summary = this.buildViewSummary(inputPath, meta, {
-      totalLines,
-      visibleCount,
-      actualStartLine: visibleCount > 0 ? startIndex + 1 : null,
-      actualEndLine: visibleCount > 0 ? startIndex + visibleCount : null,
-      rangeProvided: viewRange != null,
-    });
-
-    return {
-      summary,
-      output: segments.join('\n'),
-    };
-  }
-
-  /** Build a summary string matching read_file's format, with optional memory metadata. */
-  private buildViewSummary(
-    inputPath: string,
-    meta: MemoryFileMeta | null,
-    params: {
-      totalLines: number;
-      visibleCount: number;
-      actualStartLine: number | null;
-      actualEndLine: number | null;
-      rangeProvided: boolean;
-    },
-  ): string {
-    const { totalLines, visibleCount, actualStartLine, actualEndLine, rangeProvided } = params;
-
-    // Build metadata suffix
+    // Build metadata suffix for the summary
     const metaParts: string[] = [];
     if (meta) {
       metaParts.push(`last modified by: ${formatAttribution(meta)}`);
       if (meta.pinned) metaParts.push('pinned');
     }
-    const metaSuffix = metaParts.length > 0 ? ` (${metaParts.join(', ')})` : '';
+    const summarySuffix =
+      metaParts.length > 0 ? ` (${metaParts.join(', ')})` : '';
 
-    if (visibleCount === 0) {
-      const reason = totalLines === 0 ? 'file is empty' : 'no lines in requested range';
-      return `Read ${inputPath} (${reason})${metaSuffix}`;
-    }
-
-    const startLine = actualStartLine ?? 1;
-    const endLine = actualEndLine ?? startLine + visibleCount - 1;
-    const isFullRead =
-      !rangeProvided && startLine === 1 && endLine === totalLines;
-
-    if (isFullRead) {
-      return `Read ${inputPath}${metaSuffix}`;
-    }
-
-    const rangeLabel =
-      startLine === endLine
-        ? `line ${startLine}`
-        : `lines ${startLine}-${endLine}`;
-    return `Read ${rangeLabel} of ${inputPath}${metaSuffix}`;
+    return formatFileView({
+      path: inputPath,
+      lines,
+      startIndex,
+      endIndex,
+      rangeProvided: viewRange != null,
+      summarySuffix,
+    });
   }
 
   private async create(

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -23,7 +23,6 @@ import {
   formatFileView,
   formatLinesWithNumbers,
   requireField,
-  resolveViewRange,
 } from '../utils';
 
 // Local imports - shared memory constants and utilities
@@ -254,8 +253,6 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       );
     }
 
-    const { startLine, endLine } = resolveViewRange(viewRange, lines.length);
-
     // Build metadata suffix for the summary
     const metaParts: string[] = [];
     if (meta) {
@@ -268,9 +265,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     return formatFileView({
       path: inputPath,
       lines,
-      startLine,
-      endLine,
-      rangeProvided: viewRange != null,
+      viewRange,
       summarySuffix,
     });
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -90,6 +90,9 @@ export function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
+/** Maximum lines returned in a single file view before truncation. */
+export const READ_FILE_MAX_LINES = 2000;
+
 /** Default width for line number padding */
 const LINE_NUMBER_WIDTH = 6;
 
@@ -110,6 +113,95 @@ export function formatLinesWithNumbers(
     const prefix = lineNumber.toString().padStart(width, ' ');
     return `${prefix}\t${line}`;
   });
+}
+
+// ============================================================================
+// Shared file-view formatting
+// ============================================================================
+
+export interface FileViewOptions {
+  /** Display path used in the summary (e.g., "src/foo.ts" or "/memories/notes.md"). */
+  path: string;
+  /** All lines of the file. */
+  lines: string[];
+  /** 0-based start index (inclusive). */
+  startIndex: number;
+  /** 0-based end index (exclusive). */
+  endIndex: number;
+  /** Whether the caller supplied an explicit range. */
+  rangeProvided: boolean;
+  /** Optional suffix appended to the summary (e.g., memory metadata). */
+  summarySuffix?: string;
+}
+
+export interface FileViewResult {
+  output: string;
+  summary: string;
+}
+
+/**
+ * Shared pipeline for displaying file content with line numbers, truncation,
+ * and a standardised "Read …" summary.  Used by read_file, text_editor view,
+ * memory view, and executions readFile.
+ */
+export function formatFileView({
+  path: filePath,
+  lines,
+  startIndex,
+  endIndex,
+  rangeProvided,
+  summarySuffix = '',
+}: FileViewOptions): FileViewResult {
+  const totalLines = lines.length;
+  const selected = lines.slice(startIndex, endIndex);
+  const truncated = selected.length > READ_FILE_MAX_LINES;
+  const visibleLines = truncated
+    ? selected.slice(0, READ_FILE_MAX_LINES)
+    : selected;
+  const visibleCount = visibleLines.length;
+
+  // -- output ---------------------------------------------------------------
+  const segments: string[] = [];
+  if (visibleLines.length > 0) {
+    segments.push(
+      formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
+    );
+  }
+  if (truncated) {
+    segments.push(
+      `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
+    );
+  }
+
+  // -- summary --------------------------------------------------------------
+  let summary: string;
+
+  if (visibleCount === 0) {
+    const reason =
+      totalLines === 0 ? 'file is empty' : 'no lines in requested range';
+    summary = `Read ${filePath} (${reason})`;
+  } else {
+    const startLine = startIndex + 1;
+    const endLine = startIndex + visibleCount;
+    const isFullRead =
+      !rangeProvided && !truncated && startLine === 1 && endLine === totalLines;
+
+    if (isFullRead) {
+      summary = `Read ${filePath}`;
+    } else {
+      const rangeLabel =
+        startLine === endLine
+          ? `line ${startLine}`
+          : `lines ${startLine}-${endLine}`;
+      summary = `Read ${rangeLabel} of ${filePath}`;
+    }
+  }
+
+  if (summarySuffix) {
+    summary += summarySuffix;
+  }
+
+  return { output: segments.join('\n'), summary };
 }
 
 /**

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -130,6 +130,8 @@ export interface FileViewOptions {
    * Values are clamped to the file bounds automatically.
    */
   viewRange?: [number, number] | null;
+  /** Max visible lines before truncation. Defaults to READ_FILE_MAX_LINES (2000). */
+  maxLines?: number;
   /** Optional suffix appended to the summary (e.g., memory metadata). */
   summarySuffix?: string;
 }
@@ -148,6 +150,7 @@ export function formatFileView({
   path: filePath,
   lines,
   viewRange,
+  maxLines = READ_FILE_MAX_LINES,
   summarySuffix = '',
 }: FileViewOptions): FileViewResult {
   const totalLines = lines.length;
@@ -155,8 +158,8 @@ export function formatFileView({
   const startLine = Math.max(viewRange?.[0] ?? 1, 1);
   const endLine = Math.min(viewRange?.[1] ?? totalLines, totalLines);
   const rangeSize = Math.max(endLine - startLine + 1, 0);
-  const truncated = rangeSize > READ_FILE_MAX_LINES;
-  const sliceEnd = startLine - 1 + Math.min(rangeSize, READ_FILE_MAX_LINES);
+  const truncated = rangeSize > maxLines;
+  const sliceEnd = startLine - 1 + Math.min(rangeSize, maxLines);
   const visibleLines = lines.slice(startLine - 1, sliceEnd);
   const visibleCount = visibleLines.length;
 
@@ -169,7 +172,7 @@ export function formatFileView({
   }
   if (truncated) {
     segments.push(
-      `...(truncated, ${rangeSize - READ_FILE_MAX_LINES} more lines)`,
+      `...(truncated, ${rangeSize - maxLines} more lines)`,
     );
   }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -129,7 +129,7 @@ export interface FileViewOptions {
    * When omitted or nullish, the full file is shown.
    * Values are clamped to the file bounds automatically.
    */
-  viewRange?: number[] | null;
+  viewRange?: [number, number] | null;
   /** Optional suffix appended to the summary (e.g., memory metadata). */
   summarySuffix?: string;
 }
@@ -154,11 +154,10 @@ export function formatFileView({
   const rangeProvided = viewRange != null;
   const startLine = Math.max(viewRange?.[0] ?? 1, 1);
   const endLine = Math.min(viewRange?.[1] ?? totalLines, totalLines);
-  const selected = lines.slice(startLine - 1, endLine);
-  const truncated = selected.length > READ_FILE_MAX_LINES;
-  const visibleLines = truncated
-    ? selected.slice(0, READ_FILE_MAX_LINES)
-    : selected;
+  const rangeSize = Math.max(endLine - startLine + 1, 0);
+  const truncated = rangeSize > READ_FILE_MAX_LINES;
+  const sliceEnd = startLine - 1 + Math.min(rangeSize, READ_FILE_MAX_LINES);
+  const visibleLines = lines.slice(startLine - 1, sliceEnd);
   const visibleCount = visibleLines.length;
 
   // -- output ---------------------------------------------------------------
@@ -170,7 +169,7 @@ export function formatFileView({
   }
   if (truncated) {
     segments.push(
-      `...(truncated, ${selected.length - READ_FILE_MAX_LINES} more lines)`,
+      `...(truncated, ${rangeSize - READ_FILE_MAX_LINES} more lines)`,
     );
   }
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -119,31 +119,17 @@ export function formatLinesWithNumbers(
 // Shared file-view formatting
 // ============================================================================
 
-/**
- * Convert a 1-based `[start, end]` view range into clamped 1-based line numbers.
- * When no range is supplied, returns the full span `[1, totalLines]`.
- */
-export function resolveViewRange(
-  viewRange: number[] | null | undefined,
-  totalLines: number,
-): { startLine: number; endLine: number } {
-  return {
-    startLine: Math.max(viewRange?.[0] ?? 1, 1),
-    endLine: Math.min(viewRange?.[1] ?? totalLines, totalLines),
-  };
-}
-
 export interface FileViewOptions {
   /** Display path used in the summary (e.g., "src/foo.ts" or "/memories/notes.md"). */
   path: string;
   /** All lines of the file. */
   lines: string[];
-  /** 1-based start line (inclusive). */
-  startLine: number;
-  /** 1-based end line (inclusive). */
-  endLine: number;
-  /** Whether the caller supplied an explicit range. */
-  rangeProvided: boolean;
+  /**
+   * Optional 1-based `[start, end]` (both inclusive) line range.
+   * When omitted or nullish, the full file is shown.
+   * Values are clamped to the file bounds automatically.
+   */
+  viewRange?: number[] | null;
   /** Optional suffix appended to the summary (e.g., memory metadata). */
   summarySuffix?: string;
 }
@@ -161,12 +147,13 @@ export interface FileViewResult {
 export function formatFileView({
   path: filePath,
   lines,
-  startLine,
-  endLine,
-  rangeProvided,
+  viewRange,
   summarySuffix = '',
 }: FileViewOptions): FileViewResult {
   const totalLines = lines.length;
+  const rangeProvided = viewRange != null;
+  const startLine = Math.max(viewRange?.[0] ?? 1, 1);
+  const endLine = Math.min(viewRange?.[1] ?? totalLines, totalLines);
   const selected = lines.slice(startLine - 1, endLine);
   const truncated = selected.length > READ_FILE_MAX_LINES;
   const visibleLines = truncated

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -120,18 +120,16 @@ export function formatLinesWithNumbers(
 // ============================================================================
 
 /**
- * Convert a 1-based `[start, end]` view range into clamped 0-based indices.
- * When no range is supplied, returns the full span `[0, totalLines)`.
+ * Convert a 1-based `[start, end]` view range into clamped 1-based line numbers.
+ * When no range is supplied, returns the full span `[1, totalLines]`.
  */
 export function resolveViewRange(
   viewRange: number[] | null | undefined,
   totalLines: number,
-): { startIndex: number; endIndex: number } {
-  const requestedStart = viewRange?.[0] ?? 1;
-  const requestedEnd = viewRange?.[1] ?? totalLines;
+): { startLine: number; endLine: number } {
   return {
-    startIndex: Math.min(Math.max(requestedStart - 1, 0), totalLines),
-    endIndex: Math.min(requestedEnd, totalLines),
+    startLine: Math.max(viewRange?.[0] ?? 1, 1),
+    endLine: Math.min(viewRange?.[1] ?? totalLines, totalLines),
   };
 }
 
@@ -140,10 +138,10 @@ export interface FileViewOptions {
   path: string;
   /** All lines of the file. */
   lines: string[];
-  /** 0-based start index (inclusive). */
-  startIndex: number;
-  /** 0-based end index (exclusive). */
-  endIndex: number;
+  /** 1-based start line (inclusive). */
+  startLine: number;
+  /** 1-based end line (inclusive). */
+  endLine: number;
   /** Whether the caller supplied an explicit range. */
   rangeProvided: boolean;
   /** Optional suffix appended to the summary (e.g., memory metadata). */
@@ -163,13 +161,13 @@ export interface FileViewResult {
 export function formatFileView({
   path: filePath,
   lines,
-  startIndex,
-  endIndex,
+  startLine,
+  endLine,
   rangeProvided,
   summarySuffix = '',
 }: FileViewOptions): FileViewResult {
   const totalLines = lines.length;
-  const selected = lines.slice(startIndex, endIndex);
+  const selected = lines.slice(startLine - 1, endLine);
   const truncated = selected.length > READ_FILE_MAX_LINES;
   const visibleLines = truncated
     ? selected.slice(0, READ_FILE_MAX_LINES)
@@ -180,7 +178,7 @@ export function formatFileView({
   const segments: string[] = [];
   if (visibleLines.length > 0) {
     segments.push(
-      formatLinesWithNumbers(visibleLines, startIndex + 1).join('\n'),
+      formatLinesWithNumbers(visibleLines, startLine).join('\n'),
     );
   }
   if (truncated) {
@@ -197,18 +195,17 @@ export function formatFileView({
       totalLines === 0 ? 'file is empty' : 'no lines in requested range';
     summary = `Read ${filePath} (${reason})`;
   } else {
-    const startLine = startIndex + 1;
-    const endLine = startIndex + visibleCount;
+    const lastVisibleLine = startLine + visibleCount - 1;
     const isFullRead =
-      !rangeProvided && !truncated && startLine === 1 && endLine === totalLines;
+      !rangeProvided && !truncated && startLine === 1 && lastVisibleLine === totalLines;
 
     if (isFullRead) {
       summary = `Read ${filePath}`;
     } else {
       const rangeLabel =
-        startLine === endLine
+        startLine === lastVisibleLine
           ? `line ${startLine}`
-          : `lines ${startLine}-${endLine}`;
+          : `lines ${startLine}-${lastVisibleLine}`;
       summary = `Read ${rangeLabel} of ${filePath}`;
     }
   }

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -119,6 +119,22 @@ export function formatLinesWithNumbers(
 // Shared file-view formatting
 // ============================================================================
 
+/**
+ * Convert a 1-based `[start, end]` view range into clamped 0-based indices.
+ * When no range is supplied, returns the full span `[0, totalLines)`.
+ */
+export function resolveViewRange(
+  viewRange: number[] | null | undefined,
+  totalLines: number,
+): { startIndex: number; endIndex: number } {
+  const requestedStart = viewRange?.[0] ?? 1;
+  const requestedEnd = viewRange?.[1] ?? totalLines;
+  return {
+    startIndex: Math.min(Math.max(requestedStart - 1, 0), totalLines),
+    endIndex: Math.min(requestedEnd, totalLines),
+  };
+}
+
 export interface FileViewOptions {
   /** Display path used in the summary (e.g., "src/foo.ts" or "/memories/notes.md"). */
   path: string;


### PR DESCRIPTION
## Summary
Refactored file viewing logic across multiple tools into a shared `formatFileView()` utility function in `utils.ts`. This eliminates code duplication and ensures consistent formatting, truncation, and summary generation across read_file, text_editor, memory, and executions tools.

## Key Changes
- **Extracted `formatFileView()` utility**: Created a new shared function in `utils.ts` that handles file content display with line numbering, truncation at `READ_FILE_MAX_LINES`, and standardized "Read …" summaries
- **Moved `READ_FILE_MAX_LINES` constant**: Relocated from `ReadTool.ts` to `utils.ts` for shared access
- **Added `resolveViewRange()` helper**: New utility function to convert 1-based view ranges into clamped 0-based indices
- **Refactored `ReadFileTool`**: Removed `buildSummary()` method and inline summary logic; now delegates to `formatFileView()`
- **Updated `TextEditorTool`**: Simplified `view()` method to use `formatFileView()` and refactored `makeOutput()` to use `formatLinesWithNumbers()`
- **Updated `MemoryTool`**: Replaced custom formatting logic with `formatFileView()` and `resolveViewRange()`
- **Updated `ExecutionsTool`**: Converted `readFile()` to use `formatFileView()` instead of manual formatting
- **Improved output consistency**: Standardized directory listing output format and summary messages across tools

## Implementation Details
- `formatFileView()` accepts options for path, lines, start/end indices, range flag, and optional summary suffix
- Returns both `output` (formatted content with line numbers) and `summary` (standardized "Read …" message)
- Handles edge cases: empty files, out-of-range requests, truncation warnings
- Supports optional suffix appending for metadata (e.g., memory pinned status, range-exceeded warnings)

https://claude.ai/code/session_012yemq95ixaJtk4CENHVxUg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches output formatting and range/truncation behavior in several user-facing tools (`read_file`, `text_editor`, `memory`, `executions`), so regressions could break pagination, summaries, or line numbering even though the change is mostly refactoring.
> 
> **Overview**
> Unifies file-content rendering across tools by introducing `formatFileView()` in `tools/utils.ts` (shared line numbering, truncation via `READ_FILE_MAX_LINES`, and standardized `Read …` summaries).
> 
> Updates `read_file`, `TextEditorTool` view, `MemoryTool` view, and `ExecutionsTool` file reads to delegate to this utility, replacing bespoke slicing/summary logic, adjusting `view_range` typing (cast to `[number, number]`), and slightly standardizing messages (e.g., directory listings and memory pinned metadata in the summary suffix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cd2e38ae6bf229e34b062d883cec90dfa91d2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->