### PR TITLE
Replace fileLister singleton export with getFileLister() function

### DIFF
--- a/src/commands/files/fileSelectionCommands.ts
+++ b/src/commands/files/fileSelectionCommands.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - log
 import { showLoggedErrorMessage } from '@common/errors';
 import { FILE_SELECTION_COMMAND_IDS, getFilterExtensions } from '@common/files';
-import { fileLister } from '@frontend/files';
+import { getFileLister } from '@frontend/files';
 import { selectFile, selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
@@ -110,11 +110,11 @@ export function registerFileSelectionCommands(
     ),
     vscode.commands.registerCommand(
       FILE_SELECTION_COMMAND_IDS.refreshInputFiles,
-      () => fileLister.list('input'),
+      () => getFileLister().list('input'),
     ),
     vscode.commands.registerCommand(
       FILE_SELECTION_COMMAND_IDS.refreshBaseFiles,
-      () => fileLister.list('input'),
+      () => getFileLister().list('input'),
     ),
   );
 }

--- a/src/commands/files/openFileCommands.ts
+++ b/src/commands/files/openFileCommands.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports - common
 import { toErrorMessage } from '@common/errors';
 // Local imports - frontend
-import { fileLister } from '@frontend/files';
+import { getFileLister } from '@frontend/files';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 
 // Local imports - logging
@@ -44,8 +44,8 @@ export async function openLabel(label: string): Promise<void> {
   const escape = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
   const candidates = new Set([
-    ...(await fileLister.list('input')),
-    ...(await fileLister.list('reference')),
+    ...(await getFileLister().list('input')),
+    ...(await getFileLister().list('reference')),
   ]);
 
   for (const file of candidates) {

--- a/src/frontend/files/fileLister.ts
+++ b/src/frontend/files/fileLister.ts
@@ -180,4 +180,10 @@ export class FileLister {
   }
 }
 
-export const fileLister = FileLister.getInstance();
+/**
+ * Lazy accessor — returns the singleton without forcing construction at import time.
+ * Direct use of `FileLister.getInstance()` is equivalent; this exists for convenience.
+ */
+export function getFileLister(): FileLister {
+  return FileLister.getInstance();
+}

--- a/src/frontend/files/index.ts
+++ b/src/frontend/files/index.ts
@@ -1,3 +1,3 @@
 // Barrel export for frontend file utilities
-export { ListableFileType, FileLister, fileLister } from './fileLister';
+export { ListableFileType, FileLister, getFileLister } from './fileLister';
 export { getFilesRecursively } from './listing';

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -16,7 +16,7 @@ import {
 } from '@common/files';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
-import { fileLister } from '@frontend/files';
+import { getFileLister } from '@frontend/files';
 import { selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import type { MainViewInboundMessage } from '@shared/schemas';
@@ -135,7 +135,7 @@ export class FileManager extends BaseWebviewManager {
       path.extname(message.filePath),
     );
     const filteredEditedFiles =
-      await fileLister.listEditedFiles(baseFileNameForInput);
+      await getFileLister().listEditedFiles(baseFileNameForInput);
     this.postFileUpdate('Edited', filteredEditedFiles);
   }
 
@@ -162,7 +162,7 @@ export class FileManager extends BaseWebviewManager {
       | 'reference'
       | 'auxiliary'
       | 'media';
-    const files = await fileLister.list(listType);
+    const files = await getFileLister().list(listType);
     this.postFileUpdate(fileType, files, {
       notifyWhenEmpty: Boolean(message.notifyWhenEmpty),
     });
@@ -172,7 +172,7 @@ export class FileManager extends BaseWebviewManager {
     message: RequestEditedFileMessage,
   ): Promise<void> {
     const files = message.baseFile
-      ? await fileLister.listEditedFiles(
+      ? await getFileLister().listEditedFiles(
           path.basename(message.baseFile, path.extname(message.baseFile)),
         )
       : [];
@@ -182,7 +182,7 @@ export class FileManager extends BaseWebviewManager {
   }
 
   async handleRequestBaseFile(message: RequestBaseFileMessage): Promise<void> {
-    const files = await fileLister.list('input');
+    const files = await getFileLister().list('input');
     this.postFileUpdate('Base', files, {
       notifyWhenEmpty: Boolean(message.notifyWhenEmpty),
       additionalPayload: message.preserveBaseFile
@@ -253,10 +253,10 @@ export class FileManager extends BaseWebviewManager {
   async handleRefreshAllFiles(): Promise<void> {
     const [inputFiles, referenceFiles, auxiliaryFiles, mediaFiles] =
       await Promise.all([
-        fileLister.list('input'),
-        fileLister.list('reference'),
-        fileLister.list('auxiliary'),
-        fileLister.list('media'),
+        getFileLister().list('input'),
+        getFileLister().list('reference'),
+        getFileLister().list('auxiliary'),
+        getFileLister().list('media'),
       ]);
 
     this.postMessage({
@@ -477,7 +477,7 @@ export class FileManager extends BaseWebviewManager {
   }
 
   private async updateBaseFileSelect(): Promise<void> {
-    const baseFiles = await fileLister.list('input');
+    const baseFiles = await getFileLister().list('input');
     this.postMessage({
       command: MAIN_VIEW_COMMANDS.SET_BASE_FILE,
       files: baseFiles,


### PR DESCRIPTION
## Summary
Refactored the `fileLister` singleton export to use a lazy accessor function `getFileLister()` instead of direct singleton instantiation at import time. This change improves initialization control and makes the lazy-loading pattern more explicit.

## Key Changes
- Replaced the direct `fileLister` singleton export with a `getFileLister()` function that returns `FileLister.getInstance()`
- Updated all imports across the codebase to use `getFileLister()` instead of `fileLister`
- Added JSDoc documentation explaining the lazy accessor pattern
- Updated the barrel export in `src/frontend/files/index.ts` to export the new function

## Files Modified
- `src/frontend/files/fileLister.ts` — Converted singleton export to lazy accessor function
- `src/webview/managers/FileManager.ts` — Updated 9 call sites to use `getFileLister()`
- `src/commands/files/fileSelectionCommands.ts` — Updated 2 call sites to use `getFileLister()`
- `src/commands/files/openFileCommands.ts` — Updated 2 call sites to use `getFileLister()`
- `src/frontend/files/index.ts` — Updated barrel export

## Implementation Details
The `getFileLister()` function is functionally equivalent to calling `FileLister.getInstance()` directly, but provides a more convenient and explicit API for accessing the singleton. This pattern defers singleton construction until first use rather than at module import time, which can improve startup performance and reduce unnecessary initialization.

https://claude.ai/code/session_0162KA2QbXJajRzptB2edgq2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that changes how the `FileLister` singleton is accessed; main risk is missed import/call-site updates causing runtime errors, but usage is updated across the touched commands and webview manager.
> 
> **Overview**
> Refactors frontend file listing access to be *lazy-loaded*: removes the eager `fileLister` singleton export and adds `getFileLister()` to return `FileLister.getInstance()` when first needed.
> 
> Updates command handlers and the webview `FileManager` to call `getFileLister().list(...)` / `getFileLister().listEditedFiles(...)`, and adjusts the `@frontend/files` barrel export accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9cd7d087d19c8e1c19c93e492ab8d825896d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->