### PR TITLE
docs: add Codex CLI integration guide

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -161,6 +161,7 @@ const baseConfig = {
               text: 'Working with Overleaf',
               link: '/guide/working-with-overleaf',
             },
+            { text: 'Codex CLI', link: '/guide/codex-cli' },
             { text: 'File Management', link: '/guide/file-management' },
             { text: 'ProgressBoard', link: '/guide/progress-board' },
           ],

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -1,0 +1,157 @@
+# Connecting to the Codex CLI
+
+TeXRA can spin off an [OpenAI Codex](https://developers.openai.com/codex/cli) agent as a local tool. Codex is a sandboxed coding agent that reads files, runs commands, and edits code inside your workspace. Once connected, any TeXRA tool-use agent can delegate work to it via the `codex` tool — useful for long-running code tasks, scripted verifications, or offloading heavy reasoning to a ChatGPT subscription.
+
+## Why Use Codex From TeXRA?
+
+- **Subscription reuse:** Codex authenticates with your ChatGPT Plus / Pro account, so the compute is covered by your existing plan instead of per-token API billing.
+- **Sandboxed execution:** Commands and file writes happen under Codex's sandbox — you pick the access level.
+- **Multi-turn threads:** Each Codex run opens a dedicated stream tab. You can send follow-ups without starting a new session, and the agent can resume a thread by ID.
+- **Background mode:** Launch Codex asynchronously; TeXRA delivers the result back to the parent agent when the turn completes.
+
+## Prerequisites
+
+- Node.js and `npm` on your PATH (used by the Codex CLI installer).
+- A ChatGPT account (Plus or Pro recommended) **or** an `OPENAI_API_KEY` with Codex access.
+- TeXRA installed in VS Code ([Installation Guide](./installation.md)).
+
+## 1. Install the Codex CLI
+
+Pick whichever installer fits your platform. TeXRA's `codex` tool uses the binary from `@openai/codex` via the `@openai/codex-sdk` Node package.
+
+::: code-group
+
+```bash [npm (all platforms)]
+npm install -g @openai/codex
+```
+
+```bash [Homebrew (macOS)]
+brew install codex
+```
+
+```bash [Windows / WSL]
+# Install inside the WSL environment, not on the Windows side.
+wsl
+npm install -g @openai/codex
+```
+
+:::
+
+Verify the install:
+
+```bash
+codex --version
+```
+
+::: warning Windows users
+Codex does not ship a native Windows binary. Install it inside **WSL** (and run VS Code's WSL remote) or use the standalone Codex desktop app. TeXRA discovers the binary via the SDK's platform-specific package, so a Windows-side install will not be detected.
+:::
+
+## 2. Authenticate
+
+Choose one of the following.
+
+### Option A — ChatGPT login (recommended)
+
+```bash
+codex login
+```
+
+This opens a browser window and stores credentials at `~/.codex/auth.json`. It is the right choice if you already pay for ChatGPT Plus / Pro.
+
+### Option B — API key
+
+Export an API key with Codex access:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+```
+
+Add it to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) so VS Code inherits the variable. On Windows + WSL, export inside the WSL shell that launches `code .`.
+
+::: tip
+Codex manages its own auth state — TeXRA never reads or stores your ChatGPT credentials. You can switch accounts any time with `codex logout` followed by `codex login`.
+:::
+
+## 3. Verify the Connection in TeXRA
+
+1. Open the TeXRA Dashboard: `Ctrl+Shift+P` → **TeXRA: Show Dashboard**.
+2. Go to the **Tools** tab.
+3. Under **Computation**, find the **OpenAI Codex CLI** card.
+
+If the card shows a green check, the SDK loaded and the Codex binary was discovered. If it shows an error, hover for the detail message:
+
+| Detail message                                                     | What to do                                                                                        |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `@openai/codex-sdk not found`                                      | Run `npm install -g @openai/codex` and reload VS Code.                                            |
+| `Codex SDK loaded but native binary not found`                     | The SDK installed without its platform binary — reinstall with `npm install -g @openai/codex`.    |
+| `Platform not supported`                                           | You're on an unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.             |
+| `Codex CLI ready. Binary: /…/codex`                                | All set.                                                                                          |
+
+## 4. Configure Codex
+
+Codex-specific settings live directly on the Codex card in **Dashboard → Tools**. They are scoped to the current workspace.
+
+### Sandbox mode
+
+| Mode                 | What Codex can do                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `read-only`          | Read files and run read-only commands. No writes, no network side effects.            |
+| `workspace-write`    | Read + write inside the workspace directory. **Default.**                             |
+| `danger-full-access` | No sandbox — Codex can touch anything the user can. Use only when you trust the task. |
+
+The orchestrating agent may override this per call via the tool's `sandbox_mode` parameter, but the dashboard value is the default.
+
+### Reasoning effort
+
+Controls how much the model deliberates before responding.
+
+| Effort   | Behavior                                                                 |
+| -------- | ------------------------------------------------------------------------ |
+| `low`    | Fast, shallow.                                                           |
+| `medium` | Balanced.                                                                |
+| `high`   | Deeper reasoning. **Default.**                                           |
+| `xhigh`  | TeXRA-only UI tier. Capped to `high` when handed to the Codex CLI.       |
+
+TeXRA drives Codex with the short model name `gpt-5.4`; it is not a dropdown because the Codex CLI selects its own model family internally.
+
+### Approval prompts
+
+The **Require approval for shell commands & Codex sessions** checkbox (same **Tools** tab, under *Approval & Safety*) applies to every Codex invocation. With it enabled, TeXRA shows a confirmation prompt before each Codex call and includes the prompt preview plus the sandbox mode. Disable it only for trusted autonomous flows.
+
+## 5. Run Your First Codex Turn
+
+Any tool-use agent with `codex` in its allowed tools can delegate to Codex. The built-in `plan`, `draft`, and `code` agents include it by default. Try:
+
+```
+Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
+```
+
+What to expect:
+
+1. A child stream tab opens with the prefix `codex@codex-sdk`.
+2. The stream shows Codex's reasoning, command executions, file diffs, web searches, and todo list in real time.
+3. When the turn finishes, the tab stays in **WAITING** state — type a follow-up in the tab's input to keep the same thread going.
+4. The agent that invoked Codex receives a compact result with the final response, token usage, and a `thread_id` it can pass back to resume the conversation later.
+
+### Background mode
+
+Agents can pass `run_in_background: true` when they don't need to block on the result. TeXRA immediately returns the execution ID and stream tab, then delivers the completed output as a follow-up message once Codex finishes. Handy for long refactors while the parent agent keeps working.
+
+## Troubleshooting
+
+**Codex card stays red after installing.** Reload the VS Code window (`Developer: Reload Window`) so the extension re-checks for the binary.
+
+**Authentication prompts keep appearing.** Run `codex login` in the terminal VS Code is launched from — environment variables set in a GUI session may not reach the Codex binary. On macOS, make sure you're not launching VS Code from Finder with a clean environment.
+
+**`codex login` fails in WSL.** Make sure the WSL distro can open URLs in your host browser (`wslu` or `wslview`). Alternatively, copy the login URL and paste it into a browser manually.
+
+**The session is stuck in WAITING after a reload.** TeXRA interrupts Codex threads on extension reload. Close the stream tab and start a new turn — threads are cached to disk, so pass the previous `thread_id` if you want to continue where you left off.
+
+**Custom Codex config.** Codex reads its own config from `~/.codex/config.toml`. TeXRA only overrides `model`, `modelReasoningEffort`, `sandboxMode`, and the workspace directories — everything else (providers, MCP servers, custom instructions) comes from Codex's config and is respected as-is.
+
+## Next Steps
+
+- [Configuration](./configuration.md) — full Dashboard and settings reference
+- [LaTeX Tools](./latex-tools.md) — other local tools TeXRA plugs into
+- [Research Tools](./research-tools.md) — arXiv, Crossref, Zotero, and web search

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -1,156 +1,90 @@
 # Connecting to the Codex CLI
 
-TeXRA can spin off an [OpenAI Codex](https://developers.openai.com/codex/cli) agent as a local tool. Codex is a sandboxed coding agent that reads files, runs commands, and edits code inside your workspace. Once connected, any TeXRA tool-use agent can delegate work to it via the `codex` tool — useful for long-running code tasks, scripted verifications, or offloading heavy reasoning to a ChatGPT subscription.
+TeXRA can hand off tasks to [OpenAI Codex](https://developers.openai.com/codex/cli) — a sandboxed coding agent that runs locally, reads files, runs commands, and edits code. Once connected, any TeXRA tool-use agent can delegate to it via the `codex` tool and keep your ChatGPT Plus / Pro plan paying for the compute.
 
-## Why Use Codex From TeXRA?
+## Quick Start
 
-- **Subscription reuse:** Codex authenticates with your ChatGPT Plus / Pro account, so the compute is covered by your existing plan instead of per-token API billing.
-- **Sandboxed execution:** Commands and file writes happen under Codex's sandbox — you pick the access level.
-- **Multi-turn threads:** Each Codex run opens a dedicated stream tab. You can send follow-ups without starting a new session, and the agent can resume a thread by ID.
-- **Background mode:** Launch Codex asynchronously; TeXRA delivers the result back to the parent agent when the turn completes.
+Three steps, about two minutes.
 
-## Prerequisites
+### 1. Install the CLI
 
-- Node.js and `npm` on your PATH (used by the Codex CLI installer).
-- A ChatGPT account (Plus or Pro recommended) **or** an `OPENAI_API_KEY` with Codex access.
-- TeXRA installed in VS Code ([Installation Guide](./installation.md)).
-
-## 1. Install the Codex CLI
-
-Pick whichever installer fits your platform. TeXRA's `codex` tool uses the binary from `@openai/codex` via the `@openai/codex-sdk` Node package.
-
-::: code-group
-
-```bash [npm (all platforms)]
+```bash
 npm install -g @openai/codex
 ```
 
-```bash [Homebrew (macOS)]
-brew install codex
-```
+- macOS users can also `brew install codex`.
+- **Windows:** install inside WSL and launch VS Code with the WSL remote — Codex has no native Windows binary.
 
-```bash [Windows / WSL]
-# Install inside the WSL environment, not on the Windows side.
-wsl
-npm install -g @openai/codex
-```
-
-:::
-
-Verify the install:
+Check it installed:
 
 ```bash
 codex --version
 ```
 
-::: warning Windows users
-Codex does not ship a native Windows binary. Install it inside **WSL** (and run VS Code's WSL remote) or use the standalone Codex desktop app. TeXRA discovers the binary via the SDK's platform-specific package, so a Windows-side install will not be detected.
-:::
-
-## 2. Authenticate
-
-Choose one of the following.
-
-### Option A — ChatGPT login (recommended)
+### 2. Sign in
 
 ```bash
 codex login
 ```
 
-This opens a browser window and stores credentials at `~/.codex/auth.json`. It is the right choice if you already pay for ChatGPT Plus / Pro.
+This opens a browser and stores credentials at `~/.codex/auth.json`. Your ChatGPT Plus / Pro plan covers the compute.
 
-### Option B — API key
+Prefer API billing? Export `OPENAI_API_KEY` in the shell that launches VS Code instead — Codex picks it up automatically.
 
-Export an API key with Codex access:
+### 3. Verify in TeXRA
 
-```bash
-export OPENAI_API_KEY="sk-..."
-```
+Open **TeXRA: Show Dashboard** (`Ctrl+Shift+P`) → **Tools** (<i class="codicon codicon-tools"></i>) → **Computation** (<i class="codicon codicon-symbol-operator"></i>). The **OpenAI Codex CLI** card should read <i class="codicon codicon-check"></i> **Available**.
 
-Add it to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) so VS Code inherits the variable. On Windows + WSL, export inside the WSL shell that launches `code .`.
+If it doesn't, jump to [Troubleshooting](#troubleshooting).
 
-::: tip
-Codex manages its own auth state — TeXRA never reads or stores your ChatGPT credentials. You can switch accounts any time with `codex logout` followed by `codex login`.
+That's the whole setup — any tool-use agent with the `codex` tool enabled can now delegate to Codex.
+
+## Settings
+
+All Codex options live on the Codex card in **Dashboard → Tools** and are scoped to the current workspace.
+
+| Setting              | Options                                                                       | Default             | What it controls                                                         |
+| -------------------- | ----------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------ |
+| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                          | `workspace-write`   | File-system access. Agents may override per call via `sandbox_mode`.     |
+| **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                              | `high`              | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
+| **Require approval** | checkbox under *Approval & Safety* (<i class="codicon codicon-shield"></i>)   | on                  | Show a confirmation prompt before every Codex call.                      |
+
+TeXRA always drives Codex with the short model name `gpt-5.4`. Everything else (providers, MCP servers, custom instructions) comes from Codex's own `~/.codex/config.toml`.
+
+## Running Codex
+
+Check which agents have the `codex` tool enabled on the **Agents** tab (<i class="codicon codicon-sparkle"></i>), then prompt one of them:
+
+> Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
+
+When it fires:
+
+1. A child stream tab `codex@codex-sdk` opens on the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>).
+2. Reasoning, commands, file diffs, web searches (<i class="codicon codicon-globe"></i>), and todos stream in live.
+3. When the turn ends, the tab sits in **WAITING**. Type a follow-up to continue the thread, or press <i class="codicon codicon-debug-stop"></i> **Stop** to end it.
+4. The calling agent gets back the final response, token usage, and a `thread_id` it can resume later.
+
+::: tip Background mode
+Agents can pass `run_in_background: true` to get the execution ID immediately and receive the result as a follow-up when Codex finishes. Good for long refactors that shouldn't block the parent.
 :::
-
-## 3. Verify the Connection in TeXRA
-
-1. Open the TeXRA Dashboard: `Ctrl+Shift+P` → **TeXRA: Show Dashboard**.
-2. Go to the **Tools** tab (<i class="codicon codicon-tools"></i>).
-3. Under **Computation** (<i class="codicon codicon-symbol-operator"></i>), find the **OpenAI Codex CLI** card.
-
-If the card shows <i class="codicon codicon-check"></i> **Available**, the SDK loaded and the Codex binary was discovered. If it shows <i class="codicon codicon-warning"></i> **Not Found**, hover for the detail message:
-
-| Detail message                                                     | What to do                                                                                        |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `@openai/codex-sdk not found`                                      | Run `npm install -g @openai/codex` and reload VS Code.                                            |
-| `Codex SDK loaded but native binary not found`                     | The SDK installed without its platform binary — reinstall with `npm install -g @openai/codex`.    |
-| `Platform not supported`                                           | You're on an unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.             |
-| `Codex CLI ready. Binary: /…/codex`                                | All set.                                                                                          |
-
-The card also exposes an <i class="codicon codicon-link-external"></i> link to the Codex project page and a <i class="codicon codicon-cloud-download"></i> install guide button for quick reference.
-
-## 4. Configure Codex
-
-Codex-specific settings live directly on the Codex card in **Dashboard → Tools**. They are scoped to the current workspace.
-
-### Sandbox mode
-
-| Mode                 | What Codex can do                                                                     |
-| -------------------- | ------------------------------------------------------------------------------------- |
-| `read-only`          | Read files and run read-only commands. No writes, no network side effects.            |
-| `workspace-write`    | Read + write inside the workspace directory. **Default.**                             |
-| `danger-full-access` | No sandbox — Codex can touch anything the user can. Use only when you trust the task. |
-
-The orchestrating agent may override this per call via the tool's `sandbox_mode` parameter, but the dashboard value is the default.
-
-### Reasoning effort
-
-Controls how much the model deliberates before responding.
-
-| Effort   | Behavior                                                                 |
-| -------- | ------------------------------------------------------------------------ |
-| `low`    | Fast, shallow.                                                           |
-| `medium` | Balanced.                                                                |
-| `high`   | Deeper reasoning. **Default.**                                           |
-| `xhigh`  | TeXRA-only UI tier. Capped to `high` when handed to the Codex CLI.       |
-
-TeXRA drives Codex with the short model name `gpt-5.4`; it is not a dropdown because the Codex CLI selects its own model family internally.
-
-### Approval prompts
-
-The **Require approval for shell commands & Codex sessions** checkbox (same **Tools** tab, under *Approval & Safety* <i class="codicon codicon-shield"></i>) applies to every Codex invocation. With it enabled, TeXRA shows a confirmation prompt before each Codex call and includes the prompt preview plus the sandbox mode. Disable it only for trusted autonomous flows.
-
-## 5. Run Your First Codex Turn
-
-Any tool-use agent with `codex` in its allowed tools can delegate to Codex — check the agent's definition in the **Agents** tab (<i class="codicon codicon-sparkle"></i>) or enable it for a custom agent. Try:
-
-```
-Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
-```
-
-What to expect:
-
-1. A child stream tab opens with the prefix `codex@codex-sdk` — visible on the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>).
-2. The stream shows Codex's reasoning, command executions, file diffs, web searches (<i class="codicon codicon-globe"></i>), and todo list in real time.
-3. When the turn finishes, the tab stays in **WAITING** state — type a follow-up in the tab's input to keep the same thread going. Use <i class="codicon codicon-debug-stop"></i> **Stop** to interrupt it.
-4. The agent that invoked Codex receives a compact result with the final response, token usage, and a `thread_id` it can pass back to resume the conversation later.
-
-### Background mode
-
-Agents can pass `run_in_background: true` when they don't need to block on the result. TeXRA immediately returns the execution ID and stream tab, then delivers the completed output as a follow-up message once Codex finishes. Handy for long refactors while the parent agent keeps working.
 
 ## Troubleshooting
 
