### PR TITLE
fix(toolCard): style Open Install Page as primary when sole action

### DIFF
--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -402,7 +402,10 @@ export class ToolCard extends LitElement {
               ${this.item.installUrl
                 ? html`
                     <button
-                      class="tool-action-btn tool-action-btn--secondary"
+                      class="tool-action-btn ${this.item.installCommand ||
+                      this.item.installExtensionId
+                        ? 'tool-action-btn--secondary'
+                        : ''}"
                       @click=${this.handleInstallUrl}
                     >
                       <span class="codicon codicon-link-external"></span>

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -346,6 +346,16 @@ export class ToolCard extends LitElement {
       this.item.authCommand;
     if (!hasGuide) return nothing;
 
+    // When a primary install action exists (terminal command or extension
+    // marketplace), demote auxiliary buttons (Sign in, Open Install Page)
+    // to secondary styling.
+    const hasPrimaryInstallAction = Boolean(
+      this.item.installCommand || this.item.installExtensionId,
+    );
+    const secondaryClass = hasPrimaryInstallAction
+      ? 'tool-action-btn--secondary'
+      : '';
+
     return html`
       <button class="tool-guide-toggle" @click=${this.toggleGuide}>
         <span
@@ -376,10 +386,7 @@ export class ToolCard extends LitElement {
               ${this.item.authCommand
                 ? html`
                     <button
-                      class="tool-action-btn ${this.item.installCommand ||
-                      this.item.installExtensionId
-                        ? 'tool-action-btn--secondary'
-                        : ''}"
+                      class="tool-action-btn ${secondaryClass}"
                       @click=${this.handleRunAuthCommand}
                       title=${this.item.authCommand}
                     >
@@ -402,10 +409,7 @@ export class ToolCard extends LitElement {
               ${this.item.installUrl
                 ? html`
                     <button
-                      class="tool-action-btn ${this.item.installCommand ||
-                      this.item.installExtensionId
-                        ? 'tool-action-btn--secondary'
-                        : ''}"
+                      class="tool-action-btn ${secondaryClass}"
                       @click=${this.handleInstallUrl}
                     >
                       <span class="codicon codicon-link-external"></span>


### PR DESCRIPTION
## Summary
- The **Open Install Page** button in `ToolCard` was unconditionally styled with `tool-action-btn--secondary`, leaving cards with no primary button when `installUrl` was the only setup action (e.g. Wolfram, Zotero).
- Apply the same primary/secondary logic already used by the `Sign in` button: render as secondary only when `installCommand` or `installExtensionId` is also present; otherwise render as primary.

Closes #3056

## Test plan
- [ ] Build passes (`npm run compile:fast`).
- [ ] Typecheck passes (`npm run typecheck`).
- [ ] Manual: open the Tools tab in Settings; verify the **Wolfram** card's **Open Install Page** button renders as primary (it has no `installCommand` or `installExtensionId`).
- [ ] Manual: verify the **Zotero** card's **Open Install Page** button renders as primary.
- [ ] Manual: verify cards that also expose **Install in Terminal** or **Install Extension** still render **Open Install Page** as secondary (no regression for the multi-action case).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts button styling logic in `ToolCard` without affecting tool actions, state, or backend behavior.
> 
> **Overview**
> Fixes `ToolCard` installation guide button styling so **auxiliary actions** (`Sign in`, `Open Install Page`) are only rendered as secondary when a **primary install action** (`installCommand` or `installExtensionId`) is also present.
> 
> This prevents cards with only `installUrl` from showing no primary action by making `Open Install Page` primary in the single-action case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2a45382c310be12c2fc192036d486a5d0474b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->