### PR TITLE
Track and report edited files from tool-use subagents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1844,9 +1844,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1864,9 +1861,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1884,9 +1878,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1904,9 +1895,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1924,9 +1912,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1944,9 +1929,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -20,6 +20,7 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly onFollowUpConsumed?: () => void;
   readonly onBeforeWaiting?: (
     lastResponse: string | undefined,
+    touchedFiles: string[],
   ) => void | Promise<void>;
   readonly onProgress?: (update: SubagentProgressUpdate) => void;
   /** Persist todos to the execution KV store. Injected by runToolUseFlow. */

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -3,12 +3,14 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
-import { findLastAssistantText } from './types';
+import { findLastAssistantText, assertPreparedShared } from './types';
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
+import { FileInteractionState } from '@agent/core/AgentWorkspaceState';
 
 interface WaitPrepResult {
   lastResponse: string | undefined;
+  touchedFiles: string[];
 }
 
 export class ToolUseWaitNode<C> extends Node<
@@ -20,12 +22,22 @@ export class ToolUseWaitNode<C> extends Node<
     const { modelHandler, onBeforeWaiting } = this.services;
 
     // Only extract last response when the callback is wired (subagent mode)
-    if (!onBeforeWaiting) return { lastResponse: undefined };
+    if (!onBeforeWaiting) return { lastResponse: undefined, touchedFiles: [] };
+
+    // Extract edited file paths from workspace state for delivery to orchestrator
+    let touchedFiles: string[] = [];
+    if (shared.stateSlices?.workspaceSnapshot?.interactions) {
+      const interactions = FileInteractionState.fromSnapshot(
+        shared.stateSlices.workspaceSnapshot.interactions,
+      );
+      touchedFiles = interactions.editedFilePaths;
+    }
 
     return {
       lastResponse: findLastAssistantText(shared.messages, (m) =>
         modelHandler.extractAssistantText(m),
       ),
+      touchedFiles,
     };
   }
 
@@ -37,7 +49,7 @@ export class ToolUseWaitNode<C> extends Node<
       return { kind: 'stop' };
     }
 
