### PR TITLE
fix(palette): gate command palette entries behind texra.activated

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "Data Science"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "onColorTheme"
   ],
   "main": "./dist/extension.js",

--- a/package.json
+++ b/package.json
@@ -1091,6 +1091,7 @@
         "id": "texra.gettingStarted",
         "title": "Get started with TeXRA",
         "description": "Get TeXRA up and running in a few minutes. Connect your account, pick your field, and run your first paper through the orchestrator.",
+        "when": "texra.activated",
         "steps": [
           {
             "id": "texra.gettingStarted.sampleWorkspace",
@@ -1242,7 +1243,7 @@
     "viewsWelcome": [
       {
         "view": "texra.welcomeView",
-        "contents": "TeXRA is a multi-agent orchestration system for LaTeX research. An orchestrator coordinates specialized agents that derive results, verify proofs, run symbolic computation, generate figures, and assemble manuscripts — every step auditable, every citation grounded.\nOpen a folder to begin.\n[Open Folder](command:workbench.action.files.openFolder)\n[Clone Repository](command:git.clone)\nNew to TeXRA? [Take the tour](command:workbench.action.openWalkthrough?%22texra.gettingStarted%22) or [read the docs](https://github.com/LionSR/TeXRA#readme).",
+        "contents": "TeXRA is a multi-agent orchestration system for LaTeX research. An orchestrator coordinates specialized agents that derive results, verify proofs, run symbolic computation, generate figures, and assemble manuscripts — every step auditable, every citation grounded.\nOpen a folder to begin. The TeXRA tour and commands become available once a workspace is open.\n[Open Folder](command:workbench.action.files.openFolder)\n[Clone Repository](command:git.clone)\nWant to learn more first? [Read the docs](https://github.com/LionSR/TeXRA#readme).",
         "when": "workbenchState == empty"
       },
       {
@@ -1254,32 +1255,32 @@
     "menus": {
       "editor/title": [
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.indentCurrentTeX",
           "group": "navigation"
         },
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.applyReplacements",
           "group": "navigation"
         },
         {
-          "when": "editorLangId == latex",
+          "when": "texra.activated && editorLangId == latex",
           "command": "texra.fixCompilation",
           "group": "navigation"
         },
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.getTeXCount",
           "group": "navigation"
         },
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanOutput",
           "group": "2_texra_housekeeping@1"
         },
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanBuild",
           "group": "2_texra_housekeeping@2"
         }
@@ -1318,24 +1319,24 @@
       ],
       "editor/context": [
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanOutput",
           "group": "z_texra@1"
         },
         {
-          "when": "editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanBuild",
           "group": "z_texra@2"
         }
       ],
       "explorer/context": [
         {
-          "when": "resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanOutput",
           "group": "z_texra@1"
         },
         {
-          "when": "resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/",
+          "when": "texra.activated && resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/",
           "command": "texra.cleanBuild",
           "group": "z_texra@2"
         }
@@ -1563,33 +1564,38 @@
       {
         "command": "texra.showMainView",
         "key": "ctrl+alt+m",
-        "mac": "cmd+option+m"
+        "mac": "cmd+option+m",
+        "when": "texra.activated"
       },
       {
         "command": "texra.showProgressView",
         "key": "ctrl+alt+p",
-        "mac": "cmd+option+p"
+        "mac": "cmd+option+p",
+        "when": "texra.activated"
       },
       {
         "command": "texra.cleanOutput",
         "key": "ctrl+alt+shift+c",
-        "mac": "cmd+option+shift+c"
+        "mac": "cmd+option+shift+c",
+        "when": "texra.activated"
       },
       {
         "command": "texra.cleanBuild",
         "key": "ctrl+alt+shift+b",
-        "mac": "cmd+option+shift+b"
+        "mac": "cmd+option+shift+b",
+        "when": "texra.activated"
       },
       {
         "command": "texra.toggleView",
         "key": "ctrl+alt+t",
         "mac": "cmd+option+t",
-        "when": "focusedView == texra.mainView"
+        "when": "texra.activated && focusedView == texra.mainView"
       },
       {
         "command": "texra.execute",
         "key": "ctrl+alt+e",
-        "mac": "cmd+option+e"
+        "mac": "cmd+option+e",
+        "when": "texra.activated"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1342,36 +1342,220 @@
       ],
       "commandPalette": [
         {
+          "command": "texra.createSampleProject",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.openGettingStarted",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.cleanOutput",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.cleanBuild",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.indentTeX",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.getRecentCommits",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.cloneOverleafProject",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.refreshCommits",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.indentCurrentTeX",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.resumeAgent",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.applyReplacements",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.fixCompilation",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.getTeXCount",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.countPdfPages",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.encodeImageToBase64",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.convertPdfToImages",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.extractFigurePaths",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.extractTikzFigures",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.compileTikzFigures",
+          "when": "texra.activated"
+        },
+        {
           "command": "texra.testConnection",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
           "command": "texra.testAgentLoading",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
           "command": "texra.loadSpecificAgent",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
-          "command": "texra.testTextEditor",
-          "when": "config.texra.logger.debugMode"
+          "command": "texra.downloadArXivSource",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showImportOptions",
+          "when": "texra.activated"
         },
         {
           "command": "texra.parseXml",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
           "command": "texra.parseYaml",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
+        },
+        {
+          "command": "texra.stopAgent",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.execute",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.pack",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.clean",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.createAgentWithAI",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.setApiKey",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.removeApiKey",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.auth.signIn",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.auth.signOut",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.auth.viewProfile",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.testTextEditor",
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
           "command": "texra.showLinterMessages",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
         },
         {
           "command": "texra.countLinterMessages",
-          "when": "config.texra.logger.debugMode"
+          "when": "texra.activated && config.texra.logger.debugMode"
+        },
+        {
+          "command": "texra.openDoc",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.mainView.reset",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showAgentHistory",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showMemory",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showModels",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showAgents",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showTools",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showMultiAgent",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.openSettings",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showMainView",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showProgressView",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.toggleView",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.openProgressViewInTab",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showDashboard",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showSettingsView",
+          "when": "texra.activated"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -356,6 +356,16 @@ export async function activate(context: vscode.ExtensionContext) {
     mainViewProvider.setProgressViewProvider(progressViewProvider);
   }
 
+  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
+  // / views) on `texra.activated` keeps them hidden until every command handler
+  // is registered. This must run after ALL `registerCommand` calls in this
+  // function (including the late ones for `texra.showMainView` and
+  // `texra.toggleView`), otherwise palette entries can fire before their
+  // handlers exist and produce "command not found" errors. It must also run
+  // BEFORE the welcome walkthrough is opened below, because the walkthrough
+  // itself is gated on `texra.activated`.
+  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
+
   const welcomeKey = 'texra.welcomeShown';
   if (!context.globalState.get<boolean>(welcomeKey)) {
     // Opening the VS Code walkthrough is enough — don't double up with a
@@ -364,14 +374,6 @@ export async function activate(context: vscode.ExtensionContext) {
       .executeCommand('texra.openGettingStarted')
       .then(() => context.globalState.update(welcomeKey, true));
   }
-
-  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
-  // / views) on `texra.activated` keeps them hidden until every command handler
-  // is registered. This must run after ALL `registerCommand` calls in this
-  // function (including the late ones for `texra.showMainView` and
-  // `texra.toggleView`), otherwise palette entries can fire before their
-  // handlers exist and produce "command not found" errors.
-  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -219,13 +219,6 @@ export async function activate(context: vscode.ExtensionContext) {
   registerCommands(context);
   registerFileDecorations(context);
 
-  // Set `texra.activated` only after commands and view providers are wired up.
-  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
-  // / views) on this key means they won't appear until the corresponding
-  // handlers are actually registered, avoiding a startup window where
-  // invocations fail with "command not found".
-  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
-
   initializeNativeToolEditApproval(context);
   setLeanVscodeServices(leanVscodeIntegration);
   setExtensionChecker((id) => vscode.extensions.getExtension(id) !== undefined);
@@ -371,6 +364,14 @@ export async function activate(context: vscode.ExtensionContext) {
       .executeCommand('texra.openGettingStarted')
       .then(() => context.globalState.update(welcomeKey, true));
   }
+
+  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
+  // / views) on `texra.activated` keeps them hidden until every command handler
+  // is registered. This must run after ALL `registerCommand` calls in this
+  // function (including the late ones for `texra.showMainView` and
+  // `texra.toggleView`), otherwise palette entries can fire before their
+  // handlers exist and produce "command not found" errors.
+  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,7 +110,6 @@ export async function activate(context: vscode.ExtensionContext) {
     return;
   }
   const workspaceRoot = workspaceFolders[0].uri.fsPath;
-  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 
   dotenv.config({
     path: path.join(workspaceRoot, '.env'),
@@ -219,6 +218,13 @@ export async function activate(context: vscode.ExtensionContext) {
   configureLatexSettings();
   registerCommands(context);
   registerFileDecorations(context);
+
+  // Set `texra.activated` only after commands and view providers are wired up.
+  // Gating UI contributions (commandPalette / keybindings / menus / walkthroughs
+  // / views) on this key means they won't appear until the corresponding
+  // handlers are actually registered, avoiding a startup window where
+  // invocations fail with "command not found".
+  await vscode.commands.executeCommand('setContext', 'texra.activated', true);
 
   initializeNativeToolEditApproval(context);
   setLeanVscodeServices(leanVscodeIntegration);


### PR DESCRIPTION
## Summary
- Pre-activation (no folder open) the welcome view runs and `registerCommands(context)` returns early, leaving every `texra.*` command unregistered. Until now they still appeared in the Command Palette and would fail with "command not found" when invoked.
- Add explicit `commandPalette` menu entries with `"when": "texra.activated"` for every command that `registerCommands()` registers, matching the `view/title` gate added in #3046.
- Debug-only commands (`testConnection`, `testAgentLoading`, `loadSpecificAgent`, `testTextEditor`, `parseXml`, `parseYaml`, `showLinterMessages`, `countLinterMessages`) keep their `config.texra.logger.debugMode` requirement, now combined with the new gate (`texra.activated && config.texra.logger.debugMode`).

Closes #3052

## Test plan
- [ ] Open VS Code with **no folder** → confirm `Cmd+Shift+P` and type `texra` shows zero TeXRA commands (only the welcome view in the sidebar).
- [ ] Open a single-folder workspace → confirm the palette lists all TeXRA commands as before (and toolbar buttons appear in `view/title`).
- [ ] Toggle `texra.logger.debugMode` on with a workspace open → confirm the 8 debug commands appear; toggle off → they disappear.
- [ ] Build: `npm run compile:fast` succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only VS Code contribution visibility/activation timing to prevent invoking unregistered commands; main risk is unintentionally hiding palette entries or keybindings if `texra.activated` is not set in some activation paths.
> 
> **Overview**
> Prevents "command not found" errors by **gating all TeXRA Command Palette entries, keybindings, editor/explorer menus, and the Getting Started walkthrough** behind the `texra.activated` context so they only appear after a single-folder workspace is open and commands are registered.
> 
> Moves the `setContext('texra.activated', true)` call to the end of `activate()` (after all `registerCommand` calls) and tweaks the empty-workspace welcome copy to clarify that TeXRA commands/tour become available only once a folder is opened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ee6743a7ec9ebf779dc137c29edadd25b8566c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->