### PR TITLE
Refactor Codex logging to use shared builder functions

### DIFF
--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -284,6 +284,12 @@ export function formatToolUseTemplate(
       typeof input.prompt === 'string'
     ) {
       headerSummary = truncatePrompt(input.prompt, 60);
+    } else if (
+      toolName === 'bash' &&
+      isPlainObject(input) &&
+      typeof input.command === 'string'
+    ) {
+      headerSummary = truncatePrompt(input.command, 60);
     }
   }
   const titleText = headerSummary

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -55,6 +55,11 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
 import { createChildStream, finalizeChildStream } from './childStream';
+import {
+  buildCodexCommandToolLog,
+  buildCodexFileChangeToolLog,
+  buildCodexMcpToolLog,
+} from './codexShared';
 
 // Type-only imports (kept separate for bundler efficiency)
 import type {
@@ -268,27 +273,13 @@ function logCodexItem(
 ): void {
   switch (item.type) {
     case 'command_execution': {
-      const exitInfo =
-        item.exit_code === undefined
-          ? item.status
-          : item.exit_code === 0
-            ? 'ok'
-            : `exit ${item.exit_code}`;
-      const output = item.aggregated_output?.trim() || `(${exitInfo})`;
-      logger.logToolUse({
-        toolName: 'bash',
-        input: { command: item.command },
-        output,
-        status: 'completed',
-      });
+      logger.logToolUse(buildCodexCommandToolLog(item));
       break;
     }
     case 'file_change': {
-      const changes = item.changes.map(
-        (c: { kind: string; path: string }) => `${c.kind} ${c.path}`,
-      );
-      if (changes.length > 0) {
-        logger.info(`Files: ${changes.join(', ')}`);
+      const fileLog = buildCodexFileChangeToolLog(item);
+      if (fileLog) {
+        logger.logToolUse(fileLog);
       }
       break;
     }
@@ -299,18 +290,7 @@ function logCodexItem(
       logger.info(item.text, { messageType: MESSAGE_TYPES.THINKING });
       break;
     case 'mcp_tool_call': {
-      const mcp = item as McpToolCallItem;
-      const output = mcp.error
-        ? `Error: ${mcp.error.message}`
-        : mcp.result?.structured_content
-          ? JSON.stringify(mcp.result.structured_content)
-          : `(${mcp.status})`;
-      logger.logToolUse({
-        toolName: `mcp:${mcp.server}/${mcp.tool}`,
-        input: mcp.arguments,
-        output,
-        status: 'completed',
-      });
+      logger.logToolUse(buildCodexMcpToolLog(item as McpToolCallItem));
       break;
     }
     case 'web_search':


### PR DESCRIPTION
## Summary
Extracted common logging logic for Codex tool execution into reusable builder functions, reducing code duplication and improving maintainability.

## Key Changes
- Created three new builder functions in `codexShared.ts`:
  - `buildCodexCommandToolLog()` - formats bash command execution logs
  - `buildCodexFileChangeToolLog()` - formats file change logs
  - `buildCodexMcpToolLog()` - formats MCP tool call logs
- Refactored `logCodexItem()` in `codex.ts` to use these builder functions instead of inline formatting logic
- Updated `formatToolUseTemplate()` in `toolFormatters.ts` to recognize and truncate bash commands in tool use headers, matching the behavior for other tool types

## Implementation Details
- The builder functions encapsulate the logic for constructing tool log objects with proper formatting of inputs, outputs, and status information
- File change logging now uses `logToolUse()` instead of `logger.info()` for consistency with other tool logging
- Bash command truncation in the formatter provides better UI presentation for long commands

https://claude.ai/code/session_01JHtWhZ68CiF2dtCKEdKpzX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to log formatting/normalization for Codex events and UI header rendering, with no effect on tool execution or data persistence beyond how logs are displayed.
> 
> **Overview**
> Refactors `CodexTool` streaming item logging to use shared builder helpers in `codexShared.ts` for command execution, file change, and MCP tool-call log entries, replacing the prior inline formatting.
> 
> Updates the tool-use UI formatter to include a truncated bash `command` in collapsed headers (matching the existing Codex prompt behavior), improving readability for long shell commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23090e9234a8773bb75e2881df619faa6705e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->