### PR TITLE
Simplify and consolidate post-0.36.7 changes

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -243,17 +243,13 @@ class ToolUsePrepNode<C> extends BaseNode<
   ): Promise<{ interrupted: boolean; queuedFollowUp: string | null }> {
     const interrupted = this.services.checkInterruption();
 
-    // Check for queued follow-ups to inject before the model call
-    let queuedFollowUp: string | null = null;
-    if (this.services.session?.hasQueuedFollowUp()) {
-      // Drain without waiting (we know there's something)
-      const items = await this.services.session.waitForFollowUp(() => false);
-      if (items) {
-        queuedFollowUp = items.join('\n\n');
-      }
+    if (!this.services.session?.hasQueuedFollowUp()) {
+      return { interrupted, queuedFollowUp: null };
     }
 
-    return { interrupted, queuedFollowUp };
+    // Drain without waiting (we know there's something queued)
+    const items = await this.services.session.waitForFollowUp(() => false);
+    return { interrupted, queuedFollowUp: items?.join('\n\n') ?? null };
   }
 
   async post(
@@ -753,24 +749,23 @@ class ToolUseDispatchNode<C> extends BatchNode<
 
   private async logAndProcessMediaFiles(
     execResult: ToolExecutionResult,
-    options: ToolUseCycleServices<C>,
-    workspace: ToolUseCycleServices<C>['workspace'],
   ): Promise<void> {
     const { call, result, parsedInput, extracted, editedFiles, logRef } =
       execResult;
+    const options = this.services;
+    const { workspace } = options;
 
     // Spread sanitizedResult so editedFiles in the log don't leak into
     // extracted.sanitizedResult (which is reused for model messages in post).
-    const logOutput =
-      editedFiles.length > 0
-        ? { ...extracted.sanitizedResult, editedFiles }
-        : extracted.sanitizedResult;
+    const logOutput = editedFiles.length
+      ? { ...extracted.sanitizedResult, editedFiles }
+      : extracted.sanitizedResult;
 
     const toolUseLog = {
       toolName: call.name,
       input: parsedInput ?? call.raw,
       output: logOutput,
-      ...(editedFiles.length > 0 && { files: editedFiles }),
+      ...(editedFiles.length && { files: editedFiles }),
       isError: Boolean(result.isError),
     };
 
@@ -803,7 +798,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
           );
         }
       }
-      if (validLocations.length > 0) {
+      if (validLocations.length) {
         workspace.media.addMediaFiles(validLocations);
       }
     }
@@ -815,8 +810,7 @@ class ToolUseDispatchNode<C> extends BatchNode<
     _toolCalls: SdkToolCall[],
     execResults: (ToolExecutionResult | null)[],
   ): Promise<string | undefined> {
-    const services = this.services;
-    const { workspace } = services;
+    const { workspace } = this.services;
 
     const completedResults = execResults.filter(
       (r): r is ToolExecutionResult => r !== null,
@@ -825,16 +819,14 @@ class ToolUseDispatchNode<C> extends BatchNode<
     if (completedResults.length < execResults.length) {
       shared.shouldStop = true;
     }
-
-    if (completedResults.length === 0) {
+    if (!completedResults.length) {
       return FlowTransition.COMPLETE;
     }
 
     const assistantText = shared.text ?? '';
 
-    // Log and process media files for each result
     for (const execResult of completedResults) {
-      await this.logAndProcessMediaFiles(execResult, services, workspace);
+      await this.logAndProcessMediaFiles(execResult);
     }
 
     const extracted = completedResults.map((er) => er.extracted);
@@ -842,36 +834,36 @@ class ToolUseDispatchNode<C> extends BatchNode<
 
     // For Google/DeepSeek/Kimi handlers with multiple parallel calls, batch all tool calls
     // into a single message to preserve thought signatures / reasoning_content.
+    const { modelHandler } = this.services;
     const shouldBatch =
       calls.length > 1 &&
-      (services.modelHandler.isGoogle ||
-        services.modelHandler.isDeepSeek ||
-        services.modelHandler.isKimi ||
-        services.modelHandler.isMiniMax) &&
-      !!services.modelHandler.createBatchedToolUseFollowUpMessages;
+      (modelHandler.isGoogle ||
+        modelHandler.isDeepSeek ||
+        modelHandler.isKimi ||
+        modelHandler.isMiniMax) &&
+      !!modelHandler.createBatchedToolUseFollowUpMessages;
 
     if (shouldBatch) {
-      const followUpMsgs = await services.modelHandler
-        .createBatchedToolUseFollowUpMessages!(
-        calls,
-        extracted.map((e) => e.sanitizedResult),
-        extracted.map((e) => e.attachments),
-        workspace,
-        assistantText || undefined,
-      );
+      const followUpMsgs =
+        await modelHandler.createBatchedToolUseFollowUpMessages!(
+          calls,
+          extracted.map((e) => e.sanitizedResult),
+          extracted.map((e) => e.attachments),
+          workspace,
+          assistantText || undefined,
+        );
       shared.messages.push(...followUpMsgs);
     } else {
       for (const [index, execResult] of completedResults.entries()) {
         const { sanitizedResult, attachments } = extracted[index];
-        const followUpMsgs =
-          await services.modelHandler.createToolUseFollowUpMessages(
-            services.client,
-            execResult.call,
-            sanitizedResult,
-            attachments,
-            workspace,
-            index === 0 ? assistantText || undefined : undefined,
-          );
+        const followUpMsgs = await modelHandler.createToolUseFollowUpMessages(
+          this.services.client,
+          execResult.call,
+          sanitizedResult,
+          attachments,
+          workspace,
+          index === 0 ? assistantText || undefined : undefined,
+        );
         shared.messages.push(...followUpMsgs);
       }
     }

--- a/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseSessionLifecycle.ts
@@ -28,8 +28,7 @@ export class ToolUseSessionLifecycle implements IToolUseSession {
   }
 
   interrupt(): void {
-    this.followUps.cancelWait();
-    this.followUps.clear();
+    this.followUps.dispose();
   }
 
   dispose(): void {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -46,17 +46,13 @@ export class ToolUseCycleNode<C> extends Node<
       this.services;
 
     if (prepRes.shouldSkip) {
-      if (prepRes.workspaceState.todos.todos.length) {
-        bus.emit('updateTodos', {
-          streamId,
-          todos: prepRes.workspaceState.todos.todos,
-        });
+      const { todos } = prepRes.workspaceState.todos;
+      const { plan } = prepRes.workspaceState.plan;
+      if (todos.length) {
+        bus.emit('updateTodos', { streamId, todos });
       }
-      if (prepRes.workspaceState.plan.plan) {
-        bus.emit('updatePlan', {
-          streamId,
-          plan: prepRes.workspaceState.plan.plan,
-        });
+      if (plan) {
+        bus.emit('updatePlan', { streamId, plan });
       }
       return { outcome: 'skipped' };
     }
@@ -84,13 +80,9 @@ export class ToolUseCycleNode<C> extends Node<
     });
 
     const { onProgress, persistTodos } = this.services;
-    // Serialize writes so rapid updates don't persist out of order
     let todoPersistChain = Promise.resolve();
     prepRes.workspaceState.todos.setOnUpdate((todos) => {
-      bus.emit('updateTodos', {
-        streamId,
-        todos,
-      });
+      bus.emit('updateTodos', { streamId, todos });
       if (persistTodos) {
         todoPersistChain = todoPersistChain
           .then(() => persistTodos(todos))
@@ -99,10 +91,7 @@ export class ToolUseCycleNode<C> extends Node<
       onProgress?.({ kind: 'todos', todos });
     });
     prepRes.workspaceState.plan.setOnUpdate((plan) => {
-      bus.emit('updatePlan', {
-        streamId,
-        plan,
-      });
+      bus.emit('updatePlan', { streamId, plan });
       onProgress?.({ kind: 'plan', plan });
     });
 
@@ -170,27 +159,26 @@ export class ToolUseCycleNode<C> extends Node<
       });
     }
 
+    // All outcomes continue to WaitNode (FlowTransition.DEFAULT).
+    // Tool-use agents are conversational — the user can send a
+    // follow-up to retry after a failure, unlike workflows.
     switch (execRes.outcome) {
       case 'completed':
         shared.messages = execRes.messages;
-        return FlowTransition.DEFAULT;
-
+        break;
       case 'skipped':
-        return FlowTransition.DEFAULT;
-
+        break;
       case 'failed':
         shared.lastError = {
           message: execRes.message,
           retryable: execRes.retryable ?? false,
         };
-        // Continue to WaitNode instead of ending the flow.
-        // Tool-use agents are conversational — the user can send a
-        // follow-up to retry after a failure, unlike workflows.
-        return FlowTransition.DEFAULT;
-
+        break;
       case 'cancelled':
         shared.userCancelledRetry = true;
-        return FlowTransition.DEFAULT;
+        break;
     }
+
+    return FlowTransition.DEFAULT;
   }
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseWaitNode.ts
@@ -44,15 +44,14 @@ export class ToolUseWaitNode<C> extends Node<
       return { kind: 'stop' };
     }
 
-    // Skip subagent delivery after a failed/cancelled cycle — the
-    // orchestrator must not see a failure as a successful completion.
-    // In subagent mode, stop immediately: no orchestrator will send a
-    // follow-up since it was never notified, so waiting would hang.
-    if (prepRes.afterError) {
-      if (this.services.isSubagent) {
-        return { kind: 'stop' };
-      }
-    } else {
+    // After a failed/cancelled cycle, skip notifying the orchestrator —
+    // it must not see a failure as a successful completion.
+    // In subagent mode, stop immediately: the orchestrator was never
+    // notified, so waiting for a follow-up would hang forever.
+    if (prepRes.afterError && this.services.isSubagent) {
+      return { kind: 'stop' };
+    }
+    if (!prepRes.afterError) {
       await onBeforeWaiting?.(prepRes.lastResponse, prepRes.touchedFiles);
     }
 
@@ -72,8 +71,7 @@ export class ToolUseWaitNode<C> extends Node<
     _prepRes: WaitPrepResult,
     error: Error,
   ): Promise<WaitExecResult> {
-    const { logger } = this.services;
-    logger.error(`ToolUseWaitNode error: ${error.message}`);
+    this.services.logger.error(`ToolUseWaitNode error: ${error.message}`);
     return { kind: 'stop' };
   }
 

