### PR TITLE
Implement dynamic cache TTL strategy for Anthropic API

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -229,9 +229,18 @@ type CacheControlCompactionBlock = Extract<
   { type: 'compaction' }
 >;
 
-const EPHEMERAL_CACHE_CONTROL: CacheControlEphemeral = {
+const SHORT_CACHE_CONTROL: CacheControlEphemeral = {
   type: 'ephemeral',
 };
+
+const LONG_CACHE_CONTROL: CacheControlEphemeral = {
+  type: 'ephemeral',
+  ttl: '1h',
+};
+
+// Cache creation cost multipliers relative to base input price, by TTL.
+const CACHE_CREATION_COST_MULTIPLIER_5M = 1.25;
+const CACHE_CREATION_COST_MULTIPLIER_1H = 2.0;
 
 // Anthropic allows up to 4 cache breakpoint slots total. Top-level automatic
 // caching uses one slot, and the system prompt uses another when present.
@@ -589,6 +598,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.pruneTrackedPdfPages(messages);
     }
 
+    // Use 1-hour cache TTL for tool-use requests (which involve long-running
+    // tool execution cycles where 5-minute caches would frequently expire),
+    // and 5-minute TTL for simple non-tool requests.
+    const cacheControl = tools?.length
+      ? LONG_CACHE_CONTROL
+      : SHORT_CACHE_CONTROL;
+
     // Phase 1: BUILD - Construct provider-specific request parameters
     const options: MessageCreateParams = {
       model: this.config.fullName,
@@ -605,7 +621,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
               {
                 type: 'text' as const,
                 text: systemPrompt,
-                cache_control: EPHEMERAL_CACHE_CONTROL,
+                cache_control: cacheControl,
               },
             ]
           : systemPrompt,
@@ -613,7 +629,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       // breakpoint to the last cacheable block, moving it forward as conversations
       // grow. This replaces manual per-block cache_control assignment.
       ...(supportsCache && {
-        cache_control: EPHEMERAL_CACHE_CONTROL,
+        cache_control: cacheControl,
       }),
     };
 
@@ -1765,8 +1781,37 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     if (this.capabilities.supportsPromptCaching) {
       if (usageTotals.cacheCreationTokens > 0) {
-        basePrice +=
-          (usageTotals.cacheCreationTokens * inputPrice * 1.25) / 1e6;
+        const pricedBreakdownTokens =
+          usageTotals.cacheCreation5mTokens + usageTotals.cacheCreation1hTokens;
+
+        if (pricedBreakdownTokens > 0) {
+          basePrice +=
+            (usageTotals.cacheCreation5mTokens *
+              inputPrice *
+              CACHE_CREATION_COST_MULTIPLIER_5M) /
+            1e6;
+          basePrice +=
+            (usageTotals.cacheCreation1hTokens *
+              inputPrice *
+              CACHE_CREATION_COST_MULTIPLIER_1H) /
+            1e6;
+
+          const unclassifiedCacheCreationTokens = Math.max(
+            usageTotals.cacheCreationTokens - pricedBreakdownTokens,
+            0,
+          );
+          basePrice +=
+            (unclassifiedCacheCreationTokens *
+              inputPrice *
+              CACHE_CREATION_COST_MULTIPLIER_5M) /
+            1e6;
+        } else {
+          basePrice +=
+            (usageTotals.cacheCreationTokens *
+              inputPrice *
+              CACHE_CREATION_COST_MULTIPLIER_5M) /
+            1e6;
+        }
       }
       if (usageTotals.cacheReadTokens > 0) {
         basePrice +=
@@ -1829,6 +1874,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
     outputTokens: number;
     cacheReadTokens: number;
     cacheCreationTokens: number;
+    cacheCreation5mTokens: number;
+    cacheCreation1hTokens: number;
   } {
     const usageWithIterations = responseUsage as AnthropicUsage & {
       iterations?: BetaUsage['iterations'];
@@ -1839,12 +1886,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
       let outputTokens = 0;
       let cacheReadTokens = 0;
       let cacheCreationTokens = 0;
+      let cacheCreation5mTokens = 0;
+      let cacheCreation1hTokens = 0;
 
       for (const iteration of iterations) {
         baseInputTokens += iteration.input_tokens;
         outputTokens += iteration.output_tokens;
         cacheReadTokens += iteration.cache_read_input_tokens;
         cacheCreationTokens += iteration.cache_creation_input_tokens;
+        cacheCreation5mTokens +=
+          iteration.cache_creation?.ephemeral_5m_input_tokens ?? 0;
+        cacheCreation1hTokens +=
+          iteration.cache_creation?.ephemeral_1h_input_tokens ?? 0;
       }
 
       return {
@@ -1852,6 +1905,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         outputTokens,
         cacheReadTokens,
         cacheCreationTokens,
+        cacheCreation5mTokens,
+        cacheCreation1hTokens,
       };
     }
 
@@ -1860,6 +1915,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
       outputTokens: responseUsage.output_tokens ?? 0,
       cacheReadTokens: responseUsage.cache_read_input_tokens ?? 0,
       cacheCreationTokens: responseUsage.cache_creation_input_tokens ?? 0,
+      cacheCreation5mTokens:
+        responseUsage.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+      cacheCreation1hTokens:
+        responseUsage.cache_creation?.ephemeral_1h_input_tokens ?? 0,
     };
   }
 
