### PR TITLE
Use native @openrouter/sdk ReasoningDetailUnion type instead of local definition

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenRouter.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouter.ts
@@ -1,26 +1,7 @@
 // Third-party imports
 import OpenAI from 'openai';
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
-
-/**
- * OpenRouter reasoning_details item type.
- *
- * Note: This type is intentionally defined locally rather than imported from
- * `@openrouter/sdk/models` (Schema2 type) because:
- * - The SDK uses ESM subpath exports which require `moduleResolution: "node16"` or higher
- * - This project uses `moduleResolution: "node"` in tsconfig.json
- * - Changing moduleResolution would have broader implications across the codebase
- *
- * The SDK's Schema2 type is equivalent but includes additional optional fields
- * (signature, id, format, index) that we don't need for our use case.
- *
- * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- * @see Schema2 in @openrouter/sdk/esm/models/schema2.d.ts for SDK equivalent
- */
-type ReasoningDetailItem =
-  | { type: 'reasoning.text'; text?: string | null }
-  | { type: 'reasoning.encrypted'; data: string }
-  | { type: 'reasoning.summary'; summary: string };
+import type { ReasoningDetailUnion } from '@openrouter/sdk/models';
 
 // Local imports - agent
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
@@ -41,7 +22,7 @@ import type {
 } from 'openai/resources/chat/completions';
 
 /** Extract text content from a reasoning detail item by type */
-function getReasoningItemText(item: ReasoningDetailItem): string | undefined {
+function getReasoningItemText(item: ReasoningDetailUnion): string | undefined {
   if (item.type === 'reasoning.text') return item.text ?? undefined;
   if (item.type === 'reasoning.summary') return item.summary;
   // 'reasoning.encrypted' - encrypted content is not useful for display
@@ -54,7 +35,7 @@ function getReasoningItemText(item: ReasoningDetailItem): string | undefined {
  * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
  */
 const extractTextFromReasoningDetails = (
-  details: ReasoningDetailItem[] | unknown,
+  details: ReasoningDetailUnion[] | unknown,
 ): string => {
   if (!Array.isArray(details)) {
     // Fallback: if it's a string, return it directly
@@ -63,7 +44,7 @@ const extractTextFromReasoningDetails = (
 
   return details
     .filter(
-      (item): item is ReasoningDetailItem => !!item && typeof item === 'object',
+      (item): item is ReasoningDetailUnion => !!item && typeof item === 'object',
     )
     .map(getReasoningItemText)
     .filter((text): text is string => !!text)
@@ -83,7 +64,7 @@ const extractOpenRouterReasoningDelta = (
   if (!choice) return '';
 
   const delta = choice.delta as {
-    reasoning_details?: ReasoningDetailItem[] | string;
+    reasoning_details?: ReasoningDetailUnion[] | string;
     reasoning_content?: string;
   };
 
@@ -199,7 +180,7 @@ export class ModelHandlerOpenRouter extends ModelHandlerOpenAI {
 
   /**
    * OpenRouter returns reasoning in different formats:
-   * - reasoning_details: array of objects (normalized format, see ReasoningDetailItem)
+   * - reasoning_details: array of objects (normalized format, see ReasoningDetailUnion)
    * - reasoning: string (simple format)
    *
    * @see https://openrouter.ai/docs/guides/best-practices/reasoning-tokens

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,13 @@
       "@tools/*": ["src/tools/*"],
       "@types/*": ["src/types/*"],
       "@eventBus/*": ["src/eventBus/*"],
-      "@auth/*": ["src/auth/*"]
+      "@auth/*": ["src/auth/*"],
+      "@openrouter/sdk": [
+        "node_modules/@openrouter/sdk/esm/index.d.ts"
+      ],
+      "@openrouter/sdk/models": [
+        "node_modules/@openrouter/sdk/esm/models/index.d.ts"
+      ]
     },
     "moduleResolution": "node",
     "strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
Replace the hand-rolled ReasoningDetailItem type with the SDK's ReasoningDetailUnion,
and add tsconfig paths to resolve ESM subpath exports under moduleResolution: "node".

https://claude.ai/code/session_01Uu9nJHM8uoCDUgUoxLXJqi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type/import refactor plus TypeScript `paths` tweaks, with no functional behavior changes expected beyond build-time module resolution.
> 
> **Overview**
> Switches OpenRouter reasoning parsing in `modelHandlerOpenRouter.ts` from a locally defined `ReasoningDetailItem` union to the SDK’s `ReasoningDetailUnion`, updating helper signatures and casts accordingly.
> 
> Updates `tsconfig.json` `paths` to explicitly map `@openrouter/sdk` and `@openrouter/sdk/models` to the SDK’s ESM `.d.ts` entrypoints so the types can be imported under `moduleResolution: "node"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90797362ea20edfdd08b95d5fd4edd254729958a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->