### PR TITLE
Improve Codex agent tool and background task display

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -147,6 +147,9 @@ export class ProcessExecutionHandle implements ExecutionHandle {
   /** Ephemeral temp file paths for live output (set after construction, cleared on completion). */
   outputPaths?: { readonly stdout: string; readonly stderr: string };
 
+  /** Stable tool name for UI identification (e.g. "bash", "codex"). */
+  toolName?: string;
+
   constructor(
     readonly executionId: string,
     readonly parentStreamId: StreamTabId,
@@ -228,6 +231,9 @@ export function collectChildSummary(
     };
     if (handle instanceof AgentExecutionHandle) {
       info.childStreamId = handle.childStreamId;
+    }
+    if (handle instanceof ProcessExecutionHandle && handle.toolName) {
+      info.toolName = handle.toolName;
     }
     result.push(info);
   }

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -302,8 +302,7 @@ export class BackgroundTasksPanel extends LitElement {
     child: ActiveChildInfo,
     kind: 'process' | 'subagent',
   ): TemplateResult {
-    const icon =
-      kind === 'process' ? 'codicon-terminal' : 'codicon-server-process';
+    const icon = getTaskIcon(child, kind);
     const entry = this.processOutputs.get(child.executionId);
     const hasStdout = Boolean(entry?.stdout);
     const hasStderr = Boolean(entry?.stderr);
@@ -320,8 +319,8 @@ export class BackgroundTasksPanel extends LitElement {
               codicon: true,
               [icon]: true,
               'task-icon': true,
-              'task-icon--process': kind === 'process',
-              'task-icon--subagent': kind === 'subagent',
+              'task-icon--process': kind === 'process' && !AGENT_PROCESS_NAMES.has(child.agentName),
+              'task-icon--subagent': kind === 'subagent' || AGENT_PROCESS_NAMES.has(child.agentName),
             })}
           ></i>
           <span
@@ -393,6 +392,16 @@ export class BackgroundTasksPanel extends LitElement {
   private navigateToStream(streamId: string): void {
     this.dispatchEvent(ProgressEvents.streamSwitch({ streamId }));
   }
+}
+
+/** Agent names that represent external AI agents (distinct from plain shell processes). */
+const AGENT_PROCESS_NAMES = new Set(['codex']);
+
+/** Pick the appropriate codicon for a background task item. */
+function getTaskIcon(child: ActiveChildInfo, kind: 'process' | 'subagent'): string {
+  if (kind === 'subagent') return 'codicon-server-process';
+  if (AGENT_PROCESS_NAMES.has(child.agentName)) return 'codicon-robot';
+  return 'codicon-terminal';
 }
 
 /** Check if a child is in a waiting/idle state rather than actively processing. */

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -319,8 +319,8 @@ export class BackgroundTasksPanel extends LitElement {
               codicon: true,
               [icon]: true,
               'task-icon': true,
-              'task-icon--process': kind === 'process' && !AGENT_PROCESS_NAMES.has(child.agentName),
-              'task-icon--subagent': kind === 'subagent' || AGENT_PROCESS_NAMES.has(child.agentName),
+              'task-icon--process': kind === 'process' && !isAgentProcess(child),
+              'task-icon--subagent': kind === 'subagent' || isAgentProcess(child),
             })}
           ></i>
           <span
@@ -394,13 +394,18 @@ export class BackgroundTasksPanel extends LitElement {
   }
 }
 
-/** Agent names that represent external AI agents (distinct from plain shell processes). */
-const AGENT_PROCESS_NAMES = new Set(['codex']);
+/** Tool names that represent external AI agents (distinct from plain shell processes). */
+const AGENT_TOOL_NAMES = new Set(['codex']);
+
+/** Check if a child is an AI agent process (uses stable toolName metadata). */
+function isAgentProcess(child: ActiveChildInfo): boolean {
+  return Boolean(child.toolName && AGENT_TOOL_NAMES.has(child.toolName));
+}
 
 /** Pick the appropriate codicon for a background task item. */
 function getTaskIcon(child: ActiveChildInfo, kind: 'process' | 'subagent'): string {
   if (kind === 'subagent') return 'codicon-server-process';
-  if (AGENT_PROCESS_NAMES.has(child.agentName)) return 'codicon-robot';
+  if (isAgentProcess(child)) return 'codicon-robot';
   return 'codicon-terminal';
 }
 

--- a/src/progressView/frontend/formatters/constants.ts
+++ b/src/progressView/frontend/formatters/constants.ts
@@ -201,4 +201,7 @@ export const TOOL_ICON_MAP: Record<string, string> = {
   executions: 'codicon-history',
   runs: 'codicon-history',
   accept_run_files: 'codicon-check',
+
+  // External agents
+  codex: 'codicon-robot',
 };

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -113,6 +113,11 @@ function getToolTimeoutMs(
     return undefined;
   }
 
