### PR TITLE
fix: consolidate stale worktree fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@lit/context": "^1.1.6",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.120.0",
-        "@openrouter/sdk": "^0.12.3",
+        "@openrouter/sdk": "^0.12.6",
         "@supabase/supabase-js": "^2.103.0",
         "@vscode-elements/elements": "^2.5.1",
         "@vscode/codicons": "^0.0.45",
@@ -1718,9 +1718,9 @@
       }
     },
     "node_modules/@openrouter/sdk": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.3.tgz",
-      "integrity": "sha512-qpzxyNS3ikz7BQ4vDvSlheJ33oM/34l103M1+k1E9yjOmXK5abz5LHCLNhOEmbLNg4MvZG9rg7TPLsGgREe0Ow==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.6.tgz",
+      "integrity": "sha512-KfuhmvLi3/F7hLkvkXrZTDfS5WJRx2SdaCw0VIJHVIob0VkwvHJGb2M/smsAthH+vAMnxXX0Oaicm7eoxgzJig==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1456,7 +1456,7 @@
     "@lit/context": "^1.1.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.120.0",
-    "@openrouter/sdk": "^0.12.3",
+    "@openrouter/sdk": "^0.12.6",
     "@supabase/supabase-js": "^2.103.0",
     "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -141,6 +141,21 @@ interface UploadedAnthropicAttachment {
   mediaType?: string;
 }
 
