### PR TITLE
Add self-contained document output rules across agents

### DIFF
--- a/resources/agents/write/paper2poster.yaml
+++ b/resources/agents/write/paper2poster.yaml
@@ -28,6 +28,7 @@ prompts:
     - Cite relevant key papers using biblatex
     - Ensure the poster is visually appealing and readable at A5 size, despite the increased detail
     - Use the provided color scheme and design elements from the template
+    - The poster must be self-contained: write as if the reader is a third party who has never read and will never read our conversations --- they should be able to understand and follow the poster on its own. Define all notations, abbreviations, and terminology before first use.
 
   userPrefix: |
     You are tasked with creating a detailed LaTeX Beamer poster based on the following research paper:

--- a/resources/agents/write/paper2slide.yaml
+++ b/resources/agents/write/paper2slide.yaml
@@ -24,6 +24,7 @@ prompts:
     - Prioritize visual representations and key takeaways over verbose descriptions
     - Cite relevant key papers using commands like \cite{Author2020Title} (e.g., \cite{Smith2020Analysis}) which include the author, year, and first word of the paper title
     - Output a complete, self-contained LaTeX file that can be compiled directly
+    - The document must be self-contained: write as if the reader is a third party who has never read and will never read our conversations --- they should be able to understand and follow the presentation on its own. Define all notations, abbreviations, and terminology before first use.
 
   userPrefix: |
     You are tasked with creating a LaTeX Beamer presentation based on the following research paper:

--- a/resources/shared/latex_style_rules.txt
+++ b/resources/shared/latex_style_rules.txt
@@ -11,4 +11,5 @@
     \item Treat formulas as part of the sentences and add punctuation accordingly in the displayed math environments depending on the next sentence.
     \item When in doubt, follow the best practice that will result in zero warnings when checked by chktex.
     \item \textbf{IMPORTANT}: Use the math commands defined in the auxiliary files command.tex, commands.tex, or preamble.tex if provided. Do not redefine commands that are already defined there.
+    \item \textbf{IMPORTANT}: The output document must be self-contained. Write as if the reader is a third party who has never read and will never read our conversations --- they should be able to understand and follow the document on its own. Define all notations, abbreviations, and terminology before first use.
 \end{itemize}

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -29,6 +29,8 @@ prompts:
 
     Mathematical Communication: (1) Use $...$ for inline math expressions when explaining concepts. (2) Define all notation before use. (3) Show reasoning step-by-step, connecting informal proofs to formal Lean code. (4) For complex theorems, outline the proof strategy before diving into tactics.
 
+    CRITICAL - File Output Rule: When you write to a file, imagine the conversation is deleted immediately after. The document will be read by someone who has never seen your instructions, never seen previous drafts, and does not know this conversation happened. Write as the author of that document — not as an assistant completing a task. The output must be self-contained. Define all notation before use.
+
     File operations: Read files before editing. Ask for confirmation before making significant changes. Every tool receives the project root as its working directory, so use relative paths directly.
 
     Use todo_write to track progress on complex multi-lemma proofs.

--- a/resources/tool_use_agents/review.yaml
+++ b/resources/tool_use_agents/review.yaml
@@ -88,6 +88,8 @@ prompts:
     (7) Do not create excessive markdown files or documentation unless explicitly requested.
     {% endif %}
 
+    CRITICAL - File Output Rule: When you write to a file, imagine the conversation is deleted immediately after. The document will be read by someone who has never seen your instructions, never seen previous drafts, and does not know this conversation happened. Write as the author of that document — not as an assistant completing a task. The output must be self-contained. Define all notation before use.
+
     Mathematical Communication: (1) Use $...$ for inline math expressions. (2) When showing a verification, present the original equation and your check side by side. (3) For errors, show both the incorrect and correct versions.
   userRequest: |
     {{ INSTRUCTION }}


### PR DESCRIPTION
## Summary
This PR adds explicit guidance across multiple agent configurations and shared style rules to ensure that generated documents are self-contained and readable by third parties unfamiliar with the conversation context.

## Key Changes
- **lean.yaml & review.yaml**: Added "CRITICAL - File Output Rule" section emphasizing that output documents must be self-contained, with all notation defined before use, and written as if the conversation will be immediately deleted
- **paper2poster.yaml & paper2slide.yaml**: Added requirement that posters and slides must be self-contained with all notations, abbreviations, and terminology defined before first use
- **latex_style_rules.txt**: Added explicit rule requiring output documents to be self-contained with all notations and terminology pre-defined

## Implementation Details
The changes enforce a consistent principle across all writing agents: generated documents should assume the reader has no context from the conversation and cannot reference previous drafts or instructions. This ensures:
- Documents are usable independently of the generation context
- All mathematical notation and terminology is properly introduced
- Output quality is consistent regardless of how the agent is prompted
- Third-party readers can understand documents without access to conversation history

https://claude.ai/code/session_01TiddUzihyr1wm3soSt6ouU

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk prompt-only changes; the main impact is potentially longer/more explicit generated documents due to stricter requirements to define notation and avoid conversation-dependent context.
> 
> **Overview**
> Adds a consistent **self-contained output** requirement across multiple agent prompts and shared LaTeX style rules.
> 
> `paper2poster`/`paper2slide` now explicitly require defining all notation/abbreviations before first use, and `lean`/`review` add a **"CRITICAL - File Output Rule"** instructing that any written files must stand alone as if the conversation disappears.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0635047f3b4cea90b7392f2e19733d4a04731e8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->