### PR TITLE
Make tool-use agent failures continuable

### DIFF
--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -183,11 +183,14 @@ export class ToolUseCycleNode<C> extends Node<
           message: execRes.message,
           retryable: execRes.retryable ?? false,
         };
-        return FlowTransition.FINALIZE;
+        // Continue to WaitNode instead of ending the flow.
+        // Tool-use agents are conversational — the user can send a
+        // follow-up to retry after a failure, unlike workflows.
+        return FlowTransition.DEFAULT;
 
       case 'cancelled':
         shared.userCancelledRetry = true;
-        return FlowTransition.FINALIZE;
+        return FlowTransition.DEFAULT;
     }
   }
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -10,6 +10,8 @@ import type { ToolUseRunShared, WaitExecResult } from './types';
 interface WaitPrepResult {
   lastResponse: string | undefined;
   touchedFiles: string[];
+  /** True when entering after a failed/cancelled cycle. */
+  afterError: boolean;
 }
 
 export class ToolUseWaitNode<C> extends Node<
@@ -19,15 +21,17 @@ export class ToolUseWaitNode<C> extends Node<
 > {
   async prep(shared: ToolUseRunShared): Promise<WaitPrepResult> {
     const { modelHandler, onBeforeWaiting } = this.services;
+    const afterError = !!(shared.lastError || shared.userCancelledRetry);
 
     // Only extract when the callback is wired (subagent mode)
-    if (!onBeforeWaiting) return { lastResponse: undefined, touchedFiles: [] };
+    if (!onBeforeWaiting) return { lastResponse: undefined, touchedFiles: [], afterError };
 
     return {
       touchedFiles: extractTouchedFiles(shared.stateSlices),
       lastResponse: findLastAssistantText(shared.messages, (m) =>
         modelHandler.extractAssistantText(m),
       ),
+      afterError,
     };
   }
 
@@ -39,7 +43,11 @@ export class ToolUseWaitNode<C> extends Node<
       return { kind: 'stop' };
     }
 
-    await onBeforeWaiting?.(prepRes.lastResponse, prepRes.touchedFiles);
+    // Skip subagent delivery after a failed/cancelled cycle — the
+    // orchestrator must not see a failure as a successful completion.
+    if (!prepRes.afterError) {
+      await onBeforeWaiting?.(prepRes.lastResponse, prepRes.touchedFiles);
+    }
 
     if (!session.hasQueuedFollowUp()) {
       StreamStatusService.set(streamId, STREAM_STATUS.WAITING);

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -45,7 +45,13 @@ export class ToolUseWaitNode<C> extends Node<
 
     // Skip subagent delivery after a failed/cancelled cycle — the
     // orchestrator must not see a failure as a successful completion.
-    if (!prepRes.afterError) {
+    // In subagent mode, stop immediately: no orchestrator will send a
+    // follow-up since it was never notified, so waiting would hang.
+    if (prepRes.afterError) {
+      if (this.services.isSubagent) {
+        return { kind: 'stop' };
+      }
+    } else {
       await onBeforeWaiting?.(prepRes.lastResponse, prepRes.touchedFiles);
     }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -74,6 +74,12 @@ export class ToolUseWaitNode<C> extends Node<
       return FlowTransition.DEFAULT;
     }
 
+    // User sent a follow-up — clear any prior error/cancellation state
+    // so the next cycle starts fresh and runToolUseFlow won't treat
+    // a previously-recovered error as a terminal failure.
+    shared.lastError = undefined;
+    shared.userCancelledRetry = undefined;
+
     onFollowUpConsumed?.();
     StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
     logger.userMessage(execRes.followUp);


### PR DESCRIPTION
## Summary

- Tool-use agent cycle failures (`failed`/`cancelled`) now transition to WaitNode instead of ending the flow via FINALIZE
- WaitNode clears error/cancellation state when the user sends a follow-up, so the next cycle starts clean
- If the user interrupts during the error wait, the error state is preserved and reported correctly

Tool-use agents are conversational, not workflows — a model API failure or retry cancellation should not kill the entire agent lifecycle. The user should be able to send a follow-up message to continue.

## Test plan

- [ ] Trigger a model API error (e.g., invalid key) during a tool-use agent session — agent should enter WAITING state instead of dying
- [ ] Send a follow-up message after the error — agent should retry the cycle with the updated conversation
- [ ] Cancel a retry prompt — agent should enter WAITING state, not terminate
- [ ] Interrupt the agent during an error wait — should report error status and end gracefully
- [ ] Normal tool-use flow (no errors) should be unaffected

https://claude.ai/code/session_019So7c4xtaxnAGxre1VdUyb

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tool-use flow control around failures/cancellations and subagent orchestration callbacks, which could affect when runs stop vs wait and how errors are surfaced.
> 
> **Overview**
> Tool-use agent runs no longer terminate on cycle `failed` or `cancelled`; `ToolUseCycleNode` now records `lastError`/`userCancelledRetry` and transitions into the normal wait-for-follow-up path instead of `FINALIZE`.
> 
> `ToolUseWaitNode` adds an `afterError` mode to avoid calling `onBeforeWaiting` after an error/cancel (so subagent orchestrators don’t interpret failures as successful completion), stops immediately in subagent mode to avoid hanging, and clears error/cancellation state once a user follow-up is consumed so the next cycle starts clean.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94b93223f4d5c8ea033ed6cce5d3ee97a04bec91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->