### PR TITLE
refactor(followUp): remove unreachable error variant from SendFollowUpResult

### DIFF
--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -23,7 +23,6 @@ import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
 export type SendFollowUpResult =
   | { status: 'sent' }
   | { status: 'queued'; reason: 'resuming' | 'waiting' }
-  | { status: 'error'; message: string }
   | { status: 'no_session'; streamStatus: string | undefined };
 
 const logger = new AgentLogger('ToolUseFollowUp');

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -127,11 +127,6 @@ async function handleFollowUpResult(
         }
       }
       break;
-    case 'error':
-      await vscode.window.showErrorMessage(
-        `Failed to send follow-up: ${result.message}`,
-      );
-      break;
     case 'no_session':
       await vscode.window.showWarningMessage(
         'No active session. Start a new agent task to continue.',

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -818,11 +818,6 @@ Git worktree support: ${
             `Execution ID: ${executionId}`,
           ].join('\n'),
         };
-      case 'error':
-        deliveryState.hasDelivered = true;
-        throw new Error(
-          `Failed to send follow-up to '${handle.agentName}': ${result.message}`,
-        );
       case 'no_session':
         deliveryState.hasDelivered = true;
         throw new Error(


### PR DESCRIPTION
## Summary

The `{ status: 'error'; message: string }` variant of `SendFollowUpResult` became unreachable when the `try`/`catch` wrapper around `sendFollowUp` was removed in #2956. `sendFollowUp` no longer returns an error status under any code path.

This PR removes the dead variant and the corresponding `case 'error':` branches in the two consumers:

- `src/agent/toolUse/ToolUseFollowUp.ts` — drop the `error` member from the `SendFollowUpResult` union.
- `src/commands/agent/followUpCommand.ts` — drop the `case 'error':` branch in `handleFollowUpResult`.
- `src/tools/DelegationTools.ts` — drop the `case 'error':` branch when handling delegated follow-ups.

After the changes, the exhaustive switches over `result.status` cover only the reachable variants (`sent`, `queued`, `no_session`).

Closes #2957

## Test plan

- [x] `npm run compile:fast` succeeds
- [x] `npm run typecheck` shows only the pre-existing unrelated error in `src/latex/arxivProcessor.ts:133`
- [x] `Grep` for `SendFollowUpResult` confirms only the type definition and the two consumers reference it; both are updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type cleanup: removes an unreachable `SendFollowUpResult` variant and dead switch cases; behavior should be unchanged except no longer attempting to surface a never-returned error status.
> 
> **Overview**
> Removes the dead `{ status: 'error'; message: string }` variant from `SendFollowUpResult` and deletes the corresponding `case 'error'` handling in follow-up consumers.
> 
> Switches handling follow-up delivery now only cover the reachable statuses (`sent`, `queued`, `no_session`), simplifying follow-up UI messaging (`followUpCommand`) and delegated follow-up resume error paths (`DelegationTools`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cdf540983be5b2b5cb72f11ef1da58654507bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->