### PR TITLE
Add GitHub PR subscription tools to agent configurations

### DIFF
--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -376,7 +376,7 @@ VALUES (
   'tool-use-lean/lean.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['todo_write', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory']
+  ARRAY['todo_write', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -308,7 +308,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'external_inquiry', 'codex']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'external_inquiry', 'codex', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -408,7 +408,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/reference-agents/Lean4/lean.yaml
+++ b/reference-agents/Lean4/lean.yaml
@@ -18,6 +18,13 @@ settings:
     - grep
     - ls
     - memory
+    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
+    # Tools and configure a GitHub token in Dashboard → Git). When the
+    # feature is disabled or no git repo / token is available, these are
+    # filtered out before the model sees the tool list.
+    - subscribe_pr_activity
+    - unsubscribe_pr_activity
+    - find_current_pr
 
 prompts:
   systemPrompt: |

--- a/reference-agents/Lean4/lean.yaml
+++ b/reference-agents/Lean4/lean.yaml
@@ -18,10 +18,13 @@ settings:
     - grep
     - ls
     - memory
-    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
-    # Tools and configure a GitHub token in Dashboard → Git). When the
-    # feature is disabled or no git repo / token is available, these are
-    # filtered out before the model sees the tool list.
+    # GitHub PR subscription — opt-in. Disabled by default; enable in
+    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
+    # When disabled by the user, resolveTools() strips these from the
+    # model's tool list. When enabled but the token/git-repo check has
+    # not yet populated the availability cache (i.e. before the Tools
+    # dashboard has run its checks), the tools may still appear and
+    # calls will fail at runtime with a setup-pointing ToolError.
     - subscribe_pr_activity
     - unsubscribe_pr_activity
     - find_current_pr

--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -28,10 +28,13 @@ settings:
     - lean_loogle
     - lean_file
     - lean_project
-    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
-    # Tools and configure a GitHub token in Dashboard → Git). When the
-    # feature is disabled or no git repo / token is available, these are
-    # filtered out before the model sees the tool list.
+    # GitHub PR subscription — opt-in. Disabled by default; enable in
+    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
+    # When disabled by the user, resolveTools() strips these from the
+    # model's tool list. When enabled but the token/git-repo check has
+    # not yet populated the availability cache (i.e. before the Tools
+    # dashboard has run its checks), the tools may still appear and
+    # calls will fail at runtime with a setup-pointing ToolError.
     - subscribe_pr_activity
     - unsubscribe_pr_activity
     - find_current_pr

--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -28,6 +28,13 @@ settings:
     - lean_loogle
     - lean_file
     - lean_project
+    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
+    # Tools and configure a GitHub token in Dashboard → Git). When the
+    # feature is disabled or no git repo / token is available, these are
+    # filtered out before the model sees the tool list.
+    - subscribe_pr_activity
+    - unsubscribe_pr_activity
+    - find_current_pr
 
 prompts:
   systemPrompt: |

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -22,6 +22,13 @@ settings:
     - texcount
     - external_inquiry
     - codex
+    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
+    # Tools and configure a GitHub token in Dashboard → Git). When the
+    # feature is disabled or no git repo / token is available, these are
+    # filtered out before the model sees the tool list.
+    - subscribe_pr_activity
+    - unsubscribe_pr_activity
+    - find_current_pr
 prompts:
   systemPrompt: |
     You are an AI scientist assistant that stewards the long-term development of LaTeX research projects. Think beyond individual tasks—consider whether the project structure scales, conventions stay consistent, and accumulated work builds toward a coherent whole. Maintain modular folder organization: keep sources, figures, bibliography, and build artifacts in separate directories so the project stays navigable as it grows. Proactively propose cleanup when you see duplicated logic, dead code, or inconsistent patterns. Every change should leave the project in a better structural state, not just fulfill the immediate request.

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -22,10 +22,13 @@ settings:
     - texcount
     - external_inquiry
     - codex
