### PR TITLE
Add support for waiting on specific execution IDs

### DIFF
--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -410,7 +410,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     timeout: number,
     ids?: readonly string[] | null,
   ): Promise<void> {
-    const candidateIds = ids?.length ? [...ids] : getActiveExecutionIds();
+    const candidateIds = ids?.length ? [...new Set(ids)] : getActiveExecutionIds();
     if (candidateIds.length === 0) return;
 
     // Exclude executions that are already effectively done

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -127,7 +127,7 @@ const ExecutionsToolInputSchema = z.strictObject({
 
   /** Execution IDs to wait on (action="wait" with /executions only). */
   ids: z
-    .array(z.string())
+    .array(ExecutionIdSchema)
     .min(1)
     .max(50)
     .nullish()
@@ -312,7 +312,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     // /executions - list all executions
     if (!id) {
       if (input.action === 'wait')
-        await this.waitForAnyChange(input.timeout ?? 300, input.ids ?? undefined);
+        await this.waitForAnyChange(input.timeout ?? 300, input.ids);
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
     }
 
@@ -405,20 +405,12 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     return result.data;
   }
 
-  /**
-   * Wait for active executions to change status, with timeout.
-   * If `ids` is provided, only wait on those specific executions;
-   * otherwise wait on all active executions.
-   */
+  /** Wait for executions to change status, with timeout. */
   private async waitForAnyChange(
     timeout: number,
-    ids?: string[],
+    ids?: readonly string[] | null,
   ): Promise<void> {
-    // When specific IDs are provided, validate and use them;
-    // otherwise fall back to all active executions.
-    const candidateIds = ids
-      ? ids.map((id) => this.resolveExecutionId(id))
-      : getActiveExecutionIds();
+    const candidateIds = ids?.length ? [...ids] : getActiveExecutionIds();
     if (candidateIds.length === 0) return;
 
     // Exclude executions that are already effectively done

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -125,6 +125,18 @@ const ExecutionsToolInputSchema = z.strictObject({
       'Line range [start, end] for paginating large outputs (action="view" only).',
     ),
 
+  /** Execution IDs to wait on (action="wait" with /executions only). */
+  ids: z
+    .array(z.string())
+    .min(1)
+    .max(50)
+    .nullish()
+    .describe(
+      'List of execution IDs to wait on (action="wait" with /executions only). ' +
+        'Waits for any of the listed executions to change status. ' +
+        'If omitted, waits for any active execution.',
+    ),
+
   /** Max seconds to wait (action="wait" only). Default: 300. */
   timeout: z
     .number()
@@ -283,6 +295,7 @@ Use "current" as {id} to access the active execution.
 Use offset/limit to paginate the /executions listing (default: offset 0, limit 100).
 Use view_range: [start, end] to paginate conversation, output, and file content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
+Use action: "wait" with ids: ["id1", "id2", ...] on /executions to wait for any of the listed executions to change.
 Use action: "kill" on /executions/{id} to terminate a running execution.`,
   schema: ExecutionsToolInputSchema,
 }) {
@@ -299,7 +312,7 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     // /executions - list all executions
     if (!id) {
       if (input.action === 'wait')
-        await this.waitForAnyChange(input.timeout ?? 300);
+        await this.waitForAnyChange(input.timeout ?? 300, input.ids ?? undefined);
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
     }
 
@@ -392,14 +405,25 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     return result.data;
   }
 
-  /** Wait for any active execution to change status, with timeout. */
-  private async waitForAnyChange(timeout: number): Promise<void> {
-    const activeIds = getActiveExecutionIds();
-    if (activeIds.length === 0) return;
+  /**
+   * Wait for active executions to change status, with timeout.
+   * If `ids` is provided, only wait on those specific executions;
+   * otherwise wait on all active executions.
+   */
+  private async waitForAnyChange(
+    timeout: number,
+    ids?: string[],
+  ): Promise<void> {
+    // When specific IDs are provided, validate and use them;
+    // otherwise fall back to all active executions.
+    const candidateIds = ids
+      ? ids.map((id) => this.resolveExecutionId(id))
+      : getActiveExecutionIds();
+    if (candidateIds.length === 0) return;
 
     // Exclude executions that are already effectively done
     // (completed, inactive, or tool-use subagent WAITING with result delivered).
-    const pendingIds = activeIds.filter((id) => !shouldSkipWait(id));
+    const pendingIds = candidateIds.filter((id) => !shouldSkipWait(id));
     if (pendingIds.length === 0) return;
 
     const ac = new AbortController();


### PR DESCRIPTION
## Summary
Enhanced the ExecutionsTool to support waiting for specific execution IDs to change status, rather than only waiting for any active execution.

## Key Changes
- Added new `ids` input parameter to ExecutionsToolInputSchema that accepts an array of 1-50 execution IDs
- Updated `waitForAnyChange()` method to accept an optional `ids` parameter
- Modified the logic to use provided execution IDs when specified, falling back to active executions when omitted
- Updated tool documentation to explain the new capability

## Implementation Details
- The `ids` parameter is optional and nullish, maintaining backward compatibility
- When `ids` are provided, they are used as candidates for waiting; otherwise, active execution IDs are retrieved as before
- The filtering logic for pending executions (excluding completed/inactive ones) remains unchanged
- The feature is only available with the "wait" action on the `/executions` endpoint

https://claude.ai/code/session_013t3gKs9qQnHqG5GybzVH7Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backwards-compatible change limited to the `/executions` wait path; main risk is unexpected behavior if callers pass invalid/stale IDs, but inputs are validated and existing behavior remains the default.
> 
> **Overview**
> Adds support for `action: "wait"` on `/executions` to target a specific set of execution IDs via a new optional `ids` input (validated as 1–50 `ExecutionIdSchema` values).
> 
> Updates the wait implementation to dedupe and use provided IDs when present, otherwise falling back to active executions, and documents the new usage in the tool description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2b612f4bc35f99e35f8c51065700499b188b6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->