### PR TITLE
Add agent creation documentation and external root allowlist

### DIFF
--- a/resources/docs/agent-creation/execution_and_testing.md
+++ b/resources/docs/agent-creation/execution_and_testing.md
@@ -1,0 +1,79 @@
+# Execution & Testing Model
+
+This note explains how TeXRA runs agents, and — more importantly — how the
+`creator` agent can test a new agent before handing it back to the user.
+
+## How TeXRA runs agents
+
+Every agent run flows through one entry point: `texra.execute` command →
+`executeAgent(config, executionId?, options?)`. The runtime takes an
+`AgentConfig` (agent name, model, instruction, and optional input / memory /
+working-directory fields), resolves the YAML, and dispatches one of two
+flow shapes:
+
+- **Workflow flow** for `agentCategory: workflow`. Fixed rounds, each round
+  consumes paired `prefills[i]` / `userRequest[i]`. Operates on a single
+  `inputFile` (or the active editor selection). Emits output files per
+  `outputExt` / `documentTag` / `defaultOutputFiles`.
+- **Tool-use flow** for `agentCategory: toolUse`. Multi-step loop invoking
+  declared tools. May WAIT for interim follow-ups, spawn subagents via
+  `delegate_workflow` / `delegate_agent`, and resume.
+
+The creator agent does NOT need to call `executeAgent` directly. Instead it
+delegates through tools that handle everything (including approval and the
+follow-up queue) the way an ordinary user would.
+
+## Testing a new agent
+
+Use the `delegate_*` tools in the `tools:` list of `creator.yaml`.
+
+### Testing a workflow agent
+
+1. Make a small test input in the workspace. Example:
+   ```
+   bash: mkdir -p test_inputs
+   write_file test_inputs/sample.tex with a 5–10 line LaTeX snippet
+   ```
+2. Call `delegate_workflow`:
+   ```
+   delegate_workflow(
+     agent: "my_new_polish",
+     model: "<a configured workflow model>",
+     instruction: "Tighten the abstract",
+     inputFile: "./test_inputs/sample.tex"
+   )
+   ```
+3. When the follow-up arrives:
+   - Inspect the output file(s) the subagent produced.
+   - Confirm the agent honoured `outputExt: tex`, wrapped output correctly,
+     and produced non-empty content.
+   - Report pass/fail to the user.
+
+### Testing a tool-use agent
+
+1. Call `delegate_agent`:
+   ```
+   delegate_agent(
+     agent: "my_new_tool_agent",
+     model: "<a configured tool-use model>",
+     instruction: "Do X (small end-to-end smoke test)"
+   )
+   ```
+2. When the subagent hits WAITING (or finishes), read the output and decide
+   whether the agent did what it was supposed to.
+3. If more iteration is needed, pass the returned `execution_id` back to
+   `delegate_agent` with a follow-up `instruction` — this resumes the same
+   session with full context.
+
+## When testing is not possible
+
+Skip testing only if the user explicitly asks you to, or if the design
+depends on live resources that are not available in the current workspace
+(e.g. a real arXiv query that would burn API quota). In that case, state
+plainly in the hand-off message that the agent has not been exercised.
+
+## Iterating
+
+If a test fails — invalid YAML, missing tool, unclear prompt, wrong output
+structure — use `edit_file` on the custom YAML and re-run the delegation
+call. Both delegation tools pick up the updated file on the next invocation.

--- a/resources/docs/agent-creation/tool_catalog.md
+++ b/resources/docs/agent-creation/tool_catalog.md
@@ -1,0 +1,127 @@
+# Tool Catalog for Tool-Use Agents
+
+Every tool available to tool-use agents, organised by group. When designing a
+new agent, pick the smallest set of tools that covers its purpose — the
+recommended groups at the bottom are a good starting point.
+
+## File operations
+
+- `bash` — execute shell commands in the workspace directory. Use for
+  scripts, compilation, git, and anything else that needs a shell.
+- `read_file` — read workspace files. Supports text files (with optional
+  line ranges), PDFs, and images (as attachments for vision-capable models).
+- `write_file` — overwrite or create a workspace file. Writes under the
+  allowlisted agent directories go through the normal approval diff; writes
+  under read-only directories fail cleanly.
+- `edit_file` — exact string replacement in a file. More surgical than
+  `write_file` for targeted changes.
+- `ls` — list files and directories with optional glob filtering.
+- `glob` — find files matching glob patterns (e.g. `**/*.tex`). Returns
+  paths sorted by modification time.
+- `grep` — search file contents with regex. Supports content,
+  files-with-matches, and count output modes.
+
+## Web & search
+
+- `web_search` — search the web and return top results.
+- `web_fetch` — fetch a URL, convert HTML to Markdown, return cleaned text.
+
+## Academic research
+
+- `arxiv_search` — search arXiv. Supports `field="author"` for author
+  searches.
+- `arxiv_metadata` — fetch bibliographic metadata for an arXiv paper by ID.
+- `download_arxiv_source` — download an arXiv paper's source archive into
+  the workspace.
+- `crossref_search` — search Crossref works and return top matches.
+- `crossref_doi` — look up detailed metadata for a DOI.
+
+## LaTeX processing
+
+- `extract_figures` — list and resolve figure assets referenced in a LaTeX
+  document.
+- `extract_bib_entries` — collect BibTeX records for citations.
+- `extract_tikz_figures` — discover TikZ figures and optionally compile them
+  to PDF.
+- `texcount` — count words in LaTeX files.
+
+## Citation management
+
+- `zotero_search`, `zotero_add`, `zotero_export`, `zotero_collections` —
+  manage references with Zotero (requires Better BibTeX).
+
+## Computation
+
+- `wolfram` — execute Wolfram Language code. Sessions do NOT persist
+  between calls.
+
+## Agent delegation
+
+- `delegate_workflow` — delegate to a workflow agent for whole-document
+  operations. Pass `agent`, `model`, `instruction`, `inputFile`. Returns
+  asynchronously via the follow-up queue.
+- `delegate_agent` — delegate to another tool-use agent. Pass `agent`,
+  `model`, and `instruction` for a fresh run, or `execution_id` +
+  `instruction` to resume a WAITING subagent.
+- `executions` — view execution history and manage running executions.
+- `accept_run_files` — accept output files from a completed execution.
+
+## Lean 4
+
+- `lean_diagnostics`, `lean_file`, `lean_project`, `lean_inspect`,
+  `lean_loogle` — Lean 4 proof assistant integration.
+
+## Utility
+
+- `memory` — manage persistent memory files for cross-session knowledge.
+- `todo_write` — track progress on complex tasks with structured checklists.
+- `plan` — record structured plans.
+- `diagnostics` — retrieve linter diagnostics for source files.
+
+## Recommended tool groups by use case
+
+Most agents should include the file-operations set as a baseline.
+
+**Research agent:**
+`bash, read_file, write_file, glob, grep, ls, web_search, web_fetch,
+arxiv_search, arxiv_metadata, download_arxiv_source, crossref_search,
+crossref_doi`
+
+**Code/editing agent:**
+`bash, read_file, write_file, edit_file, glob, grep, ls, diagnostics`
+
+**LaTeX analysis agent:**
+`bash, read_file, write_file, glob, grep, ls, extract_figures,
+extract_bib_entries, extract_tikz_figures, texcount`
+
+**Literature review agent:**
+`bash, read_file, write_file, glob, grep, ls, arxiv_search, arxiv_metadata,
+crossref_search, crossref_doi, web_search, zotero_search, zotero_add,
+zotero_export`
+
+**Orchestrator agent:**
+`bash, read_file, write_file, glob, grep, ls, delegate_workflow,
+delegate_agent, executions, accept_run_files, todo_write`
+
+**Computation agent:**
+`bash, read_file, write_file, glob, grep, ls, wolfram`
+
+**Lean 4 agent:**
+`bash, read_file, write_file, edit_file, glob, grep, ls, lean_diagnostics,
+lean_file, lean_project, lean_inspect, lean_loogle`
+
+**Minimal chat agent:**
+`bash, read_file, write_file, glob, grep, ls`
+
+## System prompt best practices
+
+- Start with a clear role: "You are a [role]. Your task is to [objective]."
+- Give tool usage guidance tailored to the agent's purpose.
+- Structure complex workflows as numbered steps.
+- Mention tool limitations (e.g. wolfram sessions don't persist; bash cwd is
+  the workspace).
+- For agents with many tools, organise guidance by phase (discovery →
+  analysis → output).
+- Keep prompts focused — describe only what this specific agent needs.
+- Use `todo_write` for agents with multi-step verification or audit
+  workflows.

--- a/resources/docs/agent-creation/tooluse_schema.md
+++ b/resources/docs/agent-creation/tooluse_schema.md
@@ -1,0 +1,91 @@
+# Tool-Use Agent Schema & Reference
+
+Tool-use agents are interactive, multi-turn conversational agents with tool
+calling. They access files ONLY through their declared tools (`read_file`,
+`write_file`, `bash`, `grep`, etc.) — no pre-loaded content. The only
+template variable they receive is `{{ INSTRUCTION }}`.
+
+## YAML structure
+
+```yaml
+name: agent_name
+description: One-line description.
+
+settings:
+  agentCategory: toolUse
+  temperature: 0.7          # 0.3-0.5 for precise tasks, 0.7-0.8 for creative
+  tools:
+    - bash
+    - read_file
+    - write_file
+    - glob
+    - grep
+    - ls
+
+prompts:
+  systemPrompt: |
+    [Role, behaviour, tool usage guidance]
+  userRequest: |
+    {{ INSTRUCTION }}
+```
+
+## Critical rules
+
+- `agentCategory` MUST be `"toolUse"` (not `"workflow"`).
+- `userRequest` MUST be a single string (not an array) and MUST contain
+  `{{ INSTRUCTION }}`.
+- Do NOT use `userPrefix` — tool-use agents do not receive pre-loaded file
+  content.
+- The ONLY template variable is `{{ INSTRUCTION }}`. Do not use any
+  workflow-only variables (`INPUT_FILE`, `INPUT_CONTENT`, `ALL_INPUTS`,
+  `ALL_AUXILIARYS`, `ALL_REFERENCES`, `ADDITIONAL_INPUTS`,
+  `REFERENCE_CONTENT`, `AUXILIARY_CONTENT`, `OUTPUT_FILES_ORDER`).
+- `{% if IS_ANTHROPIC_MODEL %}...{% endif %}` works for model-specific
+  instructions.
+- Agent names: lowercase with underscores or dashes.
+
+## Choosing tools
+
+Pick only the tools the agent needs. See `tool_catalog.md` in this directory
+for the full registry and recommended tool groups by use case. Most agents
+want at least `read_file`, `write_file`, `ls`, `glob`, and `grep`; add
+`bash` when the agent must run commands.
+
+## Example: the `research` agent
+
+```yaml
+name: research
+description: Searches academic literature and synthesises findings.
+
+settings:
+  agentCategory: toolUse
+  temperature: 0.7
+  tools:
+    - bash
+    - read_file
+    - write_file
+    - glob
+    - grep
+    - ls
+    - web_search
+    - web_fetch
+    - arxiv_search
+    - arxiv_metadata
+    - download_arxiv_source
+    - crossref_search
+    - crossref_doi
+
+prompts:
+  systemPrompt: |
+    You are a research assistant. Search academic literature, download
+    relevant papers, and synthesise findings for the user.
+
+    Use arxiv_search and crossref_search to find candidates.
+    Use arxiv_metadata and crossref_doi for detailed bibliographic data.
+    Use download_arxiv_source to fetch full paper sources.
+    Use web_search and web_fetch for broader context.
+    Use read_file and write_file to work with documents in the workspace.
+
+  userRequest: |
+    {{ INSTRUCTION }}
+```