-**Codex card stays <i class="codicon codicon-warning"></i> Not Found after installing.** Reload the VS Code window (`Developer: Reload Window`) so the extension re-checks for the binary.
+**Tools card shows <i class="codicon codicon-warning"></i> Not Found.** Hover the card for the exact message:
 
-**Authentication prompts keep appearing.** Run `codex login` in the terminal VS Code is launched from — environment variables set in a GUI session may not reach the Codex binary. On macOS, make sure you're not launching VS Code from Finder with a clean environment.
+| Message                                         | Fix                                                                          |
+| ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| `@openai/codex-sdk not found`                   | `npm install -g @openai/codex`, then reload VS Code.                         |
+| `Codex SDK loaded but native binary not found`  | Reinstall — the platform binary didn't ship. On Windows, install inside WSL. |
+| `Platform not supported`                        | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.     |
 
-**`codex login` fails in WSL.** Make sure the WSL distro can open URLs in your host browser (`wslu` or `wslview`). Alternatively, copy the login URL and paste it into a browser manually.
+**Card is still Not Found after installing.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
 
-**The session is stuck in WAITING after a reload.** TeXRA interrupts Codex threads on extension reload. Close the stream tab and start a new turn — threads are cached to disk, so pass the previous `thread_id` if you want to continue where you left off.
+**Auth prompts keep appearing.** Run `codex login` in the shell VS Code inherits its environment from. On macOS, launching VS Code from Finder can strip exported variables — start it from a terminal instead.
 
-**Custom Codex config.** Codex reads its own config from `~/.codex/config.toml`. TeXRA only overrides `model`, `modelReasoningEffort`, `sandboxMode`, and the workspace directories — everything else (providers, MCP servers, custom instructions) comes from Codex's config and is respected as-is.
+**`codex login` fails in WSL.** Install `wslu` so Codex can open URLs in your host browser, or paste the login URL into a browser manually.
+
+**Session stuck in WAITING after a reload.** TeXRA interrupts Codex threads when the extension reloads. Close the tab and start a new turn — pass the previous `thread_id` if you want to continue where you left off.
 
 ## Next Steps
 

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -76,10 +76,10 @@ Codex manages its own auth state — TeXRA never reads or stores your ChatGPT cr
 ## 3. Verify the Connection in TeXRA
 
 1. Open the TeXRA Dashboard: `Ctrl+Shift+P` → **TeXRA: Show Dashboard**.
-2. Go to the **Tools** tab.
-3. Under **Computation**, find the **OpenAI Codex CLI** card.
+2. Go to the **Tools** tab (<i class="codicon codicon-tools"></i>).
+3. Under **Computation** (<i class="codicon codicon-symbol-operator"></i>), find the **OpenAI Codex CLI** card.
 
-If the card shows a green check, the SDK loaded and the Codex binary was discovered. If it shows an error, hover for the detail message:
+If the card shows <i class="codicon codicon-check"></i> **Available**, the SDK loaded and the Codex binary was discovered. If it shows <i class="codicon codicon-warning"></i> **Not Found**, hover for the detail message:
 
 | Detail message                                                     | What to do                                                                                        |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
@@ -87,6 +87,8 @@ If the card shows a green check, the SDK loaded and the Codex binary was discove
 | `Codex SDK loaded but native binary not found`                     | The SDK installed without its platform binary — reinstall with `npm install -g @openai/codex`.    |
 | `Platform not supported`                                           | You're on an unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.             |
 | `Codex CLI ready. Binary: /…/codex`                                | All set.                                                                                          |
+
+The card also exposes an <i class="codicon codicon-link-external"></i> link to the Codex project page and a <i class="codicon codicon-cloud-download"></i> install guide button for quick reference.
 
 ## 4. Configure Codex
 
@@ -117,11 +119,11 @@ TeXRA drives Codex with the short model name `gpt-5.4`; it is not a dropdown bec
 
 ### Approval prompts
 
-The **Require approval for shell commands & Codex sessions** checkbox (same **Tools** tab, under *Approval & Safety*) applies to every Codex invocation. With it enabled, TeXRA shows a confirmation prompt before each Codex call and includes the prompt preview plus the sandbox mode. Disable it only for trusted autonomous flows.
+The **Require approval for shell commands & Codex sessions** checkbox (same **Tools** tab, under *Approval & Safety* <i class="codicon codicon-shield"></i>) applies to every Codex invocation. With it enabled, TeXRA shows a confirmation prompt before each Codex call and includes the prompt preview plus the sandbox mode. Disable it only for trusted autonomous flows.
 
 ## 5. Run Your First Codex Turn
 