--- a/src/agent/implementations/flows/tooluse/nodes/types.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/types.ts
@@ -19,9 +19,10 @@ export interface StateSlicesSnapshot {
 export function extractTouchedFiles(
   stateSlices: StateSlicesSnapshot | null,
 ): string[] {
-  const edits = stateSlices?.workspaceSnapshot?.interactions?.edits;
-  if (!edits || edits.length === 0) return [];
-  return edits.map((e) => e.path);
+  return (
+    stateSlices?.workspaceSnapshot?.interactions?.edits?.map((e) => e.path) ??
+    []
+  );
 }
 
 export interface ToolUseRunShared {
@@ -33,13 +34,10 @@ export interface ToolUseRunShared {
   lastError?: RetryErrorInfo;
 }
 
-interface NodeResultStateBase {
+export interface PrepareResult {
   runState: AgentRunStateSnapshot;
   workspaceState: AgentWorkspaceState;
   userChannels: UserVariableChannels;
-}
-
-export interface PrepareResult extends NodeResultStateBase {
   messages: ProviderMessage[];
   shouldSkipCycle: boolean;
 }
@@ -48,7 +46,10 @@ export type WaitExecResult =
   | { kind: 'continue'; followUp: string }
   | { kind: 'stop' };
 
-export interface CyclePrepResult extends NodeResultStateBase {
+export interface CyclePrepResult {
+  runState: AgentRunStateSnapshot;
+  workspaceState: AgentWorkspaceState;
+  userChannels: UserVariableChannels;
   messages: ProviderMessage[];
   shouldSkip: boolean;
 }
@@ -86,7 +87,6 @@ function tryAsRunShared(
   obj: unknown,
 ): { data: ToolUseRunShared; migrated: boolean } | null {
   if (!obj || typeof obj !== 'object') return null;
-
   if (MessagesSchema.safeParse(obj).success) {
     return { data: obj as ToolUseRunShared, migrated: false };
   }
@@ -110,14 +110,10 @@ export function migrateSharedState(
 ): { data: ToolUseRunShared; migrated: boolean } | null {
   if (!shared || typeof shared !== 'object') return null;
 
-  // Try flat format first (reject nested `{ state: {...} }` wrapper)
-  if (!('state' in shared)) {
-    return tryAsRunShared(shared);
-  }
+  // Flat format (no nested `{ state: {...} }` wrapper)
+  if (!('state' in shared)) return tryAsRunShared(shared);
 
   // Nested format: unwrap and parse inner object
   const inner = tryAsRunShared((shared as Record<string, unknown>).state);
-  if (inner) return { data: inner.data, migrated: true };
-
-  return null;
+  return inner ? { data: inner.data, migrated: true } : null;
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -77,7 +77,7 @@ function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
-  options?: { isSubagent?: boolean },
+  isSubagent?: boolean,
 ): ToolDefinition[] {
   const unavailable = getUnavailableToolNamesCached();
   const excluded: string[] = [];
@@ -86,7 +86,7 @@ function resolveTools(
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
-      if (options?.isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
+      if (isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
       if (unavailable.has(def.name)) {
         logger.warn(
           `Tool "${def.name}" excluded: external dependency not installed`,
@@ -127,9 +127,12 @@ export async function runToolUseFlow<C = unknown>(
   const { logger, streamId, executionId, setting, onInterrupt } = input;
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const resolvedTools = resolveTools(setting.tools, registry, logger, {
-    isSubagent: input.isSubagent,
-  });
+  const resolvedTools = resolveTools(
+    setting.tools,
+    registry,
+    logger,
+    input.isSubagent,
+  );
 
   const kv = getExecutionStore(executionId);
 
@@ -242,12 +245,11 @@ export async function runToolUseFlow<C = unknown>(
   const lastResponse = findLastAssistantText(shared.messages, (m) =>
     input.modelHandler.extractAssistantText(m),
   );
-
   const touchedFiles = extractTouchedFiles(shared.stateSlices);
 
   return {
     status,
     lastResponse,
-    touchedFiles: touchedFiles.length > 0 ? touchedFiles : undefined,
+    touchedFiles: touchedFiles.length ? touchedFiles : undefined,
   };
 }

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -140,24 +140,15 @@ export abstract class ModelHandler<
     });
   }
 
-  /**
-   * Updates the logger instance.
-   */
   public setLogger(logger: AgentLogger): void {
     this.logger = logger;
     this.mediaProcessor.setLogger(logger);
   }
 
-  /**
-   * Records the active agent category so provider handlers can adjust behaviour per session.
-   */
   public setAgentCategory(agentCategory?: AgentCategory | null): void {
     this.agentCategory = agentCategory ?? undefined;
   }
 
-  /**
-   * Returns the agent category that is currently driving the handler, if any.
-   */
   public getAgentCategory(): AgentCategory | undefined {
     return this.agentCategory;
   }
@@ -191,23 +182,15 @@ export abstract class ModelHandler<
    * Tool-use agents use a reduced value to leave headroom for context growth.
    */
   protected getEffectiveMaxOutputTokens(): number {
-    const base = this.config.maxOutputTokens;
-    if (!this.isToolUseMode()) {
-      return base;
-    }
-    return Math.floor(base * TOOL_USE_MAX_OUTPUT_FACTOR);
+    return this.isToolUseMode()
+      ? Math.floor(this.config.maxOutputTokens * TOOL_USE_MAX_OUTPUT_FACTOR)
+      : this.config.maxOutputTokens;
   }
 
-  /**
-   * Enables or disables streaming of model output text.
-   */
   public setOutputStreaming(enabled: boolean): void {
     this.outputStreaming = enabled;
   }
 
-  /**
-   * Indicates whether model output streaming is enabled.
-   */
   public isOutputStreamingEnabled(): boolean {
     return this.outputStreaming;
   }
@@ -221,9 +204,6 @@ export abstract class ModelHandler<
     return false;
   }
 
-  /**
-   * Enables or disables Progress view updates.
-   */
   public setProgressViewEnabled(enabled: boolean): void {
     this.progressViewEnabled = enabled;
   }
@@ -300,6 +280,18 @@ export abstract class ModelHandler<
     );
   }
 
+  /** Fetch an API key for the given provider, throwing `errorMessage` on failure. */
+  private async fetchApiKeyOrThrow(
+    provider: ApiProvider,
+    errorMessage: string,
+  ): Promise<string> {
+    try {
+      return await SecretManager.getApiKey(provider);
+    } catch {
+      throw new Error(errorMessage);
+    }
+  }
+
   /**
    * Retrieves API key from environment variables based on provider and OpenRouter configuration.
    * When server-side keys are enabled (experimental), returns the user's JWT token instead,
@@ -340,13 +332,10 @@ export abstract class ModelHandler<
     // openRouterOnly models can NEVER use server-side relay - they always need OpenRouter key.
     // Allow these even in "Use Included Access" mode since included access is never possible.
     if (this.config.openRouterOnly) {
-      try {
-        return await SecretManager.getApiKey('openRouter');
-      } catch (err) {
-        throw new Error(
-          `Model "${this.config.name}" requires an OpenRouter API key. Please set it using the "Set API Key" command.`,
-        );
-      }
+      return this.fetchApiKeyOrThrow(
+        'openRouter',
+        `Model "${this.config.name}" requires an OpenRouter API key. Please set it using the "Set API Key" command.`,
+      );
     }
 
     if (useIncludedAccess && hasServerAccess) {
@@ -364,23 +353,16 @@ export abstract class ModelHandler<
     }
 
     if (shouldUseOpenRouter(this.config)) {
-      try {
-        return await SecretManager.getApiKey('openRouter');
-      } catch (err) {
-        throw new Error(
-          'Missing API key for OpenRouter. Please set it using the "Set API Key" command.',
-        );
-      }
-    }
-
-    const provider = this.config.provider.toLowerCase() as ApiProvider;
-    try {
-      return await SecretManager.getApiKey(provider);
-    } catch (err) {
-      throw new Error(
-        `Missing API key for ${this.config.provider}. Please set it using the "Set API Key" command.`,
+      return this.fetchApiKeyOrThrow(
+        'openRouter',
+        'Missing API key for OpenRouter. Please set it using the "Set API Key" command.',
       );
     }
+
+    return this.fetchApiKeyOrThrow(
+      this.config.provider.toLowerCase() as ApiProvider,
+      `Missing API key for ${this.config.provider}. Please set it using the "Set API Key" command.`,
+    );
   }
 
   /**
@@ -442,18 +424,12 @@ export abstract class ModelHandler<
 
   /**
    * Gets streaming configuration for the current model provider.
-   * @returns Boolean indicating if streaming should be enabled
    */
   public getStreamingConfig(): boolean {
-    if (shouldUseOpenRouter(this.config)) {
+    if (shouldUseOpenRouter(this.config))
       return getProviderStreaming('openrouter');
-    }
-
-    // ModelProvider.OTHERS has no provider-specific streaming config
-    if (this.config.provider === ModelProvider.OTHERS) {
+    if (this.config.provider === ModelProvider.OTHERS)
       return getGlobalStreaming();
-    }
-
     return getProviderStreaming(this.config.provider);
   }
 
@@ -590,10 +566,9 @@ export abstract class ModelHandler<
   public containCutOffMessage(
     content: Array<{ type: string; text?: string }> | string,
   ): boolean {
-    if (typeof content === 'string') {
-      return content.includes('Your response got cut off');
-    }
-    return content.some((c) => c.text?.includes('Your response got cut off'));
+    const marker = 'Your response got cut off';
+    if (typeof content === 'string') return content.includes(marker);
+    return content.some((c) => c.text?.includes(marker));
   }
 
   /**

--- a/src/agent/modelHandlers/contextManagementConstants.ts
+++ b/src/agent/modelHandlers/contextManagementConstants.ts
@@ -45,7 +45,6 @@ export function computeReducedMaxTokens(
   tokenBuffer: number = TOKEN_SAFETY_BUFFER,
 ): number {
   if (availableTokens <= 0) return 1;
-
   const buffered = availableTokens - tokenBuffer;
-  return buffered < MIN_COMPLETION_TOKENS ? availableTokens : buffered;
+  return buffered >= MIN_COMPLETION_TOKENS ? buffered : availableTokens;
 }

--- a/src/agent/modelHandlers/index.ts
+++ b/src/agent/modelHandlers/index.ts
@@ -1,10 +1,6 @@
-// Re-export all model handlers from a single entry point
-
-// Base class
 export { ModelHandler } from './ModelHandler';
 export type { IModelHandler } from './types/IModelHandler';
 
-// Specific model handler implementations
 export { ModelHandlerAnthropic } from './modelHandlerAnthropic';
 export { ModelHandlerGoogleGenAI } from './modelHandlerGoogleGenAI';
 export { ModelHandlerDeepSeek } from './modelHandlerDeepSeek';

--- a/src/agent/modelHandlers/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/modelHandlerMiniMax.ts
@@ -17,10 +17,9 @@ import type {
 function extractTextFromReasoningDetails(details: unknown): string | undefined {
   if (typeof details === 'string') return details || undefined;
   if (!Array.isArray(details)) return undefined;
-  const text = (details as Array<{ text?: string | null }>).reduce(
-    (acc, item) => acc + (item?.text ?? ''),
-    '',
-  );
+  const text = (details as Array<{ text?: string | null }>)
+    .map((item) => item?.text ?? '')
+    .join('');
   return text || undefined;
 }
 
@@ -79,24 +78,20 @@ export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
    * MiniMax returns reasoning in `reasoning_details` (array), not `reasoning_content`.
    */
   protected override extractReasoningDelta(chunk: ChatCompletionChunk): string {
-    const delta = chunk.choices[0]?.delta as
-      | { reasoning_details?: unknown }
-      | undefined;
-    if (delta && 'reasoning_details' in delta && delta.reasoning_details) {
-      return extractTextFromReasoningDetails(delta.reasoning_details) ?? '';
-    }
+    const details = (
+      chunk.choices[0]?.delta as { reasoning_details?: unknown } | undefined
+    )?.reasoning_details;
+    if (details) return extractTextFromReasoningDetails(details) ?? '';
     return super.extractReasoningDelta(chunk);
   }
 
   protected override extractReasoningFromMessage(
     message: Record<string, unknown> | undefined,
   ): string | null {
-    const details = message?.reasoning_details;
-    if (details) {
-      const extracted = extractTextFromReasoningDetails(details);
-      if (extracted) return extracted;
-    }
-    return super.extractReasoningFromMessage(message);
+    const extracted = extractTextFromReasoningDetails(
+      message?.reasoning_details,
+    );
+    return extracted ?? super.extractReasoningFromMessage(message);
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -57,6 +57,7 @@ import {
   formatToolResultAsText,
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
+import { parseToolArguments } from './utils/parseArguments';
 import { ModelHandler } from './ModelHandler';
 import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
@@ -902,29 +903,15 @@ export class ModelHandlerOpenAI<
             format: typedAudioFormat,
           },
         };
-        // actually, currently only mp3 and wav are supported
-        // openai.BadRequestError: Error code: 400 - [{'error': {'code': 400, 'message': 'Invalid audio format "m4a" for audio generation. Valid formats are: [wav, mp3]', 'status': 'INVALID_ARGUMENT'}}]
-
-        // For the size:
-        // You can use the File API to upload an audio file of any size.
-        // Always use the File API when the total request size (including the files, text prompt, system instructions, etc.) is larger than 20 MB.
-        // The maximum request size is 20 MB, which includes text prompts, system instructions, and files provided inline. If your file's size will make the total request size exceed 20 MB, then use the File API to upload files for use in requests.
-        // If you're using an audio sample multiple times, it is more efficient to use the File API.
-        // https://ai.google.dev/gemini-api/docs/audio?hl=en&lang=python
-
-        // The structure below might need adjustment based on exact API requirements
-        // Using a structure closer to the message format from documentation
-        // It seems this needs to be part of the user message content directly.
-        // Let's adapt this to return the structured object expected within the message content array.
         return [
-          { type: 'text', text: `Audio: ${media.file_name}` }, // Text description goes separately
+          { type: 'text', text: `Audio: ${media.file_name}` },
           audioContent,
         ];
       } else if (media.media_category === 'audio') {
         this.logger.warn(
           `Audio input received (${media.file_name}) but native audio is not supported by this specific model/provider (${this.config.provider}). Skipping.`,
         );
-        return []; // Return empty array if audio not supported
+        return [];
       } else {
         this.logger.warn(`Unknown media category: ${media.media_category}`);
         return [];
@@ -949,7 +936,6 @@ export class ModelHandlerOpenAI<
         const stopReason =
           responseObject.choices?.[0]?.finish_reason ?? OPENAI_CHAT_FINISH.STOP;
 
-        // For usage, we'll use empty values since they're not provided; TODO needs to test at some points
         const usage = responseObject.usage ?? {
           prompt_tokens: 0,
           completion_tokens: 0,
@@ -1053,7 +1039,7 @@ export class ModelHandlerOpenAI<
 
   /** Initializes output file and handles prefill content. */
   async initializeOutputAndPrefill(
-    agentConfig: AgentConfig,
+    _agentConfig: AgentConfig,
     agentSetting: AgentSetting,
     messages: any[],
     workspaceState: AgentWorkspaceState,
@@ -1418,19 +1404,7 @@ export class ModelHandlerOpenAI<
   }
 
   protected parseArguments(raw: unknown): unknown {
-    if (typeof raw !== 'string') {
-      return raw;
-    }
-
-    try {
-      return JSON.parse(raw);
-    } catch (error) {
-      this.logger.warn(
-        'Tool call arguments could not be parsed as JSON; using raw string.',
-        { data: error },
-      );
-      return raw;
-    }
+    return parseToolArguments(raw, this.logger);
   }
 
   extractToolUse(responseObject: ChatCompletion): TCall[] {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -45,6 +45,7 @@ import {
   loadAttachmentBuffer,
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
+import { parseToolArguments } from './utils/parseArguments';
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
 import { toOpenAIResponseTools } from './toolConversion';
 import { ModelHandler } from './ModelHandler';
@@ -2538,19 +2539,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   }
 
   private parseArguments(raw: unknown): unknown {
-    if (typeof raw !== 'string') {
-      return raw;
-    }
-
-    try {
-      return JSON.parse(raw);
-    } catch (error) {
-      this.logger.warn(
-        'OpenAI Responses tool call arguments could not be parsed as JSON; using raw string.',
-        { data: error },
-      );
-      return raw;
-    }
+    return parseToolArguments(raw, this.logger);
   }
 
   extractToolUse(response: Response): OpenAIResponseToolCall[] {
@@ -2961,21 +2950,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   private isMessageItem(
     item?: ResponseInputItem,
   ): item is EasyInputMessage | ResponseInputItem.Message {
-    if (!item || typeof item !== 'object') {
-      return false;
-    }
-
-    const role = (item as { role?: unknown }).role;
-    if (typeof role !== 'string') {
-      return false;
-    }
-
-    const type = (item as { type?: unknown }).type;
-    if (typeof type === 'string' && type !== 'message') {
-      return false;
-    }
-
-    const content = (item as { content?: unknown }).content;
+    if (!item || typeof item !== 'object') return false;
+    const { role, type, content } = item as unknown as Record<string, unknown>;
+    if (typeof role !== 'string') return false;
+    if (typeof type === 'string' && type !== 'message') return false;
     return typeof content === 'string' || Array.isArray(content);
   }
 

--- a/src/agent/modelHandlers/support/ProxyConfigResolver.ts
+++ b/src/agent/modelHandlers/support/ProxyConfigResolver.ts
@@ -16,20 +16,15 @@ import {
 
 const DEFAULT_PROXY_DOMAIN = 'proxy.texra.ai';
 
-/**
- * Normalize a URL-like string by removing any protocol prefix and trailing slashes.
- * Preserves any path component provided.
- */
+/** Normalize a URL-like string to `host/path` form (no protocol, no trailing slashes). */
 function normalizeUrl(input: string): string {
   if (!input) return '';
 
-  // Ensure protocol for URL parsing
   const withProtocol = input.includes('://') ? input : `https://${input}`;
   try {
-    const url = new URL(withProtocol);
-    return `${url.host}${url.pathname}`.replace(/\/+$/, '');
+    const { host, pathname } = new URL(withProtocol);
+    return `${host}${pathname}`.replace(/\/+$/, '');
   } catch {
-    // For malformed URLs, strip protocol and trailing slashes from original input
     return input.replace(/^https?:\/\//, '').replace(/\/+$/, '');
   }
 }
@@ -160,30 +155,28 @@ export function resolveBaseUrl(config: ProxyConfig): string | null {
     return `https://${normalizeUrl(customUrl)}`;
   }
 
-  // DashScope base URL depends on the China/international region toggle
-  if (config.provider === ModelProvider.DASHSCOPE) {
-    const domain = getDashScopeUseChina()
-      ? 'dashscope.aliyuncs.com'
-      : 'dashscope-intl.aliyuncs.com';
-    return `https://${domain}/compatible-mode/v1`;
+  // Providers with dynamic region-based URLs
+  switch (config.provider) {
+    case ModelProvider.DASHSCOPE: {
+      const domain = getDashScopeUseChina()
+        ? 'dashscope.aliyuncs.com'
+        : 'dashscope-intl.aliyuncs.com';
+      return `https://${domain}/compatible-mode/v1`;
+    }
+    case ModelProvider.MINIMAX: {
+      // China: api.minimaxi.com (note the extra 'i'), International: api.minimax.io
+      const domain = getMiniMaxUseChina()
+        ? 'api.minimaxi.com'
+        : 'api.minimax.io';
+      return `https://${domain}/v1`;
+    }
+    case ModelProvider.GLM: {
+      // China: open.bigmodel.cn, International: api.z.ai
+      const domain = getGLMUseChina() ? 'open.bigmodel.cn' : 'api.z.ai';
+      const path = getGLMCodingPlan() ? '/api/coding/paas/v4' : '/api/paas/v4';
+      return `https://${domain}${path}`;
+    }
+    default:
+      return BASE_URLS[config.provider];
   }
-
-  // MiniMax base URL depends on the China/international region toggle
-  // China: api.minimaxi.com (note the extra 'i'), International: api.minimax.io
-  // Note: Coding Plan uses the same endpoint but requires a separate API key
-  if (config.provider === ModelProvider.MINIMAX) {
-    const domain = getMiniMaxUseChina() ? 'api.minimaxi.com' : 'api.minimax.io';
-    return `https://${domain}/v1`;
-  }
-
-  // GLM base URL depends on the China/international region toggle
-  // China: open.bigmodel.cn, International: api.z.ai
-  // Coding Plan uses /api/coding/paas/v4 path instead of /api/paas/v4
-  if (config.provider === ModelProvider.GLM) {
-    const domain = getGLMUseChina() ? 'open.bigmodel.cn' : 'api.z.ai';
-    const path = getGLMCodingPlan() ? '/api/coding/paas/v4' : '/api/paas/v4';
-    return `https://${domain}${path}`;
-  }
-
-  return BASE_URLS[config.provider];
 }

--- a/src/agent/modelHandlers/utils/parseArguments.ts
+++ b/src/agent/modelHandlers/utils/parseArguments.ts
@@ -1,0 +1,21 @@
+import type { AgentLogger } from '@logger/AgentLogger';
+
+/**
+ * Safely parse tool call arguments from raw string to object.
+ * Returns the original value if not a string, or if JSON parsing fails.
+ */
+export function parseToolArguments(raw: unknown, logger: AgentLogger): unknown {
+  if (typeof raw !== 'string') {
+    return raw;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    logger.warn(
+      'Tool call arguments could not be parsed as JSON; using raw string.',
+      { data: error },
+    );
+    return raw;
+  }
+}

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -82,12 +82,12 @@ export class OutputFileProcessor {
     }
   }
 
-  private async handleEmptyOutput(
+  private handleEmptyOutput(
     round: number,
     rawLocation: FileLocation,
   ): Promise<void> {
     this.ctx.setRoundOutputs(round, []);
-    await this.captureXmlSummary(round, rawLocation, []);
+    return this.captureXmlSummary(round, rawLocation, []);
   }
 
   async processSingleOutput(
@@ -119,8 +119,7 @@ export class OutputFileProcessor {
         logger.debug(
           `No processed file was generated from ${outputLocation.absolutePath}`,
         );
-        this.ctx.setRoundOutputs(currRound, []);
-        await this.captureXmlSummary(currRound, rawLocation, []);
+        await this.handleEmptyOutput(currRound, rawLocation);
         return;
       }
 
@@ -154,8 +153,7 @@ export class OutputFileProcessor {
         storageKey,
         filesByRound: { [currRound]: [] },
       });
-      this.ctx.setRoundOutputs(currRound, []);
-      await this.captureXmlSummary(currRound, rawLocation, []);
+      await this.handleEmptyOutput(currRound, rawLocation);
     }
   }
 
@@ -168,15 +166,15 @@ export class OutputFileProcessor {
     const singleFile =
       processed.length === 1 ? processed[0].location.absolutePath : null;
 
-    const createEmptySummary = () => ({
+    const emptySummary = {
       tagContents: {},
       documents: [] as string[],
       singleOutputFile: singleFile,
       sourceLocation: rawOutput,
-    });
+    };
 
     if (!rawOutput?.absolutePath) {
-      data.xmlSummary = createEmptySummary();
+      data.xmlSummary = emptySummary;
       return;
     }
 
@@ -234,21 +232,20 @@ export class OutputFileProcessor {
         `Failed to collect XML summary for round ${round}: ${toErrorMessage(error)}`,
         { messageType: MESSAGE_TYPES.INTERNAL },
       );
-      data.xmlSummary = createEmptySummary();
+      data.xmlSummary = { ...emptySummary };
     }
   }
 
   private shouldProcessXml(agentSetting: AgentWorkflowSetting): boolean {
-    const xmlMode = agentSetting.xmlStructureMode ?? 'scratchpadOnly';
-
-    switch (xmlMode) {
+    switch (agentSetting.xmlStructureMode ?? 'scratchpadOnly') {
       case 'always':
         return true;
       case 'scratchpadOnly':
         return (
           Boolean(agentSetting.documentTag) ||
-          (agentSetting.prefills?.some((p) => SCRATCHPAD_TAG_PATTERN.test(p)) ??
-            false)
+          Boolean(
+            agentSetting.prefills?.some((p) => SCRATCHPAD_TAG_PATTERN.test(p)),
+          )
         );
       default:
         return false;

--- a/src/agent/runtime/AgentFlowResult.ts
+++ b/src/agent/runtime/AgentFlowResult.ts
@@ -23,8 +23,6 @@ const AgentFlowMetaSchema = z.object({
   streamId: StreamTabIdSchema,
 });
 
-export type AgentFlowMeta = z.infer<typeof AgentFlowMetaSchema>;
-
 export const WorkflowFlowResultSchema = AgentFlowMetaSchema.extend({
   category: z.literal('workflow'),
   status: EndGroupStatusSchema,

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -182,6 +182,20 @@ export class ProcessExecutionHandle implements ExecutionHandle {
 // Subagent lineage helpers
 // ============================================================================
 
+/** True when the handle is a child of parentStreamId (not the parent itself). */
+function isChildOf(
+  handle: ExecutionHandle,
+  parentStreamId: StreamTabId,
+): boolean {
+  if (handle.parentStreamId !== parentStreamId) return false;
+  // AgentExecutionHandles where childStreamId === parentStreamId represent
+  // the parent itself, not a child.
+  if (handle instanceof AgentExecutionHandle) {
+    return handle.childStreamId !== parentStreamId;
+  }
+  return true;
+}
+
 /**
  * Interrupt all active subagents of a parent stream.
  * Called before interrupting the parent so subagents stop
@@ -192,15 +206,9 @@ export function interruptActiveChildren(
   handles: Iterable<ExecutionHandle>,
 ): void {
   for (const handle of handles) {
-    if (handle.parentStreamId !== parentStreamId) continue;
-    // Skip the parent itself — only terminate its children
-    if (
-      handle instanceof AgentExecutionHandle &&
-      handle.childStreamId === parentStreamId
-    ) {
-      continue;
+    if (isChildOf(handle, parentStreamId)) {
+      handle.terminate();
     }
-    handle.terminate();
   }
 }
 
@@ -208,31 +216,23 @@ export function interruptActiveChildren(
 export function collectChildSummary(
   parentStreamId: StreamTabId,
   handles: Iterable<ExecutionHandle>,
-  ctor: new (...args: any[]) => ExecutionHandle,
+  ctor: typeof AgentExecutionHandle | typeof ProcessExecutionHandle,
 ): ActiveChildInfo[] {
   const result: ActiveChildInfo[] = [];
   for (const handle of handles) {
-    if (handle.parentStreamId !== parentStreamId || !(handle instanceof ctor)) {
+    if (!(handle instanceof ctor) || !isChildOf(handle, parentStreamId)) {
       continue;
     }
-    // Exclude the parent itself (parentStreamId === childStreamId)
-    if (
-      handle instanceof AgentExecutionHandle &&
-      handle.childStreamId === parentStreamId
-    ) {
-      continue;
-    }
-    const statusInfo = handle.getStatus();
+    const { status, elapsed } = handle.getStatus();
     const info: ActiveChildInfo = {
       executionId: handle.executionId,
       agentName: handle.agentName,
-      status: statusInfo.status,
-      elapsed: statusInfo.elapsed ?? null,
+      status,
+      elapsed: elapsed ?? null,
     };
     if (handle instanceof AgentExecutionHandle) {
       info.childStreamId = handle.childStreamId;
-    }
-    if (handle instanceof ProcessExecutionHandle && handle.toolName) {
+    } else if (handle instanceof ProcessExecutionHandle && handle.toolName) {
       info.toolName = handle.toolName;
     }
     result.push(info);

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -59,14 +59,11 @@ export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
 function withReasoningOverride<T extends ModelHandler>(handler: T): T {
   if (!handler.capabilities.supportsReasoningEffort) return handler;
 
-  const overrides = globalSM.get<Record<string, string>>(
+  const level = globalSM.get<Record<string, string>>(
     GlobalStateKey.REASONING_LEVELS,
     {},
-  );
-  const level = overrides[handler.config.name];
-  if (!level) return handler;
-
-  const effort = LEVEL_TO_EFFORT[level];
+  )[handler.config.name];
+  const effort = level ? LEVEL_TO_EFFORT[level] : undefined;
   if (effort === undefined) return handler;
 
   logger.debug(
@@ -85,15 +82,11 @@ function shouldUseResponsesAPI(
   if (config.provider !== ModelProvider.OPENAI || config.openRouterOnly) {
     return false;
   }
-  if (config.requiresResponsesAPI) {
-    return true;
-  }
-  if (useOpenRouter) {
-    return false;
-  }
   return (
-    getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
-    config.fullName.startsWith('gpt-oss')
+    config.requiresResponsesAPI ||
+    (!useOpenRouter &&
+      (getConfig<boolean>('texra.model.useOpenAIResponsesAPI', false) ||
+        config.fullName.startsWith('gpt-oss')))
   );
 }
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -446,12 +446,12 @@ function buildFallbackNotification(config: AgentConfig) {
     ? path.basename(config.inputFile)
     : 'selected input';
   const { outputFiles = [], useMultipleOutputs } = config;
-  let outputInfo: string;
-  if (useMultipleOutputs && outputFiles.length > 1) {
-    outputInfo = `to ${outputFiles.length} files`;
-  } else {
-    outputInfo = outputFiles[0] ? `to ${path.basename(outputFiles[0])}` : '';
-  }
+  const outputInfo =
+    useMultipleOutputs && outputFiles.length > 1
+      ? `to ${outputFiles.length} files`
+      : outputFiles[0]
+        ? `to ${path.basename(outputFiles[0])}`
+        : '';
   return {
     agentName: config.agent,
     modelName: config.model,
@@ -484,8 +484,8 @@ async function resolveAndAcquireStream(
     // Direct resolution with known stream ID (e.g., resume from snapshot)
     return resolveAgentBase(configPayload, executionId, {
       streamTabIdOverride: options.streamTabIdOverride,
-      onBeforeActivation: options?.onBeforeActivation,
-      enforceCategory: options?.enforceCategory,
+      onBeforeActivation: options.onBeforeActivation,
+      enforceCategory: options.enforceCategory,
     });
   }
 
@@ -577,19 +577,14 @@ export async function executeAgent(
     enforceCategory: options?.enforceCategory,
   });
   const { setting, streamId, config } = ctx;
-  const agentName = config.agent;
-
-  const isSubagent = options?.isSubagent;
+  const { agent: agentName } = config;
+  const { isSubagent } = options ?? {};
 
   // Fire-and-forget: generate AI session description from the user's instruction.
   // Triggered at the start so cancelled/errored sessions still get descriptions.
   // Applies to all agents including subagents so their progress tabs show
   // meaningful descriptions in multi-agent pipelines.
   generateSessionDescription(ctx.executionId, streamId, config).catch(() => {});
-  const category =
-    setting.agentCategory === AgentCategory.ToolUse
-      ? ('toolUse' as const)
-      : ('workflow' as const);
   return runFlowWithLifecycle(
     ctx,
     streamId,
@@ -694,7 +689,10 @@ export async function executeAgent(
     },
     {
       isSubagent,
-      category,
+      category:
+        setting.agentCategory === AgentCategory.ToolUse
+          ? 'toolUse'
+          : 'workflow',
       parentStreamId: options?.parentStreamId,
       onCompleted: options?.onCompleted,
     },

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -16,7 +16,7 @@ import {
   collectChildSummary,
   emitActiveSubagentsUpdate,
   emitActiveProcessesUpdate,
-  interruptActiveChildren as interruptActiveChildrenImpl,
+  interruptActiveChildren as interruptChildren,
 } from './ExecutionHandle';
 
 export type { ExecutionHandle } from './ExecutionHandle';
@@ -236,7 +236,7 @@ export function waitForAnyExecutionChange(
  * promptly instead of running to completion.
  */
 export function interruptActiveChildren(parentStreamId: StreamTabId): void {
-  interruptActiveChildrenImpl(parentStreamId, registry.values());
+  interruptChildren(parentStreamId, registry.values());
 }
 
 /**

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -42,9 +42,7 @@ export type HelperModelResult =
  */
 export function getHelperModelName(): string {
   const configuredModel = globalSM.get<string>(GlobalStateKey.HELPER_MODEL);
-  const userExplicitlySet = isNonEmptyString(configuredModel);
-
-  if (!userExplicitlySet) {
+  if (!isNonEmptyString(configuredModel)) {
     return DEFAULT_HELPER_MODEL;
   }
 
@@ -58,8 +56,9 @@ export function getHelperModelName(): string {
     GlobalStateKey.ENABLED_MODELS,
     [],
   );
-  if (enabledModels.length === 0) return resolved;
-  if (enabledModels.includes(resolved)) return resolved;
+  if (enabledModels.length === 0 || enabledModels.includes(resolved)) {
+    return resolved;
+  }
   return enabledModels[0];
 }
 

--- a/src/agent/toolUse/FollowUpQueue.ts
+++ b/src/agent/toolUse/FollowUpQueue.ts
@@ -9,16 +9,11 @@ export class FollowUpQueue {
   private readonly queued: string[] = [];
   private resolver: ((value: string | null) => void) | null = null;
 
-  /** Resolves pending wait with value and clears resolver */
-  private resolveWait(value: string | null): void {
-    const resolver = this.resolver;
-    this.resolver = null;
-    resolver?.(value);
-  }
-
   enqueue(value: string): void {
     if (this.resolver) {
-      this.resolveWait(value);
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve(value);
     } else {
       this.queued.push(value);
     }
@@ -33,7 +28,7 @@ export class FollowUpQueue {
   }
 
   waitForNext(checkInterruption: () => boolean): Promise<string | null> {
-    if (!this.isEmpty()) {
+    if (this.queued.length > 0) {
       return Promise.resolve(this.queued.shift()!);
     }
     if (checkInterruption()) {
@@ -46,40 +41,28 @@ export class FollowUpQueue {
 
   /**
    * Wait for at least one item, then drain all available.
-   * Returns all queued items as an array.
+   * Returns null if interrupted.
    */
   async waitAndDrainAll(
     checkInterruption: () => boolean,
   ): Promise<string[] | null> {
     const first = await this.waitForNext(checkInterruption);
-    if (first === null) {
-      return null;
-    }
-    // Drain any additional items that arrived while waiting
-    const rest = this.drain();
-    if (rest.length === 0) {
-      return [first];
-    }
-    return [first, ...rest];
+    if (first === null) return null;
+    return [first, ...this.drain()];
   }
 
   cancelWait(): void {
-    this.resolveWait(null);
-  }
-
-  clear(): void {
-    this.queued.length = 0;
+    const resolve = this.resolver;
+    this.resolver = null;
+    resolve?.(null);
   }
 
   dispose(): void {
     this.cancelWait();
-    this.clear();
+    this.queued.length = 0;
   }
 
-  /**
-   * Get a copy of all queued items for display purposes.
-   * This doesn't modify the queue.
-   */
+  /** Get a copy of all queued items for display purposes. */
   getAll(): string[] {
     return [...this.queued];
   }

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -31,15 +31,11 @@ const logger = new AgentLogger('ToolUseFollowUp');
  * Send a follow-up message to a tool-use session.
  *
  * Routes based on session state:
- * 1. Active agent: direct append → returns { status: 'sent' }
- * 2. Resuming/Waiting session: queue for later → returns { status: 'queued' }
- * 3. Error during send → returns { status: 'error' }
- * 4. No session found → returns { status: 'no_session' }
+ * 1. Active agent: direct append → { status: 'sent' }
+ * 2. Resuming/Waiting session: queue for later → { status: 'queued' }
+ * 3. No session found → { status: 'no_session' }
  *
- * Note: Items queued for WAITING sessions are picked up when user resumes.
- * PersistedFlow handles state persistence.
- *
- * @returns Result indicating what happened - callers handle UI notifications
+ * Items queued for WAITING sessions are picked up when user resumes.
  */
 export async function sendFollowUp(
   streamId: StreamTabId,
@@ -48,15 +44,8 @@ export async function sendFollowUp(
   // Try active flow context first
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
-    try {
-      flowContext.session.appendFollowUp(text);
-      return { status: 'sent' };
-    } catch (error) {
-      logger.error('Failed to send follow-up to active session.', {
-        data: error,
-      });
-      return { status: 'error', message: (error as Error).message };
-    }
+    flowContext.session.appendFollowUp(text);
+    return { status: 'sent' };
   }
 
   // Queue if session is resuming

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -23,11 +23,10 @@ export class ToolUseFollowUpQueue {
 
   static acquire(streamId: StreamTabId): FollowUpQueue {
     this.released.delete(streamId);
-    let queue = this.queues.get(streamId);
-    if (!queue) {
-      queue = new FollowUpQueue();
-      this.queues.set(streamId, queue);
-    }
+    const existing = this.queues.get(streamId);
+    if (existing) return existing;
+    const queue = new FollowUpQueue();
+    this.queues.set(streamId, queue);
     return queue;
   }
 
@@ -73,19 +72,10 @@ export class ToolUseFollowUpQueue {
   }
 
   static drain(streamId: StreamTabId): string[] {
-    const queue = this.queues.get(streamId);
-    if (!queue) return [];
-    const drained = queue.drain();
-    logger.debug(
-      `Drained ${drained.length} queued follow-ups for stream ${streamId}.`,
-    );
-    return drained;
+    return this.queues.get(streamId)?.drain() ?? [];
   }
 
-  /**
-   * Get all queued follow-up messages for a stream without consuming them.
-   * Used for UI display purposes.
-   */
+  /** Get all queued follow-up messages for a stream without consuming them. */
   static getAll(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.getAll() ?? [];
   }

--- a/src/agent/types/NormalizedUsage.ts
+++ b/src/agent/types/NormalizedUsage.ts
@@ -1,17 +1,12 @@
 /**
  * Unified usage statistics - the ONLY type used after API response extraction.
  * All model handlers normalize their provider-specific usage to this format.
- *
- * This provides a single source of truth for usage tracking across all providers.
  */
 import { z } from 'zod';
 
-// Local imports - single source of truth for base usage stats
 import { TokenUsageStatsSchema } from '@shared/schemas';
 
-/**
- * Provider identifiers for usage tracking - single source of truth.
- */
+/** Provider identifiers for usage tracking. */
 export const UsageProviderSchema = z.enum([
   'anthropic',
   'openai',
@@ -29,11 +24,7 @@ export const UsageProviderSchema = z.enum([
 
 export type UsageProvider = z.infer<typeof UsageProviderSchema>;
 
-/**
- * Normalized usage statistics from any model provider.
- * Extends TokenUsageStatsSchema (single source of truth) with provider-specific fields.
- * Cost is computed once during normalization and never recomputed.
- */
+/** Normalized usage statistics from any model provider. */
 export const NormalizedUsageSchema = TokenUsageStatsSchema.extend({
   /** Response time in milliseconds */
   responseTimeMs: z.number(),

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -196,10 +196,10 @@ export class ServerSideKeyService {
       return false;
     }
 
-    const tierConfigAvailable =
-      this.hasFullAccess() || this.tierService.getConfigSync() !== null;
-
-    if (this.isAccessCacheValid() && tierConfigAvailable) {
+    if (
+      this.isAccessCacheValid() &&
+      (this.hasFullAccess() || this.tierService.getConfigSync() !== null)
+    ) {
       return this.accessFetchPromise!;
     }
 
@@ -252,25 +252,20 @@ export class ServerSideKeyService {
   }
 
   shouldUseServerSideKeysSync(provider: string, modelName?: string): boolean {
-    const settingEnabled = this.getUseIncludedModelAccess();
-    const providerAvailable = this.isProviderOnServer(provider.toLowerCase());
-    const hasAccess = this.accessResult === true;
-
-    if (!settingEnabled || !providerAvailable || !hasAccess) {
+    if (
+      !this.getUseIncludedModelAccess() ||
+      !this.isProviderOnServer(provider.toLowerCase()) ||
+      !this.accessResult
+    ) {
       return false;
     }
-
     return modelName ? this.canUseModelSync(modelName) : this.hasFullAccess();
   }
 
   /** Returns null if all models allowed (Ultra), empty array if no access. */
   getAllowedModelsForCurrentUser(): string[] | null {
-    if (!this.userTier) {
-      return [];
-    }
-    if (this.hasFullAccess()) {
-      return null;
-    }
+    if (!this.userTier) return [];
+    if (this.hasFullAccess()) return null;
     return this.tierService.getAllowedModels(this.userTier);
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,11 +334,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
   disposeStatusListener?.();
-  await UsageLogService.dispose();
-  await progressViewProviderInstance?.flushState();
-
   killBackgroundProcesses();
   killActiveRecording();
+
+  await UsageLogService.dispose();
+  await progressViewProviderInstance?.flushState();
 
   clearStoreCache();
   bus.emit('extensionDeactivating', undefined);

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -1,10 +1,7 @@
-// Standard library imports
 import * as path from 'path';
 
-// Third-party imports
 import * as vscode from 'vscode';
 
-// Local imports - log
 import {
   getIncludedExtensions,
   ExtensionCategory,
@@ -13,7 +10,6 @@ import * as logger from '@logger/logUtils';
 import { getConfig, watchConfig } from '@utils/config';
 import { WorkspaceFS } from '@utils/files';
 
-// Local file imports
 import { getFilesRecursively } from './listing';
 
 const CHANNEL = 'FileLister';

--- a/src/frontend/git/gitAuthorSetup.ts
+++ b/src/frontend/git/gitAuthorSetup.ts
@@ -37,16 +37,16 @@ export function applyGitAuthorConfig(): ReturnType<
   typeof readGitAuthorSettings
 > {
   const settings = readGitAuthorSettings();
-  const { markCommits, authorName, authorEmail } = settings;
-  if (!markCommits) {
+  if (!settings.markCommits) {
     setGitAuthorEnv({});
-    return settings;
+  } else {
+    const { authorName, authorEmail } = settings;
+    setGitAuthorEnv({
+      GIT_AUTHOR_NAME: authorName,
+      GIT_AUTHOR_EMAIL: authorEmail,
+      GIT_COMMITTER_NAME: authorName,
+      GIT_COMMITTER_EMAIL: authorEmail,
+    });
   }
-  setGitAuthorEnv({
-    GIT_AUTHOR_NAME: authorName,
-    GIT_AUTHOR_EMAIL: authorEmail,
-    GIT_COMMITTER_NAME: authorName,
-    GIT_COMMITTER_EMAIL: authorEmail,
-  });
   return settings;
 }

--- a/src/frontend/media/audio.ts
+++ b/src/frontend/media/audio.ts
@@ -1,7 +1,5 @@
-// Standard library imports
 import * as path from 'path';
 
-// Third-party imports
 import * as vscode from 'vscode';
 import { execa, type Subprocess } from 'execa';
 import { MODEL_CONFIGS } from 'llm-zoo';
@@ -53,15 +51,14 @@ export async function startRecording(
     }
 
     const soxPath = resolveSoxPath();
-    const soxInstalled = await checkToolInstalled('sox', false);
-
-    if (!soxInstalled && !soxPath) {
-      return {
-        success: false,
-        error: 'Sox is required for audio recording. Please install it first.',
-      };
-    }
-    if (!soxInstalled && soxPath) {
+    if (!(await checkToolInstalled('sox', false))) {
+      if (!soxPath) {
+        return {
+          success: false,
+          error:
+            'Sox is required for audio recording. Please install it first.',
+        };
+      }
       logger.warn(CHANNEL, `Sox check failed but found at: ${soxPath}`);
     }
 

--- a/src/frontend/secretManager.ts
+++ b/src/frontend/secretManager.ts
@@ -74,15 +74,13 @@ export class SecretManager {
   }
 
   public static async anyApiKeyExists(): Promise<boolean> {
-    // Check all local API keys in parallel
     const keyChecks = await Promise.all(
       this.API_PROVIDERS.map((provider) => this.apiKeyExists(provider)),
     );
-    if (keyChecks.some(Boolean)) {
-      return true;
-    }
-    // Fall back to server-side keys (Ultra tier + enabled providers)
-    return getServerSideKeyService().canUseServerSideKeys();
+    return (
+      keyChecks.some(Boolean) ||
+      getServerSideKeyService().canUseServerSideKeys()
+    );
   }
 
   public static async apiKeyExists(provider: ApiProvider): Promise<boolean> {

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -74,19 +74,14 @@ export async function indentLatexFilesInDirectory(
   }
 
   try {
-    // Format .tex files (runLatexFormatter handles backup cleanup internally)
     await walkDirectory(directory, async (fullPath, name) => {
-      if (!hasExtension(name, '.tex')) {
-        return;
-      }
-      if (progressCallback) {
-        progressCallback(`Indenting ${path.basename(fullPath)}...`, 0);
-      }
+      if (!hasExtension(name, '.tex')) return;
 
+      progressCallback?.(`Indenting ${path.basename(fullPath)}...`, 0);
       logger.debug(CHANNEL, `Processing file: ${fullPath}`);
+
       try {
-        const success = await runLatexFormatter(fullPath);
-        if (success) {
+        if (await runLatexFormatter(fullPath)) {
           logger.info(CHANNEL, `Successfully formatted: ${fullPath}`);
           indentedCount++;
         } else {

--- a/src/housekeeping/utils.ts
+++ b/src/housekeeping/utils.ts
@@ -13,8 +13,6 @@ const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
 
 export function getAgentFirstNameChunk(agent: string): string {
-  // Extract clean agent name (strip source: prefix if present)
-  // Handles all agent sources: custom, local, remote, builtIn, builtInToolUse
   const cleanAgent = getCleanAgentName(agent);
 
   if (cleanAgent.startsWith('write-')) {
@@ -33,22 +31,23 @@ export function getFilePatterns(
   numRounds: number = 3,
 ): string[] {
   const patterns: string[] = [];
-  const agentFirstNameChunk = getAgentFirstNameChunk(agent);
+  const chunk = getAgentFirstNameChunk(agent);
 
   for (let round = 0; round < numRounds; round++) {
+    const prefix = `${base}_${chunk}_r${round}`;
     patterns.push(
-      `${base}_${agentFirstNameChunk}_r${round}_${model}`,
-      `${base}_${agentFirstNameChunk}_r${round}_${model}_diff`,
-      `${base}_${agentFirstNameChunk}_r${round}_full_${model}`,
-      `${base}_${agentFirstNameChunk}_r${round}_full_${model}_diff`,
-      `${base}_${agentFirstNameChunk}_r${round}_${model}_thinking`,
+      `${prefix}_${model}`,
+      `${prefix}_${model}_diff`,
+      `${prefix}_full_${model}`,
+      `${prefix}_full_${model}_diff`,
+      `${prefix}_${model}_thinking`,
     );
 
-    // Only add diff patterns for rounds > 0 to avoid negative references
     if (round > 0) {
+      const diffSuffix = `_diffr${round}r${round - 1}`;
       patterns.push(
-        `${base}_${agentFirstNameChunk}_r${round}_${model}_diffr${round}r${round - 1}`,
-        `${base}_${agentFirstNameChunk}_r${round}_full_${model}_diffr${round}r${round - 1}`,
+        `${prefix}_${model}${diffSuffix}`,
+        `${prefix}_full_${model}${diffSuffix}`,
       );
     }
   }
@@ -79,26 +78,26 @@ export function findFilesFromPatterns(
 
   for (const pattern of patterns) {
     for (const ext of extensions) {
-      const bracePattern = `${pattern}${ext}`;
       const isGlob = ext.includes('*');
       for (const dir of searchDirs) {
-        const matches = globSync(path.join(dir, bracePattern), {
+        const matches = globSync(path.join(dir, `${pattern}${ext}`), {
           nodir: true,
         });
-        if (matches.length > 0) {
-          if (isGlob) {
-            for (const match of matches) {
-              results.add(WorkspaceFS.relativePath(match));
-            }
-          } else {
-            results.add(WorkspaceFS.relativePath(matches[0]));
-            break;
+        if (matches.length === 0) continue;
+
+        if (isGlob) {
+          for (const match of matches) {
+            results.add(WorkspaceFS.relativePath(match));
           }
+        } else {
+          results.add(WorkspaceFS.relativePath(matches[0]));
+          break;
         }
       }
     }
   }
 
-  logger.debug(CHANNEL, `Found files: ${[...results].join(', ')}`);
-  return [...results];
+  const found = [...results];
+  logger.debug(CHANNEL, `Found files: ${found.join(', ')}`);
+  return found;
 }

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -75,21 +75,10 @@ export class ArxivSourceProcessor {
     return this.isValidId(normalized) ? normalized : null;
   }
 
-  /**
-   * Validate input that may be a URL or plain arXiv ID.
-   * @returns Error message if invalid, null if valid
-   */
+  /** @returns Error message if invalid, null if valid */
   public validateId(input: string): string | null {
-    if (!input) {
-      return 'arXiv ID or URL is required';
-    }
-
-    const normalized = this.normalizeInput(input);
-    if (!normalized) {
-      return INVALID_ARXIV_INPUT_ERROR;
-    }
-
-    return null;
+    if (!input) return 'arXiv ID or URL is required';
+    return this.normalizeInput(input) ? null : INVALID_ARXIV_INPUT_ERROR;
   }
 
   public async downloadFile(
@@ -250,8 +239,6 @@ export class ArxivSourceProcessor {
         downloadedPath.endsWith('.tar') ||
         downloadedPath.endsWith('.tar.gz') ||
         downloadedPath.endsWith('.tgz');
-
-      // Detect gzip-compressed single files (.gz but not .tar.gz/.tgz)
       const isGzipOnly = !isArchive && downloadedPath.endsWith('.gz');
 
       if (isArchive) {

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -1,10 +1,7 @@
-// Standard library imports
 import * as path from 'path';
 
-// Third-party imports
 import { sync as globSync } from 'glob';
 
-// Local imports - log
 import { isFileNotFoundError, toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
@@ -33,24 +30,25 @@ async function cleanupBackupFiles(
   fileBaseName: string,
   fileDir: string,
 ): Promise<void> {
-  const backupPatterns = [
+  const backupFiles = [
     `${fileBaseName}.tex.bak*`,
     `${fileBaseName}.bak*`,
-  ].map((pattern) => path.join(fileDir, pattern).replaceAll('\\', '/'));
+  ].flatMap((pattern) =>
+    globSync(path.join(fileDir, pattern).replaceAll('\\', '/'), {
+      nodir: true,
+    }),
+  );
 
-  for (const pattern of backupPatterns) {
-    const backupFiles = globSync(pattern, { nodir: true });
-    for (const backupFile of backupFiles) {
-      try {
-        await AbsoluteFS.delete(backupFile);
-        logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
-      } catch (err) {
-        if (!isFileNotFoundError(err)) {
-          logger.warn(
-            CHANNEL,
-            `Error removing backup file ${backupFile}: ${err}`,
-          );
-        }
+  for (const backupFile of backupFiles) {
+    try {
+      await AbsoluteFS.delete(backupFile);
+      logger.debug(CHANNEL, `Removed backup file: ${backupFile}`);
+    } catch (err) {
+      if (!isFileNotFoundError(err)) {
+        logger.warn(
+          CHANNEL,
+          `Error removing backup file ${backupFile}: ${err}`,
+        );
       }
     }
   }
@@ -85,7 +83,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
       channel: CHANNEL,
       showError: showWarning,
     });
-    const success = result !== false && result?.success;
+    const success = Boolean(result && result.success);
 
     if (success) {
       // Wait a moment for the file system to stabilize after a successful write

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -89,14 +89,14 @@ async function hasPersonalKeyForModel(
   hasOpenRouter: boolean,
 ): Promise<boolean> {
   if (config.openRouterOnly) return hasOpenRouter;
-  if (!SecretManager.API_PROVIDERS.includes(config.provider as ApiProvider)) {
-    return true;
-  }
+
+  const provider = config.provider as ApiProvider;
+  if (!SecretManager.API_PROVIDERS.includes(provider)) return true;
 
   try {
     return (
-      (await SecretManager.apiKeyExists(config.provider as ApiProvider)) ||
-      Boolean(config.openrouterFullName && hasOpenRouter)
+      (await SecretManager.apiKeyExists(provider)) ||
+      !!(config.openrouterFullName && hasOpenRouter)
     );
   } catch {
     return false;
@@ -243,32 +243,21 @@ export function invalidateModelOptionsCache(): void {
 
 /** Compute typed model options data for Lit-native rendering. */
 export async function computeModelOptionsData(): Promise<ModelOptionData[]> {
-  // Return cached result if still valid.
-  if (_resolved && Date.now() < _resolved.expiry) {
-    return _resolved.data;
-  }
+  if (_resolved && Date.now() < _resolved.expiry) return _resolved.data;
+  if (_pending) return _pending;
 
-  // Dedup concurrent callers — share the same in-flight promise.
-  if (_pending) {
-    return _pending;
-  }
-
-  const thisRequest = computeModelOptionsDataUncached();
-  _pending = thisRequest;
+  const request = computeModelOptionsDataUncached();
+  _pending = request;
 
   try {
-    const data = await thisRequest;
+    const data = await request;
     // Only populate cache if no invalidation occurred while we were awaiting.
-    // invalidateModelOptionsCache() sets _pending = null, so comparing against
-    // thisRequest detects concurrent invalidation.
-    if (_pending === thisRequest) {
+    if (_pending === request) {
       _resolved = { data, expiry: Date.now() + MODEL_OPTIONS_CACHE_TTL_MS };
     }
     return data;
   } finally {
-    if (_pending === thisRequest) {
-      _pending = null;
-    }
+    if (_pending === request) _pending = null;
   }
 }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -405,15 +405,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
 
     // Stop all running agents before clearing coordinator state
-    const stopPromises: Promise<void>[] = [];
-    for (const streamId of this.provider.state.streamLogs.keys()) {
-      stopPromises.push(
-        Promise.resolve(
+    await Promise.allSettled(
+      this.provider.state.streamLogs
+        .keys()
+        .map((streamId) =>
           vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
         ),
-      );
-    }
-    await Promise.allSettled(stopPromises);
+    );
 
     // Clear approvals, retry requests, queued follow-ups, and YOLO state
     cleanupAllApprovals();

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -272,13 +272,13 @@ export class ProgressEventHandler {
     this.state.streamLogs.ensureStream(streamId);
     // Only pass defined hint fields — spreading {key: undefined} over existing
     // hints would clear previously-set values (isRemote, hasMultipleOutputs).
-    const hints = Object.fromEntries(
-      Object.entries({
+    const hints = {
+      ...(payload.agentCategory !== undefined && {
         agentCategory: payload.agentCategory,
-        isRemote,
-        hasMultipleOutputs,
-      }).filter(([, v]) => v !== undefined),
-    );
+      }),
+      ...(isRemote !== undefined && { isRemote }),
+      ...(hasMultipleOutputs !== undefined && { hasMultipleOutputs }),
+    };
     if (Object.keys(hints).length > 0) {
       this.state.updateStreamHints(streamId, hints);
     }
@@ -405,19 +405,12 @@ export class ProgressEventHandler {
 
   private flushProgressUpdates(): void {
     this.progressThrottleTimer = null;
-    if (
-      this.pendingProgressUpdates.size === 0 ||
-      !this.webviewUpdater.isAvailable()
-    ) {
-      this.pendingProgressUpdates.clear();
-      return;
-    }
 
     const { activeStream } = this.state;
     const progress = activeStream
       ? this.pendingProgressUpdates.get(activeStream)
       : undefined;
-    if (activeStream && progress) {
+    if (progress && this.webviewUpdater.isAvailable()) {
       this.webviewUpdater.updateConversationProgress(activeStream, progress);
     }
     this.pendingProgressUpdates.clear();
@@ -659,20 +652,16 @@ export class ProgressEventHandler {
       StreamStatusService.set(streamId, status, { emit: false });
     }
 
-    if (!this.webviewUpdater.isAvailable()) {
-      return;
-    }
+    if (!this.webviewUpdater.isAvailable()) return;
 
-    const streamExists = this.state.streamLogs.has(streamId);
-    if (!streamExists) {
-      this.state.streamLogs.ensureStream(streamId);
-    }
+    const isNewStream = !this.state.streamLogs.has(streamId);
+    this.state.streamLogs.ensureStream(streamId);
     // Persisted streams may be in stream logs but missing from _streamStates;
     // getOrCreateStreamState is idempotent so safe to call unconditionally.
     const category = this.getStreamCategory(streamId) ?? AgentCategory.Workflow;
     this.state.getOrCreateStreamState(streamId, category);
 
-    if (!streamExists) {
+    if (isNewStream) {
       this.maybeUpdateFilterForCategory(this.getStreamCategory(streamId));
       const statusesForRefresh = StreamStatusService.getAll();
       statusesForRefresh.set(streamId, status);
@@ -697,12 +686,11 @@ export class ProgressEventHandler {
 
   resetRunningTasksToError(waitingStreams: Set<StreamTabId>): StreamTabId[] {
     const affectedStreams: StreamTabId[] = [];
-    const waitingSet = waitingStreams;
 
     for (const [streamId, status] of StreamStatusService.entries()) {
       if (status !== STREAM_STATUS.RUNNING) continue;
 
-      if (waitingSet.has(streamId)) {
+      if (waitingStreams.has(streamId)) {
         StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
           emit: false,
         });

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -304,12 +304,11 @@ export class BackgroundTasksPanel extends LitElement {
   ): TemplateResult {
     const icon = getTaskIcon(child, kind);
     const entry = this.processOutputs.get(child.executionId);
-    const hasStdout = Boolean(entry?.stdout);
-    const hasStderr = Boolean(entry?.stderr);
     const isClickable = kind === 'subagent' && Boolean(child.childStreamId);
     const description = child.childStreamId
       ? this.descriptions.get(child.childStreamId)
       : undefined;
+    const waiting = isWaiting(child);
 
     return html`
       <div class="task-item">
@@ -357,17 +356,17 @@ export class BackgroundTasksPanel extends LitElement {
           <span
             class=${classMap({
               'tinted-badge': true,
-              'tinted-badge--running': !isWaiting(child),
-              'tinted-badge--waiting': isWaiting(child),
+              'tinted-badge--running': !waiting,
+              'tinted-badge--waiting': waiting,
             })}
-            >${isWaiting(child) ? 'waiting' : 'running'}</span
+            >${waiting ? 'waiting' : 'running'}</span
           >
         </div>
-        ${hasStdout
-          ? this.renderOutputStream('stdout', entry!.stdout)
+        ${entry?.stdout
+          ? this.renderOutputStream('stdout', entry.stdout)
           : nothing}
-        ${hasStderr
-          ? this.renderOutputStream('stderr', entry!.stderr)
+        ${entry?.stderr
+          ? this.renderOutputStream('stderr', entry.stderr)
           : nothing}
       </div>
     `;

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -179,11 +179,7 @@ export class PlanView extends LitElement {
       return;
     }
     if (changed.has('plan')) {
-      if (this.plan) {
-        this.open = true;
-      } else {
-        this.open = false;
-      }
+      this.open = Boolean(this.plan);
     }
   }
 

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -117,11 +117,7 @@ export class TodoList extends LitElement {
       return;
     }
     if (changed.has('todos')) {
-      if (this.todos.length > 0) {
-        this.open = true;
-      } else {
-        this.open = false;
-      }
+      this.open = this.todos.length > 0;
     }
   }
 

--- a/src/progressView/frontend/formatters/constants.ts
+++ b/src/progressView/frontend/formatters/constants.ts
@@ -6,8 +6,6 @@
 import type { LogLevel } from '@shared/schemas';
 import { getBasename } from '@shared/utils/path';
 
-// Local imports - shared utilities
-
 export const EMOJI_BY_LEVEL: Record<LogLevel, string> = {
   error: '🔴',
   warn: '🟡',

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -26,8 +26,8 @@ import type {
   WorkflowAgentInput,
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import type { CodexInput } from '@tools/codex';
+import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 
 // Local imports - Lit template utilities
 import {
@@ -102,23 +102,16 @@ function getToolTimeoutMs(
 ): number | undefined {
   const defaultTimeout = TOOL_DEFAULT_TIMEOUTS[toolName];
   if (defaultTimeout === undefined) return undefined;
+  if (!isPlainObject(input)) return defaultTimeout;
 
   // Some tools only have a meaningful timeout for a specific action
   const requiredAction = TIMEOUT_GATED_BY_ACTION[toolName];
-  if (
-    requiredAction &&
-    isPlainObject(input) &&
-    input.action !== requiredAction
-  ) {
-    return undefined;
-  }
+  if (requiredAction && input.action !== requiredAction) return undefined;
 
   // Background tools return immediately — timeout timer is misleading
-  if (isPlainObject(input) && input.run_in_background === true) {
-    return undefined;
-  }
+  if (input.run_in_background === true) return undefined;
 
-  if (isPlainObject(input) && typeof input.timeout === 'number') {
+  if (typeof input.timeout === 'number') {
     return TIMEOUT_IN_SECONDS.has(toolName)
       ? input.timeout * 1000
       : input.timeout;
@@ -128,7 +121,7 @@ function getToolTimeoutMs(
 
 /** Truncate a prompt string for display in collapsed headers. */
 function truncatePrompt(text: string, maxLength: number): string {
-  const oneLine = text.replace(/\s+/g, ' ').trim();
+  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
   if (oneLine.length <= maxLength) return oneLine;
   return oneLine.slice(0, maxLength - 1) + '…';
 }
@@ -173,10 +166,7 @@ function buildBannerContent(
 
 /** Extract typed edits array from parsed tool output, if present. */
 function getOutputEdits<T>(output: unknown): T[] | undefined {
-  if (output && typeof output === 'object' && 'edits' in output) {
-    return (output as { edits?: T[] }).edits;
-  }
-  return undefined;
+  return isPlainObject(output) ? (output.edits as T[] | undefined) : undefined;
 }
 
 type ToolSectionOptions = {
@@ -258,15 +248,19 @@ export function formatToolUseTemplate(
   const titleBase = toolName || 'tool';
 
   // Surface action + path for executions tool so it's visible without expanding
-  const headerSummary =
-    normalizedToolLog.headerSummary ||
-    (toolName === 'executions' && isPlainObject(input)
-      ? `${input.action ?? EXECUTIONS_DEFAULT_ACTION} ${input.path ?? ''}`.trim()
-      : toolName === 'codex' &&
-          isPlainObject(input) &&
-          typeof input.prompt === 'string'
-        ? truncatePrompt(input.prompt, 60)
-        : '');
+  let headerSummary = normalizedToolLog.headerSummary || '';
+  if (!headerSummary) {
+    if (toolName === 'executions' && isPlainObject(input)) {
+      headerSummary =
+        `${input.action ?? EXECUTIONS_DEFAULT_ACTION} ${input.path ?? ''}`.trim();
+    } else if (
+      toolName === 'codex' &&
+      isPlainObject(input) &&
+      typeof input.prompt === 'string'
+    ) {
+      headerSummary = truncatePrompt(input.prompt, 60);
+    }
+  }
   const titleText = headerSummary
     ? `${titleBase} — ${headerSummary}`
     : titleBase;
@@ -275,9 +269,7 @@ export function formatToolUseTemplate(
   const sections: TemplateResult[] = [];
 
   const filePath =
-    isPlainObject(input) && 'path' in input
-      ? String((input as { path?: string }).path ?? '')
-      : '';
+    isPlainObject(input) && typeof input.path === 'string' ? input.path : '';
 
   // Handle edit tools with diff display
   if (TOOLS_WITH_DIFF_INPUT.has(toolName) && isPlainObject(input)) {

--- a/src/progressView/managers/StreamMetaManager.ts
+++ b/src/progressView/managers/StreamMetaManager.ts
@@ -97,11 +97,11 @@ export class StreamMetaManager {
 
   /** Return stream IDs with active tool-use sessions. */
   getActiveToolUseStreams(): Set<StreamTabId> {
-    const result = new Set<StreamTabId>();
-    for (const [stream, state] of this.taskStates) {
-      if (isToolUseTaskState(state)) result.add(stream);
-    }
-    return result;
+    return new Set(
+      [...this.taskStates]
+        .filter(([, state]) => isToolUseTaskState(state))
+        .map(([stream]) => stream),
+    );
   }
 
   // -- Lifecycle --------------------------------------------------------------
@@ -156,22 +156,13 @@ export class StreamMetaManager {
           skippedTasks++;
         }
       }
-
-      if (meta.executionId) {
+      if (meta.executionId)
         this.executionIds.set(streamId, meta.executionId as ExecutionId);
-      }
-
-      if (meta.activeRunId) {
+      if (meta.activeRunId)
         this.activeRunIds.set(streamId, normalizeRunId(meta.activeRunId));
-      }
-
-      if (meta.parentStreamId) {
+      if (meta.parentStreamId)
         this.parentStreamIds.set(streamId, meta.parentStreamId as StreamTabId);
-      }
-
-      if (meta.description) {
-        this.descriptions.set(streamId, meta.description);
-      }
+      if (meta.description) this.descriptions.set(streamId, meta.description);
     }
 
     // Backfill: streams with an executionId but no description in StreamTabMeta
@@ -261,23 +252,18 @@ export class StreamMetaManager {
   }
 
   private buildMeta(stream: StreamTabId): StreamTabMeta {
-    const meta: StreamTabMeta = {};
-
     const taskState = this.taskStates.get(stream);
-    if (taskState) meta.taskState = taskState;
-
     const executionId = this.executionIds.get(stream);
-    if (executionId) meta.executionId = executionId;
-
     const activeRunId = this.activeRunIds.get(stream);
-    if (activeRunId != null) meta.activeRunId = activeRunId;
-
     const parentStreamId = this.parentStreamIds.get(stream);
-    if (parentStreamId) meta.parentStreamId = parentStreamId;
-
     const description = this.descriptions.get(stream);
-    if (description) meta.description = description;
 
-    return meta;
+    return {
+      ...(taskState && { taskState }),
+      ...(executionId && { executionId }),
+      ...(activeRunId != null && { activeRunId }),
+      ...(parentStreamId && { parentStreamId }),
+      ...(description && { description }),
+    };
   }
 }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -64,6 +64,7 @@ import {
   dispatchSettingsViewInbound,
   type SettingsViewInboundHandlerRegistry,
   type SettingsViewInboundMessage,
+  type SettingsMessageFor,
   SETTINGS_VIEW_CMD,
   ReasoningLevelSchema,
   type ModelSelectionItem,
@@ -121,11 +122,9 @@ import { AgentHandlers } from './handlers/agentHandlers';
 import { LatexSettingsHandlers } from './handlers/latexSettingsHandlers';
 import type { SettingsHandlerContext } from './handlers/SettingsHandlerContext';
 
-// Type helper for extracting specific message types
-type MessageFor<C extends SettingsViewInboundMessage['command']> = Extract<
-  SettingsViewInboundMessage,
-  { command: C }
->;
+// Re-use the shared type helper for extracting specific message types.
+type MessageFor<C extends SettingsViewInboundMessage['command']> =
+  SettingsMessageFor<C>;
 
 /** Reliability settings surfaced in the Multi-Agent tab. */
 const RELIABILITY_SETTINGS: (Omit<NumberVscodeSetting, 'value'> & {
@@ -193,14 +192,11 @@ async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
       );
       const envValue = process.env[`${provider.toUpperCase()}_API_KEY`];
 
-      let status: ProviderKeyStatus['status'];
-      if (secretValue) {
-        status = 'set';
-      } else if (envValue) {
-        status = 'env';
-      } else {
-        status = 'not-set';
-      }
+      const status: ProviderKeyStatus['status'] = secretValue
+        ? 'set'
+        : envValue
+          ? 'env'
+          : 'not-set';
 
       return {
         provider,
@@ -373,8 +369,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleSetGlobalStreaming(data),
       [SETTINGS_VIEW_COMMANDS.SET_PROVIDER_VSCODE_SETTING]: (data) =>
         this.handleSetProviderVscodeSetting(data),
-      [SETTINGS_VIEW_COMMANDS.OPEN_EXTERNAL_URL]: (data) =>
-        this.handleOpenExternalUrl(data),
+      [SETTINGS_VIEW_COMMANDS.OPEN_EXTERNAL_URL]: async (data) => {
+        await vscode.env.openExternal(vscode.Uri.parse(data.url));
+      },
 
       // Model selection handlers
       [SETTINGS_VIEW_COMMANDS.GET_MODEL_SELECTION]: () =>
@@ -451,11 +448,20 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS]: () =>
         this.withActiveWebview((w) => this.sendGitAuthorSettings(w)),
       [SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS]: (data) =>
-        this.handleSetGitMarkCommits(data),
+        this.updateGitAuthorSetting(
+          WorkspaceStateKey.GIT_MARK_COMMITS,
+          data.enabled,
+        ),
       [SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME]: (data) =>
-        this.handleSetGitAuthorName(data),
+        this.updateGitAuthorSetting(
+          WorkspaceStateKey.GIT_AUTHOR_NAME,
+          data.name,
+        ),
       [SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_EMAIL]: (data) =>
-        this.handleSetGitAuthorEmail(data),
+        this.updateGitAuthorSetting(
+          WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+          data.email,
+        ),
 
       // ── Delegated to LatexSettingsHandlers ──
 
@@ -472,13 +478,14 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
-        this.handleGetToolDashboardData(),
-      [SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL]: (data) =>
-        this.handleOpenToolInstallUrl(data),
+        this.withActiveWebview((w) => this.sendToolDashboardData(w)),
+      [SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL]: async (data) => {
+        await vscode.env.openExternal(vscode.Uri.parse(data.url));
+      },
       [SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION]: (data) =>
         this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
-        this.handleRecheckToolStatus(),
+        this.withActiveWebview((w) => this.sendToolDashboardData(w)),
     };
   }
 
@@ -572,22 +579,20 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       )
       .map((entry): HistoryItem => {
         const cfg = entry.agentConfig!;
+        const base = {
+          agent: cfg.agent,
+          model: cfg.model,
+          instruction: cfg.instruction,
+        };
         return {
           id: entry.id,
           timestamp: entry.timestamp,
           agentConfig:
             cfg.agentCategory === 'toolUse'
-              ? {
-                  agentCategory: 'toolUse',
-                  agent: cfg.agent,
-                  model: cfg.model,
-                  instruction: cfg.instruction,
-                }
+              ? { agentCategory: 'toolUse' as const, ...base }
               : {
-                  agentCategory: 'workflow',
-                  agent: cfg.agent,
-                  model: cfg.model,
-                  instruction: cfg.instruction,
+                  agentCategory: 'workflow' as const,
+                  ...base,
                   inputFile: cfg.inputFile,
                   inputFiles: cfg.inputFiles,
                   mediaFile: cfg.mediaFile,
@@ -775,33 +780,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     const settings = applyGitAuthorConfig();
     await this.withActiveWebview((w) =>
       this.sendGitAuthorSettings(w, settings),
-    );
-  }
-
-  private async handleSetGitMarkCommits(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_MARK_COMMITS>,
-  ): Promise<void> {
-    await this.updateGitAuthorSetting(
-      WorkspaceStateKey.GIT_MARK_COMMITS,
-      data.enabled,
-    );
-  }
-
-  private async handleSetGitAuthorName(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_NAME>,
-  ): Promise<void> {
-    await this.updateGitAuthorSetting(
-      WorkspaceStateKey.GIT_AUTHOR_NAME,
-      data.name,
-    );
-  }
-
-  private async handleSetGitAuthorEmail(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_GIT_AUTHOR_EMAIL>,
-  ): Promise<void> {
-    await this.updateGitAuthorSetting(
-      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
-      data.email,
     );
   }
 
@@ -1283,12 +1261,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview((w) => this.sendProfileData(w));
   }
 
-  private async handleOpenExternalUrl(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_EXTERNAL_URL>,
-  ): Promise<void> {
-    await vscode.env.openExternal(vscode.Uri.parse(data.url));
-  }
-
   private async handleSetProviderVscodeSetting(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_VSCODE_SETTING>,
   ): Promise<void> {
@@ -1409,25 +1381,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  private async handleGetToolDashboardData(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendToolDashboardData(w));
-  }
-
-  private async handleOpenToolInstallUrl(
-    data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_TOOL_INSTALL_URL>,
-  ): Promise<void> {
-    await vscode.env.openExternal(vscode.Uri.parse(data.url));
-  }
-
   private async handleInstallToolExtension(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.INSTALL_TOOL_EXTENSION>,
   ): Promise<void> {
     await this.latexHandlers.installExtension(data.extensionId, (w) =>
       this.sendToolDashboardData(w),
     );
-  }
-
-  private async handleRecheckToolStatus(): Promise<void> {
-    await this.withActiveWebview((w) => this.sendToolDashboardData(w));
   }
 }

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -416,9 +416,10 @@ export class SettingsApp extends SettingsAppBase {
   private handleMemoryDeleteItem(
     event: CustomEvent<{ storagePath: string; displayPath?: string }>,
   ): void {
+    const { storagePath, displayPath = storagePath } = event.detail;
     postMessage(SETTINGS_VIEW_COMMANDS.DELETE_MEMORY, {
-      storagePath: event.detail.storagePath,
-      displayPath: event.detail.displayPath ?? event.detail.storagePath,
+      storagePath,
+      displayPath,
     });
   }
 

--- a/src/settingsView/frontend/components/history/HistoryList.ts
+++ b/src/settingsView/frontend/components/history/HistoryList.ts
@@ -72,20 +72,18 @@ export class HistoryList extends LitElement {
       changedProperties.has('clearSearchTrigger') &&
       this.clearSearchTrigger
     ) {
-      this.performClearSearch();
+      this.clearSearch();
       this.dispatchEvent(HistoryViewEvents.searchClearComplete());
     }
 
     if (changedProperties.has('searchTerm')) {
-      // Reset page when entering or leaving search mode
       if (this.searchTerm) {
+        // Reset page when entering search mode
         this.page = 0;
-      }
-      // Clear marks immediately when search is cleared, but defer
-      // applying a new search term to updated() so the DOM has
-      // re-rendered all items (pagination is disabled during search).
-      if (!this.searchTerm) {
-        this.performSearch('');
+      } else {
+        // Clear marks immediately when search is cleared; new search
+        // terms are deferred to updated() so the full DOM is available.
+        this.clearSearch();
       }
     }
 
@@ -118,21 +116,13 @@ export class HistoryList extends LitElement {
     }
   }
 
-  private performClearSearch(): void {
+  private clearSearch(): void {
     this.matchCounts = new Map();
-    this.performSearch('');
-  }
-
-  private performSearch(term: string): void {
-    const version = ++this.searchVersion;
-    if (!term) {
-      this.state?.setSearchIndex(-1);
-      this.state?.setTotalMatches(0);
-      this.clearItemMarks();
-      this.updateMatchCount();
-      return;
-    }
-    void this.applySearchToItems(term, version);
+    ++this.searchVersion;
+    this.state?.setSearchIndex(-1);
+    this.state?.setTotalMatches(0);
+    this.clearItemMarks();
+    this.updateMatchCount();
   }
 
   private performNavigate(direction: 'next' | 'prev'): void {
@@ -180,7 +170,7 @@ export class HistoryList extends LitElement {
     term: string,
     version: number,
   ): Promise<void> {
-    const historyItems = this.getHistoryItems();
+    const historyItems = [...(this.historyItemElements ?? [])];
     const counts = await Promise.all(
       historyItems.map(
         (item) => item.applySearch?.(term) ?? Promise.resolve(0),
@@ -190,11 +180,9 @@ export class HistoryList extends LitElement {
       return;
     }
 
-    const newMatchCounts = new Map<string, number>();
-    this.items.forEach((item, index) => {
-      newMatchCounts.set(item.id, counts[index] ?? 0);
-    });
-    this.matchCounts = newMatchCounts;
+    this.matchCounts = new Map(
+      this.items.map((item, i) => [item.id, counts[i] ?? 0]),
+    );
 
     const total = counts.reduce((sum, count) => sum + count, 0);
     this.state?.setTotalMatches(total);
@@ -209,19 +197,10 @@ export class HistoryList extends LitElement {
   }
 
   private clearItemMarks(): void {
-    const items = this.getHistoryItems();
+    const items = [...(this.historyItemElements ?? [])];
     void Promise.all(
       items.map((item) => item.applySearch?.('') ?? Promise.resolve(0)),
     );
-  }
-
-  private getHistoryItems(): Array<
-    HTMLElement & {
-      applySearch: (term: string) => Promise<number>;
-      getMarks: () => HTMLElement[];
-    }
-  > {
-    return [...(this.historyItemElements ?? [])];
   }
 
   private handleToggle(

--- a/src/settingsView/frontend/components/memory/MemoryList.ts
+++ b/src/settingsView/frontend/components/memory/MemoryList.ts
@@ -3,7 +3,13 @@
  */
 
 // Third-party imports
-import { LitElement, html, css, type TemplateResult } from 'lit';
+import {
+  LitElement,
+  html,
+  css,
+  type PropertyValues,
+  type TemplateResult,
+} from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 
@@ -45,9 +51,7 @@ export class MemoryList extends LitElement {
 
   @state() private page = 0;
 
-  protected override willUpdate(
-    changedProperties: Map<string | number | symbol, unknown>,
-  ): void {
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
     // Reset to first page when items change (e.g. refresh, delete, pin/unpin)
     if (changedProperties.has('items')) {
       this.page = 0;

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -124,7 +124,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 /** URLs for obtaining API keys from each provider. */
 export const PROVIDER_URLS: Record<string, string> = {
   ...Object.fromEntries(
-    PROVIDER_REGISTRY.filter((p) => p.keyUrl).map((p) => [p.id, p.keyUrl!]),
+    PROVIDER_REGISTRY.flatMap((p) => (p.keyUrl ? [[p.id, p.keyUrl]] : [])),
   ),
   openRouter: 'https://openrouter.ai/keys',
 };

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -38,6 +38,8 @@ const LISTS = selectorGroup(CONTAINER_NAMES, '__list');
 const ITEMS = selectorGroup(ITEM_NAMES);
 const DETAILS = selectorGroup(ITEM_NAMES, '__details');
 const ACTIONS = selectorGroup(ITEM_NAMES, '__actions');
+const FEEDBACKS = selectorGroup(ITEM_NAMES, '__feedback');
+const FEEDBACK_INPUTS = selectorGroup(ITEM_NAMES, '__feedback-input');
 
 export const requestPanelStyles: CSSResult = css`
   /* ================================================================
@@ -542,17 +544,11 @@ export const requestPanelStyles: CSSResult = css`
    * Rejection feedback (shared across panels with feedback support)
    * ================================================================ */
 
-  .approval-request__feedback,
-  .bash-approval-request__feedback,
-  .workflow-proposal__feedback,
-  .plan-approval-request__feedback {
+  :is(${FEEDBACKS}) {
     margin-top: var(--spacing-small);
   }
 
-  .approval-request__feedback-input,
-  .bash-approval-request__feedback-input,
-  .workflow-proposal__feedback-input,
-  .plan-approval-request__feedback-input {
+  :is(${FEEDBACK_INPUTS}) {
     width: 100%;
   }
 

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -416,21 +416,19 @@ async function proposeAndExecute(
   if (nonApproveResult) return nonApproveResult;
 
   // At this point result.action === 'approve' (all other cases returned above)
-  const modelOverridden =
-    result.action === 'approve' && result.model ? result.model : undefined;
-  const effective = modelOverridden
-    ? { ...proposal, model: modelOverridden }
+  const modelOverride = result.action === 'approve' ? result.model : undefined;
+  const effective = modelOverride
+    ? { ...proposal, model: modelOverride }
     : proposal;
-  const approvalMeta: ApprovalMeta = {
-    autoApproved: false,
-    ...(modelOverridden && {
-      modelOverride: modelOverridden,
-      requestedModel: proposal.model,
-    }),
-  };
   return executeSubagent(toConfigPayload(effective), agentName, streamId, {
     enableYoloOnChild: isApprovalBypassedForStream(streamId),
-    approvalMeta,
+    approvalMeta: {
+      autoApproved: false,
+      ...(modelOverride && {
+        modelOverride,
+        requestedModel: proposal.model,
+      }),
+    },
   });
 }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -271,8 +271,7 @@ function formatTodoSection(todos: TodoEntry[]): string[] {
 function formatTodoHeader(executionId: string, todos: TodoEntry[]): string {
   const completed = todos.filter((t) => t.status === 'completed').length;
   const inProgress = todos.filter((t) => t.status === 'in_progress').length;
-  const pending = todos.length - completed - inProgress;
-  return `Tasks for ${executionId} (${completed} done, ${inProgress} active, ${pending} pending):`;
+  return `Tasks for ${executionId} (${completed} done, ${inProgress} active, ${todos.length - completed - inProgress} pending):`;
 }
 
 export class ExecutionsTool extends defineTool({
@@ -329,47 +328,35 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       return this.showSummary(executionId);
     }
 
-    // /executions/{id}/config - agent configuration
-    if (resource === 'config') {
-      return this.showConfig(executionId);
-    }
-
-    // /executions/{id}/conversation - message history
-    if (resource === 'conversation') {
-      return this.showConversation(executionId, input.view_range ?? undefined);
-    }
-
-    // /executions/{id}/todos - subagent task list
-    if (resource === 'todos') {
-      return this.showTodos(executionId);
-    }
-
-    // /executions/{id}/report - persisted result report
-    if (resource === 'report') {
-      return this.showReport(executionId);
-    }
-
-    // /executions/{id}/children - child executions
-    if (resource === 'children') {
-      return this.showChildren(executionId);
-    }
-
-    // /executions/{id}/output - background process output
-    if (resource === 'output') {
-      return this.readProcessOutput(executionId, input.view_range ?? undefined);
-    }
-
-    // /executions/{id}/files or /executions/{id}/files/{path}
-    if (resource === 'files') {
-      if (rest.length === 0) {
-        return this.listFiles(executionId);
-      }
-      return this.readFile(
-        executionId,
-        rest.join('/'),
-        // Schema enforces length 2; cast since Zod infers number[]
-        input.view_range as [number, number] | undefined,
-      );
+    switch (resource) {
+      case 'config':
+        return this.showConfig(executionId);
+      case 'conversation':
+        return this.showConversation(
+          executionId,
+          input.view_range ?? undefined,
+        );
+      case 'todos':
+        return this.showTodos(executionId);
+      case 'report':
+        return this.showReport(executionId);
+      case 'children':
+        return this.showChildren(executionId);
+      case 'output':
+        return this.readProcessOutput(
+          executionId,
+          input.view_range ?? undefined,
+        );
+      case 'files':
+        if (rest.length === 0) {
+          return this.listFiles(executionId);
+        }
+        return this.readFile(
+          executionId,
+          rest.join('/'),
+          // Schema enforces length 2; cast since Zod infers number[]
+          input.view_range as [number, number] | undefined,
+        );
     }
 
     throw new ToolError(

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -140,13 +140,9 @@ export class ReadFileTool extends defineTool({
     requestedStartLine: number,
     totalLines: number,
   ): number {
-    if (range?.end != null) {
-      return range.end;
-    }
-
-    if (range?.start != null) {
+    if (range?.end != null) return range.end;
+    if (range?.start != null)
       return Math.min(requestedStartLine + READ_FILE_MAX_LINES - 1, totalLines);
-    }
     return totalLines;
   }
 

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -99,10 +99,9 @@ export class TextEditorTool extends defineTool({
   }
 
   private getAllowedCommands(): string {
-    if (this.apiType === 'text_editor_20250429') {
-      return 'view, create, str_replace, insert';
-    }
-    return 'view, create, str_replace, insert, undo_edit';
+    return this.apiType === 'text_editor_20250429'
+      ? 'view, create, str_replace, insert'
+      : 'view, create, str_replace, insert, undo_edit';
   }
 
   protected async execute(input: TextEditorInput): Promise<ToolResult> {
@@ -155,30 +154,31 @@ export class TextEditorTool extends defineTool({
   ): Promise<void> {
     const exists = await WorkspaceFS.exists(filePath);
 
-    if (!exists && command !== 'create') {
-      throw new ToolError(
-        `The path ${filePath} does not exist. Please provide a valid path.`,
-      );
+    if (!exists) {
+      if (command !== 'create') {
+        throw new ToolError(
+          `The path ${filePath} does not exist. Please provide a valid path.`,
+        );
+      }
+      return; // 'create' on non-existent path is valid — nothing more to check
     }
 
-    if (exists && command === 'create') {
+    if (command === 'create') {
       throw new ToolError(
         `File already exists at: ${filePath}. Cannot overwrite files using command 'create'.`,
       );
     }
 
     // Check if the path is a directory (only view command can be used on directories)
-    if (exists) {
-      try {
-        const stats = await AbsoluteFS.stat(WorkspaceFS.fullPath(filePath));
-        if (isDirectory(stats.type) && command !== 'view') {
-          throw new ToolError(
-            `The path ${filePath} is a directory and only the 'view' command can be used on directories`,
-          );
-        }
-      } catch (error) {
-        rethrowWithContext(error, `Error validating path`);
+    try {
+      const stats = await AbsoluteFS.stat(WorkspaceFS.fullPath(filePath));
+      if (isDirectory(stats.type) && command !== 'view') {
+        throw new ToolError(
+          `The path ${filePath} is a directory and only the 'view' command can be used on directories`,
+        );
       }
+    } catch (error) {
+      rethrowWithContext(error, `Error validating path`);
     }
   }
 
@@ -413,23 +413,18 @@ export class TextEditorTool extends defineTool({
       const newFileLines = appliedContent.split('\n');
       const snippet = newFileLines.slice(startLine - 1, endLine).join('\n');
 
-      const userDiffNote = formatUnifiedApprovalUserDiff(
+      const output = this.formatEditOutput(
         filePath,
+        snippet,
+        startLine,
         newFileContent,
         appliedContent,
+        'Review the changes and make sure they are as expected. Edit the file again if necessary.',
       );
-      const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(snippet, startLine);
-      const reviewMessage =
-        'Review the changes and make sure they are as expected. Edit the file again if necessary.';
-      const baseMsg = `${successIntro} ${snippetOutput}${reviewMessage}`;
-      const successMsg = userDiffNote
-        ? `${baseMsg}\n\n${userDiffNote}`
-        : baseMsg;
 
       return {
         summary: `Updated ${filePath}`,
-        output: successMsg,
+        output,
         userPatch: approval.userPatch,
         edits: [{ path: filePath, lineChanges: approval.lineChanges }],
       };
@@ -510,24 +505,19 @@ export class TextEditorTool extends defineTool({
         .slice(snippetStart, snippetEnd)
         .join('\n');
       const startLine = snippetStart + 1;
-      const userDiffNote = formatUnifiedApprovalUserDiff(
+
+      const output = this.formatEditOutput(
         filePath,
+        snippetText,
+        startLine,
         newFileContent,
         appliedContent,
+        'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.',
       );
-
-      const successIntro = `The file ${filePath} has been edited.`;
-      const snippetOutput = this.makeOutput(snippetText, startLine);
-      const reviewNote =
-        'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
-      const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
-      const successMsg = userDiffNote
-        ? `${baseMsg}\n\n${userDiffNote}`
-        : baseMsg;
 
       return {
         summary: `Inserted text into ${filePath}`,
-        output: successMsg,
+        output,
         userPatch: approval.userPatch,
         edits: [{ path: filePath, lineChanges: approval.lineChanges }],
       };
@@ -602,11 +592,33 @@ export class TextEditorTool extends defineTool({
     }
   }
 
+  /** Build the output message for str_replace/insert commands. */
+  private formatEditOutput(
+    filePath: string,
+    snippetText: string,
+    startLine: number,
+    proposedContent: string,
+    appliedContent: string,
+    reviewNote: string,
+  ): string {
+    const successIntro = `The file ${filePath} has been edited.`;
+    const snippetOutput = this.makeOutput(snippetText, startLine);
+    const userDiffNote = formatUnifiedApprovalUserDiff(
+      filePath,
+      proposedContent,
+      appliedContent,
+    );
+    const baseMsg = `${successIntro} ${snippetOutput}${reviewNote}`;
+    return userDiffNote ? `${baseMsg}\n\n${userDiffNote}` : baseMsg;
+  }
+
   private addToHistory(filePath: string, content: string): void {
-    if (!this.fileHistory.has(filePath)) {
-      this.fileHistory.set(filePath, []);
+    const history = this.fileHistory.get(filePath);
+    if (history) {
+      history.push(content);
+    } else {
+      this.fileHistory.set(filePath, [content]);
     }
-    this.fileHistory.get(filePath)!.push(content);
   }
 
   private makeOutput(content: string, initLine: number = 1): string {

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -47,17 +47,12 @@ async function silentUnlink(filePath: string): Promise<void> {
 async function cleanupLatexAuxFiles(filePath: string): Promise<void> {
   const ext = path.extname(filePath);
   const basePathNoExt = filePath.slice(0, -ext.length);
-  for (const tempExt of TEMP_EXTENSIONS) {
-    if (tempExt.includes('*')) {
-      // Glob pattern (e.g. '.bak*') — expand and delete all matches
-      const matches = globSync(`${basePathNoExt}${tempExt}`, { nodir: true });
-      for (const match of matches) {
-        await silentUnlink(match);
-      }
-    } else {
-      await silentUnlink(basePathNoExt + tempExt);
-    }
-  }
+  const unlinkTargets = TEMP_EXTENSIONS.flatMap((tempExt) =>
+    tempExt.includes('*')
+      ? globSync(`${basePathNoExt}${tempExt}`, { nodir: true })
+      : [basePathNoExt + tempExt],
+  );
+  await Promise.all(unlinkTargets.map(silentUnlink));
 }
 
 /** Register cleanup function with entry, or run immediately if already settled */

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -102,13 +102,7 @@ export type CodexInput = z.infer<typeof CodexInputSchema>;
  * streamed to the UI via onToolOutput and don't need to be in the result.
  */
 function formatTurnResult(turn: RunResult): string {
-  const parts: string[] = [];
-
-  if (turn.finalResponse) {
-    parts.push(turn.finalResponse);
-  } else {
-    parts.push('(no response)');
-  }
+  const parts: string[] = [turn.finalResponse || '(no response)'];
 
   if (turn.usage) {
     parts.push(
@@ -162,12 +156,14 @@ function formatCodexError(
 function formatItemForLog(item: ThreadItem): string {
   switch (item.type) {
     case 'command_execution': {
-      const status =
-        item.exit_code === undefined
-          ? item.status
-          : item.exit_code === 0
-            ? 'ok'
-            : `exit ${item.exit_code}`;
+      let status: string;
+      if (item.exit_code === undefined) {
+        status = item.status;
+      } else if (item.exit_code === 0) {
+        status = 'ok';
+      } else {
+        status = `exit ${item.exit_code}`;
+      }
       return `$ ${item.command} (${status})\n`;
     }
     case 'file_change': {

--- a/src/tools/emlParser.ts
+++ b/src/tools/emlParser.ts
@@ -134,13 +134,15 @@ function toUint8Array(content: ArrayBuffer | Uint8Array | string): Uint8Array {
   return new Uint8Array(Buffer.from(content, 'base64'));
 }
 
+const MIME_SUBTYPE_TO_EXT: Record<string, string> = {
+  jpeg: 'jpg',
+  'svg+xml': 'svg',
+  tiff: 'tif',
+};
+
 function extensionFromMime(mimeType: string): string {
   const sub = mimeType.split('/')[1] ?? 'bin';
-  // Normalize common MIME subtypes to file extensions
-  if (sub === 'jpeg') return 'jpg';
-  if (sub === 'svg+xml') return 'svg';
-  if (sub === 'tiff') return 'tif';
-  return sub;
+  return MIME_SUBTYPE_TO_EXT[sub] ?? sub;
 }
 
 function formatAddress(addr: Address): string {

--- a/src/tools/memory/MemoryTool.ts
+++ b/src/tools/memory/MemoryTool.ts
@@ -204,7 +204,7 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
   /** Return early result if the file hasn't been viewed yet. */
   private requireViewBeforeModify(
     inputPath: string,
-    operation: string = 'editing',
+    operation = 'editing',
   ): ToolResult | undefined {
     return (
       requireFileReadForEdit(
@@ -219,18 +219,15 @@ Use \`pin\` to mark a memory as a core long-term insight (techniques, strategies
     resolvedPath: string,
     inputPath: string,
   ): Promise<void> {
+    const errorMsg = `The path ${inputPath} does not exist or is a directory.`;
+    let stats;
     try {
-      const stats = await StorageFS.stat(resolvedPath);
-      if (isDirectory(stats.type)) {
-        throw new ToolError(
-          `The path ${inputPath} does not exist or is a directory.`,
-        );
-      }
-    } catch (err) {
-      if (err instanceof ToolError) throw err;
-      throw new ToolError(
-        `The path ${inputPath} does not exist or is a directory.`,
-      );
+      stats = await StorageFS.stat(resolvedPath);
+    } catch {
+      throw new ToolError(errorMsg);
+    }
+    if (isDirectory(stats.type)) {
+      throw new ToolError(errorMsg);
     }
   }
 

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -72,9 +72,10 @@ function computeReadableDiff(
   // Check if there are any actual changes.
   if (diffs.every(([op]) => op === 0)) return null;
 
+  const PREFIX: Record<number, string> = { 1: '+', [-1]: '-', 0: ' ' };
   const lines: string[] = [];
   for (const [op, text] of diffs) {
-    const prefix = op === 1 ? '+' : op === -1 ? '-' : ' ';
+    const prefix = PREFIX[op] ?? ' ';
     // Each chunk is one or more complete lines (with trailing \n).
     // Split and prefix each line, dropping the trailing empty entry from split.
     const chunkLines = text.split('\n');
@@ -194,9 +195,9 @@ function formatOutputFile(
   const attrs = [
     `path="${escapeAttr(o.relativePath)}"`,
     `location="${escapeAttr(o.location)}"`,
-    o.originalPath !== null ? `original="${escapeAttr(o.originalPath)}"` : '',
-    o.added !== null ? `added="${o.added}"` : '',
-    o.removed !== null ? `removed="${o.removed}"` : '',
+    o.originalPath !== null && `original="${escapeAttr(o.originalPath)}"`,
+    o.added !== null && `added="${o.added}"`,
+    o.removed !== null && `removed="${o.removed}"`,
   ]
     .filter(Boolean)
     .join(' ');

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -390,16 +390,11 @@ export async function buildFileAttachment({
   const bytes = Uint8Array.from(buffer);
   buffer.fill(0);
 
-  const attachment: ToolFileAttachment = {
+  return {
     path: display,
     mimeType: inferredMime,
     bytes,
+    ...(description && { description }),
+    ...(base64Data && { base64Data }),
   };
-  if (description) {
-    attachment.description = description;
-  }
-  if (base64Data) {
-    attachment.base64Data = base64Data;
-  }
-  return attachment;
 }

--- a/src/tools/zotero/ZoteroCollectionsTool.ts
+++ b/src/tools/zotero/ZoteroCollectionsTool.ts
@@ -75,15 +75,9 @@ function buildTree(collections: BbtCollection[]): CollectionNode[] {
   return roots;
 }
 
-/**
- * Count all nodes in a collection tree (including nested children).
- */
+/** Count all nodes in a collection tree (including nested children). */
 function countNodes(nodes: CollectionNode[]): number {
-  let count = 0;
-  for (const node of nodes) {
-    count += 1 + countNodes(node.children);
-  }
-  return count;
+  return nodes.reduce((sum, node) => sum + 1 + countNodes(node.children), 0);
 }
 
 /**
@@ -96,7 +90,6 @@ function formatTree(
   parentPrefix: string = '',
 ): string[] {
   const lines: string[] = [];
-  const basePrefix = indent > 0 ? parentPrefix : '  '.repeat(indent);
 
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -104,13 +97,13 @@ function formatTree(
     const connector = indent === 0 ? '' : isLast ? '└── ' : '├── ';
     const childContinuation = indent === 0 ? '' : isLast ? '    ' : '│   ';
 
-    lines.push(`${basePrefix}${connector}${node.name}/ [${node.key}]`);
+    lines.push(`${parentPrefix}${connector}${node.name}/ [${node.key}]`);
 
     if (node.children.length > 0) {
       const childLines = formatTree(
         node.children,
         1,
-        `${basePrefix}${childContinuation}`,
+        `${parentPrefix}${childContinuation}`,
       );
       lines.push(...childLines);
     }
@@ -208,22 +201,14 @@ export class ZoteroCollectionsTool extends defineTool({
 
       const fullTree = buildTree(collections);
 
-      if (query) {
-        const { tree, matchCount } = filterTree(fullTree, query);
-        if (tree.length === 0) continue;
+      const displayTree = query ? filterTree(fullTree, query) : null;
+      const tree = displayTree?.tree ?? fullTree;
+      if (tree.length === 0) continue;
 
-        totalCollections += matchCount;
-        librariesWithResults++;
-        outputParts.push(`Library: ${lib.name}`);
-        outputParts.push(...formatTree(tree, 1));
-      } else {
-        if (fullTree.length === 0) continue;
-
-        totalCollections += countNodes(fullTree);
-        librariesWithResults++;
-        outputParts.push(`Library: ${lib.name}`);
-        outputParts.push(...formatTree(fullTree, 1));
-      }
+      totalCollections += displayTree?.matchCount ?? countNodes(fullTree);
+      librariesWithResults++;
+      outputParts.push(`Library: ${lib.name}`);
+      outputParts.push(...formatTree(tree, 1));
     }
 
     if (outputParts.length === 0) {

--- a/src/tools/zotero/ZoteroSearchTool.ts
+++ b/src/tools/zotero/ZoteroSearchTool.ts
@@ -99,12 +99,8 @@ function formatSearchResult(item: BbtSearchResultItem): string {
     .join('; ');
 
   // Handle date from CSL JSON or Zotero format
-  let year = '';
-  if (item.issued?.['date-parts']?.[0]?.[0]) {
-    year = String(item.issued['date-parts'][0][0]);
-  } else if (item.date) {
-    year = item.date;
-  }
+  const datePart = item.issued?.['date-parts']?.[0]?.[0];
+  const year = datePart ? String(datePart) : (item.date ?? '');
 
   const type = item.type || item.itemType || 'item';
 

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -38,7 +38,7 @@ const ENDPOINT_KEY: Record<string, GlobalStateKey> = {
 
 /** Read the global streaming default. */
 export function getGlobalStreaming(): boolean {
-  return globalSM?.get<boolean>(GlobalStateKey.STREAMING_GLOBAL, true) ?? true;
+  return globalSM?.get(GlobalStateKey.STREAMING_GLOBAL, true) ?? true;
 }
 
 /** Set the global streaming default. */
@@ -50,8 +50,8 @@ export async function setGlobalStreaming(enabled: boolean): Promise<void> {
 export function getProviderStreaming(provider: string): boolean {
   const key = STREAMING_KEY[provider.toLowerCase()];
   if (!key) return getGlobalStreaming();
-  const global = getGlobalStreaming();
-  return globalSM?.get<boolean>(key, global) ?? global;
+  const fallback = getGlobalStreaming();
+  return globalSM?.get(key, fallback) ?? fallback;
 }
 
 /** Set per-provider streaming setting. */
@@ -69,7 +69,7 @@ export async function setProviderStreaming(
 export function getProviderEndpoint(provider: string): string {
   const key = ENDPOINT_KEY[provider.toLowerCase()];
   if (!key) return '';
-  return globalSM?.get<string>(key, '') ?? '';
+  return globalSM?.get(key, '') ?? '';
 }
 
 /** Set per-provider custom endpoint. */
@@ -97,8 +97,7 @@ export function supportsCustomEndpoint(provider: string): boolean {
  */
 export function getAnthropicDynamicFiltering(): boolean {
   return (
-    globalSM?.get<boolean>(GlobalStateKey.ANTHROPIC_DYNAMIC_FILTERING, false) ??
-    false
+    globalSM?.get(GlobalStateKey.ANTHROPIC_DYNAMIC_FILTERING, false) ?? false
   );
 }
 
@@ -115,9 +114,7 @@ export async function setAnthropicDynamicFiltering(
 
 /** Whether DashScope is set to use the China (Bailian) region. */
 export function getDashScopeUseChina(): boolean {
-  return (
-    globalSM?.get<boolean>(GlobalStateKey.DASHSCOPE_USE_CHINA, false) ?? false
-  );
+  return globalSM?.get(GlobalStateKey.DASHSCOPE_USE_CHINA, false) ?? false;
 }
 
 const BAILIAN_DISPLAY_NAME = 'Bailian';
@@ -139,16 +136,18 @@ export function getProviderKeyUrl(
   provider: string,
   defaultUrl: string,
 ): string {
-  if (provider === 'dashscope' && getDashScopeUseChina()) {
-    return BAILIAN_KEY_URL;
+  switch (provider) {
+    case 'dashscope':
+      return getDashScopeUseChina() ? BAILIAN_KEY_URL : defaultUrl;
+    case 'minimax':
+      return getMiniMaxUseChina()
+        ? 'https://platform.minimaxi.com/'
+        : defaultUrl;
+    case 'glm':
+      return getGLMUseChina() ? defaultUrl : 'https://z.ai/';
+    default:
+      return defaultUrl;
   }
-  if (provider === 'minimax' && getMiniMaxUseChina()) {
-    return 'https://platform.minimaxi.com/';
-  }
-  if (provider === 'glm' && !getGLMUseChina()) {
-    return 'https://z.ai/';
-  }
-  return defaultUrl;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,9 +156,7 @@ export function getProviderKeyUrl(
 
 /** Whether MiniMax is set to use the China region (minimaxi.com). */
 export function getMiniMaxUseChina(): boolean {
-  return (
-    globalSM?.get<boolean>(GlobalStateKey.MINIMAX_USE_CHINA, false) ?? false
-  );
+  return globalSM?.get(GlobalStateKey.MINIMAX_USE_CHINA, false) ?? false;
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +165,7 @@ export function getMiniMaxUseChina(): boolean {
 
 /** Whether GLM is set to use the China region (bigmodel.cn). Defaults to true since bigmodel.cn is the primary platform. */
 export function getGLMUseChina(): boolean {
-  return globalSM?.get<boolean>(GlobalStateKey.GLM_USE_CHINA, true) ?? true;
+  return globalSM?.get(GlobalStateKey.GLM_USE_CHINA, true) ?? true;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,7 +174,7 @@ export function getGLMUseChina(): boolean {
 
 /** Whether GLM is set to use Coding Plan (subscription-based API access). */
 export function getGLMCodingPlan(): boolean {
-  return globalSM?.get<boolean>(GlobalStateKey.GLM_CODING_PLAN, false) ?? false;
+  return globalSM?.get(GlobalStateKey.GLM_CODING_PLAN, false) ?? false;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,7 +188,7 @@ export function getGLMCodingPlan(): boolean {
  */
 export function getUseOpenRouter(): boolean {
   return (
-    globalSM?.get<boolean>(GlobalStateKey.USE_OPENROUTER, false) ??
+    globalSM?.get(GlobalStateKey.USE_OPENROUTER, false) ??
     getConfig<boolean>('texra.model.useOpenRouter', false)
   );
 }
@@ -202,7 +199,5 @@ export function getUseOpenRouter(): boolean {
 
 /** Read the WebSocket transport setting for OpenAI. */
 export function getWebSocketEnabled(): boolean {
-  return (
-    globalSM?.get<boolean>(GlobalStateKey.WEBSOCKET_OPENAI, false) ?? false
-  );
+  return globalSM?.get(GlobalStateKey.WEBSOCKET_OPENAI, false) ?? false;
 }

--- a/src/utils/system/execUtils.ts
+++ b/src/utils/system/execUtils.ts
@@ -236,16 +236,9 @@ export async function executeCommand(
       `Error executing command: ${toErrorMessage(err)}`,
     );
 
-    // Handle stderr from ExecaError
-    let stderr = null;
-    if (err instanceof ExecaError) {
-      stderr = err.stderr ? `${err.stderr}`.trim() : null;
-    }
-
-    // With reject: false, this catch block only handles actual execution errors
-    // (e.g., command not found), not timeouts or non-zero exit codes
-    const fallbackOutput = stderr || toErrorMessage(err);
-    const normalizedError = normalizeOutput(fallbackOutput);
+    const stderr =
+      err instanceof ExecaError && err.stderr ? `${err.stderr}`.trim() : null;
+    const normalizedError = normalizeOutput(stderr || toErrorMessage(err));
     return {
       success: false,
       stdout: null,

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -1,5 +1,4 @@
 // Standard library imports
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -13,9 +12,7 @@ import { isWSL } from './wslDetect';
 /** Timeout for git commands in milliseconds. */
 const GIT_TIMEOUT_MS = 3000;
 
-/**
- * Gathered workspace environment information for system prompt injection.
- */
+/** Gathered workspace environment information for system prompt injection. */
 interface WorkspaceInfo {
   workspacePath: string | undefined;
   platform: string;
@@ -30,32 +27,21 @@ interface GitInfo {
   dirty: boolean;
 }
 
-/**
- * Detect the user's default shell from environment.
- * Returns the shell basename (e.g., "bash", "zsh", "fish") or undefined.
- */
+/** Detect the user's default shell basename (e.g., "bash", "zsh", "PowerShell"). */
 function detectShell(): string | undefined {
   if (process.platform === 'win32') {
-    // On Windows, check for common shells
     const comspec = process.env.ComSpec;
-    if (comspec) {
-      const name = path.basename(comspec).toLowerCase();
-      if (name === 'powershell.exe' || name === 'pwsh.exe') return 'PowerShell';
-      if (name === 'cmd.exe') return 'cmd';
-      return name.replace(/\.exe$/, '');
-    }
-    return undefined;
+    if (!comspec) return undefined;
+    const name = path.basename(comspec).toLowerCase();
+    if (name === 'powershell.exe' || name === 'pwsh.exe') return 'PowerShell';
+    if (name === 'cmd.exe') return 'cmd';
+    return name.replace(/\.exe$/, '');
   }
-
-  // Unix: SHELL env var is the login shell
   const shell = process.env.SHELL;
-  if (!shell) return undefined;
-  return path.basename(shell); // "bash", "zsh", "fish", etc.
+  return shell ? path.basename(shell) : undefined;
 }
 
-/**
- * Get a human-readable platform name.
- */
+/** Get a human-readable platform name. */
 function getPlatformLabel(): string {
   switch (process.platform) {
     case 'darwin':
@@ -96,8 +82,7 @@ async function getGitInfo(workspacePath: string): Promise<GitInfo | null> {
     ]);
 
     const branch =
-      branchResult.exitCode === 0 ? branchResult.stdout.trim() : null; // detached HEAD
-
+      branchResult.exitCode === 0 ? branchResult.stdout.trim() : null;
     const dirty =
       statusResult.exitCode === 0 && statusResult.stdout.trim().length > 0;
 
@@ -166,15 +151,11 @@ export async function buildWorkspaceInfoBlock(
   lines.push(`Date: ${info.date}`);
 
   if (info.git) {
-    const parts = ['Git: yes'];
-    if (info.git.branch) {
-      parts.push(`branch=${escapeXml(info.git.branch)}`);
-    } else {
-      parts.push('detached HEAD');
-    }
-    if (info.git.dirty) {
-      parts.push('uncommitted changes');
-    }
+    const branchPart = info.git.branch
+      ? `branch=${escapeXml(info.git.branch)}`
+      : 'detached HEAD';
+    const parts = ['Git: yes', branchPart];
+    if (info.git.dirty) parts.push('uncommitted changes');
     lines.push(parts.join(', '));
   }
 

--- a/src/utils/text/textEnhancementUtils.ts
+++ b/src/utils/text/textEnhancementUtils.ts
@@ -68,12 +68,18 @@ function formatFileContext(ctx: FileContext): string {
   const lines: string[] = ['Current context:'];
   if (ctx.agent) lines.push(`Agent: ${ctx.agent}`);
 
+  const fileEntries: string[] = [];
+
   const singles: Array<[string, string | undefined]> = [
     ['Input File', ctx.inputFile],
     ['Reference File', ctx.referenceFile],
     ['Auxiliary File', ctx.auxiliaryFile],
     ['Figure File', ctx.mediaFile],
   ];
+  for (const [label, value] of singles) {
+    if (value) fileEntries.push(`${label}: ${value}`);
+  }
+
   const arrays: Array<[string, string[] | undefined]> = [
     ['Input Files', ctx.inputFiles],
     ['Reference Files', ctx.referenceFiles],
@@ -81,22 +87,12 @@ function formatFileContext(ctx: FileContext): string {
     ['Media Files', ctx.mediaFiles],
     ['Output Files', ctx.outputFiles],
   ];
-
-  const entries: Array<{ label: string; value: string }> = [];
-  for (const [label, value] of singles) {
-    if (value) entries.push({ label, value });
-  }
   for (const [label, files] of arrays) {
-    if (files && files.length > 0) {
-      entries.push({ label, value: files.join(', ') });
-    }
+    if (files?.length) fileEntries.push(`${label}: ${files.join(', ')}`);
   }
 
-  if (entries.length > 0) {
-    lines.push('', 'Files in the task:');
-    for (const { label, value } of entries) {
-      lines.push(`${label}: ${value}`);
-    }
+  if (fileEntries.length > 0) {
+    lines.push('', 'Files in the task:', ...fileEntries);
   }
 
   return lines.join('\n') + '\n';


### PR DESCRIPTION
## Summary

Two-pass code simplification across ~65 files changed since v0.36.7, with a focused pass on uncovered areas (commands, extension, supabase).

**Agent toolUse & flows**
- Remove dead try/catch in `ToolUseFollowUp`, flatten `NodeResultStateBase` inheritance layer
- Inline `resolveWait` helper, simplify `drain()` to optional chaining
- `interrupt()` now delegates to `dispose()`

**Agent runtime**
- Remove exported-but-unused `AgentFlowMeta` type
- Extract shared `isChildOf` helper in `ExecutionHandle`, narrow `ctor` type
- Consolidate boolean returns in `ModelFactory`, eliminate intermediate variables

**Model handlers**
- Extract shared `parseToolArguments` utility (dedup between `modelHandlerOpenAI` and `modelHandlerOpenAIResponse`)
- Remove stale dev comments/TODOs, simplify `reduce` → `map`+`join` in MiniMax handler

**Tools**
- Lookup table for MIME types in `emlParser`, switch for resource routing in `ExecutionsTool`
- Extract `formatEditOutput` helper in `TextEditorTool` (dedup ~20 lines)
- Parallel `flatMap`+`Promise.all` in `latexPreview` cleanup
- Simplified `ZoteroCollectionsTool` branches, `ZoteroSearchTool` year extraction

**Progress view**
- Conditional spread for hints/metadata in `ProgressEventHandler`/`StreamMetaManager`
- Eliminate repeated `isPlainObject` calls in `toolFormatters`
- Replace imperative loops with functional pipelines, remove unnecessary `Promise.resolve()` wrappers

**Settings view**
- Inline trivial `handleSet*` git author wrappers into dispatch table
- Merge `clearSearch` two-step dispatch, `flatMap` in `providers.ts`

**Utils / latex / frontend / output**
- Fix deactivate ordering: `killBackgroundProcesses`/`killActiveRecording` before async flushes
- `flatMap` in `latexindentpt` backup cleanup, consolidate sox checks in `audio.ts`
- Extract repeated string patterns in `housekeeping/utils.ts`, simplify `ServerSideKeyService` guard clauses

## Test plan

- [ ] Build passes: `npm run compile:fast`
- [ ] Type check: `npm run typecheck`
- [ ] All simplifications are behavior-preserving refactors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly behavior-preserving simplification across agent flows, model handlers, tools, and UI, but it also adjusts interruption/child-termination and follow-up queue disposal logic which could impact long-running tool-use sessions and subagent orchestration.
> 
> **Overview**
> Large refactor pass that simplifies control flow, removes dead branches/comments, and consolidates repeated logic across tool-use execution, runtime orchestration, model handlers, tools, and the progress/settings UIs.
> 
> Notable functional changes include: centralizing tool-call argument parsing via new `parseToolArguments`, tightening tool-use follow-up queue lifecycle (`interrupt()` now `dispose()`s queues and `ToolUsePrepNode` drains queued follow-ups via early-return logic), fixing subagent interruption/collection to only target true children (`ExecutionHandle.isChildOf`), and reordering extension deactivation to stop background/recording before async flushes. Several tools/components also get small logic cleanups (e.g., `TextEditorTool` output formatting helper, `ExecutionsTool` resource routing switch, more direct progress-view hint updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2686edbb89eec2fcdf925ac837afcb2eacef1e6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->