### PR TITLE
Add LaTeX asset extraction to WorkflowAgent

### DIFF
--- a/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 
 import {
   AGENT_CATEGORY,
+  ToolConfigSchema,
   ToolUseAgentProposalSchema,
   WorkflowAgentProposalSchema,
   type AgentProposal,
@@ -39,6 +40,7 @@ const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
   mediaFiles: z.array(z.string()).prefault([]),
   outputFiles: z.array(z.string()).prefault([]),
   useMultipleOutputs: z.boolean().prefault(false),
+  toolConfig: ToolConfigSchema,
 });
 
 const proposalInputStore = new Map<string, AgentProposal>();

--- a/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -60,9 +60,28 @@ function parseProposalInput(
   }
 
   if (toolName === 'delegate_workflow' || toolName === 'propose_workflow') {
+    // Map extraction shorthand flags into toolConfig (mirrors DelegationTools.execute)
+    const extractFigures =
+      'extractFigures' in spread ? Boolean(spread.extractFigures) : undefined;
+    const extractTikz =
+      'extractTikz' in spread ? Boolean(spread.extractTikz) : undefined;
+    const existingToolConfig = isPlainObject(spread.toolConfig)
+      ? spread.toolConfig
+      : {};
+    const toolConfig = {
+      ...existingToolConfig,
+      ...(extractFigures !== undefined && {
+        autoExtractFigure: extractFigures,
+      }),
+      ...(extractTikz !== undefined && {
+        autoExtractTikzFigure: extractTikz,
+      }),
+    };
+
     const result = LenientWorkflowProposalSchema.safeParse({
       agentCategory: AGENT_CATEGORY.WORKFLOW,
       ...spread,
+      toolConfig,
     });
     return result.success ? result.data : null;
   }

