### PR TITLE
feat: add Claude Opus 4.7 support

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,4 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-6 --allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-7 --allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -36,7 +36,7 @@ jobs:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: 'claude-opus-4-5-20251101'
+          model: 'claude-opus-4-7'
 
           # Optional: Allow Claude to run specific commands
           allowed_tools: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,4 +47,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-          claude_args: '--model claude-opus-4-6 --allowed-tools Bash(gh pr:*)'
+          claude_args: '--model claude-opus-4-7 --allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-7
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
 
           prompt: |

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -196,7 +196,7 @@ Available to Max tier subscribers (includes all free tier models).
 Available to Ultra tier subscribers (includes all lower tier models).
 
 | Model Name | Full Name                  | Provider  | Pricing (in/out per 1M) |
-| ---------- | -------------------------- | --------- | ----------------------- | --- |
+| ---------- | -------------------------- | --------- | ----------------------- |
 | `opus47`   | claude-opus-4-7            | Anthropic | $5.00/$25.00            |
 | `opus47T`  | claude-opus-4-7 (Thinking) | Anthropic | $5.00/$25.00            |
 | `opus46`   | claude-opus-4-6            | Anthropic | $5.00/$25.00            |
@@ -207,7 +207,7 @@ Available to Ultra tier subscribers (includes all lower tier models).
 | `gpt52pro` | gpt-5.2-pro                | OpenAI    | $21.00/$168.00          |
 | `gpt5`     | gpt-5                      | OpenAI    | $1.25/$10.00            |
 | `gpt51`    | gpt-5.1                    | OpenAI    | $1.25/$10.00            |
-| `gpt52`    | gpt-5.2                    | OpenAI    | $1.75/$14.00            |     |
+| `gpt52`    | gpt-5.2                    | OpenAI    | $1.75/$14.00            |
 | `grok4`    | grok-4-0709                | xAI       | $3.00/$15.00            |
 
 ## Implementation Details

--- a/docs/relay-tier-config.md
+++ b/docs/relay-tier-config.md
@@ -197,6 +197,10 @@ Available to Ultra tier subscribers (includes all lower tier models).
 
 | Model Name | Full Name                  | Provider  | Pricing (in/out per 1M) |
 | ---------- | -------------------------- | --------- | ----------------------- | --- |
+| `opus47`   | claude-opus-4-7            | Anthropic | $5.00/$25.00            |
+| `opus47T`  | claude-opus-4-7 (Thinking) | Anthropic | $5.00/$25.00            |
+| `opus46`   | claude-opus-4-6            | Anthropic | $5.00/$25.00            |
+| `opus46T`  | claude-opus-4-6 (Thinking) | Anthropic | $5.00/$25.00            |
 | `opus45`   | claude-opus-4-5            | Anthropic | $15.00/$75.00           |
 | `opus45T`  | claude-opus-4-5 (Thinking) | Anthropic | $15.00/$75.00           |
 | `gpt5pro`  | gpt-5-pro                  | OpenAI    | $15.00/$120.00          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.45",
         "lit": "^3.3.2",
-        "llm-zoo": "^1.2.1",
+        "llm-zoo": "^1.3.0",
         "mark.js": "^8.11.1",
         "markdown-it": "^14.1.1",
         "markdown-it-texmath": "^1.0.0",
@@ -7831,9 +7831,9 @@
       }
     },
     "node_modules/llm-zoo": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.2.1.tgz",
-      "integrity": "sha512-4d6efHniaAK095+5ERtnMnaY460oIhpMwEQtVE3NCHkzdfE5+I9NX0PJjQDeAxxPX6PYLYUH7YCI3FT4kYxDzg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.3.0.tgz",
+      "integrity": "sha512-XUAJ5cu8mhggjwvCmp11XhOftJESukGKBiUjaNhNhcA5blQV2189R9gg+wmKZ1YUOqzCXuO75IDhj/xsGeu5Og==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.37.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.89.0",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@cantoo/pdf-lib": "^2.6.5",
         "@google/genai": "^1.50.0",
         "@jamesgopsill/crossref-client": "^1.1.0",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.89.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.89.0.tgz",
