### PR TITLE
Update changelog for v0.36.9 with OpenRouter provider and post-release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.36.9] - 2026-03-26
+## [0.36.9] - 2026-03-27
 
 ### Features
 
 - **Context compactization for OpenAI-compatible models** — DeepSeek, Kimi, GLM, and MiniMax models now support automatic context compactization, preventing long tool-use sessions from hitting context window limits. The model summarizes older messages when token usage exceeds 75% of the context window.
 - **Wait for specific background executions** — the `executions` tool's wait action now accepts an optional `ids` parameter to monitor specific background tasks instead of waiting for any active execution.
 - **MiniMax reasoning split** — MiniMax thinking models now return structured reasoning content instead of embedded `<think>` tags, improving display and downstream processing.
+- **OpenRouter provider** — new toggle in model settings to route all API calls through OpenRouter, letting you use a single API key for any supported model.
 
 ### Bug Fixes
 
@@ -20,8 +21,9 @@ All notable changes to this project will be documented in this file.
 
 - **Extract figure badges in delegation UI** — workflow proposals now show labeled badges for auto-extract figure and TikZ flags in the approval panel and log entries.
 - **Better Codex tool display** — Codex processes show a robot icon in the background tasks panel and display structured prompt details in the progress view.
+- Removed deprecated `resume_agent` tool from orchestrator configs.
 - Updated VS Code engine requirement to 1.105.0.
-- Updated dependencies (Supabase, Hono, MCP SDK, fast-xml-parser, KaTeX, OpenAI, Vite, and others).
+- Updated dependencies (Supabase, Hono, MCP SDK, fast-xml-parser, KaTeX, OpenAI, Codex SDK, OpenRouter SDK, Vite, and others).
 
 ## [0.36.8] - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.36.9] - 2026-03-27
+## [0.36.9] - 2026-03-26
 
 ### Features
 
 - **Context compactization for OpenAI-compatible models** — DeepSeek, Kimi, GLM, and MiniMax models now support automatic context compactization, preventing long tool-use sessions from hitting context window limits. The model summarizes older messages when token usage exceeds 75% of the context window.
 - **Wait for specific background executions** — the `executions` tool's wait action now accepts an optional `ids` parameter to monitor specific background tasks instead of waiting for any active execution.
 - **MiniMax reasoning split** — MiniMax thinking models now return structured reasoning content instead of embedded `<think>` tags, improving display and downstream processing.
-- **OpenRouter provider** — new toggle in model settings to route all API calls through OpenRouter, letting you use a single API key for any supported model.
 
 ### Bug Fixes
 
@@ -21,9 +20,8 @@ All notable changes to this project will be documented in this file.
 
 - **Extract figure badges in delegation UI** — workflow proposals now show labeled badges for auto-extract figure and TikZ flags in the approval panel and log entries.
 - **Better Codex tool display** — Codex processes show a robot icon in the background tasks panel and display structured prompt details in the progress view.
-- Removed deprecated `resume_agent` tool from orchestrator configs.
 - Updated VS Code engine requirement to 1.105.0.
-- Updated dependencies (Supabase, Hono, MCP SDK, fast-xml-parser, KaTeX, OpenAI, Codex SDK, OpenRouter SDK, Vite, and others).
+- Updated dependencies (Supabase, Hono, MCP SDK, fast-xml-parser, KaTeX, OpenAI, Vite, and others).
 
 ## [0.36.8] - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-- Removed deprecated `resume_agent` references from orchestrator YAML configs.
 - Updated dependencies (KaTeX, Codex SDK, OpenRouter SDK).
 
 ## [0.36.9] - 2026-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.36.10] - 2026-03-27
+
+### Features
+
+- **OpenRouter provider** — new toggle in model settings to route all API calls through OpenRouter, letting you use a single API key for any supported model.
+
+### Improvements
+
+- Removed deprecated `resume_agent` references from orchestrator YAML configs.
+- Updated dependencies (KaTeX, Codex SDK, OpenRouter SDK).
+
 ## [0.36.9] - 2026-03-26
 
 ### Features


### PR DESCRIPTION
https://claude.ai/code/session_01Tj1JeJo8wqY23BYJppGtnP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only update to `CHANGELOG.md` with no functional code changes.
> 
> **Overview**
> Adds a new `0.36.10` changelog entry documenting an **OpenRouter provider** model-setting toggle and a small set of dependency updates (KaTeX, Codex SDK, OpenRouter SDK).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ef59a60acc0395945e334d5b60b35b7064a2508. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->