### PR TITLE
claude/disable-latexindent-popup-xM9DG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 - **No more `latexindent` install popup on first use** — the missing-`latexindent` warning is now off by default, so first-time users no longer see an unexpected install prompt after running an agent. Re-enable it with `texra.latex.showLatexindentWarning` if you want the reminder.
+- **External Inquiry is off by default** — the copy-to-ChatGPT/Claude/Gemini workflow is now opt-in for new users. Turn it on from the Tools settings tab when you want agents to ask you to relay questions to another chat model.
 
 ## [0.37.3] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Improvements
+
+- **No more `latexindent` install popup on first use** — the missing-`latexindent` warning is now off by default, so first-time users no longer see an unexpected install prompt after running an agent. Re-enable it with `texra.latex.showLatexindentWarning` if you want the reminder.
+
 ## [0.37.3] - 2026-04-15
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Improvements
 
 - **No more `latexindent` install popup on first use** — the missing-`latexindent` warning is now off by default, so first-time users no longer see an unexpected install prompt after running an agent. Re-enable it with `texra.latex.showLatexindentWarning` if you want the reminder.
-- **External Inquiry is off by default** — the copy-to-ChatGPT/Claude/Gemini workflow is now opt-in for new users. Turn it on from the Tools settings tab when you want agents to ask you to relay questions to another chat model.
+- **External Inquiry is off by default for new users** — the copy-to-ChatGPT/Claude/Gemini workflow is now opt-in on first install only. Existing users keep their current setting; new users can turn it on from the Tools settings tab when they want agents to ask them to relay questions to another chat model.
 
 ## [0.37.3] - 2026-04-15
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -204,7 +204,7 @@ Configure LaTeX formatting behavior:
 ```
 
 - `formatter`: Choose between `latexindent`, `tex-fmt`, or `none` to disable formatting.
-- `showLatexindentWarning`: Set to `false` to suppress missing `latexindent` warnings.
+- `showLatexindentWarning`: Disabled by default. Set to `true` to show a popup when `latexindent` is missing.
 - `latexindentConfig`: Path to a `latexindent` configuration file.
 - `texfmtConfig`: Path to a `tex-fmt` configuration file.
 

--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
           },
           "texra.latex.showLatexindentWarning": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "Show warning when latexindent is not installed",
             "order": 2
           },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { SecretManager } from '@frontend/secretManager';
 import {
   copyDefaultAgents,
   configureLatexSettings,
+  initializeToolDefaults,
   refreshModelListIfNeeded,
 } from '@frontend/setup';
 import { agentDirectories } from '@frontend/agents';
@@ -146,6 +147,10 @@ export async function activate(context: vscode.ExtensionContext) {
     getUserTier: () => SupabaseClient.getUserTier(),
     getAccessToken: () => SupabaseClient.getAccessToken(),
   });
+
+  // Seed first-install defaults (e.g. disabled tools) before anything writes
+  // LAST_KNOWN_VERSION, so upgrading users are not affected.
+  await initializeToolDefaults();
 
   // Copy default agents before loading the agent index so built-in agents
   // are available when the index scans directories

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -12,6 +12,7 @@ import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/computeModelOptions';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { GlobalStorageFS } from '@utils/files';
 import { isConfigExplicitlySet, updateConfig } from '@utils/config';
+import { DEFAULT_DISABLED_TOOL_IDS } from '@utils/config/constants';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 /**
@@ -28,6 +29,34 @@ const LEGACY_AGENT_FILES = [
   'agents/generic.yaml',
   'agents/generic_multiple.yaml',
 ];
+
+/**
+ * Seed the disabled-tool list for first-time users only.
+ *
+ * Runs before `copyDefaultAgents`, which writes `LAST_KNOWN_VERSION`. We use
+ * that key's absence, combined with an unset `DISABLED_TOOLS`, as the signal
+ * that this is a truly new install — existing upgrading users keep their
+ * current (usually empty) list, so we don't silently disable tools they
+ * already had available.
+ */
+export async function initializeToolDefaults(): Promise<void> {
+  const lastKnownVersion = globalSM.get<string>(
+    GlobalStateKey.LAST_KNOWN_VERSION,
+  );
+  const disabledTools = globalSM.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
+
+  if (lastKnownVersion !== undefined || disabledTools !== undefined) {
+    return;
+  }
+
+  await globalSM.update(GlobalStateKey.DISABLED_TOOLS, [
+    ...DEFAULT_DISABLED_TOOL_IDS,
+  ]);
+  logger.info(
+    'extension',
+    `First install — seeded default-disabled tools: ${DEFAULT_DISABLED_TOOL_IDS.join(', ')}`,
+  );
+}
 
 /**
  * Copies default agent files from the extension resources to the global storage directory

--- a/src/latex/formatter/latexindentpt.ts
+++ b/src/latex/formatter/latexindentpt.ts
@@ -58,7 +58,7 @@ export async function runLatexIndent(filePath: string): Promise<boolean> {
   try {
     const showWarning = getConfig<boolean>(
       'texra.latex.showLatexindentWarning',
-      true,
+      false,
     );
 
     // Resolve workspace-relative paths to absolute so cleanup works correctly.

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -38,6 +38,10 @@ export const DEBOUNCE_STATE_SAVE_MS = 500; // State persistence (slower, batched
 const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 336; // 2 weeks
 const DEFAULT_TOOL_USE_MEMORY_ENABLED = true;
 
+// Tool group IDs disabled by default for new users. These opt-in workflows
+// can be enabled from the Tools settings tab.
+const DEFAULT_DISABLED_TOOL_IDS: readonly string[] = ['external-inquiry'];
+
 /** Determine whether tool-use session persistence is enabled. */
 export function getToolUsePersistenceEnabled(): boolean {
   return getConfig<boolean>('texra.toolUse.persistence.enabled', true);
@@ -67,8 +71,8 @@ export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
 
 /** Get the set of tool group IDs disabled by the user. */
 export function getDisabledToolIds(): ReadonlySet<string> {
-  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
-  return new Set(raw);
+  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
+  return new Set(raw ?? DEFAULT_DISABLED_TOOL_IDS);
 }
 
 /** Toggle a tool group's enabled/disabled state. */
@@ -76,9 +80,8 @@ export async function setToolEnabled(
   toolId: string,
   enabled: boolean,
 ): Promise<void> {
-  const current =
-    globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
-  const set = new Set(current);
+  const current = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
+  const set = new Set(current ?? DEFAULT_DISABLED_TOOL_IDS);
   if (enabled) {
     set.delete(toolId);
   } else {

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -39,8 +39,12 @@ const DEFAULT_TOOL_USE_PERSISTENCE_TTL_HOURS = 336; // 2 weeks
 const DEFAULT_TOOL_USE_MEMORY_ENABLED = true;
 
 // Tool group IDs disabled by default for new users. These opt-in workflows
-// can be enabled from the Tools settings tab.
-const DEFAULT_DISABLED_TOOL_IDS: readonly string[] = ['external-inquiry'];
+// can be enabled from the Tools settings tab. Seeded into global state only
+// on first install via `initializeToolDefaults()` — existing profiles keep
+// whatever they had (empty == all tools enabled).
+export const DEFAULT_DISABLED_TOOL_IDS: readonly string[] = [
+  'external-inquiry',
+];
 
 /** Determine whether tool-use session persistence is enabled. */
 export function getToolUsePersistenceEnabled(): boolean {
@@ -71,8 +75,8 @@ export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
 
 /** Get the set of tool group IDs disabled by the user. */
 export function getDisabledToolIds(): ReadonlySet<string> {
-  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
-  return new Set(raw ?? DEFAULT_DISABLED_TOOL_IDS);
+  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  return new Set(raw);
 }
 
 /** Toggle a tool group's enabled/disabled state. */
@@ -80,8 +84,9 @@ export async function setToolEnabled(
   toolId: string,
   enabled: boolean,
 ): Promise<void> {
-  const current = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS);
-  const set = new Set(current ?? DEFAULT_DISABLED_TOOL_IDS);
+  const current =
+    globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  const set = new Set(current);
   if (enabled) {
     set.delete(toolId);
   } else {


### PR DESCRIPTION
First-time users could see an unexpected "latexindent is not installed"
popup the moment an agent produced a .tex file, which is confusing.
Flip the default of `texra.latex.showLatexindentWarning` to false so
the popup stays hidden unless the user opts in.

https://claude.ai/code/session_01No2kzRnbncU6zZdFtRjpkd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to default configuration and first-run seeding; main risk is misclassifying an existing profile as “new” and unexpectedly disabling a tool group.
> 
> **Overview**
> Prevents first-time users from seeing the missing-`latexindent` install popup by flipping `texra.latex.showLatexindentWarning`’s default to `false` (settings schema + runtime fallback) and updating docs/changelog accordingly.
> 
> Adds a first-install-only initializer (`initializeToolDefaults`) that seeds global `DISABLED_TOOLS` with `DEFAULT_DISABLED_TOOL_IDS` (currently `external-inquiry`) *before* `LAST_KNOWN_VERSION` is written, so new installs start with opt-in tool groups disabled while existing users’ settings remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f552e73bad9e4a9b624c85098187fa0446cb35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->