### PR TITLE
Release v0.37.0: External Inquiry, Codex overhaul, and child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,25 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- **External Inquiry tool** — consult external AI agents (like ChatGPT or Gemini) directly from a conversation. Threads persist across sessions so you can resume multi-turn consultations later. Multiple inquiries dispatch in parallel with a carousel UI for navigating responses.
-- **Codex tool overhaul** — Codex now runs as a native child stream instead of polling temp files. Follow-up turns, file diffs, command output, and todo lists all render inline. Sessions persist and can be resumed after reloading the extension.
-- **Background bash in child streams** — long-running shell commands now stream output into nested child tabs with live progress, replacing the old temp-file approach. Output is capped at 200k characters to keep memory bounded.
-- **Native OpenRouter SDK handler** — full OpenRouter SDK integration with extended message format, context compaction, and reasoning support for compatible models.
+- **External Inquiry tool** — ask external AI agents (like ChatGPT or Gemini) questions directly from a conversation. Threads persist across sessions so you can resume consultations later, and multiple inquiries run in parallel with a carousel UI for navigating responses.
+- **Codex tool redesign** — Codex sessions now appear as live child streams with inline file diffs, command output, and todo lists. Multi-turn follow-ups are supported, and sessions survive extension reloads.
+- **Native OpenRouter SDK** — full OpenRouter integration with context compaction and reasoning support for compatible models.
 
 ### Improvements
 
-- **Child stream nesting** — background tasks, Codex sessions, and sub-agents now nest under their parent tab in the sidebar with expand/collapse toggles, active-count badges, and auto-expand on creation.
-- **Performance for many child streams** — optimized rendering and state tracking for 100+ concurrent child streams (structural sharing, memoized tab renders, single-pass status computation).
-- **Tool toggle system** — toggleable tools can now be enabled or disabled from the Tools settings tab. Disabled tools are excluded from agent tool lists.
-- **Self-contained document outputs** — all document-producing agents (correct, polish, paper2slide, paper2poster, review, lean, research) now ensure their output is readable without the surrounding conversation context.
+- **Child stream nesting** — background tasks, Codex sessions, and sub-agents now nest under their parent tab in the sidebar with expand/collapse controls and active-count badges.
+- **Live background bash output** — long-running shell commands now stream output into child tabs with live progress instead of appearing only after completion.
+- **Performance for many child streams** — the sidebar stays responsive even with 100+ concurrent child streams.
+- **Tool toggles** — individual tools can now be enabled or disabled from the Tools settings tab.
+- **Self-contained document outputs** — all document-producing agents (correct, polish, paper2slide, paper2poster, review, lean, research) now produce output that is readable on its own, without needing the conversation for context.
 - Updated dependencies (@anthropic-ai/sdk, @google/genai, esbuild, fast-xml-parser, and others).
 
 ### Bug Fixes
 
-- Fixed execution leak in Codex follow-up loop and concurrent-turn race conditions.
-- Fixed interrupt race where stopping a background bash command before it started was silently ignored.
-- Fixed child stream status incorrectly overriding a user-initiated stop.
-- Fixed spurious `/files/` path segment in external inquiry execution mirrors.
-- Fixed carousel identity tracking so resolving one inquiry no longer jumps to another panel.
+- Fixed Codex sessions occasionally hanging or running duplicate turns.
+- Stopping a background command before it started is no longer silently ignored.
+- Pressing Stop now reliably halts child streams instead of being overridden.
+- Resolving one external inquiry no longer causes the carousel to jump to a different panel.
 
 ## [0.36.10] - 2026-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.0] - 2026-04-04
