### PR TITLE
fix(anthropic): restore reasoning output on Opus 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **Opus 4.7 thinking models show reasoning again** — Anthropic flipped the Opus 4.7 adaptive-thinking default so reasoning is omitted from responses unless the caller opts in. TeXRA now asks for `display: summarized` on `opus47`/`opus47T`, restoring visible chain-of-thought in the UI. Opus 4.6 and Sonnet 4.6 are unchanged.
 - **Codex CLI no longer fails on Extra High effort** — TeXRA's `xhigh` reasoning tier now maps to `high` when handed off to the Codex CLI, which only accepts `minimal | low | medium | high`. Previously Codex sessions died with `unknown variant 'xhigh'` on deserialization.
 - **`latexFixer` and similar internal agents load again** — the agent YAML schema now accepts the `internal: true` flag instead of rejecting it via `z.strictObject`, so agents that mark themselves internal no longer fail validation.
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -629,7 +629,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // and automatically enables interleaved thinking between tool calls.
         // budget_tokens is deprecated on these models.
         const effort = this.getAnthropicEffort();
-        options.thinking = { type: 'adaptive' };
+        // Opus 4.7 defaults display to 'omitted', which suppresses reasoning
+        // output. Request 'summarized' so thinking tokens still stream to the
+        // user — older adaptive-thinking models already emit reasoning by
+        // default and are unaffected.
+        options.thinking = this.isClaudeOpus47()
+          ? { type: 'adaptive', display: 'summarized' }
+          : { type: 'adaptive' };
         options.output_config = {
           ...options.output_config,
           effort,

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1031,8 +1031,8 @@ describe('ModelHandlerAnthropic message guards', () => {
     const options = messageOptions[0] ?? {};
     assert.deepEqual(
       options.thinking,
-      { type: 'adaptive' },
-      'Opus 4.7 should request adaptive thinking (budget_tokens is rejected)',
+      { type: 'adaptive', display: 'summarized' },
+      'Opus 4.7 should request adaptive thinking with display: summarized so reasoning still streams',
     );
     assert.equal(
       options.output_config?.effort,


### PR DESCRIPTION
## Summary

- Anthropic flipped the Opus 4.7 adaptive-thinking default for the `display` field from `summarized` to `omitted`. Thinking blocks still appear in the response stream, but `thinking` is empty unless the caller opts back in — so `opus47T` users stopped seeing chain-of-thought in the TeXRA UI even though the model was still reasoning.
- Pass `display: 'summarized'` explicitly on `claude-opus-4-7` requests in `ModelHandlerAnthropic` to restore the previous behaviour. Opus 4.6 and Sonnet 4.6 still default to `summarized` server-side, so their request payload is intentionally left untouched to keep the change minimal.
- Update the existing Opus 4.7 adaptive-thinking unit test to assert the new shape, and add a CHANGELOG bug-fix entry under `[Unreleased]`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Run `claude-opus-4-7` (`opus47T`) with reasoning enabled and confirm summarized thinking content streams back to the webview
- [ ] Run `claude-opus-4-6` (`opus46T`) and `claude-sonnet-4-6` (`sonnet46T`) and confirm thinking output is unchanged
- [ ] CI: validate, claude-review, Cursor Bugbot

https://claude.ai/code/session_01D3zs29i1tyqS94qHTZma7v

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a targeted request-payload tweak for `claude-opus-4-7` plus a unit test and changelog update; behavior for other Anthropic models is unchanged.
> 
> **Overview**
> Restores Opus 4.7 reasoning visibility by sending `thinking: { type: 'adaptive', display: 'summarized' }` for `claude-opus-4-7` requests, avoiding the provider’s new default that omits reasoning output.
> 
> Updates the existing Opus 4.7 unit test to assert the new `thinking` payload shape, and adds a corresponding `[Unreleased]` changelog bug-fix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46b39f5c94c41cd5d966052066c27e287a12e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->