-    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
-    # Tools and configure a GitHub token in Dashboard → Git). When the
-    # feature is disabled or no git repo / token is available, these are
-    # filtered out before the model sees the tool list.
+    # GitHub PR subscription — opt-in. Disabled by default; enable in
+    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
+    # When disabled by the user, resolveTools() strips these from the
+    # model's tool list. When enabled but the token/git-repo check has
+    # not yet populated the availability cache (i.e. before the Tools
+    # dashboard has run its checks), the tools may still appear and
+    # calls will fail at runtime with a setup-pointing ToolError.
     - subscribe_pr_activity
     - unsubscribe_pr_activity
     - find_current_pr

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -18,6 +18,13 @@ settings:
     - grep
     - ls
     - memory
+    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
+    # Tools and configure a GitHub token in Dashboard → Git). When the
+    # feature is disabled or no git repo / token is available, these are
+    # filtered out before the model sees the tool list.
+    - subscribe_pr_activity
+    - unsubscribe_pr_activity
+    - find_current_pr
 
 prompts:
   systemPrompt: |

--- a/resources/tool_use_agents/lean.yaml
+++ b/resources/tool_use_agents/lean.yaml
@@ -18,10 +18,13 @@ settings:
     - grep
     - ls
     - memory
-    # GitHub PR subscription — opt-in (off by default; enable in Dashboard →
-    # Tools and configure a GitHub token in Dashboard → Git). When the
-    # feature is disabled or no git repo / token is available, these are
-    # filtered out before the model sees the tool list.
+    # GitHub PR subscription — opt-in. Disabled by default; enable in
+    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
+    # When disabled by the user, resolveTools() strips these from the
+    # model's tool list. When enabled but the token/git-repo check has
+    # not yet populated the availability cache (i.e. before the Tools
+    # dashboard has run its checks), the tools may still appear and
+    # calls will fail at runtime with a setup-pointing ToolError.
     - subscribe_pr_activity
     - unsubscribe_pr_activity
     - find_current_pr


### PR DESCRIPTION
## Summary
This PR adds three new GitHub PR-related tools to the agent tool configurations across multiple agent types. These tools enable agents to subscribe to, unsubscribe from, and query pull request activity.

## Key Changes
- Added `subscribe_pr_activity`, `unsubscribe_pr_activity`, and `find_current_pr` tools to:
  - Reference orchestrator agent (`reference-agents/orchestrator.yaml`)
  - Lean orchestrator agent (`reference-agents/Lean4/leanOrchestrator.yaml`)
  - Lean tool-use agent (`resources/tool_use_agents/lean.yaml`)
- Updated the Supabase sync reference document to reflect these new tools in the agent tool lists
- Included documentation comments explaining that these are opt-in features (disabled by default) that require GitHub token configuration in the Dashboard

## Implementation Details
- The tools are marked as opt-in and will be filtered out before the model sees the tool list if the feature is disabled or no git repo/token is available
- Configuration requires enabling the feature in Dashboard → Tools and configuring a GitHub token in Dashboard → Git
- All three tools are added consistently across all affected agent configurations

https://claude.ai/code/session_01PdJi9g3T5by3u3BsGojbHB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that expands agent tool allowlists; main risk is unintended enablement/visibility of the new tools if downstream gating/availability checks are misconfigured.
> 
> **Overview**
> Adds the GitHub PR activity tools `subscribe_pr_activity`, `unsubscribe_pr_activity`, and `find_current_pr` to the tool lists for `orchestrator`, `lean`, and `leanOrchestrator` agent configs, including inline comments documenting that the capability is *opt-in* and requires GitHub token setup.
> 
> Updates the generated `docs/supabase/SYNC_REFERENCE_AGENTS.sql` tool arrays so remote agent metadata stays in sync with the YAML source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f023ed00da3493ff405362dc5a1fa13a1b48e050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->