### PR TITLE
claude/fix-config-deserialization-JfDnG

### DIFF
--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -7,6 +7,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   buildCodexConfig,
   buildCodexWorkspaceOptions,
+  toCodexCliReasoningEffort,
 } from '@tools/codexConfig';
 import {
   buildCodexCommandToolLog,
@@ -33,6 +34,21 @@ describe('buildCodexConfig', () => {
     assert.equal(config.model, CODEX_DISPLAY_MODEL);
     assert.equal(config.agentCategory, AgentCategory.ToolUse);
     assert.equal(config.instruction, 'Inspect the failing CI job');
+  });
+});
+
+describe('toCodexCliReasoningEffort', () => {
+  it('passes CLI-compatible tiers through unchanged', () => {
+    assert.equal(toCodexCliReasoningEffort('low'), 'low');
+    assert.equal(toCodexCliReasoningEffort('medium'), 'medium');
+    assert.equal(toCodexCliReasoningEffort('high'), 'high');
+  });
+
+  it("caps 'xhigh' to 'high' so the Codex CLI config deserializer accepts it", () => {
+    // Regression: the Codex CLI's Rust-side config deserializer rejects
+    // 'xhigh' with `unknown variant 'xhigh', expected one of 'minimal',
+    // 'low', 'medium', 'high' in 'model_reasoning_effort'`.
+    assert.equal(toCodexCliReasoningEffort('xhigh'), 'high');
   });
 });
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -562,7 +562,7 @@ export class CodexTool extends defineTool({
       ...workspace,
       sandboxMode,
       model: config.CODEX_CLI_MODEL,
-      modelReasoningEffort: config.getCodexReasoningEffort(),
+      modelReasoningEffort: config.getCodexCliReasoningEffort(),
       skipGitRepoCheck: true as const,
     };
 

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -40,6 +40,19 @@ export function getCodexReasoningEffort(): CodexReasoningEffort {
   return parseCodexReasoningEffort(raw);
 }
 
+/**
+ * Codex CLI's Rust-side config deserializer only accepts
+ * 'minimal' | 'low' | 'medium' | 'high'. TeXRA's 'xhigh' tier is a UI-only
+ * extension used by providers like Anthropic Opus 'max'; cap it to 'high'
+ * before handing the value to the Codex SDK.
+ */
+export type CodexCliReasoningEffort = 'low' | 'medium' | 'high';
+
+export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
+  const effort = getCodexReasoningEffort();
+  return effort === 'xhigh' ? 'high' : effort;
+}
+
 // ============================================================================
 // Sandbox mode
 // ============================================================================

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -41,16 +41,21 @@ export function getCodexReasoningEffort(): CodexReasoningEffort {
 }
 
 /**
- * Codex CLI's Rust-side config deserializer only accepts
- * 'minimal' | 'low' | 'medium' | 'high'. TeXRA's 'xhigh' tier is a UI-only
+ * Codex CLI's Rust-side config deserializer only accepts a subset of the
+ * reasoning effort tiers TeXRA exposes. TeXRA's 'xhigh' tier is a UI-only
  * extension used by providers like Anthropic Opus 'max'; cap it to 'high'
  * before handing the value to the Codex SDK.
  */
 export type CodexCliReasoningEffort = 'low' | 'medium' | 'high';
 
-export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
-  const effort = getCodexReasoningEffort();
+export function toCodexCliReasoningEffort(
+  effort: CodexReasoningEffort,
+): CodexCliReasoningEffort {
   return effort === 'xhigh' ? 'high' : effort;
+}
+
+export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
+  return toCodexCliReasoningEffort(getCodexReasoningEffort());
 }
 
 // ============================================================================


### PR DESCRIPTION
TeXRA exposes an 'xhigh' reasoning tier used by providers that support an
extended effort (Anthropic Opus 4.6/4.7 'max', OpenRouter, etc.), but the
Codex CLI's Rust-side config deserializer only accepts
'minimal' | 'low' | 'medium' | 'high'. Passing 'xhigh' through caused:

  Failed to deserialize overridden config: unknown variant 'xhigh',
  expected one of 'minimal', 'low', 'medium', 'high' in 'model_reasoning_effort'

Add getCodexCliReasoningEffort() which maps 'xhigh' -> 'high' and use it
when constructing Codex SDK thread options. The UI-facing getter keeps
returning the full set so user preference isn't lost for other consumers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted config mapping change that only affects Codex thread option construction and is covered by a new unit test for the regression case.
> 
> **Overview**
> Prevents Codex CLI config deserialization errors by introducing a CLI-compatible reasoning-effort getter that maps **`xhigh` → `high`** before passing `modelReasoningEffort` into Codex SDK thread options.
> 
> Adds `toCodexCliReasoningEffort`/`getCodexCliReasoningEffort` in `codexConfig.ts`, updates `codex.ts` to use it, and includes a focused unit test covering the `xhigh` regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7e5f7d1695dff4aed28b03239542406c1d07bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->