-Any tool-use agent with `codex` in its allowed tools can delegate to Codex. The built-in `plan`, `draft`, and `code` agents include it by default. Try:
+Any tool-use agent with `codex` in its allowed tools can delegate to Codex — check the agent's definition in the **Agents** tab (<i class="codicon codicon-sparkle"></i>) or enable it for a custom agent. Try:
 
 ```
 Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
@@ -129,9 +131,9 @@ Use codex to sketch a minimal FastAPI server that returns a JSON healthcheck.
 
 What to expect:
 
-1. A child stream tab opens with the prefix `codex@codex-sdk`.
-2. The stream shows Codex's reasoning, command executions, file diffs, web searches, and todo list in real time.
-3. When the turn finishes, the tab stays in **WAITING** state — type a follow-up in the tab's input to keep the same thread going.
+1. A child stream tab opens with the prefix `codex@codex-sdk` — visible on the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>).
+2. The stream shows Codex's reasoning, command executions, file diffs, web searches (<i class="codicon codicon-globe"></i>), and todo list in real time.
+3. When the turn finishes, the tab stays in **WAITING** state — type a follow-up in the tab's input to keep the same thread going. Use <i class="codicon codicon-debug-stop"></i> **Stop** to interrupt it.
 4. The agent that invoked Codex receives a compact result with the final response, token usage, and a `thread_id` it can pass back to resume the conversation later.
 
 ### Background mode
@@ -140,7 +142,7 @@ Agents can pass `run_in_background: true` when they don't need to block on the r
 
 ## Troubleshooting
 
-**Codex card stays red after installing.** Reload the VS Code window (`Developer: Reload Window`) so the extension re-checks for the binary.
+**Codex card stays <i class="codicon codicon-warning"></i> Not Found after installing.** Reload the VS Code window (`Developer: Reload Window`) so the extension re-checks for the binary.
 
 **Authentication prompts keep appearing.** Run `codex login` in the terminal VS Code is launched from — environment variables set in a GUI session may not reach the Codex binary. On macOS, make sure you're not launching VS Code from Finder with a clean environment.
 

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -1,53 +1,37 @@
 # Connecting to the Codex CLI
 
-TeXRA can hand off tasks to [OpenAI Codex](https://developers.openai.com/codex/cli) — a sandboxed coding agent that runs locally, reads files, runs commands, and edits code. Once connected, any TeXRA tool-use agent can delegate to it via the `codex` tool and keep your ChatGPT Plus / Pro plan paying for the compute.
+TeXRA can hand off tasks to [OpenAI Codex](https://developers.openai.com/codex/cli) — a sandboxed coding agent that runs locally, reads files, runs commands, and edits code. Once connected, any TeXRA tool-use agent can delegate to it via the `codex` tool and let your ChatGPT Plus / Pro plan cover the compute.
 
 ## Quick Start
 
-Three steps, about two minutes.
+Set everything up from the TeXRA Dashboard — no terminal copy-paste.
 
-### 1. Install the CLI
+1. Open **TeXRA: Show Dashboard** (`Ctrl+Shift+P`) → **Tools** tab (<i class="codicon codicon-tools"></i>) → **Computation** (<i class="codicon codicon-symbol-operator"></i>).
+2. Find the **OpenAI Codex CLI** card. When it's **Not Found**, the setup actions expand automatically.
+3. Click the two buttons in order:
+   - <i class="codicon codicon-terminal"></i> **Install in Terminal** — opens an integrated terminal and runs `npm install -g @openai/codex`.
+   - <i class="codicon codicon-sign-in"></i> **Sign in** — runs `codex login`, which completes the OAuth flow in your browser using your ChatGPT Plus / Pro account.
+4. After both finish, click the card's **Recheck** action. The status flips to <i class="codicon codicon-check"></i> **Available** and the `codex` tool is ready.
 
-```bash
-npm install -g @openai/codex
-```
+That's it — any tool-use agent with the `codex` tool enabled can now delegate to Codex.
 
-- macOS users can also `brew install codex`.
-- **Windows:** install inside WSL and launch VS Code with the WSL remote — Codex has no native Windows binary.
+::: tip Prefer API-key billing?
+Skip **Sign in** and export `OPENAI_API_KEY` in the shell you launch VS Code from. Codex picks it up automatically. You can also use the <i class="codicon codicon-link-external"></i> **Open Install Page** button on the card for the official installer if you'd rather do it outside VS Code.
+:::
 
-Check it installed:
-
-```bash
-codex --version
-```
-
-### 2. Sign in
-
-```bash
-codex login
-```
-
-This opens a browser and stores credentials at `~/.codex/auth.json`. Your ChatGPT Plus / Pro plan covers the compute.
-
-Prefer API billing? Export `OPENAI_API_KEY` in the shell that launches VS Code instead — Codex picks it up automatically.
-
-### 3. Verify in TeXRA
-
-Open **TeXRA: Show Dashboard** (`Ctrl+Shift+P`) → **Tools** (<i class="codicon codicon-tools"></i>) → **Computation** (<i class="codicon codicon-symbol-operator"></i>). The **OpenAI Codex CLI** card should read <i class="codicon codicon-check"></i> **Available**.
-
-If it doesn't, jump to [Troubleshooting](#troubleshooting).
-
-That's the whole setup — any tool-use agent with the `codex` tool enabled can now delegate to Codex.
+::: warning Windows
+Codex has no native Windows binary. Open TeXRA inside a **WSL** remote window before clicking **Install in Terminal** — otherwise the install runs in PowerShell and VS Code won't find the binary.
+:::
 
 ## Settings
 
 All Codex options live on the Codex card in **Dashboard → Tools** and are scoped to the current workspace.
 
-| Setting              | Options                                                                       | Default             | What it controls                                                         |
-| -------------------- | ----------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------ |
-| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                          | `workspace-write`   | File-system access. Agents may override per call via `sandbox_mode`.     |
+| Setting              | Options                                                                       | Default             | What it controls                                                           |
+| -------------------- | ----------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
+| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                          | `workspace-write`   | File-system access. Agents may override per call via `sandbox_mode`.       |
 | **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                              | `high`              | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
-| **Require approval** | checkbox under *Approval & Safety* (<i class="codicon codicon-shield"></i>)   | on                  | Show a confirmation prompt before every Codex call.                      |
+| **Require approval** | checkbox under *Approval & Safety* (<i class="codicon codicon-shield"></i>)   | on                  | Show a confirmation prompt before every Codex call.                        |
 
 TeXRA always drives Codex with the short model name `gpt-5.4`. Everything else (providers, MCP servers, custom instructions) comes from Codex's own `~/.codex/config.toml`.
 
@@ -70,19 +54,17 @@ Agents can pass `run_in_background: true` to get the execution ID immediately an
 
 ## Troubleshooting
 
-**Tools card shows <i class="codicon codicon-warning"></i> Not Found.** Hover the card for the exact message:
+**Card shows <i class="codicon codicon-warning"></i> Not Found after install.** Hover the card for the exact message:
 
-| Message                                         | Fix                                                                          |
-| ----------------------------------------------- | ---------------------------------------------------------------------------- |
-| `@openai/codex-sdk not found`                   | `npm install -g @openai/codex`, then reload VS Code.                         |
-| `Codex SDK loaded but native binary not found`  | Reinstall — the platform binary didn't ship. On Windows, install inside WSL. |
-| `Platform not supported`                        | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.     |
+| Message                                         | Fix                                                                               |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| `@openai/codex-sdk not found`                   | Click **Install in Terminal** again, then **Recheck**.                            |
+| `Codex SDK loaded but native binary not found`  | Reinstall — the platform binary didn't ship. On Windows, open TeXRA in WSL first. |
+| `Platform not supported`                        | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.          |
 
-**Card is still Not Found after installing.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
+**Still Not Found after everything ran.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
 
-**Auth prompts keep appearing.** Run `codex login` in the shell VS Code inherits its environment from. On macOS, launching VS Code from Finder can strip exported variables — start it from a terminal instead.
-
-**`codex login` fails in WSL.** Install `wslu` so Codex can open URLs in your host browser, or paste the login URL into a browser manually.
+**`codex login` opens a terminal but nothing happens.** The button runs `codex login` in a fresh integrated terminal. Focus the terminal and press **Enter** if the browser didn't open, or paste the login URL manually.
 
 **Session stuck in WAITING after a reload.** TeXRA interrupts Codex threads when the extension reloads. Close the tab and start a new turn — pass the previous `thread_id` if you want to continue where you left off.
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -125,7 +125,7 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 - &#123;&#123; AUXILIARY_CONTENT &#125;&#125;: Content of the primary auxiliary file.
 - &#123;&#123; EDITED_FILE &#125;&#125;: Path of the edited file (used in `merge`).
 - &#123;&#123; EDITED_CONTENT &#125;&#125;: Content of the edited file.
-- &#123;&#123; MEDIA*FILE &#125;&#125;: Path of the primary media file.
+- &#123;&#123; MEDIA_FILE &#125;&#125;: Path of the primary media file.
   \_Note: Media content itself isn't directly inserted as text; it's handled separately for multimodal models. See [Working with Figures](./working-with-figures.md).*
 
 **Multiple File Variables:**

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -7,37 +7,37 @@ This guide walks you through creating your own agent definition files (`.yaml`) 
 ::: info Agent Fundamentals
 Before creating a custom agent, it's highly recommended to understand the underlying concepts:
 
-- **Agent Architecture & Execution Flow**: Learn about the `.yaml` structure, settings, prompts, and how agents run. See the [Agent Architecture & Execution Flow](./agent-architecture.md) guide.
-- **Built-in Agents**: Review the standard agents provided by TeXRA for examples and potential inheritance parents. See the [Built-in Agent Reference](./built-in-agents.md).
-- **Agents Tab**: Browse and manage agent files from the **Agents** tab in the TeXRA Dashboard.
+- <i class="codicon codicon-symbol-structure"></i> **Agent Architecture & Execution Flow**: Learn about the `.yaml` structure, settings, prompts, and how agents run. See the [Agent Architecture & Execution Flow](./agent-architecture.md) guide.
+- <i class="codicon codicon-sparkle"></i> **Built-in Agents**: Review the standard agents provided by TeXRA for examples and potential inheritance parents. See the [Built-in Agent Reference](./built-in-agents.md).
+- <i class="codicon codicon-dashboard"></i> **Agents Tab**: Browse and manage agent files from the **Agents** tab (<i class="codicon codicon-sparkle"></i>) in the TeXRA Dashboard.
   :::
 
-## Reference Agents
+## <i class="codicon codicon-library"></i> Reference Agents
 
 TeXRA includes ready-made reference agents you can use as starting points. Think of them as recipes: copy one into your custom agents directory, tweak it, and you have a new agent in minutes. Examples range from content-enhancement workflows to notation standardizers and multi-agent orchestrators. Each also has a `_multiple` variant for multi-file output.
 
-## Creating a Custom Agent File
+## <i class="codicon codicon-new-file"></i> Creating a Custom Agent File
 
-Follow these steps to create a new custom agent:
+Follow these steps to create a new custom agent.
 
-### Step 1: Locate or Configure the Custom Agents Directory
+### <i class="codicon codicon-folder-opened"></i> Step 1 — Locate or Configure the Custom Agents Directory
 
-Custom agents reside in a dedicated directory that TeXRA prepares for you.
+Custom agents live in a dedicated directory that TeXRA prepares for you.
 
-1.  **Find the Default Folder**: TeXRA automatically seeds a `custom_agents` directory inside its global storage. Open the **Agents** tab in the TeXRA Dashboard to see this location.
-2.  **Override (Optional)**: If you prefer to manage agents elsewhere, open the **Agents** tab in the TeXRA Dashboard and click **Change** in the directory info bar to select a new folder. TeXRA will ensure that directory exists and use it instead of the default.
+1. **Find the Default Folder**: TeXRA automatically seeds a `custom_agents` directory inside its global storage. Open the **Agents** tab (<i class="codicon codicon-sparkle"></i>) in the TeXRA Dashboard to see its location.
+2. **Override (Optional)**: If you prefer to manage agents elsewhere, open the **Agents** tab and click **Change** (<i class="codicon codicon-edit"></i>) in the directory info bar to pick a new folder. TeXRA will ensure that directory exists and use it instead of the default.
 
-### Automatic Creation
+### <i class="codicon codicon-wand"></i> Automatic Creation
 
-If you'd like TeXRA to draft an agent for you, use the **New Agent** button in the **Agents** tab of the TeXRA Dashboard. The wizard only asks for a short description and the default output filenames. TeXRA sends this information to a Claude model, which replies with the YAML enclosed in `<yaml>...</yaml>` tags. The extension extracts the content between those tags and saves it as a basic CoT template (single or multiple files) in your Custom Agents folder.
+If you'd like TeXRA to draft an agent for you, click **New Agent** (<i class="codicon codicon-add"></i>) in the **Agents** tab. The wizard only asks for a short description and the default output filenames. TeXRA sends that info to a Claude model, which returns the YAML enclosed in `<yaml>...</yaml>` tags. The extension extracts the content between those tags and saves it as a basic CoT template (single or multiple files) in your Custom Agents folder.
 
-### Step 2: Create a New YAML File
+### <i class="codicon codicon-file-add"></i> Step 2 — Create a New YAML File
 
-1.  In the **Agents** tab of the TeXRA Dashboard, click **From Template** to create a new agent YAML file in your custom agents directory.
-2.  Alternatively, click **Open Folder** to open the directory and create a `.yaml` file manually.
-3.  Choose a descriptive name using underscores and ending with `.yaml` (e.g., `literature_review_generator.yaml`).
+1. In the **Agents** tab, click **From Template** (<i class="codicon codicon-file-code"></i>) to create a new agent YAML file in your custom agents directory.
+2. Alternatively, click **Open Folder** (<i class="codicon codicon-folder-opened"></i>) to open the directory and create a `.yaml` file manually.
+3. Choose a descriptive name using underscores and ending with `.yaml` (e.g. `literature_review_generator.yaml`).
 
-### Step 3: Define the Agent
+### <i class="codicon codicon-edit"></i> Step 3 — Define the Agent
 
 Open the newly created `.yaml` file and you'll find a starter template already inserted. Customize it to define your agent's structure. Here are the key fields:
 
@@ -108,7 +108,7 @@ prompts:
 > prompts. If a run requests more reflections than the list provides, the first
 > reflection template is reused.
 
-#### Using Variables in Prompts (Jinja2 Templating)
+#### <i class="codicon codicon-symbol-variable"></i> Using Variables in Prompts (Jinja2 Templating)
 
 Prompts are processed using the Jinja2 templating engine, allowing you to insert dynamic information using `{{ variable_name }}` syntax. TeXRA provides several built-in variables based on the files and instructions you select in the UI:
 
@@ -165,37 +165,37 @@ userPrefix: |
 
 **Key Considerations:**
 
-- **Architecture Overview:** For a high-level understanding of the execution flow and how prompts/settings interact, see the [Agent Architecture & Execution Flow](./agent-architecture.md) guide.
-- **Inheritance:** Inheriting from a relevant built-in agent (like `correct` or `polish`) can save significant effort. Only define the settings and prompts you need to change.
-- **Multiple Outputs:** If your agent needs to generate multiple distinct files, ensure your prompts generate the required XML structure. See the [Handling Multiple Files](./multiple-output.md) guide.
-- **Start Simple:** Begin with basic settings/prompts and add complexity incrementally.
-- **Test Iteratively:** Test frequently and review logs in the ProgressBoard.
+- <i class="codicon codicon-symbol-structure"></i> **Architecture Overview:** For a high-level understanding of the execution flow and how prompts/settings interact, see the [Agent Architecture & Execution Flow](./agent-architecture.md) guide.
+- <i class="codicon codicon-type-hierarchy"></i> **Inheritance:** Inheriting from a relevant built-in agent (like `correct` or `polish`) can save significant effort. Only define the settings and prompts you need to change.
+- <i class="codicon codicon-files"></i> **Multiple Outputs:** If your agent needs to generate multiple distinct files, ensure your prompts generate the required XML structure. See the [Handling Multiple Files](./multiple-output.md) guide.
+- <i class="codicon codicon-rocket"></i> **Start Simple:** Begin with basic settings/prompts and add complexity incrementally.
+- <i class="codicon codicon-debug-alt"></i> **Test Iteratively:** Test frequently and review logs in the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>).
 
-### Chaining Agents Together
+### <i class="codicon codicon-link"></i> Chaining Agents Together
 
 After a workflow agent finishes, TeXRA captures the output so follow-up steps can reuse it without another trip through the file picker. This is how multi-stage pipelines work—for example, an orchestrator agent can run a `polish` step, then automatically hand the result to a `correct` step, all in a single session.
 
 You don't need to configure this yourself; it happens automatically when an agent definition includes orchestration prompts. See the reference agents for working examples.
 
-### Tool-Use Agents
+### <i class="codicon codicon-tools"></i> Tool-Use Agents
 
-Tool-use agents are interactive: instead of producing a single polished file, they hold a conversation and take actions on your behalf—reading and editing files, searching the web, looking up papers, and more.
+Tool-use agents are interactive: instead of producing a single polished file, they hold a conversation and take actions on your behalf — reading and editing files, searching the web, looking up papers, and more.
 
-**Typical user story:** You're writing up results for a conference submission and realize you need three new BibTeX entries, a TikZ architecture diagram, and a consistency pass across four `.tex` files. Rather than switching between browser tabs and terminal windows, you open a `research` agent and describe what you need. The agent reads your project, searches arXiv for the missing references, drafts the TikZ code, and edits the files—all in one session.
+**Typical user story:** You're writing up results for a conference submission and realise you need three new BibTeX entries, a TikZ architecture diagram, and a consistency pass across four `.tex` files. Rather than juggling browser tabs and terminal windows, you open a `research` agent (<i class="codicon codicon-sparkle"></i>) and describe what you need. The agent reads your project, searches arXiv for the missing references, drafts the TikZ code, and edits the files — all in one session.
 
-To create your own tool-use agent, set `agentCategory: toolUse` and list the tools you want to grant. TeXRA provides tools in several categories:
+To create your own tool-use agent, set `agentCategory: toolUse` and list the tools you want to grant. TeXRA groups tools by category (matching **Dashboard → Tools** <i class="codicon codicon-tools"></i>):
 
-| Category           | What it lets the agent do                                   |
-| ------------------ | ----------------------------------------------------------- |
-| **File workspace** | Read, write, edit, search, and list files in your project   |
-| **Shell**          | Run commands (compilation, scripts, etc.)                   |
-| **Web & search**   | Fetch web pages and search the internet                     |
-| **Literature**     | Search arXiv, Crossref, and manage your Zotero library      |
-| **Math**           | Run Wolfram Language computations                           |
-| **Figures**        | Extract and compile figures and TikZ diagrams               |
-| **Memory & tasks** | Remember context across sessions; track multi-step progress |
+| Category                                                               | What it lets the agent do                                                      | Example tool names                                           |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| <i class="codicon codicon-files"></i> **File & Shell**                 | Read, write, edit, search, list, and run commands in your project              | `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `ls`, `bash` |
+| <i class="codicon codicon-file-code"></i> **LaTeX**                    | Extract figures, TikZ, and bibliography; report compile diagnostics            | `extract_figures`, `extract_tikz_figures`, `extract_bib_entries`, `diagnostics`, `texcount` |
+| <i class="codicon codicon-mortar-board"></i> **Academic Research**     | Search arXiv and Crossref, resolve DOIs, manage Zotero                         | `arxiv_search`, `arxiv_metadata`, `download_arxiv_source`, `crossref_doi`, `crossref_search`, `zotero_*` |
+| <i class="codicon codicon-globe"></i> **Web**                          | Fetch pages and search the internet                                            | `web_search`, `web_fetch`                                    |
+| <i class="codicon codicon-symbol-operator"></i> **Computation**        | Run Wolfram Language, delegate to Codex, consult another chat model            | `wolfram`, `codex`, `external_inquiry`                       |
+| <i class="codicon codicon-beaker"></i> **Lean 4**                      | Check Lean proofs and search Mathlib                                           | `lean_diagnostics`, `lean_inspect`, `lean_loogle`, `lean_file`, `lean_project` |
+| <i class="codicon codicon-type-hierarchy"></i> **Memory & Workflow**   | Persistent memory, to-do lists, sub-agent delegation                           | `memory`, `todo_write`, `plan`, `delegate_workflow`, `delegate_agent`, `executions`, `accept_run_files` |
 
