### PR TITLE
Add External Inquiry tool for human-in-the-loop external AI consultation

### DIFF
--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -20,6 +20,7 @@ settings:
     - extract_figures
     - extract_bib_entries
     - texcount
+    - external_inquiry
 prompts:
   systemPrompt: |
     You are an AI scientist assistant that stewards the long-term development of LaTeX research projects. Think beyond individual tasks—consider whether the project structure scales, conventions stay consistent, and accumulated work builds toward a coherent whole. Maintain modular folder organization: keep sources, figures, bibliography, and build artifacts in separate directories so the project stays navigable as it grows. Proactively propose cleanup when you see duplicated logic, dead code, or inconsistent patterns. Every change should leave the project in a better structural state, not just fulfill the immediate request.

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -55,6 +55,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   AGENT_PROPOSAL_ACTION: 'agentProposalAction',
   BASH_APPROVAL_ACTION: 'bashApprovalAction',
   PLAN_APPROVAL_ACTION: 'planApprovalAction',
+  EXTERNAL_INQUIRY_ACTION: 'externalInquiryAction',
   RESTORE_PROPOSAL_CONFIG: 'restoreProposalConfig',
   TOGGLE_SUPER_YOLO_BYPASS: 'toggleSuperYoloBypass',
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -8,6 +8,7 @@ import type {
   BashPermission,
   ConversationProgress,
   ExecutionId,
+  ExternalInquiryPermission,
   FileLocation,
   OutputFileInfo,
   PlanApprovalPermission,
@@ -86,6 +87,8 @@ export interface ProgressEventPayloads {
   resolveAgentProposal: { proposalId: string };
   showPlanApproval: PlanApprovalPermission;
   resolvePlanApproval: { approvalId: string };
+  showExternalInquiry: ExternalInquiryPermission;
+  resolveExternalInquiry: { requestId: string };
   updateTodos: UpdateTodosPayload;
   updatePlan: UpdatePlanPayload;
   updateConversationProgress: {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -40,6 +40,7 @@ import {
   type ProgressViewInboundHandlerRegistry,
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
+import { handleExternalInquiryAction } from '@tools/inquiry';
 import {
   cleanupAllApprovals,
   cleanupApprovalsForStream,
@@ -257,6 +258,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         handleProgressViewBashApprovalAction(data),
       [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: (data) =>
         this.handlePlanApprovalAction(data),
+      [PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION]: (data) =>
+        handleExternalInquiryAction(data),
 
       // Profile & Memory - direct command execution
       [PROGRESS_VIEW_COMMANDS.OPEN_PROFILE]: async () => {

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -21,6 +21,7 @@ import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
 import type {
   AgentProposalPermission,
   BashPermission,
+  ExternalInquiryPermission,
   ModelOptionData,
   PlanApprovalPermission,
   ProgressViewPlacement,
@@ -94,6 +95,10 @@ export class ProgressViewProvider
     PlanApprovalPermission,
     'approvalId'
   >;
+  private readonly externalInquiryHandler: ApprovalRequestHandler<
+    ExternalInquiryPermission,
+    'requestId'
+  >;
 
   constructor(protected readonly context: vscode.ExtensionContext) {
     super(context);
@@ -148,6 +153,16 @@ export class ProgressViewProvider
       (id) => u.resolvePermission(PERMISSION_KIND.PLAN_APPROVAL, id),
       canSend,
     );
+    this.externalInquiryHandler = new ApprovalRequestHandler(
+      'requestId',
+      (p) =>
+        u.showPermission({
+          kind: PERMISSION_KIND.EXTERNAL_INQUIRY,
+          data: p,
+        }),
+      (id) => u.resolvePermission(PERMISSION_KIND.EXTERNAL_INQUIRY, id),
+      canSend,
+    );
 
     this.eventHandler = new ProgressEventHandler(
       this.state,
@@ -172,6 +187,8 @@ export class ProgressViewProvider
         resolveAgentProposal: (id) => this.agentProposalHandler.resolve(id),
         showPlanApproval: (p) => this.planApprovalHandler.show(p),
         resolvePlanApproval: (id) => this.planApprovalHandler.resolve(id),
+        showExternalInquiry: (p) => this.externalInquiryHandler.show(p),
+        resolveExternalInquiry: (id) => this.externalInquiryHandler.resolve(id),
       },
       (streamId) => this.hasPendingPermissionsForStream(streamId),
     );
@@ -334,6 +351,7 @@ export class ProgressViewProvider
 
     this.toolEditHandler.replay();
     this.bashApprovalHandler.replay();
+    this.externalInquiryHandler.replay();
     // YOLO / Super YOLO state is already sent by syncFullView() which is
     // always called before replayPendingPrompts() in markWebviewReady().
 
@@ -358,7 +376,8 @@ export class ProgressViewProvider
       this.toolEditHandler.hasPendingForStream(streamId) ||
       this.bashApprovalHandler.hasPendingForStream(streamId) ||
       this.agentProposalHandler.hasPendingForStream(streamId) ||
-      this.planApprovalHandler.hasPendingForStream(streamId)
+      this.planApprovalHandler.hasPendingForStream(streamId) ||
+      this.externalInquiryHandler.hasPendingForStream(streamId)
     );
   }
 

--- a/src/progressView/events/UIEvents.ts
+++ b/src/progressView/events/UIEvents.ts
@@ -44,6 +44,10 @@ export interface UICallbacks {
     payload: ProgressEventPayloads['showPlanApproval'],
   ) => void;
   resolvePlanApproval: (approvalId: string) => void;
+  showExternalInquiry: (
+    payload: ProgressEventPayloads['showExternalInquiry'],
+  ) => void;
+  resolveExternalInquiry: (requestId: string) => void;
 }
 
 /** Helper to register an event with error handling wrapper. */
@@ -165,6 +169,22 @@ export function registerUIEvents(
     'resolvePlanApproval',
     (p) => callbacks.resolvePlanApproval(p.approvalId),
     'failed to resolve plan approval',
+    signal,
+  );
+
+  // External inquiry events
+  registerEvent(
+    bus,
+    'showExternalInquiry',
+    callbacks.showExternalInquiry,
+    'failed to show external inquiry',
+    signal,
+  );
+  registerEvent(
+    bus,
+    'resolveExternalInquiry',
+    (p) => callbacks.resolveExternalInquiry(p.requestId),
+    'failed to resolve external inquiry',
     signal,
   );
 }

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -70,6 +70,7 @@ import {
   handleFollowupModeChange,
   handleFollowupRequestOptions,
   handlePermissionAction,
+  handleExternalInquirySubmit,
   handleRunSelected,
   handleSortChange,
   handleStreamDelete,
@@ -574,6 +575,7 @@ export class ProgressApp extends ProgressAppBase {
         <tool-use-stream-content
           @toolbar-command=${this.onToolbarCommand}
           @permission-action=${this.onPermissionAction}
+          @inquiry-submit=${this.onInquirySubmit}
           @followup-change=${this.onFollowUpChange}
           @followup-send=${this.onFollowUpSend}
           @followup-polish=${this.onFollowUpPolish}
@@ -588,6 +590,7 @@ export class ProgressApp extends ProgressAppBase {
       <workflow-stream-content
         @toolbar-command=${this.onToolbarCommand}
         @permission-action=${this.onPermissionAction}
+        @inquiry-submit=${this.onInquirySubmit}
         @run-selected=${this.onRunSelected}
         @file-action=${this.onFileAction}
         @followup-request-options=${this.onFollowupRequestOptions}
@@ -725,6 +728,8 @@ export class ProgressApp extends ProgressAppBase {
   private onFileAction = (e: CustomEvent): void => handleFileAction(e);
   private onPermissionAction = (e: CustomEvent): void =>
     handlePermissionAction(e, this.createMessageHandlerContext());
+  private onInquirySubmit = (e: CustomEvent): void =>
+    handleExternalInquirySubmit(e, this.createMessageHandlerContext());
 
   // Event handlers requiring context
   private onFilterChange = (e: CustomEvent): void =>

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -70,7 +70,6 @@ import {
   handleFollowupModeChange,
   handleFollowupRequestOptions,
   handlePermissionAction,
-  handleExternalInquirySubmit,
   handleRunSelected,
   handleSortChange,
   handleStreamDelete,
@@ -575,7 +574,6 @@ export class ProgressApp extends ProgressAppBase {
         <tool-use-stream-content
           @toolbar-command=${this.onToolbarCommand}
           @permission-action=${this.onPermissionAction}
-          @inquiry-submit=${this.onInquirySubmit}
           @followup-change=${this.onFollowUpChange}
           @followup-send=${this.onFollowUpSend}
           @followup-polish=${this.onFollowUpPolish}
@@ -590,7 +588,6 @@ export class ProgressApp extends ProgressAppBase {
       <workflow-stream-content
         @toolbar-command=${this.onToolbarCommand}
         @permission-action=${this.onPermissionAction}
-        @inquiry-submit=${this.onInquirySubmit}
         @run-selected=${this.onRunSelected}
         @file-action=${this.onFileAction}
         @followup-request-options=${this.onFollowupRequestOptions}
@@ -728,8 +725,6 @@ export class ProgressApp extends ProgressAppBase {
   private onFileAction = (e: CustomEvent): void => handleFileAction(e);
   private onPermissionAction = (e: CustomEvent): void =>
     handlePermissionAction(e, this.createMessageHandlerContext());
-  private onInquirySubmit = (e: CustomEvent): void =>
-    handleExternalInquirySubmit(e, this.createMessageHandlerContext());
 
   // Event handlers requiring context
   private onFilterChange = (e: CustomEvent): void =>

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -6,13 +6,13 @@
  * Provides a textarea for the user to paste the answer back, and an optional
  * file attachment drop zone for files downloaded from the external model.
  *
- * User input (answer text, dropped files) is persisted in a static cache keyed
- * by requestId so it survives component recreation during webview hide/show
- * cycles — the permission is replayed via ApprovalRequestHandler.replay() but
- * the component is re-mounted with fresh @state. The cache restores prior input.
+ * User input (answer text, dropped files) is persisted in a module-level cache
+ * keyed by requestId so it survives component recreation during webview
+ * hide/show cycles — the permission is replayed via ApprovalRequestHandler
+ * but the component is re-mounted with fresh @state.
  */
 
-import { html, nothing, type TemplateResult } from 'lit';
+import { html, nothing, type TemplateResult, type PropertyValues } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { live } from 'lit/directives/live.js';
@@ -24,24 +24,44 @@ import {
   requestPanelStyles,
 } from '@shared/styles';
 import type { ExternalInquiryPermission } from '@shared/schemas';
+import { EXTERNAL_INQUIRY_ACTIONS } from '@shared/schemas';
 import { CopyButtonController } from '@shared/controllers/CopyButtonController';
 
 import { BaseRequestPanel } from './BaseRequestPanel';
 
-// ── Persistence across component recreation ──
-// Permissions are replayed on webview show, but local @state is lost.
-// Cache user input so a long pasted answer isn't destroyed by hide/show.
+// ── Draft persistence ──
+
 interface InquiryDraft {
   answerText: string;
   droppedFiles: string[];
 }
+
+const DRAFT_CACHE_CAP = 50;
 const draftCache = new Map<string, InquiryDraft>();
-/** Tracks resolved request IDs so disconnectedCallback doesn't re-save after clearDraft. */
 const resolvedIds = new Set<string>();
+
+function evictOldestDraft(): void {
+  if (draftCache.size <= DRAFT_CACHE_CAP) return;
+  const oldest = draftCache.keys().next().value;
+  if (oldest !== undefined) draftCache.delete(oldest);
+}
 
 function getRequestId(permission: { data: unknown }): string {
   return (permission.data as ExternalInquiryPermission).requestId;
 }
+
+/** Clear draft for a resolved inquiry. Called from eventHandlers on submit/skip. */
+export function clearInquiryDraft(requestId: string): void {
+  draftCache.delete(requestId);
+  resolvedIds.add(requestId);
+  // Bound resolvedIds like draftCache
+  if (resolvedIds.size > DRAFT_CACHE_CAP) {
+    const oldest = resolvedIds.values().next().value;
+    if (oldest !== undefined) resolvedIds.delete(oldest);
+  }
+}
+
+// ── Component ──
 
 @customElement('external-inquiry-panel')
 export class ExternalInquiryPanel extends BaseRequestPanel {
@@ -57,42 +77,40 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   @state() private dropActive = false;
 
   private copyController = new CopyButtonController(this);
+  private draftRestored = false;
 
   // ── Lifecycle ──
-
-  override connectedCallback(): void {
-    super.connectedCallback();
-    const id = getRequestId(this.permission);
-    const draft = draftCache.get(id);
-    if (draft) {
-      this.answerText = draft.answerText;
-      this.droppedFiles = draft.droppedFiles;
-    }
-  }
 
   override disconnectedCallback(): void {
     this.saveDraft();
     super.disconnectedCallback();
   }
 
+  protected override willUpdate(changed: PropertyValues): void {
+    super.willUpdate(changed);
+    // Restore draft once on first update (avoids the extra render from connectedCallback).
+    if (!this.draftRestored) {
+      this.draftRestored = true;
+      const draft = draftCache.get(getRequestId(this.permission));
+      if (draft) {
+        this.answerText = draft.answerText;
+        this.droppedFiles = draft.droppedFiles;
+      }
+    }
+  }
+
   private saveDraft(): void {
     const id = getRequestId(this.permission);
-    // Don't re-save after the inquiry was resolved (submit/skip already cleared).
     if (resolvedIds.has(id)) return;
     if (this.answerText || this.droppedFiles.length > 0) {
       draftCache.set(id, {
         answerText: this.answerText,
         droppedFiles: this.droppedFiles,
       });
+      evictOldestDraft();
     } else {
       draftCache.delete(id);
     }
-  }
-
-  /** Clean up cache entry when this inquiry is resolved. */
-  static clearDraft(requestId: string): void {
-    draftCache.delete(requestId);
-    resolvedIds.add(requestId);
   }
 
   override handleKeyboardShortcut(_key: string): boolean {
@@ -100,6 +118,10 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   }
 
   // ── Render ──
+
+  private get hasAnswer(): boolean {
+    return this.answerText.trim().length > 0;
+  }
 
   override render(): TemplateResult {
     const data = this.permission.data as ExternalInquiryPermission;
@@ -250,16 +272,16 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
           icon="check"
           label="Submit Answer"
           title="Submit the answer from the external model"
-          data-action="submit"
-          ?disabled=${!this.answerText.trim()}
+          data-action=${EXTERNAL_INQUIRY_ACTIONS[0]}
+          ?disabled=${!this.hasAnswer}
           @click=${this.handleSubmit}
         >Submit Answer</vscode-toolbar-button>
         <vscode-toolbar-button
           icon="close"
           label="Skip"
           title="Skip this external inquiry"
-          data-action="skip"
-          @click=${() => this.emitAction('skip')}
+          data-action=${EXTERNAL_INQUIRY_ACTIONS[1]}
+          @click=${() => this.emitAction(EXTERNAL_INQUIRY_ACTIONS[1])}
         >Skip</vscode-toolbar-button>
       </vscode-toolbar-container>
     `;
@@ -282,8 +304,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
     const answer = this.answerText.trim();
     if (!answer) return;
 
-    // Clear cache — this inquiry is done.
-    ExternalInquiryPanel.clearDraft(getRequestId(this.permission));
+    clearInquiryDraft(getRequestId(this.permission));
 
     // Custom event: submit carries answer + files, which doesn't fit
     // the standard permissionAction shape (action + optional feedback).
@@ -293,7 +314,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
         composed: true,
         detail: {
           permission: this.permission,
-          action: 'submit',
+          action: EXTERNAL_INQUIRY_ACTIONS[0],
           answer,
           attachedFiles: this.droppedFiles,
         },

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -8,7 +8,7 @@
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
-import { customElement, query, state } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 
 import {
   codiconIconClasses,
@@ -34,13 +34,9 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   @state() private droppedFiles: string[] = [];
   @state() private dropActive = false;
 
-  @query('.external-inquiry-request__answer-input')
-  private answerInput?: HTMLTextAreaElement;
-
   private copyController = new CopyButtonController(this);
 
   override handleKeyboardShortcut(_key: string): boolean {
-    // No single-key shortcuts — the textarea needs all keys
     return false;
   }
 
@@ -80,8 +76,9 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   }
 
   private renderQuestion(question: string): TemplateResult {
-    const copyIcon = this.copyController.state.copied ? 'check' : 'copy';
-    const copyLabel = this.copyController.state.copied ? 'Copied!' : 'Copy Question';
+    const { copied } = this.copyController.state;
+    const copyIcon = copied ? 'check' : 'copy';
+    const copyLabel = copied ? 'Copied!' : 'Copy Question';
 
     return html`
       <div class="external-inquiry-request__question">
@@ -91,7 +88,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
             icon=${copyIcon}
             label=${copyLabel}
             title="Copy question to clipboard for pasting into an external AI model"
-            @click=${() => this.handleCopy(question)}
+            @click=${() => this.copyController.copy(question)}
           >${copyLabel}</vscode-toolbar-button>
         </div>
       </div>
@@ -187,8 +184,6 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   }
 
   private renderActions(): TemplateResult {
-    const hasAnswer = this.answerText.trim().length > 0;
-
     return html`
       <vscode-toolbar-container class="external-inquiry-request__actions">
         <vscode-toolbar-button
@@ -196,7 +191,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
           label="Submit Answer"
           title="Submit the answer from the external model"
           data-action="submit"
-          ?disabled=${!hasAnswer}
+          ?disabled=${!this.answerText.trim()}
           @click=${() => this.handleSubmit()}
         >Submit Answer</vscode-toolbar-button>
         <vscode-toolbar-button
@@ -212,30 +207,22 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   // ── Event Handlers ──
 
-  private handleCopy(text: string): void {
-    void this.copyController.copy(text);
-  }
-
   private handleAnswerInput(e: Event): void {
     const target = e.target as HTMLTextAreaElement;
     this.answerText = target.value;
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
-    // Ctrl/Cmd+Enter to submit
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
-      if (this.answerText.trim()) {
-        this.handleSubmit();
-      }
+      this.handleSubmit();
     }
   }
 
   private handleSubmit(): void {
     if (!this.answerText.trim()) return;
-    // Emit a custom action with the answer text and attached files
-    // The action is 'submit' and we pass answer data via the feedback field
-    // and files via modelOverride (repurposed for this panel type)
+    // Custom event because submit carries answer data that doesn't fit
+    // the standard permissionAction shape (which only has action + feedback).
     this.dispatchEvent(
       new CustomEvent('inquiry-submit', {
         bubbles: true,
@@ -252,20 +239,19 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   private handleDragOver(e: DragEvent): void {
     e.preventDefault();
-    this.dropActive = true;
+    if (!this.dropActive) this.dropActive = true;
   }
 
   private handleDragLeave(): void {
-    this.dropActive = false;
+    if (this.dropActive) this.dropActive = false;
   }
 
   private handleDrop(e: DragEvent): void {
     e.preventDefault();
     this.dropActive = false;
     if (e.dataTransfer?.files) {
-      for (const file of Array.from(e.dataTransfer.files)) {
-        this.droppedFiles = [...this.droppedFiles, file.name];
-      }
+      const newFiles = Array.from(e.dataTransfer.files).map((f) => f.name);
+      this.droppedFiles = [...this.droppedFiles, ...newFiles];
     }
   }
 

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -28,6 +28,7 @@ import { EXTERNAL_INQUIRY_ACTIONS } from '@shared/schemas';
 import { CopyButtonController } from '@shared/controllers/CopyButtonController';
 
 import { BaseRequestPanel } from './BaseRequestPanel';
+import { ProgressEvents } from '../events';
 
 // ── Draft persistence ──
 
@@ -306,18 +307,12 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
     clearInquiryDraft(getRequestId(this.permission));
 
-    // Custom event: submit carries answer + files, which doesn't fit
-    // the standard permissionAction shape (action + optional feedback).
     this.dispatchEvent(
-      new CustomEvent('inquiry-submit', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          permission: this.permission,
-          action: EXTERNAL_INQUIRY_ACTIONS[0],
-          answer,
-          attachedFiles: this.droppedFiles,
-        },
+      ProgressEvents.permissionAction({
+        permission: this.permission,
+        action: EXTERNAL_INQUIRY_ACTIONS[0],
+        answer,
+        attachedFiles: this.droppedFiles,
       }),
     );
   }

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -160,13 +160,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
         >
           ${this.droppedFiles.length > 0
             ? this.renderDroppedFiles()
-            : html`<span>Drop files here or use the browse button</span>`}
-          <vscode-toolbar-button
-            icon="folder-opened"
-            label="Browse..."
-            title="Browse for files downloaded from the external model"
-            @click=${this.handleBrowse}
-          >Browse...</vscode-toolbar-button>
+            : html`<span>Drop files here from your file explorer</span>`}
         </div>
       </div>
     `;
@@ -273,18 +267,6 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
         this.droppedFiles = [...this.droppedFiles, file.name];
       }
     }
-  }
-
-  private handleBrowse(): void {
-    // In VS Code webview, file browsing requires posting a message to the extension host.
-    // For now, emit an event that the parent can handle.
-    this.dispatchEvent(
-      new CustomEvent('inquiry-browse-files', {
-        bubbles: true,
-        composed: true,
-        detail: { permission: this.permission },
-      }),
-    );
   }
 
   private removeFile(index: number): void {

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -5,10 +5,17 @@
  * for the user to paste into an external AI model (ChatGPT, Gemini, Claude, etc.).
  * Provides a textarea for the user to paste the answer back, and an optional
  * file attachment drop zone for files downloaded from the external model.
+ *
+ * User input (answer text, dropped files) is persisted in a static cache keyed
+ * by requestId so it survives component recreation during webview hide/show
+ * cycles — the permission is replayed via ApprovalRequestHandler.replay() but
+ * the component is re-mounted with fresh @state. The cache restores prior input.
  */
 
 import { html, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { live } from 'lit/directives/live.js';
 
 import {
   codiconIconClasses,
@@ -20,6 +27,19 @@ import type { ExternalInquiryPermission } from '@shared/schemas';
 import { CopyButtonController } from '@shared/controllers/CopyButtonController';
 
 import { BaseRequestPanel } from './BaseRequestPanel';
+
+// ── Persistence across component recreation ──
+// Permissions are replayed on webview show, but local @state is lost.
+// Cache user input so a long pasted answer isn't destroyed by hide/show.
+interface InquiryDraft {
+  answerText: string;
+  droppedFiles: string[];
+}
+const draftCache = new Map<string, InquiryDraft>();
+
+function getRequestId(permission: { data: unknown }): string {
+  return (permission.data as ExternalInquiryPermission).requestId;
+}
 
 @customElement('external-inquiry-panel')
 export class ExternalInquiryPanel extends BaseRequestPanel {
@@ -36,9 +56,45 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   private copyController = new CopyButtonController(this);
 
+  // ── Lifecycle ──
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    const id = getRequestId(this.permission);
+    const draft = draftCache.get(id);
+    if (draft) {
+      this.answerText = draft.answerText;
+      this.droppedFiles = draft.droppedFiles;
+    }
+  }
+
+  override disconnectedCallback(): void {
+    this.saveDraft();
+    super.disconnectedCallback();
+  }
+
+  private saveDraft(): void {
+    const id = getRequestId(this.permission);
+    if (this.answerText || this.droppedFiles.length > 0) {
+      draftCache.set(id, {
+        answerText: this.answerText,
+        droppedFiles: this.droppedFiles,
+      });
+    } else {
+      draftCache.delete(id);
+    }
+  }
+
+  /** Clean up cache entry when this inquiry is resolved. */
+  static clearDraft(requestId: string): void {
+    draftCache.delete(requestId);
+  }
+
   override handleKeyboardShortcut(_key: string): boolean {
     return false;
   }
+
+  // ── Render ──
 
   override render(): TemplateResult {
     const data = this.permission.data as ExternalInquiryPermission;
@@ -61,10 +117,8 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   private renderHeader(data: ExternalInquiryPermission): TemplateResult {
     return html`
-      <div style="display: flex; align-items: center; gap: var(--spacing-small); flex-wrap: wrap;">
-        <span class="external-inquiry-request__mode-badge">
-          ${data.mode === 'followup' ? 'follow-up' : 'new question'}
-        </span>
+      <div class="external-inquiry-request__mode-badge">
+        ${data.mode === 'followup' ? 'follow-up' : 'new question'}
       </div>
     `;
   }
@@ -77,19 +131,17 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   private renderQuestion(question: string): TemplateResult {
     const { copied } = this.copyController.state;
-    const copyIcon = copied ? 'check' : 'copy';
-    const copyLabel = copied ? 'Copied!' : 'Copy Question';
 
     return html`
       <div class="external-inquiry-request__question">
         <div class="external-inquiry-request__question-text">${question}</div>
         <div class="external-inquiry-request__question-actions">
           <vscode-toolbar-button
-            icon=${copyIcon}
-            label=${copyLabel}
+            icon=${copied ? 'check' : 'copy'}
+            label=${copied ? 'Copied!' : 'Copy Question'}
             title="Copy question to clipboard for pasting into an external AI model"
             @click=${() => this.copyController.copy(question)}
-          >${copyLabel}</vscode-toolbar-button>
+          >${copied ? 'Copied!' : 'Copy Question'}</vscode-toolbar-button>
         </div>
       </div>
     `;
@@ -134,7 +186,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
         <textarea
           class="external-inquiry-request__answer-input"
           placeholder="Paste the answer here..."
-          .value=${this.answerText}
+          .value=${live(this.answerText)}
           @input=${this.handleAnswerInput}
           @keydown=${this.handleKeyDown}
         ></textarea>
@@ -150,7 +202,10 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
           Attach files from external model (optional):
         </div>
         <div
-          class="external-inquiry-request__drop-zone ${this.dropActive ? 'external-inquiry-request__drop-zone--active' : ''}"
+          class=${classMap({
+            'external-inquiry-request__drop-zone': true,
+            'external-inquiry-request__drop-zone--active': this.dropActive,
+          })}
           @dragover=${this.handleDragOver}
           @dragleave=${this.handleDragLeave}
           @drop=${this.handleDrop}
@@ -192,7 +247,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
           title="Submit the answer from the external model"
           data-action="submit"
           ?disabled=${!this.answerText.trim()}
-          @click=${() => this.handleSubmit()}
+          @click=${this.handleSubmit}
         >Submit Answer</vscode-toolbar-button>
         <vscode-toolbar-button
           icon="close"
@@ -208,8 +263,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   // ── Event Handlers ──
 
   private handleAnswerInput(e: Event): void {
-    const target = e.target as HTMLTextAreaElement;
-    this.answerText = target.value;
+    this.answerText = (e.target as HTMLTextAreaElement).value;
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
@@ -220,9 +274,14 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   }
 
   private handleSubmit(): void {
-    if (!this.answerText.trim()) return;
-    // Custom event because submit carries answer data that doesn't fit
-    // the standard permissionAction shape (which only has action + feedback).
+    const answer = this.answerText.trim();
+    if (!answer) return;
+
+    // Clear cache — this inquiry is done.
+    ExternalInquiryPanel.clearDraft(getRequestId(this.permission));
+
+    // Custom event: submit carries answer + files, which doesn't fit
+    // the standard permissionAction shape (action + optional feedback).
     this.dispatchEvent(
       new CustomEvent('inquiry-submit', {
         bubbles: true,
@@ -230,7 +289,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
         detail: {
           permission: this.permission,
           action: 'submit',
-          answer: this.answerText,
+          answer,
           attachedFiles: this.droppedFiles,
         },
       }),

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -36,6 +36,8 @@ interface InquiryDraft {
   droppedFiles: string[];
 }
 const draftCache = new Map<string, InquiryDraft>();
+/** Tracks resolved request IDs so disconnectedCallback doesn't re-save after clearDraft. */
+const resolvedIds = new Set<string>();
 
 function getRequestId(permission: { data: unknown }): string {
   return (permission.data as ExternalInquiryPermission).requestId;
@@ -75,6 +77,8 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
 
   private saveDraft(): void {
     const id = getRequestId(this.permission);
+    // Don't re-save after the inquiry was resolved (submit/skip already cleared).
+    if (resolvedIds.has(id)) return;
     if (this.answerText || this.droppedFiles.length > 0) {
       draftCache.set(id, {
         answerText: this.answerText,
@@ -88,6 +92,7 @@ export class ExternalInquiryPanel extends BaseRequestPanel {
   /** Clean up cache entry when this inquiry is resolved. */
   static clearDraft(requestId: string): void {
     draftCache.delete(requestId);
+    resolvedIds.add(requestId);
   }
 
   override handleKeyboardShortcut(_key: string): boolean {

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -1,0 +1,299 @@
+/**
+ * UI panel for external inquiry requests.
+ *
+ * Displays a question formulated by the agent, with a "Copy Question" button
+ * for the user to paste into an external AI model (ChatGPT, Gemini, Claude, etc.).
+ * Provides a textarea for the user to paste the answer back, and an optional
+ * file attachment drop zone for files downloaded from the external model.
+ */
+
+import { html, nothing, type TemplateResult } from 'lit';
+import { customElement, query, state } from 'lit/decorators.js';
+
+import {
+  codiconIconClasses,
+  commonViewStyles,
+  designTokens,
+  requestPanelStyles,
+} from '@shared/styles';
+import type { ExternalInquiryPermission } from '@shared/schemas';
+import { CopyButtonController } from '@shared/controllers/CopyButtonController';
+
+import { BaseRequestPanel } from './BaseRequestPanel';
+
+@customElement('external-inquiry-panel')
+export class ExternalInquiryPanel extends BaseRequestPanel {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    codiconIconClasses,
+    requestPanelStyles,
+  ];
+
+  @state() private answerText = '';
+  @state() private droppedFiles: string[] = [];
+  @state() private dropActive = false;
+
+  @query('.external-inquiry-request__answer-input')
+  private answerInput?: HTMLTextAreaElement;
+
+  private copyController = new CopyButtonController(this);
+
+  override handleKeyboardShortcut(_key: string): boolean {
+    // No single-key shortcuts — the textarea needs all keys
+    return false;
+  }
+
+  override render(): TemplateResult {
+    const data = this.permission.data as ExternalInquiryPermission;
+
+    return html`
+      <div class="external-inquiry-request">
+        <div class="external-inquiry-request__details">
+          ${this.renderHeader(data)}
+          ${data.context ? this.renderContext(data.context) : nothing}
+          ${this.renderQuestion(data.question)}
+          ${data.suggestSearch ? this.renderSearchHint() : nothing}
+          ${data.attachFiles?.length ? this.renderAttachFiles(data.attachFiles) : nothing}
+          ${this.renderAnswerArea()}
+          ${this.renderDropZone()}
+        </div>
+        ${this.renderActions()}
+      </div>
+    `;
+  }
+
+  private renderHeader(data: ExternalInquiryPermission): TemplateResult {
+    return html`
+      <div style="display: flex; align-items: center; gap: var(--spacing-small); flex-wrap: wrap;">
+        <span class="external-inquiry-request__mode-badge">
+          ${data.mode === 'followup' ? 'follow-up' : 'new question'}
+        </span>
+      </div>
+    `;
+  }
+
+  private renderContext(context: string): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__context">${context}</div>
+    `;
+  }
+
+  private renderQuestion(question: string): TemplateResult {
+    const copyIcon = this.copyController.state.copied ? 'check' : 'copy';
+    const copyLabel = this.copyController.state.copied ? 'Copied!' : 'Copy Question';
+
+    return html`
+      <div class="external-inquiry-request__question">
+        <div class="external-inquiry-request__question-text">${question}</div>
+        <div class="external-inquiry-request__question-actions">
+          <vscode-toolbar-button
+            icon=${copyIcon}
+            label=${copyLabel}
+            title="Copy question to clipboard for pasting into an external AI model"
+            @click=${() => this.handleCopy(question)}
+          >${copyLabel}</vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSearchHint(): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__search-hint">
+        <i class="codicon codicon-lightbulb"></i>
+        Consider enabling <strong>Search</strong> mode in the external tool for this question
+      </div>
+    `;
+  }
+
+  private renderAttachFiles(files: string[]): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__attach-files">
+        <div class="external-inquiry-request__attach-label">
+          <i class="codicon codicon-cloud-upload"></i>
+          Files to upload to the external model:
+        </div>
+        <div class="external-inquiry-request__file-list">
+          ${files.map(
+            (file) => html`
+              <div class="external-inquiry-request__file-item">
+                <i class="codicon codicon-file"></i>
+                <span>${file}</span>
+              </div>
+            `,
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAnswerArea(): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__answer-area">
+        <div class="external-inquiry-request__answer-label">
+          Paste the answer from the external model:
+        </div>
+        <textarea
+          class="external-inquiry-request__answer-input"
+          placeholder="Paste the answer here..."
+          .value=${this.answerText}
+          @input=${this.handleAnswerInput}
+          @keydown=${this.handleKeyDown}
+        ></textarea>
+      </div>
+    `;
+  }
+
+  private renderDropZone(): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__answer-area">
+        <div class="external-inquiry-request__attach-label">
+          <i class="codicon codicon-cloud-download"></i>
+          Attach files from external model (optional):
+        </div>
+        <div
+          class="external-inquiry-request__drop-zone ${this.dropActive ? 'external-inquiry-request__drop-zone--active' : ''}"
+          @dragover=${this.handleDragOver}
+          @dragleave=${this.handleDragLeave}
+          @drop=${this.handleDrop}
+        >
+          ${this.droppedFiles.length > 0
+            ? this.renderDroppedFiles()
+            : html`<span>Drop files here or use the browse button</span>`}
+          <vscode-toolbar-button
+            icon="folder-opened"
+            label="Browse..."
+            title="Browse for files downloaded from the external model"
+            @click=${this.handleBrowse}
+          >Browse...</vscode-toolbar-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderDroppedFiles(): TemplateResult {
+    return html`
+      <div class="external-inquiry-request__dropped-files">
+        ${this.droppedFiles.map(
+          (file, idx) => html`
+            <div class="external-inquiry-request__dropped-file">
+              <i class="codicon codicon-check"></i>
+              <span>${file}</span>
+              <vscode-toolbar-button
+                icon="close"
+                title="Remove"
+                @click=${() => this.removeFile(idx)}
+              ></vscode-toolbar-button>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  private renderActions(): TemplateResult {
+    const hasAnswer = this.answerText.trim().length > 0;
+
+    return html`
+      <vscode-toolbar-container class="external-inquiry-request__actions">
+        <vscode-toolbar-button
+          icon="check"
+          label="Submit Answer"
+          title="Submit the answer from the external model"
+          data-action="submit"
+          ?disabled=${!hasAnswer}
+          @click=${() => this.handleSubmit()}
+        >Submit Answer</vscode-toolbar-button>
+        <vscode-toolbar-button
+          icon="close"
+          label="Skip"
+          title="Skip this external inquiry"
+          data-action="skip"
+          @click=${() => this.emitAction('skip')}
+        >Skip</vscode-toolbar-button>
+      </vscode-toolbar-container>
+    `;
+  }
+
+  // ── Event Handlers ──
+
+  private handleCopy(text: string): void {
+    void this.copyController.copy(text);
+  }
+
+  private handleAnswerInput(e: Event): void {
+    const target = e.target as HTMLTextAreaElement;
+    this.answerText = target.value;
+  }
+
+  private handleKeyDown(e: KeyboardEvent): void {
+    // Ctrl/Cmd+Enter to submit
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      if (this.answerText.trim()) {
+        this.handleSubmit();
+      }
+    }
+  }
+
+  private handleSubmit(): void {
+    if (!this.answerText.trim()) return;
+    // Emit a custom action with the answer text and attached files
+    // The action is 'submit' and we pass answer data via the feedback field
+    // and files via modelOverride (repurposed for this panel type)
+    this.dispatchEvent(
+      new CustomEvent('inquiry-submit', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          permission: this.permission,
+          action: 'submit',
+          answer: this.answerText,
+          attachedFiles: this.droppedFiles,
+        },
+      }),
+    );
+  }
+
+  private handleDragOver(e: DragEvent): void {
+    e.preventDefault();
+    this.dropActive = true;
+  }
+
+  private handleDragLeave(): void {
+    this.dropActive = false;
+  }
+
+  private handleDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.dropActive = false;
+    if (e.dataTransfer?.files) {
+      for (const file of Array.from(e.dataTransfer.files)) {
+        this.droppedFiles = [...this.droppedFiles, file.name];
+      }
+    }
+  }
+
+  private handleBrowse(): void {
+    // In VS Code webview, file browsing requires posting a message to the extension host.
+    // For now, emit an event that the parent can handle.
+    this.dispatchEvent(
+      new CustomEvent('inquiry-browse-files', {
+        bubbles: true,
+        composed: true,
+        detail: { permission: this.permission },
+      }),
+    );
+  }
+
+  private removeFile(index: number): void {
+    this.droppedFiles = this.droppedFiles.filter((_, i) => i !== index);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'external-inquiry-panel': ExternalInquiryPanel;
+  }
+}

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -12,6 +12,7 @@ import { postMessage } from '@shared/vscode';
 import type {
   AgentProposalPermission,
   BashPermission,
+  ExternalInquiryPermission,
   ModelOptionData,
   PlanApprovalPermission,
   RetryPermission,
@@ -48,6 +49,10 @@ export type PermissionState =
   | {
       kind: typeof PERMISSION_KIND.PLAN_APPROVAL;
       data: PlanApprovalPermission;
+    }
+  | {
+      kind: typeof PERMISSION_KIND.EXTERNAL_INQUIRY;
+      data: ExternalInquiryPermission;
     };
 
 /** Action button configuration */
@@ -69,6 +74,7 @@ const PERMISSION_ICONS: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.RETRY]: 'codicon-refresh',
   [PERMISSION_KIND.PROPOSAL]: 'codicon-rocket',
   [PERMISSION_KIND.PLAN_APPROVAL]: 'codicon-tasklist',
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'codicon-globe',
 };
 
 /** Title for each permission type */
@@ -78,6 +84,7 @@ const PERMISSION_TITLES: Record<PermissionState['kind'], string> = {
   [PERMISSION_KIND.RETRY]: 'Retry request',
   [PERMISSION_KIND.PROPOSAL]: 'Agent proposal',
   [PERMISSION_KIND.PLAN_APPROVAL]: 'Plan approval',
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: 'External inquiry',
 };
 
 /** Primary actions (approve/reject) for each permission type */
@@ -127,6 +134,15 @@ const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
     },
     { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
   ],
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: [
+    {
+      action: 'submit',
+      label: 'Submit Answer',
+      icon: 'codicon-check',
+      variant: 'approve',
+    },
+    { action: 'skip', label: 'Skip', icon: 'codicon-x', variant: 'reject' },
+  ],
 };
 
 /** Secondary actions for each permission type */
@@ -162,6 +178,7 @@ const SECONDARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
     },
   ],
   [PERMISSION_KIND.PLAN_APPROVAL]: [],
+  [PERMISSION_KIND.EXTERNAL_INQUIRY]: [],
 };
 
 // =============================================================================

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -134,13 +134,8 @@ const PRIMARY_ACTIONS: Record<PermissionState['kind'], ActionConfig[]> = {
     },
     { action: 'reject', label: 'Reject', icon: 'codicon-x', variant: 'reject' },
   ],
+  // External inquiry uses its own panel with answer textarea; only skip here as fallback.
   [PERMISSION_KIND.EXTERNAL_INQUIRY]: [
-    {
-      action: 'submit',
-      label: 'Submit Answer',
-      icon: 'codicon-check',
-      variant: 'approve',
-    },
     { action: 'skip', label: 'Skip', icon: 'codicon-x', variant: 'reject' },
   ],
 };

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -39,10 +39,11 @@ import './BashRequestPanel';
 import './RetryRequestPanel';
 import './ProposalRequestPanel';
 import './PlanApprovalRequestPanel';
+import './ExternalInquiryPanel';
 
 /** Selector to find any sub-panel in shadow DOM */
 const PANEL_SELECTOR =
-  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel, plan-approval-request-panel';
+  'tool-edit-request-panel, bash-request-panel, retry-request-panel, proposal-request-panel, plan-approval-request-panel, external-inquiry-panel';
 
 /** Section configuration for rendering permission groups */
 interface SectionConfig {
@@ -92,6 +93,15 @@ const SECTION_CONFIGS: Record<string, SectionConfig> = {
         .permission=${p}
       ></plan-approval-request-panel>`,
   },
+  externalInquiry: {
+    cssClass: 'external-inquiry-requests',
+    icon: 'globe',
+    title: 'External inquiry',
+    renderPanel: (p) =>
+      html`<external-inquiry-panel
+        .permission=${p}
+      ></external-inquiry-panel>`,
+  },
 };
 
 /**
@@ -133,6 +143,7 @@ export class RequestPanels extends LitElement {
   private retryPermissions: PermissionState[] = [];
   private proposalPermissions: PermissionState[] = [];
   private planApprovalPermissions: PermissionState[] = [];
+  private externalInquiryPermissions: PermissionState[] = [];
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     if (!changedProperties.has('permissions')) return;
@@ -151,6 +162,9 @@ export class RequestPanels extends LitElement {
     );
     this.planApprovalPermissions = this.permissions.filter(
       (p) => p.kind === PERMISSION_KIND.PLAN_APPROVAL,
+    );
+    this.externalInquiryPermissions = this.permissions.filter(
+      (p) => p.kind === PERMISSION_KIND.EXTERNAL_INQUIRY,
     );
   }
 
@@ -175,6 +189,10 @@ export class RequestPanels extends LitElement {
       ${this.renderSection(
         SECTION_CONFIGS.planApproval,
         this.planApprovalPermissions,
+      )}
+      ${this.renderSection(
+        SECTION_CONFIGS.externalInquiry,
+        this.externalInquiryPermissions,
       )}
     `;
   }

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -3,7 +3,6 @@ import { create } from 'mutative';
 // Local imports - shared webview
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { postMessage } from '@shared/vscode';
-import { EXTERNAL_INQUIRY_ACTIONS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
@@ -289,7 +288,8 @@ export function handlePermissionAction(
   event: CustomEvent<PermissionActionDetail>,
   ctx: MessageHandlerContext,
 ): void {
-  const { permission, action, feedback, modelOverride } = event.detail;
+  const { permission, action, feedback, modelOverride, answer, attachedFiles } =
+    event.detail;
 
   switch (permission.kind) {
     case PERMISSION_KIND.TOOL_EDIT:
@@ -371,6 +371,8 @@ export function handlePermissionAction(
       postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
         requestId,
         action,
+        answer,
+        attachedFiles,
       });
       removePrompt(
         ctx,
@@ -382,28 +384,4 @@ export function handlePermissionAction(
       break;
     }
   }
-}
-
-/**
- * Handle external inquiry submit with answer text and attached files.
- * This is emitted by the ExternalInquiryPanel's custom 'inquiry-submit' event.
- */
-export function handleExternalInquirySubmit(
-  event: CustomEvent,
-  ctx: MessageHandlerContext,
-): void {
-  const { permission, answer, attachedFiles } = event.detail;
-  postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
-    requestId: permission.data.requestId,
-    action: EXTERNAL_INQUIRY_ACTIONS[0],
-    answer,
-    attachedFiles,
-  });
-  removePrompt(
-    ctx,
-    PERMISSION_KIND.EXTERNAL_INQUIRY,
-    'requestId',
-    permission.data.requestId,
-  );
-  clearInquiryDraft(permission.data.requestId);
 }

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -364,5 +364,40 @@ export function handlePermissionAction(
         permission.data.approvalId,
       );
       break;
+    case PERMISSION_KIND.EXTERNAL_INQUIRY:
+      postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+        requestId: permission.data.requestId,
+        action,
+      });
+      removePrompt(
+        ctx,
+        PERMISSION_KIND.EXTERNAL_INQUIRY,
+        'requestId',
+        permission.data.requestId,
+      );
+      break;
   }
+}
+
+/**
+ * Handle external inquiry submit with answer text and attached files.
+ * This is emitted by the ExternalInquiryPanel's custom 'inquiry-submit' event.
+ */
+export function handleExternalInquirySubmit(
+  event: CustomEvent,
+  ctx: MessageHandlerContext,
+): void {
+  const { permission, answer, attachedFiles } = event.detail;
+  postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
+    requestId: permission.data.requestId,
+    action: 'submit',
+    answer,
+    attachedFiles,
+  });
+  removePrompt(
+    ctx,
+    PERMISSION_KIND.EXTERNAL_INQUIRY,
+    'requestId',
+    permission.data.requestId,
+  );
 }

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -3,6 +3,7 @@ import { create } from 'mutative';
 // Local imports - shared webview
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { postMessage } from '@shared/vscode';
+import { EXTERNAL_INQUIRY_ACTIONS } from '@shared/schemas';
 import type { StreamTabId } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
@@ -32,7 +33,7 @@ import type {
   ToolbarCommandDetail,
 } from './events';
 import type { MessageHandlerContext } from './messageDispatcher';
-import { ExternalInquiryPanel } from './components/ExternalInquiryPanel';
+import { clearInquiryDraft } from './components/ExternalInquiryPanel';
 
 /**
  * Context passed to frontend event handlers providing access to state and refs.
@@ -377,8 +378,7 @@ export function handlePermissionAction(
         'requestId',
         requestId,
       );
-      // Clear persisted draft on skip (submit path clears in the panel)
-      ExternalInquiryPanel.clearDraft(requestId);
+      clearInquiryDraft(requestId);
       break;
     }
   }
@@ -395,7 +395,7 @@ export function handleExternalInquirySubmit(
   const { permission, answer, attachedFiles } = event.detail;
   postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
     requestId: permission.data.requestId,
-    action: 'submit',
+    action: EXTERNAL_INQUIRY_ACTIONS[0],
     answer,
     attachedFiles,
   });
@@ -405,4 +405,5 @@ export function handleExternalInquirySubmit(
     'requestId',
     permission.data.requestId,
   );
+  clearInquiryDraft(permission.data.requestId);
 }

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -32,6 +32,7 @@ import type {
   ToolbarCommandDetail,
 } from './events';
 import type { MessageHandlerContext } from './messageDispatcher';
+import { ExternalInquiryPanel } from './components/ExternalInquiryPanel';
 
 /**
  * Context passed to frontend event handlers providing access to state and refs.
@@ -364,18 +365,22 @@ export function handlePermissionAction(
         permission.data.approvalId,
       );
       break;
-    case PERMISSION_KIND.EXTERNAL_INQUIRY:
+    case PERMISSION_KIND.EXTERNAL_INQUIRY: {
+      const { requestId } = permission.data;
       postMessage(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION, {
-        requestId: permission.data.requestId,
+        requestId,
         action,
       });
       removePrompt(
         ctx,
         PERMISSION_KIND.EXTERNAL_INQUIRY,
         'requestId',
-        permission.data.requestId,
+        requestId,
       );
+      // Clear persisted draft on skip (submit path clears in the panel)
+      ExternalInquiryPanel.clearDraft(requestId);
       break;
+    }
   }
 }
 

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -48,6 +48,10 @@ export interface PermissionActionDetail {
   action: string;
   feedback?: string;
   modelOverride?: string;
+  /** Answer text from external inquiry panel (submit action only). */
+  answer?: string;
+  /** Files attached by user from external model (submit action only). */
+  attachedFiles?: string[];
 }
 
 /**

--- a/src/progressView/frontend/slices/permissionSlice.ts
+++ b/src/progressView/frontend/slices/permissionSlice.ts
@@ -151,6 +151,9 @@ export const permissionHandlers: HandlerRegistry = {
       case PERMISSION_KIND.PLAN_APPROVAL:
         removePrompt(ctx, kind, 'approvalId', id);
         break;
+      case PERMISSION_KIND.EXTERNAL_INQUIRY:
+        removePrompt(ctx, kind, 'requestId', id);
+        break;
       default: {
         const removed = removePrompt(
           ctx,

--- a/src/progressView/frontend/slices/permissionSlice.ts
+++ b/src/progressView/frontend/slices/permissionSlice.ts
@@ -10,6 +10,7 @@ import { create } from 'mutative';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
+import { clearInquiryDraft } from '../components/ExternalInquiryPanel';
 import { updateToolUseState } from '../stateUtils';
 import type { PermissionState } from '../components/PermissionCard';
 import type {
@@ -153,6 +154,7 @@ export const permissionHandlers: HandlerRegistry = {
         break;
       case PERMISSION_KIND.EXTERNAL_INQUIRY:
         removePrompt(ctx, kind, 'requestId', id);
+        clearInquiryDraft(id);
         break;
       default: {
         const removed = removePrompt(

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -21,6 +21,7 @@ import {
   AgentProposalSchema,
   AgentProposalPermissionSchema,
   BashPermissionSchema,
+  ExternalInquiryPermissionSchema,
   PLAN_APPROVAL_ACTIONS,
   PlanApprovalPermissionSchema,
   RetryPermissionSchema,
@@ -237,6 +238,7 @@ const PermissionKindSchema = z.enum([
   'retry',
   'proposal',
   'planApproval',
+  'externalInquiry',
 ]);
 export type ProgressPermissionKind = z.infer<typeof PermissionKindSchema>;
 
@@ -261,6 +263,10 @@ const PermissionPayloadSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('planApproval'),
     data: PlanApprovalPermissionSchema,
+  }),
+  z.object({
+    kind: z.literal('externalInquiry'),
+    data: ExternalInquiryPermissionSchema,
   }),
 ]);
 export type PermissionPayload = z.infer<typeof PermissionPayloadSchema>;
@@ -621,6 +627,14 @@ const PlanApprovalActionMessageSchema = z.object({
   feedback: z.string().optional(),
 });
 
+const ExternalInquiryActionMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION),
+  requestId: z.string().min(1),
+  action: z.enum(['submit', 'skip']),
+  answer: z.string().optional(),
+  attachedFiles: z.array(z.string()).optional(),
+});
+
 const RestoreProposalConfigMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG),
   proposal: AgentProposalSchema,
@@ -726,6 +740,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     BashApprovalActionMessageSchema,
     AgentProposalActionMessageSchema,
     PlanApprovalActionMessageSchema,
+    ExternalInquiryActionMessageSchema,
     RestoreProposalConfigMessageSchema,
     ShowInformationMessageSchema,
     OpenProfileMessageSchema,

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -21,6 +21,7 @@ import {
   AgentProposalSchema,
   AgentProposalPermissionSchema,
   BashPermissionSchema,
+  EXTERNAL_INQUIRY_ACTIONS,
   ExternalInquiryPermissionSchema,
   PLAN_APPROVAL_ACTIONS,
   PlanApprovalPermissionSchema,
@@ -630,7 +631,7 @@ const PlanApprovalActionMessageSchema = z.object({
 const ExternalInquiryActionMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.EXTERNAL_INQUIRY_ACTION),
   requestId: z.string().min(1),
-  action: z.enum(['submit', 'skip']),
+  action: z.enum(EXTERNAL_INQUIRY_ACTIONS),
   answer: z.string().optional(),
   attachedFiles: z.array(z.string()).optional(),
 });

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -105,6 +105,24 @@ export type AgentProposalPermission = z.infer<
 >;
 
 // ============================================================================
+// External Inquiry
+// ============================================================================
+
+export const EXTERNAL_INQUIRY_ACTIONS = ['submit', 'skip'] as const;
+export type ExternalInquiryAction = (typeof EXTERNAL_INQUIRY_ACTIONS)[number];
+
+export const ExternalInquiryPermissionSchema = PermissionBaseSchema.extend({
+  question: z.string(),
+  mode: z.enum(['new', 'followup']),
+  context: z.string().optional(),
+  suggestSearch: z.boolean().optional(),
+  attachFiles: z.array(z.string()).optional(),
+});
+export type ExternalInquiryPermission = z.infer<
+  typeof ExternalInquiryPermissionSchema
+>;
+
+// ============================================================================
 // Plan Approval
 // ============================================================================
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -13,6 +13,7 @@ const CONTAINER_NAMES = [
   'retry-requests',
   'workflow-proposals',
   'plan-approval-requests',
+  'external-inquiry-requests',
 ] as const;
 
 /** Item class names (singular, used for individual cards and BEM children). */
@@ -22,6 +23,7 @@ const ITEM_NAMES = [
   'retry-request',
   'workflow-proposal',
   'plan-approval-request',
+  'external-inquiry-request',
 ] as const;
 
 /** Build a :is()-ready selector group from class names with an optional BEM suffix. */
@@ -93,7 +95,8 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__details,
   .bash-approval-request__details,
   .retry-request__details,
-  .plan-approval-request__details {
+  .plan-approval-request__details,
+  .external-inquiry-request__details {
     max-height: 50vh;
     overflow-y: auto;
   }
@@ -565,5 +568,200 @@ export const requestPanelStyles: CSSResult = css`
     .plan-approval-request__actions
     vscode-toolbar-button[data-action='reject']::part(control) {
     color: var(--vscode-inputValidation-warningBorder);
+  }
+
+  /* ================================================================
+   * External inquiry requests
+   * ================================================================ */
+
+  .external-inquiry-requests {
+    border: var(--border-thin) solid var(--vscode-focusBorder);
+    background: var(--vscode-editor-background);
+  }
+
+  .external-inquiry-requests__header .codicon {
+    color: var(--vscode-focusBorder);
+  }
+
+  .external-inquiry-request {
+    border-left: var(--border-thick) solid var(--vscode-focusBorder);
+  }
+
+  .external-inquiry-request__mode-badge {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: var(--spacing-tiny) var(--border-radius-large);
+    border-radius: var(--border-radius);
+    white-space: nowrap;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+  }
+
+  .external-inquiry-request__context {
+    font-size: var(--font-size-sm);
+    color: var(--vscode-descriptionForeground);
+    padding: var(--spacing-small) var(--spacing-medium);
+    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    border-radius: var(--border-radius-small);
+    border-left: var(--border-thick) solid var(--vscode-textBlockQuote-border, var(--vscode-focusBorder));
+    line-height: var(--line-height-normal);
+  }
+
+  .external-inquiry-request__question {
+    background: var(--vscode-textCodeBlock-background, rgba(0, 0, 0, 0.05));
+    border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-medium);
+    position: relative;
+  }
+
+  .external-inquiry-request__question-text {
+    font-size: var(--font-size);
+    line-height: var(--line-height-relaxed, 1.6);
+    color: var(--vscode-editor-foreground);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 40vh;
+    overflow-y: auto;
+  }
+
+  .external-inquiry-request__question-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--spacing-small);
+    padding-top: var(--spacing-small);
+    border-top: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
+  }
+
+  .external-inquiry-request__search-hint {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    font-size: var(--font-size-sm);
+    color: var(--vscode-editorInfo-foreground, var(--vscode-focusBorder));
+    padding: var(--spacing-small) 0;
+  }
+
+  .external-inquiry-request__attach-files {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-small);
+  }
+
+  .external-inquiry-request__attach-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--vscode-descriptionForeground);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+  }
+
+  .external-inquiry-request__file-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-tiny);
+    padding: var(--spacing-small);
+    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    border-radius: var(--border-radius-small);
+  }
+
+  .external-inquiry-request__file-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    font-size: var(--font-size-sm);
+    font-family: var(--vscode-editor-font-family);
+    color: var(--vscode-textLink-foreground);
+  }
+
+  .external-inquiry-request__answer-area {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-small);
+  }
+
+  .external-inquiry-request__answer-label {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--vscode-editor-foreground);
+  }
+
+  .external-inquiry-request__answer-input {
+    width: 100%;
+    min-height: 150px;
+    resize: vertical;
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--font-size);
+    line-height: var(--line-height-normal);
+    padding: var(--spacing-medium);
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: var(--border-thin) solid var(--vscode-input-border);
+    border-radius: var(--border-radius);
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+
+  .external-inquiry-request__answer-input:focus {
+    border-color: var(--vscode-focusBorder);
+  }
+
+  .external-inquiry-request__answer-input::placeholder {
+    color: var(--vscode-input-placeholderForeground);
+  }
+
+  .external-inquiry-request__drop-zone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-small);
+    padding: var(--spacing-medium);
+    border: 2px dashed var(--vscode-input-border);
+    border-radius: var(--border-radius);
+    color: var(--vscode-descriptionForeground);
+    font-size: var(--font-size-sm);
+    text-align: center;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+
+  .external-inquiry-request__drop-zone--active {
+    border-color: var(--vscode-focusBorder);
+    background: var(--vscode-list-hoverBackground);
+  }
+
+  .external-inquiry-request__dropped-files {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-tiny);
+  }
+
+  .external-inquiry-request__dropped-file {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    font-size: var(--font-size-sm);
+    font-family: var(--vscode-editor-font-family);
+    color: var(--vscode-editor-foreground);
+  }
+
+  .external-inquiry-request__dropped-file .codicon-check {
+    color: var(--color-added);
+  }
+
+  .external-inquiry-request__actions vscode-toolbar-button {
+    flex: 1 1 8rem;
+  }
+
+  .external-inquiry-request__actions
+    vscode-toolbar-button[data-action='submit']::part(control) {
+    color: var(--vscode-testing-iconPassed);
+  }
+
+  .external-inquiry-request__actions
+    vscode-toolbar-button[data-action='skip']::part(control) {
+    color: var(--vscode-descriptionForeground);
   }
 `;

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -12,6 +12,7 @@ export const PERMISSION_KIND = {
   RETRY: 'retry',
   PROPOSAL: 'proposal',
   PLAN_APPROVAL: 'planApproval',
+  EXTERNAL_INQUIRY: 'externalInquiry',
 } as const;
 
 export type PermissionKind =

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -11,20 +11,24 @@
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import type { StreamTabId } from '@shared/schemas';
 import {
+  _rejectAllPendingInquiries,
+  _rejectPendingInquiriesForStream,
+} from '@tools/inquiry';
+import {
   _rejectAllPendingBashApprovals,
   _rejectPendingBashApprovalsForStream,
 } from './bashApproval';
+import {
+  _clearAllProposalBypass,
+  _clearProposalBypassForStream,
+  _disableAllProposalBypasses,
+} from './proposalApproval';
 import {
   _clearAllApprovalBypass,
   _clearApprovalBypassForStream,
   _rejectAllPendingToolEditApprovals,
   _rejectPendingToolEditApprovalsForStream,
 } from './toolEditApproval';
-import {
-  _clearAllProposalBypass,
-  _clearProposalBypassForStream,
-  _disableAllProposalBypasses,
-} from './proposalApproval';
 
 /**
  * Clean up all approval state for a deleted stream.
@@ -33,6 +37,7 @@ import {
 export function cleanupApprovalsForStream(streamId: StreamTabId): void {
   _rejectPendingToolEditApprovalsForStream(streamId);
   _rejectPendingBashApprovalsForStream(streamId);
+  _rejectPendingInquiriesForStream(streamId);
   _clearApprovalBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
   planApprovalCoordinator.clearForStream(streamId);
@@ -45,6 +50,7 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
 export function cleanupAllApprovals(): void {
   _rejectAllPendingToolEditApprovals();
   _rejectAllPendingBashApprovals();
+  _rejectAllPendingInquiries();
   _clearAllApprovalBypass();
   _clearAllProposalBypass();
   planApprovalCoordinator.clearAll();

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -17,7 +17,6 @@ import { AgentLogger } from '@logger/AgentLogger';
 import type { ExternalInquiryAction, StreamTabId } from '@shared/schemas';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
-import type { RejectablePendingEntry } from '@tools/approval/bashApproval';
 
 const logger = new AgentLogger('ExternalInquiryTool');
 
@@ -199,19 +198,16 @@ Use attachFiles to list workspace files the user should upload to the external m
         };
       }
 
-      const parts: string[] = [];
-      parts.push(`Answer from external model:\n\n${result.answer ?? ''}`);
+      let output = `Answer from external model:\n\n${result.answer ?? ''}`;
 
-      if (result.attachedFiles && result.attachedFiles.length > 0) {
-        parts.push(
-          `\nFiles attached by user from the external model:\n` +
-            result.attachedFiles.map((f) => `- ${f}`).join('\n'),
-        );
+      if (result.attachedFiles?.length) {
+        const fileList = result.attachedFiles.map((f) => `- ${f}`).join('\n');
+        output += `\n\nFiles attached by user from the external model:\n${fileList}`;
       }
 
       return {
         summary: `Received answer from external model (${input.mode})`,
-        output: parts.join('\n'),
+        output,
       };
     } finally {
       pendingInquiries.delete(requestId);

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -1,0 +1,221 @@
+/**
+ * External Inquiry tool — human-in-the-loop bridge to external AI models.
+ *
+ * The agent formulates a self-contained question. The user copies it to
+ * an external model (ChatGPT, Gemini, Claude, etc.), gets an answer,
+ * and pastes it back. The answer (plus any attached files) is returned
+ * to the agent as the tool result.
+ *
+ * Follows the same async promise pattern as bashApproval.ts.
+ */
+
+import { z } from 'zod';
+
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import type { ExternalInquiryAction, StreamTabId } from '@shared/schemas';
+import { type ToolResult } from '@tools/result';
+import { defineTool } from '@tools/core/define';
+import type { RejectablePendingEntry } from '@tools/approval/bashApproval';
+
+const logger = new AgentLogger('ExternalInquiryTool');
+
+// ============================================================================
+// Tool Schema
+// ============================================================================
+
+const ExternalInquiryInputSchema = z.strictObject({
+  question: z
+    .string()
+    .describe(
+      'The complete, self-contained question to ask the external model. ' +
+        'MUST include all necessary background, definitions, notation, and problem setup ' +
+        'because the external model has NO context from this conversation.',
+    ),
+  mode: z
+    .enum(['new', 'followup'])
+    .describe(
+      "'new' to start a fresh topic in the external model, " +
+        "'followup' to continue a prior external conversation thread.",
+    ),
+  context: z
+    .string()
+    .optional()
+    .describe(
+      'Brief note shown to the user explaining why this question is being asked.',
+    ),
+  suggestSearch: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true to suggest the user enable web search mode in the external tool.',
+    ),
+  attachFiles: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Workspace-relative file paths the user should upload to the external model.',
+    ),
+});
+
+export type ExternalInquiryInput = z.infer<typeof ExternalInquiryInputSchema>;
+
+// ============================================================================
+// Pending Inquiry State
+// ============================================================================
+
+export interface ExternalInquiryResult {
+  submitted: boolean;
+  answer?: string;
+  attachedFiles?: string[];
+}
+
+let inquiryCounter = 0;
+const pendingInquiries = new Map<
+  string,
+  {
+    streamId?: StreamTabId;
+    settle: (result: ExternalInquiryResult) => void;
+    isSettled: () => boolean;
+  }
+>();
+
+// ============================================================================
+// Public API (called from progress view message handler)
+// ============================================================================
+
+export async function handleExternalInquiryAction(payload: {
+  requestId: string;
+  action: ExternalInquiryAction;
+  answer?: string;
+  attachedFiles?: string[];
+}): Promise<void> {
+  const entry = pendingInquiries.get(payload.requestId);
+  if (!entry || entry.isSettled()) return;
+
+  entry.settle({
+    submitted: payload.action === 'submit',
+    answer: payload.action === 'submit' ? payload.answer : undefined,
+    attachedFiles: payload.action === 'submit' ? payload.attachedFiles : undefined,
+  });
+}
+
+/** @internal Called by unified cleanup. */
+export function _rejectPendingInquiriesForStream(
+  streamId: StreamTabId,
+): void {
+  for (const entry of pendingInquiries.values()) {
+    const matches = !entry.streamId || entry.streamId === streamId;
+    if (matches && !entry.isSettled()) {
+      entry.settle({ submitted: false });
+    }
+  }
+}
+
+/** @internal Called by unified cleanup. */
+export function _rejectAllPendingInquiries(): void {
+  for (const entry of pendingInquiries.values()) {
+    if (!entry.isSettled()) {
+      entry.settle({ submitted: false });
+    }
+  }
+}
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+export class ExternalInquiryTool extends defineTool({
+  name: 'external_inquiry',
+  description: `Ask a question to an external AI model (ChatGPT, Gemini, Claude, etc.) via the user's own subscription.
+
+The user will copy the question to the external model's interface and paste the answer back. This enables consulting powerful models that are not directly accessible via API.
+
+IMPORTANT: Questions MUST be self-contained. The external model has NO context from this conversation. Include all necessary background, definitions, mathematical notation, and problem setup directly in the question. Write the question as if the reader has never seen any of the preceding discussion.
+
+Tips for effective questions:
+- State the problem completely with all definitions
+- Include relevant equations and notation
+- Specify what kind of answer you need (proof sketch, calculation, reference, etc.)
+- If this is a follow-up, summarize what was established before
+
+Use mode='followup' when continuing a thread in the same external session (the user keeps that session open). Use mode='new' when starting a fresh topic.
+
+Set suggestSearch=true when the question could benefit from the external model using web search (e.g., looking up recent papers, checking specific results).
+
+Use attachFiles to list workspace files the user should upload to the external model for reference.`,
+  schema: ExternalInquiryInputSchema,
+}) {
+  protected async execute(input: ExternalInquiryInput): Promise<ToolResult> {
+    const context = getCurrentToolFileInteractionContext();
+    const streamId = context?.streamId;
+
+    const requestId = `inquiry-${Date.now().toString(36)}-${++inquiryCounter}`;
+
+    logger.info(
+      `External inquiry [${input.mode}]: ${input.question.substring(0, 100)}...`,
+    );
+
+    try {
+      const result = await new Promise<ExternalInquiryResult>((resolve) => {
+        let settled = false;
+        const settle = (r: ExternalInquiryResult) => {
+          if (settled) return;
+          settled = true;
+          resolve(r);
+        };
+
+        pendingInquiries.set(requestId, {
+          streamId,
+          settle,
+          isSettled: () => settled,
+        });
+
+        bus.emit('requestEnsureProgressView', {});
+
+        if (streamId) {
+          bus.emit('setActiveStream', { streamId });
+        }
+
+        bus.emit('showExternalInquiry', {
+          requestId,
+          question: input.question,
+          mode: input.mode,
+          context: input.context,
+          suggestSearch: input.suggestSearch,
+          attachFiles: input.attachFiles,
+          allowBypass: false,
+          streamId: streamId ?? '',
+        });
+      });
+
+      if (!result.submitted) {
+        return {
+          summary: 'User skipped external inquiry',
+          output:
+            'The user chose to skip this external inquiry. ' +
+            'Proceed without the external answer, or try a different approach.',
+        };
+      }
+
+      const parts: string[] = [];
+      parts.push(`Answer from external model:\n\n${result.answer ?? ''}`);
+
+      if (result.attachedFiles && result.attachedFiles.length > 0) {
+        parts.push(
+          `\nFiles attached by user from the external model:\n` +
+            result.attachedFiles.map((f) => `- ${f}`).join('\n'),
+        );
+      }
+
+      return {
+        summary: `Received answer from external model (${input.mode})`,
+        output: parts.join('\n'),
+      };
+    } finally {
+      pendingInquiries.delete(requestId);
+      bus.emit('resolveExternalInquiry', { requestId });
+    }
+  }
+}

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -41,19 +41,19 @@ const ExternalInquiryInputSchema = z.strictObject({
     ),
   context: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Brief note shown to the user explaining why this question is being asked.',
     ),
   suggestSearch: z
     .boolean()
-    .optional()
+    .nullish()
     .describe(
       'Set to true to suggest the user enable web search mode in the external tool.',
     ),
   attachFiles: z
     .array(z.string())
-    .optional()
+    .nullish()
     .describe(
       'Workspace-relative file paths the user should upload to the external model.',
     ),
@@ -106,7 +106,7 @@ export function _rejectPendingInquiriesForStream(
   streamId: StreamTabId,
 ): void {
   for (const entry of pendingInquiries.values()) {
-    const matches = !entry.streamId || entry.streamId === streamId;
+    const matches = entry.streamId === streamId;
     if (matches && !entry.isSettled()) {
       entry.settle({ submitted: false });
     }
@@ -182,9 +182,9 @@ Use attachFiles to list workspace files the user should upload to the external m
           requestId,
           question: input.question,
           mode: input.mode,
-          context: input.context,
-          suggestSearch: input.suggestSearch,
-          attachFiles: input.attachFiles,
+          context: input.context ?? undefined,
+          suggestSearch: input.suggestSearch ?? undefined,
+          attachFiles: input.attachFiles ?? undefined,
           allowBypass: false,
           streamId: streamId ?? '',
         });

--- a/src/tools/inquiry/index.ts
+++ b/src/tools/inquiry/index.ts
@@ -1,0 +1,6 @@
+export { ExternalInquiryTool } from './ExternalInquiryTool';
+export {
+  handleExternalInquiryAction,
+  _rejectPendingInquiriesForStream,
+  _rejectAllPendingInquiries,
+} from './ExternalInquiryTool';

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -50,6 +50,7 @@ import {
 import { WorkflowAgentTool, DelegateAgentTool } from './DelegationTools';
 import { ExecutionsTool } from './ExecutionsTool';
 import { AcceptRunFilesTool } from './AcceptRunFilesTool';
+import { ExternalInquiryTool } from './inquiry';
 
 /** Singleton IToolRegistry instance for the default tools. */
 let defaultRegistryInstance: IToolRegistry | null = null;
@@ -106,6 +107,7 @@ function createDefaultTools() {
     delegate_agent: new DelegateAgentTool(),
     executions: new ExecutionsTool(),
     accept_run_files: new AcceptRunFilesTool(),
+    external_inquiry: new ExternalInquiryTool(),
   } satisfies Record<string, ITool>;
 }
 


### PR DESCRIPTION
## Summary

Introduces a new **External Inquiry** tool that enables agents to ask questions to external AI models (ChatGPT, Gemini, Claude, etc.) via the user's own subscription. The user copies the agent's question to an external model, pastes the answer back, and optionally attaches files—creating a human-in-the-loop bridge for consulting powerful models not directly accessible via API.

## Key Changes

- **New Tool**: `ExternalInquiryTool` (`src/tools/inquiry/ExternalInquiryTool.ts`)
  - Accepts self-contained questions with optional context, search hints, and file attachments
  - Supports `new` and `followup` modes for managing external conversation threads
  - Returns the external model's answer and any attached files to the agent
  - Follows the same async promise pattern as bash approval for user interaction

- **New UI Panel**: `ExternalInquiryPanel` (`src/progressView/frontend/components/ExternalInquiryPanel.ts`)
  - Displays the agent's question with a "Copy Question" button
  - Provides a textarea for pasting the external model's answer
  - Includes a drag-and-drop file attachment zone with optional file browsing
  - Supports Ctrl/Cmd+Enter keyboard shortcut for quick submission
  - Shows mode badge, context notes, and search mode suggestions

- **Schema & Event Infrastructure**
  - Added `ExternalInquiryPermission` schema with question, mode, context, suggestSearch, and attachFiles fields
  - Added `ExternalInquiryAction` type (`submit` | `skip`)
  - Integrated with event bus (`showExternalInquiry`, `resolveExternalInquiry`)
  - Added message handler for `EXTERNAL_INQUIRY_ACTION` command

- **UI Integration**
  - Registered external inquiry section in request panels with globe icon
  - Added comprehensive CSS styling for inquiry cards, question display, answer textarea, and drop zones
  - Integrated custom `inquiry-submit` event handler in ProgressApp
  - Added permission card support for external inquiry kind

- **Cleanup & Coordination**
  - Integrated pending inquiry rejection into unified approval cleanup system
  - Added stream-specific and global cleanup functions (`_rejectPendingInquiriesForStream`, `_rejectAllPendingInquiries`)

- **Tool Registry & Configuration**
  - Registered `ExternalInquiryTool` in tool registry
  - Added `external_inquiry` to orchestrator agent's available tools

## Notable Implementation Details

- Questions are required to be **self-contained** since the external model has no conversation context—the tool description emphasizes including all necessary background, definitions, and notation
- File attachment tracking uses file names only (not full paths) for the UI, allowing flexibility in how files are resolved
- The panel uses VS Code's design tokens and follows the same visual pattern as other approval/request panels
- Answer submission is disabled until the user provides non-empty text, preventing accidental empty submissions

https://claude.ai/code/session_01DdsnKKT77Duukma1TgtKaQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new async tool and end-to-end permission/message flow through the event bus, schemas, and webview UI, which could impact progress-view prompting/cleanup behavior if mis-wired. No auth or data-store changes, but it touches core UI event/permission plumbing.
> 
> **Overview**
> Adds a new `external_inquiry` tool that lets an agent pause execution to ask the user to query an external AI model and return the pasted answer (plus optional attached file names) back as the tool result.
> 
> Wires this through the full permission system: new `ExternalInquiryPermission`/actions in shared schemas and progress-view message types, new `showExternalInquiry`/`resolveExternalInquiry` events, a new `ExternalInquiryPanel` UI (copy question, paste answer, drag/drop attachments with draft persistence), and provider/handler support including replay and unified cleanup/rejection of pending inquiries.
> 
> Registers the tool in the tool registry and exposes it to the `orchestrator` reference agent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ae6162e0364aadc0a2f5727265cc50b3e249686. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->