### PR TITLE
Display extract figure flags in workflow delegation approval panel

### DIFF
--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -16,6 +16,7 @@ import type {
   PlanApprovalPermission,
   RetryPermission,
   ToolEditPermission,
+  WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
 import { getBasename } from '@shared/utils/path';
@@ -278,8 +279,30 @@ export class PermissionCard extends LitElement {
       <p><strong>Agent:</strong> ${data.agent}</p>
       <p><strong>Model:</strong> ${data.model}</p>
       <p><strong>Instruction:</strong> ${data.instruction}</p>
+      ${data.agentCategory === AGENT_CATEGORY.WORKFLOW
+        ? this.renderExtractFlags(data)
+        : nothing}
       ${this.renderFileGroups(data)} ${this.renderFeedbackSection()}
     `;
+  }
+
+  private renderExtractFlags(
+    data: WorkflowAgentProposalPermission,
+  ): TemplateResult | typeof nothing {
+    const flags: string[] = [];
+    if (data.toolConfig.autoExtractFigure) flags.push('Extract Figures');
+    if (data.toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
+    if (flags.length === 0) return nothing;
+    return html`<p class="extract-flags">
+      ${repeat(
+        flags,
+        (flag) => flag,
+        (flag) =>
+          html`<span class="extract-flag"
+            ><i class="codicon codicon-file-media"></i> ${flag}</span
+          >`,
+      )}
+    </p>`;
   }
 
   private renderPlanApprovalBody(data: PlanApprovalPermission): TemplateResult {

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -26,7 +26,11 @@ import {
 } from '@shared/styles';
 
 // Local imports - shared utils
-import { AGENT_CATEGORY, type AgentProposalPermission } from '@shared/schemas';
+import {
+  AGENT_CATEGORY,
+  type AgentProposalPermission,
+  type WorkflowAgentProposalPermission,
+} from '@shared/schemas';
 import { postMessage } from '@shared/vscode';
 import { renderModelOptions } from '@shared/utils/selectTemplates';
 
@@ -109,7 +113,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                 >`}
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
-          ${this.renderExtractFlags(data)}
+          ${isWorkflow ? this.renderExtractFlags(data) : nothing}
           ${this.renderProposalFiles(data)}
         </div>
         <vscode-toolbar-container class="workflow-proposal__actions">
@@ -157,17 +161,19 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   }
 
   private renderExtractFlags(
-    data: AgentProposalPermission,
+    data: WorkflowAgentProposalPermission,
   ): TemplateResult | typeof nothing {
-    if (data.agentCategory !== AGENT_CATEGORY.WORKFLOW) return nothing;
     const flags: string[] = [];
     if (data.toolConfig.autoExtractFigure) flags.push('Extract Figures');
     if (data.toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
     if (flags.length === 0) return nothing;
     return html`<div class="workflow-proposal__extract-flags">
-      ${flags.map(
+      ${repeat(
+        flags,
+        (flag) => flag,
         (flag) =>
-          html`<span class="workflow-proposal__extract-flag"
+          html`<span
+            class="workflow-proposal__category-badge workflow-proposal__category-badge--workflow workflow-proposal__extract-flag"
             ><i class="codicon codicon-file-media"></i> ${flag}</span
           >`,
       )}

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -109,6 +109,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
                 >`}
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
+          ${this.renderExtractFlags(data)}
           ${this.renderProposalFiles(data)}
         </div>
         <vscode-toolbar-container class="workflow-proposal__actions">
@@ -151,6 +152,24 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
         ({ label }) => label,
         ({ label, files, clickable }) =>
           this.renderProposalFileList(label, files, clickable),
+      )}
+    </div>`;
+  }
+
+  private renderExtractFlags(
+    data: AgentProposalPermission,
+  ): TemplateResult | typeof nothing {
+    if (data.agentCategory !== AGENT_CATEGORY.WORKFLOW) return nothing;
+    const flags: string[] = [];
+    if (data.toolConfig.autoExtractFigure) flags.push('Extract Figures');
+    if (data.toolConfig.autoExtractTikzFigure) flags.push('Extract TikZ');
+    if (flags.length === 0) return nothing;
+    return html`<div class="workflow-proposal__extract-flags">
+      ${flags.map(
+        (flag) =>
+          html`<span class="workflow-proposal__extract-flag"
+            ><i class="codicon codicon-file-media"></i> ${flag}</span
+          >`,
       )}
     </div>`;
   }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -482,6 +482,17 @@ export function formatToolUseTemplate(
       );
     }
 
