### PR TITLE
Organize arXiv papers into Papers subdirectory

### DIFF
--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -193,8 +193,9 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    // Create project directory for the arXiv paper inside Papers/ (sanitize ID to avoid path issues)
-    const paperDirRelative = path.join('Papers', id.replaceAll('/', '_'));
+    // Create project directory for the arXiv paper inside References/ (sanitize ID to avoid path issues)
+    // Use forward slashes to match WorkspaceFS.relativePath() convention (not path.join which uses backslashes on Windows)
+    const paperDirRelative = `References/${id.replaceAll('/', '_')}`;
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -193,8 +193,8 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    // Create project directory for the arXiv paper (sanitize ID to avoid path issues)
-    const paperDirRelative = id.replaceAll('/', '_');
+    // Create project directory for the arXiv paper inside Papers/ (sanitize ID to avoid path issues)
+    const paperDirRelative = path.join('Papers', id.replaceAll('/', '_'));
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.


### PR DESCRIPTION
## Summary
Modified the arXiv paper download logic to organize downloaded papers into a `Papers/` subdirectory within the workspace, rather than placing them at the root level.

## Key Changes
- Updated the paper directory path construction to include `Papers/` as a parent directory
- Changed `paperDirRelative` from `id.replaceAll('/', '_')` to `path.join('Papers', id.replaceAll('/', '_'))`
- Updated the comment to reflect that papers are now created inside the `Papers/` directory

## Implementation Details
The change uses `path.join()` to properly construct the relative path, ensuring cross-platform compatibility. This provides better workspace organization by grouping all downloaded arXiv papers in a dedicated subdirectory rather than cluttering the workspace root.

https://claude.ai/code/session_01EFR9bVReYNQU3Ac98PnTsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk path change that only affects where arXiv sources are stored; potential risk is breaking existing workflows that expect downloads at the workspace root.
> 
> **Overview**
> arXiv source downloads are now placed under a dedicated `References/` subdirectory instead of creating the paper directory at the workspace root.
> 
> The directory path construction is updated to use a forward-slash relative path (`References/${id}` with `/` sanitized) to stay consistent with `WorkspaceFS.relativePath()`’s slash normalization, avoiding Windows backslash mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3372304ac88f90a429132ea8c41f361d0504c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->