### PR TITLE
Add user-configurable reasoning effort setting for Codex

### DIFF
--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -25,8 +25,9 @@ export enum WorkspaceStateKey {
   DETACH_SUBAGENTS_ON_STOP = 'texra.detachSubagentsOnStop',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 
-  // Codex sandbox mode
+  // Codex settings
   CODEX_SANDBOX_MODE = 'texra.codexSandboxMode',
+  CODEX_REASONING_EFFORT = 'texra.codexReasoningEffort',
 
   // Git commit author settings
   GIT_MARK_COMMITS = 'texra.git.markCommits',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -76,6 +76,7 @@ export const SETTINGS_VIEW_CMD = {
   GET_APPROVAL_SETTINGS: 'getApprovalSettings',
   SET_BASH_APPROVAL_ENABLED: 'setBashApprovalEnabled',
   SET_CODEX_SANDBOX_MODE: 'setCodexSandboxMode',
+  SET_CODEX_REASONING_EFFORT: 'setCodexReasoningEffort',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,6 +49,8 @@ import { interruptAllCodexSessions } from '@tools/codex';
 import {
   parseCodexSandboxMode,
   setCodexSandboxModeGetter,
+  parseCodexReasoningEffort,
+  setCodexReasoningEffortGetter,
 } from '@tools/codexConfig';
 import { setExtensionChecker } from '@tools/externalToolDefs';
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
@@ -216,6 +218,14 @@ export async function activate(context: vscode.ExtensionContext) {
         WorkspaceStateKey.CODEX_SANDBOX_MODE,
         'workspace-write',
       ) ?? 'workspace-write',
+    ),
+  );
+  setCodexReasoningEffortGetter(() =>
+    parseCodexReasoningEffort(
+      workspaceSM.get<string>(
+        WorkspaceStateKey.CODEX_REASONING_EFFORT,
+        'high',
+      ) ?? 'high',
     ),
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,10 +222,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   setCodexReasoningEffortGetter(() =>
     parseCodexReasoningEffort(
-      workspaceSM.get<string>(
-        WorkspaceStateKey.CODEX_REASONING_EFFORT,
-        'high',
-      ) ?? 'high',
+      workspaceSM.get<string>(WorkspaceStateKey.CODEX_REASONING_EFFORT, 'high')!,
     ),
   );
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -102,7 +102,10 @@ import {
   countPinnedMemories,
 } from '@tools/memory/memoryMeta';
 import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
-import { parseCodexSandboxMode } from '@tools/codexConfig';
+import {
+  parseCodexSandboxMode,
+  parseCodexReasoningEffort,
+} from '@tools/codexConfig';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
 import { agentConfigToTaskState } from '@utils/config/configConversion';
@@ -490,6 +493,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         this.handleSetApprovalEnabled(BASH_APPROVAL_CONFIG_KEY, data.enabled),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE]: (data) =>
         this.handleSetCodexSandboxMode(data.mode),
+      [SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT]: (data) =>
+        this.handleSetCodexReasoningEffort(data.effort),
 
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
@@ -821,6 +826,12 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           'workspace-write',
         ) ?? 'workspace-write',
       ),
+      codexReasoningEffort: parseCodexReasoningEffort(
+        workspaceSM.get<string>(
+          WorkspaceStateKey.CODEX_REASONING_EFFORT,
+          'high',
+        ) ?? 'high',
+      ),
     });
   }
 
@@ -835,6 +846,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   private async handleSetCodexSandboxMode(mode: string): Promise<void> {
     await workspaceSM.update(WorkspaceStateKey.CODEX_SANDBOX_MODE, mode);
+    await this.withActiveWebview((w) => this.sendApprovalSettings(w));
+  }
+
+  private async handleSetCodexReasoningEffort(effort: string): Promise<void> {
+    await workspaceSM.update(WorkspaceStateKey.CODEX_REASONING_EFFORT, effort);
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
   }
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -492,9 +492,12 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED]: (data) =>
         this.handleSetApprovalEnabled(BASH_APPROVAL_CONFIG_KEY, data.enabled),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE]: (data) =>
-        this.handleSetCodexSandboxMode(data.mode),
+        this.updateCodexSetting(WorkspaceStateKey.CODEX_SANDBOX_MODE, data.mode),
       [SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT]: (data) =>
-        this.handleSetCodexReasoningEffort(data.effort),
+        this.updateCodexSetting(
+          WorkspaceStateKey.CODEX_REASONING_EFFORT,
+          data.effort,
+        ),
 
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
@@ -844,13 +847,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
   }
 
