### PR TITLE
feat(webview): explain workflow, interactive, and orchestrator modes inline

### DIFF
--- a/src/shared/utils/selectTemplates.ts
+++ b/src/shared/utils/selectTemplates.ts
@@ -13,7 +13,9 @@ function buildAgentTooltip(opt: AgentOptionData): string {
   const hints: string[] = [];
 
   if (opt.isOrchestrator)
-    hints.push('Coordinates agents to work on your paper');
+    hints.push(
+      'Plans a pipeline of specialized agents. Name them in your instruction to steer delegation.',
+    );
   if (opt.isRemote) hints.push(properties.remote.hint);
   if (opt.isCustom) hints.push(properties.custom.hint);
   if (opt.description) hints.push(opt.description);

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -36,6 +36,47 @@ import {
   type SessionContextValue,
 } from '../contexts/mainViewContexts';
 
+type SessionHintKey = SessionType | 'orchestrator';
+
+const SESSION_HINT_COPY: Record<
+  SessionHintKey,
+  { lede: string; body: string; time: string; ariaLabel: string }
+> = {
+  workflow: {
+    lede: 'Deep pass.',
+    body: 'Drafts, reviews its own work, then revises — across your whole document.',
+    time: 'Typically 5–10 min on fast models, 10–30 min on frontier reasoning. Pick a smaller model if you need faster turnaround.',
+    ariaLabel: 'About workflow mode',
+  },
+  toolUse: {
+    lede: 'Conversational.',
+    body: 'Reads, edits, and searches in a running dialogue you steer turn by turn.',
+    time: 'Turns stream back in seconds; tool-heavy runs take a minute or two. Pick a stronger model for longer chains of reasoning.',
+    ariaLabel: 'About interactive mode',
+  },
+  orchestrator: {
+    lede: 'Orchestrator.',
+    body: 'Plans a pipeline of specialized agents and dispatches them for you.',
+    time: 'Name specific agents in your instruction (e.g., “use polish on the intro, then review the math”) to steer delegation — otherwise it picks. Approve tasks in Progress as they arrive.',
+    ariaLabel: 'About orchestrator mode',
+  },
+};
+
+function getSessionTitle(type: SessionType): string {
+  const copy = SESSION_HINT_COPY[type];
+  return `${copy.lede} ${copy.body}`;
+}
+
+function resolveSessionHintKey(session: SessionContextValue): SessionHintKey {
+  if (session.sessionType === 'toolUse') {
+    const opt = session.toolUseAgentOptions.find(
+      (o) => o.value === session.toolUseAgent,
+    );
+    if (opt?.isOrchestrator) return 'orchestrator';
+  }
+  return session.sessionType;
+}
+
 @customElement('instruction-panel')
 export class InstructionPanel extends LitElement {
   static override styles = [
@@ -93,6 +134,34 @@ export class InstructionPanel extends LitElement {
 
       .instruction-session-toggle vscode-radio {
         font-size: var(--font-size-sm);
+      }
+
+      .session-hint {
+        display: flex;
+        gap: var(--spacing-small);
+        align-items: baseline;
+        margin-top: var(--spacing-small);
+        padding: var(--spacing-tiny) var(--spacing-small);
+        border-left: 2px solid var(--vscode-textLink-foreground);
+        color: var(--vscode-descriptionForeground);
+        font-size: var(--font-size-sm);
+        line-height: var(--line-height-relaxed);
+      }
+
+      .session-hint-lede {
+        color: var(--vscode-foreground);
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        white-space: nowrap;
+      }
+
+      .session-hint-body {
+        flex: 1 1 auto;
+      }
+
+      .session-hint-time {
+        color: var(--vscode-descriptionForeground);
+        opacity: 0.85;
       }
 
       vscode-textarea#instruction {
@@ -220,6 +289,19 @@ export class InstructionPanel extends LitElement {
     return options.find((o) => o.value === selectedValue)?.hint ?? '';
   }
 
+  private renderSessionHint(session: SessionContextValue): TemplateResult {
+    const copy = SESSION_HINT_COPY[resolveSessionHintKey(session)];
+    return html`
+      <div class="session-hint" role="note" aria-label=${copy.ariaLabel}>
+        <span class="session-hint-lede">${copy.lede}</span>
+        <span class="session-hint-body">
+          ${copy.body}
+          <span class="session-hint-time">${copy.time}</span>
+        </span>
+      </div>
+    `;
+  }
+
   private handleSessionTypeChange(event: Event): void {
     const target = event.target as HTMLInputElement | null;
     const value =
@@ -330,7 +412,7 @@ export class InstructionPanel extends LitElement {
                   value="toolUse"
                   data-session-type="toolUse"
                   ?checked=${session.sessionType === SESSION_TYPES.TOOL_USE}
-                  title="Chat-style agents that can run commands, browse files, and use tools — like a research assistant you talk to"
+                  title=${getSessionTitle(SESSION_TYPES.TOOL_USE)}
                 >
                   Interactive
                 </vscode-radio>
@@ -338,7 +420,7 @@ export class InstructionPanel extends LitElement {
                   value="workflow"
                   data-session-type="workflow"
                   ?checked=${session.sessionType === SESSION_TYPES.WORKFLOW}
-                  title="One-shot agents that read your document, apply edits, and produce a revised file — no back-and-forth needed"
+                  title=${getSessionTitle(SESSION_TYPES.WORKFLOW)}
                 >
                   Workflow
                 </vscode-radio>
@@ -402,6 +484,7 @@ export class InstructionPanel extends LitElement {
             ></vscode-toolbar-button>
           </vscode-toolbar-container>
         </div>
+        ${this.renderSessionHint(session)}
         <vscode-textarea
           id="instruction"
           rows="10"

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -68,7 +68,7 @@ function getSessionTitle(type: SessionType): string {
 }
 
 function resolveSessionHintKey(session: SessionContextValue): SessionHintKey {
-  if (session.sessionType === 'toolUse') {
+  if (session.sessionType === SESSION_TYPES.TOOL_USE) {
     const opt = session.toolUseAgentOptions.find(
       (o) => o.value === session.toolUseAgent,
     );

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -1,9 +1,10 @@
 /**
- * Banner explaining the orchestrator agent workflow.
+ * Banner with orchestrator-specific tips.
  *
- * Appears when the orchestrator is selected in the agent dropdown
- * to help users understand the delegation-based workflow.
- * Dismissable via a "Got it" button; dismissal persists to settings.
+ * Appears when the orchestrator is selected. The conceptual explanation
+ * lives in the InstructionPanel's session-hint; this banner adds only
+ * complementary info: the approval keyboard shortcut and a shortcut
+ * to Multi-Agent settings. Dismissable via "Got it".
  *
  * @fires dismiss-orchestrator - When dismiss button is clicked
  */
@@ -111,20 +112,18 @@ export class OrchestratorBanner extends LitElement {
 
     return html`
       <div class="orchestrator-banner">
-        <strong>Orchestrator selected.</strong> Hit Execute to analyze your
-        paper and generate improvement tasks. Review and approve them in
-        Progress — press <strong>y</strong>/<strong>n</strong> to approve or
-        reject quickly.
-        <div class="orchestrator-banner-footer">
-          <span class="orchestrator-tip"
-            >Customize auto-approve rules and task presets in
-            <button
-              class="settings-link"
-              @click=${this.handleOpenMultiAgentSettings}
-            >
-              Multi-Agent settings</button
-            >.</span
+        <span class="orchestrator-tip">
+          <strong>Tip:</strong> press <strong>y</strong>/<strong>n</strong> in
+          the Progress board to approve or reject proposed tasks fast. Tune
+          auto-approve rules and presets in
+          <button
+            class="settings-link"
+            @click=${this.handleOpenMultiAgentSettings}
           >
+            Multi-Agent settings</button
+          >.
+        </span>
+        <div class="orchestrator-banner-footer">
           <button
             class="got-it-btn"
             title="Dismiss (can be re-enabled in settings)"

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -47,7 +47,7 @@ export class OrchestratorBanner extends LitElement {
       .orchestrator-banner-footer {
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        justify-content: flex-end;
         margin-top: var(--spacing-small);
       }
 

--- a/src/webview/frontend/store.ts
+++ b/src/webview/frontend/store.ts
@@ -159,9 +159,9 @@ export const ONBOARDING_PLACEHOLDERS = {
     'Run LaTeX checks and report compilation warnings.',
   ],
   orchestrator: [
-    'Review my paper and suggest improvements.',
-    'Leave blank -- the orchestrator will figure out what to do.',
-    'Polish the writing, then run a critical review.',
+    'Use polish on the intro, then have review audit the math.',
+    'Run correct across the paper, then have review check every derivation.',
+    'Leave blank — the orchestrator will plan the pipeline for you.',
   ],
 } satisfies Record<SessionType | 'orchestrator', string[]>;
 


### PR DESCRIPTION
## Summary

- Adds an always-visible session hint under the Interactive / Workflow toggle in the main instruction panel. Copy adapts to the selected mode:
  - **Workflow** — *"Deep pass. Drafts, reviews its own work, then revises across your whole document."* plus typical time ranges (5–10 min fast / 10–30 min frontier reasoning) and a nudge to pick a smaller model for faster turnaround.
  - **Interactive (tool-use)** — *"Conversational. Reads, edits, and searches in a running dialogue you steer turn by turn."* plus per-turn latency expectations.
  - **Orchestrator** (tool-use agent with delegation tools) — *"Plans a pipeline of specialized agents and dispatches them for you."* plus guidance to name specific agents (e.g. `polish`, `correct`, `review`) in the instruction to steer delegation.
- Aligns sibling surfaces to the new copy so the orchestrator story reads consistently:
  - Interactive/Workflow **radio tooltips** now derive from the same `SESSION_HINT_COPY` record — one source of truth for the descriptive copy.
  - **Agent-dropdown tooltip** for orchestrator entries updated from vague "Coordinates agents" to match the new framing.
  - **`OrchestratorBanner`** trimmed to only complementary info: the y/n approval shortcut and the Multi-Agent settings link (no longer repeats the conceptual explanation now owned by the hint).
  - **`ONBOARDING_PLACEHOLDERS.orchestrator`** examples rewritten to showcase named-agent prompting.

## Test plan

- [ ] Open the main view with **Interactive** selected and a non-orchestrator tool-use agent — verify the "Conversational." hint appears under the toggle.
- [ ] Switch to **Workflow** — verify the hint morphs to "Deep pass." copy with time ranges.
- [ ] Pick an orchestrator agent (🎯 icon) while in **Interactive** mode — verify the hint morphs to "Orchestrator." copy with the named-agent guidance.
- [ ] Confirm `OrchestratorBanner` still appears on first run but now shows only the y/n tip + Multi-Agent settings link (no conceptual repeat).
- [ ] Hover the orchestrator agent option inside the dropdown — tooltip matches the new framing.
- [ ] Hover the Interactive/Workflow radios — titles are derived from the hint copy (no stale strings).
- [ ] Leave the instruction textarea empty while Interactive + orchestrator is selected — rotating placeholder examples showcase `polish` / `correct` / `review` by name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI-only copy/styling updates and tooltip/placeholder tweaks with no behavior or data-flow changes beyond which hint text is displayed.
> 
> **Overview**
> Adds an always-visible **session hint** under the Interactive/Workflow toggle in `InstructionPanel`, including dedicated orchestrator copy when a tool-use orchestrator agent is selected.
> 
> Unifies radio-button tooltips to derive from the same hint copy, updates orchestrator agent dropdown tooltip wording, trims `OrchestratorBanner` down to keyboard-shortcut/settings tips, and refreshes orchestrator onboarding placeholders to encourage named-agent prompting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406b2926431004c060338a9fd1ca0ab521522656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->