### PR TITLE
[codex] Improve Codex native stream UI

### DIFF
--- a/src/progressView/frontend/formatters/constants.ts
+++ b/src/progressView/frontend/formatters/constants.ts
@@ -133,6 +133,16 @@ export const DIFF_MARKER_THRESHOLD = 2;
 export const TRIVIAL_WRITE_OUTPUT = 'written';
 
 /**
+ * Friendly display labels for tool names that shouldn't be shown verbatim.
+ */
+export const TOOL_LABEL_MAP: Record<string, string> = {
+  codex_patch: 'Codex Files',
+  codex_thread: 'Codex Thread',
+  codex_todo: 'Codex Plan',
+  codex_turn: 'Codex Turn',
+};
+
+/**
  * Tool icon mapping for different tool types.
  * Maps tool names to VS Code codicon classes.
  */
@@ -202,4 +212,8 @@ export const TOOL_ICON_MAP: Record<string, string> = {
 
   // External agents
   codex: 'codicon-robot',
+  codex_patch: 'codicon-diff',
+  codex_thread: 'codicon-comment-discussion',
+  codex_todo: 'codicon-checklist',
+  codex_turn: 'codicon-check-all',
 };

--- a/src/progressView/frontend/formatters/litTemplates.ts
+++ b/src/progressView/frontend/formatters/litTemplates.ts
@@ -8,6 +8,7 @@
 import { html, nothing, type TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { when } from 'lit/directives/when.js';
@@ -16,5 +17,14 @@ import { when } from 'lit/directives/when.js';
 export type FormatResult = TemplateResult | null;
 
 // Re-export directives for use in formatter templates
-export { html, nothing, classMap, ifDefined, styleMap, unsafeHTML, when };
+export {
+  html,
+  nothing,
+  classMap,
+  ifDefined,
+  repeat,
+  styleMap,
+  unsafeHTML,
+  when,
+};
 export type { TemplateResult };

--- a/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -27,7 +27,7 @@ import {
 import { buildToolUseSection, wrapInPre } from '../htmlBuilders';
 import { formatTokens } from '../timestampUtils';
 
-type RenderableSection = TemplateResult | typeof nothing;
+type RenderableSection = TemplateResult | typeof nothing | undefined | null;
 type BadgeData = { iconClass: string; label: string };
 type CodexToolRenderer = (input: unknown) => RenderableSection;
 
@@ -58,7 +58,8 @@ function renderSectionGroup(
   sections: readonly RenderableSection[],
 ): RenderableSection {
   const visibleSections = sections.filter(
-    (section): section is TemplateResult => section !== nothing,
+    (section): section is TemplateResult =>
+      section !== nothing && section != null,
   );
   if (visibleSections.length === 0) {
     return nothing;

--- a/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -15,53 +15,73 @@ import {
 import { formatDuration } from '@utils/core';
 
 // Local imports - Lit template utilities
-import { html, type TemplateResult } from '../litTemplates';
+import {
+  html,
+  nothing,
+  repeat,
+  when,
+  type TemplateResult,
+} from '../litTemplates';
 
 // Local imports - formatter helpers
 import { buildToolUseSection, wrapInPre } from '../htmlBuilders';
 import { formatTokens } from '../timestampUtils';
 
-type CodexRenderableToolName =
-  | 'codex'
-  | typeof CODEX_FILE_CHANGE_TOOL
-  | typeof CODEX_THREAD_TOOL
-  | typeof CODEX_TODO_TOOL
-  | typeof CODEX_TURN_TOOL;
+type RenderableSection = TemplateResult | typeof nothing;
+type BadgeData = { iconClass: string; label: string };
+type CodexToolRenderer = (input: unknown) => RenderableSection;
 
-function compactSections(
-  sections: Array<TemplateResult | null>,
-): TemplateResult[] {
-  return sections.filter(
-    (section): section is TemplateResult => section !== null,
-  );
-}
-
-function renderBadge(iconClass: string, label: string): TemplateResult {
+function renderBadge({ iconClass, label }: BadgeData): TemplateResult {
   // prettier-ignore
   return html`<span class="extract-flag"><i class="codicon ${iconClass}"></i> ${label}</span>`;
 }
 
 function renderBadgeSection(
   label: string,
-  badges: Array<{ iconClass: string; label: string }>,
-): TemplateResult | null {
+  badges: BadgeData[],
+): RenderableSection {
   if (badges.length === 0) {
-    return null;
+    return nothing;
   }
 
   return buildToolUseSection(
     label,
-    html`${badges.map((badge) => renderBadge(badge.iconClass, badge.label))}`,
+    html`${repeat(
+      badges,
+      (badge) => `${badge.iconClass}:${badge.label}`,
+      renderBadge,
+    )}`,
   );
 }
 
-function renderCodexPromptSection(input: CodexInput): TemplateResult | null {
-  return input.prompt
-    ? buildToolUseSection('Prompt:', wrapInPre(input.prompt))
-    : null;
+function renderSectionGroup(
+  sections: readonly RenderableSection[],
+): RenderableSection {
+  const visibleSections = sections.filter(
+    (section): section is TemplateResult => section !== nothing,
+  );
+  if (visibleSections.length === 0) {
+    return nothing;
+  }
+
+  return html`${repeat(
+    visibleSections,
+    (_section, index) => index,
+    (section, index) =>
+      html`${when(
+        index > 0,
+        () => html`<hr class="tool-use-separator" />`,
+      )}${section}`,
+  )}`;
 }
 
-function renderCodexModeSection(input: CodexInput): TemplateResult | null {
+function renderCodexPromptSection(input: CodexInput): RenderableSection {
+  return when(Boolean(input.prompt), () =>
+    buildToolUseSection('Prompt:', wrapInPre(input.prompt)),
+  );
+}
+
+function renderCodexModeSection(input: CodexInput): RenderableSection {
   const badges = [
     ...(input.sandbox_mode
       ? [{ iconClass: 'codicon-shield', label: input.sandbox_mode }]
@@ -74,28 +94,27 @@ function renderCodexModeSection(input: CodexInput): TemplateResult | null {
   return renderBadgeSection('Mode:', badges);
 }
 
-function renderCodexDirectorySection(input: CodexInput): TemplateResult | null {
-  return input.working_directory
-    ? buildToolUseSection('Directory:', wrapInPre(input.working_directory))
-    : null;
+function renderCodexDirectorySection(input: CodexInput): RenderableSection {
+  const workingDirectory = input.working_directory ?? '';
+  return when(workingDirectory.length > 0, () =>
+    buildToolUseSection('Directory:', wrapInPre(workingDirectory)),
+  );
 }
 
-function renderCodexInputSections(input: unknown): TemplateResult[] | null {
+function renderCodexInputContent(input: unknown): RenderableSection {
   if (!isPlainObject(input)) {
-    return null;
+    return nothing;
   }
 
   const codexInput = input as CodexInput;
-  return compactSections([
+  return renderSectionGroup([
     renderCodexPromptSection(codexInput),
     renderCodexModeSection(codexInput),
     renderCodexDirectorySection(codexInput),
   ]);
 }
 
-function renderCodexFileStatusSection(
-  patchStatus: string,
-): TemplateResult | null {
+function renderCodexFileStatusSection(patchStatus: string): RenderableSection {
   return patchStatus
     ? renderBadgeSection('Status:', [
         {
@@ -104,25 +123,46 @@ function renderCodexFileStatusSection(
           label: patchStatus,
         },
       ])
-    : null;
+    : nothing;
+}
+
+function renderCodexFileChangeItem(change: CodexFileChange): TemplateResult {
+  return html`
+    <li class="detail-item">
+      <i class="codicon codicon-file"></i>
+      <span class="file-link clickable-link" data-file=${change.path}
+        >${change.path}</span
+      >
+      <span class="file-source">(${change.kind})</span>
+    </li>
+  `;
 }
 
 function renderCodexFileListSection(
   changes: CodexFileChange[],
-): TemplateResult | null {
-  if (changes.length === 0) {
-    return null;
-  }
-
-  // prettier-ignore
-  return buildToolUseSection('Files:', html`<ul class="detail-list">${changes.map((change) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${change.path}>${change.path}</span> <span class="file-source">(${change.kind})</span></li>`)}</ul>`);
+): RenderableSection {
+  return when(
+    changes.length > 0,
+    () => html`
+      ${buildToolUseSection(
+        'Files:',
+        html`
+          <ul class="detail-list">
+            ${repeat(
+              changes,
+              (change) => `${change.kind}:${change.path}`,
+              renderCodexFileChangeItem,
+            )}
+          </ul>
+        `,
+      )}
+    `,
+  );
 }
 
-function renderCodexFileChangeSections(
-  input: unknown,
-): TemplateResult[] | null {
+function renderCodexFileChangeContent(input: unknown): RenderableSection {
   if (!isPlainObject(input)) {
-    return null;
+    return nothing;
   }
 
   const patchInput = input as Partial<CodexFileChangeToolInput>;
@@ -135,30 +175,35 @@ function renderCodexFileChangeSections(
   const patchStatus =
     typeof patchInput.patchStatus === 'string' ? patchInput.patchStatus : '';
 
-  return compactSections([
+  return renderSectionGroup([
     renderCodexFileStatusSection(patchStatus),
     renderCodexFileListSection(changes),
   ]);
 }
 
-function renderCodexThreadSections(input: unknown): TemplateResult[] | null {
+function renderCodexThreadContent(input: unknown): RenderableSection {
   if (!isPlainObject(input)) {
-    return null;
+    return nothing;
   }
 
   const threadInput = input as Partial<CodexThreadToolInput>;
-  return compactSections([
-    typeof threadInput.threadId === 'string' && threadInput.threadId
-      ? // prettier-ignore
-        buildToolUseSection('Thread ID:', html`<code class="execution-id">${threadInput.threadId}</code>`)
-      : null,
+  return renderSectionGroup([
+    when(
+      typeof threadInput.threadId === 'string' &&
+        threadInput.threadId.length > 0,
+      () =>
+        buildToolUseSection(
+          'Thread ID:',
+          html`<code class="execution-id">${threadInput.threadId}</code>`,
+        ),
+    ),
   ]);
 }
 
 function renderCodexTodoProgressSection(
   completedCount: number,
   totalCount: number,
-): TemplateResult | null {
+): RenderableSection {
   return totalCount > 0
     ? renderBadgeSection('Progress:', [
         {
@@ -166,23 +211,50 @@ function renderCodexTodoProgressSection(
           label: `${completedCount}/${totalCount} completed`,
         },
       ])
-    : null;
+    : nothing;
+}
+
+function renderCodexTodoItem(item: {
+  text: string;
+  completed: boolean;
+}): TemplateResult {
+  return html`
+    <li class="detail-item">
+      <i
+        class="codicon ${item.completed
+          ? 'codicon-pass-filled'
+          : 'codicon-circle-large-outline'}"
+      ></i>
+      <span>${item.text}</span>
+    </li>
+  `;
 }
 
 function renderCodexTodoListSection(
   items: Array<{ text: string; completed: boolean }>,
-): TemplateResult | null {
-  if (items.length === 0) {
-    return null;
-  }
-
-  // prettier-ignore
-  return buildToolUseSection('Checklist:', html`<ul class="detail-list">${items.map((item) => html`<li class="detail-item"><i class="codicon ${item.completed ? 'codicon-pass-filled' : 'codicon-circle-large-outline'}"></i> <span>${item.text}</span></li>`)}</ul>`);
+): RenderableSection {
+  return when(
+    items.length > 0,
+    () => html`
+      ${buildToolUseSection(
+        'Checklist:',
+        html`
+          <ul class="detail-list">
+            ${repeat(
+              items,
+              (item, index) => `${index}:${item.text}:${item.completed}`,
+              renderCodexTodoItem,
+            )}
+          </ul>
+        `,
+      )}
+    `,
+  );
 }
 
-function renderCodexTodoSections(input: unknown): TemplateResult[] | null {
+function renderCodexTodoContent(input: unknown): RenderableSection {
   if (!isPlainObject(input)) {
-    return null;
+    return nothing;
   }
 
   const todoInput = input as Partial<CodexTodoToolInput>;
@@ -198,7 +270,7 @@ function renderCodexTodoSections(input: unknown): TemplateResult[] | null {
       )
     : [];
 
-  return compactSections([
+  return renderSectionGroup([
     renderCodexTodoProgressSection(completedCount, totalCount),
     renderCodexTodoListSection(items),
   ]);
@@ -212,25 +284,23 @@ function getCodexTurnStateIcon(state: string): string {
       : 'codicon-check';
 }
 
-function renderCodexTurnStateSection(state: string): TemplateResult | null {
+function renderCodexTurnStateSection(state: string): RenderableSection {
   return state
     ? renderBadgeSection('State:', [
         { iconClass: getCodexTurnStateIcon(state), label: state },
       ])
-    : null;
+    : nothing;
 }
 
-function renderCodexTurnDurationSection(
-  wallTimeMs: number,
-): TemplateResult | null {
+function renderCodexTurnDurationSection(wallTimeMs: number): RenderableSection {
   return wallTimeMs > 0
     ? buildToolUseSection('Duration:', wrapInPre(formatDuration(wallTimeMs)))
-    : null;
+    : nothing;
 }
 
 function renderCodexTurnUsageSection(
   turnInput: Partial<CodexTurnToolInput>,
-): TemplateResult | null {
+): RenderableSection {
   const badges = [
     ...(typeof turnInput.inputTokens === 'number'
       ? [
@@ -262,9 +332,9 @@ function renderCodexTurnUsageSection(
   return renderBadgeSection('Usage:', badges);
 }
 
-function renderCodexTurnSections(input: unknown): TemplateResult[] | null {
+function renderCodexTurnContent(input: unknown): RenderableSection {
   if (!isPlainObject(input)) {
-    return null;
+    return nothing;
   }
 
   const turnInput = input as Partial<CodexTurnToolInput>;
@@ -272,29 +342,17 @@ function renderCodexTurnSections(input: unknown): TemplateResult[] | null {
   const wallTimeMs =
     typeof turnInput.wallTimeMs === 'number' ? turnInput.wallTimeMs : 0;
 
-  return compactSections([
+  return renderSectionGroup([
     renderCodexTurnStateSection(state),
     renderCodexTurnDurationSection(wallTimeMs),
     renderCodexTurnUsageSection(turnInput),
   ]);
 }
 
-export function renderCodexToolSections(
-  toolName: string,
-  input: unknown,
-): TemplateResult[] | null {
-  switch (toolName as CodexRenderableToolName) {
-    case 'codex':
-      return renderCodexInputSections(input);
-    case CODEX_FILE_CHANGE_TOOL:
-      return renderCodexFileChangeSections(input);
-    case CODEX_THREAD_TOOL:
-      return renderCodexThreadSections(input);
-    case CODEX_TODO_TOOL:
-      return renderCodexTodoSections(input);
-    case CODEX_TURN_TOOL:
-      return renderCodexTurnSections(input);
-    default:
-      return null;
-  }
-}
+export const codexToolRenderers = {
+  codex: renderCodexInputContent,
+  [CODEX_FILE_CHANGE_TOOL]: renderCodexFileChangeContent,
+  [CODEX_THREAD_TOOL]: renderCodexThreadContent,
+  [CODEX_TODO_TOOL]: renderCodexTodoContent,
+  [CODEX_TURN_TOOL]: renderCodexTurnContent,
+} satisfies Record<string, CodexToolRenderer>;

--- a/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -1,0 +1,300 @@
+// Local imports - shared utilities
+import { isPlainObject } from '@shared/utils/string';
+import type { CodexInput } from '@tools/codex';
+import {
+  CODEX_FILE_CHANGE_TOOL,
+  CODEX_THREAD_TOOL,
+  CODEX_TODO_TOOL,
+  CODEX_TURN_TOOL,
+  type CodexFileChange,
+  type CodexFileChangeToolInput,
+  type CodexThreadToolInput,
+  type CodexTodoToolInput,
+  type CodexTurnToolInput,
+} from '@tools/codexShared';
+import { formatDuration } from '@utils/core';
+
+// Local imports - Lit template utilities
+import { html, type TemplateResult } from '../litTemplates';
+
+// Local imports - formatter helpers
+import { buildToolUseSection, wrapInPre } from '../htmlBuilders';
+import { formatTokens } from '../timestampUtils';
+
+type CodexRenderableToolName =
+  | 'codex'
+  | typeof CODEX_FILE_CHANGE_TOOL
+  | typeof CODEX_THREAD_TOOL
+  | typeof CODEX_TODO_TOOL
+  | typeof CODEX_TURN_TOOL;
+
+function compactSections(
+  sections: Array<TemplateResult | null>,
+): TemplateResult[] {
+  return sections.filter(
+    (section): section is TemplateResult => section !== null,
+  );
+}
+
+function renderBadge(iconClass: string, label: string): TemplateResult {
+  // prettier-ignore
+  return html`<span class="extract-flag"><i class="codicon ${iconClass}"></i> ${label}</span>`;
+}
+
+function renderBadgeSection(
+  label: string,
+  badges: Array<{ iconClass: string; label: string }>,
+): TemplateResult | null {
+  if (badges.length === 0) {
+    return null;
+  }
+
+  return buildToolUseSection(
+    label,
+    html`${badges.map((badge) => renderBadge(badge.iconClass, badge.label))}`,
+  );
+}
+
+function renderCodexPromptSection(input: CodexInput): TemplateResult | null {
+  return input.prompt
+    ? buildToolUseSection('Prompt:', wrapInPre(input.prompt))
+    : null;
+}
+
+function renderCodexModeSection(input: CodexInput): TemplateResult | null {
+  const badges = [
+    ...(input.sandbox_mode
+      ? [{ iconClass: 'codicon-shield', label: input.sandbox_mode }]
+      : []),
+    ...(input.run_in_background
+      ? [{ iconClass: 'codicon-run-all', label: 'background' }]
+      : []),
+  ];
+
+  return renderBadgeSection('Mode:', badges);
+}
+
+function renderCodexDirectorySection(input: CodexInput): TemplateResult | null {
+  return input.working_directory
+    ? buildToolUseSection('Directory:', wrapInPre(input.working_directory))
+    : null;
+}
+
+function renderCodexInputSections(input: unknown): TemplateResult[] | null {
+  if (!isPlainObject(input)) {
+    return null;
+  }
+
+  const codexInput = input as CodexInput;
+  return compactSections([
+    renderCodexPromptSection(codexInput),
+    renderCodexModeSection(codexInput),
+    renderCodexDirectorySection(codexInput),
+  ]);
+}
+
+function renderCodexFileStatusSection(
+  patchStatus: string,
+): TemplateResult | null {
+  return patchStatus
+    ? renderBadgeSection('Status:', [
+        {
+          iconClass:
+            patchStatus === 'failed' ? 'codicon-error' : 'codicon-check',
+          label: patchStatus,
+        },
+      ])
+    : null;
+}
+
+function renderCodexFileListSection(
+  changes: CodexFileChange[],
+): TemplateResult | null {
+  if (changes.length === 0) {
+    return null;
+  }
+
+  // prettier-ignore
+  return buildToolUseSection('Files:', html`<ul class="detail-list">${changes.map((change) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${change.path}>${change.path}</span> <span class="file-source">(${change.kind})</span></li>`)}</ul>`);
+}
+
+function renderCodexFileChangeSections(
+  input: unknown,
+): TemplateResult[] | null {
+  if (!isPlainObject(input)) {
+    return null;
+  }
+
+  const patchInput = input as Partial<CodexFileChangeToolInput>;
+  const changes = Array.isArray(patchInput.changes)
+    ? patchInput.changes.filter(
+        (change): change is CodexFileChange =>
+          typeof change?.path === 'string' && typeof change?.kind === 'string',
+      )
+    : [];
+  const patchStatus =
+    typeof patchInput.patchStatus === 'string' ? patchInput.patchStatus : '';
+
+  return compactSections([
+    renderCodexFileStatusSection(patchStatus),
+    renderCodexFileListSection(changes),
+  ]);
+}
+
+function renderCodexThreadSections(input: unknown): TemplateResult[] | null {
+  if (!isPlainObject(input)) {
+    return null;
+  }
+
+  const threadInput = input as Partial<CodexThreadToolInput>;
+  return compactSections([
+    typeof threadInput.threadId === 'string' && threadInput.threadId
+      ? // prettier-ignore
+        buildToolUseSection('Thread ID:', html`<code class="execution-id">${threadInput.threadId}</code>`)
+      : null,
+  ]);
+}
+
+function renderCodexTodoProgressSection(
+  completedCount: number,
+  totalCount: number,
+): TemplateResult | null {
+  return totalCount > 0
+    ? renderBadgeSection('Progress:', [
+        {
+          iconClass: 'codicon-checklist',
+          label: `${completedCount}/${totalCount} completed`,
+        },
+      ])
+    : null;
+}
+
+function renderCodexTodoListSection(
+  items: Array<{ text: string; completed: boolean }>,
+): TemplateResult | null {
+  if (items.length === 0) {
+    return null;
+  }
+
+  // prettier-ignore
+  return buildToolUseSection('Checklist:', html`<ul class="detail-list">${items.map((item) => html`<li class="detail-item"><i class="codicon ${item.completed ? 'codicon-pass-filled' : 'codicon-circle-large-outline'}"></i> <span>${item.text}</span></li>`)}</ul>`);
+}
+
+function renderCodexTodoSections(input: unknown): TemplateResult[] | null {
+  if (!isPlainObject(input)) {
+    return null;
+  }
+
+  const todoInput = input as Partial<CodexTodoToolInput>;
+  const totalCount =
+    typeof todoInput.totalCount === 'number' ? todoInput.totalCount : 0;
+  const completedCount =
+    typeof todoInput.completedCount === 'number' ? todoInput.completedCount : 0;
+  const items = Array.isArray(todoInput.items)
+    ? todoInput.items.filter(
+        (item): item is { text: string; completed: boolean } =>
+          typeof item?.text === 'string' &&
+          typeof item?.completed === 'boolean',
+      )
+    : [];
+
+  return compactSections([
+    renderCodexTodoProgressSection(completedCount, totalCount),
+    renderCodexTodoListSection(items),
+  ]);
+}
+
+function getCodexTurnStateIcon(state: string): string {
+  return state === 'failed'
+    ? 'codicon-error'
+    : state === 'running'
+      ? 'codicon-sync spin'
+      : 'codicon-check';
+}
+
+function renderCodexTurnStateSection(state: string): TemplateResult | null {
+  return state
+    ? renderBadgeSection('State:', [
+        { iconClass: getCodexTurnStateIcon(state), label: state },
+      ])
+    : null;
+}
+
+function renderCodexTurnDurationSection(
+  wallTimeMs: number,
+): TemplateResult | null {
+  return wallTimeMs > 0
+    ? buildToolUseSection('Duration:', wrapInPre(formatDuration(wallTimeMs)))
+    : null;
+}
+
+function renderCodexTurnUsageSection(
+  turnInput: Partial<CodexTurnToolInput>,
+): TemplateResult | null {
+  const badges = [
+    ...(typeof turnInput.inputTokens === 'number'
+      ? [
+          {
+            iconClass: 'codicon-arrow-up',
+            label: `${formatTokens(turnInput.inputTokens)} in`,
+          },
+        ]
+      : []),
+    ...(typeof turnInput.outputTokens === 'number'
+      ? [
+          {
+            iconClass: 'codicon-arrow-down',
+            label: `${formatTokens(turnInput.outputTokens)} out`,
+          },
+        ]
+      : []),
+    ...(typeof turnInput.cachedInputTokens === 'number' &&
+    turnInput.cachedInputTokens > 0
+      ? [
+          {
+            iconClass: 'codicon-history',
+            label: `${formatTokens(turnInput.cachedInputTokens)} cached`,
+          },
+        ]
+      : []),
+  ];
+
+  return renderBadgeSection('Usage:', badges);
+}
+
+function renderCodexTurnSections(input: unknown): TemplateResult[] | null {
+  if (!isPlainObject(input)) {
+    return null;
+  }
+
+  const turnInput = input as Partial<CodexTurnToolInput>;
+  const state = typeof turnInput.state === 'string' ? turnInput.state : '';
+  const wallTimeMs =
+    typeof turnInput.wallTimeMs === 'number' ? turnInput.wallTimeMs : 0;
+
+  return compactSections([
+    renderCodexTurnStateSection(state),
+    renderCodexTurnDurationSection(wallTimeMs),
+    renderCodexTurnUsageSection(turnInput),
+  ]);
+}
+
+export function renderCodexToolSections(
+  toolName: string,
+  input: unknown,
+): TemplateResult[] | null {
+  switch (toolName as CodexRenderableToolName) {
+    case 'codex':
+      return renderCodexInputSections(input);
+    case CODEX_FILE_CHANGE_TOOL:
+      return renderCodexFileChangeSections(input);
+    case CODEX_THREAD_TOOL:
+      return renderCodexThreadSections(input);
+    case CODEX_TODO_TOOL:
+      return renderCodexTodoSections(input);
+    case CODEX_TURN_TOOL:
+      return renderCodexTurnSections(input);
+    default:
+      return null;
+  }
+}

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -26,21 +26,8 @@ import type {
   WorkflowAgentInput,
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
-import type { CodexInput } from '@tools/codex';
-import {
-  CODEX_FILE_CHANGE_TOOL,
-  CODEX_THREAD_TOOL,
-  CODEX_TODO_TOOL,
-  CODEX_TURN_TOOL,
-  type CodexFileChange,
-  type CodexFileChangeToolInput,
-  type CodexMcpToolOutput,
-  type CodexThreadToolInput,
-  type CodexTodoToolInput,
-  type CodexTurnToolInput,
-} from '@tools/codexShared';
+import { type CodexMcpToolOutput } from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
-import { formatDuration } from '@utils/core';
 
 // Local imports - Lit template utilities
 import {
@@ -67,7 +54,7 @@ import {
 import { normalizeToolUseData } from '../logDataParsers';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage, extractCodeOnlyInput } from '../parseUtils';
-import { formatTokens } from '../timestampUtils';
+import { renderCodexToolSections } from './codexToolTemplates';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
@@ -542,148 +529,9 @@ export function formatToolUseTemplate(
       sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
     }
   }
-  // Handle codex tool with structured display
-  else if (toolName === 'codex' && isPlainObject(input)) {
-    const codexInput = input as CodexInput;
-
-    // Prompt as readable text
-    if (codexInput.prompt) {
-      sections.push(
-        buildToolUseSection('Prompt:', wrapInPre(codexInput.prompt)),
-      );
-    }
-
-    // Sandbox mode + background as compact badges
-    const badges: TemplateResult[] = [];
-    if (codexInput.sandbox_mode) {
-      // prettier-ignore
-      badges.push(html`<span class="extract-flag"><i class="codicon codicon-shield"></i> ${codexInput.sandbox_mode}</span>`);
-    }
-    if (codexInput.run_in_background) {
-      // prettier-ignore
-      badges.push(html`<span class="extract-flag"><i class="codicon codicon-run-all"></i> background</span>`);
-    }
-    if (badges.length > 0) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Mode:', html`${badges}`));
-    }
-
-    // Working directory if specified
-    if (codexInput.working_directory) {
-      sections.push(
-        buildToolUseSection(
-          'Directory:',
-          wrapInPre(codexInput.working_directory),
-        ),
-      );
-    }
-  }
-  // Handle Codex file changes as native tool-use file cards
-  else if (toolName === CODEX_FILE_CHANGE_TOOL && isPlainObject(input)) {
-    const patchInput = input as Partial<CodexFileChangeToolInput>;
-    const changes = Array.isArray(patchInput.changes)
-      ? (input.changes as CodexFileChange[]).filter(
-          (change) =>
-            typeof change?.path === 'string' &&
-            typeof change?.kind === 'string',
-        )
-      : [];
-    const patchStatus =
-      typeof patchInput.patchStatus === 'string' ? patchInput.patchStatus : '';
-
-    if (patchStatus) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${patchStatus === 'failed' ? 'codicon-error' : 'codicon-check'}"></i> ${patchStatus}</span>`));
-    }
-
-    if (changes.length > 0) {
-      // prettier-ignore
-      const fileItems = html`${changes.map((change) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${change.path}>${change.path}</span> <span class="file-source">(${change.kind})</span></li>`)}`;
-      // prettier-ignore
-      sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
-    }
-  }
-  // Handle Codex thread lifecycle cards
-  else if (toolName === CODEX_THREAD_TOOL && isPlainObject(input)) {
-    const threadInput = input as Partial<CodexThreadToolInput>;
-    if (typeof threadInput.threadId === 'string' && threadInput.threadId) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Thread ID:', html`<code class="execution-id">${threadInput.threadId}</code>`));
-    }
-  }
-  // Handle Codex todo/checklist cards
-  else if (toolName === CODEX_TODO_TOOL && isPlainObject(input)) {
-    const todoInput = input as Partial<CodexTodoToolInput>;
-    const totalCount =
-      typeof todoInput.totalCount === 'number' ? todoInput.totalCount : 0;
-    const completedCount =
-      typeof todoInput.completedCount === 'number'
-        ? todoInput.completedCount
-        : 0;
-    const items = Array.isArray(todoInput.items)
-      ? todoInput.items.filter(
-          (item) =>
-            typeof item?.text === 'string' &&
-            typeof item?.completed === 'boolean',
-        )
-      : [];
-
-    if (totalCount > 0) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Progress:', html`<span class="extract-flag"><i class="codicon codicon-checklist"></i> ${completedCount}/${totalCount} completed</span>`));
-    }
-
-    if (items.length > 0) {
-      // prettier-ignore
-      const todoItems = html`${items.map((item) => html`<li class="detail-item"><i class="codicon ${item.completed ? 'codicon-pass-filled' : 'codicon-circle-large-outline'}"></i> <span>${item.text}</span></li>`)}`;
-      // prettier-ignore
-      sections.push(buildToolUseSection('Checklist:', html`<ul class="detail-list">${todoItems}</ul>`));
-    }
-  }
-  // Handle Codex turn summaries as native tool-use cards
-  else if (toolName === CODEX_TURN_TOOL && isPlainObject(input)) {
-    const turnInput = input as Partial<CodexTurnToolInput>;
-    const state = typeof turnInput.state === 'string' ? turnInput.state : '';
-    const wallTimeMs =
-      typeof turnInput.wallTimeMs === 'number' ? turnInput.wallTimeMs : 0;
-
-    if (state) {
-      const stateIcon =
-        state === 'failed'
-          ? 'codicon-error'
-          : state === 'running'
-            ? 'codicon-sync spin'
-            : 'codicon-check';
-      // prettier-ignore
-      sections.push(buildToolUseSection('State:', html`<span class="extract-flag"><i class="codicon ${stateIcon}"></i> ${state}</span>`));
-    }
-
-    if (wallTimeMs > 0) {
-      sections.push(
-        buildToolUseSection('Duration:', wrapInPre(formatDuration(wallTimeMs))),
-      );
-    }
-
-    const badges: TemplateResult[] = [];
-    if (typeof turnInput.inputTokens === 'number') {
-      // prettier-ignore
-      badges.push(html`<span class="extract-flag"><i class="codicon codicon-arrow-up"></i> ${formatTokens(turnInput.inputTokens)} in</span>`);
-    }
-    if (typeof turnInput.outputTokens === 'number') {
-      // prettier-ignore
-      badges.push(html`<span class="extract-flag"><i class="codicon codicon-arrow-down"></i> ${formatTokens(turnInput.outputTokens)} out</span>`);
-    }
-    if (
-      typeof turnInput.cachedInputTokens === 'number' &&
-      turnInput.cachedInputTokens > 0
-    ) {
-      // prettier-ignore
-      badges.push(html`<span class="extract-flag"><i class="codicon codicon-history"></i> ${formatTokens(turnInput.cachedInputTokens)} cached</span>`);
-    }
-    if (badges.length > 0) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Usage:', html`${badges}`));
-    }
+  // Handle Codex cards through dedicated Lit-native helpers
+  else if (toolName === 'codex' || toolName.startsWith('codex_')) {
+    sections.push(...(renderCodexToolSections(toolName, input) ?? []));
   }
   // Handle MCP tool calls with richer result rendering
   else if (toolName.startsWith('mcp:')) {

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -549,6 +549,8 @@ export function formatToolUseTemplate(
   }
   // Handle MCP tool calls with richer result rendering
   else if (toolName.startsWith('mcp:')) {
+    let renderedMcpOutput = false;
+
     if (input != null) {
       const { text: inputValue, language: inputLanguage } =
         stringifyWithLanguage(input);
@@ -582,10 +584,12 @@ export function formatToolUseTemplate(
             : 'codicon-check';
       // prettier-ignore
       sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${statusIcon}"></i> ${mcpOutput.status}</span>`));
+      renderedMcpOutput = true;
     }
 
     if (textBlocks.length > 0) {
       sections.push(buildToolSection('Response:', textBlocks.join('\n\n')));
+      renderedMcpOutput = true;
     }
 
     if (mcpOutput && 'structuredContent' in mcpOutput) {
@@ -598,6 +602,7 @@ export function formatToolUseTemplate(
             language: structuredLanguage,
           }),
         );
+        renderedMcpOutput = true;
       }
     }
 
@@ -611,10 +616,11 @@ export function formatToolUseTemplate(
             language: contentLanguage,
           }),
         );
+        renderedMcpOutput = true;
       }
     }
 
-    if (sections.length === 0 && outputText) {
+    if (!renderedMcpOutput && outputText) {
       sections.push(
         buildToolSection('Result:', outputText, {
           toolName,

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -27,7 +27,20 @@ import type {
 } from '@tools/DelegationTools';
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
 import type { CodexInput } from '@tools/codex';
+import {
+  CODEX_FILE_CHANGE_TOOL,
+  CODEX_THREAD_TOOL,
+  CODEX_TODO_TOOL,
+  CODEX_TURN_TOOL,
+  type CodexFileChange,
+  type CodexFileChangeToolInput,
+  type CodexMcpToolOutput,
+  type CodexThreadToolInput,
+  type CodexTodoToolInput,
+  type CodexTurnToolInput,
+} from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
+import { formatDuration } from '@utils/core';
 
 // Local imports - Lit template utilities
 import {
@@ -54,12 +67,14 @@ import {
 import { normalizeToolUseData } from '../logDataParsers';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage, extractCodeOnlyInput } from '../parseUtils';
+import { formatTokens } from '../timestampUtils';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
   TOOLS_WITH_FILE_CONTENT,
   TOOL_OUTPUT_LANGUAGES,
   TOOL_CODE_LANGUAGES,
+  TOOL_LABEL_MAP,
   TRIVIAL_WRITE_OUTPUT,
   getLanguageFromPath,
 } from '../constants';
@@ -213,6 +228,16 @@ function buildTerminalSection(label: string, text: string): TemplateResult {
   );
 }
 
+function isMcpTextBlock(
+  block: unknown,
+): block is { type: 'text'; text: string } {
+  return (
+    isPlainObject(block) &&
+    block.type === 'text' &&
+    typeof block.text === 'string'
+  );
+}
+
 /** Format tool use log entry as TemplateResult. */
 export function formatToolUseTemplate(
   message: LogMessageData,
@@ -245,7 +270,9 @@ export function formatToolUseTemplate(
     iconClass = getToolIconClass(toolName, showAsError);
   }
 
-  const titleBase = toolName || 'tool';
+  const titleBase = toolName.startsWith('mcp:')
+    ? `MCP ${toolName.slice(4)}`
+    : (TOOL_LABEL_MAP[toolName] ?? toolName) || 'tool';
 
   // Surface action + path for executions tool so it's visible without expanding
   let headerSummary = normalizedToolLog.headerSummary || '';
@@ -548,6 +575,189 @@ export function formatToolUseTemplate(
           'Directory:',
           wrapInPre(codexInput.working_directory),
         ),
+      );
+    }
+  }
+  // Handle Codex file changes as native tool-use file cards
+  else if (toolName === CODEX_FILE_CHANGE_TOOL && isPlainObject(input)) {
+    const patchInput = input as Partial<CodexFileChangeToolInput>;
+    const changes = Array.isArray(patchInput.changes)
+      ? (input.changes as CodexFileChange[]).filter(
+          (change) =>
+            typeof change?.path === 'string' &&
+            typeof change?.kind === 'string',
+        )
+      : [];
+    const patchStatus =
+      typeof patchInput.patchStatus === 'string' ? patchInput.patchStatus : '';
+
+    if (patchStatus) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${patchStatus === 'failed' ? 'codicon-error' : 'codicon-check'}"></i> ${patchStatus}</span>`));
+    }
+
+    if (changes.length > 0) {
+      // prettier-ignore
+      const fileItems = html`${changes.map((change) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${change.path}>${change.path}</span> <span class="file-source">(${change.kind})</span></li>`)}`;
+      // prettier-ignore
+      sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
+    }
+  }
+  // Handle Codex thread lifecycle cards
+  else if (toolName === CODEX_THREAD_TOOL && isPlainObject(input)) {
+    const threadInput = input as Partial<CodexThreadToolInput>;
+    if (typeof threadInput.threadId === 'string' && threadInput.threadId) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Thread ID:', html`<code class="execution-id">${threadInput.threadId}</code>`));
+    }
+  }
+  // Handle Codex todo/checklist cards
+  else if (toolName === CODEX_TODO_TOOL && isPlainObject(input)) {
+    const todoInput = input as Partial<CodexTodoToolInput>;
+    const totalCount =
+      typeof todoInput.totalCount === 'number' ? todoInput.totalCount : 0;
+    const completedCount =
+      typeof todoInput.completedCount === 'number'
+        ? todoInput.completedCount
+        : 0;
+    const items = Array.isArray(todoInput.items)
+      ? todoInput.items.filter(
+          (item) =>
+            typeof item?.text === 'string' &&
+            typeof item?.completed === 'boolean',
+        )
+      : [];
+
+    if (totalCount > 0) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Progress:', html`<span class="extract-flag"><i class="codicon codicon-checklist"></i> ${completedCount}/${totalCount} completed</span>`));
+    }
+
+    if (items.length > 0) {
+      // prettier-ignore
+      const todoItems = html`${items.map((item) => html`<li class="detail-item"><i class="codicon ${item.completed ? 'codicon-pass-filled' : 'codicon-circle-large-outline'}"></i> <span>${item.text}</span></li>`)}`;
+      // prettier-ignore
+      sections.push(buildToolUseSection('Checklist:', html`<ul class="detail-list">${todoItems}</ul>`));
+    }
+  }
+  // Handle Codex turn summaries as native tool-use cards
+  else if (toolName === CODEX_TURN_TOOL && isPlainObject(input)) {
+    const turnInput = input as Partial<CodexTurnToolInput>;
+    const state = typeof turnInput.state === 'string' ? turnInput.state : '';
+    const wallTimeMs =
+      typeof turnInput.wallTimeMs === 'number' ? turnInput.wallTimeMs : 0;
+
+    if (state) {
+      const stateIcon =
+        state === 'failed'
+          ? 'codicon-error'
+          : state === 'running'
+            ? 'codicon-sync spin'
+            : 'codicon-check';
+      // prettier-ignore
+      sections.push(buildToolUseSection('State:', html`<span class="extract-flag"><i class="codicon ${stateIcon}"></i> ${state}</span>`));
+    }
+
+    if (wallTimeMs > 0) {
+      sections.push(
+        buildToolUseSection('Duration:', wrapInPre(formatDuration(wallTimeMs))),
+      );
+    }
+
+    const badges: TemplateResult[] = [];
+    if (typeof turnInput.inputTokens === 'number') {
+      // prettier-ignore
+      badges.push(html`<span class="extract-flag"><i class="codicon codicon-arrow-up"></i> ${formatTokens(turnInput.inputTokens)} in</span>`);
+    }
+    if (typeof turnInput.outputTokens === 'number') {
+      // prettier-ignore
+      badges.push(html`<span class="extract-flag"><i class="codicon codicon-arrow-down"></i> ${formatTokens(turnInput.outputTokens)} out</span>`);
+    }
+    if (
+      typeof turnInput.cachedInputTokens === 'number' &&
+      turnInput.cachedInputTokens > 0
+    ) {
+      // prettier-ignore
+      badges.push(html`<span class="extract-flag"><i class="codicon codicon-history"></i> ${formatTokens(turnInput.cachedInputTokens)} cached</span>`);
+    }
+    if (badges.length > 0) {
+      // prettier-ignore
+      sections.push(buildToolUseSection('Usage:', html`${badges}`));
+    }
+  }
+  // Handle MCP tool calls with richer result rendering
+  else if (toolName.startsWith('mcp:')) {
+    if (input != null) {
+      const { text: inputValue, language: inputLanguage } =
+        stringifyWithLanguage(input);
+      if (inputValue) {
+        sections.push(
+          buildToolSection('Arguments:', inputValue, {
+            toolName,
+            language: inputLanguage,
+          }),
+        );
+      }
+    }
+
+    const mcpOutput = isPlainObject(parsed.output)
+      ? (parsed.output as Partial<CodexMcpToolOutput>)
+      : null;
+    const contentBlocks = Array.isArray(mcpOutput?.contentBlocks)
+      ? mcpOutput.contentBlocks
+      : [];
+    const textBlocks = contentBlocks
+      .filter(isMcpTextBlock)
+      .map((block) => block.text);
+    const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
+
+    if (typeof mcpOutput?.status === 'string') {
+      const statusIcon =
+        mcpOutput.status === 'failed'
+          ? 'codicon-error'
+          : mcpOutput.status === 'in_progress'
+            ? 'codicon-sync spin'
+            : 'codicon-check';
+      // prettier-ignore
+      sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${statusIcon}"></i> ${mcpOutput.status}</span>`));
+    }
+
+    if (textBlocks.length > 0) {
+      sections.push(buildToolSection('Response:', textBlocks.join('\n\n')));
+    }
+
+    if (mcpOutput && 'structuredContent' in mcpOutput) {
+      const { text: structuredText, language: structuredLanguage } =
+        stringifyWithLanguage(mcpOutput.structuredContent);
+      if (structuredText) {
+        sections.push(
+          buildToolSection('Structured:', structuredText, {
+            toolName,
+            language: structuredLanguage,
+          }),
+        );
+      }
+    }
+
+    if (otherBlocks.length > 0) {
+      const { text: contentText, language: contentLanguage } =
+        stringifyWithLanguage(otherBlocks);
+      if (contentText) {
+        sections.push(
+          buildToolSection('Content:', contentText, {
+            toolName,
+            language: contentLanguage,
+          }),
+        );
+      }
+    }
+
+    if (sections.length === 0 && outputText) {
+      sections.push(
+        buildToolSection('Result:', outputText, {
+          toolName,
+          extraClass: 'tool-output-full',
+        }),
       );
     }
   }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -654,6 +654,7 @@ export function formatToolUseTemplate(
     isWriteTool && outputText.trim() === TRIVIAL_WRITE_OUTPUT;
   if (
     outputText &&
+    !toolName.startsWith('mcp:') &&
     !TOOLS_WITH_FILE_LINK.has(toolName) &&
     !isTrivialWriteOutput
   ) {

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -28,6 +28,7 @@ import type {
 import type { AcceptRunFilesInput } from '@tools/AcceptRunFilesTool';
 import { type CodexMcpToolOutput } from '@tools/codexShared';
 import type { MemoryToolInput } from '@tools/memory/MemoryTool';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local imports - Lit template utilities
 import {
@@ -124,8 +125,7 @@ function getToolTimeoutMs(
 /** Truncate a prompt string for display in collapsed headers. */
 function truncatePrompt(text: string, maxLength: number): string {
   const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  if (oneLine.length <= maxLength) return oneLine;
-  return oneLine.slice(0, maxLength - 1) + '…';
+  return truncateWithEllipsis(oneLine, maxLength);
 }
 
 /** Join template sections with horizontal rule separators. */

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -54,7 +54,6 @@ import {
 import { normalizeToolUseData } from '../logDataParsers';
 import { registerProposalInput } from '../proposalInputStore';
 import { stringifyWithLanguage, extractCodeOnlyInput } from '../parseUtils';
-import { renderCodexToolSections } from './codexToolTemplates';
 import {
   TOOLS_WITH_DIFF_INPUT,
   TOOLS_WITH_FILE_LINK,
@@ -65,6 +64,7 @@ import {
   TRIVIAL_WRITE_OUTPUT,
   getLanguageFromPath,
 } from '../constants';
+import { codexToolRenderers } from './codexToolTemplates';
 
 // Side-effect import to register <tool-timer> custom element
 import '../../components/ToolTimer';
@@ -137,6 +137,14 @@ function joinWithSeparator(sections: TemplateResult[]): TemplateResult {
         : ''}`,
   )}`;
 }
+
+type SpecializedToolRenderer = (
+  input: unknown,
+) => TemplateResult | typeof nothing;
+
+const SPECIALIZED_TOOL_SECTION_RENDERERS = {
+  ...codexToolRenderers,
+} satisfies Record<string, SpecializedToolRenderer>;
 
 // Web search provider display names
 const PROVIDER_LABELS: Record<string, string> = {
@@ -529,9 +537,15 @@ export function formatToolUseTemplate(
       sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
     }
   }
-  // Handle Codex cards through dedicated Lit-native helpers
-  else if (toolName === 'codex' || toolName.startsWith('codex_')) {
-    sections.push(...(renderCodexToolSections(toolName, input) ?? []));
+  // Handle specialized structured tool cards via renderer registry
+  else if (Object.hasOwn(SPECIALIZED_TOOL_SECTION_RENDERERS, toolName)) {
+    const content =
+      SPECIALIZED_TOOL_SECTION_RENDERERS[
+        toolName as keyof typeof SPECIALIZED_TOOL_SECTION_RENDERERS
+      ](input);
+    if (content !== nothing) {
+      sections.push(content);
+    }
   }
   // Handle MCP tool calls with richer result rendering
   else if (toolName.startsWith('mcp:')) {

--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -63,6 +63,16 @@ describe('buildCodexWorkspaceOptions', () => {
       additionalDirectories: ['/tmp/workspace'],
     });
   });
+
+  it('does not inject the current workspace into an external worktree path', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    const options = buildCodexWorkspaceOptions('/tmp/worktrees/feature-a');
+
+    assert.deepEqual(options, {
+      workingDirectory: '/tmp/worktrees/feature-a',
+    });
+  });
 });
 
 describe('buildCodexFileChangeToolLog', () => {

--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -175,6 +175,24 @@ describe('buildCodexCommandToolLog', () => {
     });
   });
 
+  it('keeps failed SDK status as error even when exit code is zero', () => {
+    const log = buildCodexCommandToolLog({
+      command: 'lake build',
+      aggregated_output: 'sandbox denied',
+      exit_code: 0,
+      status: 'failed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: 'bash',
+      summary: 'lake build',
+      input: { command: 'lake build' },
+      output: 'sandbox denied',
+      error: 'Command failed (exit 0)',
+      isError: true,
+      status: 'completed',
+    });
+  });
   it('keeps running commands in progress while streaming output', () => {
     const log = buildCodexCommandToolLog({
       command: 'lake build',

--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -1,0 +1,314 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import {
+  buildCodexConfig,
+  buildCodexWorkspaceOptions,
+} from '@tools/codexConfig';
+import {
+  buildCodexCommandToolLog,
+  buildCodexFileChangeToolLog,
+  buildCodexMcpToolLog,
+  buildCodexThreadToolLog,
+  buildCodexTodoToolLog,
+  CODEX_FILE_CHANGE_TOOL,
+  CODEX_AGENT_NAME,
+  CODEX_DISPLAY_MODEL,
+  CODEX_THREAD_TOOL,
+  CODEX_TODO_TOOL,
+  buildCodexTurnToolLog,
+  buildCodexUsageStats,
+  CODEX_TURN_TOOL,
+} from '@tools/codexShared';
+import { WorkspaceFS } from '@utils/files';
+
+describe('buildCodexConfig', () => {
+  it('uses Codex-specific tool-use metadata for child streams', () => {
+    const config = buildCodexConfig('Inspect the failing CI job');
+
+    assert.equal(config.agent, CODEX_AGENT_NAME);
+    assert.equal(config.model, CODEX_DISPLAY_MODEL);
+    assert.equal(config.agentCategory, AgentCategory.ToolUse);
+    assert.equal(config.instruction, 'Inspect the failing CI job');
+  });
+});
+
+describe('buildCodexWorkspaceOptions', () => {
+  const originalGetPath = WorkspaceFS.getPath;
+
+  afterEach(() => {
+    WorkspaceFS.getPath = originalGetPath;
+  });
+
+  it('defaults Codex to the workspace root', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    const options = buildCodexWorkspaceOptions();
+
+    assert.deepEqual(options, {
+      workingDirectory: '/tmp/workspace',
+    });
+  });
+
+  it('keeps the whole workspace available when running from a subdirectory', () => {
+    WorkspaceFS.getPath = () => '/tmp/workspace';
+
+    const options = buildCodexWorkspaceOptions('packages/app');
+
+    assert.deepEqual(options, {
+      workingDirectory: path.resolve('/tmp/workspace', 'packages/app'),
+      additionalDirectories: ['/tmp/workspace'],
+    });
+  });
+});
+
+describe('buildCodexFileChangeToolLog', () => {
+  it('builds a structured Codex patch log entry', () => {
+    const log = buildCodexFileChangeToolLog({
+      changes: [{ kind: 'update', path: '/tmp/workspace/src/App.ts' }],
+      status: 'completed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_FILE_CHANGE_TOOL,
+      summary: 'update App.ts',
+      input: {
+        changes: [{ kind: 'update', path: '/tmp/workspace/src/App.ts' }],
+        patchStatus: 'completed',
+      },
+      status: 'completed',
+    });
+  });
+
+  it('deduplicates repeated file-change entries', () => {
+    const log = buildCodexFileChangeToolLog({
+      changes: [
+        { kind: 'update', path: '/tmp/workspace/src/App.ts' },
+        { kind: 'update', path: '/tmp/workspace/src/App.ts' },
+        { kind: 'add', path: '/tmp/workspace/src/New.ts' },
+      ],
+      status: 'completed',
+    });
+
+    assert.deepEqual(log?.input, {
+      changes: [
+        { kind: 'update', path: '/tmp/workspace/src/App.ts' },
+        { kind: 'add', path: '/tmp/workspace/src/New.ts' },
+      ],
+      patchStatus: 'completed',
+    });
+  });
+
+  it('surfaces failed patches as native errors', () => {
+    const log = buildCodexFileChangeToolLog({
+      changes: [{ kind: 'update', path: '/tmp/workspace/src/App.ts' }],
+      status: 'failed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_FILE_CHANGE_TOOL,
+      summary: 'failed update App.ts',
+      input: {
+        changes: [{ kind: 'update', path: '/tmp/workspace/src/App.ts' }],
+        patchStatus: 'failed',
+      },
+      error: 'Patch apply failed',
+      isError: true,
+      status: 'completed',
+    });
+  });
+});
+
+describe('buildCodexCommandToolLog', () => {
+  it('builds a native bash log entry with command output', () => {
+    const log = buildCodexCommandToolLog({
+      command: 'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean',
+      aggregated_output: 'warning: rebuilding\n',
+      exit_code: 0,
+      status: 'completed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: 'bash',
+      summary: 'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean',
+      input: {
+        command: 'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean',
+      },
+      output: 'warning: rebuilding',
+      status: 'completed',
+    });
+  });
+
+  it('marks failed commands as errors and falls back to exit info when empty', () => {
+    const log = buildCodexCommandToolLog({
+      command:
+        'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean --very-long-flag value',
+      aggregated_output: '',
+      exit_code: 1,
+      status: 'failed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: 'bash',
+      summary: 'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean…',
+      input: {
+        command:
+          'lake env lean MPS/ParentHamiltonian/UniqueGroundState.lean --very-long-flag value',
+      },
+      output: '(exit 1)',
+      error: 'Command failed (exit 1)',
+      isError: true,
+      status: 'completed',
+    });
+  });
+
+  it('keeps running commands in progress while streaming output', () => {
+    const log = buildCodexCommandToolLog({
+      command: 'lake build',
+      aggregated_output: 'Compiling...\n',
+      status: 'in_progress',
+    });
+
+    assert.deepEqual(log, {
+      toolName: 'bash',
+      summary: 'lake build',
+      input: { command: 'lake build' },
+      output: 'Compiling...',
+      status: 'in_progress',
+    });
+  });
+});
+
+describe('buildCodexMcpToolLog', () => {
+  it('preserves structured and block MCP output for native rendering', () => {
+    const log = buildCodexMcpToolLog({
+      id: 'mcp-1',
+      type: 'mcp_tool_call',
+      server: 'github',
+      tool: 'search',
+      arguments: { query: 'codex' },
+      result: {
+        structured_content: { total: 1 },
+        content: [{ type: 'text', text: 'Found one result' }],
+      },
+      status: 'completed',
+    });
+
+    assert.deepEqual(log, {
+      toolName: 'mcp:github/search',
+      input: { query: 'codex' },
+      output: {
+        status: 'completed',
+        structuredContent: { total: 1 },
+        contentBlocks: [{ type: 'text', text: 'Found one result' }],
+      },
+      status: 'completed',
+    });
+  });
+});
+
+describe('buildCodexThreadToolLog', () => {
+  it('builds a native thread lifecycle card', () => {
+    const log = buildCodexThreadToolLog({
+      type: 'thread.started',
+      thread_id: 'thread_123',
+    });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_THREAD_TOOL,
+      summary: 'Created',
+      input: { threadId: 'thread_123' },
+      status: 'completed',
+    });
+  });
+});
+
+describe('buildCodexTodoToolLog', () => {
+  it('builds a native checklist card', () => {
+    const log = buildCodexTodoToolLog(
+      {
+        id: 'todo-1',
+        type: 'todo_list',
+        items: [
+          { text: 'Inspect logs', completed: true },
+          { text: 'Patch formatter', completed: false },
+        ],
+      },
+      'in_progress',
+    );
+
+    assert.deepEqual(log, {
+      toolName: CODEX_TODO_TOOL,
+      summary: '1/2 completed',
+      input: {
+        items: [
+          { text: 'Inspect logs', completed: true },
+          { text: 'Patch formatter', completed: false },
+        ],
+        completedCount: 1,
+        totalCount: 2,
+      },
+      status: 'in_progress',
+    });
+  });
+});
+
+describe('buildCodexTurnToolLog', () => {
+  it('builds a structured Codex turn summary entry', () => {
+    const log = buildCodexTurnToolLog({
+      state: 'completed',
+      wallTimeMs: 518_000,
+      usage: {
+        input_tokens: 5_535_644,
+        output_tokens: 17_166,
+        cached_input_tokens: 1200,
+      },
+    });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_TURN_TOOL,
+      summary: 'Completed',
+      input: {
+        state: 'completed',
+        wallTimeMs: 518_000,
+        inputTokens: 5_535_644,
+        outputTokens: 17_166,
+        cachedInputTokens: 1200,
+      },
+      status: 'completed',
+    });
+  });
+
+  it('builds a running Codex turn entry', () => {
+    const log = buildCodexTurnToolLog({ state: 'running' });
+
+    assert.deepEqual(log, {
+      toolName: CODEX_TURN_TOOL,
+      summary: 'Running',
+      input: {
+        state: 'running',
+      },
+      status: 'in_progress',
+    });
+  });
+});
+
+describe('buildCodexUsageStats', () => {
+  it('maps Codex SDK usage into the shared token usage panel shape', () => {
+    const usage = buildCodexUsageStats({
+      input_tokens: 1200,
+      output_tokens: 80,
+      cached_input_tokens: 300,
+    });
+
+    assert.deepEqual(usage, {
+      inputTokens: 1200,
+      outputTokens: 80,
+      cost: 0,
+      cacheReadInputTokens: 300,
+    });
+  });
+});

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -769,10 +769,14 @@ export class CodexTool extends defineTool({
 
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
+    const workspaceOptions =
+      input.thread_id && input.working_directory == null
+        ? {}
+        : buildCodexWorkspaceOptions(input.working_directory);
     const threadOptions = {
       sandboxMode: input.sandbox_mode,
       skipGitRepoCheck: true as const,
-      ...buildCodexWorkspaceOptions(input.working_directory),
+      ...workspaceOptions,
     };
 
     return input.thread_id

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -22,7 +22,7 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import { type AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   trackExecution,
@@ -42,7 +42,13 @@ import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import type { StreamTabId, ExecutionId, StorageKey } from '@shared/schemas';
+import { AgentUsageReporter } from '@logger/AgentUsageReporter';
+import type {
+  StreamTabId,
+  ExecutionId,
+  StorageKey,
+  ToolUseLog,
+} from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { escapeAttr, escapeText } from '@tools/subagentResults';
@@ -50,7 +56,6 @@ import {
   requestBashApproval,
   buildBashApprovalRejectedResult,
 } from '@tools/approval/bashApproval';
-import { formatDuration } from '@utils/core';
 import { agentConfigToTaskState } from '@utils/config/configConversion';
 import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
@@ -58,17 +63,26 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from './core/define';
+import { buildCodexConfig, buildCodexWorkspaceOptions } from './codexConfig';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
+import {
+  buildCodexCommandToolLog,
+  buildCodexFileChangeToolLog,
+  buildCodexMcpToolLog,
+  buildCodexThreadToolLog,
+  buildCodexTodoToolLog,
+  buildCodexTurnToolLog,
+  buildCodexUsageStats,
+  CODEX_AGENT_NAME,
+} from './codexShared';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
-  McpToolCallItem,
   RunResult,
   SandboxMode,
   Thread,
+  ThreadEvent,
   ThreadItem,
-  TodoListItem,
-  WebSearchItem,
 } from '@openai/codex-sdk';
 
 // ============================================================================
@@ -122,6 +136,15 @@ interface ActiveThread {
 }
 
 const threadRegistry = new Map<string, ActiveThread>();
+
+interface TrackedToolUseLog {
+  logId: string;
+  groupId: string | undefined;
+}
+
+interface ActiveCodexTurnLog extends TrackedToolUseLog {
+  startedAt: number;
+}
 
 /** Store a thread for multi-turn reuse and persist thread ID to disk. */
 function storeThread(threadId: string, entry: ActiveThread): void {
@@ -247,14 +270,6 @@ function formatCodexError(
 // Stream tab helpers
 // ============================================================================
 
-/** Build a synthetic AgentConfig for codex (used for TaskState and execution registration). */
-function buildCodexConfig(prompt: string): AgentConfig {
-  return AgentConfigSchema.parse({
-    agent: 'codex',
-    instruction: prompt,
-  });
-}
-
 /** Create a child stream tab for a codex execution and return its logger. */
 function createCodexStream(
   executionId: string,
@@ -285,7 +300,7 @@ function createCodexStream(
     executionId,
     parentStreamId,
     childStreamId,
-    'codex',
+    CODEX_AGENT_NAME,
     'toolUse',
   );
   trackExecution(handle);
@@ -293,34 +308,94 @@ function createCodexStream(
   return { childStreamId, logger };
 }
 
-/** Log a completed codex thread item to the child stream's logger. */
-function logCodexItem(
-  item: ThreadItem,
+function syncCodexTodoState(
+  item: Extract<ThreadItem, { type: 'todo_list' }>,
   childStreamId: StreamTabId,
+): void {
+  const todos = item.items.map((t) => ({
+    content: t.text,
+    status: t.completed ? ('completed' as const) : ('pending' as const),
+    activeForm: t.text,
+  }));
+  bus.emit('updateTodos', { streamId: childStreamId, todos });
+}
+
+function updateTrackedToolUseLog(
+  logger: AgentLogger,
+  trackedLog: TrackedToolUseLog,
+  toolLog: ToolUseLog,
+): void {
+  const { status = 'completed', ...toolLogData } = toolLog;
+  logger.updateToolUse(
+    trackedLog.logId,
+    toolLogData,
+    trackedLog.groupId,
+    status,
+  );
+}
+
+function upsertTrackedToolUseLog(
+  trackedLogs: Map<string, TrackedToolUseLog>,
+  itemId: string,
+  toolLog: ToolUseLog,
+  logger: AgentLogger,
+): void {
+  const trackedLog = trackedLogs.get(itemId);
+  if (trackedLog) {
+    updateTrackedToolUseLog(logger, trackedLog, toolLog);
+  } else {
+    trackedLogs.set(itemId, logger.emitToolUse(toolLog));
+  }
+
+  if (toolLog.status !== 'in_progress') {
+    trackedLogs.delete(itemId);
+  }
+}
+
+function handleTrackedCodexItemEvent(
+  item: Extract<
+    ThreadItem,
+    | { type: 'command_execution' }
+    | { type: 'mcp_tool_call' }
+    | { type: 'todo_list' }
+  >,
+  phase: 'started' | 'updated' | 'completed',
+  childStreamId: StreamTabId,
+  logger: AgentLogger,
+  trackedLogs: Map<string, TrackedToolUseLog>,
+): void {
+  if (item.type === 'todo_list') {
+    syncCodexTodoState(item, childStreamId);
+  }
+
+  const toolLog =
+    item.type === 'command_execution'
+      ? buildCodexCommandToolLog(item)
+      : item.type === 'mcp_tool_call'
+        ? buildCodexMcpToolLog(item)
+        : buildCodexTodoToolLog(
+            item,
+            phase === 'completed' ? 'completed' : 'in_progress',
+          );
+
+  upsertTrackedToolUseLog(trackedLogs, item.id, toolLog, logger);
+}
+
+/** Log a completed codex thread item that does not participate in live updates. */
+function logCompletedCodexItem(
+  item: Exclude<
+    ThreadItem,
+    | { type: 'command_execution' }
+    | { type: 'mcp_tool_call' }
+    | { type: 'todo_list' }
+  >,
   logger: AgentLogger,
 ): void {
   switch (item.type) {
-    case 'command_execution': {
-      const exitInfo =
-        item.exit_code === undefined
-          ? item.status
-          : item.exit_code === 0
-            ? 'ok'
-            : `exit ${item.exit_code}`;
-      logger.logToolUse({
-        toolName: 'bash',
-        input: { command: item.command },
-        output: `(${exitInfo})`,
-        status: 'completed',
-      });
-      break;
-    }
     case 'file_change': {
-      const changes = item.changes.map(
-        (c: { kind: string; path: string }) => `${c.kind} ${c.path}`,
-      );
-      if (changes.length > 0) {
-        logger.info(`Files: ${changes.join(', ')}`);
+      const fileChangeLog = buildCodexFileChangeToolLog(item);
+      if (fileChangeLog) {
+        logger.logToolUse(fileChangeLog);
       }
       break;
     }
@@ -330,74 +405,26 @@ function logCodexItem(
     case 'reasoning':
       logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
-    case 'mcp_tool_call': {
-      const mcp = item as McpToolCallItem;
-      const output = mcp.error
-        ? `Error: ${mcp.error.message}`
-        : mcp.result?.structured_content
-          ? JSON.stringify(mcp.result.structured_content)
-          : `(${mcp.status})`;
-      logger.logToolUse({
-        toolName: `mcp:${mcp.server}/${mcp.tool}`,
-        input: mcp.arguments,
-        output,
-        status: 'completed',
-      });
-      break;
-    }
     case 'web_search':
-      logger.logWebSearch({ query: (item as WebSearchItem).query });
+      logger.logWebSearch({ query: item.query });
       break;
-    case 'todo_list': {
-      const todos = (item as TodoListItem).items.map((t) => ({
-        content: t.text,
-        status: t.completed ? ('completed' as const) : ('pending' as const),
-        activeForm: t.text,
-      }));
-      bus.emit('updateTodos', { streamId: childStreamId, todos });
-      break;
-    }
     case 'error':
       logger.error(item.message);
       break;
   }
 }
 
-/** Log a turn summary to the child stream. */
-function logTurnSummary(
-  logger: AgentLogger,
-  wallTimeMs: number,
-  usage: RunResult['usage'],
-): void {
-  logger.info(`Turn completed in ${formatDuration(wallTimeMs)}`);
-  if (usage) {
-    logger.info(
-      `Tokens: ${usage.input_tokens} in / ${usage.output_tokens} out`,
-    );
-  }
-}
-
-/** Finalize a codex child stream (mark completed/error, log summary). */
+/** Finalize a codex child stream (mark completed/error). */
 function finalizeCodexStream(
   childStreamId: StreamTabId,
   executionId: string,
   logger: AgentLogger,
   options?: {
-    wallTimeMs?: number;
-    usage?: RunResult['usage'];
     error?: unknown;
   },
 ): void {
   if (options?.error) {
     logger.error(toErrorMessage(options.error));
-  }
-  if (options?.wallTimeMs != null) {
-    logger.info(`Completed in ${formatDuration(options.wallTimeMs)}`);
-  }
-  if (options?.usage) {
-    logger.info(
-      `Tokens: ${options.usage.input_tokens} in / ${options.usage.output_tokens} out`,
-    );
   }
   StreamStatusService.set(
     childStreamId,
@@ -443,16 +470,15 @@ function startFollowUpLoop(
         const userMessage = messages.join('\n\n');
 
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
-        const startedAt = Date.now();
 
         try {
-          const turn = await runStreamedTurn(
+          await runStreamedTurn(
             thread,
             userMessage,
             childStreamId,
             logger,
+            executionId,
           );
-          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (err) {
           logger.error(toErrorMessage(err));
         }
@@ -487,22 +513,16 @@ function startFollowUpLoop(
  */
 function handleTurnSuccess(
   thread: Thread,
-  turn: RunResult,
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   logger: AgentLogger,
-  wallTimeMs: number,
 ): void {
   const threadId = thread.id;
   if (threadId) {
-    logTurnSummary(logger, wallTimeMs, turn.usage);
     storeThread(threadId, { thread, childStreamId, logger, executionId });
     startFollowUpLoop(thread, childStreamId, executionId, logger);
   } else {
-    finalizeCodexStream(childStreamId, executionId, logger, {
-      wallTimeMs,
-      usage: turn.usage,
-    });
+    finalizeCodexStream(childStreamId, executionId, logger);
   }
 }
 
@@ -516,17 +536,64 @@ async function runStreamedTurn(
   prompt: string,
   childStreamId: StreamTabId,
   logger: AgentLogger,
+  executionId: ExecutionId,
 ): Promise<RunResult> {
   logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
   const { events } = await thread.runStreamed(prompt);
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;
+  const trackedLogs = new Map<string, TrackedToolUseLog>();
+  let activeTurnLog: ActiveCodexTurnLog | null = null;
+  const usageReporter = new AgentUsageReporter(
+    logger,
+    childStreamId,
+    AgentCategory.ToolUse,
+  );
 
   for await (const event of events) {
     switch (event.type) {
+      case 'thread.started':
+        logger.logToolUse(buildCodexThreadToolLog(event));
+        break;
+      case 'turn.started':
+        activeTurnLog = {
+          ...logger.emitToolUse(buildCodexTurnToolLog({ state: 'running' })),
+          startedAt: Date.now(),
+        };
+        break;
+      case 'item.started':
+      case 'item.updated':
+        if (
+          event.item.type === 'command_execution' ||
+          event.item.type === 'mcp_tool_call' ||
+          event.item.type === 'todo_list'
+        ) {
+          handleTrackedCodexItemEvent(
+            event.item,
+            event.type === 'item.started' ? 'started' : 'updated',
+            childStreamId,
+            logger,
+            trackedLogs,
+          );
+        }
+        break;
       case 'item.completed': {
         const { item } = event;
-        logCodexItem(item, childStreamId, logger);
+        if (
+          item.type === 'command_execution' ||
+          item.type === 'mcp_tool_call' ||
+          item.type === 'todo_list'
+        ) {
+          handleTrackedCodexItemEvent(
+            item,
+            'completed',
+            childStreamId,
+            logger,
+            trackedLogs,
+          );
+        } else {
+          logCompletedCodexItem(item, logger);
+        }
         if (item.type === 'agent_message') {
           responseParts.push(item.text);
         }
@@ -534,11 +601,64 @@ async function runStreamedTurn(
       }
       case 'turn.completed':
         usage = event.usage ?? null;
+        if (usage) {
+          usageReporter.report(
+            buildCodexUsageStats(usage),
+            executionId as StorageKey,
+          );
+        }
+        if (activeTurnLog) {
+          updateTrackedToolUseLog(
+            logger,
+            activeTurnLog,
+            buildCodexTurnToolLog({
+              state: 'completed',
+              wallTimeMs: Date.now() - activeTurnLog.startedAt,
+              usage,
+            }),
+          );
+          activeTurnLog = null;
+        } else {
+          logger.logToolUse(
+            buildCodexTurnToolLog({
+              state: 'completed',
+              usage,
+            }),
+          );
+        }
         break;
-      case 'turn.failed':
-        throw new ToolError(event.error.message ?? 'Codex turn failed');
-      case 'error':
-        throw new ToolError(event.message ?? 'Codex stream error');
+      case 'turn.failed': {
+        const errorMessage = event.error.message ?? 'Codex turn failed';
+        if (activeTurnLog) {
+          updateTrackedToolUseLog(
+            logger,
+            activeTurnLog,
+            buildCodexTurnToolLog({
+              state: 'failed',
+              wallTimeMs: Date.now() - activeTurnLog.startedAt,
+              error: errorMessage,
+            }),
+          );
+          activeTurnLog = null;
+        }
+        throw new ToolError(errorMessage);
+      }
+      case 'error': {
+        const errorMessage = event.message ?? 'Codex stream error';
+        if (activeTurnLog) {
+          updateTrackedToolUseLog(
+            logger,
+            activeTurnLog,
+            buildCodexTurnToolLog({
+              state: 'failed',
+              wallTimeMs: Date.now() - activeTurnLog.startedAt,
+              error: errorMessage,
+            }),
+          );
+          activeTurnLog = null;
+        }
+        throw new ToolError(errorMessage);
+      }
     }
   }
 
@@ -610,9 +730,9 @@ export class CodexTool extends defineTool({
     const CodexClass = await importCodexClass();
     const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
     const threadOptions = {
-      workingDirectory: input.working_directory,
       sandboxMode: input.sandbox_mode,
       skipGitRepoCheck: true as const,
+      ...buildCodexWorkspaceOptions(input.working_directory),
     };
 
     return input.thread_id
@@ -627,7 +747,6 @@ export class CodexTool extends defineTool({
   ): Promise<ToolResult> {
     const executionId = generateExecutionId();
     const preview = truncateWithEllipsis(input.prompt, 60);
-    const startedAt = Date.now();
     const config = buildCodexConfig(input.prompt);
 
     if (parentStreamId) {
@@ -637,7 +756,7 @@ export class CodexTool extends defineTool({
       await registerExecution(
         executionId,
         config,
-        'codex',
+        CODEX_AGENT_NAME,
         parentExecutionId,
       ).catch(() => {});
     }
@@ -653,20 +772,18 @@ export class CodexTool extends defineTool({
             input.prompt,
             stream.childStreamId,
             stream.logger,
+            executionId,
           )
         : await thread.run(input.prompt);
 
       const threadId = thread.id;
-      const wallTimeMs = Date.now() - startedAt;
 
       if (stream) {
         handleTurnSuccess(
           thread,
-          turn,
           stream.childStreamId,
           executionId,
           stream.logger,
-          wallTimeMs,
         );
       }
 
@@ -703,7 +820,12 @@ export class CodexTool extends defineTool({
     const config = buildCodexConfig(input.prompt);
 
     try {
-      await registerExecution(executionId, config, 'codex', parentExecutionId);
+      await registerExecution(
+        executionId,
+        config,
+        CODEX_AGENT_NAME,
+        parentExecutionId,
+      );
     } catch {
       throw new ToolError('Failed to register background Codex execution.');
     }
@@ -724,6 +846,7 @@ export class CodexTool extends defineTool({
           input.prompt,
           childStreamId,
           logger,
+          executionId,
         );
         const wallTimeMs = Date.now() - startedAt;
         const threadId = thread.id;
@@ -745,14 +868,7 @@ export class CodexTool extends defineTool({
         if (!threadId) {
           await writeTerminalStatus(executionId, 'completed').catch(() => {});
         }
-        handleTurnSuccess(
-          thread,
-          turn,
-          childStreamId,
-          executionId,
-          logger,
-          wallTimeMs,
-        );
+        handleTurnSuccess(thread, childStreamId, executionId, logger);
       } catch (err: unknown) {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeCodexStream(childStreamId, executionId, logger, { error: err });

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -144,6 +144,10 @@ interface TrackedToolUseLog {
   groupId: string | undefined;
 }
 
+interface ActiveTrackedToolUseLog extends TrackedToolUseLog {
+  latestToolLog: ToolUseLog;
+}
+
 interface ActiveCodexTurnLog extends TrackedToolUseLog {
   startedAt: number;
 }
@@ -337,19 +341,62 @@ function updateTrackedToolUseLog(
 }
 
 function upsertTrackedToolUseLog(
-  trackedLogs: Map<string, TrackedToolUseLog>,
+  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
   itemId: string,
   toolLog: ToolUseLog,
   logger: AgentLogger,
 ): void {
   const trackedLog = trackedLogs.get(itemId);
   if (trackedLog) {
+    trackedLog.latestToolLog = toolLog;
     updateTrackedToolUseLog(logger, trackedLog, toolLog);
   } else {
-    trackedLogs.set(itemId, logger.emitToolUse(toolLog));
+    trackedLogs.set(itemId, {
+      ...logger.emitToolUse(toolLog),
+      latestToolLog: toolLog,
+    });
   }
 
   if (toolLog.status !== 'in_progress') {
+    trackedLogs.delete(itemId);
+  }
+}
+
+function finalizeTrackedCodexItemLog(
+  toolLog: ToolUseLog,
+  errorMessage: string,
+): ToolUseLog {
+  const output =
+    toolLog.toolName?.startsWith('mcp:') &&
+    toolLog.output != null &&
+    typeof toolLog.output === 'object' &&
+    !Array.isArray(toolLog.output)
+      ? {
+          ...(toolLog.output as Record<string, unknown>),
+          status: 'failed',
+        }
+      : toolLog.output;
+
+  return {
+    ...toolLog,
+    ...(output !== undefined && { output }),
+    ...(toolLog.error ? {} : { error: errorMessage }),
+    isError: true,
+    status: 'completed',
+  };
+}
+
+function finalizeTrackedCodexItemLogs(
+  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
+  logger: AgentLogger,
+  errorMessage: string,
+): void {
+  for (const [itemId, trackedLog] of trackedLogs) {
+    updateTrackedToolUseLog(
+      logger,
+      trackedLog,
+      finalizeTrackedCodexItemLog(trackedLog.latestToolLog, errorMessage),
+    );
     trackedLogs.delete(itemId);
   }
 }
@@ -364,7 +411,7 @@ function handleTrackedCodexItemEvent(
   phase: 'started' | 'updated' | 'completed',
   childStreamId: StreamTabId,
   logger: AgentLogger,
-  trackedLogs: Map<string, TrackedToolUseLog>,
+  trackedLogs: Map<string, ActiveTrackedToolUseLog>,
 ): void {
   if (item.type === 'todo_list') {
     syncCodexTodoState(item, childStreamId);
@@ -544,7 +591,7 @@ async function runStreamedTurn(
   const { events } = await thread.runStreamed(prompt);
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;
-  const trackedLogs = new Map<string, TrackedToolUseLog>();
+  const trackedLogs = new Map<string, ActiveTrackedToolUseLog>();
   let activeTurnLog: ActiveCodexTurnLog | null = null;
   const usageReporter = new AgentUsageReporter(
     logger,
@@ -552,116 +599,106 @@ async function runStreamedTurn(
     AgentCategory.ToolUse,
   );
 
-  for await (const event of events) {
-    switch (event.type) {
-      case 'thread.started':
-        logger.logToolUse(buildCodexThreadToolLog(event));
-        break;
-      case 'turn.started':
-        activeTurnLog = {
-          ...logger.emitToolUse(buildCodexTurnToolLog({ state: 'running' })),
-          startedAt: Date.now(),
-        };
-        break;
-      case 'item.started':
-      case 'item.updated':
-        if (
-          event.item.type === 'command_execution' ||
-          event.item.type === 'mcp_tool_call' ||
-          event.item.type === 'todo_list'
-        ) {
-          handleTrackedCodexItemEvent(
-            event.item,
-            event.type === 'item.started' ? 'started' : 'updated',
-            childStreamId,
-            logger,
-            trackedLogs,
-          );
+  try {
+    for await (const event of events) {
+      switch (event.type) {
+        case 'thread.started':
+          logger.logToolUse(buildCodexThreadToolLog(event));
+          break;
+        case 'turn.started':
+          activeTurnLog = {
+            ...logger.emitToolUse(buildCodexTurnToolLog({ state: 'running' })),
+            startedAt: Date.now(),
+          };
+          break;
+        case 'item.started':
+        case 'item.updated':
+          if (
+            event.item.type === 'command_execution' ||
+            event.item.type === 'mcp_tool_call' ||
+            event.item.type === 'todo_list'
+          ) {
+            handleTrackedCodexItemEvent(
+              event.item,
+              event.type === 'item.started' ? 'started' : 'updated',
+              childStreamId,
+              logger,
+              trackedLogs,
+            );
+          }
+          break;
+        case 'item.completed': {
+          const { item } = event;
+          if (
+            item.type === 'command_execution' ||
+            item.type === 'mcp_tool_call' ||
+            item.type === 'todo_list'
+          ) {
+            handleTrackedCodexItemEvent(
+              item,
+              'completed',
+              childStreamId,
+              logger,
+              trackedLogs,
+            );
+          } else {
+            logCompletedCodexItem(item, logger);
+          }
+          if (item.type === 'agent_message') {
+            responseParts.push(item.text);
+          }
+          break;
         }
-        break;
-      case 'item.completed': {
-        const { item } = event;
-        if (
-          item.type === 'command_execution' ||
-          item.type === 'mcp_tool_call' ||
-          item.type === 'todo_list'
-        ) {
-          handleTrackedCodexItemEvent(
-            item,
-            'completed',
-            childStreamId,
-            logger,
-            trackedLogs,
-          );
-        } else {
-          logCompletedCodexItem(item, logger);
-        }
-        if (item.type === 'agent_message') {
-          responseParts.push(item.text);
-        }
-        break;
-      }
-      case 'turn.completed':
-        usage = event.usage ?? null;
-        if (usage) {
-          usageReporter.report(
-            buildCodexUsageStats(usage),
-            executionId as StorageKey,
-          );
-        }
-        if (activeTurnLog) {
-          updateTrackedToolUseLog(
-            logger,
-            activeTurnLog,
-            buildCodexTurnToolLog({
-              state: 'completed',
-              wallTimeMs: Date.now() - activeTurnLog.startedAt,
-              usage,
-            }),
-          );
-          activeTurnLog = null;
-        } else {
-          logger.logToolUse(
-            buildCodexTurnToolLog({
-              state: 'completed',
-              usage,
-            }),
-          );
-        }
-        break;
-      case 'turn.failed': {
-        const errorMessage = event.error.message ?? 'Codex turn failed';
-        if (activeTurnLog) {
-          updateTrackedToolUseLog(
-            logger,
-            activeTurnLog,
-            buildCodexTurnToolLog({
-              state: 'failed',
-              wallTimeMs: Date.now() - activeTurnLog.startedAt,
-              error: errorMessage,
-            }),
-          );
-          activeTurnLog = null;
-        }
-        throw new ToolError(errorMessage);
-      }
-      case 'error': {
-        const errorMessage = event.message ?? 'Codex stream error';
-        if (activeTurnLog) {
-          updateTrackedToolUseLog(
-            logger,
-            activeTurnLog,
-            buildCodexTurnToolLog({
-              state: 'failed',
-              wallTimeMs: Date.now() - activeTurnLog.startedAt,
-              error: errorMessage,
-            }),
-          );
-          activeTurnLog = null;
-        }
-        throw new ToolError(errorMessage);
+        case 'turn.completed':
+          usage = event.usage ?? null;
+          if (usage) {
+            usageReporter.report(
+              buildCodexUsageStats(usage),
+              executionId as StorageKey,
+            );
+          }
+          if (activeTurnLog) {
+            updateTrackedToolUseLog(
+              logger,
+              activeTurnLog,
+              buildCodexTurnToolLog({
+                state: 'completed',
+                wallTimeMs: Date.now() - activeTurnLog.startedAt,
+                usage,
+              }),
+            );
+            activeTurnLog = null;
+          } else {
+            logger.logToolUse(
+              buildCodexTurnToolLog({
+                state: 'completed',
+                usage,
+              }),
+            );
+          }
+          break;
+        case 'turn.failed':
+          throw new ToolError(event.error.message ?? 'Codex turn failed');
+        case 'error':
+          throw new ToolError(event.message ?? 'Codex stream error');
       }
     }
+  } catch (error) {
+    const errorMessage = toErrorMessage(error);
+    if (activeTurnLog) {
+      updateTrackedToolUseLog(
+        logger,
+        activeTurnLog,
+        buildCodexTurnToolLog({
+          state: 'failed',
+          wallTimeMs: Date.now() - activeTurnLog.startedAt,
+          error: errorMessage,
+        }),
+      );
+      activeTurnLog = null;
+    }
+    finalizeTrackedCodexItemLogs(trackedLogs, logger, errorMessage);
+    throw error;
   }
 
   return {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -100,8 +100,10 @@ const CodexInputSchema = z.strictObject({
   prompt: z.string().describe('Instruction for the Codex agent'),
   working_directory: z
     .string()
-    .optional()
-    .describe('Directory to run in (defaults to workspace root)'),
+    .nullish()
+    .describe(
+      'Directory to run in. Defaults to the workspace root. Accepts relative workspace paths or absolute paths such as a separate git worktree.',
+    ),
   sandbox_mode: z
     .enum(SANDBOX_MODES)
     .prefault('read-only')
@@ -114,7 +116,7 @@ const CodexInputSchema = z.strictObject({
     ),
   thread_id: z
     .string()
-    .optional()
+    .nullish()
     .describe(
       'Resume an existing Codex thread by its ID. ' +
         'When provided, continues the conversation from where it left off instead of starting a new one. ' +
@@ -678,6 +680,7 @@ export class CodexTool extends defineTool({
   description:
     'Spin off an OpenAI Codex agent to perform code analysis, generation, or research in a sandboxed environment. ' +
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +
+    'Set working_directory to a workspace subdirectory or an absolute path, including a separate git worktree; an orchestrator can prepare that worktree first when isolated changes help. ' +
     'Requires the Codex CLI to be installed (`npm install -g @openai/codex`). ' +
     'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var. ' +
     'Returns a thread_id that can be passed back to continue the conversation in subsequent calls.',

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -1,0 +1,60 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - agent config
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { WorkspaceFS } from '@utils/files';
+import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
+
+/**
+ * Build synthetic execution metadata for Codex child streams.
+ *
+ * Codex runs outside the normal model-handler pipeline, so we provide an
+ * explicit tool-use category and a stable Codex model label for the UI
+ * instead of inheriting the generic AgentConfig defaults.
+ */
+export function buildCodexConfig(prompt: string): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: CODEX_AGENT_NAME,
+    model: CODEX_DISPLAY_MODEL,
+    instruction: prompt,
+    agentCategory: AgentCategory.ToolUse,
+  });
+}
+
+export interface CodexWorkspaceOptions {
+  workingDirectory?: string;
+  additionalDirectories?: string[];
+}
+
+/**
+ * Compute Codex workspace access options.
+ *
+ * When no directory is provided, Codex runs from the workspace root.
+ * When a subdirectory is provided, we still add the workspace root so the
+ * agent can inspect sibling files across the project.
+ */
+export function buildCodexWorkspaceOptions(
+  workingDirectoryInput?: string,
+): CodexWorkspaceOptions {
+  const workspacePath = WorkspaceFS.getPath();
+  const trimmed = workingDirectoryInput?.trim();
+
+  if (!workspacePath) {
+    return trimmed ? { workingDirectory: trimmed } : {};
+  }
+
+  const workingDirectory = trimmed
+    ? path.isAbsolute(trimmed)
+      ? trimmed
+      : path.resolve(workspacePath, trimmed)
+    : workspacePath;
+
+  return path.resolve(workingDirectory) === path.resolve(workspacePath)
+    ? { workingDirectory }
+    : {
+        workingDirectory,
+        additionalDirectories: [workspacePath],
+      };
+}

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -32,11 +32,14 @@ export interface CodexWorkspaceOptions {
  * Compute Codex workspace access options.
  *
  * When no directory is provided, Codex runs from the workspace root.
- * When a subdirectory is provided, we still add the workspace root so the
- * agent can inspect sibling files across the project.
+ * When a subdirectory inside the workspace is provided, we still add the
+ * workspace root so the agent can inspect sibling files across the project.
+ * Absolute paths outside the workspace (for example a separate git worktree)
+ * run in that directory without inheriting the current workspace as an
+ * additional root.
  */
 export function buildCodexWorkspaceOptions(
-  workingDirectoryInput?: string,
+  workingDirectoryInput?: string | null,
 ): CodexWorkspaceOptions {
   const workspacePath = WorkspaceFS.getPath();
   const trimmed = workingDirectoryInput?.trim();
@@ -51,10 +54,26 @@ export function buildCodexWorkspaceOptions(
       : path.resolve(workspacePath, trimmed)
     : workspacePath;
 
-  return path.resolve(workingDirectory) === path.resolve(workspacePath)
-    ? { workingDirectory }
-    : {
+  const resolvedWorkspacePath = path.resolve(workspacePath);
+  const resolvedWorkingDirectory = path.resolve(workingDirectory);
+
+  if (resolvedWorkingDirectory === resolvedWorkspacePath) {
+    return { workingDirectory };
+  }
+
+  const relativeToWorkspace = path.relative(
+    resolvedWorkspacePath,
+    resolvedWorkingDirectory,
+  );
+  const isInsideWorkspace =
+    relativeToWorkspace.length > 0 &&
+    !relativeToWorkspace.startsWith('..') &&
+    !path.isAbsolute(relativeToWorkspace);
+
+  return isInsideWorkspace
+    ? {
         workingDirectory,
         additionalDirectories: [workspacePath],
-      };
+      }
+    : { workingDirectory };
 }

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -1,5 +1,6 @@
 // Local imports - shared schemas
 import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import type {
   CommandExecutionItem,
   FileChangeItem,
@@ -61,8 +62,7 @@ export interface CodexTurnToolInput {
 
 function truncateSummary(text: string, maxLength: number): string {
   const oneLine = text.replaceAll(/\s+/g, ' ').trim();
-  if (oneLine.length <= maxLength) return oneLine;
-  return oneLine.slice(0, maxLength - 1) + '…';
+  return truncateWithEllipsis(oneLine, maxLength);
 }
 
 function getPathBasename(filePath: string): string {
@@ -78,14 +78,14 @@ export function buildCodexCommandToolLog(
     options.status === 'in_progress' ? 'in_progress' : 'completed';
   const command = options.command.trim();
   const exitInfo =
-    options.exit_code === undefined
+    options.exit_code == null
       ? options.status?.trim() || 'completed'
       : `exit ${options.exit_code}`;
   const output =
     options.aggregated_output.trimEnd() ||
     (toolStatus === 'completed' ? `(${exitInfo})` : '');
   const isError =
-    options.exit_code === undefined
+    options.exit_code == null
       ? options.status === 'failed'
       : options.exit_code !== 0;
 

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -1,0 +1,258 @@
+// Local imports - shared schemas
+import type { TokenUsageStats, ToolUseLog } from '@shared/schemas';
+import type {
+  CommandExecutionItem,
+  FileChangeItem,
+  McpToolCallItem,
+  ThreadStartedEvent,
+  TodoListItem,
+  Usage,
+} from '@openai/codex-sdk';
+
+export const CODEX_AGENT_NAME = 'codex';
+export const CODEX_DISPLAY_MODEL = 'codex';
+export const CODEX_FILE_CHANGE_TOOL = 'codex_patch';
+export const CODEX_THREAD_TOOL = 'codex_thread';
+export const CODEX_TODO_TOOL = 'codex_todo';
+export const CODEX_TURN_TOOL = 'codex_turn';
+const CODEX_COMMAND_SUMMARY_MAX_LENGTH = 60;
+type ToolUseStatus = NonNullable<ToolUseLog['status']>;
+
+export type CodexFileChange = FileChangeItem['changes'][number];
+export type CodexCommandToolLogOptions = Pick<
+  CommandExecutionItem,
+  'command' | 'aggregated_output' | 'exit_code' | 'status'
+>;
+export type CodexTodoItem = TodoListItem['items'][number];
+export type CodexMcpContentBlock = NonNullable<
+  NonNullable<McpToolCallItem['result']>['content']
+>[number];
+
+export interface CodexFileChangeToolInput {
+  changes: CodexFileChange[];
+  patchStatus: FileChangeItem['status'];
+}
+
+export interface CodexMcpToolOutput {
+  status: McpToolCallItem['status'];
+  structuredContent?: unknown;
+  contentBlocks?: CodexMcpContentBlock[];
+}
+
+export interface CodexThreadToolInput {
+  threadId: string;
+}
+
+export interface CodexTodoToolInput {
+  items: CodexTodoItem[];
+  completedCount: number;
+  totalCount: number;
+}
+
+export type CodexTurnState = 'running' | 'completed' | 'failed';
+
+export interface CodexTurnToolInput {
+  state: CodexTurnState;
+  wallTimeMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+}
+
+function truncateSummary(text: string, maxLength: number): string {
+  const oneLine = text.replaceAll(/\s+/g, ' ').trim();
+  if (oneLine.length <= maxLength) return oneLine;
+  return oneLine.slice(0, maxLength - 1) + '…';
+}
+
+function getPathBasename(filePath: string): string {
+  const normalized = filePath.replaceAll('\\', '/');
+  return normalized.split('/').at(-1) || normalized;
+}
+
+/** Normalize Codex command execution events for the native bash tool card. */
+export function buildCodexCommandToolLog(
+  options: CodexCommandToolLogOptions,
+): ToolUseLog {
+  const toolStatus: ToolUseStatus =
+    options.status === 'in_progress' ? 'in_progress' : 'completed';
+  const command = options.command.trim();
+  const exitInfo =
+    options.exit_code === undefined
+      ? options.status?.trim() || 'completed'
+      : `exit ${options.exit_code}`;
+  const output =
+    options.aggregated_output.trimEnd() ||
+    (toolStatus === 'completed' ? `(${exitInfo})` : '');
+  const isError =
+    options.exit_code === undefined
+      ? options.status === 'failed'
+      : options.exit_code !== 0;
+
+  return {
+    toolName: 'bash',
+    summary: truncateSummary(
+      command || 'command',
+      CODEX_COMMAND_SUMMARY_MAX_LENGTH,
+    ),
+    input: { command: options.command },
+    ...(output && { output }),
+    ...(isError && {
+      error: `Command failed (${exitInfo})`,
+      isError: true,
+    }),
+    status: toolStatus,
+  };
+}
+
+/** Normalize and summarize Codex file-change events for the native tool-use UI. */
+export function buildCodexFileChangeToolLog(
+  item: Pick<FileChangeItem, 'changes' | 'status'>,
+): ToolUseLog | null {
+  const dedupedChanges: CodexFileChange[] = [];
+  const seen = new Set<string>();
+
+  for (const change of item.changes) {
+    const filePath = change.path?.trim();
+    const kind = change.kind;
+    if (!filePath || !kind) continue;
+
+    const key = `${kind}\u0000${filePath}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dedupedChanges.push({ path: filePath, kind });
+  }
+
+  if (dedupedChanges.length === 0) {
+    return null;
+  }
+
+  const summary =
+    dedupedChanges.length === 1
+      ? `${item.status === 'failed' ? 'failed ' : ''}${dedupedChanges[0].kind} ${getPathBasename(dedupedChanges[0].path)}`
+      : `${dedupedChanges.length} file changes${item.status === 'failed' ? ' failed' : ''}`;
+
+  return {
+    toolName: CODEX_FILE_CHANGE_TOOL,
+    summary,
+    input: {
+      changes: dedupedChanges,
+      patchStatus: item.status,
+    } satisfies CodexFileChangeToolInput,
+    ...(item.status === 'failed' && {
+      error: 'Patch apply failed',
+      isError: true,
+    }),
+    status: 'completed',
+  };
+}
+
+export function buildCodexMcpToolLog(item: McpToolCallItem): ToolUseLog {
+  const contentBlocks = item.result?.content ?? [];
+  const output: CodexMcpToolOutput = {
+    status: item.status,
+    ...(item.result?.structured_content !== undefined && {
+      structuredContent: item.result.structured_content,
+    }),
+    ...(contentBlocks.length > 0 && {
+      contentBlocks,
+    }),
+  };
+
+  return {
+    toolName: `mcp:${item.server}/${item.tool}`,
+    input: item.arguments,
+    output,
+    ...(item.error && {
+      error: item.error.message,
+      isError: true,
+    }),
+    status: item.status === 'in_progress' ? 'in_progress' : 'completed',
+  };
+}
+
+export function buildCodexThreadToolLog(event: ThreadStartedEvent): ToolUseLog {
+  return {
+    toolName: CODEX_THREAD_TOOL,
+    summary: 'Created',
+    input: {
+      threadId: event.thread_id,
+    } satisfies CodexThreadToolInput,
+    status: 'completed',
+  };
+}
+
+export function buildCodexTodoToolLog(
+  item: TodoListItem,
+  status: ToolUseStatus,
+): ToolUseLog {
+  const completedCount = item.items.filter((todo) => todo.completed).length;
+  const totalCount = item.items.length;
+  const summary =
+    totalCount > 0 ? `${completedCount}/${totalCount} completed` : 'No tasks';
+
+  return {
+    toolName: CODEX_TODO_TOOL,
+    summary,
+    input: {
+      items: item.items,
+      completedCount,
+      totalCount,
+    } satisfies CodexTodoToolInput,
+    status,
+  };
+}
+
+export function buildCodexTurnToolLog(options?: {
+  wallTimeMs?: number | null;
+  usage?: Usage | null;
+  state?: CodexTurnState;
+  error?: string;
+}): ToolUseLog {
+  const state = options?.state ?? (options?.error ? 'failed' : 'completed');
+  const roundedMs =
+    options?.wallTimeMs == null
+      ? undefined
+      : Math.max(0, Math.round(options.wallTimeMs));
+  const input: CodexTurnToolInput = {
+    state,
+    ...(roundedMs != null && {
+      wallTimeMs: roundedMs,
+    }),
+    ...(options?.usage && {
+      inputTokens: options.usage.input_tokens,
+      outputTokens: options.usage.output_tokens,
+      ...(options.usage.cached_input_tokens != null && {
+        cachedInputTokens: options.usage.cached_input_tokens,
+      }),
+    }),
+  };
+
+  return {
+    toolName: CODEX_TURN_TOOL,
+    summary:
+      state === 'running'
+        ? 'Running'
+        : state === 'failed'
+          ? 'Failed'
+          : 'Completed',
+    input,
+    ...(state === 'failed' &&
+      options?.error && {
+        error: options.error,
+        isError: true,
+      }),
+    status: state === 'running' ? 'in_progress' : 'completed',
+  };
+}
+
+export function buildCodexUsageStats(usage: Usage): TokenUsageStats {
+  return {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    cost: 0,
+    ...(usage.cached_input_tokens > 0 && {
+      cacheReadInputTokens: usage.cached_input_tokens,
+    }),
+  };
+}

--- a/src/tools/codexShared.ts
+++ b/src/tools/codexShared.ts
@@ -85,9 +85,8 @@ export function buildCodexCommandToolLog(
     options.aggregated_output.trimEnd() ||
     (toolStatus === 'completed' ? `(${exitInfo})` : '');
   const isError =
-    options.exit_code == null
-      ? options.status === 'failed'
-      : options.exit_code !== 0;
+    options.status === 'failed' ||
+    (options.exit_code != null && options.exit_code !== 0);
 
   return {
     toolName: 'bash',


### PR DESCRIPTION
## Summary
Improve the Codex child stream experience in the progress view so Codex sessions look and behave like native tool-use sessions instead of falling back to generic workflow or plain-text logs.

## What Changed
- fix Codex stream metadata so Codex child tabs render as conversational tool-use sessions with a Codex-specific model label
- carry workspace context into Codex threads, including workspace-root access when a subdirectory is selected
- render Codex file changes, bash commands, turn summaries, thread lifecycle, todo lists, and MCP calls as native progress-view cards
- stream live bash and MCP updates through item lifecycle events instead of only logging completed snapshots
- report Codex turn usage into the shared tool-use usage store so the bottom token statistics panel works for Codex tabs, including follow-ups

## Why
Codex SDK events were being flattened into generic log lines or partially ignored by the bridge. That led to the wrong model display, workflow-style instructions, missing native cards for Codex activity, and no accumulated usage panel for Codex sessions.

## Impact
Codex tabs now feel like first-class native tool-use sessions: follow-upable, workspace-aware, and much easier to read during live execution.

## Validation
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint` (passes with the repository's existing unrelated warnings only)

`npm test` was not run because the repository instructions explicitly say not to run it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors Codex streaming/logging to update tool-use entries in-place, adds new workspace path handling, and changes MCP output rendering—all of which can affect progress-view UX and stream state transitions.
> 
> **Overview**
> Codex child streams now emit **native tool-use cards** instead of generic log lines: file changes, thread lifecycle, checklist/todos, and turn summaries are logged as structured `ToolUseLog` entries with new friendly labels/icons (e.g. `codex_patch`, `codex_turn`) and dedicated Lit renderers.
> 
> Codex streaming is upgraded to handle `thread.started`/`turn.started` and `item.started`/`item.updated` events, **upserting** in-progress bash/MCP/todo tool logs and finalizing them on completion or error; turn token usage is also reported into the shared usage store.
> 
> Codex execution metadata/workspace handling is tightened by introducing `buildCodexConfig` (stable agent/model/category) and `buildCodexWorkspaceOptions` (workspace-root access when running in a subdirectory, support for absolute worktree paths), plus richer MCP tool-call rendering and MCP-prefixed titles in the progress view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7ee1d6df0fae147a8f8114627850c48e74ff61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->