### PR TITLE
Allow breaking executions wait via follow-up messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,9 +1923,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1940,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1957,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1974,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1991,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +2008,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7684,9 +7666,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7708,9 +7687,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7732,9 +7708,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7756,9 +7729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -12,6 +12,7 @@
 
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
@@ -45,6 +46,8 @@ export async function sendFollowUp(
   const flowContext = getToolUseFlowContext(streamId);
   if (flowContext) {
     flowContext.session.appendFollowUp(text);
+    // Notify blocking tools (e.g. ExecutionsTool wait) so they can abort early
+    bus.emit('followUpSent', { streamId });
     return { status: 'sent' };
   }
 

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -118,6 +118,10 @@ export interface ProgressEventPayloads {
     childStreamId: StreamTabId;
     parentStreamId: StreamTabId;
   };
+  /** A follow-up message was sent to an active tool-use session.
+   *  Listened by blocking tools (e.g. ExecutionsTool wait) to abort early. */
+  followUpSent: { streamId: StreamTabId };
+
   extensionDeactivating: undefined;
 
   // ── Frontend-bound events ──

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -597,6 +597,7 @@ export class ProgressApp extends ProgressAppBase {
           @followup-polish=${this.onFollowUpPolish}
           @followup-clear=${this.onFollowUpClear}
           @followup-focus-complete=${this.onFollowUpFocusComplete}
+          @followup-focus-request=${this.onFollowUpFocusRequest}
         ></tool-use-stream-content>
       `;
     }
@@ -788,6 +789,19 @@ export class ProgressApp extends ProgressAppBase {
       e,
       this.getEventHandlerContext(),
     );
+
+  /** Focus the follow-up input (e.g. from the "Send Follow-up" button in log entries). */
+  private onFollowUpFocusRequest(): void {
+    const streamId = this.appState.get().activeStreamId;
+    if (!streamId) return;
+
+    this.setStreamState(streamId, (prev) => {
+      if (!isToolUseState(prev)) return prev;
+      return create(prev, (draft) => {
+        draft.ui.shouldFocusFollowUp = true;
+      });
+    });
+  }
 
   /**
    * Reset focus/polish/transcription triggers after they've been consumed.

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -791,17 +791,17 @@ export class ProgressApp extends ProgressAppBase {
     );
 
   /** Focus the follow-up input (e.g. from the "Send Follow-up" button in log entries). */
-  private onFollowUpFocusRequest(): void {
+  private onFollowUpFocusRequest = (): void => {
     const streamId = this.appState.get().activeStreamId;
     if (!streamId) return;
 
     this.setStreamState(streamId, (prev) => {
-      if (!isToolUseState(prev)) return prev;
+      if (!isToolUseState(prev) || prev.ui.shouldFocusFollowUp) return prev;
       return create(prev, (draft) => {
         draft.ui.shouldFocusFollowUp = true;
       });
     });
-  }
+  };
 
   /**
    * Reset focus/polish/transcription triggers after they've been consumed.

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -41,6 +41,9 @@ import {
 // Local imports - progress view styles
 import { logStyles } from '../styles/logStyles';
 
+// Local imports - progress view events
+import { ProgressEvents } from '../events';
+
 // Local imports - progress view formatters
 import { getCopyContent } from '../formatters/copyContentStore';
 import { getProposalInput } from '../formatters/proposalInputStore';
@@ -270,12 +273,7 @@ export class LogList extends LitElement {
     if (breakWaitBtn) {
       event.preventDefault();
       event.stopPropagation();
-      this.dispatchEvent(
-        new CustomEvent('followup-focus-request', {
-          bubbles: true,
-          composed: true,
-        }),
-      );
+      this.dispatchEvent(ProgressEvents.followupFocusRequest());
       return;
     }
 

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -262,6 +262,23 @@ export class LogList extends LitElement {
       return;
     }
 
+    // Handle "Send Follow-up" button in executions wait entries
+    const breakWaitBtn = this.findTargetInPath<HTMLElement>(
+      event,
+      '.followup-break-wait',
+    );
+    if (breakWaitBtn) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.dispatchEvent(
+        new CustomEvent('followup-focus-request', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      return;
+    }
+
     // Handle copy buttons - content is stored in the copy registry
     const copyButton = this.findTargetInPath<HTMLElement>(
       event,

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -126,4 +126,8 @@ export const ProgressEvents = {
 
   followupFocusComplete: () =>
     createEvent('followup-focus-complete', undefined),
+
+  /** Request focus on the follow-up input (e.g. from the "Send Follow-up" button in log entries). */
+  followupFocusRequest: () =>
+    createEvent('followup-focus-request', undefined),
 } as const;

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -427,14 +427,13 @@ export function formatToolUseTemplate(
     }
 
     if (action === 'wait') {
-      // wait: show timeout info
+      // wait: show timeout info and a button to break the wait via follow-up
       const timeout = execInput.timeout ?? 300;
-      sections.push(
-        buildToolUseSection(
-          'Action:',
-          wrapInPre(`wait (timeout: ${timeout}s)`),
-        ),
-      );
+      // prettier-ignore
+      const waitContent = isInProgress
+        ? html`<pre>wait (timeout: ${timeout}s)</pre><span class="followup-break-wait" title="Focus the follow-up input to send a message and break this wait"><i class="codicon codicon-comment"></i> Send Follow-up</span>`
+        : wrapInPre(`wait (timeout: ${timeout}s)`);
+      sections.push(buildToolUseSection('Action:', waitContent));
     } else if (action === 'kill') {
       // kill: show action
       sections.push(buildToolUseSection('Action:', wrapInPre('kill')));

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -173,6 +173,38 @@ export const toolUseStyles = css`
     margin-left: auto;
   }
 
+  /* Follow-up break-wait button (shown inside executions wait entries) */
+  .followup-break-wait {
+    color: var(--color-text-link);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+    margin-top: var(--spacing-small);
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border: var(--border-thin) solid var(--color-text-link);
+    border-radius: var(--border-radius-small);
+    transition:
+      color var(--transition-fast),
+      background-color var(--transition-fast);
+  }
+
+  .followup-break-wait:hover {
+    background-color: color-mix(
+      in srgb,
+      var(--color-text-link) 15%,
+      transparent
+    );
+    text-decoration: none;
+  }
+
+  .followup-break-wait:focus-visible {
+    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+  }
+
   /* Diff styles */
   .diff-add {
     color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -147,8 +147,8 @@ export const toolUseStyles = css`
     border: var(--border-thin) solid var(--color-border);
   }
 
-  /* Proposal setup link (in summary row and body) */
-  .proposal-restore-link {
+  /* Shared base for inline action links */
+  :is(.proposal-restore-link, .followup-break-wait) {
     color: var(--color-text-link);
     cursor: pointer;
     font-size: var(--font-size-sm);
@@ -156,17 +156,20 @@ export const toolUseStyles = css`
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-tiny);
-    transition: color var(--transition-fast);
+    transition:
+      color var(--transition-fast),
+      background-color var(--transition-fast);
   }
 
