### PR TITLE
Add option to mark commits with TeXRA author info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1844,9 +1844,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,9 +1861,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1884,9 +1878,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1895,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1924,9 +1912,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1944,9 +1929,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -611,6 +611,24 @@
             "maximum": 100,
             "description": "Number of recent commits to show in the commit selection dropdown",
             "order": 1
+          },
+          "texra.git.markCommits": {
+            "type": "boolean",
+            "default": false,
+            "description": "Mark commits made by TeXRA with a custom author name and email",
+            "order": 2
+          },
+          "texra.git.authorName": {
+            "type": "string",
+            "default": "TeXRA",
+            "description": "Author name used for commits when 'Mark Commits' is enabled",
+            "order": 3
+          },
+          "texra.git.authorEmail": {
+            "type": "string",
+            "default": "texra@users.noreply.github.com",
+            "description": "Author email used for commits when 'Mark Commits' is enabled",
+            "order": 4
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -611,24 +611,6 @@
             "maximum": 100,
             "description": "Number of recent commits to show in the commit selection dropdown",
             "order": 1
-          },
-          "texra.git.markCommits": {
-            "type": "boolean",
-            "default": false,
-            "description": "Mark commits made by TeXRA with a custom author name and email",
-            "order": 2
-          },
-          "texra.git.authorName": {
-            "type": "string",
-            "default": "TeXRA",
-            "description": "Author name used for commits when 'Mark Commits' is enabled",
-            "order": 3
-          },
-          "texra.git.authorEmail": {
-            "type": "string",
-            "default": "texra@users.noreply.github.com",
-            "description": "Author email used for commits when 'Mark Commits' is enabled",
-            "order": 4
           }
         }
       },

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -23,6 +23,11 @@ export enum WorkspaceStateKey {
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
   ALLOW_ORCHESTRATOR_KILL = 'texra.allowOrchestratorKill',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
+
+  // Git commit author settings
+  GIT_MARK_COMMITS = 'texra.git.markCommits',
+  GIT_AUTHOR_NAME = 'texra.git.authorName',
+  GIT_AUTHOR_EMAIL = 'texra.git.authorEmail',
 }
 
 export enum GlobalStateKey {

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -76,6 +76,11 @@ export const SETTINGS_VIEW_CMD = {
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
+  // Git settings commands
+  GET_GIT_AUTHOR_SETTINGS: 'getGitAuthorSettings',
+  SET_GIT_MARK_COMMITS: 'setGitMarkCommits',
+  SET_GIT_AUTHOR_NAME: 'setGitAuthorName',
+  SET_GIT_AUTHOR_EMAIL: 'setGitAuthorEmail',
   // LaTeX settings commands
   GET_LATEX_SETTINGS_STATUS: 'getLatexSettingsStatus',
   APPLY_LATEX_SETTINGS: 'applyLatexSettings',
@@ -100,5 +105,6 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_SUPER_YOLO_ENABLED: 'updateSuperYoloEnabled',
   UPDATE_AGENT_MODE_PRESETS: 'updateAgentModePresets',
   UPDATE_TOOL_DASHBOARD: 'updateToolDashboard',
+  UPDATE_GIT_AUTHOR_SETTINGS: 'updateGitAuthorSettings',
   UPDATE_LATEX_SETTINGS_STATUS: 'updateLatexSettingsStatus',
 } as const;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,9 +43,9 @@ import { setExtensionChecker } from '@tools/externalToolDefs';
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
 import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
 import { StorageFS } from '@utils/files';
-import { getConfig, watchConfig } from '@utils/config';
+import { getConfig } from '@utils/config';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
-import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -55,25 +55,6 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 let progressViewProviderInstance: ProgressViewProvider | undefined;
-
-function applyGitAuthorConfig(): void {
-  const enabled = getConfig<boolean>('texra.git.markCommits', false);
-  if (!enabled) {
-    setGitAuthorEnv({});
-    return;
-  }
-  const name = getConfig<string>('texra.git.authorName', 'TeXRA');
-  const email = getConfig<string>(
-    'texra.git.authorEmail',
-    'texra@users.noreply.github.com',
-  );
-  setGitAuthorEnv({
-    GIT_AUTHOR_NAME: name,
-    GIT_AUTHOR_EMAIL: email,
-    GIT_COMMITTER_NAME: name,
-    GIT_COMMITTER_EMAIL: email,
-  });
-}
 
 async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
@@ -220,7 +201,6 @@ export async function activate(context: vscode.ExtensionContext) {
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
 
   applyGitAuthorConfig();
-  watchConfig(context, 'texra.git', applyGitAuthorConfig);
 
   setToolNotificationHandler((message, actionCommand) => {
     if (actionCommand) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,8 +43,9 @@ import { setExtensionChecker } from '@tools/externalToolDefs';
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
 import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
 import { StorageFS } from '@utils/files';
-import { getConfig } from '@utils/config';
+import { getConfig, watchConfig } from '@utils/config';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
+import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
 // Local imports - components
 import { ProgressViewProvider } from './progressView/ProgressViewProvider';
@@ -54,6 +55,25 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let apiKeyStatusBarItem: vscode.StatusBarItem | undefined;
 let disposeStatusListener: (() => void) | undefined;
 let progressViewProviderInstance: ProgressViewProvider | undefined;
+
+function applyGitAuthorConfig(): void {
+  const enabled = getConfig<boolean>('texra.git.markCommits', false);
+  if (!enabled) {
+    setGitAuthorEnv({});
+    return;
+  }
+  const name = getConfig<string>('texra.git.authorName', 'TeXRA');
+  const email = getConfig<string>(
+    'texra.git.authorEmail',
+    'texra@users.noreply.github.com',
+  );
+  setGitAuthorEnv({
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: name,
+    GIT_COMMITTER_EMAIL: email,
+  });
+}
 
 async function refreshApiKeyStatus() {
   if (!apiKeyStatusBarItem) {
@@ -198,6 +218,9 @@ export async function activate(context: vscode.ExtensionContext) {
   initializeNativeToolEditApproval(context);
   setLeanVscodeServices(leanVscodeIntegration);
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
+
+  applyGitAuthorConfig();
+  watchConfig(context, 'texra.git', applyGitAuthorConfig);
 
   setToolNotificationHandler((message, actionCommand) => {
     if (actionCommand) {

--- a/src/frontend/git/gitAuthorSetup.ts
+++ b/src/frontend/git/gitAuthorSetup.ts
@@ -32,11 +32,13 @@ export function readGitAuthorSettings(): {
   };
 }
 
-export function applyGitAuthorConfig(): void {
-  const { markCommits, authorName, authorEmail } = readGitAuthorSettings();
+/** Apply settings and return them so callers can forward without re-reading. */
+export function applyGitAuthorConfig(): ReturnType<typeof readGitAuthorSettings> {
+  const settings = readGitAuthorSettings();
+  const { markCommits, authorName, authorEmail } = settings;
   if (!markCommits) {
     setGitAuthorEnv({});
-    return;
+    return settings;
   }
   setGitAuthorEnv({
     GIT_AUTHOR_NAME: authorName,
@@ -44,4 +46,5 @@ export function applyGitAuthorConfig(): void {
     GIT_COMMITTER_NAME: authorName,
     GIT_COMMITTER_EMAIL: authorEmail,
   });
+  return settings;
 }

--- a/src/frontend/git/gitAuthorSetup.ts
+++ b/src/frontend/git/gitAuthorSetup.ts
@@ -6,26 +6,42 @@
  * Called at extension activation and after any git-author setting change.
  */
 import { WorkspaceStateKey, workspaceSM } from '@common/state';
+import {
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_AUTHOR_EMAIL,
+} from '@shared/constants/git';
 import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
+/** Read the current git author settings from workspace state with defaults. */
+export function readGitAuthorSettings(): {
+  markCommits: boolean;
+  authorName: string;
+  authorEmail: string;
+} {
+  return {
+    markCommits: workspaceSM.get<boolean>(
+      WorkspaceStateKey.GIT_MARK_COMMITS,
+      false,
+    ),
+    authorName:
+      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) ||
+      DEFAULT_GIT_AUTHOR_NAME,
+    authorEmail:
+      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
+      DEFAULT_GIT_AUTHOR_EMAIL,
+  };
+}
+
 export function applyGitAuthorConfig(): void {
-  const enabled = workspaceSM.get<boolean>(
-    WorkspaceStateKey.GIT_MARK_COMMITS,
-    false,
-  );
-  if (!enabled) {
+  const { markCommits, authorName, authorEmail } = readGitAuthorSettings();
+  if (!markCommits) {
     setGitAuthorEnv({});
     return;
   }
-  const name =
-    workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) || 'TeXRA';
-  const email =
-    workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
-    'texra@users.noreply.github.com';
   setGitAuthorEnv({
-    GIT_AUTHOR_NAME: name,
-    GIT_AUTHOR_EMAIL: email,
-    GIT_COMMITTER_NAME: name,
-    GIT_COMMITTER_EMAIL: email,
+    GIT_AUTHOR_NAME: authorName,
+    GIT_AUTHOR_EMAIL: authorEmail,
+    GIT_COMMITTER_NAME: authorName,
+    GIT_COMMITTER_EMAIL: authorEmail,
   });
 }

--- a/src/frontend/git/gitAuthorSetup.ts
+++ b/src/frontend/git/gitAuthorSetup.ts
@@ -1,0 +1,31 @@
+/**
+ * Reads git author settings from workspace state and pushes them
+ * to the shared gitAuthorEnv module so that executeCommand injects
+ * them into all spawned processes.
+ *
+ * Called at extension activation and after any git-author setting change.
+ */
+import { WorkspaceStateKey, workspaceSM } from '@common/state';
+import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+
+export function applyGitAuthorConfig(): void {
+  const enabled = workspaceSM.get<boolean>(
+    WorkspaceStateKey.GIT_MARK_COMMITS,
+    false,
+  );
+  if (!enabled) {
+    setGitAuthorEnv({});
+    return;
+  }
+  const name =
+    workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) || 'TeXRA';
+  const email =
+    workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
+    'texra@users.noreply.github.com';
+  setGitAuthorEnv({
+    GIT_AUTHOR_NAME: name,
+    GIT_AUTHOR_EMAIL: email,
+    GIT_COMMITTER_NAME: name,
+    GIT_COMMITTER_EMAIL: email,
+  });
+}

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -747,44 +747,50 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private async sendGitAuthorSettings(
     webview: vscode.Webview,
+    settings?: ReturnType<typeof readGitAuthorSettings>,
   ): Promise<void> {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
-      ...readGitAuthorSettings(),
+      ...(settings ?? readGitAuthorSettings()),
     });
+  }
+
+  private async updateGitAuthorSetting(
+    key: WorkspaceStateKey,
+    value: unknown,
+  ): Promise<void> {
+    await workspaceSM.update(key, value);
+    const settings = applyGitAuthorConfig();
+    await this.withActiveWebview((w) =>
+      this.sendGitAuthorSettings(w, settings),
+    );
   }
 
   private async handleSetGitMarkCommits(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_MARK_COMMITS>,
   ): Promise<void> {
-    await workspaceSM.update(
+    await this.updateGitAuthorSetting(
       WorkspaceStateKey.GIT_MARK_COMMITS,
       data.enabled,
     );
-    applyGitAuthorConfig();
-    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
   }
 
   private async handleSetGitAuthorName(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_NAME>,
   ): Promise<void> {
-    await workspaceSM.update(
+    await this.updateGitAuthorSetting(
       WorkspaceStateKey.GIT_AUTHOR_NAME,
       data.name,
     );
-    applyGitAuthorConfig();
-    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
   }
 
   private async handleSetGitAuthorEmail(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_EMAIL>,
   ): Promise<void> {
-    await workspaceSM.update(
+    await this.updateGitAuthorSetting(
       WorkspaceStateKey.GIT_AUTHOR_EMAIL,
       data.email,
     );
-    applyGitAuthorConfig();
-    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
   }
 
   // ============================================================

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -47,6 +47,7 @@ import {
 } from '@common/state';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { selectAgentInMainView } from '@frontend/agents/remoteAgentUtils';
+import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 import { compileLatex2Pdf } from '@latex/texTools';
 import {
   DEFAULT_MODELS,
@@ -435,6 +436,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET]: (data) =>
         this.agentHandlers.handleDeleteAgentModePreset(data),
 
+      // Git author settings handlers
+      [SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS]: () =>
+        this.withActiveWebview((w) => this.sendGitAuthorSettings(w)),
+      [SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS]: (data) =>
+        this.handleSetGitMarkCommits(data),
+      [SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME]: (data) =>
+        this.handleSetGitAuthorName(data),
+      [SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_EMAIL]: (data) =>
+        this.handleSetGitAuthorEmail(data),
+
       // ── Delegated to LatexSettingsHandlers ──
 
       [SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS]: () =>
@@ -725,6 +736,63 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       data.enabled,
     );
     await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
+  }
+
+  // ============================================================
+  // Git author settings handler implementations
+  // ============================================================
+
+  private async sendGitAuthorSettings(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    const markCommits = workspaceSM.get<boolean>(
+      WorkspaceStateKey.GIT_MARK_COMMITS,
+      false,
+    );
+    const authorName =
+      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) || 'TeXRA';
+    const authorEmail =
+      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
+      'texra@users.noreply.github.com';
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      markCommits,
+      authorName,
+      authorEmail,
+    });
+  }
+
+  private async handleSetGitMarkCommits(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_MARK_COMMITS>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.GIT_MARK_COMMITS,
+      data.enabled,
+    );
+    applyGitAuthorConfig();
+    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
+  }
+
+  private async handleSetGitAuthorName(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_NAME>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.GIT_AUTHOR_NAME,
+      data.name,
+    );
+    applyGitAuthorConfig();
+    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
+  }
+
+  private async handleSetGitAuthorEmail(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_EMAIL>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+      data.email,
+    );
+    applyGitAuthorConfig();
+    await this.withActiveWebview((w) => this.sendGitAuthorSettings(w));
   }
 
   // ============================================================

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -47,7 +47,10 @@ import {
 } from '@common/state';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { selectAgentInMainView } from '@frontend/agents/remoteAgentUtils';
-import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
+import {
+  applyGitAuthorConfig,
+  readGitAuthorSettings,
+} from '@frontend/git/gitAuthorSetup';
 import { compileLatex2Pdf } from '@latex/texTools';
 import {
   DEFAULT_MODELS,
@@ -745,20 +748,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async sendGitAuthorSettings(
     webview: vscode.Webview,
   ): Promise<void> {
-    const markCommits = workspaceSM.get<boolean>(
-      WorkspaceStateKey.GIT_MARK_COMMITS,
-      false,
-    );
-    const authorName =
-      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) || 'TeXRA';
-    const authorEmail =
-      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
-      'texra@users.noreply.github.com';
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
-      markCommits,
-      authorName,
-      authorEmail,
+      ...readGitAuthorSettings(),
     });
   }
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -43,6 +43,7 @@ import {
   UpdateSuperYoloEnabledMessageSchema,
   UpdateAgentModePresetsMessageSchema,
   UpdateToolDashboardMessageSchema,
+  UpdateGitAuthorSettingsMessageSchema,
   UpdateLatexSettingsStatusMessageSchema,
   type AgentSelectionItem,
   type NumberVscodeSetting,
@@ -64,6 +65,7 @@ import './tabs/ModelsTab';
 import './tabs/AgentsTab';
 import './tabs/MultiAgentTab';
 import './tabs/ToolsTab';
+import './tabs/GitTab';
 import './tabs/LaTeXTab';
 import type { HistoryTab } from './tabs/HistoryTab';
 
@@ -178,6 +180,12 @@ export class SettingsApp extends SettingsAppBase {
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
   private readonly toolDashboardLoaded = signal(false);
 
+  // Git author settings state
+  private readonly gitMarkCommits = signal(false);
+  private readonly gitAuthorName = signal('TeXRA');
+  private readonly gitAuthorEmail = signal('texra@users.noreply.github.com');
+  private readonly gitSettingsLoaded = signal(false);
+
   // LaTeX settings state
   private readonly latexSettingsStatus = signal({
     ...DEFAULT_LATEX_SETTINGS_STATUS,
@@ -200,6 +208,7 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED,
     SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS,
     SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA,
+    SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
     SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS,
   ] as const;
 
@@ -333,6 +342,19 @@ export class SettingsApp extends SettingsAppBase {
         if (!data) return;
         this.toolDashboardItems.set(data.items);
         this.toolDashboardLoaded.set(true);
+        return;
+      }
+
+      case SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS: {
+        const data = this.parseMessage(
+          raw,
+          UpdateGitAuthorSettingsMessageSchema,
+        );
+        if (!data) return;
+        this.gitMarkCommits.set(data.markCommits);
+        this.gitAuthorName.set(data.authorName);
+        this.gitAuthorEmail.set(data.authorEmail);
+        this.gitSettingsLoaded.set(true);
         return;
       }
 
@@ -547,6 +569,19 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
   );
 
+  // Git settings event handlers
+  private handleGitMarkCommitsToggle = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
+  );
+
+  private handleGitAuthorNameChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
+  );
+
+  private handleGitAuthorEmailChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_EMAIL,
+  );
+
   // LaTeX settings event handlers
   private handleApplyLatexSettings = forwardDetail(
     SETTINGS_VIEW_COMMANDS.APPLY_LATEX_SETTINGS,
@@ -646,6 +681,10 @@ export class SettingsApp extends SettingsAppBase {
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-tools"></span>
             Tools</vscode-tab-header
+          >
+          <vscode-tab-header slot="header"
+            ><span class="codicon codicon-git-commit"></span>
+            Git</vscode-tab-header
           >
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-file-code"></span>
@@ -748,6 +787,18 @@ export class SettingsApp extends SettingsAppBase {
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-recheck=${this.handleToolRecheck}
             ></tools-tab>
+          </vscode-tab-panel>
+
+          <vscode-tab-panel>
+            <git-tab
+              .markCommits=${this.gitMarkCommits.get()}
+              .authorName=${this.gitAuthorName.get()}
+              .authorEmail=${this.gitAuthorEmail.get()}
+              .toggleDisabled=${!this.gitSettingsLoaded.get()}
+              @git-mark-commits-toggle=${this.handleGitMarkCommitsToggle}
+              @git-author-name-change=${this.handleGitAuthorNameChange}
+              @git-author-email-change=${this.handleGitAuthorEmailChange}
+            ></git-tab>
           </vscode-tab-panel>
 
           <vscode-tab-panel>

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -50,6 +50,10 @@ import {
   type ToolDashboardItem,
   DEFAULT_LATEX_SETTINGS_STATUS,
 } from '@shared/schemas/settingsViewMessages';
+import {
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_AUTHOR_EMAIL,
+} from '@shared/constants/git';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 
 // Local imports - settings view
@@ -182,8 +186,8 @@ export class SettingsApp extends SettingsAppBase {
 
   // Git author settings state
   private readonly gitMarkCommits = signal(false);
-  private readonly gitAuthorName = signal('TeXRA');
-  private readonly gitAuthorEmail = signal('texra@users.noreply.github.com');
+  private readonly gitAuthorName = signal(DEFAULT_GIT_AUTHOR_NAME);
+  private readonly gitAuthorEmail = signal(DEFAULT_GIT_AUTHOR_EMAIL);
   private readonly gitSettingsLoaded = signal(false);
 
   // LaTeX settings state

--- a/src/settingsView/frontend/tabs/GitTab.ts
+++ b/src/settingsView/frontend/tabs/GitTab.ts
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import { LitElement, html, css, type TemplateResult } from 'lit';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
@@ -12,6 +12,12 @@ import { codiconStyles, designTokens, commonViewStyles } from '@shared/styles';
 
 // Local imports - shared utils
 import { createEvent } from '@shared/utils/events';
+
+// Local imports - shared constants
+import {
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_AUTHOR_EMAIL,
+} from '@shared/constants/git';
 
 @customElement('git-tab')
 export class GitTab extends LitElement {
@@ -61,8 +67,8 @@ export class GitTab extends LitElement {
   ];
 
   @property({ attribute: false }) markCommits = false;
-  @property({ attribute: false }) authorName = 'TeXRA';
-  @property({ attribute: false }) authorEmail = 'texra@users.noreply.github.com';
+  @property({ attribute: false }) authorName = DEFAULT_GIT_AUTHOR_NAME;
+  @property({ attribute: false }) authorEmail = DEFAULT_GIT_AUTHOR_EMAIL;
   @property({ attribute: false }) toggleDisabled = true;
 
   private handleMarkCommitsToggle(event: Event): void {
@@ -114,7 +120,7 @@ export class GitTab extends LitElement {
                   <label>Name</label>
                   <vscode-textfield
                     .value=${this.authorName}
-                    placeholder="TeXRA"
+                    placeholder=${DEFAULT_GIT_AUTHOR_NAME}
                     @change=${this.handleAuthorNameChange}
                   ></vscode-textfield>
                 </div>
@@ -122,7 +128,7 @@ export class GitTab extends LitElement {
                   <label>Email</label>
                   <vscode-textfield
                     .value=${this.authorEmail}
-                    placeholder="texra@users.noreply.github.com"
+                    placeholder=${DEFAULT_GIT_AUTHOR_EMAIL}
                     @change=${this.handleAuthorEmailChange}
                   ></vscode-textfield>
                 </div>
@@ -133,7 +139,7 @@ export class GitTab extends LitElement {
                 </p>
               </div>
             `
-          : ''}
+          : nothing}
       </div>
     `;
   }

--- a/src/settingsView/frontend/tabs/GitTab.ts
+++ b/src/settingsView/frontend/tabs/GitTab.ts
@@ -1,0 +1,146 @@
+/**
+ * GitTab component — git commit author settings for the settings view.
+ * Allows marking commits made by TeXRA with a custom author identity.
+ */
+
+// Third-party imports
+import { LitElement, html, css, type TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { codiconStyles, designTokens, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared utils
+import { createEvent } from '@shared/utils/events';
+
+@customElement('git-tab')
+export class GitTab extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .git-container {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-medium);
+      }
+
+      .setting-block {
+        padding: var(--spacing-medium);
+        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        border-radius: var(--border-radius);
+      }
+
+      .setting-description {
+        margin: var(--spacing-small) 0 0 0;
+        font-size: var(--font-size-sm);
+        color: var(--vscode-descriptionForeground);
+      }
+
+      .input-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        margin-top: var(--spacing-small);
+      }
+
+      .input-row label {
+        min-width: 80px;
+        font-size: var(--font-size-sm);
+      }
+
+      .input-row vscode-textfield {
+        flex: 1;
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) markCommits = false;
+  @property({ attribute: false }) authorName = 'TeXRA';
+  @property({ attribute: false }) authorEmail = 'texra@users.noreply.github.com';
+  @property({ attribute: false }) toggleDisabled = true;
+
+  private handleMarkCommitsToggle(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.dispatchEvent(
+      createEvent('git-mark-commits-toggle', {
+        enabled: Boolean(target?.checked),
+      }),
+    );
+  }
+
+  private handleAuthorNameChange(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const name = target?.value?.trim();
+    if (name) {
+      this.dispatchEvent(createEvent('git-author-name-change', { name }));
+    }
+  }
+
+  private handleAuthorEmailChange(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const email = target?.value?.trim();
+    if (email) {
+      this.dispatchEvent(createEvent('git-author-email-change', { email }));
+    }
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <div class="git-container">
+        <div class="setting-block">
+          <vscode-checkbox
+            ?checked=${this.markCommits}
+            ?disabled=${this.toggleDisabled}
+            @change=${this.handleMarkCommitsToggle}
+          >
+            Mark commits with TeXRA author info
+          </vscode-checkbox>
+          <p class="setting-description">
+            When enabled, commits made by TeXRA agents are attributed to a
+            custom author identity instead of your personal git config.
+          </p>
+        </div>
+
+        ${this.markCommits
+          ? html`
+              <div class="setting-block">
+                <div class="input-row">
+                  <label>Name</label>
+                  <vscode-textfield
+                    .value=${this.authorName}
+                    placeholder="TeXRA"
+                    @change=${this.handleAuthorNameChange}
+                  ></vscode-textfield>
+                </div>
+                <div class="input-row">
+                  <label>Email</label>
+                  <vscode-textfield
+                    .value=${this.authorEmail}
+                    placeholder="texra@users.noreply.github.com"
+                    @change=${this.handleAuthorEmailChange}
+                  ></vscode-textfield>
+                </div>
+                <p class="setting-description">
+                  These values are set as GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
+                  GIT_COMMITTER_NAME, and GIT_COMMITTER_EMAIL for all commands
+                  run by TeXRA.
+                </p>
+              </div>
+            `
+          : ''}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'git-tab': GitTab;
+  }
+}

--- a/src/shared/constants/git.ts
+++ b/src/shared/constants/git.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_GIT_AUTHOR_NAME = 'TeXRA';
+export const DEFAULT_GIT_AUTHOR_EMAIL = 'texra@users.noreply.github.com';

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -61,6 +61,7 @@ export const SETTINGS_TAB_ORDER = [
   'AGENTS',
   'MULTI_AGENT',
   'TOOLS',
+  'GIT',
   'LATEX',
 ] as const;
 
@@ -281,6 +282,21 @@ export const UpdateToolDashboardMessageSchema = z.object({
 });
 export type UpdateToolDashboardMessage = z.infer<
   typeof UpdateToolDashboardMessageSchema
+>;
+
+// ============================================================
+// Git author settings data schema
+// ============================================================
+
+/** Outbound: backend → frontend git author settings */
+export const UpdateGitAuthorSettingsMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS),
+  markCommits: z.boolean(),
+  authorName: z.string(),
+  authorEmail: z.string(),
+});
+export type UpdateGitAuthorSettingsMessage = z.infer<
+  typeof UpdateGitAuthorSettingsMessageSchema
 >;
 
 // ============================================================
@@ -530,6 +546,26 @@ const InstallToolExtensionMessageSchema = z.object({
 
 const RecheckToolStatusMessageSchema = commandOnly(CMD.RECHECK_TOOL_STATUS);
 
+// Git author settings inbound messages
+const GetGitAuthorSettingsMessageSchema = commandOnly(
+  CMD.GET_GIT_AUTHOR_SETTINGS,
+);
+
+const SetGitMarkCommitsMessageSchema = z.object({
+  command: z.literal(CMD.SET_GIT_MARK_COMMITS),
+  enabled: z.boolean(),
+});
+
+const SetGitAuthorNameMessageSchema = z.object({
+  command: z.literal(CMD.SET_GIT_AUTHOR_NAME),
+  name: z.string(),
+});
+
+const SetGitAuthorEmailMessageSchema = z.object({
+  command: z.literal(CMD.SET_GIT_AUTHOR_EMAIL),
+  email: z.string(),
+});
+
 // LaTeX settings inbound messages
 const GetLatexSettingsStatusMessageSchema = commandOnly(
   CMD.GET_LATEX_SETTINGS_STATUS,
@@ -624,6 +660,11 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetSuperYoloEnabledMessageSchema,
     SetSuperYoloEnabledMessageSchema,
     SetAllowOrchestratorKillMessageSchema,
+    // Git author settings messages
+    GetGitAuthorSettingsMessageSchema,
+    SetGitMarkCommitsMessageSchema,
+    SetGitAuthorNameMessageSchema,
+    SetGitAuthorEmailMessageSchema,
     // Agent mode preset messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -137,6 +137,7 @@ export interface FileViewOptions {
 }
 
 export interface FileViewResult {
+  [key: string]: unknown;
   output: string;
   summary: string;
 }

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -120,7 +120,7 @@ function formatSearchResult(item: BbtSearchResultItem): string {
 function collectionPath(chain: BbtCollectionChain): string {
   const parts: string[] = [];
   let current: BbtCollectionChain | false | undefined = chain;
-  while (current && current !== false) {
+  while (current) {
     parts.unshift(current.name);
     current = current.parentCollection;
   }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -27,6 +27,7 @@ import { toErrorMessage } from '@common/errors';
 // Internal imports
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
+import { getGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 import { IS_WINDOWS, extendEnvPath } from '@utils/system/platformPaths';
 
 const CHANNEL = 'execUtils';
@@ -104,7 +105,7 @@ export async function executeCommand(
       throw new Error('No workspace path found');
     }
 
-    const env = { ...process.env, ...options.env };
+    const env = { ...process.env, ...getGitAuthorEnv(), ...options.env };
     env.PATH = extendEnvPath(env.PATH);
 
     // Export project context so AI agents can orient themselves immediately.

--- a/src/utils/system/gitAuthorEnv.ts
+++ b/src/utils/system/gitAuthorEnv.ts
@@ -6,21 +6,17 @@
  * the configured TeXRA author identity.
  *
  * The extension host calls {@link setGitAuthorEnv} at activation (and on
- * config change) with values read from VS Code settings. This module
+ * settings change) with values read from workspace state. This module
  * stays VS Code-free.
  */
 
 let gitAuthorEnv: Record<string, string> = {};
 
-/**
- * Set the git author environment variables to inject into executed commands.
- * Pass an empty object to disable injection.
- */
+/** Pass an empty object to disable injection. */
 export function setGitAuthorEnv(env: Record<string, string>): void {
   gitAuthorEnv = env;
 }
 
-/** Get the current git author environment variables (may be empty). */
 export function getGitAuthorEnv(): Record<string, string> {
   return gitAuthorEnv;
 }

--- a/src/utils/system/gitAuthorEnv.ts
+++ b/src/utils/system/gitAuthorEnv.ts
@@ -1,0 +1,26 @@
+/**
+ * Injectable git author environment variables.
+ *
+ * When enabled, these are merged into the environment for all commands
+ * executed via {@link executeCommand}, so that any `git commit` picks up
+ * the configured TeXRA author identity.
+ *
+ * The extension host calls {@link setGitAuthorEnv} at activation (and on
+ * config change) with values read from VS Code settings. This module
+ * stays VS Code-free.
+ */
+
+let gitAuthorEnv: Record<string, string> = {};
+
+/**
+ * Set the git author environment variables to inject into executed commands.
+ * Pass an empty object to disable injection.
+ */
+export function setGitAuthorEnv(env: Record<string, string>): void {
+  gitAuthorEnv = env;
+}
+
+/** Get the current git author environment variables (may be empty). */
+export function getGitAuthorEnv(): Record<string, string> {
+  return gitAuthorEnv;
+}

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -1,4 +1,5 @@
 export * from './execUtils';
+export * from './gitAuthorEnv';
 export * from './toolUtils';
 export * from './platformPaths';
 export * from './workspaceInfo';


### PR DESCRIPTION
Adds three new settings under texra.git:
- markCommits: enable/disable author injection (default: off)
- authorName: custom author name (default: "TeXRA")
- authorEmail: custom author email

When enabled, GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME,
and GIT_COMMITTER_EMAIL are injected into the environment for all
commands executed via executeCommand, so any git commit made by TeXRA
agents is attributed to the configured identity.

Uses the injectable callback pattern (setGitAuthorEnv) to keep the
execution layer VS Code-free, with config reading wired in extension.ts.

https://claude.ai/code/session_018esdRUzKw64Tpq8acLDFWd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the global `executeCommand` environment by optionally injecting `GIT_AUTHOR_*`/`GIT_COMMITTER_*`, which can affect any spawned process and git operations. UI/settings wiring is straightforward but touches extension activation and settings messaging.
> 
> **Overview**
> Adds a new **Git** settings tab that lets users enable “mark commits” and configure an author name/email, with values persisted in workspace state and round-tripped via new settings-view commands/schemas.
> 
> When enabled, the extension applies these settings at activation and on change by setting injectable git-author env vars, and `executeCommand` now merges that env into every spawned process so TeXRA-driven `git commit` picks up the configured identity.
> 
> Includes a few small related tweaks: loosens `FileViewResult` typing, simplifies a Zotero collection parent-walk loop, and updates `package-lock.json` metadata for some optional rolldown bindings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b74c99435018ce3436d32b559a4e5725066f30d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->