### PR TITLE
Improve Anthropic streaming error reliability

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -36,6 +36,7 @@ import {
   getSdkErrorMessage,
   isContextWindowError,
   attachStreamDiagnostics,
+  attachPartialText,
 } from '@common/errors/sdkErrorUtils';
 
 // Local imports - replacement
@@ -857,6 +858,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
         const baseUrl = this.getBaseUrl();
         const isUsingRelay = this.shouldUseServerSideKeys();
         const diagnostics = streamHandler.getDiagnostics();
+        const partialText = streamHandler.getPartialText();
 
         // Enrich error with request ID from stream response headers so
         // detectRequestId() (in sdkErrorUtils) picks it up via the existing
@@ -875,21 +877,58 @@ export class ModelHandlerAnthropic extends ModelHandler<
           // Response may not be available (e.g. network error before HTTP response)
         }
 
-        this.logger.debug(
-          `Stream failed: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
+        // Enrich the "stream ended without producing a Message with role=assistant"
+        // SDK error — it's raised when the connection closes before any
+        // message_start event. Mirror the messageStop validation above with a
+        // message that carries diagnostics, so logs and retry UI surface the
+        // actual timing rather than the opaque SDK string.
+        let enrichedError: unknown = streamError;
+        if (
+          !diagnostics.messageStartReceived &&
+          streamError instanceof Error &&
+          !(streamError instanceof AnthropicUserAbortError)
+        ) {
+          const wrapper = new Error(
+            `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
+              `(${diagnostics.eventsProcessed} events${
+                streamHandler.wasSseErrorReceived()
+                  ? ', SSE error event received'
+                  : ''
+              }). Likely connection dropped before the API responded.`,
+            { cause: streamError },
+          );
+          // Preserve the request_id so downstream detection still works
+          const originalRequestId = (streamError as ErrorWithRequestId)
+            .request_id;
+          if (originalRequestId) {
+            (wrapper as ErrorWithRequestId).request_id = originalRequestId;
+          }
+          enrichedError = wrapper;
+        }
+
+        // User aborts are expected control flow, not failures — log at debug.
+        // Everything else warrants a warning so silent proxy drops are visible.
+        const isAbort = streamError instanceof AnthropicUserAbortError;
+        const logFn = isAbort ? this.logger.debug : this.logger.warn;
+        logFn.call(
+          this.logger,
+          `Stream ${isAbort ? 'aborted' : 'failed'}: ${enrichedError instanceof Error ? enrichedError.message : String(enrichedError)}`,
           {
             data: {
               isUsingRelay,
               baseUrl: baseUrl ?? 'default',
               model: this.config.fullName,
               streamDiagnostics: diagnostics,
+              partialTextLength: partialText.length,
             },
           },
         );
 
-        // Attach diagnostics to error for retry UI display
-        attachStreamDiagnostics(streamError, diagnostics);
-        throw streamError;
+        // Attach diagnostics and partial text to the error for retry UI display
+        // and future continuation-on-retry support.
+        attachStreamDiagnostics(enrichedError, diagnostics);
+        attachPartialText(enrichedError, partialText);
+        throw enrichedError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error
         streamHandler.finalize();

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -38,6 +38,9 @@ import {
   isContextWindowError,
   attachStreamDiagnostics,
   attachPartialText,
+  takeTail,
+  isUserAbort,
+  PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 
 // Local imports - replacement
@@ -163,9 +166,7 @@ function extractPartialTextTail(
     )
     .map((block) => block.text)
     .join('');
-  return text.length <= maxChars
-    ? text
-    : text.slice(text.length - maxChars);
+  return takeTail(text, maxChars);
 }
 
 /** Type guard for any thinking-related content block param */
@@ -866,9 +867,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         this.processThinkingBlock(response);
       } catch (streamError) {
         const diagnostics = streamHandler.getDiagnostics();
-        // 4KB is enough for a "continue from [tail]" prompt and UI display,
-        // and keeps error payloads small enough for webview messaging.
-        const partialText = extractPartialTextTail(stream.currentMessage, 4096);
+        const partialText = extractPartialTextTail(
+          stream.currentMessage,
+          PARTIAL_TEXT_TAIL_MAX,
+        );
         const requestId = stream.request_id;
 
         // Wrap only non-APIError stream failures. APIError subclasses carry
@@ -895,7 +897,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (enrichedError as ErrorWithRequestId).request_id = requestId;
         }
 
