### PR TITLE
feat(pr-activity): emit terminal CI events + surface review thread replies

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -427,10 +427,9 @@ export class PRPollingSource implements AsyncEventSource {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
         }
-        // Seed the terminal-CI flag so a PR whose CI was already complete at
-        // subscribe time doesn't immediately fire a terminal event next tick.
-        // Only future transitions get surfaced.
-        if (state.headSha && this.allRunsTerminal(runs)) {
+        // Seed so pre-existing terminal CI doesn't fire on the next tick —
+        // we only surface transitions that happen after subscribe.
+        if (state.headSha && runs.every((r) => r.status === 'completed')) {
           state.ciTerminalSha = state.headSha;
         }
       }
@@ -505,16 +504,12 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
 
-      // Terminal CI event. Fires once per head SHA when every run has
-      // reached `completed`. Gate on `runs.length > 0` because an empty
-      // array is ambiguous — no CI is configured, or runs haven't registered
-      // yet — and "done" isn't meaningful either way. We emit one event:
-      // `ci_pass` if all passed, `ci_complete` (with fail count) otherwise.
-      // Per-check failures still fire separately via `formatCheckFailure`.
+      // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
+      // configured vs. runs not yet registered), so "done" isn't meaningful.
       if (
         state.headSha &&
         runs.length > 0 &&
-        this.allRunsTerminal(runs) &&
+        runs.every((r) => r.status === 'completed') &&
         state.ciTerminalSha !== state.headSha
       ) {
         state.ciTerminalSha = state.headSha;
@@ -527,10 +522,6 @@ export class PRPollingSource implements AsyncEventSource {
         );
       }
     }
