### PR TITLE
Update default Git author email to texra-ai

### DIFF
--- a/src/shared/constants/git.ts
+++ b/src/shared/constants/git.ts
@@ -1,2 +1,2 @@
 export const DEFAULT_GIT_AUTHOR_NAME = 'TeXRA';
-export const DEFAULT_GIT_AUTHOR_EMAIL = 'texra@users.noreply.github.com';
+export const DEFAULT_GIT_AUTHOR_EMAIL = 'texra-ai@users.noreply.github.com';

--- a/src/shared/constants/git.ts
+++ b/src/shared/constants/git.ts
@@ -1,2 +1,2 @@
-export const DEFAULT_GIT_AUTHOR_NAME = 'TeXRA';
+export const DEFAULT_GIT_AUTHOR_NAME = 'texra-ai';
 export const DEFAULT_GIT_AUTHOR_EMAIL = 'texra-ai@users.noreply.github.com';


### PR DESCRIPTION
## Summary
Updated the default Git author email constant to reflect the new TeXRA AI identity.

## Changes
- Changed `DEFAULT_GIT_AUTHOR_EMAIL` from `texra@users.noreply.github.com` to `texra-ai@users.noreply.github.com`

## Details
This update ensures that Git commits made by the application use the correct author email address associated with the TeXRA AI account.

https://claude.ai/code/session_01DjeJChJyMpAJudyoaH6jLL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the default Git author identity used when no workspace override is set, affecting commit metadata but not runtime behavior or data handling.
> 
> **Overview**
> Updates the default Git commit author identity constants to use `texra-ai` (name and noreply email) instead of `TeXRA`, which changes the fallback author metadata applied by git author setup and settings UI when no user-configured values are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb5efac2e24209b170e862cf6ffb67caacbb8a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->