### PR TITLE
fix(relay): accept provider prefixes in ultra-only model pattern

### DIFF
--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -84,7 +84,7 @@ const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
 const ULTRA_ONLY_PATTERN = /^(?:[a-z0-9_-]+\/)?gpt-5(?:\.\d+)?-pro(?:$|[-:@/])/i;
 
 function isUltraOnlyModelName(modelName: string): boolean {
-  return ULTRA_ONLY_PATTERN.test(modelName.trim().toLowerCase());
+  return ULTRA_ONLY_PATTERN.test(modelName.trim());
 }
 
 const isUltraOnlyModel = (model: RelayModel): boolean =>

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -79,11 +79,16 @@ const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
 /**
  * Ultra-only models: reserved for Ultra-tier users even during the
  * sponsor-credit promotion. Matches gpt-5-pro, gpt-5.2-pro, gpt-5.4-pro, etc.
+ * Accepts optional provider prefixes like "openai/gpt-5.4-pro".
  */
-const ULTRA_ONLY_PATTERN = /^gpt-5(\.\d+)?-pro/i;
+const ULTRA_ONLY_PATTERN = /^(?:[a-z0-9_-]+\/)?gpt-5(?:\.\d+)?-pro(?:$|[-:@/])/i;
+
+function isUltraOnlyModelName(modelName: string): boolean {
+  return ULTRA_ONLY_PATTERN.test(modelName.trim().toLowerCase());
+}
 
 const isUltraOnlyModel = (model: RelayModel): boolean =>
-  model.apiPatterns.some((p) => ULTRA_ONLY_PATTERN.test(p));
+  model.apiPatterns.some(isUltraOnlyModelName);
 
 const NON_ULTRA_ONLY_SHORT_NAMES = RELAY_MODELS.filter(
   (m) => !isUltraOnlyModel(m),
@@ -185,7 +190,7 @@ export function isModelAllowedForTier(
 ): boolean {
   if (tier === ULTRA_TIER) return true;
   if (!modelName) return false;
-  return !ULTRA_ONLY_PATTERN.test(modelName);
+  return !isUltraOnlyModelName(modelName);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- `ULTRA_ONLY_PATTERN` now accepts optional provider prefixes (e.g. `openai/gpt-5.4-pro`) and requires the name to end after `-pro` or hit a separator, so `gpt-5-proxy` no longer false-matches.
- All call sites now route through `isUltraOnlyModelName`, which trims/lowercases before matching. This keeps the normalization in one place.

## Test plan

- [ ] `npm run typecheck` passes locally.
- [ ] Manually verify that `openai/gpt-5-pro`, `openai/gpt-5.4-pro`, and `gpt-5.4-pro` all return `true` from `isUltraOnlyModelName`.
- [ ] Verify that `gpt-5-proxy`, `gpt-4-pro`, and other non-ultra names return `false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the regex used to gate Ultra-only models, which directly affects tier-based access control and could inadvertently allow or block model usage if the pattern is wrong.
> 
> **Overview**
> Updates Ultra-only model detection to recognize optional provider prefixes (e.g. `openai/gpt-5.4-pro`) and to avoid false matches like `gpt-5-proxy` by requiring an end-of-name or separator after `-pro`.
> 
> Centralizes the matching logic in `isUltraOnlyModelName()` (with trimming) and routes tier checks and model-list filtering through this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2df1e0878521ff738d27d3559d936a4235b12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->