### PR TITLE
Add direct link to Multi-Agent settings from orchestrator banner

### DIFF
--- a/src/common/webview/mainViewCommands.ts
+++ b/src/common/webview/mainViewCommands.ts
@@ -64,6 +64,7 @@ export const MAIN_VIEW_COMMANDS = {
   SHOW_AGENT_HISTORY: 'showAgentHistory',
   OPEN_AGENT_SETTINGS: 'openAgentSettings',
   OPEN_MODEL_SETTINGS: 'openModelSettings',
+  OPEN_MULTI_AGENT_SETTINGS: 'openMultiAgentSettings',
   CLIPBOARD_IMAGE: 'clipboardImage',
   OPEN_SET_API_KEY: 'openSetApiKey',
   OPEN_SET_PROVIDER_API_KEY: 'openSetProviderApiKey',

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -38,7 +38,7 @@ const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   [AGENT_SOURCE.BUILT_IN_WORKFLOW]: 'Built-in',
   [AGENT_SOURCE.BUILT_IN_TOOL_USE]: 'Built-in',
   [AGENT_SOURCE.CUSTOM]: 'Custom',
-  [AGENT_SOURCE.REMOTE]: 'Remote',
+  [AGENT_SOURCE.REMOTE]: 'Shared',
 };
 
 function isBuiltIn(source: string): boolean {
@@ -558,16 +558,16 @@ export class AgentSelectionPanel extends LitElement {
             this.handleToggleEnabled(agent);
           }}
           title=${agent.enabled
-            ? 'Exclude from agent dropdown'
-            : 'Include in agent dropdown'}
+            ? 'Hide from agent selector'
+            : 'Show in agent selector'}
         />
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${agent.hasMultiple
-            ? html`<span title="Multiple outputs">⧉</span>`
+            ? html`<span title="Generates multiple alternatives">⧉</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Remote agent">☁</span>`
+            ? html`<span title="Shared agent">☁</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.CUSTOM
             ? html`<span title="Custom agent">★</span>`
@@ -655,8 +655,8 @@ export class AgentSelectionPanel extends LitElement {
               >`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span class="agent-source-badge" title="Remote agent"
-                >☁ Remote</span
+            ? html`<span class="agent-source-badge" title="Shared agent"
+                >☁ Shared</span
               >`
             : nothing}
         </div>
@@ -673,16 +673,16 @@ export class AgentSelectionPanel extends LitElement {
           : nothing}
 
         <div class="agent-detail-meta">
-          <span class="agent-detail-meta-label">In dropdown</span>
+          <span class="agent-detail-meta-label">Available</span>
           <span class="agent-detail-meta-value">
             ${agent.enabled ? 'Yes' : 'No'}
           </span>
 
