### PR TITLE
fix(prPolling): paginate check-runs so terminal CI fires on >100 runs

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -484,9 +484,11 @@ export class PRPollingSource implements AsyncEventSource {
         // runs.length > 0: an empty array is ambiguous (no CI configured vs.
         // runs not yet registered), so "done" isn't meaningful and seeding
         // would suppress the real terminal event once runs appear. Also
-        // require we have the full set (length >= total_count); fetchAllCheckRuns
-        // returns the latest observed total_count, so this also covers runs
-        // added mid-walk that bumped the page count.
+        // require we have the full set (length >= total_count). The runs
+        // array from fetchAllCheckRuns is deduped by id and total_count is
+        // the latest server-reported value, so this comparison is safe
+        // against mid-walk page shifts that would otherwise let a duplicate-
+        // padded array trip the gate before a newly-registered run was seen.
         if (
           state.headSha &&
           runs.length > 0 &&
@@ -585,10 +587,12 @@ export class PRPollingSource implements AsyncEventSource {
       // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
       // configured vs. runs not yet registered), so "done" isn't meaningful.
       // Also require we have the full set (length >= total_count). The API
-      // caps at per_page=100; `fetchAllCheckRuns` walks pagination AND
-      // returns the most recent `total_count` it observed (not the stale
-      // page-1 value), so this comparison correctly guards against runs
-      // added mid-walk that bumped `total_count` higher than page 1 reported.
+      // caps at per_page=100; `fetchAllCheckRuns` walks pagination, dedupes
+      // runs by id (so page-shift duplicates can't pad the count), AND
+      // returns the latest `total_count` from this tick's 200 responses
+      // (not a stale page-1 snapshot or a stuck monotonic max from a prior
+      // mid-walk inflation). A duplicate-filled buffer can therefore never
+      // trick this gate into firing "CI complete" before every run is seen.
       if (
         state.headSha &&
         runs.length > 0 &&
@@ -634,15 +638,29 @@ export class PRPollingSource implements AsyncEventSource {
    * gates (`runs.length >= total_count`) stuck false forever, stranding agents
    * waiting on "CI complete" / "CI passed".
    *
-   * ## Mid-walk additions
+   * ## Mid-walk churn (additions, removals, dedupe)
    *
-   * `total_count` can grow between pages if GitHub registers new runs while
-   * we're paginating. We re-read `total_count` from every 200 response,
-   * recompute `totalPages` against the maximum we've ever seen, and continue
-   * until we've collected at least that many runs (or hit the safety cap).
-   * The returned `total_count` is the latest observed value, never page 1's
-   * stale snapshot — downstream `runs.length >= total_count` gates can rely
-   * on it.
+   * `total_count` and the per-page set of runs can both shift while we're
+   * paginating: GitHub may register new runs (pushing earlier runs onto a
+   * later page → duplicates across our pages), or runs may be removed/replaced
+   * (a page shrinks). We defend against both:
+   *
+   * - We accumulate runs into a `Map<id, GhCheckRun>` so duplicates collapse.
+   *   The terminal gate downstream (`runs.length >= total_count`) is evaluated
+   *   against the deduped count, not the raw appended count, so a page-shift
+   *   that fills our buffer with duplicates can't trick us into emitting
+   *   "CI complete" before a newly-registered run has actually been seen.
+   *
+   * - We re-read `total_count` from every 200 response and use the LAST seen
+   *   value (not the historical max). The server's `total_count` is its
+   *   current authoritative count at the moment of that page-N fetch; if a
+   *   transient mid-walk inflation later settles back down, taking the max
+   *   would strand the gate forever (`runs.length` can never reach an
+   *   inflated, no-longer-true total).
+   *
+   * The returned `total_count` is the latest observed server value (or, on
+   * a full-304 tick, the previously-committed value carried via cache),
+   * never page 1's stale snapshot.
    *
    * ## ETag caching (multi-page)
    *
@@ -699,11 +717,21 @@ export class PRPollingSource implements AsyncEventSource {
     // We need a place to record whether *every* page returned 304 so we can
     // surface a true 304 to the caller (and skip the seeding/diff work).
     let allPagesUnchanged = true;
-    let observedTotal = 0;
+    // `latestTotal` tracks the most recent 200 response's `total_count`.
+    // Crucially we do NOT carry `cache.lastTotalCount` into this — that
+    // would let a transient prior-tick inflation persist forever once page-1
+    // starts returning 304 against the unchanged content (the cached
+    // `lastTotalCount` would seed the gate every tick and `runs.length`
+    // could never catch up to an inflated, no-longer-true total).
+    let latestTotal: number | undefined;
 
     const fetchPage = async (
       page: number,
-    ): Promise<{ runs: GhCheckRun[]; total: number; was304: boolean }> => {
+    ): Promise<{
+      runs: GhCheckRun[];
+      total: number | undefined;
+      was304: boolean;
+    }> => {
       const pageEtag = cache?.etagsByPage.get(page);
       const res = await ghGet<{
         total_count: number;
@@ -716,8 +744,14 @@ export class PRPollingSource implements AsyncEventSource {
         nextPages.set(page, cachedRuns);
         return {
           runs: cachedRuns,
-          // total_count isn't returned on 304; fall back to last-known.
-          total: cache?.lastTotalCount ?? 0,
+          // total_count isn't returned on 304. We deliberately return
+          // undefined here rather than falling back to `cache.lastTotalCount`,
+          // because that cached value may itself be stale (an inflated value
+          // committed during a prior mid-walk race). The terminal `latestTotal`
+          // is derived from this tick's 200 responses; only when *every* page
+          // is 304 do we reuse the cached total below — and that case
+          // genuinely means "nothing changed since we last committed".
+          total: undefined,
           was304: true,
         };
       }
@@ -734,7 +768,7 @@ export class PRPollingSource implements AsyncEventSource {
     // when nothing changed).
     const first = await fetchPage(1);
     if (!first.was304) allPagesUnchanged = false;
-    observedTotal = Math.max(observedTotal, first.total);
+    if (first.total !== undefined) latestTotal = first.total;
 
     // Single-page fast path. If page 1 was 304 and our last-known total fits
     // in one page, we can short-circuit the whole call without touching any
@@ -750,21 +784,35 @@ export class PRPollingSource implements AsyncEventSource {
       return { response: { status: 304 } };
     }
 
-    const allRuns: GhCheckRun[] = [...first.runs];
+    // Dedupe by run id. Pagination is not transactional on GitHub: when a
+    // new run is registered mid-walk, runs can shift across page boundaries
+    // and we'd otherwise see the same id on two different pages (or miss
+    // one entirely). A `Map<id, run>` collapses duplicates and lets the
+    // downstream `runs.length >= total_count` gate evaluate against the
+    // true unique count.
+    const runsById = new Map<number, GhCheckRun>();
+    for (const r of first.runs) runsById.set(r.id, r);
+
+    // How many pages to walk this tick. We need a starting estimate before
+    // we've seen any 200 with a non-cached total, so we fall back to the
+    // cached `lastTotalCount` when page-1 was 304 (unchanged content → the
+    // server's view almost certainly matches what we last committed). If a
+    // 200 arrives later, `latestTotal` takes precedence and we recompute.
+    const seedTotal = latestTotal ?? cache?.lastTotalCount ?? 0;
     let totalPages = Math.max(
       1,
-      Math.ceil(observedTotal / CHECK_RUNS_PAGE_SIZE),
+      Math.ceil(seedTotal / CHECK_RUNS_PAGE_SIZE),
     );
     if (totalPages > MAX_CHECK_RUNS_PAGES) {
       this.logger.warn(
         `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-          `total_count=${observedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
+          `total_count=${seedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
       );
       totalPages = MAX_CHECK_RUNS_PAGES;
     }
     if (totalPages > 1) {
       this.logger.info(
-        `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${observedTotal} → ${totalPages} pages`,
+        `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${seedTotal} → ${totalPages} pages`,
       );
     }
 
@@ -772,17 +820,23 @@ export class PRPollingSource implements AsyncEventSource {
     while (page <= totalPages) {
       const result = await fetchPage(page);
       if (!result.was304) allPagesUnchanged = false;
-      allRuns.push(...result.runs);
+      for (const r of result.runs) runsById.set(r.id, r);
 
-      // total_count can grow if GitHub registers new runs mid-walk. Re-read
-      // it from every 200 response and extend the walk if needed.
-      if (result.total > observedTotal) {
-        observedTotal = result.total;
-        const newTotalPages = Math.ceil(observedTotal / CHECK_RUNS_PAGE_SIZE);
+      // Use the LATEST observed `total_count` (from this page's 200) as the
+      // authoritative server view. Walk-length adapts to it whether it grew
+      // OR shrank: a transient inflation that has since settled back down
+      // must be allowed to take effect, otherwise a max-style monotonic
+      // tracker would strand the terminal gate forever.
+      if (result.total !== undefined) {
+        latestTotal = result.total;
+        const newTotalPages = Math.max(
+          1,
+          Math.ceil(latestTotal / CHECK_RUNS_PAGE_SIZE),
+        );
         if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
           this.logger.warn(
             `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
-              `total_count grew to ${observedTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
+              `total_count is ${latestTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
           );
           totalPages = MAX_CHECK_RUNS_PAGES;
         } else {
@@ -792,6 +846,15 @@ export class PRPollingSource implements AsyncEventSource {
       page += 1;
     }
 
+    // Resolve the total we'll surface and cache. Priority order:
+    //  1. The last 200's `total_count` (current server-authoritative value).
+    //  2. If every page was 304, the previously-committed `lastTotalCount`
+    //     — nothing actually changed, so the prior commit is still correct.
+    //  3. Fall back to the deduped run count (degenerate case, no 200s and
+    //     no cache; e.g. brand-new subscription with empty results).
+    const reportedTotal =
+      latestTotal ?? cache?.lastTotalCount ?? runsById.size;
+
     // Stage the per-page caches. The caller commits to `state.checkRunsCache`
     // only after successfully consuming the response — see the type doc above.
     // We always overwrite on commit: any pages from a previous tick that we
@@ -799,7 +862,7 @@ export class PRPollingSource implements AsyncEventSource {
     const stagedCache = {
       etagsByPage: nextEtags,
       pagesByPage: nextPages,
-      lastTotalCount: observedTotal,
+      lastTotalCount: reportedTotal,
     };
 
     // True end-to-end 304: every page came back unchanged. Caller can skip
@@ -811,7 +874,10 @@ export class PRPollingSource implements AsyncEventSource {
     return {
       response: {
         status: 200,
-        data: { total_count: observedTotal, check_runs: allRuns },
+        data: {
+          total_count: reportedTotal,
+          check_runs: [...runsById.values()],
+        },
         // No single ETag covers a multi-page response. The per-page cache on
         // `state.checkRunsCache` is what enables conditional reuse next tick.
         etag: undefined,

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -48,6 +48,13 @@ const COALESCE_THRESHOLD = 3;
 // Per-resource id history is trimmed to this many entries so long-running
 // subscriptions don't grow the state map unboundedly.
 const MAX_SEEN_IDS = 1000;
+// GitHub caps the check-runs endpoint at 100 per page.
+const CHECK_RUNS_PAGE_SIZE = 100;
+// Hard ceiling on how many check-runs pages we'll walk in a single fetch.
+// 50 pages = 5,000 runs — well above any realistic monorepo matrix build.
+// Without a cap a malformed/runaway `total_count` could fan out into
+// hundreds of GETs per tick.
+const MAX_CHECK_RUNS_PAGES = 50;
 
 export interface PRKey {
   owner: string;
@@ -114,7 +121,25 @@ interface SubscriptionState {
     issueComments?: string;
     reviewComments?: string;
     reviews?: string;
-    checkRuns?: string;
+  };
+  /**
+   * Per-page cache for the paginated check-runs endpoint.
+   *
+   * Single-page PRs (<=100 runs) only ever touch page 1, so this still gives
+   * us the cheap 304 path. Multi-page PRs (>100 runs) issue conditional GETs
+   * per page; pages that haven't changed return 304 and we reuse the cached
+   * `check_runs` for that page. This is what keeps the polling cost bounded
+   * on large matrix builds — a steady-state tick should be N HEAD-cheap 304s,
+   * not N unconditional full-page GETs.
+   *
+   * `lastTotalCount` is the most recent `total_count` we saw from a 200
+   * response; it lets us decide how many pages to walk on a tick where
+   * page 1 came back 304.
+   */
+  checkRunsCache?: {
+    etagsByPage: Map<number, string>;
+    pagesByPage: Map<number, GhCheckRun[]>;
+    lastTotalCount: number;
   };
   // ISO `since` cursors for server-side filtering on the comments endpoints.
   // Advance to the newest seen item's timestamp so PRs with >100 comments
@@ -350,10 +375,15 @@ export class PRPollingSource implements AsyncEventSource {
       state.state = newState;
       state.merged = newMerged;
       // New push invalidates prior CI terminal state — the next completion
-      // on the new SHA should re-emit both terminal events.
+      // on the new SHA should re-emit both terminal events. Also drop the
+      // per-page check-runs cache: it's keyed only by page number, and the
+      // ETags from the previous SHA can never match the new SHA's responses.
+      // Letting it linger would cost one wasted If-None-Match per page on
+      // the first post-push tick before the cache naturally refreshes.
       if (state.headSha !== newHead) {
         state.ciCompleteSha = undefined;
         state.ciPassedSha = undefined;
+        state.checkRunsCache = undefined;
       }
       state.headSha = newHead;
     }
@@ -400,12 +430,7 @@ export class PRPollingSource implements AsyncEventSource {
           state.etags.reviews,
         ),
         state.headSha
-          ? this.fetchAllCheckRuns(
-              pr.owner,
-              pr.repo,
-              state.headSha,
-              state.etags.checkRuns,
-            )
+          ? this.fetchAllCheckRuns(pr.owner, pr.repo, state.headSha, state)
           : Promise.resolve({ status: 304 as const }),
       ]);
 
@@ -436,7 +461,8 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
       if (checksRes.status === 200) {
-        state.etags.checkRuns = checksRes.etag;
+        // ETag/page caching is owned by `fetchAllCheckRuns` via
+        // `state.checkRunsCache`; nothing to record on `state.etags` here.
         const runs = checksRes.data.check_runs;
         for (const r of runs) {
           if (this.isCheckFailure(r)) {
@@ -449,7 +475,8 @@ export class PRPollingSource implements AsyncEventSource {
         // runs not yet registered), so "done" isn't meaningful and seeding
         // would suppress the real terminal event once runs appear. Also
         // require we have the full set (length >= total_count); fetchAllCheckRuns
-        // walks pagination, but a mid-walk addition could still leave us short.
+        // returns the latest observed total_count, so this also covers runs
+        // added mid-walk that bumped the page count.
         if (
           state.headSha &&
           runs.length > 0 &&
@@ -511,7 +538,8 @@ export class PRPollingSource implements AsyncEventSource {
     }
 
     if (checksRes.status === 200) {
-      state.etags.checkRuns = checksRes.etag;
+      // ETag/page caching is owned by `fetchAllCheckRuns` via
+      // `state.checkRunsCache`; nothing to record on `state.etags` here.
       const runs = checksRes.data.check_runs;
       const newFailures: GhCheckRun[] = [];
       const currentFailureKeys = new Set<string>();
@@ -542,9 +570,10 @@ export class PRPollingSource implements AsyncEventSource {
       // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
       // configured vs. runs not yet registered), so "done" isn't meaningful.
       // Also require we have the full set (length >= total_count). The API
-      // caps at per_page=100, but `fetchAllCheckRuns` walks pagination so
-      // PRs with >100 check runs do reach this gate; the comparison still
-      // guards against a mid-walk addition that could leave us short.
+      // caps at per_page=100; `fetchAllCheckRuns` walks pagination AND
+      // returns the most recent `total_count` it observed (not the stale
+      // page-1 value), so this comparison correctly guards against runs
+      // added mid-walk that bumped `total_count` higher than page 1 reported.
       if (
         state.headSha &&
         runs.length > 0 &&
@@ -581,63 +610,166 @@ export class PRPollingSource implements AsyncEventSource {
    * gates (`runs.length >= total_count`) stuck false forever, stranding agents
    * waiting on "CI complete" / "CI passed".
    *
-   * ETag handling: we send `If-None-Match` only on page 1 and only honor a
-   * 304 short-circuit when page 1 reports a single-page result
-   * (`total_count <= 100`). A 304 on page 1 says nothing about pages 2+,
-   * and we'd need a combined ETag (which GitHub doesn't provide) to safely
-   * cache the multi-page case. Page 1 is also the cheapest probe — if a
-   * later push changed any run on any page, page 1's ETag will rotate and
-   * force a refetch. Subsequent pages are unconditional GETs; they're only
-   * walked when page 1 already returned 200.
+   * ## Mid-walk additions
+   *
+   * `total_count` can grow between pages if GitHub registers new runs while
+   * we're paginating. We re-read `total_count` from every 200 response,
+   * recompute `totalPages` against the maximum we've ever seen, and continue
+   * until we've collected at least that many runs (or hit the safety cap).
+   * The returned `total_count` is the latest observed value, never page 1's
+   * stale snapshot — downstream `runs.length >= total_count` gates can rely
+   * on it.
+   *
+   * ## ETag caching (multi-page)
+   *
+   * Each page's ETag is cached on the subscription so subsequent ticks can
+   * issue conditional `If-None-Match` requests per page. A 304 means we
+   * reuse the previously-cached page contents; a 200 refreshes them.
+   *
+   * - Single-page (`total_count <= 100`): unchanged fast path — the page-1
+   *   ETag covers the whole result and a 304 short-circuits the entire call.
+   * - Multi-page: each page is independently conditional. In steady state
+   *   (no new push, all runs settled) every page returns 304 and we make
+   *   N HEAD-cheap requests instead of N full-page GETs, keeping the polling
+   *   cost bounded on large matrix builds.
+   *
+   * ## Runaway guard
+   *
+   * `MAX_CHECK_RUNS_PAGES` caps the walk at 50 pages (5,000 runs). If a
+   * misbehaving GitHub response or a runaway matrix would push us past it,
+   * we log a warning and return what we have — better to under-report than
+   * fan out into hundreds of GETs every 30s.
    */
   private async fetchAllCheckRuns(
     owner: string,
     repo: string,
     sha: string,
-    etag: string | undefined,
+    state: SubscriptionState,
   ): Promise<
     ConditionalResponse<{ total_count: number; check_runs: GhCheckRun[] }>
   > {
-    const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`;
-    const firstRes = await ghGet<{
-      total_count: number;
-      check_runs: GhCheckRun[];
-    }>(`${basePath}&page=1`, etag);
+    const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
+    const cache = state.checkRunsCache;
 
-    if (firstRes.status === 304) return { status: 304 };
+    // Seed scratch caches we'll commit at the end. We rebuild from scratch
+    // each tick (rather than mutating in-place) so any pages dropped on
+    // this tick — e.g. new push reduced page count from 5 to 3 — don't
+    // leave stale entries behind.
+    const nextEtags = new Map<number, string>();
+    const nextPages = new Map<number, GhCheckRun[]>();
 
-    const total = firstRes.data.total_count;
-    const firstRuns = firstRes.data.check_runs;
+    // We need a place to record whether *every* page returned 304 so we can
+    // surface a true 304 to the caller (and skip the seeding/diff work).
+    let allPagesUnchanged = true;
+    let observedTotal = 0;
 
-    // Single-page fast path: keep the page-1 ETag so the next tick can 304.
-    if (firstRuns.length >= total) {
-      return firstRes;
-    }
-
-    // Multi-page: walk remaining pages. Drop the ETag (return undefined) so
-    // a future tick re-fetches page 1 unconditionally — a stale 304 would
-    // skip newer runs that landed on later pages without rotating page 1's
-    // ETag.
-    const allRuns: GhCheckRun[] = [...firstRuns];
-    const totalPages = Math.ceil(total / 100);
-    this.logger.info(
-      `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${total} → ${totalPages} pages`,
-    );
-    for (let page = 2; page <= totalPages; page += 1) {
-      const pageRes = await ghGet<{
+    const fetchPage = async (
+      page: number,
+    ): Promise<{ runs: GhCheckRun[]; total: number; was304: boolean }> => {
+      const pageEtag = cache?.etagsByPage.get(page);
+      const res = await ghGet<{
         total_count: number;
         check_runs: GhCheckRun[];
-      }>(`${basePath}&page=${page}`);
-      if (pageRes.status === 304) continue; // shouldn't happen w/o etag, but be safe
-      allRuns.push(...pageRes.data.check_runs);
-      // total_count can shift across pages if runs are added mid-walk; keep
-      // looping until we've actually collected total_count or run out of
-      // pages relative to the page count we computed.
+      }>(`${basePath}&page=${page}`, pageEtag);
+      if (res.status === 304) {
+        // Reuse cached page. Carry forward the ETag we sent.
+        const cachedRuns = cache?.pagesByPage.get(page) ?? [];
+        if (pageEtag) nextEtags.set(page, pageEtag);
+        nextPages.set(page, cachedRuns);
+        return {
+          runs: cachedRuns,
+          // total_count isn't returned on 304; fall back to last-known.
+          total: cache?.lastTotalCount ?? 0,
+          was304: true,
+        };
+      }
+      if (res.etag) nextEtags.set(page, res.etag);
+      nextPages.set(page, res.data.check_runs);
+      return {
+        runs: res.data.check_runs,
+        total: res.data.total_count,
+        was304: false,
+      };
+    };
+
+    // Page 1 always runs — we need its `total_count` (or a 304 fast-path
+    // when nothing changed).
+    const first = await fetchPage(1);
+    if (!first.was304) allPagesUnchanged = false;
+    observedTotal = Math.max(observedTotal, first.total);
+
+    // Single-page fast path. If page 1 was 304 and our last-known total fits
+    // in one page, we can short-circuit the whole call without touching any
+    // other state — this is the common steady-state for typical PRs.
+    if (
+      first.was304 &&
+      cache &&
+      cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
+      cache.etagsByPage.size === 1
+    ) {
+      return { status: 304 };
     }
+
+    const allRuns: GhCheckRun[] = [...first.runs];
+    let totalPages = Math.max(
+      1,
+      Math.ceil(observedTotal / CHECK_RUNS_PAGE_SIZE),
+    );
+    if (totalPages > MAX_CHECK_RUNS_PAGES) {
+      this.logger.warn(
+        `Pagination cap hit for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
+          `total_count=${observedTotal} would need ${totalPages} pages, capping at ${MAX_CHECK_RUNS_PAGES}.`,
+      );
+      totalPages = MAX_CHECK_RUNS_PAGES;
+    }
+    if (totalPages > 1) {
+      this.logger.info(
+        `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${observedTotal} → ${totalPages} pages`,
+      );
+    }
+
+    let page = 2;
+    while (page <= totalPages) {
+      const result = await fetchPage(page);
+      if (!result.was304) allPagesUnchanged = false;
+      allRuns.push(...result.runs);
+
+      // total_count can grow if GitHub registers new runs mid-walk. Re-read
+      // it from every 200 response and extend the walk if needed.
+      if (result.total > observedTotal) {
+        observedTotal = result.total;
+        const newTotalPages = Math.ceil(observedTotal / CHECK_RUNS_PAGE_SIZE);
+        if (newTotalPages > MAX_CHECK_RUNS_PAGES) {
+          this.logger.warn(
+            `Pagination cap hit mid-walk for ${owner}/${repo}@${sha.slice(0, 7)} check-runs: ` +
+              `total_count grew to ${observedTotal} (${newTotalPages} pages), capping at ${MAX_CHECK_RUNS_PAGES}.`,
+          );
+          totalPages = MAX_CHECK_RUNS_PAGES;
+        } else {
+          totalPages = newTotalPages;
+        }
+      }
+      page += 1;
+    }
+
+    // Commit the per-page caches. We always overwrite — any pages from a
+    // previous tick that we didn't touch this tick (e.g. page count
+    // shrank) are intentionally evicted.
+    state.checkRunsCache = {
+      etagsByPage: nextEtags,
+      pagesByPage: nextPages,
+      lastTotalCount: observedTotal,
+    };
+
+    // True end-to-end 304: every page came back unchanged. Caller can skip
+    // the diff/seed work entirely.
+    if (allPagesUnchanged) return { status: 304 };
 
     return {
       status: 200,
-      data: { total_count: total, check_runs: allRuns },
+      data: { total_count: observedTotal, check_runs: allRuns },
+      // No single ETag covers a multi-page response. The per-page cache on
+      // `state.checkRunsCache` is what enables conditional reuse next tick.
       etag: undefined,
     };
   }

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -26,7 +26,12 @@ import {
   formatSubscriptionError,
   isPassingConclusion,
 } from './formatPREvent';
-import { GitHubAuthError, GitHubRateLimitError, ghGet } from './githubClient';
+import {
+  GitHubAuthError,
+  GitHubRateLimitError,
+  type ConditionalResponse,
+  ghGet,
+} from './githubClient';
 import type { AsyncEventSource, Disposable } from './AsyncEventSource';
 import type {
   GhCheckRun,
@@ -395,8 +400,10 @@ export class PRPollingSource implements AsyncEventSource {
           state.etags.reviews,
         ),
         state.headSha
-          ? ghGet<{ total_count: number; check_runs: GhCheckRun[] }>(
-              `/repos/${pr.owner}/${pr.repo}/commits/${state.headSha}/check-runs?per_page=100`,
+          ? this.fetchAllCheckRuns(
+              pr.owner,
+              pr.repo,
+              state.headSha,
               state.etags.checkRuns,
             )
           : Promise.resolve({ status: 304 as const }),
@@ -441,8 +448,8 @@ export class PRPollingSource implements AsyncEventSource {
         // runs.length > 0: an empty array is ambiguous (no CI configured vs.
         // runs not yet registered), so "done" isn't meaningful and seeding
         // would suppress the real terminal event once runs appear. Also
-        // require a complete page — the API caps at per_page=100, so a PR
-        // with more check runs would be evaluated from a truncated list.
+        // require we have the full set (length >= total_count); fetchAllCheckRuns
+        // walks pagination, but a mid-walk addition could still leave us short.
         if (
           state.headSha &&
           runs.length > 0 &&
@@ -534,9 +541,10 @@ export class PRPollingSource implements AsyncEventSource {
       //
       // Gate on `runs.length > 0`: an empty array is ambiguous (no CI
       // configured vs. runs not yet registered), so "done" isn't meaningful.
-      // Also require a complete page (length >= total_count) — the API caps
-      // at per_page=100, so a PR with more check runs would prematurely
-      // emit a terminal event based on the first page alone.
+      // Also require we have the full set (length >= total_count). The API
+      // caps at per_page=100, but `fetchAllCheckRuns` walks pagination so
+      // PRs with >100 check runs do reach this gate; the comparison still
+      // guards against a mid-walk addition that could leave us short.
       if (
         state.headSha &&
         runs.length > 0 &&
@@ -563,6 +571,75 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
     }
+  }
+
+  /**
+   * Fetch all check-runs for a commit, walking pages when `total_count > 100`.
+   *
+   * The check-runs endpoint caps at `per_page=100`. PRs with more registered
+   * runs (large monorepos, matrix builds) would otherwise have their terminal
+   * gates (`runs.length >= total_count`) stuck false forever, stranding agents
+   * waiting on "CI complete" / "CI passed".
+   *
+   * ETag handling: we send `If-None-Match` only on page 1 and only honor a
+   * 304 short-circuit when page 1 reports a single-page result
+   * (`total_count <= 100`). A 304 on page 1 says nothing about pages 2+,
+   * and we'd need a combined ETag (which GitHub doesn't provide) to safely
+   * cache the multi-page case. Page 1 is also the cheapest probe — if a
+   * later push changed any run on any page, page 1's ETag will rotate and
+   * force a refetch. Subsequent pages are unconditional GETs; they're only
+   * walked when page 1 already returned 200.
+   */
+  private async fetchAllCheckRuns(
+    owner: string,
+    repo: string,
+    sha: string,
+    etag: string | undefined,
+  ): Promise<
+    ConditionalResponse<{ total_count: number; check_runs: GhCheckRun[] }>
+  > {
+    const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`;
+    const firstRes = await ghGet<{
+      total_count: number;
+      check_runs: GhCheckRun[];
+    }>(`${basePath}&page=1`, etag);
+
+    if (firstRes.status === 304) return { status: 304 };
+
+    const total = firstRes.data.total_count;
+    const firstRuns = firstRes.data.check_runs;
+
+    // Single-page fast path: keep the page-1 ETag so the next tick can 304.
+    if (firstRuns.length >= total) {
+      return firstRes;
+    }
+
+    // Multi-page: walk remaining pages. Drop the ETag (return undefined) so
+    // a future tick re-fetches page 1 unconditionally — a stale 304 would
+    // skip newer runs that landed on later pages without rotating page 1's
+    // ETag.
+    const allRuns: GhCheckRun[] = [...firstRuns];
+    const totalPages = Math.ceil(total / 100);
+    this.logger.info(
+      `Pagination: ${owner}/${repo}@${sha.slice(0, 7)} check-runs total_count=${total} → ${totalPages} pages`,
+    );
+    for (let page = 2; page <= totalPages; page += 1) {
+      const pageRes = await ghGet<{
+        total_count: number;
+        check_runs: GhCheckRun[];
+      }>(`${basePath}&page=${page}`);
+      if (pageRes.status === 304) continue; // shouldn't happen w/o etag, but be safe
+      allRuns.push(...pageRes.data.check_runs);
+      // total_count can shift across pages if runs are added mid-walk; keep
+      // looping until we've actually collected total_count or run out of
+      // pages relative to the page count we computed.
+    }
+
+    return {
+      status: 200,
+      data: { total_count: total, check_runs: allRuns },
+      etag: undefined,
+    };
   }
 
   private isCheckFailure(r: GhCheckRun): boolean {

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -421,7 +421,7 @@ export class PRPollingSource implements AsyncEventSource {
       `${prPath}/comments?per_page=100`,
       state.sinceCursors.reviewComments,
     );
-    const [commentsRes, reviewCommentsRes, reviewsRes, checksRes] =
+    const [commentsRes, reviewCommentsRes, reviewsRes, checksOutcome] =
       await Promise.all([
         ghGet<GhIssueComment[]>(issueCommentsUrl, state.etags.issueComments),
         ghGet<GhReviewComment[]>(reviewCommentsUrl, state.etags.reviewComments),
@@ -431,8 +431,18 @@ export class PRPollingSource implements AsyncEventSource {
         ),
         state.headSha
           ? this.fetchAllCheckRuns(pr.owner, pr.repo, state.headSha, state)
-          : Promise.resolve({ status: 304 as const }),
+          : Promise.resolve({
+              response: { status: 304 as const },
+              stagedCache: undefined,
+            }),
       ]);
+    // Destructure separately so we can commit `stagedCache` only at the end
+    // of the success path (after the diff branch). If a sibling rejection
+    // had thrown above, the cache would not have been advanced — preventing
+    // a stale cache + 304 next tick from silently swallowing check-run
+    // transitions.
+    const checksRes = checksOutcome.response;
+    const stagedCheckRunsCache = checksOutcome.stagedCache;
 
     // First tick only seeds cursors so we never replay history.
     if (!state.initialized) {
@@ -488,6 +498,11 @@ export class PRPollingSource implements AsyncEventSource {
             state.ciPassedSha = state.headSha;
           }
         }
+      }
+      // Commit the deferred check-runs cache only after successfully
+      // consuming the response. See `fetchAllCheckRuns` for why we defer.
+      if (stagedCheckRunsCache !== undefined) {
+        state.checkRunsCache = stagedCheckRunsCache;
       }
       state.initialized = true;
       return;
@@ -600,6 +615,15 @@ export class PRPollingSource implements AsyncEventSource {
         }
       }
     }
+
+    // Commit the deferred check-runs cache only after successfully consuming
+    // the response (including the diff branch above). See `fetchAllCheckRuns`
+    // for why we defer: this prevents a sibling rejection in the `Promise.all`
+    // from advancing the cache while the diff never ran, which would cause
+    // the next tick to get 304 and silently skip the missed transitions.
+    if (stagedCheckRunsCache !== undefined) {
+      state.checkRunsCache = stagedCheckRunsCache;
+    }
   }
 
   /**
@@ -645,15 +669,29 @@ export class PRPollingSource implements AsyncEventSource {
     repo: string,
     sha: string,
     state: SubscriptionState,
-  ): Promise<
-    ConditionalResponse<{ total_count: number; check_runs: GhCheckRun[] }>
-  > {
+  ): Promise<{
+    response: ConditionalResponse<{
+      total_count: number;
+      check_runs: GhCheckRun[];
+    }>;
+    /**
+     * New per-page cache value to commit only after the caller has
+     * successfully consumed the response. `undefined` means "no change" —
+     * either the single-page 304 fast path (existing cache is still valid)
+     * or this method itself short-circuited before fetching anything.
+     *
+     * Deferring the commit prevents a sibling rejection in `Promise.all`
+     * from advancing the cache while the diff branch never runs: a stale
+     * cache + 304 next tick would silently swallow check-run transitions.
+     */
+    stagedCache?: SubscriptionState['checkRunsCache'];
+  }> {
     const basePath = `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=${CHECK_RUNS_PAGE_SIZE}`;
     const cache = state.checkRunsCache;
 
-    // Seed scratch caches we'll commit at the end. We rebuild from scratch
-    // each tick (rather than mutating in-place) so any pages dropped on
-    // this tick — e.g. new push reduced page count from 5 to 3 — don't
+    // Seed scratch caches we'll stage on the return value. We rebuild from
+    // scratch each tick (rather than mutating in-place) so any pages dropped
+    // on this tick — e.g. new push reduced page count from 5 to 3 — don't
     // leave stale entries behind.
     const nextEtags = new Map<number, string>();
     const nextPages = new Map<number, GhCheckRun[]>();
@@ -700,14 +738,16 @@ export class PRPollingSource implements AsyncEventSource {
 
     // Single-page fast path. If page 1 was 304 and our last-known total fits
     // in one page, we can short-circuit the whole call without touching any
-    // other state — this is the common steady-state for typical PRs.
+    // other state — this is the common steady-state for typical PRs. No
+    // staged cache: the existing `state.checkRunsCache` is still valid and
+    // we never built a replacement.
     if (
       first.was304 &&
       cache &&
       cache.lastTotalCount <= CHECK_RUNS_PAGE_SIZE &&
       cache.etagsByPage.size === 1
     ) {
-      return { status: 304 };
+      return { response: { status: 304 } };
     }
 
     const allRuns: GhCheckRun[] = [...first.runs];
@@ -752,10 +792,11 @@ export class PRPollingSource implements AsyncEventSource {
       page += 1;
     }
 
-    // Commit the per-page caches. We always overwrite — any pages from a
-    // previous tick that we didn't touch this tick (e.g. page count
-    // shrank) are intentionally evicted.
-    state.checkRunsCache = {
+    // Stage the per-page caches. The caller commits to `state.checkRunsCache`
+    // only after successfully consuming the response — see the type doc above.
+    // We always overwrite on commit: any pages from a previous tick that we
+    // didn't touch this tick (e.g. page count shrank) are intentionally evicted.
+    const stagedCache = {
       etagsByPage: nextEtags,
       pagesByPage: nextPages,
       lastTotalCount: observedTotal,
@@ -763,14 +804,19 @@ export class PRPollingSource implements AsyncEventSource {
 
     // True end-to-end 304: every page came back unchanged. Caller can skip
     // the diff/seed work entirely.
-    if (allPagesUnchanged) return { status: 304 };
+    if (allPagesUnchanged) {
+      return { response: { status: 304 }, stagedCache };
+    }
 
     return {
-      status: 200,
-      data: { total_count: observedTotal, check_runs: allRuns },
-      // No single ETag covers a multi-page response. The per-page cache on
-      // `state.checkRunsCache` is what enables conditional reuse next tick.
-      etag: undefined,
+      response: {
+        status: 200,
+        data: { total_count: observedTotal, check_runs: allRuns },
+        // No single ETag covers a multi-page response. The per-page cache on
+        // `state.checkRunsCache` is what enables conditional reuse next tick.
+        etag: undefined,
+      },
+      stagedCache,
     };
   }
 


### PR DESCRIPTION
## Summary

- The check-runs endpoint caps at `per_page=100`. The single fetch in `PRPollingSource` left `runs.length >= total_count` permanently false on PRs with more than 100 registered check runs (large monorepos, matrix builds), so the terminal `CI completed` / `CI passed` events never emitted and agents subscribed via PR-activity tools were stranded waiting on CI.
- Added a `fetchAllCheckRuns` helper that walks pages until the full set is collected, then both terminal-state gates (initial seeding and emit) are evaluated against the assembled list.
- ETag handling preserves the cheap 304 cache hit for the common single-page case (`total_count <= 100`); on multi-page responses the stored ETag is dropped because a 304 on page 1 doesn't imply pages 2+ are unchanged and GitHub doesn't expose a combined ETag.

Closes #3072

## Test plan

- [x] `npm run typecheck` passes (the pre-existing `src/latex/arxivProcessor.ts:133` axios error is unrelated).
- [x] `npm run compile:fast` succeeds.
- [ ] Manual verification on a PR with >100 check runs is hard to reproduce locally; confirmed by code review:
  - Single-page (`total_count <= 100`): unchanged fast path, ETag is preserved, next tick can 304.
  - Multi-page: page 1 is conditional, pages 2..N are unconditional GETs, results concatenated, terminal gates fire once `runs.length >= total_count`.
  - 304 on page 1 still short-circuits the whole call (covers the common steady-state).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core polling/state logic and adds multi-request pagination with caching, so bugs could cause missed CI transitions or increased GitHub API load; changes are localized to `PRPollingSource`.
> 
> **Overview**
> Fixes a long-standing bug where PR subscriptions could *never* emit terminal CI events when a commit had more than 100 check-runs by adding a paginated `fetchAllCheckRuns` path and evaluating CI completion/pass gates against the fully-assembled run set.
> 
> Introduces per-page ETag/page-content caching for check-runs (with a single-page 304 fast path), dedupes runs by id to handle mid-pagination churn, caps maximum pages to limit runaway API fanout, and defers cache commits until after successful diff/emit processing (also clearing the cache on new head SHA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce222da6d5782c60a9cdc76d899f5daad8f44a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->