### PR TITLE
feat: prompt user for arXiv download location (root vs References)

### DIFF
--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -4,7 +4,10 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { toErrorMessage } from '@common/errors';
-import { arxivProcessor } from '@latex/arxivProcessor';
+import {
+  arxivProcessor,
+  type ArxivDownloadDestination,
+} from '@latex/arxivProcessor';
 import * as logger from '@logger/logUtils';
 
 const CHANNEL = 'arXivCommands';
@@ -32,6 +35,36 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
             return;
           }
 
+          const normalizedId = arxivProcessor.normalizeInput(arxivId);
+          const paperId = normalizedId
+            ? normalizedId.replaceAll('/', '_')
+            : arxivId;
+
+          const destinationPick = await vscode.window.showQuickPick(
+            [
+              {
+                label: `References/${paperId}`,
+                description: 'Download into References folder',
+                value: 'references' as ArxivDownloadDestination,
+              },
+              {
+                label: 'Workspace root',
+                description: 'Download directly into the workspace root',
+                value: 'root' as ArxivDownloadDestination,
+              },
+            ],
+            {
+              placeHolder: 'Where should the source be downloaded?',
+              canPickMany: false,
+            },
+          );
+
+          if (!destinationPick) {
+            return;
+          }
+
+          const destination = destinationPick.value;
+
           const autoIndent =
             (await vscode.window.showQuickPick(['Yes', 'No'], {
               placeHolder: 'Auto-indent LaTeX files after download?',
@@ -52,6 +85,7 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
                 arxivId,
                 (message, increment) => progress.report({ message, increment }),
                 autoIndent,
+                destination,
               );
               return downloadResult.path;
             },

--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -62,7 +62,9 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
 
           const destination = destinationPick.value;
 
+          // Auto-indent is not supported for root destination (would reformat all workspace files)
           const autoIndent =
+            destination !== 'root' &&
             (await vscode.window.showQuickPick(['Yes', 'No'], {
               placeHolder: 'Auto-indent LaTeX files after download?',
               canPickMany: false,

--- a/src/commands/latex/arXivCommands.ts
+++ b/src/commands/latex/arXivCommands.ts
@@ -35,10 +35,7 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
             return;
           }
 
-          const normalizedId = arxivProcessor.normalizeInput(arxivId);
-          const paperId = normalizedId
-            ? normalizedId.replaceAll('/', '_')
-            : arxivId;
+          const paperId = arxivProcessor.getPaperDirName(arxivId);
 
           const destinationPick = await vscode.window.showQuickPick(
             [
@@ -83,9 +80,12 @@ export function registerArXivCommands(context: vscode.ExtensionContext) {
 
               const downloadResult = await arxivProcessor.downloadSource(
                 arxivId,
-                (message, increment) => progress.report({ message, increment }),
-                autoIndent,
-                destination,
+                {
+                  progressCallback: (message, increment) =>
+                    progress.report({ message, increment }),
+                  autoIndent,
+                  destination,
+                },
               );
               return downloadResult.path;
             },

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -25,6 +25,12 @@ export interface ExtractOptions {
 
 export type ArxivDownloadDestination = 'root' | 'references';
 
+export interface DownloadSourceOptions {
+  progressCallback?: (msg: string, increment?: number) => void;
+  autoIndent?: boolean;
+  destination?: ArxivDownloadDestination;
+}
+
 const INVALID_ARXIV_INPUT_ERROR =
   'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
 
@@ -81,6 +87,12 @@ export class ArxivSourceProcessor {
   public validateId(input: string): string | null {
     if (!input) return 'arXiv ID or URL is required';
     return this.normalizeInput(input) ? null : INVALID_ARXIV_INPUT_ERROR;
+  }
+
+  /** Sanitized directory name for a paper (e.g. `2404.12175` or `cs_0501072`). */
+  public getPaperDirName(input: string): string {
+    const id = this.normalizeInput(input);
+    return id ? id.replaceAll('/', '_') : input;
   }
 
   public async downloadFile(
@@ -168,10 +180,14 @@ export class ArxivSourceProcessor {
 
   public async downloadSource(
     input: string,
-    progressCallback?: (msg: string, increment?: number) => void,
-    autoIndent = true,
-    destination: ArxivDownloadDestination = 'references',
+    options: DownloadSourceOptions = {},
   ): Promise<{ path: string; alreadyExisted: boolean }> {
+    const {
+      progressCallback,
+      autoIndent = true,
+      destination = 'references',
+    } = options;
+
     // Normalize input (URL or ID) to plain arXiv ID
     const id = this.normalizeInput(input);
     if (!id) {
@@ -185,18 +201,18 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    // Determine download location based on destination preference.
-    // 'references' places files in References/{id}, 'root' places files directly in the workspace root.
+    const isRoot = destination === 'root';
     // Use forward slashes to match WorkspaceFS.relativePath() convention (not path.join which uses backslashes on Windows)
-    const paperDirRelative =
-      destination === 'root' ? '.' : `References/${id.replaceAll('/', '_')}`;
+    const paperDirRelative = isRoot
+      ? '.'
+      : `References/${id.replaceAll('/', '_')}`;
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.
-    // A .tex file in the paper directory is a reliable signal that extraction completed,
-    // regardless of whether the staging 'download' dir was cleaned up afterwards.
+    // Skip for root destination — the workspace root likely already contains .tex files
+    // that would produce a false positive.
     let needsDownload = true;
-    if (await WorkspaceFS.exists(paperDirRelative)) {
+    if (!isRoot && (await WorkspaceFS.exists(paperDirRelative))) {
       const entries = await WorkspaceFS.readDir(paperDirRelative);
       const hasTexFiles = entries.some(([name]) => name.endsWith('.tex'));
       if (hasTexFiles) {
@@ -232,9 +248,12 @@ export class ArxivSourceProcessor {
         await AbsoluteFS.delete(downloadDirFull, { recursive: true }).catch(
           () => undefined,
         );
-        await AbsoluteFS.delete(paperDirFull, { recursive: true }).catch(
-          () => undefined,
-        );
+        // Only clean up the paper directory when it was created for this download
+        if (!isRoot) {
+          await AbsoluteFS.delete(paperDirFull, { recursive: true }).catch(
+            () => undefined,
+          );
+        }
         throw new Error(
           'This arXiv paper only has a PDF submission — no LaTeX source is available for download',
         );
@@ -295,7 +314,8 @@ export class ArxivSourceProcessor {
       );
     }
 
-    if (autoIndent) {
+    // Skip auto-indent for root destination to avoid reformatting existing workspace files
+    if (autoIndent && !isRoot) {
       progressCallback?.('Formatting LaTeX files...', 85);
 
       const indentedCount = await indentLatexFilesInDirectory(

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -23,6 +23,8 @@ export interface ExtractOptions {
   channel?: string;
 }
 
+export type ArxivDownloadDestination = 'root' | 'references';
+
 const INVALID_ARXIV_INPUT_ERROR =
   'Invalid arXiv ID or URL. Please provide a valid arXiv ID (e.g., 2404.12175) or URL (e.g., https://arxiv.org/abs/2404.12175)';
 
@@ -168,6 +170,7 @@ export class ArxivSourceProcessor {
     input: string,
     progressCallback?: (msg: string, increment?: number) => void,
     autoIndent = true,
+    destination: ArxivDownloadDestination = 'references',
   ): Promise<{ path: string; alreadyExisted: boolean }> {
     // Normalize input (URL or ID) to plain arXiv ID
     const id = this.normalizeInput(input);
@@ -182,9 +185,11 @@ export class ArxivSourceProcessor {
       throw new Error('No workspace folder is open');
     }
 
-    // Create project directory for the arXiv paper inside References/ (sanitize ID to avoid path issues)
+    // Determine download location based on destination preference.
+    // 'references' places files in References/{id}, 'root' places files directly in the workspace root.
     // Use forward slashes to match WorkspaceFS.relativePath() convention (not path.join which uses backslashes on Windows)
-    const paperDirRelative = `References/${id.replaceAll('/', '_')}`;
+    const paperDirRelative =
+      destination === 'root' ? '.' : `References/${id.replaceAll('/', '_')}`;
     const paperDirFull = WorkspaceFS.fullPath(paperDirRelative);
 
     // Check if source was already downloaded successfully.

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -227,11 +227,12 @@ export class ArxivSourceProcessor {
     if (needsDownload) {
       await WorkspaceFS.ensureDir(paperDirRelative);
 
-      // Create temporary download subdirectory for staging the archive
-      const downloadDirRelative = path.join(paperDirRelative, 'download');
+      // Use a unique staging directory name to avoid clobbering an existing 'download/' folder at root
+      const stagingDirName = `.arxiv-download-${id.replaceAll('/', '_')}`;
+      const downloadDirRelative = path.join(paperDirRelative, stagingDirName);
       await WorkspaceFS.ensureDir(downloadDirRelative);
 
-      const downloadDirFull = path.join(paperDirFull, 'download');
+      const downloadDirFull = path.join(paperDirFull, stagingDirName);
       const downloadBasePath = path.join(downloadDirFull, 'source');
 
       progressCallback?.(`Downloading arXiv source for ${id}...`, 20);

--- a/src/test/tools/ArxivDownloadTool.test.ts
+++ b/src/test/tools/ArxivDownloadTool.test.ts
@@ -12,9 +12,8 @@ declare module '@latex/arxivProcessor' {
   interface ArxivSourceProcessor {
     validateId(id: string): string | null;
     downloadSource(
-      id: string,
-      progress?: (msg: string, increment?: number) => void,
-      autoIndent?: boolean,
+      input: string,
+      options?: DownloadSourceOptions,
     ): Promise<{ path: string; alreadyExisted: boolean }>;
   }
 }
@@ -54,9 +53,9 @@ describe('ArxivDownloadTool', () => {
       return null;
     };
 
-    processor.downloadSource = async (id, _progress, autoIndent) => {
+    processor.downloadSource = async (id, options) => {
       receivedId = id;
-      receivedAutoIndent = autoIndent;
+      receivedAutoIndent = options?.autoIndent;
       return { path: '/workspace/project/sample', alreadyExisted: false };
     };
 

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
-import { arxivProcessor } from '@latex/arxivProcessor';
+import {
+  arxivProcessor,
+  type ArxivDownloadDestination,
+} from '@latex/arxivProcessor';
 import { LsTool } from '@tools/ls';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatToolOutput } from '@tools/utils';
@@ -17,6 +20,10 @@ const ArxivDownloadInputSchema = z.strictObject({
     .boolean()
     .nullish()
     .transform((v) => v ?? true),
+  destination: z
+    .enum(['root', 'references'])
+    .nullish()
+    .transform((v): ArxivDownloadDestination => v ?? 'references'),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
@@ -24,7 +31,7 @@ export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
 export class ArxivDownloadTool extends defineTool({
   name: 'download_arxiv_source',
   description:
-    'Download an arXiv paper source archive into the workspace and list the extracted files. If the source was already downloaded, it skips re-downloading and indicates that the source already exists.',
+    'Download an arXiv paper source archive into the workspace and list the extracted files. Use "destination" to choose where files are placed: "references" (default) saves to References/{paper_id}, "root" saves directly to the workspace root. If the source was already downloaded, it skips re-downloading and indicates that the source already exists.',
   schema: ArxivDownloadInputSchema,
 }) {
   protected async execute(input: ArxivDownloadInput): Promise<ToolResult> {
@@ -40,6 +47,7 @@ export class ArxivDownloadTool extends defineTool({
         arxivId,
         undefined,
         input.autoIndent,
+        input.destination,
       );
     } catch (err) {
       throw new ToolError(

--- a/src/tools/arxiv/ArxivDownloadTool.ts
+++ b/src/tools/arxiv/ArxivDownloadTool.ts
@@ -3,10 +3,7 @@ import { z } from 'zod';
 
 // Local imports - tools
 import { toErrorMessage } from '@common/errors';
-import {
-  arxivProcessor,
-  type ArxivDownloadDestination,
-} from '@latex/arxivProcessor';
+import { arxivProcessor } from '@latex/arxivProcessor';
 import { LsTool } from '@tools/ls';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatToolOutput } from '@tools/utils';
@@ -23,7 +20,7 @@ const ArxivDownloadInputSchema = z.strictObject({
   destination: z
     .enum(['root', 'references'])
     .nullish()
-    .transform((v): ArxivDownloadDestination => v ?? 'references'),
+    .transform((v) => v ?? ('references' as const)),
 });
 
 export type ArxivDownloadInput = z.infer<typeof ArxivDownloadInputSchema>;
@@ -43,12 +40,10 @@ export class ArxivDownloadTool extends defineTool({
 
     let downloadResult: { path: string; alreadyExisted: boolean };
     try {
-      downloadResult = await arxivProcessor.downloadSource(
-        arxivId,
-        undefined,
-        input.autoIndent,
-        input.destination,
-      );
+      downloadResult = await arxivProcessor.downloadSource(arxivId, {
+        autoIndent: input.autoIndent,
+        destination: input.destination,
+      });
     } catch (err) {
       throw new ToolError(
         `Failed to download arXiv source: ${toErrorMessage(err)}`,


### PR DESCRIPTION
When downloading arXiv source, users are now asked whether to save files
to the workspace root or to References/{paper_id}. This applies to both
the VS Code command and the agent tool (via a new "destination" parameter).

https://claude.ai/code/session_01A4YQK7RkRb6Gaz57URgxme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes where files are written and how existing-download detection/cleanup works, which could overwrite workspace files or leave staging artifacts if edge cases are missed. Auto-formatting is now disabled for root downloads to reduce blast radius.
> 
> **Overview**
> Adds a user-selectable arXiv download destination (**workspace root** vs `References/{paper_id}`) for both the VS Code command and the `download_arxiv_source` agent tool (new `destination` input, defaulting to `references`).
> 
> Refactors `arxivProcessor.downloadSource` to take an options object and implements root-specific behavior: uses `.` as the target directory, avoids “already downloaded” detection and LaTeX auto-indent at root, uses a unique hidden staging directory name, and prevents deleting the workspace root during PDF-only cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385fccca27a39afae099fde7944eae8a62fe8851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->