-        const isAbort = streamError instanceof AnthropicUserAbortError;
+        const isAbort = isUserAbort(streamError);
         const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}: ${enrichedError instanceof Error ? enrichedError.message : String(enrichedError)}`;
         const logData = {
           data: {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -851,15 +851,9 @@ export class ModelHandlerAnthropic extends ModelHandler<
               `Stream truncated, likely proxy idle timeout during extended thinking.`,
           );
           attachStreamDiagnostics(truncatedError, diagnostics);
-          this.logger.warn(
-            'Stream truncated: response received without message_stop',
-            {
-              data: {
-                model: this.config.fullName,
-                streamDiagnostics: diagnostics,
-              },
-            },
-          );
+          // The catch block below will log this at warn with full diagnostics
+          // in the log data — no inner log here, otherwise one truncation
+          // event produces two warn entries.
           throw truncatedError;
         }
 

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -146,15 +146,15 @@ interface UploadedAnthropicAttachment {
 type ErrorWithRequestId = Error & { request_id?: string };
 
 /**
- * Extracts the tail of text content from a (possibly partial) BetaMessage,
- * concatenating all text blocks and capping at maxChars by keeping the
- * suffix — which is what a continuation prompt references.
- * The SDK's stream.currentMessage exposes exactly the accumulated state
- * we need, so no custom buffering is required.
+ * Extracts the tail of text content from a (possibly partial) BetaMessage.
+ * The SDK's stream.currentMessage accumulates all content blocks as they
+ * arrive, so on a stream failure this already holds whatever text was
+ * generated — no custom buffering required. Returns the suffix because
+ * continuation prompts only reference the last few hundred chars.
  */
-function extractPartialText(
+function extractPartialTextTail(
   message: BetaMessage | undefined,
-  maxChars = 65536,
+  maxChars: number,
 ): string {
   if (!message?.content) return '';
   const text = message.content
@@ -865,30 +865,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } catch (streamError) {
-        const baseUrl = this.getBaseUrl();
-        const isUsingRelay = this.shouldUseServerSideKeys();
         const diagnostics = streamHandler.getDiagnostics();
-        // Native SDK primitives: stream.currentMessage holds whatever the SDK
-        // accumulated before the error (undefined if no message_start arrived),
-        // and stream.request_id exposes the response header synchronously — no
-        // need to await stream.response or parse headers ourselves.
-        const partialText = extractPartialText(stream.currentMessage);
+        // 4KB is enough for a "continue from [tail]" prompt and UI display,
+        // and keeps error payloads small enough for webview messaging.
+        const partialText = extractPartialTextTail(stream.currentMessage, 4096);
         const requestId = stream.request_id;
         if (requestId && streamError instanceof Error) {
           (streamError as ErrorWithRequestId).request_id = requestId;
         }
 
-        // Enrich the "stream ended without producing a Message with role=assistant"
-        // SDK error — it's raised when the connection closes before any
-        // message_start event. Mirror the messageStop validation above with a
-        // message that carries diagnostics, so logs and retry UI surface the
-        // actual timing rather than the opaque SDK string.
-        //
-        // Only wrap non-APIError stream failures: AnthropicAPIError instances
-        // (HTTP 4xx/5xx, rate limits, auth, connection) already carry status,
-        // headers, requestID, and body metadata that formatProviderHttpError
-        // relies on for retry classification. Replacing them with a plain
-        // Error would hide that info and misclassify e.g. 401 as generic.
+        // Wrap only non-APIError stream failures. APIError subclasses carry
+        // status/headers/requestID/type that formatProviderHttpError needs
+        // for retry classification; replacing them loses that metadata and
+        // misclassifies e.g. 401 as generic retryable.
         let enrichedError: unknown = streamError;
         if (
           !stream.currentMessage &&
@@ -907,36 +896,27 @@ export class ModelHandlerAnthropic extends ModelHandler<
           enrichedError = wrapper;
         }
 
-        // User aborts are expected control flow, not failures — log at debug.
-        // Everything else warrants a warning so silent proxy drops are visible.
         const isAbort = streamError instanceof AnthropicUserAbortError;
-        const logFn = isAbort ? this.logger.debug : this.logger.warn;
-        logFn.call(
-          this.logger,
-          `Stream ${isAbort ? 'aborted' : 'failed'}: ${enrichedError instanceof Error ? enrichedError.message : String(enrichedError)}`,
-          {
-            data: {
-              isUsingRelay,
-              baseUrl: baseUrl ?? 'default',
-              model: this.config.fullName,
-              streamDiagnostics: diagnostics,
-              partialTextLength: partialText.length,
-            },
+        const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}: ${enrichedError instanceof Error ? enrichedError.message : String(enrichedError)}`;
+        const logData = {
+          data: {
+            isUsingRelay: this.shouldUseServerSideKeys(),
+            baseUrl: this.getBaseUrl() ?? 'default',
+            model: this.config.fullName,
+            streamDiagnostics: diagnostics,
+            partialTextLength: partialText.length,
           },
-        );
+        };
+        // Aborts are control flow, not failures. Everything else is a warn
+        // so silent proxy drops surface without debug logging enabled.
+        if (isAbort) {
+          this.logger.debug(logMessage, logData);
+        } else {
+          this.logger.warn(logMessage, logData);
+        }
 
-        // Attach diagnostics and a bounded tail of partial text to the error
-        // for retry UI display and future continuation-on-retry support.
-        // A 4KB tail is plenty for a "your response ended with [X], continue
-        // from there" prompt and for UI display, while keeping the error
-        // small enough to round-trip through webview messages without bloat.
-        const ATTACHED_PARTIAL_TEXT_MAX = 4096;
-        const attachedPartialText =
-          partialText.length > ATTACHED_PARTIAL_TEXT_MAX
-            ? partialText.slice(partialText.length - ATTACHED_PARTIAL_TEXT_MAX)
-            : partialText;
         attachStreamDiagnostics(enrichedError, diagnostics);
