### PR TITLE
Deduplicate agents at source instead of at consumption point

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -14,7 +14,7 @@ import * as logger from '@agent/core/logger';
 import { getGlobalState, getWorkspaceState } from '@agent/core/stateStore';
 import { GlobalStateKey, WorkspaceStateKey } from '@common/state';
 import type { AgentOptionData } from '@shared/schemas';
-import { agentKey as createKey } from '@shared/schemas/agent';
+import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
 
@@ -344,26 +344,23 @@ export function resolveAgent(
   };
 }
 
-/** Get all workflow agents, deduplicated by name (excludes internal agents by default). */
-export function getWorkflowAgents(includeInternal = false): AgentEntry[] {
+function getAgentsByCategory(
+  category: AgentCategory,
+  includeInternal: boolean,
+): AgentEntry[] {
   return deduplicateByName(
     [...cache.values()].filter(
-      (e) =>
-        e.category === AgentCategory.Workflow &&
-        (includeInternal || !e.internal),
+      (e) => e.category === category && (includeInternal || !e.internal),
     ),
   );
 }
 
-/** Get all tool-use agents, deduplicated by name (excludes internal agents by default). */
+export function getWorkflowAgents(includeInternal = false): AgentEntry[] {
+  return getAgentsByCategory(AgentCategory.Workflow, includeInternal);
+}
+
 export function getToolUseAgents(includeInternal = false): AgentEntry[] {
-  return deduplicateByName(
-    [...cache.values()].filter(
-      (e) =>
-        e.category === AgentCategory.ToolUse &&
-        (includeInternal || !e.internal),
-    ),
-  );
+  return getAgentsByCategory(AgentCategory.ToolUse, includeInternal);
 }
 
 /** Get agents by source. */
@@ -620,7 +617,8 @@ export function resolveAgentKey(
 
 /**
  * Extract the clean agent name from an identifier.
- * Handles source:name format (e.g., "custom:summarize" → "summarize").
+ * Like agentName() but validates the prefix is a known AgentSource first,
+ * so arbitrary strings with colons (e.g. URLs) pass through unchanged.
  */
 export function getCleanAgentName(agentIdentifier: string): string {
   const colonIdx = agentIdentifier.indexOf(':');
@@ -629,7 +627,7 @@ export function getCleanAgentName(agentIdentifier: string): string {
   const source = agentIdentifier.slice(0, colonIdx);
   if (!AgentSource.safeParse(source).success) return agentIdentifier;
 
-  return agentIdentifier.slice(colonIdx + 1);
+  return agentName(agentIdentifier);
 }
 
 // =============================================================================
@@ -712,22 +710,9 @@ function filterVisible(
 ): AgentEntry[] {
   // undefined = never configured → show all; [] = explicitly empty → show none
   if (configured === undefined) return entries;
-  const configuredSet = new Set(configured);
-
-  // Extract plain names from stored keys (e.g. "builtInToolUse:lean" → "lean")
-  // so visibility survives when dedup changes the winning source.
-  const configuredNames = new Set<string>();
-  for (const key of configured) {
-    const idx = key.indexOf(':');
-    if (idx >= 0) configuredNames.add(key.slice(idx + 1));
-  }
-
-  return entries.filter(
-    (entry) =>
-      configuredSet.has(createKey(entry.source, entry.name)) ||
-      configuredSet.has(entry.name) ||
-      configuredNames.has(entry.name),
-  );
+  // Match by name so visibility survives when dedup changes the winning source.
+  const enabledNames = new Set(configured.map(agentName));
+  return entries.filter((entry) => enabledNames.has(entry.name));
 }
 
 // =============================================================================

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -714,12 +714,19 @@ function filterVisible(
   if (configured === undefined) return entries;
   const configuredSet = new Set(configured);
 
-  // All agents (including remote) are filtered by the configured visibility set.
-  // Remote agents are visible by default when never configured (handled above).
+  // Extract plain names from stored keys (e.g. "builtInToolUse:lean" → "lean")
+  // so visibility survives when dedup changes the winning source.
+  const configuredNames = new Set<string>();
+  for (const key of configured) {
+    const idx = key.indexOf(':');
+    if (idx >= 0) configuredNames.add(key.slice(idx + 1));
+  }
+
   return entries.filter(
     (entry) =>
       configuredSet.has(createKey(entry.source, entry.name)) ||
-      configuredSet.has(entry.name),
+      configuredSet.has(entry.name) ||
+      configuredNames.has(entry.name),
   );
 }
 

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -344,19 +344,25 @@ export function resolveAgent(
   };
 }
 
-/** Get all workflow agents (excludes internal agents by default). */
+/** Get all workflow agents, deduplicated by name (excludes internal agents by default). */
 export function getWorkflowAgents(includeInternal = false): AgentEntry[] {
-  return [...cache.values()].filter(
-    (e) =>
-      e.category === AgentCategory.Workflow && (includeInternal || !e.internal),
+  return deduplicateByName(
+    [...cache.values()].filter(
+      (e) =>
+        e.category === AgentCategory.Workflow &&
+        (includeInternal || !e.internal),
+    ),
   );
 }
 
-/** Get all tool-use agents (excludes internal agents by default). */
+/** Get all tool-use agents, deduplicated by name (excludes internal agents by default). */
 export function getToolUseAgents(includeInternal = false): AgentEntry[] {
-  return [...cache.values()].filter(
-    (e) =>
-      e.category === AgentCategory.ToolUse && (includeInternal || !e.internal),
+  return deduplicateByName(
+    [...cache.values()].filter(
+      (e) =>
+        e.category === AgentCategory.ToolUse &&
+        (includeInternal || !e.internal),
+    ),
   );
 }
 
@@ -658,7 +664,8 @@ export function isRemoteAgent(identifier: string | undefined): boolean {
 // =============================================================================
 
 /**
- * Get visible agents for a category (filtered and deduplicated).
+ * Get visible agents for a category (filtered by user visibility config).
+ * Agents are already deduplicated by name from the getter functions.
  * No default → undefined means "never configured" (show all).
  */
 export function getVisibleAgents(
@@ -670,7 +677,7 @@ export function getVisibleAgents(
     ? WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS
     : WorkspaceStateKey.ENABLED_AGENTS;
   const raw = getWorkspaceState().get<string[]>(stateKey);
-  return deduplicateByName(filterVisible(entries, raw));
+  return filterVisible(entries, raw);
 }
 
 /**
@@ -679,7 +686,7 @@ export function getVisibleAgents(
  * When the same agent name exists in multiple sources (e.g. local + remote),
  * only the highest-priority version appears in the dropdown.
  */
-export function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
+function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
   const byKey = new Map<string, AgentEntry>();
 
   for (const entry of entries) {

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -124,17 +124,17 @@ const MULTIPLE_SUFFIX = '_multiple';
 /** Source priority for lookups (higher priority first). */
 const LOOKUP_PRIORITY: AgentSource[] = [
   'custom',
+  'remote',
   'builtInWorkflow',
   'builtInToolUse',
-  'remote',
 ];
 
-/** Source priority for tool-use sessions (prefers tool-use agents). */
+/** Source priority for tool-use sessions (prefers tool-use agents over workflow). */
 const TOOL_USE_LOOKUP_PRIORITY: AgentSource[] = [
   'custom',
+  'remote',
   'builtInToolUse',
   'builtInWorkflow',
-  'remote',
 ];
 
 /**
@@ -236,7 +236,7 @@ async function doLoad(): Promise<void> {
  * Supports "source:name" format or just "name" (finds first match by priority).
  *
  * When preferToolUse is true, uses tool-use lookup priority:
- * custom → builtInToolUse → builtInWorkflow → remote
+ * custom → remote → builtInToolUse → builtInWorkflow
  *
  * This handles name collisions where a workflow agent shadows a tool-use agent.
  */
@@ -682,7 +682,7 @@ export function getVisibleAgents(
 
 /**
  * Deduplicate agents by name, keeping only the highest priority source.
- * Priority: custom > builtInWorkflow > builtInToolUse > remote.
+ * Priority: custom > remote > builtInWorkflow > builtInToolUse.
  * When the same agent name exists in multiple sources (e.g. local + remote),
  * only the highest-priority version appears in the dropdown.
  */

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -675,19 +675,15 @@ export function getVisibleAgents(
 
 /**
  * Deduplicate agents by name, keeping only the highest priority source.
- * Custom agents override built-in agents with the same name.
- * Remote agents use source:name keys to prevent deduplication.
+ * Priority: custom > builtInWorkflow > builtInToolUse > remote.
+ * When the same agent name exists in multiple sources (e.g. local + remote),
+ * only the highest-priority version appears in the dropdown.
  */
 export function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
   const byKey = new Map<string, AgentEntry>();
 
   for (const entry of entries) {
-    // Remote agents use source:name key to preserve uniqueness
-    const key =
-      entry.source === 'remote'
-        ? createKey(entry.source, entry.name)
-        : entry.name;
-    const existing = byKey.get(key);
+    const existing = byKey.get(entry.name);
 
     // Keep entry if none exists or if this one has higher priority
     const isHigherPriority =
@@ -696,7 +692,7 @@ export function deduplicateByName(entries: AgentEntry[]): AgentEntry[] {
         LOOKUP_PRIORITY.indexOf(existing.source);
 
     if (isHigherPriority) {
-      byKey.set(key, entry);
+      byKey.set(entry.name, entry);
     }
   }
 

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -32,8 +32,6 @@ export {
   isRemoteAgent,
   // Visible agents (for dropdowns and tools)
   getVisibleAgents,
-  // Deduplication
-  deduplicateByName,
   // Description update (for remote agent loading)
   updateAgentDescription,
 } from './agentRegistry';

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -383,9 +383,9 @@ export class AgentSelectionPanel extends LitElement {
 
   private static readonly SOURCE_ORDER = [
     AGENT_SOURCE.CUSTOM,
+    AGENT_SOURCE.REMOTE,
     AGENT_SOURCE.BUILT_IN_WORKFLOW,
     AGENT_SOURCE.BUILT_IN_TOOL_USE,
-    AGENT_SOURCE.REMOTE,
   ];
 
   protected override willUpdate(changed: PropertyValues): void {

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -12,7 +12,6 @@ import { z } from 'zod';
 import {
   type AgentEntry,
   createKey,
-  deduplicateByName,
   getAgent,
   getVisibleAgents,
   getWorkflowAgents,
@@ -725,9 +724,8 @@ prompts:
     category: 'workflow' | 'toolUse',
     names: Set<string>,
   ): string[] {
-    const entries = deduplicateByName(
-      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents(),
-    );
+    const entries =
+      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
     return entries
       .filter((e) => names.has(e.name))
       .map((e) => createKey(e.source, e.name));

--- a/src/shared/schemas/agent.ts
+++ b/src/shared/schemas/agent.ts
@@ -54,3 +54,9 @@ export type AgentMetadataBase = z.infer<typeof AgentMetadataBaseSchema>;
 export function agentKey(source: string, name: string): string {
   return `${source}:${name}`;
 }
+
+/** Extract the plain agent name from a possibly source-qualified key ("source:name" → "name"). */
+export function agentName(key: string): string {
+  const idx = key.indexOf(':');
+  return idx >= 0 ? key.slice(idx + 1) : key;
+}

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { getExecutionStore, registerExecution } from '@agent/storage';
-import { getAgent, getVisibleAgents } from '@agent/index/agentRegistry';
+import { getVisibleAgents } from '@agent/index/agentRegistry';
 import {
   AgentConfigSchema,
   type AgentConfigPayload,
@@ -532,20 +532,13 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
-    // Validate agent exists and is a workflow agent
-    const agentEntry = getAgent(input.agent);
+    // Validate agent is visible and is a workflow agent
+    const visible = getVisibleAgents('workflow');
+    const agentEntry = visible.find((a) => a.name === input.agent);
     if (!agentEntry) {
-      const available = getVisibleAgents('workflow')
-        .map((a) => a.name)
-        .join(', ');
+      const available = visible.map((a) => a.name).join(', ');
       throw new Error(
         `Unknown workflow agent '${input.agent}'. Available: ${available}`,
-      );
-    }
-
-    if (agentEntry.category !== AgentCategory.Workflow) {
-      throw new Error(
-        `'${input.agent}' is not a workflow agent. Use delegate_agent for tool-use agents.`,
       );
     }
 
@@ -693,20 +686,13 @@ Example (resume): execution_id=exec_abc123, instruction="Also fix the bibliograp
       );
     }
 
-    // Validate agent exists and is a tool-use agent
-    const agentEntry = getAgent(input.agent);
+    // Validate agent is visible and is a tool-use agent
+    const visible = getVisibleAgents('toolUse');
+    const agentEntry = visible.find((a) => a.name === input.agent);
     if (!agentEntry) {
-      const available = getVisibleAgents('toolUse')
-        .map((a) => a.name)
-        .join(', ');
+      const available = visible.map((a) => a.name).join(', ');
       throw new Error(
         `Unknown tool-use agent '${input.agent}'. Available: ${available}`,
-      );
-    }
-
-    if (agentEntry.category !== AgentCategory.ToolUse) {
-      throw new Error(
-        `'${input.agent}' is not a tool-use agent. Use delegate_workflow for document processing.`,
       );
     }
 

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -328,6 +328,19 @@ function formatAgentList(
     .join('\n');
 }
 
+/** Find a visible agent by name or throw with available agents listed. */
+function resolveVisibleAgent(category: 'workflow' | 'toolUse', name: string) {
+  const visible = getVisibleAgents(category);
+  const entry = visible.find((a) => a.name === name);
+  if (!entry) {
+    const available = visible.map((a) => a.name).join(', ');
+    throw new Error(
+      `Unknown ${category} agent '${name}'. Available: ${available}`,
+    );
+  }
+  return entry;
+}
+
 /** Build a concise summary of proposal parameters for rejection echo. */
 function summarizeProposal(
   proposal: WorkflowAgentProposal | ToolUseAgentProposal,
@@ -532,16 +545,7 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
   schema: WorkflowAgentInputSchema,
 }) {
   protected async execute(input: WorkflowAgentInput): Promise<ToolResult> {
-    // Validate agent is visible and is a workflow agent
-    const visible = getVisibleAgents('workflow');
-    const agentEntry = visible.find((a) => a.name === input.agent);
-    if (!agentEntry) {
-      const available = visible.map((a) => a.name).join(', ');
-      throw new Error(
-        `Unknown workflow agent '${input.agent}'. Available: ${available}`,
-      );
-    }
-
+    const agentEntry = resolveVisibleAgent('workflow', input.agent);
     const ctx = getRequiredContext();
 
     // Resolve model: explicit input → parent model → first visible model
@@ -686,15 +690,7 @@ Example (resume): execution_id=exec_abc123, instruction="Also fix the bibliograp
       );
     }
 
-    // Validate agent is visible and is a tool-use agent
-    const visible = getVisibleAgents('toolUse');
-    const agentEntry = visible.find((a) => a.name === input.agent);
-    if (!agentEntry) {
-      const available = visible.map((a) => a.name).join(', ');
-      throw new Error(
-        `Unknown tool-use agent '${input.agent}'. Available: ${available}`,
-      );
-    }
+    const agentEntry = resolveVisibleAgent('toolUse', input.agent);
 
     const ctx = getRequiredContext();
 

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -46,6 +46,7 @@ import {
   type SessionTypeChangeDetail,
 } from '@shared/schemas';
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
+import { agentName } from '@shared/schemas/agent';
 import { capitalize } from '@shared/utils/string';
 
 import './components/FileSelectGroup';
@@ -619,24 +620,18 @@ export class MainApp extends MainAppBase {
   }
 
   /**
-   * Validate agent selection with name-based matching.
-   * Handles source changes (e.g. remote:lean → builtInToolUse:lean after dedup)
-   * and plain-name defaults (e.g. 'orchestrator' matching 'remote:orchestrator').
-   * Does NOT silently fall back — if the agent is gone, keeps the stale value
+   * No silent fallback — if the agent is gone, keeps the stale value
    * so the dropdown shows no selection and execution errors explicitly.
    */
   private validateAgentSelection(
     options: AgentOptionData[],
     currentValue: string,
   ): string {
-    // Exact match (source:name)
     if (options.some((opt) => opt.value === currentValue)) {
       return currentValue;
     }
     // Match by name: handles source changes and plain-name defaults
-    const name = currentValue.includes(':')
-      ? currentValue.slice(currentValue.indexOf(':') + 1)
-      : currentValue;
+    const name = agentName(currentValue);
     const byName = options.find((opt) => opt.label === name);
     if (byName) return byName.value;
     // No match — keep stale value so the UI shows no selection.

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -619,10 +619,11 @@ export class MainApp extends MainAppBase {
   }
 
   /**
-   * Validate agent selection with name-based fallback.
+   * Validate agent selection with name-based matching.
    * Handles source changes (e.g. remote:lean → builtInToolUse:lean after dedup)
    * and plain-name defaults (e.g. 'orchestrator' matching 'remote:orchestrator').
-   * Falls back to first option (the preferred agent, since options are sorted).
+   * Does NOT silently fall back — if the agent is gone, keeps the stale value
+   * so the dropdown shows no selection and execution errors explicitly.
    */
   private validateAgentSelection(
     options: AgentOptionData[],
@@ -638,8 +639,9 @@ export class MainApp extends MainAppBase {
       : currentValue;
     const byName = options.find((opt) => opt.label === name);
     if (byName) return byName.value;
-    // Fall back to first option (preferred agent due to sorting)
-    return options[0]?.value ?? '';
+    // No match — keep stale value so the UI shows no selection.
+    // Execution will error with "unknown agent" if the user proceeds.
+    return currentValue;
   }
 
   private handleSetSingleFileOptions(

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -600,10 +600,9 @@ export class MainApp extends MainAppBase {
     if (optionsData.workflow) {
       this.workflowAgentOptions.set(optionsData.workflow);
       this.workflowAgent.set(
-        this.validateSelection(
+        this.validateAgentSelection(
           optionsData.workflow,
           this.workflowAgent.get(),
-          true, // preferEnabled for consistency (agents don't have disabled, but future-proof)
         ),
       );
     }
@@ -611,13 +610,36 @@ export class MainApp extends MainAppBase {
     if (optionsData.toolUse) {
       this.toolUseAgentOptions.set(optionsData.toolUse);
       this.toolUseAgent.set(
-        this.validateSelection(
+        this.validateAgentSelection(
           optionsData.toolUse,
           this.toolUseAgent.get(),
-          true,
         ),
       );
     }
+  }
+
+  /**
+   * Validate agent selection with name-based fallback.
+   * Handles source changes (e.g. remote:lean → builtInToolUse:lean after dedup)
+   * and plain-name defaults (e.g. 'orchestrator' matching 'remote:orchestrator').
+   * Falls back to first option (the preferred agent, since options are sorted).
+   */
+  private validateAgentSelection(
+    options: AgentOptionData[],
+    currentValue: string,
+  ): string {
+    // Exact match (source:name)
+    if (options.some((opt) => opt.value === currentValue)) {
+      return currentValue;
+    }
+    // Match by name: handles source changes and plain-name defaults
+    const name = currentValue.includes(':')
+      ? currentValue.slice(currentValue.indexOf(':') + 1)
+      : currentValue;
+    const byName = options.find((opt) => opt.label === name);
+    if (byName) return byName.value;
+    // Fall back to first option (preferred agent due to sorting)
+    return options[0]?.value ?? '';
   }
 
   private handleSetSingleFileOptions(


### PR DESCRIPTION
## Summary
- Consolidate agent dropdown to show one entry per name using a priority list
- Priority: custom > remote > builtInWorkflow > builtInToolUse
- Delegation tools validate against visible agents only — fail explicitly instead of silently falling back
- Agent selection in UI keeps stale value instead of silently switching to correct/chat

## Changes
- **Dedup at the source**: `getWorkflowAgents()` / `getToolUseAgents()` now return deduplicated results via shared `getAgentsByCategory()`, so every consumer gets a clean list
- **Priority reordered**: remote agents take precedence over built-in (user-requested), custom always wins
- **filterVisible**: matches by plain name (via `agentName()`) so visibility survives when dedup changes the winning source
- **Delegation validation**: `resolveVisibleAgent()` validates against `getVisibleAgents()` instead of the full cache — hidden/disabled agents are not delegatable
- **No silent fallback**: `validateAgentSelection()` in MainApp keeps the stale value when the agent is gone, so the dropdown shows no selection and execution errors explicitly
- **Shared utilities**: extracted `agentName()` into `@shared/schemas/agent.ts` as inverse of `agentKey()`, deduplicated name-extraction across 4 call sites
- **SOURCE_ORDER** in settings panel aligned with priority

https://claude.ai/code/session_01NG7zeuX2NDDM7xFqhp2DKb