### PR TITLE
Stop running agents to prevent process leaks on cleanup

### DIFF
--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -358,6 +358,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
+    // Stop the agent if it is still running so the process does not leak
+    await vscode.commands.executeCommand('texra.stopAgent', streamId);
+
     // Clear pending approvals, retry requests, queued follow-ups, and YOLO state
     cleanupApprovalsForStream(streamId);
     retryCoordinator.clearRequest(streamId);
@@ -399,6 +402,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     if (confirmation !== 'Delete All') {
       return;
+    }
+
+    // Stop all running agents so processes do not leak
+    for (const streamId of this.provider.state.streamLogs.keys()) {
+      await vscode.commands.executeCommand('texra.stopAgent', streamId);
     }
 
     // Clear approvals, retry requests, queued follow-ups, and YOLO state

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -408,7 +408,9 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     const stopPromises: Promise<void>[] = [];
     for (const streamId of this.provider.state.streamLogs.keys()) {
       stopPromises.push(
-        vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
+        Promise.resolve(
+          vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
+        ),
       );
     }
     await Promise.allSettled(stopPromises);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -404,19 +404,21 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Stop all running agents and clear per-stream coordinator state
+    // Stop all running agents before clearing coordinator state
     const stopPromises: Promise<void>[] = [];
     for (const streamId of this.provider.state.streamLogs.keys()) {
       stopPromises.push(
         vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
       );
+    }
+    await Promise.allSettled(stopPromises);
+
+    // Clear approvals, retry requests, queued follow-ups, and YOLO state
+    cleanupAllApprovals();
+    for (const streamId of this.provider.state.streamLogs.keys()) {
       retryCoordinator.clearRequest(streamId);
       ToolUseFollowUpQueue.release(streamId);
     }
-    await Promise.all(stopPromises);
-
-    // Clear approval state
-    cleanupAllApprovals();
     this.modelOutputBackups.clear();
     this.provider.webviewBridge.clearAll();
     await this.provider.state.clearAll();

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -404,17 +404,19 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Stop all running agents so processes do not leak
+    // Stop all running agents and clear per-stream coordinator state
+    const stopPromises: Promise<void>[] = [];
     for (const streamId of this.provider.state.streamLogs.keys()) {
-      await vscode.commands.executeCommand('texra.stopAgent', streamId);
-    }
-
-    // Clear approvals, retry requests, queued follow-ups, and YOLO state
-    cleanupAllApprovals();
-    for (const streamId of this.provider.state.streamLogs.keys()) {
+      stopPromises.push(
+        vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
+      );
       retryCoordinator.clearRequest(streamId);
       ToolUseFollowUpQueue.release(streamId);
     }
+    await Promise.all(stopPromises);
+
+    // Clear approval state
+    cleanupAllApprovals();
     this.modelOutputBackups.clear();
     this.provider.webviewBridge.clearAll();
     await this.provider.state.clearAll();


### PR DESCRIPTION
## Summary
This change adds explicit agent cleanup to prevent process leaks when streams are closed or all streams are cleared. The agent processes are now properly terminated before other cleanup operations occur.

## Key Changes
- **Single stream cleanup**: Added `texra.stopAgent` command execution when closing an individual stream to ensure the agent process is terminated
- **Bulk cleanup**: Added a loop to stop all running agents when clearing all streams, preventing multiple process leaks during bulk operations

## Implementation Details
- The agent stop commands are executed before other cleanup operations (approvals, retry requests, queued follow-ups, etc.) to ensure proper resource cleanup order
- Both cleanup paths (single stream and all streams) now follow the same pattern of stopping agents first
- Uses the existing `texra.stopAgent` command that was already available in the codebase

https://claude.ai/code/session_01XQJfsavb1G4jwAKDD73Wpu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream deletion flows to actively interrupt running agent processes; incorrect stream IDs or timing could stop the wrong work or surface new race conditions during cleanup.
> 
> **Overview**
> Prevents agent process leaks by explicitly invoking `texra.stopAgent` during stream cleanup.
> 
> When deleting a single stream, the handler now stops the associated agent *before* clearing approvals, retries, follow-ups, and webview/state. When deleting all streams, it attempts to stop agents for every stream (via `Promise.allSettled`) prior to bulk coordinator/state cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88e5865c137cfb506e7624d7391a7d24038b79b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->