### PR TITLE
fix: aux-bar persistence, selected-tab contrast, and tool-filter noise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1226,33 +1226,13 @@
     "views": {
       "texra": [
         {
-          "type": "tree",
-          "id": "texra.welcomeView",
-          "name": "TeXRA",
-          "contextualTitle": "TeXRA",
-          "when": "!texra.activated"
-        },
-        {
           "type": "webview",
           "id": "texra.mainView",
           "name": "TeXRA",
-          "contextualTitle": "TeXRA",
-          "when": "texra.activated"
+          "contextualTitle": "TeXRA"
         }
       ]
     },
-    "viewsWelcome": [
-      {
-        "view": "texra.welcomeView",
-        "contents": "TeXRA is a multi-agent orchestration system for LaTeX research. An orchestrator coordinates specialized agents that derive results, verify proofs, run symbolic computation, generate figures, and assemble manuscripts — every step auditable, every citation grounded.\nOpen a folder to begin. The TeXRA tour and commands become available once a workspace is open.\n[Open Folder](command:workbench.action.files.openFolder)\n[Clone Repository](command:git.clone)\nWant to learn more first? [Read the docs](https://texra.ai).",
-        "when": "workbenchState == empty"
-      },
-      {
-        "view": "texra.welcomeView",
-        "contents": "TeXRA supports one folder at a time. Open a single folder to continue.\n[Open Folder](command:workbench.action.files.openFolder)",
-        "when": "workbenchState == workspace"
-      }
-    ],
     "menus": {
       "editor/title": [
         {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -87,28 +87,24 @@ function resolveTools(
   const unavailable = getUnavailableToolNamesCached();
   const missingDependency: string[] = [];
 
+  // Routine filtering reasons (user-disabled, missing external dep, not in the
+  // current registry) are intentional outcomes of user configuration, not
+  // warnings. Agent YAML typos are already surfaced once at load time by
+  // `resolveToolDefinitions` in agentLoad.ts / RemoteAgentLoader.ts; missing
+  // external dependencies are surfaced via `notifyUnavailableTools`. Don't
+  // emit per-cycle warnings here — they show up as yellow bubbles on every
+  // tool-use run and drown out real issues.
   const toolConfigs = Array.isArray(tools) ? tools : [];
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
       if (isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
-      if (disabled.has(def.name)) {
-        logger.warn(
-          `Tool "${def.name}" excluded: disabled in Settings > Tools`,
-        );
-        return false;
-      }
+      if (disabled.has(def.name)) return false;
       if (unavailable.has(def.name)) {
-        logger.warn(
-          `Tool "${def.name}" excluded: external dependency not installed`,
-        );
         missingDependency.push(def.name);
         return false;
       }
-      if (!registry.has(def.name)) {
-        logger.warn(`Tool "${def.name}" not found in registry`);
-        return false;
-      }
+      if (!registry.has(def.name)) return false;
       return true;
     });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -87,13 +87,11 @@ function resolveTools(
   const unavailable = getUnavailableToolNamesCached();
   const missingDependency: string[] = [];
 
-  // Routine filtering reasons (user-disabled, missing external dep, not in the
-  // current registry) are intentional outcomes of user configuration, not
-  // warnings. Agent YAML typos are already surfaced once at load time by
-  // `resolveToolDefinitions` in agentLoad.ts / RemoteAgentLoader.ts; missing
-  // external dependencies are surfaced via `notifyUnavailableTools`. Don't
-  // emit per-cycle warnings here — they show up as yellow bubbles on every
-  // tool-use run and drown out real issues.
+  // Don't warn on routine filtering outcomes (user-disabled, unavailable,
+  // not in registry): they fire on every tool-use cycle and drown out real
+  // issues. Agent YAML typos are surfaced once at load time by
+  // `resolveToolDefinitions`; missing external deps are surfaced via
+  // `notifyUnavailableTools` below.
   const toolConfigs = Array.isArray(tools) ? tools : [];
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))

--- a/src/frontend/ui/welcomeView.ts
+++ b/src/frontend/ui/welcomeView.ts
@@ -1,21 +1,88 @@
 import * as vscode from 'vscode';
 
-// The welcome view is a tree view declared in package.json with `viewsWelcome`
-// content. It becomes visible when `texra.activated` is unset (no-folder or
-// multi-root). Registering an empty data provider satisfies VS Code's tree
-// view contract; the actual copy and command links come from the
-// `contributes.viewsWelcome` block. When the workspace becomes single-folder,
-// reload the window so the full activation path runs.
-export function registerWelcomeView(context: vscode.ExtensionContext): void {
-  const emptyProvider: vscode.TreeDataProvider<never> = {
-    getTreeItem: () => {
-      throw new Error('texra.welcomeView has no tree items');
-    },
-    getChildren: () => [],
-  };
+/**
+ * No-workspace webview for `texra.mainView`.
+ *
+ * In the single-folder case the full `MainViewProvider` owns this view id.
+ * When no folder is open, we still want the same view id to exist so VS Code
+ * restores its user-chosen location (e.g. the auxiliary sidebar) on startup —
+ * splitting into a separate `texra.welcomeView` caused VS Code to forget the
+ * moved-to-aux-bar position because the active view id kept changing between
+ * sessions.
+ *
+ * This provider serves a minimal HTML welcome screen and reloads the window
+ * once the user opens a single folder so the full activation path can run.
+ */
+class WelcomeWebviewProvider implements vscode.WebviewViewProvider {
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    webviewView.webview.options = {
+      enableScripts: true,
+      enableCommandUris: true,
+    };
+    webviewView.webview.html = renderWelcomeHtml();
+  }
+}
 
+function renderWelcomeHtml(): string {
+  const openFolder = 'command:workbench.action.files.openFolder';
+  const cloneRepo = 'command:git.clone';
+  const docs = 'https://texra.ai';
+  const nonce = Math.random().toString(36).slice(2);
+
+  return /* html */ `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';"
+  />
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-foreground);
+      background: transparent;
+      padding: 16px;
+      line-height: 1.5;
+    }
+    p { margin: 0 0 12px; }
+    .muted { color: var(--vscode-descriptionForeground); }
+    .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }
+    a {
+      color: var(--vscode-textLink-foreground);
+      text-decoration: none;
+    }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <p>
+    TeXRA is a multi-agent orchestration system for LaTeX research. An
+    orchestrator coordinates specialized agents that derive results, verify
+    proofs, run symbolic computation, generate figures, and assemble
+    manuscripts &mdash; every step auditable, every citation grounded.
+  </p>
+  <p class="muted">
+    Open a folder to begin. The TeXRA tour and commands become available once
+    a workspace is open.
+  </p>
+  <div class="actions">
+    <a href="${openFolder}">Open Folder</a>
+    <a href="${cloneRepo}">Clone Repository</a>
+    <a href="${docs}">Read the docs</a>
+  </div>
+</body>
+</html>`;
+}
+
+export function registerWelcomeView(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.window.registerTreeDataProvider('texra.welcomeView', emptyProvider),
+    vscode.window.registerWebviewViewProvider(
+      'texra.mainView',
+      new WelcomeWebviewProvider(),
+    ),
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
       if (vscode.workspace.workspaceFolders?.length === 1) {
         void vscode.commands.executeCommand('workbench.action.reloadWindow');

--- a/src/frontend/ui/welcomeView.ts
+++ b/src/frontend/ui/welcomeView.ts
@@ -1,17 +1,11 @@
 import * as vscode from 'vscode';
 
 /**
- * No-workspace webview for `texra.mainView`.
- *
- * In the single-folder case the full `MainViewProvider` owns this view id.
- * When no folder is open, we still want the same view id to exist so VS Code
- * restores its user-chosen location (e.g. the auxiliary sidebar) on startup —
- * splitting into a separate `texra.welcomeView` caused VS Code to forget the
- * moved-to-aux-bar position because the active view id kept changing between
- * sessions.
- *
- * This provider serves a minimal HTML welcome screen and reloads the window
- * once the user opens a single folder so the full activation path can run.
+ * No-workspace provider for `texra.mainView`. Keeping the same view id across
+ * workspace states is required for VS Code to persist the user's chosen
+ * location (e.g. auxiliary sidebar) — splitting into a separate welcome view
+ * id caused the aux-bar position to be lost between sessions. Reloads the
+ * window once a single folder is opened so the full activation path runs.
  */
 class WelcomeWebviewProvider implements vscode.WebviewViewProvider {
   resolveWebviewView(webviewView: vscode.WebviewView): void {

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -218,12 +218,10 @@ export class StreamTab extends LitElement {
       }
 
       /*
-       * Match VS Code's list-item selection pattern: on active, flip both
-       * background and foreground so every descendant text/icon renders in
-       * the selection foreground. The descendant-wildcard selector guarantees
-       * nested spans (.last-active, .model) and codicon glyphs inherit the
-       * selection color even when intermediate elements (.tab-meta,
-       * .tab-description) define their own color.
+       * Match VS Code's list-item selection: flip background + foreground
+       * together. The descendant-wildcard selector below forces nested spans
+       * (.last-active, .model) and codicon glyphs to inherit the selection
+       * color even when intermediate elements define their own.
        */
       .tab-container.is-active {
         background-color: var(--vscode-list-activeSelectionBackground);
@@ -247,9 +245,9 @@ export class StreamTab extends LitElement {
       }
 
       /*
-       * Preserve the destructive-action hover/focus cue on active tabs.
-       * The descendant-wildcard selector above would otherwise keep the close
-       * icon stuck on the inherited foreground.
+       * Re-apply the destructive-action cue on active tabs — the
+       * descendant-wildcard above would otherwise hold the close icon on
+       * the selection foreground.
        */
       .tab-container.is-active .tab-delete:hover,
       .tab-container.is-active .tab-delete:focus-within,
@@ -258,11 +256,8 @@ export class StreamTab extends LitElement {
         color: var(--vscode-errorForeground);
       }
 
-      /*
-       * When active, drop the dim-by-default opacity on meta/description so
-       * the flipped foreground renders at full contrast on the blue selection
-       * background.
-       */
+      /* Drop the dim-by-default opacity so the flipped foreground renders
+       * at full contrast on the selection background. */
       .tab-container.is-active .tab-meta,
       .tab-container.is-active .tab-description {
         opacity: var(--opacity-full);

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -217,6 +217,14 @@ export class StreamTab extends LitElement {
         background-color: var(--vscode-list-hoverBackground);
       }
 
+      /*
+       * Match VS Code's list-item selection pattern: on active, flip both
+       * background and foreground so every descendant text/icon renders in
+       * the selection foreground. The descendant-wildcard selector guarantees
+       * nested spans (.last-active, .model) and codicon glyphs inherit the
+       * selection color even when intermediate elements (.tab-meta,
+       * .tab-description) define their own color.
+       */
       .tab-container.is-active {
         background-color: var(--vscode-list-activeSelectionBackground);
         color: var(
@@ -225,26 +233,36 @@ export class StreamTab extends LitElement {
         );
       }
 
+      .tab-container.is-active *,
       .tab-container.is-active .tab,
+      .tab-container.is-active .tab-title,
       .tab-container.is-active .tab-meta,
       .tab-container.is-active .tab-description,
       .tab-container.is-active .tab-delete,
       .tab-container.is-active .tab-expand {
-        color: inherit;
+        color: var(
+          --vscode-list-activeSelectionForeground,
+          var(--vscode-foreground)
+        );
       }
 
       /*
        * Preserve the destructive-action hover/focus cue on active tabs.
-       * Without this, the .tab-container.is-active .tab-delete rule above
-       * (specificity 0,3,0) would permanently override the base
-       * .tab-delete:hover rule (0,2,0), leaving the close icon stuck on
-       * the inherited foreground.
+       * The descendant-wildcard selector above would otherwise keep the close
+       * icon stuck on the inherited foreground.
        */
       .tab-container.is-active .tab-delete:hover,
-      .tab-container.is-active .tab-delete:focus-within {
+      .tab-container.is-active .tab-delete:focus-within,
+      .tab-container.is-active .tab-delete:hover *,
+      .tab-container.is-active .tab-delete:focus-within * {
         color: var(--vscode-errorForeground);
       }
 
+      /*
+       * When active, drop the dim-by-default opacity on meta/description so
+       * the flipped foreground renders at full contrast on the blue selection
+       * background.
+       */
       .tab-container.is-active .tab-meta,
       .tab-container.is-active .tab-description {
         opacity: var(--opacity-full);


### PR DESCRIPTION
## Summary

Three small user-visible fixes in the TeXRA main view and tool-use flow:

1. **TeXRA panel auto-restores on the auxiliary sidebar.** After #3046 split the `texra` container into two sibling views gated by `when: texra.activated` / `!texra.activated`, VS Code lost the user's saved aux-bar position for `texra.mainView` — at startup the context key is false until the end of `activate()`, so when VS Code restored layout the `mainView` id did not yet exist. Collapse back to a single always-visible view id (`texra.mainView`) and serve the welcome screen from a lightweight `WebviewViewProvider` in the no-workspace path. View-location state now persists across sessions.

2. **Selected stream tab matches VS Code's list selection pattern.** Active-tab styling relied on `color: inherit` cascading into `.tab-meta`'s span/codicon descendants. The meta row rendered dim against the blue selection background ("overshadowed"). Force the selection foreground on every descendant via a `*` selector so title, meta, `.last-active`, `.model`, and codicon glyphs flip together. Destructive-action cue on `.tab-delete:hover` preserved.

3. **Silence per-cycle tool-filter noise.** `resolveTools` emitted yellow warnings every tool-use cycle for intentional filtering outcomes ("excluded: disabled in Settings > Tools", "excluded: external dependency not installed", "not found in registry"). Drop them. Agent YAML typos are already warned once at load time in `agentLoad.ts` / `RemoteAgentLoader.ts`; missing external dependencies are surfaced via `notifyUnavailableTools`. Keeps the "Memory tool not found in registry" warning — genuine bug signal.

## Changes

- `package.json`: drop `texra.welcomeView` + `viewsWelcome` block; remove `when: texra.activated` gate from `texra.mainView`.
- `src/frontend/ui/welcomeView.ts`: rewrite as a `WebviewViewProvider` for `texra.mainView` serving welcome HTML with native `command:` links; still reloads the window when workspace becomes single-folder.
- `src/progressView/frontend/components/StreamTabs.ts`: force selection foreground onto every descendant of `.tab-container.is-active`; preserve delete-hover error cue.
- `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`: drop the three routine filter-warning log calls in `resolveTools`.

## Test plan

- [ ] Drag TeXRA to the auxiliary sidebar, close + reopen VS Code → panel auto-restores on the right.
- [ ] Launch VS Code with no folder open → welcome screen renders with working Open Folder / Clone / Docs links.
- [ ] Open a folder from the welcome screen → window reloads into the full TeXRA UI.
- [ ] Select a stream tab → title, time, model, and category icon all render in the selection foreground (no dim meta row).
- [ ] Hover the close icon on a selected tab → flips to error foreground.
- [ ] Disable a tool in Settings > Tools or start a tool-use agent whose YAML references a tool missing a dependency → no yellow warning bubble per tool-use cycle; genuine typos still warn once at agent load.