### PR TITLE
Upgrade Node.js to v22 and setup-node action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,9 +19,9 @@ jobs:
           ref: main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Configure Git


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to use Node.js v22 and the latest setup-node action (v5).

## Changes
- Upgraded `actions/setup-node` from v4 to v5 in both CI and version-bump workflows
- Updated Node.js version from 20 to 22 in both workflows

## Details
These updates ensure the CI/CD pipelines use the latest stable Node.js LTS version and the most recent setup-node action, which may include performance improvements and bug fixes.

https://claude.ai/code/session_01TCdhKZPFKZ8WbKtDQtSXFx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates GitHub Actions tooling/runtime versions; potential issues are limited to CI/version-bump workflow compatibility with Node 22 or `setup-node@v5`.
> 
> **Overview**
> Updates GitHub Actions workflows to run on **Node.js 22** and use **`actions/setup-node@v5`** (from Node 20 / `setup-node@v4`) for both CI validation and the release-triggered version-bump automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a60465432bdf362a5ad59ef14ee0a849a78e05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->