### PR TITLE
refactor(output): extract shared collectOutputFileLocations helper

### DIFF
--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { bus } from '@eventBus/ProgressEventBus';
+import { collectOutputFileLocations } from '@shared/schemas';
 import type { OutputFileInfo } from '@shared/schemas';
 
 // Session-scoped: the touched set is not persisted across window reloads so
@@ -45,22 +46,15 @@ class TeXRAFileDecorationProvider implements vscode.FileDecorationProvider {
   }
 }
 
-// Mirrors `OutputFilesManager.collectPaths` so an edit workflow's original
-// workspace file (stored in `lineage.original`) is decorated, not just the
-// agent's staged output which is often under runStorage.
+// Decorate workspace files reachable from this output info — including the
+// original workspace file referenced via `lineage.original` for edit
+// workflows whose agent output sits under runStorage.
 function collectWorkspacePaths(
   target: Set<string>,
   info: OutputFileInfo,
 ): void {
-  const { lineage } = info;
-  const locations = [
-    info.location,
-    lineage?.original,
-    lineage?.diffBase,
-    lineage?.diffFile,
-  ];
-  for (const loc of locations) {
-    if (loc?.kind === 'workspace') {
+  for (const loc of collectOutputFileLocations(info)) {
+    if (loc.kind === 'workspace') {
       target.add(loc.absolutePath);
     }
   }

--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
 
 import { bus } from '@eventBus/ProgressEventBus';
-import { collectOutputFileLocations } from '@shared/schemas';
-import type { OutputFileInfo } from '@shared/schemas';
+import {
+  collectOutputFileLocations,
+  type OutputFileInfo,
+} from '@shared/schemas/output';
 
 // Session-scoped: the touched set is not persisted across window reloads so
 // the badges clear on restart and track only the current session's activity.

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -6,8 +6,8 @@ import {
   collectOutputFileLocations,
   OutputFileInfoListSchema,
   type OutputFileInfo,
-  type StreamTabId,
-} from '@shared/schemas';
+} from '@shared/schemas/output';
+import type { StreamTabId } from '@shared/schemas/identifiers';
 
 /**
  * Manages output files per stream tab with disk-backed persistence.

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -3,6 +3,7 @@ import { RoundKeySchema } from '@progressView/persistence/streamTabSchemas';
 import { mapToRecord } from '@progressView/persistence/serializationUtils';
 import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
 import {
+  collectOutputFileLocations,
   OutputFileInfoListSchema,
   type OutputFileInfo,
   type StreamTabId,
@@ -117,16 +118,8 @@ export class OutputFilesManager {
     info: OutputFileInfo,
     workspaceOnly: boolean,
   ): void {
-    const { lineage } = info;
-    const locations = [
-      info.location,
-      lineage?.original,
-      lineage?.diffBase,
-      lineage?.diffFile,
-    ];
-
-    for (const loc of locations) {
-      if (loc?.absolutePath && (!workspaceOnly || loc.kind === 'workspace')) {
+    for (const loc of collectOutputFileLocations(info)) {
+      if (!workspaceOnly || loc.kind === 'workspace') {
         target.add(loc.absolutePath);
       }
     }

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -86,7 +86,9 @@ export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 /**
  * Return every `FileLocation` reachable from an `OutputFileInfo`: the primary
  * `location` plus any lineage entries (`original`, `diffBase`, `diffFile`).
- * Locations without an `absolutePath` are skipped.
+ * Missing lineage entries (`null`/`undefined`) are skipped; defensively, any
+ * entry with a falsy `absolutePath` is also dropped, though valid
+ * `FileLocation`s always have one.
  *
  * Callers that only care about workspace files should filter the result by
  * `loc.kind === 'workspace'` themselves — the workspace-scope check is
@@ -104,7 +106,7 @@ export function collectOutputFileLocations(
   ];
   const result: FileLocation[] = [];
   for (const loc of candidates) {
-    if (loc?.absolutePath) {
+    if (loc != null && loc.absolutePath) {
       result.push(loc);
     }
   }

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -82,3 +82,31 @@ export const RoundOutputSchema = z.strictObject({
   xmlSummary: OutputXmlSummarySchema,
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
+
+/**
+ * Return every `FileLocation` reachable from an `OutputFileInfo`: the primary
+ * `location` plus any lineage entries (`original`, `diffBase`, `diffFile`).
+ * Locations without an `absolutePath` are skipped.
+ *
+ * Callers that only care about workspace files should filter the result by
+ * `loc.kind === 'workspace'` themselves — the workspace-scope check is
+ * platform-coupled and intentionally lives outside this VS Code-free module.
+ */
+export function collectOutputFileLocations(
+  info: OutputFileInfo,
+): FileLocation[] {
+  const { lineage } = info;
+  const candidates: (FileLocation | null | undefined)[] = [
+    info.location,
+    lineage?.original,
+    lineage?.diffBase,
+    lineage?.diffFile,
+  ];
+  const result: FileLocation[] = [];
+  for (const loc of candidates) {
+    if (loc?.absolutePath) {
+      result.push(loc);
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds `collectOutputFileLocations(info: OutputFileInfo): FileLocation[]` to `src/shared/schemas/output.ts`, walking the primary `location` plus `lineage.original` / `diffBase` / `diffFile`.
- Replaces the duplicated traversals in `src/frontend/ui/fileDecorations.ts` (`collectWorkspacePaths`) and `src/progressView/managers/OutputFilesManager.ts` (private `collectPaths`) with calls to the new helper.
- Each caller still applies its own workspace-scope filter so the shared schema module stays VS Code-free per the project's separation-of-concerns rules.

Closes #3054

## Test plan
- [x] `npm run compile:fast` (clean build)
- [x] `npm run typecheck` (no new errors)
- [ ] Manual: confirm "T" file decoration still appears for workspace files touched by an agent run
- [ ] Manual: confirm `OutputFilesManager.getKnownFilePaths(stream, { workspaceOnly: true })` still returns the expected set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes output-file location traversal; behavior should remain the same aside from any edge cases around skipping missing/invalid lineage entries.
> 
> **Overview**
> Adds `collectOutputFileLocations(info)` in `src/shared/schemas/output.ts` to return the primary output `location` plus any lineage locations (`original`, `diffBase`, `diffFile`).
> 
> Refactors the file-decoration workflow and `OutputFilesManager` path collection to use this shared helper (and updates imports/types accordingly), keeping caller-side filtering for `workspace` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2898a47352de820bba0fbc9041e4a461f5923130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->