### PR TITLE
feat(openai): default workflow GPT requests to background mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
           },
           "texra.model.useBackgroundResponses": {
             "type": "boolean",
-            "default": false,
-            "description": "Keep long-running OpenAI requests alive in the background instead of timing out after 10 minutes. Useful for complex tasks but adds slight overhead.",
+            "default": true,
+            "description": "Keep long-running OpenAI requests alive in the background (polling) instead of timing out after 10 minutes. Applies automatically to GPT models running workflow agents; ignored otherwise. Disable to fall back to synchronous streaming requests.",
             "scope": "resource"
           },
           "texra.model.openaiParallelToolCalls": {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -216,7 +216,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
   public override isBackgroundModeActive(): boolean {
     const useBackgroundResponses = getConfig<boolean>(
       'texra.model.useBackgroundResponses',
-      false,
+      true,
     );
     return useBackgroundResponses && this.isBackgroundModeEligible();
   }
@@ -233,12 +233,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Determines if background mode should be enabled for this request.
-   * Background mode is only supported for GPT 5 series models when running
-   * workflow agents (CoT or Direct), not tool-use agents.
+   * Enabled for GPT-family models (gpt4*, gpt5*, etc.) when running a
+   * workflow agent (CoT or Direct) — not for tool-use agents, which rely
+   * on per-step streaming.
    */
   private isBackgroundModeEligible(): boolean {
-    const isGpt5 = this.config.name.toLowerCase().startsWith('gpt5');
-    return isGpt5 && this.isWorkflowMode();
+    const isGpt = this.config.name.toLowerCase().startsWith('gpt');
+    return isGpt && this.isWorkflowMode();
   }
 
   private static readonly BACKGROUND_POLL_INTERVAL_MS = 15000;
@@ -1546,7 +1547,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     const streamingToggleEnabled = this.getStreamingConfig();
     const backgroundToggleEnabled = getConfig<boolean>(
       'texra.model.useBackgroundResponses',
-      false,
+      true,
     );
     const useBackgroundResponses =
       this.backgroundModeSupported &&
@@ -1559,7 +1560,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (backgroundToggleEnabled && !useBackgroundResponses) {
       const reason = !this.backgroundModeSupported
         ? 'this handler does not support background execution'
-        : 'not eligible for this model/agent type (requires GPT 5 series with workflow agents)';
+        : 'not eligible for this model/agent type (requires a GPT model with a workflow agent)';
       this.logger.debug(
         `Background mode toggle is enabled but ${reason}. Falling back to synchronous requests.`,
       );


### PR DESCRIPTION
## Summary

- Workflow-mode runs on GPT models often exceed the 10-minute synchronous timeout on the OpenAI Responses API. Background mode exists but was gated behind a user toggle defaulted to off, and only eligible for GPT-5.
- **Widen eligibility** in `isBackgroundModeEligible()` from \`startsWith('gpt5')\` to \`startsWith('gpt')\`, covering gpt-4*/4o/4.1/4.5/5* variants. Tool-use agents remain excluded (per-step streaming is intentional for them).
- **Flip the default** of \`texra.model.useBackgroundResponses\` from \`false\` → \`true\` (and update both \`getConfig\` fallbacks to match). The setting still acts as a master opt-out; non-GPT or non-workflow handlers are unaffected because the eligibility guard short-circuits.

## Scope

Changes:
- \`src/agent/modelHandlers/modelHandlerOpenAIResponse.ts\` — eligibility check + two \`getConfig\` fallbacks + the fallback-reason log text.
- \`package.json\` — \`texra.model.useBackgroundResponses\` default + description.

Unchanged: \`backgroundModeSupported\`, polling interval/max-duration, streaming/WebSocket incompatibility, compaction logic.

## Test plan

- [ ] Run a workflow agent on a GPT-4o / gpt-4.1 / gpt-5 model without touching settings. Confirm the request uses \`background: true\` (look for \`client.responses.create({ background: true, ... })\` in logs / network).
- [ ] Run a tool-use agent on a GPT model. Confirm it still streams (background guard rejects tool-use).
- [ ] Manually set \`texra.model.useBackgroundResponses\` to \`false\`. Confirm workflow GPT runs fall back to synchronous streaming.
- [ ] Run a workflow agent on a non-GPT OpenAI model (e.g. \`o3\`). Confirm behavior is unchanged (eligibility returns false; no "falling back to synchronous" log).
- [ ] \`npm run typecheck\` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default execution mode for OpenAI GPT workflow requests from synchronous streaming to background polling, which can impact latency/UX and error-handling behavior. Eligibility logic is broadened from GPT-5-only to all `gpt*` models, increasing the blast radius.
> 
> **Overview**
> **Background mode is now on by default** via `texra.model.useBackgroundResponses` (default `false` → `true`) and updated copy clarifying it uses polling and is an opt-out.
> 
> `ModelHandlerOpenAIResponse` now treats background mode as eligible for *any* `gpt*` model when running workflow agents (still excluding tool-use agents), and updates config fallbacks/log messaging to match the new default and wider eligibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2ae9c9d1ed4ef5cfc4400515fd61e4e3a9f7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->