### PR TITLE
Soften stream tab selection background

### DIFF
--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -218,11 +218,14 @@ export class StreamTab extends LitElement {
       }
 
       .tab-container.is-active {
-        background-color: var(--vscode-list-activeSelectionBackground);
+        background-color: var(--vscode-list-inactiveSelectionBackground);
       }
 
       .tab-container.is-active .tab {
-        color: var(--vscode-list-activeSelectionForeground);
+        color: var(
+          --vscode-list-inactiveSelectionForeground,
+          var(--vscode-foreground)
+        );
       }
 
       .tab-container.is-compact .tab {


### PR DESCRIPTION
## Summary

- The selected stream tab in the Progress View used `--vscode-list-activeSelectionBackground` / `activeSelectionForeground`, which renders as a harsh, over-saturated blue in most VS Code themes.
- Webview lists don't participate in VS Code's native tree-focus model, so the "active" variant is the wrong semantic — the "inactive" variant is the idiomatic muted selection color for this context.
- Switched `.tab-container.is-active` in `src/progressView/frontend/components/StreamTabs.ts` to `--vscode-list-inactiveSelectionBackground` / `inactiveSelectionForeground` (with `--vscode-foreground` fallback).

## Test plan

- [ ] Open the Progress View sidebar with multiple streams (ideally an orchestrator parent with children).
- [ ] Select a stream and verify the highlighted tab shows a muted, theme-appropriate selection color rather than a saturated blue.
- [ ] Check both a dark and a light VS Code theme.
- [ ] Confirm the status-indicating left border (running/error/waiting/etc.) is still clearly visible against the new background.
- [ ] Confirm hover and pending-approval pulse states still look correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change affecting the selected stream tab appearance; could slightly impact contrast/readability across themes.
> 
> **Overview**
> Updates Progress View stream tab selection styling to use VS Code’s *inactive* selection background/foreground tokens instead of the *active* ones, with a `--vscode-foreground` fallback for text color to avoid oversaturated highlight colors in webviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dad129fcac46155d25c50cae1769c1fe11c4aa21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->