### PR TITLE
fix: accept internal field in AgentSettingSchema

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -32,6 +32,8 @@ export const AgentSettingBaseSchema = z.strictObject({
     )
     .prefault([]),
   tools: z.array(ToolDefinitionSchema).prefault([]),
+  /** Registry metadata: hides the agent from default launcher listings. */
+  internal: z.boolean().optional(),
 });
 
 const XmlStructureMode = z.enum(['never', 'scratchpadOnly', 'always']);

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -100,23 +100,6 @@ export function ensureAgentCategoryForSource<
   return settings;
 }
 
-/**
- * YAML settings fields that are registry metadata (read by scanYaml)
- * and not part of the runtime AgentSettingSchema.
- * Add new YAML-only metadata fields here to prevent z.strictObject rejection.
- */
-const YAML_METADATA_FIELDS: ReadonlySet<string> = new Set(['internal']);
-
-function stripYamlMetadata(
-  raw: Record<string, unknown>,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(raw)) {
-    if (!YAML_METADATA_FIELDS.has(k)) result[k] = v;
-  }
-  return result;
-}
-
 export async function loadAgentSettingAndPrompts(
   resolution: ResolvedAgent,
   options?: AgentLoadOptions,
@@ -145,13 +128,8 @@ export async function loadAgentSettingAndPrompts(
     const rawConfig = await loadYaml(resolution.definitionPath);
     const config = AgentDefinitionSchema.parse(rawConfig);
 
-    // Strip YAML-only metadata that scanYaml already reads during registry
-    // scanning but that isn't part of AgentSettingSchema (z.strictObject
-    // rejects unknown keys). Strip once before settings enter the pipeline.
-    const rawSettings = stripYamlMetadata(config.settings);
-
     // Initialize with own settings/prompts (spread creates a mutable copy)
-    let settings: Partial<AgentSetting> = { ...rawSettings };
+    let settings: Partial<AgentSetting> = { ...config.settings };
     let prompts: Partial<AgentPrompt> = { ...config.prompts };
 
     // Merge with parent if inheritance is specified
@@ -168,7 +146,7 @@ export async function loadAgentSettingAndPrompts(
         await loadAgentSettingAndPrompts(parentResolution);
 
       // Parent provides defaults, child overrides
-      settings = deepmerge(parentSettings, rawSettings, {
+      settings = deepmerge(parentSettings, config.settings, {
         arrayMerge: (_d, s) => s,
       });
       prompts = deepmerge(parentPrompts, config.prompts, {

--- a/src/agent/runtime/agentLoad.ts
+++ b/src/agent/runtime/agentLoad.ts
@@ -100,6 +100,23 @@ export function ensureAgentCategoryForSource<
   return settings;
 }
 
+/**
+ * YAML settings fields that are registry metadata (read by scanYaml)
+ * and not part of the runtime AgentSettingSchema.
+ * Add new YAML-only metadata fields here to prevent z.strictObject rejection.
+ */
+const YAML_METADATA_FIELDS: ReadonlySet<string> = new Set(['internal']);
+
+function stripYamlMetadata(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (!YAML_METADATA_FIELDS.has(k)) result[k] = v;
+  }
+  return result;
+}
+
 export async function loadAgentSettingAndPrompts(
   resolution: ResolvedAgent,
   options?: AgentLoadOptions,
@@ -128,8 +145,13 @@ export async function loadAgentSettingAndPrompts(
     const rawConfig = await loadYaml(resolution.definitionPath);
     const config = AgentDefinitionSchema.parse(rawConfig);
 
+    // Strip YAML-only metadata that scanYaml already reads during registry
+    // scanning but that isn't part of AgentSettingSchema (z.strictObject
+    // rejects unknown keys). Strip once before settings enter the pipeline.
+    const rawSettings = stripYamlMetadata(config.settings);
+
     // Initialize with own settings/prompts (spread creates a mutable copy)
-    let settings: Partial<AgentSetting> = { ...config.settings };
+    let settings: Partial<AgentSetting> = { ...rawSettings };
     let prompts: Partial<AgentPrompt> = { ...config.prompts };
 
     // Merge with parent if inheritance is specified
@@ -146,7 +168,7 @@ export async function loadAgentSettingAndPrompts(
         await loadAgentSettingAndPrompts(parentResolution);
 
       // Parent provides defaults, child overrides
-      settings = deepmerge(parentSettings, config.settings, {
+      settings = deepmerge(parentSettings, rawSettings, {
         arrayMerge: (_d, s) => s,
       });
       prompts = deepmerge(parentPrompts, config.prompts, {

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -91,6 +91,43 @@ describe('loadAgentSettingAndPrompts', () => {
     assert.strictEqual(prompts.userRequest, 'multiple variant');
   });
 
+  it('accepts the internal registry-metadata field in agent settings', async () => {
+    const agentPath = path.join('/', 'tmp', 'agents');
+    const definitionPath = path.join(agentPath, 'latexFixer.yaml');
+    const resolution: ResolvedAgent = {
+      entry: {
+        source: 'builtInToolUse',
+        name: 'latexFixer',
+        path: definitionPath,
+        category: AgentCategory.ToolUse,
+        internal: true,
+      },
+      definitionPath,
+      resolvedName: 'latexFixer',
+      usedFallback: false,
+    };
+
+    fileContents.set(
+      normalize(definitionPath),
+      [
+        'name: latexFixer',
+        'settings:',
+        '  agentCategory: toolUse',
+        '  internal: true',
+        'prompts:',
+        '  userRequest: fix it',
+        '',
+      ].join('\n'),
+    );
+
+    const [settings] = await loadAgentSettingAndPrompts(resolution);
+    assert.strictEqual(
+      (settings as { internal?: boolean }).internal,
+      true,
+      'internal: true should round-trip through AgentSettingSchema',
+    );
+  });
+
   it('falls back to the base definition when _multiple is missing', async () => {
     const agentPath = path.join('/', 'tmp', 'agents');
     const baseDefinitionPath = path.join(agentPath, 'summarize.yaml');

--- a/src/test/agent/runtime/agentLoad.test.ts
+++ b/src/test/agent/runtime/agentLoad.test.ts
@@ -96,11 +96,10 @@ describe('loadAgentSettingAndPrompts', () => {
     const definitionPath = path.join(agentPath, 'latexFixer.yaml');
     const resolution: ResolvedAgent = {
       entry: {
-        source: 'builtInToolUse',
+        source: 'custom',
         name: 'latexFixer',
         path: definitionPath,
         category: AgentCategory.ToolUse,
-        internal: true,
       },
       definitionPath,
       resolvedName: 'latexFixer',
@@ -122,7 +121,7 @@ describe('loadAgentSettingAndPrompts', () => {
 
     const [settings] = await loadAgentSettingAndPrompts(resolution);
     assert.strictEqual(
-      (settings as { internal?: boolean }).internal,
+      settings.internal,
       true,
       'internal: true should round-trip through AgentSettingSchema',
     );


### PR DESCRIPTION
## Summary

- **Fix**: `latexFixer` (and any other agent with `settings.internal: true`) crashes silently on launch because `z.strictObject` in `AgentSettingBaseSchema` rejects the unknown key.
- **Approach**: Declare `internal: z.boolean().optional()` on `AgentSettingBaseSchema` so the field is valid at schema time. Simpler than a load-boundary strip, and it also covers `validateAgentYamlContent` — the parallel path raised by both Copilot and cursor[bot] reviews.

## Why the schema approach over stripping

The original approach stripped `internal` in `loadAgentSettingAndPrompts`. Reviewers (rightly) pointed out that `validateAgentYamlContent` parses `data.settings` with the same schema and would still reject YAMLs containing `internal`. Adding the field to the schema fixes both call sites in one place with no runtime logic.

Registry scanning in `agentRegistry.ts` reads the raw YAML before schema parsing (`rawSettings.internal === true`), so that flow is unchanged. The runtime keeps a typed `internal?: boolean` on the merged `AgentSetting` which can be consumed if needed; nothing reads it today.

## Files

- `src/agent/core/AgentDataclass.ts`: adds `internal: z.boolean().optional()` to `AgentSettingBaseSchema`.
- `src/agent/runtime/agentLoad.ts`: reverts the `stripYamlMetadata` helper and the central `YAML_METADATA_FIELDS` set — no longer needed.
- `src/test/agent/runtime/agentLoad.test.ts`: test case that loads a YAML with `settings.internal: true` and asserts the field round-trips through parsed settings without throwing (addresses Copilot's test-coverage ask).

## Test plan

- [x] `npm run typecheck` passes
- [x] New unit test covers `settings.internal: true` round-trip
- [ ] Launch `latexFixer` via "Fix Compilation" — should run instead of producing an empty stream
- [ ] Launch `latexFixer` from the Launcher with an instruction — should work
- [ ] Launch other tool-use agents (chat, research, etc.) — no regression
- [ ] Launch workflow agents (correct, devise, etc.) — no regression
- [ ] Agent with `inherits` — parent settings should still merge correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only broadens agent YAML settings validation to accept an optional boolean field and adds a regression test, without changing load/merge behavior.
> 
> **Overview**
> Fixes agent YAML parsing/validation to **accept `settings.internal`** by adding an optional `internal?: boolean` field to `AgentSettingBaseSchema` (previously rejected by `z.strictObject`).
> 
> Adds a unit test in `agentLoad.test.ts` ensuring an agent definition containing `settings.internal: true` loads successfully and the value round-trips through `loadAgentSettingAndPrompts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c9fb62555f895dbcbee780bc95b788b57527dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->