-      "integrity": "sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "@lit-labs/virtualizer": "^2.1.1",
         "@lit/context": "^1.1.6",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex-sdk": "^0.120.0",
-        "@openrouter/sdk": "^0.12.6",
-        "@supabase/supabase-js": "^2.103.0",
+        "@openai/codex-sdk": "^0.121.0",
+        "@openrouter/sdk": "^0.12.14",
+        "@supabase/supabase-js": "^2.103.3",
         "@vscode-elements/elements": "^2.5.1",
         "@vscode/codicons": "^0.0.45",
         "@xterm/addon-fit": "^0.11.0",
@@ -108,7 +108,7 @@
         "vscode-languageserver-protocol": "^3.17.5",
         "webpack": "^5.106.1",
         "webpack-cli": "^7.0.2",
-        "zod-v3-to-v4": "^1.20.0"
+        "zod-v3-to-v4": "^1.21.1"
       },
       "engines": {
         "vscode": "^1.105.0"
@@ -1557,48 +1557,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@openai/codex": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0.tgz",
-      "integrity": "sha512-e2P1Gya3dwsRe9IPOiswVz5JfR700u+/sWCqDc3jkqv2QViPkNiBmZoGhFnZL5jBpKakSjehC4/Fpspg70nHTw==",
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0.tgz",
+      "integrity": "sha512-kCJ2NeATd4QBQRmqV04ymdN1ZU3MSwnJQDm/KzjpuzGvCuUVEn7no/T2mRyxQ2x77AACqriNOyPPoM/yufyvNg==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -1607,19 +1569,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.120.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.120.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.120.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.120.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.120.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.120.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.121.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.121.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.121.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.121.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.121.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.121.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-arm64.tgz",
-      "integrity": "sha512-7CU+I5kBaMuoqfG3xisq0mUWzxoEHvfu34cB8a0KpBiIhAgu12fKpmYgZ4/DvRP6Wm9Fu6LJYKVF5apUHFp8nQ==",
+      "version": "0.121.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-darwin-arm64.tgz",
+      "integrity": "sha512-ZyBqIB6Fb4I0hGb/h65Vu7ePYjHSmGiqqfm+/1djEuxDPkqjfi4wkxYxNYNY+6najyNGN4UijOSTTf19eDCrqw==",
       "cpu": [
         "arm64"
       ],
@@ -1634,9 +1596,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-darwin-x64.tgz",
-      "integrity": "sha512-d7joNYuwrmd5iIdp/xAE5f8bZT1r82MnmU6Hzgxq3G+xClwEyhxU737ZWnstFSpnZNfxJ5zXCuFUJh4CAkHNtQ==",
+      "version": "0.121.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-darwin-x64.tgz",
+      "integrity": "sha512-1/OAtdkAZ5yPI3xqaEFlHuPziS1yCqL2gOZdswE7HTmmwpIxi6Z3FCo60JWDPluIp89z4tftdjq73/OCN0YVcw==",
       "cpu": [
         "x64"
       ],
@@ -1651,9 +1613,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-arm64.tgz",
-      "integrity": "sha512-sVYY25/URlpZPtb0Q0ryLh+lcq9UTEtHAkdZKa0a/R7mAdyPuhpU9V6jWmxwiUh7s53XZOEVFoKmLfH8YIDWCQ==",
+      "version": "0.121.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-linux-arm64.tgz",
+      "integrity": "sha512-2UgMmdo237o7SCMsfb529cOSEM2HFUgN6OBkv5SBLwfNY1NO2Ex6JnUjlppEXlX6/4cXfZ5qjDghVz5j/+B9zw==",
       "cpu": [
         "arm64"
       ],
@@ -1668,9 +1630,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-linux-x64.tgz",
-      "integrity": "sha512-VcP9B/c/O+EFEgqoetCzvHrLfAdo8vrt09Gx1lJ8ikewctqAuJ/ozj/6wuvlz7XaaK64ib5cge01pOAeCyt2Sg==",
+      "version": "0.121.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-linux-x64.tgz",
+      "integrity": "sha512-vlpNJXIqss800J+32Vy7TUZzv31n61b45OLxmsVQGFkTNLJcjFrj9jDUC7I62eC4F16gLioilefNfv4CdJQOEw==",
       "cpu": [
         "x64"
       ],
@@ -1684,12 +1646,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.120.0.tgz",
-      "integrity": "sha512-Y6y3EyLpSSJjRGqIFxxb1G9X6Hod+B1CnWzGoO7qrg3URPnjBL/DLLQWdZSENU5yIlRjHEQDSu7y1rKBlx+jUA==",
+      "version": "0.121.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.121.0.tgz",
+      "integrity": "sha512-LfDbIBIrRYya6Y+zR8i5ci+wGx8zyTpzTy9iSeRTzZnb4N8Cn30cW+un1Vd2JfjoWhxGXcOTpXy8sSjlSeyvKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.120.0"
+        "@openai/codex": "0.121.0"
       },
       "engines": {
         "node": ">=18"
@@ -1697,9 +1659,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.120.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-arm64.tgz",
-      "integrity": "sha512-SAaTQU1XHa1qDnmQldmbyROIY5SiaspF+Cw3ziWeeTgyAET3rWusm4ELOElx6QiY1ugYW5ZD+7AFufS2z1xtpQ==",
+      "version": "0.121.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-win32-arm64.tgz",
+      "integrity": "sha512-m88q4f3XI5npn1t6OG0nWGHWWAjO5FgjRwxh4hdujbLO6t9CiCNfhfPZIOSsoATbrCNwLC+6S77m3cjbNToPNg==",
       "cpu": [
         "arm64"
       ],
@@ -1714,9 +1676,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.120.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.120.0-win32-x64.tgz",
-      "integrity": "sha512-zja1GNrbHyOUTvOy5FVMa+rAYIs3m+FOS8rAXftxMEhodMmkMw2O8zcvso657SHhZR0hIEiZ6T70lcyH2YX0mQ==",
+      "version": "0.121.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.121.0-win32-x64.tgz",
+      "integrity": "sha512-Fp0ecVOyM+VcBi/y4HVvRzhifO9YqRiHzhV3rhtAppC7flh22WPguLC4kmvXYAR0p3RPzbo35M2CedWnkOT+cw==",
       "cpu": [
         "x64"
       ],
@@ -1730,9 +1692,9 @@
       }
     },
     "node_modules/@openrouter/sdk": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.8.tgz",