-  .proposal-restore-link:hover {
-    text-decoration: underline;
-  }
-
-  .proposal-restore-link:focus-visible {
+  :is(.proposal-restore-link, .followup-break-wait):focus-visible {
     outline: var(--border-thin) solid var(--vscode-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
+  }
+
+  /* Proposal setup link (in summary row and body) */
+  .proposal-restore-link:hover {
+    text-decoration: underline;
   }
 
   .proposal-banner-setup {
@@ -175,20 +178,10 @@ export const toolUseStyles = css`
 
   /* Follow-up break-wait button (shown inside executions wait entries) */
   .followup-break-wait {
-    color: var(--color-text-link);
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-tiny);
     margin-top: var(--spacing-small);
     padding: var(--spacing-tiny) var(--spacing-small);
     border: var(--border-thin) solid var(--color-text-link);
     border-radius: var(--border-radius-small);
-    transition:
-      color var(--transition-fast),
-      background-color var(--transition-fast);
   }
 
   .followup-break-wait:hover {
@@ -197,12 +190,6 @@ export const toolUseStyles = css`
       var(--color-text-link) 15%,
       transparent
     );
-    text-decoration: none;
-  }
-
-  .followup-break-wait:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
-    outline-offset: 1px;
   }
 
   /* Diff styles */

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -108,13 +108,19 @@ function listenForFollowUp(ac: AbortController): () => void {
   if (!ctx?.streamId) return () => {};
 
   const streamId = ctx.streamId;
-  return bus.on(
+  // `ready` gate: bus.on() replays buffered events synchronously during
+  // registration. Setting `ready` after the call ensures stale replayed
+  // events are ignored — only events emitted after subscription trigger abort.
+  let ready = false;
+  const cleanup = bus.on(
     'followUpSent',
     (payload) => {
-      if (payload.streamId === streamId) ac.abort();
+      if (ready && payload.streamId === streamId) ac.abort();
     },
     { signal: ac.signal },
   );
+  ready = true;
+  return cleanup;
 }
 
 // ============================================================================

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -38,6 +38,7 @@ import {
 // Local imports - utils
 import { WorkspaceStateKey, workspaceSM } from '@common/state';
 import { isDirectory } from '@common/files/fsEntryType';
+import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
   EXECUTION_STATUS,
@@ -93,6 +94,27 @@ function getAvailablePaths(category?: string, hasChildren?: boolean): string[] {
     default:
       return [...common, 'conversation', 'todos', 'files', 'output'];
   }
+}
+
+/**
+ * Listen for follow-up messages on the current stream and abort the given
+ * AbortController when one arrives. This lets users break out of a blocking
+ * `executions wait` by sending a follow-up message.
+ *
+ * Returns a cleanup function that removes the listener.
+ */
+function listenForFollowUp(ac: AbortController): () => void {
+  const ctx = getCurrentToolFileInteractionContext();
+  if (!ctx?.streamId) return () => {};
+
+  const streamId = ctx.streamId;
+  return bus.on(
+    'followUpSent',
+    (payload) => {
+      if (payload.streamId === streamId) ac.abort();
+    },
+    { signal: ac.signal },
+  );
 }
 
 // ============================================================================
@@ -409,12 +431,15 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
+    // Abort early if a follow-up is sent to this stream (user wants to break the wait)
+    const cleanupFollowUp = listenForFollowUp(ac);
     // Register callback before re-checking to close the race window
     const waitPromise = waitForAnyExecutionChange(pendingIds, ac.signal);
     // Re-check after registration: if all resolved in the gap, abort.
     if (pendingIds.every(shouldSkipWait)) ac.abort();
     await waitPromise;
     clearTimeout(timer);
+    cleanupFollowUp();
   }
 
   /** Wait for a specific execution to change status, with timeout. */
