### PR TITLE
fix: improve Codex CLI detection for WSL users

### DIFF
--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -18,8 +18,6 @@ import { createRequire } from 'module';
 import * as path from 'path';
 import { existsSync } from 'fs';
 
-import { isWSL, windowsToWslPath } from '@utils/system/wslDetect';
-
 type CodexConstructor = new (options?: any) => any;
 
 // ---------------------------------------------------------------------------
@@ -177,14 +175,6 @@ function findCodexBinaryPathUncached(): string | undefined {
     // codex not on PATH
   }
 
-  // Strategy 4 (WSL only): try Windows-side installation.
-  // Windows .exe files are executable under WSL via interop, so a
-  // Codex binary installed on the Windows side works transparently.
-  if (isWSL()) {
-    const winResult = findCodexInWindowsSide();
-    if (winResult) return winResult;
-  }
-
   return undefined;
 }
 
@@ -217,60 +207,5 @@ function resolveCodexBinary(
   } catch {
     // Platform package not resolvable
   }
-  return undefined;
-}
-
-/**
- * WSL-only: attempt to locate the Codex binary from a Windows-side npm
- * installation.  Windows executables are runnable under WSL via binfmt_misc
- * interop, so we can return a `.exe` path directly.
- */
-function findCodexInWindowsSide(): string | undefined {
-  const winInfo = PLATFORM_INFO[`win32-${process.arch}`];
-  if (!winInfo) return undefined;
-
-  // Strategy 4a: resolve from the Windows npm global prefix via cmd.exe
-  try {
-    const rawPrefix = execSync('cmd.exe /c npm prefix -g', {
-      encoding: 'utf8',
-      timeout: 10_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-
-    if (rawPrefix) {
-      const wslPrefix = windowsToWslPath(rawPrefix);
-      if (wslPrefix) {
-        const codexPkgDir = path.join(
-          wslPrefix,
-          'node_modules',
-          '@openai',
-          'codex',
-        );
-        const result = resolveCodexBinary(codexPkgDir, winInfo, 'codex.exe');
-        if (result) return result;
-      }
-    }
-  } catch {
-    // cmd.exe or npm not available (WSL interop may be disabled)
-  }
-
-  // Strategy 4b: codex.exe on PATH (Windows PATH exposed via WSL interop)
-  try {
-    const pathHits = execSync('which codex.exe', {
-      encoding: 'utf8',
-      timeout: 5000,
-    })
-      .trim()
-      .split(/\r?\n/);
-
-    for (const hit of pathHits) {
-      const p = hit.trim();
-      if (!p) continue;
-      if (existsSync(p)) return p;
-    }
-  } catch {
-    // codex.exe not on PATH
-  }
-
   return undefined;
 }

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -123,14 +123,13 @@ function findCodexBinaryPathUncached(): string | undefined {
 
   // Strategy 1: resolve from local project's node_modules
   // Highest priority — matches the SDK version in package.json.
-  try {
-    const localReq = createRequire(path.join(__dirname, 'package.json'));
-    const pkgJson = localReq.resolve(`${info.pkg}/package.json`);
-    const vendorRoot = path.join(path.dirname(pkgJson), 'vendor');
-    const binary = path.join(vendorRoot, info.triple, 'codex', binaryName);
-    if (existsSync(binary)) return binary;
-  } catch {
-    // Not available locally
+  {
+    const result = resolveCodexBinary(
+      path.join(__dirname, '..'),
+      info,
+      binaryName,
+    );
+    if (result) return result;
   }
 
   // Strategy 2: resolve from global npm prefix
@@ -142,23 +141,13 @@ function findCodexBinaryPathUncached(): string | undefined {
     }).trim();
 
     const roots = [
-      path.join(prefix, 'lib', 'node_modules'),
-      path.join(prefix, 'node_modules'),
+      path.join(prefix, 'lib', 'node_modules', '@openai', 'codex'),
+      path.join(prefix, 'node_modules', '@openai', 'codex'),
     ];
 
-    for (const root of roots) {
-      const codexPkgDir = path.join(root, '@openai', 'codex');
-      if (!existsSync(codexPkgDir)) continue;
-
-      try {
-        const req = createRequire(path.join(codexPkgDir, 'package.json'));
-        const platformPkgJson = req.resolve(`${info.pkg}/package.json`);
-        const vendorRoot = path.join(path.dirname(platformPkgJson), 'vendor');
-        const binary = path.join(vendorRoot, info.triple, 'codex', binaryName);
-        if (existsSync(binary)) return binary;
-      } catch {
-        // Platform package not resolvable from this root
-      }
+    for (const codexPkgDir of roots) {
+      const result = resolveCodexBinary(codexPkgDir, info, binaryName);
+      if (result) return result;
     }
   } catch {
     // npm prefix -g failed
@@ -200,6 +189,39 @@ function findCodexBinaryPathUncached(): string | undefined {
 }
 
 /**
+ * Resolve the native Codex binary from a directory that contains (or nests)
+ * the platform-specific package.  Returns the binary path if found, or
+ * `undefined`.
+ *
+ * Works for both a direct `@openai/codex` package dir and any ancestor
+ * that Node module resolution can traverse from.
+ */
+function resolveCodexBinary(
+  baseDir: string,
+  platformInfo: (typeof PLATFORM_INFO)[string],
+  binaryName: string,
+): string | undefined {
+  if (!existsSync(baseDir)) return undefined;
+  try {
+    const req = createRequire(path.join(baseDir, 'package.json'));
+    const platformPkgJson = req.resolve(
+      `${platformInfo.pkg}/package.json`,
+    );
+    const binary = path.join(
+      path.dirname(platformPkgJson),
+      'vendor',
+      platformInfo.triple,
+      'codex',
+      binaryName,
+    );
+    if (existsSync(binary)) return binary;
+  } catch {
+    // Platform package not resolvable
+  }
+  return undefined;
+}
+
+/**
  * WSL-only: attempt to locate the Codex binary from a Windows-side npm
  * installation.  Windows executables are runnable under WSL via binfmt_misc
  * interop, so we can return a `.exe` path directly.
@@ -219,32 +241,14 @@ function findCodexInWindowsSide(): string | undefined {
     if (rawPrefix) {
       const wslPrefix = windowsToWslPath(rawPrefix);
       if (wslPrefix) {
-        // Windows npm stores globals in <prefix>/node_modules
-        const root = path.join(wslPrefix, 'node_modules');
-        const codexPkgDir = path.join(root, '@openai', 'codex');
-        if (existsSync(codexPkgDir)) {
-          try {
-            const req = createRequire(
-              path.join(codexPkgDir, 'package.json'),
-            );
-            const platformPkgJson = req.resolve(
-              `${winInfo.pkg}/package.json`,
-            );
-            const vendorRoot = path.join(
-              path.dirname(platformPkgJson),
-              'vendor',
-            );
-            const binary = path.join(
-              vendorRoot,
-              winInfo.triple,
-              'codex',
-              'codex.exe',
-            );
-            if (existsSync(binary)) return binary;
-          } catch {
-            // Platform package not resolvable from this root
-          }
-        }
+        const codexPkgDir = path.join(
+          wslPrefix,
+          'node_modules',
+          '@openai',
+          'codex',
+        );
+        const result = resolveCodexBinary(codexPkgDir, winInfo, 'codex.exe');
+        if (result) return result;
       }
     }
   } catch {

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -18,6 +18,8 @@ import { createRequire } from 'module';
 import * as path from 'path';
 import { existsSync } from 'fs';
 
+import { isWSL, windowsToWslPath } from '@utils/system/wslDetect';
+
 type CodexConstructor = new (options?: any) => any;
 
 // ---------------------------------------------------------------------------
@@ -184,6 +186,87 @@ function findCodexBinaryPathUncached(): string | undefined {
     }
   } catch {
     // codex not on PATH
+  }
+
+  // Strategy 4 (WSL only): try Windows-side installation.
+  // Windows .exe files are executable under WSL via interop, so a
+  // Codex binary installed on the Windows side works transparently.
+  if (isWSL()) {
+    const winResult = findCodexInWindowsSide();
+    if (winResult) return winResult;
+  }
+
+  return undefined;
+}
+
+/**
+ * WSL-only: attempt to locate the Codex binary from a Windows-side npm
+ * installation.  Windows executables are runnable under WSL via binfmt_misc
+ * interop, so we can return a `.exe` path directly.
+ */
+function findCodexInWindowsSide(): string | undefined {
+  const winInfo = PLATFORM_INFO[`win32-${process.arch}`];
+  if (!winInfo) return undefined;
+
+  // Strategy 4a: resolve from the Windows npm global prefix via cmd.exe
+  try {
+    const rawPrefix = execSync('cmd.exe /c npm prefix -g', {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    if (rawPrefix) {
+      const wslPrefix = windowsToWslPath(rawPrefix);
+      if (wslPrefix) {
+        // Windows npm stores globals in <prefix>/node_modules
+        const root = path.join(wslPrefix, 'node_modules');
+        const codexPkgDir = path.join(root, '@openai', 'codex');
+        if (existsSync(codexPkgDir)) {
+          try {
+            const req = createRequire(
+              path.join(codexPkgDir, 'package.json'),
+            );
+            const platformPkgJson = req.resolve(
+              `${winInfo.pkg}/package.json`,
+            );
+            const vendorRoot = path.join(
+              path.dirname(platformPkgJson),
+              'vendor',
+            );
+            const binary = path.join(
+              vendorRoot,
+              winInfo.triple,
+              'codex',
+              'codex.exe',
+            );
+            if (existsSync(binary)) return binary;
+          } catch {
+            // Platform package not resolvable from this root
+          }
+        }
+      }
+    }
+  } catch {
+    // cmd.exe or npm not available (WSL interop may be disabled)
+  }
+
+  // Strategy 4b: codex.exe on PATH (Windows PATH exposed via WSL interop)
+  try {
+    const pathHits = execSync('which codex.exe', {
+      encoding: 'utf8',
+      timeout: 5000,
+    })
+      .trim()
+      .split(/\r?\n/);
+
+    for (const hit of pathHits) {
+      const p = hit.trim();
+      if (!p) continue;
+      if (existsSync(p)) return p;
+    }
+  } catch {
+    // codex.exe not on PATH
   }
 
   return undefined;

--- a/src/tools/codexImport.ts
+++ b/src/tools/codexImport.ts
@@ -201,7 +201,6 @@ function resolveCodexBinary(
   platformInfo: (typeof PLATFORM_INFO)[string],
   binaryName: string,
 ): string | undefined {
-  if (!existsSync(baseDir)) return undefined;
   try {
     const req = createRequire(path.join(baseDir, 'package.json'));
     const platformPkgJson = req.resolve(

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -20,6 +20,7 @@ import type { RegisteredToolName } from '@tools/registry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
+import { isWSL } from '@utils/system/wslDetect';
 
 const LEAN4_EXT_ID = 'leanprover.lean4';
 
@@ -219,6 +220,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  npm install -g @openai/codex\n' +
       '  brew install codex          (macOS)\n\n' +
       'On Windows, use WSL or the Codex app.\n' +
+      'In WSL, install inside the WSL environment (not on the Windows side).\n' +
       'See: https://developers.openai.com/codex/cli\n\n' +
       'Authentication (choose one):\n' +
       '  • codex login        — sign in with ChatGPT account (recommended)\n' +
@@ -257,7 +259,11 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       // Step 2: Can we find the native binary?
       const codexPath = findCodexBinaryPath();
       if (!codexPath) {
-        return 'Codex SDK loaded but native binary not found. Install with: npm install -g @openai/codex';
+        return (
+          'Codex SDK loaded but native binary not found. ' +
+          'Install with: npm install -g @openai/codex' +
+          (isWSL() ? ' (run this inside WSL, not on the Windows side)' : '')
+        );
       }
 
       return `Codex CLI ready. Binary: ${codexPath}`;

--- a/src/utils/system/index.ts
+++ b/src/utils/system/index.ts
@@ -2,4 +2,5 @@ export * from './execUtils';
 export * from './gitAuthorEnv';
 export * from './toolUtils';
 export * from './platformPaths';
+export * from './wslDetect';
 export * from './workspaceInfo';

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -10,7 +10,6 @@ import { execa } from 'execa';
 import { WorkspaceFS } from '@utils/files';
 import { isWSL } from './wslDetect';
 
-// Re-export so existing consumers continue to work.
 export { isWSL };
 
 /** Timeout for git commands in milliseconds. */

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -10,8 +10,6 @@ import { execa } from 'execa';
 import { WorkspaceFS } from '@utils/files';
 import { isWSL } from './wslDetect';
 
-export { isWSL };
-
 /** Timeout for git commands in milliseconds. */
 const GIT_TIMEOUT_MS = 3000;
 

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -8,6 +8,10 @@ import { execa } from 'execa';
 
 // Local imports
 import { WorkspaceFS } from '@utils/files';
+import { isWSL } from './wslDetect';
+
+// Re-export so existing consumers continue to work.
+export { isWSL };
 
 /** Timeout for git commands in milliseconds. */
 const GIT_TIMEOUT_MS = 3000;
@@ -50,29 +54,6 @@ function detectShell(): string | undefined {
   const shell = process.env.SHELL;
   if (!shell) return undefined;
   return path.basename(shell); // "bash", "zsh", "fish", etc.
-}
-
-/** Cached WSL detection result (null = not yet checked). */
-let wslDetected: boolean | null = null;
-
-/**
- * Detect whether we are running inside Windows Subsystem for Linux (WSL).
- * Checks /proc/version for the "microsoft" or "WSL" marker strings that
- * Microsoft's WSL kernel injects.  Result is cached after the first call.
- */
-export function isWSL(): boolean {
-  if (wslDetected !== null) return wslDetected;
-  if (process.platform !== 'linux') {
-    wslDetected = false;
-    return false;
-  }
-  try {
-    const version = fs.readFileSync('/proc/version', 'utf-8');
-    wslDetected = /microsoft|wsl/i.test(version);
-  } catch {
-    wslDetected = false;
-  }
-  return wslDetected;
 }
 
 /**

--- a/src/utils/system/wslDetect.ts
+++ b/src/utils/system/wslDetect.ts
@@ -1,0 +1,49 @@
+/**
+ * WSL (Windows Subsystem for Linux) detection utilities.
+ *
+ * This module is intentionally free of VS Code dependencies so it can be
+ * imported from VS Code-free zones like `src/tools/`.
+ */
+
+import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+
+/** Cached WSL detection result (null = not yet checked). */
+let wslDetected: boolean | null = null;
+
+/**
+ * Detect whether we are running inside Windows Subsystem for Linux (WSL).
+ * Checks /proc/version for the "microsoft" or "WSL" marker strings that
+ * Microsoft's WSL kernel injects.  Result is cached after the first call.
+ */
+export function isWSL(): boolean {
+  if (wslDetected !== null) return wslDetected;
+  if (process.platform !== 'linux') {
+    wslDetected = false;
+    return false;
+  }
+  try {
+    const version = readFileSync('/proc/version', 'utf-8');
+    wslDetected = /microsoft|wsl/i.test(version);
+  } catch {
+    wslDetected = false;
+  }
+  return wslDetected;
+}
+
+/**
+ * Convert a Windows path to its WSL mount equivalent using `wslpath`.
+ * Returns `undefined` if the conversion fails (e.g. `wslpath` not available
+ * or WSL interop disabled).
+ */
+export function windowsToWslPath(windowsPath: string): string | undefined {
+  try {
+    const result = execFileSync('wslpath', ['-u', windowsPath], {
+      encoding: 'utf8',
+      timeout: 5000,
+    }).trim();
+    return result || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/utils/system/wslDetect.ts
+++ b/src/utils/system/wslDetect.ts
@@ -1,12 +1,11 @@
 /**
- * WSL (Windows Subsystem for Linux) detection utilities.
+ * WSL (Windows Subsystem for Linux) detection.
  *
  * This module is intentionally free of VS Code dependencies so it can be
  * imported from VS Code-free zones like `src/tools/`.
  */
 
 import { readFileSync } from 'fs';
-import { execFileSync } from 'child_process';
 
 /** Cached WSL detection result (null = not yet checked). */
 let wslDetected: boolean | null = null;
@@ -29,21 +28,4 @@ export function isWSL(): boolean {
     wslDetected = false;
   }
   return wslDetected;
-}
-
-/**
- * Convert a Windows path to its WSL mount equivalent using `wslpath`.
- * Returns `undefined` if the conversion fails (e.g. `wslpath` not available
- * or WSL interop disabled).
- */
-export function windowsToWslPath(windowsPath: string): string | undefined {
-  try {
-    const result = execFileSync('wslpath', ['-u', windowsPath], {
-      encoding: 'utf8',
-      timeout: 5000,
-    }).trim();
-    return result || undefined;
-  } catch {
-    return undefined;
-  }
 }


### PR DESCRIPTION
## Summary

- **WSL-specific install guidance**: Install guide and `detailCheck` now tell WSL users to install Codex inside WSL, not on the Windows side
- **Extract `isWSL()` to standalone module**: Moved WSL detection from `workspaceInfo.ts` into `wslDetect.ts` (VS Code-free) so `src/tools/` can import it
- **Extract `resolveCodexBinary()` helper**: Deduplicated the `createRequire` → resolve → existsSync pattern that was repeated across strategies 1, 2

## Details

The Codex SDK spawns the native binary via `child_process.spawn()` and passes filesystem paths as CLI arguments (`--cd`, `--image`, `--add-dir`). A Windows `.exe` running via WSL binfmt_misc interop can launch, but it cannot resolve Linux paths like `/home/user/project` — WSL only translates the executable path, not command-line arguments. This means finding a Windows-side Codex binary from WSL would silently break at runtime.

Instead of a broken fallback, the fix improves diagnostics:
- Install guide adds: "In WSL, install inside the WSL environment (not on the Windows side)"
- `detailCheck` appends a WSL-specific hint when the binary isn't found under WSL

Other cleanup:
- `resolveCodexBinary()` helper eliminates copy-paste across strategies 1, 2
- Removed TOCTOU pre-check (`existsSync(baseDir)`) — `createRequire` already throws on invalid paths

## Test plan

- [x] Verify `npm run compile:fast` succeeds (confirmed)
- [ ] On WSL without Codex installed: `detailCheck` should show WSL-specific install hint
- [ ] On native Linux/macOS/Windows: no behavior change, existing strategies 1-3 work as before
- [ ] Install guide in settings view shows WSL-specific line

https://claude.ai/code/session_0153P2Z3iuBdBa4V856eH7ij

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly refactors Codex binary path probing and adds WSL-specific messaging; behavior change is limited to where the CLI is searched and what guidance is shown when missing.
> 
> **Overview**
> Improves Codex CLI detection by deduplicating native-binary resolution into `resolveCodexBinary()` and tightening global npm lookup to probe `@openai/codex` package roots directly.
> 
> Adds WSL-aware guidance: introduces a shared `isWSL()` utility (`wslDetect.ts`), updates the Codex install guide, and appends a WSL-specific hint to `detailCheck` when the SDK loads but no native binary is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68ce4eba6dad9ea774bd7323531a977447d0b9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->