-      "integrity": "sha512-KHI7Gy0c/4ecerfEPnnVeU/OTpSdFHjNHZOvp7GJVl30jxcWNVDId86N87MefdVyR5T70yZYItDTnlbb49ESGQ==",
+      "version": "0.12.14",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.14.tgz",
+      "integrity": "sha512-G32CZ1IkmtsGfQF7/mzcvt7W0Lmd6HUHFGjDWv5knBvL6sJcMmX6i3VPSIpHQYSgEqRQSxFuDROP6iErTu7XcA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2153,9 +2115,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.2.tgz",
-      "integrity": "sha512-gHCp8J7TJ3ZrNsT5NiJt8Sa5SK7QnotUtxkBEaJ/vuimZ6MsWn6p4JWoDc01uZBmJTiISH3gQqTF2/S+kglDIw==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
+      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2165,9 +2127,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.2.tgz",
-      "integrity": "sha512-VescBNuZPVcoFpH3R44YbLDDFPZnMtzBHuY1cNyL75h8Vlw9YBHv9qztVgDalKRoeA9wNQhuHqawXdTgCobhIQ==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
+      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2183,9 +2145,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.2.tgz",
-      "integrity": "sha512-Qi9Dn0azoI/RhaVnZsggeQg6MY+7jg3jHVPt2vlh9nojMjOBniTbBeSrdSSEdufpbwXxPne3Z13OPva1VmC9CA==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
+      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2195,9 +2157,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.2.tgz",
-      "integrity": "sha512-zj/JruFaSJScdtq0W2cI+WbLuQmwYBD8i++0YFlzwyAeeZy9RwEAfjT1mkvhBNHPCy2V4LIsE4F0rAHSGR8AOg==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
+      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "^0.4.0",
@@ -2210,9 +2172,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.2.tgz",
-      "integrity": "sha512-d40lZ29EyWJ4cOTtSBH4myaRuYSa9kOdt+NFkUmR+a3SAy2VpbdI1/nE3QWIrdifOa4pxTo8RXGC3BngPMVhRw==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
+      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -2223,31 +2185,31 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.103.2",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.2.tgz",
-      "integrity": "sha512-GlC5me7/WlyS1ZCpwLoCm7ezggRWxyMxfckDhtnJvGanoVZAOnCKSqrNkjmDF8aufdh/kOoXRc/P3zJ/eUKMTg==",
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
+      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.103.2",
-        "@supabase/functions-js": "2.103.2",
-        "@supabase/postgrest-js": "2.103.2",
-        "@supabase/realtime-js": "2.103.2",
-        "@supabase/storage-js": "2.103.2"
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
-      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.3.3",
         "minimatch": "^10.0.1",