@@ -426,12 +451,15 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeout * 1000);
+    // Abort early if a follow-up is sent to this stream (user wants to break the wait)
+    const cleanupFollowUp = listenForFollowUp(ac);
     // Register callback before re-checking to close the race window
     const waitPromise = waitForExecutionChange(executionId, ac.signal);
     // Re-check after registration: if state changed in the gap, abort.
     if (shouldSkipWait(executionId)) ac.abort();
     await waitPromise;
     clearTimeout(timer);
+    cleanupFollowUp();
   }
 
   private async listExecutions(


### PR DESCRIPTION
## Summary
This PR enables users to break out of blocking `executions wait` operations by sending a follow-up message. A new "Send Follow-up" button is displayed in the UI during wait operations, and the backend listens for follow-up messages to abort the wait early.

## Key Changes

- **UI Enhancement**: Added a "Send Follow-up" button in the log formatter for `executions wait` actions that appears only while the wait is in progress
- **Styling**: Refactored inline action link styles to share a common base (`:is(.proposal-restore-link, .followup-break-wait)`) and added specific styling for the new follow-up button with hover effects
- **Event System**: 
  - Added `followUpSent` event to the progress event bus to notify blocking tools when a follow-up is sent
  - Added `followupFocusRequest` event to request focus on the follow-up input from log entries
- **Backend Logic**: 
  - Implemented `listenForFollowUp()` function in ExecutionsTool that aborts the wait AbortController when a follow-up message arrives on the same stream
  - Integrated the listener into both `waitForAnyExecutionChange()` and `waitForExecutionChange()` methods with proper cleanup
- **Frontend Integration**:
  - Added click handler in LogList for the "Send Follow-up" button that dispatches a focus request event
  - Added handler in ProgressApp to set the `shouldFocusFollowUp` flag when the button is clicked
  - Emits `followUpSent` event in `sendFollowUp()` to notify the backend

## Implementation Details

The solution uses an AbortController-based approach where the ExecutionsTool registers a listener on the progress event bus. When a follow-up message is sent to the same stream, the event bus emits `followUpSent`, which triggers the abort and breaks the wait. The listener is properly cleaned up after the wait completes to prevent memory leaks.

https://claude.ai/code/session_01Prn8SrF62YGCpd9hnzzvNx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the blocking `executions wait` control flow by aborting waits on a new cross-cutting event bus signal, which could alter timing/race behavior across streams if mis-scoped. UI additions are low risk, but incorrect event buffering/cleanup could cause unexpected aborts or leaks.
> 
> **Overview**
> Users can now interrupt a blocking `executions wait` by sending a follow-up message.
> 
> When `sendFollowUp()` targets an active tool-use session it emits a new `ProgressEventBus` event (`followUpSent`), and `ExecutionsTool` subscribes during `wait` operations to abort its `AbortController` early (with explicit cleanup and a guard against replayed buffered events).
> 
> The progress UI surfaces this with a new inline "Send Follow-up" action shown on in-progress `executions wait` log entries, wiring a new `followup-focus-request` event through `LogList` → `ProgressApp` to focus the follow-up input, plus shared styling for the new button/link treatment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5006bb45b3b89f1bb9e110f5eb02e64ab9179d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->