-For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `research`, `search`, or `ask`) in the **Agents** tab—their `tools:` array shows exactly which tools are available.
+For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `research`, `search`, `ask`, or `code`) in the **Agents** tab — their `tools:` array shows exactly which tools are wired up.
 
 Example skeleton:
 
@@ -211,9 +211,9 @@ settings:
     - web_search
 ```
 
-The ProgressBoard logs every tool call and its result, so you can always see what the agent is doing.
+The ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>) logs every tool call and its result, so you can always see what the agent is doing.
 
-### Example: Multiple Output Agent
+### <i class="codicon codicon-files"></i> Example: Multiple Output Agent
 
 If your workflow requires several output files, your agent must structure its
 response using the `OUTPUT_FILES_ORDER` variable. Below is a simplified template
@@ -253,14 +253,14 @@ This structure lets TeXRA save each `<document>` block to the corresponding
 filename from the UI list. See [Handling Multiple Files](./multiple-output.md)
 for more details.
 
-### Step 4: Save and Reload
+### <i class="codicon codicon-save"></i> Step 4 — Save and Reload
 
-1.  Save your `.yaml` file.
-2.  Reload the VS Code window (Command Palette > `Developer: Reload Window`).
-3.  Your new custom agent should now appear in the "Agent" dropdown menu in the TeXRA UI.
+1. Save your `.yaml` file.
+2. Reload the VS Code window (Command Palette → `Developer: Reload Window`).
+3. Your new custom agent should now appear in the **Agent** dropdown (<i class="codicon codicon-sparkle"></i>) of the TeXRA UI.
 
-### Strict XML Extraction
+### <i class="codicon codicon-shield"></i> Strict XML Extraction
 
-TeXRA expects the model's output to use properly closed XML tags. For agents producing multiple files, each `<document>` block must include a `name` attribute matching one of the filenames from the UI. If tags are mismatched or a filename doesn't match, extraction fails and no files are saved—check the ProgressBoard logs for details.
+TeXRA expects the model's output to use properly closed XML tags. For agents producing multiple files, each `<document>` block must include a `name` attribute matching one of the filenames from the UI. If tags are mismatched or a filename doesn't match, extraction fails and no files are saved — check the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>) logs for details.
 
-For more examples and advanced options, browse the built-in agent definitions through the **Agents** tab in the TeXRA Dashboard.
+For more examples and advanced options, browse the built-in agent definitions through the **Agents** tab (<i class="codicon codicon-sparkle"></i>) in the TeXRA Dashboard.

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -25,7 +25,7 @@ TeXRA uses formatters to keep LaTeX code consistent and readable.
 - **`latexindent`** — the default formatter; highly configurable
 - **`tex-fmt`** — a faster alternative with simpler configuration
 
-Formatting runs automatically after agent execution and is also available via the Command Palette (`Ctrl+Shift+P`) → **TeXRA: Format Document**.
+Formatting runs automatically after agent execution and is also available via the Command Palette (`Ctrl+Shift+P`) → **TeXRA: Indent Current TeX** (or **Indent All LaTeX Files** for the whole workspace).
 
 **Configuration:** Formatter selection and installation live on the **LaTeX** tab (<i class="codicon codicon-file-code"></i>) of the TeXRA Dashboard. See [Configuration](./configuration.md#latex-configuration) for the full set of settings.
 
@@ -73,7 +73,7 @@ The `extract_figures` tool finds `\includegraphics` references and returns the i
 
 The `extract_tikz_figures` tool discovers `tikzpicture` environments, compiles them to standalone PDFs, and returns the rendered output.
 
-**Requirements (all checked on the Tools dashboard):**
+**Requirements (all checked on Dashboard → Tools):**
 
 - `latexmk` (preferred) or `pdflatex`
 - `GraphicsMagick` or `ImageMagick` for conversion

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -1,108 +1,115 @@
 # LaTeX Tools
 
-TeXRA doesn't just send text to an AI and hope for the best. It plugs into battle-tested LaTeX tools so formatting, diffing, and figure extraction are handled by the right software—not by a language model guessing at syntax.
+TeXRA doesn't just send text to an AI and hope for the best. It plugs into battle-tested LaTeX tools so formatting, diffing, figure extraction, and citation lookup are handled by the right software — not by a language model guessing at syntax.
 
 ## Overview
 
-| What it does            | Tool behind the scenes     |
-| ----------------------- | -------------------------- |
-| Code formatting         | `latexindent` or `tex-fmt` |
-| Version comparison      | `latexdiff`                |
-| Document statistics     | `texcount`                 |
-| Figure extraction       | Built-in                   |
-| TikZ compilation        | Built-in                   |
-| Bibliography resolution | Built-in                   |
+| What it does                                                         | Tool behind the scenes     |
+| -------------------------------------------------------------------- | -------------------------- |
+| <i class="codicon codicon-symbol-keyword"></i> Code formatting       | `latexindent` or `tex-fmt` |
+| <i class="codicon codicon-diff-single"></i> Version comparison       | `latexdiff`                |
+| <i class="codicon codicon-symbol-numeric"></i> Document statistics   | `texcount`                 |
+| <i class="codicon codicon-file-media"></i> Figure extraction         | Built-in                   |
+| <i class="codicon codicon-symbol-structure"></i> TikZ compilation    | Built-in                   |
+| <i class="codicon codicon-book"></i> Bibliography resolution         | Built-in                   |
+| <i class="codicon codicon-symbol-operator"></i> Symbolic math        | `wolfram`                  |
 
-## Formatting Tools
+All are configured from **Dashboard → Tools** (<i class="codicon codicon-tools"></i>) or **Dashboard → LaTeX** (<i class="codicon codicon-file-code"></i>). Missing dependencies show <i class="codicon codicon-warning"></i> **Not Found**; ready ones show <i class="codicon codicon-check"></i> **Available**.
 
-TeXRA uses formatters to ensure consistent, readable LaTeX code.
+## <i class="codicon codicon-symbol-keyword"></i> Formatting Tools
+
+TeXRA uses formatters to keep LaTeX code consistent and readable.
 
 **Supported formatters:**
 
-- **latexindent** - The default formatter, highly configurable
-- **tex-fmt** - A faster alternative with simpler configuration
+- **`latexindent`** — the default formatter; highly configurable
+- **`tex-fmt`** — a faster alternative with simpler configuration
 
-Formatting runs automatically after agent execution and is available via the `TeXRA: Format Document` command.
+Formatting runs automatically after agent execution and is also available via the Command Palette (`Ctrl+Shift+P`) → **TeXRA: Format Document**.
 
-**Configuration:** See [VS Code Settings](./configuration.md#latex-configuration) for formatter selection and options.
+**Configuration:** Formatter selection and installation live on the **LaTeX** tab (<i class="codicon codicon-file-code"></i>) of the TeXRA Dashboard. See [Configuration](./configuration.md#latex-configuration) for the full set of settings.
 
-## Version Comparison with latexdiff
+## <i class="codicon codicon-diff-single"></i> Version Comparison with `latexdiff`
 
-The `latexdiff` tool visualizes changes between document versions, generating a PDF with additions and deletions clearly marked. TeXRA can automatically generate diffs after agent runs.
+`latexdiff` visualises changes between two versions of a document, producing a PDF with additions and deletions clearly marked. TeXRA can generate diffs automatically after an agent runs.
 
 **Usage:**
 
-- After an agent modifies your document, a diff PDF shows exactly what changed
-- Use `latexdiff-vc` to compare against git history
+- After an agent modifies your document, a diff PDF shows exactly what changed.
+- Use `latexdiff-vc` to compare the current file against a git commit — pick the commit from the <i class="codicon codicon-git-commit"></i> **Commit** dropdown.
 
-**Configuration:** See the [LaTeX Diff guide](./latex-diff.md) for detailed setup and options.
+See the [LaTeX Diff guide](./latex-diff.md) for the full workflow.
 
-## Document Statistics with texcount
+## <i class="codicon codicon-symbol-numeric"></i> Document Statistics with `texcount`
 
-`texcount` provides document statistics including word counts, heading counts, and math element counts. This information helps the LLM understand document scale and structure.
+`texcount` reports word counts, heading counts, and math element counts so the LLM can reason about document scale and structure.
 
-**Enabling texcount:**
+**Enabling `texcount`:**
 
-1. **For context:** Enable "Attach TeX Count" in the Tool Configuration dropdown (see [File Management](./file-management.md#tool-config-dropdown))
-2. **As a tool:** Tool-use agents can invoke `texcount` directly to analyze files on demand
+1. **For context:** toggle <i class="codicon codicon-symbol-numeric"></i> **Attach TeX Count** in the Tool Configuration dropdown — see [File Management](./file-management.md#tool-config-dropdown).
+2. **As a tool:** tool-use agents can invoke `texcount` directly to analyse files on demand.
 
 **Modes:**
 
-- `separate` (default) - Count each file independently
-- `include` - Follow `\input{}`/`\include{}` directives from the main file
-- `sum` - Aggregate totals across multiple top-level files
+- `separate` (default) — count each file independently
+- `include` — follow `\input{}` / `\include{}` directives from the main file
+- `sum` — aggregate totals across multiple top-level files
 
 ::: warning Requirement
-Ensure `texcount` is in your system's PATH. It's typically included with TeX distributions.
+`texcount` must be on your `PATH`. It ships with most TeX distributions. Check **Dashboard → Tools** (<i class="codicon codicon-tools"></i>) → **LaTeX** — if the card shows <i class="codicon codicon-warning"></i> Not Found, install it with your TeX package manager.
 :::
 
-## Figure Extraction
+## <i class="codicon codicon-file-media"></i> Figure Extraction
 
-TeXRA extracts and processes figures for AI analysis.
+TeXRA extracts figures from your LaTeX so vision-capable models can "see" them.
 
 ### Standard Figures
 
-The `extract_figures` tool finds figure references (`\includegraphics`) and returns the images as attachments, allowing the LLM to "see" your figures.
+The `extract_figures` tool finds `\includegraphics` references and returns the images as attachments.
 
-**Auto-extraction:** Enable "Auto Extract Figures" in the UI to automatically include figures in prompts. See [Working with Figures](./working-with-figures.md).
+**Auto-extraction:** toggle <i class="codicon codicon-wand"></i> **Auto Extract → Figures** in the main UI to include figures in every prompt automatically. See [Working with Figures](./working-with-figures.md).
 
 ### TikZ Figures
 
-The `extract_tikz_figures` tool discovers TikZ environments, compiles them to standalone PDFs, and returns the rendered output.
+The `extract_tikz_figures` tool discovers `tikzpicture` environments, compiles them to standalone PDFs, and returns the rendered output.
 
-**Requirements:**
+**Requirements (all checked on the Tools dashboard):**
 
 - `latexmk` (preferred) or `pdflatex`
-- `GraphicsMagick` or `ImageMagick` (for conversion)
-- `Ghostscript` (for PDF processing)
+- `GraphicsMagick` or `ImageMagick` for conversion
+- `Ghostscript` for PDF processing
 
-See the [TikZ Figures guide](./tikz-figures.md) for detailed workflows and the [Installation guide](./installation.md) for dependency setup.
+See the [TikZ Figures guide](./tikz-figures.md) for workflows and the [Installation guide](./installation.md) for dependency setup.
 
-## Bibliography Extraction
+## <i class="codicon codicon-book"></i> Bibliography Extraction
 
-The `extract_bib_entries` tool resolves bibliography context for your LaTeX document:
+The `extract_bib_entries` tool resolves citation context for your LaTeX document:
 
 1. Finds `\bibliography{}` and `\addbibresource{}` directives
 2. Loads the referenced `.bib` files
 3. Returns BibTeX entries for every cited key
 
-This is useful when the agent needs exact citation records to edit, format, or validate references.
+Useful whenever an agent needs exact citation records to edit, format, or validate references.
 
-## Symbolic Math with Wolfram
+## <i class="codicon codicon-symbol-operator"></i> Symbolic Math with Wolfram
 
-The `wolfram` tool executes Wolfram Language code through `wolframscript`, letting agents verify calculations or perform symbolic algebra. While not LaTeX-specific, it's particularly useful for validating mathematical content in your documents.
+The `wolfram` tool executes Wolfram Language code through `wolframscript`, letting agents verify calculations or perform symbolic algebra. While not LaTeX-specific, it's invaluable for validating mathematical content in papers and derivations.
 
-## Configuring Tool Usage
+The Wolfram card sits under **Dashboard → Tools → Computation** (<i class="codicon codicon-symbol-operator"></i>). Requires a local [Wolfram Engine](https://www.wolfram.com/engine/) install.
 
-Control how TeXRA uses tools through the UI:
+## <i class="codicon codicon-settings-gear"></i> Configuring Tool Usage
 
-- **Tool Config Dropdown:** Enable/disable helpers like "Attach TeX Count" or "Attach Diagnostics" for the current run. See [Configuration](./configuration.md#agent-execution-settings-webview-interface).
-- **Auto Extract Dropdown:** Enable/disable automatic extraction of Figures or TikZ Figures. See [Working with Figures](./working-with-figures.md).
+Control how TeXRA uses these tools from the UI:
+
+- **Tool Config Dropdown** (<i class="codicon codicon-tools"></i>): enable per-run helpers like **Attach TeX Count** (<i class="codicon codicon-symbol-numeric"></i>) or **Attach Diagnostics** (<i class="codicon codicon-tools"></i>). See [Configuration](./configuration.md#agent-execution-settings-webview-interface).
+- **Auto Extract Dropdown** (<i class="codicon codicon-wand"></i>): toggle automatic extraction of Figures or TikZ Figures. See [Working with Figures](./working-with-figures.md).
+- **Dashboard → Tools** (<i class="codicon codicon-tools"></i>): enable/disable whole tool groups, view install guides, and run one-click installers.
 
 For detailed tool settings (formatter paths, TikZ processing options, etc.), see the [Configuration guide](./configuration.md).
 
 ## Next Steps
 
-- [TikZ Figures](./tikz-figures.md) - Advanced TikZ workflows
-- [LaTeX Diff](./latex-diff.md) - Version comparison in detail
-- [Research Tools](./research-tools.md) - arXiv, Crossref, and web search
+- [TikZ Figures](./tikz-figures.md) — advanced TikZ workflows
+- [LaTeX Diff](./latex-diff.md) — version comparison in detail
+- [Research Tools](./research-tools.md) — arXiv, Crossref, Zotero, and web search
+- [Codex CLI](./codex-cli.md) — one-click Codex agent setup

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -73,7 +73,7 @@ Set `texra.bib.defaultPath` in your VS Code settings (<i class="codicon codicon-
 
 ### <i class="codicon codicon-symbol-operator"></i> Verify Math with Wolfram
 
-The `research` agent can call `wolfram` to run Wolfram Language code and check symbolic algebra, integrals, or limits before you commit them to the manuscript. Requires a local [Wolfram Engine](https://www.wolfram.com/engine/); status shows on **Dashboard → Tools → Computation**.
+The `research` agent can call `wolfram` to run Wolfram Language code and check symbolic algebra, integrals, or limits before you commit them to the manuscript. Requires a local [Wolfram Engine](https://www.wolfram.com/engine/); status shows on **Dashboard → Tools** (<i class="codicon codicon-tools"></i>) → **Computation** (<i class="codicon codicon-symbol-operator"></i>).
 
 ### <i class="codicon codicon-comment-discussion"></i> Ask Another Model for a Second Opinion
 

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -1,21 +1,21 @@
 # Research Tools
 
-You're deep in a manuscript and realize you need to cite "that attention paper from 2017" but can't remember the exact title. Or you want to verify that an integral in your appendix is correct. Or you need to pull twenty BibTeX entries from your Zotero library into a new project. TeXRA's research agents handle all of this without leaving VS Code.
+You're deep in a manuscript and realise you need to cite "that attention paper from 2017" but can't remember the title. Or you want to verify an integral in your appendix. Or you need to pull twenty BibTeX entries from your Zotero library into a new project. TeXRA's research agents handle all of this without leaving VS Code.
 
 ## What You Can Do
 
-### Find Papers
+### <i class="codicon codicon-mortar-board"></i> Find Papers
 
-Ask any research agent to search for papers. TeXRA searches **arXiv** (preprints) and **Crossref** (published works) automatically:
+Ask any research agent to search for papers. TeXRA queries **arXiv** (preprints) and **Crossref** (published works) automatically:
 
 ```
 Find recent papers on transformer architectures for document understanding.
 Focus on work from 2023-2024 that handles mathematical equations.
 ```
 
-**User story:** A postdoc is writing a related-work section for a NeurIPS submission. She opens the `search` agent and asks for papers on "efficient self-attention for long documents." In seconds she has a table of relevant arXiv preprints with titles, authors, and abstracts—ready to cite.
+**User story:** A postdoc is writing the related-work section of a NeurIPS submission. She opens the `search` agent (<i class="codicon codicon-sparkle"></i>) and asks for papers on "efficient self-attention for long documents." In seconds she has a table of relevant arXiv preprints with titles, authors, and abstracts — ready to cite.
 
-### Look Up Citations
+### <i class="codicon codicon-link"></i> Look Up Citations
 
 Give a DOI or arXiv ID to get full bibliographic details:
 
@@ -27,7 +27,9 @@ Get the citation info for arxiv:2401.12345
 Look up DOI 10.1038/nature12373
 ```
 
