### PR TITLE
fix(progress): pin user instruction to top in workflow streams

### DIFF
--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -264,8 +264,10 @@ export class ProgressViewProvider
   private async sendProposalModelOptions(
     proposal: AgentProposalPermission,
   ): Promise<void> {
-    // Fall back to static metadata if ServerSideKeyService or the agent
-    // registry hasn't finished loading — so the dropdowns still appear.
+    // Model options have a static fallback (buildBasicModelOptionsData) so
+    // the dropdown still appears if ServerSideKeyService isn't ready. Agent
+    // options have no static equivalent, so the agent dropdown is omitted
+    // when the registry fetch fails.
     const isWorkflow = proposal.agentCategory === AGENT_CATEGORY.WORKFLOW;
     const loadAgentOptions = async () => {
       const all = await computeAgentOptionsData();

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -267,13 +267,15 @@ export class ProgressViewProvider
     // Fall back to static metadata if ServerSideKeyService or the agent
     // registry hasn't finished loading — so the dropdowns still appear.
     const isWorkflow = proposal.agentCategory === AGENT_CATEGORY.WORKFLOW;
+    const loadAgentOptions = async () => {
+      const all = await computeAgentOptionsData();
+      const raw = isWorkflow ? all.workflow : all.toolUse;
+      // proposal.agent is a plain name (not source/name), so use label as value.
+      return raw.map((opt) => ({ ...opt, value: opt.label }));
+    };
     const [modelOptions, agentOptions] = await Promise.all([
       computeModelOptionsData().catch(() => buildBasicModelOptionsData()),
-      computeAgentOptionsData()
-        .then((all) => (isWorkflow ? all.workflow : all.toolUse))
-        // proposal.agent is a plain name (not source/name), so use label as value.
-        .then((raw) => raw.map((opt) => ({ ...opt, value: opt.label })))
-        .catch(() => undefined),
+      loadAgentOptions().catch(() => undefined),
     ]);
     if (!this.agentProposalHandler.get(proposal.proposalId)) return;
     this.webviewUpdater.showPermission({

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -1,7 +1,7 @@
 /**
  * LogList component - declarative log rendering with per-stream DOM caching.
  *
- * Consumes streamLogContext to get groups, messages, and isToolUse.
+ * Consumes streamLogContext to get groups and messages.
  * Renders one TaskGroupList per visited stream, hiding inactive ones with
  * display:none. Tab switching toggles visibility — zero DOM re-creation.
  *
@@ -61,7 +61,6 @@ const LogListStateSchema = z
 interface CachedStream {
   groups: TaskGroup[];
   messages: LogMessageData[];
-  isToolUse: boolean;
   toggleStates: ToggleStateStore;
   ref: Ref<TaskGroupList>;
 }
@@ -116,7 +115,6 @@ export class LogList extends LitElement {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
       entry.messages = this.streamContext.logs;
-      entry.isToolUse = this.streamContext.isToolUse;
 
       // Evict oldest non-active entries when cache exceeds cap
       this.evictStaleCacheEntries();
@@ -139,7 +137,6 @@ export class LogList extends LitElement {
           style=${id === this.activeStreamId ? '' : 'display:none'}
           .groups=${data.groups}
           .messages=${data.messages}
-          .isToolUse=${data.isToolUse}
           .hasStreams=${this.streamContext.hasStreams}
           .toggleStates=${data.toggleStates}
         ></task-group-list>
@@ -215,7 +212,6 @@ export class LogList extends LitElement {
     entry = {
       groups: [],
       messages: [],
-      isToolUse: false,
       toggleStates,
       ref: createRef<TaskGroupList>(),
     };

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -46,6 +46,13 @@ import { PERMISSION_KIND } from '@shared/utils/uiConstants';
 
 // Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
+import type { PermissionState } from './PermissionCard';
+
+function proposalIdOf(
+  p: PermissionState | null | undefined,
+): string | undefined {
+  return p?.kind === PERMISSION_KIND.PROPOSAL ? p.data.proposalId : undefined;
+}
 
 @customElement('proposal-request-panel')
 export class ProposalRequestPanel extends BaseFeedbackPanel {
@@ -60,14 +67,13 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   @state() private selectedModel: string | null = null;
   @state() private selectedAgent: string | null = null;
 
-  // Reset selections when the rendered proposal changes, so a prior proposal's
-  // stale pick doesn't leak into the next approve.
+  // Reset selections only when the proposal's identity changes, so an async
+  // permission upsert that just adds dropdown options doesn't wipe the user's
+  // in-progress pick for the same proposal.
   protected override willUpdate(changed: Map<string, unknown>): void {
     if (!changed.has('permission')) return;
-    type MaybeProposal = { data?: { proposalId?: string } } | null | undefined;
-    const previous = changed.get('permission') as MaybeProposal;
-    const current = this.permission as MaybeProposal;
-    if (previous?.data?.proposalId !== current?.data?.proposalId) {
+    const previous = changed.get('permission') as PermissionState | null | undefined;
+    if (proposalIdOf(previous) !== proposalIdOf(this.permission)) {
       this.selectedModel = null;
       this.selectedAgent = null;
     }

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -63,7 +63,11 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   // Reset selections when the rendered proposal changes, so a prior proposal's
   // stale pick doesn't leak into the next approve.
   protected override willUpdate(changed: Map<string, unknown>): void {
-    if (changed.has('permission')) {
+    if (!changed.has('permission')) return;
+    type MaybeProposal = { data?: { proposalId?: string } } | null | undefined;
+    const previous = changed.get('permission') as MaybeProposal;
+    const current = this.permission as MaybeProposal;
+    if (previous?.data?.proposalId !== current?.data?.proposalId) {
       this.selectedModel = null;
       this.selectedAgent = null;
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -74,9 +74,6 @@ export class TaskGroupList extends LitElement {
   /** All log messages to render */
   @property({ attribute: false }) messages: LogMessageData[] = [];
 
-  /** Whether this is a tool-use session (affects timeline rendering) */
-  @property({ attribute: false }) isToolUse = false;
-
   /** Whether there are any streams in the current filter (controls placeholder) */
   @property({ attribute: false }) hasStreams = false;
 
@@ -170,8 +167,10 @@ export class TaskGroupList extends LitElement {
       }
     }
 
-    // Recompute tool-use timeline incrementally when possible
-    if (this.isToolUse && (groupsChanged || messagesChanged)) {
+    // Recompute the interleaved timeline incrementally when possible.
+    // Used by both tool-use and workflow streams so the user's original
+    // instruction (the earliest ungrouped message) stays at the top.
+    if (groupsChanged || messagesChanged) {
       if (groupsChanged) {
         // Structural change — full timeline rebuild (rare)
         this.cachedTimeline = this.buildFullTimeline();
@@ -568,31 +567,11 @@ export class TaskGroupList extends LitElement {
       `;
     }
 
-    if (this.isToolUse) {
-      // Tool-use: interleave ungrouped messages (user input, follow-ups, errors)
-      // with groups chronologically so the conversation reads top-to-bottom.
-      // Timeline is memoized in willUpdate() — only rebuilt when inputs change.
-      return html`
-        <vscode-scrollable
-          id=${ELEMENT_IDS.LOG_CONTENT}
-          class="log-container"
-          @vsc-scrollable-scroll=${this.handleVscScroll}
-        >
-          ${repeat(
-            this.cachedTimeline,
-            (item) => item.key,
-            (item) =>
-              'msg' in item
-                ? guard([item.msg], () => formatLogEntry(item.msg))
-                : this.renderGroupNode(item.tree),
-          )}
-        </vscode-scrollable>
-      `;
-    }
-
-    // Workflow: groups first, then ungrouped messages.
-    // Workflow stages are hierarchical (not conversational), so structure-first
-    // ordering keeps stage execution visually separate from stray messages.
+    // Interleave ungrouped messages (user input, follow-ups, errors) with run
+    // groups chronologically so the conversation reads top-to-bottom. The
+    // user's original instruction always surfaces at the top because it has
+    // the earliest timestamp. Timeline is memoized in willUpdate() — only
+    // rebuilt when inputs change.
     return html`
       <vscode-scrollable
         id=${ELEMENT_IDS.LOG_CONTENT}
@@ -600,14 +579,12 @@ export class TaskGroupList extends LitElement {
         @vsc-scrollable-scroll=${this.handleVscScroll}
       >
         ${repeat(
-          this.cachedTree,
-          (t) => t.group.id,
-          (t) => this.renderGroupNode(t),
-        )}
-        ${repeat(
-          this.cachedUngrouped,
-          (m) => m.id,
-          (m) => guard([m], () => formatLogEntry(m)),
+          this.cachedTimeline,
+          (item) => item.key,
+          (item) =>
+            'msg' in item
+              ? guard([item.msg], () => formatLogEntry(item.msg))
+              : this.renderGroupNode(item.tree),
         )}
       </vscode-scrollable>
     `;

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -170,8 +170,9 @@ export class TaskGroupList extends LitElement {
     // Used by both tool-use and workflow streams so the user's original
     // instruction (the earliest ungrouped message) stays at the top.
     if (groupsChanged || messagesChanged) {
-      if (groupsChanged) {
-        // Structural change — full timeline rebuild (rare)
+      if (groupsChanged || this.messages.length < prevCount) {
+        // Structural change, or messages shrunk (e.g. clear/resync) —
+        // removed IDs must be pruned from cachedTimeline, so rebuild.
         this.cachedTimeline = this.buildFullTimeline();
       } else if (this.messages.length > prevCount) {
         // Append-only: classify each new message and insert ungrouped ones
@@ -182,8 +183,8 @@ export class TaskGroupList extends LitElement {
         // LOG_DELTA may also mutate existing timeline entries in the same batch.
         this.updateTimelineMessageRefs();
       } else {
-        // Same-length (streaming update): update msg refs on timeline entries in-place.
-        // guard([item.msg]) in render() detects new refs.
+        // Same length — streaming update. guard([item.msg]) in render()
+        // detects new refs on existing timeline entries.
         this.updateTimelineMessageRefs();
       }
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -143,7 +143,6 @@ export class TaskGroupList extends LitElement {
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;
     const prevCount = prevMessages?.length ?? 0;
-    const prevUngroupedCount = this.cachedUngrouped.length;
 
     if (groupsChanged) {
       // Structural change — always full rebuild
@@ -175,9 +174,11 @@ export class TaskGroupList extends LitElement {
         // Structural change — full timeline rebuild (rare)
         this.cachedTimeline = this.buildFullTimeline();
       } else if (this.messages.length > prevCount) {
-        // Append-only: add new ungrouped entries to timeline.
-        // Grouped messages are already referenced via tree nodes in timeline entries.
-        this.appendToTimeline(prevUngroupedCount);
+        // Append-only: classify each new message and insert ungrouped ones
+        // into the timeline. Iterate the messages slice (not the ungrouped
+        // array) so a new message spliced into the middle of cachedUngrouped
+        // by appendNewMessages still gets picked up.
+        this.appendToTimeline(prevCount);
         // LOG_DELTA may also mutate existing timeline entries in the same batch.
         this.updateTimelineMessageRefs();
       } else {
@@ -387,10 +388,21 @@ export class TaskGroupList extends LitElement {
     ].sort((a, b) => a.time - b.time);
   }
 
-  /** Append new ungrouped messages to the timeline in sorted order. */
-  private appendToTimeline(prevUngroupedCount: number): void {
-    for (let i = prevUngroupedCount; i < this.cachedUngrouped.length; i++) {
-      const m = this.cachedUngrouped[i];
+  /**
+   * Insert timeline entries for ungrouped messages appended since `startIndex`.
+   * Grouped messages are already referenced via their tree node in timeline,
+   * so we skip them here. Iterating the messages slice — rather than the
+   * cachedUngrouped array — keeps this correct when a message with an earlier
+   * timestamp gets spliced into the middle of cachedUngrouped by
+   * appendNewMessages.
+   */
+  private appendToTimeline(startIndex: number): void {
+    for (let i = startIndex; i < this.messages.length; i++) {
+      const m = this.messages[i];
+      const inGroupNode = m.groupId
+        ? this.groupNodeIndex.has(m.groupId)
+        : false;
+      if (inGroupNode) continue;
       const entry = { key: m.id, time: m.timestamp ?? 0, msg: m };
       const lastTime =
         this.cachedTimeline.length > 0

--- a/src/replacement/advanced.ts
+++ b/src/replacement/advanced.ts
@@ -367,7 +367,7 @@ const CRITICIZE_INLINE_RE = new RegExp(
 // Whole-line form runs first so a macro occupying its own line is removed
 // without leaving a trailing blank line.
 const CRITICIZE_WHOLE_LINE_RE = new RegExp(
-  String.raw`^[ \t]*\\criticize\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}[ \t]*\r?\n?`,
+  String.raw`^[ \t]*\\criticize\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}\{${CRITICIZE_ARG}\}[ \t]*$\r?\n?`,
   'gm',
 );
 

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -163,10 +163,10 @@ Optional:
         }
 
         const rawContent = await flexibleFS.read(sourceLocation);
-        const stripped = strip_criticize
-          ? stripCriticizeAnnotations(rawContent)
-          : { content: rawContent, count: 0 };
-        const proposedContent = stripped.content;
+        const { content: proposedContent, count: strippedCount } =
+          strip_criticize
+            ? stripCriticizeAnnotations(rawContent)
+            : { content: rawContent, count: 0 };
         const destExists = await WorkspaceFS.exists(dest.relativePath);
 
         // Determine original content for diff display
@@ -188,7 +188,7 @@ Optional:
           proposedContent,
           originalContent,
           destExists,
-          strippedCount: stripped.count,
+          strippedCount,
         };
       }),
     );

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -477,12 +477,31 @@ async function proposeAndExecute(
 
   // At this point result.action === 'approve' (all other cases returned above)
   const modelOverride = result.action === 'approve' ? result.model : undefined;
-  const agentOverride =
+  const requestedAgentOverride =
     result.action === 'approve' &&
     result.agent &&
     result.agent !== proposal.agent
       ? result.agent
       : undefined;
+
+  // Re-validate the agent override against the current registry. Between
+  // proposal display and approval the registry may have changed (agent
+  // removed/renamed), or the approval could carry a malformed value. Fail
+  // fast with a clear ToolResult so the orchestrator sees the problem
+  // synchronously, rather than executeSubagent silently swallowing it.
+  let agentOverride = requestedAgentOverride;
+  if (requestedAgentOverride) {
+    const visible = getVisibleAgents(proposal.agentCategory);
+    if (!visible.some((a) => a.name === requestedAgentOverride)) {
+      return {
+        summary: `Approved agent override '${requestedAgentOverride}' is not available`,
+        output: `Cannot launch '${requestedAgentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
+        isError: true,
+      };
+    }
+    agentOverride = requestedAgentOverride;
+  }
+
   const effective = {
     ...proposal,
     ...(modelOverride && { model: modelOverride }),

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -340,8 +340,11 @@ async function executeSubagent(
     const modelInfo = meta.modelOverride
       ? `Model: ${meta.modelOverride} (overridden from ${meta.requestedModel ?? 'default'})`
       : `Model: ${configPayload.model}`;
+    const agentInfo = meta.agentOverride
+      ? ` Agent: ${meta.agentOverride} (overridden from ${meta.requestedAgent ?? 'default'}).`
+      : '';
     metaLines.push(
-      `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.`,
+      `Approval: ${meta.autoApproved ? 'auto-approved' : 'user-approved'}. ${modelInfo}.${agentInfo}`,
     );
   }
   return {

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -480,29 +480,26 @@ async function proposeAndExecute(
 
   // At this point result.action === 'approve' (all other cases returned above)
   const modelOverride = result.action === 'approve' ? result.model : undefined;
-  const requestedAgentOverride =
+  const agentOverride =
     result.action === 'approve' &&
     result.agent &&
     result.agent !== proposal.agent
       ? result.agent
       : undefined;
 
-  // Re-validate the agent override against the current registry. Between
-  // proposal display and approval the registry may have changed (agent
-  // removed/renamed), or the approval could carry a malformed value. Fail
-  // fast with a clear ToolResult so the orchestrator sees the problem
-  // synchronously, rather than executeSubagent silently swallowing it.
-  let agentOverride = requestedAgentOverride;
-  if (requestedAgentOverride) {
+  // Re-validate against the current registry — between proposal display and
+  // approval the agent may have been removed/renamed, or the approval could
+  // carry a malformed value. Fail fast so the orchestrator sees the problem
+  // synchronously instead of after an async launch.
+  if (agentOverride) {
     const visible = getVisibleAgents(proposal.agentCategory);
-    if (!visible.some((a) => a.name === requestedAgentOverride)) {
+    if (!visible.some((a) => a.name === agentOverride)) {
       return {
-        summary: `Approved agent override '${requestedAgentOverride}' is not available`,
-        output: `Cannot launch '${requestedAgentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
+        summary: `Approved agent override '${agentOverride}' is not available`,
+        output: `Cannot launch '${agentOverride}': it is not currently a visible ${proposal.agentCategory} agent (removed, renamed, or disabled since the proposal was shown). Re-propose the delegation.`,
         isError: true,
       };
     }
-    agentOverride = requestedAgentOverride;
   }
 
   const effective = {


### PR DESCRIPTION
## Summary

Workflow streams were rendering run groups first and ungrouped messages second, pushing the user's original instruction bubble below every run group output — so the conversation read upside down. Regressed in #3061 when ungrouped user messages were merged into a single `cachedUngrouped` list.

## Fix

Unify the two render paths: both tool-use and workflow now use `cachedTimeline`, which interleaves ungrouped messages and run groups chronologically. The instruction always carries the earliest timestamp, so it surfaces at the top. Matches how tool-use streams already render.

Incidental cleanup: the `isToolUse` prop on `TaskGroupList` and its plumbing through `LogList.CachedStream` are no longer read anywhere, so they're dropped.

## Commits

1. **`fix(progress)`** — pin user instruction to top in workflow streams (main change).
2. **`refactor(progress,tools)`** — tighten PR-#3088 diff readability: named `loadAgentOptions` helper in `ProgressViewProvider`, `MaybeProposal` alias in `ProposalRequestPanel`, destructured `stripCriticizeAnnotations` result. No behavior change.
3. **`fix(progress)`** — handle non-monotonic timeline appends. Iterate the `messages` slice (not `cachedUngrouped`) when appending so a message with an earlier timestamp spliced into the middle of `cachedUngrouped` still gets rendered. (Addresses Codex P2 review on this PR.)
4. **`fix(tools)`** — validate the approved agent override against the visible registry before launching the subagent; return an error `ToolResult` synchronously if the override is stale/malformed. (Addresses Codex P2 review on this PR.)
5. **`fix(pr-review)`** — restore three small fixes from the pre-rebase branch that were dropped when #3088 squash-merged without them:
   - `advanced.ts`: missing `$` end-of-line anchor in `CRITICIZE_WHOLE_LINE_RE`.
   - `DelegationTools.executeSubagent`: surface `agentOverride`/`requestedAgent` in the approval meta output.
   - `ProgressViewProvider`: reword the fallback comment to match behavior.

## Test plan

- [ ] Run any workflow agent (e.g. `criticize`, `polish`). Confirm the user-instruction blue bubble appears at the TOP of the Progress tab.
- [ ] Send a follow-up message mid-stream. Confirm it appears near its timestamp, not below run groups.
- [ ] Run a tool-use agent. Confirm ordering unchanged.
- [ ] Approve a proposal with an agent override whose agent has been removed/disabled; confirm the delegation returns an immediate error (not async failure).
- [ ] Run `accept_run_files` with `strip_criticize` on a file containing `\criticize{...}{...}{...} trailing text`; confirm the trailing text is preserved (regex no longer matches across it).
- [ ] `npm run typecheck` and `npm run compile:fast` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes core progress-view log ordering and incremental timeline caching, plus adds validation in the delegation approval path that could block launches if registry state is unexpected.
> 
> **Overview**
> Unifies workflow and tool-use log rendering so **ungrouped messages and run groups are always interleaved chronologically**, keeping the user’s original instruction pinned at the top of workflow streams. This removes the now-unused `isToolUse` plumbing from `LogList`/`TaskGroupList` and adjusts incremental timeline updates to handle non-monotonic message timestamps.
> 
> Tightens proposal/delegation UX and safety: proposal dropdown selections are preserved across async permission upserts, proposal agent options loading is clarified/isolated, and delegation approval output now includes agent override info. On approve, agent overrides are **re-validated against the current visible agent registry** and fail fast with a synchronous error if stale/malformed.
> 
> Also fixes `stripCriticizeAnnotations` whole-line regex anchoring so `\criticize{...}` removal doesn’t eat trailing text, and simplifies `accept_run_files` result handling via destructuring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f905767d127de1ab286ab08e60a66d99451f41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->