### PR TITLE
Inherit extract figure flags from parent agent in workflow delegation

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -649,6 +649,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           toolCallId: call.callId,
           model: options.modelName ?? options.config.model,
           agentName: options.agentName,
+          toolConfig: options.config.toolConfig,
           onExecutionReady,
           onToolOutput,
         },

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -5,6 +5,7 @@ import type {
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import type { ToolConfig } from '@shared/schemas/toolConfig';
 
 export interface ToolFileInteractionContext {
   streamId?: StreamTabId;
@@ -14,6 +15,8 @@ export interface ToolFileInteractionContext {
   model?: string;
   /** Agent name of the parent agent (e.g. "orchestrator", "search-agent"). */
   agentName?: string;
+  /** Parent agent's tool configuration (extraction flags, etc.). Used by delegation tools to inherit settings. */
+  toolConfig?: ToolConfig;
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */
   todoState?: TodoState;

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -15,7 +15,7 @@ export interface ToolFileInteractionContext {
   model?: string;
   /** Agent name of the parent agent (e.g. "orchestrator", "search-agent"). */
   agentName?: string;
-  /** Parent agent's tool configuration (extraction flags, etc.). Used by delegation tools to inherit settings. */
+  /** Tool configuration inherited from the parent agent, if any. */
   toolConfig?: ToolConfig;
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */

--- a/src/progressView/frontend/formatters/proposalInputStore.ts
+++ b/src/progressView/frontend/formatters/proposalInputStore.ts
@@ -61,11 +61,19 @@ function parseProposalInput(
   }
 
   if (toolName === 'delegate_workflow' || toolName === 'propose_workflow') {
-    // Map extraction shorthand flags into toolConfig (mirrors DelegationTools.execute)
+    // Map extraction shorthand flags into toolConfig.
+    // Note: at runtime, DelegationTools.execute also inherits flags from the
+    // parent agent's toolConfig when omitted. That inheritance can't be
+    // replicated here (no access to parent context), so the store reflects
+    // only what the LLM explicitly requested.
     const extractFigures =
-      'extractFigures' in spread ? Boolean(spread.extractFigures) : undefined;
+      'extractFigures' in spread && spread.extractFigures != null
+        ? Boolean(spread.extractFigures)
+        : undefined;
     const extractTikz =
-      'extractTikz' in spread ? Boolean(spread.extractTikz) : undefined;
+      'extractTikz' in spread && spread.extractTikz != null
+        ? Boolean(spread.extractTikz)
+        : undefined;
     const existingToolConfig = isPlainObject(spread.toolConfig)
       ? spread.toolConfig
       : {};

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -488,13 +488,13 @@ const WorkflowAgentInputSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles. Inherits from parent agent settings when omitted.',
+      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
     ),
   extractTikz: z
     .boolean()
     .optional()
     .describe(
-      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files. Inherits from parent agent settings when omitted.',
+      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
     ),
   outputFiles: z
     .array(z.string())
@@ -599,14 +599,9 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       throw new Error(`${missing.label} not found: ${missing.path}`);
     }
 
-    // Construct workflow proposal
-    // Extraction flags are mapped to toolConfig so they flow through to the
-    // agent execution pipeline (MediaExtractionNode → LatexMediaManager)
-    // and are preserved when the user clicks "Setup" in the proposal UI.
-    // When the LLM omits extractFigures/extractTikz, inherit from the parent
-    // agent's toolConfig so user-configured extraction settings carry through.
-    // Memory paths are already validated by memoriesField's .superRefine() at schema parse time.
-    const parentToolConfig = ctx.toolConfig;
+    // Extraction flags map to toolConfig, flowing through the proposal UI and
+    // into MediaExtractionNode → LatexMediaManager at runtime.
+    // When omitted, flags inherit from the parent agent's toolConfig.
     const proposal = WorkflowAgentProposalSchema.parse({
       agentCategory: AgentCategory.Workflow,
       agent: input.agent,
@@ -625,9 +620,9 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       toolConfig: {
         ...DEFAULT_TOOL_CONFIG,
         autoExtractFigure:
-          input.extractFigures ?? parentToolConfig?.autoExtractFigure ?? false,
+          input.extractFigures ?? ctx.toolConfig?.autoExtractFigure ?? false,
         autoExtractTikzFigure:
-          input.extractTikz ?? parentToolConfig?.autoExtractTikzFigure ?? false,
+          input.extractTikz ?? ctx.toolConfig?.autoExtractTikzFigure ?? false,
       },
       memories: input.memories,
     } satisfies WorkflowAgentProposal);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -486,13 +486,13 @@ const WorkflowAgentInputSchema = z.object({
     .describe('Additional media files'),
   extractFigures: z
     .boolean()
-    .optional()
+    .nullish()
     .describe(
       'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
     ),
   extractTikz: z
     .boolean()
-    .optional()
+    .nullish()
     .describe(
       'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
     ),

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -486,15 +486,15 @@ const WorkflowAgentInputSchema = z.object({
     .describe('Additional media files'),
   extractFigures: z
     .boolean()
-    .prefault(false)
+    .optional()
     .describe(
-      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles.',
+      'When true, automatically extracts figures referenced by the input LaTeX file(s) (via \\includegraphics, \\begin{overpic}) and attaches them as media files. Merges with any explicitly provided mediaFile/mediaFiles. Inherits from parent agent settings when omitted.',
     ),
   extractTikz: z
     .boolean()
-    .prefault(false)
+    .optional()
     .describe(
-      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files.',
+      'When true, extracts TikZ figures from the input LaTeX file(s), compiles them into standalone PDFs, and attaches them as media files. Inherits from parent agent settings when omitted.',
     ),
   outputFiles: z
     .array(z.string())
@@ -603,7 +603,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
     // Extraction flags are mapped to toolConfig so they flow through to the
     // agent execution pipeline (MediaExtractionNode → LatexMediaManager)
     // and are preserved when the user clicks "Setup" in the proposal UI.
+    // When the LLM omits extractFigures/extractTikz, inherit from the parent
+    // agent's toolConfig so user-configured extraction settings carry through.
     // Memory paths are already validated by memoriesField's .superRefine() at schema parse time.
+    const parentToolConfig = ctx.toolConfig;
     const proposal = WorkflowAgentProposalSchema.parse({
       agentCategory: AgentCategory.Workflow,
       agent: input.agent,
@@ -621,8 +624,10 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       useMultipleOutputs: input.useMultipleOutputs,
       toolConfig: {
         ...DEFAULT_TOOL_CONFIG,
-        autoExtractFigure: input.extractFigures,
-        autoExtractTikzFigure: input.extractTikz,
+        autoExtractFigure:
+          input.extractFigures ?? parentToolConfig?.autoExtractFigure ?? false,
+        autoExtractTikzFigure:
+          input.extractTikz ?? parentToolConfig?.autoExtractTikzFigure ?? false,
       },
       memories: input.memories,
     } satisfies WorkflowAgentProposal);


### PR DESCRIPTION
## Summary

- When the orchestrator delegates a workflow via `delegate_workflow`, extraction flags (`extractFigures`/`extractTikz`) were only applied when the LLM explicitly included them in the tool call input. If omitted, they defaulted to `false` — even when the parent agent (orchestrator) had auto-extract enabled in its `toolConfig`.
- Fix by propagating the parent's `toolConfig` through `ToolFileInteractionContext` and using it as fallback when the LLM omits the extraction flags. The schema fields change from `.prefault(false)` to `.optional()` so we can distinguish "LLM explicitly set false" from "LLM omitted the field".
- This ensures user-configured extraction settings (e.g. Figures enabled in the main view) carry through to delegated workflows automatically, while still allowing the LLM to explicitly override them.

## Test plan

- [ ] Launch orchestrator with auto-extract figures enabled in the main view config
- [ ] Have orchestrator delegate a workflow without explicitly setting `extractFigures` — verify figures are extracted
- [ ] Have orchestrator delegate a workflow with `extractFigures=true` — verify figures are extracted
- [ ] Have orchestrator delegate a workflow with `extractFigures=false` — verify figures are NOT extracted (explicit override)
- [ ] Verify extract flag badges appear in the proposal approval panel when flags are inherited
- [ ] Verify Setup mode correctly shows inherited extraction flags
- [ ] Verify non-orchestrator (direct main view) workflow execution still works normally

https://claude.ai/code/session_01SKCctHGDbrtuxq1hHJuVW6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delegation parameter defaults and propagates `toolConfig` through tool execution context, which can alter figure/TikZ extraction behavior for delegated workflows and affect generated media attachments.
> 
> **Overview**
> Delegated workflow runs (`delegate_workflow`/`propose_workflow`) now **inherit LaTeX media extraction settings** from the parent agent when `extractFigures`/`extractTikz` are omitted, instead of defaulting to `false`.
> 
> This propagates the parent `toolConfig` through `ToolFileInteractionContext`, updates `delegate_workflow` input schema to allow `null`/omitted extraction flags, and adjusts proposal-input parsing in the progress view to only record flags explicitly provided by the LLM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f332313e5086484380542e131fa005d32ffdd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->