+type ErrorWithRequestId = Error & { request_id?: string };
+
+interface StreamWithResponse {
+  response: Promise<Response>;
+}
+
+function hasHttpResponse(value: unknown): value is StreamWithResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'response' in value &&
+    value.response instanceof Promise
+  );
+}
+
 /** Type guard for any thinking-related content block param */
 const isAnyThinkingBlockParam = (
   block: ContentBlockParam,
@@ -837,14 +852,14 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // detectRequestId() (in sdkErrorUtils) picks it up via the existing
         // ProviderError.requestId path — no duplicate field needed.
         try {
-          const httpResponse = await (
-            stream as unknown as { response: Promise<Response> }
-          ).response;
-          const reqId =
-            httpResponse?.headers?.get?.('request-id') ??
-            httpResponse?.headers?.get?.('x-request-id');
-          if (reqId && streamError instanceof Error) {
-            (streamError as Error & { request_id?: string }).request_id = reqId;
+          if (hasHttpResponse(stream)) {
+            const httpResponse = await stream.response;
+            const reqId =
+              httpResponse.headers.get('request-id') ??
+              httpResponse.headers.get('x-request-id');
+            if (reqId && streamError instanceof Error) {
+              (streamError as ErrorWithRequestId).request_id = reqId;
+            }
           }
         } catch {
           // Response may not be available (e.g. network error before HTTP response)

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -8,6 +8,7 @@ import {
   ChatCompletionContentPart,
   ChatCompletionContentPartInputAudio,
   ChatCompletionAssistantMessageParam,
+  ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
   ChatCompletionMessageFunctionToolCall,
   ChatCompletionMessageParam,
@@ -80,6 +81,12 @@ type ChatCompletionRequestBase = Omit<
   ChatCompletionCreateParamsStreaming,
   'stream' | 'stream_options'
 >;
+type ChatCompletionRequestWithThinking = ChatCompletionRequestBase & {
+  thinking?: { type: 'enabled' | 'disabled' };
+};
+type ChatCompletionSummaryParams = ChatCompletionCreateParamsNonStreaming & {
+  thinking?: { type: 'disabled' };
+};
 
 // Reasoning content type for DeepSeek, o1 models (not in SDK)
 type ReasoningContent = string | Array<{ type: string; text?: string }>;
@@ -232,7 +239,7 @@ export class ModelHandlerOpenAI<
       : conversationMessages;
 
     try {
-      const summaryParams: Record<string, unknown> = {
+      const summaryParams: ChatCompletionSummaryParams = {
         model: this.config.fullName,
         messages: [
           { role: 'system', content: COMPACTION_SYSTEM_PROMPT },
@@ -247,12 +254,10 @@ export class ModelHandlerOpenAI<
       if (this.getThinkingParameter() || this.capabilities.supportsReasoning) {
         summaryParams.thinking = { type: 'disabled' };
       }
-      const summaryResponse = (await client.chat.completions.create(
-        summaryParams as unknown as Parameters<
-          typeof client.chat.completions.create
-        >[0],
+      const summaryResponse = await client.chat.completions.create(
+        summaryParams,
         { signal },
-      )) as ChatCompletion;
+      );
 
       const summaryText = summaryResponse.choices[0]?.message?.content?.trim();
       if (!summaryText) {
@@ -352,10 +357,10 @@ export class ModelHandlerOpenAI<
     systemPrompt?: string,
     endTag?: string,
     tools?: ToolDefinition[],
-  ): ChatCompletionRequestBase {
+  ): ChatCompletionRequestWithThinking {
     const effectiveMaxTokens = this.getEffectiveMaxOutputTokens();
 
-    const baseParams: ChatCompletionRequestBase = {
+    const baseParams: ChatCompletionRequestWithThinking = {
       model: this.config.fullName,
       messages,
       ...(this.isOReasoningModel
@@ -382,7 +387,7 @@ export class ModelHandlerOpenAI<
     // Add thinking parameter if specified by subclass (Kimi K2.5, DeepSeek)
     const thinking = this.getThinkingParameter();
     if (thinking) {
-      (baseParams as Record<string, unknown>).thinking = thinking;
+      baseParams.thinking = thinking;
     }
 
     if (tools?.length) {
@@ -631,9 +636,10 @@ export class ModelHandlerOpenAI<
         const maxTokensKey = this.isOReasoningModel
           ? 'max_completion_tokens'
           : 'max_tokens';
-        const currentMaxTokens = (baseParams as Record<string, unknown>)[
-          maxTokensKey
-        ] as number;
+        const currentMaxTokens = this.isOReasoningModel
+          ? (baseParams.max_completion_tokens ??
+            this.getEffectiveMaxOutputTokens())
+          : (baseParams.max_tokens ?? this.getEffectiveMaxOutputTokens());
         const tokenBuffer = this.isToolUseMode()
           ? TOOL_USE_SAFETY_BUFFER
           : undefined;
@@ -659,8 +665,11 @@ export class ModelHandlerOpenAI<
               details: `OpenAI: ${maxTokensKey} reduced to fit context window`,
             },
           );
-          (baseParams as Record<string, unknown>)[maxTokensKey] =
-            validation.adjustedMaxTokens;
+          if (this.isOReasoningModel) {
+            baseParams.max_completion_tokens = validation.adjustedMaxTokens;
+          } else {
+            baseParams.max_tokens = validation.adjustedMaxTokens;
+          }
         }
       } catch (err) {
         if (isContextWindowError(err)) throw err;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -139,6 +139,10 @@ interface WebSocketExecutionResult {
   state: StreamingEventState;
 }
 
+interface RequestIdTaggedError extends Error {
+  request_id?: string;
+}
+
 /**
  * MIME types that the OpenAI Responses API accepts as `input_file` content.
  * Composed from the shared OFFICE_MIME_TYPES plus PDF.
@@ -173,6 +177,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   private isOpenRouterRoutingEnabled(): boolean {
     return this.config.openRouterOnly || getUseOpenRouter();
+  }
+
+  private getEventResponseId(event: ResponseStreamEvent): string | undefined {
+    return 'response_id' in event && typeof event.response_id === 'string'
+      ? event.response_id
+      : undefined;
   }
 
   /**
@@ -502,11 +512,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         if (!currentResponseId) return;
 
         // Filter events by response ID: skip events from stale responses
-        if (
-          'response_id' in e &&
-          typeof (e as Record<string, unknown>).response_id === 'string' &&
-          (e as Record<string, unknown>).response_id !== currentResponseId
-        ) {
+        const eventResponseId = this.getEventResponseId(e);
+        if (eventResponseId && eventResponseId !== currentResponseId) {
           return;
         }
 
@@ -1338,11 +1345,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         continue;
       }
 
-      const contentList = (
-        item as ResponseInputItem & {
-          content?: ResponseInputMessageContentList;
-        }
-      ).content;
+      const contentList = item.content;
 
       if (!Array.isArray(contentList)) {
         continue;
@@ -2229,7 +2232,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // non-retryable classification) work correctly with full HTTP metadata.
         const statusCode = (err as { status?: number }).status;
         if (statusCode === 404) {
-          const pollingError = new Error(
+          const pollingError: RequestIdTaggedError = new Error(
             `Background response polling failed for ${responseId}: ${getSdkErrorMessage(err)}`,
             { cause: err },
           );
@@ -2237,8 +2240,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           // logging diagnostics (detectRequestId doesn't follow the cause chain)
           const origRequestId = (err as { request_id?: string }).request_id;
           if (origRequestId) {
-            (pollingError as unknown as Record<string, unknown>).request_id =
-              origRequestId;
+            pollingError.request_id = origRequestId;
           }
           throw pollingError;
         }
@@ -2952,9 +2954,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     item?: ResponseInputItem,
   ): item is EasyInputMessage | ResponseInputItem.Message {
     if (!item || typeof item !== 'object') return false;
-    const { role, type, content } = item as unknown as Record<string, unknown>;
-    if (typeof role !== 'string') return false;
-    if (typeof type === 'string' && type !== 'message') return false;
+    if (!('role' in item) || typeof item.role !== 'string') return false;
+    if (
+      'type' in item &&
+      typeof item.type === 'string' &&
+      item.type !== 'message'
+    ) {
+      return false;
+    }
+    if (!('content' in item)) return false;
+    const { content } = item;
     return typeof content === 'string' || Array.isArray(content);
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenRouterNative.ts
@@ -45,6 +45,8 @@ import type {
   ChatAssistantMessage,
   ChatToolCall,
   ChatContentItems,
+  ChatRequest,
+  ChatFinishReasonEnum,
   ReasoningDetailUnion,
 } from '@openrouter/sdk/models';
 import type {
@@ -54,6 +56,26 @@ import type {
   OpenRouterToolCall,
 } from './types/IModelHandler';
 import type { ProviderStopReason } from './types/StopReasonTypes';
+
+type OpenRouterReasoningEffort = NonNullable<
+  NonNullable<ChatRequest['reasoning']>['effort']
+>;
+
+function toOpenRouterReasoningEffort(
+  effort: string,
+): OpenRouterReasoningEffort {
+  switch (effort) {
+    case 'xhigh':
+    case 'high':
+    case 'medium':
+    case 'low':
+    case 'minimal':
+    case 'none':
+      return effort;
+    default:
+      return 'low';
+  }
+}
 
 // ============================================================================
 // Streaming aggregator
@@ -75,7 +97,7 @@ class OpenRouterStreamAggregator {
       function: { name: string; arguments: string };
     }
   >();
-  private finishReason: string | null = null;
+  private finishReason: ChatFinishReasonEnum | null = null;
   private usage: ChatUsage | null = null;
   private model = '';
   private id = '';
@@ -101,7 +123,7 @@ class OpenRouterStreamAggregator {
     if (!choice) return { contentDelta: '', reasoningDelta: '' };
 
     if (choice.finishReason != null) {
-      this.finishReason = String(choice.finishReason);
+      this.finishReason = choice.finishReason;
     }
 
     const delta = choice.delta;
@@ -182,7 +204,7 @@ class OpenRouterStreamAggregator {
         {
           index: 0,
           message,
-          finishReason: this.finishReason as any,
+          finishReason: this.finishReason,
         },
       ],
       created: this.created || Math.floor(Date.now() / 1000),
@@ -276,7 +298,7 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
 
     const useStreaming = this.getStreamingConfig();
 
-    const params: Record<string, unknown> = {
+    const request: ChatRequest = {
       model: this.config.openrouterFullName,
       messages: messagesToUse,
       maxTokens: this.getEffectiveMaxOutputTokens(),
@@ -292,31 +314,32 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
         ? (this.getEffectiveReasoningEffort() ?? 'low')
         : 'low';
       const effort = effective === 'none' ? 'low' : effective;
-      params.reasoning = {
-        effort: this.validateReasoningEffort(effort),
+      request.reasoning = {
+        effort: toOpenRouterReasoningEffort(
+          this.validateReasoningEffort(effort),
+        ),
       };
     }
 
     if (tools && tools.length > 0) {
-      params.tools = toOpenAITools(tools);
-      params.toolChoice = 'auto';
+      request.tools = toOpenAITools(tools) as ChatRequest['tools'];
+      request.toolChoice = 'auto';
     }
 
     if (endTag) {
-      params.stop = [endTag];
+      request.stop = [endTag];
     }
 
     if (useStreaming) {
-      params.stream = true;
-      params.streamOptions = { includeUsage: true };
-
-      const result = await client.chat.send(
-        { chatRequest: params as any },
+      const streamRequest: ChatRequest & { stream: true } = {
+        ...request,
+        stream: true,
+        streamOptions: { includeUsage: true },
+      };
+      const stream = await client.chat.send(
+        { chatRequest: streamRequest },
         { signal },
       );
-
-      // Streaming returns EventStream (AsyncIterable)
-      const stream = result as unknown as AsyncIterable<ChatStreamChunk>;
       const aggregator = new OpenRouterStreamAggregator();
       const thinking = this.createThinkingStream();
       const output = this.isOutputStreamingEnabled()
@@ -356,11 +379,14 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     // Non-streaming
-    params.stream = false;
-    const response = (await client.chat.send(
-      { chatRequest: params as any },
+    const nonStreamingRequest: ChatRequest & { stream: false } = {
+      ...request,
+      stream: false,
+    };
+    const response = await client.chat.send(
+      { chatRequest: nonStreamingRequest },
       { signal },
-    )) as ChatResult;
+    );
 
     if (response.usage?.promptTokens) {
       this.lastKnownInputTokens = response.usage.promptTokens;
@@ -420,28 +446,27 @@ export class ModelHandlerOpenRouterNative extends ModelHandler<
     }
 
     try {
-      const summaryResponse = (await client.chat.send(
-        {
-          chatRequest: {
-            model: this.config.openrouterFullName,
-            messages: [
-              {
-                role: 'system',
-                content: COMPACTION_SYSTEM_PROMPT,
-              },
-              ...conversationMessages,
-            ],
-            maxTokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
-            temperature: 0,
-            stream: false,
-            // Minimize reasoning for summarization — use lowest valid effort
-            ...(this.capabilities.supportsReasoningEffort
-              ? { reasoning: { effort: 'low' } }
-              : {}),
-          } as any,
-        },
+      const summaryRequest: ChatRequest & { stream: false } = {
+        model: this.config.openrouterFullName,
+        messages: [
+          {
+            role: 'system',
+            content: COMPACTION_SYSTEM_PROMPT,
+          },
+          ...conversationMessages,
+        ],
+        maxTokens: CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
+        temperature: 0,
+        stream: false,
+        // Minimize reasoning for summarization — use lowest valid effort
+        ...(this.capabilities.supportsReasoningEffort
+          ? { reasoning: { effort: 'low' } }
+          : {}),
+      };
+      const summaryResponse = await client.chat.send(
+        { chatRequest: summaryRequest },
         { signal },
-      )) as ChatResult;
+      );
 
       const summaryText = summaryResponse.choices[0]?.message?.content;
       const summary = typeof summaryText === 'string' ? summaryText.trim() : '';

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -6,12 +6,12 @@ import type { ToolDefinition } from '@model';
 import type {
   Tool as AnthropicTool,
   ToolUnion,
-} from '@anthropic-ai/sdk/resources/messages/messages';
+} from '@anthropic-ai/sdk/resources/messages';
 import type {
   Tool as GeminiTool,
   FunctionDeclaration,
   Schema,
-} from '@google/genai/dist/genai';
+} from '@google/genai';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,

--- a/src/agent/modelHandlers/types/ProviderMessage.ts
+++ b/src/agent/modelHandlers/types/ProviderMessage.ts
@@ -1,6 +1,6 @@
 // Third-party imports
 import { z } from 'zod';
-import type { MessageParam } from '@anthropic-ai/sdk/resources/messages/messages';
+import type { MessageParam } from '@anthropic-ai/sdk/resources/messages';
 import type { Content } from '@google/genai';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type { ResponseInputItem } from 'openai/resources/responses/responses';

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -13,8 +13,14 @@
  */
 
 import { z } from 'zod';
-
 import latexPreamble from '../../../resources/templates/chatExport.tex';
+import type { Part } from '@google/genai';
+import type { ChatCompletionMessageToolCall } from 'openai/resources/chat/completions';
+import type {
+  ResponseFunctionCallOutputItemList,
+  ResponseFunctionToolCall,
+  ResponseInputItem,
+} from 'openai/resources/responses/responses';
 
 // ============================================================
 // Input schemas (single source of truth)
@@ -202,7 +208,7 @@ function latexListing(text: string): string {
 function extractBlocks(msg: ConversationMessage): ContentBlock[] {
   // Google GenAI: field-based Parts → type-based ContentBlocks
   if (Array.isArray(msg.parts)) {
-    return (msg.parts as Record<string, unknown>[]).flatMap(googlePartToBlocks);
+    return (msg.parts as Part[]).flatMap(googlePartToBlocks);
   }
 
   if (typeof msg.content === 'string') {
@@ -218,7 +224,7 @@ function extractBlocks(msg: ConversationMessage): ContentBlock[] {
 }
 
 /** Convert a Google GenAI Part (field-based discrimination) to type-based ContentBlock(s). */
-function googlePartToBlocks(part: Record<string, unknown>): ContentBlock[] {
+function googlePartToBlocks(part: Part): ContentBlock[] {
   // Google GenAI: thought is a boolean flag; the actual text is in part.text.
   // Must check before the plain text branch to avoid exposing thinking as assistant text.
   if (part.thought === true && typeof part.text === 'string') {
@@ -228,7 +234,7 @@ function googlePartToBlocks(part: Record<string, unknown>): ContentBlock[] {
     return [{ type: 'text', text: part.text }];
   }
   if (part.functionCall && typeof part.functionCall === 'object') {
-    const fc = part.functionCall as { name?: string; args?: unknown };
+    const fc = part.functionCall;
     return [
       {
         type: 'tool_use',
@@ -238,10 +244,7 @@ function googlePartToBlocks(part: Record<string, unknown>): ContentBlock[] {
     ];
   }
   if (part.functionResponse && typeof part.functionResponse === 'object') {
-    const fr = part.functionResponse as {
-      name?: string;
-      response?: unknown;
-    };
+    const fr = part.functionResponse;
     return [
       {
         type: 'tool_result',
@@ -376,12 +379,12 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
     const item = raw as Record<string, unknown>;
 
     // OpenAI Response API: top-level function_call items (not wrapped in a message)
-    if (item.type === 'function_call') {
-      const name = typeof item.name === 'string' ? item.name : 'unknown';
+    if (isResponseFunctionCallItem(item)) {
       const args =
         typeof item.arguments === 'string'
           ? item.arguments
           : JSON.stringify(item.arguments ?? {}, null, 2);
+      const name = item.name ?? 'unknown';
       nodes.push({ kind: 'tool-call', name, input: args });
       lastAssistantHadToolUse = true;
       continue;
@@ -389,10 +392,10 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
 
     // OpenAI Response API: top-level function_call_output items.
     // output can be a string OR an array of input_text/input_file/input_image parts.
-    if (item.type === 'function_call_output') {
+    if (isResponseFunctionCallOutputItem(item)) {
       if (Array.isArray(item.output)) {
         const textParts: string[] = [];
-        for (const part of item.output as Record<string, unknown>[]) {
+        for (const part of item.output as ResponseFunctionCallOutputItemList) {
           if (part.type === 'input_text' && typeof part.text === 'string') {
             textParts.push(part.text);
           } else if (part.type === 'input_image') {
@@ -446,14 +449,12 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
 
       // OpenAI Chat Completions: tool_calls array on assistant messages
       if (Array.isArray(msg.tool_calls)) {
-        for (const tc of msg.tool_calls as Record<string, unknown>[]) {
-          const fn = tc.function as
-            | { name?: string; arguments?: string }
-            | undefined;
-          if (fn) {
+        for (const tc of msg.tool_calls as ChatCompletionMessageToolCall[]) {
+          const fn = tc.type === 'function' ? tc.function : undefined;
+          if (fn?.name) {
             nodes.push({
               kind: 'tool-call',
-              name: fn.name ?? 'unknown',
+              name: fn.name,
               input: fn.arguments ?? '{}',
             });
             lastAssistantHadToolUse = true;
@@ -475,6 +476,28 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
   }
 
   return nodes;
+}
+
+function isResponseFunctionCallItem(
+  item: unknown,
+): item is ResponseFunctionToolCall {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    item.type === 'function_call'
+  );
+}
+
+function isResponseFunctionCallOutputItem(
+  item: unknown,
+): item is ResponseInputItem.FunctionCallOutput {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'type' in item &&
+    item.type === 'function_call_output'
+  );
 }
 
 // ============================================================

--- a/src/latex/textConnection.ts
+++ b/src/latex/textConnection.ts
@@ -125,8 +125,10 @@ export async function bestConnectionMethodAnthropic(
             messages: [{ role: 'user', content: prompt }],
           })
           .then((response) => {
-            const content = response.content[0];
-            return 'text' in content ? content.text.trim() : 'B';
+            const textBlock = response.content.find(
+              (block) => block.type === 'text',
+            );
+            return textBlock?.text.trim() || 'B';
           }),
       ),
     );

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -9,7 +9,7 @@ import {
 
 // Type imports
 import type { ToolDefinition } from '@model';
-import type { Tool as GeminiTool } from '@google/genai/dist/genai';
+import type { Tool as GeminiTool } from '@google/genai';
 import type { FunctionTool } from 'openai/resources/responses/responses';
 
 describe('toOpenAIResponseTools', () => {

--- a/src/test/utils/files/mimeUtils.test.ts
+++ b/src/test/utils/files/mimeUtils.test.ts
@@ -1,0 +1,22 @@
+// Third-party imports
+import * as assert from 'assert';
+
+// Local imports - utils
+import { getMimeType } from '@utils/files';
+
+describe('mimeUtils Test Suite', () => {
+  it('applies audio override for known extensions from file paths', () => {
+    assert.strictEqual(getMimeType('/tmp/clip.opus'), 'audio/opus');
+    assert.strictEqual(getMimeType('C:\\tmp\\clip.l16'), 'audio/l16');
+  });
+
+  it('applies audio override for bare extension values', () => {
+    assert.strictEqual(getMimeType('opus'), 'audio/opus');
+    assert.strictEqual(getMimeType('.mulaw'), 'audio/mulaw');
+  });
+
+  it('does not apply audio override to extensionless file paths', () => {
+    assert.strictEqual(getMimeType('/tmp/opus'), null);
+    assert.strictEqual(getMimeType('C:\\tmp\\mulaw'), null);
+  });
+});

--- a/src/utils/files/mimeUtils.ts
+++ b/src/utils/files/mimeUtils.ts
@@ -10,6 +10,7 @@ const AUDIO_MIME_TYPE_OVERRIDES: Readonly<Record<string, string>> = {
 };
 
 function getExtension(pathOrExtension: string): string {
+  const hasPathSeparator = /[\\/]/.test(pathOrExtension);
   const fileName = pathOrExtension.split(/[\\/]/).at(-1) ?? pathOrExtension;
   if (fileName.startsWith('.') && !fileName.slice(1).includes('.')) {
     return fileName.toLowerCase();
@@ -18,6 +19,10 @@ function getExtension(pathOrExtension: string): string {
   const dotIndex = fileName.lastIndexOf('.');
   if (dotIndex >= 0) {
     return fileName.slice(dotIndex).toLowerCase();
+  }
+
+  if (hasPathSeparator) {
+    return '';
   }
 
   return `.${fileName.toLowerCase()}`;
@@ -29,7 +34,7 @@ function getExtension(pathOrExtension: string): string {
  */
 export function getMimeType(filePath: string): string | null {
   const extension = getExtension(filePath);
-  if (Object.hasOwn(AUDIO_MIME_TYPE_OVERRIDES, extension)) {
+  if (extension && Object.hasOwn(AUDIO_MIME_TYPE_OVERRIDES, extension)) {
     return AUDIO_MIME_TYPE_OVERRIDES[extension];
   }
 


### PR DESCRIPTION
## Summary
- consolidate useful stale worktree fixes for provider SDK typing and request handling
- update OpenRouter SDK usage to typed request objects for the current dependency bump
- fix MIME detection for extensionless paths and add coverage
- retire superseded scratch worktrees after folding in their useful changes

## Verification
- npm run format
- npm run compile:safe
- npm run lint (passes with existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core provider request/streaming paths (Anthropic/OpenAI/OpenRouter), so subtle typing-to-runtime mismatches or token parameter changes could affect model calls, though changes are mostly type-safety and error-handling improvements.
> 
> **Overview**
> Bumps `@openrouter/sdk` to `0.12.6` and updates the OpenRouter native handler to build **typed `ChatRequest` objects** for both streaming and non-streaming calls, including stricter handling of `finishReason` and reasoning-effort values.
> 
> Improves robustness across provider handlers by tightening type guards/casts and propagating request IDs for debugging: Anthropic stream failures now attach `request-id`/`x-request-id` when available; OpenAI chat compaction and token-limit adjustment use typed request params; OpenAI Responses streaming filters events via a dedicated `response_id` extractor and forwards `request_id` through wrapped polling errors.
> 
> Fixes `getMimeType()` so extensionless *file paths* no longer get treated as bare extensions (preventing incorrect audio MIME overrides), and adds unit tests for the new behavior. Also updates GenAI/Anthropic import paths and strengthens chat export normalization with proper SDK types and explicit type guards for Response API tool-call items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb0ac1ed1c59359fd7aa4f3cd2a92a575bd5fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->