### PR TITLE
perf+ux: optimize stream tabs for 100+ child streams

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -328,19 +328,17 @@ export class ProgressApp extends ProgressAppBase {
    * every status or timestamp update.
    */
   private childStreamsByParent$ = new Signal.Computed(() => {
-      const streams = this.streamById$.get();
-      let map: Map<StreamTabId, StreamTabInfo[]> | undefined;
-      for (const s of streams.values()) {
-        if (!s.parentStreamId) continue;
-        if (!map) map = new Map();
-        let children = map.get(s.parentStreamId);
-        if (!children) {
-          children = [];
-          map.set(s.parentStreamId, children);
-        }
-        children.push(s);
+    const grouped = new Map<StreamTabId, StreamTabInfo[]>();
+    for (const stream of this.streamById$.get().values()) {
+      if (!stream.parentStreamId) continue;
+      const siblings = grouped.get(stream.parentStreamId);
+      if (siblings) {
+        siblings.push(stream);
+      } else {
+        grouped.set(stream.parentStreamId, [stream]);
       }
-      return map ?? EMPTY_CHILD_MAP;
+    }
+    return grouped.size > 0 ? grouped : EMPTY_CHILD_MAP;
   });
 
   // --- Fine-grained active-stream selectors ---

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -347,22 +347,6 @@ export class ProgressApp extends ProgressAppBase {
       return map ?? EMPTY_CHILD_MAP;
   });
 
-  /**
-   * Status and timestamp for ALL streams (single pass over streamStates).
-   * Covers both top-level and child streams so StreamTabs can look up
-   * any stream without requiring a separate computation per nesting level.
-   */
-  private statusAndTimestampById$ = new Signal.Computed(() => {
-    const states = this.streamStates$.get();
-    const statusMap = new Map<StreamTabId, string>();
-    const timestampMap = new Map<StreamTabId, number | undefined>();
-    for (const [name, state] of states) {
-      statusMap.set(name, state?.status ?? STREAM_STATUS.READY);
-      timestampMap.set(name, state?.lastTimestamp);
-    }
-    return { statusMap, timestampMap };
-  });
-
   // --- Fine-grained active-stream selectors ---
   // These return stable Map entry values (via Mutative structural sharing).
   // When stream B's state changes, activeStreamState$ still returns stream A's
@@ -574,9 +558,7 @@ export class ProgressApp extends ProgressAppBase {
               .activeStreamId=${this.activeStreamId$.get()}
               .filter=${this.streamFilter$.get()}
               .sort=${this.streamSort$.get()}
-              .streamStatusById=${this.statusAndTimestampById$.get().statusMap}
-              .streamLastTimestampById=${this.statusAndTimestampById$.get()
-                .timestampMap}
+              .streamStates=${this.streamStates$.get()}
               .pendingApprovalStreamIds=${this.pendingApprovalIds$.get()}
               .childStreamsByParent=${this.childStreamsByParent$.get()}
               @stream-switch=${this.onStreamSwitch}

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -294,18 +294,27 @@ export class ProgressApp extends ProgressAppBase {
   // --- Derived computeds: only re-evaluate when selector inputs propagate ---
 
   /**
-   * All streams sorted (unfiltered).  Used for active-stream lookup so
-   * navigating to a child stream from BackgroundTasksPanel always works
-   * regardless of the current filter selection.
+   * All streams sorted (unfiltered).
+   *
+   * For agent/inputFile sort: depends only on streamById$ (stable after
+   * stream creation — no re-sort on status/timestamp updates).
+   *
+   * For time sort: also reads streamStates$ for lastTimestamp, so log
+   * appends trigger a re-sort. This is unavoidable since time sort IS
+   * the timestamp ordering.
    */
-  private sortedStreams$ = combine(
-    [this.streamById$, this.streamSort$, this.streamStates$] as const,
-    (streamById, sort, states) =>
-      sortStreams([...streamById.values()], sort, {
-        getLastActivityTimestamp: (stream) =>
-          states.get(stream.name)?.lastTimestamp,
-      }),
-  );
+  private sortedStreams$ = new Signal.Computed(() => {
+    const streamById = this.streamById$.get();
+    const sort = this.streamSort$.get();
+    // Only read streamStates$ when time-sorting — for agent/inputFile
+    // sort, this signal won't re-evaluate on status/timestamp changes.
+    const states = sort === 'time' ? this.streamStates$.get() : undefined;
+    return sortStreams([...streamById.values()], sort, {
+      getLastActivityTimestamp: states
+        ? (stream) => states.get(stream.name)?.lastTimestamp
+        : undefined,
+    });
+  });
 
 
   /**
@@ -353,7 +362,7 @@ export class ProgressApp extends ProgressAppBase {
   });
 
   private hasStreams$ = new Signal.Computed(
-    () => this.sortedStreams$.get().length > 0,
+    () => this.streamById$.get().size > 0,
   );
 
   /** Only changes when the ACTIVE stream's state changes, not any stream. */

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -327,13 +327,14 @@ export class ProgressApp extends ProgressAppBase {
 
   /**
    * Child streams grouped by parent stream ID.
-   * Includes both active and finished children so the user can still
-   * navigate to completed/errored child streams.
+   * Depends only on streamById$ (stream registry), NOT streamStates$,
+   * so it only recomputes when streams are added/removed — not on
+   * every status or timestamp update.
    */
   private childStreamsByParent$ = new Signal.Computed(() => {
-      const sorted = this.sortedStreams$.get();
+      const streams = this.streamById$.get();
       let map: Map<StreamTabId, StreamTabInfo[]> | undefined;
-      for (const s of sorted) {
+      for (const s of streams.values()) {
         if (!s.parentStreamId) continue;
         if (!map) map = new Map();
         let children = map.get(s.parentStreamId);
@@ -346,28 +347,21 @@ export class ProgressApp extends ProgressAppBase {
       return map ?? EMPTY_CHILD_MAP;
   });
 
-  /** Status and timestamp for all visible streams (top-level + active children). */
-  private statusAndTimestampById$ = combine(
-    [this.streamStates$, this.tabStreams$, this.childStreamsByParent$] as const,
-    (states, streams, childMap) => {
-      const statusMap = new Map<StreamTabId, string>();
-      const timestampMap = new Map<StreamTabId, number | undefined>();
-      for (const stream of streams) {
-        const state = states.get(stream.name);
-        statusMap.set(stream.name, state?.status ?? STREAM_STATUS.READY);
-        timestampMap.set(stream.name, state?.lastTimestamp);
-        const children = childMap.get(stream.name);
-        if (children) {
-          for (const child of children) {
-            const cs = states.get(child.name);
-            statusMap.set(child.name, cs?.status ?? STREAM_STATUS.READY);
-            timestampMap.set(child.name, cs?.lastTimestamp);
-          }
-        }
-      }
-      return { statusMap, timestampMap };
-    },
-  );
+  /**
+   * Status and timestamp for ALL streams (single pass over streamStates).
+   * Covers both top-level and child streams so StreamTabs can look up
+   * any stream without requiring a separate computation per nesting level.
+   */
+  private statusAndTimestampById$ = new Signal.Computed(() => {
+    const states = this.streamStates$.get();
+    const statusMap = new Map<StreamTabId, string>();
+    const timestampMap = new Map<StreamTabId, number | undefined>();
+    for (const [name, state] of states) {
+      statusMap.set(name, state?.status ?? STREAM_STATUS.READY);
+      timestampMap.set(name, state?.lastTimestamp);
+    }
+    return { statusMap, timestampMap };
+  });
 
   // --- Fine-grained active-stream selectors ---
   // These return stable Map entry values (via Mutative structural sharing).

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -307,10 +307,6 @@ export class ProgressApp extends ProgressAppBase {
       }),
   );
 
-  /** Map of ALL streams for active-stream lookup (filter-independent). */
-  private filteredStreamMap$ = new Signal.Computed(
-    () => new Map(this.sortedStreams$.get().map((s) => [s.name, s])),
-  );
 
   /**
    * Top-level streams for the sidebar tab list (child streams excluded).
@@ -355,7 +351,7 @@ export class ProgressApp extends ProgressAppBase {
   /** Only changes when active stream switches or stream list changes. */
   private activeStreamInfo$ = new Signal.Computed(() => {
     const id = this.activeStreamId$.get();
-    return id ? (this.filteredStreamMap$.get().get(id) ?? null) : null;
+    return id ? (this.streamById$.get().get(id) ?? null) : null;
   });
 
   private hasStreams$ = new Signal.Computed(

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -294,7 +294,7 @@ export class StreamTab extends LitElement {
   /** Number of child streams (0 = no toggle shown). */
   @property({ type: Number }) childCount = 0;
   /** Whether the child list is expanded. */
-  @property({ type: Boolean }) expanded = false;
+  @property({ type: Boolean, reflect: true }) expanded = false;
 
   // Cached derived values — only recomputed when inputs change
   private _cachedInfo: StreamTabInfo | null = null;
@@ -576,14 +576,12 @@ export class StreamTabs extends LitElement {
     if (dirty) this.expandedParents = next;
   }
 
-  /** Look up stream status from the states map (O(1), no allocation). */
-  private getStatus(name: string): string {
-    return this.streamStates.get(name as StreamTabId)?.status ?? STREAM_STATUS.READY;
+  private getStatus(name: StreamTabId): string {
+    return this.streamStates.get(name)?.status ?? STREAM_STATUS.READY;
   }
 
-  /** Look up last timestamp from the states map (O(1), no allocation). */
-  private getTimestamp(name: string): number | undefined {
-    return this.streamStates.get(name as StreamTabId)?.lastTimestamp;
+  private getTimestamp(name: StreamTabId): number | undefined {
+    return this.streamStates.get(name)?.lastTimestamp;
   }
 
   override render(): TemplateResult {

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -314,9 +314,10 @@ export class StreamTab extends LitElement {
       const raw =
         `${stream.parentStreamId ? '↳' : ''}${stream.label || stream.name}`.trim();
       this._compactLabel = raw.length > 8 ? raw.slice(0, 7) + '…' : raw;
+      this._cachedTooltipKey = ''; // invalidate tooltip when info changes
     }
 
-    // Memoize tooltip (changes on status or timestamp, not on every render)
+    // Memoize tooltip (changes on info, status, or timestamp)
     const tooltipKey = `${status}\0${this.lastTimestamp}`;
     if (this._cachedTooltipKey !== tooltipKey) {
       this._cachedTooltipKey = tooltipKey;
@@ -596,7 +597,7 @@ export class StreamTabs extends LitElement {
               (stream) => {
                 const children =
                   this.childStreamsByParent.get(stream.name);
-                const childCount = children?.length ?? 0;
+                const childCount = !this.compact ? (children?.length ?? 0) : 0;
                 const expanded =
                   childCount > 0 && this.expandedParents.has(stream.name);
 

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -247,6 +247,36 @@ export class StreamTab extends LitElement {
       .tab-delete:focus-within {
         color: var(--vscode-errorForeground);
       }
+
+      /* Expand/collapse chevron for parent tabs with children */
+      .tab-expand {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        min-width: 20px;
+        height: 100%;
+        border: none;
+        background: none;
+        cursor: pointer;
+        color: var(--vscode-icon-foreground, var(--vscode-foreground));
+        opacity: 0.6;
+        padding: 0;
+      }
+
+      .tab-expand:hover {
+        opacity: 1;
+        background-color: var(--vscode-toolbar-hoverBackground);
+      }
+
+      .tab-expand .codicon {
+        font-size: var(--font-size-xs);
+        transition: transform var(--transition-fast);
+      }
+
+      .tab-expand[aria-expanded='true'] .codicon {
+        transform: rotate(90deg);
+      }
     `,
   ];
 
@@ -256,6 +286,10 @@ export class StreamTab extends LitElement {
   @property({ type: Boolean }) active = false;
   @property({ type: Boolean }) compact = false;
   @property({ type: Boolean }) hasPendingApproval = false;
+  /** Number of child streams (0 = no toggle shown). */
+  @property({ type: Number }) childCount = 0;
+  /** Whether the child list is expanded. */
+  @property({ type: Boolean }) expanded = false;
 
   override render(): TemplateResult {
     const stream = this.info;
@@ -268,6 +302,7 @@ export class StreamTab extends LitElement {
       rawCompactLabel.length > 8
         ? rawCompactLabel.slice(0, 7) + '…'
         : rawCompactLabel;
+    const hasChildren = this.childCount > 0 && !this.compact;
 
     return html`
       <div
@@ -276,10 +311,24 @@ export class StreamTab extends LitElement {
           'stream-tab': true,
           'is-active': this.active,
           'is-compact': this.compact,
+          'has-children': hasChildren,
           [`status-${status}`]: Boolean(status),
           'has-pending-approval': this.hasPendingApproval,
         })}
       >
+        ${hasChildren
+          ? html`<button
+              class="tab-expand"
+              data-stream=${stream.name}
+              data-action="toggle-children"
+              title=${this.expanded
+                ? 'Collapse child streams'
+                : `${this.childCount} child stream${this.childCount > 1 ? 's' : ''}`}
+              aria-expanded=${this.expanded ? 'true' : 'false'}
+            >
+              <i class="codicon codicon-chevron-right"></i>
+            </button>`
+          : nothing}
         <button
           class="tab"
           data-stream=${stream.name}
@@ -440,35 +489,6 @@ export class StreamTabs extends LitElement {
         opacity: var(--opacity-subtle, 0.5);
       }
 
-      .child-toggle {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-tiny);
-        padding: var(--spacing-tiny) var(--spacing-small);
-        border: none;
-        background: none;
-        color: var(--vscode-descriptionForeground, var(--vscode-foreground));
-        opacity: 0.7;
-        font-size: var(--font-size-xs);
-        font-family: var(--font-family);
-        cursor: pointer;
-        width: 100%;
-        text-align: left;
-      }
-
-      .child-toggle:hover {
-        opacity: 1;
-        background-color: var(--vscode-list-hoverBackground);
-      }
-
-      .child-toggle .codicon {
-        font-size: var(--font-size-xs);
-        transition: transform var(--transition-fast);
-      }
-
-      .child-toggle[aria-expanded='true'] .codicon {
-        transform: rotate(90deg);
-      }
     `,
   ];
 
@@ -539,28 +559,17 @@ export class StreamTabs extends LitElement {
               (stream) => {
                 const children =
                   this.childStreamsByParent.get(stream.name);
-                const hasChildren = children && children.length > 0;
+                const childCount = children?.length ?? 0;
                 const expanded =
-                  hasChildren && this.expandedParents.has(stream.name);
-                const activeCount = hasChildren
-                  ? children.filter((c) => {
-                      const s =
-                        this.streamStatusById.get(c.name) ??
-                        STREAM_STATUS.READY;
-                      return ACTIVE_CHILD_STATUSES.has(s);
-                    }).length
-                  : 0;
-                const toggleLabel = activeCount > 0
-                  ? `${activeCount} active`
-                  : `${children?.length ?? 0} done`;
+                  childCount > 0 && this.expandedParents.has(stream.name);
 
                 // prettier-ignore
-                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}></stream-tab>${hasChildren && !this.compact ? html`<button class="child-toggle" aria-expanded=${expanded ? 'true' : 'false'} data-parent=${stream.name} @click=${this.handleChildToggle} title=${expanded ? 'Collapse child streams' : `${children.length} child stream${children.length > 1 ? 's' : ''}`}><i class="codicon codicon-chevron-right"></i><span>${toggleLabel}</span></button>${expanded ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => {
+                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${childCount} ?expanded=${expanded}></stream-tab>${expanded && children ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => {
                   const childStatus = this.streamStatusById.get(child.name) ?? STREAM_STATUS.READY;
                   const isFinished = !ACTIVE_CHILD_STATUSES.has(childStatus);
                   // prettier-ignore
                   return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.streamLastTimestampById.get(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
-                })}</div>` : nothing}` : nothing}`;
+                })}</div>` : nothing}`;
               },
             )}
           </div>
@@ -648,15 +657,15 @@ export class StreamTabs extends LitElement {
       case 'delete':
         this.dispatchEvent(ProgressEvents.streamDelete({ streamId }));
         break;
+      case 'toggle-children':
+        this.toggleChildren(streamId);
+        break;
       default:
         break;
     }
   }
 
-  private handleChildToggle(event: MouseEvent): void {
-    const button = event.currentTarget as HTMLElement;
-    const parentId = button.dataset.parent;
-    if (!parentId) return;
+  private toggleChildren(parentId: string): void {
     const next = new Set(this.expandedParents);
     if (next.has(parentId)) {
       next.delete(parentId);

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -6,7 +6,12 @@ import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
 // Local imports
-import { STREAM_STATUS, type StreamTabInfo } from '@shared/schemas';
+import {
+  STREAM_STATUS,
+  type StreamTabId,
+  type StreamTabInfo,
+} from '@shared/schemas';
+import type { StreamState } from '../store';
 import {
   designTokens,
   animationStyles,
@@ -291,17 +296,36 @@ export class StreamTab extends LitElement {
   /** Whether the child list is expanded. */
   @property({ type: Boolean }) expanded = false;
 
+  // Cached derived values — only recomputed when inputs change
+  private _cachedInfo: StreamTabInfo | null = null;
+  private _compactLabel = '';
+  private _agentDecorator = getAgentCategoryDecorator('toolUse');
+  private _cachedTooltipKey = '';
+  private _tooltip = '';
+
   override render(): TemplateResult {
     const stream = this.info;
     const status = this.status || STREAM_STATUS.READY;
-    const tooltip = buildTooltip(stream, this.lastTimestamp, status);
-    const agentDecorator = getAgentCategoryDecorator(stream.agentCategory);
-    const rawCompactLabel =
-      `${stream.parentStreamId ? '↳' : ''}${stream.label || stream.name}`.trim();
-    const compactLabel =
-      rawCompactLabel.length > 8
-        ? rawCompactLabel.slice(0, 7) + '…'
-        : rawCompactLabel;
+
+    // Memoize info-derived values (only change when stream identity changes)
+    if (this._cachedInfo !== stream) {
+      this._cachedInfo = stream;
+      this._agentDecorator = getAgentCategoryDecorator(stream.agentCategory);
+      const raw =
+        `${stream.parentStreamId ? '↳' : ''}${stream.label || stream.name}`.trim();
+      this._compactLabel = raw.length > 8 ? raw.slice(0, 7) + '…' : raw;
+    }
+
+    // Memoize tooltip (changes on status or timestamp, not on every render)
+    const tooltipKey = `${status}\0${this.lastTimestamp}`;
+    if (this._cachedTooltipKey !== tooltipKey) {
+      this._cachedTooltipKey = tooltipKey;
+      this._tooltip = buildTooltip(stream, this.lastTimestamp, status);
+    }
+
+    const tooltip = this._tooltip;
+    const agentDecorator = this._agentDecorator;
+    const compactLabel = this._compactLabel;
     const hasChildren = this.childCount > 0 && !this.compact;
 
     return html`
@@ -497,10 +521,13 @@ export class StreamTabs extends LitElement {
   @property({ attribute: false }) activeStreamId: string | null = null;
   @property({ attribute: false }) filter: StreamFilter = 'all';
   @property({ attribute: false }) sort: StreamSort = 'time';
+  /**
+   * Stream states map — passed directly from ProgressApp's streamStates$.
+   * Stable Mutative reference (only changed entries get new refs), so
+   * Lit's Object.is() check prevents unnecessary re-renders.
+   */
   @property({ attribute: false })
-  streamStatusById: Map<string, string> = new Map();
-  @property({ attribute: false })
-  streamLastTimestampById: Map<string, number | undefined> = new Map();
+  streamStates: Map<StreamTabId, StreamState> = new Map();
   @property({ attribute: false })
   pendingApprovalStreamIds: Set<string> = new Set();
   @property({ attribute: false })
@@ -548,6 +575,16 @@ export class StreamTabs extends LitElement {
     if (dirty) this.expandedParents = next;
   }
 
+  /** Look up stream status from the states map (O(1), no allocation). */
+  private getStatus(name: string): string {
+    return this.streamStates.get(name as StreamTabId)?.status ?? STREAM_STATUS.READY;
+  }
+
+  /** Look up last timestamp from the states map (O(1), no allocation). */
+  private getTimestamp(name: string): number | undefined {
+    return this.streamStates.get(name as StreamTabId)?.lastTimestamp;
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="tabs">
@@ -564,11 +601,11 @@ export class StreamTabs extends LitElement {
                   childCount > 0 && this.expandedParents.has(stream.name);
 
                 // prettier-ignore
-                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.streamStatusById.get(stream.name) ?? STREAM_STATUS.READY} .lastTimestamp=${this.streamLastTimestampById.get(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${childCount} ?expanded=${expanded}></stream-tab>${expanded && children ? html`<div class="child-streams">${repeat(children, (child) => child.name, (child) => {
-                  const childStatus = this.streamStatusById.get(child.name) ?? STREAM_STATUS.READY;
+                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.getStatus(stream.name)} .lastTimestamp=${this.getTimestamp(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${childCount} ?expanded=${expanded}></stream-tab>${children && childCount > 0 ? html`<div class="child-streams" ?hidden=${!expanded}>${repeat(children, (child) => child.name, (child) => {
+                  const childStatus = this.getStatus(child.name);
                   const isFinished = !ACTIVE_CHILD_STATUSES.has(childStatus);
                   // prettier-ignore
-                  return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.streamLastTimestampById.get(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
+                  return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.getTimestamp(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
                 })}</div>` : nothing}`;
               },
             )}


### PR DESCRIPTION
## Summary

Fixes performance bottlenecks and UX issues with the stream tab sidebar when there are 100+ child streams (e.g. orchestrator with many codex subagents).

Follow-up to #2967 which introduced child stream nesting.

## Performance fixes

- **Eliminate Map allocation cascade**: Remove `statusAndTimestampById$` computed that allocated two new Maps on every `streamStates` change. Pass `streamStates` Map directly to `<stream-tabs>` — Mutative structural sharing ensures stable references for unchanged entries, so `Object.is()` passes and Lit skips re-renders for unaffected tabs.
- **Stabilize `childStreamsByParent$`**: Depend on `streamById$` (stream registry) instead of `sortedStreams$` (re-sorts on every state tick). Only recomputes when streams are added/removed.
- **Preserve child DOM on toggle**: Use `?hidden` attribute instead of conditional template for `.child-streams` div, avoiding create/destroy of 100+ child `<stream-tab>` components on expand/collapse.
- **Memoize StreamTab render internals**: Cache `agentDecorator`, `compactLabel` (by `info` identity), and `tooltip` string (by status+timestamp key) so they're not rebuilt on every render cycle.

## UX fix

- **Inline expand/collapse chevron**: Add `▶`/`▼` button directly on parent stream tabs (left side, before tab title). Clicking the chevron toggles child visibility without navigating to the stream. Replaces the separate toggle button that was below the tab.

## Test plan

- [ ] Open Progress View with an orchestrator that has 10+ child codex streams
- [ ] Verify expand/collapse chevron appears on parent tabs and toggles children
- [ ] Verify no visible lag when streams update status (RUNNING → READY)
- [ ] Verify compact mode (narrow sidebar) hides chevron and children
- [ ] Verify finished children appear dimmed, active children at full opacity

https://claude.ai/code/session_018XWj533EomKYFF5JRKEh4h

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to refactoring reactive/computed dependencies and tab rendering behavior; mistakes could cause stale ordering, incorrect active stream lookup, or broken expand/collapse interactions under heavy stream updates.
> 
> **Overview**
> Improves Progress View sidebar performance for large numbers of child streams by reducing reactive recomputation and avoiding per-update `Map` allocations; `<stream-tabs>` now receives the shared `streamStates` map directly.
> 
> Refactors stream/child grouping computeds so they only recompute when the stream registry changes (and only time-sorting reads timestamps), and updates active-stream lookup to use `streamById`.
> 
> Updates the child-stream UX by moving expand/collapse into an inline chevron on parent tabs and preserves child DOM on toggle via `?hidden`; `StreamTab` also memoizes tooltip/label/icon derivations to cut render work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88950f231067f8a9946f6886645a750c3e2d96bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->