-    await onBeforeWaiting?.(prepRes.lastResponse);
+    await onBeforeWaiting?.(prepRes.lastResponse, prepRes.touchedFiles);
 
     if (!session.hasQueuedFollowUp()) {
       StreamStatusService.set(streamId, STREAM_STATUS.WAITING);

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -3,10 +3,9 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { STREAM_STATUS } from '@shared/schemas';
 
-import { findLastAssistantText, assertPreparedShared } from './types';
+import { findLastAssistantText, extractTouchedFiles } from './types';
 import type { ToolUseServices, ToolUseFlowParams } from '../ToolUseServices';
 import type { ToolUseRunShared, WaitExecResult } from './types';
-import { FileInteractionState } from '@agent/core/AgentWorkspaceState';
 
 interface WaitPrepResult {
   lastResponse: string | undefined;
@@ -21,23 +20,14 @@ export class ToolUseWaitNode<C> extends Node<
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {
     const { modelHandler, onBeforeWaiting } = this.services;
 
-    // Only extract last response when the callback is wired (subagent mode)
+    // Only extract when the callback is wired (subagent mode)
     if (!onBeforeWaiting) return { lastResponse: undefined, touchedFiles: [] };
 
-    // Extract edited file paths from workspace state for delivery to orchestrator
-    let touchedFiles: string[] = [];
-    if (shared.stateSlices?.workspaceSnapshot?.interactions) {
-      const interactions = FileInteractionState.fromSnapshot(
-        shared.stateSlices.workspaceSnapshot.interactions,
-      );
-      touchedFiles = interactions.editedFilePaths;
-    }
-
     return {
+      touchedFiles: extractTouchedFiles(shared.stateSlices),
       lastResponse: findLastAssistantText(shared.messages, (m) =>
         modelHandler.extractAssistantText(m),
       ),
-      touchedFiles,
     };
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -15,7 +15,7 @@ export interface StateSlicesSnapshot {
   userChannels: UserVariableChannels;
 }
 
-/** Extract edited file paths directly from a workspace snapshot without reconstructing state classes. */
+/** Extract edited file paths from a workspace state snapshot. */
 export function extractTouchedFiles(stateSlices: StateSlicesSnapshot | null): string[] {
   const edits = stateSlices?.workspaceSnapshot?.interactions?.edits;
   if (!edits || edits.length === 0) return [];

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -15,6 +15,13 @@ export interface StateSlicesSnapshot {
   userChannels: UserVariableChannels;
 }
 
+/** Extract edited file paths directly from a workspace snapshot without reconstructing state classes. */
+export function extractTouchedFiles(stateSlices: StateSlicesSnapshot | null): string[] {
+  const edits = stateSlices?.workspaceSnapshot?.interactions?.edits;
+  if (!edits || edits.length === 0) return [];
+  return edits.map((e) => e.path);
+}
+
 export interface ToolUseRunShared {
   messages: ProviderMessage[];
   shouldSkipCycle: boolean;

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -12,7 +12,6 @@ import {
 } from '@agent/node/persistedFlow';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
-import { FileInteractionState } from '@agent/core/AgentWorkspaceState';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
@@ -34,6 +33,7 @@ import { ToolUseCycleNode } from './nodes/ToolUseCycleNode';
 import { ToolUseWaitNode } from './nodes/ToolUseWaitNode';
 import {
   findLastAssistantText,
+  extractTouchedFiles,
   migrateSharedState,
   type ToolUseRunShared,
 } from './nodes/types';
@@ -240,15 +240,11 @@ export async function runToolUseFlow<C = unknown>(
     input.modelHandler.extractAssistantText(m),
   );
 
-  // Extract edited file paths from workspace state for delivery to orchestrator.
-  let touchedFiles: string[] | undefined;
-  if (shared.stateSlices?.workspaceSnapshot?.interactions) {
-    const interactions = FileInteractionState.fromSnapshot(
-      shared.stateSlices.workspaceSnapshot.interactions,
-    );
-    const paths = interactions.editedFilePaths;
-    if (paths.length > 0) touchedFiles = paths;
-  }
+  const touchedFiles = extractTouchedFiles(shared.stateSlices);
 
-  return { status, lastResponse, touchedFiles };
+  return {
+    status,
+    lastResponse,
+    touchedFiles: touchedFiles.length > 0 ? touchedFiles : undefined,
+  };
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -12,6 +12,7 @@ import {
 } from '@agent/node/persistedFlow';
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
+import { FileInteractionState } from '@agent/core/AgentWorkspaceState';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { executionToEndStatus } from '@common/constants/streamStatus';
@@ -49,7 +50,7 @@ export interface RunToolUseFlowInput<
   /** When true, delegation tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /** Fires before the subagent enters WAITING, delivering the last response to the orchestrator. */
-  onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
+  onBeforeWaiting?: (lastResponse: string | undefined, touchedFiles: string[]) => void | Promise<void>;
   /** Fires on meaningful progress: todo changes, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
 }
@@ -57,6 +58,8 @@ export interface RunToolUseFlowInput<
 export interface RunToolUseFlowResult {
   status: EndGroupStatus;
   lastResponse?: string;
+  /** Workspace-relative paths of files edited by tool calls during this session. */
+  touchedFiles?: string[];
 }
 
 export interface ToolUseFlowContext {
@@ -237,5 +240,15 @@ export async function runToolUseFlow<C = unknown>(
     input.modelHandler.extractAssistantText(m),
   );
 
-  return { status, lastResponse };
+  // Extract edited file paths from workspace state for delivery to orchestrator.
+  let touchedFiles: string[] | undefined;
+  if (shared.stateSlices?.workspaceSnapshot?.interactions) {
+    const interactions = FileInteractionState.fromSnapshot(
+      shared.stateSlices.workspaceSnapshot.interactions,
+    );
+    const paths = interactions.editedFilePaths;
+    if (paths.length > 0) touchedFiles = paths;
+  }
+
+  return { status, lastResponse, touchedFiles };
 }

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -37,6 +37,8 @@ export const ToolUseFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('toolUse'),
   status: EndGroupStatusSchema,
   lastResponse: z.string().optional(),
+  /** Workspace-relative paths of files edited by tool calls during this session. */
+  touchedFiles: z.array(z.string()).optional(),
 });
 
 export type ToolUseFlowResult = z.infer<typeof ToolUseFlowResultSchema>;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -557,7 +557,7 @@ export interface ExecuteAgentOptions {
   /** Fires with the real streamId before the stream is activated (before UI sync). */
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
-  onBeforeWaiting?: (lastResponse: string | undefined) => void | Promise<void>;
+  onBeforeWaiting?: (lastResponse: string | undefined, touchedFiles: string[]) => void | Promise<void>;
   /** Fires on meaningful progress: todo changes, round completions, tool call milestones. */
   onProgress?: (update: SubagentProgressUpdate) => void;
   /** Fires after flow completes but BEFORE untrackExecution, so follow-ups are enqueued before waiters resolve. */
@@ -659,6 +659,7 @@ export async function executeAgent(
             category: 'toolUse' as const,
             status: result.status,
             lastResponse: result.lastResponse,
+            touchedFiles: result.touchedFiles,
             executionId: ctx.executionId,
             streamId,
           };
@@ -791,6 +792,7 @@ export async function resumeToolUseFromSnapshot(
         category: 'toolUse' as const,
         status: result.status,
         lastResponse: result.lastResponse,
+        touchedFiles: result.touchedFiles,
         executionId: ctx.executionId,
         streamId,
       };

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -219,7 +219,7 @@ async function executeSubagent(
       }
     },
     onProgress,
-    onBeforeWaiting: async (lastResponse) => {
+    onBeforeWaiting: async (lastResponse, touchedFiles) => {
       if (deliveryState.hasDelivered || !childStreamId) return;
       const wallTimeMs = Date.now() - startedAt;
       const msg = formatSubagentDelivery(
@@ -228,6 +228,7 @@ async function executeSubagent(
           category: 'toolUse' as const,
           status: 'stopped' as const,
           lastResponse,
+          touchedFiles,
           executionId,
           streamId: childStreamId,
         },

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -274,8 +274,17 @@ export function formatSubagentDelivery(
 
   if (result.category === 'workflow' && result.outputs.length > 0) {
     lines.push(...formatWorkflowOutputs(result.outputs, options?.diffInfos));
-  } else if (result.category === 'toolUse' && result.lastResponse) {
-    lines.push('<response>', result.lastResponse, '</response>');
+  } else if (result.category === 'toolUse') {
+    if (result.lastResponse) {
+      lines.push('<response>', result.lastResponse, '</response>');
+    }
+    if (result.touchedFiles && result.touchedFiles.length > 0) {
+      lines.push(
+        '<touched-files>',
+        ...result.touchedFiles.map((f) => `<file path="${escapeAttr(f)}" />`),
+        '</touched-files>',
+      );
+    }
   }
 
   lines.push('</subagent-result>');


### PR DESCRIPTION
## Summary
This PR adds tracking and reporting of files edited by tool-use subagents back to their orchestrators. When a subagent completes or enters a waiting state, it now communicates which workspace files were modified during its execution.

## Key Changes
- **ToolUseWaitNode**: Extract edited file paths from workspace state snapshots and pass them to the `onBeforeWaiting` callback alongside the last response
- **runToolUseFlow**: Collect edited file paths from workspace interactions and include them in the flow result
- **Result schemas and types**: Updated `ToolUseFlowResult`, `RunToolUseFlowInput`, and `ExecuteAgentOptions` to include `touchedFiles` array
- **Subagent delivery formatting**: Enhanced `formatSubagentDelivery` to include a `<touched-files>` XML section listing all edited files with their paths
- **DelegationTools**: Updated subagent execution to pass `touchedFiles` to the delivery formatter
- **FileInteractionState integration**: Use `FileInteractionState.fromSnapshot()` to extract edited file paths from workspace state

## Implementation Details
- Edited file paths are extracted from `shared.stateSlices.workspaceSnapshot.interactions` using the `FileInteractionState` utility
- The `touchedFiles` array is only included in results when there are actual file modifications (empty arrays are omitted)
- File paths are workspace-relative and are properly escaped when formatted in XML output
- The callback signature for `onBeforeWaiting` now includes both `lastResponse` and `touchedFiles` parameters

https://claude.ai/code/session_013iC13MX28mZtsNdpyAC7Uf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily plumbs additional metadata (`touchedFiles`) through existing tool-use subagent callbacks/results and adjusts XML formatting, with no changes to core execution control flow.
> 
> **Overview**
> Tool-use subagents now report which workspace files they edited by extracting paths from the workspace interaction snapshot and propagating them through the tool-use flow.
> 
> This expands `onBeforeWaiting` and tool-use flow results/schemas to include a `touchedFiles` array, forwards it through `executeAgent` and `DelegationTools`, and extends subagent delivery XML to emit a `<touched-files>` section when present.
> 
> Also updates `package-lock.json` to drop `libc` metadata on several optional `@rolldown` Linux bindings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eb5194e4f7b82857f7d2b093e598cdb831aac22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->