### PR TITLE
fix(toolUse): queue follow-ups while subagents are still running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **Follow-up messages are queued while subagents finish** — sending a message from the orchestrator tab no longer shows "No active session" when a delegated subagent is still running. The message is queued and picked up when the orchestrator resumes to process the subagent's result.
 - **Opus 4.7 thinking models show reasoning again** — Anthropic flipped the Opus 4.7 adaptive-thinking default so reasoning is omitted from responses unless the caller opts in. TeXRA now asks for `display: summarized` on `opus47`/`opus47T`, restoring visible chain-of-thought in the UI. Opus 4.6 and Sonnet 4.6 are unchanged.
 - **Codex CLI no longer fails on Extra High effort** — TeXRA's `xhigh` reasoning tier now maps to `high` when handed off to the Codex CLI, which only accepts `minimal | low | medium | high`. Previously Codex sessions died with `unknown variant 'xhigh'` on deserialization.
 - **`latexFixer` and similar internal agents load again** — the agent YAML schema now accepts the `internal: true` flag instead of rejecting it via `z.strictObject`, so agents that mark themselves internal no longer fail validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
+- **Codex tool matches the delegate_agent model** — calling `codex` is now async: the tool returns immediately with an execution ID, and each turn's result is delivered as a follow-up message to the orchestrator (response, token usage, and `thread_id`). To continue a running Codex session, pass `thread_id` with a new prompt — it's queued as the next turn instead of interrupting the one in progress, and errors with "still processing" if a turn is mid-flight. The `run_in_background` flag is gone (all codex calls are async now); no changes to how you invoke Codex from the chat.
 - **Untrusted-workspace guard** — TeXRA now declares itself incompatible with untrusted workspaces, so opening an untrusted folder shows VS Code's standard trust prompt with a clear rationale (agents read files and execute shell commands). Previously the extension could activate silently in untrusted mode.
 - **No more `latexindent` install popup on first use** — the missing-`latexindent` warning is now off by default, so first-time users no longer see an unexpected install prompt after running an agent. Re-enable it with `texra.latex.showLatexindentWarning` if you want the reminder.
 - **External Inquiry is off by default for new users** — the copy-to-ChatGPT/Claude/Gemini workflow is now opt-in on first install only. Existing users keep their current setting; new users can turn it on from the Tools settings tab when they want agents to ask them to relay questions to another chat model.

--- a/docs/guide/built-in-agents.md
+++ b/docs/guide/built-in-agents.md
@@ -4,22 +4,22 @@ TeXRA ships with built-in agents for common research tasks—polishing prose, fi
 
 ## Quick Reference
 
-| Agent              | Type     | Purpose                                  |
-| ------------------ | -------- | ---------------------------------------- |
-| `ask`              | Tool-use | Read-only questions and exploration      |
-| `research`         | Tool-use | Computational verification with Wolfram  |
-| `review`           | Tool-use | Mathematical and manuscript verification |
-| `lean`             | Tool-use | Lean 4 proof development                 |
-| `presenter`        | Tool-use | Interactive presentation builder         |
+| Agent              | Type     | Purpose                                                                   |
+| ------------------ | -------- | ------------------------------------------------------------------------- |
+| `ask`              | Tool-use | Read-only questions and exploration                                       |
+| `research`         | Tool-use | Computational verification with Wolfram                                   |
+| `review`           | Tool-use | Mathematical and manuscript verification                                  |
+| `lean`             | Tool-use | Lean 4 proof development                                                  |
+| `presenter`        | Tool-use | Interactive presentation builder                                          |
 | `chat`             | Tool-use | General assistance, file editing (opt-in; not in any default team preset) |
-| `correct`          | Workflow | Fix errors without style changes         |
-| `polish`           | Workflow | Improve writing quality                  |
-| `paper2slide`      | Workflow | Convert papers to beamer slides          |
-| `paper2poster`     | Workflow | Create academic posters                  |
-| `draw`             | Workflow | Create/enhance TikZ figures              |
-| `ocr`              | Workflow | Extract text from images/PDFs            |
-| `transcribe_audio` | Workflow | Transcribe audio to text                 |
-| `merge`            | Workflow | Intelligently merge document versions    |
+| `correct`          | Workflow | Fix errors without style changes                                          |
+| `polish`           | Workflow | Improve writing quality                                                   |
+| `paper2slide`      | Workflow | Convert papers to beamer slides                                           |
+| `paper2poster`     | Workflow | Create academic posters                                                   |
+| `draw`             | Workflow | Create/enhance TikZ figures                                               |
+| `ocr`              | Workflow | Extract text from images/PDFs                                             |
+| `transcribe_audio` | Workflow | Transcribe audio to text                                                  |
+| `merge`            | Workflow | Intelligently merge document versions                                     |
 
 ::: warning Important Note
 The underlying prompts and specific behaviors of these built-in agents may change slightly between TeXRA versions as we continue to optimize them. If you require precise, unchanging behavior or wish to heavily customize the process, consider creating a [Custom Agent](./custom-agents.md) based on these examples.

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -46,10 +46,10 @@ When it fires:
 1. A child stream tab `codex@codex-sdk` opens on the ProgressBoard (<i class="codicon codicon-type-hierarchy"></i>).
 2. Reasoning, commands, file diffs, web searches (<i class="codicon codicon-globe"></i>), and todos stream in live.
 3. When the turn ends, the tab sits in **WAITING**. Type a follow-up to continue the thread, or press <i class="codicon codicon-debug-stop"></i> **Stop** to end it.
-4. The calling agent gets back the final response, token usage, and a `thread_id` it can resume later.
+4. Every turn is delivered to the calling agent as a follow-up message (final response, token usage, and `thread_id`). Calls are async — the tool returns immediately with an execution ID.
 
-::: tip Background mode
-Agents can pass `run_in_background: true` to get the execution ID immediately and receive the result as a follow-up when Codex finishes. Good for long refactors that shouldn't block the parent.
+::: tip Follow-up instructions
+To send a follow-up from the calling agent, call `codex` again with `thread_id` set to the ID from the previous delivery. The prompt is queued as the next turn and errors if the thread is still processing — same contract as `delegate_agent(execution_id=…)`.
 :::
 
 ## Troubleshooting

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -27,11 +27,11 @@ Codex has no native Windows binary. Open TeXRA inside a **WSL** remote window be
 
 All Codex options live on the Codex card in **Dashboard → Tools** and are scoped to the current workspace.
 
-| Setting              | Options                                                                       | Default             | What it controls                                                           |
-| -------------------- | ----------------------------------------------------------------------------- | ------------------- | -------------------------------------------------------------------------- |
-| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                          | `workspace-write`   | File-system access. Agents may override per call via `sandbox_mode`.       |
-| **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                              | `high`              | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
-| **Require approval** | checkbox under *Approval & Safety* (<i class="codicon codicon-shield"></i>)   | on                  | Show a confirmation prompt before every Codex call.                        |
+| Setting              | Options                                                                     | Default           | What it controls                                                           |
+| -------------------- | --------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                        | `workspace-write` | File-system access. Agents may override per call via `sandbox_mode`.       |
+| **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                            | `high`            | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
+| **Require approval** | checkbox under _Approval & Safety_ (<i class="codicon codicon-shield"></i>) | on                | Show a confirmation prompt before every Codex call.                        |
 
 TeXRA always drives Codex with the short model name `gpt-5.4`. Everything else (providers, MCP servers, custom instructions) comes from Codex's own `~/.codex/config.toml`.
 
@@ -56,11 +56,11 @@ To send a follow-up from the calling agent, call `codex` again with `thread_id` 
 
 **Card shows <i class="codicon codicon-warning"></i> Not Found after install.** Hover the card for the exact message:
 
-| Message                                         | Fix                                                                               |
-| ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| `@openai/codex-sdk not found`                   | Click **Install in Terminal** again, then **Recheck**.                            |
-| `Codex SDK loaded but native binary not found`  | Reinstall — the platform binary didn't ship. On Windows, open TeXRA in WSL first. |
-| `Platform not supported`                        | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.          |
+| Message                                        | Fix                                                                               |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `@openai/codex-sdk not found`                  | Click **Install in Terminal** again, then **Recheck**.                            |
+| `Codex SDK loaded but native binary not found` | Reinstall — the platform binary didn't ship. On Windows, open TeXRA in WSL first. |
+| `Platform not supported`                       | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.          |
 
 **Still Not Found after everything ran.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
 

--- a/docs/guide/custom-agents.md
+++ b/docs/guide/custom-agents.md
@@ -126,7 +126,7 @@ This mechanism is sometimes referred to as **Variable Retrieval (VR)**—the ext
 - &#123;&#123; EDITED_FILE &#125;&#125;: Path of the edited file (used in `merge`).
 - &#123;&#123; EDITED_CONTENT &#125;&#125;: Content of the edited file.
 - &#123;&#123; MEDIA_FILE &#125;&#125;: Path of the primary media file.
-  \_Note: Media content itself isn't directly inserted as text; it's handled separately for multimodal models. See [Working with Figures](./working-with-figures.md).*
+  \_Note: Media content itself isn't directly inserted as text; it's handled separately for multimodal models. See [Working with Figures](./working-with-figures.md).\*
 
 **Multiple File Variables:**
 
@@ -185,15 +185,15 @@ Tool-use agents are interactive: instead of producing a single polished file, th
 
 To create your own tool-use agent, set `agentCategory: toolUse` and list the tools you want to grant. TeXRA groups tools by category (matching **Dashboard → Tools** <i class="codicon codicon-tools"></i>):
 
