### PR TITLE
Remove compact label truncation logic from StreamTab

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -201,9 +201,7 @@ export class ProgressApp extends ProgressAppBase {
       }
 
       .main-container.narrow stream-tabs {
-        width: 60px;
         min-width: 48px;
-        max-width: 64px;
       }
 
       .content-area {

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -298,7 +298,6 @@ export class StreamTab extends LitElement {
 
   // Cached derived values — only recomputed when inputs change
   private _cachedInfo: StreamTabInfo | null = null;
-  private _compactLabel = '';
   private _agentDecorator = getAgentCategoryDecorator('toolUse');
   private _cachedTooltipKey = '';
   private _tooltip = '';
@@ -311,9 +310,6 @@ export class StreamTab extends LitElement {
     if (this._cachedInfo !== stream) {
       this._cachedInfo = stream;
       this._agentDecorator = getAgentCategoryDecorator(stream.agentCategory);
-      const raw =
-        `${stream.parentStreamId ? '↳' : ''}${stream.label || stream.name}`.trim();
-      this._compactLabel = raw.length > 8 ? raw.slice(0, 7) + '…' : raw;
       this._cachedTooltipKey = ''; // invalidate tooltip when info changes
     }
 
@@ -326,7 +322,6 @@ export class StreamTab extends LitElement {
 
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
-    const compactLabel = this._compactLabel;
     const hasChildren = this.childCount > 0 && !this.compact;
 
     return html`
@@ -361,11 +356,10 @@ export class StreamTab extends LitElement {
           title=${tooltip}
         >
           <div class="tab-header">
-            <span class="tab-title">
-              ${this.compact
-                ? compactLabel
-                : `${stream.parentStreamId ? '↳ ' : ''}${stream.label || stream.name}`}
-            </span>
+            <span class="tab-title"
+              >${stream.parentStreamId ? '↳ ' : ''}${stream.label ||
+              stream.name}</span
+            >
           </div>
           ${this.compact
             ? nothing


### PR DESCRIPTION
## Summary
This PR removes the compact label truncation feature from the StreamTab component and simplifies the tab title rendering logic. The changes eliminate unnecessary caching and conditional formatting of stream labels.

## Key Changes
- Removed `_compactLabel` private field and its computation logic that truncated labels longer than 8 characters
- Simplified tab title rendering to always display the full label without compact mode truncation
- Removed unused `compactLabel` variable from the render method
- Cleaned up CSS width constraints in ProgressApp for narrow layout (removed explicit `width` and `max-width`, keeping only `min-width`)

## Implementation Details
- The stream label now consistently displays as `${stream.parentStreamId ? '↳ ' : ''}${stream.label || stream.name}` regardless of compact mode
- Removed the caching logic that was recomputing the truncated label whenever stream info changed
- The compact mode flag is still respected for other UI elements (e.g., `hasChildren` visibility), but no longer affects label display

https://claude.ai/code/session_01PxxgxGk4FgmWMAp2AZZWvY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: stream tab titles in compact mode now show the full label, and narrow sidebar CSS constraints were loosened, which may affect layout/overflow but not data or logic.
> 
> **Overview**
> **Stream tab labels no longer get specially truncated in compact mode.** `StreamTab` drops the cached `_compactLabel` logic and always renders the full `${parentPrefix}${labelOrName}` string.
> 
> **Narrow layout sizing was simplified.** `ProgressApp` removes explicit `width`/`max-width` constraints for `stream-tabs` in the narrow container, keeping only a `min-width`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d616ba49decb42b1c195a5c04ced0431334afd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->