--- a/resources/docs/agent-creation/workflow_schema.md
+++ b/resources/docs/agent-creation/workflow_schema.md
@@ -1,0 +1,150 @@
+# Workflow Agent Schema & Reference
+
+Workflow agents process LaTeX documents in a fixed number of rounds (1 or 2),
+producing output wrapped in XML tags. Each round uses a chain-of-thought with
+`<scratchpad>` planning before the final output.
+
+## YAML structure
+
+```yaml
+name: agent_name
+description: One-line description.
+# inherits: parent_agent   # optional — inherit and override an existing agent
+
+settings:
+  agentCategory: workflow
+  isRewrite: true            # true = editing existing docs, false = creating new
+  rounds: 2                  # 1 or 2 (default 2)
+  temperature: 0.1           # 0.1 for editing, 0.5-0.8 for creative tasks
+  outputExt: tex             # MUST be "tex" — TeXRA is a LaTeX tool
+  documentTag: latex_document
+  endTag: "</latex_document>"
+  prefills:                  # MUST have exactly `rounds` entries
+    - "<scratchpad>"
+    - "<scratchpad>"
+
+prompts:
+  systemPrompt: |
+    [Role, LaTeX conventions, task instructions — use LaTeX formatting like \begin{itemize}]
+  userPrefix: |
+    <documents>
+    {{ ALL_AUXILIARYS }}
+    {{ ALL_REFERENCES }}
+    {{ ADDITIONAL_INPUTS }}
+    <document name="{{ INPUT_FILE }}">
+    {{ INPUT_CONTENT }}
+    </document>
+    </documents>
+    <instruction>{{ INSTRUCTION }}</instruction>
+  userRequest:               # MUST be an array with exactly `rounds` entries
+    - |
+      [Round 1: plan in <scratchpad>, then emit output wrapped in <latex_document>]
+    - |
+      [Round 2: reflect in <scratchpad>, then emit the refined <latex_document>]
+```
+
+## Critical rules
+
+- `outputExt` MUST be `"tex"`. TeXRA is a LaTeX tool — nothing else is valid.
+- `prefills` and `userRequest` MUST both have the same number of entries as
+  `rounds`. Round 1 → one entry each; round 2 → two entries each.
+- Always include `{{ INSTRUCTION }}` somewhere so user instructions pass
+  through.
+- System prompts should use LaTeX formatting (`\begin{itemize}`,
+  `\textbf{}`, etc.), not Markdown.
+- Agent names: lowercase with underscores or dashes. No spaces, no YAML
+  special characters.
+
+## Template variables (Nunjucks)
+
+Workflow agent prompts receive:
+
+- `{{ INPUT_FILE }}` — path of the main input file
+- `{{ INPUT_CONTENT }}` — full text of the main input file
+- `{{ ALL_INPUTS }}` — XML list of all input files (when multiple selected)
+- `{{ ALL_AUXILIARYS }}` — auxiliary files (preamble, commands, etc.)
+- `{{ ALL_REFERENCES }}` — reference/bibliography files
+- `{{ ADDITIONAL_INPUTS }}` — extra context files
+- `{{ INSTRUCTION }}` — the user's free-text instruction for this run
+- `{{ REFERENCE_CONTENT }}` — content of reference files
+- `{{ AUXILIARY_CONTENT }}` — content of auxiliary files
+- `{{ OUTPUT_FILES_ORDER }}` — ordered list of output filenames (multiple-
+  output agents only)
+
+Both categories support `{% if IS_ANTHROPIC_MODEL %}...{% endif %}` blocks
+for model-specific instructions.
+
+## Settings guide
+
+- `isRewrite`: true when the agent edits / revises / corrects existing
+  documents, false when it creates new content from scratch.
+- `temperature`: low (0.1) for editing and correction, higher (0.5–0.8) for
+  creative or generative work.
+- `rounds`: 1 for single-pass tasks, 2 when reflection materially improves
+  the output.
+
+## Multiple-output agents
+
+For agents producing several files at once, ship a separate `_multiple`
+variant alongside the single-output file:
+
+- Set `isMultipleOutput: true`.
+- Use `documentTag: latex_documents` (plural) and `endTag: "</latex_documents>"`.
+- Add `defaultOutputFiles` with the list of files.
+- Instruct the model to wrap each file in `<document name="...">` blocks
+  inside `<latex_documents>`.
+- Name the file `<agent_name>_multiple.yaml` next to `<agent_name>.yaml`.
+
+## Inheritance
+
+Agents can inherit from existing agents via `inherits: parent_name`. Only the
+fields you specify are overridden; everything else comes from the parent.
+
+## Example: the `polish` agent
+
+```yaml
+name: polish
+description: Improves writing quality and clarity based on your instructions.
+
+settings:
+  agentCategory: workflow
+  documentTag: latex_document
+  endTag: "</latex_document>"
+  outputExt: tex
+  prefills:
+    - "<scratchpad>"
+    - "<scratchpad>"
+
+prompts:
+  systemPrompt: |
+    You are a professional scientist. Your task is to improve a LaTeX research
+    paper focused solely on the given instructions.
+
+    When writing a \LaTeX document, you must:
+    \begin{itemize}
+      \item Follow chktex-friendly conventions.
+      \item Use consistent notation.
+      \item Preserve comments starting with `%'.
+      \item Use `` or '' rather than straight quotes.
+      \item \textbf{IMPORTANT:} Emit the complete output with all sections in
+      original order.
+    \end{itemize}
+
+  userPrefix: |
+    <documents>
+    {{ ALL_AUXILIARYS }}
+    {{ ALL_REFERENCES }}
+    {{ ADDITIONAL_INPUTS }}
+    <document name="{{ INPUT_FILE }}">
+    {{ INPUT_CONTENT }}
+    </document>
+    </documents>
+    <instruction>{{ INSTRUCTION }}</instruction>
+
+  userRequest:
+    - |
+      Brainstorm in <scratchpad>, then output the revised LaTeX inside
+      <latex_document> tags.
+    - |
+      Reflect in <scratchpad>, then emit the improved <latex_document>.
+```

--- a/resources/templates/agentTemplate-toolUse.yaml
+++ b/resources/templates/agentTemplate-toolUse.yaml
@@ -1,5 +1,5 @@
 name: {{ AGENT_NAME }}
-description: {{ DESCRIPTION }}
+description: '{{ DESCRIPTION | replace("'", "''") }}'
 
 # --- Agent Settings ---
 settings:

--- a/resources/templates/agentTemplate-workflowMultiple.yaml
+++ b/resources/templates/agentTemplate-workflowMultiple.yaml
@@ -1,7 +1,7 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
 name: {{ AGENT_NAME }}
-description: {{ DESCRIPTION }}
+description: '{{ DESCRIPTION | replace("'", "''") }}'
 
 # --- Agent Settings ---
 settings:

--- a/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/resources/templates/agentTemplate-workflowSingle.yaml
@@ -1,7 +1,7 @@
 # --- Agent Inheritance (Optional) ---
 # inherits: base
 name: {{ AGENT_NAME }}
-description: {{ DESCRIPTION }}
+description: '{{ DESCRIPTION | replace("'", "''") }}'
 
 # --- Agent Settings ---
 settings:

--- a/resources/tool_use_agents/creator.yaml
+++ b/resources/tool_use_agents/creator.yaml
@@ -1,0 +1,141 @@
+name: creator
+description: Designs, writes, and tests new TeXRA agents through conversation.
+
+settings:
+  agentCategory: toolUse
+  tools:
+    - read_file
+    - write_file
+    - edit_file
+    - ls
+    - glob
+    - grep
+    - bash
+    - delegate_workflow
+    - delegate_agent
+    - todo_write
+
+prompts:
+  systemPrompt: |
+    You are an expert agent designer for **TeXRA**, a VS Code extension that
+    runs YAML-defined AI agents for LaTeX research. Your role is to help users
+    create new agents through conversation: understand their needs, study
+    existing agents for reference, design appropriate YAML definitions, write
+    them to disk, and — whenever possible — **test the new agent before
+    handing off** so the user receives something that has actually run.
+
+    ## Where agents live
+
+    The extension has registered four absolute directories with the file
+    tools so you can operate on them with the standard `read_file`,
+    `write_file`, `edit_file`, `ls`, `glob`, and `grep` tools. Their
+    absolute paths for this install are:
+
+    - `{{ BUILTIN_WORKFLOW_DIR }}` — built-in workflow agents (read-only)
+    - `{{ BUILTIN_TOOLUSE_DIR }}` — built-in tool-use agents (read-only)
+    - `{{ CUSTOM_AGENTS_DIR }}` — where you write new agents (writable)
+    - `{{ AGENT_DOCS_DIR }}` — schema and tool catalog reference (read-only)
+
+    These paths also appear in `workspace_info`. Writes under the read-only
+    roots fail cleanly. Writes under the custom directory go through the
+    normal approval diff — the user reviews every change before it lands.
+
+    ## Two agent categories
+
+    **Workflow agents** (`agentCategory: workflow`):
+    - Process LaTeX documents in fixed rounds (1 or 2).
+    - Receive pre-loaded file content via template variables
+      ({% raw %}`{{ INPUT_CONTENT }}`, `{{ ALL_INPUTS }}`{% endraw %}, etc.).
+    - Produce output wrapped in XML tags (e.g. `<latex_document>`).
+    - Use chain-of-thought with `<scratchpad>` planning before the final
+      output.
+    - Best for: editing, polishing, correcting, merging, or creating LaTeX
+      documents.
+
+    **Tool-use agents** (`agentCategory: toolUse`):
+    - Interactive, multi-turn conversation with tool calling.
+    - Access files ONLY through tools (`read_file`, `write_file`, `bash`,
+      `grep`, etc.) — no pre-loaded content.
+    - Only receive {% raw %}`{{ INSTRUCTION }}`{% endraw %} as a template
+      variable.
+    - Best for: research, code editing, analysis, interactive exploration,
+      multi-step tasks.
+
+    ## Reference documentation (read this before designing)
+
+    Always skim the relevant reference docs first — do not guess the schema
+    or invent tool names. Read them with `read_file` against
+    `{{ AGENT_DOCS_DIR }}`:
+
+    - `workflow_schema.md` — workflow agent YAML schema, template variables,
+      rules, full example.
+    - `tooluse_schema.md` — tool-use agent YAML schema, rules, full example.
+    - `tool_catalog.md` — every tool in the registry, recommended groups by
+      use case, system-prompt best practices.
+    - `execution_and_testing.md` — how TeXRA runs agents and how to test a
+      new agent with `delegate_workflow` / `delegate_agent`.
+
+    ## How TeXRA runs agents (quick model)
+
+    You do not call the agent runtime directly. TeXRA exposes two delegation
+    tools that invoke a registered agent exactly the way the user would:
+
+    - `delegate_workflow` — for workflow agents. Pass `agent`, `model`,
+      `instruction`, and an `inputFile`. Runs the fixed-round workflow on
+      that file, writes output files, returns asynchronously via the
+      follow-up queue.
+    - `delegate_agent` — for tool-use agents. Pass `agent`, `model`, and
+      `instruction`. Starts a subagent session. Resume by passing
+      `execution_id` back with the next `instruction`.
+
+    Use these tools to test the agent you just wrote.
+
+    ## Your working process
+
+    1. **Understand the need.** Ask what the agent should do. Nail down:
+       workflow vs tool-use, single vs multi-output, which tools are
+       required.
+    2. **Read reference docs.** Always include `tool_catalog.md` plus the
+       matching schema file.
+    3. **Study examples.** `ls {{ BUILTIN_WORKFLOW_DIR }}` or
+       `{{ BUILTIN_TOOLUSE_DIR }}`, then `read_file` on a close analogue
+       (e.g. `polish.yaml` for editing-style workflows, `research.yaml` for
+       tool-use with wolfram + bash).
+    4. **Draft.** Write the YAML to
+       `{{ CUSTOM_AGENTS_DIR }}/<agent_name>.yaml`. The file name must be
+       lowercase with underscores or dashes — no spaces or YAML-special
+       characters.
+    5. **Test.** Pick a minimal test input:
+       - **Workflow agent:** create a tiny `.tex` file in the workspace
+         (e.g. `./test_inputs/sample.tex`) and call `delegate_workflow`
+         with `agent: "<new_agent>"`, a configured `model`, a short
+         `instruction`, and `inputFile: "./test_inputs/sample.tex"`. When
+         the follow-up arrives, inspect the output and report pass/fail.
+       - **Tool-use agent:** call `delegate_agent` with
+         `agent: "<new_agent>"`, a configured `model`, and a short
+         `instruction`. When the subagent hits WAITING, review what it did
+         and, if needed, resume with another instruction using the
+         returned `execution_id`.
+    6. **Iterate.** If the test surfaces issues — malformed YAML, missing
+       tool, unclear prompt — use `edit_file` on the custom YAML and
+       re-test.
+    7. **Hand off.** Once the agent works, summarise what was created and
+       where. The user sees the new agent in the settings dropdown
+       immediately.
+
+    ## Rules
+
+    - Agent names: lowercase, underscores or dashes only.
+    - Keep prompts focused. Write precisely what the agent needs for its
+      specific purpose — do not pad with boilerplate.
+    - For workflow agents, `outputExt` must be `tex`. Always.
+    - For workflow agents, `prefills` and `userRequest` must have the same
+      number of entries as `rounds`.
+    - For tool-use agents, `userRequest` must be a single string that
+      contains {% raw %}`{{ INSTRUCTION }}`{% endraw %}.
+    - Agents can inherit from existing agents via `inherits: parent_name`.
+    - Before you claim success, you must have exercised the new agent with a
+      delegation call unless the user explicitly asks you to skip testing.
+
+  userRequest: |
+    {{ INSTRUCTION }}

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -14,7 +14,10 @@ import { parseFrontmatter } from '@tools/memory/memoryMeta';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getListOfFiles, getXmlFormatFromFiles } from '@utils/prompt';
-import { listExternalRoots } from '@utils/files/externalRoots';
+import {
+  listExternalRoots,
+  type ExternalRootKind,
+} from '@utils/files/externalRoots';
 import { setVarFromFile } from '@utils/files/varsUtils';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -161,15 +164,16 @@ function getBasicVars(
  * Inject the absolute paths of registered agent directories as template
  * variables so agents (notably `creator`) can reference the real paths in
  * their system prompts. Reads from the external-roots registry populated at
- * activation — returns empty strings when a root is not registered (e.g.
- * during tests that don't spin up the VS Code setup).
+ * activation — keyed off the stable `kind` field so renaming a user-visible
+ * label cannot break prompt rendering. Absent roots render as empty strings
+ * (e.g. in tests that don't run activation).
  */
 function getAgentDirectoryVars(): UserVars {
-  const LABEL_TO_VAR: Record<string, string> = {
-    'Built-in workflow agents': 'BUILTIN_WORKFLOW_DIR',
-    'Built-in tool-use agents': 'BUILTIN_TOOLUSE_DIR',
-    'Custom agents': 'CUSTOM_AGENTS_DIR',
-    'Agent creation docs': 'AGENT_DOCS_DIR',
+  const KIND_TO_VAR: Record<ExternalRootKind, string> = {
+    builtInWorkflow: 'BUILTIN_WORKFLOW_DIR',
+    builtInToolUse: 'BUILTIN_TOOLUSE_DIR',
+    custom: 'CUSTOM_AGENTS_DIR',
+    agentDocs: 'AGENT_DOCS_DIR',
   };
   const vars: UserVars = {
     BUILTIN_WORKFLOW_DIR: '',
@@ -178,10 +182,7 @@ function getAgentDirectoryVars(): UserVars {
     AGENT_DOCS_DIR: '',
   };
   for (const root of listExternalRoots()) {
-    const key = LABEL_TO_VAR[root.label];
-    if (key) {
-      vars[key] = root.absolutePath;
-    }
+    vars[KIND_TO_VAR[root.kind]] = root.absolutePath;
   }
   return vars;
 }

--- a/src/agent/utils/userVars.ts
+++ b/src/agent/utils/userVars.ts
@@ -14,6 +14,7 @@ import { parseFrontmatter } from '@tools/memory/memoryMeta';
 import { displayToStoragePath } from '@tools/memory/memoryUtils';
 import { AbsoluteFS, WorkspaceFS } from '@utils/files';
 import { getListOfFiles, getXmlFormatFromFiles } from '@utils/prompt';
+import { listExternalRoots } from '@utils/files/externalRoots';
 import { setVarFromFile } from '@utils/files/varsUtils';
 import { StorageFS } from '@utils/files/storageFS';
 
@@ -152,7 +153,37 @@ function getBasicVars(
     TOOL_USE_AGENTS: toolUseAgentsList,
     CWD: workspacePath ?? WorkspaceFS.getPath() ?? '.',
     DEFAULT_BIB_PATH: defaultBibPath,
+    ...getAgentDirectoryVars(),
   };
+}
+
+/**
+ * Inject the absolute paths of registered agent directories as template
+ * variables so agents (notably `creator`) can reference the real paths in
+ * their system prompts. Reads from the external-roots registry populated at
+ * activation — returns empty strings when a root is not registered (e.g.
+ * during tests that don't spin up the VS Code setup).
+ */
+function getAgentDirectoryVars(): UserVars {
+  const LABEL_TO_VAR: Record<string, string> = {
+    'Built-in workflow agents': 'BUILTIN_WORKFLOW_DIR',
+    'Built-in tool-use agents': 'BUILTIN_TOOLUSE_DIR',
+    'Custom agents': 'CUSTOM_AGENTS_DIR',
+    'Agent creation docs': 'AGENT_DOCS_DIR',
+  };
+  const vars: UserVars = {
+    BUILTIN_WORKFLOW_DIR: '',
+    BUILTIN_TOOLUSE_DIR: '',
+    CUSTOM_AGENTS_DIR: '',
+    AGENT_DOCS_DIR: '',
+  };
+  for (const root of listExternalRoots()) {
+    const key = LABEL_TO_VAR[root.label];
+    if (key) {
+      vars[key] = root.absolutePath;
+    }
+  }
+  return vars;
 }
 
 /**

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -229,8 +229,10 @@ const TOOL_GROUPS: Record<string, ToolGroup> = {
 
 // ── Infrastructure ──────────────────────────────────────────
 
-/* autoescape off: templates contain Nunjucks/YAML syntax, not HTML */
-const nunjucksEnv = nunjucks.configure({ autoescape: false });
+/* autoescape off: templates contain Nunjucks/YAML syntax, not HTML.
+ * Isolated Environment so the setting does not leak into Nunjucks' shared
+ * singleton used by other renderers in the extension. */
+const nunjucksEnv = new nunjucks.Environment(null, { autoescape: false });
 
 /** Lazily built and cached for the extension host lifetime. Schemas are static. */
 let schemaRefCache: Record<AgentCategory, string> | null = null;

--- a/src/commands/agent/agentCreatorCommands.ts
+++ b/src/commands/agent/agentCreatorCommands.ts
@@ -15,6 +15,7 @@ import {
 } from '@agent/core/AgentDataclass';
 import { createHelperModelKit } from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
+import { renderAgentTemplateString } from '@commands/agent/agentTemplateRenderer';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import {
   agentDirectories,
@@ -646,10 +647,15 @@ class GenerateNode extends Node<AgentCreatorShared> {
       `AI generation failed, using template: ${error.message}`,
     );
     const { blueprint } = prepRes;
-    return nunjucksEnv.renderString(blueprint.fallbackTemplate, {
-      ...PASSTHROUGH[blueprint.category],
-      ...blueprint.fallbackVars,
-    });
+    // Route through the shared renderer so both the Settings "new from
+    // template" flow and this fallback produce byte-identical output for
+    // matching inputs. Category-specific passthrough is unnecessary here —
+    // the shared helper passes every runtime token through, and the
+    // bundled templates only reference the ones they need.
+    return renderAgentTemplateString(
+      blueprint.fallbackTemplate,
+      blueprint.fallbackVars,
+    );
   }
 
   async post(

--- a/src/commands/agent/agentTemplateRenderer.ts
+++ b/src/commands/agent/agentTemplateRenderer.ts
@@ -1,0 +1,100 @@
+import * as path from 'path';
+
+import * as vscode from 'vscode';
+import * as nunjucks from 'nunjucks';
+
+import { AbsoluteFS } from '@utils/files';
+
+/**
+ * Render a bundled agent-template YAML with caller-provided variables.
+ *
+ * This is the single source of truth for producing template YAML — both the
+ * "New agent from template" action in Settings and the AI-creator fallback
+ * path call through here. Centralising keeps the output in lockstep with the
+ * schema (e.g. `agentCategory`, `prefills` length, `userRequest` shape).
+ */
+
+export type AgentTemplateKind = 'toolUse' | 'workflowSingle' | 'workflowMultiple';
+
+const FILES: Record<AgentTemplateKind, string> = {
+  toolUse: 'agentTemplate-toolUse.yaml',
+  workflowSingle: 'agentTemplate-workflowSingle.yaml',
+  workflowMultiple: 'agentTemplate-workflowMultiple.yaml',
+};
+
+/**
+ * Variables the bundled templates accept.
+ *
+ * Only `AGENT_NAME` and `DESCRIPTION` are required. `TOOLS_YAML` is used by
+ * the tool-use template and `OUTPUT_FILES` by the multi-output workflow
+ * template; both are optional here and default to sensible empty values.
+ */
+export interface AgentTemplateVars {
+  agentName: string;
+  description: string;
+  /** YAML list string for the tool-use template, e.g. `    - bash\n    - read_file`. */
+  toolsYaml?: string;
+  /** YAML list string for the multi-output template, e.g. `- fileA.tex\n    - fileB.tex`. */
+  outputFilesYaml?: string;
+}
+
+const env = nunjucks.configure({ autoescape: false });
+
+/**
+ * Tokens that the generated agent itself needs to keep literal — they are
+ * consumed by the agent runtime when the agent runs, not at template-render
+ * time. We map each to its literal form so Nunjucks leaves them alone.
+ */
+const AGENT_RUNTIME_TOKENS = [
+  'INSTRUCTION',
+  'INPUT_FILE',
+  'INPUT_CONTENT',
+  'ALL_INPUTS',
+  'ALL_AUXILIARYS',
+  'ALL_REFERENCES',
+  'ADDITIONAL_INPUTS',
+  'REFERENCE_CONTENT',
+  'AUXILIARY_CONTENT',
+  'OUTPUT_FILES_ORDER',
+] as const;
+
+function buildPassthrough(): Record<string, string> {
+  return Object.fromEntries(AGENT_RUNTIME_TOKENS.map((v) => [v, `{{ ${v} }}`]));
+}
+
+const DEFAULT_TOOLS_YAML = [
+  'bash',
+  'read_file',
+  'write_file',
+  'edit_file',
+  'glob',
+  'grep',
+  'ls',
+]
+  .map((t) => `    - ${t}`)
+  .join('\n');
+
+function buildRenderVars(vars: AgentTemplateVars): Record<string, string> {
+  return {
+    ...buildPassthrough(),
+    AGENT_NAME: vars.agentName,
+    DESCRIPTION: vars.description,
+    TOOLS_YAML: vars.toolsYaml ?? DEFAULT_TOOLS_YAML,
+    OUTPUT_FILES: vars.outputFilesYaml ?? '',
+  };
+}
+
+export async function renderAgentTemplateFromBundle(
+  context: vscode.ExtensionContext,
+  kind: AgentTemplateKind,
+  vars: AgentTemplateVars,
+): Promise<string> {
+  const templatePath = path.join(
+    context.extensionPath,
+    'resources',
+    'templates',
+    FILES[kind],
+  );
+  const raw = await AbsoluteFS.read(templatePath);
+  return env.renderString(raw, buildRenderVars(vars));
+}

--- a/src/commands/agent/agentTemplateRenderer.ts
+++ b/src/commands/agent/agentTemplateRenderer.ts
@@ -38,7 +38,10 @@ export interface AgentTemplateVars {
   outputFilesYaml?: string;
 }
 
-const env = nunjucks.configure({ autoescape: false });
+// Isolated Nunjucks environment so `autoescape: false` does not leak into the
+// shared singleton that `nunjucks.configure` / `nunjucks.renderString` would
+// otherwise set for every other caller in the extension.
+const env = new nunjucks.Environment(null, { autoescape: false });
 
 /**
  * Tokens that the generated agent itself needs to keep literal — they are

--- a/src/commands/agent/agentTemplateRenderer.ts
+++ b/src/commands/agent/agentTemplateRenderer.ts
@@ -79,12 +79,32 @@ const DEFAULT_TOOLS_YAML = [
 
 function buildRenderVars(vars: AgentTemplateVars): Record<string, string> {
   return {
-    ...buildPassthrough(),
     AGENT_NAME: vars.agentName,
     DESCRIPTION: vars.description,
     TOOLS_YAML: vars.toolsYaml ?? DEFAULT_TOOLS_YAML,
     OUTPUT_FILES: vars.outputFilesYaml ?? '',
   };
+}
+
+/**
+ * Render a template string with agent-runtime-token passthrough applied.
+ *
+ * Callers pass their own render variables on top of the passthrough so
+ * tokens like `{{ INSTRUCTION }}` that the generated agent expects at
+ * runtime survive this render step. Used by:
+ *  - `renderAgentTemplateFromBundle` below (Settings "new from template")
+ *  - `execFallback` in `agentCreatorCommands.ts` (AI creator fallback)
+ *
+ * Any caller-provided vars win over the passthrough defaults.
+ */
+export function renderAgentTemplateString(
+  templateString: string,
+  vars: Record<string, unknown>,
+): string {
+  return env.renderString(templateString, {
+    ...buildPassthrough(),
+    ...vars,
+  });
 }
 
 export async function renderAgentTemplateFromBundle(
@@ -99,5 +119,5 @@ export async function renderAgentTemplateFromBundle(
     FILES[kind],
   );
   const raw = await AbsoluteFS.read(templatePath);
-  return env.renderString(raw, buildRenderVars(vars));
+  return renderAgentTemplateString(raw, buildRenderVars(vars));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import {
   configureLatexSettings,
   initializeToolDefaults,
   refreshModelListIfNeeded,
+  registerAgentDirectoryRoots,
 } from '@frontend/setup';
 import { agentDirectories } from '@frontend/agents';
 import { FileLister } from '@frontend/files';
@@ -151,6 +152,11 @@ export async function activate(context: vscode.ExtensionContext) {
   // Copy default agents before loading the agent index so built-in agents
   // are available when the index scans directories
   await copyDefaultAgents(context);
+
+  // Expose agent directories to file tools via the external-roots allowlist.
+  // Must run after copyDefaultAgents so the built-in directories exist.
+  await registerAgentDirectoryRoots(context);
+
   await refreshModelListIfNeeded();
 
   loadAgents().catch((err) => {

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -150,14 +150,17 @@ export async function registerAgentDirectoryRoots(
     ]);
 
     registerExternalRoot(builtIn, {
+      kind: 'builtInWorkflow',
       writable: false,
       label: 'Built-in workflow agents',
     });
     registerExternalRoot(builtInToolUse, {
+      kind: 'builtInToolUse',
       writable: false,
       label: 'Built-in tool-use agents',
     });
     registerExternalRoot(custom, {
+      kind: 'custom',
       writable: true,
       label: 'Custom agents',
     });
@@ -170,6 +173,7 @@ export async function registerAgentDirectoryRoots(
       'agent-creation',
     );
     registerExternalRoot(docsRoot, {
+      kind: 'agentDocs',
       writable: false,
       label: 'Agent creation docs',
     });
@@ -193,6 +197,7 @@ export async function refreshCustomAgentRoot(): Promise<void> {
       unregisterExternalRoot(currentCustomAgentRoot);
     }
     registerExternalRoot(custom, {
+      kind: 'custom',
       writable: true,
       label: 'Custom agents',
     });

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 
 import { toErrorMessage } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
+import { agentDirectories } from '@frontend/agents';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
@@ -13,6 +14,10 @@ import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { GlobalStorageFS } from '@utils/files';
 import { isConfigExplicitlySet, updateConfig } from '@utils/config';
+import {
+  registerExternalRoot,
+  unregisterExternalRoot,
+} from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 /**
@@ -118,6 +123,85 @@ async function deleteLegacyAgentFiles(): Promise<void> {
         `Failed to delete legacy agent file ${legacyFile}: ${toErrorMessage(err)}`,
       );
     }
+  }
+}
+
+/**
+ * Last registered custom-agents path, tracked so we can unregister it when
+ * the user points at a new directory via Settings.
+ */
+let currentCustomAgentRoot: string | undefined;
+
+/**
+ * Register agent directories + bundled reference docs with the external-roots
+ * allowlist so the creator tool-use agent can read/write them through the
+ * standard file tools (read_file, write_file, ls, grep, glob, edit_file).
+ *
+ * Call this after copyDefaultAgents(), which populates the built-in dirs.
+ */
+export async function registerAgentDirectoryRoots(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  try {
+    const [builtIn, builtInToolUse, custom] = await Promise.all([
+      agentDirectories.builtIn(),
+      agentDirectories.builtInToolUse(),
+      agentDirectories.custom(),
+    ]);
+
+    registerExternalRoot(builtIn, {
+      writable: false,
+      label: 'Built-in workflow agents',
+    });
+    registerExternalRoot(builtInToolUse, {
+      writable: false,
+      label: 'Built-in tool-use agents',
+    });
+    registerExternalRoot(custom, {
+      writable: true,
+      label: 'Custom agents',
+    });
+    currentCustomAgentRoot = custom;
+
+    const docsRoot = path.join(
+      context.extensionPath,
+      'resources',
+      'docs',
+      'agent-creation',
+    );
+    registerExternalRoot(docsRoot, {
+      writable: false,
+      label: 'Agent creation docs',
+    });
+  } catch (err) {
+    logger.error(
+      'extension',
+      `Failed to register agent directory roots: ${toErrorMessage(err)}`,
+    );
+  }
+}
+
+/**
+ * Re-register the custom agents directory after the user changes its location
+ * via Settings. Unregisters the previous path first so stale entries do not
+ * linger in the allowlist.
+ */
+export async function refreshCustomAgentRoot(): Promise<void> {
+  try {
+    const custom = await agentDirectories.custom();
+    if (currentCustomAgentRoot && currentCustomAgentRoot !== custom) {
+      unregisterExternalRoot(currentCustomAgentRoot);
+    }
+    registerExternalRoot(custom, {
+      writable: true,
+      label: 'Custom agents',
+    });
+    currentCustomAgentRoot = custom;
+  } catch (err) {
+    logger.error(
+      'extension',
+      `Failed to refresh custom agents root: ${toErrorMessage(err)}`,
+    );
   }
 }
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -14,10 +14,7 @@ import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { GlobalStorageFS } from '@utils/files';
 import { isConfigExplicitlySet, updateConfig } from '@utils/config';
-import {
-  registerExternalRoot,
-  unregisterExternalRoot,
-} from '@utils/files/externalRoots';
+import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
 
 /**
@@ -127,12 +124,6 @@ async function deleteLegacyAgentFiles(): Promise<void> {
 }
 
 /**
- * Last registered custom-agents path, tracked so we can unregister it when
- * the user points at a new directory via Settings.
- */
-let currentCustomAgentRoot: string | undefined;
-
-/**
  * Register agent directories + bundled reference docs with the external-roots
  * allowlist so the creator tool-use agent can read/write them through the
  * standard file tools (read_file, write_file, ls, grep, glob, edit_file).
@@ -164,7 +155,6 @@ export async function registerAgentDirectoryRoots(
       writable: true,
       label: 'Custom agents',
     });
-    currentCustomAgentRoot = custom;
 
     const docsRoot = path.join(
       context.extensionPath,
@@ -186,22 +176,18 @@ export async function registerAgentDirectoryRoots(
 }
 
 /**
- * Re-register the custom agents directory after the user changes its location
- * via Settings. Unregisters the previous path first so stale entries do not
- * linger in the allowlist.
+ * Re-register the custom agents directory after the user changes its
+ * location via Settings. Registering the same `kind` overwrites the
+ * previous slot, so no separate unregister step is needed.
  */
 export async function refreshCustomAgentRoot(): Promise<void> {
   try {
     const custom = await agentDirectories.custom();
-    if (currentCustomAgentRoot && currentCustomAgentRoot !== custom) {
-      unregisterExternalRoot(currentCustomAgentRoot);
-    }
     registerExternalRoot(custom, {
       kind: 'custom',
       writable: true,
       label: 'Custom agents',
     });
-    currentCustomAgentRoot = custom;
   } catch (err) {
     logger.error(
       'extension',

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -133,46 +133,58 @@ async function deleteLegacyAgentFiles(): Promise<void> {
 export async function registerAgentDirectoryRoots(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  try {
-    const [builtIn, builtInToolUse, custom] = await Promise.all([
-      agentDirectories.builtIn(),
-      agentDirectories.builtInToolUse(),
-      agentDirectories.custom(),
-    ]);
+  // Register each root independently so one failing directory resolution
+  // (e.g. a misconfigured custom agents path) does not take out the others —
+  // the creator agent still needs its reference docs and built-in examples.
+  const registrations: Array<
+    () => Promise<void> | void
+  > = [
+    async () =>
+      registerExternalRoot(await agentDirectories.builtIn(), {
+        kind: 'builtInWorkflow',
+        writable: false,
+        label: 'Built-in workflow agents',
+      }),
+    async () =>
+      registerExternalRoot(await agentDirectories.builtInToolUse(), {
+        kind: 'builtInToolUse',
+        writable: false,
+        label: 'Built-in tool-use agents',
+      }),
+    async () =>
+      registerExternalRoot(await agentDirectories.custom(), {
+        kind: 'custom',
+        writable: true,
+        label: 'Custom agents',
+      }),
+    () =>
+      registerExternalRoot(
+        path.join(
+          context.extensionPath,
+          'resources',
+          'docs',
+          'agent-creation',
+        ),
+        {
+          kind: 'agentDocs',
+          writable: false,
+          label: 'Agent creation docs',
+        },
+      ),
+  ];
 
-    registerExternalRoot(builtIn, {
-      kind: 'builtInWorkflow',
-      writable: false,
-      label: 'Built-in workflow agents',
-    });
-    registerExternalRoot(builtInToolUse, {
-      kind: 'builtInToolUse',
-      writable: false,
-      label: 'Built-in tool-use agents',
-    });
-    registerExternalRoot(custom, {
-      kind: 'custom',
-      writable: true,
-      label: 'Custom agents',
-    });
-
-    const docsRoot = path.join(
-      context.extensionPath,
-      'resources',
-      'docs',
-      'agent-creation',
-    );
-    registerExternalRoot(docsRoot, {
-      kind: 'agentDocs',
-      writable: false,
-      label: 'Agent creation docs',
-    });
-  } catch (err) {
-    logger.error(
-      'extension',
-      `Failed to register agent directory roots: ${toErrorMessage(err)}`,
-    );
-  }
+  await Promise.all(
+    registrations.map(async (register) => {
+      try {
+        await register();
+      } catch (err) {
+        logger.error(
+          'extension',
+          `Failed to register agent directory root: ${toErrorMessage(err)}`,
+        );
+      }
+    }),
+  );
 }
 
 /**

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -301,12 +301,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly agentHandlers: AgentHandlers;
   private readonly latexHandlers: LatexSettingsHandlers;
 
-  constructor(_context: vscode.ExtensionContext) {
+  constructor(context: vscode.ExtensionContext) {
     super('SettingsView', { trackActiveView: true });
 
     const ctx: SettingsHandlerContext = {
       channel: this.channel,
       logger: this.logger,
+      extensionContext: context,
       withActiveWebview: (fn) => this.withActiveWebview(fn),
     };
 

--- a/src/settingsView/handlers/SettingsHandlerContext.ts
+++ b/src/settingsView/handlers/SettingsHandlerContext.ts
@@ -15,6 +15,8 @@ export interface SettingsHandlerContext {
     error: (channel: string, msg: string, options?: LogUtilsOptions) => void;
     debug: (channel: string, msg: string, options?: LogUtilsOptions) => void;
   };
+  /** VS Code extension context, used to resolve bundled resources. */
+  readonly extensionContext: vscode.ExtensionContext;
   /** Run a callback with the active webview, if available. */
   withActiveWebview: (
     fn: (w: vscode.Webview) => Promise<void>,

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -720,8 +720,8 @@ export class AgentHandlers {
       const baseName = name.replace(/\.yaml$/, '');
       const defaultDescription =
         category === 'toolUse'
-          ? `${baseName}: interactive tool-use agent.`
-          : `${baseName}: workflow agent.`;
+          ? `${baseName} — interactive tool-use agent`
+          : `${baseName} — workflow agent`;
 
       const template = await renderAgentTemplateFromBundle(
         this.ctx.extensionContext,

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -21,6 +21,7 @@ import {
 import { EdgeFunctionResponseSchema } from '@agent/remote/types';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { ULTRA_TIER, SUPABASE_CONFIG } from '@auth/config';
+import { renderAgentTemplateFromBundle } from '@commands/agent/agentTemplateRenderer';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview';
 import { showLoggedErrorMessage } from '@common/errors';
 import {
@@ -356,7 +357,7 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.CREATE_AGENT>,
   ): Promise<void> {
     if (data.mode === 'template') {
-      await this.createAgentFromTemplate();
+      await this.createAgentFromTemplate(data.category);
     } else {
       await vscode.commands.executeCommand(
         'texra.createAgentWithAI',
@@ -683,10 +684,13 @@ export class AgentHandlers {
 
   // ── Private helpers ──
 
-  private async createAgentFromTemplate(): Promise<void> {
+  private async createAgentFromTemplate(
+    category: 'workflow' | 'toolUse',
+  ): Promise<void> {
     try {
+      const categoryLabel = category === 'toolUse' ? 'Tool Use' : 'Workflow';
       const name = await vscode.window.showInputBox({
-        prompt: 'Enter a name for the new agent (without .yaml extension)',
+        prompt: `Enter a name for the new ${categoryLabel} agent (without .yaml extension)`,
         placeHolder: 'my_agent',
         validateInput: (value) => {
           if (!value) return 'Name cannot be empty';
@@ -714,35 +718,19 @@ export class AgentHandlers {
       }
 
       const baseName = name.replace(/\.yaml$/, '');
-      const template = `# --- Agent Inheritance (Optional) ---
-# inherits: base
+      const defaultDescription =
+        category === 'toolUse'
+          ? `${baseName}: interactive tool-use agent.`
+          : `${baseName}: workflow agent.`;
 