-| Category                                                               | What it lets the agent do                                                      | Example tool names                                           |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------ |
-| <i class="codicon codicon-files"></i> **File & Shell**                 | Read, write, edit, search, list, and run commands in your project              | `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `ls`, `bash` |
-| <i class="codicon codicon-file-code"></i> **LaTeX**                    | Extract figures, TikZ, and bibliography; report compile diagnostics            | `extract_figures`, `extract_tikz_figures`, `extract_bib_entries`, `diagnostics`, `texcount` |
-| <i class="codicon codicon-mortar-board"></i> **Academic Research**     | Search arXiv and Crossref, resolve DOIs, manage Zotero                         | `arxiv_search`, `arxiv_metadata`, `download_arxiv_source`, `crossref_doi`, `crossref_search`, `zotero_*` |
-| <i class="codicon codicon-globe"></i> **Web**                          | Fetch pages and search the internet                                            | `web_search`, `web_fetch`                                    |
-| <i class="codicon codicon-symbol-operator"></i> **Computation**        | Run Wolfram Language, delegate to Codex, consult another chat model            | `wolfram`, `codex`, `external_inquiry`                       |
-| <i class="codicon codicon-beaker"></i> **Lean 4**                      | Check Lean proofs and search Mathlib                                           | `lean_diagnostics`, `lean_inspect`, `lean_loogle`, `lean_file`, `lean_project` |
-| <i class="codicon codicon-type-hierarchy"></i> **Memory & Workflow**   | Persistent memory, to-do lists, sub-agent delegation                           | `memory`, `todo_write`, `plan`, `delegate_workflow`, `delegate_agent`, `executions`, `accept_run_files` |
+| Category                                                             | What it lets the agent do                                           | Example tool names                                                                                       |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| <i class="codicon codicon-files"></i> **File & Shell**               | Read, write, edit, search, list, and run commands in your project   | `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `ls`, `bash`                                     |
+| <i class="codicon codicon-file-code"></i> **LaTeX**                  | Extract figures, TikZ, and bibliography; report compile diagnostics | `extract_figures`, `extract_tikz_figures`, `extract_bib_entries`, `diagnostics`, `texcount`              |
+| <i class="codicon codicon-mortar-board"></i> **Academic Research**   | Search arXiv and Crossref, resolve DOIs, manage Zotero              | `arxiv_search`, `arxiv_metadata`, `download_arxiv_source`, `crossref_doi`, `crossref_search`, `zotero_*` |
+| <i class="codicon codicon-globe"></i> **Web**                        | Fetch pages and search the internet                                 | `web_search`, `web_fetch`                                                                                |
+| <i class="codicon codicon-symbol-operator"></i> **Computation**      | Run Wolfram Language, delegate to Codex, consult another chat model | `wolfram`, `codex`, `external_inquiry`                                                                   |
+| <i class="codicon codicon-beaker"></i> **Lean 4**                    | Check Lean proofs and search Mathlib                                | `lean_diagnostics`, `lean_inspect`, `lean_loogle`, `lean_file`, `lean_project`                           |
+| <i class="codicon codicon-type-hierarchy"></i> **Memory & Workflow** | Persistent memory, to-do lists, sub-agent delegation                | `memory`, `todo_write`, `plan`, `delegate_workflow`, `delegate_agent`, `executions`, `accept_run_files`  |
 
 For the exact tool names to list in your YAML, browse any of the built-in tool-use agents (like `research`, `search`, `ask`, or `code`) in the **Agents** tab — their `tools:` array shows exactly which tools are wired up.
 

--- a/docs/guide/latex-tools.md
+++ b/docs/guide/latex-tools.md
@@ -4,15 +4,15 @@ TeXRA doesn't just send text to an AI and hope for the best. It plugs into battl
 
 ## Overview
 
-| What it does                                                         | Tool behind the scenes     |
-| -------------------------------------------------------------------- | -------------------------- |
-| <i class="codicon codicon-symbol-keyword"></i> Code formatting       | `latexindent` or `tex-fmt` |
-| <i class="codicon codicon-diff-single"></i> Version comparison       | `latexdiff`                |
-| <i class="codicon codicon-symbol-numeric"></i> Document statistics   | `texcount`                 |
-| <i class="codicon codicon-file-media"></i> Figure extraction         | Built-in                   |
-| <i class="codicon codicon-symbol-structure"></i> TikZ compilation    | Built-in                   |
-| <i class="codicon codicon-book"></i> Bibliography resolution         | Built-in                   |
-| <i class="codicon codicon-symbol-operator"></i> Symbolic math        | `wolfram`                  |
+| What it does                                                       | Tool behind the scenes     |
+| ------------------------------------------------------------------ | -------------------------- |
+| <i class="codicon codicon-symbol-keyword"></i> Code formatting     | `latexindent` or `tex-fmt` |
+| <i class="codicon codicon-diff-single"></i> Version comparison     | `latexdiff`                |
+| <i class="codicon codicon-symbol-numeric"></i> Document statistics | `texcount`                 |
+| <i class="codicon codicon-file-media"></i> Figure extraction       | Built-in                   |
+| <i class="codicon codicon-symbol-structure"></i> TikZ compilation  | Built-in                   |
+| <i class="codicon codicon-book"></i> Bibliography resolution       | Built-in                   |
+| <i class="codicon codicon-symbol-operator"></i> Symbolic math      | `wolfram`                  |
 
 All are configured from **Dashboard → Tools** (<i class="codicon codicon-tools"></i>) or **Dashboard → LaTeX** (<i class="codicon codicon-file-code"></i>). Missing dependencies show <i class="codicon codicon-warning"></i> **Not Found**; ready ones show <i class="codicon codicon-check"></i> **Available**.
 

--- a/docs/guide/research-tools.md
+++ b/docs/guide/research-tools.md
@@ -81,12 +81,12 @@ The `external_inquiry` tool lets a TeXRA agent paste a question to an external c
 
 ## Which Agent to Use
 
-| Agent        | Best for                                                       |
-| ------------ | -------------------------------------------------------------- |
-| `search`     | Finding papers, literature reviews, fact-checking              |
-| `research`   | Computational verification with Wolfram and literature lookups |
-| `discuss`    | Brainstorming research directions with literature context      |
-| `ask`        | Quick lookups about your documents and related work            |
+| Agent      | Best for                                                       |
+| ---------- | -------------------------------------------------------------- |
+| `search`   | Finding papers, literature reviews, fact-checking              |
+| `research` | Computational verification with Wolfram and literature lookups |
+| `discuss`  | Brainstorming research directions with literature context      |
+| `ask`      | Quick lookups about your documents and related work            |
 
 Pick any of them from the **Agent** dropdown (<i class="codicon codicon-sparkle"></i>). Check `Dashboard → Agents` (<i class="codicon codicon-sparkle"></i>) to see exactly which tools each one has enabled.
 