-### Download Paper Sources
+Behind the scenes this calls the `arxiv_metadata` and `crossref_doi` tools.
+
+### <i class="codicon codicon-cloud-download"></i> Download Paper Sources
 
 For deeper analysis, ask to download the LaTeX source of a paper:
 
@@ -35,7 +37,9 @@ For deeper analysis, ask to download the LaTeX source of a paper:
 Download the source files for arxiv:2401.12345 so I can see how they made their figures.
 ```
 
-### Search the Web
+This uses the `download_arxiv_source` tool and lands the files in your workspace.
+
+### <i class="codicon codicon-globe"></i> Search the Web
 
 For documentation, project pages, or general info:
 
@@ -43,9 +47,11 @@ For documentation, project pages, or general info:
 Find the official PyTorch documentation for attention mechanisms.
 ```
 
-### Manage References with Zotero
+The `web_search` tool prefers the active provider's native search (Anthropic, OpenAI, Gemini) and falls back to DuckDuckGo Instant Answers. `web_fetch` retrieves a specific URL and extracts its main content.
 
-If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Just make sure Zotero is running when you use these features.
+### <i class="codicon codicon-book"></i> Manage References with Zotero
+
+If you use [Zotero](https://www.zotero.org/) with the [Better BibTeX](https://retorque.re/zotero-better-bibtex/) plugin, TeXRA can search, export, and add items to your library directly. Make sure Zotero is running while you use these features — check status on **Dashboard → Tools** (<i class="codicon codicon-tools"></i>) → **Academic Research** (<i class="codicon codicon-mortar-board"></i>).
 
 ```
 Search my Zotero library for papers by Vaswani on attention mechanisms.
@@ -59,17 +65,33 @@ Export the selected Zotero items as a .bib file for my project.
 Add this arXiv paper to my Zotero library.
 ```
 
-**User story:** A PhD student is collecting references for a thesis chapter. She asks the `search` agent to find key papers on graph neural networks, then says "add these to my Zotero and export them to `references.bib`." The agent handles the lookup, adds entries to her Zotero library, and writes the BibTeX file—all in one conversation.
+**User story:** A PhD student is collecting references for a thesis chapter. She asks the `search` agent to find key papers on graph neural networks, then says "add these to my Zotero and export them to `references.bib`." The agent handles the lookup, adds entries to her Zotero library, and writes the BibTeX file — all in one conversation.
 
 ::: tip Default Bibliography Path
-Set `texra.bib.defaultPath` in your VS Code settings to specify where Zotero exports land by default, so agents always know where to save bibliography entries.
+Set `texra.bib.defaultPath` in your VS Code settings (<i class="codicon codicon-gear"></i>) to specify where Zotero exports land by default, so agents always know where to save bibliography entries.
 :::
+
+### <i class="codicon codicon-symbol-operator"></i> Verify Math with Wolfram
+
+The `research` agent can call `wolfram` to run Wolfram Language code and check symbolic algebra, integrals, or limits before you commit them to the manuscript. Requires a local [Wolfram Engine](https://www.wolfram.com/engine/); status shows on **Dashboard → Tools → Computation**.
+
+### <i class="codicon codicon-comment-discussion"></i> Ask Another Model for a Second Opinion
+
+The `external_inquiry` tool lets a TeXRA agent paste a question to an external chat (ChatGPT, Claude, Gemini) via a copy/paste hand-off so you can bring a second opinion into the loop without switching windows. No API key required — uses your existing subscription.
 
 ## Which Agent to Use
 
-| Agent      | Best for                                                  |
-| ---------- | --------------------------------------------------------- |
-| `search`   | Finding papers, literature reviews, fact-checking         |
-| `research` | Computational verification with Wolfram and literature    |
-| `discuss`  | Brainstorming research directions with literature context |
-| `ask`      | Quick lookups about your documents and related work       |
+| Agent        | Best for                                                       |
+| ------------ | -------------------------------------------------------------- |
+| `search`     | Finding papers, literature reviews, fact-checking              |
+| `research`   | Computational verification with Wolfram and literature lookups |
+| `discuss`    | Brainstorming research directions with literature context      |
+| `ask`        | Quick lookups about your documents and related work            |
+
+Pick any of them from the **Agent** dropdown (<i class="codicon codicon-sparkle"></i>). Check `Dashboard → Agents` (<i class="codicon codicon-sparkle"></i>) to see exactly which tools each one has enabled.
+
+## Next Steps
+
+- [LaTeX Tools](./latex-tools.md) — formatting, diffs, texcount, figures, bibliography
+- [Codex CLI](./codex-cli.md) — delegate long-running code tasks to OpenAI Codex
+- [Working with Figures](./working-with-figures.md) — feed figures and PDFs to vision models

--- a/docs/guide/tikz-figures.md
+++ b/docs/guide/tikz-figures.md
@@ -1,16 +1,16 @@
 # Working with TikZ Figures
 
-[TikZ](https://github.com/pgf-tikz/pgf) is a powerful LaTeX package for creating vector graphics programmatically. It's widely used in academia for diagrams, plots, and technical illustrations due to its high quality and seamless LaTeX integration. While mastering TikZ can feel like learning a new language, TeXRA is here to help!
+[TikZ](https://github.com/pgf-tikz/pgf) is a powerful LaTeX package for creating vector graphics programmatically. It's widely used in academia for diagrams, plots, and technical illustrations because of its high quality and seamless LaTeX integration. Mastering TikZ can feel like learning a new language — TeXRA is here to help.
 
-TeXRA offers specialized features for working with TikZ, leveraging the `draw` agent and specific extraction/compilation tools. This guide focuses on TikZ-specific workflows.
+TeXRA offers specialised features for TikZ, built around the `draw` agent (<i class="codicon codicon-sparkle"></i>) and dedicated extraction / compilation tools. This guide focuses on TikZ-specific workflows.
 
 ::: tip General Media Handling
-For information on managing other types of figures (like standard images or PDFs) and general media selection in the UI, see the [Working with Figures](./working-with-figures.md) guide.
+For managing other figure types (standard images, PDFs) and general media selection in the UI, see the [Working with Figures](./working-with-figures.md) guide.
 :::
 
-## What is TikZ? (A Brief Intro)
+## <i class="codicon codicon-info"></i> What is TikZ? (A Brief Intro)
 
-Instead of using a graphical editor, TikZ lets you describe graphics using commands within your LaTeX document. For example:
+Instead of using a graphical editor, TikZ lets you describe graphics with commands inside your LaTeX document. For example:
 
 ```latex
 \documentclass[tikz, border=2mm]{standalone}
@@ -25,25 +25,23 @@ Instead of using a graphical editor, TikZ lets you describe graphics using comma
 
 This code draws a blue circle with text inside. TeXRA's tools help manage and generate this kind of code.
 
-## The `draw` Agent
+## <i class="codicon codicon-sparkle"></i> The `draw` Agent
 
-TeXRA's `draw` agent is specifically designed to work with TikZ figures (think of it as your AI graphics assistant). It can:
+TeXRA's `draw` agent is designed specifically for TikZ figures — think of it as your AI graphics assistant. It can:
 
-1. **Create new TikZ figures** based on textual descriptions.
-2. **Enhance existing figures** with improvements or additions.
-3. **Fix errors** or issues in TikZ code.
-4. **Add annotations** or labels to diagrams.
+1. <i class="codicon codicon-add"></i> **Create new TikZ figures** from a textual description.
+2. <i class="codicon codicon-edit"></i> **Enhance existing figures** with improvements or additions.
+3. <i class="codicon codicon-wrench"></i> **Fix errors** in TikZ code.
+4. <i class="codicon codicon-comment"></i> **Add annotations** or labels to diagrams.
 
 ![TikZ Figure Example](/images/tikz-figure-example.png)
 
 ### Creating New Figures
 
-To create a new TikZ figure:
-
-1. Select the agent: `draw`
-2. Choose a model (Models like `sonnet46T`, `opus46T`, or `gemini31p` are often good choices for complex drawing tasks).
-3. Provide a detailed description of the desired figure
-4. Execute the agent
+1. Select the agent: `draw` (<i class="codicon codicon-sparkle"></i>).
+2. Pick a model (<i class="codicon codicon-robot"></i>) — `sonnet46T`, `opus46T`, `gpt54`, or `gemini31p` are good choices for complex drawings.
+3. Provide a detailed description of the figure you want.
+4. Click Execute (<i class="codicon codicon-play"></i>).
 
 **Example instruction:**
 
@@ -56,55 +54,50 @@ Connect the steps with arrows and add appropriate labels.
 
 ### Enhancing Existing Figures
 
-To enhance an existing figure:
-
-1. Select the input file containing the TikZ code
-2. Select the `draw` agent
-3. Provide instructions for the desired improvements
-4. Execute the agent
+1. Select the input file (<i class="codicon codicon-file-code"></i>) containing the TikZ code.
+2. Select the `draw` agent.
+3. Provide instructions for the desired improvements.
+4. Execute (<i class="codicon codicon-play"></i>).
 
 **Example instruction:**
 
 ```
-
 Enhance the existing TikZ figure to add color coding for different components.
 Use blue for input components, green for processing steps, and red for output.
 Add a legend explaining the color scheme and improve the layout for better readability.
 ```
 
-## TikZ Extraction
+## <i class="codicon codicon-file-submodule"></i> TikZ Extraction
 
-TeXRA can automatically extract TikZ figures from your LaTeX documents for separate processing and management.
+TeXRA can pull TikZ figures out of your LaTeX source for separate processing.
 
 ### Automatic Extraction
 
-To enable automatic TikZ extraction:
-
-1. Click on the "Auto Extract" dropdown near the Figure selection
-2. Enable "TikZ Figures"
-3. Select your input file(s)
-4. Execute your chosen agent
+1. Open the **Auto Extract** dropdown (<i class="codicon codicon-wand"></i>) next to the Media selector.
+2. Enable **TikZ Figures**.
+3. Select your input file(s) (<i class="codicon codicon-file-code"></i>).
+4. Execute your chosen agent (<i class="codicon codicon-play"></i>).
 
 When automatic extraction is enabled, TeXRA will:
 
-1. Scan your LaTeX documents for TikZ environments
-2. Extract each figure as a separate file
-3. Compile the figures to create PNG previews
-4. Make both the TikZ code and previews available to the agent
+1. <i class="codicon codicon-search"></i> Scan your LaTeX documents for `tikzpicture` environments.
+2. <i class="codicon codicon-file-add"></i> Extract each figure as a separate file.
+3. <i class="codicon codicon-output"></i> Compile the figures to generate PNG previews.
+4. <i class="codicon codicon-eye"></i> Make both the TikZ code and previews available to the agent.
 
 ### Manual Extraction Commands
 
-You can also extract TikZ figures manually using VSCode commands:
+You can also extract TikZ figures from the Command Palette:
 
-1. Open a LaTeX file containing TikZ figures
-2. Open the Command Palette (Ctrl+Shift+P or Cmd+Shift+P on macOS)
-3. Run "TeXRA: Extract TikZ Figures from Current File"
+1. Open a LaTeX file containing TikZ figures.
+2. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
+3. Run **TeXRA: Extract TikZ Figures from Current File**.
 
-This will create standalone files for each TikZ figure in your document.
+This creates standalone files for each TikZ figure in your document.
 
 ### Agent Tool Calls
 
-Tool-use agents can invoke `extract_tikz_figures` to perform the same discovery and, optionally, compilation steps programmatically. Pass a payload such as:
+Tool-use agents can invoke `extract_tikz_figures` to perform the same discovery and optional compilation steps programmatically:
 
 ```json
 {
@@ -116,74 +109,72 @@ Tool-use agents can invoke `extract_tikz_figures` to perform the same discovery 
 }
 ```
 
-When `compile` is `true`, the tool produces standalone PDFs (one per TikZ figure) and attaches them to the result so models like Anthropic Claude or the OpenAI Responses API can receive the binary output directly. Set `compile` to `false` if you only need a summary of labels or plan to modify the extracted TikZ code yourself.
+With `compile: true` the tool emits standalone PDFs (one per figure) and attaches them so multimodal models can read the binary output directly. Set `compile: false` if you only need a summary of labels or plan to edit the extracted TikZ code yourself.
 
-## TikZ Compilation
+## <i class="codicon codicon-play-circle"></i> TikZ Compilation
 
-Once extracted, TikZ figures can be compiled into viewable images:
+Once extracted, TikZ figures can be compiled into viewable images.
 
 ### Automatic Compilation
 
-When using the automatic extraction feature, TeXRA will:
+With automatic extraction on, TeXRA will:
 
-1. Create a standalone LaTeX document for each TikZ figure
-2. Compile it using your LaTeX distribution
-3. Convert the resulting PDF to PNG for viewing
+1. Create a standalone LaTeX document per TikZ figure.
+2. Compile it with your LaTeX distribution (`latexmk`/`pdflatex`).
+3. Convert the PDF to PNG for preview via GraphicsMagick / ImageMagick + Ghostscript.
+
+Missing system dependencies show <i class="codicon codicon-warning"></i> on **Dashboard → LaTeX** (<i class="codicon codicon-file-code"></i>).
 
 ### Manual Compilation
 
-You can manually compile extracted figures:
+1. Open the Command Palette (`Ctrl+Shift+P`).
+2. Run **TeXRA: Compile TikZ Figures from Current File**.
 
-1. Open the Command Palette
-2. Run "TeXRA: Compile TikZ Figures from Current File"
+This compiles all extracted figures and generates preview images.
 
-This will compile all extracted figures and generate preview images.
+## <i class="codicon codicon-settings-gear"></i> Customising TikZ Processing
 
-## Customizing TikZ Processing
-
-You can customize how TeXRA handles TikZ figures through several settings:
+Several settings tune how TeXRA handles TikZ. Access them through **Dashboard → LaTeX** (<i class="codicon codicon-file-code"></i>) or VS Code Settings (<i class="codicon codicon-gear"></i>).
 
 ### TikZ Template
 
-The TikZ template determines the standalone document structure used for extracted figures:
+The standalone document structure TeXRA uses for each extracted figure:
 
 ```json
 "texra.latex.tikzTemplate": "\\documentclass[tikz,border=10pt]{standalone}\n\\usepackage{tikz}\n\\usepackage{pgfplots}\n\\usetikzlibrary{positioning}\n\\usetikzlibrary{patterns}\n\\usetikzlibrary{arrows.meta, shapes.geometric, matrix, calc, decorations.pathreplacing}\n\\usetikzlibrary{shapes, arrows}\n\n\\begin{document}\n{{ tikzpicture }}\n\\end{document}"
 ```
 
-Customize this template to include additional packages or settings required by your figures.
+Customise this template to include additional packages or settings your figures need.
 
 ### TikZ Input Directory
 
-If your TikZ figures depend on custom styles or macros, you can specify an input directory:
+If your TikZ figures depend on custom styles or macros, specify an input directory:
 
 ```json
 "texra.latex.tikzInputDirectory": "/path/to/tikz/inputs"
 ```
 
-This directory will be added to the LaTeX search path when compiling figures.
+The directory is added to the LaTeX search path when compiling figures.
 
-### Including Workspace in TEXINPUTS
+### Including Workspace in `TEXINPUTS`
 
-By default, TeXRA includes your workspace root in the TEXINPUTS environment variable:
+By default TeXRA adds your workspace root to `TEXINPUTS`:
 
 ```json
 "texra.latex.includeWorkspaceInTexinputs": true
 ```
 
-This helps LaTeX find packages and styles located elsewhere in your project.
+This helps LaTeX locate packages and styles stored elsewhere in the project.
 
-## Figure Libraries
+## <i class="codicon codicon-library"></i> Figure Libraries
 
-The `draw` agent can utilize existing figures as references when creating new ones.
+The `draw` agent can reuse existing figures as references when creating new ones.
 
 ### Using Reference Figures
 
-To leverage existing figures as references:
-
-1. Add previous TikZ figures as reference files
-2. Mention them specifically in your instructions
-3. Ask the agent to adopt similar styles or approaches
+1. Add previous TikZ figures to the **Reference** section (<i class="codicon codicon-book"></i>).
+2. Mention them explicitly in your instructions.
+3. Ask the agent to adopt similar styles or approaches.
 
 **Example instruction:**
 
@@ -193,65 +184,55 @@ the reference file, but add an attention mechanism between the encoder and decod
 Maintain the same visual style and color scheme as the reference figure.
 ```
 
-## Troubleshooting TikZ Issues
+## <i class="codicon codicon-debug"></i> Troubleshooting TikZ Issues
 
-### Compilation Errors
+### <i class="codicon codicon-error"></i> Compilation Errors
 
-If TikZ figures fail to compile:
+1. Check the LaTeX log for specific error messages (build directory).
+2. Verify required TikZ libraries are in the template.
+3. Ensure your LaTeX distribution has the necessary packages.
+4. Simplify complex figures that might exceed compiler limits.
 
-1. Check the LaTeX log for specific error messages (look in the build directory)
-2. Verify that all required TikZ libraries are included in the template
-3. Ensure your LaTeX distribution has the necessary packages
-4. Try simplifying complex figures that might exceed compiler limits
+### <i class="codicon codicon-package"></i> Missing Packages
 
-### Missing Packages
+1. Install the required packages through your LaTeX distribution manager.
+2. Add the packages to your TikZ template.
+3. Ensure package paths are in `TEXINPUTS`.
 
-If compilation fails due to missing packages:
+### <i class="codicon codicon-symbol-ruler"></i> Figure Size Issues
 
-1. Install the required packages through your LaTeX distribution manager
-2. Add the packages to your TikZ template
-3. Ensure package paths are correctly included in TEXINPUTS
+1. Adjust the `border` parameter in the standalone document class.
+2. Scale the figure using TikZ's `scale` option.
+3. Resize specific elements rather than the entire figure.
 
-### Figure Size Issues
-
-For figures that are too large or small:
-
-1. Adjust the `border` parameter in the standalone document class
-2. Scale the figure using TikZ's `scale` option
-3. Resize specific elements rather than the entire figure
-
-## Best Practices
+## <i class="codicon codicon-lightbulb"></i> Best Practices
 
 ### Effective TikZ Instructions
 
-For best results with the `draw` agent:
+For best results with `draw`:
 
-1. **Be Specific**: Clearly describe all elements and their relationships
-2. **Provide Context**: Include the purpose and intended audience
-3. **Specify Style**: Mention colors, line styles, and text formatting
-4. **Reference Examples**: Point to similar figures when possible
+1. <i class="codicon codicon-target"></i> **Be specific** — describe all elements and their relationships.
+2. <i class="codicon codicon-info"></i> **Provide context** — include purpose and intended audience.
+3. <i class="codicon codicon-symbol-color"></i> **Specify style** — mention colours, line styles, text formatting.
+4. <i class="codicon codicon-link"></i> **Reference examples** — point to similar figures when possible.
 
-### Figure Organization
+### Figure Organisation
 
-Organize your TikZ figures effectively:
-
-1. Use consistent naming conventions for figures
-2. Store extracted figures in a dedicated directory
-3. Include comments in TikZ code explaining complex parts
-4. Maintain a library of reusable figure components
+1. Use consistent naming conventions for figures.
+2. Store extracted figures in a dedicated directory.
+3. Include comments in TikZ code explaining complex parts.
+4. Maintain a library of reusable figure components.
 
 ### Performance Considerations
 
 TikZ compilation can be resource-intensive:
 
-1. Split very complex figures into multiple smaller ones
-2. Use the `external` library for caching compiled figures
-3. Consider simplified versions for drafts and detailed versions for final documents
+1. Split very complex figures into multiple smaller ones.
+2. Use the `external` library for caching compiled figures.
+3. Keep simplified versions for drafts; full detail for finals.
 
 ## Next Steps
 
-Now that you understand how to work with TikZ figures in TeXRA, you may want to learn about:
-
-- [LaTeX Diff](/guide/latex-diff) - Learn how to compare document versions including figures
-- [Tool Integration](/guide/tool-integration) - Discover other tools TeXRA integrates with
-- [Best Practices](/guide/best-practices) - Learn general best practices for working with TeXRA
+- [LaTeX Diff](./latex-diff.md) — compare document versions including figures
+- [LaTeX Tools](./latex-tools.md) — the full set of LaTeX tools TeXRA plugs into
+- [Best Practices](./best-practices.md) — general tips for working with TeXRA

--- a/docs/guide/working-with-figures.md
+++ b/docs/guide/working-with-figures.md
@@ -1,58 +1,60 @@
 # Working with Figures
 
-TeXRA allows AI agents to analyze, reference, and generate figures within your documents.
+TeXRA lets AI agents analyse, reference, and generate figures inside your documents — from `.png` screenshots to embedded TikZ diagrams and PDFs.
 
-## Quick Task: Add a Figure Caption
+## <i class="codicon codicon-rocket"></i> Quick Task: Add a Figure Caption
 
-1. Select the `polish` agent from the dropdown
-2. Choose a vision-capable model (e.g., `gemini25p`, `gpt4o`)
-3. Select your figure in the **Media** section
-4. Enter instruction: "Write a detailed caption for this figure"
-5. Click Execute
+1. Select the `polish` agent from the agent dropdown (<i class="codicon codicon-sparkle"></i>).
+2. Pick a vision-capable model (<i class="codicon codicon-robot"></i>) — e.g. `gpt54`, `sonnet46`, `gemini31p`.
+3. Select your figure in the **Media** (<i class="codicon codicon-file-media"></i>) section.
+4. Type the instruction: "Write a detailed caption for this figure."
+5. Click Execute (<i class="codicon codicon-play"></i>).
 
-## The Media Section
+## <i class="codicon codicon-file-media"></i> The Media Section
 
-The main TeXRA panel includes a "Media" section for managing figure files:
+The main TeXRA panel includes a **Media** section for figure files:
 
-- **Dropdown**: Select a primary media file
-- **Multiple Toggle**: Expand to select multiple files
-- **Auto Extract Dropdown**: Configure automatic figure extraction
+- **Dropdown** (<i class="codicon codicon-file-media"></i>): pick a primary media file from the workspace.
+- **Multiple Toggle** (<i class="codicon codicon-list-unordered"></i>): expand to select multiple files.
+- **Auto Extract Dropdown** (<i class="codicon codicon-wand"></i>): configure automatic figure extraction.
+- **Current Button** (<i class="codicon codicon-file-code"></i>): select the figure currently open in the editor.
+- **Empty Button** (<i class="codicon codicon-close"></i>): clear the selection.
 
-## Supported File Types
+## <i class="codicon codicon-file-symlink-file"></i> Supported File Types
 
 Configurable via `texra.files.included.mediaExtensions`:
 
 - **Images**: `.png`, `.jpeg`, `.jpg`, `.gif`, `.heic`, `.heif`, `.webp`
-- **Documents**: `.pdf` (native or converted to images)
+- **Documents**: `.pdf` (native on Anthropic/Gemini/OpenAI, otherwise rasterised)
 - **Audio** (experimental): `.wav`, `.m4a`, `.mp3`, `.aiff`, `.aac`, `.ogg`, `.flac`
 
-PDFs are processed natively when supported (Anthropic/Gemini/OpenAI). Otherwise, TeXRA uses GraphicsMagick/ImageMagick + Ghostscript for conversion.
+PDFs use native multimodal support when the provider offers it. Otherwise TeXRA converts them via GraphicsMagick / ImageMagick + Ghostscript — status for those system dependencies lives on **Dashboard → LaTeX** (<i class="codicon codicon-file-code"></i>).
 
-## Clipboard Images
+## <i class="codicon codicon-clippy"></i> Clipboard Images
 
 Paste images directly into the instruction area:
 
-1. Copy any image to clipboard
-2. Paste with Ctrl/Cmd+V
-3. Image is saved and referenced as `[pasted_timestamp_hash.ext]`
-4. Media Files list updates automatically
+1. Copy any image to the clipboard.
+2. Paste with `Ctrl/Cmd+V`.
+3. The image is saved and referenced as `[pasted_timestamp_hash.ext]`.
+4. The **Media Files** list (<i class="codicon codicon-file-media"></i>) updates automatically.
 
 Pasted images are stored temporarily and cleaned up after 3 days.
 
-## Automatic Figure Extraction
+## <i class="codicon codicon-wand"></i> Automatic Figure Extraction
 
-Enable via the Auto-extract dropdown near the Media label:
+Enable via the **Auto Extract** dropdown (<i class="codicon codicon-wand"></i>) near the Media label:
 
-- **Figures**: Extracts images from `\includegraphics` commands
-- **TikZ Figures**: Extracts `tikzpicture` environments as `.tikz` files
+- **Figures** (<i class="codicon codicon-file-media"></i>): extracts images from `\includegraphics` commands.
+- **TikZ Figures** (<i class="codicon codicon-symbol-structure"></i>): extracts `tikzpicture` environments as `.tikz` files and compiles them.
 
-## Figure Extraction Tools
+## <i class="codicon codicon-tools"></i> Figure Extraction Tools
 
-Tool-use agents can extract figures programmatically:
+Tool-use agents can extract figures programmatically. These are part of the **LaTeX Extraction** built-in tool group — always available.
 
 ### `extract_figures`
 
-Scans for `\includegraphics` and returns referenced files (max 20 attachments):
+Scans for `\includegraphics` and returns referenced files (up to 20 attachments):
 
 ```json
 {
@@ -63,7 +65,7 @@ Scans for `\includegraphics` and returns referenced files (max 20 attachments):
 
 ### `extract_tikz_figures`
 
-Extracts and optionally compiles TikZ environments (max 12 PDFs):
+Extracts and optionally compiles `tikzpicture` environments (up to 12 PDFs):
 
 ```json
 {
@@ -72,23 +74,25 @@ Extracts and optionally compiles TikZ environments (max 12 PDFs):
 }
 ```
 
+Setting `compile: true` runs `latexmk`/`pdflatex` on each snippet and attaches the resulting PDFs so multimodal models can read them directly.
+
 ### `extract_bib_entries`
 
-Retrieves BibTeX records for citations.
+Retrieves BibTeX records for every citation key found in the document.
 
-## Using Media Files
+## <i class="codicon codicon-eye"></i> Using Media Files with Models
 
-When you provide media files:
+When you provide media files, they're handed to the model according to its capabilities:
 
-- **Vision models** (GPT-4o, Gemini): Images are encoded and included with the prompt
-- **Audio models**: Audio files are uploaded for transcription
-- **Non-multimodal models**: Filenames provide context
+- **Vision models** (GPT-5.4, Claude 4.6 Sonnet/Opus, Gemini 3.1 Pro, …): images are encoded and attached to the prompt.
+- **Audio models**: audio files are uploaded for transcription.
+- **Non-multimodal models**: only filenames are passed as context.
 
 Common use cases:
 
-- Write captions for images (`polish` agent)
-- Verify text matches figures (`correct` agent)
-- Generate text from images/PDFs (`ocr` agent)
-- Transcribe audio (`transcribe_audio` agent)
+- <i class="codicon codicon-pencil"></i> Write captions for images (`polish` agent)
+- <i class="codicon codicon-check"></i> Verify text matches figures (`correct` agent)
+- <i class="codicon codicon-file-text"></i> Generate text from images/PDFs (`ocr` agent)
+- <i class="codicon codicon-unmute"></i> Transcribe audio (`transcribe_audio` agent)
 
 For TikZ-specific workflows, see [TikZ Figures](./tikz-figures.md).

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -84,6 +84,7 @@ export const SETTINGS_VIEW_CMD = {
   INSTALL_TOOL_EXTENSION: 'installToolExtension',
   RECHECK_TOOL_STATUS: 'recheckToolStatus',
   TOGGLE_TOOL: 'toggleTool',
+  RUN_TOOL_COMMAND: 'runToolCommand',
   // Git settings commands
   GET_GIT_AUTHOR_SETTINGS: 'getGitAuthorSettings',
   SET_GIT_MARK_COMMITS: 'setGitMarkCommits',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -97,7 +97,7 @@ import {
   parseCodexSandboxMode,
   parseCodexReasoningEffort,
 } from '@tools/codexConfig';
-import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
   MEMORY_STORAGE_ROOT,
   MAX_PINNED_MEMORIES,
@@ -535,7 +535,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private handleRunToolCommand(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.RUN_TOOL_COMMAND>,
   ): void {
-    const def = EXTERNAL_TOOL_DEFS.find((d) => d.id === data.toolId);
+    const def = findExternalToolDef(data.toolId);
     const command =
       data.kind === 'install' ? def?.installCommand : def?.authCommand;
     if (!command) {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -97,6 +97,7 @@ import {
   parseCodexSandboxMode,
   parseCodexReasoningEffort,
 } from '@tools/codexConfig';
+import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import {
   MEMORY_STORAGE_ROOT,
   MAX_PINNED_MEMORIES,
@@ -526,7 +527,26 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           this.sendToolDashboardData(w, { skipChecks: true }),
         );
       },
+      [SETTINGS_VIEW_COMMANDS.RUN_TOOL_COMMAND]: (data) =>
+        this.handleRunToolCommand(data),
     };
+  }
+
+  private handleRunToolCommand(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.RUN_TOOL_COMMAND>,
+  ): void {
+    const def = EXTERNAL_TOOL_DEFS.find((d) => d.id === data.toolId);
+    const command =
+      data.kind === 'install' ? def?.installCommand : def?.authCommand;
+    if (!command) {
+      this.logger.debug(this.channel, 'No command for tool', { data });
+      return;
+    }
+    const terminal = vscode.window.createTerminal({
+      name: `TeXRA: ${def?.name ?? data.toolId}`,
+    });
+    terminal.show();
+    terminal.sendText(command);
   }
 
   public override async handleMessage(

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -607,6 +607,10 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleToolToggle = forwardDetail(SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL);
 
+  private handleToolRunCommand = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.RUN_TOOL_COMMAND,
+  );
+
   // Approval settings event handlers
   private handleBashApprovalToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED,
@@ -850,6 +854,7 @@ export class SettingsApp extends SettingsAppBase {
               .codexReasoningEffort=${this.codexReasoningEffort.get()}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
+              @tool-run-command=${this.handleToolRunCommand}
               @tool-recheck=${this.handleToolRecheck}
               @tool-toggle=${this.handleToolToggle}
               @bash-approval-toggle=${this.handleBashApprovalToggle}

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -12,7 +12,10 @@ import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared schemas
 import { createEvent } from '@shared/utils/events';
-import type { ToolDashboardItem } from '@shared/schemas/settingsViewMessages';
+import type {
+  ToolCommandKind,
+  ToolDashboardItem,
+} from '@shared/schemas/settingsViewMessages';
 
 @customElement('tool-card')
 export class ToolCard extends LitElement {
@@ -248,7 +251,7 @@ export class ToolCard extends LitElement {
 
   @state() private guideExpanded = false;
 
-  /** Auto-expand the guide once when the tool lands in a not-found state. */
+  /** Reveal the install buttons immediately when a tool first reports missing. */
   override willUpdate(changed: Map<string, unknown>): void {
     if (!changed.has('item')) return;
     const prev = changed.get('item') as ToolDashboardItem | undefined;
@@ -279,23 +282,14 @@ export class ToolCard extends LitElement {
     }
   }
 
-  private handleRunInstallCommand(): void {
+  private runCommand(kind: ToolCommandKind): void {
     this.dispatchEvent(
-      createEvent('tool-run-command', {
-        toolId: this.item.id,
-        kind: 'install',
-      }),
+      createEvent('tool-run-command', { toolId: this.item.id, kind }),
     );
   }
 
-  private handleRunAuthCommand(): void {
-    this.dispatchEvent(
-      createEvent('tool-run-command', {
-        toolId: this.item.id,
-        kind: 'auth',
-      }),
-    );
-  }
+  private handleRunInstallCommand = (): void => this.runCommand('install');
+  private handleRunAuthCommand = (): void => this.runCommand('auth');
 
   private handleToggle(e: Event): void {
     const target = e.currentTarget as HTMLInputElement | null;
@@ -347,9 +341,6 @@ export class ToolCard extends LitElement {
       this.item.authCommand;
     if (!hasGuide) return nothing;
 
-    const primaryAction =
-      this.item.installExtensionId || this.item.installCommand;
-
     return html`
       <button class="tool-guide-toggle" @click=${this.toggleGuide}>
         <span
@@ -380,7 +371,8 @@ export class ToolCard extends LitElement {
               ${this.item.authCommand
                 ? html`
                     <button
-                      class="tool-action-btn ${primaryAction
+                      class="tool-action-btn ${this.item.installCommand ||
+                      this.item.installExtensionId
                         ? 'tool-action-btn--secondary'
                         : ''}"
                       @click=${this.handleRunAuthCommand}

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -248,6 +248,15 @@ export class ToolCard extends LitElement {
 
   @state() private guideExpanded = false;
 
+  /** Auto-expand the guide once when the tool lands in a not-found state. */
+  override willUpdate(changed: Map<string, unknown>): void {
+    if (!changed.has('item')) return;
+    const prev = changed.get('item') as ToolDashboardItem | undefined;
+    if (prev?.status !== 'not-found' && this.item.status === 'not-found') {
+      this.guideExpanded = true;
+    }
+  }
+
   private toggleGuide(): void {
     this.guideExpanded = !this.guideExpanded;
   }
@@ -268,6 +277,24 @@ export class ToolCard extends LitElement {
         }),
       );
     }
+  }
+
+  private handleRunInstallCommand(): void {
+    this.dispatchEvent(
+      createEvent('tool-run-command', {
+        toolId: this.item.id,
+        kind: 'install',
+      }),
+    );
+  }
+
+  private handleRunAuthCommand(): void {
+    this.dispatchEvent(
+      createEvent('tool-run-command', {
+        toolId: this.item.id,
+        kind: 'auth',
+      }),
+    );
   }
 
   private handleToggle(e: Event): void {
@@ -313,8 +340,15 @@ export class ToolCard extends LitElement {
   private renderGuide(): TemplateResult | typeof nothing {
     if (!this.item.requiresSetup) return nothing;
 
-    const hasGuide = this.item.installGuide || this.item.installUrl;
+    const hasGuide =
+      this.item.installGuide ||
+      this.item.installUrl ||
+      this.item.installCommand ||
+      this.item.authCommand;
     if (!hasGuide) return nothing;
+
+    const primaryAction =
+      this.item.installExtensionId || this.item.installCommand;
 
     return html`
       <button class="tool-guide-toggle" @click=${this.toggleGuide}>
@@ -327,8 +361,36 @@ export class ToolCard extends LitElement {
       </button>
       ${this.guideExpanded
         ? html`
-            <div class="tool-guide">${this.item.installGuide}</div>
+            ${this.item.installGuide
+              ? html`<div class="tool-guide">${this.item.installGuide}</div>`
+              : nothing}
             <div class="tool-guide-actions">
+              ${this.item.installCommand
+                ? html`
+                    <button
+                      class="tool-action-btn"
+                      @click=${this.handleRunInstallCommand}
+                      title=${this.item.installCommand}
+                    >
+                      <span class="codicon codicon-terminal"></span>
+                      Install in Terminal
+                    </button>
+                  `
+                : nothing}
+              ${this.item.authCommand
+                ? html`
+                    <button
+                      class="tool-action-btn ${primaryAction
+                        ? 'tool-action-btn--secondary'
+                        : ''}"
+                      @click=${this.handleRunAuthCommand}
+                      title=${this.item.authCommand}
+                    >
+                      <span class="codicon codicon-sign-in"></span>
+                      Sign in
+                    </button>
+                  `
+                : nothing}
               ${this.item.installExtensionId
                 ? html`
                     <button
@@ -343,9 +405,7 @@ export class ToolCard extends LitElement {
               ${this.item.installUrl
                 ? html`
                     <button
-                      class="tool-action-btn ${this.item.installExtensionId
-                        ? 'tool-action-btn--secondary'
-                        : ''}"
+                      class="tool-action-btn tool-action-btn--secondary"
                       @click=${this.handleInstallUrl}
                     >
                       <span class="codicon codicon-link-external"></span>

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -288,8 +288,13 @@ export class ToolCard extends LitElement {
     );
   }
 
-  private handleRunInstallCommand = (): void => this.runCommand('install');
-  private handleRunAuthCommand = (): void => this.runCommand('auth');
+  private handleRunInstallCommand(): void {
+    this.runCommand('install');
+  }
+
+  private handleRunAuthCommand(): void {
+    this.runCommand('auth');
+  }
 
   private handleToggle(e: Event): void {
     const target = e.currentTarget as HTMLInputElement | null;

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -11,7 +11,7 @@ import type {
   ToolDashboardItem,
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
-import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
+import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
   getDefaultToolRegistry,
   type RegisteredToolName,
@@ -167,7 +167,7 @@ export async function buildToolDashboardItems(
     ? (lastDetailResults ?? results.map(() => undefined))
     : await Promise.all(
         results.map(async ({ id }) => {
-          const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
+          const def = findExternalToolDef(id);
           if (!def?.detailCheck) return undefined;
           try {
             return await def.detailCheck();
@@ -178,12 +178,11 @@ export async function buildToolDashboardItems(
       );
   lastDetailResults = detailResults;
 
-  // Merge check results with UI metadata from EXTERNAL_TOOL_DEFS
   const disabledIds = getDisabledToolIds();
   const externalItems: ToolDashboardItem[] = [];
   for (let i = 0; i < results.length; i++) {
     const { id, tools, status } = results[i];
-    const def = EXTERNAL_TOOL_DEFS.find((c) => c.id === id);
+    const def = findExternalToolDef(id);
     if (!def || def.hideFromDashboard) continue;
     externalItems.push({
       id: def.id,

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -196,6 +196,8 @@ export async function buildToolDashboardItems(
       installGuide: def.installGuide,
       installUrl: def.installUrl,
       installExtensionId: def.installExtensionId,
+      installCommand: def.installCommand,
+      authCommand: def.authCommand,
       configNotes: def.configNotes,
       statusDetail: detailResults[i],
       authNote: def.authNote,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -273,6 +273,8 @@ export const ToolDashboardItemSchema = z.object({
   installGuide: z.string().optional(),
   installUrl: z.string().optional(),
   installExtensionId: z.string().optional(),
+  installCommand: z.string().optional(),
+  authCommand: z.string().optional(),
   configNotes: z.string().optional(),
   statusDetail: z.string().optional(),
   authNote: z.string().optional(),
@@ -601,6 +603,12 @@ const ToggleToolMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+const RunToolCommandMessageSchema = z.object({
+  command: z.literal(CMD.RUN_TOOL_COMMAND),
+  toolId: z.string().min(1),
+  kind: z.enum(['install', 'auth']),
+});
+
 // Git author settings inbound messages
 const GetGitAuthorSettingsMessageSchema = commandOnly(
   CMD.GET_GIT_AUTHOR_SETTINGS,
@@ -676,6 +684,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     InstallToolExtensionMessageSchema,
     RecheckToolStatusMessageSchema,
     ToggleToolMessageSchema,
+    RunToolCommandMessageSchema,
     // LaTeX settings messages
     GetLatexSettingsStatusMessageSchema,
     ApplyLatexSettingsMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -608,6 +608,9 @@ const RunToolCommandMessageSchema = z.object({
   toolId: z.string().min(1),
   kind: z.enum(['install', 'auth']),
 });
+export type ToolCommandKind = z.infer<
+  typeof RunToolCommandMessageSchema
+>['kind'];
 
 // Git author settings inbound messages
 const GetGitAuthorSettingsMessageSchema = commandOnly(

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -298,3 +298,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
   // System dependencies (latexindent, image processing) have moved to the
   // LaTeX settings tab — see LaTeXTab.ts and SettingsViewMessageHandler.ts.
 ];
+
+/** Look up a tool definition by id. */
+export function findExternalToolDef(id: string): ExternalToolDef | undefined {
+  return EXTERNAL_TOOL_DEFS.find((d) => d.id === id);
+}

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -16,10 +16,10 @@ import axios from 'axios';
 
 // Local imports
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
+import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 import type { RegisteredToolName } from '@tools/registry';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { checkToolInstalled } from '@utils/system/toolUtils';
-import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 import { isWSL } from '@utils/system/wslDetect';
 
 const LEAN4_EXT_ID = 'leanprover.lean4';
@@ -59,6 +59,10 @@ export interface ExternalToolDef {
   readonly installUrl?: string;
   /** VS Code extension ID — when present, the dashboard offers a direct "Install" button. */
   readonly installExtensionId?: string;
+  /** Shell command the dashboard can run in an integrated terminal to install the tool. */
+  readonly installCommand?: string;
+  /** Shell command the dashboard can run to sign the user in (e.g. `codex login`). */
+  readonly authCommand?: string;
   readonly configNotes?: string;
   /** When true, the tool is checked for availability but not shown in the Tools tab dashboard. */
   readonly hideFromDashboard?: boolean;
@@ -243,6 +247,8 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  • codex login        — sign in with ChatGPT account (recommended)\n' +
       '  • OPENAI_API_KEY     — environment variable with API key',
     installUrl: 'https://github.com/openai/codex',
+    installCommand: 'npm install -g @openai/codex',
+    authCommand: 'codex login',
     configNotes:
       'Requires @openai/codex npm package with platform binaries. Used by @openai/codex-sdk. ' +
       'Supports OAuth via `codex login` or OPENAI_API_KEY env var.',


### PR DESCRIPTION
Covers installing the Codex CLI (npm / brew / WSL), authenticating via
`codex login` or OPENAI_API_KEY, verifying the connection from
Dashboard → Tools, and the sandbox mode, reasoning effort, and approval
settings TeXRA exposes. Adds the page to the Integrations sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new webview command path that spawns an integrated terminal and runs predefined install/auth shell commands, which can impact user environments if misconfigured. Most other changes are documentation-only.
> 
> **Overview**
> Adds a new `RUN_TOOL_COMMAND` message/command that lets the Settings Tools dashboard trigger predefined external-tool `installCommand`/`authCommand` actions by opening an integrated terminal and sending the command.
> 
> Extends external tool definitions and tool dashboard item schema to carry these commands (including Codex’s `npm install -g @openai/codex` and `codex login`), updates the Tool card UI to show **Install in Terminal** / **Sign in** buttons (auto-expanding when a tool becomes *Not Found*).
> 
> Documentation updates add a new `Codex CLI` guide page and link it in the sidebar, plus various guide touch-ups to reflect the dashboard-driven setup flow and tool categories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43cf44f06e6747bef63f52508156e7fa6145ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->