--- a/src/shared/schemas/proposalFields.ts
+++ b/src/shared/schemas/proposalFields.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { ToolConfigSchema } from './toolConfig';
+
 export const BaseProposalFieldsSchema = z.object({
   agent: z.string(),
   model: z.string(),
@@ -22,6 +24,7 @@ const FileFieldsSchema = z.object({
 
 export const WorkflowSpecificFieldsSchema = FileFieldsSchema.extend({
   useMultipleOutputs: z.boolean(),
+  toolConfig: ToolConfigSchema,
 });
 
 /** File fields shape used by all three rendering sites (toolFormatters, RequestPanels, PermissionCard). */

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -10,6 +10,7 @@
 
 // Third-party imports
 import { randomUUID } from 'crypto';
+import * as path from 'path';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -32,6 +33,9 @@ import {
 } from '@agent/toolUse/ToolFileInteractionContext';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+
+// Local imports - latex
+import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -72,7 +76,7 @@ import { defineTool } from '@tools/core/define';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
 
 // Local imports - utils
-import { WorkspaceFS } from '@utils/files';
+import { WorkspaceFS, pathToLocation } from '@utils/files';
 import { generateExecutionId } from '@utils/core/executionId';
 
 // ============================================================================
@@ -471,6 +475,12 @@ const WorkflowAgentInputSchema = z.object({
     .array(z.string())
     .prefault([])
     .describe('Additional media files'),
+  extractFigures: z
+    .boolean()
+    .prefault(false)
+    .describe(
+      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
+    ),
   outputFiles: z
     .array(z.string())
     .prefault([])
@@ -500,7 +510,9 @@ ${formatAgentList(getVisibleAgents('workflow'))}
 Available models: ${getVisibleModels().join(', ')}
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
 
-Example: agent=correct, inputFile=paper.tex, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
+Set extractFigures=true to automatically extract figures referenced by the input LaTeX file(s) (\\includegraphics, \\begin{overpic}) and attach them as media. Merges with any explicit mediaFile/mediaFiles.
+
+Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
@@ -569,6 +581,50 @@ Example: agent=correct, inputFile=paper.tex, instruction="This research paper pr
       throw new Error(`${missing.label} not found: ${missing.path}`);
     }
 
+    // Extract figures from input file(s) when requested
+    const effectiveMediaFile = input.mediaFile;
+    const effectiveMediaFiles = [...input.mediaFiles];
+
+    if (input.extractFigures) {
+      const allInputFiles = [input.inputFile, ...input.inputFiles];
+      const extractedPaths = new Set<string>();
+
+      for (const inputFilePath of allInputFiles) {
+        if (!inputFilePath.endsWith('.tex')) continue;
+        try {
+          const location = pathToLocation(inputFilePath);
+          const figurePaths =
+            await extractFigurePathsFromLatex(location);
+          const inputDir = path.dirname(inputFilePath);
+          for (const figurePath of figurePaths) {
+            // Convert from latex-dir-relative to workspace-relative
+            const workspaceRelative = path.normalize(
+              path.join(inputDir, figurePath),
+            );
+            extractedPaths.add(workspaceRelative);
+          }
+        } catch {
+          // Figure extraction failure is non-fatal — proceed without extracted figures
+          logger.debug(
+            LOG_CHANNEL,
+            `Figure extraction skipped for ${inputFilePath}`,
+          );
+        }
+      }
+
+      if (extractedPaths.size > 0) {
+        // Merge extracted figures with explicit media files, avoiding duplicates
+        const existingMedia = new Set(
+          [effectiveMediaFile, ...effectiveMediaFiles].filter(Boolean),
+        );
+        for (const extracted of extractedPaths) {
+          if (!existingMedia.has(extracted)) {
+            effectiveMediaFiles.push(extracted);
+          }
+        }
+      }
+    }
+
     // Construct workflow proposal
     // Memory paths are already validated by memoriesField's .superRefine() at schema parse time.
     const proposal = WorkflowAgentProposalSchema.parse({
@@ -582,8 +638,8 @@ Example: agent=correct, inputFile=paper.tex, instruction="This research paper pr
       referenceFiles: input.referenceFiles,
       auxiliaryFile: input.auxiliaryFile,
       auxiliaryFiles: input.auxiliaryFiles,
-      mediaFile: input.mediaFile,
-      mediaFiles: input.mediaFiles,
+      mediaFile: effectiveMediaFile,
+      mediaFiles: effectiveMediaFiles,
       outputFiles: input.outputFiles,
       useMultipleOutputs: input.useMultipleOutputs,
       memories: input.memories,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -10,7 +10,6 @@
 
 // Third-party imports
 import { randomUUID } from 'crypto';
-import * as path from 'path';
 import { z } from 'zod';
 
 // Local imports - agent
@@ -33,10 +32,6 @@ import {
 } from '@agent/toolUse/ToolFileInteractionContext';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-
-// Local imports - latex
-import { extractFigurePathsFromLatex } from '@latex/extractFigure';
-import { tikzPictureManager } from '@latex/TikzPictureManager';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -77,7 +72,7 @@ import { defineTool } from '@tools/core/define';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
 
 // Local imports - utils
-import { WorkspaceFS, pathToLocation } from '@utils/files';
+import { WorkspaceFS } from '@utils/files';
 import { generateExecutionId } from '@utils/core/executionId';
 
 // ============================================================================
@@ -591,73 +586,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       throw new Error(`${missing.label} not found: ${missing.path}`);
     }
 
-    // Collect effective file lists — extraction options may add entries
-    const effectiveMediaFiles = [...input.mediaFiles];
-
-    const allInputTexFiles = [input.inputFile, ...input.inputFiles].filter(
-      (f) => f.toLowerCase().endsWith('.tex'),
-    );
-
-    // Build a normalized set of existing media paths for dedup across extractions
-    const normalizedMediaSet = new Set(
-      [input.mediaFile, ...effectiveMediaFiles]
-        .filter((p): p is string => Boolean(p))
-        .map((p) => path.normalize(p)),
-    );
-
-    // Extract figures from input file(s) when requested
-    if (input.extractFigures) {
-      for (const inputFilePath of allInputTexFiles) {
-        try {
-          const location = pathToLocation(inputFilePath);
-          const figurePaths =
-            await extractFigurePathsFromLatex(location);
-          const inputDir = path.dirname(inputFilePath);
-          for (const figurePath of figurePaths) {
-            const normalized = path.normalize(
-              path.join(inputDir, figurePath),
-            );
-            if (!normalizedMediaSet.has(normalized)) {
-              effectiveMediaFiles.push(normalized);
-              normalizedMediaSet.add(normalized);
-            }
-          }
-        } catch {
-          logger.debug(
-            LOG_CHANNEL,
-            `Figure extraction skipped for ${inputFilePath}`,
-          );
-        }
-      }
-    }
-
-    // Extract and compile TikZ figures when requested
-    if (input.extractTikz) {
-      for (const inputFilePath of allInputTexFiles) {
-        try {
-          const location = pathToLocation(inputFilePath);
-          const compiledPdfs = await tikzPictureManager.compile(location);
-          for (const pdfLocation of compiledPdfs) {
-            const normalized = path.normalize(
-              pdfLocation.kind !== 'external'
-                ? pdfLocation.relativePath
-                : pdfLocation.absolutePath,
-            );
-            if (!normalizedMediaSet.has(normalized)) {
-              effectiveMediaFiles.push(normalized);
-              normalizedMediaSet.add(normalized);
-            }
-          }
-        } catch {
-          logger.debug(
-            LOG_CHANNEL,
-            `TikZ extraction skipped for ${inputFilePath}`,
-          );
-        }
-      }
-    }
-
     // Construct workflow proposal
+    // Extraction flags are mapped to toolConfig so they flow through to the
+    // agent execution pipeline (MediaExtractionNode → LatexMediaManager)
+    // and are preserved when the user clicks "Setup" in the proposal UI.
     // Memory paths are already validated by memoriesField's .superRefine() at schema parse time.
     const proposal = WorkflowAgentProposalSchema.parse({
       agentCategory: AgentCategory.Workflow,
@@ -671,11 +603,15 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       auxiliaryFile: input.auxiliaryFile,
       auxiliaryFiles: input.auxiliaryFiles,
       mediaFile: input.mediaFile,
-      mediaFiles: effectiveMediaFiles,
+      mediaFiles: input.mediaFiles,
       outputFiles: input.outputFiles,
       useMultipleOutputs: input.useMultipleOutputs,
+      toolConfig: {
+        autoExtractFigure: input.extractFigures,
+        autoExtractTikzFigure: input.extractTikz,
+      },
       memories: input.memories,
-    } satisfies WorkflowAgentProposal);
+    });
 
     return proposeAndExecute(proposal, input.agent, ctx.streamId);
   }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -35,7 +35,11 @@ import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
 // Local imports - latex
-import { extractBibliographyContext } from '@latex/extractBibliography';
+import {
+  extractBibliographyContext,
+  loadBibliographyEntries,
+  summarizeBibliographyEntries,
+} from '@latex/extractBibliography';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import { tikzPictureManager } from '@latex/TikzPictureManager';
 
@@ -493,7 +497,7 @@ const WorkflowAgentInputSchema = z.object({
     .boolean()
     .prefault(false)
     .describe(
-      'When true, discovers .bib files referenced by the input LaTeX file(s) and attaches them as auxiliary files. Merges with any explicitly provided auxiliaryFile/auxiliaryFiles.',
+      'When true, resolves cited BibTeX entries from .bib files referenced by the input LaTeX file(s) and appends them to the instruction. Only cited entries are included (capped at 50) to avoid bloating the prompt with large bibliography files.',
     ),
   outputFiles: z
     .array(z.string())
@@ -527,7 +531,7 @@ Model selection: use the largest models for challenging tasks requiring deep rea
 Extraction attachments — automatically discover and attach assets from input LaTeX file(s):
 - extractFigures=true: Extract \\includegraphics/\\begin{overpic} figures and attach as media files.
 - extractTikz=true: Compile TikZ figures into standalone PDFs and attach as media files.
-- extractBibliography=true: Discover referenced .bib files and attach as auxiliary files.
+- extractBibliography=true: Resolve cited BibTeX entries and include them in the instruction.
 All extraction options merge with explicitly provided files and are non-fatal on failure.
 
 Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliography=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
@@ -601,7 +605,6 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
 
     // Collect effective file lists — extraction options may add entries
     const effectiveMediaFiles = [...input.mediaFiles];
-    const effectiveAuxiliaryFiles = [...input.auxiliaryFiles];
 
     const allInputTexFiles = [input.inputFile, ...input.inputFiles].filter(
       (f) => f.toLowerCase().endsWith('.tex'),
@@ -668,24 +671,49 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
       }
     }
 
-    // Discover .bib files referenced by input file(s) when requested
+    // Extract cited bibliography entries when requested.
+    // Instead of attaching raw .bib files (which can be very large),
+    // we resolve only the cited entries and append them to the instruction.
+    let bibEntriesSuffix = '';
     if (input.extractBibliography) {
-      const existingAux = new Set(
-        [input.auxiliaryFile, ...effectiveAuxiliaryFiles].filter(Boolean),
-      );
+      const allBibFiles = new Set<string>();
+      const allCitationKeys = new Set<string>();
+
       for (const inputFilePath of allInputTexFiles) {
         try {
           const context = await extractBibliographyContext(inputFilePath);
           for (const bibFile of context.bibliographyFiles) {
-            if (!existingAux.has(bibFile)) {
-              effectiveAuxiliaryFiles.push(bibFile);
-              existingAux.add(bibFile);
-            }
+            allBibFiles.add(bibFile);
+          }
+          for (const key of context.citationKeys) {
+            allCitationKeys.add(key);
           }
         } catch {
           logger.debug(
             LOG_CHANNEL,
             `Bibliography extraction skipped for ${inputFilePath}`,
+          );
+        }
+      }
+
+      if (allBibFiles.size > 0 && allCitationKeys.size > 0) {
+        try {
+          const MAX_BIB_ENTRIES = 50;
+          const { entries } = await loadBibliographyEntries(
+            [...allBibFiles],
+            [...allCitationKeys],
+          );
+          if (entries.size > 0) {
+            const lines = summarizeBibliographyEntries(
+              entries,
+              MAX_BIB_ENTRIES,
+            );
+            bibEntriesSuffix = `\n\n<bibliography>\n${lines.join('\n')}\n</bibliography>`;
+          }
+        } catch {
+          logger.debug(
+            LOG_CHANNEL,
+            'Bibliography entry loading failed',
           );
         }
       }
@@ -697,13 +725,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
       agentCategory: AgentCategory.Workflow,
       agent: input.agent,
       model,
-      instruction: input.instruction,
+      instruction: input.instruction + bibEntriesSuffix,
       inputFile: input.inputFile,
       inputFiles: input.inputFiles,
       referenceFile: input.referenceFile,
       referenceFiles: input.referenceFiles,
       auxiliaryFile: input.auxiliaryFile,
-      auxiliaryFiles: effectiveAuxiliaryFiles,
+      auxiliaryFiles: input.auxiliaryFiles,
       mediaFile: input.mediaFile,
       mediaFiles: effectiveMediaFiles,
       outputFiles: input.outputFiles,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -35,11 +35,6 @@ import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
 // Local imports - latex
-import {
-  extractBibliographyContext,
-  loadBibliographyEntries,
-  summarizeBibliographyEntries,
-} from '@latex/extractBibliography';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import { tikzPictureManager } from '@latex/TikzPictureManager';
 
@@ -493,12 +488,6 @@ const WorkflowAgentInputSchema = z.object({
     .describe(
       'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
     ),
-  extractBibliography: z
-    .boolean()
-    .prefault(false)
-    .describe(
-      'When true, resolves cited BibTeX entries from .bib files referenced by the input LaTeX file(s) and appends them to the instruction. Only cited entries are included (capped at 50) to avoid bloating the prompt with large bibliography files.',
-    ),
   outputFiles: z
     .array(z.string())
     .prefault([])
@@ -531,10 +520,9 @@ Model selection: use the largest models for challenging tasks requiring deep rea
 Extraction attachments — automatically discover and attach assets from input LaTeX file(s):
 - extractFigures=true: Extract \\includegraphics/\\begin{overpic} figures and attach as media files.
 - extractTikz=true: Compile TikZ figures into standalone PDFs and attach as media files.
-- extractBibliography=true: Resolve cited BibTeX entries and include them in the instruction.
 All extraction options merge with explicitly provided files and are non-fatal on failure.
 
-Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliography=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
+Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
@@ -671,61 +659,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
       }
     }
 
-    // Extract cited bibliography entries when requested.
-    // Instead of attaching raw .bib files (which can be very large),
-    // we resolve only the cited entries and append them to the instruction.
-    let bibEntriesSuffix = '';
-    if (input.extractBibliography) {
-      const allBibFiles = new Set<string>();
-      const allCitationKeys = new Set<string>();
-
-      for (const inputFilePath of allInputTexFiles) {
-        try {
-          const context = await extractBibliographyContext(inputFilePath);
-          for (const bibFile of context.bibliographyFiles) {
-            allBibFiles.add(bibFile);
-          }
-          for (const key of context.citationKeys) {
-            allCitationKeys.add(key);
-          }
-        } catch {
-          logger.debug(
-            LOG_CHANNEL,
-            `Bibliography extraction skipped for ${inputFilePath}`,
-          );
-        }
-      }
-
-      if (allBibFiles.size > 0 && allCitationKeys.size > 0) {
-        try {
-          const MAX_BIB_ENTRIES = 50;
-          const { entries } = await loadBibliographyEntries(
-            [...allBibFiles],
-            [...allCitationKeys],
-          );
-          if (entries.size > 0) {
-            const lines = summarizeBibliographyEntries(
-              entries,
-              MAX_BIB_ENTRIES,
-            );
-            bibEntriesSuffix = `\n\n<bibliography>\n${lines.join('\n')}\n</bibliography>`;
-          }
-        } catch {
-          logger.debug(
-            LOG_CHANNEL,
-            'Bibliography entry loading failed',
-          );
-        }
-      }
-    }
-
     // Construct workflow proposal
     // Memory paths are already validated by memoriesField's .superRefine() at schema parse time.
     const proposal = WorkflowAgentProposalSchema.parse({
       agentCategory: AgentCategory.Workflow,
       agent: input.agent,
       model,
-      instruction: input.instruction + bibEntriesSuffix,
+      instruction: input.instruction,
       inputFile: input.inputFile,
       inputFiles: input.inputFiles,
       referenceFile: input.referenceFile,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -598,10 +598,15 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       (f) => f.toLowerCase().endsWith('.tex'),
     );
 
+    // Build a normalized set of existing media paths for dedup across extractions
+    const normalizedMediaSet = new Set(
+      [input.mediaFile, ...effectiveMediaFiles]
+        .filter((p): p is string => Boolean(p))
+        .map((p) => path.normalize(p)),
+    );
+
     // Extract figures from input file(s) when requested
     if (input.extractFigures) {
-      const extractedPaths = new Set<string>();
-
       for (const inputFilePath of allInputTexFiles) {
         try {
           const location = pathToLocation(inputFilePath);
@@ -609,9 +614,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
             await extractFigurePathsFromLatex(location);
           const inputDir = path.dirname(inputFilePath);
           for (const figurePath of figurePaths) {
-            extractedPaths.add(
-              path.normalize(path.join(inputDir, figurePath)),
+            const normalized = path.normalize(
+              path.join(inputDir, figurePath),
             );
+            if (!normalizedMediaSet.has(normalized)) {
+              effectiveMediaFiles.push(normalized);
+              normalizedMediaSet.add(normalized);
+            }
           }
         } catch {
           logger.debug(
@@ -620,22 +629,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
           );
         }
       }
-
-      const existingMedia = new Set(
-        [input.mediaFile, ...effectiveMediaFiles].filter(Boolean),
-      );
-      for (const extracted of extractedPaths) {
-        if (!existingMedia.has(extracted)) {
-          effectiveMediaFiles.push(extracted);
-        }
-      }
     }
 
     // Extract and compile TikZ figures when requested
     if (input.extractTikz) {
-      const existingMedia = new Set(
-        [input.mediaFile, ...effectiveMediaFiles].filter(Boolean),
-      );
       for (const inputFilePath of allInputTexFiles) {
         try {
           const location = pathToLocation(inputFilePath);
@@ -645,9 +642,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
               pdfLocation.kind !== 'external'
                 ? pdfLocation.relativePath
                 : pdfLocation.absolutePath;
-            if (!existingMedia.has(pdfPath)) {
+            const normalized = path.normalize(pdfPath);
+            if (!normalizedMediaSet.has(normalized)) {
               effectiveMediaFiles.push(pdfPath);
-              existingMedia.add(pdfPath);
+              normalizedMediaSet.add(normalized);
             }
           }
         } catch {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -35,7 +35,9 @@ import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
 // Local imports - latex
+import { extractBibliographyContext } from '@latex/extractBibliography';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
+import { tikzPictureManager } from '@latex/TikzPictureManager';
 
 // Local imports - logger
 import * as logger from '@logger/logUtils';
@@ -70,6 +72,7 @@ import {
   formatSubagentProgress,
   formatFollowUpInstruction,
 } from '@tools/subagentResults';
+import { resolveAndFormat } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - memory
@@ -481,6 +484,18 @@ const WorkflowAgentInputSchema = z.object({
     .describe(
       'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
     ),
+  extractTikz: z
+    .boolean()
+    .prefault(false)
+    .describe(
+      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
+    ),
+  extractBibliography: z
+    .boolean()
+    .prefault(false)
+    .describe(
+      'When true, discovers .bib files referenced by the input LaTeX file(s) and attaches them as auxiliary files. Merges with any explicitly provided auxiliaryFile/auxiliaryFiles.',
+    ),
   outputFiles: z
     .array(z.string())
     .prefault([])
@@ -510,9 +525,13 @@ ${formatAgentList(getVisibleAgents('workflow'))}
 Available models: ${getVisibleModels().join(', ')}
 Model selection: use the largest models for challenging tasks requiring deep reasoning; use cheaper long-context models for tedious but lengthy tasks; use cost-effective models for highly parallelizable routine work.
 
-Set extractFigures=true to automatically extract figures referenced by the input LaTeX file(s) (\\includegraphics, \\begin{overpic}) and attach them as media. Merges with any explicit mediaFile/mediaFiles.
+Extraction attachments — automatically discover and attach assets from input LaTeX file(s):
+- extractFigures=true: Extract \\includegraphics/\\begin{overpic} figures and attach as media files.
+- extractTikz=true: Compile TikZ figures into standalone PDFs and attach as media files.
+- extractBibliography=true: Discover referenced .bib files and attach as auxiliary files.
+All extraction options merge with explicitly provided files and are non-fatal on failure.
 
-Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
+Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliography=true, instruction="This research paper proposes a new quantum error correction scheme. Please fix grammar errors, improve sentence clarity, and ensure consistent terminology throughout. Pay particular attention to the abstract and introduction where the key contributions are summarized."`,
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
@@ -581,16 +600,21 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       throw new Error(`${missing.label} not found: ${missing.path}`);
     }
 
-    // Extract figures from input file(s) when requested
+    // Collect effective file lists — extraction options may add entries
     const effectiveMediaFile = input.mediaFile;
     const effectiveMediaFiles = [...input.mediaFiles];
+    const effectiveAuxiliaryFile = input.auxiliaryFile;
+    const effectiveAuxiliaryFiles = [...input.auxiliaryFiles];
 
+    const allInputTexFiles = [input.inputFile, ...input.inputFiles].filter(
+      (f) => f.endsWith('.tex'),
+    );
+
+    // Extract figures from input file(s) when requested
     if (input.extractFigures) {
-      const allInputFiles = [input.inputFile, ...input.inputFiles];
       const extractedPaths = new Set<string>();
 
-      for (const inputFilePath of allInputFiles) {
-        if (!inputFilePath.endsWith('.tex')) continue;
+      for (const inputFilePath of allInputTexFiles) {
         try {
           const location = pathToLocation(inputFilePath);
           const figurePaths =
@@ -604,7 +628,6 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
             extractedPaths.add(workspaceRelative);
           }
         } catch {
-          // Figure extraction failure is non-fatal — proceed without extracted figures
           logger.debug(
             LOG_CHANNEL,
             `Figure extraction skipped for ${inputFilePath}`,
@@ -613,7 +636,6 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       }
 
       if (extractedPaths.size > 0) {
-        // Merge extracted figures with explicit media files, avoiding duplicates
         const existingMedia = new Set(
           [effectiveMediaFile, ...effectiveMediaFiles].filter(Boolean),
         );
@@ -621,6 +643,57 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
           if (!existingMedia.has(extracted)) {
             effectiveMediaFiles.push(extracted);
           }
+        }
+      }
+    }
+
+    // Extract and compile TikZ figures when requested
+    if (input.extractTikz) {
+      for (const inputFilePath of allInputTexFiles) {
+        try {
+          const location = pathToLocation(inputFilePath);
+          const compiledPdfs = await tikzPictureManager.compile(location);
+          const existingMedia = new Set(
+            [effectiveMediaFile, ...effectiveMediaFiles].filter(Boolean),
+          );
+          for (const pdfLocation of compiledPdfs) {
+            const pdfPath = pdfLocation.absolutePath;
+            if (!existingMedia.has(pdfPath)) {
+              effectiveMediaFiles.push(pdfPath);
+              existingMedia.add(pdfPath);
+            }
+          }
+        } catch {
+          logger.debug(
+            LOG_CHANNEL,
+            `TikZ extraction skipped for ${inputFilePath}`,
+          );
+        }
+      }
+    }
+
+    // Discover .bib files referenced by input file(s) when requested
+    if (input.extractBibliography) {
+      const existingAux = new Set(
+        [effectiveAuxiliaryFile, ...effectiveAuxiliaryFiles].filter(Boolean),
+      );
+      for (const inputFilePath of allInputTexFiles) {
+        try {
+          const { path: resolvedPath } = resolveAndFormat(inputFilePath);
+          const context = await extractBibliographyContext(
+            resolvedPath.relative,
+          );
+          for (const bibFile of context.bibliographyFiles) {
+            if (!existingAux.has(bibFile)) {
+              effectiveAuxiliaryFiles.push(bibFile);
+              existingAux.add(bibFile);
+            }
+          }
+        } catch {
+          logger.debug(
+            LOG_CHANNEL,
+            `Bibliography extraction skipped for ${inputFilePath}`,
+          );
         }
       }
     }
@@ -636,8 +709,8 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       inputFiles: input.inputFiles,
       referenceFile: input.referenceFile,
       referenceFiles: input.referenceFiles,
-      auxiliaryFile: input.auxiliaryFile,
-      auxiliaryFiles: input.auxiliaryFiles,
+      auxiliaryFile: effectiveAuxiliaryFile,
+      auxiliaryFiles: effectiveAuxiliaryFiles,
       mediaFile: effectiveMediaFile,
       mediaFiles: effectiveMediaFiles,
       outputFiles: input.outputFiles,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -72,7 +72,6 @@ import {
   formatSubagentProgress,
   formatFollowUpInstruction,
 } from '@tools/subagentResults';
-import { resolveAndFormat } from '@tools/utils';
 import { defineTool } from '@tools/core/define';
 
 // Local imports - memory
@@ -601,9 +600,7 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
     }
 
     // Collect effective file lists — extraction options may add entries
-    const effectiveMediaFile = input.mediaFile;
     const effectiveMediaFiles = [...input.mediaFiles];
-    const effectiveAuxiliaryFile = input.auxiliaryFile;
     const effectiveAuxiliaryFiles = [...input.auxiliaryFiles];
 
     const allInputTexFiles = [input.inputFile, ...input.inputFiles].filter(
@@ -621,11 +618,9 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
             await extractFigurePathsFromLatex(location);
           const inputDir = path.dirname(inputFilePath);
           for (const figurePath of figurePaths) {
-            // Convert from latex-dir-relative to workspace-relative
-            const workspaceRelative = path.normalize(
-              path.join(inputDir, figurePath),
+            extractedPaths.add(
+              path.normalize(path.join(inputDir, figurePath)),
             );
-            extractedPaths.add(workspaceRelative);
           }
         } catch {
           logger.debug(
@@ -635,27 +630,25 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
         }
       }
 
-      if (extractedPaths.size > 0) {
-        const existingMedia = new Set(
-          [effectiveMediaFile, ...effectiveMediaFiles].filter(Boolean),
-        );
-        for (const extracted of extractedPaths) {
-          if (!existingMedia.has(extracted)) {
-            effectiveMediaFiles.push(extracted);
-          }
+      const existingMedia = new Set(
+        [input.mediaFile, ...effectiveMediaFiles].filter(Boolean),
+      );
+      for (const extracted of extractedPaths) {
+        if (!existingMedia.has(extracted)) {
+          effectiveMediaFiles.push(extracted);
         }
       }
     }
 
     // Extract and compile TikZ figures when requested
     if (input.extractTikz) {
+      const existingMedia = new Set(
+        [input.mediaFile, ...effectiveMediaFiles].filter(Boolean),
+      );
       for (const inputFilePath of allInputTexFiles) {
         try {
           const location = pathToLocation(inputFilePath);
           const compiledPdfs = await tikzPictureManager.compile(location);
-          const existingMedia = new Set(
-            [effectiveMediaFile, ...effectiveMediaFiles].filter(Boolean),
-          );
           for (const pdfLocation of compiledPdfs) {
             const pdfPath = pdfLocation.absolutePath;
             if (!existingMedia.has(pdfPath)) {
@@ -675,14 +668,11 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
     // Discover .bib files referenced by input file(s) when requested
     if (input.extractBibliography) {
       const existingAux = new Set(
-        [effectiveAuxiliaryFile, ...effectiveAuxiliaryFiles].filter(Boolean),
+        [input.auxiliaryFile, ...effectiveAuxiliaryFiles].filter(Boolean),
       );
       for (const inputFilePath of allInputTexFiles) {
         try {
-          const { path: resolvedPath } = resolveAndFormat(inputFilePath);
-          const context = await extractBibliographyContext(
-            resolvedPath.relative,
-          );
+          const context = await extractBibliographyContext(inputFilePath);
           for (const bibFile of context.bibliographyFiles) {
             if (!existingAux.has(bibFile)) {
               effectiveAuxiliaryFiles.push(bibFile);
@@ -709,9 +699,9 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
       inputFiles: input.inputFiles,
       referenceFile: input.referenceFile,
       referenceFiles: input.referenceFiles,
-      auxiliaryFile: effectiveAuxiliaryFile,
+      auxiliaryFile: input.auxiliaryFile,
       auxiliaryFiles: effectiveAuxiliaryFiles,
-      mediaFile: effectiveMediaFile,
+      mediaFile: input.mediaFile,
       mediaFiles: effectiveMediaFiles,
       outputFiles: input.outputFiles,
       useMultipleOutputs: input.useMultipleOutputs,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -43,6 +43,7 @@ import {
 } from '@model/computeModelOptions';
 import {
   AGENT_CATEGORY,
+  DEFAULT_TOOL_CONFIG,
   WorkflowAgentProposalSchema,
   ToolUseAgentProposalSchema,
   type WorkflowAgentProposal,
@@ -607,11 +608,12 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       outputFiles: input.outputFiles,
       useMultipleOutputs: input.useMultipleOutputs,
       toolConfig: {
+        ...DEFAULT_TOOL_CONFIG,
         autoExtractFigure: input.extractFigures,
         autoExtractTikzFigure: input.extractTikz,
       },
       memories: input.memories,
-    });
+    } satisfies WorkflowAgentProposal);
 
     return proposeAndExecute(proposal, input.agent, ctx.streamId);
   }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -604,7 +604,7 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
     const effectiveAuxiliaryFiles = [...input.auxiliaryFiles];
 
     const allInputTexFiles = [input.inputFile, ...input.inputFiles].filter(
-      (f) => f.endsWith('.tex'),
+      (f) => f.toLowerCase().endsWith('.tex'),
     );
 
     // Extract figures from input file(s) when requested
@@ -650,7 +650,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, extractBibliog
           const location = pathToLocation(inputFilePath);
           const compiledPdfs = await tikzPictureManager.compile(location);
           for (const pdfLocation of compiledPdfs) {
-            const pdfPath = pdfLocation.absolutePath;
+            const pdfPath =
+              pdfLocation.kind !== 'external'
+                ? pdfLocation.relativePath
+                : pdfLocation.absolutePath;
             if (!existingMedia.has(pdfPath)) {
               effectiveMediaFiles.push(pdfPath);
               existingMedia.add(pdfPath);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -638,13 +638,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
           const location = pathToLocation(inputFilePath);
           const compiledPdfs = await tikzPictureManager.compile(location);
           for (const pdfLocation of compiledPdfs) {
-            const pdfPath =
+            const normalized = path.normalize(
               pdfLocation.kind !== 'external'
                 ? pdfLocation.relativePath
-                : pdfLocation.absolutePath;
-            const normalized = path.normalize(pdfPath);
+                : pdfLocation.absolutePath,
+            );
             if (!normalizedMediaSet.has(normalized)) {
-              effectiveMediaFiles.push(pdfPath);
+              effectiveMediaFiles.push(normalized);
               normalizedMediaSet.add(normalized);
             }
           }


### PR DESCRIPTION
## Summary
Extends the WorkflowAgent tool with automatic extraction and attachment of LaTeX assets (figures, TikZ diagrams, and bibliography files) from input LaTeX documents.

## Key Changes
- **New extraction options**: Added three boolean parameters to `WorkflowAgentInputSchema`:
  - `extractFigures`: Automatically discovers and attaches figures referenced via `\includegraphics` and `\begin{overpic}`
  - `extractTikz`: Compiles TikZ figures into standalone PDFs and attaches them
  - `extractBibliography`: Discovers and attaches `.bib` files referenced by input LaTeX files

- **Asset discovery logic**: Implemented extraction pipeline that:
  - Processes all input `.tex` files (both `inputFile` and `inputFiles`)
  - Uses existing LaTeX utilities (`extractFigurePathsFromLatex`, `tikzPictureManager`, `extractBibliographyContext`)
  - Merges extracted assets with explicitly provided files, avoiding duplicates
  - Gracefully handles extraction failures with debug logging

- **Updated imports**: Added imports for LaTeX extraction utilities and `path` module

- **Enhanced documentation**: Updated tool description with extraction examples and usage guidance

## Implementation Details
- Extracted assets are deduplicated against explicitly provided files using `Set` data structures
- All extraction operations are non-fatal; failures are logged at debug level and don't block workflow execution
- Effective file lists are built incrementally, allowing multiple extraction options to work together
- Path normalization ensures consistent file references across different input formats

https://claude.ai/code/session_011xEpa8mTosXeT7vNq8fc2Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `delegate_workflow` inputs and proposal schemas to carry new extraction options via `toolConfig`, which can change how workflow executions attach media assets and how proposals are reconstructed in the UI.
> 
> **Overview**
> Adds `extractFigures`/`extractTikz` boolean inputs to `delegate_workflow` and documents their usage for automatically attaching LaTeX-derived assets.
> 
> Maps these flags into the workflow proposal’s `toolConfig` (seeded from `DEFAULT_TOOL_CONFIG`) so the settings flow through execution and are preserved when reopening a proposal via “Setup”.
> 
> Extends shared workflow proposal field schemas and the progress-view `proposalInputStore` parser to include `toolConfig` and to translate legacy/shorthand extraction flags into the new config shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74a967b7ab7389586c87a49e6172309d789d9e96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->