### PR TITLE
feat: agent-selection dropdown on proposal card + strip_criticize on accept_run_files

### DIFF
--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -25,7 +25,7 @@ import {
 
 /** Result of an agent proposal (workflow or tool-use). */
 export type ProposalResult =
-  | { action: 'approve'; model?: string }
+  | { action: 'approve'; model?: string; agent?: string }
   | { action: 'reject'; feedback?: string }
   | { action: 'setup' }
   | { action: 'timeout' };

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -571,6 +571,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         proposalCoordinator.resolveRequest(proposalId, {
           action: 'approve',
           model: data.model,
+          agent: data.agent,
         });
         break;
       case 'reject':

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -18,17 +18,18 @@ import {
 import { ApprovalRequestHandler } from '@progressView/managers/ApprovalRequestHandler';
 import { WebviewBridge } from '@progressView/managers/WebviewBridge';
 import { WebviewUpdater } from '@progressView/managers/WebviewUpdater';
+import { computeAgentOptionsData } from '@agent/index';
 import type {
   AgentProposalPermission,
   BashPermission,
   ExternalInquiryPermission,
-  ModelOptionData,
   PlanApprovalPermission,
   ProgressViewPlacement,
   StorageKey,
   StreamTabId,
   ToolEditPermission,
 } from '@shared/schemas';
+import { AGENT_CATEGORY } from '@shared/schemas';
 import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 import { ProgressEventHandler } from './events/ProgressEventHandler';
@@ -263,19 +264,28 @@ export class ProgressViewProvider
   private async sendProposalModelOptions(
     proposal: AgentProposalPermission,
   ): Promise<void> {
-    let modelOptions: ModelOptionData[];
-    try {
-      modelOptions = await computeModelOptionsData();
-    } catch {
-      // Availability check failed (e.g. ServerSideKeyService not yet initialized) —
-      // fall back to static model metadata so the dropdown still appears.
-      modelOptions = buildBasicModelOptionsData();
-    }
+    // Availability check fallback: ServerSideKeyService may not be initialized
+    // yet, or the agent registry may not have loaded — fall back so the
+    // dropdown still appears with static metadata.
+    const [modelOptions, agentOptions] = await Promise.all([
+      computeModelOptionsData().catch(() => buildBasicModelOptionsData()),
+      computeAgentOptionsData()
+        .then((all) =>
+          proposal.agentCategory === AGENT_CATEGORY.WORKFLOW
+            ? all.workflow
+            : all.toolUse,
+        )
+        // Use agent name (label) as the option value so it matches proposal.agent,
+        // which is a simple name — not the source/name key used elsewhere.
+        .then((raw) => raw.map((opt) => ({ ...opt, value: opt.label })))
+        .catch(() => undefined),
+    ]);
     if (!this.agentProposalHandler.get(proposal.proposalId)) return;
     this.webviewUpdater.showPermission({
       kind: PERMISSION_KIND.PROPOSAL,
       data: proposal,
       modelOptionsData: modelOptions,
+      agentOptionsData: agentOptions,
     });
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -264,19 +264,14 @@ export class ProgressViewProvider
   private async sendProposalModelOptions(
     proposal: AgentProposalPermission,
   ): Promise<void> {
-    // Availability check fallback: ServerSideKeyService may not be initialized
-    // yet, or the agent registry may not have loaded — fall back so the
-    // dropdown still appears with static metadata.
+    // Fall back to static metadata if ServerSideKeyService or the agent
+    // registry hasn't finished loading — so the dropdowns still appear.
+    const isWorkflow = proposal.agentCategory === AGENT_CATEGORY.WORKFLOW;
     const [modelOptions, agentOptions] = await Promise.all([
       computeModelOptionsData().catch(() => buildBasicModelOptionsData()),
       computeAgentOptionsData()
-        .then((all) =>
-          proposal.agentCategory === AGENT_CATEGORY.WORKFLOW
-            ? all.workflow
-            : all.toolUse,
-        )
-        // Use agent name (label) as the option value so it matches proposal.agent,
-        // which is a simple name — not the source/name key used elsewhere.
+        .then((all) => (isWorkflow ? all.workflow : all.toolUse))
+        // proposal.agent is a plain name (not source/name), so use label as value.
         .then((raw) => raw.map((opt) => ({ ...opt, value: opt.label })))
         .catch(() => undefined),
     ]);

--- a/src/progressView/frontend/components/BaseRequestPanel.ts
+++ b/src/progressView/frontend/components/BaseRequestPanel.ts
@@ -28,6 +28,7 @@ export abstract class BaseRequestPanel extends LitElement {
     action: string,
     feedback?: string,
     modelOverride?: string,
+    agentOverride?: string,
   ): void {
     this.dispatchEvent(
       ProgressEvents.permissionAction({
@@ -35,6 +36,7 @@ export abstract class BaseRequestPanel extends LitElement {
         action,
         feedback,
         modelOverride,
+        agentOverride,
       }),
     );
   }

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -10,6 +10,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { AGENT_CATEGORY } from '@shared/schemas';
 import { postMessage } from '@shared/vscode';
 import type {
+  AgentOptionData,
   AgentProposalPermission,
   BashPermission,
   ExternalInquiryPermission,
@@ -46,6 +47,7 @@ export type PermissionState =
       kind: typeof PERMISSION_KIND.PROPOSAL;
       data: AgentProposalPermission;
       modelOptions?: ModelOptionData[];
+      agentOptions?: AgentOptionData[];
     }
   | {
       kind: typeof PERMISSION_KIND.PLAN_APPROVAL;

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -274,26 +274,26 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   };
 
   // ===========================================================================
-  // Override emitAction to include model override for approve
+  // Override emitAction to include model/agent overrides for approve
   // ===========================================================================
 
   protected override emitAction(action: string, feedback?: string): void {
+    if (action !== 'approve') {
+      super.emitAction(action, feedback);
+      return;
+    }
     const data = this.permission.data as AgentProposalPermission;
-    const isApprove = action === 'approve';
-    const modelOverride = isApprove
-      ? this.resolveOverride(this.selectedModel, data.model)
-      : undefined;
-    const agentOverride = isApprove
-      ? this.resolveOverride(this.selectedAgent, data.agent)
-      : undefined;
-    super.emitAction(action, feedback, modelOverride, agentOverride);
-  }
-
-  private resolveOverride(
-    selected: string | null,
-    original: string,
-  ): string | undefined {
-    return selected && selected !== original ? selected : undefined;
+    const pickIfChanged = (
+      selected: string | null,
+      original: string,
+    ): string | undefined =>
+      selected && selected !== original ? selected : undefined;
+    super.emitAction(
+      action,
+      feedback,
+      pickIfChanged(this.selectedModel, data.model),
+      pickIfChanged(this.selectedAgent, data.agent),
+    );
   }
 }
 

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -32,7 +32,10 @@ import {
   type WorkflowAgentProposalPermission,
 } from '@shared/schemas';
 import { postMessage } from '@shared/vscode';
-import { renderModelOptions } from '@shared/utils/selectTemplates';
+import {
+  renderAgentOptions,
+  renderModelOptions,
+} from '@shared/utils/selectTemplates';
 
 // Local imports - shared schemas
 import { getProposalFileGroups } from '@shared/schemas/proposalFields';
@@ -55,6 +58,16 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   ];
 
   @state() private selectedModel: string | null = null;
+  @state() private selectedAgent: string | null = null;
+
+  // Reset selections when the rendered proposal changes, so a prior proposal's
+  // stale pick doesn't leak into the next approve.
+  protected override willUpdate(changed: Map<string, unknown>): void {
+    if (changed.has('permission')) {
+      this.selectedModel = null;
+      this.selectedAgent = null;
+    }
+  }
 
   protected override handleExtraKey(key: string): boolean {
     if (key === 's') {
@@ -70,10 +83,16 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       this.permission.kind === PERMISSION_KIND.PROPOSAL
         ? (this.permission.modelOptions ?? [])
         : [];
+    const agentOptions =
+      this.permission.kind === PERMISSION_KIND.PROPOSAL
+        ? (this.permission.agentOptions ?? [])
+        : [];
     const isWorkflow = data.agentCategory === AGENT_CATEGORY.WORKFLOW;
     const categoryLabel = isWorkflow ? 'Workflow' : 'Tool-Use';
     const currentModel = this.selectedModel ?? data.model;
+    const currentAgent = this.selectedAgent ?? data.agent;
     const hasModelOptions = modelOptions.length > 0;
+    const hasAgentOptions = agentOptions.length > 0;
 
     return html`
       <div
@@ -93,7 +112,23 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
             >
               ${categoryLabel}
             </span>
-            <span class="workflow-proposal__agent">${data.agent}</span>
+            ${hasAgentOptions
+              ? html`
+                  <div class="workflow-proposal__agent-select">
+                    <i class="codicon codicon-sparkle"></i>
+                    <vscode-single-select
+                      class="proposal-agent-dropdown"
+                      position="below"
+                      .value=${currentAgent}
+                      @change=${this.handleAgentSelectChange}
+                    >
+                      ${renderAgentOptions(agentOptions, currentAgent)}
+                    </vscode-single-select>
+                  </div>
+                `
+              : html`<span class="workflow-proposal__agent"
+                  >${data.agent}</span
+                >`}
             ${hasModelOptions
               ? html`
                   <div class="workflow-proposal__model-select">
@@ -231,21 +266,34 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
     }
   };
 
+  private handleAgentSelectChange = (event: Event): void => {
+    const value = (event.target as HTMLSelectElement).value;
+    if (value) {
+      this.selectedAgent = value;
+    }
+  };
+
   // ===========================================================================
   // Override emitAction to include model override for approve
   // ===========================================================================
 
   protected override emitAction(action: string, feedback?: string): void {
-    const modelOverride =
-      action === 'approve' ? this.getModelOverride() : undefined;
-    super.emitAction(action, feedback, modelOverride);
+    const data = this.permission.data as AgentProposalPermission;
+    const isApprove = action === 'approve';
+    const modelOverride = isApprove
+      ? this.resolveOverride(this.selectedModel, data.model)
+      : undefined;
+    const agentOverride = isApprove
+      ? this.resolveOverride(this.selectedAgent, data.agent)
+      : undefined;
+    super.emitAction(action, feedback, modelOverride, agentOverride);
   }
 
-  private getModelOverride(): string | undefined {
-    const data = this.permission.data as AgentProposalPermission;
-    return this.selectedModel && this.selectedModel !== data.model
-      ? this.selectedModel
-      : undefined;
+  private resolveOverride(
+    selected: string | null,
+    original: string,
+  ): string | undefined {
+    return selected && selected !== original ? selected : undefined;
   }
 }
 

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -273,7 +273,8 @@ export function handlePermissionAction(
   event: CustomEvent<PermissionActionDetail>,
   ctx: MessageHandlerContext,
 ): void {
-  const { permission, action, feedback, modelOverride, answer } = event.detail;
+  const { permission, action, feedback, modelOverride, agentOverride, answer } =
+    event.detail;
   const { sessionLinks } = event.detail;
 
   switch (permission.kind) {
@@ -326,6 +327,7 @@ export function handlePermissionAction(
         action,
         feedback,
         model: modelOverride,
+        agent: agentOverride,
       });
       // Optimistic removal — track resolved ID so late SHOW is a no-op
       const removed = removePrompt(

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -44,6 +44,7 @@ export interface PermissionActionDetail {
   action: string;
   feedback?: string;
   modelOverride?: string;
+  agentOverride?: string;
   /** Answer text from external inquiry panel (submit action only). */
   answer?: string;
   /** External chat/thread links captured from the user (submit action only). */

--- a/src/progressView/frontend/slices/permissionSlice.ts
+++ b/src/progressView/frontend/slices/permissionSlice.ts
@@ -114,6 +114,7 @@ export const permissionHandlers: HandlerRegistry = {
           kind: PERMISSION_KIND.PROPOSAL,
           data: permission.data,
           modelOptions: permission.modelOptionsData,
+          agentOptions: permission.agentOptionsData,
         });
       } else {
         // Prepend newest permissions so keyboard shortcuts target the latest request.

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -359,6 +359,38 @@ export function fixLatexQuoteIssues(text: string): string {
   return text;
 }
 
+const CRITICIZE_ARG = String.raw`(?:[^{}]|\{[^{}]*\})*`;
+const CRITICIZE_INLINE_RE = new RegExp(
+  String.raw`\\criticize\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}`,
+  'g',
+);
+// Whole-line form runs first so a macro occupying its own line is removed
+// without leaving a trailing blank line.
+const CRITICIZE_WHOLE_LINE_RE = new RegExp(
+  String.raw`^[ \t]*\\criticize\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}[ \t]*\r?\n?`,
+  'gm',
+);
+
+/**
+ * Strip all `\criticize{comment}{severity}{confidence}` LaTeX annotations
+ * (inserted by critique-style agents) from LaTeX content.
+ */
+export function stripCriticizeAnnotations(content: string): {
+  content: string;
+  count: number;
+} {
+  if (!content.includes('\\criticize')) return { content, count: 0 };
+  let count = 0;
+  const tally = () => {
+    count++;
+    return '';
+  };
+  const out = content
+    .replace(CRITICIZE_WHOLE_LINE_RE, tally)
+    .replace(CRITICIZE_INLINE_RE, tally);
+  return { content: out, count };
+}
+
 /**
  * Wrap bare \critique and \comment commands in align environments with \intertext.
  * Handles simple nested braces within critique/comment content.

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -247,6 +247,7 @@ const PermissionPayloadSchema = z.discriminatedUnion('kind', [
     kind: z.literal('proposal'),
     data: AgentProposalPermissionSchema,
     modelOptionsData: z.array(ModelOptionDataSchema).optional(),
+    agentOptionsData: z.array(AgentOptionDataSchema).optional(),
   }),
   z.object({
     kind: z.literal('planApproval'),
@@ -600,6 +601,7 @@ const AgentProposalActionMessageSchema = z.object({
   action: z.enum(['approve', 'reject', 'setup']),
   feedback: z.string().optional(),
   model: z.string().optional(),
+  agent: z.string().optional(),
 });
 
 const PlanApprovalActionMessageSchema = z.object({

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -408,21 +408,32 @@ export const requestPanelStyles: CSSResult = css`
     margin-right: var(--spacing-small);
   }
 
+  .workflow-proposal__agent-select,
   .workflow-proposal__model-select {
     display: flex;
     align-items: center;
     gap: var(--spacing-small);
-    margin-left: auto;
   }
 
+  .workflow-proposal__agent-select .codicon,
   .workflow-proposal__model-select .codicon {
     color: var(--vscode-descriptionForeground);
     flex-shrink: 0;
   }
 
+  /* Model dropdown floats to the right edge of the header row. */
+  .workflow-proposal__model-select {
+    margin-left: auto;
+  }
+
   .proposal-model-dropdown {
     min-width: 8rem;
     max-width: 12rem;
+  }
+
+  .proposal-agent-dropdown {
+    min-width: 7rem;
+    max-width: 11rem;
   }
 
   .workflow-proposal__instruction {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -20,6 +20,7 @@ import { z } from 'zod';
 // Local imports - shared
 import { getExecutionStore } from '@agent/storage';
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
+import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 // Local imports - tools
@@ -32,6 +33,7 @@ import {
   getApprovedContent,
   writeApprovedContent,
 } from '@tools/approval/toolEditApproval';
+import { formatResultCount, pluralize } from '@tools/utils';
 
 // Local imports - utils
 import {
@@ -77,10 +79,7 @@ const AcceptRunFilesInputSchema = z.strictObject({
     .array(FileMapping)
     .min(1)
     .describe('Files to copy from run storage to workspace'),
-  /**
-   * If true, strip all `\criticize{...}{...}{...}` LaTeX annotations from
-   * each file's content before the approval diff is shown.
-   */
+  /** If true, strip `\criticize{...}{...}{...}` annotations before approval. */
   strip_criticize: z
     .boolean()
     .nullish()
@@ -165,7 +164,7 @@ Optional:
 
         const rawContent = await flexibleFS.read(sourceLocation);
         const stripped = strip_criticize
-          ? this.stripCriticizeAnnotations(rawContent)
+          ? stripCriticizeAnnotations(rawContent)
           : { content: rawContent, count: 0 };
         const proposedContent = stripped.content;
         const destExists = await WorkspaceFS.exists(dest.relativePath);
@@ -266,47 +265,14 @@ Optional:
     const accepted = files.length - rejected;
     const strippedSuffix =
       totalStripped > 0
-        ? ` (stripped ${totalStripped} \\criticize annotation${totalStripped > 1 ? 's' : ''})`
+        ? ` (stripped ${formatResultCount(totalStripped, '\\criticize annotation')})`
         : '';
-    const summary = `Accepted ${accepted}/${files.length} file${files.length > 1 ? 's' : ''} from run ${executionId}${strippedSuffix}`;
+    const summary = `Accepted ${accepted}/${files.length} ${pluralize(files.length, 'file')} from run ${executionId}${strippedSuffix}`;
     return {
       summary,
       output: `${summary}:\n${results.map((r) => `  - ${r}`).join('\n')}`,
       edits,
     };
-  }
-
-  /**
-   * Remove all `\criticize{...}{...}{...}` LaTeX annotations from content.
-   * Handles one level of nested braces inside each argument (same shape as
-   * `wrapCritiqueInAlign` in `src/replacement/advanced.ts`). When a macro is
-   * the only non-whitespace content on its line, the whole line is removed
-   * so no blank line is left behind.
-   */
-  private stripCriticizeAnnotations(content: string): {
-    content: string;
-    count: number;
-  } {
-    const criticizeArg = String.raw`(?:[^{}]|\{[^{}]*\})*`;
-    const inlineRe = new RegExp(
-      String.raw`\\criticize\{${criticizeArg}\}\{${criticizeArg}\}\{${criticizeArg}\}`,
-      'g',
-    );
-    const wholeLineRe = new RegExp(
-      String.raw`^[ \t]*\\criticize\{${criticizeArg}\}\{${criticizeArg}\}\{${criticizeArg}\}[ \t]*\r?\n?`,
-      'gm',
-    );
-
-    let count = 0;
-    let out = content.replace(wholeLineRe, () => {
-      count++;
-      return '';
-    });
-    out = out.replace(inlineRe, () => {
-      count++;
-      return '';
-    });
-    return { content: out, count };
   }
 
   /**

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -77,6 +77,16 @@ const AcceptRunFilesInputSchema = z.strictObject({
     .array(FileMapping)
     .min(1)
     .describe('Files to copy from run storage to workspace'),
+  /**
+   * If true, strip all `\criticize{...}{...}{...}` LaTeX annotations from
+   * each file's content before the approval diff is shown.
+   */
+  strip_criticize: z
+    .boolean()
+    .nullish()
+    .describe(
+      'If true, remove all \\criticize{...}{...}{...} LaTeX annotations from each file before approval. Use when accepting output from critique-style agents that embed review markers.',
+    ),
 });
 
 export type AcceptRunFilesInput = z.infer<typeof AcceptRunFilesInputSchema>;
@@ -109,11 +119,14 @@ Example — given delivery:
 
 Call:
   execution_id: "a1b2c3d4"
-  files: [{path: "paper__correct__r0_gemini.tex", original: "paper.tex"}]`,
+  files: [{path: "paper__correct__r0_gemini.tex", original: "paper.tex"}]
+
+Optional:
+  strip_criticize  when true, remove all \\criticize{...}{...}{...} annotations from accepted files before the approval diff`,
   schema: AcceptRunFilesInputSchema,
 }) {
   protected async execute(input: AcceptRunFilesInput): Promise<ToolResult> {
-    const { execution_id: executionId, files } = input;
+    const { execution_id: executionId, files, strip_criticize } = input;
     const runDir = await resolveStoragePath(executionId);
     const runDirExists = runDir !== undefined;
 
@@ -150,7 +163,11 @@ Call:
           );
         }
 
-        const proposedContent = await flexibleFS.read(sourceLocation);
+        const rawContent = await flexibleFS.read(sourceLocation);
+        const stripped = strip_criticize
+          ? this.stripCriticizeAnnotations(rawContent)
+          : { content: rawContent, count: 0 };
+        const proposedContent = stripped.content;
         const destExists = await WorkspaceFS.exists(dest.relativePath);
 
         // Determine original content for diff display
@@ -159,7 +176,7 @@ Call:
           sourceAbsolute === dest.absolutePath;
         let originalContent: string;
         if (isSameFile) {
-          originalContent = proposedContent;
+          originalContent = rawContent;
         } else if (destExists) {
           originalContent = await WorkspaceFS.read(dest.relativePath);
         } else {
@@ -172,6 +189,7 @@ Call:
           proposedContent,
           originalContent,
           destExists,
+          strippedCount: stripped.count,
         };
       }),
     );
@@ -182,6 +200,8 @@ Call:
     const acceptedEntries: { outputPath: string; originalPath: string }[] = [];
     let rejected = 0;
     const rejectionMessages: string[] = [];
+
+    let totalStripped = 0;
 
     for (const entry of prepared) {
       const mappingNote =
@@ -209,7 +229,14 @@ Call:
       );
 
       const action = entry.destExists ? 'replaced' : 'created';
-      results.push(`${action}: ${entry.original}${mappingNote}`);
+      const strippedNote =
+        entry.strippedCount > 0
+          ? ` (stripped ${entry.strippedCount} \\criticize)`
+          : '';
+      totalStripped += entry.strippedCount;
+      results.push(
+        `${action}: ${entry.original}${mappingNote}${strippedNote}`,
+      );
       edits.push({
         path: entry.original,
         lineChanges: approval.lineChanges,
@@ -237,12 +264,49 @@ Call:
     }
 
     const accepted = files.length - rejected;
-    const summary = `Accepted ${accepted}/${files.length} file${files.length > 1 ? 's' : ''} from run ${executionId}`;
+    const strippedSuffix =
+      totalStripped > 0
+        ? ` (stripped ${totalStripped} \\criticize annotation${totalStripped > 1 ? 's' : ''})`
+        : '';
+    const summary = `Accepted ${accepted}/${files.length} file${files.length > 1 ? 's' : ''} from run ${executionId}${strippedSuffix}`;
     return {
       summary,
       output: `${summary}:\n${results.map((r) => `  - ${r}`).join('\n')}`,
       edits,
     };
+  }
+
+  /**
+   * Remove all `\criticize{...}{...}{...}` LaTeX annotations from content.
+   * Handles one level of nested braces inside each argument (same shape as
+   * `wrapCritiqueInAlign` in `src/replacement/advanced.ts`). When a macro is
+   * the only non-whitespace content on its line, the whole line is removed
+   * so no blank line is left behind.
+   */
+  private stripCriticizeAnnotations(content: string): {
+    content: string;
+    count: number;
+  } {
+    const criticizeArg = String.raw`(?:[^{}]|\{[^{}]*\})*`;
+    const inlineRe = new RegExp(
+      String.raw`\\criticize\{${criticizeArg}\}\{${criticizeArg}\}\{${criticizeArg}\}`,
+      'g',
+    );
+    const wholeLineRe = new RegExp(
+      String.raw`^[ \t]*\\criticize\{${criticizeArg}\}\{${criticizeArg}\}\{${criticizeArg}\}[ \t]*\r?\n?`,
+      'gm',
+    );
+
+    let count = 0;
+    let out = content.replace(wholeLineRe, () => {
+      count++;
+      return '';
+    });
+    out = out.replace(inlineRe, () => {
+      count++;
+      return '';
+    });
+    return { content: out, count };
   }
 
   /**

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -199,6 +199,8 @@ interface ApprovalMeta {
   autoApproved: boolean;
   modelOverride?: string;
   requestedModel?: string;
+  agentOverride?: string;
+  requestedAgent?: string;
 }
 
 /**
@@ -475,19 +477,37 @@ async function proposeAndExecute(
 
   // At this point result.action === 'approve' (all other cases returned above)
   const modelOverride = result.action === 'approve' ? result.model : undefined;
-  const effective = modelOverride
-    ? { ...proposal, model: modelOverride }
-    : proposal;
-  return executeSubagent(toConfigPayload(effective), agentName, streamId, {
-    enableYoloOnChild: isApprovalBypassedForStream(streamId),
-    approvalMeta: {
-      autoApproved: false,
-      ...(modelOverride && {
-        modelOverride,
-        requestedModel: proposal.model,
-      }),
+  const agentOverride =
+    result.action === 'approve' &&
+    result.agent &&
+    result.agent !== proposal.agent
+      ? result.agent
+      : undefined;
+  const effective = {
+    ...proposal,
+    ...(modelOverride && { model: modelOverride }),
+    ...(agentOverride && { agent: agentOverride }),
+  };
+  const effectiveAgentName = agentOverride ?? agentName;
+  return executeSubagent(
+    toConfigPayload(effective),
+    effectiveAgentName,
+    streamId,
+    {
+      enableYoloOnChild: isApprovalBypassedForStream(streamId),
+      approvalMeta: {
+        autoApproved: false,
+        ...(modelOverride && {
+          modelOverride,
+          requestedModel: proposal.model,
+        }),
+        ...(agentOverride && {
+          agentOverride,
+          requestedAgent: proposal.agent,
+        }),
+      },
     },
-  });
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Two independent quality-of-life changes:

### 1. Agent-selection dropdown on the proposal card
Approving a delegation proposal now lets the user pick a different agent (within the same category) from a dropdown — mirroring the existing model dropdown. The chosen agent replaces both `proposal.agent` and the `agentName` passed to `executeSubagent`, so the overridden agent actually runs, and `agentOverride`/`requestedAgent` are recorded in approval meta.

Touches:
- `src/shared/schemas/progressView.ts` — adds `agentOptionsData` to the proposal permission variant and `agent` to `AgentProposalActionMessageSchema`.
- `src/progressView/ProgressViewProvider.ts` — computes agent options (filtered by category) alongside model options in parallel; remaps option `value → label` so it matches `proposal.agent` (a plain name, not a `source/name` key).
- `src/progressView/frontend/components/ProposalRequestPanel.ts` — adds a second `vscode-single-select` in the header row; resets selections when the rendered proposal changes to avoid stale picks; consolidates the model/agent override resolver.
- Plumbing: `BaseRequestPanel.emitAction`, `PermissionActionDetail`, `permissionSlice`, `eventHandlers`, `AgentProposalCoordinator.ProposalResult`, `DelegationTools.proposeAndExecute`.
- Styling: shared select-group rules in `requestPanelStyles.ts`.

### 2. `strip_criticize` flag on `accept_run_files`
Accepting output from critique-style agents often requires stripping `\\criticize{...}{...}{...}` review markers before the diff is shown. Adds an optional `strip_criticize` flag on the `accept_run_files` tool that removes both inline and whole-line occurrences (so no blank lines are left behind) and surfaces per-file and aggregate strip counts in the tool result.

## Test plan

- [ ] Trigger a `delegate_workflow` or `delegate_agent` proposal — confirm the agent dropdown appears after the async upgrade, pre-selects the proposed agent, and lists only agents of the same category.
- [ ] Pick a different agent, approve — verify the delegated subagent runs under the picked agent (not the proposed one) and approval meta records `agentOverride`/`requestedAgent`.
- [ ] Dismiss one proposal, see a fresh one — verify `selectedAgent`/`selectedModel` reset (don't carry over).
- [ ] Approve without changing the dropdowns — verify no override fields are set (backwards-compatible path).
- [ ] Call `accept_run_files` with `strip_criticize: true` on a file containing `\\criticize{a}{b}{c}` — verify annotations are stripped before the approval diff and the count appears in the summary.
- [ ] Call `accept_run_files` without the flag — verify unchanged behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes delegation approval/execution to allow overriding the agent that actually runs, and adds content-rewriting behavior during file acceptance (LaTeX annotation stripping) that could affect diffs and written output.
> 
> **Overview**
> **Delegation proposals can now override the agent at approval time.** The progress-view proposal card gains an agent dropdown (alongside model), backend sends `agentOptionsData`, and the approval action message/coordinator result now carry an optional `agent` override.
> 
> **Overrides are plumbed through to execution.** `DelegationTools` applies `agentOverride` to both the effective proposal config and the `executeSubagent` agent name, and records `agentOverride`/`requestedAgent` in approval metadata.
> 
> **`accept_run_files` can optionally strip critique markers.** Adds `strip_criticize` to the tool input, implements `stripCriticizeAnnotations()` to remove inline/whole-line `\criticize{...}{...}{...}` macros, and reports per-file and aggregate strip counts in the tool output/summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625a67830b1ae065cf630467b963be1c8d452cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->