### PR TITLE
Add compactization strategy for OpenAI-compatible models

### DIFF
--- a/prds/plan-claude-client-compactization.md
+++ b/prds/plan-claude-client-compactization.md
@@ -467,6 +467,8 @@ Exports shared across all providers:
 - `COMPACTION_MODEL_MAP` — Constant map from primary model → cheaper compaction model (PRD Section 4.3)
 - `getCompactionModel()` — Lookup function with same-model fallback
 
+**Also:** Remove the local `COMPACTION_SYSTEM_PROMPT` from `modelHandlerOpenAI.ts` (line 93) and replace it with an import from the shared file. One constant, one source of truth.
+
 ### Step 2: Remove server-side context editing
 
 **Files:**

--- a/prds/plan-claude-client-compactization.md
+++ b/prds/plan-claude-client-compactization.md
@@ -48,9 +48,8 @@ From `node_modules/@anthropic-ai/sdk/lib/tools/BetaToolRunner.js` (lines 65-133)
 | SDK Behavior                        | Our Adaptation                                        | Reason                                                                      |
 | ----------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------- |
 | Compaction runs **after** API call  | Run **after** API call (match SDK)                    | Better UX: user sees response immediately, compaction happens between turns |
-| Appends summary prompt as user msg  | **Swap system prompt** to summarization instructions  | Cleaner: summarization instructions are system-level, not a user turn       |
+| Appends summary prompt as user msg  | **Swap system prompt** to `COMPACTION_SYSTEM_PROMPT`  | Cleaner: summarization instructions are system-level, not a user turn       |
 | Sends messages as-is                | **Send messages as-is** (match SDK)                   | Model sees actual structured messages — richer than serialized text         |
-| No system prompt in compaction call | **Swap** system prompt to `COMPACTION_SYSTEM_PROMPT`  | Dedicated summarization instructions replace the agent's system prompt      |
 | Same `max_tokens` as main request   | Fixed **8192** for compaction                         | Summaries rarely need >4K tokens; avoid wasting budget                      |
 | Hard throw on non-text response     | **Graceful fallback** to original messages            | More robust in production                                                   |
 | No logging                          | Full **context management logging**                   | TeXRA's progress view needs visibility                                      |
