### PR TITLE
Upgrade create-pull-request action from v5 to v8

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
@@ -54,7 +54,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: main
@@ -54,7 +54,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: bump version to ${{ steps.bump_version.outputs.NEW_VERSION }}'


### PR DESCRIPTION
## Summary
Updates the `peter-evans/create-pull-request` GitHub Action to the latest major version (v8) in the version-bump workflow.

## Changes
- Upgraded `peter-evans/create-pull-request` from v5 to v8 in the version-bump workflow

## Details
This upgrade brings the action to the latest major version, which includes bug fixes, performance improvements, and new features. The action configuration remains compatible with v8, requiring no changes to the workflow parameters.

https://claude.ai/code/session_011ppkzCJHws7ZSZVbDansGM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a dependency bump in a GitHub Actions workflow with no changes to versioning logic or repo code paths, though it may slightly affect PR-creation behavior if the action has breaking changes.
> 
> **Overview**
> Updates the release-triggered `version-bump.yml` workflow to use `peter-evans/create-pull-request@v8` instead of `@v5` when opening the automated version bump PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3c073c50b0910b1fc4ff0aa44690ba8149e347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->