-        attachPartialText(enrichedError, attachedPartialText);
+        attachPartialText(enrichedError, partialText);
         throw enrichedError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -843,18 +843,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // returning truncated output.
         const diagnostics = streamHandler.getDiagnostics();
         if (!diagnostics.messageStopReceived) {
-          const truncatedError = new Error(
+          // The catch block below will read current diagnostics, attach them
+          // to the enriched error, and log at warn — no inner attach/log
+          // here, otherwise one truncation event produces two warns and
+          // two diagnostics snapshots (with drifting elapsedSecs).
+          throw new Error(
             `Stream ended without message_stop after ${diagnostics.elapsedSecs}s ` +
               `(${diagnostics.eventsProcessed} events, ` +
               `${diagnostics.thinkingChars} thinking chars, ` +
               `${diagnostics.textChars} text chars). ` +
               `Stream truncated, likely proxy idle timeout during extended thinking.`,
           );
-          attachStreamDiagnostics(truncatedError, diagnostics);
-          // The catch block below will log this at warn with full diagnostics
-          // in the log data — no inner log here, otherwise one truncation
-          // event produces two warn entries.
-          throw truncatedError;
         }
 
         // Store thinking blocks for API conversation continuation

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -5,6 +5,7 @@ import { basename } from 'node:path';
 // Third-party imports
 import {
   Anthropic,
+  APIError as AnthropicAPIError,
   APIUserAbortError as AnthropicUserAbortError,
   toFile,
 } from '@anthropic-ai/sdk';
@@ -882,11 +883,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // message_start event. Mirror the messageStop validation above with a
         // message that carries diagnostics, so logs and retry UI surface the
         // actual timing rather than the opaque SDK string.
+        //
+        // Only wrap non-APIError stream failures: AnthropicAPIError instances
+        // (HTTP 4xx/5xx, rate limits, auth, connection) already carry status,
+        // headers, requestID, and body metadata that formatProviderHttpError
+        // relies on for retry classification. Replacing them with a plain
+        // Error would hide that info and misclassify e.g. 401 as generic.
         let enrichedError: unknown = streamError;
         if (
           !stream.currentMessage &&
           streamError instanceof Error &&
-          !(streamError instanceof AnthropicUserAbortError)
+          !(streamError instanceof AnthropicAPIError)
         ) {
           const wrapper = new Error(
             `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
@@ -918,10 +925,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
           },
         );
 
-        // Attach diagnostics and partial text to the error for retry UI display
-        // and future continuation-on-retry support.
+        // Attach diagnostics and a bounded tail of partial text to the error
+        // for retry UI display and future continuation-on-retry support.
+        // A 4KB tail is plenty for a "your response ended with [X], continue
+        // from there" prompt and for UI display, while keeping the error
+        // small enough to round-trip through webview messages without bloat.
+        const ATTACHED_PARTIAL_TEXT_MAX = 4096;
+        const attachedPartialText =
+          partialText.length > ATTACHED_PARTIAL_TEXT_MAX
+            ? partialText.slice(partialText.length - ATTACHED_PARTIAL_TEXT_MAX)
+            : partialText;
         attachStreamDiagnostics(enrichedError, diagnostics);
-        attachPartialText(enrichedError, partialText);
+        attachPartialText(enrichedError, attachedPartialText);
         throw enrichedError;
       } finally {
         // Always finalize stream handler to prevent memory leaks on error

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -144,17 +144,27 @@ interface UploadedAnthropicAttachment {
 
 type ErrorWithRequestId = Error & { request_id?: string };
 
-interface StreamWithResponse {
-  response: Promise<Response>;
-}
-
-function hasHttpResponse(value: unknown): value is StreamWithResponse {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'response' in value &&
-    value.response instanceof Promise
-  );
+/**
+ * Extracts the tail of text content from a (possibly partial) BetaMessage,
+ * concatenating all text blocks and capping at maxChars by keeping the
+ * suffix — which is what a continuation prompt references.
+ * The SDK's stream.currentMessage exposes exactly the accumulated state
+ * we need, so no custom buffering is required.
+ */
+function extractPartialText(
+  message: BetaMessage | undefined,
+  maxChars = 65536,
+): string {
+  if (!message?.content) return '';
+  const text = message.content
+    .filter((block): block is Extract<BetaContentBlock, { type: 'text' }> =>
+      block.type === 'text',
+    )
+    .map((block) => block.text)
+    .join('');
+  return text.length <= maxChars
+    ? text
+    : text.slice(text.length - maxChars);
 }
 
 /** Type guard for any thinking-related content block param */
@@ -854,27 +864,17 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } catch (streamError) {
-        // Log enhanced diagnostics for stream failures, especially useful for relay debugging
         const baseUrl = this.getBaseUrl();
         const isUsingRelay = this.shouldUseServerSideKeys();
         const diagnostics = streamHandler.getDiagnostics();
-        const partialText = streamHandler.getPartialText();
-
-        // Enrich error with request ID from stream response headers so
-        // detectRequestId() (in sdkErrorUtils) picks it up via the existing
-        // ProviderError.requestId path — no duplicate field needed.
-        try {
-          if (hasHttpResponse(stream)) {
-            const httpResponse = await stream.response;
-            const reqId =
-              httpResponse.headers.get('request-id') ??
-              httpResponse.headers.get('x-request-id');
-            if (reqId && streamError instanceof Error) {
-              (streamError as ErrorWithRequestId).request_id = reqId;
-            }
-          }
-        } catch {
-          // Response may not be available (e.g. network error before HTTP response)
+        // Native SDK primitives: stream.currentMessage holds whatever the SDK
+        // accumulated before the error (undefined if no message_start arrived),
+        // and stream.request_id exposes the response header synchronously — no
+        // need to await stream.response or parse headers ourselves.
+        const partialText = extractPartialText(stream.currentMessage);
+        const requestId = stream.request_id;
+        if (requestId && streamError instanceof Error) {
+          (streamError as ErrorWithRequestId).request_id = requestId;
         }
 
         // Enrich the "stream ended without producing a Message with role=assistant"
@@ -884,24 +884,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // actual timing rather than the opaque SDK string.
         let enrichedError: unknown = streamError;
         if (
-          !diagnostics.messageStartReceived &&
+          !stream.currentMessage &&
           streamError instanceof Error &&
           !(streamError instanceof AnthropicUserAbortError)
         ) {
           const wrapper = new Error(
             `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
-              `(${diagnostics.eventsProcessed} events${
-                streamHandler.wasSseErrorReceived()
-                  ? ', SSE error event received'
-                  : ''
-              }). Likely connection dropped before the API responded.`,
+              `(${diagnostics.eventsProcessed} events). ` +
+              `Likely connection dropped before the API responded.`,
             { cause: streamError },
           );
-          // Preserve the request_id so downstream detection still works
-          const originalRequestId = (streamError as ErrorWithRequestId)
-            .request_id;
-          if (originalRequestId) {
-            (wrapper as ErrorWithRequestId).request_id = originalRequestId;
+          if (requestId) {
+            (wrapper as ErrorWithRequestId).request_id = requestId;
           }
           enrichedError = wrapper;
         }

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -870,9 +870,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // and keeps error payloads small enough for webview messaging.
         const partialText = extractPartialTextTail(stream.currentMessage, 4096);
         const requestId = stream.request_id;
-        if (requestId && streamError instanceof Error) {
-          (streamError as ErrorWithRequestId).request_id = requestId;
-        }
 
         // Wrap only non-APIError stream failures. APIError subclasses carry
         // status/headers/requestID/type that formatProviderHttpError needs
@@ -884,16 +881,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
           streamError instanceof Error &&
           !(streamError instanceof AnthropicAPIError)
         ) {
-          const wrapper = new Error(
+          enrichedError = new Error(
             `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
               `(${diagnostics.eventsProcessed} events). ` +
               `Likely connection dropped before the API responded.`,
             { cause: streamError },
           );
-          if (requestId) {
-            (wrapper as ErrorWithRequestId).request_id = requestId;
-          }
-          enrichedError = wrapper;
+        }
+
+        // detectRequestId() reads .request_id off the thrown error, so set it
+        // on whichever object we're throwing (the wrapper or the original).
+        if (requestId && enrichedError instanceof Error) {
+          (enrichedError as ErrorWithRequestId).request_id = requestId;
         }
 
         const isAbort = streamError instanceof AnthropicUserAbortError;

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -46,6 +46,8 @@ import {
   getSdkErrorMessage,
   isContextWindowError,
   attachPartialText,
+  takeTail,
+  PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -712,16 +714,15 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           `Content blocked by safety filter: ${JSON.stringify(errorWithResponse.response?.promptFeedback)}`,
         );
       }
-      // If the stream produced any text before failing, attach a 4KB tail to
-      // the error so the retry UI can show progress and future continuation
-      // logic can reference it. Google's SDK has no currentMessage accessor,
-      // so we rely on the manually accumulated buffer above.
+      // If the stream produced any text before failing, attach a tail to the
+      // error so the retry UI can show progress and future continuation logic
+      // can reference it. Google's SDK has no currentMessage accessor, so we
+      // rely on the manually accumulated buffer above.
       if (aggregatedText) {
-        const tail =
-          aggregatedText.length > 4096
-            ? aggregatedText.slice(aggregatedText.length - 4096)
-            : aggregatedText;
-        attachPartialText(error, tail);
+        attachPartialText(
+          error,
+          takeTail(aggregatedText, PARTIAL_TEXT_TAIL_MAX),
+        );
       }
       throw error;
     }

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -45,6 +45,7 @@ import { K_SLICE } from '@agent/core/constants';
 import {
   getSdkErrorMessage,
   isContextWindowError,
+  attachPartialText,
 } from '@common/errors/sdkErrorUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 
@@ -552,6 +553,10 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
     // Phase 4: EXECUTE - Make the API call
     const useStreaming = this.getStreamingConfig();
+    // Hoisted so the outer catch can attach any text produced before a
+    // mid-stream failure (Google's SDK has no currentMessage accessor, so
+    // we accumulate manually as we iterate).
+    let aggregatedText = '';
 
     try {
       this.logger.debug(
@@ -580,7 +585,6 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           | NonNullable<GenerateContentResponse['candidates']>[number]
           | undefined;
         const aggregatedParts: Part[] = [];
-        let aggregatedText = '';
         let usageFromChunks: GenerateContentResponseUsageMetadata | undefined;
 
         for await (const chunk of stream) {
@@ -707,6 +711,17 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
         this.logger.warn(
           `Content blocked by safety filter: ${JSON.stringify(errorWithResponse.response?.promptFeedback)}`,
         );
+      }
+      // If the stream produced any text before failing, attach a 4KB tail to
+      // the error so the retry UI can show progress and future continuation
+      // logic can reference it. Google's SDK has no currentMessage accessor,
+      // so we rely on the manually accumulated buffer above.
+      if (aggregatedText) {
+        const tail =
+          aggregatedText.length > 4096
+            ? aggregatedText.slice(aggregatedText.length - 4096)
+            : aggregatedText;
+        attachPartialText(error, tail);
       }
       throw error;
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import OpenAI from 'openai';
+import OpenAI, { APIUserAbortError as OpenAIUserAbortError } from 'openai';
 
 // Local imports - core utilities
 import {
@@ -35,6 +35,7 @@ import {
   getSdkErrorMessage,
   isContextWindowError,
   isMissingFinishReasonError,
+  attachPartialText,
 } from '@common/errors/sdkErrorUtils';
 
 // Local imports - tools and utils
@@ -115,6 +116,21 @@ function extractReasoningDelta(chunk: ChatCompletionChunk): string {
     | undefined;
   if (!delta || !('reasoning_content' in delta)) return '';
   return extractReasoningText(delta.reasoning_content);
+}
+
+/**
+ * Extracts a capped tail of the assistant content accumulated by the SDK's
+ * ChatCompletionStream in its currentChatCompletionSnapshot. Returns the
+ * suffix because continuation prompts reference the tail of the response.
+ */
+function extractOpenAIPartialTail(
+  snapshot: { choices?: Array<{ message?: { content?: string | null } }> } | undefined,
+  maxChars: number,
+): string {
+  const content = snapshot?.choices?.[0]?.message?.content ?? '';
+  return content.length <= maxChars
+    ? content
+    : content.slice(content.length - maxChars);
 }
 
 /**
@@ -490,6 +506,26 @@ export class ModelHandlerOpenAI<
 
       this.finalizeStreams(thinking, output, finalResponse);
       return finalResponse;
+    } catch (streamError) {
+      // On mid-stream failure, lift the partial content the SDK already
+      // accumulated (currentChatCompletionSnapshot) onto the error so the
+      // retry UI can show it and future continuation logic can reference
+      // the tail. Aborts are control flow; log at debug, skip warn.
+      const isAbort = streamError instanceof OpenAIUserAbortError;
+      const partialText = extractOpenAIPartialTail(
+        stream.currentChatCompletionSnapshot,
+        4096,
+      );
+      if (partialText) {
+        attachPartialText(streamError, partialText);
+      }
+      if (!isAbort) {
+        this.logger.warn(
+          `Stream failed: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
+          { data: { model: this.config.fullName, partialTextLength: partialText.length } },
+        );
+      }
+      throw streamError;
     } finally {
       cleanup();
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -1,5 +1,5 @@
 // Third-party imports
-import OpenAI, { APIUserAbortError as OpenAIUserAbortError } from 'openai';
+import OpenAI from 'openai';
 
 // Local imports - core utilities
 import {
@@ -36,6 +36,9 @@ import {
   isContextWindowError,
   isMissingFinishReasonError,
   attachPartialText,
+  takeTail,
+  isUserAbort,
+  PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 
 // Local imports - tools and utils
@@ -128,9 +131,7 @@ function extractOpenAIPartialTail(
   maxChars: number,
 ): string {
   const content = snapshot?.choices?.[0]?.message?.content ?? '';
-  return content.length <= maxChars
-    ? content
-    : content.slice(content.length - maxChars);
+  return takeTail(content, maxChars);
 }
 
 /**
@@ -511,15 +512,14 @@ export class ModelHandlerOpenAI<
       // accumulated (currentChatCompletionSnapshot) onto the error so the
       // retry UI can show it and future continuation logic can reference
       // the tail. Aborts are control flow; log at debug, skip warn.
-      const isAbort = streamError instanceof OpenAIUserAbortError;
       const partialText = extractOpenAIPartialTail(
         stream.currentChatCompletionSnapshot,
-        4096,
+        PARTIAL_TEXT_TAIL_MAX,
       );
       if (partialText) {
         attachPartialText(streamError, partialText);
       }
-      if (!isAbort) {
+      if (!isUserAbort(streamError)) {
         this.logger.warn(
           `Stream failed: ${streamError instanceof Error ? streamError.message : String(streamError)}`,
           { data: { model: this.config.fullName, partialTextLength: partialText.length } },

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -476,6 +476,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     }
 
     const state = this.createStreamingEventState();
+    // Accumulate text deltas so we can attach a tail to the error on reject,
+    // mirroring the HTTP streaming path. Without this, a WebSocket failure
+    // mid-response would lose any text that had already been generated.
+    let streamedText = '';
 
     return new Promise<WebSocketExecutionResult>((resolve, reject) => {
       let settled = false;
@@ -500,7 +504,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // events (including response.created) from the prior response, causing
         // the new request to resolve with the wrong response.
         this.closeWebSocket();
-        reject(new DOMException('The operation was aborted', 'AbortError'));
+        rejectWithPartial(
+          new DOMException('The operation was aborted', 'AbortError'),
+        );
       };
       signal?.addEventListener('abort', onAbort, { once: true });
 
@@ -526,6 +532,17 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         }
 
         this.processStreamingEvent(e, state);
+        if (this.isTextDeltaEvent(e)) {
+          streamedText += e.delta;
+        }
+      };
+
+      /** Attach partial-text tail to an error before rejecting with it. */
+      const rejectWithPartial = (err: unknown): void => {
+        if (streamedText) {
+          attachPartialText(err, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
+        }
+        reject(err);
       };
 
       const finalizeSuccess = (response: Response): void => {
@@ -548,7 +565,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         cleanup();
         const errorMsg =
           event.response.error?.message ?? 'Response failed without details';
-        reject(new Error(`OpenAI WebSocket response failed: ${errorMsg}`));
+        rejectWithPartial(
+          new Error(`OpenAI WebSocket response failed: ${errorMsg}`),
+        );
       };
 
       // Incomplete responses are resolved (not rejected) to match the HTTP
@@ -566,7 +585,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // The server may close the socket after sending the error, but the close event
         // fires after this handler and would be a no-op (settled=true).
         this.closeWebSocket();
-        reject(error);
+        rejectWithPartial(error);
       };
 
       // Handle unexpected socket close during a request
@@ -575,7 +594,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         settled = true;
         cleanup();
         this.closeWebSocket();
-        reject(
+        rejectWithPartial(
           new Error(
             `WebSocket closed unexpectedly (code: ${code}, reason: ${reason.toString()})`,
           ),

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -3,7 +3,11 @@ import { Buffer } from 'node:buffer';
 import * as path from 'path';
 
 // Third-party imports
-import OpenAI, { APIConnectionTimeoutError, toFile } from 'openai';
+import OpenAI, {
+  APIConnectionTimeoutError,
+  APIError as OpenAIAPIError,
+  toFile,
+} from 'openai';
 import { ResponsesWS } from 'openai/resources/responses/ws';
 import { WebSocketError } from 'openai/resources/responses/internal-base';
 
@@ -1414,10 +1418,14 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         delete content.filename;
       }
     } catch (err) {
-      // APIConnectionTimeoutError is the SDK's native timeout signal — no
-      // need for a message-substring fallback; the class check covers both
-      // client-side (SDK timeout) and server-side (408) timeout cases.
-      if (err instanceof APIConnectionTimeoutError) {
+      // Two native SDK timeout signals: APIConnectionTimeoutError (client-side
+      // SDK timeout) and APIError with status 408 (server-side Request Timeout).
+      // Status 408 is NOT mapped to APIConnectionTimeoutError by the SDK —
+      // it falls through to a bare APIError — so both must be checked.
+      const isTimeout =
+        err instanceof APIConnectionTimeoutError ||
+        (err instanceof OpenAIAPIError && err.status === 408);
+      if (isTimeout) {
         this.logger.warn(
           `Timed out uploading file ${filename}. Falling back to inline payload.`,
         );

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -23,6 +23,7 @@ import {
   isContextWindowError,
   isPreviousResponseIdError,
   isRetryableStatusCode,
+  attachPartialText,
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
@@ -1764,6 +1765,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Wrap execution in try-catch to handle previousResponseId errors
     // When an error indicates the response ID is invalid, we clear it so
     // the retry logic can recover by starting a fresh conversation.
+    //
+    // Text accumulated from `response.output_text.delta` events during
+    // streaming. Hoisted here so the catch block can surface it as
+    // partial text on mid-stream failures. ResponseStream has no native
+    // currentMessage accessor (unlike ChatCompletionStream), so we
+    // accumulate manually from the events we already iterate.
+    let streamedText = '';
     try {
       // Try to resume a pending background response (for retry after connection error)
       if (useBackgroundResponses && this.pendingBackgroundResponseId) {
@@ -1830,6 +1838,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
         for await (const event of stream) {
           this.processStreamingEvent(event, state);
+          if (event.type === 'response.output_text.delta') {
+            streamedText += event.delta;
+          }
         }
 
         let response = await stream.finalResponse();
@@ -1983,6 +1994,16 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
       // Clear diagnostic state to avoid stale comparison on retry
       this._diagPreFlightTokens = null;
+
+      // Attach a 4KB tail of any streamed text to the error so the retry UI
+      // can surface progress. No-op when nothing was streamed.
+      if (streamedText) {
+        const tail =
+          streamedText.length > 4096
+            ? streamedText.slice(streamedText.length - 4096)
+            : streamedText;
+        attachPartialText(error, tail);
+      }
 
       throw error;
     }

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -28,6 +28,8 @@ import {
   isPreviousResponseIdError,
   isRetryableStatusCode,
   attachPartialText,
+  takeTail,
+  PARTIAL_TEXT_TAIL_MAX,
 } from '@common/errors/sdkErrorUtils';
 
 // Type imports
@@ -2003,14 +2005,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // Clear diagnostic state to avoid stale comparison on retry
       this._diagPreFlightTokens = null;
 
-      // Attach a 4KB tail of any streamed text to the error so the retry UI
-      // can surface progress. No-op when nothing was streamed.
+      // Attach a capped tail of any streamed text to the error so the retry
+      // UI can surface progress. No-op when nothing was streamed.
       if (streamedText) {
-        const tail =
-          streamedText.length > 4096
-            ? streamedText.slice(streamedText.length - 4096)
-            : streamedText;
-        attachPartialText(error, tail);
+        attachPartialText(error, takeTail(streamedText, PARTIAL_TEXT_TAIL_MAX));
       }
 
       throw error;

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1413,12 +1413,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         delete content.filename;
       }
     } catch (err) {
-      const errorMessage = getSdkErrorMessage(err);
-
-      if (
-        err instanceof APIConnectionTimeoutError ||
-        errorMessage.includes('Request timed out')
-      ) {
+      // APIConnectionTimeoutError is the SDK's native timeout signal — no
+      // need for a message-substring fallback; the class check covers both
+      // client-side (SDK timeout) and server-side (408) timeout cases.
+      if (err instanceof APIConnectionTimeoutError) {
         this.logger.warn(
           `Timed out uploading file ${filename}. Falling back to inline payload.`,
         );
@@ -1426,7 +1424,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       this.logger.logError(
-        `Failed to upload file ${filename}: ${errorMessage}`,
+        `Failed to upload file ${filename}: ${getSdkErrorMessage(err)}`,
         err,
         { operation: 'upload file' },
       );

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -29,6 +29,7 @@ interface AnthropicMessageStream {
     event: 'streamEvent',
     callback: (event: BetaRawMessageStreamEvent) => void,
   ): void;
+  on(event: 'error', callback: (err: unknown) => void): void;
 }
 
 /**
@@ -36,6 +37,15 @@ interface AnthropicMessageStream {
  * Prevents memory growth for very long queries/URLs.
  */
 const MAX_SERVER_TOOL_INPUT_SIZE = 65536;
+
+/**
+ * Maximum size for the accumulated partial-text buffer (64KB).
+ * Used to preserve generated text when a stream fails mid-response,
+ * so the caller can surface it to the user or use it for continuation.
+ * When exceeded, only the tail (the last 64KB) is kept — continuation
+ * prompts only need the final few hundred chars anyway.
+ */
+const MAX_PARTIAL_TEXT_SIZE = 65536;
 
 /**
  * State tracked during Anthropic streaming.
@@ -132,6 +142,14 @@ export class AnthropicStreamHandler {
     stopReason: null,
     anthropicMessageId: null,
   };
+  /** Rolling buffer of accumulated text deltas, capped at MAX_PARTIAL_TEXT_SIZE.
+   *  Preserved across block boundaries so a continuation prompt can reference
+   *  the actual tail of generated text when a stream fails. */
+  private partialText = '';
+  /** True when an SSE `event: error` was dispatched by the SDK before the
+   *  stream promise rejected. Lets the catch path report the API-level cause
+   *  (e.g. overloaded_error) instead of a generic connection failure. */
+  private sseErrorReceived = false;
 
   constructor(
     private readonly logger: AgentLogger,
@@ -145,6 +163,14 @@ export class AnthropicStreamHandler {
   attachToStream(stream: AnthropicMessageStream): void {
     stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
       this.handleStreamEvent(event);
+    });
+    // The SDK surfaces SSE `event: error` (e.g. overloaded_error) via the
+    // 'error' channel and rejects the stream promise with the same error.
+    // We register a no-op listener so Node doesn't log an unhandled 'error'
+    // event warning, and flag it so the catch path can distinguish
+    // "API returned an error mid-stream" from "connection dropped".
+    stream.on('error', () => {
+      this.sseErrorReceived = true;
     });
   }
 
@@ -160,6 +186,25 @@ export class AnthropicStreamHandler {
    */
   getEmittedFetchIds(): Set<string> {
     return this.state.emittedFetchIds;
+  }
+
+  /**
+   * Returns the accumulated text received so far (capped at MAX_PARTIAL_TEXT_SIZE).
+   * When a stream fails mid-response, this preserves the generated content
+   * for the caller — either to show the user what was produced, or to build
+   * a continuation prompt on retry. Returns empty string if no text was received.
+   */
+  getPartialText(): string {
+    return this.partialText;
+  }
+
+  /**
+   * True if the SDK dispatched an SSE `event: error` during streaming.
+   * Distinguishes API-level errors (e.g. overloaded_error) from transport-level
+   * failures (network drops, proxy timeouts).
+   */
+  wasSseErrorReceived(): boolean {
+    return this.sseErrorReceived;
   }
 
   /**
@@ -328,6 +373,7 @@ export class AnthropicStreamHandler {
       case 'text_delta':
         this.diagnostics.textChars += event.delta.text.length;
         this.state.outputStream?.append(event.delta.text);
+        this.appendPartialText(event.delta.text);
         break;
       case 'input_json_delta':
         this.diagnostics.toolInputChars += event.delta.partial_json.length;
@@ -425,6 +471,20 @@ export class AnthropicStreamHandler {
 
     // Clean up
     this.state.pendingFetches.delete(block.tool_use_id);
+  }
+
+  /**
+   * Appends a text delta to the partial-text buffer, capped at
+   * MAX_PARTIAL_TEXT_SIZE by keeping the tail (which is what continuation
+   * prompts reference — "your response ended with [X]").
+   */
+  private appendPartialText(text: string): void {
+    if (!text) return;
+    const combined = this.partialText + text;
+    this.partialText =
+      combined.length <= MAX_PARTIAL_TEXT_SIZE
+        ? combined
+        : combined.slice(combined.length - MAX_PARTIAL_TEXT_SIZE);
   }
 
   /**

--- a/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
+++ b/src/agent/modelHandlers/support/AnthropicStreamHandler.ts
@@ -29,7 +29,6 @@ interface AnthropicMessageStream {
     event: 'streamEvent',
     callback: (event: BetaRawMessageStreamEvent) => void,
   ): void;
-  on(event: 'error', callback: (err: unknown) => void): void;
 }
 
 /**
@@ -37,15 +36,6 @@ interface AnthropicMessageStream {
  * Prevents memory growth for very long queries/URLs.
  */
 const MAX_SERVER_TOOL_INPUT_SIZE = 65536;
-
-/**
- * Maximum size for the accumulated partial-text buffer (64KB).
- * Used to preserve generated text when a stream fails mid-response,
- * so the caller can surface it to the user or use it for continuation.
- * When exceeded, only the tail (the last 64KB) is kept — continuation
- * prompts only need the final few hundred chars anyway.
- */
-const MAX_PARTIAL_TEXT_SIZE = 65536;
 
 /**
  * State tracked during Anthropic streaming.
@@ -142,14 +132,6 @@ export class AnthropicStreamHandler {
     stopReason: null,
     anthropicMessageId: null,
   };
-  /** Rolling buffer of accumulated text deltas, capped at MAX_PARTIAL_TEXT_SIZE.
-   *  Preserved across block boundaries so a continuation prompt can reference
-   *  the actual tail of generated text when a stream fails. */
-  private partialText = '';
-  /** True when an SSE `event: error` was dispatched by the SDK before the
-   *  stream promise rejected. Lets the catch path report the API-level cause
-   *  (e.g. overloaded_error) instead of a generic connection failure. */
-  private sseErrorReceived = false;
 
   constructor(
     private readonly logger: AgentLogger,
@@ -163,14 +145,6 @@ export class AnthropicStreamHandler {
   attachToStream(stream: AnthropicMessageStream): void {
     stream.on('streamEvent', (event: BetaRawMessageStreamEvent) => {
       this.handleStreamEvent(event);
-    });
-    // The SDK surfaces SSE `event: error` (e.g. overloaded_error) via the
-    // 'error' channel and rejects the stream promise with the same error.
-    // We register a no-op listener so Node doesn't log an unhandled 'error'
-    // event warning, and flag it so the catch path can distinguish
-    // "API returned an error mid-stream" from "connection dropped".
-    stream.on('error', () => {
-      this.sseErrorReceived = true;
     });
   }
 
@@ -186,25 +160,6 @@ export class AnthropicStreamHandler {
    */
   getEmittedFetchIds(): Set<string> {
     return this.state.emittedFetchIds;
-  }
-
-  /**
-   * Returns the accumulated text received so far (capped at MAX_PARTIAL_TEXT_SIZE).
-   * When a stream fails mid-response, this preserves the generated content
-   * for the caller — either to show the user what was produced, or to build
-   * a continuation prompt on retry. Returns empty string if no text was received.
-   */
-  getPartialText(): string {
-    return this.partialText;
-  }
-
-  /**
-   * True if the SDK dispatched an SSE `event: error` during streaming.
-   * Distinguishes API-level errors (e.g. overloaded_error) from transport-level
-   * failures (network drops, proxy timeouts).
-   */
-  wasSseErrorReceived(): boolean {
-    return this.sseErrorReceived;
   }
 
   /**
@@ -373,7 +328,6 @@ export class AnthropicStreamHandler {
       case 'text_delta':
         this.diagnostics.textChars += event.delta.text.length;
         this.state.outputStream?.append(event.delta.text);
-        this.appendPartialText(event.delta.text);
         break;
       case 'input_json_delta':
         this.diagnostics.toolInputChars += event.delta.partial_json.length;
@@ -471,20 +425,6 @@ export class AnthropicStreamHandler {
 
     // Clean up
     this.state.pendingFetches.delete(block.tool_use_id);
-  }
-
-  /**
-   * Appends a text delta to the partial-text buffer, capped at
-   * MAX_PARTIAL_TEXT_SIZE by keeping the tail (which is what continuation
-   * prompts reference — "your response ended with [X]").
-   */
-  private appendPartialText(text: string): void {
-    if (!text) return;
-    const combined = this.partialText + text;
-    this.partialText =
-      combined.length <= MAX_PARTIAL_TEXT_SIZE
-        ? combined
-        : combined.slice(combined.length - MAX_PARTIAL_TEXT_SIZE);
   }
 
   /**

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -329,45 +329,75 @@ function detectRawErrorBody(err: unknown): unknown {
   return undefined;
 }
 
-const STREAM_DIAGNOSTICS_KEY = Symbol.for('texra.streamDiagnostics');
-const PARTIAL_TEXT_KEY = Symbol.for('texra.partialText');
+/** Max tail size (chars) for partial text attached to streaming errors.
+ *  4KB is enough for a "continue from [tail]" prompt and UI display,
+ *  while staying well under webview message-size limits. */
+export const PARTIAL_TEXT_TAIL_MAX = 4096;
+
+/** Returns the last `maxChars` of `text`. If `text` is shorter, returns it
+ *  as-is. Used by streaming handlers to cap partial output on error. */
+export function takeTail(text: string, maxChars: number): string {
+  return text.length <= maxChars ? text : text.slice(text.length - maxChars);
+}
+
+/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+export function isUserAbort(err: unknown): boolean {
+  return (
+    err instanceof OpenAIUserAbortError ||
+    err instanceof AnthropicUserAbortError
+  );
+}
+
+/** Factory for symbol-keyed error metadata. Creates matched attach/detect
+ *  accessors that share a single Symbol.for key. The optional typeGuard
+ *  validates the value on retrieval; without it, raw retrieval is returned. */
+function createErrorMetadata<T>(
+  name: string,
+  typeGuard?: (v: unknown) => v is T,
+): {
+  attach: (err: unknown, value: T) => void;
+  detect: (err: unknown) => T | undefined;
+} {
+  const key = Symbol.for(`texra.${name}`);
+  return {
+    attach: (err, value) => {
+      if (isObject(err)) {
+        (err as Record<symbol, unknown>)[key] = value;
+      }
+    },
+    detect: (err) => {
+      if (!isObject(err)) return undefined;
+      const value = (err as Record<symbol, unknown>)[key];
+      if (typeGuard) {
+        return typeGuard(value) ? value : undefined;
+      }
+      return value as T | undefined;
+    },
+  };
+}
+
+const streamDiagnosticsMetadata = createErrorMetadata<StreamDiagnostics>(
+  'streamDiagnostics',
+  (v): v is StreamDiagnostics => isObject(v) && 'eventsProcessed' in v,
+);
 
 /** Attaches stream diagnostics to an error before rethrowing. */
-export function attachStreamDiagnostics(
-  err: unknown,
-  diagnostics: StreamDiagnostics,
-): void {
-  if (isObject(err)) {
-    (err as Record<symbol, unknown>)[STREAM_DIAGNOSTICS_KEY] = diagnostics;
-  }
-}
+export const attachStreamDiagnostics = streamDiagnosticsMetadata.attach;
+const detectStreamDiagnostics = streamDiagnosticsMetadata.detect;
 
-function detectStreamDiagnostics(err: unknown): StreamDiagnostics | undefined {
-  if (!isObject(err)) {
-    return undefined;
-  }
-  const diagnostics = (err as Record<symbol, unknown>)[STREAM_DIAGNOSTICS_KEY];
-  // Basic type check - diagnostics should be an object with expected fields
-  if (isObject(diagnostics) && 'eventsProcessed' in diagnostics) {
-    return diagnostics as StreamDiagnostics;
-  }
-  return undefined;
-}
+const partialTextMetadata = createErrorMetadata<string>(
+  'partialText',
+  (v): v is string => isString(v) && v.length > 0,
+);
 
 /** Attaches partial text (generated before a stream failure) to an error.
  *  Lets the caller surface the partial content to the user or use it as the
  *  basis for a continuation prompt on retry. No-op if the text is empty. */
 export function attachPartialText(err: unknown, text: string): void {
-  if (text && isObject(err)) {
-    (err as Record<symbol, unknown>)[PARTIAL_TEXT_KEY] = text;
-  }
+  if (text) partialTextMetadata.attach(err, text);
 }
 
-function detectPartialText(err: unknown): string | undefined {
-  if (!isObject(err)) return undefined;
-  const text = (err as Record<symbol, unknown>)[PARTIAL_TEXT_KEY];
-  return isString(text) && text.length > 0 ? text : undefined;
-}
+const detectPartialText = partialTextMetadata.detect;
 
 /**
  * Maps Anthropic error type strings to their corresponding HTTP status codes.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -330,6 +330,7 @@ function detectRawErrorBody(err: unknown): unknown {
 }
 
 const STREAM_DIAGNOSTICS_KEY = Symbol.for('texra.streamDiagnostics');
+const PARTIAL_TEXT_KEY = Symbol.for('texra.partialText');
 
 /** Attaches stream diagnostics to an error before rethrowing. */
 export function attachStreamDiagnostics(
@@ -351,6 +352,21 @@ function detectStreamDiagnostics(err: unknown): StreamDiagnostics | undefined {
     return diagnostics as StreamDiagnostics;
   }
   return undefined;
+}
+
+/** Attaches partial text (generated before a stream failure) to an error.
+ *  Lets the caller surface the partial content to the user or use it as the
+ *  basis for a continuation prompt on retry. No-op if the text is empty. */
+export function attachPartialText(err: unknown, text: string): void {
+  if (text && isObject(err)) {
+    (err as Record<symbol, unknown>)[PARTIAL_TEXT_KEY] = text;
+  }
+}
+
+function detectPartialText(err: unknown): string | undefined {
+  if (!isObject(err)) return undefined;
+  const text = (err as Record<symbol, unknown>)[PARTIAL_TEXT_KEY];
+  return isString(text) && text.length > 0 ? text : undefined;
 }
 
 /**
@@ -411,6 +427,7 @@ function isRelayError(rawErrorBody: unknown): boolean {
 export function formatProviderHttpError(err: unknown): ProviderError {
   const rawErrorBody = detectRawErrorBody(err);
   const streamDiagnostics = detectStreamDiagnostics(err);
+  const partialText = detectPartialText(err);
   const isRelay = isRelayError(rawErrorBody);
 
   // Handle DOMException AbortError (from AbortController.abort())
@@ -421,6 +438,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       isRelayError: false,
       rawErrorBody,
       streamDiagnostics,
+      partialText,
     };
   }
 
@@ -433,6 +451,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       isRelayError: isRelay,
       rawErrorBody,
       streamDiagnostics,
+      partialText,
     };
   }
 
@@ -470,6 +489,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     requestId,
     rawErrorBody,
     streamDiagnostics,
+    partialText,
   };
 }
 

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -142,6 +142,20 @@ export class RetryRequestPanel extends BaseRequestPanel {
       lines.push('--- Stream Diagnostics ---', ...entries);
     }
 
+    // Show the tail of text that was generated before the failure — useful
+    // both for diagnostics and for letting the user see progress wasn't lost.
+    const partialText = details.partialText;
+    if (partialText) {
+      const tail =
+        partialText.length > 1024
+          ? '…' + partialText.slice(partialText.length - 1024)
+          : partialText;
+      lines.push(
+        `--- Partial Output (${partialText.length} chars) ---`,
+        tail,
+      );
+    }
+
     return lines.length > 0 ? lines.join('\n') : null;
   }
 }

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -146,14 +146,15 @@ export class RetryRequestPanel extends BaseRequestPanel {
     // both for diagnostics and for letting the user see progress wasn't lost.
     const partialText = details.partialText;
     if (partialText) {
-      const tail =
-        partialText.length > 1024
-          ? '…' + partialText.slice(partialText.length - 1024)
-          : partialText;
-      lines.push(
-        `--- Partial Output (${partialText.length} chars) ---`,
-        tail,
-      );
+      const maxTailChars = 1024;
+      const isTruncated = partialText.length > maxTailChars;
+      const tail = isTruncated
+        ? '…' + partialText.slice(partialText.length - maxTailChars)
+        : partialText;
+      const header = isTruncated
+        ? `--- Partial Output (last ${maxTailChars} of ${partialText.length} chars) ---`
+        : `--- Partial Output (${partialText.length} chars) ---`;
+      lines.push(header, tail);
     }
 
     return lines.length > 0 ? lines.join('\n') : null;

--- a/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/messageFormatters.ts
@@ -68,7 +68,11 @@ export function formatProgressStatusTemplate(
       )}</div>`;
 }
 
-// Error detail fields in display order (matches ProviderError schema)
+// Error detail fields to render in the flat banner, in display order.
+// `satisfies` ties each name to ErrorLogData's keys so adding/renaming/removing
+// a schema field becomes a type error here — no silent drift.
+// Fields omitted on purpose: streamDiagnostics and partialText render
+// separately in RetryRequestPanel; cause is not shown in the flat list.
 const ERROR_DETAIL_FIELDS = [
   'message',
   'operation',
@@ -81,7 +85,7 @@ const ERROR_DETAIL_FIELDS = [
   'requestId',
   'rawMessage',
   'rawErrorBody',
-] as const;
+] as const satisfies ReadonlyArray<keyof ErrorLogData>;
 
 /** Format error message as TemplateResult. */
 export function formatErrorTemplate(message: LogMessageData): FormatResult {

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -34,6 +34,10 @@ const ProviderErrorSchema = z.object({
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),
+  /** Tail of text generated before a streaming failure (capped). Present when
+   *  the stream produced any text before dying — lets the caller show it to
+   *  the user or construct a continuation prompt on retry. */
+  partialText: z.string().optional(),
 });
 export type ProviderError = z.infer<typeof ProviderErrorSchema>;
 

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -34,10 +34,15 @@ const ProviderErrorSchema = z.object({
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),
-  /** Tail of text generated before a streaming failure (capped). Present when
-   *  the stream produced any text before dying — lets the caller show it to
-   *  the user or construct a continuation prompt on retry. */
-  partialText: z.string().optional(),
+  /** Tail of text generated before a streaming failure (capped to 64KB).
+   *  Present when the stream produced any text before dying — lets the
+   *  caller show it to the user or construct a continuation prompt on retry.
+   *  Schema-level max enforces the bound in case an upstream source
+   *  misbehaves; producers are expected to truncate before attaching. */
+  partialText: z
+    .string()
+    .max(64 * 1024)
+    .optional(),
 });
 export type ProviderError = z.infer<typeof ProviderErrorSchema>;
 

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -34,15 +34,12 @@ const ProviderErrorSchema = z.object({
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),
-  /** Tail of text generated before a streaming failure (capped to 64KB).
-   *  Present when the stream produced any text before dying — lets the
-   *  caller show it to the user or construct a continuation prompt on retry.
-   *  Schema-level max enforces the bound in case an upstream source
-   *  misbehaves; producers are expected to truncate before attaching. */
-  partialText: z
-    .string()
-    .max(64 * 1024)
-    .optional(),
+  /** Tail of text generated before a streaming failure. Present when the
+   *  stream produced any text before dying — lets the caller show it to the
+   *  user or construct a continuation prompt on retry. Producers truncate
+   *  to a few KB before attaching; this schema is inferred only, not parsed
+   *  at runtime, so size enforcement is the producer's responsibility. */
+  partialText: z.string().optional(),
 });
 export type ProviderError = z.infer<typeof ProviderErrorSchema>;
 


### PR DESCRIPTION
Three graceful, SDK-native improvements for long-running streams that
drop before completion (extended thinking over flaky proxies, etc.):

1. Preserve partial text across stream failures. AnthropicStreamHandler
   accumulates text deltas into a 64KB tail buffer and exposes it via
   getPartialText(). On failure, the text is attached to the error
   (attachPartialText) and flows through ProviderError.partialText for
   the retry UI to display — the user sees what was generated instead
   of a bare error.

2. Enrich the "stream ended without producing a Message with role=assistant"
   SDK error. When messageStartReceived is false, wrap the opaque SDK
   message with diagnostics (elapsed time, event count, SSE-error hint)
   mirroring the existing messageStopReceived branch. Retains request_id
   and sets `cause` so the original error is still inspectable.

3. Log stream failures at warn (was debug), keeping user-initiated aborts
   at debug. Silent proxy drops are now visible without enabling debug logs.

Also registers an 'error' listener on the SDK stream so SSE event: error
(e.g. overloaded_error) is flagged via wasSseErrorReceived() and surfaced
in the enriched message, and avoids Node's unhandled-error warning.

https://claude.ai/code/session_012dRaTsCqHM14sJTZxWPKF9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming error handling across Anthropic/OpenAI/Google handlers and the shared ProviderError shape, which can affect retry classification and user-visible error reporting if metadata is mis-attached or truncated incorrectly.
> 
> **Overview**
> Improves streaming failure observability by **capturing and attaching partial generated text** (capped tail) to errors across Anthropic, OpenAI ChatCompletions, OpenAI Responses (HTTP + WebSocket), and Google GenAI, and plumbing it through `ProviderError.partialText` for display.
> 
> Refactors `sdkErrorUtils` to support symbol-keyed error metadata for both `streamDiagnostics` and `partialText`, adds shared helpers (`takeTail`, `PARTIAL_TEXT_TAIL_MAX`, `isUserAbort`), and updates logging so non-user-abort stream drops are logged at `warn` with diagnostics/partial-output sizing.
> 
> Tightens a few provider-specific edge cases: Anthropic avoids double-logging on truncation and preserves APIError metadata when enriching stream errors; OpenAI Responses treats HTTP 408 `APIError` as an upload timeout fallback; the retry UI (`RetryRequestPanel`) now renders partial output tail separately from flat error fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc79c56506ec3c937ac0256aed61e9aadad70fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->