@@ -141,31 +140,32 @@ private async compactConversation(
   const tokensBefore = this.compactionState.lastUsageTokens;
   const contextWindow = this.config.contextWindow;
 
-  // 1. Deep-copy and clean last assistant message (remove pending tool_use blocks)
+  // 1. Clean last assistant message if it has pending tool_use blocks.
   //    Without this, the API returns 400 ("tool_use requires tool_result").
-  const cleanedMessages: MessageParam[] = structuredClone(messages);
-  const lastMsg = cleanedMessages.at(-1);
+  //    Only clone when mutation is needed to avoid deep-copying the entire array.
+  let cleanedMessages = messages;
+  const lastMsg = messages.at(-1);
   if (lastMsg?.role === 'assistant' && Array.isArray(lastMsg.content)) {
     const nonToolBlocks = (lastMsg.content as BetaContentBlockParam[]).filter(
       (b) => b.type !== 'tool_use',
     );
     if (nonToolBlocks.length === 0) {
-      cleanedMessages.pop();
-    } else {
-      (cleanedMessages[cleanedMessages.length - 1] as MessageParam).content = nonToolBlocks;
+      cleanedMessages = messages.slice(0, -1);
+    } else if (nonToolBlocks.length < lastMsg.content.length) {
+      cleanedMessages = [...messages.slice(0, -1), { ...lastMsg, content: nonToolBlocks }];
     }
   }
 
-  // 2. Call API with swapped system prompt — messages sent as-is, no serialization
-  //    The compaction system prompt replaces the agent's original system prompt,
-  //    instructing the model to summarize the conversation it sees in the messages.
+  // 2. Call API with swapped system prompt — no serialization needed.
+  //    The original agent system prompt is not passed; its domain context
+  //    is already embedded in the conversation messages themselves.
   const compactionModel = this.getCompactionModel();
   try {
     const response = await client.beta.messages.create(
       {
         model: compactionModel,
-        system: COMPACTION_SYSTEM_PROMPT, // Swapped from original agent system prompt
-        messages: cleanedMessages,        // Conversation messages as-is
+        system: COMPACTION_SYSTEM_PROMPT,
+        messages: cleanedMessages,
         max_tokens: 8192,
       },
       { signal },
@@ -181,15 +181,20 @@ private async compactConversation(
     }
 
     const summary = summaryBlock.text;
+    const summaryOutputTokens = response.usage?.output_tokens ?? 0;
+    const estimatedTokensAfter = Math.max(1, summaryOutputTokens);
+    const utilizationAfter = (estimatedTokensAfter / contextWindow) * 100;
 
     // 4. Log compaction event
     this.logger.logContextManagement(
-      `Compacted: ${tokensBefore.toLocaleString()} → summary`,
+      `Compacted: ${tokensBefore.toLocaleString()} → ~${estimatedTokensAfter.toLocaleString()} tokens`,
       {
         action: 'compaction',
         tokensBefore,
+        tokensAfter: estimatedTokensAfter,
         contextWindow,
         utilizationBefore: (tokensBefore / contextWindow) * 100,
+        utilizationAfter: Number(utilizationAfter.toFixed(1)),
         details: `Client-side compaction (model: ${compactionModel})`,
       },
     );
@@ -207,7 +212,7 @@ private async compactConversation(
 }
 ```
 
-**Note:** The `systemPrompt` parameter from the original agent is intentionally NOT passed to the compaction call. The compactor gets its own dedicated system prompt (`COMPACTION_SYSTEM_PROMPT`) that instructs it to summarize. The original system prompt context (LaTeX/research domain) is implicitly captured in the conversation messages themselves.
+**Context window safety:** The compaction call sends all messages to the compactor model. Since compaction triggers at 75% of the primary model's context window, and the compactor model (e.g., Sonnet) has the same 200K context, the messages fit comfortably — 150K input + 8K max_tokens + system prompt is well within 200K. If a future compactor model has a smaller context window, the API will return an error and the graceful fallback keeps original messages. For models with smaller context windows, consider adding a pre-check: skip compaction if `tokensBefore + 8192 > compactorContextWindow`.
 
 ### 3.5 Compaction Model Selection
 

--- a/prds/plan-claude-client-compactization.md
+++ b/prds/plan-claude-client-compactization.md
@@ -14,7 +14,7 @@ This plan implements **Phase 3** (Integration with Handlers) of the PRD for the 
 
 ## 1. Summary
 
-Add client-side compaction to `ModelHandlerAnthropic`, following the pattern proven in the Anthropic SDK's `BetaToolRunner._checkAndCompact()`. This approach works with **all Anthropic models** (not just Opus 4.6), uses a **cheaper model** for summarization, and requires **no SDK type additions**.
+Add client-side compaction to `ModelHandlerAnthropic`, inspired by the Anthropic SDK's `BetaToolRunner._checkAndCompact()` but using a **system-prompt-swap** strategy instead of serialization. The compaction call swaps the system prompt to summarization instructions and sends conversation messages as-is — no serialization, no "last K messages" windowing. This approach works with **all Anthropic models** (not just Opus 4.6), uses a **cheaper model** for summarization, and requires **no SDK type additions**.
 
 This is the same approach proposed in the main PRD (`docs/prd-context-compactization.md`) Section 4.2 for all non-OpenAI-Responses providers. Implementing it for Anthropic first validates the pattern before rolling out to Google, DeepSeek, Kimi, and OpenAI Chat.
 
@@ -45,13 +45,15 @@ From `node_modules/@anthropic-ai/sdk/lib/tools/BetaToolRunner.js` (lines 65-133)
 
 ### What to change
 
-| SDK Behavior                        | Our Adaptation                             | Reason                                                                      |
-| ----------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------- |
-| Compaction runs **after** API call  | Run **after** API call (match SDK)         | Better UX: user sees response immediately, compaction happens between turns |
-| No system prompt in compaction call | **Include** system prompt                  | TeXRA's system prompts contain important LaTeX/research context             |
-| Same `max_tokens` as main request   | Fixed **8192** for compaction              | Summaries rarely need >4K tokens; avoid wasting budget                      |
-| Hard throw on non-text response     | **Graceful fallback** to original messages | More robust in production                                                   |
-| No logging                          | Full **context management logging**        | TeXRA's progress view needs visibility                                      |
+| SDK Behavior                        | Our Adaptation                                        | Reason                                                                      |
+| ----------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| Compaction runs **after** API call  | Run **after** API call (match SDK)                    | Better UX: user sees response immediately, compaction happens between turns |
+| Appends summary prompt as user msg  | **Swap system prompt** to summarization instructions  | Cleaner: summarization instructions are system-level, not a user turn       |
+| Sends messages as-is                | **Send messages as-is** (match SDK)                   | Model sees actual structured messages — richer than serialized text         |
+| No system prompt in compaction call | **Swap** system prompt to `COMPACTION_SYSTEM_PROMPT`  | Dedicated summarization instructions replace the agent's system prompt      |
+| Same `max_tokens` as main request   | Fixed **8192** for compaction                         | Summaries rarely need >4K tokens; avoid wasting budget                      |
+| Hard throw on non-text response     | **Graceful fallback** to original messages            | More robust in production                                                   |
+| No logging                          | Full **context management logging**                   | TeXRA's progress view needs visibility                                      |
 
 ---
 
@@ -119,19 +121,28 @@ private shouldCompact(): boolean {
 }
 ```
 
-### 3.4 Compaction Execution
+### 3.4 Compaction Execution — System Prompt Swap Strategy
+
+The key insight: **send the conversation messages as-is** to the compactor model, but **swap the system prompt** to summarization instructions. No serialization, no "last K messages" windowing. The model reads the actual structured messages (with proper roles, tool calls, tool results) and produces a summary naturally.
+
+**Why this is better than serialization + windowing:**
+
+- The model sees native message structure — roles, tool_call IDs, tool results — far richer than flattened text
+- No information loss from serialization heuristics
+- No arbitrary "recent window" boundary — the model decides what matters
+- Simpler code: no `serializeMessagesForSummary()`, no boundary detection, no truncation logic
 
 ```typescript
 private async compactConversation(
   client: Anthropic,
   messages: MessageParam[],
-  systemPrompt?: string,
   signal?: AbortSignal,
 ): Promise<{ compacted: boolean; newMessages: MessageParam[]; summary?: string }> {
   const tokensBefore = this.compactionState.lastUsageTokens;
   const contextWindow = this.config.contextWindow;
 
   // 1. Deep-copy and clean last assistant message (remove pending tool_use blocks)
+  //    Without this, the API returns 400 ("tool_use requires tool_result").
   const cleanedMessages: MessageParam[] = structuredClone(messages);
   const lastMsg = cleanedMessages.at(-1);
   if (lastMsg?.role === 'assistant' && Array.isArray(lastMsg.content)) {
@@ -145,30 +156,22 @@ private async compactConversation(
     }
   }
 
-  // 2. Append summary prompt as user message
-  // Note: This may create consecutive user messages (e.g., when last message is
-  // tool_result). This is intentional and matches the Anthropic SDK's
-  // BetaToolRunner._checkAndCompact() pattern (lines 108-118), which the API accepts.
-  // The compaction result replaces all messages anyway, so alternation is restored.
-  cleanedMessages.push({
-    role: 'user',
-    content: [{ type: 'text', text: COMPACTION_SUMMARY_PROMPT }],
-  });
-
-  // 3. Call API (non-streaming) with compaction model
+  // 2. Call API with swapped system prompt — messages sent as-is, no serialization
+  //    The compaction system prompt replaces the agent's original system prompt,
+  //    instructing the model to summarize the conversation it sees in the messages.
   const compactionModel = this.getCompactionModel();
   try {
     const response = await client.beta.messages.create(
       {
         model: compactionModel,
-        messages: cleanedMessages,
+        system: COMPACTION_SYSTEM_PROMPT, // Swapped from original agent system prompt
+        messages: cleanedMessages,        // Conversation messages as-is
         max_tokens: 8192,
-        ...(systemPrompt && { system: systemPrompt }),
       },
       { signal },
     );
 
-    // 4. Extract summary text
+    // 3. Extract summary text
     const summaryBlock = response.content.find(
       (b): b is Extract<typeof b, { type: 'text' }> => b.type === 'text',
     );
@@ -179,7 +182,7 @@ private async compactConversation(
 
     const summary = summaryBlock.text;
 
-    // 5. Log compaction event
+    // 4. Log compaction event
     this.logger.logContextManagement(
       `Compacted: ${tokensBefore.toLocaleString()} → summary`,
       {
@@ -191,7 +194,7 @@ private async compactConversation(
       },
     );
 
-    // 6. Replace ALL messages with single user message containing summary
+    // 5. Replace ALL messages with single user message containing summary
     const newMessages: MessageParam[] = [
       { role: 'user', content: [{ type: 'text', text: summary }] },
     ];
@@ -203,6 +206,8 @@ private async compactConversation(
   }
 }
 ```
+
+**Note:** The `systemPrompt` parameter from the original agent is intentionally NOT passed to the compaction call. The compactor gets its own dedicated system prompt (`COMPACTION_SYSTEM_PROMPT`) that instructs it to summarize. The original system prompt context (LaTeX/research domain) is implicitly captured in the conversation messages themselves.
 
 ### 3.5 Compaction Model Selection
 
@@ -246,43 +251,60 @@ private getCompactionModel(): string {
 
 **No thinking mode for summarizer** (per PRD Section 4.3): The Anthropic SDK's compaction call doesn't pass thinking parameters — summarization is straightforward and doesn't need extended thinking.
 
-### 3.6 Summary Prompt
+### 3.6 Compaction System Prompt
 
-Define locally in `src/agent/modelHandlers/compactionPrompt.ts` (shared across providers):
+Define locally in `src/agent/modelHandlers/compactionPrompt.ts` (shared across providers).
+
+This is used as the **system prompt** for the compaction call (replacing the agent's original system prompt). The model reads the actual conversation messages and follows these instructions to produce a summary.
 
 ```typescript
-export const COMPACTION_SUMMARY_PROMPT = `You have been working on the task described above but have not yet completed it.
-Write a continuation summary that will allow you (or another instance of yourself)
-to resume work efficiently in a future context window where the conversation
-history will be replaced with this summary. Your summary should be structured,
-concise, and actionable. Include:
+export const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer. The messages below represent a conversation
+between a user and an AI assistant. The conversation may be incomplete — the task
+may not yet be finished.
+
+Write a continuation summary that will allow an AI assistant to resume work
+efficiently in a future context window where the conversation history will be
+replaced with this summary. Your summary should be structured, concise, and
+actionable. Include:
+
 1. Task Overview
-The user's core request and success criteria
-Any clarifications or constraints they specified
+   The user's core request and success criteria
+   Any clarifications or constraints they specified
+
 2. Current State
-What has been completed so far
-Files created, modified, or analyzed (with paths if relevant)
-Key outputs or artifacts produced
+   What has been completed so far
+   Files created, modified, or analyzed (with paths if relevant)
+   Key outputs or artifacts produced
+
 3. Important Discoveries
-Technical constraints or requirements uncovered
-Decisions made and their rationale
-Errors encountered and how they were resolved
-What approaches were tried that didn't work (and why)
+   Technical constraints or requirements uncovered
+   Decisions made and their rationale
+   Errors encountered and how they were resolved
+   What approaches were tried that didn't work (and why)
+
 4. Next Steps
-Specific actions needed to complete the task
-Any blockers or open questions to resolve
-Priority order if multiple steps remain
+   Specific actions needed to complete the task
+   Any blockers or open questions to resolve
+   Priority order if multiple steps remain
+
 5. Context to Preserve
-User preferences or style requirements
-Domain-specific details that aren't obvious
-Any promises made to the user
-Be concise but complete—err on the side of including information that would
+   User preferences or style requirements
+   Domain-specific details that aren't obvious
+   Any promises made to the user
+
+Be concise but complete — err on the side of including information that would
 prevent duplicate work or repeated mistakes. Write in a way that enables
 immediate resumption of the task.
+
 Wrap your summary in <summary></summary> tags.`;
 ```
 
-Based on the Anthropic SDK's `DEFAULT_SUMMARY_PROMPT` (`lib/tools/CompactionControl.js`). Defined locally to avoid importing from an unstable internal SDK path.
+**Key difference from SDK:** The SDK appends the prompt as a user message at the end of the conversation. We use it as the system prompt instead. This is cleaner because:
+- Summarization instructions are system-level directives, not a user turn
+- Avoids potential consecutive-user-message issues
+- The model sees the unmodified conversation messages — no appended instruction mixed in with the conversation
+
+Based on the Anthropic SDK's `DEFAULT_SUMMARY_PROMPT` (`lib/tools/CompactionControl.js`), adapted for use as a system prompt. Defined locally to avoid importing from an unstable internal SDK path.
 
 ### 3.7 Integration with `createResponse()`
 
@@ -306,7 +328,7 @@ async createResponse(
     this.logger.logProgress(
       `Compacting conversation (${this.compactionState.lastUsageTokens.toLocaleString()} tokens exceed threshold)`,
     );
-    const result = await this.compactConversation(client, messages, systemPrompt, signal);
+    const result = await this.compactConversation(client, messages, signal);
     if (result.compacted) {
       updatedMessages = result.newMessages;
     }
@@ -436,7 +458,7 @@ The `context_management` parameter and beta header are removed entirely. Context
 
 Exports shared across all providers:
 
-- `COMPACTION_SUMMARY_PROMPT` — The 5-section structured prompt (from Anthropic SDK)
+- `COMPACTION_SYSTEM_PROMPT` — The 5-section structured system prompt for compaction calls (adapted from Anthropic SDK)
 - `COMPACTION_MODEL_MAP` — Constant map from primary model → cheaper compaction model (PRD Section 4.3)
 - `getCompactionModel()` — Lookup function with same-model fallback
 
@@ -474,8 +496,10 @@ Add:
 
 Add the method as described in Section 3.4. Key behaviors:
 
+- **System prompt swap**: Use `COMPACTION_SYSTEM_PROMPT` as the system prompt (not the agent's original)
+- **Messages as-is**: Send conversation messages directly — no serialization, no windowing
 - `structuredClone` messages before mutation
-- Clean `tool_use` blocks from last assistant message
+- Clean `tool_use` blocks from last assistant message (API requirement)
 - Non-streaming API call to compaction model
 - Graceful fallback on failure
 - Structured logging via `logger.logContextManagement()`

--- a/prds/plan-claude-client-compactization.md
+++ b/prds/plan-claude-client-compactization.md
@@ -505,7 +505,7 @@ Add the method as described in Section 3.4. Key behaviors:
 
 - **System prompt swap**: Use `COMPACTION_SYSTEM_PROMPT` as the system prompt (not the agent's original)
 - **Messages as-is**: Send conversation messages directly — no serialization, no windowing
-- `structuredClone` messages before mutation
+- Shallow-copy only when last message needs `tool_use` cleanup (no deep clone)
 - Clean `tool_use` blocks from last assistant message (API requirement)
 - Non-streaming API call to compaction model
 - Graceful fallback on failure

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -39,9 +39,6 @@ export function getAnthropicMaxPdfPages(contextWindow: number): number {
 /** Max tokens for the compaction summary response (client-side compaction for OpenAI-compatible models). */
 export const CLIENT_COMPACTION_SUMMARY_MAX_TOKENS = 2000;
 
-/** Number of recent messages to preserve during client-side compaction (keeps immediate context). */
-export const CLIENT_COMPACTION_RECENT_MESSAGES = 4;
-
 /** Compute reduced max tokens under context pressure (minimum 1). */
 export function computeReducedMaxTokens(
   availableTokens: number,

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -36,6 +36,12 @@ export function getAnthropicMaxPdfPages(contextWindow: number): number {
     : ANTHROPIC_MAX_PDF_PAGES_200K;
 }
 
+/** Max tokens for the compaction summary response (client-side compaction for OpenAI-compatible models). */
+export const CLIENT_COMPACTION_SUMMARY_MAX_TOKENS = 2000;
+
+/** Number of recent messages to preserve during client-side compaction (keeps immediate context). */
+export const CLIENT_COMPACTION_RECENT_MESSAGES = 4;
+
 /** Compute reduced max tokens under context pressure (minimum 1). */
 export function computeReducedMaxTokens(
   availableTokens: number,

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -59,7 +59,6 @@ import {
 } from './utils/toolAttachmentUtils';
 import { ModelHandler } from './ModelHandler';
 import {
-  CLIENT_COMPACTION_RECENT_MESSAGES,
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   DEFAULT_COMPACTION_THRESHOLD_PERCENT,
   TOOL_USE_SAFETY_BUFFER,
@@ -170,7 +169,7 @@ export class ModelHandlerOpenAI<
     if (!this.isToolUseMode()) return false;
 
     if (this.compactionRequested) {
-      return this.lastKnownInputTokens > 0;
+      return true;
     }
 
     const thresholdPercent = this.getCompactionThresholdPercent();
@@ -183,66 +182,9 @@ export class ModelHandlerOpenAI<
   }
 
   /**
-   * Serialize messages to text for the compaction summary prompt.
-   * Converts ChatCompletionMessageParam[] into a readable text format.
-   */
-  private serializeMessagesForSummary(
-    messages: ChatCompletionMessageParam[],
-  ): string {
-    return messages
-      .map((msg) => {
-        const role = msg.role.toUpperCase();
-        let content: string;
-        if (typeof msg.content === 'string') {
-          content = msg.content;
-        } else if (Array.isArray(msg.content)) {
-          content = (msg.content as ChatCompletionContentPart[])
-            .map((part: ChatCompletionContentPart) => {
-              if ('text' in part) return part.text;
-              if (part.type === 'image_url') return '[image]';
-              if (part.type === 'input_audio') return '[audio]';
-              return `[${part.type}]`;
-            })
-            .join('\n');
-        } else {
-          content = '';
-        }
-
-        // Include tool calls if present
-        const assistantMsg = msg as ChatCompletionAssistantMessageParam;
-        if (assistantMsg.tool_calls?.length) {
-          const toolSummary = assistantMsg.tool_calls
-            .map((tc: ChatCompletionMessageToolCall) => {
-              const fn = (tc as unknown as Record<string, unknown>).function as
-                | { name?: string; arguments?: string }
-                | undefined;
-              const name = fn?.name ?? 'unknown';
-              const args = fn?.arguments ?? '';
-              return `[Tool call: ${name}(${args.substring(0, 200)}${args.length > 200 ? '...' : ''})]`;
-            })
-            .join('\n');
-          content = content ? `${content}\n${toolSummary}` : toolSummary;
-        }
-
-        // Include tool result for tool messages
-        const toolMsg = msg as ChatCompletionToolMessageParam;
-        if (toolMsg.role === 'tool' && toolMsg.tool_call_id) {
-          const toolContent =
-            typeof toolMsg.content === 'string'
-              ? toolMsg.content.substring(0, 500)
-              : '[structured content]';
-          content = `[Tool result for ${toolMsg.tool_call_id}]: ${toolContent}${typeof toolMsg.content === 'string' && toolMsg.content.length > 500 ? '...' : ''}`;
-        }
-
-        return `[${role}]: ${content}`;
-      })
-      .join('\n\n');
-  }
-
-  /**
-   * Compact the conversation using client-side summarization.
-   * Sends a separate chat completion to generate a summary, then replaces
-   * messages with system prompt + summary + recent messages.
+   * Compact the conversation using client-side summarization via system-prompt-swap.
+   * Sends conversation messages as-is to the model with a summarization system prompt,
+   * then replaces all messages with the summary.
    *
    * @returns The compacted messages array, or original messages if compaction fails
    */
@@ -262,12 +204,11 @@ export class ModelHandlerOpenAI<
       `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${contextWindow} context window)`,
     );
 
-    // Separate system messages from conversation messages
+    // Separate system/developer messages from conversation messages
     const systemMessages: ChatCompletionMessageParam[] = [];
     const conversationMessages: ChatCompletionMessageParam[] = [];
     for (const msg of messages) {
       if (msg.role === 'system' || (msg.role as string) === 'developer') {
-        // Only treat leading system/developer messages as system prompt
         if (conversationMessages.length === 0) {
           systemMessages.push(msg);
         } else {
@@ -278,75 +219,31 @@ export class ModelHandlerOpenAI<
       }
     }
 
-    // Keep recent messages for immediate context.
-    // Expand the window backwards to include complete tool-call/result pairs —
-    // if we split in the middle, the model loses tool_call_id associations.
-    let recentStart = Math.max(
-      0,
-      conversationMessages.length - CLIENT_COMPACTION_RECENT_MESSAGES,
-    );
-    // Walk backwards to include complete tool-call/result pairs.
-    // Limit expansion to avoid consuming the entire conversation in tool-heavy sessions.
-    const maxExpansion = CLIENT_COMPACTION_RECENT_MESSAGES * 2;
-    let expanded = 0;
-    while (recentStart > 0 && expanded < maxExpansion) {
-      const msg = conversationMessages[recentStart];
-      if (
-        msg.role === 'tool' ||
-        (msg.role === 'assistant' &&
-          (msg as ChatCompletionAssistantMessageParam).tool_calls?.length)
-      ) {
-        recentStart--;
-        expanded++;
-      } else {
-        break;
-      }
-    }
-
-    const messagesToSummarize = conversationMessages.slice(0, recentStart);
-    const recentMessages = conversationMessages.slice(recentStart);
-
     // Nothing to summarize if conversation is too short
-    if (messagesToSummarize.length <= 2) {
+    if (conversationMessages.length <= 2) {
       this.logger.debug(
         'Conversation too short for compaction, skipping',
       );
       return { compactedMessages: messages, didCompact: false };
     }
 
-    let serialized = this.serializeMessagesForSummary(messagesToSummarize);
-
-    // Truncate serialized text to fit within the model's context window.
-    // Reserve space for the system prompt (~300 tokens) and summary output.
-    // Rough heuristic: 1 token ≈ 4 characters.
-    const maxSummaryInputChars =
-      (this.config.contextWindow - CLIENT_COMPACTION_SUMMARY_MAX_TOKENS - 300) *
-      4;
-    if (serialized.length > maxSummaryInputChars) {
-      this.logger.debug(
-        `Truncating serialized conversation from ${serialized.length} to ${maxSummaryInputChars} chars for summary call`,
-      );
-      serialized = serialized.substring(0, maxSummaryInputChars) + '\n\n[...truncated]';
-    }
-
+    // System-prompt-swap: replace the agent's system prompt with summarization
+    // instructions and send conversation messages as-is. The model reads the
+    // actual structured messages (roles, tool calls, tool results) natively.
     try {
       const summaryParams: Record<string, unknown> = {
         model: this.config.fullName,
         messages: [
           { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
-          {
-            role: 'user',
-            content: `Summarize the following conversation:\n\n${serialized}`,
-          },
+          ...conversationMessages,
         ],
         max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
         temperature: 0,
         stream: false,
       };
-      // Explicitly disable thinking for the summary call — reasoning
-      // models (DeepSeek, Kimi K2.5, GLM) don't need to think for summarization
-      // and it wastes tokens / may cause issues with some providers.
-      if (this.getThinkingParameter()) {
+      // Disable thinking for the summary call — reasoning models
+      // (DeepSeek, Kimi K2.5, GLM) don't need to think for summarization.
+      if (this.getThinkingParameter() || this.capabilities.supportsReasoning) {
         summaryParams.thinking = { type: 'disabled' };
       }
       const summaryResponse = (await client.chat.completions.create(
@@ -363,35 +260,18 @@ export class ModelHandlerOpenAI<
         return { compactedMessages: messages, didCompact: false };
       }
 
-      // Build compacted message array
+      // Replace ALL messages with system prompt + summary
       const compactedMessages: ChatCompletionMessageParam[] = [
         ...systemMessages,
         {
           role: 'user',
           content: `[Previous conversation summary]\n\n${summaryText}`,
         },
-        ...recentMessages,
       ];
 
-      // Estimate token reduction.
-      // The summary output tokens are bounded by CLIENT_COMPACTION_SUMMARY_MAX_TOKENS.
-      // We estimate the compacted conversation as:
-      //   system prompt tokens (kept) + summary tokens + recent messages tokens (kept)
-      // Approximate recent messages' share proportionally from the original.
       const summaryOutputTokens =
         summaryResponse.usage?.completion_tokens ?? 0;
-      const totalConvMessages = conversationMessages.length;
-      const recentTokenEstimate =
-        totalConvMessages > 0
-          ? Math.floor(
-              tokensBefore * (recentMessages.length / totalConvMessages),
-            )
-          : 0;
-      // The actual count will be measured on the next API call via prompt_tokens
-      const estimatedTokensAfter = Math.max(
-        1,
-        summaryOutputTokens + recentTokenEstimate,
-      );
+      const estimatedTokensAfter = Math.max(1, summaryOutputTokens);
       const utilizationAfter = (estimatedTokensAfter / contextWindow) * 100;
       const reduction = tokensBefore - estimatedTokensAfter;
       const reductionPercent =
@@ -408,7 +288,7 @@ export class ModelHandlerOpenAI<
           contextWindow,
           utilizationBefore: Number(utilizationBefore.toFixed(1)),
           utilizationAfter: Number(utilizationAfter.toFixed(1)),
-          details: `Client-side compaction: ${messagesToSummarize.length} messages summarized, ${recentMessages.length} recent messages preserved`,
+          details: `Client-side compaction: ${conversationMessages.length} messages summarized`,
         },
       );
 

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -280,18 +280,31 @@ export class ModelHandlerOpenAI<
       }
     }
 
-    // Keep recent messages for immediate context
-    const recentCount = Math.min(
-      CLIENT_COMPACTION_RECENT_MESSAGES,
-      conversationMessages.length,
-    );
-    const messagesToSummarize = conversationMessages.slice(
+    // Keep recent messages for immediate context.
+    // Expand the window backwards to include complete tool-call/result pairs —
+    // if we split in the middle, the model loses tool_call_id associations.
+    let recentStart = Math.max(
       0,
-      conversationMessages.length - recentCount,
+      conversationMessages.length - CLIENT_COMPACTION_RECENT_MESSAGES,
     );
-    const recentMessages = conversationMessages.slice(
-      conversationMessages.length - recentCount,
-    );
+    // Walk backwards: if recentStart lands on a tool result, include its
+    // preceding assistant+tool_call message; if it lands on a tool message,
+    // keep going back to include the full tool-call group.
+    while (recentStart > 0) {
+      const msg = conversationMessages[recentStart];
+      if (
+        msg.role === 'tool' ||
+        (msg.role === 'assistant' &&
+          (msg as ChatCompletionAssistantMessageParam).tool_calls?.length)
+      ) {
+        recentStart--;
+      } else {
+        break;
+      }
+    }
+
+    const messagesToSummarize = conversationMessages.slice(0, recentStart);
+    const recentMessages = conversationMessages.slice(recentStart);
 
     // Nothing to summarize if conversation is too short
     if (messagesToSummarize.length <= 2) {
@@ -301,7 +314,20 @@ export class ModelHandlerOpenAI<
       return { compactedMessages: messages, didCompact: false };
     }
 
-    const serialized = this.serializeMessagesForSummary(messagesToSummarize);
+    let serialized = this.serializeMessagesForSummary(messagesToSummarize);
+
+    // Truncate serialized text to fit within the model's context window.
+    // Reserve space for the system prompt (~300 tokens) and summary output.
+    // Rough heuristic: 1 token ≈ 4 characters.
+    const maxSummaryInputChars =
+      (this.config.contextWindow - CLIENT_COMPACTION_SUMMARY_MAX_TOKENS - 300) *
+      4;
+    if (serialized.length > maxSummaryInputChars) {
+      this.logger.debug(
+        `Truncating serialized conversation from ${serialized.length} to ${maxSummaryInputChars} chars for summary call`,
+      );
+      serialized = serialized.substring(0, maxSummaryInputChars) + '\n\n[...truncated]';
+    }
 
     try {
       const summaryResponse = await client.chat.completions.create(
@@ -338,16 +364,24 @@ export class ModelHandlerOpenAI<
         ...recentMessages,
       ];
 
-      // Estimate token reduction from compaction summary usage
-      const summaryInputTokens =
-        summaryResponse.usage?.prompt_tokens ?? 0;
+      // Estimate token reduction.
+      // The summary output tokens are bounded by CLIENT_COMPACTION_SUMMARY_MAX_TOKENS.
+      // We estimate the compacted conversation as:
+      //   system prompt tokens (kept) + summary tokens + recent messages tokens (kept)
+      // Approximate recent messages' share proportionally from the original.
       const summaryOutputTokens =
         summaryResponse.usage?.completion_tokens ?? 0;
-      // Rough estimate: compacted messages ≈ system prompt tokens + summary tokens + recent message tokens
+      const totalConvMessages = conversationMessages.length;
+      const recentTokenEstimate =
+        totalConvMessages > 0
+          ? Math.floor(
+              tokensBefore * (recentMessages.length / totalConvMessages),
+            )
+          : 0;
       // The actual count will be measured on the next API call via prompt_tokens
       const estimatedTokensAfter = Math.max(
         1,
-        tokensBefore - summaryInputTokens + summaryOutputTokens,
+        summaryOutputTokens + recentTokenEstimate,
       );
       const utilizationAfter = (estimatedTokensAfter / contextWindow) * 100;
       const reduction = tokensBefore - estimatedTokensAfter;

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -576,6 +576,9 @@ export class ModelHandlerOpenAI<
 
     if (this.shouldCompact()) {
       const isManual = this.compactionRequested;
+      // Clear manual flag immediately when attempted — matches Anthropic and
+      // OpenAI Responses handlers. Prevents infinite retry on graceful failure.
+      this.compactionRequested = false;
 
       const threshold = this.getCompactionThresholdPercent();
       if (isManual) {
@@ -674,12 +677,6 @@ export class ModelHandlerOpenAI<
     // Phase 5: TRACK - Record prompt_tokens for compaction threshold checks
     if (response.usage?.prompt_tokens) {
       this.lastKnownInputTokens = response.usage.prompt_tokens;
-    }
-
-    // Clear manual compaction flag only after the main API call succeeds.
-    // If Phase 4 throws, the flag is preserved so the request can be retried.
-    if (updatedMessages) {
-      this.compactionRequested = false;
     }
 
     return { response, updatedMessages };

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -230,12 +230,19 @@ export class ModelHandlerOpenAI<
     // System-prompt-swap: replace the agent's system prompt with summarization
     // instructions and send conversation messages as-is. The model reads the
     // actual structured messages (roles, tool calls, tool results) natively.
+    // Apply provider-specific normalization (e.g., DeepSeek's convertContentToString,
+    // mergeConsecutiveRoles) so the compaction call doesn't get rejected.
+    const normOptions = this.getMessageNormalizationOptions();
+    const normalizedConversation = normOptions
+      ? this.prepareNormalizedMessages(conversationMessages, normOptions)
+      : conversationMessages;
+
     try {
       const summaryParams: Record<string, unknown> = {
         model: this.config.fullName,
         messages: [
           { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
-          ...conversationMessages,
+          ...normalizedConversation,
         ],
         max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
         temperature: 0,
@@ -586,9 +593,6 @@ export class ModelHandlerOpenAI<
       if (didCompact) {
         messagesToUse = compactedMessages;
         updatedMessages = compactedMessages;
-        // Clear manual request flag only after successful compaction
-        // so the request is preserved for retry if compaction fails.
-        this.compactionRequested = false;
       }
     }
 
@@ -670,6 +674,12 @@ export class ModelHandlerOpenAI<
     // Phase 5: TRACK - Record prompt_tokens for compaction threshold checks
     if (response.usage?.prompt_tokens) {
       this.lastKnownInputTokens = response.usage.prompt_tokens;
+    }
+
+    // Clear manual compaction flag only after the main API call succeeds.
+    // If Phase 4 throws, the flag is preserved so the request can be retried.
+    if (updatedMessages) {
+      this.compactionRequested = false;
     }
 
     return { response, updatedMessages };

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -58,7 +58,12 @@ import {
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
 import { ModelHandler } from './ModelHandler';
-import { TOOL_USE_SAFETY_BUFFER } from './contextManagementConstants';
+import {
+  CLIENT_COMPACTION_RECENT_MESSAGES,
+  CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+  DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+  TOOL_USE_SAFETY_BUFFER,
+} from './contextManagementConstants';
 import type {
   CreateResponseOptions,
   CreateResponseResult,
@@ -84,6 +89,16 @@ function extractReasoningText(content: ReasoningContent | undefined): string {
 }
 
 const DEEPSEEK_OFFICIAL_API_MAX_TOKENS = 8192;
+
+const COMPACTION_SYSTEM_PROMPT = `You are a conversation summarizer. Create a concise but complete summary of the conversation below. Preserve:
+- The original user request and goals
+- All key decisions made
+- File paths and code changes discussed or made
+- Tool call results and their outcomes
+- Current state of the task (what is done, what is pending)
+- Any errors encountered and how they were resolved
+
+Format the summary as a structured narrative that allows the conversation to continue seamlessly. Do NOT add any preamble or explanation — output only the summary.`;
 
 export interface StreamingAggregator {
   appendContent(delta: string): void;
@@ -113,6 +128,258 @@ export class ModelHandlerOpenAI<
   OpenAI,
   ChatCompletion
 > {
+  // ── Client-side compaction state ──────────────────────────────────────
+  /** Tracks prompt_tokens from the last API response for compaction threshold checks. */
+  private lastKnownInputTokens = 0;
+
+  /** Flag to force compaction on the next API call, set by requestCompaction(). */
+  private compactionRequested = false;
+
+  /** Whether the conversation has been compacted at least once. */
+  private isCompacted = false;
+
+  // ── Compaction interface overrides ────────────────────────────────────
+
+  /** Client-side compaction is available for tool-use sessions. */
+  override get supportsManualCompaction(): boolean {
+    return this.isToolUseMode();
+  }
+
+  override requestCompaction(): void {
+    this.compactionRequested = true;
+  }
+
+  // ── Compaction internals ──────────────────────────────────────────────
+
+  /**
+   * Get the configured compaction threshold percentage.
+   * Returns 0 if compaction is disabled.
+   */
+  private getCompactionThresholdPercent(): number {
+    return getConfig<number>(
+      'texra.model.compactionThresholdPercent',
+      DEFAULT_COMPACTION_THRESHOLD_PERCENT,
+    );
+  }
+
+  /**
+   * Check if the conversation should be compacted based on token usage.
+   * Compaction is only triggered when:
+   * - In tool-use mode (only mode with multi-turn message accumulation)
+   * - Manual request via requestCompaction(), OR
+   * - Last known input tokens exceed the configured threshold
+   */
+  private shouldCompact(): boolean {
+    if (!this.isToolUseMode()) return false;
+
+    if (this.compactionRequested) {
+      return this.lastKnownInputTokens > 0;
+    }
+
+    const thresholdPercent = this.getCompactionThresholdPercent();
+    if (thresholdPercent <= 0) return false;
+
+    const threshold = Math.floor(
+      (thresholdPercent / 100) * this.config.contextWindow,
+    );
+    return this.lastKnownInputTokens > threshold;
+  }
+
+  /**
+   * Serialize messages to text for the compaction summary prompt.
+   * Converts ChatCompletionMessageParam[] into a readable text format.
+   */
+  private serializeMessagesForSummary(
+    messages: ChatCompletionMessageParam[],
+  ): string {
+    return messages
+      .map((msg) => {
+        const role = msg.role.toUpperCase();
+        let content: string;
+        if (typeof msg.content === 'string') {
+          content = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          content = (msg.content as ChatCompletionContentPart[])
+            .map((part: ChatCompletionContentPart) => {
+              if ('text' in part) return part.text;
+              if (part.type === 'image_url') return '[image]';
+              if (part.type === 'input_audio') return '[audio]';
+              return `[${part.type}]`;
+            })
+            .join('\n');
+        } else {
+          content = '';
+        }
+
+        // Include tool calls if present
+        const assistantMsg = msg as ChatCompletionAssistantMessageParam;
+        if (assistantMsg.tool_calls?.length) {
+          const toolSummary = assistantMsg.tool_calls
+            .map(
+              (tc: ChatCompletionMessageToolCall) =>
+                `[Tool call: ${tc.function.name}(${tc.function.arguments.substring(0, 200)}${tc.function.arguments.length > 200 ? '...' : ''})]`,
+            )
+            .join('\n');
+          content = content ? `${content}\n${toolSummary}` : toolSummary;
+        }
+
+        // Include tool result for tool messages
+        const toolMsg = msg as ChatCompletionToolMessageParam;
+        if (toolMsg.role === 'tool' && toolMsg.tool_call_id) {
+          const toolContent =
+            typeof toolMsg.content === 'string'
+              ? toolMsg.content.substring(0, 500)
+              : '[structured content]';
+          content = `[Tool result for ${toolMsg.tool_call_id}]: ${toolContent}${typeof toolMsg.content === 'string' && toolMsg.content.length > 500 ? '...' : ''}`;
+        }
+
+        return `[${role}]: ${content}`;
+      })
+      .join('\n\n');
+  }
+
+  /**
+   * Compact the conversation using client-side summarization.
+   * Sends a separate chat completion to generate a summary, then replaces
+   * messages with system prompt + summary + recent messages.
+   *
+   * @returns The compacted messages array, or original messages if compaction fails
+   */
+  private async compactConversation(
+    client: OpenAI,
+    messages: ChatCompletionMessageParam[],
+    signal?: AbortSignal,
+  ): Promise<{
+    compactedMessages: ChatCompletionMessageParam[];
+    didCompact: boolean;
+  }> {
+    const tokensBefore = this.lastKnownInputTokens;
+    const contextWindow = this.config.contextWindow;
+    const utilizationBefore = (tokensBefore / contextWindow) * 100;
+
+    this.logger.debug(
+      `Compacting conversation with ${tokensBefore} input tokens (${utilizationBefore.toFixed(1)}% of ${contextWindow} context window)`,
+    );
+
+    // Separate system messages from conversation messages
+    const systemMessages: ChatCompletionMessageParam[] = [];
+    const conversationMessages: ChatCompletionMessageParam[] = [];
+    for (const msg of messages) {
+      if (
+        msg.role === 'system' ||
+        (msg.role === 'developer' as string)
+      ) {
+        // Only treat leading system/developer messages as system prompt
+        if (conversationMessages.length === 0) {
+          systemMessages.push(msg);
+        } else {
+          conversationMessages.push(msg);
+        }
+      } else {
+        conversationMessages.push(msg);
+      }
+    }
+
+    // Keep recent messages for immediate context
+    const recentCount = Math.min(
+      CLIENT_COMPACTION_RECENT_MESSAGES,
+      conversationMessages.length,
+    );
+    const messagesToSummarize = conversationMessages.slice(
+      0,
+      conversationMessages.length - recentCount,
+    );
+    const recentMessages = conversationMessages.slice(
+      conversationMessages.length - recentCount,
+    );
+
+    // Nothing to summarize if conversation is too short
+    if (messagesToSummarize.length <= 2) {
+      this.logger.debug(
+        'Conversation too short for compaction, skipping',
+      );
+      return { compactedMessages: messages, didCompact: false };
+    }
+
+    const serialized = this.serializeMessagesForSummary(messagesToSummarize);
+
+    try {
+      const summaryResponse = await client.chat.completions.create(
+        {
+          model: this.config.fullName,
+          messages: [
+            { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
+            {
+              role: 'user',
+              content: `Summarize the following conversation:\n\n${serialized}`,
+            },
+          ],
+          max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+          temperature: 0,
+          stream: false,
+        },
+        { signal },
+      );
+
+      const summaryText =
+        summaryResponse.choices[0]?.message?.content?.trim();
+      if (!summaryText) {
+        this.logger.warn('Compaction returned empty summary, skipping');
+        return { compactedMessages: messages, didCompact: false };
+      }
+
+      // Build compacted message array
+      const compactedMessages: ChatCompletionMessageParam[] = [
+        ...systemMessages,
+        {
+          role: 'user',
+          content: `[Previous conversation summary]\n\n${summaryText}`,
+        },
+        ...recentMessages,
+      ];
+
+      // Estimate token reduction from compaction summary usage
+      const summaryInputTokens =
+        summaryResponse.usage?.prompt_tokens ?? 0;
+      const summaryOutputTokens =
+        summaryResponse.usage?.completion_tokens ?? 0;
+      // Rough estimate: compacted messages ≈ system prompt tokens + summary tokens + recent message tokens
+      // The actual count will be measured on the next API call via prompt_tokens
+      const estimatedTokensAfter = Math.max(
+        1,
+        tokensBefore - summaryInputTokens + summaryOutputTokens,
+      );
+      const utilizationAfter = (estimatedTokensAfter / contextWindow) * 100;
+      const reduction = tokensBefore - estimatedTokensAfter;
+      const reductionPercent =
+        tokensBefore > 0
+          ? ((reduction / tokensBefore) * 100).toFixed(1)
+          : '0';
+
+      this.logger.logContextManagement(
+        `Compacted conversation: ${tokensBefore.toLocaleString()} → ~${estimatedTokensAfter.toLocaleString()} tokens (${reductionPercent}% reduction)`,
+        {
+          action: 'compaction',
+          tokensBefore,
+          tokensAfter: estimatedTokensAfter,
+          contextWindow,
+          utilizationBefore: Number(utilizationBefore.toFixed(1)),
+          utilizationAfter: Number(utilizationAfter.toFixed(1)),
+          details: `Client-side compaction: ${messagesToSummarize.length} messages summarized, ${recentMessages.length} recent messages preserved`,
+        },
+      );
+
+      this.isCompacted = true;
+
+      return { compactedMessages, didCompact: true };
+    } catch (err) {
+      this.logger.warn(
+        `Compaction failed, continuing with original messages: ${getSdkErrorMessage(err)}`,
+      );
+      return { compactedMessages: messages, didCompact: false };
+    }
+  }
+
   /**
    * Creates a new OpenAI client using the stored credentials.
    * Handles API key retrieval, base URL resolution, and logging.
@@ -375,11 +642,38 @@ export class ModelHandlerOpenAI<
       tools,
     } = options;
 
+    // Phase 0: COMPACT - Check if conversation should be compacted
+    let updatedMessages: ChatCompletionMessageParam[] | undefined;
+    let messagesToUse = rawMessages;
+
+    if (this.shouldCompact()) {
+      const isManual = this.compactionRequested;
+      this.compactionRequested = false;
+
+      const threshold = this.getCompactionThresholdPercent();
+      if (isManual) {
+        this.logger.debug(
+          `Compacting conversation (manually requested, ${this.lastKnownInputTokens} input tokens)`,
+        );
+      } else {
+        this.logger.debug(
+          `Compacting conversation (${this.lastKnownInputTokens} tokens exceed ${threshold}% threshold of ${Math.floor((threshold / 100) * this.config.contextWindow)} tokens)`,
+        );
+      }
+
+      const { compactedMessages, didCompact } =
+        await this.compactConversation(client, rawMessages, signal);
+      if (didCompact) {
+        messagesToUse = compactedMessages;
+        updatedMessages = compactedMessages;
+      }
+    }
+
     // Apply message normalization if subclass specifies options
     const normOptions = this.getMessageNormalizationOptions();
     const messages = normOptions
-      ? this.prepareNormalizedMessages(rawMessages, normOptions)
-      : rawMessages;
+      ? this.prepareNormalizedMessages(messagesToUse, normOptions)
+      : messagesToUse;
 
     // Phase 1: BUILD - Construct provider-specific request parameters
     const useStreaming = this.getStreamingConfig();
@@ -449,7 +743,13 @@ export class ModelHandlerOpenAI<
     const response = useStreaming
       ? await this.executeStreamingChat(client, baseParams, signal)
       : await this.executeNonStreamingChat(client, baseParams, signal);
-    return { response };
+
+    // Phase 5: TRACK - Record prompt_tokens for compaction threshold checks
+    if (response.usage?.prompt_tokens) {
+      this.lastKnownInputTokens = response.usage.prompt_tokens;
+    }
+
+    return { response, updatedMessages };
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -135,9 +135,6 @@ export class ModelHandlerOpenAI<
   /** Flag to force compaction on the next API call, set by requestCompaction(). */
   private compactionRequested = false;
 
-  /** Whether the conversation has been compacted at least once. */
-  private isCompacted = false;
-
   // ── Compaction interface overrides ────────────────────────────────────
 
   /** Client-side compaction is available for tool-use sessions. */
@@ -215,10 +212,14 @@ export class ModelHandlerOpenAI<
         const assistantMsg = msg as ChatCompletionAssistantMessageParam;
         if (assistantMsg.tool_calls?.length) {
           const toolSummary = assistantMsg.tool_calls
-            .map(
-              (tc: ChatCompletionMessageToolCall) =>
-                `[Tool call: ${tc.function.name}(${tc.function.arguments.substring(0, 200)}${tc.function.arguments.length > 200 ? '...' : ''})]`,
-            )
+            .map((tc: ChatCompletionMessageToolCall) => {
+              const fn = (tc as unknown as Record<string, unknown>).function as
+                | { name?: string; arguments?: string }
+                | undefined;
+              const name = fn?.name ?? 'unknown';
+              const args = fn?.arguments ?? '';
+              return `[Tool call: ${name}(${args.substring(0, 200)}${args.length > 200 ? '...' : ''})]`;
+            })
             .join('\n');
           content = content ? `${content}\n${toolSummary}` : toolSummary;
         }
@@ -265,10 +266,7 @@ export class ModelHandlerOpenAI<
     const systemMessages: ChatCompletionMessageParam[] = [];
     const conversationMessages: ChatCompletionMessageParam[] = [];
     for (const msg of messages) {
-      if (
-        msg.role === 'system' ||
-        (msg.role === 'developer' as string)
-      ) {
+      if (msg.role === 'system' || (msg.role as string) === 'developer') {
         // Only treat leading system/developer messages as system prompt
         if (conversationMessages.length === 0) {
           systemMessages.push(msg);
@@ -287,10 +285,11 @@ export class ModelHandlerOpenAI<
       0,
       conversationMessages.length - CLIENT_COMPACTION_RECENT_MESSAGES,
     );
-    // Walk backwards: if recentStart lands on a tool result, include its
-    // preceding assistant+tool_call message; if it lands on a tool message,
-    // keep going back to include the full tool-call group.
-    while (recentStart > 0) {
+    // Walk backwards to include complete tool-call/result pairs.
+    // Limit expansion to avoid consuming the entire conversation in tool-heavy sessions.
+    const maxExpansion = CLIENT_COMPACTION_RECENT_MESSAGES * 2;
+    let expanded = 0;
+    while (recentStart > 0 && expanded < maxExpansion) {
       const msg = conversationMessages[recentStart];
       if (
         msg.role === 'tool' ||
@@ -298,6 +297,7 @@ export class ModelHandlerOpenAI<
           (msg as ChatCompletionAssistantMessageParam).tool_calls?.length)
       ) {
         recentStart--;
+        expanded++;
       } else {
         break;
       }
@@ -330,22 +330,31 @@ export class ModelHandlerOpenAI<
     }
 
     try {
-      const summaryResponse = await client.chat.completions.create(
-        {
-          model: this.config.fullName,
-          messages: [
-            { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
-            {
-              role: 'user',
-              content: `Summarize the following conversation:\n\n${serialized}`,
-            },
-          ],
-          max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
-          temperature: 0,
-          stream: false,
-        },
+      const summaryParams: Record<string, unknown> = {
+        model: this.config.fullName,
+        messages: [
+          { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: `Summarize the following conversation:\n\n${serialized}`,
+          },
+        ],
+        max_tokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+      };
+      // Explicitly disable thinking for the summary call — reasoning
+      // models (DeepSeek, Kimi K2.5, GLM) don't need to think for summarization
+      // and it wastes tokens / may cause issues with some providers.
+      if (this.getThinkingParameter()) {
+        summaryParams.thinking = { type: 'disabled' };
+      }
+      const summaryResponse = (await client.chat.completions.create(
+        summaryParams as unknown as Parameters<
+          typeof client.chat.completions.create
+        >[0],
         { signal },
-      );
+      )) as ChatCompletion;
 
       const summaryText =
         summaryResponse.choices[0]?.message?.content?.trim();
@@ -402,8 +411,6 @@ export class ModelHandlerOpenAI<
           details: `Client-side compaction: ${messagesToSummarize.length} messages summarized, ${recentMessages.length} recent messages preserved`,
         },
       );
-
-      this.isCompacted = true;
 
       return { compactedMessages, didCompact: true };
     } catch (err) {
@@ -682,7 +689,6 @@ export class ModelHandlerOpenAI<
 
     if (this.shouldCompact()) {
       const isManual = this.compactionRequested;
-      this.compactionRequested = false;
 
       const threshold = this.getCompactionThresholdPercent();
       if (isManual) {
@@ -700,6 +706,9 @@ export class ModelHandlerOpenAI<
       if (didCompact) {
         messagesToUse = compactedMessages;
         updatedMessages = compactedMessages;
+        // Clear manual request flag only after successful compaction
+        // so the request is preserved for retry if compaction fails.
+        this.compactionRequested = false;
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds client-side conversation compactization for OpenAI-compatible models (DeepSeek, Kimi, GLM, MiniMax) that previously had no way to recover from context window pressure during long tool-use sessions
- Implements model-based summarization in `ModelHandlerOpenAI` (base class) so all four providers get compaction automatically without subclass changes
- Tracks `prompt_tokens` from each API response and triggers compaction when usage exceeds the configured threshold (default 75% of context window)

## How it works

Since these providers have no native compact endpoint (unlike Anthropic's server-side `context_management` or OpenAI's `responses.compact()`), this uses a **client-side approach**:

1. After each API call, `prompt_tokens` from the response usage is stored as `lastKnownInputTokens`
2. Before the next API call, `shouldCompact()` checks if tokens exceed the threshold
3. If triggered, a separate chat completion asks the model to summarize older messages
4. Messages are replaced with: `[system prompt] + [summary] + [last 4 messages]`
5. The compacted messages are returned via `updatedMessages` so the tool-use flow replaces its message array

Manual compaction via the UI command ("Compact Context") is also supported — previously showed "not yet available" for these models.

## Test plan

- [ ] Verify `npm run typecheck` has no new errors (confirmed: all errors are pre-existing)
- [ ] Verify `npm run lint` has no new errors (confirmed: 0 errors)
- [ ] Verify `npm run compile:fast` succeeds (confirmed)
- [ ] Test with a DeepSeek/Kimi/GLM/MiniMax model in tool-use mode with a long session to verify compaction triggers automatically
- [ ] Test manual compaction via the "Compact Context" command
- [ ] Verify progress view shows "Compacted" event with token stats
- [ ] Verify conversation continues normally after compaction

https://claude.ai/code/session_01FCdsaSZarangVKUMGiSsPy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/response flow in the shared OpenAI handler by adding an extra summarization call and message-replacement behavior, which could impact tool-use continuity and provider-specific message validity if edge cases slip through.
> 
> **Overview**
> Adds **client-side conversation compaction** to `ModelHandlerOpenAI` (covering OpenAI-compatible providers like DeepSeek/Kimi/GLM/MiniMax) to recover from long tool-use sessions hitting context-window pressure.
> 
> The handler now tracks `prompt_tokens` from each response, supports a manual “compact” request, and (when triggered) makes a separate non-streaming summarization call using a swapped system prompt, then returns `updatedMessages` that replace the conversation with preserved system/developer messages plus a single user summary. A new `CLIENT_COMPACTION_SUMMARY_MAX_TOKENS` constant centralizes the summary size limit, and the Anthropic compaction plan doc is updated to reflect the same system-prompt-swap strategy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6898f14ef7d796b0109321646560c86198e7606. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->