@@ -2212,7 +2271,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     return assistantContent.map((block) =>
       block.type === 'compaction'
-        ? { ...block, cache_control: EPHEMERAL_CACHE_CONTROL }
+        ? { ...block, cache_control: LONG_CACHE_CONTROL }
         : block,
     );
   }

--- a/src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts
+++ b/src/test-kernel/agent/modelHandlers/AnthropicCachePricing.vitest.ts
@@ -1,0 +1,65 @@
+// Third-party imports
+import { DEFAULT_MODEL_CAPABILITIES, ModelProvider } from 'llm-zoo';
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent model handlers
+import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
+
+function createHandler(): ModelHandlerAnthropic {
+  return new ModelHandlerAnthropic({
+    name: 'test-anthropic',
+    label: 'Test Anthropic',
+    fullName: 'claude-test',
+    shortName: 'claude-test',
+    provider: ModelProvider.ANTHROPIC,
+    maxOutputTokens: 1024,
+    inputPrice: 3,
+    outputPrice: 15,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsPromptCaching: true,
+    },
+    openRouterOnly: false,
+  });
+}
+
+describe('Anthropic cache pricing', () => {
+  it('prices cache creation by TTL breakdown when Anthropic reports it', () => {
+    const price = createHandler().computePrice({
+      input_tokens: 1000,
+      output_tokens: 100,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 30,
+      cache_creation: {
+        ephemeral_5m_input_tokens: 10,
+        ephemeral_1h_input_tokens: 20,
+      },
+      server_tool_use: null,
+      service_tier: 'standard',
+    } as any);
+
+    const expected =
+      (1000 * 3) / 1e6 +
+      (100 * 15) / 1e6 +
+      (10 * 3 * 1.25) / 1e6 +
+      (20 * 3 * 2) / 1e6;
+    expect(price).toBeCloseTo(expected, 12);
+  });
+
+  it('falls back to 5-minute pricing when the TTL breakdown is absent', () => {
+    const price = createHandler().computePrice({
+      input_tokens: 1000,
+      output_tokens: 100,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 30,
+      cache_creation: {},
+      server_tool_use: null,
+      service_tier: 'standard',
+    } as any);
+
+    const expected =
+      (1000 * 3) / 1e6 + (100 * 15) / 1e6 + (30 * 3 * 1.25) / 1e6;
+    expect(price).toBeCloseTo(expected, 12);
+  });
+});


### PR DESCRIPTION
## Summary
This PR implements a dynamic cache TTL (time-to-live) strategy for the Anthropic model handler, using different cache durations based on request characteristics and improving cache cost calculation accuracy.

## Key Changes
- **Dynamic cache TTL selection**: Tool-use requests now use 1-hour cache TTL (to avoid expiration during long-running tool execution cycles), while simple non-tool requests use 5-minute TTL
- **Renamed cache control constant**: `EPHEMERAL_CACHE_CONTROL` → `SHORT_CACHE_CONTROL` for clarity, with new `LONG_CACHE_CONTROL` constant for 1-hour TTL
- **Added cache cost multiplier constants**: Defined `CACHE_CREATION_COST_MULTIPLIER_5M` (1.25x) and `CACHE_CREATION_COST_MULTIPLIER_1H` (2.0x) to match Anthropic's pricing structure
- **Improved cache cost calculation**: Updated pricing logic to use per-TTL breakdown when available from the API response (`cache_creation.ephemeral_5m_input_tokens` and `cache_creation.ephemeral_1h_input_tokens`), with fallback to 5-minute assumption for older API responses
- **Updated compaction block caching**: Compaction blocks now use `LONG_CACHE_CONTROL` instead of short-lived cache

## Implementation Details
- The cache TTL selection logic checks if the request includes tools: `tools?.length ? LONG_CACHE_CONTROL : SHORT_CACHE_CONTROL`
- Cache cost calculation includes a fallback mechanism for API responses that don't provide TTL-specific token breakdowns, ensuring backward compatibility
- All cache control assignments throughout the request building process now use the dynamically selected `cacheControl` variable

https://claude.ai/code/session_01SPjaYDHbNsRxz9efMJZ5eq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Anthropic request caching behavior (5m vs 1h) and alters billing calculations for prompt-cache creation tokens, which could impact latency/cost if misclassified or if API usage fields differ across models.
> 
> **Overview**
> Anthropic requests now choose **cache TTL dynamically**: tool-use calls use a 1-hour ephemeral cache while non-tool calls keep the short-lived cache, and compaction blocks are updated to use the long TTL.
> 
> Pricing for prompt cache creation is updated to apply different cost multipliers for 5-minute vs 1-hour cache creation tokens when Anthropic reports a TTL breakdown, with a fallback to 5-minute pricing when it does not. A new Vitest suite (`AnthropicCachePricing.vitest.ts`) covers both pricing paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c7c83d287f7d28753c19a964572a8332adbf1e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->