-  }
-
-  private allRunsTerminal(runs: readonly GhCheckRun[]): boolean {
-    return runs.every((r) => r.status === 'completed');
   }
 
   private isCheckFailure(r: GhCheckRun): boolean {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -24,6 +24,7 @@ import {
   formatReview,
   formatReviewComment,
   formatSubscriptionError,
+  isPassingConclusion,
 } from './formatPREvent';
 import {
   GitHubAuthError,
@@ -96,10 +97,7 @@ interface SubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
-  /** Head SHA of the last tick where we emitted a terminal CI event. */
   ciTerminalSha: string | undefined;
-  /** Head SHA of the last tick where we emitted a CI-all-passed event. */
-  ciPassedSha: string | undefined;
   headSha: string | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
@@ -175,7 +173,6 @@ export class PRPollingSource implements AsyncEventSource {
         seenReviewIds: new Set(),
         lastFailedCheckKeys: new Set(),
         ciTerminalSha: undefined,
-        ciPassedSha: undefined,
         headSha: undefined,
         state: undefined,
         merged: false,
@@ -336,11 +333,8 @@ export class PRPollingSource implements AsyncEventSource {
       state.state = newState;
       state.merged = newMerged;
       // New push invalidates prior CI terminal state — the next completion
-      // on the new SHA should re-emit terminal events.
-      if (state.headSha !== newHead) {
-        state.ciTerminalSha = undefined;
-        state.ciPassedSha = undefined;
-      }
+      // on the new SHA should re-emit a terminal event.
+      if (state.headSha !== newHead) state.ciTerminalSha = undefined;
       state.headSha = newHead;
     }
 
@@ -433,12 +427,11 @@ export class PRPollingSource implements AsyncEventSource {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
         }
-        // Seed terminal-CI flags so a PR whose CI was already complete at
-        // subscribe time doesn't immediately emit a `ci_complete`/`ci_pass`
-        // event on the next tick. We only surface future transitions.
+        // Seed the terminal-CI flag so a PR whose CI was already complete at
+        // subscribe time doesn't immediately fire a terminal event next tick.
+        // Only future transitions get surfaced.
         if (state.headSha && this.allRunsTerminal(runs)) {
           state.ciTerminalSha = state.headSha;
-          if (this.allRunsPassing(runs)) state.ciPassedSha = state.headSha;
         }
       }
       state.initialized = true;
@@ -512,10 +505,12 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
 
-      // Terminal CI events. Fire once per head SHA when every run has
+      // Terminal CI event. Fires once per head SHA when every run has
       // reached `completed`. Gate on `runs.length > 0` because an empty
-      // array means either no CI is configured or runs haven't registered
-      // yet — either way, there's nothing to signal "done" about.
+      // array is ambiguous — no CI is configured, or runs haven't registered
+      // yet — and "done" isn't meaningful either way. We emit one event:
+      // `ci_pass` if all passed, `ci_complete` (with fail count) otherwise.
+      // Per-check failures still fire separately via `formatCheckFailure`.
       if (
         state.headSha &&
         runs.length > 0 &&
@@ -523,35 +518,19 @@ export class PRPollingSource implements AsyncEventSource {
         state.ciTerminalSha !== state.headSha
       ) {
         state.ciTerminalSha = state.headSha;
+        const allPassed = runs.every((r) => isPassingConclusion(r.conclusion));
         this.emit(
           state,
-          formatCIComplete(state.slug, pr.pullNumber, state.headSha, runs),
+          allPassed
+            ? formatCIPassed(state.slug, pr.pullNumber, state.headSha, runs)
+            : formatCIComplete(state.slug, pr.pullNumber, state.headSha, runs),
         );
-        if (
-          this.allRunsPassing(runs) &&
-          state.ciPassedSha !== state.headSha
-        ) {
-          state.ciPassedSha = state.headSha;
-          this.emit(
-            state,
-            formatCIPassed(state.slug, pr.pullNumber, state.headSha, runs),
-          );
-        }
       }
     }
   }
 
   private allRunsTerminal(runs: readonly GhCheckRun[]): boolean {
     return runs.every((r) => r.status === 'completed');
-  }
-
-  private allRunsPassing(runs: readonly GhCheckRun[]): boolean {
-    return runs.every(
-      (r) =>
-        r.conclusion === 'success' ||
-        r.conclusion === 'neutral' ||
-        r.conclusion === 'skipped',
-    );
   }
 
   private isCheckFailure(r: GhCheckRun): boolean {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -97,7 +97,10 @@ interface SubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
-  ciTerminalSha: string | undefined;
+  /** Head SHA for which the one-shot "CI complete" event has been emitted. */
+  ciCompleteSha: string | undefined;
+  /** Head SHA for which the one-shot "CI passed" event has been emitted. */
+  ciPassedSha: string | undefined;
   headSha: string | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
@@ -172,7 +175,8 @@ export class PRPollingSource implements AsyncEventSource {
         seenReviewCommentIds: new Set(),
         seenReviewIds: new Set(),
         lastFailedCheckKeys: new Set(),
-        ciTerminalSha: undefined,
+        ciCompleteSha: undefined,
+        ciPassedSha: undefined,
         headSha: undefined,
         state: undefined,
         merged: false,
@@ -333,8 +337,11 @@ export class PRPollingSource implements AsyncEventSource {
       state.state = newState;
       state.merged = newMerged;
       // New push invalidates prior CI terminal state — the next completion
-      // on the new SHA should re-emit a terminal event.
-      if (state.headSha !== newHead) state.ciTerminalSha = undefined;
+      // on the new SHA should re-emit both terminal events.
+      if (state.headSha !== newHead) {
+        state.ciCompleteSha = undefined;
+        state.ciPassedSha = undefined;
+      }
       state.headSha = newHead;
     }
 
@@ -428,9 +435,19 @@ export class PRPollingSource implements AsyncEventSource {
           }
         }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
-        // we only surface transitions that happen after subscribe.
-        if (state.headSha && runs.every((r) => r.status === 'completed')) {
-          state.ciTerminalSha = state.headSha;
+        // we only surface transitions that happen after subscribe. Gate on
+        // runs.length > 0: an empty array is ambiguous (no CI configured vs.
+        // runs not yet registered), so "done" isn't meaningful and seeding
+        // would suppress the real terminal event once runs appear.
+        if (
+          state.headSha &&
+          runs.length > 0 &&
+          runs.every((r) => r.status === 'completed')
+        ) {
+          state.ciCompleteSha = state.headSha;
+          if (runs.every((r) => isPassingConclusion(r.conclusion))) {
+            state.ciPassedSha = state.headSha;
+          }
         }
       }
       state.initialized = true;
@@ -504,22 +521,37 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
 
+      // Emit two one-shot events per head SHA: "CI complete" on first
+      // terminal state (any conclusion), then "CI passed" the first time
+      // all checks pass (which may happen via a later rerun). Each is
+      // deduped against its own marker so a rerun turning red→green still
+      // emits "CI passed" even after "CI complete" already fired.
+      //
       // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
       // configured vs. runs not yet registered), so "done" isn't meaningful.
       if (
         state.headSha &&
         runs.length > 0 &&
-        runs.every((r) => r.status === 'completed') &&
-        state.ciTerminalSha !== state.headSha
+        runs.every((r) => r.status === 'completed')
       ) {
-        state.ciTerminalSha = state.headSha;
-        const allPassed = runs.every((r) => isPassingConclusion(r.conclusion));
-        this.emit(
-          state,
-          allPassed
-            ? formatCIPassed(state.slug, pr.pullNumber, state.headSha, runs)
-            : formatCIComplete(state.slug, pr.pullNumber, state.headSha, runs),
-        );
+        const headSha = state.headSha;
+        if (state.ciCompleteSha !== headSha) {
+          state.ciCompleteSha = headSha;
+          this.emit(
+            state,
+            formatCIComplete(state.slug, pr.pullNumber, headSha, runs),
+          );
+        }
+        if (
+          state.ciPassedSha !== headSha &&
+          runs.every((r) => isPassingConclusion(r.conclusion))
+        ) {
+          state.ciPassedSha = headSha;
+          this.emit(
+            state,
+            formatCIPassed(state.slug, pr.pullNumber, headSha, runs),
+          );
+        }
       }
     }
   }

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -393,7 +393,7 @@ export class PRPollingSource implements AsyncEventSource {
           state.etags.reviews,
         ),
         state.headSha
