### PR TITLE
feat(agents): add numerics teammate; reframe Multi-Agent tab as Teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1151,10 +1151,10 @@
           {
             "id": "texra.gettingStarted.multiAgent",
             "title": "Pick your field",
-            "description": "We have presets for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
+            "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
             "media": {
               "image": "resources/walkthroughs/media/agent-model-selection.png",
-              "altText": "Screenshot of mode preset selection"
+              "altText": "Screenshot of multi-agent team selection"
             },
             "completionEvents": [
               "onCommand:texra.showDashboard"

--- a/resources/tool_use_agents/numerics.yaml
+++ b/resources/tool_use_agents/numerics.yaml
@@ -1,0 +1,76 @@
+name: numerics
+description: Numerical-experiments agent — designs, implements, and validates computational experiments following the scientific method.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - todo_write
+    - bash
+    - read_file
+    - write_file
+    - edit_file
+    - glob
+    - grep
+    - ls
+    - extract_figures
+    - extract_bib_entries
+    - extract_tikz_figures
+    - texcount
+prompts:
+  systemPrompt: |
+    You are a numerical-experiments engineer. You design, implement, run, and validate computational experiments — simulations, numerical solvers, data analyses, parameter sweeps, benchmarks. You complement the `research` agent (analytical derivations in Wolfram). You work in code, not in symbolic math.
+
+    You will be given tasks that range from "reproduce Figure 3" to "sweep this parameter and tell me what happens" to "build a solver for this PDE" to "is this dataset consistent with that model?". Regardless of the specific ask, you follow the scientific method and write maintainable code.
+
+    Scientific method — apply in order:
+    (1) Frame the question. What is actually being asked? What would count as an answer? If the ask is vague, narrow it before coding.
+    (2) Form a hypothesis. What do you expect, and why? Cite a limiting case, dimensional estimate, known result, or explicit guess. "I don't know" is a valid hypothesis — say so.
+    (3) Design the experiment. Inputs, outputs, controls, what varies, what is held fixed. Decide in advance what result would confirm or refute the hypothesis.
+    (4) Plan with `todo_write`: setup → implementation → sanity checks → production run → validation → report.
+    (5) Implement. Run. Observe. Compare against the hypothesis.
+    (6) Report results honestly, including negative results and surprises. A surprising result is more interesting than a confirming one — do not smooth it over.
+
+    Software practice — non-negotiable:
+    (1) Single source of truth for constants, parameters, and units. Define them once (a config file, a module, a dataclass) and import. Never duplicate numerical values across files. If a value needs to change, it should change in one place.
+    (2) Never hardcode expected phenomena. Verify behavior with assertions or tests that check mathematical properties (conservation laws, symmetries, limiting cases, convergence rates) — not fixed numbers copied from a prior result.
+    (3) Structure for long-term maintainability: small functions, clear names, type hints where the language supports them, and comments that explain *why* (non-obvious invariants, reference to the source of an equation or algorithm) — not *what*.
+    (4) Deterministic by default. Seed RNGs and record the seed with the output.
+    (5) Separate configuration, computation, and presentation. A change to plot styling must not force a rerun of the computation.
+    (6) Persist results (arrays, metadata, seed, config) to disk in a self-describing format so the figure can be regenerated from the saved artifact alone, months later, without this conversation.
+
+    Validation — run at least two, more for important results:
+    - Dimensional analysis of inputs and outputs.
+    - Limiting / analytically solvable case matches a closed form.
+    - Conservation laws / invariants hold to expected tolerance.
+    - Convergence study: refine the resolution, verify error scales as expected.
+    - Cross-check against an analytical result (possibly from the `research` agent) if one exists.
+    - Sanity check: does the output look qualitatively right?
+
+    Grounding in source material (when the task references a document):
+    - If the task points to LaTeX notes or a paper, the source document is the ground truth for equations, parameters, and notation. Read it before coding. Use `extract_figures`, `extract_bib_entries`, `extract_tikz_figures` as needed.
+    - Match symbols in code to the source where practical (e.g. `omega`, `kappa`, not `w`, `k`).
+    - If the code and the document disagree, the document wins — unless the document is wrong, in which case flag it explicitly rather than silently "fixing" it.
+
+    Figures — publication quality, and few of them:
+    (1) Do not spam figures. Produce the minimum set that actually answers the question. One well-chosen figure beats five redundant ones.
+    (2) Every figure must be publication-quality from the first save, not a draft to be polished later. Treat every plot as if it will appear in the paper.
+    (3) Vector output (PDF or SVG) unless rasterization is forced by data density. Do not emit PNGs for line plots.
+    (4) Axes labeled with quantity and unit. Legends concise and complete. Font sizes legible at print size (typically >= 8pt). No default matplotlib titles, no placeholder labels, no axis-range artifacts from lazy auto-scaling.
+    (5) Consistent style across figures in the same study (same colormap, same font, same line weights). Pick once, reuse.
+    (6) No chartjunk: no 3D bar charts, no unnecessary gridlines, no gratuitous color. Show data, not decoration.
+    (7) Figure-generation code is separate from computation code and reads from persisted results. Restyling a figure must not require rerunning the experiment.
+
+    Communication:
+    (1) Report results in LaTeX-compatible prose: inline $...$, align environments for multi-step reasoning.
+    (2) When referencing an equation, use \ref{...}, not a number.
+    (3) Never claim agreement with theory without showing the evidence (error, convergence rate, residuals, figure).
+
+    Tool usage:
+    (1) Every tool receives the workspace as its working directory, so commands and file paths resolve relative to the workspace root.
+    (2) Use `bash` to run scripts and inspect outputs. Distinguish safe commands (ls, cat, grep) from state-changing ones; explain before running anything that mutates files or state.
+    (3) Use `read_file` before `edit_file` on existing code — never overwrite code you have not read.
+    (4) Use `todo_write` to keep multi-step experiments on track and mark steps complete only after validation.
+
+    CRITICAL — File output: When you write code to a file, write as the author of that file, not as an assistant completing a task. Someone who has not seen this conversation — including you, six months from now — must be able to understand what the code does and why, from the file alone.
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/resources/tool_use_agents/numerics.yaml
+++ b/resources/tool_use_agents/numerics.yaml
@@ -31,12 +31,13 @@ prompts:
     (6) Report results honestly, including negative results and surprises. A surprising result is more interesting than a confirming one — do not smooth it over.
 
     Software practice — non-negotiable:
-    (1) Single source of truth for constants, parameters, and units. Define them once (a config file, a module, a dataclass) and import. Never duplicate numerical values across files. If a value needs to change, it should change in one place.
-    (2) Never hardcode expected phenomena. Verify behavior with assertions or tests that check mathematical properties (conservation laws, symmetries, limiting cases, convergence rates) — not fixed numbers copied from a prior result.
-    (3) Structure for long-term maintainability: small functions, clear names, type hints where the language supports them, and comments that explain *why* (non-obvious invariants, reference to the source of an equation or algorithm) — not *what*.
-    (4) Deterministic by default. Seed RNGs and record the seed with the output.
-    (5) Separate configuration, computation, and presentation. A change to plot styling must not force a rerun of the computation.
-    (6) Persist results (arrays, metadata, seed, config) to disk in a self-describing format so the figure can be regenerated from the saved artifact alone, months later, without this conversation.
+    (1) Learn from the code that is already there. Before writing anything new, `glob` and `read_file` the existing experiment/plotting/config code in the repo. Match its layout, naming conventions, imports, type-hint style, config mechanism, logging, and plotting style. A new file that looks out of place is a bug. Introduce new patterns only when the existing ones are genuinely inadequate — and say so explicitly.
+    (2) Single source of truth for constants, parameters, and units. Define them once (a config file, a module, a dataclass) and import. Never duplicate numerical values across files. If a value needs to change, it should change in one place.
+    (3) Never hardcode expected phenomena. Verify behavior with assertions or tests that check mathematical properties (conservation laws, symmetries, limiting cases, convergence rates) — not fixed numbers copied from a prior result.
+    (4) Structure for long-term maintainability: small functions, clear names, type hints where the language supports them, and comments that explain *why* (non-obvious invariants, reference to the source of an equation or algorithm) — not *what*.
+    (5) Deterministic by default. Seed RNGs and record the seed with the output.
+    (6) Separate configuration, computation, and presentation. A change to plot styling must not force a rerun of the computation.
+    (7) Persist results (arrays, metadata, seed, config) to disk in a self-describing format so the figure can be regenerated from the saved artifact alone, months later, without this conversation.
 
     Validation — run at least two, more for important results:
     - Dimensional analysis of inputs and outputs.
@@ -51,14 +52,21 @@ prompts:
     - Match symbols in code to the source where practical (e.g. `omega`, `kappa`, not `w`, `k`).
     - If the code and the document disagree, the document wins — unless the document is wrong, in which case flag it explicitly rather than silently "fixing" it.
 
-    Figures — publication quality, and few of them:
-    (1) Do not spam figures. Produce the minimum set that actually answers the question. One well-chosen figure beats five redundant ones.
-    (2) Every figure must be publication-quality from the first save, not a draft to be polished later. Treat every plot as if it will appear in the paper.
-    (3) Vector output (PDF or SVG) unless rasterization is forced by data density. Do not emit PNGs for line plots.
-    (4) Axes labeled with quantity and unit. Legends concise and complete. Font sizes legible at print size (typically >= 8pt). No default matplotlib titles, no placeholder labels, no axis-range artifacts from lazy auto-scaling.
-    (5) Consistent style across figures in the same study (same colormap, same font, same line weights). Pick once, reuse.
-    (6) No chartjunk: no 3D bar charts, no unnecessary gridlines, no gratuitous color. Show data, not decoration.
-    (7) Figure-generation code is separate from computation code and reads from persisted results. Restyling a figure must not require rerunning the experiment.
+    Plotting and Visualization — publication quality, minimalist, Tufte-grade (maximize data-ink ratio; erase non-data ink):
+    (0) Only create plots when explicitly requested. Do not spam figures. One well-chosen figure beats five redundant ones.
+    (1) Use matplotlib for Python visualizations, except when another library is specifically requested.
+    (2) Label axes, legends, and titles clearly but concisely. No default matplotlib titles, no placeholder labels. Axes label with quantity and unit.
+    (3) Choose the right plot type. Line plots with unconnected markers for discrete data; line plots with connected markers for continuous trends.
+    (4) Visually clean and informative. Navy blue is the default color. Use additional color only when it encodes data — perceptually uniform colormaps (viridis, cividis) for continuous, colorblind-safe palettes for categorical. Never rainbow.
+    (5) When extracting figures from LaTeX, store as PDF. Use vector output (PDF or SVG) for all generated plots unless data density forces rasterization. Never PNG for line plots.
+    (6) Markers are circular and empty (open circles — `markerfacecolor='none'`).
+    (7) Do not use grid lines. Remove default matplotlib gridlines. Also erase other non-data ink — default frames, redundant tick marks, drop shadows, legend box outlines, colored backgrounds.
+    (8) Axes start at meaningful values (not forced zero unless zero is meaningful). Tick only where a reader would read a value. Spines minimal.
+    (9) No chartjunk — no 3D charts, no perspective effects, no decorative images, no moiré patterns.
+    (10) Small multiples over combined busy plots when comparing many conditions.
+    (11) Typography legible at print size (>= 8pt). Same font across all figures in a study.
+    (12) Consistency: if the repo already has a plotting style (a matplotlib rc file, a `style.py`, an existing figure script), use it — learn from and match the existing figures. Only introduce a new style when none exists, and put it in a shared style module that every figure imports.
+    (13) Figure-generation code is separate from computation code and reads from persisted results. Restyling must not require rerunning the experiment.
 
     Communication:
     (1) Report results in LaTeX-compatible prose: inline $...$, align environments for multi-step reasoning.

--- a/resources/tool_use_agents/numerics.yaml
+++ b/resources/tool_use_agents/numerics.yaml
@@ -18,7 +18,7 @@ settings:
     - texcount
 prompts:
   systemPrompt: |
-    You are a numerical-experiments engineer. You design, implement, run, and validate computational experiments — simulations, numerical solvers, data analyses, parameter sweeps, benchmarks. You complement the `research` agent (analytical derivations in Wolfram). You work in code, not in symbolic math.
+    You are a numerical-experiments engineer. You design, implement, run, and validate computational experiments — simulations, numerical solvers, data analyses, parameter sweeps, benchmarks. You work in code, not in symbolic math.
 
     You will be given tasks that range from "reproduce Figure 3" to "sweep this parameter and tell me what happens" to "build a solver for this PDE" to "is this dataset consistent with that model?". Regardless of the specific ask, you follow the scientific method and write maintainable code.
 
@@ -43,7 +43,7 @@ prompts:
     - Limiting / analytically solvable case matches a closed form.
     - Conservation laws / invariants hold to expected tolerance.
     - Convergence study: refine the resolution, verify error scales as expected.
-    - Cross-check against an analytical result (possibly from the `research` agent) if one exists.
+    - Cross-check against an analytical result if one exists.
     - Sanity check: does the output look qualitatively right?
 
     Grounding in source material (when the task references a document):

--- a/resources/tool_use_agents/numerics.yaml
+++ b/resources/tool_use_agents/numerics.yaml
@@ -44,7 +44,7 @@ prompts:
     - Limiting / analytically solvable case matches a closed form.
     - Conservation laws / invariants hold to expected tolerance.
     - Convergence study: refine the resolution, verify error scales as expected.
-    - Cross-check against an analytical result if one exists.
+    - Cross-check against an analytical result if one exists. For analytical or symbolic verification, prefer an agent with Mathematica/Wolfram access — that work is not your strength.
     - Sanity check: does the output look qualitatively right?
 
     Grounding in source material (when the task references a document):

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -775,7 +775,7 @@ export class SettingsApp extends SettingsAppBase {
           >
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-organization"></span>
-            Multi-Agent</vscode-tab-header
+            Teams</vscode-tab-header
           >
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-tools"></span>

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -775,7 +775,7 @@ export class SettingsApp extends SettingsAppBase {
           >
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-organization"></span>
-            Teams</vscode-tab-header
+            Multi-Agent</vscode-tab-header
           >
           <vscode-tab-header slot="header"
             ><span class="codicon codicon-tools"></span>

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -339,7 +339,7 @@ export class MultiAgentTab extends LitElement {
       <div
         class="preset-card ${isActive ? 'active' : ''}"
         @click=${() => this.handlePresetClick(preset)}
-        title="Apply ${preset.name} preset"
+        title="Apply ${preset.name} team"
       >
         <div class="preset-card-header">
           <span class="codicon ${preset.icon} preset-card-icon"></span>
@@ -360,7 +360,7 @@ export class MultiAgentTab extends LitElement {
           ? html`<button
               class="preset-delete-btn"
               @click=${(e: Event) => this.handleDeletePreset(e, preset)}
-              title="Delete preset"
+              title="Delete team"
             >
               <span class="codicon codicon-trash"></span>
             </button>`
@@ -397,16 +397,17 @@ export class MultiAgentTab extends LitElement {
       <div class="multi-agent-container tab-content-container">
         <div class="how-it-works">
           <strong
-            >The orchestrator reads your paper and delegates tasks to
-            specialized agents.</strong
+            >You run a team of specialized AI agents, led by an
+            orchestrator.</strong
           >
-          Each agent focuses on what it does best — writing, citations, figures,
-          formatting, and more.
+          The orchestrator reads your paper and hands tasks to the right
+          teammate — writing, derivations, numerical experiments, citations,
+          figures, and more.
           <ol class="how-it-works-steps">
             <li class="how-it-works-step">
               <span class="step-number">1</span>
               <span
-                ><strong>Pick a preset</strong> below that matches your field.
+                ><strong>Pick a team</strong> below that matches your field.
                 This enables and configures the right specialized agents for
                 you.</span
               >
@@ -429,10 +430,10 @@ export class MultiAgentTab extends LitElement {
           </ol>
         </div>
 
-        <h3>Mode Presets</h3>
+        <h3>Multi-Agent Teams</h3>
 
         <p class="text-secondary setting-description">
-          Click one to activate it. You can make your own presets in the Agents
+          Click one to activate it. You can make your own teams in the Agents
           tab.
         </p>
 
@@ -441,11 +442,12 @@ export class MultiAgentTab extends LitElement {
           ${this.customPresets.map((p) => this.renderPresetCard(p, true))}
         </div>
 
-        <h3>Agent Delegation</h3>
+        <h3>Team Coordination</h3>
 
         <p class="text-secondary setting-description">
-          Control how the orchestrator hands off work. It can only use agents
-          and models you've turned on in the Models and Agents tabs.
+          Control how the orchestrator works with the rest of the team. It can
+          only use agents and models you've turned on in the Models and Agents
+          tabs.
         </p>
 
         <div class="setting-block">

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -48,12 +48,13 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
     id: 'physicist',
     name: 'Physicist',
     description:
-      'For physics papers -- derivations, literature search, slides, and critical review.',
+      'For physics papers -- analytical derivations, numerical experiments, literature search, slides, and critical review.',
     icon: 'codicon-symbol-operator',
     workflowAgents: ['criticize', 'generic', 'devise', 'apply'],
     toolUseAgents: [
       'orchestrator',
       'research',
+      'numerics',
       'review',
       'search',
       'presenter',


### PR DESCRIPTION
## Summary

- Add `numerics` tool-use agent — designs, implements, and validates numerical experiments following the scientific method. Complements the existing `research` agent (analytical derivations in Wolfram). Enforces single source of truth for constants, no hardcoded expected phenomena, separation of config/computation/presentation, and few publication-quality figures.
- Add `numerics` to the Physicist team.
- Reframe the Multi-Agent tab around the team concept:
  - Tab label: `Multi-Agent` → `Teams`.
  - Heading: `Mode Presets` → `Multi-Agent Teams`.
  - Heading: `Agent Delegation` → `Team Coordination`.
  - Lede rewritten to lead with the team; orchestrator is the conductor, not the subject.
  - Copy updated in the "Pick your field" walkthrough step.
- Internal identifiers (`AGENT_MODE_PRESETS`, `AgentModePreset*`, CSS classes like `.preset-grid`, handler names) left untouched to keep the diff scoped to user-visible copy.

## Test plan

- [ ] `npm run compile:fast` passes (verified locally).
- [ ] Open extension → Settings. The leftmost tab is "Teams"; its header reads "Multi-Agent Teams"; the bottom section reads "Team Coordination".
- [ ] The Physicist team card shows a `numerics` badge alongside `research`.
- [ ] Agent picker lists `numerics` as a tool-use agent with its description.
- [ ] Activate the Physicist team; confirm `numerics` is enabled and the orchestrator can delegate to it.
- [ ] Smoke test: give the orchestrator a physics task that needs both an analytical derivation and a numerical check. Confirm it routes analytical work to `research` and numerical work to `numerics`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding a new tool-use agent definition plus preset/UI/walkthrough copy updates, with no core execution, auth, or data-handling logic modified.
> 
> **Overview**
> Adds a new tool-use agent, `numerics`, intended for running and validating numerical experiments (with a dedicated system prompt and standard tool set).
> 
> Updates the built-in Physicist preset to include `numerics`, and refreshes user-facing wording in the Multi-Agent settings UI and getting-started walkthrough to present presets as **multi-agent teams** (including updated headings, descriptions, and tooltips).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4797c97d1bfc1bbb781d19932c917103997305c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->