### PR TITLE
docs(guide): add workflow-mode guidance tip to agent architecture

### DIFF
--- a/docs/guide/agent-architecture.md
+++ b/docs/guide/agent-architecture.md
@@ -2,6 +2,12 @@
 
 Every time you click "Execute" in TeXRA, an **agent** takes your files and instructions, asks an AI model to do the work, and delivers the result. This page explains what happens under the hood—enough to understand the system, customize it, and troubleshoot when things go sideways.
 
+::: tip When to use workflow mode
+Workflow agents are built for **deep, single-shot thinking**—things like rewriting a whole section, deriving or checking equations step-by-step, converting a paper to slides, or merging edits. They plan in a `<scratchpad>`, produce a full XML-wrapped output, and optionally reflect on it for another round, so runs with frontier reasoning models can take **10–30 minutes** to finish.
+
+If you want a snappier turnaround (e.g. quick polishes, small corrections), pick a **smaller or faster model** in the model dropdown—output quality drops somewhat, but wall-clock time drops a lot. For short, conversational edits or read-only questions, use a **tool-use agent** (`chat`, `ask`, `research`) instead: those stream back in seconds and don't go through the full workflow pipeline.
+:::
+
 ## Agent Definition Files (`.yaml`)
 
 Each agent is defined in a simple `.yaml` file that tells TeXRA what to say to the AI model and how to handle the response. You can browse and manage these files from the **Agents** tab in the TeXRA Dashboard, or create your own (see [Custom Agents](./custom-agents.md)).


### PR DESCRIPTION
## Summary

- Adds a **\"When to use workflow mode\"** tip near the top of \`docs/guide/agent-architecture.md\` so users understand the 10–30 minute runtime trade-off before they start a workflow run.
- Points users at the faster alternatives: smaller/faster models in the dropdown, or tool-use agents (\`chat\`, \`ask\`, \`research\`) for short conversational or read-only requests.

No code changes — documentation only.

## Test plan

- [ ] \`pnpm --filter docs build\` (or the site's usual docs build) — verify the VitePress \`::: tip\` block renders correctly and the header/list layout on the rest of the page is unchanged.
- [ ] Eyeball the rendered page locally at \`/guide/agent-architecture\` to confirm the tip appears between the intro paragraph and the \"Agent Definition Files\" heading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds guidance on when to use workflow agents vs faster alternatives, with no impact on runtime behavior.
> 
> **Overview**
> Adds a new VitePress `::: tip` near the top of `docs/guide/agent-architecture.md` explaining when to use *workflow mode*, including the typical **10–30 minute** runtime for frontier reasoning models.
> 
> Directs users toward faster options (choosing a smaller/faster model, or using tool-use agents like `chat`, `ask`, `research`) for quick edits or read-only questions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc29d096931c2375598014c6609414e747a8882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->