### PR TITLE
Codex tool: native stream tabs, multi-turn follow-ups, all item types, and tool toggle

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -490,7 +490,7 @@ const SLOW_TOOLS = new Set([
 const DEFERRED_LOG_TOOLS = new Set(['bash', 'codex']);
 
 /** Tools that support streaming partial output to the UI. */
-const STREAMABLE_TOOLS = new Set(['bash', 'codex']);
+const STREAMABLE_TOOLS = new Set(['bash']);
 
 /** Maximum size of the streaming output buffer sent to the UI (bytes). */
 const STREAM_BUFFER_MAX = 50_000;

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -89,6 +89,9 @@ export enum GlobalStateKey {
 
   // Transport settings
   WEBSOCKET_OPENAI = 'texra.websocket.openai',
+
+  // Tool settings
+  DISABLED_TOOLS = 'texra.tools.disabled',
 }
 
 /** Prefix used for per-instruction suppression flags */

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -77,6 +77,7 @@ export const SETTINGS_VIEW_CMD = {
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
+  TOGGLE_TOOL: 'toggleTool',
   // Git settings commands
   GET_GIT_AUTHOR_SETTINGS: 'getGitAuthorSettings',
   SET_GIT_MARK_COMMITS: 'setGitMarkCommits',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
 import * as logger from '@logger/logUtils';
 import { UsageLogService } from '@logger/UsageLogService';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
+import { interruptAllCodexSessions } from '@tools/codex';
 import { setExtensionChecker } from '@tools/externalToolDefs';
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
 import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
@@ -335,6 +336,7 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate() {
   disposeStatusListener?.();
   killBackgroundProcesses();
+  interruptAllCodexSessions();
   killActiveRecording();
 
   await UsageLogService.dispose();

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -395,12 +395,9 @@ export class BackgroundTasksPanel extends LitElement {
   }
 }
 
-/** Tool names that represent external AI agents (distinct from plain shell processes). */
-const AGENT_TOOL_NAMES = new Set(['codex']);
-
-/** Check if a child is an AI agent process (uses stable toolName metadata). */
+/** Check if a child process represents an AI agent (distinct from plain shell). */
 function isAgentProcess(child: ActiveChildInfo): boolean {
-  return Boolean(child.toolName && AGENT_TOOL_NAMES.has(child.toolName));
+  return child.toolName === 'codex';
 }
 
 /** Pick the appropriate codicon for a background task item. */

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -116,6 +116,7 @@ import {
   getProviderKeyUrl,
 } from '@utils/config/providerConfig';
 import { getConfig } from '@utils/config/configUtils';
+import { setToolEnabled } from '@utils/config/constants';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import { AgentHandlers } from './handlers/agentHandlers';
@@ -486,6 +487,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
         this.withActiveWebview((w) => this.sendToolDashboardData(w)),
+      [SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL]: async (data) => {
+        await setToolEnabled(data.toolId, data.enabled);
+        await this.withActiveWebview((w) => this.sendToolDashboardData(w));
+      },
     };
   }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -88,6 +88,10 @@ import {
   setToolEditApprovalSessionBypass,
 } from '@tools/approval';
 import {
+  getLastCheckResults,
+  refreshDisabledToolCache,
+} from '@tools/toolAvailability';
+import {
   MEMORY_STORAGE_ROOT,
   MAX_PINNED_MEMORIES,
 } from '@tools/memory/constants';
@@ -489,7 +493,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.withActiveWebview((w) => this.sendToolDashboardData(w)),
       [SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL]: async (data) => {
         await setToolEnabled(data.toolId, data.enabled);
-        await this.withActiveWebview((w) => this.sendToolDashboardData(w));
+        refreshDisabledToolCache();
+        // Re-render with cached check results — no network re-probe needed
+        await this.withActiveWebview((w) =>
+          this.sendToolDashboardData(w, { skipChecks: true }),
+        );
       },
     };
   }
@@ -1378,8 +1386,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Tool dashboard handler implementations
   // ============================================================
 
-  public async sendToolDashboardData(webview: vscode.Webview): Promise<void> {
-    const items = await buildToolDashboardItems();
+  public async sendToolDashboardData(
+    webview: vscode.Webview,
+    options?: { skipChecks?: boolean },
+  ): Promise<void> {
+    const cachedResults =
+      options?.skipChecks ? (getLastCheckResults() ?? undefined) : undefined;
+    const items = await buildToolDashboardItems(cachedResults);
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
       items,

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -580,6 +580,10 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
   );
 
+  private handleToolToggle = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL,
+  );
+
   // Git settings event handlers
   private handleGitMarkCommitsToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
