### PR TITLE
docs(codex): correct Windows binary discovery guidance

### DIFF
--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -20,7 +20,11 @@ Skip **Sign in** and export `OPENAI_API_KEY` in the shell you launch VS Code fro
 :::
 
 ::: warning Windows
-Codex has no native Windows binary. Open TeXRA inside a **WSL** remote window before clicking **Install in Terminal** — otherwise the install runs in PowerShell and VS Code won't find the binary.
+TeXRA discovers the Codex binary from the same environment where the VS Code extension host runs, so install Codex there:
+
+- **WSL Remote** — open TeXRA inside the WSL window and run **Install in Terminal**; Codex is installed inside WSL alongside the extension host.
+- **Native Windows** — install Codex on Windows so a real `codex.exe` is available (via `npm install -g @openai/codex` or the official installer). TeXRA spawns the binary directly and skips `.cmd` / PowerShell shims, so the resolver needs the actual `codex.exe`, not an npm wrapper.
+
 :::
 
 ## Settings
@@ -56,11 +60,11 @@ Agents can pass `run_in_background: true` to get the execution ID immediately an
 
 **Card shows <i class="codicon codicon-warning"></i> Not Found after install.** Hover the card for the exact message:
 
-| Message                                        | Fix                                                                               |
-| ---------------------------------------------- | --------------------------------------------------------------------------------- |
-| `@openai/codex-sdk not found`                  | Click **Install in Terminal** again, then **Recheck**.                            |
-| `Codex SDK loaded but native binary not found` | Reinstall — the platform binary didn't ship. On Windows, open TeXRA in WSL first. |
-| `Platform not supported`                       | Unsupported OS/arch. Use WSL on Windows or a supported Linux/macOS host.          |
+| Message                                        | Fix                                                                                                                                                                                                         |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@openai/codex-sdk not found`                  | Click **Install in Terminal** again, then **Recheck**.                                                                                                                                                      |
+| `Codex SDK loaded but native binary not found` | Reinstall in the same environment as the extension host (WSL when using WSL Remote, Windows for a native window). On Windows, ensure a real `codex.exe` is on PATH — `.cmd` / PowerShell shims are skipped. |
+| `Platform not supported`                       | Unsupported OS/arch. Codex ships native binaries for Linux, macOS, and Windows (`x64` and `arm64`); other platforms are not supported.                                                                      |
 
 **Still Not Found after everything ran.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
 

--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -20,12 +20,11 @@ Skip **Sign in** and export `OPENAI_API_KEY` in the shell you launch VS Code fro
 :::
 
 ::: warning Windows
-TeXRA discovers the Codex binary from the same environment where the VS Code extension host runs, so install Codex there:
+TeXRA looks up Codex in the same environment as the VS Code extension host, so install it there:
 
-- **WSL Remote** — open TeXRA inside the WSL window and run **Install in Terminal**; Codex is installed inside WSL alongside the extension host.
-- **Native Windows** — install Codex on Windows so a real `codex.exe` is available (via `npm install -g @openai/codex` or the official installer). TeXRA spawns the binary directly and skips `.cmd` / PowerShell shims, so the resolver needs the actual `codex.exe`, not an npm wrapper.
-
-:::
+- **WSL Remote** — open TeXRA inside the WSL window before clicking **Install in Terminal**.
+- **Native Windows** — install Codex on Windows so a real `codex.exe` is on PATH. TeXRA spawns the binary directly and skips `.cmd` / PowerShell shims, so an npm wrapper alone won't be found.
+  :::
 
 ## Settings
 
@@ -60,11 +59,11 @@ Agents can pass `run_in_background: true` to get the execution ID immediately an
 
 **Card shows <i class="codicon codicon-warning"></i> Not Found after install.** Hover the card for the exact message:
 
-| Message                                        | Fix                                                                                                                                                                                                         |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@openai/codex-sdk not found`                  | Click **Install in Terminal** again, then **Recheck**.                                                                                                                                                      |
-| `Codex SDK loaded but native binary not found` | Reinstall in the same environment as the extension host (WSL when using WSL Remote, Windows for a native window). On Windows, ensure a real `codex.exe` is on PATH — `.cmd` / PowerShell shims are skipped. |
-| `Platform not supported`                       | Unsupported OS/arch. Codex ships native binaries for Linux, macOS, and Windows (`x64` and `arm64`); other platforms are not supported.                                                                      |
+| Message                                        | Fix                                                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `@openai/codex-sdk not found`                  | Click **Install in Terminal** again, then **Recheck**.                                                             |
+| `Codex SDK loaded but native binary not found` | Reinstall in the same environment as the extension host. On Windows, see the **Windows** note above for the catch. |
+| `Platform not supported`                       | Codex ships native binaries for Linux, macOS, and Windows (`x64` / `arm64`). On other hosts, fall back to WSL.     |
 
 **Still Not Found after everything ran.** Reload the window (`Developer: Reload Window`) so the extension re-checks for the binary.
 


### PR DESCRIPTION
## Summary

- Replaces the inaccurate "Codex has no native Windows binary, use WSL" warning in `docs/guide/codex-cli.md`. `src/tools/codexImport.ts` actually resolves `@openai/codex-win32-x64` / `@openai/codex-win32-arm64` and probes for `codex.exe` (`where codex`), so native Windows is supported.
- Reframes the warning around the real constraint: TeXRA finds Codex in the same environment as the extension host. WSL Remote requires installing Codex inside WSL; native Windows requires a real `codex.exe` on PATH (the resolver explicitly skips `.cmd` / PowerShell shims).
- Updates the troubleshooting table entries for `Codex SDK loaded but native binary not found` and `Platform not supported` to match.

Closes #3055

## Test plan

- [x] Verified actual platform support against `src/tools/codexImport.ts` lines 88-95 (`win32-x64`, `win32-arm64`) and the resolver behavior at lines 117-176 (probes `codex.exe`, runs `where codex`, skips `.cm` / `.ps1` shims).
- [x] `npx prettier --check docs/guide/codex-cli.md` passes.
- [ ] Render `docs/guide/codex-cli.md` in VitePress and confirm the `::: warning Windows` container, the bullet list inside it, and the troubleshooting table all render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the main risk is confusing setup if the updated Windows guidance renders incorrectly or is misinterpreted.
> 
> **Overview**
> Clarifies Windows setup for the Codex CLI by replacing the previous “no native Windows binary” warning with guidance that Codex must be installed in the *same environment as the VS Code extension host* (WSL Remote vs native Windows with a real `codex.exe` on `PATH`, not `.cmd`/PowerShell shims).
> 
> Updates the troubleshooting table to align with this behavior, including revised fixes for `Codex SDK loaded but native binary not found` and a corrected `Platform not supported` message describing supported OS/arch and WSL fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb0655487f40f12df2b07728fdeff1851c56b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->