### PR TITLE
Fix import.meta.url polyfill for ESM dependencies bundled as CJS

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -123,7 +123,7 @@ const extensionConfig = {
   // bundled into CJS. Without this, esbuild replaces import.meta with {} and
   // calls like createRequire(import.meta.url) throw at runtime.
   banner: {
-    js: `var importMetaUrl = require("url").pathToFileURL(__filename).href;`,
+    js: `"use strict"; var importMetaUrl = require("url").pathToFileURL(__filename).href;`,
   },
   define: {
     'process.env.NODE_ENV': production ? '"production"' : '"development"',

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -119,8 +119,15 @@ const extensionConfig = {
   loader: { '.tex': 'text' },
   plugins: [aliasPlugin, progressPlugin],
   logLevel: 'warning',
+  // Polyfill import.meta.url for ESM-only dependencies (e.g. @openai/codex-sdk)
+  // bundled into CJS. Without this, esbuild replaces import.meta with {} and
+  // calls like createRequire(import.meta.url) throw at runtime.
+  banner: {
+    js: `var importMetaUrl = require("url").pathToFileURL(__filename).href;`,
+  },
   define: {
     'process.env.NODE_ENV': production ? '"production"' : '"development"',
+    'import.meta.url': 'importMetaUrl',
   },
 };
 


### PR DESCRIPTION
## Summary
Add a polyfill for `import.meta.url` to support ESM-only dependencies (like @openai/codex-sdk) when bundled into CommonJS format. This prevents runtime errors where `createRequire(import.meta.url)` calls would fail because esbuild replaces `import.meta` with an empty object.

## Key Changes
- Added a banner that injects `importMetaUrl` variable using Node's `url.pathToFileURL(__filename)` to provide the equivalent of `import.meta.url` in a CJS context
- Updated the `define` configuration to replace `import.meta.url` references with the injected `importMetaUrl` variable during bundling

## Implementation Details
The solution works by:
1. Injecting a banner at the top of the bundled JS that creates `importMetaUrl` from the current file's path
2. Using esbuild's `define` option to globally replace `import.meta.url` with `importMetaUrl` during the build process
3. This allows ESM code that relies on `import.meta.url` to work correctly when bundled as CommonJS

https://claude.ai/code/session_01WjCQAyZA8EEWpw1sjjNcmD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the extension bundling configuration and injects a new banner/define replacement that affects all emitted JS, so mistakes could cause runtime breakage despite being a small, targeted change.
> 
> **Overview**
> Fixes runtime failures from ESM-only dependencies when bundling the VS Code extension as CommonJS by **polyfilling `import.meta.url`**.
> 
> `esbuild.config.mjs` now injects a banner that computes an `importMetaUrl` from `__filename` and uses `define` to replace `import.meta.url` with that value during bundling, preventing crashes in code paths like `createRequire(import.meta.url)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebb2d23846d98d7b256151571c1a807d5cbded5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->