@@ -800,6 +804,7 @@ export class SettingsApp extends SettingsAppBase {
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-recheck=${this.handleToolRecheck}
+              @tool-toggle=${this.handleToolToggle}
             ></tools-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -97,6 +97,11 @@ export class ToolCard extends LitElement {
         background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
       }
 
+      .tool-badge--disabled {
+        color: var(--color-text-secondary);
+        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+      }
+
       .tool-description {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
@@ -330,7 +335,7 @@ export class ToolCard extends LitElement {
   private renderBadge(): TemplateResult {
     if (this.item.toggleable && this.item.enabled === false) {
       return html`
-        <span class="tool-badge tool-badge--unknown">
+        <span class="tool-badge tool-badge--disabled">
           <span class="codicon codicon-circle-slash"></span>
           Disabled
         </span>

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -205,6 +205,74 @@ export class ToolCard extends LitElement {
         );
       }
 
+      .tool-auth-note {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        padding: var(--border-thin) var(--spacing-small);
+        font-size: var(--font-size-xs, 11px);
+        border-radius: var(--border-radius);
+        white-space: nowrap;
+        font-weight: var(--font-weight-medium);
+        color: var(--vscode-charts-blue, #3794ff);
+        background: color-mix(
+          in srgb,
+          var(--vscode-charts-blue, #3794ff) 12%,
+          transparent
+        );
+      }
+
+      .tool-toggle {
+        position: relative;
+        display: inline-block;
+        width: 36px;
+        height: 20px;
+        flex-shrink: 0;
+      }
+
+      .tool-toggle input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+
+      .tool-toggle-slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: var(--vscode-input-background, rgba(128, 128, 128, 0.3));
+        border-radius: 10px;
+        transition: background var(--transition-fast);
+      }
+
+      .tool-toggle-slider::before {
+        content: '';
+        position: absolute;
+        height: 14px;
+        width: 14px;
+        left: 3px;
+        bottom: 3px;
+        background: var(--vscode-foreground);
+        border-radius: 50%;
+        transition: transform var(--transition-fast);
+      }
+
+      .tool-toggle input:checked + .tool-toggle-slider {
+        background: var(--vscode-button-background, #0e639c);
+      }
+
+      .tool-toggle input:checked + .tool-toggle-slider::before {
+        transform: translateX(16px);
+      }
+
+      .tool-toggle input:focus-visible + .tool-toggle-slider {
+        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline-offset: 1px;
+      }
+
       .tool-config-note {
         margin-top: var(--spacing-small);
         font-size: var(--font-size-xs, 11px);
@@ -238,6 +306,16 @@ export class ToolCard extends LitElement {
         }),
       );
     }
+  }
+
+  private handleToggle(e: Event): void {
+    const checked = (e.target as HTMLInputElement).checked;
+    this.dispatchEvent(
+      createEvent('tool-toggle', {
+        toolId: this.item.id,
+        enabled: checked,
+      }),
+    );
   }
 
   private static readonly STATUS_CONFIG: Record<
@@ -316,6 +394,30 @@ export class ToolCard extends LitElement {
     `;
   }
 
+  private renderToggle(): TemplateResult | typeof nothing {
+    if (!this.item.toggleable) return nothing;
+    return html`
+      <label class="tool-toggle" title="${this.item.enabled !== false ? 'Disable' : 'Enable'} ${this.item.name}">
+        <input
+          type="checkbox"
+          .checked=${this.item.enabled !== false}
+          @change=${this.handleToggle}
+        />
+        <span class="tool-toggle-slider"></span>
+      </label>
+    `;
+  }
+
+  private renderAuthNote(): TemplateResult | typeof nothing {
+    if (!this.item.authNote) return nothing;
+    return html`
+      <span class="tool-auth-note">
+        <span class="codicon codicon-key"></span>
+        ${this.item.authNote}
+      </span>
+    `;
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="tool-card">
@@ -323,7 +425,9 @@ export class ToolCard extends LitElement {
           <div class="tool-title-group">
             <span class="tool-name">${this.item.name}</span>
             ${this.renderBadge()}
+            ${this.renderAuthNote()}
           </div>
+          ${this.renderToggle()}
         </div>
         <div class="tool-description">${this.item.description}</div>
         ${this.item.statusDetail

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -328,6 +328,14 @@ export class ToolCard extends LitElement {
   };
 
   private renderBadge(): TemplateResult {
+    if (this.item.toggleable && this.item.enabled === false) {
+      return html`
+        <span class="tool-badge tool-badge--unknown">
+          <span class="codicon codicon-circle-slash"></span>
+          Disabled
+        </span>
+      `;
+    }
     const { status } = this.item;
     const config =
       ToolCard.STATUS_CONFIG[status] ?? ToolCard.STATUS_CONFIG.unknown;

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -181,7 +181,7 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
       category: def.category,
       description: def.description,
       tools: enrichTools(tools),
-      status: disabledIds.has(def.id) ? 'not-found' : status,
+      status,
       requiresSetup: true,
       installGuide: def.installGuide,
       installUrl: def.installUrl,

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -140,6 +140,9 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
 // Public API
 // ============================================================
 
+/** Cached detail check results from the last full probe. */
+let lastDetailResults: (string | undefined)[] | null = null;
+
 /**
  * Build the complete tool dashboard items list.
  *
@@ -159,18 +162,21 @@ export async function buildToolDashboardItems(
 
   const results = cachedResults ?? (await runExternalToolChecks());
 
-  // Resolve optional detail checks in parallel
-  const detailResults = await Promise.all(
-    results.map(async ({ id }) => {
-      const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
-      if (!def?.detailCheck) return undefined;
-      try {
-        return await def.detailCheck();
-      } catch {
-        return undefined;
-      }
-    }),
-  );
+  // Skip detail checks when using cached results (toggle path)
+  const detailResults = cachedResults
+    ? lastDetailResults ?? results.map(() => undefined)
+    : await Promise.all(
+        results.map(async ({ id }) => {
+          const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
+          if (!def?.detailCheck) return undefined;
+          try {
+            return await def.detailCheck();
+          } catch {
+            return undefined;
+          }
+        }),
+      );
+  lastDetailResults = detailResults;
 
   // Merge check results with UI metadata from EXTERNAL_TOOL_DEFS
   const disabledIds = getDisabledToolIds();

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -12,11 +12,12 @@ import type {
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
-import { runExternalToolChecks } from '@tools/toolAvailability';
 import {
   getDefaultToolRegistry,
   type RegisteredToolName,
 } from '@tools/registry';
+import { runExternalToolChecks } from '@tools/toolAvailability';
+import { getDisabledToolIds } from '@utils/config/constants';
 
 // ============================================================
 // Tool description enrichment
@@ -168,6 +169,7 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
   );
 
   // Merge check results with UI metadata from EXTERNAL_TOOL_DEFS
+  const disabledIds = getDisabledToolIds();
   const externalItems: ToolDashboardItem[] = [];
   for (let i = 0; i < results.length; i++) {
     const { id, tools, status } = results[i];
@@ -179,13 +181,16 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
       category: def.category,
       description: def.description,
       tools: enrichTools(tools),
-      status,
+      status: disabledIds.has(def.id) ? 'not-found' : status,
       requiresSetup: true,
       installGuide: def.installGuide,
       installUrl: def.installUrl,
       installExtensionId: def.installExtensionId,
       configNotes: def.configNotes,
       statusDetail: detailResults[i],
+      authNote: def.authNote,
+      toggleable: def.toggleable,
+      enabled: !disabledIds.has(def.id),
     });
   }
 

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -16,7 +16,11 @@ import {
   getDefaultToolRegistry,
   type RegisteredToolName,
 } from '@tools/registry';
-import { runExternalToolChecks } from '@tools/toolAvailability';
+import {
+  getLastCheckResults,
+  runExternalToolChecks,
+  type ExternalToolCheckResult,
+} from '@tools/toolAvailability';
 import { getDisabledToolIds } from '@utils/config/constants';
 
 // ============================================================
@@ -137,13 +141,14 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
 // ============================================================
 
 /**
- * Build the complete tool dashboard items list with runtime availability checks.
+ * Build the complete tool dashboard items list.
  *
- * Always runs fresh external checks (and updates the availability cache
- * in {@link @tools/toolAvailability} as a side effect).
+ * @param cachedResults — when provided, skips network probes and uses
+ *   these results. Used by the toggle handler for instant UI updates.
  */
-export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
-  // Built-in tools are always available
+export async function buildToolDashboardItems(
+  cachedResults?: ExternalToolCheckResult[],
+): Promise<ToolDashboardItem[]> {
   const builtinItems: ToolDashboardItem[] = BUILTIN_TOOLS.map(
     ({ toolNames, ...rest }) => ({
       ...rest,
@@ -152,8 +157,7 @@ export async function buildToolDashboardItems(): Promise<ToolDashboardItem[]> {
     }),
   );
 
-  // Run fresh checks — also updates the availability cache
-  const results = await runExternalToolChecks();
+  const results = cachedResults ?? (await runExternalToolChecks());
 
   // Resolve optional detail checks in parallel
   const detailResults = await Promise.all(

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -273,6 +273,9 @@ export const ToolDashboardItemSchema = z.object({
   installExtensionId: z.string().optional(),
   configNotes: z.string().optional(),
   statusDetail: z.string().optional(),
+  authNote: z.string().optional(),
+  toggleable: z.boolean().optional(),
+  enabled: z.boolean().optional(),
 });
 export type ToolDashboardItem = z.infer<typeof ToolDashboardItemSchema>;
 
@@ -552,6 +555,12 @@ const InstallToolExtensionMessageSchema = z.object({
 
 const RecheckToolStatusMessageSchema = commandOnly(CMD.RECHECK_TOOL_STATUS);
 
+const ToggleToolMessageSchema = z.object({
+  command: z.literal(CMD.TOGGLE_TOOL),
+  toolId: z.string().min(1),
+  enabled: z.boolean(),
+});
+
 // Git author settings inbound messages
 const GetGitAuthorSettingsMessageSchema = commandOnly(
   CMD.GET_GIT_AUTHOR_SETTINGS,
@@ -606,6 +615,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     OpenToolInstallUrlMessageSchema,
     InstallToolExtensionMessageSchema,
     RecheckToolStatusMessageSchema,
+    ToggleToolMessageSchema,
     // LaTeX settings messages
     GetLatexSettingsStatusMessageSchema,
     ApplyLatexSettingsMessageSchema,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -223,7 +223,7 @@ function logCodexItem(
   }
 }
 
-/** Finalize a codex child stream (mark ready, log summary). */
+/** Finalize a codex child stream (mark completed/error, log summary). */
 function finalizeCodexStream(
   childStreamId: StreamTabId,
   executionId: string,
@@ -245,7 +245,10 @@ function finalizeCodexStream(
       `Tokens: ${options.usage.input_tokens} in / ${options.usage.output_tokens} out`,
     );
   }
-  StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+  StreamStatusService.set(
+    childStreamId,
+    options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+  );
   untrackExecution(executionId);
 }
 
@@ -442,16 +445,10 @@ export class CodexTool extends defineTool({
           case 'turn.completed':
             usage = event.usage ?? null;
             break;
-          case 'turn.failed': {
-            const msg = event.error.message ?? 'Codex turn failed';
-            logger.error(msg);
-            throw new Error(msg);
-          }
-          case 'error': {
-            const msg = event.message ?? 'Codex stream error';
-            logger.error(msg);
-            throw new Error(msg);
-          }
+          case 'turn.failed':
+            throw new Error(event.error.message ?? 'Codex turn failed');
+          case 'error':
+            throw new Error(event.message ?? 'Codex stream error');
         }
       }
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -116,7 +116,7 @@ interface ActiveThread {
   thread: Thread;
   childStreamId: StreamTabId;
   logger: AgentLogger;
-  executionId: string;
+  executionId: ExecutionId;
 }
 
 const threadRegistry = new Map<string, ActiveThread>();
@@ -124,21 +124,16 @@ const threadRegistry = new Map<string, ActiveThread>();
 /** Store a thread for multi-turn reuse and persist thread ID to disk. */
 function storeThread(threadId: string, entry: ActiveThread): void {
   threadRegistry.set(threadId, entry);
-  // Persist thread ID so the orchestrator can resume after extension reload.
-  // The SDK stores conversation history in ~/.codex/sessions — this ID is
-  // the key needed by codex.resumeThread() to reconstruct the thread.
-  void getExecutionStore(entry.executionId as ExecutionId)
+  // Extension reload clears memory but SDK stores sessions on disk —
+  // persist the ID so resumeThread() can reconstruct the conversation.
+  void getExecutionStore(entry.executionId)
     .write('codex_thread_id', threadId)
     .catch(() => {});
 }
 
-/**
- * Interrupt all active codex follow-up sessions.
- * Called during extension deactivation to clean up in-memory state
- * so streams don't remain in stale WAITING state.
- */
+/** Prevents codex streams from remaining in stale WAITING state during reload. */
 export function interruptAllCodexSessions(): void {
-  for (const { childStreamId } of threadRegistry.values()) {
+  for (const { childStreamId } of [...threadRegistry.values()]) {
     getInterruptible(childStreamId)?.interrupt();
   }
 }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -121,9 +121,26 @@ interface ActiveThread {
 
 const threadRegistry = new Map<string, ActiveThread>();
 
-/** Store a thread for multi-turn reuse. Called from both execution paths. */
+/** Store a thread for multi-turn reuse and persist thread ID to disk. */
 function storeThread(threadId: string, entry: ActiveThread): void {
   threadRegistry.set(threadId, entry);
+  // Persist thread ID so the orchestrator can resume after extension reload.
+  // The SDK stores conversation history in ~/.codex/sessions — this ID is
+  // the key needed by codex.resumeThread() to reconstruct the thread.
+  void getExecutionStore(entry.executionId as ExecutionId)
+    .write('codex_thread_id', threadId)
+    .catch(() => {});
+}
+
+/**
+ * Interrupt all active codex follow-up sessions.
+ * Called during extension deactivation to clean up in-memory state
+ * so streams don't remain in stale WAITING state.
+ */
+export function interruptAllCodexSessions(): void {
+  for (const { childStreamId } of threadRegistry.values()) {
+    getInterruptible(childStreamId)?.interrupt();
+  }
 }
 
 // ============================================================================
@@ -385,6 +402,11 @@ function startFollowUpLoop(
   registerInterruptible(childStreamId, session);
 
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+
+  // Start a log group so endRunningGroups() marks it as errored on reload,
+  // giving the user a visual cue that the session was interrupted.
+  const groupId = logger.startGroup('Codex session');
+
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
 
   void (async () => {
@@ -409,6 +431,7 @@ function startFollowUpLoop(
         StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
       }
     } finally {
+      logger.endGroup(groupId, 'stopped');
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       untrackExecution(executionId);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,7 +22,7 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import { AgentConfigSchema } from '@agent/core/AgentConfig';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   trackExecution,
@@ -51,6 +51,7 @@ import {
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
 import { formatDuration } from '@utils/core';
+import { agentConfigToTaskState } from '@utils/config/configConversion';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -244,11 +245,20 @@ function formatCodexError(
 // Stream tab helpers
 // ============================================================================
 
+/** Build a synthetic AgentConfig for codex (used for TaskState and execution registration). */
+function buildCodexConfig(prompt: string): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: 'codex',
+    instruction: prompt,
+  });
+}
+
 /** Create a child stream tab for a codex execution and return its logger. */
 function createCodexStream(
   executionId: string,
   parentStreamId: StreamTabId,
   prompt: string,
+  config: AgentConfig,
 ): { childStreamId: StreamTabId; logger: AgentLogger } {
   const childStreamId = `codex@codex-sdk#${executionId}` as StreamTabId;
 
@@ -256,6 +266,12 @@ function createCodexStream(
   bus.emit('setActiveStream', {
     streamId: childStreamId,
     agentCategory: AgentCategory.ToolUse,
+  });
+  bus.emit('setTaskState', {
+    streamId: childStreamId,
+    executionId,
+    taskState: agentConfigToTaskState(config),
+    storageKey: executionId,
   });
   bus.emit('updateStreamDescription', {
     streamId: childStreamId,
@@ -597,9 +613,16 @@ export class CodexTool extends defineTool({
     await ensureRunDir(executionId);
     const preview = truncateWithEllipsis(input.prompt, 60);
     const startedAt = Date.now();
+    const config = buildCodexConfig(input.prompt);
+
+    if (parentStreamId) {
+      const parentExecutionId = getCurrentToolFileInteractionContext()?.executionId;
+      await registerExecution(executionId, config, 'codex', parentExecutionId)
+        .catch(() => {});
+    }
 
     const stream = parentStreamId
-      ? createCodexStream(executionId, parentStreamId, input.prompt)
+      ? createCodexStream(executionId, parentStreamId, input.prompt, config)
       : undefined;
 
     try {
@@ -644,19 +667,10 @@ export class CodexTool extends defineTool({
     await ensureRunDir(executionId);
 
     const preview = truncateWithEllipsis(input.prompt, 60);
-
-    const syntheticConfig = AgentConfigSchema.parse({
-      agent: 'codex',
-      instruction: input.prompt,
-    });
+    const config = buildCodexConfig(input.prompt);
 
     try {
-      await registerExecution(
-        executionId,
-        syntheticConfig,
-        'codex',
-        parentExecutionId,
-      );
+      await registerExecution(executionId, config, 'codex', parentExecutionId);
     } catch {
       throw new ToolError('Failed to register background Codex execution.');
     }
@@ -665,6 +679,7 @@ export class CodexTool extends defineTool({
       executionId,
       parentStreamId,
       input.prompt,
+      config,
     );
 
     const startedAt = Date.now();

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -9,48 +9,35 @@
  * externalToolDefs.ts.
  */
 
-// Node builtins
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-
 // Third-party imports
 import { z } from 'zod';
-import type {
-  CommandExecutionItem,
-  FileChangeItem,
-  RunResult,
-  SandboxMode,
-  Thread,
-  ThreadEvent,
-  ThreadItem,
-} from '@openai/codex-sdk';
 
-// Local imports - agent
+// Local imports
 import {
   getExecutionStore,
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   trackExecution,
   untrackExecution,
-  ProcessExecutionHandle,
+  AgentExecutionHandle,
 } from '@agent/runtime/executionRegistry';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-
-// Local imports - tools
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
+import { STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
+import { escapeAttr, escapeText } from '@tools/subagentResults';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
-import { escapeAttr, escapeText } from '@tools/subagentResults';
-
-// Local imports - utils
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -58,6 +45,14 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
+
+// Type-only imports (kept separate for bundler efficiency)
+import type {
+  RunResult,
+  SandboxMode,
+  Thread,
+  ThreadItem,
+} from '@openai/codex-sdk';
 
 // ============================================================================
 // Schema
@@ -99,7 +94,7 @@ export type CodexInput = z.infer<typeof CodexInputSchema>;
  *
  * Only includes the final model response (what the LLM needs to act on) plus
  * a compact usage note. Intermediate details (commands run, files changed) are
- * streamed to the UI via onToolOutput and don't need to be in the result.
+ * streamed to the child stream tab and don't need to be in the result.
  */
 function formatTurnResult(turn: RunResult): string {
   const parts: string[] = [turn.finalResponse || '(no response)'];
@@ -152,33 +147,107 @@ function formatCodexError(
   ].join('\n');
 }
 
-/** Format a completed thread item as a human-readable log line for the process view. */
-function formatItemForLog(item: ThreadItem): string {
+// ============================================================================
+// Stream tab helpers
+// ============================================================================
+
+/** Create a child stream tab for a codex execution and return its logger. */
+function createCodexStream(
+  executionId: string,
+  parentStreamId: StreamTabId,
+  prompt: string,
+): { childStreamId: StreamTabId; logger: AgentLogger } {
+  const childStreamId = `codex@codex-sdk#${executionId}` as StreamTabId;
+
+  // Acquire stream lock and activate the tab
+  StreamStatusService.tryAcquire(childStreamId);
+  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+
+  // Activate the stream tab with proper category so the UI creates execution state
+  bus.emit('setActiveStream', {
+    streamId: childStreamId,
+    agentCategory: AgentCategory.ToolUse,
+  });
+
+  // Set a human-readable description for the stream tab
+  bus.emit('updateStreamDescription', {
+    streamId: childStreamId,
+    description: truncateWithEllipsis(prompt, 80),
+  });
+
+  // Create agent logger for the child stream
+  const logger = new AgentLogger(childStreamId, true);
+
+  // Register parent-child linkage via AgentExecutionHandle
+  const handle = new AgentExecutionHandle(
+    executionId,
+    parentStreamId,
+    childStreamId,
+    'codex',
+    'toolUse',
+  );
+  trackExecution(handle);
+
+  return { childStreamId, logger };
+}
+
+/** Log a completed codex thread item to the child stream's logger. */
+function logCodexItem(
+  item: ThreadItem,
+  logger: AgentLogger,
+): void {
   switch (item.type) {
     case 'command_execution': {
-      let status: string;
-      if (item.exit_code === undefined) {
-        status = item.status;
-      } else if (item.exit_code === 0) {
-        status = 'ok';
-      } else {
-        status = `exit ${item.exit_code}`;
-      }
-      return `$ ${item.command} (${status})\n`;
+      const exitInfo =
+        item.exit_code === undefined
+          ? item.status
+          : item.exit_code === 0
+            ? 'ok'
+            : `exit ${item.exit_code}`;
+      logger.logToolUse({
+        toolName: 'bash',
+        input: { command: item.command },
+        output: `(${exitInfo})`,
+        status: 'completed',
+      });
+      break;
     }
     case 'file_change': {
-      const changed = item.changes.map((c) => `${c.kind} ${c.path}`).join(', ');
-      return changed ? `Files: ${changed}\n` : '';
+      const changes = item.changes.map((c: { kind: string; path: string }) => `${c.kind} ${c.path}`);
+      if (changes.length > 0) {
+        logger.info(`Files: ${changes.join(', ')}`);
+      }
+      break;
     }
     case 'agent_message':
-      return `${item.text}\n`;
+      logger.info(item.text, { messageType: 'modelResponse' });
+      break;
     case 'reasoning':
-      return `[reasoning] ${item.text}\n`;
+      logger.info(item.text, { messageType: 'thinking' });
+      break;
     case 'error':
-      return `Error: ${item.message}\n`;
-    default:
-      return '';
+      logger.error(item.message);
+      break;
   }
+}
+
+/** Finalize a codex child stream (mark ready, log summary). */
+function finalizeCodexStream(
+  childStreamId: StreamTabId,
+  executionId: string,
+  logger: AgentLogger,
+  wallTimeMs: number,
+  usage: RunResult['usage'],
+): void {
+  const durationSec = (wallTimeMs / 1000).toFixed(1);
+  logger.info(`Completed in ${durationSec}s`);
+  if (usage) {
+    logger.info(
+      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
+    );
+  }
+  StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+  untrackExecution(executionId);
 }
 
 // ============================================================================
@@ -232,33 +301,65 @@ export class CodexTool extends defineTool({
       );
     }
 
-    return this.executeForeground(thread, input, ctx?.onToolOutput);
+    return this.executeForeground(thread, input, ctx?.streamId);
   }
 
   private async executeForeground(
     thread: Thread,
     input: CodexInput,
-    onToolOutput?: (chunk: string) => void,
+    parentStreamId?: StreamTabId,
   ): Promise<ToolResult> {
-    // Use streaming path when the framework provides a live-output callback,
-    // so partial results appear in the UI as they arrive (like slow bash).
-    const turn = onToolOutput
-      ? await this.runStreamedForeground(thread, input, onToolOutput)
-      : await thread.run(input.prompt);
-
+    const executionId = generateExecutionId();
     const preview = truncateWithEllipsis(input.prompt, 60);
+    const startedAt = Date.now();
 
-    return {
-      summary: `Codex: ${preview}`,
-      output: formatTurnResult(turn),
-    };
+    // Create a child stream tab for the codex execution
+    const hasParent = !!parentStreamId;
+    const stream = hasParent
+      ? createCodexStream(executionId, parentStreamId, input.prompt)
+      : undefined;
+
+    try {
+      const turn = await this.runStreamedForeground(
+        thread,
+        input,
+        stream?.logger,
+      );
+
+      if (stream) {
+        finalizeCodexStream(
+          stream.childStreamId,
+          executionId,
+          stream.logger,
+          Date.now() - startedAt,
+          turn.usage,
+        );
+      }
+
+      return {
+        summary: `Codex: ${preview}`,
+        output: formatTurnResult(turn),
+      };
+    } catch (err) {
+      if (stream) {
+        stream.logger.error(
+          err instanceof Error ? err.message : String(err),
+        );
+        StreamStatusService.set(
+          stream.childStreamId,
+          STREAM_STATUS.READY,
+        );
+        untrackExecution(executionId);
+      }
+      throw err;
+    }
   }
 
-  /** Run a foreground turn via the streaming API, pushing chunks to the UI. */
+  /** Run a foreground turn via the streaming API, logging events to the child stream. */
   private async runStreamedForeground(
     thread: Thread,
     input: CodexInput,
-    onToolOutput: (chunk: string) => void,
+    logger?: AgentLogger,
   ): Promise<RunResult> {
     const { events } = await thread.runStreamed(input.prompt);
     const items: ThreadItem[] = [];
@@ -270,8 +371,9 @@ export class CodexTool extends defineTool({
         case 'item.completed': {
           const { item } = event;
           items.push(item);
-          const line = formatItemForLog(item);
-          if (line) onToolOutput(line);
+          if (logger) {
+            logCodexItem(item, logger);
+          }
           if (item.type === 'agent_message') {
             responseParts.push(item.text);
           }
@@ -316,57 +418,25 @@ export class CodexTool extends defineTool({
       instruction: input.prompt,
     });
 
-    // Temp file for live output — the execution registry poller reads this
-    // incrementally and surfaces it in the clickable process view.
-    const stdoutPath = path.join(
-      os.tmpdir(),
-      `texra-bg-${executionId}-stdout.log`,
-    );
-    const stderrPath = path.join(
-      os.tmpdir(),
-      `texra-bg-${executionId}-stderr.log`,
-    );
-    const stdoutStream = fs.createWriteStream(stdoutPath, { flags: 'a' });
-    const stderrStream = fs.createWriteStream(stderrPath, { flags: 'a' });
-    stdoutStream.on('error', () => {}); // prevent unhandled emitter crash
-    stderrStream.on('error', () => {});
-
-    const handle = new ProcessExecutionHandle(
-      executionId,
-      parentStreamId,
-      preview,
-      () => false, // Codex SDK doesn't expose PID for kill — AbortController would be future work
-    );
-    handle.toolName = 'codex';
-    handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
-
     try {
       await registerExecution(
         executionId,
         syntheticConfig,
         'codex',
         parentExecutionId,
-        'process',
       );
     } catch {
-      stdoutStream.end();
-      stderrStream.end();
-      void fs.promises.unlink(stdoutPath).catch(() => {});
-      void fs.promises.unlink(stderrPath).catch(() => {});
       throw new ToolError('Failed to register background Codex execution.');
     }
 
-    trackExecution(handle);
+    // Create a child stream tab — codex events stream here in real time
+    const { childStreamId, logger } = createCodexStream(
+      executionId,
+      parentStreamId,
+      input.prompt,
+    );
 
     const startedAt = Date.now();
-
-    const cleanupTempFiles = (): void => {
-      stdoutStream.end();
-      stderrStream.end();
-      handle.outputPaths = undefined;
-      void fs.promises.unlink(stdoutPath).catch(() => {});
-      void fs.promises.unlink(stderrPath).catch(() => {});
-    };
 
     const promise = (async (): Promise<RunResult> => {
       const { events } = await thread.runStreamed(input.prompt);
@@ -377,8 +447,7 @@ export class CodexTool extends defineTool({
         switch (event.type) {
           case 'item.completed': {
             const { item } = event;
-            const line = formatItemForLog(item);
-            if (line) stdoutStream.write(line);
+            logCodexItem(item, logger);
             if (item.type === 'agent_message') {
               responseParts.push(item.text);
             }
@@ -389,12 +458,12 @@ export class CodexTool extends defineTool({
             break;
           case 'turn.failed': {
             const msg = event.error.message ?? 'Codex turn failed';
-            stderrStream.write(`Error: ${msg}\n`);
+            logger.error(msg);
             throw new Error(msg);
           }
           case 'error': {
             const msg = event.message ?? 'Codex stream error';
-            stderrStream.write(`Error: ${msg}\n`);
+            logger.error(msg);
             throw new Error(msg);
           }
         }
@@ -414,6 +483,14 @@ export class CodexTool extends defineTool({
 
         await writeTerminalStatus(executionId, 'completed').catch(() => {});
 
+        finalizeCodexStream(
+          childStreamId,
+          executionId,
+          logger,
+          wallTimeMs,
+          turn.usage,
+        );
+
         const msg = formatCodexDelivery(
           executionId,
           input.prompt,
@@ -426,13 +503,13 @@ export class CodexTool extends defineTool({
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
 
+        logger.error(err instanceof Error ? err.message : String(err));
+        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+        untrackExecution(executionId);
+
         const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-      })
-      .finally(() => {
-        untrackExecution(executionId);
-        cleanupTempFiles();
       });
 
     return {
@@ -440,8 +517,7 @@ export class CodexTool extends defineTool({
       output: [
         `Codex agent launched in background (${input.sandbox_mode}).`,
         `Execution ID: ${executionId}`,
-        `To read output: executions tool with path=/executions/${executionId}/output`,
-        `To wait for completion: executions tool with path=/executions/${executionId} action=wait`,
+        `Stream tab: ${childStreamId}`,
         'Result will be delivered as a follow-up message when complete.',
       ].join('\n'),
     };

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -556,14 +556,13 @@ export class CodexTool extends defineTool({
   private async resolveThread(input: CodexInput): Promise<Thread> {
     if (input.thread_id) {
       const stored = threadRegistry.get(input.thread_id);
-      // Only reuse the in-memory thread if the follow-up loop is idle (WAITING).
-      // If RUNNING, a turn is in progress — fall through to disk resume to
-      // avoid concurrent streaming turns on the same Thread object.
-      if (
-        stored &&
-        StreamStatusService.get(stored.childStreamId) === STREAM_STATUS.WAITING
-      ) {
+      if (stored) {
+        // Always interrupt the old follow-up loop. If it's WAITING, the
+        // interrupt is clean. If RUNNING, the in-progress turn will error
+        // out — but this prevents orphaned loops and concurrent turns on
+        // the same Thread object.
         getInterruptible(stored.childStreamId)?.interrupt();
+        threadRegistry.delete(input.thread_id);
         return stored.thread;
       }
     }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -271,7 +271,7 @@ function createCodexStream(
     streamId: childStreamId,
     executionId,
     taskState: agentConfigToTaskState(config),
-    storageKey: executionId as string as StorageKey,
+    storageKey: executionId as StorageKey,
   });
   bus.emit('updateStreamDescription', {
     streamId: childStreamId,
@@ -613,12 +613,12 @@ export class CodexTool extends defineTool({
     parentStreamId?: StreamTabId,
   ): Promise<ToolResult> {
     const executionId = generateExecutionId();
-    await ensureRunDir(executionId);
     const preview = truncateWithEllipsis(input.prompt, 60);
     const startedAt = Date.now();
     const config = buildCodexConfig(input.prompt);
 
     if (parentStreamId) {
+      await ensureRunDir(executionId);
       const parentExecutionId = getCurrentToolFileInteractionContext()?.executionId;
       await registerExecution(executionId, config, 'codex', parentExecutionId)
         .catch(() => {});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -404,6 +404,7 @@ function finalizeCodexStream(
 function startFollowUpLoop(
   thread: Thread,
   childStreamId: StreamTabId,
+  executionId: string,
   logger: AgentLogger,
 ): void {
   const followUpSession = new CodexFollowUpSession();
@@ -435,12 +436,11 @@ function startFollowUpLoop(
     } finally {
       followUpSession.dispose();
       unregisterInterruptible(childStreamId);
+      untrackExecution(executionId);
 
-      // Clean up thread from registry
       const threadId = thread.id;
       if (threadId) removeThread(threadId);
 
-      // If still in WAITING, mark as READY (session ended)
       if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
         StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
       }
@@ -586,17 +586,15 @@ export class CodexTool extends defineTool({
       const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
-        logTurnSummary(stream.logger, wallTimeMs, turn.usage);
-
-        // Store thread and start follow-up loop for user interaction
         if (threadId) {
+          logTurnSummary(stream.logger, wallTimeMs, turn.usage);
           storeThread(threadId, {
             thread,
             childStreamId: stream.childStreamId,
             logger: stream.logger,
             executionId,
           });
-          startFollowUpLoop(thread, stream.childStreamId, stream.logger);
+          startFollowUpLoop(thread, stream.childStreamId, executionId, stream.logger);
         } else {
           finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
             wallTimeMs,
@@ -668,7 +666,6 @@ export class CodexTool extends defineTool({
         const store = getExecutionStore(executionId);
 
         await writeTerminalStatus(executionId, 'completed').catch(() => {});
-        logTurnSummary(logger, wallTimeMs, turn.usage);
 
         const msg = formatCodexDelivery(
           executionId,
@@ -680,10 +677,10 @@ export class CodexTool extends defineTool({
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
-        // Keep thread alive for follow-ups
         if (threadId) {
+          logTurnSummary(logger, wallTimeMs, turn.usage);
           storeThread(threadId, { thread, childStreamId, logger, executionId });
-          startFollowUpLoop(thread, childStreamId, logger);
+          startFollowUpLoop(thread, childStreamId, executionId, logger);
         } else {
           finalizeCodexStream(childStreamId, executionId, logger, {
             wallTimeMs,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -594,6 +594,7 @@ export class CodexTool extends defineTool({
     parentStreamId?: StreamTabId,
   ): Promise<ToolResult> {
     const executionId = generateExecutionId();
+    await ensureRunDir(executionId);
     const preview = truncateWithEllipsis(input.prompt, 60);
     const startedAt = Date.now();
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -31,13 +31,14 @@ import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
-import { STREAM_STATUS } from '@shared/schemas';
+import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { escapeAttr, escapeText } from '@tools/subagentResults';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
+import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -159,26 +160,17 @@ function createCodexStream(
 ): { childStreamId: StreamTabId; logger: AgentLogger } {
   const childStreamId = `codex@codex-sdk#${executionId}` as StreamTabId;
 
-  // Acquire stream lock and activate the tab
-  StreamStatusService.tryAcquire(childStreamId);
   StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
-
-  // Activate the stream tab with proper category so the UI creates execution state
   bus.emit('setActiveStream', {
     streamId: childStreamId,
     agentCategory: AgentCategory.ToolUse,
   });
-
-  // Set a human-readable description for the stream tab
   bus.emit('updateStreamDescription', {
     streamId: childStreamId,
     description: truncateWithEllipsis(prompt, 80),
   });
 
-  // Create agent logger for the child stream
   const logger = new AgentLogger(childStreamId, true);
-
-  // Register parent-child linkage via AgentExecutionHandle
   const handle = new AgentExecutionHandle(
     executionId,
     parentStreamId,
@@ -220,10 +212,10 @@ function logCodexItem(
       break;
     }
     case 'agent_message':
-      logger.info(item.text, { messageType: 'modelResponse' });
+      logger.info(item.text, { messageType: MESSAGE_TYPES.MODEL_RESPONSE });
       break;
     case 'reasoning':
-      logger.info(item.text, { messageType: 'thinking' });
+      logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
     case 'error':
       logger.error(item.message);
@@ -236,14 +228,21 @@ function finalizeCodexStream(
   childStreamId: StreamTabId,
   executionId: string,
   logger: AgentLogger,
-  wallTimeMs: number,
-  usage: RunResult['usage'],
+  options?: { wallTimeMs?: number; usage?: RunResult['usage']; error?: unknown },
 ): void {
-  const durationSec = (wallTimeMs / 1000).toFixed(1);
-  logger.info(`Completed in ${durationSec}s`);
-  if (usage) {
+  if (options?.error) {
+    const msg =
+      options.error instanceof Error
+        ? options.error.message
+        : String(options.error);
+    logger.error(msg);
+  }
+  if (options?.wallTimeMs != null) {
+    logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
+  }
+  if (options?.usage) {
     logger.info(
-      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
+      `Tokens: ${options.usage.input_tokens} in / ${options.usage.output_tokens} out`,
     );
   }
   StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
@@ -313,9 +312,7 @@ export class CodexTool extends defineTool({
     const preview = truncateWithEllipsis(input.prompt, 60);
     const startedAt = Date.now();
 
-    // Create a child stream tab for the codex execution
-    const hasParent = !!parentStreamId;
-    const stream = hasParent
+    const stream = parentStreamId
       ? createCodexStream(executionId, parentStreamId, input.prompt)
       : undefined;
 
@@ -327,13 +324,10 @@ export class CodexTool extends defineTool({
       );
 
       if (stream) {
-        finalizeCodexStream(
-          stream.childStreamId,
-          executionId,
-          stream.logger,
-          Date.now() - startedAt,
-          turn.usage,
-        );
+        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+          wallTimeMs: Date.now() - startedAt,
+          usage: turn.usage,
+        });
       }
 
       return {
@@ -342,14 +336,9 @@ export class CodexTool extends defineTool({
       };
     } catch (err) {
       if (stream) {
-        stream.logger.error(
-          err instanceof Error ? err.message : String(err),
-        );
-        StreamStatusService.set(
-          stream.childStreamId,
-          STREAM_STATUS.READY,
-        );
-        untrackExecution(executionId);
+        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+          error: err,
+        });
       }
       throw err;
     }
@@ -362,7 +351,6 @@ export class CodexTool extends defineTool({
     logger?: AgentLogger,
   ): Promise<RunResult> {
     const { events } = await thread.runStreamed(input.prompt);
-    const items: ThreadItem[] = [];
     const responseParts: string[] = [];
     let usage: RunResult['usage'] = null;
 
@@ -370,7 +358,6 @@ export class CodexTool extends defineTool({
       switch (event.type) {
         case 'item.completed': {
           const { item } = event;
-          items.push(item);
           if (logger) {
             logCodexItem(item, logger);
           }
@@ -390,7 +377,7 @@ export class CodexTool extends defineTool({
     }
 
     return {
-      items,
+      items: [],
       finalResponse: responseParts.join('\n\n'),
       usage,
     };
@@ -429,7 +416,6 @@ export class CodexTool extends defineTool({
       throw new ToolError('Failed to register background Codex execution.');
     }
 
-    // Create a child stream tab — codex events stream here in real time
     const { childStreamId, logger } = createCodexStream(
       executionId,
       parentStreamId,
@@ -483,13 +469,10 @@ export class CodexTool extends defineTool({
 
         await writeTerminalStatus(executionId, 'completed').catch(() => {});
 
-        finalizeCodexStream(
-          childStreamId,
-          executionId,
-          logger,
+        finalizeCodexStream(childStreamId, executionId, logger, {
           wallTimeMs,
-          turn.usage,
-        );
+          usage: turn.usage,
+        });
 
         const msg = formatCodexDelivery(
           executionId,
@@ -503,9 +486,7 @@ export class CodexTool extends defineTool({
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
 
-        logger.error(err instanceof Error ? err.message : String(err));
-        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
-        untrackExecution(executionId);
+        finalizeCodexStream(childStreamId, executionId, logger, { error: err });
 
         const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -417,7 +417,6 @@ function startFollowUpLoop(
         if (!messages || session.isInterrupted()) break;
 
         const userMessage = messages.join('\n\n');
-        logger.info(userMessage, { messageType: MESSAGE_TYPES.USER_MESSAGE });
 
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
         const startedAt = Date.now();
@@ -486,6 +485,7 @@ async function runStreamedTurn(
   childStreamId: StreamTabId,
   logger: AgentLogger,
 ): Promise<RunResult> {
+  logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
   const { events } = await thread.runStreamed(prompt);
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -271,6 +271,7 @@ function createCodexStream(
 /** Log a completed codex thread item to the child stream's logger. */
 function logCodexItem(
   item: ThreadItem,
+  childStreamId: StreamTabId,
   logger: AgentLogger,
 ): void {
   switch (item.type) {
@@ -307,13 +308,15 @@ function logCodexItem(
         server: string;
         tool: string;
         arguments: unknown;
-        result?: { content: unknown[] };
+        result?: { content: unknown[]; structured_content: unknown };
         error?: { message: string };
         status: string;
       };
       const output = mcpItem.error
         ? `Error: ${mcpItem.error.message}`
-        : `(${mcpItem.status})`;
+        : mcpItem.result?.structured_content
+          ? JSON.stringify(mcpItem.result.structured_content, null, 2)
+          : `(${mcpItem.status})`;
       logger.logToolUse({
         toolName: `mcp:${mcpItem.server}/${mcpItem.tool}`,
         input: mcpItem.arguments,
@@ -329,10 +332,15 @@ function logCodexItem(
     }
     case 'todo_list': {
       const todoItem = item as { items: { text: string; completed: boolean }[] };
-      const lines = todoItem.items.map(
-        (t) => `${t.completed ? '✓' : '○'} ${t.text}`,
-      );
-      logger.info(lines.join('\n'), { messageType: MESSAGE_TYPES.DEFAULT });
+      // Map SDK todo items to TeXRA's native todo format and emit to the UI
+      const todos = todoItem.items.map((t) => ({
+        content: t.text,
+        status: t.completed
+          ? ('completed' as const)
+          : ('pending' as const),
+        activeForm: t.text,
+      }));
+      bus.emit('updateTodos', { streamId: childStreamId, todos });
       break;
     }
     case 'error':
@@ -416,7 +424,7 @@ function startFollowUpLoop(
         const startedAt = Date.now();
 
         try {
-          const turn = await runStreamedTurn(thread, userMessage, logger);
+          const turn = await runStreamedTurn(thread, userMessage, childStreamId, logger);
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
           StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
         } catch (err) {
@@ -448,6 +456,7 @@ function startFollowUpLoop(
 async function runStreamedTurn(
   thread: Thread,
   prompt: string,
+  childStreamId: StreamTabId,
   logger: AgentLogger,
 ): Promise<RunResult> {
   const { events } = await thread.runStreamed(prompt);
@@ -458,7 +467,7 @@ async function runStreamedTurn(
     switch (event.type) {
       case 'item.completed': {
         const { item } = event;
-        logCodexItem(item, logger);
+        logCodexItem(item, childStreamId, logger);
         if (item.type === 'agent_message') {
           responseParts.push(item.text);
         }
@@ -569,6 +578,7 @@ export class CodexTool extends defineTool({
       const turn = await runStreamedTurn(
         thread,
         input.prompt,
+        stream?.childStreamId ?? ('' as StreamTabId),
         stream?.logger ?? new AgentLogger('codex-fg'),
       );
 
@@ -652,7 +662,7 @@ export class CodexTool extends defineTool({
 
     void (async () => {
       try {
-        const turn = await runStreamedTurn(thread, input.prompt, logger);
+        const turn = await runStreamedTurn(thread, input.prompt, childStreamId, logger);
         const wallTimeMs = Date.now() - startedAt;
         const threadId = thread.id;
         const store = getExecutionStore(executionId);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -441,6 +441,31 @@ function startFollowUpLoop(
   })();
 }
 
+/**
+ * After a successful turn, either start a follow-up loop (if the SDK
+ * assigned a thread ID) or finalize the stream.
+ */
+function handleTurnSuccess(
+  thread: Thread,
+  turn: RunResult,
+  childStreamId: StreamTabId,
+  executionId: ExecutionId,
+  logger: AgentLogger,
+  wallTimeMs: number,
+): void {
+  const threadId = thread.id;
+  if (threadId) {
+    logTurnSummary(logger, wallTimeMs, turn.usage);
+    storeThread(threadId, { thread, childStreamId, logger, executionId });
+    startFollowUpLoop(thread, childStreamId, executionId, logger);
+  } else {
+    finalizeCodexStream(childStreamId, executionId, logger, {
+      wallTimeMs,
+      usage: turn.usage,
+    });
+  }
+}
+
 // ============================================================================
 // Streaming helpers
 // ============================================================================
@@ -530,9 +555,13 @@ export class CodexTool extends defineTool({
   private async resolveThread(input: CodexInput): Promise<Thread> {
     if (input.thread_id) {
       const stored = threadRegistry.get(input.thread_id);
-      if (stored) {
-        // Interrupt the old follow-up loop so it doesn't compete or
-        // corrupt the registry when its finally block runs.
+      // Only reuse the in-memory thread if the follow-up loop is idle (WAITING).
+      // If RUNNING, a turn is in progress — fall through to disk resume to
+      // avoid concurrent streaming turns on the same Thread object.
+      if (
+        stored &&
+        StreamStatusService.get(stored.childStreamId) === STREAM_STATUS.WAITING
+      ) {
         getInterruptible(stored.childStreamId)?.interrupt();
         return stored.thread;
       }
@@ -573,21 +602,7 @@ export class CodexTool extends defineTool({
       const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
-        if (threadId) {
-          logTurnSummary(stream.logger, wallTimeMs, turn.usage);
-          storeThread(threadId, {
-            thread,
-            childStreamId: stream.childStreamId,
-            logger: stream.logger,
-            executionId,
-          });
-          startFollowUpLoop(thread, stream.childStreamId, executionId, stream.logger);
-        } else {
-          finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
-            wallTimeMs,
-            usage: turn.usage,
-          });
-        }
+        handleTurnSuccess(thread, turn, stream.childStreamId, executionId, stream.logger, wallTimeMs);
       }
 
       return {
@@ -664,16 +679,7 @@ export class CodexTool extends defineTool({
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
-        if (threadId) {
-          logTurnSummary(logger, wallTimeMs, turn.usage);
-          storeThread(threadId, { thread, childStreamId, logger, executionId });
-          startFollowUpLoop(thread, childStreamId, executionId, logger);
-        } else {
-          finalizeCodexStream(childStreamId, executionId, logger, {
-            wallTimeMs,
-            usage: turn.usage,
-          });
-        }
+        handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
       } catch (err: unknown) {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeCodexStream(childStreamId, executionId, logger, { error: err });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -32,12 +32,12 @@ import {
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
+  getInterruptible,
   registerInterruptible,
   unregisterInterruptible,
   type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
@@ -130,39 +130,32 @@ function removeThread(threadId: string): void {
 }
 
 // ============================================================================
-// Codex follow-up session — duck-types as IInterruptible with a session
+// Codex follow-up session — IInterruptible only (no ToolUseFlowContext)
 // ============================================================================
 
 /**
- * Lightweight session that registers with the ToolUseAgentRegistry so
- * the follow-up input in the child stream tab can deliver messages.
- * Uses duck typing: `sendFollowUp()` checks for `session.appendFollowUp()`.
+ * Lightweight interruptible registered with the ToolUseAgentRegistry so the
+ * stop button works on codex child streams.
+ *
+ * Does NOT implement the session duck-type (no `session.appendFollowUp`),
+ * which prevents `getToolUseFlowContext()` from matching it — commands like
+ * `compactResponse` that access `flowContext.modelHandler` won't crash.
+ *
+ * Follow-ups route through the WAITING state queue path instead:
+ * `sendFollowUp()` → stream is WAITING → `ToolUseFollowUpQueue.enqueue()`.
  */
 class CodexFollowUpSession implements IInterruptible {
-  private readonly queue = new FollowUpQueue();
   private interrupted = false;
-
-  /** Duck-typed session interface expected by `isToolUseFlowContext()`. */
-  readonly session = {
-    appendFollowUp: (text: string): void => this.queue.enqueue(text),
-    hasQueuedFollowUp: (): boolean => !this.queue.isEmpty(),
-  };
 
   interrupt(): void {
     this.interrupted = true;
-    this.queue.cancelWait();
+    ToolUseFollowUpQueue.release(this.streamId);
   }
+
+  constructor(private readonly streamId: StreamTabId) {}
 
   isInterrupted(): boolean {
     return this.interrupted;
-  }
-
-  async waitForFollowUp(): Promise<string[] | null> {
-    return this.queue.waitAndDrainAll(() => this.interrupted);
-  }
-
-  dispose(): void {
-    this.queue.dispose();
   }
 }
 
@@ -407,16 +400,18 @@ function startFollowUpLoop(
   executionId: string,
   logger: AgentLogger,
 ): void {
-  const followUpSession = new CodexFollowUpSession();
-  registerInterruptible(childStreamId, followUpSession);
+  const session = new CodexFollowUpSession(childStreamId);
+  registerInterruptible(childStreamId, session);
 
+  // Acquire a queue so sendFollowUp() → WAITING path → enqueue works
+  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
 
   void (async () => {
     try {
-      while (!followUpSession.isInterrupted()) {
-        const messages = await followUpSession.waitForFollowUp();
-        if (!messages || followUpSession.isInterrupted()) break;
+      while (!session.isInterrupted()) {
+        const messages = await queue.waitAndDrainAll(() => session.isInterrupted());
+        if (!messages || session.isInterrupted()) break;
 
         const userMessage = messages.join('\n\n');
         logger.info(userMessage, { messageType: MESSAGE_TYPES.USER_MESSAGE });
@@ -427,15 +422,15 @@ function startFollowUpLoop(
         try {
           const turn = await runStreamedTurn(thread, userMessage, childStreamId, logger);
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
         } catch (err) {
           logger.error(err instanceof Error ? err.message : String(err));
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
         }
+
+        StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
       }
     } finally {
-      followUpSession.dispose();
       unregisterInterruptible(childStreamId);
+      ToolUseFollowUpQueue.release(childStreamId);
       untrackExecution(executionId);
 
       const threadId = thread.id;
@@ -535,10 +530,14 @@ export class CodexTool extends defineTool({
 
   /** Resolve thread — resume existing or start new. */
   private async resolveThread(input: CodexInput): Promise<Thread> {
-    // If thread_id provided, try to reuse the in-memory thread first
     if (input.thread_id) {
       const stored = getStoredThread(input.thread_id);
-      if (stored) return stored.thread;
+      if (stored) {
+        // Interrupt the old follow-up loop so it doesn't compete or
+        // corrupt the registry when its finally block runs.
+        getInterruptible(stored.childStreamId)?.interrupt();
+        return stored.thread;
+      }
     }
 
     const CodexClass = await importCodexClass();

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -430,6 +430,7 @@ function startFollowUpLoop(
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
       untrackExecution(executionId);
+      void writeTerminalStatus(executionId, 'completed').catch(() => {});
 
       const threadId = thread.id;
       if (threadId) threadRegistry.delete(threadId);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -38,6 +38,7 @@ import {
   type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
@@ -59,10 +60,13 @@ import { importCodexClass, findCodexBinaryPath } from './codexImport';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
+  McpToolCallItem,
   RunResult,
   SandboxMode,
   Thread,
   ThreadItem,
+  TodoListItem,
+  WebSearchItem,
 } from '@openai/codex-sdk';
 
 // ============================================================================
@@ -117,16 +121,9 @@ interface ActiveThread {
 
 const threadRegistry = new Map<string, ActiveThread>();
 
+/** Store a thread for multi-turn reuse. Called from both execution paths. */
 function storeThread(threadId: string, entry: ActiveThread): void {
   threadRegistry.set(threadId, entry);
-}
-
-function getStoredThread(threadId: string): ActiveThread | undefined {
-  return threadRegistry.get(threadId);
-}
-
-function removeThread(threadId: string): void {
-  threadRegistry.delete(threadId);
 }
 
 // ============================================================================
@@ -218,10 +215,9 @@ function formatCodexError(
   prompt: string,
   err: unknown,
 ): string {
-  const message = err instanceof Error ? err.message : String(err);
   return [
     `<codex-error id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}">`,
-    `<message>${escapeText(message)}</message>`,
+    `<message>${escapeText(toErrorMessage(err))}</message>`,
     '</codex-error>',
   ].join('\n');
 }
@@ -297,36 +293,25 @@ function logCodexItem(
       logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
     case 'mcp_tool_call': {
-      const mcpItem = item as {
-        server: string;
-        tool: string;
-        arguments: unknown;
-        result?: { content: unknown[]; structured_content: unknown };
-        error?: { message: string };
-        status: string;
-      };
-      const output = mcpItem.error
-        ? `Error: ${mcpItem.error.message}`
-        : mcpItem.result?.structured_content
-          ? JSON.stringify(mcpItem.result.structured_content, null, 2)
-          : `(${mcpItem.status})`;
+      const mcp = item as McpToolCallItem;
+      const output = mcp.error
+        ? `Error: ${mcp.error.message}`
+        : mcp.result?.structured_content
+          ? JSON.stringify(mcp.result.structured_content)
+          : `(${mcp.status})`;
       logger.logToolUse({
-        toolName: `mcp:${mcpItem.server}/${mcpItem.tool}`,
-        input: mcpItem.arguments,
+        toolName: `mcp:${mcp.server}/${mcp.tool}`,
+        input: mcp.arguments,
         output,
         status: 'completed',
       });
       break;
     }
-    case 'web_search': {
-      const searchItem = item as { query: string };
-      logger.logWebSearch({ query: searchItem.query });
+    case 'web_search':
+      logger.logWebSearch({ query: (item as WebSearchItem).query });
       break;
-    }
     case 'todo_list': {
-      const todoItem = item as { items: { text: string; completed: boolean }[] };
-      // Map SDK todo items to TeXRA's native todo format and emit to the UI
-      const todos = todoItem.items.map((t) => ({
+      const todos = (item as TodoListItem).items.map((t) => ({
         content: t.text,
         status: t.completed
           ? ('completed' as const)
@@ -364,11 +349,7 @@ function finalizeCodexStream(
   options?: { wallTimeMs?: number; usage?: RunResult['usage']; error?: unknown },
 ): void {
   if (options?.error) {
-    const msg =
-      options.error instanceof Error
-        ? options.error.message
-        : String(options.error);
-    logger.error(msg);
+    logger.error(toErrorMessage(options.error));
   }
   if (options?.wallTimeMs != null) {
     logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
@@ -403,7 +384,6 @@ function startFollowUpLoop(
   const session = new CodexFollowUpSession(childStreamId);
   registerInterruptible(childStreamId, session);
 
-  // Acquire a queue so sendFollowUp() → WAITING path → enqueue works
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
 
@@ -423,7 +403,7 @@ function startFollowUpLoop(
           const turn = await runStreamedTurn(thread, userMessage, childStreamId, logger);
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (err) {
-          logger.error(err instanceof Error ? err.message : String(err));
+          logger.error(toErrorMessage(err));
         }
 
         StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
@@ -434,7 +414,7 @@ function startFollowUpLoop(
       untrackExecution(executionId);
 
       const threadId = thread.id;
-      if (threadId) removeThread(threadId);
+      if (threadId) threadRegistry.delete(threadId);
 
       if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
         StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
@@ -531,7 +511,7 @@ export class CodexTool extends defineTool({
   /** Resolve thread — resume existing or start new. */
   private async resolveThread(input: CodexInput): Promise<Thread> {
     if (input.thread_id) {
-      const stored = getStoredThread(input.thread_id);
+      const stored = threadRegistry.get(input.thread_id);
       if (stored) {
         // Interrupt the old follow-up loop so it doesn't compete or
         // corrupt the registry when its finally block runs.
@@ -541,23 +521,16 @@ export class CodexTool extends defineTool({
     }
 
     const CodexClass = await importCodexClass();
-    const codexPathOverride = findCodexBinaryPath();
-    const codex = new CodexClass({ codexPathOverride });
-
-    if (input.thread_id) {
-      // Resume from disk (~/.codex/sessions)
-      return codex.resumeThread(input.thread_id, {
-        workingDirectory: input.working_directory,
-        sandboxMode: input.sandbox_mode,
-        skipGitRepoCheck: true,
-      });
-    }
-
-    return codex.startThread({
+    const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
+    const threadOptions = {
       workingDirectory: input.working_directory,
       sandboxMode: input.sandbox_mode,
-      skipGitRepoCheck: true,
-    });
+      skipGitRepoCheck: true as const,
+    };
+
+    return input.thread_id
+      ? codex.resumeThread(input.thread_id, threadOptions)
+      : codex.startThread(threadOptions);
   }
 
   private async executeForeground(
@@ -574,12 +547,9 @@ export class CodexTool extends defineTool({
       : undefined;
 
     try {
-      const turn = await runStreamedTurn(
-        thread,
-        input.prompt,
-        stream?.childStreamId ?? ('' as StreamTabId),
-        stream?.logger ?? new AgentLogger('codex-fg'),
-      );
+      const turn = stream
+        ? await runStreamedTurn(thread, input.prompt, stream.childStreamId, stream.logger)
+        : await thread.run(input.prompt);
 
       const threadId = thread.id;
       const wallTimeMs = Date.now() - startedAt;

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -164,7 +164,7 @@ class CodexFollowUpSession implements IInterruptible {
     this.queue?.cancelWait();
   }
 
-  constructor(private readonly streamId: StreamTabId) {}
+  constructor() {}
 
   setQueue(q: FollowUpQueue): void {
     this.queue = q;
@@ -415,7 +415,7 @@ function startFollowUpLoop(
   executionId: string,
   logger: AgentLogger,
 ): void {
-  const session = new CodexFollowUpSession(childStreamId);
+  const session = new CodexFollowUpSession();
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
   session.setQueue(queue);
   registerInterruptible(childStreamId, session);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -667,8 +667,6 @@ export class CodexTool extends defineTool({
         const threadId = thread.id;
         const store = getExecutionStore(executionId);
 
-        await writeTerminalStatus(executionId, 'completed').catch(() => {});
-
         const msg = formatCodexDelivery(
           executionId,
           input.prompt,
@@ -680,6 +678,12 @@ export class CodexTool extends defineTool({
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
         handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
+
+        // Only mark terminal status if no follow-up loop started — the
+        // loop manages its own lifecycle and may end in error later.
+        if (!threadId) {
+          await writeTerminalStatus(executionId, 'completed').catch(() => {});
+        }
       } catch (err: unknown) {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeCodexStream(childStreamId, executionId, logger, { error: err });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -1,9 +1,13 @@
 /**
  * Codex tool — spin off an OpenAI Codex agent via the @openai/codex-sdk.
  *
- * Supports foreground (blocking) and background (async follow-up) modes,
- * mirroring the BashTool pattern. The Codex CLI handles its own auth
- * (~/.codex/auth.json from `codex login`, OPENAI_API_KEY, config files).
+ * Supports foreground (blocking) and background (async follow-up) modes.
+ * Threads are multi-turn: after the first turn, the child stream enters
+ * WAITING state and accepts follow-ups from the user (via the stream tab's
+ * follow-up input) or from the orchestrator (via the `thread_id` parameter).
+ *
+ * The Codex CLI handles its own auth (~/.codex/auth.json from `codex login`,
+ * OPENAI_API_KEY, config files).
  *
  * Requires the Codex CLI binary — gated by the availability check in
  * externalToolDefs.ts.
@@ -27,7 +31,13 @@ import {
 } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import {
+  registerInterruptible,
+  unregisterInterruptible,
+  type IInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId, ExecutionId } from '@shared/schemas';
@@ -82,9 +92,79 @@ const CodexInputSchema = z.strictObject({
     .describe(
       'Run asynchronously. Returns immediately with execution ID. Result delivered as follow-up when complete.',
     ),
+  thread_id: z
+    .string()
+    .optional()
+    .describe(
+      'Resume an existing Codex thread by its ID. ' +
+        'When provided, continues the conversation from where it left off instead of starting a new one. ' +
+        'Get the thread_id from the result of a previous codex call.',
+    ),
 });
 
 export type CodexInput = z.infer<typeof CodexInputSchema>;
+
+// ============================================================================
+// Thread registry — keeps threads alive between turns for follow-ups
+// ============================================================================
+
+interface ActiveThread {
+  thread: Thread;
+  childStreamId: StreamTabId;
+  logger: AgentLogger;
+  executionId: string;
+}
+
+const threadRegistry = new Map<string, ActiveThread>();
+
+function storeThread(threadId: string, entry: ActiveThread): void {
+  threadRegistry.set(threadId, entry);
+}
+
+function getStoredThread(threadId: string): ActiveThread | undefined {
+  return threadRegistry.get(threadId);
+}
+
+function removeThread(threadId: string): void {
+  threadRegistry.delete(threadId);
+}
+
+// ============================================================================
+// Codex follow-up session — duck-types as IInterruptible with a session
+// ============================================================================
+
+/**
+ * Lightweight session that registers with the ToolUseAgentRegistry so
+ * the follow-up input in the child stream tab can deliver messages.
+ * Uses duck typing: `sendFollowUp()` checks for `session.appendFollowUp()`.
+ */
+class CodexFollowUpSession implements IInterruptible {
+  private readonly queue = new FollowUpQueue();
+  private interrupted = false;
+
+  /** Duck-typed session interface expected by `isToolUseFlowContext()`. */
+  readonly session = {
+    appendFollowUp: (text: string): void => this.queue.enqueue(text),
+    hasQueuedFollowUp: (): boolean => !this.queue.isEmpty(),
+  };
+
+  interrupt(): void {
+    this.interrupted = true;
+    this.queue.cancelWait();
+  }
+
+  isInterrupted(): boolean {
+    return this.interrupted;
+  }
+
+  async waitForFollowUp(): Promise<string[] | null> {
+    return this.queue.waitAndDrainAll(() => this.interrupted);
+  }
+
+  dispose(): void {
+    this.queue.dispose();
+  }
+}
 
 // ============================================================================
 // Result formatting
@@ -97,13 +177,17 @@ export type CodexInput = z.infer<typeof CodexInputSchema>;
  * a compact usage note. Intermediate details (commands run, files changed) are
  * streamed to the child stream tab and don't need to be in the result.
  */
-function formatTurnResult(turn: RunResult): string {
+function formatTurnResult(turn: RunResult, threadId?: string | null): string {
   const parts: string[] = [turn.finalResponse || '(no response)'];
 
   if (turn.usage) {
     parts.push(
       `[Tokens: ${turn.usage.input_tokens} in / ${turn.usage.output_tokens} out]`,
     );
+  }
+
+  if (threadId) {
+    parts.push(`[Thread ID: ${threadId} — use thread_id to continue this session]`);
   }
 
   return parts.join('\n\n');
@@ -115,11 +199,12 @@ function formatCodexDelivery(
   prompt: string,
   wallTimeMs: number,
   turn: RunResult,
+  threadId?: string | null,
 ): string {
   const durationSec = (wallTimeMs / 1000).toFixed(1);
   const response = turn.finalResponse || '(no response)';
   const lines = [
-    `<codex-result id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}">`,
+    `<codex-result id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}"${threadId ? ` thread-id="${escapeAttr(threadId)}"` : ''}>`,
     `<wall-time>${durationSec}s</wall-time>`,
     `<response>${escapeText(response)}</response>`,
   ];
@@ -217,9 +302,56 @@ function logCodexItem(
     case 'reasoning':
       logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
+    case 'mcp_tool_call': {
+      const mcpItem = item as {
+        server: string;
+        tool: string;
+        arguments: unknown;
+        result?: { content: unknown[] };
+        error?: { message: string };
+        status: string;
+      };
+      const output = mcpItem.error
+        ? `Error: ${mcpItem.error.message}`
+        : `(${mcpItem.status})`;
+      logger.logToolUse({
+        toolName: `mcp:${mcpItem.server}/${mcpItem.tool}`,
+        input: mcpItem.arguments,
+        output,
+        status: 'completed',
+      });
+      break;
+    }
+    case 'web_search': {
+      const searchItem = item as { query: string };
+      logger.logWebSearch({ query: searchItem.query });
+      break;
+    }
+    case 'todo_list': {
+      const todoItem = item as { items: { text: string; completed: boolean }[] };
+      const lines = todoItem.items.map(
+        (t) => `${t.completed ? '✓' : '○'} ${t.text}`,
+      );
+      logger.info(lines.join('\n'), { messageType: MESSAGE_TYPES.DEFAULT });
+      break;
+    }
     case 'error':
       logger.error(item.message);
       break;
+  }
+}
+
+/** Log a turn summary to the child stream. */
+function logTurnSummary(
+  logger: AgentLogger,
+  wallTimeMs: number,
+  usage: RunResult['usage'],
+): void {
+  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
+  if (usage) {
+    logger.info(
+      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
+    );
   }
 }
 
@@ -253,6 +385,103 @@ function finalizeCodexStream(
 }
 
 // ============================================================================
+// Follow-up loop — runs additional turns when user sends follow-ups
+// ============================================================================
+
+/**
+ * After the initial turn, enter a loop that waits for user follow-ups
+ * in the child stream tab and runs them on the same Codex thread.
+ * The loop runs until interrupted or the session is disposed.
+ */
+function startFollowUpLoop(
+  thread: Thread,
+  childStreamId: StreamTabId,
+  logger: AgentLogger,
+): void {
+  const followUpSession = new CodexFollowUpSession();
+  registerInterruptible(childStreamId, followUpSession);
+
+  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+
+  void (async () => {
+    try {
+      while (!followUpSession.isInterrupted()) {
+        const messages = await followUpSession.waitForFollowUp();
+        if (!messages || followUpSession.isInterrupted()) break;
+
+        const userMessage = messages.join('\n\n');
+        logger.info(userMessage, { messageType: MESSAGE_TYPES.USER_MESSAGE });
+
+        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+        const startedAt = Date.now();
+
+        try {
+          const turn = await runStreamedTurn(thread, userMessage, logger);
+          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+        } catch (err) {
+          logger.error(err instanceof Error ? err.message : String(err));
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+        }
+      }
+    } finally {
+      followUpSession.dispose();
+      unregisterInterruptible(childStreamId);
+
+      // Clean up thread from registry
+      const threadId = thread.id;
+      if (threadId) removeThread(threadId);
+
+      // If still in WAITING, mark as READY (session ended)
+      if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
+        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+      }
+    }
+  })();
+}
+
+// ============================================================================
+// Streaming helpers
+// ============================================================================
+
+/** Run a single streamed turn, logging events to the child stream. */
+async function runStreamedTurn(
+  thread: Thread,
+  prompt: string,
+  logger: AgentLogger,
+): Promise<RunResult> {
+  const { events } = await thread.runStreamed(prompt);
+  const responseParts: string[] = [];
+  let usage: RunResult['usage'] = null;
+
+  for await (const event of events) {
+    switch (event.type) {
+      case 'item.completed': {
+        const { item } = event;
+        logCodexItem(item, logger);
+        if (item.type === 'agent_message') {
+          responseParts.push(item.text);
+        }
+        break;
+      }
+      case 'turn.completed':
+        usage = event.usage ?? null;
+        break;
+      case 'turn.failed':
+        throw new ToolError(event.error.message ?? 'Codex turn failed');
+      case 'error':
+        throw new ToolError(event.message ?? 'Codex stream error');
+    }
+  }
+
+  return {
+    items: [],
+    finalResponse: responseParts.join('\n\n'),
+    usage,
+  };
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 
@@ -262,7 +491,8 @@ export class CodexTool extends defineTool({
     'Spin off an OpenAI Codex agent to perform code analysis, generation, or research in a sandboxed environment. ' +
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +
     'Requires the Codex CLI to be installed (`npm install -g @openai/codex`). ' +
-    'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var.',
+    'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var. ' +
+    'Returns a thread_id that can be passed back to continue the conversation in subsequent calls.',
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
@@ -280,19 +510,7 @@ export class CodexTool extends defineTool({
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    // Dynamic import — resolved at runtime, not bundled (see webpack externals)
-    const Codex = await importCodexClass();
-
-    // The SDK resolves the native binary relative to itself, but we don't
-    // ship the 130 MB platform binaries in the VSIX. Find the binary from
-    // the user's global npm install and pass it via codexPathOverride.
-    const codexPathOverride = findCodexBinaryPath();
-    const codex = new Codex({ codexPathOverride });
-    const thread = codex.startThread({
-      workingDirectory: input.working_directory,
-      sandboxMode: input.sandbox_mode,
-      skipGitRepoCheck: true,
-    });
+    const thread = await this.resolveThread(input);
 
     if (input.run_in_background) {
       return this.executeBackground(
@@ -304,6 +522,34 @@ export class CodexTool extends defineTool({
     }
 
     return this.executeForeground(thread, input, ctx?.streamId);
+  }
+
+  /** Resolve thread — resume existing or start new. */
+  private async resolveThread(input: CodexInput): Promise<Thread> {
+    // If thread_id provided, try to reuse the in-memory thread first
+    if (input.thread_id) {
+      const stored = getStoredThread(input.thread_id);
+      if (stored) return stored.thread;
+    }
+
+    const CodexClass = await importCodexClass();
+    const codexPathOverride = findCodexBinaryPath();
+    const codex = new CodexClass({ codexPathOverride });
+
+    if (input.thread_id) {
+      // Resume from disk (~/.codex/sessions)
+      return codex.resumeThread(input.thread_id, {
+        workingDirectory: input.working_directory,
+        sandboxMode: input.sandbox_mode,
+        skipGitRepoCheck: true,
+      });
+    }
+
+    return codex.startThread({
+      workingDirectory: input.working_directory,
+      sandboxMode: input.sandbox_mode,
+      skipGitRepoCheck: true,
+    });
   }
 
   private async executeForeground(
@@ -320,22 +566,38 @@ export class CodexTool extends defineTool({
       : undefined;
 
     try {
-      const turn = await this.runStreamedForeground(
+      const turn = await runStreamedTurn(
         thread,
-        input,
-        stream?.logger,
+        input.prompt,
+        stream?.logger ?? new AgentLogger('codex-fg'),
       );
 
+      const threadId = thread.id;
+      const wallTimeMs = Date.now() - startedAt;
+
       if (stream) {
-        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
-          wallTimeMs: Date.now() - startedAt,
-          usage: turn.usage,
-        });
+        logTurnSummary(stream.logger, wallTimeMs, turn.usage);
+
+        // Store thread and start follow-up loop for user interaction
+        if (threadId) {
+          storeThread(threadId, {
+            thread,
+            childStreamId: stream.childStreamId,
+            logger: stream.logger,
+            executionId,
+          });
+          startFollowUpLoop(thread, stream.childStreamId, stream.logger);
+        } else {
+          finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+            wallTimeMs,
+            usage: turn.usage,
+          });
+        }
       }
 
       return {
         summary: `Codex: ${preview}`,
-        output: formatTurnResult(turn),
+        output: formatTurnResult(turn, threadId),
       };
     } catch (err) {
       if (stream) {
@@ -345,45 +607,6 @@ export class CodexTool extends defineTool({
       }
       throw err;
     }
-  }
-
-  /** Run a foreground turn via the streaming API, logging events to the child stream. */
-  private async runStreamedForeground(
-    thread: Thread,
-    input: CodexInput,
-    logger?: AgentLogger,
-  ): Promise<RunResult> {
-    const { events } = await thread.runStreamed(input.prompt);
-    const responseParts: string[] = [];
-    let usage: RunResult['usage'] = null;
-
-    for await (const event of events) {
-      switch (event.type) {
-        case 'item.completed': {
-          const { item } = event;
-          if (logger) {
-            logCodexItem(item, logger);
-          }
-          if (item.type === 'agent_message') {
-            responseParts.push(item.text);
-          }
-          break;
-        }
-        case 'turn.completed':
-          usage = event.usage ?? null;
-          break;
-        case 'turn.failed':
-          throw new ToolError(event.error.message ?? 'Codex turn failed');
-        case 'error':
-          throw new ToolError(event.message ?? 'Codex stream error');
-      }
-    }
-
-    return {
-      items: [],
-      finalResponse: responseParts.join('\n\n'),
-      usage,
-    };
   }
 
   private async executeBackground(
@@ -427,68 +650,45 @@ export class CodexTool extends defineTool({
 
     const startedAt = Date.now();
 
-    const promise = (async (): Promise<RunResult> => {
-      const { events } = await thread.runStreamed(input.prompt);
-      const responseParts: string[] = [];
-      let usage: RunResult['usage'] = null;
-
-      for await (const event of events) {
-        switch (event.type) {
-          case 'item.completed': {
-            const { item } = event;
-            logCodexItem(item, logger);
-            if (item.type === 'agent_message') {
-              responseParts.push(item.text);
-            }
-            break;
-          }
-          case 'turn.completed':
-            usage = event.usage ?? null;
-            break;
-          case 'turn.failed':
-            throw new Error(event.error.message ?? 'Codex turn failed');
-          case 'error':
-            throw new Error(event.message ?? 'Codex stream error');
-        }
-      }
-
-      return {
-        items: [],
-        finalResponse: responseParts.join('\n\n'),
-        usage,
-      };
-    })();
-
-    void promise
-      .then(async (turn) => {
+    void (async () => {
+      try {
+        const turn = await runStreamedTurn(thread, input.prompt, logger);
         const wallTimeMs = Date.now() - startedAt;
+        const threadId = thread.id;
         const store = getExecutionStore(executionId);
 
         await writeTerminalStatus(executionId, 'completed').catch(() => {});
-
-        finalizeCodexStream(childStreamId, executionId, logger, {
-          wallTimeMs,
-          usage: turn.usage,
-        });
+        logTurnSummary(logger, wallTimeMs, turn.usage);
 
         const msg = formatCodexDelivery(
           executionId,
           input.prompt,
           wallTimeMs,
           turn,
+          threadId,
         );
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-      })
-      .catch(async (err: unknown) => {
-        await writeTerminalStatus(executionId, 'error').catch(() => {});
 
+        // Keep thread alive for follow-ups
+        if (threadId) {
+          storeThread(threadId, { thread, childStreamId, logger, executionId });
+          startFollowUpLoop(thread, childStreamId, logger);
+        } else {
+          finalizeCodexStream(childStreamId, executionId, logger, {
+            wallTimeMs,
+            usage: turn.usage,
+          });
+        }
+      } catch (err: unknown) {
+        await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeCodexStream(childStreamId, executionId, logger, { error: err });
 
         const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-      });
+      }
+    })();
 
     return {
       summary: `Launched Codex: ${preview}`,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -38,6 +38,7 @@ import {
   type IInterruptible,
 } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -155,13 +156,18 @@ export function interruptAllCodexSessions(): void {
  */
 class CodexFollowUpSession implements IInterruptible {
   private interrupted = false;
+  private queue: FollowUpQueue | null = null;
 
   interrupt(): void {
     this.interrupted = true;
-    ToolUseFollowUpQueue.release(this.streamId);
+    this.queue?.cancelWait();
   }
 
   constructor(private readonly streamId: StreamTabId) {}
+
+  setQueue(q: FollowUpQueue): void {
+    this.queue = q;
+  }
 
   isInterrupted(): boolean {
     return this.interrupted;
@@ -354,12 +360,12 @@ function logTurnSummary(
 }
 
 /** Finalize a codex child stream (mark completed/error, log summary). */
-async function finalizeCodexStream(
+function finalizeCodexStream(
   childStreamId: StreamTabId,
   executionId: string,
   logger: AgentLogger,
   options?: { wallTimeMs?: number; usage?: RunResult['usage']; error?: unknown },
-): Promise<void> {
+): void {
   if (options?.error) {
     logger.error(toErrorMessage(options.error));
   }
@@ -375,10 +381,6 @@ async function finalizeCodexStream(
     childStreamId,
     options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
   );
-  // Persist terminal status before untracking — untrackExecution fires
-  // notifyWaiters, so consumers must see the final status on disk.
-  const status = options?.error ? 'error' : 'completed';
-  await writeTerminalStatus(executionId, status).catch(() => {});
   untrackExecution(executionId);
 }
 
@@ -398,9 +400,9 @@ function startFollowUpLoop(
   logger: AgentLogger,
 ): void {
   const session = new CodexFollowUpSession(childStreamId);
-  registerInterruptible(childStreamId, session);
-
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  session.setQueue(queue);
+  registerInterruptible(childStreamId, session);
 
   // Start a log group so endRunningGroups() marks it as errored on reload,
   // giving the user a visual cue that the session was interrupted.
@@ -452,21 +454,21 @@ function startFollowUpLoop(
  * After a successful turn, either start a follow-up loop (if the SDK
  * assigned a thread ID) or finalize the stream.
  */
-async function handleTurnSuccess(
+function handleTurnSuccess(
   thread: Thread,
   turn: RunResult,
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   logger: AgentLogger,
   wallTimeMs: number,
-): Promise<void> {
+): void {
   const threadId = thread.id;
   if (threadId) {
     logTurnSummary(logger, wallTimeMs, turn.usage);
     storeThread(threadId, { thread, childStreamId, logger, executionId });
     startFollowUpLoop(thread, childStreamId, executionId, logger);
   } else {
-    await finalizeCodexStream(childStreamId, executionId, logger, {
+    finalizeCodexStream(childStreamId, executionId, logger, {
       wallTimeMs,
       usage: turn.usage,
     });
@@ -608,7 +610,7 @@ export class CodexTool extends defineTool({
       const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
-        await handleTurnSuccess(thread, turn, stream.childStreamId, executionId, stream.logger, wallTimeMs);
+        handleTurnSuccess(thread, turn, stream.childStreamId, executionId, stream.logger, wallTimeMs);
       }
 
       return {
@@ -617,7 +619,7 @@ export class CodexTool extends defineTool({
       };
     } catch (err) {
       if (stream) {
-        await finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
           error: err,
         });
       }
@@ -683,9 +685,16 @@ export class CodexTool extends defineTool({
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
-        await handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
+        // Write terminal status before handleTurnSuccess, which may call
+        // finalizeCodexStream → untrackExecution → notifyWaiters.
+        // When a follow-up loop starts, the loop's finally writes its own status.
+        if (!threadId) {
+          await writeTerminalStatus(executionId, 'completed').catch(() => {});
+        }
+        handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
       } catch (err: unknown) {
-        await finalizeCodexStream(childStreamId, executionId, logger, { error: err });
+        await writeTerminalStatus(executionId, 'error').catch(() => {});
+        finalizeCodexStream(childStreamId, executionId, logger, { error: err });
 
         const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -354,12 +354,12 @@ function logTurnSummary(
 }
 
 /** Finalize a codex child stream (mark completed/error, log summary). */
-function finalizeCodexStream(
+async function finalizeCodexStream(
   childStreamId: StreamTabId,
   executionId: string,
   logger: AgentLogger,
   options?: { wallTimeMs?: number; usage?: RunResult['usage']; error?: unknown },
-): void {
+): Promise<void> {
   if (options?.error) {
     logger.error(toErrorMessage(options.error));
   }
@@ -375,6 +375,10 @@ function finalizeCodexStream(
     childStreamId,
     options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
   );
+  // Persist terminal status before untracking — untrackExecution fires
+  // notifyWaiters, so consumers must see the final status on disk.
+  const status = options?.error ? 'error' : 'completed';
+  await writeTerminalStatus(executionId, status).catch(() => {});
   untrackExecution(executionId);
 }
 
@@ -429,8 +433,10 @@ function startFollowUpLoop(
       logger.endGroup(groupId, 'stopped');
       unregisterInterruptible(childStreamId);
       ToolUseFollowUpQueue.release(childStreamId);
+      // Persist terminal status before untracking — untrackExecution fires
+      // notifyWaiters, so consumers must see the final status on disk.
+      await writeTerminalStatus(executionId, 'completed').catch(() => {});
       untrackExecution(executionId);
-      void writeTerminalStatus(executionId, 'completed').catch(() => {});
 
       const threadId = thread.id;
       if (threadId) threadRegistry.delete(threadId);
@@ -446,21 +452,21 @@ function startFollowUpLoop(
  * After a successful turn, either start a follow-up loop (if the SDK
  * assigned a thread ID) or finalize the stream.
  */
-function handleTurnSuccess(
+async function handleTurnSuccess(
   thread: Thread,
   turn: RunResult,
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   logger: AgentLogger,
   wallTimeMs: number,
-): void {
+): Promise<void> {
   const threadId = thread.id;
   if (threadId) {
     logTurnSummary(logger, wallTimeMs, turn.usage);
     storeThread(threadId, { thread, childStreamId, logger, executionId });
     startFollowUpLoop(thread, childStreamId, executionId, logger);
   } else {
-    finalizeCodexStream(childStreamId, executionId, logger, {
+    await finalizeCodexStream(childStreamId, executionId, logger, {
       wallTimeMs,
       usage: turn.usage,
     });
@@ -602,7 +608,7 @@ export class CodexTool extends defineTool({
       const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
-        handleTurnSuccess(thread, turn, stream.childStreamId, executionId, stream.logger, wallTimeMs);
+        await handleTurnSuccess(thread, turn, stream.childStreamId, executionId, stream.logger, wallTimeMs);
       }
 
       return {
@@ -611,7 +617,7 @@ export class CodexTool extends defineTool({
       };
     } catch (err) {
       if (stream) {
-        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+        await finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
           error: err,
         });
       }
@@ -677,16 +683,9 @@ export class CodexTool extends defineTool({
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
-        handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
-
-        // Only mark terminal status if no follow-up loop started — the
-        // loop manages its own lifecycle and may end in error later.
-        if (!threadId) {
-          await writeTerminalStatus(executionId, 'completed').catch(() => {});
-        }
+        await handleTurnSuccess(thread, turn, childStreamId, executionId, logger, wallTimeMs);
       } catch (err: unknown) {
-        await writeTerminalStatus(executionId, 'error').catch(() => {});
-        finalizeCodexStream(childStreamId, executionId, logger, { error: err });
+        await finalizeCodexStream(childStreamId, executionId, logger, { error: err });
 
         const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -444,7 +444,10 @@ function startFollowUpLoop(
           logger.error(toErrorMessage(err));
         }
 
-        StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+        // Don't override STOPPED — the user pressed the stop button
+        if (!session.isInterrupted()) {
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+        }
       }
     } finally {
       logger.endGroup(groupId, 'stopped');

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -42,7 +42,7 @@ import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import type { StreamTabId, ExecutionId } from '@shared/schemas';
+import type { StreamTabId, ExecutionId, StorageKey } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { escapeAttr, escapeText } from '@tools/subagentResults';
@@ -271,7 +271,7 @@ function createCodexStream(
     streamId: childStreamId,
     executionId,
     taskState: agentConfigToTaskState(config),
-    storageKey: executionId,
+    storageKey: executionId as string as StorageKey,
   });
   bus.emit('updateStreamDescription', {
     streamId: childStreamId,

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -62,6 +62,10 @@ export interface ExternalToolDef {
   readonly configNotes?: string;
   /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
   readonly hideFromDashboard?: boolean;
+  /** Short auth/billing note shown as a badge (e.g. "Uses ChatGPT subscription"). */
+  readonly authNote?: string;
+  /** When true, the dashboard shows an enable/disable toggle for this tool group. */
+  readonly toggleable?: boolean;
 }
 
 // ============================================================
@@ -229,6 +233,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     configNotes:
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',
+    authNote: 'Uses ChatGPT subscription (free with Plus/Pro)',
+    toggleable: true,
     check: async () => {
       try {
         await importCodexClass();

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -13,6 +13,7 @@
 // Local imports
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import { getDisabledToolIds } from '@utils/config/constants';
 
 // ============================================================
 // Result type
@@ -63,13 +64,18 @@ export async function runExternalToolChecks(): Promise<
     ),
   );
 
-  // Update cache — only exclude tools whose check definitively failed.
-  // 'unknown' (check threw) is not treated as missing: the tool may still
-  // work fine and will produce a clear error at call time if it doesn't.
+  // Update cache — exclude tools whose check failed AND user-disabled tools.
   const unavailable = new Set<string>();
+  const disabledIds = getDisabledToolIds();
   for (const r of results) {
     if (r.status === 'not-found') {
       for (const t of r.tools) unavailable.add(t);
+    }
+  }
+  // User-disabled tool groups: look up their tool names from definitions
+  for (const def of EXTERNAL_TOOL_DEFS) {
+    if (disabledIds.has(def.id)) {
+      for (const t of def.tools) unavailable.add(t);
     }
   }
   cached = unavailable;

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -34,6 +34,9 @@ export interface ExternalToolCheckResult {
 /** Cached set of unavailable tool names. */
 let cached: ReadonlySet<string> | null = null;
 
+/** Last check results — kept for rebuilding the cache without re-probing. */
+let lastResults: ExternalToolCheckResult[] | null = null;
+
 /**
  * Run all external tool checks in parallel.
  * Always performs fresh checks and updates the availability cache.
@@ -67,20 +70,47 @@ export async function runExternalToolChecks(): Promise<
   // Update cache — exclude tools whose check failed AND user-disabled tools.
   const unavailable = new Set<string>();
   const disabledIds = getDisabledToolIds();
-  for (const r of results) {
-    if (r.status === 'not-found') {
-      for (const t of r.tools) unavailable.add(t);
-    }
-  }
-  // User-disabled tool groups: look up their tool names from definitions
-  for (const def of EXTERNAL_TOOL_DEFS) {
-    if (disabledIds.has(def.id)) {
-      for (const t of def.tools) unavailable.add(t);
+  for (let i = 0; i < results.length; i++) {
+    const { id, tools, status } = results[i];
+    if (status === 'not-found' || disabledIds.has(id)) {
+      for (const t of tools) unavailable.add(t);
     }
   }
   cached = unavailable;
+  lastResults = results;
 
   return results;
+}
+
+/**
+ * Rebuild the availability cache from the last check results without
+ * re-probing external tools. Used after toggling a tool on/off so the
+ * cache reflects the new disabled state immediately.
+ */
+/**
+ * Return the last check results without re-probing. Returns null if
+ * checks haven't been run yet. Used by the toggle handler to rebuild
+ * the dashboard without network I/O.
+ */
+export function getLastCheckResults(): ExternalToolCheckResult[] | null {
+  return lastResults;
+}
+
+/**
+ * Rebuild the availability cache from the last check results without
+ * re-probing external tools. Called after toggling a tool on/off.
+ */
+export function refreshDisabledToolCache(): void {
+  if (!lastResults) return;
+  const unavailable = new Set<string>();
+  const disabledIds = getDisabledToolIds();
+  for (let i = 0; i < lastResults.length; i++) {
+    const { id, tools, status } = lastResults[i];
+    if (status === 'not-found' || disabledIds.has(id)) {
+      for (const t of tools) unavailable.add(t);
+    }
+  }
+  cached = unavailable;
 }
 
 /**

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -67,30 +67,27 @@ export async function runExternalToolChecks(): Promise<
     ),
   );
 
-  // Update cache — exclude tools whose check failed AND user-disabled tools.
-  const unavailable = new Set<string>();
-  const disabledIds = getDisabledToolIds();
-  for (let i = 0; i < results.length; i++) {
-    const { id, tools, status } = results[i];
-    if (status === 'not-found' || disabledIds.has(id)) {
-      for (const t of tools) unavailable.add(t);
-    }
-  }
-  cached = unavailable;
+  cached = buildUnavailableSet(results);
   lastResults = results;
 
   return results;
 }
 
-/**
- * Rebuild the availability cache from the last check results without
- * re-probing external tools. Used after toggling a tool on/off so the
- * cache reflects the new disabled state immediately.
- */
+/** Build the set of unavailable tool names from check results + disabled IDs. */
+function buildUnavailableSet(results: ExternalToolCheckResult[]): ReadonlySet<string> {
+  const unavailable = new Set<string>();
+  const disabledIds = getDisabledToolIds();
+  for (const { id, tools, status } of results) {
+    if (status === 'not-found' || disabledIds.has(id)) {
+      for (const t of tools) unavailable.add(t);
+    }
+  }
+  return unavailable;
+}
+
 /**
  * Return the last check results without re-probing. Returns null if
- * checks haven't been run yet. Used by the toggle handler to rebuild
- * the dashboard without network I/O.
+ * checks haven't been run yet.
  */
 export function getLastCheckResults(): ExternalToolCheckResult[] | null {
   return lastResults;
@@ -102,15 +99,7 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  */
 export function refreshDisabledToolCache(): void {
   if (!lastResults) return;
-  const unavailable = new Set<string>();
-  const disabledIds = getDisabledToolIds();
-  for (let i = 0; i < lastResults.length; i++) {
-    const { id, tools, status } = lastResults[i];
-    if (status === 'not-found' || disabledIds.has(id)) {
-      for (const t of tools) unavailable.add(t);
-    }
-  }
-  cached = unavailable;
+  cached = buildUnavailableSet(lastResults);
 }
 
 /**

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -83,6 +83,28 @@ export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
   await globalSM?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
 }
 
+/** Get the set of tool group IDs disabled by the user. */
+export function getDisabledToolIds(): ReadonlySet<string> {
+  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  return new Set(raw);
+}
+
+/** Toggle a tool group's enabled/disabled state. */
+export async function setToolEnabled(
+  toolId: string,
+  enabled: boolean,
+): Promise<void> {
+  const current =
+    globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  const set = new Set(current);
+  if (enabled) {
+    set.delete(toolId);
+  } else {
+    set.add(toolId);
+  }
+  await globalSM?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
+}
+
 /** Get the maximum number of automatic retry attempts for model calls. */
 export function getModelRetryMaxAttempts(): number {
   return getConfig<number>('texra.model.retry.maxAttempts', 1);


### PR DESCRIPTION
## Summary

Overhauls the Codex tool from inline terminal output to a full native stream tab experience with multi-turn conversation support, tool toggle UI, and proper lifecycle management.

## Key Changes

### Stream Tab Display
- Each codex execution (foreground + background) gets its own **child stream tab** linked to the parent agent's stream via `AgentExecutionHandle`
- Events render using native progress view formatters: tool cards for commands, markdown bubbles for responses, collapsible thinking blocks for reasoning, native `<todo-list>` for todos
- Prompt logged as `USER_MESSAGE` at the start of each turn so you see what was asked
- `setTaskState` emitted with synthetic `AgentConfig` for full UI parity with real subagent streams (metadata, status badges, parent link)
- Both foreground and background executions registered via `registerExecution` for history listing

### Multi-Turn Follow-Up Support
- **`thread_id` parameter**: orchestrator can continue codex sessions across multiple tool calls
- **User follow-ups**: after the first turn, child stream enters WAITING state and accepts messages via the follow-up input
- `CodexFollowUpSession` registers as `IInterruptible` (stop button works, preserves STOPPED status) but does NOT duck-type as `ToolUseFlowContext` (prevents `compactResponse` crash)
- Follow-ups route through the WAITING → `ToolUseFollowUpQueue.enqueue()` path
- Thread registry keeps `Thread` instances alive; `resolveThread()` interrupts old loops before reuse

### All 8 ThreadItem Types Handled
- `command_execution` → tool-use cards (bash formatter)
- `file_change` → info entries
- `agent_message` → model response with markdown
- `reasoning` → collapsible thinking blocks
- `mcp_tool_call` → tool-use cards with `mcp:{server}/{tool}` name and structured output
- `web_search` → native web search log entries
- `todo_list` → native `<todo-list>` component via `bus.emit('updateTodos')`
- `error` → error entries

### Persistence & Reload
- Thread ID persisted to `ExecutionKVStore` (`codex_thread_id` key) — resumable via `codex.resumeThread(id)` after reload
- `interruptAllCodexSessions()` called during extension deactivation for clean shutdown
- Log group ("Codex session") marked as errored by `endRunningGroups()` on unclean reload
- Terminal status written before `untrackExecution` to prevent race with `notifyWaiters`

### Auth Note & Tool Toggle
- **Auth badge**: Codex tool card shows "Uses ChatGPT subscription (free with Plus/Pro)" with a key icon
- **Enable/disable toggle**: Toggle switch on the codex tool card in the Tools tab. Disabled tools excluded from availability cache. Toggle skips network re-probes (uses cached results + cached detail checks for instant UI update). "Disabled" badge shown instead of misleading "Not Found". Infrastructure is generic — any `ExternalToolDef` can set `toggleable: true`.

### Code Quality
- Uses `toErrorMessage()` from `@common/errors`, SDK types (`McpToolCallItem`, etc.), `formatDuration()`, `MESSAGE_TYPES` constants
- Extracted `handleTurnSuccess()`, `runStreamedTurn()`, `buildUnavailableSet()`, `buildCodexConfig()` to eliminate duplication
- `ActiveThread.executionId` properly typed as `ExecutionId`
- Removed codex from `STREAMABLE_TOOLS` (no longer uses `onToolOutput` callback)

https://claude.ai/code/session_015KCNVTqjG67zXQn4MSDjYx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: rewrites `codex` execution/lifecycle and introduces a new global disabled-tools state that affects tool availability resolution, which could impact background task tracking and tool routing if edge cases slip through.
> 
> **Overview**
> Overhauls the `codex` tool to run as a **native child stream tab** (foreground and background) with streamed event logging, execution tracking, and clean shutdown/interrupt handling (including on extension deactivate).
> 
> Adds **multi-turn Codex sessions** via a new `thread_id` parameter plus a WAITING follow-up loop, and expands item rendering/logging to cover additional Codex SDK event types.
> 
> Introduces a **Tools dashboard enable/disable toggle** backed by new global state (`texra.tools.disabled`), updates availability caching to treat disabled tool groups as unavailable without re-probing, and enhances tool cards with a disabled badge and optional auth note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b56c732be98a10e37001436d9d88aa200be055e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->