+  // Background tools return immediately — timeout timer is misleading
+  if (isPlainObject(input) && input.run_in_background === true) {
+    return undefined;
+  }
+
   if (isPlainObject(input) && typeof input.timeout === 'number') {
     return TIMEOUT_IN_SECONDS.has(toolName)
       ? input.timeout * 1000

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -27,6 +27,7 @@ import type {
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
+import type { CodexInput } from '@tools/codex';
 
 // Local imports - Lit template utilities
 import {
@@ -71,6 +72,7 @@ import '../../components/TerminalOutput';
 const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {
   bash: 120_000, // matches BASH_TIMEOUT_MS in src/tools/bash.ts
   executions: 300_000, // matches code default in ExecutionsTool.ts
+  codex: 300_000, // generous default — Codex turns can be slow
 };
 
 /**
@@ -117,6 +119,13 @@ function getToolTimeoutMs(
       : input.timeout;
   }
   return defaultTimeout;
+}
+
+/** Truncate a prompt string for display in collapsed headers. */
+function truncatePrompt(text: string, maxLength: number): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= maxLength) return oneLine;
+  return oneLine.slice(0, maxLength - 1) + '…';
 }
 
 /** Join template sections with horizontal rule separators. */
@@ -248,7 +257,9 @@ export function formatToolUseTemplate(
     normalizedToolLog.headerSummary ||
     (toolName === 'executions' && isPlainObject(input)
       ? `${input.action ?? EXECUTIONS_DEFAULT_ACTION} ${input.path ?? ''}`.trim()
-      : '');
+      : toolName === 'codex' && isPlainObject(input) && typeof input.prompt === 'string'
+        ? truncatePrompt(input.prompt, 60)
+        : '');
   const titleText = headerSummary
     ? `${titleBase} — ${headerSummary}`
     : titleBase;
@@ -502,6 +513,42 @@ export function formatToolUseTemplate(
       sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
     }
   }
+  // Handle codex tool with structured display
+  else if (toolName === 'codex' && isPlainObject(input)) {
+    const codexInput = input as CodexInput;
+
+    // Prompt as readable text
+    if (codexInput.prompt) {
+      sections.push(
+        buildToolUseSection('Prompt:', wrapInPre(codexInput.prompt)),
+      );
+    }
+
+    // Sandbox mode + background as compact badges
+    const badges: TemplateResult[] = [];
+    if (codexInput.sandbox_mode) {
+      // prettier-ignore
+      badges.push(html`<span class="extract-flag"><i class="codicon codicon-shield"></i> ${codexInput.sandbox_mode}</span>`);
+    }
+    if (codexInput.run_in_background) {
+      // prettier-ignore
+      badges.push(html`<span class="extract-flag"><i class="codicon codicon-run-all"></i> background</span>`);
+    }
+    if (badges.length > 0) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Mode:', html`${badges}`));
+    }
+
+    // Working directory if specified
+    if (codexInput.working_directory) {
+      sections.push(
+        buildToolUseSection(
+          'Directory:',
+          wrapInPre(codexInput.working_directory),
+        ),
+      );
+    }
+  }
   // Default handling for other tools
   else if (input != null) {
     const codeLanguage = TOOL_CODE_LANGUAGES.get(toolName);
@@ -537,7 +584,7 @@ export function formatToolUseTemplate(
     !isTrivialWriteOutput
   ) {
     sections.push(
-      toolName === 'bash'
+      toolName === 'bash' || toolName === 'codex'
         ? buildTerminalSection('', outputText)
         : buildToolSection('', outputText, {
             toolName,

--- a/src/shared/schemas/streamState.ts
+++ b/src/shared/schemas/streamState.ts
@@ -39,6 +39,8 @@ export const ActiveChildInfoSchema = z.object({
   status: z.string().optional(),
   /** Formatted elapsed time (e.g. "1m 23s"). */
   elapsed: z.string().nullable().optional(),
+  /** Tool name that spawned this process (e.g. "bash", "codex"). Absent for subagents. */
+  toolName: z.string().optional(),
 });
 
 export type ActiveChildInfo = z.infer<typeof ActiveChildInfoSchema>;

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -341,6 +341,7 @@ export class CodexTool extends defineTool({
       preview,
       () => false, // Codex SDK doesn't expose PID for kill — AbortController would be future work
     );
+    handle.toolName = 'codex';
     handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
 
     try {


### PR DESCRIPTION
## Summary

- **Specialized codex tool formatter**: Shows prompt text, sandbox mode/background badges, and working directory in a structured layout instead of raw JSON dump
- **Better collapsed headers**: Codex tool entries show a truncated prompt preview in the summary line for quick scanning without expanding
- **Terminal output for codex results**: Uses the same `<terminal-output>` renderer as bash (with ANSI color support) since codex streams command execution logs
- **Distinct icons in background tasks panel**: Codex processes show a robot icon (`codicon-robot`) with blue info tint, visually distinguishing them from plain shell processes (terminal icon, yellow warning tint)
- **Timeout timer**: Adds a 5-minute default timeout display for in-progress codex tool calls

## Test plan

- [ ] Trigger a foreground codex tool call and verify the structured display (prompt, mode badges, directory)
- [ ] Verify collapsed header shows truncated prompt preview
- [ ] Trigger a background codex tool call and verify the robot icon appears in the Background Tasks panel with blue tint
- [ ] Verify codex output renders in terminal output component (not raw code block)
- [ ] Verify existing bash/delegation/other tool displays are unaffected

https://claude.ai/code/session_01KNAMA686iFDe1Ud32do66n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view rendering and shared `ActiveChildInfo` schema by adding `toolName` metadata; low algorithmic complexity but could affect badge/task display and message validation for active processes.
> 
> **Overview**
> Improves how `codex` executions surface in the progress UI by adding stable `toolName` metadata to `ProcessExecutionHandle` and propagating it through `ActiveChildInfo`, enabling the Background Tasks panel to render Codex-launched processes with a distinct robot icon.
> 
> Enhances tool-use log rendering for `codex`: collapsed headers now show a truncated prompt preview, the expanded view shows structured fields (prompt/mode/directory), output is rendered via the terminal-style component, and a default timeout is shown for in-progress calls while suppressing the timer for `run_in_background` invocations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e409f928e331369066de489a0aba413f787817b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->