### PR TITLE
Add Super YOLO mode auto-approval for plans

### DIFF
--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -135,12 +135,8 @@ Best practices:
         isSuperYoloFeatureEnabled() &&
         isProposalBypassedForStream(context.streamId)
       ) {
-        logger.info('Plan auto-approved via Super YOLO mode');
-        return {
-          summary: 'Plan auto-approved (Super YOLO) — proceed with implementation',
-          output:
-            'Plan auto-approved via Super YOLO mode. You may now begin implementing the plan steps. Update step statuses as you work through them.',
-        };
+        logger.info('Plan auto-approved (Super YOLO bypass active)');
+        return this.buildApprovedResult();
       } else {
         return this.requestApproval(
           input.plan,
@@ -173,11 +169,7 @@ Best practices:
 
     if (result.action === 'approve') {
       logger.info('Plan approved by user');
-      return {
-        summary: 'Plan approved — proceed with implementation',
-        output:
-          'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
-      };
+      return this.buildApprovedResult();
     }
 
     // Rejected or timed out — clear the plan from UI
@@ -205,6 +197,14 @@ Best practices:
       output: `The user rejected this plan.${feedbackNote}\nPlease revise your approach based on the feedback and create an updated plan.`,
       isError: true,
       ...(feedback ? { userInstruction: feedback } : {}),
+    };
+  }
+
+  private buildApprovedResult(): ToolResult {
+    return {
+      summary: 'Plan approved — proceed with implementation',
+      output:
+        'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
     };
   }
 

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -29,6 +29,10 @@ import {
   countByStatus,
   type Plan,
 } from '@shared/schemas';
+import {
+  isProposalBypassedForStream,
+  isSuperYoloFeatureEnabled,
+} from '@tools/approval';
 import { type ToolResult } from '@tools/result';
 import { defineTool } from '@tools/core/define';
 
@@ -127,6 +131,16 @@ Best practices:
         logger.warn(
           'New plan created without streamId — skipping approval gate',
         );
+      } else if (
+        isSuperYoloFeatureEnabled() &&
+        isProposalBypassedForStream(context.streamId)
+      ) {
+        logger.info('Plan auto-approved via Super YOLO mode');
+        return {
+          summary: 'Plan auto-approved (Super YOLO) — proceed with implementation',
+          output:
+            'Plan auto-approved via Super YOLO mode. You may now begin implementing the plan steps. Update step statuses as you work through them.',
+        };
       } else {
         return this.requestApproval(
           input.plan,

--- a/src/tools/plan/PlanTool.ts
+++ b/src/tools/plan/PlanTool.ts
@@ -136,7 +136,7 @@ Best practices:
         isProposalBypassedForStream(context.streamId)
       ) {
         logger.info('Plan auto-approved (Super YOLO bypass active)');
-        return this.buildApprovedResult();
+        return this.buildApprovedResult({ autoApproved: true });
       } else {
         return this.requestApproval(
           input.plan,
@@ -169,7 +169,7 @@ Best practices:
 
     if (result.action === 'approve') {
       logger.info('Plan approved by user');
-      return this.buildApprovedResult();
+      return this.buildApprovedResult({ autoApproved: false });
     }
 
     // Rejected or timed out — clear the plan from UI
@@ -200,11 +200,19 @@ Best practices:
     };
   }
 
-  private buildApprovedResult(): ToolResult {
+  private buildApprovedResult({
+    autoApproved,
+  }: {
+    autoApproved: boolean;
+  }): ToolResult {
+    const prefix = autoApproved
+      ? 'Plan auto-approved (Super YOLO bypass active — user did not review).'
+      : 'Plan approved by the user.';
     return {
-      summary: 'Plan approved — proceed with implementation',
-      output:
-        'Plan approved by the user. You may now begin implementing the plan steps. Update step statuses as you work through them.',
+      summary: autoApproved
+        ? 'Plan auto-approved — proceed with implementation'
+        : 'Plan approved — proceed with implementation',
+      output: `${prefix} You may now begin implementing the plan steps. Update step statuses as you work through them.`,
     };
   }
 


### PR DESCRIPTION
## Summary
Added support for automatically approving plans when Super YOLO mode is enabled and the proposal is bypassed for the stream, eliminating the need for manual approval in these cases.

## Key Changes
- Imported `isProposalBypassedForStream` and `isSuperYoloFeatureEnabled` from the approval tools module
- Added conditional logic to check if Super YOLO mode is enabled and the proposal is bypassed for the current stream
- When both conditions are met, plans are now auto-approved with an informative message indicating the approval was granted via Super YOLO mode
- Users can proceed directly to implementation without waiting for manual approval

## Implementation Details
- The auto-approval check is performed after the streamId validation but before the standard approval request flow
- Returns a success response with clear messaging that the plan was auto-approved via Super YOLO mode
- Includes guidance for users to begin implementing plan steps and update their statuses accordingly

https://claude.ai/code/session_01CeC99MXKXeREUbZUk3GiVd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the plan approval gating logic and can bypass manual review under certain settings; misconfiguration or incorrect bypass state could unintentionally allow unreviewed plans to proceed.
> 
> **Overview**
> Adds a Super YOLO auto-approval path for *new* plans: when `isSuperYoloFeatureEnabled()` and `isProposalBypassedForStream(streamId)` are true, `PlanTool` returns success immediately instead of waiting for user approval.
> 
> Refactors the approval success response into `buildApprovedResult({ autoApproved })`, and updates messaging to clearly distinguish auto-approved vs user-approved plans (including an explicit note that the user did not review in auto-approve cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9e27788ac936b440425f7493628d5dd5179412c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->