### PR TITLE
Handle quota/billing errors gracefully with retry prompts

### DIFF
--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -68,6 +68,8 @@ export interface RunReflectionFlowInput<
 export interface RunReflectionFlowResult {
   roundOutputs: RoundOutput[];
   status: EndGroupStatus;
+  /** Error message when status is 'error'. Used for graceful error reporting. */
+  errorMessage?: string;
 }
 
 function deriveConfig(
@@ -309,9 +311,9 @@ export async function runReflectionFlow<C = unknown>(
 
     if (shared?.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Re-throw so runFlowWithLifecycle logs the error and shows
-      // the user notification. State was already projected per-step.
-      throw new Error(shared.lastError.message);
+      // Don't throw — return error status so the agent stops gracefully.
+      // runFlowWithLifecycle handles logging and user notification for
+      // error results without crashing the agent.
     } else {
       status = executionToEndStatus(flowStatus) as EndGroupStatus;
     }
@@ -336,5 +338,6 @@ export async function runReflectionFlow<C = unknown>(
   return {
     roundOutputs: shared?.roundOutputs ?? [],
     status,
+    errorMessage: shared?.lastError?.message,
   };
 }

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -311,9 +311,6 @@ export async function runReflectionFlow<C = unknown>(
 
     if (shared?.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Don't throw — return error status so the agent stops gracefully.
-      // runFlowWithLifecycle handles logging and user notification for
-      // error results without crashing the agent.
     } else {
       status = executionToEndStatus(flowStatus) as EndGroupStatus;
     }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -210,9 +210,6 @@ export async function runToolUseFlow<C = unknown>(
 
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Don't throw — return error status so the agent stops gracefully.
-      // runFlowWithLifecycle handles logging and user notification for
-      // error results without crashing the agent.
     } else {
       const execStatus = input.checkInterruption()
         ? EXECUTION_STATUS.INTERRUPTED

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -60,6 +60,8 @@ export interface RunToolUseFlowResult {
   lastResponse?: string;
   /** Workspace-relative paths of files edited by tool calls during this session. */
   touchedFiles?: string[];
+  /** Error message when status is 'error'. Used for graceful error reporting. */
+  errorMessage?: string;
 }
 
 export interface ToolUseFlowContext {
@@ -208,9 +210,9 @@ export async function runToolUseFlow<C = unknown>(
 
     if (shared.lastError) {
       status = END_GROUP_STATUS.ERROR;
-      // Re-throw so runFlowWithLifecycle logs the error and shows
-      // the user notification. State was already projected per-step.
-      throw new Error(shared.lastError.message);
+      // Don't throw — return error status so the agent stops gracefully.
+      // runFlowWithLifecycle handles logging and user notification for
+      // error results without crashing the agent.
     } else {
       const execStatus = input.checkInterruption()
         ? EXECUTION_STATUS.INTERRUPTED
@@ -246,5 +248,6 @@ export async function runToolUseFlow<C = unknown>(
     status,
     lastResponse,
     touchedFiles: touchedFiles.length > 0 ? touchedFiles : undefined,
+    errorMessage: shared.lastError?.message,
   };
 }

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -29,6 +29,8 @@ export const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('workflow'),
   status: EndGroupStatusSchema,
   outputs: z.array(OutputFileSummarySchema),
+  /** Error message when status is 'error'. Allows graceful error propagation without throwing. */
+  errorMessage: z.string().optional(),
 });
 
 export type WorkflowFlowResult = z.infer<typeof WorkflowFlowResultSchema>;
@@ -39,6 +41,8 @@ export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   lastResponse: z.string().optional(),
   /** Workspace-relative paths of files edited by tool calls during this session. */
   touchedFiles: z.array(z.string()).optional(),
+  /** Error message when status is 'error'. Allows graceful error propagation without throwing. */
+  errorMessage: z.string().optional(),
 });
 
 export type ToolUseFlowResult = z.infer<typeof ToolUseFlowResultSchema>;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -392,17 +392,10 @@ async function runFlowWithLifecycle(
       StreamStatusService.set(streamId, status);
     }
 
-    // When the flow returned an error status gracefully (without throwing),
-    // log the error and notify the user. This handles quota errors, provider
-    // failures, and other issues that were already shown via retry prompt.
-    if (result.status === 'error' && result.errorMessage) {
-      const errorMsg = `Error executing agent ${agentName}: ${result.errorMessage}`;
-      await ctx.logger.logError(errorMsg, new Error(result.errorMessage), {
-        operation: `execute ${agentName}`,
+    if (result.status === 'error' && result.errorMessage && !options?.isSubagent) {
+      bus.emit('requestShowError', {
+        message: `Error executing agent ${agentName}: ${result.errorMessage}`,
       });
-      if (!options?.isSubagent) {
-        bus.emit('requestShowError', { message: errorMsg });
-      }
     }
 
     logger.debug(`Task completed with status: ${result.status}`);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -381,6 +381,15 @@ async function runFlowWithLifecycle(
   try {
     const result = await runner();
     await options?.onCompleted?.(result);
+
+    // Graceful error results (e.g., quota errors) are delivered via
+    // onCompleted above so subagents get the error message. After delivery,
+    // re-throw so the catch block handles logging, notifications, and
+    // resume-caller semantics consistently.
+    if (result.status === 'error' && result.errorMessage) {
+      throw new Error(result.errorMessage);
+    }
+
     await writeTerminalStatus(ctx.executionId, result.status).catch(() => {});
 
     untrackExecution(ctx.executionId);
@@ -390,12 +399,6 @@ async function runFlowWithLifecycle(
       const status =
         result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
       StreamStatusService.set(streamId, status);
-    }
-
-    if (result.status === 'error' && result.errorMessage && !options?.isSubagent) {
-      bus.emit('requestShowError', {
-        message: `Error executing agent ${agentName}: ${result.errorMessage}`,
-      });
     }
 
     logger.debug(`Task completed with status: ${result.status}`);

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -391,6 +391,20 @@ async function runFlowWithLifecycle(
         result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
       StreamStatusService.set(streamId, status);
     }
+
+    // When the flow returned an error status gracefully (without throwing),
+    // log the error and notify the user. This handles quota errors, provider
+    // failures, and other issues that were already shown via retry prompt.
+    if (result.status === 'error' && result.errorMessage) {
+      const errorMsg = `Error executing agent ${agentName}: ${result.errorMessage}`;
+      await ctx.logger.logError(errorMsg, new Error(result.errorMessage), {
+        operation: `execute ${agentName}`,
+      });
+      if (!options?.isSubagent) {
+        bus.emit('requestShowError', { message: errorMsg });
+      }
+    }
+
     logger.debug(`Task completed with status: ${result.status}`);
     return result;
   } catch (err) {
@@ -660,6 +674,7 @@ export async function executeAgent(
             status: result.status,
             lastResponse: result.lastResponse,
             touchedFiles: result.touchedFiles,
+            errorMessage: result.errorMessage,
             executionId: ctx.executionId,
             streamId,
           };
@@ -684,6 +699,7 @@ export async function executeAgent(
           category: 'workflow' as const,
           status: result.status,
           outputs: toOutputSummaries(result.roundOutputs),
+          errorMessage: result.errorMessage,
           executionId: ctx.executionId,
           streamId,
         };
@@ -743,6 +759,7 @@ export async function executeMergeAgent(
         category: 'workflow' as const,
         status: result.status,
         outputs: toOutputSummaries(result.roundOutputs),
+        errorMessage: result.errorMessage,
         executionId: ctx.executionId,
         streamId,
       };
@@ -793,6 +810,7 @@ export async function resumeToolUseFromSnapshot(
         status: result.status,
         lastResponse: result.lastResponse,
         touchedFiles: result.touchedFiles,
+        errorMessage: result.errorMessage,
         executionId: ctx.executionId,
         streamId,
       };

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -427,9 +427,13 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Try matching a known SDK error type (connection, abort, HTTP errors)
   const sdkMatch = matchSdkError(err, rawErrorBody);
   if (sdkMatch) {
+    // Quota/billing errors should always be retryable so the retry prompt
+    // is shown and the user can fix billing and retry (or dismiss gracefully).
+    const retryable =
+      isRelay || sdkMatch.retryable || isQuotaErrorMessage(sdkMatch.message);
     return {
       ...sdkMatch,
-      retryable: isRelay || sdkMatch.retryable,
+      retryable,
       isRelayError: isRelay,
       rawErrorBody,
       streamDiagnostics,
@@ -449,8 +453,11 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
   // No status code on an unrecognized error likely means a network-level failure
   // (DNS, proxy, TLS, etc.) — treat as retryable for safety.
+  // Quota/billing errors are also retryable (user can fix billing and retry).
   const retryable =
-    isRelay || (statusCode ? isRetryableStatusCode(statusCode) : true);
+    isRelay ||
+    (statusCode ? isRetryableStatusCode(statusCode) : true) ||
+    isQuotaErrorMessage(finalMessage);
 
   let message = finalMessage;
   if (statusCode) {
@@ -475,6 +482,28 @@ export function formatProviderHttpError(err: unknown): ProviderError {
 
 export function getSdkErrorMessage(err: unknown): string {
   return formatProviderHttpError(err).message;
+}
+
+/**
+ * Quota/billing error patterns. These are transient from the user's perspective
+ * (fixable by updating billing) and should show a retry prompt rather than
+ * immediately failing the agent.
+ */
+const QUOTA_ERROR_PATTERNS = [
+  'exceeded your current quota', // OpenAI
+  'insufficient_quota', // OpenAI error code
+  'billing hard limit', // OpenAI
+  'exceeded your monthly', // OpenAI
+  'account is not active', // OpenAI
+  'rate limit reached', // OpenAI / generic
+  'credit balance is too low', // Anthropic
+  'monthly spend limit', // Various providers
+] as const;
+
+/** Checks if an error message indicates a quota/billing issue. */
+function isQuotaErrorMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return QUOTA_ERROR_PATTERNS.some((pattern) => lower.includes(pattern));
 }
 
 const CONTEXT_WINDOW_PATTERNS = [

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -453,11 +453,10 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     extractErrorMessage(err) ?? fallbackMessage ?? 'Provider request failed';
   // No status code on an unrecognized error likely means a network-level failure
   // (DNS, proxy, TLS, etc.) — treat as retryable for safety.
-  // Quota/billing errors are also retryable (user can fix billing and retry).
   const retryable =
     isRelay ||
-    (statusCode ? isRetryableStatusCode(statusCode) : true) ||
-    isQuotaErrorMessage(finalMessage);
+    isQuotaErrorMessage(finalMessage) ||
+    (statusCode ? isRetryableStatusCode(statusCode) : true);
 
   let message = finalMessage;
   if (statusCode) {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -248,6 +248,22 @@ async function executeSubagent(
       if (deliveryState.hasDelivered) return;
       deliveryState.hasDelivered = true;
 
+      const wallTimeMs = Date.now() - startedAt;
+
+      // Graceful error results (e.g., quota errors) should use the error
+      // format so the orchestrator sees the error message.
+      if (result.status === 'error' && result.errorMessage) {
+        const msg = formatSubagentError(
+          executionId,
+          agentName,
+          result.errorMessage,
+          { wallTimeMs },
+        );
+        void getExecutionStore(executionId).writeReport(msg);
+        ToolUseFollowUpQueue.enqueue(orchestratorStreamId, msg);
+        return;
+      }
+
       // For workflow results, compute diffs and write them as files to the
       // execution's run directory. The delivery references diff file paths
       // so the orchestrator can read them on demand via /executions/{id}/files/.
@@ -265,7 +281,6 @@ async function executeSubagent(
         }
       }
 
-      const wallTimeMs = Date.now() - startedAt;
       const msg = formatSubagentDelivery(agentName, result, {
         diffInfos,
         wallTimeMs,


### PR DESCRIPTION
## Closure Note

Closed on 2026-05-13 as superseded by #3879 and #3904.

The quota and billing retry behavior is now implemented on `main` through the current provider-error classification path, including the follow-up fix for statusless OpenAI background failures. This branch is 1008 commits behind `main` and still contains unresolved review findings around graceful error propagation, resume failure signaling, missing-key guidance, and duplicate subagent error delivery. It should not be merged as a basis for future work.

If graceful flow-result propagation is still desired, it should be redesigned as a fresh issue or PR against current `main`.

## Original Summary

This PR improved error handling for quota and billing errors by treating them as retryable conditions that show a retry prompt to users, allowing them to fix billing issues and retry without the agent crashing. Additionally, errors were returned gracefully instead of being thrown, enabling better error reporting and user notifications.

## Original Key Changes

- Quota/billing error detection with pattern matching for common quota and billing messages from OpenAI, Anthropic, and other providers.
- Retryable error classification so users see a retry prompt instead of an immediate failure.
- Graceful error propagation from flow implementations with an `errorMessage` field.
- Error reporting in agent execution through `requestShowError`.
- Schema updates to carry optional error information through `AgentFlowResult`.
