### PR TITLE
feat: stream background bash in child tabs

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -81,6 +81,9 @@ export class AgentExecutionHandle implements ExecutionHandle {
   private progress: { currentRound?: number; totalRounds?: number } = {};
   private _parentStreamId: StreamTabId;
 
+  /** Stable tool name for UI identification (e.g. "bash", "codex"). */
+  toolName?: string;
+
   constructor(
     readonly executionId: string,
     parentStreamId: StreamTabId,
@@ -232,6 +235,7 @@ export function collectChildSummary(
     };
     if (handle instanceof AgentExecutionHandle) {
       info.childStreamId = handle.childStreamId;
+      if (handle.toolName) info.toolName = handle.toolName;
     } else if (handle instanceof ProcessExecutionHandle && handle.toolName) {
       info.toolName = handle.toolName;
     }

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -343,17 +343,15 @@ export class ProgressApp extends ProgressAppBase {
   );
 
   /**
-   * Active child streams grouped by parent stream ID.
-   * Only includes children that are still running/waiting — finished ones
-   * are omitted so the nested list auto-cleans.
+   * Child streams grouped by parent stream ID.
+   * Includes both active and finished children so the user can still
+   * navigate to completed/errored child streams.
    */
-  private childStreamsByParent$ = combine(
-    [this.sortedStreams$, this.streamStates$] as const,
-    (sorted, states) => {
+  private childStreamsByParent$ = new Signal.Computed(() => {
+      const sorted = this.sortedStreams$.get();
       let map: Map<StreamTabId, StreamTabInfo[]> | undefined;
       for (const s of sorted) {
         if (!s.parentStreamId) continue;
-        if (!isActiveChildStream(s, states)) continue;
         if (!map) map = new Map();
         let children = map.get(s.parentStreamId);
         if (!children) {
@@ -363,8 +361,7 @@ export class ProgressApp extends ProgressAppBase {
         children.push(s);
       }
       return map ?? EMPTY_CHILD_MAP;
-    },
-  );
+  });
 
   /** Status and timestamp for all visible streams (top-level + active children). */
   private statusAndTimestampById$ = combine(

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -290,39 +290,68 @@ export class ProgressApp extends ProgressAppBase {
   // --- Derived computeds: only re-evaluate when selector inputs propagate ---
 
   /**
-   * Filtered + sorted stream list.
-   * Uses fine-grained selectors so log appends (which only change streamLogs$)
-   * don't trigger recomputation.
+   * All streams sorted (unfiltered).  Used for active-stream lookup so
+   * navigating to a child stream from BackgroundTasksPanel always works
+   * regardless of the current filter selection.
    */
-  private filteredStreams$ = combine(
-    [
-      this.streamById$,
-      this.streamFilter$,
-      this.streamSort$,
-      this.streamStates$,
-    ] as const,
-    (streamById, filter, sort, states) => {
-      const sorted = sortStreams([...streamById.values()], sort, {
+  private sortedStreams$ = combine(
+    [this.streamById$, this.streamSort$, this.streamStates$] as const,
+    (streamById, sort, states) =>
+      sortStreams([...streamById.values()], sort, {
         getLastActivityTimestamp: (stream) =>
           states.get(stream.name)?.lastTimestamp,
-      });
-      if (filter === 'all') return sorted;
-      return sorted.filter((stream) => stream.agentCategory === filter);
-    },
+      }),
   );
 
+  /** Map of ALL streams for active-stream lookup (filter-independent). */
   private filteredStreamMap$ = new Signal.Computed(
-    () => new Map(this.filteredStreams$.get().map((s) => [s.name, s])),
+    () => new Map(this.sortedStreams$.get().map((s) => [s.name, s])),
+  );
+
+  /** Active background statuses — child streams in these states are shown. */
+  private static readonly ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set(
+    [
+      STREAM_STATUS.RUNNING,
+      STREAM_STATUS.WAITING,
+      STREAM_STATUS.INITIALIZING,
+      STREAM_STATUS.RESUMING,
+    ],
   );
 
   /**
    * Streams visible in the sidebar tab list.
-   * Child streams (those with a parentStreamId) are excluded — they're
-   * accessible via the BackgroundTasksPanel inside the content area.
+   *
+   * - **all / workflow / toolUse**: top-level streams only (child streams
+   *   are accessible via the BackgroundTasksPanel inside the content area).
+   * - **background**: active child streams only — finished ones auto-hide.
    */
-  private tabStreams$ = new Signal.Computed(() =>
-    this.filteredStreams$.get().filter((s) => !s.parentStreamId),
+  private tabStreams$ = combine(
+    [
+      this.sortedStreams$,
+      this.streamFilter$,
+      this.streamStates$,
+    ] as const,
+    (sorted, filter, states) => {
+      if (filter === 'background') {
+        return sorted.filter((s) => {
+          if (!s.parentStreamId) return false;
+          const status =
+            states.get(s.name)?.status ?? STREAM_STATUS.READY;
+          return ProgressApp.ACTIVE_STREAM_STATUSES.has(status);
+        });
+      }
+      // All other filters exclude child streams
+      const topLevel = sorted.filter((s) => !s.parentStreamId);
+      if (filter === 'all') return topLevel;
+      return topLevel.filter((s) => s.agentCategory === filter);
+    },
   );
+
+  /**
+   * Filtered streams (legacy alias used by hasStreams$).
+   * Same as tabStreams$ for determining whether the view has content.
+   */
+  private filteredStreams$ = this.tabStreams$;
 
   /** Status and timestamp per stream tab (single pass over tab-visible streams). */
   private statusAndTimestampById$ = combine(

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -56,23 +56,6 @@ const EMPTY_TASK_GROUPS: TaskGroup[] = [];
 /** Stable empty map returned when no parent has active children. */
 const EMPTY_CHILD_MAP: Map<StreamTabId, StreamTabInfo[]> = new Map();
 
-/** Stream statuses that represent an active (non-terminal) child stream. */
-const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.WAITING,
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.RESUMING,
-]);
-
-/** Check whether a child stream is still active (used for sidebar grouping). */
-function isActiveChildStream(
-  stream: StreamTabInfo,
-  states: Map<StreamTabId, StreamState>,
-): boolean {
-  const status = states.get(stream.name)?.status ?? STREAM_STATUS.READY;
-  return ACTIVE_CHILD_STATUSES.has(status);
-}
-
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
   streamFilter: AgentCategoryFilterSchema.catch('all'),

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -25,6 +25,7 @@ import {
   type ProgressViewPlacement,
   type ProgressViewOutboundMessage,
   type StreamTabId,
+  type StreamTabInfo,
   type TaskGroup,
 } from '@shared/schemas';
 import {
@@ -59,6 +60,15 @@ const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
   STREAM_STATUS.INITIALIZING,
   STREAM_STATUS.RESUMING,
 ]);
+
+/** Check whether a child stream is still active (used for sidebar grouping). */
+function isActiveChildStream(
+  stream: StreamTabInfo,
+  states: Map<StreamTabId, StreamState>,
+): boolean {
+  const status = states.get(stream.name)?.status ?? STREAM_STATUS.READY;
+  return ACTIVE_CHILD_STATUSES.has(status);
+}
 
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
@@ -317,44 +327,56 @@ export class ProgressApp extends ProgressAppBase {
   );
 
   /**
-   * Streams visible in the sidebar tab list.
-   *
-   * - **all / workflow / toolUse**: top-level streams only (child streams
-   *   are accessible via the BackgroundTasksPanel inside the content area).
-   * - **background**: active child streams only — finished ones auto-hide.
+   * Top-level streams for the sidebar tab list (child streams excluded).
+   * Child streams are shown nested under their parent via childStreamsByParent$.
    */
   private tabStreams$ = combine(
-    [
-      this.sortedStreams$,
-      this.streamFilter$,
-      this.streamStates$,
-    ] as const,
-    (sorted, filter, states) => {
-      if (filter === 'background') {
-        return sorted.filter((s) => {
-          if (!s.parentStreamId) return false;
-          const status =
-            states.get(s.name)?.status ?? STREAM_STATUS.READY;
-          return ACTIVE_CHILD_STATUSES.has(status);
-        });
-      }
-      // All other filters exclude child streams
+    [this.sortedStreams$, this.streamFilter$] as const,
+    (sorted, filter) => {
       const topLevel = sorted.filter((s) => !s.parentStreamId);
       if (filter === 'all') return topLevel;
       return topLevel.filter((s) => s.agentCategory === filter);
     },
   );
 
-  /** Status and timestamp per stream tab (single pass over tab-visible streams). */
+  /**
+   * Active child streams grouped by parent stream ID.
+   * Only includes children that are still running/waiting — finished ones
+   * are omitted so the nested list auto-cleans.
+   */
+  private childStreamsByParent$ = combine(
+    [this.sortedStreams$, this.streamStates$] as const,
+    (sorted, states) => {
+      const map = new Map<StreamTabId, StreamTabInfo[]>();
+      for (const s of sorted) {
+        if (!s.parentStreamId) continue;
+        if (!isActiveChildStream(s, states)) continue;
+        let children = map.get(s.parentStreamId);
+        if (!children) {
+          children = [];
+          map.set(s.parentStreamId, children);
+        }
+        children.push(s);
+      }
+      return map;
+    },
+  );
+
+  /** Status and timestamp for all visible streams (top-level + active children). */
   private statusAndTimestampById$ = combine(
-    [this.streamStates$, this.tabStreams$] as const,
-    (states, streams) => {
+    [this.streamStates$, this.tabStreams$, this.childStreamsByParent$] as const,
+    (states, streams, childMap) => {
       const statusMap = new Map<StreamTabId, string>();
       const timestampMap = new Map<StreamTabId, number | undefined>();
+      const populate = (s: StreamTabInfo): void => {
+        const state = states.get(s.name);
+        statusMap.set(s.name, state?.status ?? STREAM_STATUS.READY);
+        timestampMap.set(s.name, state?.lastTimestamp);
+      };
       for (const stream of streams) {
-        const state = states.get(stream.name);
-        statusMap.set(stream.name, state?.status ?? STREAM_STATUS.READY);
-        timestampMap.set(stream.name, state?.lastTimestamp);
+        populate(stream);
+        const children = childMap.get(stream.name);
+        if (children) children.forEach(populate);
       }
       return { statusMap, timestampMap };
     },
@@ -575,6 +597,7 @@ export class ProgressApp extends ProgressAppBase {
               .streamLastTimestampById=${this.statusAndTimestampById$.get()
                 .timestampMap}
               .pendingApprovalStreamIds=${this.pendingApprovalIds$.get()}
+              .childStreamsByParent=${this.childStreamsByParent$.get()}
               @stream-switch=${this.onStreamSwitch}
               @stream-delete=${this.onStreamDelete}
               @filter-change=${this.onFilterChange}

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -315,9 +315,18 @@ export class ProgressApp extends ProgressAppBase {
     () => new Map(this.filteredStreams$.get().map((s) => [s.name, s])),
   );
 
-  /** Status and timestamp per stream tab (single pass over filtered streams). */
+  /**
+   * Streams visible in the sidebar tab list.
+   * Child streams (those with a parentStreamId) are excluded — they're
+   * accessible via the BackgroundTasksPanel inside the content area.
+   */
+  private tabStreams$ = new Signal.Computed(() =>
+    this.filteredStreams$.get().filter((s) => !s.parentStreamId),
+  );
+
+  /** Status and timestamp per stream tab (single pass over tab-visible streams). */
   private statusAndTimestampById$ = combine(
-    [this.streamStates$, this.filteredStreams$] as const,
+    [this.streamStates$, this.tabStreams$] as const,
     (states, streams) => {
       const statusMap = new Map<StreamTabId, string>();
       const timestampMap = new Map<StreamTabId, number | undefined>();
@@ -537,7 +546,7 @@ export class ProgressApp extends ProgressAppBase {
             <stream-tabs
               slot="end"
               .compact=${compactTabs}
-              .streams=${this.filteredStreams$.get()}
+              .streams=${this.tabStreams$.get()}
               .activeStreamId=${this.activeStreamId$.get()}
               .filter=${this.streamFilter$.get()}
               .sort=${this.streamSort$.get()}

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -52,6 +52,14 @@ import {
 /** Stable empty array for activeTaskGroups$ default (avoids new [] per read). */
 const EMPTY_TASK_GROUPS: TaskGroup[] = [];
 
+/** Stream statuses that represent an active (non-terminal) child stream. */
+const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.WAITING,
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.RESUMING,
+]);
+
 /** Schema for persisted preferences. */
 const ProgressViewPrefsSchema = z.object({
   streamFilter: AgentCategoryFilterSchema.catch('all'),
@@ -308,16 +316,6 @@ export class ProgressApp extends ProgressAppBase {
     () => new Map(this.sortedStreams$.get().map((s) => [s.name, s])),
   );
 
-  /** Active background statuses — child streams in these states are shown. */
-  private static readonly ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set(
-    [
-      STREAM_STATUS.RUNNING,
-      STREAM_STATUS.WAITING,
-      STREAM_STATUS.INITIALIZING,
-      STREAM_STATUS.RESUMING,
-    ],
-  );
-
   /**
    * Streams visible in the sidebar tab list.
    *
@@ -337,7 +335,7 @@ export class ProgressApp extends ProgressAppBase {
           if (!s.parentStreamId) return false;
           const status =
             states.get(s.name)?.status ?? STREAM_STATUS.READY;
-          return ProgressApp.ACTIVE_STREAM_STATUSES.has(status);
+          return ACTIVE_CHILD_STATUSES.has(status);
         });
       }
       // All other filters exclude child streams
@@ -346,12 +344,6 @@ export class ProgressApp extends ProgressAppBase {
       return topLevel.filter((s) => s.agentCategory === filter);
     },
   );
-
-  /**
-   * Filtered streams (legacy alias used by hasStreams$).
-   * Same as tabStreams$ for determining whether the view has content.
-   */
-  private filteredStreams$ = this.tabStreams$;
 
   /** Status and timestamp per stream tab (single pass over tab-visible streams). */
   private statusAndTimestampById$ = combine(
@@ -380,7 +372,7 @@ export class ProgressApp extends ProgressAppBase {
   });
 
   private hasStreams$ = new Signal.Computed(
-    () => this.filteredStreams$.get().length > 0,
+    () => this.sortedStreams$.get().length > 0,
   );
 
   /** Only changes when the ACTIVE stream's state changes, not any stream. */

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -53,6 +53,9 @@ import {
 /** Stable empty array for activeTaskGroups$ default (avoids new [] per read). */
 const EMPTY_TASK_GROUPS: TaskGroup[] = [];
 
+/** Stable empty map returned when no parent has active children. */
+const EMPTY_CHILD_MAP: Map<StreamTabId, StreamTabInfo[]> = new Map();
+
 /** Stream statuses that represent an active (non-terminal) child stream. */
 const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
   STREAM_STATUS.RUNNING,
@@ -347,10 +350,11 @@ export class ProgressApp extends ProgressAppBase {
   private childStreamsByParent$ = combine(
     [this.sortedStreams$, this.streamStates$] as const,
     (sorted, states) => {
-      const map = new Map<StreamTabId, StreamTabInfo[]>();
+      let map: Map<StreamTabId, StreamTabInfo[]> | undefined;
       for (const s of sorted) {
         if (!s.parentStreamId) continue;
         if (!isActiveChildStream(s, states)) continue;
+        if (!map) map = new Map();
         let children = map.get(s.parentStreamId);
         if (!children) {
           children = [];
@@ -358,7 +362,7 @@ export class ProgressApp extends ProgressAppBase {
         }
         children.push(s);
       }
-      return map;
+      return map ?? EMPTY_CHILD_MAP;
     },
   );
 
@@ -368,15 +372,18 @@ export class ProgressApp extends ProgressAppBase {
     (states, streams, childMap) => {
       const statusMap = new Map<StreamTabId, string>();
       const timestampMap = new Map<StreamTabId, number | undefined>();
-      const populate = (s: StreamTabInfo): void => {
-        const state = states.get(s.name);
-        statusMap.set(s.name, state?.status ?? STREAM_STATUS.READY);
-        timestampMap.set(s.name, state?.lastTimestamp);
-      };
       for (const stream of streams) {
-        populate(stream);
+        const state = states.get(stream.name);
+        statusMap.set(stream.name, state?.status ?? STREAM_STATUS.READY);
+        timestampMap.set(stream.name, state?.lastTimestamp);
         const children = childMap.get(stream.name);
-        if (children) children.forEach(populate);
+        if (children) {
+          for (const child of children) {
+            const cs = states.get(child.name);
+            statusMap.set(child.name, cs?.status ?? STREAM_STATUS.READY);
+            timestampMap.set(child.name, cs?.lastTimestamp);
+          }
+        }
       }
       return { statusMap, timestampMap };
     },

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -66,6 +66,12 @@ export class BackgroundTasksPanel extends LitElement {
         gap: var(--spacing-tiny);
       }
 
+      .section-content {
+        max-height: 16rem;
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+      }
+
       .task-item {
         margin-bottom: var(--spacing-tiny);
       }
@@ -282,18 +288,20 @@ export class BackgroundTasksPanel extends LitElement {
               : nothing}</span
           >
         </summary>
-        ${hasActive
-          ? repeat(
-              active,
-              (c) => c.executionId,
-              (c) => this.renderTaskItem(c, kind),
-            )
-          : nothing}
-        ${!hasActive && hasFinished
-          ? html`<div class="empty-message">
-              All ${finishedCount} ${label.toLowerCase()} completed
-            </div>`
-          : nothing}
+        <div class="section-content">
+          ${hasActive
+            ? repeat(
+                active,
+                (c) => c.executionId,
+                (c) => this.renderTaskItem(c, kind),
+              )
+            : nothing}
+          ${!hasActive && hasFinished
+            ? html`<div class="empty-message">
+                All ${finishedCount} ${label.toLowerCase()} completed
+              </div>`
+            : nothing}
+        </div>
       </details>
     `;
   }

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -403,7 +403,8 @@ export class BackgroundTasksPanel extends LitElement {
 
 /** True when the child is an AI agent (codex, delegation) rather than a plain shell tool. */
 function isAgentTool(child: ActiveChildInfo): boolean {
-  return child.toolName === 'codex';
+  // Explicit tool name match, or subagent with no tool name (delegation/workflow)
+  return child.toolName === 'codex' || (!child.toolName && Boolean(child.childStreamId));
 }
 
 /** Pick the appropriate codicon for a background task item. */

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -302,9 +302,9 @@ export class BackgroundTasksPanel extends LitElement {
     child: ActiveChildInfo,
     kind: 'process' | 'subagent',
   ): TemplateResult {
-    const icon = getTaskIcon(child, kind);
+    const icon = getTaskIcon(child);
     const entry = this.processOutputs.get(child.executionId);
-    const isClickable = kind === 'subagent' && Boolean(child.childStreamId);
+    const isClickable = Boolean(child.childStreamId);
     const description = child.childStreamId
       ? this.descriptions.get(child.childStreamId)
       : undefined;
@@ -318,10 +318,8 @@ export class BackgroundTasksPanel extends LitElement {
               codicon: true,
               [icon]: true,
               'task-icon': true,
-              'task-icon--process':
-                kind === 'process' && !isAgentProcess(child),
-              'task-icon--subagent':
-                kind === 'subagent' || isAgentProcess(child),
+              'task-icon--process': !isAgentTool(child),
+              'task-icon--subagent': isAgentTool(child),
             })}
           ></i>
           <span
@@ -395,19 +393,20 @@ export class BackgroundTasksPanel extends LitElement {
   }
 }
 
-/** Check if a child process represents an AI agent (distinct from plain shell). */
-function isAgentProcess(child: ActiveChildInfo): boolean {
+/** True when the child is an AI agent (codex, delegation) rather than a plain shell tool. */
+function isAgentTool(child: ActiveChildInfo): boolean {
   return child.toolName === 'codex';
 }
 
 /** Pick the appropriate codicon for a background task item. */
-function getTaskIcon(
-  child: ActiveChildInfo,
-  kind: 'process' | 'subagent',
-): string {
-  if (kind === 'subagent') return 'codicon-server-process';
-  if (isAgentProcess(child)) return 'codicon-robot';
-  return 'codicon-terminal';
+function getTaskIcon(child: ActiveChildInfo): string {
+  if (child.toolName === 'bash') return 'codicon-terminal';
+  if (isAgentTool(child)) return 'codicon-robot';
+  // Subagents (delegation, workflow) default to server-process;
+  // processes without a toolName fall back to terminal.
+  return child.childStreamId
+    ? 'codicon-server-process'
+    : 'codicon-terminal';
 }
 
 /** Check if a child is in a waiting/idle state rather than actively processing. */

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
@@ -412,6 +412,47 @@ export class StreamTabs extends LitElement {
       .sort-btn.active::part(control) {
         background-color: var(--vscode-toolbar-hoverBackground);
       }
+
+      /* Child stream nesting */
+      .stream-group {
+        display: contents;
+      }
+
+      .child-streams {
+        padding-left: var(--spacing-medium, 12px);
+        border-left: var(--border-thin) solid var(--color-border);
+        margin-left: var(--spacing-small);
+      }
+
+      .child-toggle {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-tiny);
+        padding: var(--spacing-tiny) var(--spacing-small);
+        border: none;
+        background: none;
+        color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+        opacity: 0.7;
+        font-size: var(--font-size-xs);
+        font-family: var(--font-family);
+        cursor: pointer;
+        width: 100%;
+        text-align: left;
+      }
+
+      .child-toggle:hover {
+        opacity: 1;
+        background-color: var(--vscode-list-hoverBackground);
+      }
+
+      .child-toggle .codicon {
+        font-size: var(--font-size-xs);
+        transition: transform var(--transition-fast);
+      }
+
+      .child-toggle[aria-expanded='true'] .codicon {
+        transform: rotate(90deg);
+      }
     `,
   ];
 
@@ -426,6 +467,36 @@ export class StreamTabs extends LitElement {
   streamLastTimestampById: Map<string, number | undefined> = new Map();
   @property({ attribute: false })
   pendingApprovalStreamIds: Set<string> = new Set();
+  @property({ attribute: false })
+  childStreamsByParent: Map<string, StreamTabInfo[]> = new Map();
+
+  /** Which parent streams have their child list expanded. */
+  @state() private expandedParents: Set<string> = new Set();
+
+  /** Auto-expand parents when children appear, auto-collapse when gone. */
+  protected override willUpdate(
+    changed: import('lit').PropertyValues,
+  ): void {
+    if (changed.has('childStreamsByParent')) {
+      const next = new Set(this.expandedParents);
+      let dirty = false;
+      // Auto-expand parents that gained children
+      for (const parentId of this.childStreamsByParent.keys()) {
+        if (!next.has(parentId)) {
+          next.add(parentId);
+          dirty = true;
+        }
+      }
+      // Auto-collapse parents that lost all children
+      for (const parentId of next) {
+        if (!this.childStreamsByParent.has(parentId)) {
+          next.delete(parentId);
+          dirty = true;
+        }
+      }
+      if (dirty) this.expandedParents = next;
+    }
+  }
 
   override render(): TemplateResult {
     return html`
@@ -435,21 +506,71 @@ export class StreamTabs extends LitElement {
             ${repeat(
               this.streams,
               (stream) => stream.name,
-              (stream) => html`
-                <stream-tab
-                  .info=${stream}
-                  .compact=${this.compact}
-                  .status=${this.streamStatusById.get(stream.name) ??
-                  STREAM_STATUS.READY}
-                  .lastTimestamp=${this.streamLastTimestampById.get(
-                    stream.name,
-                  )}
-                  ?active=${stream.name === this.activeStreamId}
-                  .hasPendingApproval=${this.pendingApprovalStreamIds.has(
-                    stream.name,
-                  )}
-                ></stream-tab>
-              `,
+              (stream) => {
+                const children =
+                  this.childStreamsByParent.get(stream.name);
+                const hasChildren = children && children.length > 0;
+                const expanded =
+                  hasChildren && this.expandedParents.has(stream.name);
+
+                return html`
+                  <div class="stream-group">
+                    <stream-tab
+                      .info=${stream}
+                      .compact=${this.compact}
+                      .status=${this.streamStatusById.get(stream.name) ??
+                      STREAM_STATUS.READY}
+                      .lastTimestamp=${this.streamLastTimestampById.get(
+                        stream.name,
+                      )}
+                      ?active=${stream.name === this.activeStreamId}
+                      .hasPendingApproval=${this.pendingApprovalStreamIds.has(
+                        stream.name,
+                      )}
+                    ></stream-tab>
+                    ${hasChildren && !this.compact
+                      ? html`
+                          <button
+                            class="child-toggle"
+                            aria-expanded=${expanded ? 'true' : 'false'}
+                            data-parent=${stream.name}
+                            data-action="toggle-children"
+                            title=${expanded
+                              ? 'Collapse child streams'
+                              : `${children.length} active child stream${children.length > 1 ? 's' : ''}`}
+                          >
+                            <i class="codicon codicon-chevron-right"></i>
+                            <span>${children.length} active</span>
+                          </button>
+                          ${expanded
+                            ? html`
+                                <div class="child-streams">
+                                  ${repeat(
+                                    children,
+                                    (child) => child.name,
+                                    (child) => html`
+                                      <stream-tab
+                                        .info=${child}
+                                        .compact=${false}
+                                        .status=${this.streamStatusById.get(
+                                          child.name,
+                                        ) ?? STREAM_STATUS.READY}
+                                        .lastTimestamp=${this.streamLastTimestampById.get(
+                                          child.name,
+                                        )}
+                                        ?active=${child.name ===
+                                        this.activeStreamId}
+                                      ></stream-tab>
+                                    `,
+                                  )}
+                                </div>
+                              `
+                            : nothing}
+                        `
+                      : nothing}
+                  </div>
+                `;
+              },
             )}
           </div>
           ${when(
@@ -522,11 +643,28 @@ export class StreamTabs extends LitElement {
   private handleTabClick(event: MouseEvent): void {
     const actionElement = getComposedPathElement<HTMLElement>(
       event,
-      '[data-stream][data-action]',
+      '[data-action]',
     );
     if (!(actionElement instanceof HTMLElement)) return;
 
-    const { stream: streamId, action } = actionElement.dataset;
+    const { action } = actionElement.dataset;
+
+    // Handle child-stream toggle
+    if (action === 'toggle-children') {
+      const parentId = actionElement.dataset.parent;
+      if (!parentId) return;
+      const next = new Set(this.expandedParents);
+      if (next.has(parentId)) {
+        next.delete(parentId);
+      } else {
+        next.add(parentId);
+      }
+      this.expandedParents = next;
+      return;
+    }
+
+    // Handle stream tab actions (select, delete)
+    const streamId = actionElement.dataset.stream;
     if (!streamId) return;
 
     switch (action) {

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -469,42 +469,43 @@ export class StreamTabs extends LitElement {
   /** Which parent streams have their child list expanded. */
   @state() private expandedParents: Set<string> = new Set();
 
+  /**
+   * Parents the user has manually collapsed. Auto-expand won't override
+   * these — only cleared when all children finish (parent leaves the map).
+   */
+  private manuallyCollapsed: Set<string> = new Set();
+
   /** Auto-expand parents when children appear, auto-collapse when gone. */
   protected override willUpdate(
     changed: import('lit').PropertyValues,
   ): void {
     if (!changed.has('childStreamsByParent')) return;
 
-    // Quick check: is there anything to add or remove?
-    let needsExpand = false;
-    let needsCollapse = false;
-    for (const parentId of this.childStreamsByParent.keys()) {
-      if (!this.expandedParents.has(parentId)) {
-        needsExpand = true;
-        break;
-      }
-    }
-    if (!needsExpand) {
-      for (const parentId of this.expandedParents) {
-        if (!this.childStreamsByParent.has(parentId)) {
-          needsCollapse = true;
-          break;
-        }
-      }
-    }
-    if (!needsExpand && !needsCollapse) return;
-
-    // Only allocate when we know something changed
+    let dirty = false;
     const next = new Set(this.expandedParents);
+
+    // Auto-expand NEW parents (not yet seen and not manually collapsed)
     for (const parentId of this.childStreamsByParent.keys()) {
-      next.add(parentId);
+      if (!next.has(parentId) && !this.manuallyCollapsed.has(parentId)) {
+        next.add(parentId);
+        dirty = true;
+      }
     }
+    // Auto-collapse parents that lost all children + clear manual state
     for (const parentId of next) {
       if (!this.childStreamsByParent.has(parentId)) {
         next.delete(parentId);
+        this.manuallyCollapsed.delete(parentId);
+        dirty = true;
       }
     }
-    this.expandedParents = next;
+    // Also clean manual set for parents no longer in the map
+    for (const parentId of this.manuallyCollapsed) {
+      if (!this.childStreamsByParent.has(parentId)) {
+        this.manuallyCollapsed.delete(parentId);
+      }
+    }
+    if (dirty) this.expandedParents = next;
   }
 
   override render(): TemplateResult {
@@ -623,8 +624,10 @@ export class StreamTabs extends LitElement {
     const next = new Set(this.expandedParents);
     if (next.has(parentId)) {
       next.delete(parentId);
+      this.manuallyCollapsed.add(parentId);
     } else {
       next.add(parentId);
+      this.manuallyCollapsed.delete(parentId);
     }
     this.expandedParents = next;
   }

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -414,10 +414,6 @@ export class StreamTabs extends LitElement {
       }
 
       /* Child stream nesting */
-      .stream-group {
-        display: contents;
-      }
-
       .child-streams {
         padding-left: var(--spacing-medium, 12px);
         border-left: var(--border-thin) solid var(--color-border);
@@ -477,25 +473,38 @@ export class StreamTabs extends LitElement {
   protected override willUpdate(
     changed: import('lit').PropertyValues,
   ): void {
-    if (changed.has('childStreamsByParent')) {
-      const next = new Set(this.expandedParents);
-      let dirty = false;
-      // Auto-expand parents that gained children
-      for (const parentId of this.childStreamsByParent.keys()) {
-        if (!next.has(parentId)) {
-          next.add(parentId);
-          dirty = true;
-        }
+    if (!changed.has('childStreamsByParent')) return;
+
+    // Quick check: is there anything to add or remove?
+    let needsExpand = false;
+    let needsCollapse = false;
+    for (const parentId of this.childStreamsByParent.keys()) {
+      if (!this.expandedParents.has(parentId)) {
+        needsExpand = true;
+        break;
       }
-      // Auto-collapse parents that lost all children
-      for (const parentId of next) {
-        if (!this.childStreamsByParent.has(parentId)) {
-          next.delete(parentId);
-          dirty = true;
-        }
-      }
-      if (dirty) this.expandedParents = next;
     }
+    if (!needsExpand) {
+      for (const parentId of this.expandedParents) {
+        if (!this.childStreamsByParent.has(parentId)) {
+          needsCollapse = true;
+          break;
+        }
+      }
+    }
+    if (!needsExpand && !needsCollapse) return;
+
+    // Only allocate when we know something changed
+    const next = new Set(this.expandedParents);
+    for (const parentId of this.childStreamsByParent.keys()) {
+      next.add(parentId);
+    }
+    for (const parentId of next) {
+      if (!this.childStreamsByParent.has(parentId)) {
+        next.delete(parentId);
+      }
+    }
+    this.expandedParents = next;
   }
 
   override render(): TemplateResult {
@@ -513,63 +522,8 @@ export class StreamTabs extends LitElement {
                 const expanded =
                   hasChildren && this.expandedParents.has(stream.name);
 
-                return html`
-                  <div class="stream-group">
-                    <stream-tab
-                      .info=${stream}
-                      .compact=${this.compact}
-                      .status=${this.streamStatusById.get(stream.name) ??
-                      STREAM_STATUS.READY}
-                      .lastTimestamp=${this.streamLastTimestampById.get(
-                        stream.name,
-                      )}
-                      ?active=${stream.name === this.activeStreamId}
-                      .hasPendingApproval=${this.pendingApprovalStreamIds.has(
-                        stream.name,
-                      )}
-                    ></stream-tab>
-                    ${hasChildren && !this.compact
-                      ? html`
-                          <button
-                            class="child-toggle"
-                            aria-expanded=${expanded ? 'true' : 'false'}
-                            data-parent=${stream.name}
-                            data-action="toggle-children"
-                            title=${expanded
-                              ? 'Collapse child streams'
-                              : `${children.length} active child stream${children.length > 1 ? 's' : ''}`}
-                          >
-                            <i class="codicon codicon-chevron-right"></i>
-                            <span>${children.length} active</span>
-                          </button>
-                          ${expanded
-                            ? html`
-                                <div class="child-streams">
-                                  ${repeat(
-                                    children,
-                                    (child) => child.name,
-                                    (child) => html`
-                                      <stream-tab
-                                        .info=${child}
-                                        .compact=${false}
-                                        .status=${this.streamStatusById.get(
-                                          child.name,
-                                        ) ?? STREAM_STATUS.READY}
-                                        .lastTimestamp=${this.streamLastTimestampById.get(
-                                          child.name,
-                                        )}
-                                        ?active=${child.name ===
-                                        this.activeStreamId}
-                                      ></stream-tab>
-                                    `,
-                                  )}
-                                </div>
-                              `
-                            : nothing}
-                        `
-                      : nothing}
-                  </div>
-                `;
+                // prettier-ignore
+                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}></stream-tab>${hasChildren && !this.compact ? html`<button class="child-toggle" aria-expanded=${expanded ? 'true' : 'false'} data-parent=${stream.name} @click=${this.handleChildToggle} title=${expanded ? 'Collapse child streams' : `${children.length} active child stream${children.length > 1 ? 's' : ''}`}><i class="codicon codicon-chevron-right"></i><span>${children.length} active</span></button>${expanded ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => html`<stream-tab .info=${child} .compact=${false} .status=${this.streamStatusById.get(child.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(child.name)} ?active=${child.name === this.activeStreamId}></stream-tab>`)}</div>` : nothing}` : nothing}`;
               },
             )}
           </div>
@@ -643,28 +597,11 @@ export class StreamTabs extends LitElement {
   private handleTabClick(event: MouseEvent): void {
     const actionElement = getComposedPathElement<HTMLElement>(
       event,
-      '[data-action]',
+      '[data-stream][data-action]',
     );
     if (!(actionElement instanceof HTMLElement)) return;
 
-    const { action } = actionElement.dataset;
-
-    // Handle child-stream toggle
-    if (action === 'toggle-children') {
-      const parentId = actionElement.dataset.parent;
-      if (!parentId) return;
-      const next = new Set(this.expandedParents);
-      if (next.has(parentId)) {
-        next.delete(parentId);
-      } else {
-        next.add(parentId);
-      }
-      this.expandedParents = next;
-      return;
-    }
-
-    // Handle stream tab actions (select, delete)
-    const streamId = actionElement.dataset.stream;
+    const { stream: streamId, action } = actionElement.dataset;
     if (!streamId) return;
 
     switch (action) {
@@ -677,6 +614,19 @@ export class StreamTabs extends LitElement {
       default:
         break;
     }
+  }
+
+  private handleChildToggle(event: MouseEvent): void {
+    const button = event.currentTarget as HTMLElement;
+    const parentId = button.dataset.parent;
+    if (!parentId) return;
+    const next = new Set(this.expandedParents);
+    if (next.has(parentId)) {
+      next.delete(parentId);
+    } else {
+      next.add(parentId);
+    }
+    this.expandedParents = next;
   }
 
   private handleFilterChange(event: Event): void {

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -24,6 +24,14 @@ import { ProgressEvents } from '../events';
 import { getComposedPathElement, getRadioValue } from '../utils';
 import type { StreamFilter, StreamSort } from '../store';
 
+/** Stream statuses considered active (non-terminal) for child stream display. */
+const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.WAITING,
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.RESUMING,
+]);
+
 function buildTooltip(
   info: StreamTabInfo,
   lastTimestamp: number | undefined,
@@ -418,6 +426,18 @@ export class StreamTabs extends LitElement {
         padding-left: var(--spacing-medium, 12px);
         border-left: var(--border-thin) solid var(--color-border);
         margin-left: var(--spacing-small);
+        max-height: 12rem;
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+      }
+
+      .child-streams stream-tab {
+        opacity: 1;
+        transition: opacity var(--transition-fast);
+      }
+
+      .child-streams stream-tab.is-finished {
+        opacity: var(--opacity-subtle, 0.5);
       }
 
       .child-toggle {
@@ -522,9 +542,25 @@ export class StreamTabs extends LitElement {
                 const hasChildren = children && children.length > 0;
                 const expanded =
                   hasChildren && this.expandedParents.has(stream.name);
+                const activeCount = hasChildren
+                  ? children.filter((c) => {
+                      const s =
+                        this.streamStatusById.get(c.name) ??
+                        STREAM_STATUS.READY;
+                      return ACTIVE_CHILD_STATUSES.has(s);
+                    }).length
+                  : 0;
+                const toggleLabel = activeCount > 0
+                  ? `${activeCount} active`
+                  : `${children?.length ?? 0} done`;
 
                 // prettier-ignore
-                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}></stream-tab>${hasChildren && !this.compact ? html`<button class="child-toggle" aria-expanded=${expanded ? 'true' : 'false'} data-parent=${stream.name} @click=${this.handleChildToggle} title=${expanded ? 'Collapse child streams' : `${children.length} active child stream${children.length > 1 ? 's' : ''}`}><i class="codicon codicon-chevron-right"></i><span>${children.length} active</span></button>${expanded ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => html`<stream-tab .info=${child} .compact=${false} .status=${this.streamStatusById.get(child.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(child.name)} ?active=${child.name === this.activeStreamId}></stream-tab>`)}</div>` : nothing}` : nothing}`;
+                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}></stream-tab>${hasChildren && !this.compact ? html`<button class="child-toggle" aria-expanded=${expanded ? 'true' : 'false'} data-parent=${stream.name} @click=${this.handleChildToggle} title=${expanded ? 'Collapse child streams' : `${children.length} child stream${children.length > 1 ? 's' : ''}`}><i class="codicon codicon-chevron-right"></i><span>${toggleLabel}</span></button>${expanded ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => {
+                  const childStatus = this.streamStatusById.get(child.name) ?? STREAM_STATUS.READY;
+                  const isFinished = !ACTIVE_CHILD_STATUSES.has(childStatus);
+                  // prettier-ignore
+                  return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.streamLastTimestampById.get(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
+                })}</div>` : nothing}` : nothing}`;
               },
             )}
           </div>

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -1,4 +1,5 @@
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+import type { AgentCategoryFilter } from '@shared/schemas';
 
 /**
  * DOM element IDs used across the progress view.
@@ -211,7 +212,13 @@ export const SORT_BUTTONS = [
   },
 ];
 
-export const FILTER_BUTTONS = [
+interface FilterButton {
+  readonly id: string;
+  readonly label: string;
+  readonly filter: AgentCategoryFilter;
+}
+
+export const FILTER_BUTTONS: readonly FilterButton[] = [
   {
     id: ELEMENT_IDS.FILTER_ALL_BTN,
     label: 'All',

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -234,9 +234,4 @@ export const FILTER_BUTTONS: readonly FilterButton[] = [
     label: 'Chat',
     filter: 'toolUse',
   },
-  {
-    id: 'filterBackgroundBtn',
-    label: 'Background',
-    filter: 'background',
-  },
 ];

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -227,4 +227,9 @@ export const FILTER_BUTTONS = [
     label: 'Chat',
     filter: 'toolUse',
   },
+  {
+    id: 'filterBackgroundBtn',
+    label: 'Background',
+    filter: 'background',
+  },
 ];

--- a/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -1,16 +1,16 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - shared utilities
-import { isPlainObject } from '@shared/utils/string';
-import type { CodexInput } from '@tools/codex';
 import {
   CODEX_FILE_CHANGE_TOOL,
   CODEX_THREAD_TOOL,
   CODEX_TODO_TOOL,
   CODEX_TURN_TOOL,
-  type CodexFileChange,
-  type CodexFileChangeToolInput,
-  type CodexThreadToolInput,
-  type CodexTodoToolInput,
-  type CodexTurnToolInput,
+  CodexFileChangeToolInputSchema,
+  CodexThreadToolInputSchema,
+  CodexTodoToolInputSchema,
+  CodexTurnToolInputSchema,
 } from '@tools/codexShared';
 import { formatDuration } from '@utils/core';
 
@@ -29,6 +29,18 @@ import { buildToolUseSection, wrapInPre } from '../htmlBuilders';
 type RenderableSection = TemplateResult | typeof nothing | undefined | null;
 type BadgeData = { iconClass: string; label: string };
 type CodexToolRenderer = (input: unknown) => TemplateResult | typeof nothing;
+
+/** Lenient schema for parsing codex tool input in the renderer. */
+const CodexInputDisplaySchema = z.object({
+  prompt: z.string().optional().default(''),
+  sandbox_mode: z.string().optional(),
+  run_in_background: z.boolean().optional(),
+  working_directory: z.string().optional(),
+});
+
+type CodexInputDisplay = z.infer<typeof CodexInputDisplaySchema>;
+type CodexFileChangeToolInput = z.infer<typeof CodexFileChangeToolInputSchema>;
+type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
 
 function renderBadge({ iconClass, label }: BadgeData): TemplateResult {
   // prettier-ignore
@@ -75,13 +87,15 @@ function renderSectionGroup(
   )}`;
 }
 
-function renderCodexPromptSection(input: CodexInput): RenderableSection {
+function renderCodexPromptSection(
+  input: CodexInputDisplay,
+): RenderableSection {
   return when(Boolean(input.prompt), () =>
     buildToolUseSection('Prompt:', wrapInPre(input.prompt)),
   );
 }
 
-function renderCodexModeSection(input: CodexInput): RenderableSection {
+function renderCodexModeSection(input: CodexInputDisplay): RenderableSection {
   const badges = [
     ...(input.sandbox_mode
       ? [{ iconClass: 'codicon-shield', label: input.sandbox_mode }]
@@ -94,7 +108,9 @@ function renderCodexModeSection(input: CodexInput): RenderableSection {
   return renderBadgeSection('Mode:', badges);
 }
 
-function renderCodexDirectorySection(input: CodexInput): RenderableSection {
+function renderCodexDirectorySection(
+  input: CodexInputDisplay,
+): RenderableSection {
   const workingDirectory = input.working_directory ?? '';
   return when(workingDirectory.length > 0, () =>
     buildToolUseSection('Directory:', wrapInPre(workingDirectory)),
@@ -104,15 +120,13 @@ function renderCodexDirectorySection(input: CodexInput): RenderableSection {
 function renderCodexInputContent(
   input: unknown,
 ): TemplateResult | typeof nothing {
-  if (!isPlainObject(input)) {
-    return nothing;
-  }
+  const parsed = CodexInputDisplaySchema.safeParse(input);
+  if (!parsed.success) return nothing;
 
-  const codexInput = input as CodexInput;
   return renderSectionGroup([
-    renderCodexPromptSection(codexInput),
-    renderCodexModeSection(codexInput),
-    renderCodexDirectorySection(codexInput),
+    renderCodexPromptSection(parsed.data),
+    renderCodexModeSection(parsed.data),
+    renderCodexDirectorySection(parsed.data),
   ]);
 }
 
@@ -128,7 +142,9 @@ function renderCodexFileStatusSection(patchStatus: string): RenderableSection {
     : nothing;
 }
 
-function renderCodexFileChangeItem(change: CodexFileChange): TemplateResult {
+function renderCodexFileChangeItem(
+  change: CodexFileChangeToolInput['changes'][number],
+): TemplateResult {
   return html`
     <li class="detail-item">
       <i class="codicon codicon-file"></i>
@@ -141,7 +157,7 @@ function renderCodexFileChangeItem(change: CodexFileChange): TemplateResult {
 }
 
 function renderCodexFileListSection(
-  changes: CodexFileChange[],
+  changes: CodexFileChangeToolInput['changes'],
 ): RenderableSection {
   return when(
     changes.length > 0,
@@ -165,43 +181,27 @@ function renderCodexFileListSection(
 function renderCodexFileChangeContent(
   input: unknown,
 ): TemplateResult | typeof nothing {
-  if (!isPlainObject(input)) {
-    return nothing;
-  }
-
-  const patchInput = input as Partial<CodexFileChangeToolInput>;
-  const changes = Array.isArray(patchInput.changes)
-    ? patchInput.changes.filter(
-        (change): change is CodexFileChange =>
-          typeof change?.path === 'string' && typeof change?.kind === 'string',
-      )
-    : [];
-  const patchStatus =
-    typeof patchInput.patchStatus === 'string' ? patchInput.patchStatus : '';
+  const parsed = CodexFileChangeToolInputSchema.safeParse(input);
+  if (!parsed.success) return nothing;
 
   return renderSectionGroup([
-    renderCodexFileStatusSection(patchStatus),
-    renderCodexFileListSection(changes),
+    renderCodexFileStatusSection(parsed.data.patchStatus ?? ''),
+    renderCodexFileListSection(parsed.data.changes),
   ]);
 }
 
 function renderCodexThreadContent(
   input: unknown,
 ): TemplateResult | typeof nothing {
-  if (!isPlainObject(input)) {
-    return nothing;
-  }
+  const parsed = CodexThreadToolInputSchema.safeParse(input);
+  if (!parsed.success) return nothing;
 
-  const threadInput = input as Partial<CodexThreadToolInput>;
   return renderSectionGroup([
-    when(
-      typeof threadInput.threadId === 'string' &&
-        threadInput.threadId.length > 0,
-      () =>
-        buildToolUseSection(
-          'Thread ID:',
-          html`<code class="execution-id">${threadInput.threadId}</code>`,
-        ),
+    when(parsed.data.threadId.length > 0, () =>
+      buildToolUseSection(
+        'Thread ID:',
+        html`<code class="execution-id">${parsed.data.threadId}</code>`,
+      ),
     ),
   ]);
 }
@@ -237,7 +237,7 @@ function renderCodexTodoItem(item: {
 }
 
 function renderCodexTodoListSection(
-  items: Array<{ text: string; completed: boolean }>,
+  items: CodexTodoToolInput['items'],
 ): RenderableSection {
   return when(
     items.length > 0,
@@ -261,26 +261,15 @@ function renderCodexTodoListSection(
 function renderCodexTodoContent(
   input: unknown,
 ): TemplateResult | typeof nothing {
-  if (!isPlainObject(input)) {
-    return nothing;
-  }
-
-  const todoInput = input as Partial<CodexTodoToolInput>;
-  const totalCount =
-    typeof todoInput.totalCount === 'number' ? todoInput.totalCount : 0;
-  const completedCount =
-    typeof todoInput.completedCount === 'number' ? todoInput.completedCount : 0;
-  const items = Array.isArray(todoInput.items)
-    ? todoInput.items.filter(
-        (item): item is { text: string; completed: boolean } =>
-          typeof item?.text === 'string' &&
-          typeof item?.completed === 'boolean',
-      )
-    : [];
+  const parsed = CodexTodoToolInputSchema.safeParse(input);
+  if (!parsed.success) return nothing;
 
   return renderSectionGroup([
-    renderCodexTodoProgressSection(completedCount, totalCount),
-    renderCodexTodoListSection(items),
+    renderCodexTodoProgressSection(
+      parsed.data.completedCount,
+      parsed.data.totalCount,
+    ),
+    renderCodexTodoListSection(parsed.data.items),
   ]);
 }
 
@@ -309,18 +298,12 @@ function renderCodexTurnDurationSection(wallTimeMs: number): RenderableSection {
 function renderCodexTurnContent(
   input: unknown,
 ): TemplateResult | typeof nothing {
-  if (!isPlainObject(input)) {
-    return nothing;
-  }
-
-  const turnInput = input as Partial<CodexTurnToolInput>;
-  const state = typeof turnInput.state === 'string' ? turnInput.state : '';
-  const wallTimeMs =
-    typeof turnInput.wallTimeMs === 'number' ? turnInput.wallTimeMs : 0;
+  const parsed = CodexTurnToolInputSchema.safeParse(input);
+  if (!parsed.success) return nothing;
 
   return renderSectionGroup([
-    renderCodexTurnStateSection(state),
-    renderCodexTurnDurationSection(wallTimeMs),
+    renderCodexTurnStateSection(parsed.data.state),
+    renderCodexTurnDurationSection(parsed.data.wallTimeMs ?? 0),
   ]);
 }
 

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -26,7 +26,10 @@ import type {
   WorkflowAgentInput,
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import { type CodexMcpToolOutput } from '@tools/codexShared';
+import {
+  CodexMcpToolOutputSchema,
+  type CodexMcpToolOutput,
+} from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
@@ -564,8 +567,9 @@ export function formatToolUseTemplate(
       }
     }
 
-    const mcpOutput = isPlainObject(parsed.output)
-      ? (parsed.output as Partial<CodexMcpToolOutput>)
+    const mcpParsed = CodexMcpToolOutputSchema.safeParse(parsed.output);
+    const mcpOutput: CodexMcpToolOutput | null = mcpParsed.success
+      ? mcpParsed.data
       : null;
     const contentBlocks = Array.isArray(mcpOutput?.contentBlocks)
       ? mcpOutput.contentBlocks

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -49,7 +49,6 @@ import { ContextStateSchema, TokenUsageStatsSchema } from './usage';
 
 export const AgentCategoryFilterSchema = z.union([
   z.literal('all'),
-  z.literal('background'),
   AgentCategorySchema,
 ]);
 export type AgentCategoryFilter = z.infer<typeof AgentCategoryFilterSchema>;

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -49,6 +49,7 @@ import { ContextStateSchema, TokenUsageStatsSchema } from './usage';
 
 export const AgentCategoryFilterSchema = z.union([
   z.literal('all'),
+  z.literal('background'),
   AgentCategorySchema,
 ]);
 export type AgentCategoryFilter = z.infer<typeof AgentCategoryFilterSchema>;

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -72,14 +72,21 @@ function appendTail(current: string, chunk: string, maxChars: number): string {
 
 class BashBackgroundSession implements IInterruptible {
   private pid: number | undefined;
+  private interrupted = false;
 
   setPid(pid: number): void {
     this.pid = pid;
+    // If interrupt() was called before pid arrived, kill now
+    if (this.interrupted) {
+      signalProcessGroup(pid, 'SIGTERM');
+    }
   }
 
   interrupt(): void {
-    if (!this.pid) return;
-    signalProcessGroup(this.pid, 'SIGTERM');
+    this.interrupted = true;
+    if (this.pid) {
+      signalProcessGroup(this.pid, 'SIGTERM');
+    }
   }
 }
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -203,6 +203,7 @@ export class BashTool extends defineTool({
         agentName: 'bash',
         description: command,
         config: syntheticConfig,
+        toolName: 'bash',
       },
     );
     let stdoutTail = '';

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -38,6 +38,7 @@ import { defineTool } from './core/define';
 import { createChildStream, finalizeChildStream } from './childStream';
 
 const BASH_TIMEOUT_MS = 120_000; // 120 s
+const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
 
 const BashInputSchema = z.strictObject({
   command: z.string(),
@@ -58,6 +59,14 @@ const BashInputSchema = z.strictObject({
 });
 
 export type BashInput = z.infer<typeof BashInputSchema>;
+
+function appendTail(current: string, chunk: string, maxChars: number): string {
+  if (!chunk) return current;
+  const combined = current + chunk;
+  return combined.length > maxChars
+    ? combined.slice(combined.length - maxChars)
+    : combined;
+}
 
 class BashBackgroundSession implements IInterruptible {
   private pid: number | undefined;
@@ -196,8 +205,8 @@ export class BashTool extends defineTool({
         config: syntheticConfig,
       },
     );
-    const stdoutLog = logger.createStream('default');
-    const stderrLog = logger.createStream('default', { level: 'warn' });
+    let stdoutTail = '';
+    let stderrTail = '';
     const session = new BashBackgroundSession();
     registerInterruptible(childStreamId, session);
 
@@ -208,8 +217,22 @@ export class BashTool extends defineTool({
       onPid: (p) => {
         session.setPid(p);
       },
-      onStdout: (chunk) => stdoutLog.append(chunk),
-      onStderr: (chunk) => stderrLog.append(chunk),
+      onStdout: (chunk) => {
+        stdoutTail = appendTail(
+          stdoutTail,
+          chunk,
+          BACKGROUND_OUTPUT_TAIL_CHARS,
+        );
+        logger.info(chunk);
+      },
+      onStderr: (chunk) => {
+        stderrTail = appendTail(
+          stderrTail,
+          chunk,
+          BACKGROUND_OUTPUT_TAIL_CHARS,
+        );
+        logger.warn(chunk);
+      },
     });
 
     void promise
@@ -223,9 +246,6 @@ export class BashTool extends defineTool({
           timedOut: result.timedOut,
           command,
         });
-        const outputTail = stdoutLog.finalize();
-        const stderrTail = stderrLog.finalize();
-
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
         finalizeChildStream(childStreamId, executionId, logger, {
@@ -243,15 +263,13 @@ export class BashTool extends defineTool({
           command,
           wallTimeMs,
           result,
-          outputTail,
+          stdoutTail,
           stderrTail,
         );
         await store.writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
       })
       .catch(async (err: unknown) => {
-        stdoutLog.finalize();
-        stderrLog.finalize();
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeChildStream(childStreamId, executionId, logger, {
           error: err,

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -39,6 +39,8 @@ import { createChildStream, finalizeChildStream } from './childStream';
 
 const BASH_TIMEOUT_MS = 120_000; // 120 s
 const BACKGROUND_OUTPUT_TAIL_CHARS = 12_000;
+/** Max chars logged to the child stream tab to prevent unbounded memory growth. */
+const BACKGROUND_LOG_CAP_CHARS = 200_000;
 
 const BashInputSchema = z.strictObject({
   command: z.string(),
@@ -208,8 +210,23 @@ export class BashTool extends defineTool({
     );
     let stdoutTail = '';
     let stderrTail = '';
+    let loggedChars = 0;
+    let logCapReached = false;
     const session = new BashBackgroundSession();
     registerInterruptible(childStreamId, session);
+
+    const logChunk = (chunk: string, level: 'info' | 'warn'): void => {
+      if (logCapReached) return;
+      loggedChars += chunk.length;
+      if (loggedChars > BACKGROUND_LOG_CAP_CHARS) {
+        logCapReached = true;
+        logger.warn(
+          `[Stream log truncated at ${(BACKGROUND_LOG_CAP_CHARS / 1000).toFixed(0)}k chars — tail available in follow-up result]`,
+        );
+        return;
+      }
+      logger[level](chunk);
+    };
 
     const startedAt = Date.now();
     const promise = executeCommand(command, {
@@ -224,7 +241,7 @@ export class BashTool extends defineTool({
           chunk,
           BACKGROUND_OUTPUT_TAIL_CHARS,
         );
-        logger.info(chunk);
+        logChunk(chunk, 'info');
       },
       onStderr: (chunk) => {
         stderrTail = appendTail(
@@ -232,7 +249,7 @@ export class BashTool extends defineTool({
           chunk,
           BACKGROUND_OUTPUT_TAIL_CHARS,
         );
-        logger.warn(chunk);
+        logChunk(chunk, 'warn');
       },
     });
 

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -1,8 +1,3 @@
-// Standard library imports
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-
 // Third-party imports
 import { z } from 'zod';
 
@@ -14,10 +9,11 @@ import {
 } from '@agent/storage';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
-  trackExecution,
-  untrackExecution,
-  ProcessExecutionHandle,
-} from '@agent/runtime/executionRegistry';
+  registerInterruptible,
+  unregisterInterruptible,
+  type IInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 
@@ -29,16 +25,17 @@ import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
 } from '@tools/approval/bashApproval';
-import { executeCommand, signalProcessGroup } from '@utils/system/execUtils';
 
 // Local imports - utils
+import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
-import { formatDuration } from '@utils/core';
+import { executeCommand, signalProcessGroup } from '@utils/system/execUtils';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { createChildStream, finalizeChildStream } from './childStream';
 
 const BASH_TIMEOUT_MS = 120_000; // 120 s
 
@@ -56,11 +53,24 @@ const BashInputSchema = z.strictObject({
     .boolean()
     .prefault(false)
     .describe(
-      'Run command in background. Returns immediately with execution ID. Output captured to executions/{id}/output. Result delivered as follow-up when complete.',
+      'Run command in background. Returns immediately with execution ID and child stream tab. Result delivered as follow-up when complete.',
     ),
 });
 
 export type BashInput = z.infer<typeof BashInputSchema>;
+
+class BashBackgroundSession implements IInterruptible {
+  private pid: number | undefined;
+
+  setPid(pid: number): void {
+    this.pid = pid;
+  }
+
+  interrupt(): void {
+    if (!this.pid) return;
+    signalProcessGroup(this.pid, 'SIGTERM');
+  }
+}
 
 export class BashTool extends defineTool({
   name: 'bash',
@@ -154,55 +164,41 @@ export class BashTool extends defineTool({
 
     const executionId = generateExecutionId();
 
-    // Ephemeral temp files for live output (cleaned up on completion)
-    const stdoutPath = path.join(
-      os.tmpdir(),
-      `texra-bg-${executionId}-stdout.log`,
-    );
-    const stderrPath = path.join(
-      os.tmpdir(),
-      `texra-bg-${executionId}-stderr.log`,
-    );
-    const stdoutStream = fs.createWriteStream(stdoutPath, { flags: 'a' });
-    const stderrStream = fs.createWriteStream(stderrPath, { flags: 'a' });
-    stdoutStream.on('error', () => {}); // prevent unhandled emitter crash
-    stderrStream.on('error', () => {});
-
     await ensureRunDir(executionId);
 
     const preview = truncateWithEllipsis(command, 60);
-
-    let pid: number | undefined;
-    const startedAt = Date.now();
-    const promise = executeCommand(command, {
-      timeout: timeoutMs,
-      buffer: false, // Output is streamed to disk; don't buffer in memory
-      onPid: (p) => {
-        pid = p;
-      },
-      onStdout: (chunk) => stdoutStream.write(chunk),
-      onStderr: (chunk) => stderrStream.write(chunk),
-    });
-
-    const kill = (): boolean => {
-      if (!pid) return false;
-      return signalProcessGroup(pid, 'SIGTERM');
-    };
 
     const syntheticConfig = AgentConfigSchema.parse({
       agent: 'bash',
       instruction: command,
     });
 
-    // Attach lifecycle handlers BEFORE registerExecution so they're
-    // always wired, even if registration throws.
-    const handle = new ProcessExecutionHandle(
+    const { childStreamId, logger } = createChildStream(
       executionId,
       parentStreamId,
-      preview,
-      kill,
+      {
+        streamPrefix: 'bash@tool',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'bash',
+        description: command,
+        config: syntheticConfig,
+      },
     );
-    handle.outputPaths = { stdout: stdoutPath, stderr: stderrPath };
+    const stdoutLog = logger.createStream('default');
+    const stderrLog = logger.createStream('default', { level: 'warn' });
+    const session = new BashBackgroundSession();
+    registerInterruptible(childStreamId, session);
+
+    const startedAt = Date.now();
+    const promise = executeCommand(command, {
+      timeout: timeoutMs,
+      buffer: false,
+      onPid: (p) => {
+        session.setPid(p);
+      },
+      onStdout: (chunk) => stdoutLog.append(chunk),
+      onStderr: (chunk) => stderrLog.append(chunk),
+    });
 
     try {
       await registerExecution(
@@ -210,27 +206,15 @@ export class BashTool extends defineTool({
         syntheticConfig,
         'bash',
         parentExecutionId,
-        'process',
+        'toolUse',
       );
     } catch {
-      // Registration failed — still attach cleanup but don't track
       void promise.finally(() => {
-        stdoutStream.end();
-        stderrStream.end();
+        stdoutLog.finalize();
+        stderrLog.finalize();
       });
       throw new ToolError('Failed to register background execution.');
     }
-
-    trackExecution(handle);
-
-    const cleanupTempFiles = (): void => {
-      stdoutStream.end();
-      stderrStream.end();
-      handle.outputPaths = undefined;
-      // Fire-and-forget unlink
-      void fs.promises.unlink(stdoutPath).catch(() => {});
-      void fs.promises.unlink(stderrPath).catch(() => {});
-    };
 
     void promise
       .then(async (result) => {
@@ -243,17 +227,15 @@ export class BashTool extends defineTool({
           timedOut: result.timedOut,
           command,
         });
-
-        // Read tail of temp files before cleanup (fixes blank preview bug
-        // caused by buffer:false leaving result.stdout empty)
-        const [outputTail, stderrTail] = await Promise.all([
-          fs.promises.readFile(stdoutPath, 'utf-8').catch(() => ''),
-          fs.promises.readFile(stderrPath, 'utf-8').catch(() => ''),
-        ]);
+        const outputTail = stdoutLog.finalize();
+        const stderrTail = stderrLog.finalize();
 
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
-        untrackExecution(executionId);
+        finalizeChildStream(childStreamId, executionId, logger, {
+          wallTimeMs,
+        });
+        unregisterInterruptible(childStreamId);
 
         const msg = formatBashDelivery(
           executionId,
@@ -267,21 +249,25 @@ export class BashTool extends defineTool({
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
       })
       .catch(async (err: unknown) => {
+        stdoutLog.finalize();
+        stderrLog.finalize();
         await writeTerminalStatus(executionId, 'error').catch(() => {});
-        untrackExecution(executionId);
+        finalizeChildStream(childStreamId, executionId, logger, {
+          error: err,
+        });
+        unregisterInterruptible(childStreamId);
 
         const msg = formatBashError(executionId, command, err);
         await getExecutionStore(executionId).writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-      })
-      .finally(cleanupTempFiles);
+      });
 
     return {
       summary: `Launched background: ${preview}`,
       output: [
         `Command launched in background.`,
         `Execution ID: ${executionId}`,
-        `To read output: executions tool with path=/executions/${executionId}/output`,
+        `Stream tab: ${childStreamId}`,
         `To wait for completion: executions tool with path=/executions/${executionId} action=wait`,
         'Result will be delivered as a follow-up message when complete.',
       ].join('\n'),

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -173,6 +173,18 @@ export class BashTool extends defineTool({
       instruction: command,
     });
 
+    try {
+      await registerExecution(
+        executionId,
+        syntheticConfig,
+        'bash',
+        parentExecutionId,
+        'toolUse',
+      );
+    } catch {
+      throw new ToolError('Failed to register background execution.');
+    }
+
     const { childStreamId, logger } = createChildStream(
       executionId,
       parentStreamId,
@@ -200,22 +212,6 @@ export class BashTool extends defineTool({
       onStderr: (chunk) => stderrLog.append(chunk),
     });
 
-    try {
-      await registerExecution(
-        executionId,
-        syntheticConfig,
-        'bash',
-        parentExecutionId,
-        'toolUse',
-      );
-    } catch {
-      void promise.finally(() => {
-        stdoutLog.finalize();
-        stderrLog.finalize();
-      });
-      throw new ToolError('Failed to register background execution.');
-    }
-
     void promise
       .then(async (result) => {
         const wallTimeMs = Date.now() - startedAt;
@@ -234,6 +230,11 @@ export class BashTool extends defineTool({
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
         finalizeChildStream(childStreamId, executionId, logger, {
           wallTimeMs,
+          error: result.success
+            ? undefined
+            : new ToolError(
+                `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
+              ),
         });
         unregisterInterruptible(childStreamId);
 

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -105,9 +105,13 @@ export function finalizeChildStream(
     );
   }
 
-  StreamStatusService.set(
-    childStreamId,
-    hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
-  );
+  // Preserve user-initiated STOPPED status — don't overwrite with ERROR/READY
+  const currentStatus = StreamStatusService.get(childStreamId);
+  if (currentStatus !== STREAM_STATUS.STOPPED) {
+    StreamStatusService.set(
+      childStreamId,
+      hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+    );
+  }
   untrackExecution(executionId);
 }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -30,6 +30,8 @@ interface CreateChildStreamOptions {
   agentName: string;
   description: string;
   config: AgentConfig;
+  /** Tool that spawned this child (e.g. "bash", "codex"). Used for icon selection in the UI. */
+  toolName?: string;
 }
 
 interface FinalizeChildStreamOptions {
@@ -67,15 +69,15 @@ export function createChildStream(
   });
 
   const logger = new AgentLogger(childStreamId, true);
-  trackExecution(
-    new AgentExecutionHandle(
-      executionId,
-      parentStreamId,
-      childStreamId,
-      options.agentName,
-      'toolUse',
-    ),
+  const handle = new AgentExecutionHandle(
+    executionId,
+    parentStreamId,
+    childStreamId,
+    options.agentName,
+    'toolUse',
   );
+  if (options.toolName) handle.toolName = options.toolName;
+  trackExecution(handle);
 
   return { childStreamId, logger };
 }

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -16,7 +16,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 
 // Local imports - shared
-import type { StreamTabId, StorageKey } from '@shared/schemas';
+import type { ExecutionId, StreamTabId, StorageKey } from '@shared/schemas';
 import { STREAM_STATUS } from '@shared/schemas';
 
 // Local imports - utils
@@ -44,7 +44,7 @@ interface FinalizeChildStreamOptions {
 
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
-  executionId: string,
+  executionId: ExecutionId,
   parentStreamId: StreamTabId,
   options: CreateChildStreamOptions,
 ): { childStreamId: StreamTabId; logger: AgentLogger } {
@@ -83,7 +83,7 @@ export function createChildStream(
 /** Finalize a child stream tab and untrack its execution handle. */
 export function finalizeChildStream(
   childStreamId: StreamTabId,
-  executionId: string,
+  executionId: ExecutionId,
   logger: AgentLogger,
   options?: FinalizeChildStreamOptions,
 ): void {

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -1,0 +1,109 @@
+// Local imports - agent
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentCategory } from '@agent/core/AgentDataclass';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  AgentExecutionHandle,
+  trackExecution,
+  untrackExecution,
+} from '@agent/runtime/executionRegistry';
+
+// Local imports - event bus
+import { toErrorMessage } from '@common/errors';
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - logger
+import { AgentLogger } from '@logger/AgentLogger';
+
+// Local imports - shared
+import type { StreamTabId, StorageKey } from '@shared/schemas';
+import { STREAM_STATUS } from '@shared/schemas';
+
+// Local imports - utils
+import { formatDuration } from '@utils/core';
+import { agentConfigToTaskState } from '@utils/config/configConversion';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
+
+interface CreateChildStreamOptions {
+  streamPrefix: string;
+  streamCategory: AgentCategory;
+  agentName: string;
+  description: string;
+  config: AgentConfig;
+}
+
+interface FinalizeChildStreamOptions {
+  wallTimeMs?: number;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  } | null;
+  error?: unknown;
+  errorMessage?: string;
+}
+
+/** Create a child stream tab and execution handle for a background child task. */
+export function createChildStream(
+  executionId: string,
+  parentStreamId: StreamTabId,
+  options: CreateChildStreamOptions,
+): { childStreamId: StreamTabId; logger: AgentLogger } {
+  const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
+
+  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+  bus.emit('setActiveStream', {
+    streamId: childStreamId,
+    agentCategory: options.streamCategory,
+  });
+  bus.emit('setTaskState', {
+    streamId: childStreamId,
+    executionId,
+    taskState: agentConfigToTaskState(options.config),
+    storageKey: executionId as StorageKey,
+  });
+  bus.emit('updateStreamDescription', {
+    streamId: childStreamId,
+    description: truncateWithEllipsis(options.description, 80),
+  });
+
+  const logger = new AgentLogger(childStreamId, true);
+  trackExecution(
+    new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      options.agentName,
+      'toolUse',
+    ),
+  );
+
+  return { childStreamId, logger };
+}
+
+/** Finalize a child stream tab and untrack its execution handle. */
+export function finalizeChildStream(
+  childStreamId: StreamTabId,
+  executionId: string,
+  logger: AgentLogger,
+  options?: FinalizeChildStreamOptions,
+): void {
+  if (options?.errorMessage) {
+    logger.error(options.errorMessage);
+  } else if (options?.error) {
+    logger.error(toErrorMessage(options.error));
+  }
+  if (options?.wallTimeMs != null) {
+    logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
+  }
+  if (options?.usage) {
+    logger.info(
+      `Tokens: ${options.usage.input_tokens} in / ${options.usage.output_tokens} out`,
+    );
+  }
+
+  StreamStatusService.set(
+    childStreamId,
+    options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+  );
+  untrackExecution(executionId);
+}

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -87,6 +87,8 @@ export function finalizeChildStream(
   logger: AgentLogger,
   options?: FinalizeChildStreamOptions,
 ): void {
+  const hasError = options?.error != null || options?.errorMessage != null;
+
   if (options?.errorMessage) {
     logger.error(options.errorMessage);
   } else if (options?.error) {
@@ -103,7 +105,7 @@ export function finalizeChildStream(
 
   StreamStatusService.set(
     childStreamId,
-    options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+    hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
   );
   untrackExecution(executionId);
 }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -67,7 +67,6 @@ import { createChildStream, finalizeChildStream } from './childStream';
 import type {
   McpToolCallItem,
   RunResult,
-  SandboxMode,
   Thread,
   ThreadItem,
   TodoListItem,
@@ -78,13 +77,6 @@ import type {
 // Schema
 // ============================================================================
 
-/** All sandbox modes from the SDK, exposed to the LLM. */
-const SANDBOX_MODES = [
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-] as const satisfies readonly SandboxMode[];
-
 const CodexInputSchema = z.strictObject({
   prompt: z.string().describe('Instruction for the Codex agent'),
   working_directory: z
@@ -92,7 +84,7 @@ const CodexInputSchema = z.strictObject({
     .optional()
     .describe('Directory to run in (defaults to workspace root)'),
   sandbox_mode: z
-    .enum(SANDBOX_MODES)
+    .enum(CODEX_SANDBOX_MODES)
     .optional()
     .describe(
       'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
@@ -543,7 +535,13 @@ export class CodexTool extends defineTool({
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
     const sandboxMode = input.sandbox_mode ?? getCodexSandboxMode();
-    const workspace = buildCodexWorkspaceOptions(input.working_directory);
+    // Only compute workspace for new threads — resumed threads keep their
+    // stored workspace unless the caller explicitly overrides.
+    const workspace = input.working_directory
+      ? buildCodexWorkspaceOptions(input.working_directory)
+      : input.thread_id
+        ? {}
+        : buildCodexWorkspaceOptions();
     const threadOptions = {
       ...workspace,
       sandboxMode,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -97,11 +97,11 @@ const CodexInputSchema = z.strictObject({
   prompt: z.string().describe('Instruction for the Codex agent'),
   working_directory: z
     .string()
-    .optional()
+    .nullish()
     .describe('Directory to run in (defaults to workspace root)'),
   sandbox_mode: z
     .enum(CODEX_SANDBOX_MODES)
-    .optional()
+    .nullish()
     .describe(
       'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
     ),
@@ -113,7 +113,7 @@ const CodexInputSchema = z.strictObject({
     ),
   thread_id: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Resume an existing Codex thread by its ID. ' +
         'When provided, continues the conversation from where it left off instead of starting a new one. ' +

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -494,6 +494,9 @@ export class CodexTool extends defineTool({
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
+    // Resolve sandbox mode default early so it's available for approval label + output
+    input.sandbox_mode = input.sandbox_mode ?? getCodexSandboxMode();
+
     // Request approval — same pattern as BashTool
     const approvalLabel = `[codex ${input.sandbox_mode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,7 +22,7 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -38,7 +38,7 @@ import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import type { StreamTabId, ExecutionId } from '@shared/schemas';
+import type { StreamTabId, ExecutionId, StorageKey } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { escapeAttr, escapeText } from '@tools/subagentResults';
@@ -55,10 +55,6 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, finalizeChildStream } from './childStream';
-import {
-  CODEX_AGENT_NAME,
-  CODEX_DISPLAY_MODEL,
-} from './codexShared';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
@@ -72,14 +68,13 @@ import type {
 } from '@openai/codex-sdk';
 
 // ============================================================================
-// Codex config (inlined to avoid importing codexConfig.ts which pulls in vscode)
+// Codex config
 // ============================================================================
 
-/** Short model name passed to the Codex CLI via --model. */
-const CODEX_CLI_MODEL = 'gpt-5.4';
-
-/** Default reasoning effort passed to the Codex CLI. */
-const CODEX_REASONING_EFFORT = 'high' as const;
+// CODEX_SANDBOX_MODES must be inlined (used at module-level by the schema).
+// All other config (model, reasoning, buildCodexConfig, workspace, sandbox
+// getter) is lazy-imported from codexConfig.ts at runtime to avoid pulling
+// vscode into the module graph — src/tools/ is a VS Code-free zone.
 
 /** All sandbox modes from the SDK, exposed to the LLM. */
 const CODEX_SANDBOX_MODES = [
@@ -88,14 +83,10 @@ const CODEX_SANDBOX_MODES = [
   'danger-full-access',
 ] as const satisfies readonly SandboxMode[];
 
-/** Build synthetic AgentConfig for codex child streams. */
-function buildCodexConfig(prompt: string): AgentConfig {
-  return AgentConfigSchema.parse({
-    agent: CODEX_AGENT_NAME,
-    model: CODEX_DISPLAY_MODEL,
-    instruction: prompt,
-    agentCategory: AgentCategory.ToolUse,
-  });
+/** Lazy accessor for codexConfig.ts exports (loaded once, cached). */
+let _configModule: typeof import('./codexConfig') | null = null;
+async function getCodexConfig(): Promise<typeof import('./codexConfig')> {
+  return (_configModule ??= await import('./codexConfig'));
 }
 
 // ============================================================================
@@ -441,6 +432,20 @@ function handleTurnSuccess(
   logger: AgentLogger,
   wallTimeMs: number,
 ): void {
+  // Persist structured usage stats for the UI
+  if (turn.usage) {
+    bus.emit('updateStreamUsage', {
+      streamId: childStreamId,
+      storageKey: executionId as StorageKey,
+      executionId,
+      usage: {
+        inputTokens: turn.usage.input_tokens,
+        outputTokens: turn.usage.output_tokens,
+        cost: 0,
+      },
+    });
+  }
+
   const threadId = thread.id;
   if (threadId) {
     logTurnSummary(logger, wallTimeMs, turn.usage);
@@ -513,10 +518,9 @@ export class CodexTool extends defineTool({
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
     // Resolve sandbox mode default early so it's available for approval label + output.
-    // Lazy import to avoid pulling vscode into the module graph at parse time.
     if (!input.sandbox_mode) {
-      const { getCodexSandboxMode } = await import('./codexConfig');
-      input.sandbox_mode = getCodexSandboxMode();
+      const config = await getCodexConfig();
+      input.sandbox_mode = config.getCodexSandboxMode();
     }
 
     // Request approval — same pattern as BashTool
@@ -564,21 +568,20 @@ export class CodexTool extends defineTool({
 
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
+    const config = await getCodexConfig();
     // sandbox_mode is always resolved in execute() before this is called
     const sandboxMode = input.sandbox_mode;
     // Only compute workspace for new threads — resumed threads keep their
     // stored workspace unless the caller explicitly overrides.
-    // Lazy import to avoid pulling vscode into the module graph at parse time.
-    let workspace: { workingDirectory?: string; additionalDirectories?: string[] } = {};
-    if (input.working_directory || !input.thread_id) {
-      const { buildCodexWorkspaceOptions } = await import('./codexConfig');
-      workspace = buildCodexWorkspaceOptions(input.working_directory);
-    }
+    const workspace =
+      input.working_directory || !input.thread_id
+        ? config.buildCodexWorkspaceOptions(input.working_directory)
+        : {};
     const threadOptions = {
       ...workspace,
       sandboxMode,
-      model: CODEX_CLI_MODEL,
-      modelReasoningEffort: CODEX_REASONING_EFFORT,
+      model: config.CODEX_CLI_MODEL,
+      modelReasoningEffort: config.CODEX_REASONING_EFFORT,
       skipGitRepoCheck: true as const,
     };
 
@@ -595,7 +598,8 @@ export class CodexTool extends defineTool({
     const executionId = generateExecutionId();
     const preview = truncateWithEllipsis(input.prompt, 60);
     const startedAt = Date.now();
-    const config = buildCodexConfig(input.prompt);
+    const codexConfig = await getCodexConfig();
+    const config = codexConfig.buildCodexConfig(input.prompt);
 
     if (parentStreamId) {
       await ensureRunDir(executionId);
@@ -675,7 +679,8 @@ export class CodexTool extends defineTool({
     await ensureRunDir(executionId);
 
     const preview = truncateWithEllipsis(input.prompt, 60);
-    const config = buildCodexConfig(input.prompt);
+    const codexConfig = await getCodexConfig();
+    const config = codexConfig.buildCodexConfig(input.prompt);
 
     try {
       await registerExecution(executionId, config, 'codex', parentExecutionId);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -58,6 +58,7 @@ import {
   buildCodexWorkspaceOptions,
   CODEX_CLI_MODEL,
   CODEX_REASONING_EFFORT,
+  CODEX_SANDBOX_MODES,
   getCodexSandboxMode,
 } from './codexConfig';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,13 +22,9 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import { type AgentConfig } from '@agent/core/AgentConfig';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import {
-  trackExecution,
-  untrackExecution,
-  AgentExecutionHandle,
-} from '@agent/runtime/executionRegistry';
+import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
@@ -42,79 +38,56 @@ import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import { AgentUsageReporter } from '@logger/AgentUsageReporter';
-import type {
-  StreamTabId,
-  ExecutionId,
-  StorageKey,
-  TodoItem,
-  ToolUseLog,
-} from '@shared/schemas';
+import type { StreamTabId, ExecutionId } from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
-import {
-  escapeAttr,
-  escapeText,
-  formatSubagentProgress,
-} from '@tools/subagentResults';
+import { escapeAttr, escapeText } from '@tools/subagentResults';
 import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
-import { agentConfigToTaskState } from '@utils/config/configConversion';
+import { formatDuration } from '@utils/core';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import {
-  buildCodexConfig,
-  buildCodexWorkspaceOptions,
-  CODEX_CLI_MODEL,
-  CODEX_REASONING_EFFORT,
-  CODEX_SANDBOX_MODES,
-  getCodexSandboxMode,
-} from './codexConfig';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
-import {
-  buildCodexCommandToolLog,
-  buildCodexFileChangeToolLog,
-  buildCodexMcpToolLog,
-  buildCodexThreadToolLog,
-  buildCodexTodoToolLog,
-  buildCodexTurnToolLog,
-  buildCodexUsageStats,
-  CODEX_AGENT_NAME,
-} from './codexShared';
+import { createChildStream, finalizeChildStream } from './childStream';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
+  McpToolCallItem,
   RunResult,
   SandboxMode,
   Thread,
-  ThreadEvent,
   ThreadItem,
+  TodoListItem,
+  WebSearchItem,
 } from '@openai/codex-sdk';
 
 // ============================================================================
 // Schema
 // ============================================================================
 
+/** All sandbox modes from the SDK, exposed to the LLM. */
+const SANDBOX_MODES = [
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+] as const satisfies readonly SandboxMode[];
+
 const CodexInputSchema = z.strictObject({
   prompt: z.string().describe('Instruction for the Codex agent'),
   working_directory: z
     .string()
-    .nullish()
-    .describe(
-      'Directory to run in. Defaults to the workspace root. Accepts relative workspace paths or absolute paths such as a separate git worktree.',
-    ),
+    .optional()
+    .describe('Directory to run in (defaults to workspace root)'),
   sandbox_mode: z
-    .enum(CODEX_SANDBOX_MODES)
-    .nullish()
-    .describe(
-      'File access level for the Codex agent. Defaults to the user-configured sandbox mode (usually workspace-write).',
-    ),
+    .enum(SANDBOX_MODES)
+    .prefault('read-only')
+    .describe('File access level for the Codex agent'),
   run_in_background: z
     .boolean()
     .prefault(false)
@@ -123,7 +96,7 @@ const CodexInputSchema = z.strictObject({
     ),
   thread_id: z
     .string()
-    .nullish()
+    .optional()
     .describe(
       'Resume an existing Codex thread by its ID. ' +
         'When provided, continues the conversation from where it left off instead of starting a new one. ' +
@@ -145,19 +118,6 @@ interface ActiveThread {
 }
 
 const threadRegistry = new Map<string, ActiveThread>();
-
-interface TrackedToolUseLog {
-  logId: string;
-  groupId: string | undefined;
-}
-
-interface ActiveTrackedToolUseLog extends TrackedToolUseLog {
-  latestToolLog: ToolUseLog;
-}
-
-interface ActiveCodexTurnLog extends TrackedToolUseLog {
-  startedAt: number;
-}
 
 /** Store a thread for multi-turn reuse and persist thread ID to disk. */
 function storeThread(threadId: string, entry: ActiveThread): void {
@@ -243,6 +203,7 @@ function formatTurnResult(turn: RunResult, threadId?: string | null): string {
 /** Format a Codex result for background delivery as XML. */
 function formatCodexDelivery(
   executionId: string,
+  prompt: string,
   wallTimeMs: number,
   turn: RunResult,
   threadId?: string | null,
@@ -250,7 +211,7 @@ function formatCodexDelivery(
   const durationSec = (wallTimeMs / 1000).toFixed(1);
   const response = turn.finalResponse || '(no response)';
   const lines = [
-    `<codex-result id="${escapeAttr(executionId)}"${threadId ? ` thread-id="${escapeAttr(threadId)}"` : ''}>`,
+    `<codex-result id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}"${threadId ? ` thread-id="${escapeAttr(threadId)}"` : ''}>`,
     `<wall-time>${durationSec}s</wall-time>`,
     `<response>${escapeText(response)}</response>`,
   ];
@@ -266,9 +227,13 @@ function formatCodexDelivery(
 }
 
 /** Format a Codex error for background delivery. */
-function formatCodexError(executionId: string, err: unknown): string {
+function formatCodexError(
+  executionId: string,
+  prompt: string,
+  err: unknown,
+): string {
   return [
-    `<codex-error id="${escapeAttr(executionId)}">`,
+    `<codex-error id="${escapeAttr(executionId)}" prompt="${escapeAttr(prompt.slice(0, 200))}">`,
     `<message>${escapeText(toErrorMessage(err))}</message>`,
     '</codex-error>',
   ].join('\n');
@@ -278,198 +243,42 @@ function formatCodexError(executionId: string, err: unknown): string {
 // Stream tab helpers
 // ============================================================================
 
-/** Create a child stream tab for a codex execution and return its logger. */
-function createCodexStream(
-  executionId: string,
-  parentStreamId: StreamTabId,
-  prompt: string,
-  config: AgentConfig,
-): { childStreamId: StreamTabId; logger: AgentLogger } {
-  const childStreamId = `codex@codex-sdk#${executionId}` as StreamTabId;
-
-  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
-  bus.emit('setActiveStream', {
-    streamId: childStreamId,
-    agentCategory: AgentCategory.ToolUse,
+/** Build a synthetic AgentConfig for codex (used for TaskState and execution registration). */
+function buildCodexConfig(prompt: string): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: 'codex',
+    instruction: prompt,
   });
-  bus.emit('setTaskState', {
-    streamId: childStreamId,
-    executionId,
-    taskState: agentConfigToTaskState(config),
-    storageKey: executionId as StorageKey,
-  });
-  bus.emit('updateStreamDescription', {
-    streamId: childStreamId,
-    description: truncateWithEllipsis(prompt, 80),
-  });
-
-  const logger = new AgentLogger(childStreamId, true);
-  const handle = new AgentExecutionHandle(
-    executionId,
-    parentStreamId,
-    childStreamId,
-    CODEX_AGENT_NAME,
-    'toolUse',
-  );
-  trackExecution(handle);
-
-  return { childStreamId, logger };
 }
 
-interface OrchestratorContext {
-  parentStreamId: StreamTabId;
-  executionId: ExecutionId;
-}
-
-/** Per-stream snapshot of the last emitted todo state, used to skip no-op updates. */
-const lastTodoSnapshot = new Map<StreamTabId, string>();
-
-function syncCodexTodoState(
-  item: Extract<ThreadItem, { type: 'todo_list' }>,
+/** Log a completed codex thread item to the child stream's logger. */
+function logCodexItem(
+  item: ThreadItem,
   childStreamId: StreamTabId,
-  orchestrator?: OrchestratorContext,
-): void {
-  const todos: TodoItem[] = item.items.map((t) => ({
-    content: t.text,
-    status: t.completed ? ('completed' as const) : ('pending' as const),
-    activeForm: t.text,
-  }));
-
-  const snapshot = JSON.stringify(todos);
-  if (snapshot === lastTodoSnapshot.get(childStreamId)) return;
-  lastTodoSnapshot.set(childStreamId, snapshot);
-
-  bus.emit('updateTodos', { streamId: childStreamId, todos });
-  if (orchestrator) {
-    const msg = formatSubagentProgress(
-      orchestrator.executionId,
-      CODEX_AGENT_NAME,
-      { kind: 'todos', todos },
-    );
-    ToolUseFollowUpQueue.enqueue(orchestrator.parentStreamId, msg);
-  }
-}
-
-function updateTrackedToolUseLog(
-  logger: AgentLogger,
-  trackedLog: TrackedToolUseLog,
-  toolLog: ToolUseLog,
-): void {
-  const { status = 'completed', ...toolLogData } = toolLog;
-  logger.updateToolUse(
-    trackedLog.logId,
-    toolLogData,
-    trackedLog.groupId,
-    status,
-  );
-}
-
-function upsertTrackedToolUseLog(
-  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
-  itemId: string,
-  toolLog: ToolUseLog,
-  logger: AgentLogger,
-): void {
-  const trackedLog = trackedLogs.get(itemId);
-  if (trackedLog) {
-    trackedLog.latestToolLog = toolLog;
-    updateTrackedToolUseLog(logger, trackedLog, toolLog);
-  } else {
-    trackedLogs.set(itemId, {
-      ...logger.emitToolUse(toolLog),
-      latestToolLog: toolLog,
-    });
-  }
-
-  if (toolLog.status !== 'in_progress') {
-    trackedLogs.delete(itemId);
-  }
-}
-
-function finalizeTrackedCodexItemLog(
-  toolLog: ToolUseLog,
-  errorMessage: string,
-): ToolUseLog {
-  const output =
-    toolLog.toolName?.startsWith('mcp:') &&
-    toolLog.output != null &&
-    typeof toolLog.output === 'object' &&
-    !Array.isArray(toolLog.output)
-      ? {
-          ...(toolLog.output as Record<string, unknown>),
-          status: 'failed',
-        }
-      : toolLog.output;
-
-  return {
-    ...toolLog,
-    ...(output !== undefined && { output }),
-    ...(toolLog.error ? {} : { error: errorMessage }),
-    isError: true,
-    status: 'completed',
-  };
-}
-
-function finalizeTrackedCodexItemLogs(
-  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
-  logger: AgentLogger,
-  errorMessage: string,
-): void {
-  for (const [itemId, trackedLog] of trackedLogs) {
-    updateTrackedToolUseLog(
-      logger,
-      trackedLog,
-      finalizeTrackedCodexItemLog(trackedLog.latestToolLog, errorMessage),
-    );
-    trackedLogs.delete(itemId);
-  }
-}
-
-function handleTrackedCodexItemEvent(
-  item: Extract<
-    ThreadItem,
-    | { type: 'command_execution' }
-    | { type: 'mcp_tool_call' }
-    | { type: 'todo_list' }
-  >,
-  phase: 'started' | 'updated' | 'completed',
-  childStreamId: StreamTabId,
-  logger: AgentLogger,
-  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
-  orchestrator?: OrchestratorContext,
-): void {
-  if (item.type === 'todo_list') {
-    syncCodexTodoState(item, childStreamId, orchestrator);
-  }
-
-  const toolLog =
-    item.type === 'command_execution'
-      ? buildCodexCommandToolLog(item)
-      : item.type === 'mcp_tool_call'
-        ? buildCodexMcpToolLog(item)
-        : buildCodexTodoToolLog(
-            item,
-            phase === 'completed' ? 'completed' : 'in_progress',
-          );
-
-  upsertTrackedToolUseLog(trackedLogs, item.id, toolLog, logger);
-}
-
-/** Log a completed codex thread item that does not participate in live updates. */
-function logCompletedCodexItem(
-  item: Exclude<
-    ThreadItem,
-    | { type: 'command_execution' }
-    | { type: 'mcp_tool_call' }
-    | { type: 'todo_list' }
-  >,
   logger: AgentLogger,
 ): void {
   switch (item.type) {
+    case 'command_execution': {
+      const exitInfo =
+        item.exit_code === undefined
+          ? item.status
+          : item.exit_code === 0
+            ? 'ok'
+            : `exit ${item.exit_code}`;
+      logger.logToolUse({
+        toolName: 'bash',
+        input: { command: item.command },
+        output: `(${exitInfo})`,
+        status: 'completed',
+      });
+      break;
+    }
     case 'file_change': {
-      const fileChangeLog = buildCodexFileChangeToolLog(item);
-      if (fileChangeLog) {
-        logger.logToolUse(fileChangeLog);
+      const changes = item.changes.map(
+        (c: { kind: string; path: string }) => `${c.kind} ${c.path}`,
+      );
+      if (changes.length > 0) {
+        logger.info(`Files: ${changes.join(', ')}`);
       }
       break;
     }
@@ -479,33 +288,51 @@ function logCompletedCodexItem(
     case 'reasoning':
       logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
-    case 'web_search':
-      logger.logWebSearch({ query: item.query });
+    case 'mcp_tool_call': {
+      const mcp = item as McpToolCallItem;
+      const output = mcp.error
+        ? `Error: ${mcp.error.message}`
+        : mcp.result?.structured_content
+          ? JSON.stringify(mcp.result.structured_content)
+          : `(${mcp.status})`;
+      logger.logToolUse({
+        toolName: `mcp:${mcp.server}/${mcp.tool}`,
+        input: mcp.arguments,
+        output,
+        status: 'completed',
+      });
       break;
+    }
+    case 'web_search':
+      logger.logWebSearch({ query: (item as WebSearchItem).query });
+      break;
+    case 'todo_list': {
+      const todos = (item as TodoListItem).items.map((t) => ({
+        content: t.text,
+        status: t.completed ? ('completed' as const) : ('pending' as const),
+        activeForm: t.text,
+      }));
+      bus.emit('updateTodos', { streamId: childStreamId, todos });
+      break;
+    }
     case 'error':
       logger.error(item.message);
       break;
   }
 }
 
-/** Finalize a codex child stream (mark completed/error). */
-function finalizeCodexStream(
-  childStreamId: StreamTabId,
-  executionId: string,
+/** Log a turn summary to the child stream. */
+function logTurnSummary(
   logger: AgentLogger,
-  options?: {
-    error?: unknown;
-  },
+  wallTimeMs: number,
+  usage: RunResult['usage'],
 ): void {
-  if (options?.error) {
-    logger.error(toErrorMessage(options.error));
+  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
+  if (usage) {
+    logger.info(
+      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
+    );
   }
-  StreamStatusService.set(
-    childStreamId,
-    options?.error ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
-  );
-  lastTodoSnapshot.delete(childStreamId);
-  untrackExecution(executionId);
 }
 
 // ============================================================================
@@ -545,15 +372,16 @@ function startFollowUpLoop(
         const userMessage = messages.join('\n\n');
 
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+        const startedAt = Date.now();
 
         try {
-          await runStreamedTurn(
+          const turn = await runStreamedTurn(
             thread,
             userMessage,
             childStreamId,
             logger,
-            executionId,
           );
+          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (err) {
           logger.error(toErrorMessage(err));
         }
@@ -574,7 +402,6 @@ function startFollowUpLoop(
 
       const threadId = thread.id;
       if (threadId) threadRegistry.delete(threadId);
-      lastTodoSnapshot.delete(childStreamId);
 
       if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
         StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
@@ -589,16 +416,22 @@ function startFollowUpLoop(
  */
 function handleTurnSuccess(
   thread: Thread,
+  turn: RunResult,
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   logger: AgentLogger,
+  wallTimeMs: number,
 ): void {
   const threadId = thread.id;
   if (threadId) {
+    logTurnSummary(logger, wallTimeMs, turn.usage);
     storeThread(threadId, { thread, childStreamId, logger, executionId });
     startFollowUpLoop(thread, childStreamId, executionId, logger);
   } else {
-    finalizeCodexStream(childStreamId, executionId, logger);
+    finalizeChildStream(childStreamId, executionId, logger, {
+      wallTimeMs,
+      usage: turn.usage,
+    });
   }
 }
 
@@ -612,121 +445,30 @@ async function runStreamedTurn(
   prompt: string,
   childStreamId: StreamTabId,
   logger: AgentLogger,
-  executionId: ExecutionId,
-  orchestrator?: OrchestratorContext,
 ): Promise<RunResult> {
   logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
   const { events } = await thread.runStreamed(prompt);
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;
-  const trackedLogs = new Map<string, ActiveTrackedToolUseLog>();
-  let activeTurnLog: ActiveCodexTurnLog | null = null;
-  const usageReporter = new AgentUsageReporter(
-    logger,
-    childStreamId,
-    AgentCategory.ToolUse,
-  );
 
-  try {
-    for await (const event of events) {
-      switch (event.type) {
-        case 'thread.started':
-          logger.logToolUse(buildCodexThreadToolLog(event));
-          break;
-        case 'turn.started':
-          activeTurnLog = {
-            ...logger.emitToolUse(buildCodexTurnToolLog({ state: 'running' })),
-            startedAt: Date.now(),
-          };
-          break;
-        case 'item.started':
-        case 'item.updated':
-          if (
-            event.item.type === 'command_execution' ||
-            event.item.type === 'mcp_tool_call' ||
-            event.item.type === 'todo_list'
-          ) {
-            handleTrackedCodexItemEvent(
-              event.item,
-              event.type === 'item.started' ? 'started' : 'updated',
-              childStreamId,
-              logger,
-              trackedLogs,
-              orchestrator,
-            );
-          }
-          break;
-        case 'item.completed': {
-          const { item } = event;
-          if (
-            item.type === 'command_execution' ||
-            item.type === 'mcp_tool_call' ||
-            item.type === 'todo_list'
-          ) {
-            handleTrackedCodexItemEvent(
-              item,
-              'completed',
-              childStreamId,
-              logger,
-              trackedLogs,
-              orchestrator,
-            );
-          } else {
-            logCompletedCodexItem(item, logger);
-          }
-          if (item.type === 'agent_message') {
-            responseParts.push(item.text);
-          }
-          break;
+  for await (const event of events) {
+    switch (event.type) {
+      case 'item.completed': {
+        const { item } = event;
+        logCodexItem(item, childStreamId, logger);
+        if (item.type === 'agent_message') {
+          responseParts.push(item.text);
         }
-        case 'turn.completed':
-          usage = event.usage ?? null;
-          if (usage) {
-            usageReporter.report(
-              buildCodexUsageStats(usage),
-              executionId as StorageKey,
-            );
-          }
-          if (activeTurnLog) {
-            updateTrackedToolUseLog(
-              logger,
-              activeTurnLog,
-              buildCodexTurnToolLog({
-                state: 'completed',
-                wallTimeMs: Date.now() - activeTurnLog.startedAt,
-              }),
-            );
-            activeTurnLog = null;
-          } else {
-            logger.logToolUse(
-              buildCodexTurnToolLog({
-                state: 'completed',
-              }),
-            );
-          }
-          break;
-        case 'turn.failed':
-          throw new ToolError(event.error.message ?? 'Codex turn failed');
-        case 'error':
-          throw new ToolError(event.message ?? 'Codex stream error');
+        break;
       }
+      case 'turn.completed':
+        usage = event.usage ?? null;
+        break;
+      case 'turn.failed':
+        throw new ToolError(event.error.message ?? 'Codex turn failed');
+      case 'error':
+        throw new ToolError(event.message ?? 'Codex stream error');
     }
-  } catch (error) {
-    const errorMessage = toErrorMessage(error);
-    if (activeTurnLog) {
-      updateTrackedToolUseLog(
-        logger,
-        activeTurnLog,
-        buildCodexTurnToolLog({
-          state: 'failed',
-          wallTimeMs: Date.now() - activeTurnLog.startedAt,
-          error: errorMessage,
-        }),
-      );
-      activeTurnLog = null;
-    }
-    finalizeTrackedCodexItemLogs(trackedLogs, logger, errorMessage);
-    throw error;
   }
 
   return {
@@ -745,20 +487,14 @@ export class CodexTool extends defineTool({
   description:
     'Spin off an OpenAI Codex agent to perform code analysis, generation, or research in a sandboxed environment. ' +
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +
-    'Set working_directory to a workspace subdirectory or an absolute path, including a separate git worktree; an orchestrator can prepare that worktree first when isolated changes help. ' +
     'Requires the Codex CLI to be installed (`npm install -g @openai/codex`). ' +
     'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var. ' +
-    'MULTI-TURN: Each call returns a thread_id. Pass it back via the thread_id parameter to resume the same session — ' +
-    'the agent retains full conversation history, file context, and in-progress work. ' +
-    'Always resume an existing thread when following up, providing feedback, or asking for corrections on prior codex work.',
+    'Returns a thread_id that can be passed back to continue the conversation in subsequent calls.',
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
-    // Apply user-configured default sandbox mode
-    const sandboxMode = input.sandbox_mode ?? getCodexSandboxMode();
-
     // Request approval — same pattern as BashTool
-    const approvalLabel = `[codex ${sandboxMode}] ${input.prompt}`;
+    const approvalLabel = `[codex ${input.sandbox_mode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });
     if (!approval.accepted) {
       return buildBashApprovalRejectedResult(
@@ -771,13 +507,12 @@ export class CodexTool extends defineTool({
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    const thread = await this.resolveThread(input, sandboxMode);
+    const thread = await this.resolveThread(input);
 
     if (input.run_in_background) {
       return this.executeBackground(
         thread,
         input,
-        sandboxMode,
         ctx?.streamId,
         ctx?.executionId,
       );
@@ -787,10 +522,7 @@ export class CodexTool extends defineTool({
   }
 
   /** Resolve thread — resume existing or start new. */
-  private async resolveThread(
-    input: CodexInput,
-    sandboxMode: SandboxMode,
-  ): Promise<Thread> {
+  private async resolveThread(input: CodexInput): Promise<Thread> {
     if (input.thread_id) {
       const stored = threadRegistry.get(input.thread_id);
       if (stored) {
@@ -806,16 +538,10 @@ export class CodexTool extends defineTool({
 
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
-    const workspaceOptions =
-      input.thread_id && input.working_directory == null
-        ? {}
-        : buildCodexWorkspaceOptions(input.working_directory);
     const threadOptions = {
-      model: CODEX_CLI_MODEL,
-      modelReasoningEffort: CODEX_REASONING_EFFORT,
-      sandboxMode,
+      workingDirectory: input.working_directory,
+      sandboxMode: input.sandbox_mode,
       skipGitRepoCheck: true as const,
-      ...workspaceOptions,
     };
 
     return input.thread_id
@@ -830,6 +556,7 @@ export class CodexTool extends defineTool({
   ): Promise<ToolResult> {
     const executionId = generateExecutionId();
     const preview = truncateWithEllipsis(input.prompt, 60);
+    const startedAt = Date.now();
     const config = buildCodexConfig(input.prompt);
 
     if (parentStreamId) {
@@ -839,13 +566,19 @@ export class CodexTool extends defineTool({
       await registerExecution(
         executionId,
         config,
-        CODEX_AGENT_NAME,
+        'codex',
         parentExecutionId,
       ).catch(() => {});
     }
 
     const stream = parentStreamId
-      ? createCodexStream(executionId, parentStreamId, input.prompt, config)
+      ? createChildStream(executionId, parentStreamId, {
+          streamPrefix: 'codex@codex-sdk',
+          streamCategory: AgentCategory.ToolUse,
+          agentName: 'codex',
+          description: input.prompt,
+          config,
+        })
       : undefined;
 
     try {
@@ -855,18 +588,20 @@ export class CodexTool extends defineTool({
             input.prompt,
             stream.childStreamId,
             stream.logger,
-            executionId,
           )
         : await thread.run(input.prompt);
 
       const threadId = thread.id;
+      const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
         handleTurnSuccess(
           thread,
+          turn,
           stream.childStreamId,
           executionId,
           stream.logger,
+          wallTimeMs,
         );
       }
 
@@ -876,8 +611,9 @@ export class CodexTool extends defineTool({
       };
     } catch (err) {
       if (stream) {
-        finalizeCodexStream(stream.childStreamId, executionId, stream.logger, {
+        finalizeChildStream(stream.childStreamId, executionId, stream.logger, {
           error: err,
+          errorMessage: toErrorMessage(err),
         });
       }
       throw err;
@@ -887,7 +623,6 @@ export class CodexTool extends defineTool({
   private async executeBackground(
     thread: Thread,
     input: CodexInput,
-    sandboxMode: SandboxMode,
     parentStreamId: StreamTabId | undefined,
     parentExecutionId: ExecutionId | undefined,
   ): Promise<ToolResult> {
@@ -904,25 +639,24 @@ export class CodexTool extends defineTool({
     const config = buildCodexConfig(input.prompt);
 
     try {
-      await registerExecution(
-        executionId,
-        config,
-        CODEX_AGENT_NAME,
-        parentExecutionId,
-      );
+      await registerExecution(executionId, config, 'codex', parentExecutionId);
     } catch {
       throw new ToolError('Failed to register background Codex execution.');
     }
 
-    const { childStreamId, logger } = createCodexStream(
+    const { childStreamId, logger } = createChildStream(
       executionId,
       parentStreamId,
-      input.prompt,
-      config,
+      {
+        streamPrefix: 'codex@codex-sdk',
+        streamCategory: AgentCategory.ToolUse,
+        agentName: 'codex',
+        description: input.prompt,
+        config,
+      },
     );
 
     const startedAt = Date.now();
-    const orchestrator: OrchestratorContext = { parentStreamId, executionId };
 
     void (async () => {
       try {
@@ -931,8 +665,6 @@ export class CodexTool extends defineTool({
           input.prompt,
           childStreamId,
           logger,
-          executionId,
-          orchestrator,
         );
         const wallTimeMs = Date.now() - startedAt;
         const threadId = thread.id;
@@ -940,6 +672,7 @@ export class CodexTool extends defineTool({
 
         const msg = formatCodexDelivery(
           executionId,
+          input.prompt,
           wallTimeMs,
           turn,
           threadId,
@@ -948,17 +681,27 @@ export class CodexTool extends defineTool({
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
 
         // Write terminal status before handleTurnSuccess, which may call
-        // finalizeCodexStream → untrackExecution → notifyWaiters.
+        // finalizeChildStream → untrackExecution → notifyWaiters.
         // When a follow-up loop starts, the loop's finally writes its own status.
         if (!threadId) {
           await writeTerminalStatus(executionId, 'completed').catch(() => {});
         }
-        handleTurnSuccess(thread, childStreamId, executionId, logger);
+        handleTurnSuccess(
+          thread,
+          turn,
+          childStreamId,
+          executionId,
+          logger,
+          wallTimeMs,
+        );
       } catch (err: unknown) {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
-        finalizeCodexStream(childStreamId, executionId, logger, { error: err });
+        finalizeChildStream(childStreamId, executionId, logger, {
+          error: err,
+          errorMessage: toErrorMessage(err),
+        });
 
-        const msg = formatCodexError(executionId, err);
+        const msg = formatCodexError(executionId, input.prompt, err);
         await getExecutionStore(executionId).writeReport(msg);
         ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
       }
@@ -967,7 +710,7 @@ export class CodexTool extends defineTool({
     return {
       summary: `Launched Codex: ${preview}`,
       output: [
-        `Codex agent launched in background (${sandboxMode}).`,
+        `Codex agent launched in background (${input.sandbox_mode}).`,
         `Execution ID: ${executionId}`,
         `Stream tab: ${childStreamId}`,
         'Result will be delivered as a follow-up message when complete.',

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -283,10 +283,11 @@ function logCodexItem(
           : item.exit_code === 0
             ? 'ok'
             : `exit ${item.exit_code}`;
+      const output = item.aggregated_output?.trim() || `(${exitInfo})`;
       logger.logToolUse({
         toolName: 'bash',
         input: { command: item.command },
-        output: `(${exitInfo})`,
+        output,
         status: 'completed',
       });
       break;

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,7 +22,7 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -53,26 +53,50 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
-import {
-  buildCodexConfig,
-  buildCodexWorkspaceOptions,
-  CODEX_CLI_MODEL,
-  CODEX_REASONING_EFFORT,
-  CODEX_SANDBOX_MODES,
-  getCodexSandboxMode,
-} from './codexConfig';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, finalizeChildStream } from './childStream';
+import {
+  CODEX_AGENT_NAME,
+  CODEX_DISPLAY_MODEL,
+} from './codexShared';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
   McpToolCallItem,
   RunResult,
+  SandboxMode,
   Thread,
   ThreadItem,
   TodoListItem,
   WebSearchItem,
 } from '@openai/codex-sdk';
+
+// ============================================================================
+// Codex config (inlined to avoid importing codexConfig.ts which pulls in vscode)
+// ============================================================================
+
+/** Short model name passed to the Codex CLI via --model. */
+const CODEX_CLI_MODEL = 'gpt-5.4';
+
+/** Default reasoning effort passed to the Codex CLI. */
+const CODEX_REASONING_EFFORT = 'high' as const;
+
+/** All sandbox modes from the SDK, exposed to the LLM. */
+const CODEX_SANDBOX_MODES = [
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+] as const satisfies readonly SandboxMode[];
+
+/** Build synthetic AgentConfig for codex child streams. */
+function buildCodexConfig(prompt: string): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: CODEX_AGENT_NAME,
+    model: CODEX_DISPLAY_MODEL,
+    instruction: prompt,
+    agentCategory: AgentCategory.ToolUse,
+  });
+}
 
 // ============================================================================
 // Schema
@@ -487,8 +511,12 @@ export class CodexTool extends defineTool({
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
-    // Resolve sandbox mode default early so it's available for approval label + output
-    input.sandbox_mode = input.sandbox_mode ?? getCodexSandboxMode();
+    // Resolve sandbox mode default early so it's available for approval label + output.
+    // Lazy import to avoid pulling vscode into the module graph at parse time.
+    if (!input.sandbox_mode) {
+      const { getCodexSandboxMode } = await import('./codexConfig');
+      input.sandbox_mode = getCodexSandboxMode();
+    }
 
     // Request approval — same pattern as BashTool
     const approvalLabel = `[codex ${input.sandbox_mode}] ${input.prompt}`;
@@ -535,14 +563,16 @@ export class CodexTool extends defineTool({
 
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
-    const sandboxMode = input.sandbox_mode ?? getCodexSandboxMode();
+    // sandbox_mode is always resolved in execute() before this is called
+    const sandboxMode = input.sandbox_mode;
     // Only compute workspace for new threads — resumed threads keep their
     // stored workspace unless the caller explicitly overrides.
-    const workspace = input.working_directory
-      ? buildCodexWorkspaceOptions(input.working_directory)
-      : input.thread_id
-        ? {}
-        : buildCodexWorkspaceOptions();
+    // Lazy import to avoid pulling vscode into the module graph at parse time.
+    let workspace: { workingDirectory?: string; additionalDirectories?: string[] } = {};
+    if (input.working_directory || !input.thread_id) {
+      const { buildCodexWorkspaceOptions } = await import('./codexConfig');
+      workspace = buildCodexWorkspaceOptions(input.working_directory);
+    }
     const threadOptions = {
       ...workspace,
       sandboxMode,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,7 +22,7 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -53,6 +53,13 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import {
+  buildCodexConfig,
+  buildCodexWorkspaceOptions,
+  CODEX_CLI_MODEL,
+  CODEX_REASONING_EFFORT,
+  getCodexSandboxMode,
+} from './codexConfig';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, finalizeChildStream } from './childStream';
 
@@ -86,8 +93,10 @@ const CodexInputSchema = z.strictObject({
     .describe('Directory to run in (defaults to workspace root)'),
   sandbox_mode: z
     .enum(SANDBOX_MODES)
-    .prefault('read-only')
-    .describe('File access level for the Codex agent'),
+    .optional()
+    .describe(
+      'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
+    ),
   run_in_background: z
     .boolean()
     .prefault(false)
@@ -242,14 +251,6 @@ function formatCodexError(
 // ============================================================================
 // Stream tab helpers
 // ============================================================================
-
-/** Build a synthetic AgentConfig for codex (used for TaskState and execution registration). */
-function buildCodexConfig(prompt: string): AgentConfig {
-  return AgentConfigSchema.parse({
-    agent: 'codex',
-    instruction: prompt,
-  });
-}
 
 /** Log a completed codex thread item to the child stream's logger. */
 function logCodexItem(
@@ -538,9 +539,13 @@ export class CodexTool extends defineTool({
 
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
+    const sandboxMode = input.sandbox_mode ?? getCodexSandboxMode();
+    const workspace = buildCodexWorkspaceOptions(input.working_directory);
     const threadOptions = {
-      workingDirectory: input.working_directory,
-      sandboxMode: input.sandbox_mode,
+      ...workspace,
+      sandboxMode,
+      model: CODEX_CLI_MODEL,
+      modelReasoningEffort: CODEX_REASONING_EFFORT,
       skipGitRepoCheck: true as const,
     };
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -578,6 +578,7 @@ export class CodexTool extends defineTool({
           agentName: 'codex',
           description: input.prompt,
           config,
+          toolName: 'codex',
         })
       : undefined;
 
@@ -653,6 +654,7 @@ export class CodexTool extends defineTool({
         agentName: 'codex',
         description: input.prompt,
         config,
+        toolName: 'codex',
       },
     );
 

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -1,3 +1,6 @@
+// Third-party imports
+import { z } from 'zod';
+
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -29,33 +32,60 @@ export type CodexMcpContentBlock = NonNullable<
   NonNullable<McpToolCallItem['result']>['content']
 >[number];
 
-export interface CodexFileChangeToolInput {
-  changes: CodexFileChange[];
-  patchStatus: FileChangeItem['status'];
-}
+// ---------------------------------------------------------------------------
+// Zod schemas for codex tool-log inputs (used for safe parsing in renderers)
+// ---------------------------------------------------------------------------
 
-export interface CodexMcpToolOutput {
-  status: McpToolCallItem['status'];
-  structuredContent?: unknown;
-  contentBlocks?: CodexMcpContentBlock[];
-}
+const CodexFileChangeItemSchema = z.object({
+  path: z.string(),
+  kind: z.string(),
+});
 
-export interface CodexThreadToolInput {
-  threadId: string;
-}
+export const CodexFileChangeToolInputSchema = z.object({
+  changes: z.array(CodexFileChangeItemSchema),
+  patchStatus: z.string().optional(),
+});
 
-export interface CodexTodoToolInput {
-  items: CodexTodoItem[];
-  completedCount: number;
-  totalCount: number;
-}
+export type CodexFileChangeToolInput = z.infer<
+  typeof CodexFileChangeToolInputSchema
+>;
 
-export type CodexTurnState = 'running' | 'completed' | 'failed';
+export const CodexMcpToolOutputSchema = z.object({
+  status: z.string().optional(),
+  structuredContent: z.unknown().optional(),
+  contentBlocks: z.array(z.record(z.unknown())).optional(),
+});
 
-export interface CodexTurnToolInput {
-  state: CodexTurnState;
-  wallTimeMs?: number;
-}
+export type CodexMcpToolOutput = z.infer<typeof CodexMcpToolOutputSchema>;
+
+export const CodexThreadToolInputSchema = z.object({
+  threadId: z.string(),
+});
+
+export type CodexThreadToolInput = z.infer<typeof CodexThreadToolInputSchema>;
+
+const CodexTodoItemSchema = z.object({
+  text: z.string(),
+  completed: z.boolean(),
+});
+
+export const CodexTodoToolInputSchema = z.object({
+  items: z.array(CodexTodoItemSchema),
+  completedCount: z.number(),
+  totalCount: z.number(),
+});
+
+export type CodexTodoToolInput = z.infer<typeof CodexTodoToolInputSchema>;
+
+export const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
+export type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
+
+export const CodexTurnToolInputSchema = z.object({
+  state: z.string(),
+  wallTimeMs: z.number().optional(),
+});
+
+export type CodexTurnToolInput = z.infer<typeof CodexTurnToolInputSchema>;
 
 function truncateSummary(text: string, maxLength: number): string {
   const oneLine = text.replaceAll(/\s+/g, ' ').trim();

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -53,7 +53,7 @@ export type CodexFileChangeToolInput = z.infer<
 export const CodexMcpToolOutputSchema = z.object({
   status: z.string().optional(),
   structuredContent: z.unknown().optional(),
-  contentBlocks: z.array(z.record(z.unknown())).optional(),
+  contentBlocks: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 export type CodexMcpToolOutput = z.infer<typeof CodexMcpToolOutputSchema>;

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -81,7 +81,7 @@ export const CodexTurnStateSchema = z.enum(['running', 'completed', 'failed']);
 export type CodexTurnState = z.infer<typeof CodexTurnStateSchema>;
 
 export const CodexTurnToolInputSchema = z.object({
-  state: z.string(),
+  state: CodexTurnStateSchema,
   wallTimeMs: z.number().optional(),
 });
 


### PR DESCRIPTION
### Motivation
- Replace temp-file polling and `ProcessExecutionHandle` for background `bash` runs with dedicated child stream tabs to match the codex UX and provide clickable, formatted logs.
- Reduce duplicated child-stream lifecycle code between `codex` and `bash` by centralizing stream setup/finalization.

### Description
- Add shared helpers `createChildStream` and `finalizeChildStream` in `src/tools/childStream.ts` to centralized child tab creation, `AgentExecutionHandle` tracking, `setTaskState` emission and finalization/untracking logic.
- Refactor background `bash` (`src/tools/bash.ts`) to create a child stream via `createChildStream`, stream stdout/stderr live into the stream using `AgentLogger.createStream`, register an interruptible session for stop behavior, and finalize with `finalizeChildStream` on completion/error instead of writing to temp files.
- Migrate `codex` (`src/tools/codex.ts`) to use the new shared child-stream helpers and remove duplicated codex-specific stream creation/finalization code while preserving follow-up loop semantics and status transitions.
- Update background `bash` registration to use category `toolUse` and include the created `childStreamId` in the tool output so callers can navigate to the stream tab.

### Testing
- Ran formatting with `npm run format` which completed successfully.
- Built webviews and extension with `npm run compile:fast` which completed successfully.
- Ran lint with `npm run lint` and targeted `npx eslint` on changed files; lint completed successfully with only pre-existing repository warnings (no new lint errors).
- Verified the modified files compile and the dev webview builds completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8cfabc6c8324a11cfb223fcd1c39)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes background execution tracking/interrupt handling and reshapes the progress view’s stream list to support nested child streams, which could affect task lifecycle/status updates and navigation.
> 
> **Overview**
> Background `bash` runs now create a dedicated *child stream tab* and stream stdout/stderr into it live (with log truncation + tail capture for follow-up delivery), replacing the prior temp-file polling + `ProcessExecutionHandle` approach.
> 
> Child stream lifecycle is centralized in new `createChildStream`/`finalizeChildStream` helpers, and `codex` is refactored to use these helpers while also lazy-loading `codexConfig` to keep VS Code dependencies out of `src/tools/`.
> 
> The progress UI is updated to support *nested child streams* under their parent in `StreamTabs` (auto-expand/collapse, finished-state styling), ensure stream lookup is filter-independent, and improve background task icons/click-through behavior using a propagated `toolName` on `AgentExecutionHandle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105f0bbfe894dbd369fd488197609d607110695e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->