### PR TITLE
fix: retain pending background response ID on network retrieval failure

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -22,6 +22,7 @@ import {
   getSdkErrorMessage,
   isContextWindowError,
   isPreviousResponseIdError,
+  isRetryableStatusCode,
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
@@ -688,25 +689,23 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
         throw err;
       }
-      // Transient failures (network, 5xx, 429, 408) — the background response
-      // is likely still alive server-side, so retain the ID and rethrow. The
-      // outer retry will resume the same ID instead of duplicating work.
-      // Definitive failures (404 expired, 401/403 auth, other 4xx) — clear
-      // the ID and signal that a new request is needed.
+      // Transient failures (no status / 5xx / 429 / 408) — the background
+      // response is likely still alive server-side, so retain the ID and
+      // rethrow so the outer retry resumes the same ID. Definitive failures
+      // (4xx, notably 404 expired) — clear the ID and create a new request.
+      //
+      // Check statusCode directly rather than formatted.retryable: the latter
+      // is force-true for relay errors, which would incorrectly retain the ID
+      // on a relay-wrapped 404 and loop until retries are exhausted.
       const formatted = formatProviderHttpError(err);
-      if (formatted.retryable) {
+      const code = formatted.statusCode;
+      if (code === undefined || isRetryableStatusCode(code)) {
         throw err;
       }
       this.logger.warn(
         `Failed to retrieve pending background response ${pendingId}: ${formatted.message}. ` +
           'Will create new request.',
-        {
-          data: {
-            responseId: pendingId,
-            error: formatted.message,
-            statusCode: formatted.statusCode,
-          },
-        },
+        { data: { responseId: pendingId, error: formatted.message, statusCode: code } },
       );
       this.clearPendingBackgroundResponse();
       return null;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -684,37 +684,29 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         signal ? { signal } : undefined,
       );
     } catch (err) {
-      // User cancellation - clear pending ID and propagate
       if (err instanceof DOMException && err.name === 'AbortError') {
         this.clearPendingBackgroundResponse();
         throw err;
       }
-      // Transient failures (network errors with no status, 5xx, 429, 408) are
-      // classified retryable by formatProviderHttpError. The background response
-      // is likely still alive server-side in these cases, so retain the pending
-      // ID and rethrow — the outer retry will attempt to resume the same ID on
-      // the next pass instead of starting a duplicate background job.
+      // Transient failures (network, 5xx, 429, 408) — the background response
+      // is likely still alive server-side, so retain the ID and rethrow. The
+      // outer retry will resume the same ID instead of duplicating work.
+      // Definitive failures (404 expired, 401/403 auth, other 4xx) — clear
+      // the ID and signal that a new request is needed.
       const formatted = formatProviderHttpError(err);
       if (formatted.retryable) {
-        this.logger.warn(
-          `Transient failure retrieving pending background response ${pendingId}: ${formatted.message}. ` +
-            'Retaining ID so next retry resumes the same response.',
-          {
-            data: {
-              responseId: pendingId,
-              error: formatted.message,
-              statusCode: formatted.statusCode,
-            },
-          },
-        );
         throw err;
       }
-      // Definitive failures (404 expired/deleted, 401/403 auth, other 4xx) -
-      // clear and signal that a new request is needed
       this.logger.warn(
-        `Failed to retrieve pending background response ${pendingId}: ${getSdkErrorMessage(err)}. ` +
+        `Failed to retrieve pending background response ${pendingId}: ${formatted.message}. ` +
           'Will create new request.',
-        { data: { responseId: pendingId, error: getSdkErrorMessage(err) } },
+        {
+          data: {
+            responseId: pendingId,
+            error: formatted.message,
+            statusCode: formatted.statusCode,
+          },
+        },
       );
       this.clearPendingBackgroundResponse();
       return null;
@@ -1982,9 +1974,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         );
       }
 