+    // Extract figure flags (workflow delegation only)
+    const extractFlags: string[] = [];
+    if ('extractFigures' in delegateInput && delegateInput.extractFigures)
+      extractFlags.push('Extract Figures');
+    if ('extractTikz' in delegateInput && delegateInput.extractTikz)
+      extractFlags.push('Extract TikZ');
+    if (extractFlags.length > 0) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><i class="codicon codicon-file-media"></i> ${f}</span>`)}`));
+    }
+
     // File groups (workflow file fields + memories for both delegation types)
     const fileGroups = getProposalFileGroups(delegateInput);
     if (fileGroups.length > 0) {

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -255,4 +255,17 @@ export const logEntryStyles = css`
   .banner-details:not([open]) .banner-content {
     display: none;
   }
+
+  .extract-flag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border-radius: var(--border-radius);
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    margin-right: var(--spacing-small);
+  }
 `;

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -136,6 +136,24 @@ export const permissionCardStyles: CSSResult = css`
     margin-left: var(--spacing-small);
   }
 
+  .extract-flags {
+    display: flex;
+    gap: var(--spacing-small);
+    flex-wrap: wrap;
+  }
+
+  .extract-flag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border-radius: var(--border-radius);
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+  }
+
   .file-list {
     margin: var(--spacing-small) 0;
   }

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -416,6 +416,25 @@ export const requestPanelStyles: CSSResult = css`
     border-bottom: var(--border-thin) solid var(--vscode-editorWidget-border);
   }
 
+  .workflow-proposal__extract-flags {
+    display: flex;
+    gap: var(--spacing-small);
+    flex-wrap: wrap;
+    margin-top: var(--spacing-small);
+  }
+
+  .workflow-proposal__extract-flag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    padding: var(--spacing-tiny) var(--border-radius-large);
+    border-radius: var(--border-radius);
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+  }
+
   .workflow-proposal__files {
     display: flex;
     flex-direction: column;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -427,12 +427,8 @@ export const requestPanelStyles: CSSResult = css`
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-tiny);
-    font-size: var(--font-size-xs);
-    font-weight: var(--font-weight-semibold);
-    padding: var(--spacing-tiny) var(--border-radius-large);
-    border-radius: var(--border-radius);
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    text-transform: none;
+    letter-spacing: normal;
   }
 
   .workflow-proposal__files {


### PR DESCRIPTION
When a workflow proposal has autoExtractFigure or autoExtractTikzFigure
flags set, show them as labeled badges between the instruction text and
file groups so users can see extraction settings before approving.

https://claude.ai/code/session_01LSGJj3PxpXkDQawixMTVbW

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that surfaces existing workflow delegation options; minimal logic added and gated to workflow inputs.
> 
> **Overview**
> Displays workflow proposal extraction settings (`autoExtractFigure` / `autoExtractTikzFigure`) as badge-like flags in both the modal `PermissionCard` and the in-list `ProposalRequestPanel`, positioned between the instruction and file groups.
> 
> Also surfaces workflow delegation extraction options in tool-use log entries (delegation formatter) and adds shared styling for the new `extract-flag`/flag-container classes in `permissionCardStyles`, `requestPanelStyles`, and `logEntryStyles`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a86c5c0aca8609409ab742053bd65a674fb5fff2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->