### PR TITLE
feat: mirror \input, \include, and bibliography dependencies to run storage

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -141,10 +141,8 @@ export class LatexMediaManager {
   }
 
   /**
-   * Parse \input, \include, \bibliography, and \addbibresource commands
-   * from LaTeX files and mirror the discovered dependencies into run storage.
-   * This ensures output files in run storage can be compiled successfully
-   * when the main document references other files.
+   * Mirror \input, \include, and bibliography dependencies into run storage
+   * so output files can be compiled outside the workspace.
    */
   private async mirrorLatexFileDependencies(
     files: FileLocation[],
@@ -153,36 +151,37 @@ export class LatexMediaManager {
       return;
     }
 
-    for (const file of files) {
-      try {
-        const deps = await extractLatexFileDependencies(file);
-        if (deps.length === 0) continue;
+    await pMap(
+      files,
+      async (file) => {
+        try {
+          const deps = await extractLatexFileDependencies(file);
+          if (deps.length === 0) return;
 
-        const baseDir = path.dirname(file.absolutePath);
-        const tasks = deps.map(async (relative) => {
-          const absolutePath = path.normalize(path.join(baseDir, relative));
-          try {
-            await this.fileService!.mirrorWorkspaceFile(
-              pathToLocation(absolutePath),
-            );
-          } catch (error) {
-            const message = toErrorMessage(error);
-            this.logger.debug(
-              `Unable to mirror LaTeX dependency ${absolutePath}: ${message}`,
-            );
-          }
-        });
-
-        await Promise.all(tasks);
-        this.logger.debug(
-          `Mirrored ${deps.length} LaTeX file dependencies from ${file.absolutePath}`,
-        );
-      } catch (error) {
-        this.logger.debug(
-          `Unable to extract LaTeX dependencies from ${file.absolutePath}: ${toErrorMessage(error)}`,
-        );
-      }
-    }
+          await Promise.all(
+            deps.map(async (absolutePath) => {
+              try {
+                await this.fileService!.mirrorWorkspaceFile(
+                  pathToLocation(absolutePath),
+                );
+              } catch (error) {
+                this.logger.debug(
+                  `Unable to mirror LaTeX dependency ${absolutePath}: ${toErrorMessage(error)}`,
+                );
+              }
+            }),
+          );
+          this.logger.debug(
+            `Mirrored ${deps.length} LaTeX file dependencies from ${file.absolutePath}`,
+          );
+        } catch (error) {
+          this.logger.debug(
+            `Unable to extract LaTeX dependencies from ${file.absolutePath}: ${toErrorMessage(error)}`,
+          );
+        }
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+    );
   }
 
   private async extractFiguresFromFiles(

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -16,6 +16,7 @@ import {
 import { hasExtension } from '@utils/core/pathCore';
 
 // Local file imports
+import { extractLatexFileDependencies } from './extractFileDependencies';
 import { extractFigurePathsFromLatex } from './extractFigure';
 import { tikzPictureManager } from './TikzPictureManager';
 import { compileLatex2Pdf } from './texTools';
@@ -135,6 +136,51 @@ export class LatexMediaManager {
     for (const result of compileResults) {
       if (result) {
         workspaceState.media.addMediaFiles([result]);
+      }
+    }
+  }
+
+  /**
+   * Parse \input, \include, \bibliography, and \addbibresource commands
+   * from LaTeX files and mirror the discovered dependencies into run storage.
+   * This ensures output files in run storage can be compiled successfully
+   * when the main document references other files.
+   */
+  private async mirrorLatexFileDependencies(
+    files: FileLocation[],
+  ): Promise<void> {
+    if (!this.fileService?.hasRunDirectory() || files.length === 0) {
+      return;
+    }
+
+    for (const file of files) {
+      try {
+        const deps = await extractLatexFileDependencies(file);
+        if (deps.length === 0) continue;
+
+        const baseDir = path.dirname(file.absolutePath);
+        const tasks = deps.map(async (relative) => {
+          const absolutePath = path.normalize(path.join(baseDir, relative));
+          try {
+            await this.fileService!.mirrorWorkspaceFile(
+              pathToLocation(absolutePath),
+            );
+          } catch (error) {
+            const message = toErrorMessage(error);
+            this.logger.debug(
+              `Unable to mirror LaTeX dependency ${absolutePath}: ${message}`,
+            );
+          }
+        });
+
+        await Promise.all(tasks);
+        this.logger.debug(
+          `Mirrored ${deps.length} LaTeX file dependencies from ${file.absolutePath}`,
+        );
+      } catch (error) {
+        this.logger.debug(
+          `Unable to extract LaTeX dependencies from ${file.absolutePath}: ${toErrorMessage(error)}`,
+        );
       }
     }
   }
@@ -272,6 +318,10 @@ export class LatexMediaManager {
 
     if (includeFigureExtraction && cfg.autoExtractFigure) {
       await this.extractFiguresFromFiles(existingFiles, workspaceState);
+    }
+
+    if (includeFigureExtraction) {
+      await this.mirrorLatexFileDependencies(existingFiles);
     }
 
     if (includeTikzCompilation && cfg.autoExtractTikzFigure) {

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -151,8 +151,13 @@ export class LatexMediaManager {
       return;
     }
 
+    const texFiles = files.filter((file) =>
+      hasExtension(file.absolutePath, '.tex'),
+    );
+    if (texFiles.length === 0) return;
+
     await pMap(
-      files,
+      texFiles,
       async (file) => {
         try {
           const deps = await extractLatexFileDependencies(file);

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -278,12 +278,14 @@ export class LatexMediaManager {
     supportsVision: boolean,
     {
       includeFigureExtraction,
+      mirrorFileDependencies,
       includeTikzCompilation,
       includePdfCompilation,
       extraMediaFiles = [],
       logTikzSummary = false,
     }: {
       includeFigureExtraction: boolean;
+      mirrorFileDependencies: boolean;
       includeTikzCompilation: boolean;
       includePdfCompilation: boolean;
       extraMediaFiles?: PathInput[];
@@ -319,7 +321,7 @@ export class LatexMediaManager {
       await this.extractFiguresFromFiles(existingFiles, workspaceState);
     }
 
-    if (includeFigureExtraction) {
+    if (mirrorFileDependencies) {
       await this.mirrorLatexFileDependencies(existingFiles);
     }
 
@@ -353,6 +355,7 @@ export class LatexMediaManager {
   ): Promise<void> {
     await this.processFiles(inputFiles, workspaceState, cfg, supportsVision, {
       includeFigureExtraction: true,
+      mirrorFileDependencies: true,
       includeTikzCompilation: true,
       includePdfCompilation: true,
       extraMediaFiles,
@@ -371,6 +374,7 @@ export class LatexMediaManager {
   ): Promise<void> {
     await this.processFiles(outputFiles, workspaceState, cfg, supportsVision, {
       includeFigureExtraction: false,
+      mirrorFileDependencies: false,
       includeTikzCompilation: true,
       includePdfCompilation: true,
     });

--- a/src/latex/extractBibliography.ts
+++ b/src/latex/extractBibliography.ts
@@ -8,6 +8,9 @@ import { BibEntry, parseBibFile } from 'bibtex';
 import { WorkspaceFS } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
+// Local file imports
+import { stripLatexComments, BIB_DIRECTIVE_PATTERN } from './latexParsingUtils';
+
 const CITE_COMMANDS = [
   'cite',
   'citet',
@@ -26,17 +29,10 @@ const CITE_COMMANDS = [
 ];
 
 // Compiled regex patterns (matchAll clones the regex, so module-level is safe)
-const DIRECTIVE_PATTERN = new RegExp(
-  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
-  'g',
-);
-
 const CITATION_PATTERN = new RegExp(
   `\\\\(?:${CITE_COMMANDS.join('|')})\\*?(?:\\[[^\\]]*\\])*\\{([^}]*)\\}`,
   'g',
 );
-
-const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
 export interface BibliographyReferenceResult {
   /** Paths to bibliography files that exist, relative to the workspace. */
@@ -54,10 +50,6 @@ export interface BibliographyEntriesResult {
   missingKeys: string[];
 }
 
-function stripComments(content: string): string {
-  return content.replaceAll(COMMENT_PATTERN, '$1');
-}
-
 function normalizeBibPath(baseDir: string, target: string): string {
   const trimmed = target.trim();
   if (!trimmed) {
@@ -69,7 +61,7 @@ function normalizeBibPath(baseDir: string, target: string): string {
 function collectBibliographyPaths(baseDir: string, content: string): string[] {
   const paths = new Set<string>();
 
-  for (const match of content.matchAll(DIRECTIVE_PATTERN)) {
+  for (const match of content.matchAll(BIB_DIRECTIVE_PATTERN)) {
     const block = match[1];
     for (const raw of block.split(',')) {
       const normalized = normalizeBibPath(baseDir, raw);
@@ -103,7 +95,7 @@ export async function extractBibliographyContext(
 ): Promise<BibliographyReferenceResult> {
   const texDir = path.dirname(texPath);
   const content = await WorkspaceFS.read(texPath);
-  const uncommented = stripComments(content);
+  const uncommented = stripLatexComments(content);
 
   const referencedPaths = collectBibliographyPaths(texDir, uncommented);
   const existing: string[] = [];

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -15,14 +15,8 @@ import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
-/** Comment line pattern — lines starting with optional whitespace then %. */
 const COMMENT_LINE = /^\s*%/;
 
-/**
- * Strip full-line comments from LaTeX content.
- * Inline comments (mid-line %) are kept to avoid breaking regex matching
- * on the same line; the extracted paths themselves never contain %.
- */
 function stripCommentLines(content: string): string {
   return content
     .split('\n')
@@ -34,26 +28,23 @@ function stripCommentLines(content: string): string {
 // Regex patterns
 // ---------------------------------------------------------------------------
 
-/** Matches \input{path} — LaTeX does NOT add .tex automatically for \input
- *  but many authors omit it. We try both with and without .tex. */
 const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
-
-/** Matches \include{path} — LaTeX always appends .tex for \include. */
 const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
 
-/** Matches \bibliography{file1,file2,...} */
-const BIBLIOGRAPHY_PATTERN = /\\bibliography\s*\{([^}]+)\}/g;
-
-/** Matches \addbibresource{file.bib} (biblatex). */
-const ADDBIBRESOURCE_PATTERN = /\\addbibresource\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}/g;
+/** Matches both \bibliography{...} and \addbibresource[...]{...}.
+ *  Same pattern shape as extractBibliography.ts DIRECTIVE_PATTERN. */
+const BIB_DIRECTIVE_PATTERN = new RegExp(
+  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
+  'g',
+);
 
 // ---------------------------------------------------------------------------
 // Resolution helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Try to resolve a TeX input path to an existing file.
- * Checks the path as-is first, then with .tex appended.
+ * Resolve a TeX input path to an existing absolute path.
+ * Checks as-is first, then with .tex appended.
  */
 async function resolveTexInputPath(
   rawPath: string,
@@ -63,29 +54,25 @@ async function resolveTexInputPath(
   if (!trimmed) return null;
 
   const absolute = joinLatexPath(baseDir, trimmed);
-
-  // Check as-is first (author may have included .tex)
   if (
     await flexibleFS.exists({ kind: 'external', absolutePath: absolute })
   ) {
-    return path.relative(baseDir, absolute);
+    return absolute;
   }
 
-  // Try with .tex appended
   const withExt = ensureExtension(absolute, '.tex');
   if (
     withExt !== absolute &&
     (await flexibleFS.exists({ kind: 'external', absolutePath: withExt }))
   ) {
-    return path.relative(baseDir, withExt);
+    return withExt;
   }
 
   return null;
 }
 
 /**
- * Try to resolve a bibliography path to an existing file.
- * Always ensures .bib extension.
+ * Resolve a bibliography path to an existing absolute path.
  */
 async function resolveBibPath(
   rawPath: string,
@@ -94,13 +81,11 @@ async function resolveBibPath(
   const trimmed = rawPath.trim();
   if (!trimmed) return null;
 
-  const withExt = ensureExtension(trimmed, '.bib');
-  const absolute = joinLatexPath(baseDir, withExt);
-
+  const absolute = joinLatexPath(baseDir, ensureExtension(trimmed, '.bib'));
   if (
     await flexibleFS.exists({ kind: 'external', absolutePath: absolute })
   ) {
-    return path.relative(baseDir, absolute);
+    return absolute;
   }
 
   return null;
@@ -112,10 +97,7 @@ async function resolveBibPath(
 
 /**
  * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
- * from a LaTeX file. Returns workspace-relative paths to existing files.
- *
- * Only returns files that actually exist on disk, similar to how
- * extractFigurePathsFromLatex works for \includegraphics.
+ * from a LaTeX file. Returns absolute paths to existing files.
  */
 export async function extractLatexFileDependencies(
   latexFileLocation: FileLocation,
@@ -123,16 +105,6 @@ export async function extractLatexFileDependencies(
   const latexDir = path.dirname(latexFileLocation.absolutePath);
   const content = await flexibleFS.read(latexFileLocation);
   const uncommented = stripCommentLines(content);
-
-  const discovered = new Set<string>();
-  const results: string[] = [];
-
-  const addResult = (relativePath: string) => {
-    if (!discovered.has(relativePath)) {
-      discovered.add(relativePath);
-      results.push(relativePath);
-    }
-  };
 
   // Collect raw paths from all patterns
   const texInputPaths: string[] = [];
@@ -144,31 +116,25 @@ export async function extractLatexFileDependencies(
   }
 
   const bibPaths: string[] = [];
-  for (const match of uncommented.matchAll(BIBLIOGRAPHY_PATTERN)) {
-    // \bibliography can have comma-separated entries
+  for (const match of uncommented.matchAll(BIB_DIRECTIVE_PATTERN)) {
     for (const entry of match[1].split(',')) {
       bibPaths.push(entry);
     }
   }
-  for (const match of uncommented.matchAll(ADDBIBRESOURCE_PATTERN)) {
-    bibPaths.push(match[1]);
-  }
 
-  // Resolve TeX input dependencies
-  const texResolved = await Promise.all(
-    texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir)),
-  );
+  // Resolve all paths in parallel
+  const [texResolved, bibResolved] = await Promise.all([
+    Promise.all(texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir))),
+    Promise.all(bibPaths.map((raw) => resolveBibPath(raw, latexDir))),
+  ]);
+
+  const results = new Set<string>();
   for (const resolved of texResolved) {
-    if (resolved) addResult(resolved);
+    if (resolved) results.add(resolved);
   }
-
-  // Resolve bibliography dependencies
-  const bibResolved = await Promise.all(
-    bibPaths.map((raw) => resolveBibPath(raw, latexDir)),
-  );
   for (const resolved of bibResolved) {
-    if (resolved) addResult(resolved);
+    if (resolved) results.add(resolved);
   }
 
-  return results;
+  return [...results];
 }

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -16,12 +16,11 @@ import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
-/** Strip everything after an unescaped % on each line (same approach as extractBibliography.ts). */
-const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
-
-function stripComments(content: string): string {
-  return content.replaceAll(COMMENT_PATTERN, '$1');
-}
+// Local file imports
+import {
+  stripLatexComments,
+  BIB_DIRECTIVE_PATTERN,
+} from './latexParsingUtils';
 
 // ---------------------------------------------------------------------------
 // Regex patterns
@@ -29,13 +28,6 @@ function stripComments(content: string): string {
 
 const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
 const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
-
-/** Matches both \bibliography{...} and \addbibresource[...]{...}.
- *  Same pattern shape as extractBibliography.ts DIRECTIVE_PATTERN. */
-const BIB_DIRECTIVE_PATTERN = new RegExp(
-  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
-  'g',
-);
 
 // ---------------------------------------------------------------------------
 // Resolution helpers
@@ -110,7 +102,7 @@ export async function extractLatexFileDependencies(
   const latexDir = path.dirname(realPath);
 
   const content = await flexibleFS.read(latexFileLocation);
-  const uncommented = stripComments(content);
+  const uncommented = stripLatexComments(content);
 
   // Collect raw paths from all patterns
   const texInputPaths: string[] = [];

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -1,0 +1,174 @@
+/**
+ * Extract file dependencies from LaTeX content.
+ *
+ * Parses \input{}, \include{}, \bibliography{}, and \addbibresource{}
+ * commands to discover files that the main document depends on.
+ * Used by LatexMediaManager to mirror these dependencies into run storage
+ * so that output files can be compiled outside the workspace.
+ */
+
+// Standard library imports
+import * as path from 'path';
+
+// Local imports
+import { flexibleFS } from '@utils/files';
+import type { FileLocation } from '@utils/files';
+import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
+
+/** Comment line pattern — lines starting with optional whitespace then %. */
+const COMMENT_LINE = /^\s*%/;
+
+/**
+ * Strip full-line comments from LaTeX content.
+ * Inline comments (mid-line %) are kept to avoid breaking regex matching
+ * on the same line; the extracted paths themselves never contain %.
+ */
+function stripCommentLines(content: string): string {
+  return content
+    .split('\n')
+    .filter((line) => !COMMENT_LINE.test(line))
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+/** Matches \input{path} — LaTeX does NOT add .tex automatically for \input
+ *  but many authors omit it. We try both with and without .tex. */
+const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
+
+/** Matches \include{path} — LaTeX always appends .tex for \include. */
+const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
+
+/** Matches \bibliography{file1,file2,...} */
+const BIBLIOGRAPHY_PATTERN = /\\bibliography\s*\{([^}]+)\}/g;
+
+/** Matches \addbibresource{file.bib} (biblatex). */
+const ADDBIBRESOURCE_PATTERN = /\\addbibresource\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}/g;
+
+// ---------------------------------------------------------------------------
+// Resolution helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Try to resolve a TeX input path to an existing file.
+ * Checks the path as-is first, then with .tex appended.
+ */
+async function resolveTexInputPath(
+  rawPath: string,
+  baseDir: string,
+): Promise<string | null> {
+  const trimmed = rawPath.trim();
+  if (!trimmed) return null;
+
+  const absolute = joinLatexPath(baseDir, trimmed);
+
+  // Check as-is first (author may have included .tex)
+  if (
+    await flexibleFS.exists({ kind: 'external', absolutePath: absolute })
+  ) {
+    return path.relative(baseDir, absolute);
+  }
+
+  // Try with .tex appended
+  const withExt = ensureExtension(absolute, '.tex');
+  if (
+    withExt !== absolute &&
+    (await flexibleFS.exists({ kind: 'external', absolutePath: withExt }))
+  ) {
+    return path.relative(baseDir, withExt);
+  }
+
+  return null;
+}
+
+/**
+ * Try to resolve a bibliography path to an existing file.
+ * Always ensures .bib extension.
+ */
+async function resolveBibPath(
+  rawPath: string,
+  baseDir: string,
+): Promise<string | null> {
+  const trimmed = rawPath.trim();
+  if (!trimmed) return null;
+
+  const withExt = ensureExtension(trimmed, '.bib');
+  const absolute = joinLatexPath(baseDir, withExt);
+
+  if (
+    await flexibleFS.exists({ kind: 'external', absolutePath: absolute })
+  ) {
+    return path.relative(baseDir, absolute);
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
+ * from a LaTeX file. Returns workspace-relative paths to existing files.
+ *
+ * Only returns files that actually exist on disk, similar to how
+ * extractFigurePathsFromLatex works for \includegraphics.
+ */
+export async function extractLatexFileDependencies(
+  latexFileLocation: FileLocation,
+): Promise<string[]> {
+  const latexDir = path.dirname(latexFileLocation.absolutePath);
+  const content = await flexibleFS.read(latexFileLocation);
+  const uncommented = stripCommentLines(content);
+
+  const discovered = new Set<string>();
+  const results: string[] = [];
+
+  const addResult = (relativePath: string) => {
+    if (!discovered.has(relativePath)) {
+      discovered.add(relativePath);
+      results.push(relativePath);
+    }
+  };
+
+  // Collect raw paths from all patterns
+  const texInputPaths: string[] = [];
+  for (const match of uncommented.matchAll(INPUT_PATTERN)) {
+    texInputPaths.push(match[1]);
+  }
+  for (const match of uncommented.matchAll(INCLUDE_PATTERN)) {
+    texInputPaths.push(match[1]);
+  }
+
+  const bibPaths: string[] = [];
+  for (const match of uncommented.matchAll(BIBLIOGRAPHY_PATTERN)) {
+    // \bibliography can have comma-separated entries
+    for (const entry of match[1].split(',')) {
+      bibPaths.push(entry);
+    }
+  }
+  for (const match of uncommented.matchAll(ADDBIBRESOURCE_PATTERN)) {
+    bibPaths.push(match[1]);
+  }
+
+  // Resolve TeX input dependencies
+  const texResolved = await Promise.all(
+    texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir)),
+  );
+  for (const resolved of texResolved) {
+    if (resolved) addResult(resolved);
+  }
+
+  // Resolve bibliography dependencies
+  const bibResolved = await Promise.all(
+    bibPaths.map((raw) => resolveBibPath(raw, latexDir)),
+  );
+  for (const resolved of bibResolved) {
+    if (resolved) addResult(resolved);
+  }
+
+  return results;
+}

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -22,16 +22,8 @@ import {
   BIB_DIRECTIVE_PATTERN,
 } from './latexParsingUtils';
 
-// ---------------------------------------------------------------------------
-// Regex patterns
-// ---------------------------------------------------------------------------
-
 const INPUT_PATTERN = /\\input\s*\{([^}]+)\}/g;
 const INCLUDE_PATTERN = /\\include\s*\{([^}]+)\}/g;
-
-// ---------------------------------------------------------------------------
-// Resolution helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Resolve a TeX input path to an existing absolute path.
@@ -82,10 +74,6 @@ async function resolveBibPath(
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
 /**
  * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
  * from a LaTeX file. Returns absolute paths to existing files.
@@ -104,7 +92,6 @@ export async function extractLatexFileDependencies(
   const content = await flexibleFS.read(latexFileLocation);
   const uncommented = stripLatexComments(content);
 
-  // Collect raw paths from all patterns
   const texInputPaths: string[] = [];
   for (const match of uncommented.matchAll(INPUT_PATTERN)) {
     texInputPaths.push(match[1]);
@@ -120,7 +107,6 @@ export async function extractLatexFileDependencies(
     }
   }
 
-  // Resolve all paths in parallel
   const [texResolved, bibResolved] = await Promise.all([
     Promise.all(texInputPaths.map((raw) => resolveTexInputPath(raw, latexDir))),
     Promise.all(bibPaths.map((raw) => resolveBibPath(raw, latexDir))),

--- a/src/latex/extractFileDependencies.ts
+++ b/src/latex/extractFileDependencies.ts
@@ -9,19 +9,18 @@
 
 // Standard library imports
 import * as path from 'path';
+import { promises as fs } from 'fs';
 
 // Local imports
 import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { ensureExtension, joinLatexPath } from '@utils/core/pathCore';
 
-const COMMENT_LINE = /^\s*%/;
+/** Strip everything after an unescaped % on each line (same approach as extractBibliography.ts). */
+const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
-function stripCommentLines(content: string): string {
-  return content
-    .split('\n')
-    .filter((line) => !COMMENT_LINE.test(line))
-    .join('\n');
+function stripComments(content: string): string {
+  return content.replaceAll(COMMENT_PATTERN, '$1');
 }
 
 // ---------------------------------------------------------------------------
@@ -98,13 +97,20 @@ async function resolveBibPath(
 /**
  * Extract file dependencies (\input, \include, \bibliography, \addbibresource)
  * from a LaTeX file. Returns absolute paths to existing files.
+ *
+ * Uses fs.realpath to follow symlinks so that when the input file lives in
+ * run storage (as a symlink to the workspace), dependencies are resolved
+ * relative to the original workspace location where they actually exist.
  */
 export async function extractLatexFileDependencies(
   latexFileLocation: FileLocation,
 ): Promise<string[]> {
-  const latexDir = path.dirname(latexFileLocation.absolutePath);
+  // Follow symlinks so run-storage paths resolve against the workspace
+  const realPath = await fs.realpath(latexFileLocation.absolutePath);
+  const latexDir = path.dirname(realPath);
+
   const content = await flexibleFS.read(latexFileLocation);
-  const uncommented = stripCommentLines(content);
+  const uncommented = stripComments(content);
 
   // Collect raw paths from all patterns
   const texInputPaths: string[] = [];

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -11,6 +11,12 @@ export { TikzPictureManager, tikzPictureManager } from './TikzPictureManager';
 export { extractFigurePathsFromLatex } from './extractFigure';
 
 // -----------------------------------------------------------------------------
+// File Dependency Extraction
+// -----------------------------------------------------------------------------
+
+export { extractLatexFileDependencies } from './extractFileDependencies';
+
+// -----------------------------------------------------------------------------
 // Bibliography Utilities
 // -----------------------------------------------------------------------------
 

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared LaTeX content parsing utilities.
+ *
+ * Common patterns used by both extractBibliography.ts and
+ * extractFileDependencies.ts for comment stripping and
+ * bibliography directive matching.
+ */
+
+/** Strips everything after an unescaped % on each line. */
+const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
+
+export function stripLatexComments(content: string): string {
+  return content.replaceAll(COMMENT_PATTERN, '$1');
+}
+
+/**
+ * Matches both \bibliography{...} and \addbibresource[...]{...}.
+ * matchAll clones the regex, so a single module-level instance is safe.
+ */
+export const BIB_DIRECTIVE_PATTERN = new RegExp(
+  '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
+  'g',
+);


### PR DESCRIPTION
When workflow agents run in taskRunStorage mode, output files are
written to executions/{id}/ but compilation fails because \input,
\include, and \bibliography referenced files are not present.

Add extractLatexFileDependencies() that parses these commands from
LaTeX content and integrate it into LatexMediaManager to automatically
symlink discovered dependencies into run storage alongside the
existing figure mirroring logic. This enables output files to compile
successfully when the main document inputs other files.

https://claude.ai/code/session_01XxrsjsNCdoVaQL5U5yeu5n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new LaTeX dependency parsing and run-storage mirroring, which can affect compilation behavior and file I/O paths; failures are handled as best-effort but could change which files are copied/symlinked during runs.
> 
> **Overview**
> Ensures LaTeX compilation in task-run storage mode works when documents reference other files by **mirroring `\input`, `\include`, and bibliography (`\bibliography`/`\addbibresource`) dependencies** into the run directory before compiling.
> 
> Introduces `extractLatexFileDependencies()` (with symlink-aware resolution via `realpath`) plus shared parsing helpers in `latexParsingUtils.ts`, and refactors `extractBibliography.ts` to reuse the shared comment-stripping and bibliography directive regex. `LatexMediaManager` now optionally runs this dependency-mirroring step for input file processing (but not output file processing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31508af66db1a07085e7cc8726e055cc9cdcda23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->