-      // Log info about pending background response for retry logic
-      // Note: We intentionally keep pendingBackgroundResponseId for connection errors
-      // so that retry logic can resume polling the same response
+      // Retention of pendingBackgroundResponseId is decided at the point of
+      // failure (tryResumeBackgroundResponse and waitForBackgroundCompletion).
+      // If it survived to here, the next retry will try to resume the same ID.
       if (this.pendingBackgroundResponseId) {
         this.logger.info(
           `Retaining pendingBackgroundResponseId=${this.pendingBackgroundResponseId} for retry - ` +

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -689,8 +689,21 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
         throw err;
       }
-      // Failed to retrieve - could be network error or 404 (expired/deleted)
-      // Clear and signal that a new request is needed
+      // Network-level failure (no HTTP status): the retrieve never reached the
+      // server or got no response. The background response may still be alive
+      // remotely, so retain the pending ID and rethrow — the outer retry will
+      // attempt to resume the same ID on the next pass.
+      const formatted = formatProviderHttpError(err);
+      if (formatted.retryable && formatted.statusCode === undefined) {
+        this.logger.warn(
+          `Network failure retrieving pending background response ${pendingId}: ${formatted.message}. ` +
+            'Retaining ID so next retry resumes the same response.',
+          { data: { responseId: pendingId, error: formatted.message } },
+        );
+        throw err;
+      }
+      // Other failures (404 expired/deleted, auth, etc.) - clear and signal
+      // that a new request is needed
       this.logger.warn(
         `Failed to retrieve pending background response ${pendingId}: ${getSdkErrorMessage(err)}. ` +
           'Will create new request.',

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -2233,16 +2233,20 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           this.clearPendingBackgroundResponse();
           throw err;
         }
-        // Only wrap 404 "response not found" errors. These are retryable because
-        // the response existed but disappeared during polling, and a retry will
-        // create a new request. Wrapping strips the 404 status code so
-        // formatProviderHttpError classifies it as a network-like error (retryable).
+        // 404 "response not found" during polling means the response is truly
+        // gone server-side. Clear the pending ID so the next retry creates a
+        // fresh background request instead of routing through
+        // tryResumeBackgroundResponse to rediscover the 404. The wrapping
+        // below strips the 404 status so formatProviderHttpError classifies
+        // the error as retryable (network-like), which keeps the retry loop
+        // engaged rather than bailing out on a non-retryable 4xx.
         //
         // All other errors (401, 403, 5xx, network, etc.) propagate unchanged
         // so downstream handlers (relay 401 token refresh, retryability checks,
         // non-retryable classification) work correctly with full HTTP metadata.
         const statusCode = (err as { status?: number }).status;
         if (statusCode === 404) {
+          this.clearPendingBackgroundResponse();
           const pollingError: RequestIdTaggedError = new Error(
             `Background response polling failed for ${responseId}: ${getSdkErrorMessage(err)}`,
             { cause: err },

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -689,21 +689,28 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
         throw err;
       }
-      // Network-level failure (no HTTP status): the retrieve never reached the
-      // server or got no response. The background response may still be alive
-      // remotely, so retain the pending ID and rethrow — the outer retry will
-      // attempt to resume the same ID on the next pass.
+      // Transient failures (network errors with no status, 5xx, 429, 408) are
+      // classified retryable by formatProviderHttpError. The background response
+      // is likely still alive server-side in these cases, so retain the pending
+      // ID and rethrow — the outer retry will attempt to resume the same ID on
+      // the next pass instead of starting a duplicate background job.
       const formatted = formatProviderHttpError(err);
-      if (formatted.retryable && formatted.statusCode === undefined) {
+      if (formatted.retryable) {
         this.logger.warn(
-          `Network failure retrieving pending background response ${pendingId}: ${formatted.message}. ` +
+          `Transient failure retrieving pending background response ${pendingId}: ${formatted.message}. ` +
             'Retaining ID so next retry resumes the same response.',
-          { data: { responseId: pendingId, error: formatted.message } },
+          {
+            data: {
+              responseId: pendingId,
+              error: formatted.message,
+              statusCode: formatted.statusCode,
+            },
+          },
         );
         throw err;
       }
-      // Other failures (404 expired/deleted, auth, etc.) - clear and signal
-      // that a new request is needed
+      // Definitive failures (404 expired/deleted, 401/403 auth, other 4xx) -
+      // clear and signal that a new request is needed
       this.logger.warn(
         `Failed to retrieve pending background response ${pendingId}: ${getSdkErrorMessage(err)}. ` +
           'Will create new request.',

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -124,7 +124,7 @@ const SDK_ERRORS: SdkErrorEntry[] = [
 
 /** Server errors (5xx), rate limits (429), and request timeouts (408) are retryable
  *  — these are transient. Other client errors (4xx) are deterministic. */
-function isRetryableStatusCode(statusCode?: number): boolean {
+export function isRetryableStatusCode(statusCode?: number): boolean {
   if (statusCode === undefined) return false;
   if (statusCode >= 500) return true;
   return (


### PR DESCRIPTION
When retrying a background-mode OpenAI Responses request, tryResumeBackgroundResponse
was clearing pendingBackgroundResponseId on any retrieve() failure, forcing a new
request even when the failure was a transient network error. The background
response is often still alive server-side in that case, so the next retry should
resume the same ID rather than start over.

Distinguish network-level failures (no HTTP status) from definitive failures
(404 expired, auth errors). Network errors now retain the ID and rethrow so the
outer retry loop can attempt to resume the same response.

https://claude.ai/code/session_01FzL9YsTwT1aVC65UumwLtX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/polling error handling for background Responses requests; mistakes could cause unnecessary new requests or retry loops, but scope is limited to OpenAI background-mode retrieval paths.
> 
> **Overview**
> Improves background-mode retry behavior for OpenAI Responses by **retaining `pendingBackgroundResponseId` on transient `retrieve()` failures** (no HTTP status / 5xx / 429 / 408) so retries resume polling the same server-side job instead of starting over.
> 
> Treats definitive HTTP failures as terminal: `tryResumeBackgroundResponse()` now clears the pending ID and logs structured status info before creating a new request, and background polling explicitly clears the pending ID on 404 “response not found” so the next retry rebuilds a fresh background request.
> 
> Exports `isRetryableStatusCode()` from `sdkErrorUtils` to share the status-based retryability check across these call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f5a573df5c9109b08fdf017a6f11e3a12f1049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->