-        "path-browserify": "^1.0.1"
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5497,23 +5459,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5587,16 +5532,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
       }
     },
     "node_modules/fdir": {
@@ -8049,16 +7984,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -9473,27 +9398,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/random-int": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/random-int/-/random-int-3.1.0.tgz",
@@ -9793,17 +9697,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -9852,30 +9745,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -11018,13 +10887,13 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
-      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ts-morph/common": "~0.27.0",
+        "@ts-morph/common": "~0.28.1",
         "code-block-writer": "^13.0.3"
       }
     },
@@ -12198,16 +12067,16 @@
       }
     },
     "node_modules/zod-v3-to-v4": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/zod-v3-to-v4/-/zod-v3-to-v4-1.20.0.tgz",
-      "integrity": "sha512-cWqmrshZuBKQse/KSCPRQu8wmfiR0LtNAC7CI04dwxdKLLd5LXUpNzGPT3RF5AvcxtyxADqnOT0bRG8v6hU01A==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/zod-v3-to-v4/-/zod-v3-to-v4-1.21.1.tgz",
+      "integrity": "sha512-AASv50rV9nnVpEk50Yh0PLq1fOEnrO/7HFimTFmpKRJDQVmw+q5R17nnAMAIOUDmZj0Wn+O6UOlsdPsqVk+YZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.0.1",
         "@vue/compiler-sfc": "3.5.27",
         "tinyglobby": "0.2.15",
-        "ts-morph": "26.0.0",
+        "ts-morph": "27.0.2",
         "zod": "3.25.12"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1467,7 +1467,7 @@
   },
   "homepage": "https://texra.ai",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.89.0",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@cantoo/pdf-lib": "^2.6.5",
     "@google/genai": "^1.50.0",
     "@jamesgopsill/crossref-client": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1436,7 +1436,7 @@
     "vscode-languageserver-protocol": "^3.17.5",
     "webpack": "^5.106.1",
     "webpack-cli": "^7.0.2",
-    "zod-v3-to-v4": "^1.20.0"
+    "zod-v3-to-v4": "^1.21.1"
   },
   "repository": {
     "type": "git",
@@ -1475,9 +1475,9 @@
     "@lit-labs/virtualizer": "^2.1.1",
     "@lit/context": "^1.1.6",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.120.0",
-    "@openrouter/sdk": "^0.12.6",
-    "@supabase/supabase-js": "^2.103.0",
+    "@openai/codex-sdk": "^0.121.0",
+    "@openrouter/sdk": "^0.12.14",
+    "@supabase/supabase-js": "^2.103.3",
     "@vscode-elements/elements": "^2.5.1",
     "@vscode/codicons": "^0.0.45",
     "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1501,7 +1501,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.45",
     "lit": "^3.3.2",
-    "llm-zoo": "^1.2.1",
+    "llm-zoo": "^1.3.0",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.1.1",
     "markdown-it-texmath": "^1.0.0",

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -178,13 +178,14 @@ const CONTEXT_MANAGEMENT_BETA: AnthropicBeta = 'context-management-2025-06-27';
 const COMPACTION_BETA: AnthropicBeta = 'compact-2026-01-12';
 
 const OPUS_46_FULLNAME = 'claude-opus-4-6';
+const OPUS_47_FULLNAME = 'claude-opus-4-7';
 const SONNET_46_FULLNAME = 'claude-sonnet-4-6';
 
 /** Compaction must be triggered at or above this minimum input token threshold. */
 const MIN_COMPACTION_TRIGGER_TOKENS = 50_000;
 
 /**
- * 1M context window is available natively for Opus 4.6 and Sonnet 4.6
+ * 1M context window is available natively for Opus 4.6, Opus 4.7, and Sonnet 4.6
  * at standard pricing (no beta header needed). Context window sizes
  * are provided directly by llm-zoo. Other Claude models use 200K.
  */
@@ -284,6 +285,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
     return this.config.fullName.startsWith(OPUS_46_FULLNAME);
   }
 
