### PR TITLE
fix(latex): mirror figure deps into run-storage workspace

### DIFF
--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -204,8 +204,13 @@ export class LatexMediaManager {
       return;
     }
 
+    const texFiles = files.filter((file) =>
+      hasExtension(file.absolutePath, '.tex'),
+    );
+    if (texFiles.length === 0) return;
+
     await pMap(
-      files,
+      texFiles,
       async (file) => {
         try {
           const figures = await extractFigurePathsFromLatex(file);

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -18,6 +18,7 @@ import { hasExtension } from '@utils/core/pathCore';
 // Local file imports
 import { extractLatexFileDependencies } from './extractFileDependencies';
 import { extractFigurePathsFromLatex } from './extractFigure';
+import { resolveLatexDir } from './latexParsingUtils';
 import { tikzPictureManager } from './TikzPictureManager';
 import { compileLatex2Pdf } from './texTools';
 
@@ -47,7 +48,10 @@ export class LatexMediaManager {
       return;
     }
 
-    const baseDir = path.dirname(latexFile.absolutePath);
+    // Resolve against the workspace directory so figure paths from a
+    // run-storage symlink map back to real workspace files (otherwise
+    // mirrorWorkspaceFile would classify them as external and skip).
+    const baseDir = await resolveLatexDir(latexFile.absolutePath);
     const targetLocations = new Set<FileLocation>();
     for (const relative of figures) {
       const trimmed = relative?.trim();
@@ -189,6 +193,34 @@ export class LatexMediaManager {
     );
   }
 
+  /**
+   * Mirror figure dependencies from LaTeX files into run storage without
+   * adding figures to the model's vision context. Used for output files
+   * (round 1+) so newly-referenced figures are available for PDF compilation
+   * but not re-sent to the model on every round.
+   */
+  private async mirrorFiguresForFiles(files: FileLocation[]): Promise<void> {
+    if (!this.fileService?.hasRunDirectory() || files.length === 0) {
+      return;
+    }
+
+    await pMap(
+      files,
+      async (file) => {
+        try {
+          const figures = await extractFigurePathsFromLatex(file);
+          if (figures.length === 0) return;
+          await this.mirrorFigureDependencies(file, figures);
+        } catch (error) {
+          this.logger.debug(
+            `Unable to mirror figures from ${file.absolutePath}: ${toErrorMessage(error)}`,
+          );
+        }
+      },
+      { concurrency: LATEX_CONCURRENCY, stopOnError: false },
+    );
+  }
+
   private async extractFiguresFromFiles(
     files: FileLocation[],
     workspaceState: AgentWorkspaceState,
@@ -217,7 +249,10 @@ export class LatexMediaManager {
         `Extracted ${figures.length} figures from ${file.absolutePath}`,
       );
 
-      const baseDir = path.dirname(file.absolutePath);
+      // Match the resolution in extractFigurePathsFromLatex so the returned
+      // figure paths (relative to the real latexDir) map back to workspace
+      // files when the .tex is symlinked into run storage.
+      const baseDir = await resolveLatexDir(file.absolutePath);
       const fileLocations = figures.map((relativePath) => {
         const absolutePath = path.normalize(path.join(baseDir, relativePath));
         return pathToLocation(absolutePath);
@@ -282,14 +317,21 @@ export class LatexMediaManager {
     cfg: ToolConfig,
     supportsVision: boolean,
     {
-      includeFigureExtraction,
+      figureMode,
       mirrorFileDependencies,
       includeTikzCompilation,
       includePdfCompilation,
       extraMediaFiles = [],
       logTikzSummary = false,
     }: {
-      includeFigureExtraction: boolean;
+      /**
+       * How to handle \includegraphics figures:
+       *  - 'extract': discover + add to vision context + mirror into run storage
+       *  - 'mirror':  discover + mirror only (no vision)
+       *  - 'none':    skip
+       * All modes are additionally gated by `cfg.autoExtractFigure`.
+       */
+      figureMode: 'extract' | 'mirror' | 'none';
       mirrorFileDependencies: boolean;
       includeTikzCompilation: boolean;
       includePdfCompilation: boolean;
@@ -322,8 +364,12 @@ export class LatexMediaManager {
       workspaceState.media.addMediaFiles(fileLocations);
     }
 
-    if (includeFigureExtraction && cfg.autoExtractFigure) {
-      await this.extractFiguresFromFiles(existingFiles, workspaceState);
+    if (cfg.autoExtractFigure) {
+      if (figureMode === 'extract') {
+        await this.extractFiguresFromFiles(existingFiles, workspaceState);
+      } else if (figureMode === 'mirror') {
+        await this.mirrorFiguresForFiles(existingFiles);
+      }
     }
 
     if (mirrorFileDependencies) {
@@ -359,7 +405,7 @@ export class LatexMediaManager {
     extraMediaFiles: PathInput[] = [],
   ): Promise<void> {
     await this.processFiles(inputFiles, workspaceState, cfg, supportsVision, {
-      includeFigureExtraction: true,
+      figureMode: 'extract',
       mirrorFileDependencies: true,
       includeTikzCompilation: true,
       includePdfCompilation: true,
@@ -369,7 +415,11 @@ export class LatexMediaManager {
   }
 
   /**
-   * Process output files to compile TikZ pictures and PDFs, attach texcount.
+   * Process output files to compile TikZ pictures and PDFs.
+   *
+   * Mirrors newly-referenced figure and \input dependencies into run storage
+   * so agent-introduced references compile outside the workspace. Figures are
+   * mirrored only (not added to vision context) — they were sent on round 0.
    */
   async processOutputFiles(
     outputFiles: FileLocation[],
@@ -378,8 +428,8 @@ export class LatexMediaManager {
     supportsVision: boolean,
   ): Promise<void> {
     await this.processFiles(outputFiles, workspaceState, cfg, supportsVision, {
-      includeFigureExtraction: false,
-      mirrorFileDependencies: false,
+      figureMode: 'mirror',
+      mirrorFileDependencies: true,
       includeTikzCompilation: true,
       includePdfCompilation: true,
     });

--- a/src/latex/LatexMediaManager.ts
+++ b/src/latex/LatexMediaManager.ts
@@ -52,27 +52,26 @@ export class LatexMediaManager {
     // run-storage symlink map back to real workspace files (otherwise
     // mirrorWorkspaceFile would classify them as external and skip).
     const baseDir = await resolveLatexDir(latexFile.absolutePath);
-    const targetLocations = new Set<FileLocation>();
+    const absolutePaths = new Set<string>();
     for (const relative of figures) {
       const trimmed = relative?.trim();
       if (!trimmed) {
         continue;
       }
-      const absolutePath = path.normalize(path.join(baseDir, trimmed));
-      targetLocations.add(pathToLocation(absolutePath));
+      absolutePaths.add(path.normalize(path.join(baseDir, trimmed)));
     }
 
-    if (targetLocations.size === 0) {
+    if (absolutePaths.size === 0) {
       return;
     }
 
-    const tasks = [...targetLocations].map(async (targetLocation) => {
+    const tasks = [...absolutePaths].map(async (absolutePath) => {
       try {
-        await this.fileService!.mirrorWorkspaceFile(targetLocation);
+        await this.fileService!.mirrorWorkspaceFile(pathToLocation(absolutePath));
       } catch (error) {
         const message = toErrorMessage(error);
         this.logger.debug(
-          `Unable to mirror figure dependency ${targetLocation.absolutePath}: ${message}`,
+          `Unable to mirror figure dependency ${absolutePath}: ${message}`,
         );
       }
     });

--- a/src/latex/extractFigure.ts
+++ b/src/latex/extractFigure.ts
@@ -7,6 +7,8 @@ import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 import { joinLatexPath } from '@utils/core/pathCore';
 
+import { resolveLatexDir } from './latexParsingUtils';
+
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
@@ -83,8 +85,7 @@ export async function extractFigurePathsFromLatex(
 ): Promise<string[]> {
   const figurePaths: string[] = [];
 
-  const latexFile = latexFileLocation.absolutePath;
-  const latexDir = path.dirname(latexFile);
+  const latexDir = await resolveLatexDir(latexFileLocation.absolutePath);
   const graphicspaths = [latexDir]; // Start with the directory of the LaTeX file
 
   // Regular expressions to match figure inclusion commands

--- a/src/latex/latexParsingUtils.ts
+++ b/src/latex/latexParsingUtils.ts
@@ -6,6 +6,9 @@
  * bibliography directive matching.
  */
 
+import * as path from 'path';
+import { promises as fs } from 'fs';
+
 /** Strips everything after an unescaped % on each line. */
 const COMMENT_PATTERN = /(^|[^\\])%.*$/gm;
 
@@ -21,3 +24,13 @@ export const BIB_DIRECTIVE_PATTERN = new RegExp(
   '(?:bibliography|addbibresource)(?:\\s*\\[[^\\]]*\\])?\\s*\\{([^}]*)\\}',
   'g',
 );
+
+/**
+ * Directory containing a LaTeX file, following symlinks so references
+ * inside a file mirrored into run storage resolve against the workspace.
+ * Falls back to the literal dirname if the file can't be realpath'd.
+ */
+export async function resolveLatexDir(absolutePath: string): Promise<string> {
+  const resolved = await fs.realpath(absolutePath).catch(() => absolutePath);
+  return path.dirname(resolved);
+}

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -40,6 +40,7 @@ import { codiconStyles } from '@shared/styles/codiconStyles';
 
 // Local imports - progress view frontend
 import { webviewStorage } from './webviewStorage';
+import { setsEqual } from './utils';
 import {
   createInitialState,
   EMPTY_STREAM_LOGS,
@@ -120,13 +121,7 @@ import type { PermissionState } from './components/PermissionCard';
 // Signal.Computed evaluations that run on every state change.
 // ---------------------------------------------------------------------------
 
-function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
-  if (a.size !== b.size) return false;
-  for (const v of a) {
-    if (!b.has(v)) return false;
-  }
-  return true;
-}
+// setsEqual is provided by the shared frontend utils module.
 
 // Cast: BaseWebviewApp is abstract, but SignalWatcher expects a concrete constructor.
 // Safe because ProgressApp implements all abstract members below.

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -575,34 +575,69 @@ export class StreamTabs extends LitElement {
    */
   private manuallyCollapsed: Set<string> = new Set();
 
-  /** Auto-expand parents when children appear, auto-collapse when gone. */
+  /**
+   * Parents where the "all children finished" transition has already been
+   * handled — either we auto-collapsed, or the user manually expanded after.
+   * Prevents re-collapsing a parent the user has chosen to keep open.
+   * Cleared when any child becomes active again (new run).
+   */
+  private finishedCollapseHandled: Set<string> = new Set();
+
+  /** Auto-expand when children appear, auto-collapse when gone or finished. */
   protected override willUpdate(changed: import('lit').PropertyValues): void {
-    if (!changed.has('childStreamsByParent')) return;
+    const childrenChanged = changed.has('childStreamsByParent');
+    const statesChanged = changed.has('streamStates');
+    if (!childrenChanged && !statesChanged) return;
 
     let dirty = false;
     const next = new Set(this.expandedParents);
 
-    // Auto-expand NEW parents (not yet seen and not manually collapsed)
-    for (const parentId of this.childStreamsByParent.keys()) {
-      if (!next.has(parentId) && !this.manuallyCollapsed.has(parentId)) {
-        next.add(parentId);
-        dirty = true;
+    if (childrenChanged) {
+      for (const parentId of this.childStreamsByParent.keys()) {
+        if (!next.has(parentId) && !this.manuallyCollapsed.has(parentId)) {
+          next.add(parentId);
+          dirty = true;
+        }
+      }
+      for (const parentId of next) {
+        if (!this.childStreamsByParent.has(parentId)) {
+          next.delete(parentId);
+          this.manuallyCollapsed.delete(parentId);
+          this.finishedCollapseHandled.delete(parentId);
+          dirty = true;
+        }
+      }
+      // Parents dropped from `next` above are already cleaned; these passes
+      // cover parents still tracked but no longer in childStreamsByParent.
+      for (const parentId of this.manuallyCollapsed) {
+        if (!this.childStreamsByParent.has(parentId)) {
+          this.manuallyCollapsed.delete(parentId);
+        }
+      }
+      for (const parentId of this.finishedCollapseHandled) {
+        if (!this.childStreamsByParent.has(parentId)) {
+          this.finishedCollapseHandled.delete(parentId);
+        }
       }
     }
-    // Auto-collapse parents that lost all children + clear manual state
+
+    // Auto-collapse once per finish-transition; reset when a child reactivates.
     for (const parentId of next) {
-      if (!this.childStreamsByParent.has(parentId)) {
-        next.delete(parentId);
-        this.manuallyCollapsed.delete(parentId);
-        dirty = true;
+      const children = this.childStreamsByParent.get(parentId);
+      if (!children) continue;
+      const allFinished = children.every(
+        (c) => !ACTIVE_CHILD_STATUSES.has(this.getStatus(c.name)),
+      );
+      if (!allFinished) {
+        this.finishedCollapseHandled.delete(parentId);
+        continue;
       }
+      if (this.finishedCollapseHandled.has(parentId)) continue;
+      next.delete(parentId);
+      this.finishedCollapseHandled.add(parentId);
+      dirty = true;
     }
-    // Also clean manual set for parents no longer in the map
-    for (const parentId of this.manuallyCollapsed) {
-      if (!this.childStreamsByParent.has(parentId)) {
-        this.manuallyCollapsed.delete(parentId);
-      }
-    }
+
     if (dirty) this.expandedParents = next;
   }
 
@@ -746,6 +781,9 @@ export class StreamTabs extends LitElement {
     } else {
       next.add(parentId);
       this.manuallyCollapsed.delete(parentId);
+      // Mark finish-transition as handled so willUpdate doesn't immediately
+      // re-collapse a parent the user just chose to expand.
+      this.finishedCollapseHandled.add(parentId);
     }
     this.expandedParents = next;
   }

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -26,7 +26,7 @@ import { formatRelativeTime } from '@shared/utils/string';
 import { layoutStyles } from '../styles/logStyles';
 import { ELEMENT_IDS, FILTER_BUTTONS, SORT_BUTTONS } from '../constants';
 import { ProgressEvents } from '../events';
-import { getComposedPathElement, getRadioValue } from '../utils';
+import { getComposedPathElement, getRadioValue, setsEqual } from '../utils';
 import type { StreamFilter, StreamSort } from '../store';
 
 /** Stream statuses considered active (non-terminal) for child stream display. */
@@ -36,6 +36,23 @@ const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
   STREAM_STATUS.INITIALIZING,
   STREAM_STATUS.RESUMING,
 ]);
+
+type ChildActivity = 'active' | 'finished' | 'unknown';
+
+/**
+ * Classify a child stream's lifecycle. Absent entries in `streamStates`
+ * (e.g., child just appeared in `childStreamsByParent` before its first
+ * status event) are `unknown` — neither active nor finished — so the
+ * parent's expand/collapse decision can wait for a real signal.
+ */
+function classifyChild(
+  streamStates: ReadonlyMap<StreamTabId, StreamState>,
+  name: StreamTabId,
+): ChildActivity {
+  const status = streamStates.get(name)?.status;
+  if (status === undefined) return 'unknown';
+  return ACTIVE_CHILD_STATUSES.has(status) ? 'active' : 'finished';
+}
 
 function buildTooltip(
   info: StreamTabInfo,
@@ -566,79 +583,62 @@ export class StreamTabs extends LitElement {
   @property({ attribute: false })
   childStreamsByParent: Map<string, StreamTabInfo[]> = new Map();
 
-  /** Which parent streams have their child list expanded. */
+  /** Which parent streams have their child list expanded — derived from
+   *  inputs + `userOverride` on every reactive update. Not a source of truth. */
   @state() private expandedParents: Set<string> = new Set();
 
   /**
-   * Parents the user has manually collapsed. Auto-expand won't override
-   * these — only cleared when all children finish (parent leaves the map).
+   * Per-parent user intent that overrides the auto-expand/collapse rules.
+   * Entries live as long as the parent is in `childStreamsByParent`; a new
+   * appearance (new run) starts from auto. One map replaces the former
+   * `manuallyCollapsed` + `finishedCollapseHandled` sets.
    */
-  private manuallyCollapsed: Set<string> = new Set();
+  private userOverride: Map<string, 'expanded' | 'collapsed'> = new Map();
+
+  protected override willUpdate(changed: import('lit').PropertyValues): void {
+    if (!changed.has('childStreamsByParent') && !changed.has('streamStates'))
+      return;
+
+    for (const parentId of this.userOverride.keys()) {
+      if (!this.childStreamsByParent.has(parentId)) {
+        this.userOverride.delete(parentId);
+      }
+    }
+
+    const next = new Set<string>();
+    for (const [parentId, children] of this.childStreamsByParent) {
+      if (this.computeExpanded(parentId, children)) next.add(parentId);
+    }
+
+    if (!setsEqual(next, this.expandedParents)) this.expandedParents = next;
+  }
 
   /**
-   * Parents where the "all children finished" transition has already been
-   * handled — either we auto-collapsed, or the user manually expanded after.
-   * Prevents re-collapsing a parent the user has chosen to keep open.
-   * Cleared when any child becomes active again (new run).
+   * Single source of truth for "is this parent's child list expanded?".
+   * Rules (top to bottom):
+   *   1. Honor user intent if set.
+   *   2. Expand if any child is actively running.
+   *   3. Collapse once all children have reached a terminal status.
+   *   4. Otherwise (mixed / still-unknown), keep expanded — default on
+   *      first appearance before status events arrive.
    */
-  private finishedCollapseHandled: Set<string> = new Set();
+  private computeExpanded(
+    parentId: string,
+    children: readonly StreamTabInfo[],
+  ): boolean {
+    const override = this.userOverride.get(parentId);
+    if (override) return override === 'expanded';
 
-  /** Auto-expand when children appear, auto-collapse when gone or finished. */
-  protected override willUpdate(changed: import('lit').PropertyValues): void {
-    const childrenChanged = changed.has('childStreamsByParent');
-    const statesChanged = changed.has('streamStates');
-    if (!childrenChanged && !statesChanged) return;
-
-    let dirty = false;
-    const next = new Set(this.expandedParents);
-
-    if (childrenChanged) {
-      for (const parentId of this.childStreamsByParent.keys()) {
-        if (!next.has(parentId) && !this.manuallyCollapsed.has(parentId)) {
-          next.add(parentId);
-          dirty = true;
-        }
-      }
-      for (const parentId of next) {
-        if (!this.childStreamsByParent.has(parentId)) {
-          next.delete(parentId);
-          this.manuallyCollapsed.delete(parentId);
-          this.finishedCollapseHandled.delete(parentId);
-          dirty = true;
-        }
-      }
-      // Parents dropped from `next` above are already cleaned; these passes
-      // cover parents still tracked but no longer in childStreamsByParent.
-      for (const parentId of this.manuallyCollapsed) {
-        if (!this.childStreamsByParent.has(parentId)) {
-          this.manuallyCollapsed.delete(parentId);
-        }
-      }
-      for (const parentId of this.finishedCollapseHandled) {
-        if (!this.childStreamsByParent.has(parentId)) {
-          this.finishedCollapseHandled.delete(parentId);
-        }
-      }
+    let anyActive = false;
+    let anyUnknown = false;
+    for (const child of children) {
+      const activity = classifyChild(this.streamStates, child.name);
+      if (activity === 'active') anyActive = true;
+      else if (activity === 'unknown') anyUnknown = true;
     }
-
-    // Auto-collapse once per finish-transition; reset when a child reactivates.
-    for (const parentId of next) {
-      const children = this.childStreamsByParent.get(parentId);
-      if (!children) continue;
-      const allFinished = children.every(
-        (c) => !ACTIVE_CHILD_STATUSES.has(this.getStatus(c.name)),
-      );
-      if (!allFinished) {
-        this.finishedCollapseHandled.delete(parentId);
-        continue;
-      }
-      if (this.finishedCollapseHandled.has(parentId)) continue;
-      next.delete(parentId);
-      this.finishedCollapseHandled.add(parentId);
-      dirty = true;
-    }
-
-    if (dirty) this.expandedParents = next;
+    if (anyActive) return true;
+    if (anyUnknown) return true;
+    return false;
   }
 
   private getStatus(name: StreamTabId): string {
@@ -674,7 +674,7 @@ export class StreamTabs extends LitElement {
                 // prettier-ignore
                 return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.getStatus(stream.name)} .lastTimestamp=${this.getTimestamp(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${childCount} ?expanded=${expanded}></stream-tab>${children && childCount > 0 ? html`<div class="child-streams" ?hidden=${!expanded}>${repeat(children, (child) => child.name, (child) => {
                   const childStatus = this.getStatus(child.name);
-                  const isFinished = !ACTIVE_CHILD_STATUSES.has(childStatus);
+                  const isFinished = classifyChild(this.streamStates, child.name) === 'finished';
                   // prettier-ignore
                   return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.getTimestamp(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
                 })}</div>` : nothing}`;
@@ -775,16 +775,10 @@ export class StreamTabs extends LitElement {
 
   private toggleChildren(parentId: string): void {
     const next = new Set(this.expandedParents);
-    if (next.has(parentId)) {
-      next.delete(parentId);
-      this.manuallyCollapsed.add(parentId);
-    } else {
-      next.add(parentId);
-      this.manuallyCollapsed.delete(parentId);
-      // Mark finish-transition as handled so willUpdate doesn't immediately
-      // re-collapse a parent the user just chose to expand.
-      this.finishedCollapseHandled.add(parentId);
-    }
+    const nowExpanded = !next.has(parentId);
+    if (nowExpanded) next.add(parentId);
+    else next.delete(parentId);
+    this.userOverride.set(parentId, nowExpanded ? 'expanded' : 'collapsed');
     this.expandedParents = next;
   }
 

--- a/src/progressView/frontend/utils.ts
+++ b/src/progressView/frontend/utils.ts
@@ -33,3 +33,13 @@ export function getComposedPathElement<T extends Element>(
   }
   return null;
 }
+
+/** Shallow equality check — avoids triggering Lit re-renders when the
+ *  derived set is the same as the previous one. */
+export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) {
+    if (!b.has(v)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

- Workflow-mode agents with `storageMode = taskRunStorage` (and all subagents, which force run storage) mimic the workspace under `executions/<id>/` via symlinks. Figures referenced via `\includegraphics` weren't being mirrored, so `latexmk` inside the run dir failed when any figure was referenced.
- `extractFigurePathsFromLatex` took `path.dirname(file.absolutePath)` as the search root — for a symlinked `.tex` that's the run-storage dir, where the figures don't exist, so extraction returned empty. The same bug was in `mirrorFigureDependencies`: even a correct figure list produced run-storage absolute paths, which `pathToLocation` classified as external and `mirrorWorkspaceFile` then skipped.
- `processOutputFiles` (round 1+) disabled both figure and `\input` mirroring, so figures newly referenced by agent edits weren't available at compile time either.

## Changes

- New `resolveLatexDir()` helper in `src/latex/latexParsingUtils.ts` that `fs.realpath`-resolves a tex file's directory (with a graceful fallback for missing files). Mirrors the pattern already used by `extractFileDependencies`.
- `extractFigurePathsFromLatex`, `mirrorFigureDependencies`, and the `extractFiguresFromFiles` inner loop all use it — figure paths now resolve against the real workspace dir when the tex is symlinked into run storage.
- New private `mirrorFiguresForFiles()` mirrors figure deps without touching the model's vision context (so output files don't re-send figures as images each round).
- Replaced the `includeFigureExtraction` / `mirrorFigureDeps` boolean pair with a single `figureMode: 'extract' | 'mirror' | 'none'` to make the mutual exclusivity explicit.
- `processOutputFiles` now runs `figureMode: 'mirror'` + `mirrorFileDependencies: true` so newly-referenced figures and `\input` targets are symlinked before PDF compilation.

## Test plan

- [ ] Set `texra.agentOutputs.storageMode = taskRunStorage` and run a workflow agent on a doc that references `\includegraphics{figures/plot.pdf}` and `\input{subfile.tex}`. Confirm `executions/<id>/figures/plot.pdf` and `…/subfile.tex` are symlinks after round 0, and `executions/<id>/build/<paper>.pdf` compiles.
- [ ] Round 1+: prompt the agent to introduce a new `\includegraphics` reference. Confirm the figure is symlinked and the output PDF compiles.
- [ ] Subagent: trigger a subagent workflow (always forces run storage). Same checks as above.
- [ ] Regression: with default `storageMode = workspace`, confirm behavior unchanged (realpath is a no-op; `mirrorWorkspaceFile` remains idempotent).
- [ ] `npm run typecheck` and `npm run compile:fast` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how LaTeX figure/dependency paths are resolved and mirrored when files are symlinked into run storage, which can affect PDF compilation behavior across workflow rounds. Also adjusts Progress view child-stream auto expand/collapse logic, potentially impacting sidebar UX state handling.
> 
> **Overview**
> Fixes LaTeX compilation in `taskRunStorage` mode by resolving `.tex` directories via realpath (new `resolveLatexDir`) so `\\includegraphics` figure paths and mirroring target the underlying workspace files instead of run-storage symlink paths.
> 
> Updates output-round processing to *mirror* newly referenced figures and `\\input`/include/bib dependencies into run storage without re-adding figures to the vision context, and replaces the previous figure booleans with an explicit `figureMode: 'extract' | 'mirror' | 'none'`.
> 
> Refactors Progress view utilities by centralizing `setsEqual` and revises `StreamTabs` parent expansion to be derived from stream state (active/unknown/finished) with a per-parent user override, reducing unnecessary re-renders and making expand/collapse behavior more predictable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddfbe9a8b8ebef41fb524395835cf0fe44d05cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->