-  private async handleSetCodexSandboxMode(mode: string): Promise<void> {
-    await workspaceSM.update(WorkspaceStateKey.CODEX_SANDBOX_MODE, mode);
-    await this.withActiveWebview((w) => this.sendApprovalSettings(w));
-  }
-
-  private async handleSetCodexReasoningEffort(effort: string): Promise<void> {
-    await workspaceSM.update(WorkspaceStateKey.CODEX_REASONING_EFFORT, effort);
+  private async updateCodexSetting(
+    key: WorkspaceStateKey,
+    value: string,
+  ): Promise<void> {
+    await workspaceSM.update(key, value);
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
   }
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -185,6 +185,7 @@ export class SettingsApp extends SettingsAppBase {
   // Approval settings state
   private readonly bashApprovalEnabled = signal(true);
   private readonly codexSandboxMode = signal<string>('workspace-write');
+  private readonly codexReasoningEffort = signal<string>('high');
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
@@ -357,6 +358,7 @@ export class SettingsApp extends SettingsAppBase {
         if (!data) return;
         this.bashApprovalEnabled.set(data.bashApprovalEnabled);
         this.codexSandboxMode.set(data.codexSandboxMode);
+        this.codexReasoningEffort.set(data.codexReasoningEffort);
         return;
       }
 
@@ -608,6 +610,10 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE,
   );
 
+  private handleCodexReasoningEffortChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT,
+  );
+
   // Git settings event handlers
   private handleGitMarkCommitsToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
