### PR TITLE
Update Supabase and Hono dependencies

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [closed]
   pull_request:
-    types: [closed, opened, edited, labeled, review_requested]
+    types: [closed, opened, labeled, review_requested]
   pull_request_review:
     types: [submitted]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@openai/codex-sdk": "^0.116.0",
         "@openrouter/sdk": "^0.9.11",
-        "@supabase/supabase-js": "^2.100.0",
+        "@supabase/supabase-js": "^2.100.1",
         "@vscode-elements/elements": "^2.5.1",
         "@vscode/codicons": "^0.0.45",
         "@xterm/addon-fit": "^0.11.0",
@@ -110,7 +110,7 @@
         "zod-v3-to-v4": "^1.20.0"
       },
       "engines": {
-        "vscode": "^1.99.3"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.0.tgz",
-      "integrity": "sha512-pdT3ye3UVRN1Cg0wom6BmyY+XTtp5DiJaYnPi6j8ht5i8Lq8kfqxJMJz9GI9YDKk3w1nhGOPnh6Qz5qpyYm+1w==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2091,9 +2091,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.0.tgz",
-      "integrity": "sha512-keLg79RPwP+uiwHuxFPTFgDRxPV46LM4j/swjyR2GKJgWniTVSsgiBHfbIBDcrQwehLepy09b/9QSHUywtKRWQ==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2109,9 +2109,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.0.tgz",
-      "integrity": "sha512-xYNvNbBJaXOGcrZ44wxwp5830uo1okMHGS8h8dm3u4f0xcZ39yzbryUsubTJW41MG2gbL/6U57cA4Pi6YMZ9pA==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2121,9 +2121,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.0.tgz",
-      "integrity": "sha512-2AZs00zzEF0HuCKY8grz5eCYlwEfVi5HONLZFoNR6aDfxQivl8zdQYNjyFoqN2MZiVhQHD7u6XV/xHwM8mCEHw==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.0",
@@ -2136,9 +2136,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.0.tgz",
-      "integrity": "sha512-d4EeuK6RNIgYNA2MU9kj8lQrLm5AzZ+WwpWjGkii6SADQNIGTC/uiaTRu02XJ5AmFALQfo8fLl9xuCkO6Xw+iQ==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -2149,16 +2149,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.100.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.0.tgz",
-      "integrity": "sha512-r0tlcukejJXJ1m/2eG/Ya5eYs4W8AC7oZfShpG3+SIo/eIU9uIt76ZeYI1SoUwUmcmzlAbgch+HDZDR/toVQPQ==",
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.100.0",
-        "@supabase/functions-js": "2.100.0",
-        "@supabase/postgrest-js": "2.100.0",
-        "@supabase/realtime-js": "2.100.0",
-        "@supabase/storage-js": "2.100.0"
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -1392,7 +1392,7 @@
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@openai/codex-sdk": "^0.116.0",
     "@openrouter/sdk": "^0.9.11",
-    "@supabase/supabase-js": "^2.100.0",
+    "@supabase/supabase-js": "^2.100.1",
     "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",
     "@xterm/addon-fit": "^0.11.0",

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -14,8 +14,8 @@
  * - JWTs signed with Supabase's JWT secret
  */
 
-import { Hono } from 'jsr:@hono/hono@4';
-import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
+import { Hono } from 'jsr:@hono/hono@4.12.9';
+import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
 import { create, getNumericDate } from 'https://deno.land/x/djwt@v3.0.2/mod.ts';
 import { handleCors } from '../_shared/cors.ts';
 

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -7,7 +7,7 @@
  * - POST /get-agent-config - Fetch agent YAML config by name
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
+import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -14,7 +14,7 @@
  * - RLS: Only SELECT policy for users, inserts use service role key
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
+import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -59,9 +59,9 @@
  * (SDKs send JWT in provider-specific headers, not the standard Authorization header).
  */
 
-import { Hono } from 'jsr:@hono/hono@4.11.1';
-import { cors } from 'jsr:@hono/hono@4.11.1/cors';
-import { createClient } from 'jsr:@supabase/supabase-js@2.89.0';
+import { Hono } from 'jsr:@hono/hono@4.12.9';
+import { cors } from 'jsr:@hono/hono@4.12.9/cors';
+import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,


### PR DESCRIPTION
## Summary
- Bump `@supabase/supabase-js` from `2.89.0` to `2.100.1` in all 4 edge functions (`relay`, `auth-github`, `log-usage`, `get-agent-config`) and in `package.json`
- Pin `@hono/hono` to `4.12.9` in `relay` and `auth-github` (was `4.11.1` and `4` respectively)
- All functions redeployed (`relay` with `--no-verify-jwt`)

## Test plan
- [ ] Verify relay proxy works (authenticated request through a provider)
- [ ] Verify GitHub auth exchange flow
- [ ] Verify usage logging
- [ ] Verify agent config fetching

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because this upgrades core dependencies used by auth, relay proxying, and usage logging edge functions, which could introduce runtime/API behavior changes despite minimal code edits.
> 
> **Overview**
> Updates Supabase client dependencies across the repo: bumps `@supabase/supabase-js` to `2.100.1` in `package.json`/`package-lock.json` and in all Supabase edge functions via `jsr:` imports.
> 
> Pins the edge-function web framework to `@hono/hono@4.12.9` in `relay` and `auth-github`, and adjusts the Issue Tracker GitHub Action trigger to stop running on `pull_request` `edited` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aad97975e8e04ce9c67a687c481568690b5d2e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->