+  private isClaudeOpus47(): boolean {
+    return this.config.fullName.startsWith(OPUS_47_FULLNAME);
+  }
+
   private isClaudeSonnet46(): boolean {
     return this.config.fullName.startsWith(SONNET_46_FULLNAME);
   }
@@ -295,17 +300,22 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /**
    * Whether this model supports adaptive thinking with the effort parameter.
-   * Per Anthropic docs, only Opus 4.6 and Sonnet 4.6 support adaptive thinking.
+   * Per Anthropic docs, Opus 4.6, Opus 4.7, and Sonnet 4.6 support adaptive thinking.
+   * Opus 4.7 only accepts adaptive thinking — manual budget_tokens returns 400.
    */
   private supportsAdaptiveThinking(): boolean {
-    return this.isClaudeOpus46() || this.isClaudeSonnet46();
+    return (
+      this.isClaudeOpus46() ||
+      this.isClaudeOpus47() ||
+      this.isClaudeSonnet46()
+    );
   }
 
   /**
    * Returns the Anthropic effort level for the current model.
    * Maps the llm-zoo ReasoningEffort enum to Anthropic's effort levels.
    * Falls back to 'high' (the API default) when no specific effort is configured.
-   * 'max' is only valid for Opus 4.6.
+   * 'max' is only valid for Opus-tier models (Opus 4.6 and Opus 4.7).
    */
   private getAnthropicEffort(): BetaOutputConfig['effort'] {
     const reasoningEffort = this.getEffectiveReasoningEffort();
@@ -315,8 +325,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
     switch (reasoningEffort) {
       case 'xhigh':
-        // 'max' is only supported on Opus 4.6
-        return this.isClaudeOpus46() ? 'max' : 'high';
+        // 'max' is supported on Opus 4.6 and Opus 4.7
+        return this.isClaudeOpus46() || this.isClaudeOpus47()
+          ? 'max'
+          : 'high';
       case 'high':
         return 'high';
       case 'medium':
@@ -332,7 +344,11 @@ export class ModelHandlerAnthropic extends ModelHandler<
 
   /** Whether this model supports Anthropic's native server-side context compaction. */
   private isCompactionEligibleModel(): boolean {
-    return this.isClaudeOpus46() || this.isClaudeSonnet46();
+    return (
+      this.isClaudeOpus46() ||
+      this.isClaudeOpus47() ||
+      this.isClaudeSonnet46()
+    );
   }
 
   override get supportsManualCompaction(): boolean {
@@ -614,7 +630,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       this.logger.debug('Enabling thinking for model with reasoning support');
 
       if (this.supportsAdaptiveThinking()) {
-        // Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort parameter.
+        // Opus 4.6, Opus 4.7, and Sonnet 4.6: use adaptive thinking with effort parameter.
         // Adaptive thinking lets the model decide when and how much to think,
         // and automatically enables interleaved thinking between tool calls.
         // budget_tokens is deprecated on these models.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -26,14 +26,9 @@ export const DEFAULT_MODELS = [
   'gemini3f',
   'sonnet46T',
   'opus47T',
-  'opus46T',
   'gpt54',
-  'gpt54pro',
-  'gpt53codex',
-  'gpt41',
   'deepseekT',
   'kimi25T',
-  'grok4',
   'minimaxM27',
   'glm47',
 ];
@@ -44,7 +39,7 @@ export const DEFAULT_MODELS = [
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 9;
+export const MODEL_LIST_VERSION = 10;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -29,8 +29,6 @@ export const DEFAULT_MODELS = [
   'gpt54',
   'deepseekT',
   'kimi25T',
-  'minimaxM27',
-  'glm47',
 ];
 
 /**
@@ -39,7 +37,7 @@ export const DEFAULT_MODELS = [
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 10;
+export const MODEL_LIST_VERSION = 11;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -25,6 +25,7 @@ export const DEFAULT_MODELS = [
   'gemini31p',
   'gemini3f',
   'sonnet46T',
+  'opus47T',
   'opus46T',
   'gpt54',
   'gpt54pro',
@@ -43,7 +44,7 @@ export const DEFAULT_MODELS = [
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 8;
+export const MODEL_LIST_VERSION = 9;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -920,6 +920,123 @@ describe('ModelHandlerAnthropic message guards', () => {
     );
   });
 
+  it('adds native compaction context edit for Claude Opus 4.7 tool-use runs', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.config.fullName = 'claude-opus-4-7';
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    stubHandlerForTest(handler, { logContextManagement: () => {} });
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-7',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    const originalGetConfig = configModule.getConfig;
+    try {
+      (configModule as any).getConfig = (
+        path: string,
+        defaultValue?: unknown,
+      ) => {
+        if (path === 'texra.model.compactionThresholdPercent') return 75;
+        return defaultValue as unknown;
+      };
+
+      await handler.createResponse({ client, messages, temperature: 0 });
+    } finally {
+      (configModule as any).getConfig = originalGetConfig;
+    }
+
+    const options = messageOptions[0] ?? {};
+    const betas: string[] = options.betas ?? [];
+    assert.ok(
+      betas.includes('compact-2026-01-12'),
+      'should include compaction beta header',
+    );
+
+    const edits = options.context_management?.edits ?? [];
+    const compactionEdit = edits.find(
+      (edit: { type: string }) => edit.type === 'compact_20260112',
+    );
+    assert.ok(compactionEdit, 'should configure compact_20260112 context edit');
+    assert.equal(compactionEdit.trigger?.type, 'input_tokens');
+  });
+
+  it('uses adaptive thinking with max effort for Opus 4.7 xhigh reasoning', async () => {
+    const handler = createAnthropicHandler({
+      supportsReasoning: true,
+      supportsReasoningEffort: true,
+      reasoningEffort: 'xhigh' as any,
+    });
+    handler.config.fullName = 'claude-opus-4-7';
+
+    stubHandlerForTest(handler, { logContextManagement: () => {} });
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+    const messageOptions: any[] = [];
+    const client = {
+      beta: {
+        messages: {
+          create: async (opts: any) => {
+            messageOptions.push(opts);
+            return {
+              id: 'msg',
+              type: 'message',
+              role: 'assistant',
+              model: 'claude-opus-4-7',
+              content: [{ type: 'text', text: 'ok' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 1, output_tokens: 1 },
+            } as any;
+          },
+        },
+      },
+    } as any;
+
+    await handler.createResponse({ client, messages, temperature: 0 });
+
+    const options = messageOptions[0] ?? {};
+    assert.deepEqual(
+      options.thinking,
+      { type: 'adaptive' },
+      'Opus 4.7 should request adaptive thinking (budget_tokens is rejected)',
+    );
+    assert.equal(
+      options.output_config?.effort,
+      'max',
+      'xhigh reasoning effort should map to max on Opus 4.7',
+    );
+  });
+
   it('uses the Anthropic minimum trigger for manual compaction requests', async () => {
     const handler = createAnthropicHandler({
       supportsTokenCounting: false,

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -7,6 +7,7 @@ import {
   type ModelCapabilities,
   type ModelConfig,
   ModelProvider,
+  ReasoningEffort,
 } from 'llm-zoo';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
@@ -983,14 +984,17 @@ describe('ModelHandlerAnthropic message guards', () => {
       (edit: { type: string }) => edit.type === 'compact_20260112',
     );
     assert.ok(compactionEdit, 'should configure compact_20260112 context edit');
+    assert.equal(compactionEdit.pause_after_compaction, false);
     assert.equal(compactionEdit.trigger?.type, 'input_tokens');
+    assert.equal(compactionEdit.trigger?.value, 150000);
+    assert.equal(compactionEdit.instructions, undefined);
   });
 
   it('uses adaptive thinking with max effort for Opus 4.7 xhigh reasoning', async () => {
     const handler = createAnthropicHandler({
       supportsReasoning: true,
       supportsReasoningEffort: true,
-      reasoningEffort: 'xhigh' as any,
+      reasoningEffort: ReasoningEffort.XHIGH,
     });
     handler.config.fullName = 'claude-opus-4-7';
 


### PR DESCRIPTION
## Summary

- Wire Opus 4.7 into the Anthropic handler alongside Opus 4.6 and Sonnet 4.6: adaptive-only thinking, native server-side compaction, and the `xhigh` → `max` effort mapping.
- Add `opus47T` to `DEFAULT_MODELS` and curate the list to 7 frontier models (one thinking-capable model per provider). `MODEL_LIST_VERSION` 8 → 11 so existing users pick up the new defaults.
- Bump all Claude Code Action workflows (`claude.yml`, `claude-code-review.yml`, `issue-tracker.yml`, `claude-dispatch.yml`) to `claude-opus-4-7`. Also drops the stale date suffix on `claude-dispatch.yml` (was `claude-opus-4-5-20251101`).
- Backfill the hand-maintained relay tier doc with `opus47` / `opus47T` / `opus46` / `opus46T` entries ($5.00/$25.00 per 1M) and fix the Ultra-tier table formatting.
- Upgrade `llm-zoo` 1.2.1 → 1.3.0 (ships `opus47` / `opus47T` with `fullName: "claude-opus-4-7"`) and `@anthropic-ai/sdk` 0.89.0 → 0.90.0 (adds `claude-opus-4-7` to the `Model` union). Also bumps patch-level SDKs: `@openrouter/sdk`, `@openai/codex-sdk`, `@supabase/supabase-js`, `zod-v3-to-v4`.
- Add Opus 4.7 handler tests at parity with the existing 4.6 coverage: native `compact_20260112` edit for tool-use runs, and `xhigh` reasoning mapping to adaptive thinking + `output_config.effort === 'max'`.

## DEFAULT_MODELS change (user-visible)

New-user default list goes from 13 to 7 entries. All removed models remain available via the model picker — they are just not enabled by default.

Kept (7): `gemini31p`, `gemini3f`, `sonnet46T`, `opus47T`, `gpt54`, `deepseekT`, `kimi25T`.

Removed from defaults: `opus46T` (superseded by `opus47T`), `gpt54pro`, `gpt53codex`, `gpt41`, `grok4`, `minimaxM27`, `glm47`.

Existing users' enabled-model lists are merged additively on the version bump, so existing installs gain `opus47T` without losing any models they already had.

## Files

- `src/agent/modelHandlers/modelHandlerAnthropic.ts`: new `OPUS_47_FULLNAME` constant, `isClaudeOpus47()`, and gate extensions for `supportsAdaptiveThinking` / `isCompactionEligibleModel` / `getAnthropicEffort`.
- `src/model/computeModelOptions.ts`: trimmed default list + version bump 8 → 11.
- `src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts`: two new Opus 4.7 tests.
- `.github/workflows/{claude,claude-code-review,issue-tracker,claude-dispatch}.yml`: model bump.
- `docs/relay-tier-config.md`: Ultra-tier table additions + formatting fix.
- `package.json` / `package-lock.json`: SDK bumps.

## Not changed (intentional)

- `supabase/functions/relay/models.ts` derives `RELAY_MODELS` from `llm-zoo`'s `MODEL_CONFIGS` at runtime — picks up `opus47T` automatically with the 1.3.0 bump.
- Existing `claude-opus-4-6` test fixtures in `ModelHandlerAnthropic.test.ts` still validate the 4.6 branch of the handler, which remains correct.

## Test plan

- [x] `npm run typecheck` passes locally
- [x] New Opus 4.7 tests added (compaction edit + `xhigh` → `max`)
- [ ] Verify Opus 4.7 is selectable in the model dropdown
- [ ] Verify adaptive thinking engages on Opus 4.7 (check request payload for `thinking: {type: "adaptive"}` and `output_config.effort`)
- [ ] Verify native compaction triggers on Opus 4.7 past the threshold
- [ ] Verify `xhigh` reasoning effort maps to `max` on Opus 4.7
- [ ] Smoke-test the Claude Code Action workflows once merged