@@ -827,12 +833,14 @@ export class SettingsApp extends SettingsAppBase {
               .loaded=${this.toolDashboardLoaded.get()}
               .bashApprovalEnabled=${this.bashApprovalEnabled.get()}
               .codexSandboxMode=${this.codexSandboxMode.get()}
+              .codexReasoningEffort=${this.codexReasoningEffort.get()}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @bash-approval-toggle=${this.handleBashApprovalToggle}
               @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
+              @codex-reasoning-effort-change=${this.handleCodexReasoningEffortChange}
             ></tools-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -264,23 +264,20 @@ export class ToolsTab extends LitElement {
     this.emitToggle('bash-approval-toggle', e);
   };
 
-  private handleCodexSandboxModeChange(e: Event): void {
-    const target = e.target as HTMLSelectElement | null;
-    const mode = target?.value;
-    if (mode) {
-      this.dispatchEvent(createEvent('codex-sandbox-mode-change', { mode }));
+  private emitSelect(eventName: string, key: string, e: Event): void {
+    const value = (e.target as HTMLSelectElement | null)?.value;
+    if (value) {
+      this.dispatchEvent(createEvent(eventName, { [key]: value }));
     }
   }
 
-  private handleCodexReasoningEffortChange(e: Event): void {
-    const target = e.target as HTMLSelectElement | null;
-    const effort = target?.value;
-    if (effort) {
-      this.dispatchEvent(
-        createEvent('codex-reasoning-effort-change', { effort }),
-      );
-    }
-  }
+  private handleCodexSandboxModeChange = (e: Event): void => {
+    this.emitSelect('codex-sandbox-mode-change', 'mode', e);
+  };
+
+  private handleCodexReasoningEffortChange = (e: Event): void => {
+    this.emitSelect('codex-reasoning-effort-change', 'effort', e);
+  };
 
   private renderApprovalSettings(): TemplateResult {
     return html`

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -17,6 +17,7 @@ import type {
   ToolDashboardItem,
   ToolCategory,
   CodexSandboxMode,
+  CodexReasoningEffort,
 } from '@shared/schemas/settingsViewMessages';
 
 // Side-effect: register tool card component
@@ -30,6 +31,16 @@ const SANDBOX_MODE_OPTIONS: readonly {
   { value: 'read-only', label: 'Read-only' },
   { value: 'workspace-write', label: 'Workspace write' },
   { value: 'danger-full-access', label: 'Full access' },
+] as const;
+
+/** Reasoning effort display labels — single source of truth for the UI. */
+const REASONING_EFFORT_OPTIONS: readonly {
+  value: CodexReasoningEffort;
+  label: string;
+}[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
 ] as const;
 
 /** Per-category display metadata. */
@@ -236,6 +247,7 @@ export class ToolsTab extends LitElement {
   @property({ type: Boolean }) loaded = false;
   @property({ type: Boolean }) bashApprovalEnabled = true;
   @property({ type: String }) codexSandboxMode = 'workspace-write';
+  @property({ type: String }) codexReasoningEffort = 'high';
 
   private handleRecheck(): void {
     this.dispatchEvent(createEvent('tool-recheck'));
@@ -257,6 +269,16 @@ export class ToolsTab extends LitElement {
     const mode = target?.value;
     if (mode) {
       this.dispatchEvent(createEvent('codex-sandbox-mode-change', { mode }));
+    }
+  }
+
+  private handleCodexReasoningEffortChange(e: Event): void {
+    const target = e.target as HTMLSelectElement | null;
+    const effort = target?.value;
+    if (effort) {
+      this.dispatchEvent(
+        createEvent('codex-reasoning-effort-change', { effort }),
+      );
     }
   }
 
@@ -295,6 +317,25 @@ export class ToolsTab extends LitElement {
                 <vscode-option
                   value=${opt.value}
                   ?selected=${this.codexSandboxMode === opt.value}
+                >
+                  ${opt.label}
+                </vscode-option>
+              `,
+            )}
+          </vscode-single-select>
+        </div>
+        <div class="sandbox-mode-row">
+          <label>Reasoning effort</label>
+          <vscode-single-select
+            class="sandbox-mode-select"
+            .value=${this.codexReasoningEffort}
+            @change=${this.handleCodexReasoningEffortChange}
+          >
+            ${REASONING_EFFORT_OPTIONS.map(
+              (opt) => html`
+                <vscode-option
+                  value=${opt.value}
+                  ?selected=${this.codexReasoningEffort === opt.value}
                 >
                   ${opt.label}
                 </vscode-option>

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -225,19 +225,19 @@ export class ToolsTab extends LitElement {
         margin-bottom: var(--spacing-small);
       }
 
-      .sandbox-mode-row {
+      .setting-row {
         display: flex;
         align-items: center;
         gap: var(--spacing-medium);
       }
 
-      .sandbox-mode-row label {
+      .setting-row label {
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         white-space: nowrap;
       }
 
-      .sandbox-mode-select {
+      .setting-select {
         min-width: 10rem;
         max-width: 14rem;
       }
@@ -300,47 +300,50 @@ export class ToolsTab extends LitElement {
     `;
   }
 
+  private renderSelectRow(
+    label: string,
+    value: string,
+    options: readonly { value: string; label: string }[],
+    onChange: (e: Event) => void,
+  ): TemplateResult {
+    return html`
+      <div class="setting-row">
+        <label>${label}</label>
+        <vscode-single-select
+          class="setting-select"
+          .value=${value}
+          @change=${onChange}
+        >
+          ${options.map(
+            (opt) => html`
+              <vscode-option
+                value=${opt.value}
+                ?selected=${value === opt.value}
+              >
+                ${opt.label}
+              </vscode-option>
+            `,
+          )}
+        </vscode-single-select>
+      </div>
+    `;
+  }
+
   private renderCodexInlineSettings(): TemplateResult {
     return html`
       <div class="codex-inline-settings">
-        <div class="sandbox-mode-row">
-          <label>Sandbox mode</label>
-          <vscode-single-select
-            class="sandbox-mode-select"
-            .value=${this.codexSandboxMode}
-            @change=${this.handleCodexSandboxModeChange}
-          >
-            ${SANDBOX_MODE_OPTIONS.map(
-              (opt) => html`
-                <vscode-option
-                  value=${opt.value}
-                  ?selected=${this.codexSandboxMode === opt.value}
-                >
-                  ${opt.label}
-                </vscode-option>
-              `,
-            )}
-          </vscode-single-select>
-        </div>
-        <div class="sandbox-mode-row">
-          <label>Reasoning effort</label>
-          <vscode-single-select
-            class="sandbox-mode-select"
-            .value=${this.codexReasoningEffort}
-            @change=${this.handleCodexReasoningEffortChange}
-          >
-            ${REASONING_EFFORT_OPTIONS.map(
-              (opt) => html`
-                <vscode-option
-                  value=${opt.value}
-                  ?selected=${this.codexReasoningEffort === opt.value}
-                >
-                  ${opt.label}
-                </vscode-option>
-              `,
-            )}
-          </vscode-single-select>
-        </div>
+        ${this.renderSelectRow(
+          'Sandbox mode',
+          this.codexSandboxMode,
+          SANDBOX_MODE_OPTIONS,
+          this.handleCodexSandboxModeChange,
+        )}
+        ${this.renderSelectRow(
+          'Reasoning effort',
+          this.codexReasoningEffort,
+          REASONING_EFFORT_OPTIONS,
+          this.handleCodexReasoningEffortChange,
+        )}
       </div>
     `;
   }

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -41,6 +41,7 @@ const REASONING_EFFORT_OPTIONS: readonly {
   { value: 'low', label: 'Low' },
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
+  { value: 'xhigh', label: 'Extra high' },
 ] as const;
 
 /** Per-category display metadata. */

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -301,7 +301,12 @@ export const CodexSandboxModeSchema = z.enum([
 export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
 
 /** Valid Codex reasoning effort levels (mirrors CODEX_REASONING_EFFORTS in codexConfig.ts). */
-export const CodexReasoningEffortSchema = z.enum(['low', 'medium', 'high']);
+export const CodexReasoningEffortSchema = z.enum([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
 
 /** Outbound: backend → frontend approval settings */

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -300,11 +300,16 @@ export const CodexSandboxModeSchema = z.enum([
 ]);
 export type CodexSandboxMode = z.infer<typeof CodexSandboxModeSchema>;
 
+/** Valid Codex reasoning effort levels (mirrors CODEX_REASONING_EFFORTS in codexConfig.ts). */
+export const CodexReasoningEffortSchema = z.enum(['low', 'medium', 'high']);
+export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
+
 /** Outbound: backend → frontend approval settings */
 export const UpdateApprovalSettingsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS),
   bashApprovalEnabled: z.boolean(),
   codexSandboxMode: CodexSandboxModeSchema,
+  codexReasoningEffort: CodexReasoningEffortSchema,
 });
 export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
@@ -630,6 +635,10 @@ const SetCodexSandboxModeMessageSchema = z.object({
   command: z.literal(CMD.SET_CODEX_SANDBOX_MODE),
   mode: CodexSandboxModeSchema,
 });
+const SetCodexReasoningEffortMessageSchema = z.object({
+  command: z.literal(CMD.SET_CODEX_REASONING_EFFORT),
+  effort: CodexReasoningEffortSchema,
+});
 
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
@@ -719,6 +728,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     GetApprovalSettingsMessageSchema,
     SetBashApprovalEnabledMessageSchema,
     SetCodexSandboxModeMessageSchema,
+    SetCodexReasoningEffortMessageSchema,
     // Agent mode preset messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -581,7 +581,7 @@ export class CodexTool extends defineTool({
       ...workspace,
       sandboxMode,
       model: config.CODEX_CLI_MODEL,
-      modelReasoningEffort: config.CODEX_REASONING_EFFORT,
+      modelReasoningEffort: config.getCodexReasoningEffort(),
       skipGitRepoCheck: true as const,
     };
 

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -14,8 +14,37 @@ import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 /** Short model name passed to the Codex CLI via --model. */
 export const CODEX_CLI_MODEL = 'gpt-5.4';
 
-/** Default reasoning effort passed to the Codex CLI. */
-export const CODEX_REASONING_EFFORT = 'high' as const;
+// ============================================================================
+// Reasoning effort config (injectable — VS Code layer sets the real getter)
+// ============================================================================
+
+export const CODEX_REASONING_EFFORTS = ['low', 'medium', 'high'] as const;
+
+export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
+
+const DEFAULT_REASONING_EFFORT: CodexReasoningEffort = 'high';
+
+/** Validate a raw string into a reasoning effort, falling back to the default. */
+export function parseCodexReasoningEffort(raw: string): CodexReasoningEffort {
+  return CODEX_REASONING_EFFORTS.includes(raw as CodexReasoningEffort)
+    ? (raw as CodexReasoningEffort)
+    : DEFAULT_REASONING_EFFORT;
+}
+
+let reasoningEffortGetter: () => CodexReasoningEffort = () =>
+  DEFAULT_REASONING_EFFORT;
+
+/** Register a platform-specific getter for the configured reasoning effort. */
+export function setCodexReasoningEffortGetter(
+  getter: () => CodexReasoningEffort,
+): void {
+  reasoningEffortGetter = getter;
+}
+
+/** Read the user-configured reasoning effort. */
+export function getCodexReasoningEffort(): CodexReasoningEffort {
+  return reasoningEffortGetter();
+}
 
 // ============================================================================
 // Sandbox mode config (injectable — VS Code layer sets the real getter)

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -18,7 +18,12 @@ export const CODEX_CLI_MODEL = 'gpt-5.4';
 // Reasoning effort config (injectable — VS Code layer sets the real getter)
 // ============================================================================
 
-export const CODEX_REASONING_EFFORTS = ['low', 'medium', 'high'] as const;
+export const CODEX_REASONING_EFFORTS = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+] as const;
 
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
 

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -15,76 +15,62 @@ import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 export const CODEX_CLI_MODEL = 'gpt-5.4';
 
 // ============================================================================
-// Reasoning effort config (injectable — VS Code layer sets the real getter)
+// Injectable config factory — used for Codex settings that the VS Code layer
+// provides at startup via a getter, keeping src/tools/ free of vscode imports.
 // ============================================================================
 
-export const CODEX_REASONING_EFFORTS = [
-  'low',
-  'medium',
+interface CodexConfigSetting<T extends string> {
+  readonly values: readonly T[];
+  parse: (raw: string) => T;
+  get: () => T;
+  setGetter: (getter: () => T) => void;
+}
+
+function createCodexSetting<const T extends string>(
+  values: readonly T[],
+  defaultValue: NoInfer<T>,
+): CodexConfigSetting<T> {
+  let getter: () => T = () => defaultValue;
+  return {
+    values,
+    parse: (raw: string): T =>
+      (values as readonly string[]).includes(raw) ? (raw as T) : defaultValue,
+    get: () => getter(),
+    setGetter: (fn: () => T) => {
+      getter = fn;
+    },
+  };
+}
+
+// ============================================================================
+// Reasoning effort
+// ============================================================================
+
+const reasoningEffort = createCodexSetting(
+  ['low', 'medium', 'high', 'xhigh'] as const,
   'high',
-  'xhigh',
-] as const;
+);
 
+export const CODEX_REASONING_EFFORTS = reasoningEffort.values;
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
-
-const DEFAULT_REASONING_EFFORT: CodexReasoningEffort = 'high';
-
-/** Validate a raw string into a reasoning effort, falling back to the default. */
-export function parseCodexReasoningEffort(raw: string): CodexReasoningEffort {
-  return CODEX_REASONING_EFFORTS.includes(raw as CodexReasoningEffort)
-    ? (raw as CodexReasoningEffort)
-    : DEFAULT_REASONING_EFFORT;
-}
-
-let reasoningEffortGetter: () => CodexReasoningEffort = () =>
-  DEFAULT_REASONING_EFFORT;
-
-/** Register a platform-specific getter for the configured reasoning effort. */
-export function setCodexReasoningEffortGetter(
-  getter: () => CodexReasoningEffort,
-): void {
-  reasoningEffortGetter = getter;
-}
-
-/** Read the user-configured reasoning effort. */
-export function getCodexReasoningEffort(): CodexReasoningEffort {
-  return reasoningEffortGetter();
-}
+export const parseCodexReasoningEffort = reasoningEffort.parse;
+export const getCodexReasoningEffort = reasoningEffort.get;
+export const setCodexReasoningEffortGetter = reasoningEffort.setGetter;
 
 // ============================================================================
-// Sandbox mode config (injectable — VS Code layer sets the real getter)
+// Sandbox mode
 // ============================================================================
 
-export const CODEX_SANDBOX_MODES = [
-  'read-only',
+const sandboxMode = createCodexSetting(
+  ['read-only', 'workspace-write', 'danger-full-access'] as const,
   'workspace-write',
-  'danger-full-access',
-] as const;
+);
 
+export const CODEX_SANDBOX_MODES = sandboxMode.values;
 export type CodexSandboxMode = (typeof CODEX_SANDBOX_MODES)[number];
-
-const DEFAULT_SANDBOX_MODE: CodexSandboxMode = 'workspace-write';
-
-/** Validate a raw string into a sandbox mode, falling back to the default. */
-export function parseCodexSandboxMode(raw: string): CodexSandboxMode {
-  return CODEX_SANDBOX_MODES.includes(raw as CodexSandboxMode)
-    ? (raw as CodexSandboxMode)
-    : DEFAULT_SANDBOX_MODE;
-}
-
-let sandboxModeGetter: () => CodexSandboxMode = () => DEFAULT_SANDBOX_MODE;
-
-/** Register a platform-specific getter for the configured sandbox mode. */
-export function setCodexSandboxModeGetter(
-  getter: () => CodexSandboxMode,
-): void {
-  sandboxModeGetter = getter;
-}
-
-/** Read the user-configured default sandbox mode. */
-export function getCodexSandboxMode(): CodexSandboxMode {
-  return sandboxModeGetter();
-}
+export const parseCodexSandboxMode = sandboxMode.parse;
+export const getCodexSandboxMode = sandboxMode.get;
+export const setCodexSandboxModeGetter = sandboxMode.setGetter;
 
 /**
  * Build synthetic execution metadata for Codex child streams.


### PR DESCRIPTION
## Summary
This PR adds a new user-configurable "reasoning effort" setting for Codex, allowing users to choose between low, medium, and high effort levels. The setting is persisted in workspace state and integrated into the settings UI alongside the existing sandbox mode configuration.

## Key Changes

- **New reasoning effort configuration system** (`codexConfig.ts`):
  - Added `CODEX_REASONING_EFFORTS` constant defining valid effort levels
  - Created `CodexReasoningEffort` type for type-safe effort values
  - Implemented `parseCodexReasoningEffort()` validation function
  - Added injectable getter/setter pattern (`getCodexReasoningEffort()`, `setCodexReasoningEffortGetter()`) for platform-specific configuration, mirroring the existing sandbox mode pattern

- **Settings UI integration** (`ToolsTab.ts`):
  - Added `REASONING_EFFORT_OPTIONS` constant with display labels
  - Created new `codexReasoningEffort` property with default value 'high'
  - Refactored `handleCodexSandboxModeChange()` into a generic `emitSelect()` helper to reduce duplication
  - Added `handleCodexReasoningEffortChange()` handler
  - Rendered new reasoning effort dropdown selector in approval settings section

- **Message schema updates** (`settingsViewMessages.ts`):
  - Added `CodexReasoningEffortSchema` and `CodexReasoningEffort` type
  - Extended `UpdateApprovalSettingsMessage` to include `codexReasoningEffort`
  - Added `SetCodexReasoningEffortMessage` schema for inbound commands

- **Backend message handling** (`SettingsViewMessageHandler.ts`):
  - Added `handleSetCodexReasoningEffort()` to persist setting to workspace state
  - Updated `sendApprovalSettings()` to include reasoning effort from workspace state
  - Wired new command handler in message dispatcher

- **Frontend state management** (`SettingsApp.ts`):
  - Added `codexReasoningEffort` signal for reactive state
  - Updated message handler to populate signal from backend
  - Added event handler forwarding for reasoning effort changes
  - Passed state and handler to `ToolsTab` component

- **Extension initialization** (`extension.ts`):
  - Registered reasoning effort getter with workspace state lookup
  - Integrated with existing configuration injection pattern

- **Codex execution** (`codex.ts`):
  - Changed from hardcoded `CODEX_REASONING_EFFORT` constant to dynamic `getCodexReasoningEffort()` call

- **Workspace state** (`stateManager.ts`):
  - Added `CODEX_REASONING_EFFORT` key to `WorkspaceStateKey` enum

- **Command definitions** (`settingsViewCommands.ts`):
  - Added `SET_CODEX_REASONING_EFFORT` command constant

## Notable Implementation Details

- The reasoning effort configuration follows the same injectable getter pattern as sandbox mode, allowing the VS Code extension layer to provide platform-specific configuration
- The UI dropdown is rendered using the same component structure as the existing sandbox mode selector for consistency
- Validation is performed at parse time with fallback to default ('high') for invalid values
- The setting is persisted to workspace state and restored on settings view initialization

https://claude.ai/code/session_01T72ivZBgcEmHKs6mBs3TPP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted setting that changes how Codex threads are started/resumed, plus new settings-view message schemas and handlers; mistakes could lead to invalid CLI options or broken settings UI flow.
> 
> **Overview**
> Adds a **workspace-persisted Codex “reasoning effort” setting** and exposes it in the Settings view alongside sandbox mode.
> 
> The extension now injects a `getCodexReasoningEffort()` getter from `workspaceSM`, the settings webview can read/update this value via new `SET_CODEX_REASONING_EFFORT` messages, and Codex thread creation uses the configured effort instead of a hardcoded constant. `codexConfig.ts` is refactored to a reusable injectable setting factory shared by both sandbox mode and reasoning effort, with parsing/validation and defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48349dee3f1119242746f92a6d62804b7f88ffa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->