-          <span class="agent-detail-meta-label">Multi-output</span>
+          <span class="agent-detail-meta-label">Multiple alternatives</span>
           <span class="agent-detail-meta-value">
             ${agent.hasMultiple
-              ? 'Yes — generates multiple alternatives per run'
-              : 'No — produces a single output'}
+              ? 'Yes — generates several options per run'
+              : 'No — produces a single result'}
           </span>
 
           ${agent.tools && agent.tools.length > 0

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -38,7 +38,7 @@ const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   [AGENT_SOURCE.BUILT_IN_WORKFLOW]: 'Built-in',
   [AGENT_SOURCE.BUILT_IN_TOOL_USE]: 'Built-in',
   [AGENT_SOURCE.CUSTOM]: 'Custom',
-  [AGENT_SOURCE.REMOTE]: 'Shared',
+  [AGENT_SOURCE.REMOTE]: 'Online',
 };
 
 function isBuiltIn(source: string): boolean {
@@ -564,10 +564,10 @@ export class AgentSelectionPanel extends LitElement {
         <span class="agent-list-item-name">${agent.name}</span>
         <span class="agent-list-item-badges">
           ${agent.hasMultiple
-            ? html`<span title="Generates multiple alternatives">⧉</span>`
+            ? html`<span title="Can produce multiple output files">⧉</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Shared agent">☁</span>`
+            ? html`<span title="Online agent">☁</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.CUSTOM
             ? html`<span title="Custom agent">★</span>`
@@ -655,8 +655,8 @@ export class AgentSelectionPanel extends LitElement {
               >`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span class="agent-source-badge" title="Shared agent"
-                >☁ Shared</span
+            ? html`<span class="agent-source-badge" title="Online agent"
+                >☁ Online</span
               >`
             : nothing}
         </div>
@@ -678,11 +678,11 @@ export class AgentSelectionPanel extends LitElement {
             ${agent.enabled ? 'Yes' : 'No'}
           </span>
 
-          <span class="agent-detail-meta-label">Multiple alternatives</span>
+          <span class="agent-detail-meta-label">Multiple outputs</span>
           <span class="agent-detail-meta-value">
             ${agent.hasMultiple
-              ? 'Yes — generates several options per run'
-              : 'No — produces a single result'}
+              ? 'Yes — can produce multiple output files per run'
+              : 'No — produces a single output file'}
           </span>
 
           ${agent.tools && agent.tools.length > 0

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -38,7 +38,7 @@ const SOURCE_DISPLAY_NAMES: Record<string, string> = {
   [AGENT_SOURCE.BUILT_IN_WORKFLOW]: 'Built-in',
   [AGENT_SOURCE.BUILT_IN_TOOL_USE]: 'Built-in',
   [AGENT_SOURCE.CUSTOM]: 'Custom',
-  [AGENT_SOURCE.REMOTE]: 'Online',
+  [AGENT_SOURCE.REMOTE]: 'Remote',
 };
 
 function isBuiltIn(source: string): boolean {
@@ -567,7 +567,7 @@ export class AgentSelectionPanel extends LitElement {
             ? html`<span title="Can produce multiple output files">⧉</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span title="Online agent">☁</span>`
+            ? html`<span title="Remote agent">☁</span>`
             : nothing}
           ${agent.source === AGENT_SOURCE.CUSTOM
             ? html`<span title="Custom agent">★</span>`
@@ -655,8 +655,8 @@ export class AgentSelectionPanel extends LitElement {
               >`
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE
-            ? html`<span class="agent-source-badge" title="Online agent"
-                >☁ Online</span
+            ? html`<span class="agent-source-badge" title="Remote agent"
+                >☁ Remote</span
               >`
             : nothing}
         </div>

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -402,7 +402,8 @@ export class MultiAgentTab extends LitElement {
               <span class="step-number">1</span>
               <span
                 ><strong>Pick a preset</strong> below that matches your field.
-                This decides which specialized agents are available.</span
+                This enables and configures the right specialized agents for
+                you.</span
               >
             </li>
             <li class="how-it-works-step">

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -392,33 +392,32 @@ export class MultiAgentTab extends LitElement {
       <div class="multi-agent-container tab-content-container">
         <div class="how-it-works">
           <strong
-            >The orchestrator reads your paper and figures out what to
-            do.</strong
+            >The orchestrator reads your paper and delegates tasks to
+            specialized agents.</strong
           >
-          It breaks the work into tasks and hands each one to the right agent.
+          Each agent focuses on what it does best — writing, citations, figures,
+          formatting, and more.
           <ol class="how-it-works-steps">
             <li class="how-it-works-step">
               <span class="step-number">1</span>
               <span
                 ><strong>Pick a preset</strong> below that matches your field.
-                This decides which agents the orchestrator can use.</span
+                This decides which specialized agents are available.</span
               >
             </li>
             <li class="how-it-works-step">
               <span class="step-number">2</span>
               <span
-                ><strong>Select orchestrator</strong> from the Interactive agent
-                dropdown in the main view (look for the 🎯 icon), then click
-                Execute.</span
+                ><strong>Select orchestrator</strong> from the agent dropdown
+                (look for the 🎯 icon), then click Execute.</span
               >
             </li>
             <li class="how-it-works-step">
               <span class="step-number">3</span>
               <span
-                ><strong>Approve tasks</strong> in the Progress view as they
-                come in -- press <strong>y</strong> to approve or
-                <strong>n</strong> to reject. Or turn on auto-approve
-                below.</span
+                ><strong>Approve tasks</strong> in Progress as they come in —
+                press <strong>y</strong> to approve or <strong>n</strong> to
+                reject. Or turn on auto-approve below.</span
               >
             </li>
           </ol>

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -702,6 +702,7 @@ const CommonMessages = [
 const SettingsMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.SETTINGS_OPEN),
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS),
+  commandOnly(MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS),
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_AGENT_DOCS),
   commandOnly(MAIN_VIEW_COMMANDS.OPEN_INSTALLATION_DOCS),
   z.object({

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -130,6 +130,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         ),
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: () =>
         safeExecuteCommand('texra.showModels', [], this.viewName),
+      [MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS]: () =>
+        safeExecuteCommand('texra.showMultiAgent', [], this.viewName),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
         if (!m.customDirSet) {
           await safeExecuteCommand('texra.showAgents', [], this.viewName);

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -10,8 +10,10 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-// Local imports - shared styles
+// Local imports
+import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { postMessage } from '@shared/vscode';
 
 @customElement('orchestrator-banner')
 export class OrchestratorBanner extends LitElement {
@@ -72,6 +74,20 @@ export class OrchestratorBanner extends LitElement {
         outline: var(--border-thin) solid var(--vscode-focusBorder);
         outline-offset: 1px;
       }
+
+      .settings-link {
+        background: none;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        text-decoration: underline;
+        padding: 0;
+        font: inherit;
+      }
+
+      .settings-link:hover {
+        opacity: 0.8;
+      }
     `,
   ];
 
@@ -82,20 +98,28 @@ export class OrchestratorBanner extends LitElement {
     this.dismissed = true;
   }
 
+  private handleOpenMultiAgentSettings(): void {
+    postMessage(MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS);
+  }
+
   override render(): TemplateResult | typeof nothing {
     if (!this.visible || this.dismissed) return nothing;
 
     return html`
       <div class="orchestrator-banner">
-        <strong>Orchestrator selected.</strong> Hit Execute and it will read
-        your paper, figure out what needs work, and propose tasks for you to
-        approve in the Progress view. Press <strong>y</strong>/<strong
-          >n</strong
-        >
-        to approve or reject quickly.
+        <strong>Orchestrator selected.</strong> Hit Execute to analyze your
+        paper and generate improvement tasks. Review and approve them in the
+        Progress view — press <strong>y</strong>/<strong>n</strong> to approve
+        or reject quickly.
         <div class="orchestrator-banner-footer">
           <span class="orchestrator-tip"
-            >Configure auto-approve and presets in Multi-Agent settings.</span
+            >Customize auto-approve rules and task presets in
+            <button
+              class="settings-link"
+              @click=${this.handleOpenMultiAgentSettings}
+            >
+              Multi-Agent settings</button
+            >.</span
           >
           <button class="got-it-btn" @click=${this.handleDismiss}>
             Got it

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -108,9 +108,9 @@ export class OrchestratorBanner extends LitElement {
     return html`
       <div class="orchestrator-banner">
         <strong>Orchestrator selected.</strong> Hit Execute to analyze your
-        paper and generate improvement tasks. Review and approve them in the
-        Progress view — press <strong>y</strong>/<strong>n</strong> to approve
-        or reject quickly.
+        paper and generate improvement tasks. Review and approve them in
+        Progress — press <strong>y</strong>/<strong>n</strong> to approve or
+        reject quickly.
         <div class="orchestrator-banner-footer">
           <span class="orchestrator-tip"
             >Customize auto-approve rules and task presets in


### PR DESCRIPTION
## Summary
This PR improves the user experience by adding a clickable link to Multi-Agent settings directly from the orchestrator banner, eliminating the need for users to navigate separately. It also includes UX improvements to terminology and messaging throughout the orchestrator and Multi-Agent configuration interfaces.

## Key Changes

- **Orchestrator Banner Enhancement**: Added a clickable "Multi-Agent settings" link in the orchestrator banner footer that opens the Multi-Agent settings view via a new `OPEN_MULTI_AGENT_SETTINGS` command
- **New Command**: Introduced `OPEN_MULTI_AGENT_SETTINGS` command in `mainViewCommands.ts` and wired it up in `MainViewMessageHandler.ts` to execute `texra.showMultiAgent`
- **Schema Update**: Added the new command to the settings messages schema in `mainView.ts`
- **UI/UX Improvements**:
  - Clarified orchestrator banner messaging to be more concise and action-oriented
  - Updated Multi-Agent tab instructions with clearer language about agent specialization and workflow
  - Improved terminology consistency: "agent dropdown" → "agent selector", "In dropdown" → "Available", "Multi-output" → "Multiple outputs"
  - Enhanced tooltip text for better clarity (e.g., "Can produce multiple output files" instead of "Multiple outputs")
- **Styling**: Added `.settings-link` button styles to match the banner's visual design with hover effects

## Implementation Details

- The settings link is implemented as a styled button within the banner's footer text, maintaining visual consistency
- The `handleOpenMultiAgentSettings()` method uses the existing `postMessage` utility to communicate with the VS Code extension
- All messaging updates focus on clarity and reducing jargon while maintaining technical accuracy

https://claude.ai/code/session_017MTwLC6voUrLT5HrDwABJe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new UI command and handler to open an existing settings view, plus copy/tooltip updates with no data/auth logic changes.
> 
> **Overview**
> Adds a new `OPEN_MULTI_AGENT_SETTINGS` main-view command and wires it through the inbound schema and `MainViewMessageHandler` to open the Multi-Agent settings (`texra.showMultiAgent`).
> 
> Updates the orchestrator banner to include a clickable “Multi-Agent settings” link (styled as an inline button) and refreshes UX copy across the banner, Multi-Agent tab instructions, and agent selection terminology/tooltips for clarity and consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6c1bb89a4eeb19e06f1c056a7cb6a452cdcc40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->