### PR TITLE
Fix minimax and GLM showing as unknown providers in relay

### DIFF
--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -22,6 +22,8 @@ export const UsageProviderSchema = z.enum([
   'dashscope',
   'xai',
   'moonshot',
+  'minimax',
+  'glm',
   'unknown',
 ]);
 

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -34,6 +34,8 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
   deepseek: '/v1',
   moonshot: '/v1',
   dashscope: '/compatible-mode/v1',
+  minimax: '/v1',
+  glm: '/api/paas/v4',
 };
 
 /** Global state key for the "use included model access" preference. */

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -53,7 +53,7 @@
  *
  * Example: /relay/openai/v1/chat/completions
  *
- * Supported providers: openai, anthropic, google, xai, deepseek, moonshot, dashscope
+ * Supported providers: openai, anthropic, google, xai, deepseek, moonshot, dashscope, minimax, glm
  *
  * IMPORTANT: Deploy with --no-verify-jwt flag since we validate JWTs manually
  * (SDKs send JWT in provider-specific headers, not the standard Authorization header).
@@ -104,7 +104,9 @@ type ProviderKey =
   | 'xai'
   | 'deepseek'
   | 'moonshot'
-  | 'dashscope';
+  | 'dashscope'
+  | 'minimax'
+  | 'glm';
 
 // =============================================================================
 // Provider Configuration
@@ -144,6 +146,16 @@ const PROVIDER_CONFIGS: Record<ProviderKey, ProviderConfig> = {
   dashscope: {
     baseUrl: 'https://dashscope-intl.aliyuncs.com',
     envKey: 'DASHSCOPE_API_KEY',
+    authType: 'bearer',
+  },
+  minimax: {
+    baseUrl: 'https://api.minimax.io',
+    envKey: 'MINIMAX_API_KEY',
+    authType: 'bearer',
+  },
+  glm: {
+    baseUrl: 'https://api.z.ai',
+    envKey: 'GLM_API_KEY',
     authType: 'bearer',
   },
 };


### PR DESCRIPTION
## Summary
- Add `minimax` and `glm` to relay proxy's `ProviderKey` type and `PROVIDER_CONFIGS` so requests are routed instead of rejected as "Unsupported provider"
- Add `minimax` and `glm` to `UsageProviderSchema` so usage tracking records the correct provider instead of falling back to `'unknown'`
- Add relay path suffixes for both providers in `ServerSideKeyService` (`/v1` for minimax, `/api/paas/v4` for GLM)

## Test plan
- [ ] Verify minimax models work through relay (server-side keys) without "unknown provider" errors
- [ ] Verify GLM models work through relay (server-side keys) without "unknown provider" errors
- [ ] Verify usage tracking shows correct provider names instead of "unknown"
- [ ] Verify `/relay/providers` endpoint includes minimax/glm when their env keys are set

https://claude.ai/code/session_01NyGk33ev8CsaQ6T3RZ4p6X

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes relay proxy/provider routing and server-side relay URL construction; misconfigured base paths or env keys could break requests for these providers (and potentially provider listing).
> 
> **Overview**
> Fixes `minimax` and `glm` being treated as unsupported/unknown by **adding them as first-class providers** across the relay stack.
> 
> The Supabase relay function now accepts these providers and routes them via new `PROVIDER_CONFIGS` entries (base URLs + `MINIMAX_API_KEY`/`GLM_API_KEY` env keys), while the VS Code `ServerSideKeyService` adds matching relay path suffixes for correct upstream URL construction.
> 
> Usage normalization now includes `minimax` and `glm` in `UsageProviderSchema`, so usage tracking records the actual provider instead of falling back to `unknown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5c2fd616a206e58011033a1bfea78201775028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->