### PR TITLE
Collapse plan and todo views when switching streams

### DIFF
--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -163,15 +163,15 @@ export class PlanView extends LitElement {
   ];
 
   @property({ attribute: false }) plan: Plan | null = null;
-  @property({ type: String }) streamId = '';
 
-  /** Open state — auto-expands on plan updates, auto-collapses when cleared.
-   *  Collapses when switching to a different stream. */
+  /** When this key changes, the panel collapses. Used by the parent to reset
+   *  open state on context switches (e.g. switching streams). */
+  @property({ type: String }) collapseKey = '';
+
   @state() private open = true;
 
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('streamId') && changed.get('streamId') !== undefined) {
-      // Collapse when switching streams
+    if (changed.has('collapseKey') && changed.get('collapseKey') !== undefined) {
       this.open = false;
       return;
     }

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -163,11 +163,18 @@ export class PlanView extends LitElement {
   ];
 
   @property({ attribute: false }) plan: Plan | null = null;
+  @property({ type: String }) streamId = '';
 
-  /** Open state — auto-expands on plan updates, auto-collapses when cleared. */
+  /** Open state — auto-expands on plan updates, auto-collapses when cleared.
+   *  Collapses when switching to a different stream. */
   @state() private open = true;
 
   protected override willUpdate(changed: PropertyValues): void {
+    if (changed.has('streamId') && changed.get('streamId') !== undefined) {
+      // Collapse when switching streams
+      this.open = false;
+      return;
+    }
     if (changed.has('plan')) {
       if (this.plan) {
         this.open = true;

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -101,15 +101,15 @@ export class TodoList extends LitElement {
   ];
 
   @property({ attribute: false }) todos: TodoItem[] = [];
-  @property({ type: String }) streamId = '';
 
-  /** Open state — auto-expands on todo updates, auto-collapses when cleared.
-   *  Collapses when switching to a different stream. */
+  /** When this key changes, the panel collapses. Used by the parent to reset
+   *  open state on context switches (e.g. switching streams). */
+  @property({ type: String }) collapseKey = '';
+
   @state() private open = true;
 
   protected override willUpdate(changed: PropertyValues): void {
-    if (changed.has('streamId') && changed.get('streamId') !== undefined) {
-      // Collapse when switching streams
+    if (changed.has('collapseKey') && changed.get('collapseKey') !== undefined) {
       this.open = false;
       return;
     }

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -101,11 +101,18 @@ export class TodoList extends LitElement {
   ];
 
   @property({ attribute: false }) todos: TodoItem[] = [];
+  @property({ type: String }) streamId = '';
 
-  /** Open state — auto-expands on todo updates, auto-collapses when cleared. */
+  /** Open state — auto-expands on todo updates, auto-collapses when cleared.
+   *  Collapses when switching to a different stream. */
   @state() private open = true;
 
   protected override willUpdate(changed: PropertyValues): void {
+    if (changed.has('streamId') && changed.get('streamId') !== undefined) {
+      // Collapse when switching streams
+      this.open = false;
+      return;
+    }
     if (changed.has('todos')) {
       if (this.todos.length > 0) {
         this.open = true;

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -106,9 +106,9 @@ export class ToolUseStreamContent extends LitElement {
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
 
-      <todo-list .todos=${currentState.todos} .streamId=${streamInfo.name}></todo-list>
+      <todo-list .todos=${currentState.todos} .collapseKey=${streamInfo.name}></todo-list>
 
-      <plan-view .plan=${currentState.plan} .streamId=${streamInfo.name}></plan-view>
+      <plan-view .plan=${currentState.plan} .collapseKey=${streamInfo.name}></plan-view>
 
       <background-tasks-panel
         .activeProcesses=${currentState.activeProcesses}

--- a/src/progressView/frontend/components/ToolUseStreamContent.ts
+++ b/src/progressView/frontend/components/ToolUseStreamContent.ts
@@ -106,9 +106,9 @@ export class ToolUseStreamContent extends LitElement {
 
       <request-panels .permissions=${this.filteredPermissions}></request-panels>
 
-      <todo-list .todos=${currentState.todos}></todo-list>
+      <todo-list .todos=${currentState.todos} .streamId=${streamInfo.name}></todo-list>
 
-      <plan-view .plan=${currentState.plan}></plan-view>
+      <plan-view .plan=${currentState.plan} .streamId=${streamInfo.name}></plan-view>
 
       <background-tasks-panel
         .activeProcesses=${currentState.activeProcesses}


### PR DESCRIPTION
## Summary
Added stream tracking to PlanView and TodoList components to automatically collapse their expanded state when the user switches to a different stream.

## Key Changes
- Added `streamId` property to both `PlanView` and `TodoList` components to track the current stream
- Updated `willUpdate` lifecycle method in both components to collapse (`open = false`) when `streamId` changes
- Modified `ToolUseStreamContent` template to pass `streamInfo.name` as the `streamId` property to both child components
- Updated JSDoc comments to document the new stream-switching collapse behavior

## Implementation Details
The collapse logic is implemented by checking if the `streamId` property has changed in the `willUpdate` method. When a stream switch is detected (indicated by `streamId` changing from a defined value), the component's `open` state is set to `false` before other property change handlers execute. This ensures a clean UX where expanding a plan or todo list in one stream doesn't carry over visual state when navigating to a different stream.

https://claude.ai/code/session_01LW8vga844cXtcwq2eyV7Bv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to collapsible open/closed behavior when switching streams; main risk is minor UX regression if `collapseKey` updates unexpectedly.
> 
> **Overview**
> Resets the expanded/collapsed UI state for `todo-list` and `plan-view` when switching streams by introducing a parent-controlled `collapseKey` prop.
> 
> `TodoList` and `PlanView` now immediately set `open = false` when `collapseKey` changes (before reacting to `todos`/`plan` updates), and `ToolUseStreamContent` wires this by passing `streamInfo.name` as the key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d743f60c8107542f196e8cad84e16bc25f6a7df1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->