### PR TITLE
Add pagination support to history, memory, and tool listings

### DIFF
--- a/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/src/settingsView/frontend/components/history/HistoryList.ts
@@ -1,6 +1,9 @@
 /**
  * HistoryList component - renders list of history items with search functionality.
  * Receives search state via reactive properties and handles navigation.
+ *
+ * Pagination is active when there is no search term; during search, all items
+ * are shown so that match navigation works across the full list.
  */
 
 // Third-party imports
@@ -16,6 +19,13 @@ import { repeat } from 'lit/directives/repeat.js';
 // Local imports - shared
 import type { HistoryItem as HistoryItemData } from '@shared/schemas';
 import { designTokens, commonViewStyles } from '@shared/styles';
+
+// Local imports - shared components & pagination utility
+import {
+  paginate,
+  DEFAULT_PAGE_SIZE,
+  type PageChangeDetail,
+} from '../shared/Pagination';
 
 // Local imports - history view
 import { HistoryViewEvents } from './events';
@@ -41,6 +51,9 @@ export class HistoryList extends LitElement {
 
   @state() private searchVersion = 0;
 
+  /** Current zero-based page index (used when not searching). */
+  @state() private page = 0;
+
   @queryAll('history-item')
   private historyItemElements!: Array<
     HTMLElement & {
@@ -48,6 +61,11 @@ export class HistoryList extends LitElement {
       getMarks: () => HTMLElement[];
     }
   >;
+
+  /** Whether pagination is active (no active search). */
+  private get paginated(): boolean {
+    return !this.searchTerm;
+  }
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
     if (
@@ -59,12 +77,27 @@ export class HistoryList extends LitElement {
     }
 
     if (changedProperties.has('searchTerm')) {
+      // Reset page when entering or leaving search mode
+      if (this.searchTerm) {
+        this.page = 0;
+      }
       this.performSearch(this.searchTerm);
     }
 
     if (changedProperties.has('searchAction') && this.searchAction) {
       this.performNavigate(this.searchAction);
       this.dispatchEvent(HistoryViewEvents.searchNavigateComplete());
+    }
+
+    // Clamp page when items change (e.g. delete)
+    if (changedProperties.has('items') && this.paginated) {
+      const totalPages = Math.max(
+        1,
+        Math.ceil(this.items.length / DEFAULT_PAGE_SIZE),
+      );
+      if (this.page >= totalPages) {
+        this.page = Math.max(0, totalPages - 1);
+      }
     }
   }
 
@@ -193,6 +226,10 @@ export class HistoryList extends LitElement {
     this.dispatchEvent(HistoryViewEvents.clearHistory());
   }
 
+  private handlePageChange(event: CustomEvent<PageChangeDetail>): void {
+    this.page = event.detail.page;
+  }
+
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
@@ -208,6 +245,11 @@ export class HistoryList extends LitElement {
     const hasMatches = (this.state?.totalMatches ?? 0) > 0;
     const forceOpen = Boolean(this.searchTerm && hasMatches);
 
+    // When searching, show all items; otherwise paginate
+    const displayItems = this.paginated
+      ? paginate(this.items, this.page, DEFAULT_PAGE_SIZE).paged
+      : this.items;
+
     return html`
       <div class="clear-container">
         <vscode-toolbar-button
@@ -218,9 +260,17 @@ export class HistoryList extends LitElement {
           @click=${this.handleClear}
         ></vscode-toolbar-button>
       </div>
+      ${this.paginated
+        ? html`<list-pagination
+            .page=${this.page}
+            .totalItems=${this.items.length}
+            .pageSize=${DEFAULT_PAGE_SIZE}
+            @page-change=${this.handlePageChange}
+          ></list-pagination>`
+        : ''}
       <div class="history-container">
         ${repeat(
-          this.items,
+          displayItems,
           (item) => item.id,
           (item) => html`
             <history-item
@@ -233,6 +283,14 @@ export class HistoryList extends LitElement {
           `,
         )}
       </div>
+      ${this.paginated
+        ? html`<list-pagination
+            .page=${this.page}
+            .totalItems=${this.items.length}
+            .pageSize=${DEFAULT_PAGE_SIZE}
+            @page-change=${this.handlePageChange}
+          ></list-pagination>`
+        : ''}
     `;
   }
 }

--- a/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/src/settingsView/frontend/components/history/HistoryList.ts
@@ -81,7 +81,12 @@ export class HistoryList extends LitElement {
       if (this.searchTerm) {
         this.page = 0;
       }
-      this.performSearch(this.searchTerm);
+      // Clear marks immediately when search is cleared, but defer
+      // applying a new search term to updated() so the DOM has
+      // re-rendered all items (pagination is disabled during search).
+      if (!this.searchTerm) {
+        this.performSearch('');
+      }
     }
 
     if (changedProperties.has('searchAction') && this.searchAction) {
@@ -102,8 +107,12 @@ export class HistoryList extends LitElement {
   }
 
   protected updated(changedProps: Map<string, unknown>): void {
-    // Re-apply search when items change (e.g., new history loaded)
-    if (changedProps.has('items') && this.searchTerm) {
+    // Apply search after DOM update so all items are rendered
+    // (pagination is disabled during search, so we need the full DOM).
+    if (
+      this.searchTerm &&
+      (changedProps.has('searchTerm') || changedProps.has('items'))
+    ) {
       const version = ++this.searchVersion;
       void this.applySearchToItems(this.searchTerm, version);
     }

--- a/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -1,10 +1,10 @@
 /**
- * MemoryList component - renders list of saved memory items.
+ * MemoryList component - renders list of saved memory items with pagination.
  */
 
 // Third-party imports
 import { LitElement, html, css, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 // Local imports - shared styles
@@ -13,8 +13,18 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 // Local imports - memory view components (side-effect: register)
 import './MemoryItem';
 
+// Local imports - shared components (side-effect: register)
+import '../shared/Pagination';
+
 // Local imports - shared schemas
 import type { MemoryViewItem } from '@shared/schemas';
+
+// Local imports - pagination utility
+import {
+  paginate,
+  DEFAULT_PAGE_SIZE,
+  type PageChangeDetail,
+} from '../shared/Pagination';
 
 @customElement('memory-list')
 export class MemoryList extends LitElement {
@@ -36,6 +46,27 @@ export class MemoryList extends LitElement {
 
   @property({ attribute: false }) items: MemoryViewItem[] = [];
 
+  @state() private page = 0;
+
+  protected override willUpdate(
+    changedProperties: Map<string | number | symbol, unknown>,
+  ): void {
+    // Reset to first page when items change (e.g. refresh, delete, pin/unpin)
+    if (changedProperties.has('items')) {
+      const totalPages = Math.max(
+        1,
+        Math.ceil(this.items.length / DEFAULT_PAGE_SIZE),
+      );
+      if (this.page >= totalPages) {
+        this.page = Math.max(0, totalPages - 1);
+      }
+    }
+  }
+
+  private handlePageChange(event: CustomEvent<PageChangeDetail>): void {
+    this.page = event.detail.page;
+  }
+
   override render(): TemplateResult {
     if (!this.items.length) {
       return html`<div class="empty-state">
@@ -48,14 +79,32 @@ export class MemoryList extends LitElement {
       </div>`;
     }
 
+    const { paged, totalPages: _ } = paginate(
+      this.items,
+      this.page,
+      DEFAULT_PAGE_SIZE,
+    );
+
     return html`
+      <list-pagination
+        .page=${this.page}
+        .totalItems=${this.items.length}
+        .pageSize=${DEFAULT_PAGE_SIZE}
+        @page-change=${this.handlePageChange}
+      ></list-pagination>
       <div class="memory-list">
         ${repeat(
-          this.items,
+          paged,
           (item) => item.storagePath,
           (item) => html`<memory-item .item=${item}></memory-item>`,
         )}
       </div>
+      <list-pagination
+        .page=${this.page}
+        .totalItems=${this.items.length}
+        .pageSize=${DEFAULT_PAGE_SIZE}
+        @page-change=${this.handlePageChange}
+      ></list-pagination>
     `;
   }
 }

--- a/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -13,13 +13,10 @@ import { designTokens, commonViewStyles } from '@shared/styles';
 // Local imports - memory view components (side-effect: register)
 import './MemoryItem';
 
-// Local imports - shared components (side-effect: register)
-import '../shared/Pagination';
-
 // Local imports - shared schemas
 import type { MemoryViewItem } from '@shared/schemas';
 
-// Local imports - pagination utility
+// Local imports - pagination
 import {
   paginate,
   DEFAULT_PAGE_SIZE,
@@ -53,13 +50,7 @@ export class MemoryList extends LitElement {
   ): void {
     // Reset to first page when items change (e.g. refresh, delete, pin/unpin)
     if (changedProperties.has('items')) {
-      const totalPages = Math.max(
-        1,
-        Math.ceil(this.items.length / DEFAULT_PAGE_SIZE),
-      );
-      if (this.page >= totalPages) {
-        this.page = Math.max(0, totalPages - 1);
-      }
+      this.page = 0;
     }
   }
 
@@ -79,11 +70,7 @@ export class MemoryList extends LitElement {
       </div>`;
     }
 
-    const { paged, totalPages: _ } = paginate(
-      this.items,
-      this.page,
-      DEFAULT_PAGE_SIZE,
-    );
+    const { paged } = paginate(this.items, this.page, DEFAULT_PAGE_SIZE);
 
     return html`
       <list-pagination

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -11,8 +11,9 @@
 import { LitElement, html, css, type TemplateResult, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-// Local imports - shared styles
+// Local imports - shared styles and utilities
 import { designTokens, commonViewStyles } from '@shared/styles';
+import { createEvent } from '@shared/utils/events';
 
 /** Detail payload for the `page-change` custom event. */
 export interface PageChangeDetail {
@@ -136,13 +137,7 @@ export class Pagination extends LitElement {
   }
 
   private emitPageChange(page: number): void {
-    this.dispatchEvent(
-      new CustomEvent<PageChangeDetail>('page-change', {
-        detail: { page },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    this.dispatchEvent(createEvent<PageChangeDetail>('page-change', { page }));
   }
 
   private goFirst(): void {

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -20,7 +20,7 @@ export interface PageChangeDetail {
 }
 
 /** Default number of items per page. */
-export const DEFAULT_PAGE_SIZE = 50;
+export const DEFAULT_PAGE_SIZE = 100;
 
 /**
  * Compute the page slice for a given items array.

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -20,7 +20,7 @@ export interface PageChangeDetail {
 }
 
 /** Default number of items per page. */
-export const DEFAULT_PAGE_SIZE = 25;
+export const DEFAULT_PAGE_SIZE = 50;
 
 /**
  * Compute the page slice for a given items array.

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -1,0 +1,222 @@
+/**
+ * Pagination component — Unix-style page navigation for list views.
+ *
+ * Displays a compact status bar with page info and prev/next controls,
+ * inspired by Unix pagers like `less`.
+ *
+ * Fires `page-change` events with the new page index when the user navigates.
+ */
+
+// Third-party imports
+import { LitElement, html, css, type TemplateResult, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { designTokens, commonViewStyles } from '@shared/styles';
+
+/** Detail payload for the `page-change` custom event. */
+export interface PageChangeDetail {
+  page: number;
+}
+
+/** Default number of items per page. */
+export const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Compute the page slice for a given items array.
+ * Returns `{ paged, totalPages }` where `paged` is the current page's items.
+ */
+export function paginate<T>(
+  items: readonly T[],
+  page: number,
+  pageSize: number,
+): { paged: T[]; totalPages: number } {
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+  const safePage = Math.max(0, Math.min(page, totalPages - 1));
+  const start = safePage * pageSize;
+  return {
+    paged: items.slice(start, start + pageSize) as T[],
+    totalPages,
+  };
+}
+
+@customElement('list-pagination')
+export class Pagination extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .pagination-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--spacing-small) 0;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        user-select: none;
+      }
+
+      .pagination-status {
+        font-family: var(--vscode-editor-font-family, monospace);
+        letter-spacing: 0.02em;
+      }
+
+      .pagination-controls {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+      }
+
+      .page-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--height-control);
+        height: var(--height-control);
+        padding: 0 var(--spacing-small);
+        font-size: var(--font-size-xs);
+        font-family: var(--vscode-editor-font-family, monospace);
+        color: var(--color-text-secondary);
+        background: none;
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        transition:
+          color var(--transition-fast),
+          border-color var(--transition-fast);
+      }
+
+      .page-btn:hover:not(:disabled) {
+        color: var(--vscode-foreground);
+        border-color: var(--vscode-focusBorder);
+      }
+
+      .page-btn:active:not(:disabled) {
+        background: var(
+          --vscode-toolbar-activeBackground,
+          rgba(99, 102, 103, 0.31)
+        );
+      }
+
+      .page-btn:disabled {
+        opacity: var(--opacity-disabled);
+        cursor: default;
+      }
+
+      .page-btn:focus-visible {
+        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline-offset: 1px;
+      }
+    `,
+  ];
+
+  /** Current zero-based page index. */
+  @property({ type: Number }) page = 0;
+
+  /** Total number of items across all pages. */
+  @property({ type: Number }) totalItems = 0;
+
+  /** Items per page. */
+  @property({ type: Number }) pageSize = DEFAULT_PAGE_SIZE;
+
+  private get totalPages(): number {
+    return Math.max(1, Math.ceil(this.totalItems / this.pageSize));
+  }
+
+  private get rangeStart(): number {
+    return this.totalItems === 0 ? 0 : this.page * this.pageSize + 1;
+  }
+
+  private get rangeEnd(): number {
+    return Math.min((this.page + 1) * this.pageSize, this.totalItems);
+  }
+
+  private emitPageChange(page: number): void {
+    this.dispatchEvent(
+      new CustomEvent<PageChangeDetail>('page-change', {
+        detail: { page },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private goFirst(): void {
+    if (this.page > 0) this.emitPageChange(0);
+  }
+
+  private goPrev(): void {
+    if (this.page > 0) this.emitPageChange(this.page - 1);
+  }
+
+  private goNext(): void {
+    if (this.page < this.totalPages - 1) this.emitPageChange(this.page + 1);
+  }
+
+  private goLast(): void {
+    if (this.page < this.totalPages - 1)
+      this.emitPageChange(this.totalPages - 1);
+  }
+
+  override render(): TemplateResult | typeof nothing {
+    if (this.totalPages <= 1) return nothing;
+
+    const atFirst = this.page === 0;
+    const atLast = this.page >= this.totalPages - 1;
+
+    return html`
+      <div class="pagination-bar">
+        <span class="pagination-status">
+          ${this.rangeStart}\u2013${this.rangeEnd} of ${this.totalItems}
+        </span>
+        <div class="pagination-controls">
+          <button
+            class="page-btn"
+            title="First page"
+            ?disabled=${atFirst}
+            @click=${this.goFirst}
+          >
+            \u00AB
+          </button>
+          <button
+            class="page-btn"
+            title="Previous page"
+            ?disabled=${atFirst}
+            @click=${this.goPrev}
+          >
+            \u2039
+          </button>
+          <span class="pagination-status">
+            ${this.page + 1}/${this.totalPages}
+          </span>
+          <button
+            class="page-btn"
+            title="Next page"
+            ?disabled=${atLast}
+            @click=${this.goNext}
+          >
+            \u203A
+          </button>
+          <button
+            class="page-btn"
+            title="Last page"
+            ?disabled=${atLast}
+            @click=${this.goLast}
+          >
+            \u00BB
+          </button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'list-pagination': Pagination;
+  }
+}

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -437,7 +437,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     // Paginate the listing
     const total = entries.length;
-    const safeOffset = Math.min(offset, total);
+    const safeOffset = Math.min(offset, Math.max(0, total - 1));
     const page = entries.slice(safeOffset, safeOffset + limit);
     const lines = page.map(formatListingLine);
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -50,7 +50,11 @@ import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
-import { formatFileView } from './utils';
+import {
+  formatFileView,
+  paginateToolListing,
+  formatPaginationHint,
+} from './utils';
 
 // ============================================================================
 // Category-aware field filtering
@@ -435,10 +439,11 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       return { output: 'No execution history found.' };
     }
 
-    // Paginate the listing
-    const total = entries.length;
-    const safeOffset = Math.min(offset, Math.max(0, total - 1));
-    const page = entries.slice(safeOffset, safeOffset + limit);
+    const { page, start, end, total } = paginateToolListing(
+      entries,
+      offset,
+      limit,
+    );
     const lines = page.map(formatListingLine);
 
     // Count active background processes for the header
@@ -446,25 +451,15 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     const bgCount = activeIds.filter(
       (id) => getHandle(id)?.category === 'process',
     ).length;
-
-    const rangeEnd = safeOffset + page.length;
     const bgSuffix =
       bgCount > 0
         ? `, ${bgCount} background process${bgCount > 1 ? 'es' : ''} running`
         : '';
-    const header = `Executions (showing ${safeOffset + 1}\u2013${rangeEnd} of ${total}${bgSuffix}, most recent first):`;
 
-    const parts = [header, '', ...lines];
-
-    // Add pagination hint when there are more entries
-    if (rangeEnd < total) {
-      parts.push(
-        '',
-        `(${total - rangeEnd} more — use offset: ${rangeEnd} to see next page)`,
-      );
-    }
-
-    return { output: parts.join('\n') };
+    const header = `Executions (showing ${start}\u2013${end} of ${total}${bgSuffix}, most recent first):`;
+    return {
+      output: `${header}\n\n${lines.join('\n')}${formatPaginationHint(end, total)}`,
+    };
   }
 
   private async showSummary(executionId: ExecutionId): Promise<ToolResult> {

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -147,7 +147,7 @@ const ExecutionsToolInputSchema = z.strictObject({
     .max(200)
     .nullish()
     .describe(
-      'Max entries to return from /executions listing. Default: 50, max: 200.',
+      'Max entries to return from /executions listing. Default: 100, max: 200.',
     ),
 });
 
@@ -276,7 +276,7 @@ Paths:
 - /executions/{id}/files/{path} - Read specific generated file (workflows only)
 
 Use "current" as {id} to access the active execution.
-Use offset/limit to paginate the /executions listing (default: offset 0, limit 50).
+Use offset/limit to paginate the /executions listing (default: offset 0, limit 100).
 Use view_range: [start, end] to paginate conversation, output, and file content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
 Use action: "kill" on /executions/{id} to terminate a running execution.`,
@@ -296,7 +296,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     if (!id) {
       if (input.action === 'wait')
         await this.waitForAnyChange(input.timeout ?? 300);
-      return this.listExecutions(input.offset ?? 0, input.limit ?? 50);
+      return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
     }
 
     const executionId = this.resolveExecutionId(id);

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -130,6 +130,25 @@ const ExecutionsToolInputSchema = z.strictObject({
     .describe(
       'Max seconds to wait for a status change (action="wait" only). Default: 300, max: 1800.',
     ),
+
+  /** Zero-based offset for paginating the /executions listing (action="view" only). */
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Zero-based offset into the executions list. Use with limit for pagination on /executions. Default: 0.',
+    ),
+
+  /** Maximum number of entries to return from the /executions listing (action="view" only). */
+  limit: z
+    .int()
+    .min(1)
+    .max(200)
+    .nullish()
+    .describe(
+      'Max entries to return from /executions listing. Default: 50, max: 200.',
+    ),
 });
 
 export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
@@ -245,7 +264,7 @@ export class ExecutionsTool extends defineTool({
   description: `View execution history and manage running executions.
 
 Paths:
-- /executions - List all executions (with status and elapsed time)
+- /executions - List executions (paginated; use offset/limit for pages)
 - /executions/{id} - Execution summary (agent, model, timestamp, status, progress, children, todos)
 - /executions/{id}/config - Agent configuration JSON
 - /executions/{id}/conversation - Full message history (subagents)
@@ -257,6 +276,7 @@ Paths:
 - /executions/{id}/files/{path} - Read specific generated file (workflows only)
 
 Use "current" as {id} to access the active execution.
+Use offset/limit to paginate the /executions listing (default: offset 0, limit 50).
 Use view_range: [start, end] to paginate conversation, output, and file content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
 Use action: "kill" on /executions/{id} to terminate a running execution.`,
@@ -276,7 +296,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     if (!id) {
       if (input.action === 'wait')
         await this.waitForAnyChange(input.timeout ?? 300);
-      return this.listExecutions();
+      return this.listExecutions(input.offset ?? 0, input.limit ?? 50);
     }
 
     const executionId = this.resolveExecutionId(id);
@@ -405,28 +425,46 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     clearTimeout(timer);
   }
 
-  private async listExecutions(): Promise<ToolResult> {
+  private async listExecutions(
+    offset: number,
+    limit: number,
+  ): Promise<ToolResult> {
     const entries = await listExecutions();
 
     if (entries.length === 0) {
       return { output: 'No execution history found.' };
     }
 
-    const lines = entries.map(formatListingLine);
+    // Paginate the listing
+    const total = entries.length;
+    const safeOffset = Math.min(offset, total);
+    const page = entries.slice(safeOffset, safeOffset + limit);
+    const lines = page.map(formatListingLine);
 
     // Count active background processes for the header
     const activeIds = getActiveExecutionIds();
     const bgCount = activeIds.filter(
       (id) => getHandle(id)?.category === 'process',
     ).length;
-    const header =
-      bgCount > 0
-        ? `Executions (${entries.length} total, ${bgCount} background process${bgCount > 1 ? 'es' : ''} running):`
-        : `Executions (${entries.length}, most recent first):`;
 
-    return {
-      output: `${header}\n\n${lines.join('\n')}`,
-    };
+    const rangeEnd = safeOffset + page.length;
+    const bgSuffix =
+      bgCount > 0
+        ? `, ${bgCount} background process${bgCount > 1 ? 'es' : ''} running`
+        : '';
+    const header = `Executions (showing ${safeOffset + 1}\u2013${rangeEnd} of ${total}${bgSuffix}, most recent first):`;
+
+    const parts = [header, '', ...lines];
+
+    // Add pagination hint when there are more entries
+    if (rangeEnd < total) {
+      parts.push(
+        '',
+        `(${total - rangeEnd} more — use offset: ${rangeEnd} to see next page)`,
+      );
+    }
+
+    return { output: parts.join('\n') };
   }
 
   private async showSummary(executionId: ExecutionId): Promise<ToolResult> {

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -261,7 +261,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       recordToolFileRead(inputPath);
 
       const total = allEntries.length;
-      const safeOffset = Math.min(offset, total);
+      const safeOffset = total > 0 ? Math.min(offset, total - 1) : 0;
       const page = allEntries.slice(safeOffset, safeOffset + limit);
       const rangeEnd = safeOffset + page.length;
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -22,6 +22,8 @@ import {
   countOccurrences,
   formatFileView,
   formatLinesWithNumbers,
+  formatPaginationHint,
+  paginateToolListing,
   requireField,
 } from '../utils';
 
@@ -260,27 +262,16 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
       const allEntries = await this.buildDirectoryListing(resolvedPath);
       recordToolFileRead(inputPath);
 
-      const total = allEntries.length;
-      const safeOffset = total > 0 ? Math.min(offset, total - 1) : 0;
-      const page = allEntries.slice(safeOffset, safeOffset + limit);
-      const rangeEnd = safeOffset + page.length;
+      const { page, start, end, total } = paginateToolListing(
+        allEntries,
+        offset,
+        limit,
+      );
 
-      const parts = [
-        `Contents of ${inputPath} (showing ${safeOffset + 1}\u2013${rangeEnd} of ${total}, up to 2 levels deep):`,
-        `SIZE\tMODIFIED\tBY\tPATH`,
-        ...page,
-      ];
-
-      if (rangeEnd < total) {
-        parts.push(
-          '',
-          `(${total - rangeEnd} more — use offset: ${rangeEnd} to see next page)`,
-        );
-      }
-
+      const header = `Contents of ${inputPath} (showing ${start}\u2013${end} of ${total}, up to 2 levels deep):`;
       return {
-        summary: `Listed directory: ${inputPath} (${safeOffset + 1}\u2013${rangeEnd} of ${total})`,
-        output: parts.join('\n'),
+        summary: `Listed directory: ${inputPath} (${start}\u2013${end} of ${total})`,
+        output: `${header}\nSIZE\tMODIFIED\tBY\tPATH\n${page.join('\n')}${formatPaginationHint(end, total)}`,
       };
     }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -70,6 +70,25 @@ const MemoryToolInputSchema = z.strictObject({
   insert_text: z.string().nullish(),
   old_path: z.string().nullish(),
   new_path: z.string().nullish(),
+
+  /** Zero-based offset for paginating directory listings (command="view" on a directory). */
+  offset: z
+    .int()
+    .min(0)
+    .nullish()
+    .describe(
+      'Zero-based offset into the directory listing. Use with limit for pagination. Default: 0.',
+    ),
+
+  /** Maximum entries to return from a directory listing (command="view" on a directory). */
+  limit: z
+    .int()
+    .min(1)
+    .max(200)
+    .nullish()
+    .describe(
+      'Max entries to return from directory listing. Default: 50, max: 200.',
+    ),
 });
 
 /** Derived from MemoryToolInputSchema - single source of truth */
@@ -83,6 +102,7 @@ export class MemoryTool extends defineTool({
   description: `Manage persistent memory files under /memories (view, create, str_replace, insert, delete, rename, pin, unpin).
 
 Paths must start with /memories. Use /memories to list files, /memories/file.md for specific files. "/" alone is invalid.
+Directory listings are paginated — use offset/limit to page through results (default: offset 0, limit 50).
 
 Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies, pitfalls, best practices). Pinned memories are always loaded at session start. Use \`unpin\` to remove the pinned status. Maximum ${MAX_PINNED_MEMORIES} pinned memories allowed.`,
   schema: MemoryToolInputSchema,
@@ -103,6 +123,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           this.canonicalize(requireField(input.path, 'path', input.command)),
           // Schema enforces length 2; cast since Zod infers number[]
           input.view_range as [number, number] | undefined,
+          input.offset ?? 0,
+          input.limit ?? 50,
         );
       case 'create':
         return this.create(
@@ -213,6 +235,8 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
   private async view(
     inputPath: string,
     viewRange?: [number, number],
+    offset = 0,
+    limit = 50,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);
@@ -233,15 +257,30 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
 
     const stats = await StorageFS.stat(resolvedPath);
     if (isDirectory(stats.type)) {
-      const listing = await this.buildDirectoryListing(resolvedPath);
+      const allEntries = await this.buildDirectoryListing(resolvedPath);
       recordToolFileRead(inputPath);
+
+      const total = allEntries.length;
+      const safeOffset = Math.min(offset, total);
+      const page = allEntries.slice(safeOffset, safeOffset + limit);
+      const rangeEnd = safeOffset + page.length;
+
+      const parts = [
+        `Contents of ${inputPath} (showing ${safeOffset + 1}\u2013${rangeEnd} of ${total}, up to 2 levels deep):`,
+        `SIZE\tMODIFIED\tBY\tPATH`,
+        ...page,
+      ];
+
+      if (rangeEnd < total) {
+        parts.push(
+          '',
+          `(${total - rangeEnd} more — use offset: ${rangeEnd} to see next page)`,
+        );
+      }
+
       return {
-        summary: `Listed directory: ${inputPath}`,
-        output: [
-          `Contents of ${inputPath} (up to 2 levels deep):`,
-          `SIZE\tMODIFIED\tBY\tPATH`,
-          ...listing,
-        ].join('\n'),
+        summary: `Listed directory: ${inputPath} (${safeOffset + 1}\u2013${rangeEnd} of ${total})`,
+        output: parts.join('\n'),
       };
     }
 

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -87,7 +87,7 @@ const MemoryToolInputSchema = z.strictObject({
     .max(200)
     .nullish()
     .describe(
-      'Max entries to return from directory listing. Default: 50, max: 200.',
+      'Max entries to return from directory listing. Default: 100, max: 200.',
     ),
 });
 
@@ -102,7 +102,7 @@ export class MemoryTool extends defineTool({
   description: `Manage persistent memory files under /memories (view, create, str_replace, insert, delete, rename, pin, unpin).
 
 Paths must start with /memories. Use /memories to list files, /memories/file.md for specific files. "/" alone is invalid.
-Directory listings are paginated — use offset/limit to page through results (default: offset 0, limit 50).
+Directory listings are paginated — use offset/limit to page through results (default: offset 0, limit 100).
 
 Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies, pitfalls, best practices). Pinned memories are always loaded at session start. Use \`unpin\` to remove the pinned status. Maximum ${MAX_PINNED_MEMORIES} pinned memories allowed.`,
   schema: MemoryToolInputSchema,
@@ -124,7 +124,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
           // Schema enforces length 2; cast since Zod infers number[]
           input.view_range as [number, number] | undefined,
           input.offset ?? 0,
-          input.limit ?? 50,
+          input.limit ?? 100,
         );
       case 'create':
         return this.create(
@@ -236,7 +236,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     inputPath: string,
     viewRange?: [number, number],
     offset = 0,
-    limit = 50,
+    limit = 100,
   ): Promise<ToolResult> {
     const resolvedPath = this.resolveMemoryPath(inputPath);
     const exists = await StorageFS.exists(resolvedPath);

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -305,6 +305,33 @@ export async function wrapApiCall<T>(
   }
 }
 
+// ============================================================================
+// Offset-based pagination for tool listings
+// ============================================================================
+
+/**
+ * Slice an array by offset/limit and build display header + "next page" hint.
+ *
+ * All entries are loaded first then sliced client-side — this bounds the
+ * text returned to the model, not the I/O cost of building the listing.
+ */
+export function paginateToolListing<T>(
+  entries: readonly T[],
+  offset: number,
+  limit: number,
+): { page: readonly T[]; start: number; end: number; total: number } {
+  const total = entries.length;
+  const safeOffset = total > 0 ? Math.min(offset, total - 1) : 0;
+  const page = entries.slice(safeOffset, safeOffset + limit);
+  return { page, start: safeOffset + 1, end: safeOffset + page.length, total };
+}
+
+/** Format a "N more — use offset: X" hint, or empty string if no more pages. */
+export function formatPaginationHint(end: number, total: number): string {
+  if (end >= total) return '';
+  return `\n(${total - end} more \u2014 use offset: ${end} to see next page)`;
+}
+
 export interface BuildFileAttachmentOptions {
   /** Path to a workspace file (relative or absolute) */
   filePath: string;


### PR DESCRIPTION
## Summary
This PR introduces pagination across the UI and tool APIs to improve performance and usability when dealing with large lists. A new reusable `Pagination` component provides Unix-style page navigation, and pagination logic is integrated into history, memory, and execution/memory tool listings.

## Key Changes

### New Pagination Component
- **`Pagination.ts`**: New reusable web component (`<list-pagination>`) with:
  - Compact status bar showing item range and page numbers
  - First/Previous/Next/Last navigation buttons
  - `paginate()` utility function for slicing arrays by page
  - `DEFAULT_PAGE_SIZE` constant (50 items)
  - Fires `page-change` custom events with new page index
  - Unix-inspired monospace styling with VSCode design tokens

### Frontend UI Updates
- **`HistoryList.ts`**: 
  - Pagination active only when no search term (full list shown during search for match navigation)
  - Displays pagination controls above and below the list
  - Resets page when entering/leaving search mode
  - Clamps page when items are deleted
  
- **`MemoryList.ts`**: 
  - Integrated pagination with 50 items per page
  - Displays pagination controls above and below the list
  - Resets page when items change (refresh, delete, pin/unpin)

### Tool API Updates
- **`ExecutionsTool.ts`**: 
  - Added `offset` and `limit` parameters to `/executions` listing
  - Default: offset 0, limit 50 (max 200)
  - Updated listing output to show pagination info and hints for next page
  - Updated tool description to document pagination usage

- **`MemoryTool.ts`**: 
  - Added `offset` and `limit` parameters to directory listing (command="view" on directories)
  - Default: offset 0, limit 50 (max 200)
  - Updated directory listing output with pagination info and next-page hints
  - Updated tool description to document pagination usage

## Implementation Details
- Pagination is **opt-in** for search (HistoryList shows all items during search to enable cross-list match navigation)
- Page is automatically clamped when items are deleted or list changes
- Tool APIs provide pagination hints in output (e.g., "use offset: 50 to see next page")
- All pagination uses consistent 50-item default with configurable limits
- Pagination controls are hidden when there's only one page or fewer

https://claude.ai/code/session_01E6VsCiaDbmFZiLcEv8VTi1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new pagination behavior to settings UI lists and changes tool input/output contracts for `/executions` and `/memories` directory views, which could affect callers and edge cases (offset/limit bounds, page clamping). The change is localized but touches user-visible listing behavior and tool schemas.
> 
> **Overview**
> **Adds shared pagination across UI list views and tool listings.** Introduces reusable `paginate()` + `<list-pagination>` (`Pagination.ts`) and wires it into `HistoryList` and `MemoryList` to page large lists (with controls above/below), including page reset/clamping and special-casing history search to disable pagination so match navigation spans the full list.
> 
> **Extends tool listing APIs with offset/limit paging.** `ExecutionsTool` and `MemoryTool` accept new `offset`/`limit` inputs, slice listings via new `paginateToolListing()`/`formatPaginationHint()` helpers, and update listing headers/output to show ranges and provide a next-page hint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a24162899e6b57ed314540b517f767ae0170236c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->