### PR TITLE
Add persistent banner dismissal and import options command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1923,9 +1923,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1940,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,9 +1957,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1974,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2003,9 +1991,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2023,9 +2008,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7684,9 +7666,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7708,9 +7687,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7732,9 +7708,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7756,9 +7729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -66,6 +66,18 @@
             "description": "Show login banner prompting users to sign in for access to remote agents",
             "scope": "resource"
           },
+          "texra.ui.showGettingStartedBanner": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show getting started banner with import options when no LaTeX files are found",
+            "scope": "resource"
+          },
+          "texra.ui.showOrchestratorBanner": {
+            "type": "boolean",
+            "default": true,
+            "description": "Show orchestrator workflow explanation when the orchestrator agent is selected",
+            "scope": "resource"
+          },
           "texra.auth.enableVSCodeGitHub": {
             "type": "boolean",
             "default": false,
@@ -866,6 +878,12 @@
         "command": "texra.downloadArXivSource",
         "title": "Download arXiv Source",
         "category": "TeXRA"
+      },
+      {
+        "command": "texra.showImportOptions",
+        "title": "Import or Create LaTeX Project",
+        "category": "TeXRA",
+        "icon": "$(cloud-download)"
       },
       {
         "command": "texra.parseXml",

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -3,11 +3,15 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { computeAgentOptionsData, refresh } from '@agent/index';
+import { arXivCommands } from '@commands/latex';
+import { gitCommands } from '@commands/git/gitCommands';
 import { toErrorMessage } from '@common/errors';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { computeModelOptionsData } from '@model/computeModelOptions';
+
+import { sampleProjectCommands } from './sampleProjectCommands';
 
 const CHANNEL = 'mainViewCommands';
 
@@ -124,17 +128,17 @@ export function registerMainViewCommands(
             {
               label: '$(repo-clone) Pull from Overleaf',
               description: 'Import an existing Overleaf/ShareLaTeX project',
-              command: 'texra.cloneOverleafProject',
+              command: gitCommands.cloneOverleafProject,
             },
             {
               label: '$(cloud-download) Grab from arXiv',
               description: "Download a paper's source files",
-              command: 'texra.downloadArXivSource',
+              command: arXivCommands.downloadArXivSource,
             },
             {
               label: '$(file-add) Try the sample project',
               description: 'Create a sample project to play around risk-free',
-              command: 'texra.createSampleProject',
+              command: sampleProjectCommands.createSampleProject,
             },
             {
               label: '$(book) Walk me through setup',

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -16,6 +16,7 @@ export const mainViewCommands = {
   refreshModelOptions: 'texra.refreshModelOptions',
   refreshAgentOptions: 'texra.refreshAgentOptions',
   refreshAllOptions: 'texra.refreshAllOptions',
+  showImportOptions: 'texra.showImportOptions',
 };
 
 /**
@@ -111,6 +112,40 @@ export function registerMainViewCommands(
           vscode.window.showErrorMessage(
             `Failed to refresh options: ${message}`,
           );
+        }
+      },
+    ),
+
+    vscode.commands.registerCommand(
+      mainViewCommands.showImportOptions,
+      async () => {
+        const picked = await vscode.window.showQuickPick(
+          [
+            {
+              label: '$(repo-clone) Pull from Overleaf',
+              description: 'Import an existing Overleaf/ShareLaTeX project',
+              command: 'texra.cloneOverleafProject',
+            },
+            {
+              label: '$(cloud-download) Grab from arXiv',
+              description: "Download a paper's source files",
+              command: 'texra.downloadArXivSource',
+            },
+            {
+              label: '$(file-add) Try the sample project',
+              description: 'Create a sample project to play around risk-free',
+              command: 'texra.createSampleProject',
+            },
+            {
+              label: '$(book) Walk me through setup',
+              description: 'Open the getting started walkthrough',
+              command: 'texra.openGettingStarted',
+            },
+          ],
+          { placeHolder: 'Import or create a LaTeX project' },
+        );
+        if (picked) {
+          await vscode.commands.executeCommand(picked.command);
         }
       },
     ),

--- a/src/common/webview/mainViewCommands.ts
+++ b/src/common/webview/mainViewCommands.ts
@@ -90,6 +90,7 @@ export const MAIN_VIEW_COMMANDS = {
   DISMISS_LOGIN_BANNER: 'dismissLoginBanner',
   DISMISS_GETTING_STARTED_BANNER: 'dismissGettingStartedBanner',
   DISMISS_ORCHESTRATOR_BANNER: 'dismissOrchestratorBanner',
+  HIDE_ORCHESTRATOR_BANNER: 'hideOrchestratorBanner',
 
   // Extension response events
   INSTRUCTION_TEXT_POLISHED: 'instructionTextPolished',

--- a/src/common/webview/mainViewCommands.ts
+++ b/src/common/webview/mainViewCommands.ts
@@ -88,6 +88,8 @@ export const MAIN_VIEW_COMMANDS = {
   HIDE_LOGIN_BANNER: 'hideLoginBanner',
   SIGN_IN_FROM_BANNER: 'signInFromBanner',
   DISMISS_LOGIN_BANNER: 'dismissLoginBanner',
+  DISMISS_GETTING_STARTED_BANNER: 'dismissGettingStartedBanner',
+  DISMISS_ORCHESTRATOR_BANNER: 'dismissOrchestratorBanner',
 
   // Extension response events
   INSTRUCTION_TEXT_POLISHED: 'instructionTextPolished',

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -555,6 +555,10 @@ export const HideGettingStartedBannerMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER),
 });
 
+export const DismissOrchestratorBannerMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER),
+});
+
 export const ShowLoginBannerMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER),
 });
@@ -650,6 +654,7 @@ export const MainViewMessageSchema = z.discriminatedUnion('command', [
   HideDependencyBannerMessageSchema,
   ShowGettingStartedBannerMessageSchema,
   HideGettingStartedBannerMessageSchema,
+  DismissOrchestratorBannerMessageSchema,
   ShowLoginBannerMessageSchema,
   HideLoginBannerMessageSchema,
   SetSelectedAgentMessageSchema,
@@ -864,6 +869,8 @@ const BannerMessages = [
   commandOnly(MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER),
   commandOnly(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER),
+  commandOnly(MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER),
+  commandOnly(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER),
   z.object({
     command: z.literal(MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER),
     missingTools: z.array(z.string()).optional(),

--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -555,8 +555,8 @@ export const HideGettingStartedBannerMessageSchema = z.object({
   command: z.literal(MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER),
 });
 
-export const DismissOrchestratorBannerMessageSchema = z.object({
-  command: z.literal(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER),
+export const HideOrchestratorBannerMessageSchema = z.object({
+  command: z.literal(MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER),
 });
 
 export const ShowLoginBannerMessageSchema = z.object({
@@ -654,7 +654,7 @@ export const MainViewMessageSchema = z.discriminatedUnion('command', [
   HideDependencyBannerMessageSchema,
   ShowGettingStartedBannerMessageSchema,
   HideGettingStartedBannerMessageSchema,
-  DismissOrchestratorBannerMessageSchema,
+  HideOrchestratorBannerMessageSchema,
   ShowLoginBannerMessageSchema,
   HideLoginBannerMessageSchema,
   SetSelectedAgentMessageSchema,

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -4,6 +4,7 @@ export const COMMAND_LINKS = {
   CREATE_SAMPLE_PROJECT: 'command:texra.createSampleProject',
   CLONE_OVERLEAF: 'command:texra.cloneOverleafProject',
   DOWNLOAD_ARXIV: 'command:texra.downloadArXivSource',
+  SHOW_IMPORT_OPTIONS: 'command:texra.showImportOptions',
 } as const;
 
 export const PERMISSION_KIND = {

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -4,7 +4,6 @@ export const COMMAND_LINKS = {
   CREATE_SAMPLE_PROJECT: 'command:texra.createSampleProject',
   CLONE_OVERLEAF: 'command:texra.cloneOverleafProject',
   DOWNLOAD_ARXIV: 'command:texra.downloadArXivSource',
-  SHOW_IMPORT_OPTIONS: 'command:texra.showImportOptions',
 } as const;
 
 export const PERMISSION_KIND = {

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -438,7 +438,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       );
       if (!showOrchestratorBanner) {
         webviewView.webview.postMessage({
-          command: MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER,
+          command: MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER,
         });
       }
     } catch (error) {

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -331,21 +331,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           );
         }
       },
-      [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: async () => {
-        await updateConfig('ui.showLoginBanner', false);
-        this.postToActiveView({
-          command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
-        });
-      },
-      [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: async () => {
-        await updateConfig('ui.showGettingStartedBanner', false);
-        this.postToActiveView({
-          command: MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
-        });
-      },
-      [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: async () => {
-        await updateConfig('ui.showOrchestratorBanner', false);
-      },
+      [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: () =>
+        updateConfig('ui.showLoginBanner', false),
+      [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: () =>
+        updateConfig('ui.showGettingStartedBanner', false),
+      [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: () =>
+        updateConfig('ui.showOrchestratorBanner', false),
 
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: (m) =>
         this.diffManager.handleRequestRecentCommits(m),

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -337,6 +337,15 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
         });
       },
+      [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: async () => {
+        await updateConfig('ui.showGettingStartedBanner', false);
+        this.postToActiveView({
+          command: MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
+        });
+      },
+      [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: async () => {
+        await updateConfig('ui.showOrchestratorBanner', false);
+      },
 
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: (m) =>
         this.diffManager.handleRequestRecentCommits(m),
@@ -414,14 +423,24 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         optionsData: agentOptions,
       });
 
-      const showBanner =
+      const showLoginBanner =
         !authStatus.authenticated &&
         getConfig<boolean>('ui.showLoginBanner', true);
       webviewView.webview.postMessage({
-        command: showBanner
+        command: showLoginBanner
           ? MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER
           : MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
       });
+
+      const showOrchestratorBanner = getConfig<boolean>(
+        'ui.showOrchestratorBanner',
+        true,
+      );
+      if (!showOrchestratorBanner) {
+        webviewView.webview.postMessage({
+          command: MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER,
+        });
+      }
     } catch (error) {
       this.logger.error(
         this.channel,

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -1692,6 +1692,7 @@ export class MainApp extends MainAppBase {
 
   private handleComponentDismissLogin(): void {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER);
+    this.loginBannerVisible.set(false);
   }
 
   private handleComponentDismissGettingStarted(): void {

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -178,6 +178,12 @@ export class MainApp extends MainAppBase {
     visible: false,
   });
   private readonly gettingStartedVisible = signal(false);
+  private readonly orchestratorBannerDismissed = signal(false);
+  private readonly orchestratorBannerVisible$ = new Signal.Computed(() =>
+    this.isSelectedAgentOrchestrator()
+      ? !this.orchestratorBannerDismissed.get()
+      : false,
+  );
   private readonly loginBannerVisible = signal(false);
   private readonly instructionPlaceholder = signal(
     ONBOARDING_PLACEHOLDERS[DEFAULT_STATE.sessionType][0],
@@ -328,6 +334,9 @@ export class MainApp extends MainAppBase {
     },
     [MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER]: () => {
       this.gettingStartedVisible.set(false);
+    },
+    [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: () => {
+      this.orchestratorBannerDismissed.set(true);
     },
     [MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER]: () => {
       this.loginBannerVisible.set(true);
@@ -1685,6 +1694,16 @@ export class MainApp extends MainAppBase {
     postMessage(MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER);
   }
 
+  private handleComponentDismissGettingStarted(): void {
+    postMessage(MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER);
+    this.gettingStartedVisible.set(false);
+  }
+
+  private handleComponentDismissOrchestrator(): void {
+    postMessage(MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER);
+    this.orchestratorBannerDismissed.set(true);
+  }
+
   private handleComponentLatexDiffsToggle(
     e: CustomEvent<LatexDiffsToggleDetail>,
   ): void {
@@ -1981,7 +2000,7 @@ export class MainApp extends MainAppBase {
             }}
             .gettingStartedVisible=${this.gettingStartedVisible.get()}
             .loginBannerVisible=${this.loginBannerVisible.get()}
-            .orchestratorSelected=${this.isSelectedAgentOrchestrator()}
+            .orchestratorVisible=${this.orchestratorBannerVisible$.get()}
             @api-key-action=${this.handleComponentApiKeyAction}
             @agent-config-action=${this.handleComponentAgentConfigAction}
             @dependency-dismiss=${this.handleComponentDependencyDismiss}
@@ -1989,6 +2008,8 @@ export class MainApp extends MainAppBase {
             @open-install-guide=${this.handleComponentOpenInstallGuide}
             @sign-in=${this.handleComponentSignIn}
             @dismiss-login=${this.handleComponentDismissLogin}
+            @dismiss-getting-started=${this.handleComponentDismissGettingStarted}
+            @dismiss-orchestrator=${this.handleComponentDismissOrchestrator}
           ></banner-group>
         </div>
 

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -335,7 +335,7 @@ export class MainApp extends MainAppBase {
     [MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER]: () => {
       this.gettingStartedVisible.set(false);
     },
-    [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: () => {
+    [MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER]: () => {
       this.orchestratorBannerDismissed.set(true);
     },
     [MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER]: () => {

--- a/src/webview/frontend/components/BannerGroup.ts
+++ b/src/webview/frontend/components/BannerGroup.ts
@@ -49,7 +49,7 @@ export class BannerGroup extends LitElement {
 
   @property({ attribute: false }) loginBannerVisible = false;
 
-  @property({ attribute: false }) orchestratorSelected = false;
+  @property({ attribute: false }) orchestratorVisible = false;
 
   override render(): TemplateResult {
     return html`
@@ -63,7 +63,7 @@ export class BannerGroup extends LitElement {
       ></getting-started-banner>
       <login-banner .visible=${this.loginBannerVisible}></login-banner>
       <orchestrator-banner
-        .visible=${this.orchestratorSelected}
+        .visible=${this.orchestratorVisible}
       ></orchestrator-banner>
     `;
   }

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -40,7 +40,6 @@ export class GettingStartedBanner extends LitElement {
         border: var(--border-thin) solid
           var(--vscode-inputValidation-infoBorder);
         line-height: var(--line-height-relaxed);
-        position: relative;
       }
 
       .getting-started-banner a {

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -3,6 +3,8 @@
  *
  * Displays an info banner with links to various getting started
  * actions when no files are found in the workspace.
+ *
+ * @fires dismiss-getting-started - When dismiss button is clicked
  */
 
 // Third-party imports
@@ -14,6 +16,9 @@ import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
 
 // Local imports - shared utilities
 import { COMMAND_LINKS } from '@shared/utils/uiConstants';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
 
 @customElement('getting-started-banner')
 export class GettingStartedBanner extends LitElement {
@@ -35,6 +40,7 @@ export class GettingStartedBanner extends LitElement {
         border: var(--border-thin) solid
           var(--vscode-inputValidation-infoBorder);
         line-height: var(--line-height-relaxed);
+        position: relative;
       }
 
       .getting-started-banner a {
@@ -51,20 +57,38 @@ export class GettingStartedBanner extends LitElement {
         padding-left: var(--spacing-large);
         line-height: var(--line-height-relaxed);
       }
+
+      .getting-started-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
     `,
   ];
 
   @property({ type: Boolean }) visible = false;
+
+  private handleDismiss(): void {
+    this.dispatchEvent(MainViewEvents.dismissGettingStarted());
+  }
 
   override render(): TemplateResult | typeof nothing {
     if (!this.visible) return nothing;
 
     return html`
       <div id="gettingStartedBanner" class="getting-started-banner">
-        <span class="getting-started-text">
-          <strong>Welcome to TeXRA!</strong> Open a workspace with LaTeX files,
-          or get started with one of these:
-        </span>
+        <div class="getting-started-header">
+          <span class="getting-started-text">
+            <strong>Welcome to TeXRA!</strong> Open a workspace with LaTeX
+            files, or get started with one of these:
+          </span>
+          <vscode-toolbar-button
+            icon="close"
+            title="Dismiss (can be re-enabled in settings)"
+            aria-label="Dismiss getting started banner"
+            @click=${this.handleDismiss}
+          ></vscode-toolbar-button>
+        </div>
         <ul class="getting-started-list">
           <li>
             <a href=${COMMAND_LINKS.GETTING_STARTED}>Walk me through setup</a>

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -3,17 +3,22 @@
  *
  * Appears when the orchestrator is selected in the agent dropdown
  * to help users understand the delegation-based workflow.
- * Dismissable via a "Got it" button.
+ * Dismissable via a "Got it" button; dismissal persists to settings.
+ *
+ * @fires dismiss-orchestrator - When dismiss button is clicked
  */
 
 // Third-party imports
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 
 // Local imports
 import { MAIN_VIEW_COMMANDS } from '@common/webview/commands';
 import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
 import { postMessage } from '@shared/vscode';
+
+// Local imports - main view events
+import { MainViewEvents } from '../events';
 
 @customElement('orchestrator-banner')
 export class OrchestratorBanner extends LitElement {
@@ -92,10 +97,9 @@ export class OrchestratorBanner extends LitElement {
   ];
 
   @property({ type: Boolean }) visible = false;
-  @state() private dismissed = false;
 
   private handleDismiss(): void {
-    this.dismissed = true;
+    this.dispatchEvent(MainViewEvents.dismissOrchestrator());
   }
 
   private handleOpenMultiAgentSettings(): void {
@@ -103,7 +107,7 @@ export class OrchestratorBanner extends LitElement {
   }
 
   override render(): TemplateResult | typeof nothing {
-    if (!this.visible || this.dismissed) return nothing;
+    if (!this.visible) return nothing;
 
     return html`
       <div class="orchestrator-banner">
@@ -121,7 +125,11 @@ export class OrchestratorBanner extends LitElement {
               Multi-Agent settings</button
             >.</span
           >
-          <button class="got-it-btn" @click=${this.handleDismiss}>
+          <button
+            class="got-it-btn"
+            title="Dismiss (can be re-enabled in settings)"
+            @click=${this.handleDismiss}
+          >
             Got it
           </button>
         </div>

--- a/src/webview/frontend/events.ts
+++ b/src/webview/frontend/events.ts
@@ -95,6 +95,11 @@ export const MainViewEvents = {
 
   dismissLogin: () => createEvent('dismiss-login', undefined),
 
+  dismissGettingStarted: () =>
+    createEvent('dismiss-getting-started', undefined),
+
+  dismissOrchestrator: () => createEvent('dismiss-orchestrator', undefined),
+
   // LaTeXDiffs events
   latexDiffsToggle: (detail: LatexDiffsToggleDetail) =>
     createEvent('latexdiffs-toggle', detail),

--- a/src/webview/managers/FileManager.ts
+++ b/src/webview/managers/FileManager.ts
@@ -26,6 +26,8 @@ import {
   deriveBaseFileFromLatexDiff,
 } from '@utils/files';
 
+import { getConfig } from '@utils/config';
+
 import { BaseWebviewManager } from './BaseWebviewManager';
 
 type MessageFor<C extends MainViewInboundMessage['command']> = Extract<
@@ -467,10 +469,12 @@ export class FileManager extends BaseWebviewManager {
     });
   }
 
-  /** Post show/hide getting started banner based on condition */
+  /** Post show/hide getting started banner based on condition and setting */
   private postGettingStartedBanner(show: boolean): void {
+    const enabled = show &&
+      getConfig<boolean>('ui.showGettingStartedBanner', true);
     this.postMessage({
-      command: show
+      command: enabled
         ? MAIN_VIEW_COMMANDS.SHOW_GETTING_STARTED_BANNER
         : MAIN_VIEW_COMMANDS.HIDE_GETTING_STARTED_BANNER,
     });


### PR DESCRIPTION
## Summary
This PR enhances the banner system by adding persistent dismissal functionality and introduces a new command for importing or creating LaTeX projects. Users can now dismiss the getting started and orchestrator banners, with their preferences saved to settings.

## Key Changes

- **New Import Options Command**: Added `texra.showImportOptions` command that displays a quick pick menu with four options:
  - Pull from Overleaf
  - Grab from arXiv
  - Try the sample project
  - Walk me through setup

- **Persistent Banner Dismissal**: 
  - Added `ui.showGettingStartedBanner` and `ui.showOrchestratorBanner` configuration settings (both default to `true`)
  - Getting started and orchestrator banners now have dismiss buttons that persist the user's preference
  - Banners respect the configuration settings and won't show if previously dismissed

- **UI Improvements**:
  - Added close button to getting started banner with improved layout using flexbox
  - Updated orchestrator banner dismiss button with tooltip
  - Refactored orchestrator banner visibility logic to use a computed signal based on both agent selection and dismissal state

- **Event System**: 
  - Added `dismissGettingStarted` and `dismissOrchestrator` events to the MainViewEvents system
  - Updated BannerGroup component to properly wire dismiss event handlers

- **Message Handling**:
  - Added handlers for `DISMISS_GETTING_STARTED_BANNER` and `DISMISS_ORCHESTRATOR_BANNER` commands
  - Updated FileManager to respect the getting started banner setting when deciding whether to show the banner

- **Schema Updates**: Extended mainView message schema to include new dismiss orchestrator banner message type

## Implementation Details

The dismissal state is managed at the application level using signals, with persistence handled through the configuration system. The orchestrator banner visibility is now computed based on both whether the orchestrator agent is selected AND whether the banner has been dismissed, ensuring the dismissal state is properly maintained across interactions.

https://claude.ai/code/session_01S6maXAcjaxEgbzPTfU2Gxv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to VS Code command wiring and webview banner UI/state, with persistence via extension settings but no auth/data-processing logic changes.
> 
> **Overview**
> Adds a new command `texra.showImportOptions` that opens a Quick Pick to import/create a LaTeX project (Overleaf clone, arXiv download, sample project, or the getting-started walkthrough).
> 
> Makes the Getting Started and Orchestrator banners *dismissible and persistent* by introducing `texra.ui.showGettingStartedBanner`/`texra.ui.showOrchestratorBanner` settings, adding new webview commands/events for dismissal, and updating frontend/backend handlers so banners respect stored preferences on startup and when deciding whether to show.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3266e62eceae0f489875d62483e62499c2c67b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->