-name: ${baseName}
-
-# --- Agent Settings ---
-settings:
-  temperature: 0.1
-  isRewrite: true
-  documentTag: document
-  endTag: '</document>'
-  outputExt: tex
-  prefills:
-    - "<document>"
-
-# --- Agent Prompts ---
-prompts:
-  systemPrompt: |
-    [Define the AI's role and core instructions]
-
-  userPrefix: |
-    [Provide context using variables like {{ INPUT_CONTENT }}]
-
-  userRequest:
-    - |
-        [Define the initial task prompt]
-    - |
-        [Optional reflection prompt — remove this item if you only need one round]
-`;
+      const template = await renderAgentTemplateFromBundle(
+        this.ctx.extensionContext,
+        category === 'toolUse' ? 'toolUse' : 'workflowSingle',
+        {
+          agentName: baseName,
+          description: defaultDescription,
+        },
+      );
 
       await AbsoluteFS.write(filePath, template);
       const doc = await vscode.workspace.openTextDocument(
@@ -761,6 +749,8 @@ prompts:
   /** Refresh agent dir + selection after a directory change. */
   private async refreshAgentDirUI(): Promise<void> {
     await agentDirectories.refreshAfterDirChange();
+    const { refreshCustomAgentRoot } = await import('@frontend/setup');
+    await refreshCustomAgentRoot();
     await this.ctx.withActiveWebview(async (w) => {
       await Promise.all([
         this.sendCustomAgentDir(w),

--- a/src/tools/EditTool.ts
+++ b/src/tools/EditTool.ts
@@ -8,6 +8,7 @@ import {
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
 import {
+  assertWritable,
   countOccurrences,
   pluralize,
   resolveAndFormat,
@@ -50,6 +51,7 @@ export class EditFileTool extends defineTool({
       input.path,
       root,
     );
+    assertWritable(resolved, displayPath);
     const targetPath = resolved.fsPath;
 
     if (old_str.length === 0) {

--- a/src/tools/TextEditorTool.ts
+++ b/src/tools/TextEditorTool.ts
@@ -27,6 +27,7 @@ import { splitContentLines } from '@utils/text/stringUtils';
 import { defineTool } from './core/define';
 import { ToolResult, ToolError } from './result';
 import {
+  assertWritable,
   formatFileView,
   formatLinesWithNumbers,
   requireField,
@@ -121,6 +122,13 @@ export class TextEditorTool extends defineTool({
       root,
     );
     const filePath = resolved.fsPath;
+
+    // Every command except `view` mutates the target file. Enforce the
+    // external-root writable policy here (workspace paths are always allowed
+    // — assertWritable is a no-op for them).
+    if (command !== 'view') {
+      assertWritable(resolved, displayPath);
+    }
 
     await this.validatePath(command, filePath, displayPath);
 

--- a/src/tools/WriteTool.ts
+++ b/src/tools/WriteTool.ts
@@ -9,7 +9,11 @@ import {
   recordToolFileRead,
   requireFileReadForEdit,
 } from '@tools/fileInteractions';
-import { resolveAndFormat, parseWorkingDirectory } from '@tools/utils';
+import {
+  assertWritable,
+  resolveAndFormat,
+  parseWorkingDirectory,
+} from '@tools/utils';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
   buildApprovalRejectedResult,
@@ -44,6 +48,7 @@ export class WriteFileTool extends defineTool({
       input.path,
       root,
     );
+    assertWritable(resolved, displayPath);
     const filePath = resolved.fsPath;
 
     const exists = await WorkspaceFS.exists(filePath);

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -83,9 +83,10 @@ export function resolveWorkspaceRelativePath(
     }
     const resolved = locatePathInRoot(root, input);
     if (resolved.kind === 'external') {
-      const external = externalAllowance(resolved.absolutePath);
-      if (external) {
-        return external;
+      // `annotateExternal` in `locatePathInRoot` already consulted the
+      // registry, so reuse that match instead of paying for a second lookup.
+      if (resolved.allowed) {
+        return externalResolution(resolved.absolutePath, resolved.allowed);
       }
       throw new ToolError('Path must stay within the working directory.');
     }
@@ -112,23 +113,38 @@ export function resolveWorkspaceRelativePath(
 
   if (resolved.kind === 'external') {
     if (resolved.allowed) {
-      const allowed = resolved.allowed;
-      return {
-        relative: allowed.relative || '.',
-        absolute: resolved.absolutePath,
-        fsPath: resolved.absolutePath,
-        external: {
-          root: allowed.absolutePath,
-          writable: allowed.writable,
-          label: allowed.label,
-        },
-      };
+      return externalResolution(resolved.absolutePath, resolved.allowed);
     }
     throw new ToolError('Path must stay within the workspace.');
   }
 
   const relative = resolved.relativePath || '.';
   return { relative, absolute: resolved.absolutePath, fsPath: relative };
+}
+
+/**
+ * Build a WorkspacePathResolution for an absolute path that sits inside a
+ * registered external root, using a pre-resolved allowlist match.
+ *
+ * `relative` is set to the full absolute path so the display (rendered via
+ * `toPosixPath(relative)`) unambiguously signals an external operation —
+ * agents and users should never confuse an external write with a workspace
+ * write, even when file basenames collide.
+ */
+function externalResolution(
+  absolutePath: string,
+  match: { absolutePath: string; writable: boolean; label: string },
+): WorkspacePathResolution {
+  return {
+    relative: absolutePath,
+    absolute: absolutePath,
+    fsPath: absolutePath,
+    external: {
+      root: match.absolutePath,
+      writable: match.writable,
+      label: match.label,
+    },
+  };
 }
 
 /**
@@ -140,16 +156,7 @@ function externalAllowance(
 ): WorkspacePathResolution | undefined {
   const match = findExternalRoot(absolutePath);
   if (!match) return undefined;
-  return {
-    relative: match.relative || '.',
-    absolute: absolutePath,
-    fsPath: absolutePath,
-    external: {
-      root: match.absolutePath,
-      writable: match.writable,
-      label: match.label,
-    },
-  };
+  return externalResolution(absolutePath, match);
 }
 
 /**

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -14,6 +14,7 @@ import { ToolError, type ToolFileAttachment } from '@tools/result';
 // Local imports - core utilities
 import { isNonEmptyString } from '@utils/core';
 import { WorkspaceFS, getMimeType } from '@utils/files';
+import { findExternalRoot } from '@utils/files/externalRoots';
 import { locatePathInRoot } from '@utils/files/workspaceRoot';
 import { toPosixPath } from '@utils/core/pathCore';
 
@@ -26,6 +27,12 @@ export interface WorkspacePathResolution {
    * workspace-relative otherwise (for WorkspaceFS compatibility).
    */
   fsPath: string;
+  /**
+   * When the resolved path falls inside a registered external root, this
+   * describes that root (label, writable flag). Undefined for workspace paths
+   * and for any external path outside the allowlist.
+   */
+  external?: { root: string; writable: boolean; label: string };
 }
 
 /** Trim and validate a working_directory value. Must be absolute if provided. */
@@ -66,12 +73,20 @@ export function resolveWorkspaceRelativePath(
       // (locatePathInRoot and WorkspaceFS.locatePath already do this).
       const relative = path.relative(root, input).replaceAll('\\', '/');
       if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        const external = externalAllowance(input);
+        if (external) {
+          return external;
+        }
         throw new ToolError('Path must stay within the working directory.');
       }
       return { relative: relative || '.', absolute: input, fsPath: input };
     }
     const resolved = locatePathInRoot(root, input);
     if (resolved.kind === 'external') {
+      const external = externalAllowance(resolved.absolutePath);
+      if (external) {
+        return external;
+      }
       throw new ToolError('Path must stay within the working directory.');
     }
     const relative = resolved.relativePath || '.';
@@ -83,17 +98,74 @@ export function resolveWorkspaceRelativePath(
   }
 
   if (!WorkspaceFS.getPath()) {
+    // No workspace — fall back to the allowlist so agent-dir calls still work.
+    if (input && path.isAbsolute(input)) {
+      const external = externalAllowance(input);
+      if (external) {
+        return external;
+      }
+    }
     throw new ToolError('Workspace path is not available.');
   }
 
   const resolved = WorkspaceFS.locatePath(input);
 
   if (resolved.kind === 'external') {
+    if (resolved.allowed) {
+      const allowed = resolved.allowed;
+      return {
+        relative: allowed.relative || '.',
+        absolute: resolved.absolutePath,
+        fsPath: resolved.absolutePath,
+        external: {
+          root: allowed.absolutePath,
+          writable: allowed.writable,
+          label: allowed.label,
+        },
+      };
+    }
     throw new ToolError('Path must stay within the workspace.');
   }
 
   const relative = resolved.relativePath || '.';
   return { relative, absolute: resolved.absolutePath, fsPath: relative };
+}
+
+/**
+ * Build a WorkspacePathResolution for an absolute path that sits inside a
+ * registered external root. Returns undefined when no root matches.
+ */
+function externalAllowance(
+  absolutePath: string,
+): WorkspacePathResolution | undefined {
+  const match = findExternalRoot(absolutePath);
+  if (!match) return undefined;
+  return {
+    relative: match.relative || '.',
+    absolute: absolutePath,
+    fsPath: absolutePath,
+    external: {
+      root: match.absolutePath,
+      writable: match.writable,
+      label: match.label,
+    },
+  };
+}
+
+/**
+ * Throw a ToolError when the resolved path points into a read-only external
+ * root. Workspace paths and writable externals pass through. Call this from
+ * write/edit tools immediately before requesting approval.
+ */
+export function assertWritable(
+  resolved: WorkspacePathResolution,
+  displayPath: string,
+): void {
+  if (resolved.external && !resolved.external.writable) {
+    throw new ToolError(
+      `Cannot write ${displayPath}: ${resolved.external.label} is read-only.`,
+    );
+  }
 }
 
 /**

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -79,7 +79,11 @@ export function resolveWorkspaceRelativePath(
         }
         throw new ToolError('Path must stay within the working directory.');
       }
-      return { relative: relative || '.', absolute: input, fsPath: input };
+      return annotateExternalPermission({
+        relative: relative || '.',
+        absolute: input,
+        fsPath: input,
+      });
     }
     const resolved = locatePathInRoot(root, input);
     if (resolved.kind === 'external') {
@@ -91,11 +95,11 @@ export function resolveWorkspaceRelativePath(
       throw new ToolError('Path must stay within the working directory.');
     }
     const relative = resolved.relativePath || '.';
-    return {
+    return annotateExternalPermission({
       relative,
       absolute: resolved.absolutePath,
       fsPath: resolved.absolutePath,
-    };
+    });
   }
 
   if (!WorkspaceFS.getPath()) {
@@ -157,6 +161,34 @@ function externalAllowance(
   const match = findExternalRoot(absolutePath);
   if (!match) return undefined;
   return externalResolution(absolutePath, match);
+}
+
+/**
+ * Attach external-root permission metadata when a resolution (from the
+ * working_directory branch) happens to land inside a registered root.
+ *
+ * Without this, a subagent launched with `working_directory` set to a
+ * read-only external root (e.g. the built-in agents dir) could bypass
+ * `assertWritable` by addressing files with paths relative to `root` —
+ * the in-root branches return without touching the allowlist otherwise.
+ *
+ * Preserves `relative`/`absolute`/`fsPath` as the caller already built
+ * them so display and I/O remain unchanged; only `external` is added.
+ */
+function annotateExternalPermission(
+  resolution: WorkspacePathResolution,
+): WorkspacePathResolution {
+  if (resolution.external) return resolution;
+  const match = findExternalRoot(resolution.absolute);
+  if (!match) return resolution;
+  return {
+    ...resolution,
+    external: {
+      root: match.absolutePath,
+      writable: match.writable,
+      label: match.label,
+    },
+  };
 }
 
 /**

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -1,0 +1,86 @@
+import * as path from 'path';
+
+/**
+ * Allowlist of external filesystem roots that tools may read or write.
+ *
+ * Tools like read_file, write_file, ls, glob, and grep normally refuse any path
+ * outside the workspace. Registering a root here lets those tools operate on
+ * absolute paths that fall inside it, while paths outside the registry keep
+ * their current "stay within the workspace" rejection.
+ *
+ * Registration happens in the VS Code activation layer (see frontend/setup.ts);
+ * the registry itself is platform-agnostic.
+ */
+
+export interface ExternalRoot {
+  /** Absolute filesystem path (symlinks resolved by caller). */
+  absolutePath: string;
+  /** Whether writes are permitted. */
+  writable: boolean;
+  /** Human-readable label shown in workspace_info. */
+  label: string;
+}
+
+export interface MatchedExternalRoot extends ExternalRoot {
+  /** Path component relative to `absolutePath` (POSIX separators, '' for the root itself). */
+  relative: string;
+}
+
+const roots = new Map<string, ExternalRoot>();
+
+function normalise(absolutePath: string): string {
+  return path.resolve(absolutePath);
+}
+
+/** Register or replace an external root. */
+export function registerExternalRoot(
+  absolutePath: string,
+  options: { writable: boolean; label: string },
+): void {
+  const key = normalise(absolutePath);
+  roots.set(key, { absolutePath: key, writable: options.writable, label: options.label });
+}
+
+/** Remove a previously registered root. */
+export function unregisterExternalRoot(absolutePath: string): void {
+  roots.delete(normalise(absolutePath));
+}
+
+/**
+ * Return the registered root that contains `absolutePath`, or null when no
+ * registered root matches.
+ *
+ * The input must be absolute and already symlink-resolved by the caller; we
+ * compare after `path.resolve` to collapse `..` segments so traversal cannot
+ * escape a registered root.
+ */
+export function findExternalRoot(
+  absolutePath: string,
+): MatchedExternalRoot | null {
+  if (!path.isAbsolute(absolutePath)) return null;
+  const resolved = normalise(absolutePath);
+
+  for (const root of roots.values()) {
+    if (resolved === root.absolutePath) {
+      return { ...root, relative: '' };
+    }
+    const prefix = root.absolutePath + path.sep;
+    if (resolved.startsWith(prefix)) {
+      const relative = resolved
+        .slice(prefix.length)
+        .replaceAll(path.sep, '/');
+      return { ...root, relative };
+    }
+  }
+  return null;
+}
+
+/** Snapshot of the current registry for display purposes. */
+export function listExternalRoots(): ExternalRoot[] {
+  return [...roots.values()];
+}
+
+/** Clear all registrations. Intended for tests. */
+export function resetExternalRoots(): void {
+  roots.clear();
+}

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -181,8 +181,3 @@ export function findExternalRoot(
 export function listExternalRoots(): ExternalRoot[] {
   return [...roots.values()];
 }
-
-/** Clear all registrations. Intended for tests. */
-export function resetExternalRoots(): void {
-  roots.clear();
-}

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -16,12 +16,19 @@ import * as path from 'path';
  * --------------
  * - `registerExternalRoot` rejects non-absolute inputs so the registry cannot
  *   be seeded with process-CWD-relative values.
- * - `findExternalRoot` resolves real paths before matching, so a symlink
- *   inside a writable root that points outside the root (e.g. at
- *   `/etc/passwd`) will NOT match and tools will reject it.
+ * - Both register and find canonicalise inputs through the same pipeline
+ *   (resolve → realpath), so symlinks in any registered root component do
+ *   not cause silent matching failures. Canonicalisation is tolerant of
+ *   non-existent trailing segments (essential for writes that create new
+ *   files) and fails closed on permission errors (any EACCES/EPERM makes
+ *   `findExternalRoot` return null rather than admit an un-verifiable path).
+ * - A symlink inside a writable root that resolves outside the root (e.g.
+ *   at `/etc/passwd`) is NOT matched and tools reject it.
  * - Containment is tested via `path.relative`, which works correctly even
  *   for filesystem roots like `/` or `C:\` (where `root + path.sep` would
- *   produce a bad prefix).
+ *   produce a bad prefix). When multiple registered roots could contain a
+ *   path (nested registration), the most specific (longest) wins so
+ *   read-only children defeat writable parents.
  */
 
 /** Stable identifier for each registered root — keyed off by callers that need
@@ -51,33 +58,32 @@ export interface MatchedExternalRoot extends ExternalRoot {
 
 const roots = new Map<string, ExternalRoot>();
 
-function normalise(absolutePath: string): string {
-  return path.resolve(absolutePath);
-}
-
 /**
- * Resolve a path through any intermediate symlinks. Falls back gracefully
- * when the path (or a trailing segment) does not exist yet — essential for
- * write operations that create new files. The longest existing prefix is
- * realpath-resolved; the non-existent tail is re-appended unchanged.
+ * Canonicalise an absolute path: resolve `.`/`..` segments, then walk
+ * symlinks via realpath. When the final segment does not exist yet
+ * (ENOENT / ENOTDIR) we recursively canonicalise the longest existing
+ * prefix and re-append the non-existent tail — writes that create new
+ * files must still match.
+ *
+ * Throws on permission errors (EACCES/EPERM) or any unexpected error so
+ * callers can fail closed: a path we cannot verify must never be admitted
+ * to the allowlist.
  */
-function resolveRealPath(p: string): string {
+function canonicalise(p: string): string {
+  const resolved = path.resolve(p);
   try {
     return fs.realpathSync.native
-      ? fs.realpathSync.native(p)
-      : fs.realpathSync(p);
+      ? fs.realpathSync.native(resolved)
+      : fs.realpathSync(resolved);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-      // Permissions or other error — fall back to the caller-supplied path so
-      // downstream logic can surface a meaningful error instead of us
-      // silently approving an unresolvable location.
-      return p;
+      throw err;
     }
-    const parent = path.dirname(p);
-    if (parent === p) return p; // reached the filesystem root
-    const base = path.basename(p);
-    return path.join(resolveRealPath(parent), base);
+    const parent = path.dirname(resolved);
+    if (parent === resolved) return resolved; // reached the filesystem root
+    const base = path.basename(resolved);
+    return path.join(canonicalise(parent), base);
   }
 }
 
@@ -91,7 +97,16 @@ export function registerExternalRoot(
       `External root path must be absolute, got: ${absolutePath}`,
     );
   }
-  const key = normalise(absolutePath);
+  // Canonicalise at registration so find-time canonicalisation lands in the
+  // same space. Falls back to path.resolve only on canonicalise failure —
+  // registration is setup-time and the caller already has a try/catch that
+  // will surface a meaningful error.
+  let key: string;
+  try {
+    key = canonicalise(absolutePath);
+  } catch {
+    key = path.resolve(absolutePath);
+  }
   roots.set(key, {
     kind: options.kind,
     absolutePath: key,
@@ -107,24 +122,40 @@ export function unregisterExternalRoot(absolutePath: string): void {
       `External root path must be absolute, got: ${absolutePath}`,
     );
   }
-  roots.delete(normalise(absolutePath));
+  // Try both canonical and raw keys so callers can unregister with the same
+  // path they passed to register, even if canonicalisation was partial.
+  let canonicalKey: string | undefined;
+  try {
+    canonicalKey = canonicalise(absolutePath);
+  } catch {
+    // fall through to raw key only
+  }
+  if (canonicalKey !== undefined) {
+    roots.delete(canonicalKey);
+  }
+  roots.delete(path.resolve(absolutePath));
 }
 
 /**
  * Return the registered root that contains `absolutePath`, or null when no
- * registered root matches. Uses `path.relative` for containment so
- * filesystem-root registrations (e.g. `/` on POSIX) behave correctly, and
- * picks the most-specific registered root when multiple would match.
- *
- * Symlinks are resolved before matching. An allowlisted-looking path that
- * actually symlinks outside the root is rejected.
+ * registered root matches or the path cannot be canonicalised (fail closed).
+ * Uses `path.relative` for containment so filesystem-root registrations
+ * (e.g. `/` on POSIX) behave correctly, and picks the most-specific
+ * registered root when multiple would match.
  */
 export function findExternalRoot(
   absolutePath: string,
 ): MatchedExternalRoot | null {
   if (!path.isAbsolute(absolutePath)) return null;
-  const normalised = normalise(absolutePath);
-  const resolved = resolveRealPath(normalised);
+
+  let resolved: string;
+  try {
+    resolved = canonicalise(absolutePath);
+  } catch {
+    // Permission error or unexpected failure — refuse to admit the path
+    // rather than approve something we cannot verify.
+    return null;
+  }
 
   let best: MatchedExternalRoot | null = null;
   for (const root of roots.values()) {

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -126,11 +126,6 @@ export function registerExternalRoot(
   });
 }
 
-/** Remove the registered root for the given kind. */
-export function unregisterExternalRoot(kind: ExternalRootKind): void {
-  roots.delete(kind);
-}
-
 /**
  * Return the registered root that contains `absolutePath`, or null when no
  * registered root matches or the path cannot be canonicalised (fail closed).

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -1,19 +1,42 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 /**
  * Allowlist of external filesystem roots that tools may read or write.
  *
- * Tools like read_file, write_file, ls, glob, and grep normally refuse any path
- * outside the workspace. Registering a root here lets those tools operate on
- * absolute paths that fall inside it, while paths outside the registry keep
- * their current "stay within the workspace" rejection.
+ * Tools like read_file, write_file, ls, glob, and grep normally refuse any
+ * path outside the workspace. Registering a root here lets those tools
+ * operate on absolute paths that fall inside it, while paths outside the
+ * registry keep their current "stay within the workspace" rejection.
  *
  * Registration happens in the VS Code activation layer (see frontend/setup.ts);
  * the registry itself is platform-agnostic.
+ *
+ * Security notes
+ * --------------
+ * - `registerExternalRoot` rejects non-absolute inputs so the registry cannot
+ *   be seeded with process-CWD-relative values.
+ * - `findExternalRoot` resolves real paths before matching, so a symlink
+ *   inside a writable root that points outside the root (e.g. at
+ *   `/etc/passwd`) will NOT match and tools will reject it.
+ * - Containment is tested via `path.relative`, which works correctly even
+ *   for filesystem roots like `/` or `C:\` (where `root + path.sep` would
+ *   produce a bad prefix).
  */
 
+/** Stable identifier for each registered root — keyed off by callers that need
+ *  to locate a specific root (e.g. template-variable injection). Label strings
+ *  are for display only and must not be used as keys. */
+export type ExternalRootKind =
+  | 'builtInWorkflow'
+  | 'builtInToolUse'
+  | 'custom'
+  | 'agentDocs';
+
 export interface ExternalRoot {
-  /** Absolute filesystem path (symlinks resolved by caller). */
+  /** Stable key, independent of UI text. */
+  kind: ExternalRootKind;
+  /** Absolute, canonical filesystem path. */
   absolutePath: string;
   /** Whether writes are permitted. */
   writable: boolean;
@@ -32,47 +55,95 @@ function normalise(absolutePath: string): string {
   return path.resolve(absolutePath);
 }
 
+/**
+ * Resolve a path through any intermediate symlinks. Falls back gracefully
+ * when the path (or a trailing segment) does not exist yet — essential for
+ * write operations that create new files. The longest existing prefix is
+ * realpath-resolved; the non-existent tail is re-appended unchanged.
+ */
+function resolveRealPath(p: string): string {
+  try {
+    return fs.realpathSync.native
+      ? fs.realpathSync.native(p)
+      : fs.realpathSync(p);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+      // Permissions or other error — fall back to the caller-supplied path so
+      // downstream logic can surface a meaningful error instead of us
+      // silently approving an unresolvable location.
+      return p;
+    }
+    const parent = path.dirname(p);
+    if (parent === p) return p; // reached the filesystem root
+    const base = path.basename(p);
+    return path.join(resolveRealPath(parent), base);
+  }
+}
+
 /** Register or replace an external root. */
 export function registerExternalRoot(
   absolutePath: string,
-  options: { writable: boolean; label: string },
+  options: { kind: ExternalRootKind; writable: boolean; label: string },
 ): void {
+  if (!path.isAbsolute(absolutePath)) {
+    throw new Error(
+      `External root path must be absolute, got: ${absolutePath}`,
+    );
+  }
   const key = normalise(absolutePath);
-  roots.set(key, { absolutePath: key, writable: options.writable, label: options.label });
+  roots.set(key, {
+    kind: options.kind,
+    absolutePath: key,
+    writable: options.writable,
+    label: options.label,
+  });
 }
 
 /** Remove a previously registered root. */
 export function unregisterExternalRoot(absolutePath: string): void {
+  if (!path.isAbsolute(absolutePath)) {
+    throw new Error(
+      `External root path must be absolute, got: ${absolutePath}`,
+    );
+  }
   roots.delete(normalise(absolutePath));
 }
 
 /**
  * Return the registered root that contains `absolutePath`, or null when no
- * registered root matches.
+ * registered root matches. Uses `path.relative` for containment so
+ * filesystem-root registrations (e.g. `/` on POSIX) behave correctly, and
+ * picks the most-specific registered root when multiple would match.
  *
- * The input must be absolute and already symlink-resolved by the caller; we
- * compare after `path.resolve` to collapse `..` segments so traversal cannot
- * escape a registered root.
+ * Symlinks are resolved before matching. An allowlisted-looking path that
+ * actually symlinks outside the root is rejected.
  */
 export function findExternalRoot(
   absolutePath: string,
 ): MatchedExternalRoot | null {
   if (!path.isAbsolute(absolutePath)) return null;
-  const resolved = normalise(absolutePath);
+  const normalised = normalise(absolutePath);
+  const resolved = resolveRealPath(normalised);
 
+  let best: MatchedExternalRoot | null = null;
   for (const root of roots.values()) {
-    if (resolved === root.absolutePath) {
-      return { ...root, relative: '' };
-    }
-    const prefix = root.absolutePath + path.sep;
-    if (resolved.startsWith(prefix)) {
-      const relative = resolved
-        .slice(prefix.length)
-        .replaceAll(path.sep, '/');
-      return { ...root, relative };
+    const relativePath = path.relative(root.absolutePath, resolved);
+    const contained =
+      relativePath === '' ||
+      (!relativePath.startsWith('..') &&
+        relativePath !== '..' &&
+        !path.isAbsolute(relativePath));
+    if (!contained) continue;
+
+    if (best === null || root.absolutePath.length > best.absolutePath.length) {
+      best = {
+        ...root,
+        relative: relativePath.replaceAll(path.sep, '/'),
+      };
     }
   }
-  return null;
+  return best;
 }
 
 /** Snapshot of the current registry for display purposes. */

--- a/src/utils/files/externalRoots.ts
+++ b/src/utils/files/externalRoots.ts
@@ -27,13 +27,20 @@ import * as path from 'path';
  * - Containment is tested via `path.relative`, which works correctly even
  *   for filesystem roots like `/` or `C:\` (where `root + path.sep` would
  *   produce a bad prefix). When multiple registered roots could contain a
- *   path (nested registration), the most specific (longest) wins so
- *   read-only children defeat writable parents.
+ *   path (nested registration), the most specific (longest) wins; ties on
+ *   path length prefer read-only so a writable entry cannot silently grant
+ *   write access to a directory that is also registered read-only under a
+ *   different kind (e.g. if a user points the custom agents dir at the
+ *   built-in agents dir).
+ * - The registry keys on `ExternalRootKind`, not on the path — each kind
+ *   gets exactly one slot. Two different kinds may canonicalise to the
+ *   same path (legitimate when a user overlays a custom dir on a built-in
+ *   one) and both coexist; tiebreaking in `findExternalRoot` makes the
+ *   read-only one win for permission purposes.
  */
 
-/** Stable identifier for each registered root — keyed off by callers that need
- *  to locate a specific root (e.g. template-variable injection). Label strings
- *  are for display only and must not be used as keys. */
+/** Stable identifier for each registered root. Label strings are for display
+ *  only and must not be used as keys. */
 export type ExternalRootKind =
   | 'builtInWorkflow'
   | 'builtInToolUse'
@@ -56,7 +63,7 @@ export interface MatchedExternalRoot extends ExternalRoot {
   relative: string;
 }
 
-const roots = new Map<string, ExternalRoot>();
+const roots = new Map<ExternalRootKind, ExternalRoot>();
 
 /**
  * Canonicalise an absolute path: resolve `.`/`..` segments, then walk
@@ -87,7 +94,11 @@ function canonicalise(p: string): string {
   }
 }
 
-/** Register or replace an external root. */
+/**
+ * Register or replace the external root for the given kind. Calling again
+ * with the same kind (e.g. when the custom agents dir changes) replaces
+ * the previous entry for that kind in place.
+ */
 export function registerExternalRoot(
   absolutePath: string,
   options: { kind: ExternalRootKind; writable: boolean; label: string },
@@ -101,39 +112,23 @@ export function registerExternalRoot(
   // same space. Falls back to path.resolve only on canonicalise failure —
   // registration is setup-time and the caller already has a try/catch that
   // will surface a meaningful error.
-  let key: string;
+  let canonicalPath: string;
   try {
-    key = canonicalise(absolutePath);
+    canonicalPath = canonicalise(absolutePath);
   } catch {
-    key = path.resolve(absolutePath);
+    canonicalPath = path.resolve(absolutePath);
   }
-  roots.set(key, {
+  roots.set(options.kind, {
     kind: options.kind,
-    absolutePath: key,
+    absolutePath: canonicalPath,
     writable: options.writable,
     label: options.label,
   });
 }
 
-/** Remove a previously registered root. */
-export function unregisterExternalRoot(absolutePath: string): void {
-  if (!path.isAbsolute(absolutePath)) {
-    throw new Error(
-      `External root path must be absolute, got: ${absolutePath}`,
-    );
-  }
-  // Try both canonical and raw keys so callers can unregister with the same
-  // path they passed to register, even if canonicalisation was partial.
-  let canonicalKey: string | undefined;
-  try {
-    canonicalKey = canonicalise(absolutePath);
-  } catch {
-    // fall through to raw key only
-  }
-  if (canonicalKey !== undefined) {
-    roots.delete(canonicalKey);
-  }
-  roots.delete(path.resolve(absolutePath));
+/** Remove the registered root for the given kind. */
+export function unregisterExternalRoot(kind: ExternalRootKind): void {
+  roots.delete(kind);
 }
 
 /**
@@ -141,7 +136,9 @@ export function unregisterExternalRoot(absolutePath: string): void {
  * registered root matches or the path cannot be canonicalised (fail closed).
  * Uses `path.relative` for containment so filesystem-root registrations
  * (e.g. `/` on POSIX) behave correctly, and picks the most-specific
- * registered root when multiple would match.
+ * registered root when multiple would match. Ties on path length prefer
+ * read-only so overlapping registrations can never silently grant write
+ * access.
  */
 export function findExternalRoot(
   absolutePath: string,
@@ -167,11 +164,19 @@ export function findExternalRoot(
         !path.isAbsolute(relativePath));
     if (!contained) continue;
 
-    if (best === null || root.absolutePath.length > best.absolutePath.length) {
-      best = {
-        ...root,
-        relative: relativePath.replaceAll(path.sep, '/'),
-      };
+    if (best === null) {
+      best = { ...root, relative: relativePath.replaceAll(path.sep, '/') };
+      continue;
+    }
+
+    // Prefer the most-specific (longest) match; on ties, prefer read-only
+    // so a writable entry cannot override a colocated read-only one.
+    const thisLen = root.absolutePath.length;
+    const bestLen = best.absolutePath.length;
+    if (thisLen > bestLen) {
+      best = { ...root, relative: relativePath.replaceAll(path.sep, '/') };
+    } else if (thisLen === bestLen && best.writable && !root.writable) {
+      best = { ...root, relative: relativePath.replaceAll(path.sep, '/') };
     }
   }
   return best;

--- a/src/utils/files/workspaceFS.ts
+++ b/src/utils/files/workspaceFS.ts
@@ -5,7 +5,11 @@ import { getWorkspaceProvider } from '@agent/core/workspace';
 
 // Local imports - filesystem
 import { RelativeFS } from './relativeFS';
-import { locatePathInRoot, type ResolvedPath } from './workspaceRoot';
+import {
+  annotateExternal,
+  locatePathInRoot,
+  type ResolvedPath,
+} from './workspaceRoot';
 
 /**
  * Static filesystem rooted at the workspace folder.
@@ -48,7 +52,10 @@ export class WorkspaceFS extends RelativeFS {
 
     if (!root) {
       if (!inputPath) return { kind: 'external', absolutePath: '' };
-      return { kind: 'external', absolutePath: path.resolve(inputPath) };
+      return annotateExternal({
+        kind: 'external',
+        absolutePath: path.resolve(inputPath),
+      });
     }
 
     // Absolute paths: platform's asRelativePath for symlink handling
@@ -61,7 +68,7 @@ export class WorkspaceFS extends RelativeFS {
           relativePath: relative,
         };
       }
-      return { kind: 'external', absolutePath: inputPath };
+      return annotateExternal({ kind: 'external', absolutePath: inputPath });
     }
 
     // Empty + relative paths: pure path logic

--- a/src/utils/files/workspaceRoot.ts
+++ b/src/utils/files/workspaceRoot.ts
@@ -1,12 +1,36 @@
 import * as path from 'path';
 
+import {
+  findExternalRoot,
+  type MatchedExternalRoot,
+} from './externalRoots';
+
 /**
  * Result of resolving a path against a workspace root.
  * 'workspace' paths live inside the root; 'external' paths do not.
+ *
+ * External paths may additionally match an allowlisted external root (see
+ * `externalRoots.ts`). When they do, `allowed` is populated so tools can
+ * operate on the path instead of rejecting it outright.
  */
 export type ResolvedPath =
   | { kind: 'workspace'; absolutePath: string; relativePath: string }
-  | { kind: 'external'; absolutePath: string };
+  | {
+      kind: 'external';
+      absolutePath: string;
+      allowed?: MatchedExternalRoot;
+    };
+
+/**
+ * Wrap an external result with allowlist info. Returns the input unchanged
+ * when the path does not match any registered external root.
+ */
+export function annotateExternal(
+  resolved: { kind: 'external'; absolutePath: string },
+): { kind: 'external'; absolutePath: string; allowed?: MatchedExternalRoot } {
+  const match = findExternalRoot(resolved.absolutePath);
+  return match ? { ...resolved, allowed: match } : resolved;
+}
 
 /**
  * Resolve a relative path against a workspace root.
@@ -22,10 +46,10 @@ export function locatePathInRoot(
   // On POSIX, backslashes are valid filename chars — path.normalize would preserve them.
   const relative = path.posix.normalize(inputPath.replaceAll('\\', '/'));
   if (relative.startsWith('..')) {
-    return {
+    return annotateExternal({
       kind: 'external',
       absolutePath: path.resolve(root, inputPath),
-    };
+    });
   }
   return {
     kind: 'workspace',

--- a/src/utils/system/workspaceInfo.ts
+++ b/src/utils/system/workspaceInfo.ts
@@ -7,6 +7,7 @@ import { execa } from 'execa';
 
 // Local imports
 import { WorkspaceFS } from '@utils/files';
+import { listExternalRoots } from '@utils/files/externalRoots';
 import { isWSL } from './wslDetect';
 
 /** Timeout for git commands in milliseconds. */
@@ -157,6 +158,20 @@ export async function buildWorkspaceInfoBlock(
     const parts = ['Git: yes', branchPart];
     if (info.git.dirty) parts.push('uncommitted changes');
     lines.push(parts.join(', '));
+  }
+
+  const externalRoots = listExternalRoots();
+  if (externalRoots.length > 0) {
+    lines.push('');
+    lines.push(
+      'Accessible external directories (absolute paths — use read_file, write_file, ls, grep, glob, edit_file):',
+    );
+    for (const root of externalRoots) {
+      const rw = root.writable ? 'writable' : 'read-only';
+      lines.push(
+        `  ${escapeXml(root.absolutePath)} — ${escapeXml(root.label)} (${rw})`,
+      );
+    }
   }
 
   return `\n<workspace_info>\n${lines.join('\n')}\n</workspace_info>`;


### PR DESCRIPTION
## Summary

This PR introduces comprehensive agent creation documentation and infrastructure to support the `creator` tool-use agent in designing and testing new agents. It adds schema references for both workflow and tool-use agents, establishes an external filesystem allowlist for agent directories, and integrates template rendering for agent scaffolding.

## Key Changes

- **Agent creation documentation** (`resources/docs/agent-creation/`):
  - `workflow_schema.md` — complete YAML schema, template variables, critical rules, and examples for workflow agents
  - `tooluse_schema.md` — YAML schema and rules for tool-use agents
  - `tool_catalog.md` — registry of all available tools, recommended groups by use case, and system prompt best practices
  - `execution_and_testing.md` — how TeXRA runs agents and how the creator agent can test new agents before handoff

- **External filesystem allowlist** (`src/utils/files/externalRoots.ts`):
  - New `ExternalRoot` registry allowing tools (`read_file`, `write_file`, `ls`, `glob`, `grep`, `edit_file`) to operate on absolute paths outside the workspace
  - Functions to register/unregister roots and match paths against the allowlist
  - Enables the creator agent to read/write agent YAML files and documentation

- **Agent template rendering** (`src/commands/agent/agentTemplateRenderer.ts`):
  - Centralized template renderer for bundled agent scaffolds (tool-use, workflow single-output, workflow multi-output)
  - Nunjucks-based rendering with passthrough of agent runtime tokens (`{{ INSTRUCTION }}`, `{{ INPUT_CONTENT }}`, etc.)
  - Used by both Settings UI and creator agent fallback path

- **Integration with agent directories**:
  - `registerAgentDirectoryRoots()` in `src/frontend/setup.ts` registers built-in and custom agent directories plus documentation root at activation
  - `refreshCustomAgentRoot()` handles re-registration when user changes custom agent directory via Settings
  - Agent directory paths injected as template variables (`BUILTIN_WORKFLOW_DIR`, `BUILTIN_TOOLUSE_DIR`, `CUSTOM_AGENTS_DIR`, `AGENT_DOCS_DIR`) for use in agent prompts

- **Path resolution enhancements**:
  - `src/utils/files/workspaceRoot.ts` — `annotateExternal()` function to attach allowlist metadata to external paths
  - `src/tools/utils.ts` — `resolveWorkspaceRelativePath()` now checks external allowlist before rejecting out-of-workspace paths
  - `src/tools/WriteTool.ts` and `src/tools/EditTool.ts` — `assertWritable()` checks to enforce write permissions on external roots

- **Workspace info display**:
  - `src/utils/system/workspaceInfo.ts` — lists registered external directories with their labels and paths so agents can reference them

- **Settings UI updates**:
  - `src/settingsView/handlers/agentHandlers.ts` — `createAgentFromTemplate()` now accepts category parameter and uses `renderAgentTemplateFromBundle()` instead of inline template strings

- **Creator agent definition** (`resources/tool_use_agents/creator.yaml`):
  - New tool-use agent for designing, writing, and testing TeXRA agents through conversation
  - Includes comprehensive system prompt with agent design workflow, reference documentation guidance, and testing procedures
  - Declares tools: file operations, delegation, bash, and utility tools

## Notable Implementation Details

- External roots are registered at extension activation and re-registered when the custom agent directory setting changes
- Path resolution is layered: workspace paths first, then external allowlist, then rejection — preserving security while enabling agent-directory access
- Template variables for agent directories are injected into all agent prompts via `getAgentDirectoryVars()`, making them available to any agent that needs them
- The creator agent's system prompt references all four documentation files and provides step-by-step guidance for agent design, testing with `delegate_workflow`/`delegate_agent`, and iteration

https://claude.ai/code/session_01GyH8UL1pL3ybCK1HoTwAUN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new path-allowlisting and write-permission enforcement that affects multiple file tools and path resolution flows; mistakes could unintentionally block legitimate writes or (worse) widen filesystem access beyond intended roots.
> 
> **Overview**
> Adds **agent creation documentation** and a new `creator` tool-use agent that can design, write, and *test* newly generated agents via `delegate_workflow`/`delegate_agent`.
> 
> Introduces an **external filesystem root allowlist** for tools, registers the built-in/custom agent directories + agent-creation docs at activation, injects their absolute paths into prompt variables (`BUILTIN_WORKFLOW_DIR`, `CUSTOM_AGENTS_DIR`, etc.), and enforces read-only vs writable roots in `write_file`/`edit_file` paths.
> 
> Centralizes **agent template rendering** (with runtime-token passthrough) so Settings “create from template” and the AI-creator fallback generate identical YAML, and updates the Settings flow to use the bundled templates and refresh the custom-agent root when the directory changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7433c91661e9487a8b9bbd4d5f8974d7ea714237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->