--- a/package.json
+++ b/package.json
@@ -1224,7 +1224,7 @@
     "viewsWelcome": [
       {
         "view": "texra.welcomeView",
-        "contents": "TeXRA is a multi-agent orchestration system for LaTeX research. An orchestrator coordinates specialized agents that derive results, verify proofs, run symbolic computation, generate figures, and assemble manuscripts — every step auditable, every citation grounded.\nOpen a folder to begin.\n[Open Folder](command:workbench.action.files.openFolder)\n[Clone Repository](command:git.clone)\nNew to TeXRA? [Take the tour](command:workbench.action.openWalkthrough?%22texra.gettingStarted%22) or [read the docs](https://github.com/LionSR/TeXRA#readme).",
+        "contents": "TeXRA is a multi-agent orchestration system for LaTeX research. An orchestrator coordinates specialized agents that derive results, verify proofs, run symbolic computation, generate figures, and assemble manuscripts — every step auditable, every citation grounded.\nOpen a folder to begin.\n[Open Folder](command:workbench.action.files.openFolder)\n[Clone Repository](command:git.clone)\nNew to TeXRA? [Take the tour](command:workbench.action.openWalkthrough?%22texra.gettingStarted%22) or [read the docs](https://texra.ai).",
         "when": "workbenchState == empty"
       },
       {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -705,7 +705,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       this.logger.warn(
         `Failed to retrieve pending background response ${pendingId}: ${formatted.message}. ` +
           'Will create new request.',
-        { data: { responseId: pendingId, error: formatted.message, statusCode: code } },
+        {
+          data: {
+            responseId: pendingId,
+            error: formatted.message,
+            statusCode: code,
+          },
+        },
       );
       this.clearPendingBackgroundResponse();
       return null;

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -69,14 +69,8 @@ export async function sendFollowUp(
   }
 
   // Queue if subagents/processes are still running under this stream.
-  // The orchestrator's flow context may have exited before its children
-  // finished (subagents execute asynchronously). The child results arrive
-  // via the same queue, so the user's message rides along and will be
-  // drained when the parent resumes.
-  //
-  // `acquire` clears any prior "released" mark left by sessionLifecycle
-  // disposal — otherwise the subsequent `enqueue` would silently drop
-  // the message (along with any still-pending child deliveries).
+  // `acquire` clears any prior "released" mark from sessionLifecycle
+  // disposal, otherwise `enqueue` would silently drop the message.
   const { subagents, processes } = getActiveChildren(streamId);
   if (subagents.length > 0 || processes.length > 0) {
     ToolUseFollowUpQueue.acquire(streamId);

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -25,7 +25,7 @@ export type SendFollowUpResult =
   | { status: 'sent' }
   | {
       status: 'queued';
-      reason: 'resuming' | 'waiting' | 'subagent_running';
+      reason: 'resuming' | 'waiting' | 'children_running';
     }
   | { status: 'error'; message: string }
   | { status: 'no_session'; streamStatus: string | undefined };
@@ -73,10 +73,15 @@ export async function sendFollowUp(
   // finished (subagents execute asynchronously). The child results arrive
   // via the same queue, so the user's message rides along and will be
   // drained when the parent resumes.
+  //
+  // `acquire` clears any prior "released" mark left by sessionLifecycle
+  // disposal — otherwise the subsequent `enqueue` would silently drop
+  // the message (along with any still-pending child deliveries).
   const { subagents, processes } = getActiveChildren(streamId);
   if (subagents.length > 0 || processes.length > 0) {
+    ToolUseFollowUpQueue.acquire(streamId);
     ToolUseFollowUpQueue.enqueue(streamId, text);
-    return { status: 'queued', reason: 'subagent_running' };
+    return { status: 'queued', reason: 'children_running' };
   }
 
   // No active/waiting session found - caller should handle UI notification

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -70,10 +70,10 @@ export async function sendFollowUp(
 
   const { subagents, processes } = getActiveChildren(streamId);
   if (subagents.length > 0 || processes.length > 0) {
-    // acquire clears the released flag left by sessionLifecycle disposal,
-    // otherwise enqueue would silently drop.
-    ToolUseFollowUpQueue.acquire(streamId);
-    ToolUseFollowUpQueue.enqueue(streamId, text);
+    // Force reopens the queue if it was released by sessionLifecycle
+    // disposal. Caller is responsible for auto-resuming the parent or
+    // re-releasing the queue so late child deliveries don't leak across runs.
+    ToolUseFollowUpQueue.enqueue(streamId, text, { force: true });
     return { status: 'queued', reason: 'children_running' };
   }
 

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -10,6 +10,7 @@
  * showing appropriate UI notifications based on the returned result.
  */
 
+import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -22,7 +23,10 @@ import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
  */
 export type SendFollowUpResult =
   | { status: 'sent' }
-  | { status: 'queued'; reason: 'resuming' | 'waiting' }
+  | {
+      status: 'queued';
+      reason: 'resuming' | 'waiting' | 'subagent_running';
+    }
   | { status: 'error'; message: string }
   | { status: 'no_session'; streamStatus: string | undefined };
 
@@ -62,6 +66,17 @@ export async function sendFollowUp(
   if (status === STREAM_STATUS.WAITING) {
     ToolUseFollowUpQueue.enqueue(streamId, text);
     return { status: 'queued', reason: 'waiting' };
+  }
+
+  // Queue if subagents/processes are still running under this stream.
+  // The orchestrator's flow context may have exited before its children
+  // finished (subagents execute asynchronously). The child results arrive
+  // via the same queue, so the user's message rides along and will be
+  // drained when the parent resumes.
+  const { subagents, processes } = getActiveChildren(streamId);
+  if (subagents.length > 0 || processes.length > 0) {
+    ToolUseFollowUpQueue.enqueue(streamId, text);
+    return { status: 'queued', reason: 'subagent_running' };
   }
 
   // No active/waiting session found - caller should handle UI notification

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -68,11 +68,10 @@ export async function sendFollowUp(
     return { status: 'queued', reason: 'waiting' };
   }
 
-  // Queue if subagents/processes are still running under this stream.
-  // `acquire` clears any prior "released" mark from sessionLifecycle
-  // disposal, otherwise `enqueue` would silently drop the message.
   const { subagents, processes } = getActiveChildren(streamId);
   if (subagents.length > 0 || processes.length > 0) {
+    // acquire clears the released flag left by sessionLifecycle disposal,
+    // otherwise enqueue would silently drop.
     ToolUseFollowUpQueue.acquire(streamId);
     ToolUseFollowUpQueue.enqueue(streamId, text);
     return { status: 'queued', reason: 'children_running' };

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -70,9 +70,9 @@ export async function sendFollowUp(
 
   const { subagents, processes } = getActiveChildren(streamId);
   if (subagents.length > 0 || processes.length > 0) {
-    // Force reopens the queue if it was released by sessionLifecycle
-    // disposal. Caller is responsible for auto-resuming the parent or
-    // re-releasing the queue so late child deliveries don't leak across runs.
+    // force:true reopens a queue sealed by sessionLifecycle disposal — the
+    // caller must auto-resume the parent or re-release, or late child
+    // deliveries will leak into the next run on this stream.
     ToolUseFollowUpQueue.enqueue(streamId, text, { force: true });
     return { status: 'queued', reason: 'children_running' };
   }

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -56,19 +56,32 @@ export class ToolUseFollowUpQueue {
    * Enqueue a follow-up for a stream.
    *
    * Auto-creates the queue if it doesn't exist yet (needed for WAITING streams
-   * from prior sessions). Silently discards if the queue was explicitly released
-   * (orchestrator disposed — late-arriving subagent results).
+   * from prior sessions). Returns false and silently discards if the queue was
+   * explicitly released (orchestrator disposed — late-arriving subagent
+   * results). Pass `{ force: true }` for explicit user actions that should
+   * reopen a released queue (caller is responsible for ensuring a consumer
+   * will drain it, or releasing again on failure).
    */
-  static enqueue(streamId: StreamTabId, followUp: string): void {
-    if (this.released.has(streamId)) {
+  static enqueue(
+    streamId: StreamTabId,
+    followUp: string,
+    options?: { force?: boolean },
+  ): boolean {
+    if (this.released.has(streamId) && !options?.force) {
       logger.debug(
         `Queue for stream ${streamId} was released, discarding follow-up.`,
       );
-      return;
+      return false;
     }
     const queue = this.acquire(streamId);
     queue.enqueue(followUp);
     logger.debug(`Queued follow-up for stream ${streamId}.`);
+    return true;
+  }
+
+  /** Whether the stream's queue was explicitly released (no consumer). */
+  static isReleased(streamId: StreamTabId): boolean {
+    return this.released.has(streamId);
   }
 
   static drain(streamId: StreamTabId): string[] {

--- a/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
+++ b/src/agent/toolUse/ToolUseFollowUpQueueManager.ts
@@ -79,11 +79,6 @@ export class ToolUseFollowUpQueue {
     return true;
   }
 
-  /** Whether the stream's queue was explicitly released (no consumer). */
-  static isReleased(streamId: StreamTabId): boolean {
-    return this.released.has(streamId);
-  }
-
   static drain(streamId: StreamTabId): string[] {
     return this.queues.get(streamId)?.drain() ?? [];
   }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -462,9 +462,9 @@ export function getToolFlags(
     AUTO_COMPILE_INPUT_PDF: agentConfig.toolConfig.autoCompileInputPdf,
     CODEX_GUIDANCE: agentSetting.tools.some((t) => t.name === 'codex')
       ? 'Choose codex for coding tasks that benefit from a separate OpenAI agent — it runs in its own sandbox with independent tool use. ' +
-        'Codex is multi-turn: each call returns a thread_id. Always pass thread_id back when following up on a previous codex task — ' +
-        'this resumes the same session with full history and file context intact. ' +
-        'Use this to provide feedback, request corrections, or continue iterative work without re-explaining context. ' +
+        'Codex is async and multi-turn, mirroring delegate_agent: each call returns an execution ID, and results arrive as follow-up messages that include a thread_id. ' +
+        'Pass that thread_id back on a later codex call to send a follow-up instruction to the same session — the agent retains full history and file context. ' +
+        'The follow-up errors out if the thread is still processing; wait for its delivery before resuming. ' +
         'When multiple codex agents need to edit the same files, or when you want to isolate experimental changes, ' +
         'use a git worktree (`git worktree add ../worktree-name branch-name`) and pass its path as working_directory.'
       : '',

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -120,9 +120,8 @@ async function handleFollowUpResult(
       bus.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
-        // Only surface the failure for 'waiting' — for 'children_running'
-        // the message stays queued and a child delivery may still trigger
-        // a resume, so a toast here would be premature and noisy.
+        // children_running stays silent: a child delivery may still trigger
+        // a resume, so a toast here would be premature.
         if (!resumed && result.reason === 'waiting') {
           await vscode.window.showInformationMessage(
             'Message queued. Auto-resume failed — start a new agent task to continue.',

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -118,10 +118,10 @@ async function handleFollowUpResult(
       break;
     case 'queued':
       bus.emit('updateQueuedFollowUps', { streamId });
-      if (result.reason === 'waiting' || result.reason === 'subagent_running') {
-        // 'subagent_running': orchestrator's flow context has exited but a
-        // child is still running. Try to resume so the parent can process
-        // the queued message alongside the subagent's eventual result.
+      if (result.reason === 'waiting' || result.reason === 'children_running') {
+        // 'children_running': orchestrator's flow context has exited but a
+        // subagent or background process is still running. Try to resume so
+        // the parent can process the queued message alongside child results.
         const resumed = await tryAutoResume(streamId);
         if (!resumed && result.reason === 'waiting') {
           await vscode.window.showInformationMessage(

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -119,10 +119,10 @@ async function handleFollowUpResult(
     case 'queued':
       bus.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
-        // 'children_running': orchestrator's flow context has exited but a
-        // subagent or background process is still running. Try to resume so
-        // the parent can process the queued message alongside child results.
         const resumed = await tryAutoResume(streamId);
+        // Only surface the failure for 'waiting' — for 'children_running'
+        // the message stays queued and a child delivery may still trigger
+        // a resume, so a toast here would be premature and noisy.
         if (!resumed && result.reason === 'waiting') {
           await vscode.window.showInformationMessage(
             'Message queued. Auto-resume failed — start a new agent task to continue.',

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -118,9 +118,12 @@ async function handleFollowUpResult(
       break;
     case 'queued':
       bus.emit('updateQueuedFollowUps', { streamId });
-      if (result.reason === 'waiting') {
+      if (result.reason === 'waiting' || result.reason === 'subagent_running') {
+        // 'subagent_running': orchestrator's flow context has exited but a
+        // child is still running. Try to resume so the parent can process
+        // the queued message alongside the subagent's eventual result.
         const resumed = await tryAutoResume(streamId);
-        if (!resumed) {
+        if (!resumed && result.reason === 'waiting') {
           await vscode.window.showInformationMessage(
             'Message queued. Auto-resume failed — start a new agent task to continue.',
           );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -7,6 +7,7 @@ import {
   sendFollowUp,
   type SendFollowUpResult,
 } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -120,9 +121,14 @@ async function handleFollowUpResult(
       bus.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
-        // children_running stays silent: a child delivery may still trigger
-        // a resume, so a toast here would be premature.
-        if (!resumed && result.reason === 'waiting') {
+        if (!resumed) {
+          if (result.reason === 'children_running') {
+            // sendFollowUp force-reopened a released queue on behalf of the
+            // auto-resume attempt. Re-release it so late child deliveries
+            // don't leak into the next run on this stream.
+            ToolUseFollowUpQueue.release(streamId);
+            bus.emit('updateQueuedFollowUps', { streamId });
+          }
           await vscode.window.showInformationMessage(
             'Message queued. Auto-resume failed — start a new agent task to continue.',
           );

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -121,7 +121,10 @@ async function handleFollowUpResult(
       bus.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
-        if (!resumed) {
+        // tryAutoResume also returns false when the stream is already
+        // active/resuming — another consumer is on the way, so neither
+        // branch below should drop the queue or warn the user.
+        if (!resumed && !StreamStatusService.isActiveOrResuming(streamId)) {
           if (result.reason === 'children_running') {
             // sendFollowUp force-reopened a released queue on behalf of the
             // auto-resume attempt. Re-release drops the just-enqueued message

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -124,14 +124,19 @@ async function handleFollowUpResult(
         if (!resumed) {
           if (result.reason === 'children_running') {
             // sendFollowUp force-reopened a released queue on behalf of the
-            // auto-resume attempt. Re-release it so late child deliveries
-            // don't leak into the next run on this stream.
+            // auto-resume attempt. Re-release drops the just-enqueued message
+            // too, but that's the lesser evil — leaving the queue open would
+            // leak late child deliveries into the next run on this stream.
             ToolUseFollowUpQueue.release(streamId);
             bus.emit('updateQueuedFollowUps', { streamId });
+            await vscode.window.showWarningMessage(
+              'Message dropped — no session available to receive it. Start a new agent task to continue.',
+            );
+          } else {
+            await vscode.window.showInformationMessage(
+              'Message queued. Auto-resume failed — start a new agent task to continue.',
+            );
           }
-          await vscode.window.showInformationMessage(
-            'Message queued. Auto-resume failed — start a new agent task to continue.',
-          );
         }
       }
       break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,11 +110,7 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
   const workspaceRoot = workspaceFolders[0].uri.fsPath;
-  await vscode.commands.executeCommand(
-    'setContext',
-    'texra.activated',
-    true,
-  );
+  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 
   dotenv.config({
     path: path.join(workspaceRoot, '.env'),

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -93,7 +93,9 @@ export function formatCost(
 function buildModelHint(config: ModelConfig): string {
   const base = hint(config);
   if (!isFastFirstResponseModel(config.inputPrice)) return base;
-  return base ? `${FAST_FIRST_RESPONSE_HINT} | ${base}` : FAST_FIRST_RESPONSE_HINT;
+  return base
+    ? `${FAST_FIRST_RESPONSE_HINT} | ${base}`
+    : FAST_FIRST_RESPONSE_HINT;
 }
 
 /** Check if a model is available via personal API keys. */

--- a/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
+++ b/src/progressView/frontend/formatters/logFormatters/codexToolTemplates.ts
@@ -34,7 +34,7 @@ type CodexToolRenderer = (input: unknown) => TemplateResult | typeof nothing;
 const CodexInputDisplaySchema = z.object({
   prompt: z.string().optional().default(''),
   sandbox_mode: z.string().optional(),
-  run_in_background: z.boolean().optional(),
+  thread_id: z.string().optional(),
 });
 
 type CodexInputDisplay = z.infer<typeof CodexInputDisplaySchema>;
@@ -97,8 +97,8 @@ function renderCodexModeSection(input: CodexInputDisplay): RenderableSection {
     ...(input.sandbox_mode
       ? [{ iconClass: 'codicon-shield', label: input.sandbox_mode }]
       : []),
-    ...(input.run_in_background
-      ? [{ iconClass: 'codicon-run-all', label: 'background' }]
+    ...(input.thread_id
+      ? [{ iconClass: 'codicon-comment-discussion', label: 'follow-up' }]
       : []),
   ];
 

--- a/src/settingsView/frontend/components/profile/ProfileInfo.ts
+++ b/src/settingsView/frontend/components/profile/ProfileInfo.ts
@@ -61,13 +61,8 @@ export class ProfileInfo extends LitElement {
           </span>
         </div>
         <div class="profile-notice">
-          ${PROMO_NOTICE_LONG.promoLead}<code
-            >${PROMO_NOTICE_LONG.promoCode}</code
-          >${PROMO_NOTICE_LONG.promoTail} ${PROMO_NOTICE_LONG.privacyLead}<strong
-            >${PROMO_NOTICE_LONG.privacyNot}</strong
-          >${PROMO_NOTICE_LONG.privacyMiddle}<strong
-            >${PROMO_NOTICE_LONG.privacyNever}</strong
-          >${PROMO_NOTICE_LONG.privacyTrailing}
+          ${PROMO_NOTICE_LONG.promoLead}<code>${PROMO_NOTICE_LONG.promoCode}</code>${PROMO_NOTICE_LONG.promoTail}
+          ${PROMO_NOTICE_LONG.privacyLead}<strong>${PROMO_NOTICE_LONG.privacyNot}</strong>${PROMO_NOTICE_LONG.privacyMiddle}<strong>${PROMO_NOTICE_LONG.privacyNever}</strong>${PROMO_NOTICE_LONG.privacyTrailing}
         </div>
         ${expiration
           ? html`

--- a/src/shared/constants/fastModels.ts
+++ b/src/shared/constants/fastModels.ts
@@ -27,5 +27,7 @@ export const FAST_FIRST_RESPONSE_HINT =
 export function isFastFirstResponseModel(
   inputPrice: number | undefined,
 ): boolean {
-  return inputPrice !== undefined && inputPrice < FAST_FIRST_RESPONSE_PRICE_CEILING;
+  return (
+    inputPrice !== undefined && inputPrice < FAST_FIRST_RESPONSE_PRICE_CEILING
+  );
 }

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -5,7 +5,13 @@ import { strict as assert } from 'assert';
 import { AgentConfigSchema } from '@agent/core/AgentConfig';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { createRunState } from '@agent/core/AgentState';
+import {
+  AgentExecutionHandle,
+  trackExecution,
+  untrackExecution,
+} from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 // Type imports
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse/ToolUseSessionTypes';
 import * as AgentRegistry from '@agent/toolUse/ToolUseAgentRegistry';
@@ -58,6 +64,39 @@ describe('ToolUseFollowUp', () => {
     assert.equal(calls.length, 1);
     assert.equal(calls[0], 'hello');
     assert.deepEqual(result, { status: 'sent' });
+  });
+
+  it('queues follow-ups when subagents are still running', async () => {
+    // No active flow context — parent's flow has exited.
+    (AgentRegistry as any).getToolUseFlowContext = () => undefined;
+
+    const parentStreamId = 'parent-stream-subagent' as StreamTabId;
+    const childStreamId = 'child-stream-subagent' as StreamTabId;
+    const executionId = 'exec-subagent-running';
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+    );
+    trackExecution(handle);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, 'hello while running');
+
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'subagent_running',
+      });
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+        'hello while running',
+      ]);
+    } finally {
+      untrackExecution(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
   });
 
   it('creates valid snapshot structure', () => {

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -67,7 +67,6 @@ describe('ToolUseFollowUp', () => {
   });
 
   it('queues follow-ups when children are still running', async () => {
-    // No active flow context — parent's flow has exited.
     (AgentRegistry as any).getToolUseFlowContext = () => undefined;
 
     const parentStreamId = 'parent-stream-children' as StreamTabId;
@@ -100,10 +99,8 @@ describe('ToolUseFollowUp', () => {
   });
 
   it('survives prior queue release when children are running', async () => {
-    // Simulates the orchestrator's flow having just disposed its session
-    // (sessionLifecycle.dispose → ToolUseFollowUpQueue.release) while a
-    // subagent is still running. Without the fix, enqueue would silently
-    // drop the message because the stream is marked as released.
+    // Regression: without acquire(), enqueue() silently drops messages
+    // on streams previously released by sessionLifecycle.dispose().
     (AgentRegistry as any).getToolUseFlowContext = () => undefined;
 
     const parentStreamId = 'parent-stream-released' as StreamTabId;
@@ -118,7 +115,6 @@ describe('ToolUseFollowUp', () => {
       'toolUse',
     );
     trackExecution(handle);
-    // Mark the queue as released, mirroring sessionLifecycle.dispose().
     ToolUseFollowUpQueue.release(parentStreamId);
 
     try {

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -99,7 +99,7 @@ describe('ToolUseFollowUp', () => {
   });
 
   it('survives prior queue release when children are running', async () => {
-    // Regression: without acquire(), enqueue() silently drops messages
+    // Regression: without force:true, enqueue() silently drops messages
     // on streams previously released by sessionLifecycle.dispose().
     (AgentRegistry as any).getToolUseFlowContext = () => undefined;
 

--- a/src/test/agent/toolUse/ToolUseFollowUp.test.ts
+++ b/src/test/agent/toolUse/ToolUseFollowUp.test.ts
@@ -66,13 +66,13 @@ describe('ToolUseFollowUp', () => {
     assert.deepEqual(result, { status: 'sent' });
   });
 
-  it('queues follow-ups when subagents are still running', async () => {
+  it('queues follow-ups when children are still running', async () => {
     // No active flow context — parent's flow has exited.
     (AgentRegistry as any).getToolUseFlowContext = () => undefined;
 
-    const parentStreamId = 'parent-stream-subagent' as StreamTabId;
-    const childStreamId = 'child-stream-subagent' as StreamTabId;
-    const executionId = 'exec-subagent-running';
+    const parentStreamId = 'parent-stream-children' as StreamTabId;
+    const childStreamId = 'child-stream-children' as StreamTabId;
+    const executionId = 'exec-children-running';
 
     const handle = new AgentExecutionHandle(
       executionId,
@@ -88,10 +88,48 @@ describe('ToolUseFollowUp', () => {
 
       assert.deepEqual(result, {
         status: 'queued',
-        reason: 'subagent_running',
+        reason: 'children_running',
       });
       assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
         'hello while running',
+      ]);
+    } finally {
+      untrackExecution(executionId);
+      ToolUseFollowUpQueue.release(parentStreamId);
+    }
+  });
+
+  it('survives prior queue release when children are running', async () => {
+    // Simulates the orchestrator's flow having just disposed its session
+    // (sessionLifecycle.dispose → ToolUseFollowUpQueue.release) while a
+    // subagent is still running. Without the fix, enqueue would silently
+    // drop the message because the stream is marked as released.
+    (AgentRegistry as any).getToolUseFlowContext = () => undefined;
+
+    const parentStreamId = 'parent-stream-released' as StreamTabId;
+    const childStreamId = 'child-stream-released' as StreamTabId;
+    const executionId = 'exec-released';
+
+    const handle = new AgentExecutionHandle(
+      executionId,
+      parentStreamId,
+      childStreamId,
+      'test-subagent',
+      'toolUse',
+    );
+    trackExecution(handle);
+    // Mark the queue as released, mirroring sessionLifecycle.dispose().
+    ToolUseFollowUpQueue.release(parentStreamId);
+
+    try {
+      const result = await sendFollowUp(parentStreamId, 'after release');
+
+      assert.deepEqual(result, {
+        status: 'queued',
+        reason: 'children_running',
+      });
+      assert.deepEqual(ToolUseFollowUpQueue.getAll(parentStreamId), [
+        'after release',
       ]);
     } finally {
       untrackExecution(executionId);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -390,6 +390,14 @@ function startCodexLoop(params: {
   // giving the user a visual cue that the session was interrupted.
   const groupId = logger.startGroup('Codex session');
 
+  // Register resumed threads immediately — without this, a second codex call
+  // with the same thread_id during the first turn would bypass the in-memory
+  // guard and start a concurrent loop. Fresh threads don't have thread.id
+  // yet; they're registered after the first turn completes.
+  if (thread.id) {
+    storeThread(thread.id, { thread, childStreamId, executionId });
+  }
+
   // Seed the initial prompt; the loop drains it as the first turn.
   queue.enqueue(initialPrompt);
   StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -489,7 +489,12 @@ async function createCodexThread(
   const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
   const config = await getCodexConfig();
   const sandboxMode = input.sandbox_mode;
-  const workspace = config.buildCodexWorkspaceOptions(workingDir);
+  // Resumed threads keep their stored workspace unless the caller explicitly
+  // overrides it — compute workspace only for new threads or explicit overrides.
+  const workspace =
+    workingDir || !input.thread_id
+      ? config.buildCodexWorkspaceOptions(workingDir)
+      : {};
   const threadOptions = {
     ...workspace,
     sandboxMode,
@@ -497,7 +502,9 @@ async function createCodexThread(
     modelReasoningEffort: config.getCodexCliReasoningEffort(),
     skipGitRepoCheck: true as const,
   };
-  return codex.startThread(threadOptions);
+  return input.thread_id
+    ? codex.resumeThread(input.thread_id, threadOptions)
+    : codex.startThread(threadOptions);
 }
 
 // ============================================================================
@@ -533,9 +540,12 @@ export class CodexTool extends defineTool({
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    if (input.thread_id) {
+    if (input.thread_id && threadRegistry.has(input.thread_id)) {
       return resumeCodexThread(input.thread_id, input.prompt);
     }
+    // Either a fresh session or a thread_id whose in-memory loop is gone
+    // (extension reload, crash). `createCodexThread` resumes via the SDK
+    // when input.thread_id is set, otherwise starts a new thread.
     return launchCodexSession(input, ctx?.streamId, ctx?.executionId);
   }
 }
@@ -624,9 +634,15 @@ async function resumeCodexThread(
     );
   }
   deliveryState.hasDelivered = false;
-
-  const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
-  queue.enqueue(prompt);
+  try {
+    const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
+    queue.enqueue(prompt);
+  } catch (err) {
+    // Restore the flag so the thread doesn't get permanently locked if the
+    // enqueue path ever starts throwing (mirrors DelegationTools).
+    deliveryState.hasDelivered = true;
+    throw err;
+  }
 
   const preview = truncateWithEllipsis(prompt, 60);
   return {

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -489,8 +489,7 @@ async function createCodexThread(
   const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
   const config = await getCodexConfig();
   const sandboxMode = input.sandbox_mode;
-  // Resumed threads keep their stored workspace unless the caller explicitly
-  // overrides it — compute workspace only for new threads or explicit overrides.
+  // Resumed threads keep their stored workspace unless explicitly overridden.
   const workspace =
     workingDir || !input.thread_id
       ? config.buildCodexWorkspaceOptions(workingDir)
@@ -543,9 +542,8 @@ export class CodexTool extends defineTool({
     if (input.thread_id && threadRegistry.has(input.thread_id)) {
       return resumeCodexThread(input.thread_id, input.prompt);
     }
-    // Either a fresh session or a thread_id whose in-memory loop is gone
-    // (extension reload, crash). `createCodexThread` resumes via the SDK
-    // when input.thread_id is set, otherwise starts a new thread.
+    // Fall through when the thread's in-memory loop is gone (extension
+    // reload, crash): createCodexThread resumes via the SDK from disk.
     return launchCodexSession(input, ctx?.streamId, ctx?.executionId);
   }
 }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -1,10 +1,14 @@
 /**
  * Codex tool — spin off an OpenAI Codex agent via the @openai/codex-sdk.
  *
- * Supports foreground (blocking) and background (async follow-up) modes.
- * Threads are multi-turn: after the first turn, the child stream enters
- * WAITING state and accepts follow-ups from the user (via the stream tab's
- * follow-up input) or from the orchestrator (via the `thread_id` parameter).
+ * Mirrors the `delegate_agent` model: every call is async. Without a
+ * thread_id, a new Codex session is launched and the result is delivered
+ * as a follow-up to the parent stream. With a thread_id, the prompt is
+ * enqueued as a follow-up instruction to an existing session (errors if
+ * the session is still processing — never interrupts a running turn).
+ * Each turn's result is delivered back to the parent via the follow-up
+ * queue, so the orchestrator sees responses uniformly whether it or the
+ * user drove the turn.
  *
  * The Codex CLI handles its own auth (~/.codex/auth.json from `codex login`,
  * OPENAI_API_KEY, config files).
@@ -22,7 +26,6 @@ import {
   registerExecution,
   writeTerminalStatus,
 } from '@agent/storage';
-import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
@@ -55,7 +58,7 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 // Local file imports
 import { defineTool } from './core/define';
 import { importCodexClass, findCodexBinaryPath } from './codexImport';
-import { createChildStream, finalizeChildStream } from './childStream';
+import { createChildStream } from './childStream';
 import {
   buildCodexCommandToolLog,
   buildCodexFileChangeToolLog,
@@ -100,26 +103,22 @@ async function getCodexConfig(): Promise<typeof import('./codexConfig')> {
 // ============================================================================
 
 const CodexInputSchema = z.strictObject({
-  prompt: z.string().describe('Instruction for the Codex agent'),
+  prompt: z
+    .string()
+    .describe(
+      'Instruction for the Codex agent. For a new session, describe the task. For a resume (thread_id set), describe the follow-up.',
+    ),
   sandbox_mode: z
     .enum(CODEX_SANDBOX_MODES)
     .nullish()
     .describe(
       'File access level for the Codex agent (defaults to user-configured mode, typically workspace-write)',
     ),
-  run_in_background: z
-    .boolean()
-    .prefault(false)
-    .describe(
-      'Run asynchronously. Returns immediately with execution ID. Result delivered as follow-up when complete.',
-    ),
   thread_id: z
     .string()
     .nullish()
     .describe(
-      'Resume an existing Codex thread by its ID. ' +
-        'When provided, continues the conversation from where it left off instead of starting a new one. ' +
-        'Get the thread_id from the result of a previous codex call.',
+      'Resume an existing Codex thread with a follow-up instruction. The prompt is enqueued as the next turn; if the thread is currently processing, the call errors — wait for its delivery before resuming.',
     ),
 });
 
@@ -132,7 +131,6 @@ export type CodexInput = z.infer<typeof CodexInputSchema>;
 interface ActiveThread {
   thread: Thread;
   childStreamId: StreamTabId;
-  logger: AgentLogger;
   executionId: ExecutionId;
 }
 
@@ -142,7 +140,7 @@ const threadRegistry = new Map<string, ActiveThread>();
 function storeThread(threadId: string, entry: ActiveThread): void {
   threadRegistry.set(threadId, entry);
   // Extension reload clears memory but SDK stores sessions on disk —
-  // persist the ID so resumeThread() can reconstruct the conversation.
+  // persist the ID so later code can display or cross-reference it.
   void getExecutionStore(entry.executionId)
     .write('codex_thread_id', threadId)
     .catch(() => {});
@@ -156,6 +154,21 @@ export function interruptAllCodexSessions(): void {
 }
 
 // ============================================================================
+// Codex delivery state — mirrors DelegationTools.activeSubagentDelivery
+// ============================================================================
+
+/**
+ * `hasDelivered` is true between turns (the loop is WAITING) and false while
+ * a turn is in flight. Resume via thread_id refuses when !hasDelivered so the
+ * orchestrator can't pile up concurrent prompts on the same thread.
+ */
+interface CodexDeliveryState {
+  hasDelivered: boolean;
+}
+
+const activeCodexDelivery = new Map<ExecutionId, CodexDeliveryState>();
+
+// ============================================================================
 // Codex follow-up session — IInterruptible only (no ToolUseFlowContext)
 // ============================================================================
 
@@ -167,7 +180,7 @@ export function interruptAllCodexSessions(): void {
  * which prevents `getToolUseFlowContext()` from matching it — commands like
  * `compactResponse` that access `flowContext.modelHandler` won't crash.
  *
- * Follow-ups route through the WAITING state queue path instead:
+ * Follow-ups route through the WAITING state queue path:
  * `sendFollowUp()` → stream is WAITING → `ToolUseFollowUpQueue.enqueue()`.
  */
 class CodexFollowUpSession implements IInterruptible {
@@ -178,8 +191,6 @@ class CodexFollowUpSession implements IInterruptible {
     this.interrupted = true;
     this.queue?.cancelWait();
   }
-
-  constructor() {}
 
   setQueue(q: FollowUpQueue): void {
     this.queue = q;
@@ -194,32 +205,7 @@ class CodexFollowUpSession implements IInterruptible {
 // Result formatting
 // ============================================================================
 
-/**
- * Format a completed Codex turn for the tool result returned to the LLM.
- *
- * Only includes the final model response (what the LLM needs to act on) plus
- * a compact usage note. Intermediate details (commands run, files changed) are
- * streamed to the child stream tab and don't need to be in the result.
- */
-function formatTurnResult(turn: RunResult, threadId?: string | null): string {
-  const parts: string[] = [turn.finalResponse || '(no response)'];
-
-  if (turn.usage) {
-    parts.push(
-      `[Tokens: ${turn.usage.input_tokens} in / ${turn.usage.output_tokens} out]`,
-    );
-  }
-
-  if (threadId) {
-    parts.push(
-      `[Thread ID: ${threadId} — use thread_id to continue this session]`,
-    );
-  }
-
-  return parts.join('\n\n');
-}
-
-/** Format a Codex result for background delivery as XML. */
+/** Format a Codex result for delivery as XML on the parent's follow-up queue. */
 function formatCodexDelivery(
   executionId: string,
   prompt: string,
@@ -245,7 +231,7 @@ function formatCodexDelivery(
   return lines.join('\n');
 }
 
-/** Format a Codex error for background delivery. */
+/** Format a Codex error for delivery on the parent's follow-up queue. */
 function formatCodexError(
   executionId: string,
   prompt: string,
@@ -323,120 +309,6 @@ function logTurnSummary(
 }
 
 // ============================================================================
-// Follow-up loop — runs additional turns when user sends follow-ups
-// ============================================================================
-
-/**
- * After the initial turn, enter a loop that waits for user follow-ups
- * in the child stream tab and runs them on the same Codex thread.
- * The loop runs until interrupted or the session is disposed.
- */
-function startFollowUpLoop(
-  thread: Thread,
-  childStreamId: StreamTabId,
-  executionId: string,
-  logger: AgentLogger,
-): void {
-  const session = new CodexFollowUpSession();
-  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
-  session.setQueue(queue);
-  registerInterruptible(childStreamId, session);
-
-  // Start a log group so endRunningGroups() marks it as errored on reload,
-  // giving the user a visual cue that the session was interrupted.
-  const groupId = logger.startGroup('Codex session');
-
-  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
-
-  void (async () => {
-    try {
-      while (!session.isInterrupted()) {
-        const messages = await queue.waitAndDrainAll(() =>
-          session.isInterrupted(),
-        );
-        if (!messages || session.isInterrupted()) break;
-
-        const userMessage = messages.join('\n\n');
-
-        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
-        const startedAt = Date.now();
-
-        try {
-          const turn = await runStreamedTurn(
-            thread,
-            userMessage,
-            childStreamId,
-            logger,
-          );
-          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
-        } catch (err) {
-          logger.error(toErrorMessage(err));
-        }
-
-        // Don't override STOPPED — the user pressed the stop button
-        if (!session.isInterrupted()) {
-          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
-        }
-      }
-    } finally {
-      logger.endGroup(groupId, 'stopped');
-      unregisterInterruptible(childStreamId);
-      ToolUseFollowUpQueue.release(childStreamId);
-      // Persist terminal status before untracking — untrackExecution fires
-      // notifyWaiters, so consumers must see the final status on disk.
-      await writeTerminalStatus(executionId, 'completed').catch(() => {});
-      untrackExecution(executionId);
-
-      const threadId = thread.id;
-      if (threadId) threadRegistry.delete(threadId);
-
-      if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
-        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
-      }
-    }
-  })();
-}
-
-/**
- * After a successful turn, either start a follow-up loop (if the SDK
- * assigned a thread ID) or finalize the stream.
- */
-function handleTurnSuccess(
-  thread: Thread,
-  turn: RunResult,
-  childStreamId: StreamTabId,
-  executionId: ExecutionId,
-  logger: AgentLogger,
-  wallTimeMs: number,
-): void {
-  // Persist structured usage stats for the UI
-  if (turn.usage) {
-    bus.emit('updateStreamUsage', {
-      streamId: childStreamId,
-      storageKey: executionId as StorageKey,
-      executionId,
-      usage: {
-        inputTokens: turn.usage.input_tokens,
-        outputTokens: turn.usage.output_tokens,
-        cost: 0,
-      },
-    });
-  }
-
-  const threadId = thread.id;
-  if (threadId) {
-    logTurnSummary(logger, wallTimeMs, turn.usage);
-    storeThread(threadId, { thread, childStreamId, logger, executionId });
-    startFollowUpLoop(thread, childStreamId, executionId, logger);
-  } else {
-    finalizeChildStream(childStreamId, executionId, logger, {
-      wallTimeMs,
-      usage: turn.usage,
-    });
-  }
-}
-
-// ============================================================================
 // Streaming helpers
 // ============================================================================
 
@@ -480,6 +352,155 @@ async function runStreamedTurn(
 }
 
 // ============================================================================
+// Codex session loop — one turn per enqueued prompt, delivers to parent
+// ============================================================================
+
+/**
+ * Run the Codex session loop. The loop processes prompts from the child's
+ * follow-up queue one at a time and delivers each turn's result to the
+ * parent's follow-up queue. The initial prompt is seeded into the queue so
+ * the first turn goes through the same code path as every follow-up turn.
+ */
+function startCodexLoop(params: {
+  thread: Thread;
+  childStreamId: StreamTabId;
+  parentStreamId: StreamTabId;
+  executionId: ExecutionId;
+  logger: AgentLogger;
+  initialPrompt: string;
+}): void {
+  const {
+    thread,
+    childStreamId,
+    parentStreamId,
+    executionId,
+    logger,
+    initialPrompt,
+  } = params;
+
+  const session = new CodexFollowUpSession();
+  const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  session.setQueue(queue);
+  registerInterruptible(childStreamId, session);
+
+  const deliveryState: CodexDeliveryState = { hasDelivered: true };
+  activeCodexDelivery.set(executionId, deliveryState);
+
+  // Start a log group so endRunningGroups() marks it as errored on reload,
+  // giving the user a visual cue that the session was interrupted.
+  const groupId = logger.startGroup('Codex session');
+
+  // Seed the initial prompt; the loop drains it as the first turn.
+  queue.enqueue(initialPrompt);
+  StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+
+  void (async () => {
+    try {
+      while (!session.isInterrupted()) {
+        const messages = await queue.waitAndDrainAll(() =>
+          session.isInterrupted(),
+        );
+        if (!messages || session.isInterrupted()) break;
+
+        const prompt = messages.join('\n\n');
+        deliveryState.hasDelivered = false;
+        StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
+        const startedAt = Date.now();
+
+        let turn: RunResult | null = null;
+        let err: unknown = null;
+        try {
+          turn = await runStreamedTurn(thread, prompt, childStreamId, logger);
+          logTurnSummary(logger, Date.now() - startedAt, turn.usage);
+        } catch (caught) {
+          err = caught;
+          logger.error(toErrorMessage(caught));
+        }
+
+        const wallTimeMs = Date.now() - startedAt;
+        const threadId = thread.id;
+        if (threadId && !threadRegistry.has(threadId)) {
+          storeThread(threadId, { thread, childStreamId, executionId });
+        }
+
+        if (turn?.usage) {
+          bus.emit('updateStreamUsage', {
+            streamId: childStreamId,
+            storageKey: executionId as StorageKey,
+            executionId,
+            usage: {
+              inputTokens: turn.usage.input_tokens,
+              outputTokens: turn.usage.output_tokens,
+              cost: 0,
+            },
+          });
+        }
+
+        const msg =
+          turn && !err
+            ? formatCodexDelivery(
+                executionId,
+                prompt,
+                wallTimeMs,
+                turn,
+                threadId,
+              )
+            : formatCodexError(executionId, prompt, err);
+        try {
+          await getExecutionStore(executionId).writeReport(msg);
+        } catch {
+          // Best-effort; delivery must not block on storage.
+        }
+        deliveryState.hasDelivered = true;
+        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
+
+        if (!session.isInterrupted()) {
+          StreamStatusService.set(childStreamId, STREAM_STATUS.WAITING);
+        }
+      }
+    } finally {
+      logger.endGroup(groupId, 'stopped');
+      unregisterInterruptible(childStreamId);
+      ToolUseFollowUpQueue.release(childStreamId);
+      activeCodexDelivery.delete(executionId);
+      const threadId = thread.id;
+      if (threadId) threadRegistry.delete(threadId);
+      // Persist terminal status before untracking — untrackExecution fires
+      // notifyWaiters, so consumers must see the final status on disk.
+      await writeTerminalStatus(executionId, 'completed').catch(() => {});
+      untrackExecution(executionId);
+
+      if (StreamStatusService.get(childStreamId) === STREAM_STATUS.WAITING) {
+        StreamStatusService.set(childStreamId, STREAM_STATUS.READY);
+      }
+    }
+  })();
+}
+
+// ============================================================================
+// Thread creation
+// ============================================================================
+
+async function createCodexThread(
+  input: CodexInput,
+  workingDir?: string,
+): Promise<Thread> {
+  const CodexClass = await importCodexClass();
+  const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
+  const config = await getCodexConfig();
+  const sandboxMode = input.sandbox_mode;
+  const workspace = config.buildCodexWorkspaceOptions(workingDir);
+  const threadOptions = {
+    ...workspace,
+    sandboxMode,
+    model: config.CODEX_CLI_MODEL,
+    modelReasoningEffort: config.getCodexCliReasoningEffort(),
+    skipGitRepoCheck: true as const,
+  };
+  return codex.startThread(threadOptions);
+}
+
+// ============================================================================
 // Tool
 // ============================================================================
 
@@ -490,17 +511,16 @@ export class CodexTool extends defineTool({
     'The agent runs the Codex CLI locally and can read files, run commands, and make edits within its sandbox. ' +
     'Requires the Codex CLI to be installed (`npm install -g @openai/codex`). ' +
     'Auth is handled by the CLI itself — use `codex login` (OAuth, recommended) or set OPENAI_API_KEY env var. ' +
-    'Returns a thread_id that can be passed back to continue the conversation in subsequent calls.',
+    'Always async: returns immediately with an execution ID; each turn is delivered back as a follow-up message (including the thread_id). ' +
+    'Pass thread_id on a later call to send a follow-up instruction to an existing session — mirrors delegate_agent(execution_id=…).',
   schema: CodexInputSchema,
 }) {
   protected async execute(input: CodexInput): Promise<ToolResult> {
-    // Resolve sandbox mode default early so it's available for approval label + output.
     if (!input.sandbox_mode) {
       const config = await getCodexConfig();
       input.sandbox_mode = config.getCodexSandboxMode();
     }
 
-    // Request approval — same pattern as BashTool
     const approvalLabel = `[codex ${input.sandbox_mode}] ${input.prompt}`;
     const approval = await requestBashApproval({ command: approvalLabel });
     if (!approval.accepted) {
@@ -510,237 +530,110 @@ export class CodexTool extends defineTool({
       );
     }
 
-    // Signal execution starting
     const ctx = getCurrentToolFileInteractionContext();
     ctx?.onExecutionReady?.();
 
-    const workingDir = parseWorkingDirectory(ctx?.workingDirectory);
-    const thread = await this.resolveThread(input, workingDir);
-
-    if (input.run_in_background) {
-      return this.executeBackground(
-        thread,
-        input,
-        ctx?.streamId,
-        ctx?.executionId,
-      );
-    }
-
-    return this.executeForeground(thread, input, ctx?.streamId);
-  }
-
-  /** Resolve thread — resume existing or start new. */
-  private async resolveThread(
-    input: CodexInput,
-    workingDir?: string,
-  ): Promise<Thread> {
     if (input.thread_id) {
-      const stored = threadRegistry.get(input.thread_id);
-      if (stored) {
-        // Always interrupt the old follow-up loop. If it's WAITING, the
-        // interrupt is clean. If RUNNING, the in-progress turn will error
-        // out — but this prevents orphaned loops and concurrent turns on
-        // the same Thread object.
-        getInterruptible(stored.childStreamId)?.interrupt();
-        threadRegistry.delete(input.thread_id);
-        return stored.thread;
-      }
+      return resumeCodexThread(input.thread_id, input.prompt);
     }
-
-    const CodexClass = await importCodexClass();
-    const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
-    const config = await getCodexConfig();
-    // sandbox_mode is always resolved in execute() before this is called
-    const sandboxMode = input.sandbox_mode;
-    // Only compute workspace for new threads — resumed threads keep their
-    // stored workspace unless the caller explicitly overrides.
-    const workspace =
-      workingDir || !input.thread_id
-        ? config.buildCodexWorkspaceOptions(workingDir)
-        : {};
-    const threadOptions = {
-      ...workspace,
-      sandboxMode,
-      model: config.CODEX_CLI_MODEL,
-      modelReasoningEffort: config.getCodexCliReasoningEffort(),
-      skipGitRepoCheck: true as const,
-    };
-
-    return input.thread_id
-      ? codex.resumeThread(input.thread_id, threadOptions)
-      : codex.startThread(threadOptions);
+    return launchCodexSession(input, ctx?.streamId, ctx?.executionId);
   }
+}
 
-  private async executeForeground(
-    thread: Thread,
-    input: CodexInput,
-    parentStreamId?: StreamTabId,
-  ): Promise<ToolResult> {
-    const executionId = generateExecutionId();
-    const preview = truncateWithEllipsis(input.prompt, 60);
-    const startedAt = Date.now();
-    const codexConfig = await getCodexConfig();
-    const config = codexConfig.buildCodexConfig(input.prompt);
-
-    if (parentStreamId) {
-      await ensureRunDir(executionId);
-      const parentExecutionId =
-        getCurrentToolFileInteractionContext()?.executionId;
-      await registerExecution(
-        executionId,
-        config,
-        'codex',
-        parentExecutionId,
-      ).catch(() => {});
-    }
-
-    const stream = parentStreamId
-      ? createChildStream(executionId, parentStreamId, {
-          streamPrefix: 'codex@codex-sdk',
-          streamCategory: AgentCategory.ToolUse,
-          agentName: 'codex',
-          description: input.prompt,
-          config,
-          toolName: 'codex',
-        })
-      : undefined;
-
-    try {
-      const turn = stream
-        ? await runStreamedTurn(
-            thread,
-            input.prompt,
-            stream.childStreamId,
-            stream.logger,
-          )
-        : await thread.run(input.prompt);
-
-      const threadId = thread.id;
-      const wallTimeMs = Date.now() - startedAt;
-
-      if (stream) {
-        handleTurnSuccess(
-          thread,
-          turn,
-          stream.childStreamId,
-          executionId,
-          stream.logger,
-          wallTimeMs,
-        );
-      }
-
-      return {
-        summary: `Codex: ${preview}`,
-        output: formatTurnResult(turn, threadId),
-      };
-    } catch (err) {
-      if (stream) {
-        finalizeChildStream(stream.childStreamId, executionId, stream.logger, {
-          error: err,
-          errorMessage: toErrorMessage(err),
-        });
-      }
-      throw err;
-    }
-  }
-
-  private async executeBackground(
-    thread: Thread,
-    input: CodexInput,
-    parentStreamId: StreamTabId | undefined,
-    parentExecutionId: ExecutionId | undefined,
-  ): Promise<ToolResult> {
-    if (!parentStreamId) {
-      throw new ToolError(
-        'Background execution requires a parent stream context.',
-      );
-    }
-
-    const executionId = generateExecutionId();
-    await ensureRunDir(executionId);
-
-    const preview = truncateWithEllipsis(input.prompt, 60);
-    const codexConfig = await getCodexConfig();
-    const config = codexConfig.buildCodexConfig(input.prompt);
-
-    try {
-      await registerExecution(executionId, config, 'codex', parentExecutionId);
-    } catch {
-      throw new ToolError('Failed to register background Codex execution.');
-    }
-
-    const { childStreamId, logger } = createChildStream(
-      executionId,
-      parentStreamId,
-      {
-        streamPrefix: 'codex@codex-sdk',
-        streamCategory: AgentCategory.ToolUse,
-        agentName: 'codex',
-        description: input.prompt,
-        config,
-        toolName: 'codex',
-      },
+async function launchCodexSession(
+  input: CodexInput,
+  parentStreamId: StreamTabId | undefined,
+  parentExecutionId: ExecutionId | undefined,
+): Promise<ToolResult> {
+  if (!parentStreamId) {
+    throw new ToolError(
+      'Codex requires a parent stream context — it must be called from an active tool-use agent.',
     );
-
-    const startedAt = Date.now();
-
-    void (async () => {
-      try {
-        const turn = await runStreamedTurn(
-          thread,
-          input.prompt,
-          childStreamId,
-          logger,
-        );
-        const wallTimeMs = Date.now() - startedAt;
-        const threadId = thread.id;
-        const store = getExecutionStore(executionId);
-
-        const msg = formatCodexDelivery(
-          executionId,
-          input.prompt,
-          wallTimeMs,
-          turn,
-          threadId,
-        );
-        await store.writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-
-        // Write terminal status before handleTurnSuccess, which may call
-        // finalizeChildStream → untrackExecution → notifyWaiters.
-        // When a follow-up loop starts, the loop's finally writes its own status.
-        if (!threadId) {
-          await writeTerminalStatus(executionId, 'completed').catch(() => {});
-        }
-        handleTurnSuccess(
-          thread,
-          turn,
-          childStreamId,
-          executionId,
-          logger,
-          wallTimeMs,
-        );
-      } catch (err: unknown) {
-        await writeTerminalStatus(executionId, 'error').catch(() => {});
-        finalizeChildStream(childStreamId, executionId, logger, {
-          error: err,
-          errorMessage: toErrorMessage(err),
-        });
-
-        const msg = formatCodexError(executionId, input.prompt, err);
-        await getExecutionStore(executionId).writeReport(msg);
-        ToolUseFollowUpQueue.enqueue(parentStreamId, msg);
-      }
-    })();
-
-    return {
-      summary: `Launched Codex: ${preview}`,
-      output: [
-        `Codex agent launched in background (${input.sandbox_mode}).`,
-        `Execution ID: ${executionId}`,
-        `Stream tab: ${childStreamId}`,
-        'Result will be delivered as a follow-up message when complete.',
-      ].join('\n'),
-    };
   }
+
+  const ctx = getCurrentToolFileInteractionContext();
+  const workingDir = parseWorkingDirectory(ctx?.workingDirectory);
+  const thread = await createCodexThread(input, workingDir);
+
+  const executionId = generateExecutionId();
+  await ensureRunDir(executionId);
+
+  const codexConfig = await getCodexConfig();
+  const config = codexConfig.buildCodexConfig(input.prompt);
+
+  try {
+    await registerExecution(executionId, config, 'codex', parentExecutionId);
+  } catch {
+    throw new ToolError('Failed to register Codex execution.');
+  }
+
+  const { childStreamId, logger } = createChildStream(
+    executionId,
+    parentStreamId,
+    {
+      streamPrefix: 'codex@codex-sdk',
+      streamCategory: AgentCategory.ToolUse,
+      agentName: 'codex',
+      description: input.prompt,
+      config,
+      toolName: 'codex',
+    },
+  );
+
+  startCodexLoop({
+    thread,
+    childStreamId,
+    parentStreamId,
+    executionId,
+    logger,
+    initialPrompt: input.prompt,
+  });
+
+  const preview = truncateWithEllipsis(input.prompt, 60);
+  return {
+    summary: `Launched Codex: ${preview}`,
+    output: [
+      `Codex agent launched (sandbox: ${input.sandbox_mode}).`,
+      `Execution ID: ${executionId}`,
+      `Stream tab: ${childStreamId}`,
+      `Result will be delivered as a follow-up message when the turn completes. The delivery includes the thread_id — pass it to codex on a later call to send a follow-up instruction.`,
+    ].join('\n'),
+  };
+}
+
+async function resumeCodexThread(
+  threadId: string,
+  prompt: string,
+): Promise<ToolResult> {
+  const stored = threadRegistry.get(threadId);
+  if (!stored) {
+    throw new ToolError(
+      `Codex thread '${threadId}' is not active. It may have completed or been stopped; start a new session without thread_id.`,
+    );
+  }
+
+  const deliveryState = activeCodexDelivery.get(stored.executionId);
+  if (!deliveryState) {
+    throw new ToolError(
+      `Codex execution '${stored.executionId}' is no longer tracked for delivery.`,
+    );
+  }
+  if (!deliveryState.hasDelivered) {
+    throw new ToolError(
+      `Codex thread '${threadId}' is still processing. Wait for its result before sending a follow-up.`,
+    );
+  }
+  deliveryState.hasDelivered = false;
+
+  const queue = ToolUseFollowUpQueue.acquire(stored.childStreamId);
+  queue.enqueue(prompt);
+
+  const preview = truncateWithEllipsis(prompt, 60);
+  return {
+    summary: `Follow-up sent to Codex: ${preview}`,
+    output: [
+      `Follow-up instruction queued for Codex thread '${threadId}'. The agent will process it and deliver a new result automatically.`,
+      `Execution ID: ${stored.executionId}`,
+    ].join('\n'),
+  };
 }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -131,6 +131,7 @@ export type CodexInput = z.infer<typeof CodexInputSchema>;
 interface ActiveThread {
   thread: Thread;
   childStreamId: StreamTabId;
+  parentStreamId: StreamTabId;
   executionId: ExecutionId;
 }
 
@@ -395,7 +396,12 @@ function startCodexLoop(params: {
   // guard and start a concurrent loop. Fresh threads don't have thread.id
   // yet; they're registered after the first turn completes.
   if (thread.id) {
-    storeThread(thread.id, { thread, childStreamId, executionId });
+    storeThread(thread.id, {
+      thread,
+      childStreamId,
+      parentStreamId,
+      executionId,
+    });
   }
 
   // Seed the initial prompt; the loop drains it as the first turn.
@@ -428,7 +434,12 @@ function startCodexLoop(params: {
         const wallTimeMs = Date.now() - startedAt;
         const threadId = thread.id;
         if (threadId && !threadRegistry.has(threadId)) {
-          storeThread(threadId, { thread, childStreamId, executionId });
+          storeThread(threadId, {
+            thread,
+            childStreamId,
+            parentStreamId,
+            executionId,
+          });
         }
 
         if (turn?.usage) {
@@ -548,7 +559,7 @@ export class CodexTool extends defineTool({
     ctx?.onExecutionReady?.();
 
     if (input.thread_id && threadRegistry.has(input.thread_id)) {
-      return resumeCodexThread(input.thread_id, input.prompt);
+      return resumeCodexThread(input.thread_id, input.prompt, ctx?.streamId);
     }
     // Fall through when the thread's in-memory loop is gone (extension
     // reload, crash): createCodexThread resumes via the SDK from disk.
@@ -620,11 +631,21 @@ async function launchCodexSession(
 async function resumeCodexThread(
   threadId: string,
   prompt: string,
+  callerStreamId: StreamTabId | undefined,
 ): Promise<ToolResult> {
   const stored = threadRegistry.get(threadId);
   if (!stored) {
     throw new ToolError(
       `Codex thread '${threadId}' is not active. It may have completed or been stopped; start a new session without thread_id.`,
+    );
+  }
+
+  // The turn result is delivered to the stored parent stream, so refuse
+  // callers from a different stream — otherwise the sender reports "sent"
+  // while the response lands on someone else's orchestrator.
+  if (callerStreamId && stored.parentStreamId !== callerStreamId) {
+    throw new ToolError(
+      `Codex thread '${threadId}' is owned by a different session; start a new session without thread_id to run in this context.`,
     );
   }
 


### PR DESCRIPTION
When the orchestrator's flow context has exited but a delegated subagent
is still running, user follow-ups hit the 'no_session' branch and were
rejected with "No active session". Now sendFollowUp also checks
getActiveChildren() and queues the message, and the command layer tries
auto-resume so the orchestrator picks it up alongside the subagent's
eventual result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes follow-up routing/queue lifecycle and refactors the `codex` tool to be always-async with new delivery semantics, which could impact tool-use session continuity and message ordering if edge cases were missed.
> 
> **Overview**
> Fixes orchestrator follow-ups being rejected during delegation by queuing messages when the parent flow has no active session but still has active child subagents/processes (`getActiveChildren`), and adds a `{ force: true }` option to reopen previously-released follow-up queues.
> 
> Updates the follow-up command to auto-resume in this new queued state and to explicitly drop/re-release forced queues when no consumer can resume the session, preventing late deliveries from leaking into future runs.
> 
> Refactors the `codex` tool to **always run async** (removes `run_in_background`), delivering each turn back to the parent via the follow-up queue with an execution ID + `thread_id`, plus corresponding UI renderer/schema and documentation updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc385067a776ba997048433a16ea24bc0fc952b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->