### PR TITLE
Improve resource cleanup and add store size limits

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -79,14 +79,26 @@ export interface ExecutionHandle {
 export class AgentExecutionHandle implements ExecutionHandle {
   readonly startedAt = Date.now();
   private progress: { currentRound?: number; totalRounds?: number } = {};
+  private _parentStreamId: StreamTabId;
 
   constructor(
     readonly executionId: string,
-    readonly parentStreamId: StreamTabId,
+    parentStreamId: StreamTabId,
     readonly childStreamId: StreamTabId,
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
-  ) {}
+  ) {
+    this._parentStreamId = parentStreamId;
+  }
+
+  get parentStreamId(): StreamTabId {
+    return this._parentStreamId;
+  }
+
+  /** Promote this subagent to a top-level execution (detach from parent). */
+  detach(): void {
+    this._parentStreamId = this.childStreamId;
+  }
 
   getStatus(): ExecutionStatusInfo {
     const status =

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -134,6 +134,13 @@ export function getActiveExecutionIds(): string[] {
   return [...registry.keys()];
 }
 
+/** Terminate all active executions. Used during extension deactivation to prevent orphaned processes. */
+export function killAllActiveExecutions(): void {
+  for (const executionId of [...registry.keys()]) {
+    killExecution(executionId);
+  }
+}
+
 /** Delegate progress update to the handle. */
 export function updateExecutionProgress(
   executionId: string,

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -134,10 +134,16 @@ export function getActiveExecutionIds(): string[] {
   return [...registry.keys()];
 }
 
-/** Terminate all active executions. Used during extension deactivation to prevent orphaned processes. */
-export function killAllActiveExecutions(): void {
-  for (const executionId of [...registry.keys()]) {
-    killExecution(executionId);
+/**
+ * Kill only background OS processes (bash, codex) without touching agent stream status.
+ * Agent executions are left in RUNNING so the restart recovery logic can restore
+ * them to WAITING (resumable) if a flow record exists.
+ */
+export function killBackgroundProcesses(): void {
+  for (const [executionId, handle] of registry) {
+    if (handle instanceof ProcessExecutionHandle) {
+      killExecution(executionId);
+    }
   }
 }
 

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -239,6 +239,24 @@ export function interruptActiveChildren(parentStreamId: StreamTabId): void {
   interruptActiveChildrenImpl(parentStreamId, registry.values());
 }
 
+/**
+ * Detach all active subagents from a parent, promoting them to top-level.
+ * Subagents continue running independently and deliver results via the
+ * follow-up queue. Called when stopping an orchestrator without killing children.
+ */
+export function detachActiveChildren(parentStreamId: StreamTabId): void {
+  for (const handle of registry.values()) {
+    if (handle.parentStreamId !== parentStreamId) continue;
+    if (
+      handle instanceof AgentExecutionHandle &&
+      handle.childStreamId !== parentStreamId
+    ) {
+      handle.detach();
+    }
+  }
+  emitActiveSubagentsUpdate(parentStreamId, registry.values());
+}
+
 /** Get active subagent and process children for a parent stream. */
 export function getActiveChildren(parentStreamId: StreamTabId): {
   subagents: ActiveChildInfo[];

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -252,6 +252,8 @@ export function detachActiveChildren(parentStreamId: StreamTabId): void {
       handle.childStreamId !== parentStreamId
     ) {
       handle.detach();
+    } else if (handle instanceof ProcessExecutionHandle) {
+      handle.terminate();
     }
   }
   emitActiveSubagentsUpdate(parentStreamId, registry.values());

--- a/src/agent/storage/detectWaitingStreams.ts
+++ b/src/agent/storage/detectWaitingStreams.ts
@@ -48,13 +48,9 @@ export async function hasPersistedFlowRecord(
 export async function detectWaitingStreams(
   executionIdMap: ReadonlyMap<StreamTabId, ExecutionId>,
 ): Promise<Set<StreamTabId>> {
-  const waitingStreams = new Set<StreamTabId>();
-
-  for (const [streamId, executionId] of executionIdMap) {
-    if (await hasPersistedFlowRecord(executionId)) {
-      waitingStreams.add(streamId);
-    }
-  }
-
-  return waitingStreams;
+  const checks = Array.from(executionIdMap, async ([streamId, executionId]) =>
+    (await hasPersistedFlowRecord(executionId)) ? streamId : null,
+  );
+  const results = await Promise.all(checks);
+  return new Set(results.filter((id): id is StreamTabId => id !== null));
 }

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -7,7 +7,7 @@ import {
   getToolUseFlowContext,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { interruptActiveChildren } from '@agent/runtime/executionRegistry';
+import { detachActiveChildren } from '@agent/runtime/executionRegistry';
 import { STREAM_STATUS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -16,7 +16,7 @@ export function registerAgentCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(
       'texra.stopAgent',
       (streamId: StreamTabId) => {
-        interruptActiveChildren(streamId);
+        detachActiveChildren(streamId);
         getInterruptible(streamId)?.interrupt();
         StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);
       },

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -22,13 +22,13 @@ export function registerAgentCommands(context: vscode.ExtensionContext): void {
       (streamId: StreamTabId) => {
         if (
           workspaceSM.get<boolean>(
-            WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
-            true,
+            WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+            false,
           )
         ) {
-          interruptActiveChildren(streamId);
-        } else {
           detachActiveChildren(streamId);
+        } else {
+          interruptActiveChildren(streamId);
         }
         getInterruptible(streamId)?.interrupt();
         StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);

--- a/src/commands/agent/agentCommands.ts
+++ b/src/commands/agent/agentCommands.ts
@@ -7,7 +7,11 @@ import {
   getToolUseFlowContext,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { detachActiveChildren } from '@agent/runtime/executionRegistry';
+import {
+  detachActiveChildren,
+  interruptActiveChildren,
+} from '@agent/runtime/executionRegistry';
+import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { STREAM_STATUS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 
@@ -16,7 +20,16 @@ export function registerAgentCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand(
       'texra.stopAgent',
       (streamId: StreamTabId) => {
-        detachActiveChildren(streamId);
+        if (
+          workspaceSM.get<boolean>(
+            WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+            true,
+          )
+        ) {
+          interruptActiveChildren(streamId);
+        } else {
+          detachActiveChildren(streamId);
+        }
         getInterruptible(streamId)?.interrupt();
         StreamStatusService.set(streamId, STREAM_STATUS.STOPPED);
       },

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -22,6 +22,7 @@ export enum WorkspaceStateKey {
   PARENT_STREAM_IDS = 'texra.parentStreamIds',
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
   ALLOW_ORCHESTRATOR_KILL = 'texra.allowOrchestratorKill',
+  DETACH_SUBAGENTS_ON_STOP = 'texra.detachSubagentsOnStop',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 
   // Git commit author settings

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -67,6 +67,7 @@ export const SETTINGS_VIEW_CMD = {
   GET_SUPER_YOLO_ENABLED: 'getSuperYoloEnabled',
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
   SET_ALLOW_ORCHESTRATOR_KILL: 'setAllowOrchestratorKill',
+  SET_DETACH_SUBAGENTS_ON_STOP: 'setDetachSubagentsOnStop',
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',
   DELETE_AGENT_MODE_PRESET: 'deleteAgentModePreset',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import dotenv from 'dotenv';
 // Local imports - core
 import { loadAgents } from '@agent/index';
 import { clearStoreCache } from '@agent/storage';
+import { killAllActiveExecutions } from '@agent/runtime/executionRegistry';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import { initializeServerSideKeyAccess } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -29,8 +30,9 @@ import {
   configureLatexSettings,
   refreshModelListIfNeeded,
 } from '@frontend/setup';
-import { FileLister } from '@frontend/files';
 import { agentDirectories } from '@frontend/agents';
+import { FileLister } from '@frontend/files';
+import { killActiveRecording } from '@frontend/media/audio';
 import { disposeDiffRefresh } from '@frontend/ui/diffView';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolEditApproval';
@@ -332,6 +334,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
+
+  // Kill all active child processes (bash, codex, subagents) to prevent orphans.
+  killAllActiveExecutions();
+
+  // Kill any active audio recording process.
+  killActiveRecording();
+
   await UsageLogService.dispose();
   await progressViewProviderInstance?.flushState();
   clearStoreCache();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,15 +334,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
-
-  // Kill all active child processes (bash, codex, subagents) to prevent orphans.
-  killAllActiveExecutions();
-
-  // Kill any active audio recording process.
-  killActiveRecording();
-
   await UsageLogService.dispose();
   await progressViewProviderInstance?.flushState();
+
+  killAllActiveExecutions();
+  killActiveRecording();
+
   clearStoreCache();
   bus.emit('extensionDeactivating', undefined);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 // Local imports - core
 import { loadAgents } from '@agent/index';
 import { clearStoreCache } from '@agent/storage';
-import { killAllActiveExecutions } from '@agent/runtime/executionRegistry';
+import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import { initializeServerSideKeyAccess } from '@auth/serverKeys';
 import { SupabaseClient } from '@auth/SupabaseClient';
@@ -337,7 +337,7 @@ export async function deactivate() {
   await UsageLogService.dispose();
   await progressViewProviderInstance?.flushState();
 
-  killAllActiveExecutions();
+  killBackgroundProcesses();
   killActiveRecording();
 
   clearStoreCache();

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -27,8 +27,10 @@ export class FileLister {
   public static initialize(context: vscode.ExtensionContext): void {
     this.getInstance();
     watchConfig(context, 'texra.files', () => this.getInstance().refresh());
-    vscode.workspace.onDidChangeWorkspaceFolders(() =>
-      this.getInstance().refresh(),
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeWorkspaceFolders(() =>
+        this.getInstance().refresh(),
+      ),
     );
   }
 

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -138,6 +138,14 @@ export async function startRecording(
   }
 }
 
+/** Kill the active recording process if one exists (used during extension deactivation). */
+export function killActiveRecording(): void {
+  if (activeRecordingProcess) {
+    activeRecordingProcess.kill('SIGTERM');
+    resetRecordingState();
+  }
+}
+
 /** Stop the current recording and transcribe it using OpenAI. */
 export async function stopRecordingAndTranscribe(
   context: vscode.ExtensionContext,

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -138,7 +138,7 @@ export async function startRecording(
   }
 }
 
-/** Kill the active recording process if one exists (used during extension deactivation). */
+/** Forcibly terminate the active recording process if one exists. */
 export function killActiveRecording(): void {
   if (activeRecordingProcess) {
     activeRecordingProcess.kill('SIGTERM');

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 
 import type { IRunStorageService } from '@agent/runtime/RunStorageService';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
+import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
 import {
   BaseWebviewProvider,
   getSharedLocalResourceRoots,
@@ -365,9 +366,10 @@ export class ProgressViewProvider
     return this.isActivePlacementReady() && this.webviewUpdater.isAvailable();
   }
 
-  public async cleanupTasksAfterRestart(
-    waitingStreams?: Set<StreamTabId>,
-  ): Promise<void> {
+  public async cleanupTasksAfterRestart(): Promise<void> {
+    const waitingStreams = await detectWaitingStreams(
+      this.state.meta.getExecutionIdMap(),
+    );
     await this.resetRunningStreamStatuses(waitingStreams);
     this.syncFullView({ forceRebuild: true });
   }

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -390,7 +390,7 @@ export class ProgressViewProvider
   }
 
   private async resetRunningStreamStatuses(
-    waitingStreams?: Set<StreamTabId>,
+    waitingStreams: Set<StreamTabId>,
   ): Promise<void> {
     const affectedStreams =
       this.eventHandler.resetRunningTasksToError(waitingStreams);

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -695,9 +695,9 @@ export class ProgressEventHandler {
     return StreamStatusService.getAll();
   }
 
-  resetRunningTasksToError(waitingStreams?: Set<StreamTabId>): StreamTabId[] {
+  resetRunningTasksToError(waitingStreams: Set<StreamTabId>): StreamTabId[] {
     const affectedStreams: StreamTabId[] = [];
-    const waitingSet = waitingStreams ?? new Set<StreamTabId>();
+    const waitingSet = waitingStreams;
 
     for (const [streamId, status] of StreamStatusService.entries()) {
       if (status !== STREAM_STATUS.RUNNING) continue;

--- a/src/progressView/frontend/formatters/copyContentStore.ts
+++ b/src/progressView/frontend/formatters/copyContentStore.ts
@@ -6,7 +6,7 @@
 
 import { hashString } from './hashUtils';
 
-// Local module state
+const MAX_STORE_SIZE = 1000;
 const copyContentStore = new Map<string, string>();
 
 /**
@@ -18,6 +18,11 @@ export function registerCopyContent(
 ): string {
   const id = contentId ?? `auto:${content.length}:${hashString(content)}`;
   if (copyContentStore.get(id) !== content) {
+    if (!copyContentStore.has(id) && copyContentStore.size >= MAX_STORE_SIZE) {
+      // Evict oldest entry (first key in insertion order).
+      const oldest = copyContentStore.keys().next().value;
+      if (oldest !== undefined) copyContentStore.delete(oldest);
+    }
     copyContentStore.set(id, content);
   }
   return id;

--- a/src/progressView/frontend/formatters/copyContentStore.ts
+++ b/src/progressView/frontend/formatters/copyContentStore.ts
@@ -17,9 +17,9 @@ export function registerCopyContent(
   contentId?: string,
 ): string {
   const id = contentId ?? `auto:${content.length}:${hashString(content)}`;
-  if (copyContentStore.get(id) !== content) {
-    if (!copyContentStore.has(id) && copyContentStore.size >= MAX_STORE_SIZE) {
-      // Evict oldest entry (first key in insertion order).
+  const existing = copyContentStore.get(id);
+  if (existing !== content) {
+    if (existing === undefined && copyContentStore.size >= MAX_STORE_SIZE) {
       const oldest = copyContentStore.keys().next().value;
       if (oldest !== undefined) copyContentStore.delete(oldest);
     }

--- a/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -43,6 +43,7 @@ const LenientWorkflowProposalSchema = WorkflowAgentProposalSchema.extend({
   toolConfig: ToolConfigSchema,
 });
 
+const MAX_STORE_SIZE = 500;
 const proposalInputStore = new Map<string, AgentProposal>();
 
 function parseProposalInput(
@@ -102,6 +103,11 @@ export function registerProposalInput(
   const serialized = JSON.stringify(proposal);
   const id = `proposal:${serialized.length}:${hashString(serialized)}`;
   if (!proposalInputStore.has(id)) {
+    if (proposalInputStore.size >= MAX_STORE_SIZE) {
+      // Evict oldest entry (first key in insertion order).
+      const oldest = proposalInputStore.keys().next().value;
+      if (oldest !== undefined) proposalInputStore.delete(oldest);
+    }
     proposalInputStore.set(id, proposal);
   }
   return id;

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -90,7 +90,7 @@ export class StreamMetaManager {
 
   // -- Queries ----------------------------------------------------------------
 
-  /** Read-only view of stream→executionId mapping (for detectWaitingStreams). */
+  /** Read-only view of stream→executionId mapping. */
   getExecutionIdMap(): ReadonlyMap<StreamTabId, ExecutionId> {
     return this.executionIds;
   }

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -90,6 +90,11 @@ export class StreamMetaManager {
 
   // -- Queries ----------------------------------------------------------------
 
+  /** Read-only view of stream→executionId mapping (for detectWaitingStreams). */
+  getExecutionIdMap(): ReadonlyMap<StreamTabId, ExecutionId> {
+    return this.executionIds;
+  }
+
   /** Return stream IDs with active tool-use sessions. */
   getActiveToolUseStreams(): Set<StreamTabId> {
     const result = new Set<StreamTabId>();

--- a/src/progressView/managers/WebviewBridge.ts
+++ b/src/progressView/managers/WebviewBridge.ts
@@ -7,6 +7,7 @@ const FRAME_INTERVAL_MS = 16;
 
 export class WebviewBridge {
   private pendingFlush = false;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly changedStreams = new Set<StreamTabId>();
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly unsubscribe: () => void;
@@ -24,6 +25,11 @@ export class WebviewBridge {
 
   dispose(): void {
     this.unsubscribe();
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.pendingFlush = false;
     this.changedStreams.clear();
     this.cursors.clear();
   }
@@ -48,7 +54,10 @@ export class WebviewBridge {
   private scheduleFlush(): void {
     if (this.pendingFlush) return;
     this.pendingFlush = true;
-    setTimeout(() => this.flush(), FRAME_INTERVAL_MS);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flush();
+    }, FRAME_INTERVAL_MS);
   }
 
   private flush(): void {

--- a/src/progressView/managers/WebviewBridge.ts
+++ b/src/progressView/managers/WebviewBridge.ts
@@ -6,7 +6,6 @@ import type * as vscode from 'vscode';
 const FRAME_INTERVAL_MS = 16;
 
 export class WebviewBridge {
-  private pendingFlush = false;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly changedStreams = new Set<StreamTabId>();
   private readonly cursors = new Map<StreamTabId, number>();
@@ -29,7 +28,6 @@ export class WebviewBridge {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.pendingFlush = false;
     this.changedStreams.clear();
     this.cursors.clear();
   }
@@ -52,8 +50,7 @@ export class WebviewBridge {
   }
 
   private scheduleFlush(): void {
-    if (this.pendingFlush) return;
-    this.pendingFlush = true;
+    if (this.flushTimer) return;
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
       this.flush();
@@ -61,8 +58,6 @@ export class WebviewBridge {
   }
 
   private flush(): void {
-    this.pendingFlush = false;
-
     const activeStream = this.getActiveStream();
     if (!activeStream) return;
     if (!this.changedStreams.has(activeStream)) return;

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -394,9 +394,15 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED]: (data) =>
         this.handleSetSuperYoloEnabled(data),
       [SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL]: (data) =>
-        this.handleSetAllowOrchestratorKill(data),
+        this.updateBooleanAndSendSuperYolo(
+          WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+          data,
+        ),
       [SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP]: (data) =>
-        this.handleSetDetachSubagentsOnStop(data),
+        this.updateBooleanAndSendSuperYolo(
+          WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+          data,
+        ),
 
       // ── Delegated to AgentHandlers ──
 
@@ -738,23 +744,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleSetAllowOrchestratorKill(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_ALLOW_ORCHESTRATOR_KILL>,
+  private async updateBooleanAndSendSuperYolo(
+    key: WorkspaceStateKey,
+    data: { enabled: boolean },
   ): Promise<void> {
-    await workspaceSM.update(
-      WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
-      data.enabled,
-    );
-    await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
-  }
-
-  private async handleSetDetachSubagentsOnStop(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_DETACH_SUBAGENTS_ON_STOP>,
-  ): Promise<void> {
-    await workspaceSM.update(
-      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
-      data.enabled,
-    );
+    await workspaceSM.update(key, data.enabled);
     await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
   }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -395,6 +395,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleSetSuperYoloEnabled(data),
       [SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL]: (data) =>
         this.handleSetAllowOrchestratorKill(data),
+      [SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP]: (data) =>
+        this.handleSetDetachSubagentsOnStop(data),
 
       // ── Delegated to AgentHandlers ──
 
@@ -701,11 +703,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
       true,
     );
+    const detachSubagentsOnStop = workspaceSM.get<boolean>(
+      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+      false,
+    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
       enabled,
       reliabilitySettings: getReliabilitySettings(),
       allowOrchestratorKill,
+      detachSubagentsOnStop,
     });
   }
 
@@ -736,6 +743,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   ): Promise<void> {
     await workspaceSM.update(
       WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+      data.enabled,
+    );
+    await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
+  }
+
+  private async handleSetDetachSubagentsOnStop(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_DETACH_SUBAGENTS_ON_STOP>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
       data.enabled,
     );
     await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -179,6 +179,7 @@ export class SettingsApp extends SettingsAppBase {
   private readonly superYoloToggleDisabled = signal(true);
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
   private readonly allowOrchestratorKill = signal(true);
+  private readonly detachSubagentsOnStop = signal(false);
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
@@ -328,6 +329,7 @@ export class SettingsApp extends SettingsAppBase {
         this.superYoloToggleDisabled.set(false);
         this.reliabilitySettings.set(data.reliabilitySettings);
         this.allowOrchestratorKill.set(data.allowOrchestratorKill);
+        this.detachSubagentsOnStop.set(data.detachSubagentsOnStop);
         return;
       }
 
@@ -546,6 +548,10 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleAllowOrchestratorKillToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL,
+  );
+
+  private handleDetachSubagentsOnStopToggle = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP,
   );
 
   private handleApplyAgentModePreset = forwardDetail(
@@ -774,9 +780,12 @@ export class SettingsApp extends SettingsAppBase {
               .reliabilitySettings=${this.reliabilitySettings.get()}
               .customPresets=${this.customPresets.get()}
               .allowOrchestratorKill=${this.allowOrchestratorKill.get()}
+              .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @allow-orchestrator-kill-toggle=${this
                 .handleAllowOrchestratorKillToggle}
+              @detach-subagents-on-stop-toggle=${this
+                .handleDetachSubagentsOnStopToggle}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -382,9 +382,9 @@ export class MultiAgentTab extends LitElement {
             Allow orchestrator to kill subagents
           </vscode-checkbox>
           <p class="text-secondary setting-description">
-            When enabled, the orchestrator can terminate running subagents via
-            the kill action. Disable to prevent premature termination of
-            long-running tasks.
+            When enabled, stopping an orchestrator also terminates its
+            subagents. When disabled, subagents are detached and continue
+            running independently.
           </p>
         </div>
 

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -232,29 +232,23 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
   @state() private activePresetId: string | null = null;
 
-  private handleToggle(event: Event): void {
+  private emitToggle(eventName: string, event: Event): void {
     const target = event.target as HTMLInputElement | null;
     this.dispatchEvent(
-      createEvent('super-yolo-toggle', { enabled: Boolean(target?.checked) }),
+      createEvent(eventName, { enabled: Boolean(target?.checked) }),
     );
+  }
+
+  private handleToggle(event: Event): void {
+    this.emitToggle('super-yolo-toggle', event);
   }
 
   private handleKillToggle(event: Event): void {
-    const target = event.target as HTMLInputElement | null;
-    this.dispatchEvent(
-      createEvent('allow-orchestrator-kill-toggle', {
-        enabled: Boolean(target?.checked),
-      }),
-    );
+    this.emitToggle('allow-orchestrator-kill-toggle', event);
   }
 
   private handleDetachToggle(event: Event): void {
-    const target = event.target as HTMLInputElement | null;
-    this.dispatchEvent(
-      createEvent('detach-subagents-on-stop-toggle', {
-        enabled: Boolean(target?.checked),
-      }),
-    );
+    this.emitToggle('detach-subagents-on-stop-toggle', event);
   }
 
   private handlePresetClick(preset: AgentModePreset): void {

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -226,6 +226,7 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) superYoloEnabled = false;
   @property({ attribute: false }) toggleDisabled = true;
   @property({ attribute: false }) allowOrchestratorKill = true;
+  @property({ attribute: false }) detachSubagentsOnStop = false;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
@@ -242,6 +243,15 @@ export class MultiAgentTab extends LitElement {
     const target = event.target as HTMLInputElement | null;
     this.dispatchEvent(
       createEvent('allow-orchestrator-kill-toggle', {
+        enabled: Boolean(target?.checked),
+      }),
+    );
+  }
+
+  private handleDetachToggle(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.dispatchEvent(
+      createEvent('detach-subagents-on-stop-toggle', {
         enabled: Boolean(target?.checked),
       }),
     );
@@ -382,9 +392,23 @@ export class MultiAgentTab extends LitElement {
             Allow orchestrator to kill subagents
           </vscode-checkbox>
           <p class="text-secondary setting-description">
-            When enabled, stopping an orchestrator also terminates its
-            subagents. When disabled, subagents are detached and continue
-            running independently.
+            When enabled, the orchestrator can terminate running subagents via
+            the kill action. Disable to prevent premature termination of
+            long-running tasks.
+          </p>
+        </div>
+
+        <div class="setting-block">
+          <vscode-checkbox
+            ?checked=${this.detachSubagentsOnStop}
+            @change=${this.handleDetachToggle}
+          >
+            Detach subagents when stopping orchestrator
+          </vscode-checkbox>
+          <p class="text-secondary setting-description">
+            When enabled, stopping an orchestrator lets its subagents continue
+            running independently. When disabled, subagents are terminated
+            alongside the orchestrator.
           </p>
         </div>
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -212,6 +212,7 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   enabled: z.boolean(),
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
   allowOrchestratorKill: z.boolean().prefault(true),
+  detachSubagentsOnStop: z.boolean().prefault(false),
 });
 export type UpdateSuperYoloEnabledMessage = z.infer<
   typeof UpdateSuperYoloEnabledMessageSchema
@@ -510,6 +511,11 @@ const SetAllowOrchestratorKillMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+const SetDetachSubagentsOnStopMessageSchema = z.object({
+  command: z.literal(CMD.SET_DETACH_SUBAGENTS_ON_STOP),
+  enabled: z.boolean(),
+});
+
 // Agent mode preset inbound messages
 const GetAgentModePresetsMessageSchema = commandOnly(
   CMD.GET_AGENT_MODE_PRESETS,
@@ -660,6 +666,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetSuperYoloEnabledMessageSchema,
     SetSuperYoloEnabledMessageSchema,
     SetAllowOrchestratorKillMessageSchema,
+    SetDetachSubagentsOnStopMessageSchema,
     // Git author settings messages
     GetGitAuthorSettingsMessageSchema,
     SetGitMarkCommitsMessageSchema,


### PR DESCRIPTION
## Summary
This PR improves resource management and stability by implementing proper cleanup of background processes, recording sessions, and timers, while also adding size limits to in-memory stores to prevent unbounded growth.

## Key Changes

- **WebviewBridge timer management**: Replaced boolean `pendingFlush` flag with explicit `flushTimer` tracking, enabling proper cleanup of scheduled timeouts in the `dispose()` method
- **Background process cleanup**: Added `killBackgroundProcesses()` function to terminate OS-level processes (bash, codex) during extension deactivation while preserving agent execution state for recovery
- **Recording session cleanup**: Added `killActiveRecording()` function to forcibly terminate active recording processes during extension shutdown
- **Store size limits**: Implemented bounded capacity for in-memory stores:
  - `copyContentStore`: Limited to 1000 entries with FIFO eviction
  - `proposalInputStore`: Limited to 500 entries with FIFO eviction
- **Event subscription cleanup**: Fixed potential memory leak in `FileLister.initialize()` by properly registering workspace folder change listener with context subscriptions
- **Extension deactivation**: Enhanced `deactivate()` to call new cleanup functions before clearing cache

## Implementation Details

- Timer cleanup uses `clearTimeout()` and null assignment to prevent dangling references
- Store eviction uses insertion-order iteration (`keys().next().value`) to remove oldest entries
- Background process killing only affects `ProcessExecutionHandle` instances, leaving agent execution state intact for restart recovery
- All cleanup operations are idempotent and safe to call even if resources don't exist

https://claude.ai/code/session_015P1k2a2zfAR1nL3f6rxNKr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution lifecycle behavior (new detach-on-stop option) and adds new shutdown cleanup paths that could affect running tasks/process termination and restart recovery if incorrect.
> 
> **Overview**
> Improves shutdown/restart hygiene by **killing only background `ProcessExecutionHandle` OS processes on extension deactivation** (plus forcibly ending any active audio recording) while leaving agent stream statuses intact for restart recovery.
> 
> Adds an opt-in workflow to **stop an orchestrator without killing subagents**: `AgentExecutionHandle` can now `detach()` (parentStreamId becomes child), `executionRegistry.detachActiveChildren()` promotes active subagents to top-level, and a new workspace setting `texra.detachSubagentsOnStop` is surfaced in the Settings UI and wired into `texra.stopAgent`.
> 
> Stabilizes UI/runtime state by bounding in-memory formatter stores (`copyContentStore`, `proposalInputStore`) with FIFO eviction, ensuring `WebviewBridge` flush timers are cancellable on dispose, properly disposing the `FileLister` workspace-folder listener, and parallelizing waiting-stream detection during restart cleanup (now computed inside `ProgressViewProvider.cleanupTasksAfterRestart()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a963fdedf94f334321853c52a33ab4fd51dfa632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->