+
+### Features
+
+- **External Inquiry tool** — consult external AI agents (like ChatGPT or Gemini) directly from a conversation. Threads persist across sessions so you can resume multi-turn consultations later. Multiple inquiries dispatch in parallel with a carousel UI for navigating responses.
+- **Codex tool overhaul** — Codex now runs as a native child stream instead of polling temp files. Follow-up turns, file diffs, command output, and todo lists all render inline. Sessions persist and can be resumed after reloading the extension.
+- **Background bash in child streams** — long-running shell commands now stream output into nested child tabs with live progress, replacing the old temp-file approach. Output is capped at 200k characters to keep memory bounded.
+- **Native OpenRouter SDK handler** — full OpenRouter SDK integration with extended message format, context compaction, and reasoning support for compatible models.
+
+### Improvements
+
+- **Child stream nesting** — background tasks, Codex sessions, and sub-agents now nest under their parent tab in the sidebar with expand/collapse toggles, active-count badges, and auto-expand on creation.
+- **Performance for many child streams** — optimized rendering and state tracking for 100+ concurrent child streams (structural sharing, memoized tab renders, single-pass status computation).
+- **Tool toggle system** — toggleable tools can now be enabled or disabled from the Tools settings tab. Disabled tools are excluded from agent tool lists.
+- **Self-contained document outputs** — all document-producing agents (correct, polish, paper2slide, paper2poster, review, lean, research) now ensure their output is readable without the surrounding conversation context.
+- Updated dependencies (@anthropic-ai/sdk, @google/genai, esbuild, fast-xml-parser, and others).
+
+### Bug Fixes
+
+- Fixed execution leak in Codex follow-up loop and concurrent-turn race conditions.
+- Fixed interrupt race where stopping a background bash command before it started was silently ignored.
+- Fixed child stream status incorrectly overriding a user-initiated stop.
+- Fixed spurious `/files/` path segment in external inquiry execution mirrors.
+- Fixed carousel identity tracking so resolving one inquiry no longer jumps to another panel.
+
 ## [0.36.10] - 2026-03-28
 
 ### Features


### PR DESCRIPTION
## Summary

This release introduces major architectural improvements to agent capabilities and UI organization. The primary changes include a new External Inquiry tool for consulting external AI agents, a complete Codex tool rewrite using native child streams, background bash command streaming, and comprehensive child stream nesting in the sidebar with performance optimizations for handling 100+ concurrent streams.

## Key Changes

- **External Inquiry tool** — New tool enabling direct consultation with external AI agents (ChatGPT, Gemini, etc.) with persistent multi-turn threads that resume across sessions. Multiple inquiries dispatch in parallel with carousel UI for response navigation.

- **Codex tool rewrite** — Migrated from polling temp files to native child stream architecture. Follow-up turns, file diffs, command output, and todo lists now render inline. Sessions persist and can be resumed after extension reload.

- **Background bash streaming** — Long-running shell commands now stream output into nested child tabs with live progress indicators, replacing the temp-file polling approach. Output is capped at 200k characters for memory efficiency.

- **OpenRouter SDK integration** — Added native OpenRouter SDK handler with extended message format, context compaction, and reasoning model support.

- **Child stream nesting UI** — Background tasks, Codex sessions, and sub-agents now nest hierarchically under parent tabs with expand/collapse toggles, active-count badges, and auto-expand on creation.

- **Child stream performance** — Optimized rendering and state tracking for 100+ concurrent child streams using structural sharing, memoized tab renders, and single-pass status computation.

- **Tool toggle system** — Tools can now be enabled/disabled from the Tools settings tab, with disabled tools automatically excluded from agent tool lists.

- **Self-contained document outputs** — All document-producing agents (correct, polish, paper2slide, paper2poster, review, lean, research) now generate outputs readable without surrounding conversation context.

## Bug Fixes

- Fixed execution leak in Codex follow-up loop and concurrent-turn race conditions
- Fixed interrupt race where stopping background bash before startup was silently ignored
- Fixed child stream status incorrectly overriding user-initiated stops
- Fixed spurious `/files/` path segment in external inquiry execution mirrors
- Fixed carousel identity tracking preventing inquiry panel jumping on resolution

https://claude.ai/code/session_01DUqWCTV4TseEec6ZsT8yc7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates `CHANGELOG.md` and does not modify runtime code or behavior.
> 
> **Overview**
> Adds a new `0.37.0` entry to `CHANGELOG.md`, documenting the release’s new features (External Inquiry tool, Codex redesign, native OpenRouter SDK), UI/performance improvements (nested child streams, streaming bash output, tool toggles, self-contained document outputs), and several related bug fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495df25b450042b1a75e1a1c459b1d19929817f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->