-          ? ghGet<{ check_runs: GhCheckRun[] }>(
+          ? ghGet<{ total_count: number; check_runs: GhCheckRun[] }>(
               `/repos/${pr.owner}/${pr.repo}/commits/${state.headSha}/check-runs?per_page=100`,
               state.etags.checkRuns,
             )
@@ -438,10 +438,13 @@ export class PRPollingSource implements AsyncEventSource {
         // we only surface transitions that happen after subscribe. Gate on
         // runs.length > 0: an empty array is ambiguous (no CI configured vs.
         // runs not yet registered), so "done" isn't meaningful and seeding
-        // would suppress the real terminal event once runs appear.
+        // would suppress the real terminal event once runs appear. Also
+        // require a complete page — the API caps at per_page=100, so a PR
+        // with more check runs would be evaluated from a truncated list.
         if (
           state.headSha &&
           runs.length > 0 &&
+          runs.length >= checksRes.data.total_count &&
           runs.every((r) => r.status === 'completed')
         ) {
           state.ciCompleteSha = state.headSha;
@@ -529,9 +532,13 @@ export class PRPollingSource implements AsyncEventSource {
       //
       // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
       // configured vs. runs not yet registered), so "done" isn't meaningful.
+      // Also require a complete page (length >= total_count) — the API caps
+      // at per_page=100, so a PR with more check runs would prematurely
+      // emit a terminal event based on the first page alone.
       if (
         state.headSha &&
         runs.length > 0 &&
+        runs.length >= checksRes.data.total_count &&
         runs.every((r) => r.status === 'completed')
       ) {
         const headSha = state.headSha;

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -17,6 +17,8 @@ import { AgentLogger } from '@logger/AgentLogger';
 import {
   formatCheckFailure,
   formatCheckFailureSummary,
+  formatCIComplete,
+  formatCIPassed,
   formatIssueComment,
   formatPRClosed,
   formatReview,
@@ -94,6 +96,10 @@ interface SubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
+  /** Head SHA of the last tick where we emitted a terminal CI event. */
+  ciTerminalSha: string | undefined;
+  /** Head SHA of the last tick where we emitted a CI-all-passed event. */
+  ciPassedSha: string | undefined;
   headSha: string | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
@@ -168,6 +174,8 @@ export class PRPollingSource implements AsyncEventSource {
         seenReviewCommentIds: new Set(),
         seenReviewIds: new Set(),
         lastFailedCheckKeys: new Set(),
+        ciTerminalSha: undefined,
+        ciPassedSha: undefined,
         headSha: undefined,
         state: undefined,
         merged: false,
@@ -327,6 +335,12 @@ export class PRPollingSource implements AsyncEventSource {
       }
       state.state = newState;
       state.merged = newMerged;
+      // New push invalidates prior CI terminal state — the next completion
+      // on the new SHA should re-emit terminal events.
+      if (state.headSha !== newHead) {
+        state.ciTerminalSha = undefined;
+        state.ciPassedSha = undefined;
+      }
       state.headSha = newHead;
     }
 
@@ -413,10 +427,18 @@ export class PRPollingSource implements AsyncEventSource {
       }
       if (checksRes.status === 200) {
         state.etags.checkRuns = checksRes.etag;
-        for (const r of checksRes.data.check_runs) {
+        const runs = checksRes.data.check_runs;
+        for (const r of runs) {
           if (this.isCheckFailure(r)) {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
+        }
+        // Seed terminal-CI flags so a PR whose CI was already complete at
+        // subscribe time doesn't immediately emit a `ci_complete`/`ci_pass`
+        // event on the next tick. We only surface future transitions.
+        if (state.headSha && this.allRunsTerminal(runs)) {
+          state.ciTerminalSha = state.headSha;
+          if (this.allRunsPassing(runs)) state.ciPassedSha = state.headSha;
         }
       }
       state.initialized = true;
@@ -469,9 +491,10 @@ export class PRPollingSource implements AsyncEventSource {
 
     if (checksRes.status === 200) {
       state.etags.checkRuns = checksRes.etag;
+      const runs = checksRes.data.check_runs;
       const newFailures: GhCheckRun[] = [];
       const currentFailureKeys = new Set<string>();
-      for (const r of checksRes.data.check_runs) {
+      for (const r of runs) {
         if (!this.isCheckFailure(r)) continue;
         const key = this.checkKey(r);
         currentFailureKeys.add(key);
@@ -488,7 +511,47 @@ export class PRPollingSource implements AsyncEventSource {
           this.emit(state, formatCheckFailure(state.slug, pr.pullNumber, r));
         }
       }
+
+      // Terminal CI events. Fire once per head SHA when every run has
+      // reached `completed`. Gate on `runs.length > 0` because an empty
+      // array means either no CI is configured or runs haven't registered
+      // yet — either way, there's nothing to signal "done" about.
+      if (
+        state.headSha &&
+        runs.length > 0 &&
+        this.allRunsTerminal(runs) &&
+        state.ciTerminalSha !== state.headSha
+      ) {
+        state.ciTerminalSha = state.headSha;
+        this.emit(
+          state,
+          formatCIComplete(state.slug, pr.pullNumber, state.headSha, runs),
+        );
+        if (
+          this.allRunsPassing(runs) &&
+          state.ciPassedSha !== state.headSha
+        ) {
+          state.ciPassedSha = state.headSha;
+          this.emit(
+            state,
+            formatCIPassed(state.slug, pr.pullNumber, state.headSha, runs),
+          );
+        }
+      }
     }
+  }
+
+  private allRunsTerminal(runs: readonly GhCheckRun[]): boolean {
+    return runs.every((r) => r.status === 'completed');
+  }
+
+  private allRunsPassing(runs: readonly GhCheckRun[]): boolean {
+    return runs.every(
+      (r) =>
+        r.conclusion === 'success' ||
+        r.conclusion === 'neutral' ||
+        r.conclusion === 'skipped',
+    );
   }
 
   private isCheckFailure(r: GhCheckRun): boolean {

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -80,7 +80,7 @@ export function formatReviewComment(
   const loc = line ? `${c.path}:${line}` : c.path;
   const prefix =
     c.in_reply_to_id != null
-      ? 'Reply in line review thread'
+      ? 'Reply to inline review thread'
       : 'New line review comment';
   return wrap(
     `${prefix} on ${slug}#${prNumber} by @${author} at ${loc}:\n\n${truncate(c.body)}\n\n${c.html_url}`,

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -133,11 +133,19 @@ export function formatCheckFailureSummary(
 }
 
 /**
- * Terminal CI event: every check run on the head commit has reached
- * `completed` and they all passed (success/neutral/skipped). Fires once per
- * head SHA. Paired with `formatCIComplete`, which fires once per SHA when
- * all runs are terminal regardless of outcome.
+ * A check run conclusion counts as passing if it didn't hold up the merge:
+ * `success` obviously, `neutral` (advisory), and `skipped` (didn't run for a
+ * reason — typically path/branch filters). Everything else — failure,
+ * timed_out, cancelled, action_required, stale — blocks.
  */
+export function isPassingConclusion(conclusion: string | null): boolean {
+  return (
+    conclusion === 'success' ||
+    conclusion === 'neutral' ||
+    conclusion === 'skipped'
+  );
+}
+
 export function formatCIPassed(
   slug: string,
   prNumber: number,
@@ -149,24 +157,13 @@ export function formatCIPassed(
   );
 }
 
-/**
- * Terminal CI event: every check run on the head commit has reached
- * `completed`. Fires once per head SHA regardless of outcome. Individual
- * failures are still emitted separately via `formatCheckFailure`, so this
- * event is primarily a "CI is done, you can decide" signal for gating logic.
- */
 export function formatCIComplete(
   slug: string,
   prNumber: number,
   sha: string,
   runs: GhCheckRun[],
 ): string {
-  const passed = runs.filter(
-    (r) =>
-      r.conclusion === 'success' ||
-      r.conclusion === 'neutral' ||
-      r.conclusion === 'skipped',
-  ).length;
+  const passed = runs.filter((r) => isPassingConclusion(r.conclusion)).length;
   const failed = runs.length - passed;
   return wrap(
     `CI completed on ${slug}#${prNumber} (head ${sha.slice(0, 7)}): ${passed} passed, ${failed} failed.`,

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -78,12 +78,12 @@ export function formatReviewComment(
   const author = c.user?.login ?? 'someone';
   const line = c.line ?? c.original_line;
   const loc = line ? `${c.path}:${line}` : c.path;
-  const header =
+  const prefix =
     c.in_reply_to_id != null
-      ? `Reply in line review thread on ${slug}#${prNumber} by @${author} at ${loc}`
-      : `New line review comment on ${slug}#${prNumber} by @${author} at ${loc}`;
+      ? 'Reply in line review thread'
+      : 'New line review comment';
   return wrap(
-    `${header}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
+    `${prefix} on ${slug}#${prNumber} by @${author} at ${loc}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
   );
 }
 
@@ -132,12 +132,7 @@ export function formatCheckFailureSummary(
   );
 }
 
-/**
- * A check run conclusion counts as passing if it didn't hold up the merge:
- * `success` obviously, `neutral` (advisory), and `skipped` (didn't run for a
- * reason — typically path/branch filters). Everything else — failure,
- * timed_out, cancelled, action_required, stale — blocks.
- */
+/** Non-blocking conclusions: `success`, `neutral` (advisory), `skipped`. */
 export function isPassingConclusion(conclusion: string | null): boolean {
   return (
     conclusion === 'success' ||

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -78,8 +78,12 @@ export function formatReviewComment(
   const author = c.user?.login ?? 'someone';
   const line = c.line ?? c.original_line;
   const loc = line ? `${c.path}:${line}` : c.path;
+  const header =
+    c.in_reply_to_id != null
+      ? `Reply in line review thread on ${slug}#${prNumber} by @${author} at ${loc}`
+      : `New line review comment on ${slug}#${prNumber} by @${author} at ${loc}`;
   return wrap(
-    `New line review comment on ${slug}#${prNumber} by @${author} at ${loc}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
+    `${header}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
   );
 }
 
@@ -125,6 +129,47 @@ export function formatCheckFailureSummary(
   );
   return wrap(
     `${runs.length} CI checks on ${slug}#${prNumber} failed:\n${lines.join('\n')}`,
+  );
+}
+
+/**
+ * Terminal CI event: every check run on the head commit has reached
+ * `completed` and they all passed (success/neutral/skipped). Fires once per
+ * head SHA. Paired with `formatCIComplete`, which fires once per SHA when
+ * all runs are terminal regardless of outcome.
+ */
+export function formatCIPassed(
+  slug: string,
+  prNumber: number,
+  sha: string,
+  runs: GhCheckRun[],
+): string {
+  return wrap(
+    `All ${runs.length} CI checks passed on ${slug}#${prNumber} (head ${sha.slice(0, 7)}).`,
+  );
+}
+
+/**
+ * Terminal CI event: every check run on the head commit has reached
+ * `completed`. Fires once per head SHA regardless of outcome. Individual
+ * failures are still emitted separately via `formatCheckFailure`, so this
+ * event is primarily a "CI is done, you can decide" signal for gating logic.
+ */
+export function formatCIComplete(
+  slug: string,
+  prNumber: number,
+  sha: string,
+  runs: GhCheckRun[],
+): string {
+  const passed = runs.filter(
+    (r) =>
+      r.conclusion === 'success' ||
+      r.conclusion === 'neutral' ||
+      r.conclusion === 'skipped',
+  ).length;
+  const failed = runs.length - passed;
+  return wrap(
+    `CI completed on ${slug}#${prNumber} (head ${sha.slice(0, 7)}): ${passed} passed, ${failed} failed.`,
   );
 }
 

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -23,7 +23,6 @@ export interface GhReviewComment {
   path: string;
   line?: number | null;
   original_line?: number | null;
-  /** Present on replies; references the top-level comment that started the thread. */
   in_reply_to_id?: number | null;
   html_url: string;
   created_at: string;

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -23,6 +23,8 @@ export interface GhReviewComment {
   path: string;
   line?: number | null;
   original_line?: number | null;
+  /** Present on replies; references the top-level comment that started the thread. */
+  in_reply_to_id?: number | null;
   html_url: string;
   created_at: string;
   updated_at?: string;


### PR DESCRIPTION
Adds two one-shot events per head SHA to PR subscriptions:
- CI complete: every check run reached `completed` (any conclusion)
- CI passed: every check run completed with success/neutral/skipped

Tracked via `ciTerminalSha`/`ciPassedSha` in `SubscriptionState`, reset
when the head SHA advances (new push), and seeded on first tick so
pre-existing terminal CI doesn't immediately fire on subscribe. Lets
agents gate merges on "CI is green" without polling manually.

Also threads review-comment replies: `in_reply_to_id` is pulled from the
REST response and the formatter prefixes reply events with "Reply in
line review thread" so bot inline follow-ups read as part of a
conversation rather than isolated drops.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR polling event semantics by adding new one-shot CI terminal notifications and new deduping state, which could affect downstream automations if edge cases (empty/partial check-run pages, SHA changes) are mishandled.
> 
> **Overview**
> Adds **terminal CI notifications** to PR subscriptions: emits one-shot `CI complete` (all check runs `completed`) and `CI passed` (all runs pass via `success`/`neutral`/`skipped`) per head SHA, with state reset on new pushes and seeding on first tick to avoid replaying pre-existing CI status.
> 
> Improves review comment activity text by distinguishing inline thread replies vs new inline comments (via `in_reply_to_id`), and extends the check-runs fetch typing to use `total_count` so terminal CI events are only emitted when the full page of runs is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f33206c5f1d0f7708715ad91ecb6757af0feda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->