### PR TITLE
fix(anthropic): preserve user-abort errors before message_start

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -873,13 +873,10 @@ export class ModelHandlerAnthropic extends ModelHandler<
         );
         const requestId = stream.request_id;
 
-        // Wrap only non-APIError stream failures. APIError subclasses carry
-        // status/headers/requestID/type that formatProviderHttpError needs
-        // for retry classification; replacing them loses that metadata and
-        // misclassifies e.g. 401 as generic retryable. User aborts must also
-        // pass through unwrapped: AnthropicUserAbortError extends
-        // AnthropicError directly (sibling of AnthropicAPIError), so the
-        // APIError guard alone would wrap them and break downstream
+        // Wrap only non-APIError, non-abort stream failures. APIError
+        // subclasses carry status/headers/requestID/type needed for retry
+        // classification; AnthropicUserAbortError is a sibling of
+        // AnthropicAPIError, so wrapping it would break downstream
         // `instanceof AnthropicUserAbortError` checks.
         const isAbort = isUserAbort(streamError);
         let enrichedError: unknown = streamError;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -876,12 +876,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Wrap only non-APIError stream failures. APIError subclasses carry
         // status/headers/requestID/type that formatProviderHttpError needs
         // for retry classification; replacing them loses that metadata and
-        // misclassifies e.g. 401 as generic retryable.
+        // misclassifies e.g. 401 as generic retryable. User aborts must also
+        // pass through unwrapped: AnthropicUserAbortError extends
+        // AnthropicError directly (sibling of AnthropicAPIError), so the
+        // APIError guard alone would wrap them and break downstream
+        // `instanceof AnthropicUserAbortError` checks.
+        const isAbort = isUserAbort(streamError);
         let enrichedError: unknown = streamError;
         if (
           !stream.currentMessage &&
           streamError instanceof Error &&
-          !(streamError instanceof AnthropicAPIError)
+          !(streamError instanceof AnthropicAPIError) &&
+          !isAbort
         ) {
           enrichedError = new Error(
             `Stream closed before message_start after ${diagnostics.elapsedSecs}s ` +
@@ -897,7 +903,6 @@ export class ModelHandlerAnthropic extends ModelHandler<
           (enrichedError as ErrorWithRequestId).request_id = requestId;
         }
 
-        const isAbort = isUserAbort(streamError);
         const logMessage = `Stream ${isAbort ? 'aborted' : 'failed'}: ${enrichedError instanceof Error ? enrichedError.message : String(enrichedError)}`;
         const logData = {
           data: {

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1,6 +1,9 @@
 // Standard library imports
 import { strict as assert } from 'assert';
 
+// Third-party imports
+import { APIUserAbortError as AnthropicUserAbortError } from '@anthropic-ai/sdk';
+
 // Local imports - agent
 import {
   DEFAULT_MODEL_CAPABILITIES,
@@ -1296,5 +1299,80 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(eventData.tokensBefore, 185000);
     assert.equal(eventData.tokensAfter, 25600);
     assert.equal(eventData.summary, '<summary>state</summary>');
+  });
+});
+
+describe('ModelHandlerAnthropic pre-message_start error handling', () => {
+  /**
+   * Builds a minimal stream stub that mimics the surface of the Anthropic
+   * SDK's MessageStream used by ModelHandlerAnthropic.createResponse:
+   *   - `.on()` for event listener registration (no-op)
+   *   - `.controller.abort()` (no-op)
+   *   - `.finalMessage()` returning a promise that rejects with `error`
+   *   - `.currentMessage` undefined (simulates no message_start received)
+   *   - `.request_id` undefined
+   */
+  function buildStreamStub(error: unknown): unknown {
+    return {
+      on: () => {},
+      controller: { abort: () => {} },
+      finalMessage: async () => {
+        throw error;
+      },
+      currentMessage: undefined,
+      request_id: undefined,
+    };
+  }
+
+  it('preserves AnthropicUserAbortError thrown before message_start (does not wrap it)', async () => {
+    const handler = createAnthropicHandler({
+      supportsTokenCounting: false,
+      supportsReasoning: false,
+    });
+    handler.setLogger(createLoggerStub() as unknown as AgentLogger);
+    // Force streaming path so we exercise the pre-message_start catch block.
+    (handler as any).getStreamingConfig = () => true;
+
+    const abortError = new AnthropicUserAbortError();
+    const streamStub = buildStreamStub(abortError);
+
+    const client = {
+      beta: {
+        messages: {
+          stream: () => streamStub,
+        },
+      },
+    } as any;
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello', citations: null }],
+      },
+    ];
+
+    await assert.rejects(
+      handler.createResponse({ client, messages, temperature: 0 }),
+      (err: unknown) => {
+        // The fix under test: aborts thrown before message_start must NOT be
+        // wrapped in a generic Error, otherwise downstream
+        // `instanceof AnthropicUserAbortError` checks (e.g. retry classifiers)
+        // would silently misclassify user aborts as generic stream failures.
+        assert.ok(
+          err instanceof AnthropicUserAbortError,
+          `expected AnthropicUserAbortError, got ${
+            err instanceof Error ? `${err.constructor.name}: ${err.message}` : String(err)
+          }`,
+        );
+        // And the wrap-guard message must not appear for the abort path.
+        assert.ok(
+          !/Stream closed before message_start/.test(
+            err instanceof Error ? err.message : '',
+          ),
+          'abort error must not be wrapped with the pre-message_start sentinel message',
+        );
+        return true;
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- The pre-`message_start` wrap in `modelHandlerAnthropic.ts` guarded only against `AnthropicAPIError`, but `AnthropicUserAbortError` extends `AnthropicError` directly (sibling of `AnthropicAPIError`). User aborts that occurred before the first `message_start` event were therefore wrapped into a generic `Error`, and the original abort survived only on `.cause` — breaking downstream `instanceof AnthropicUserAbortError` checks and treating the abort as a generic stream failure.
- Compute `isUserAbort(streamError)` earlier in the catch (it was already used a few lines below for log-level selection) and add `!isAbort` to the wrap guard so aborts pass through unwrapped while preserving the existing protections for `APIError` subclasses.

## Test plan

- [x] `npm run compile:fast`
- [x] `npm run typecheck` (clean)
- [x] Unit test: `pre-message_start error handling` in `src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts` mocks a streaming response whose `finalMessage()` rejects with `AnthropicUserAbortError` (no `message_start` received) and asserts the thrown error remains `instanceof AnthropicUserAbortError` and is not wrapped with the `Stream closed before message_start ...` sentinel.
- [ ] Manual: trigger a user abort against an Anthropic model before `message_start` arrives and confirm downstream code observes the original `AnthropicUserAbortError`.

Closes #3057

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to streaming error wrapping so `AnthropicUserAbortError` is no longer converted into a generic `Error`; main risk is altered downstream retry/logging classification for early stream failures.
> 
> **Overview**
> Fixes Anthropic streaming error handling so user aborts thrown *before* the first `message_start` event are preserved as `AnthropicUserAbortError` instead of being wrapped in a generic pre-`message_start` sentinel `Error`, keeping downstream `instanceof` checks and retry classification accurate.
> 
> Adds a focused unit test that stubs an Anthropic stream whose `finalMessage()` rejects with `AnthropicUserAbortError` (with no `currentMessage`) and asserts the handler rethrows the original abort without the wrap message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0f20849b637da3f43e54c864c8b3aa76fdf6ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->