### PR TITLE
fix(settings): refresh Tools tab after GitHub token change

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -154,6 +154,13 @@ export interface ProgressEventPayloads {
   /** Active PR-activity subscription keys changed; frontends refresh their list. */
   prSubscriptionsChanged: { keys: readonly string[] };
 
+  /**
+   * External tool availability was re-probed. Frontends (Tools tab) refresh
+   * their dashboard from the updated cache. Emitted by
+   * {@link invalidateToolAvailability}.
+   */
+  toolAvailabilityChanged: undefined;
+
   // ── Frontend-bound events ──
   // Emitted by agent core/runtime; consumed by frontend listeners.
   // Keeps @agent/ free of @frontend/ imports.

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -157,7 +157,7 @@ export interface ProgressEventPayloads {
   /**
    * External tool availability was re-probed. Frontends (Tools tab) refresh
    * their dashboard from the updated cache. Emitted by
-   * {@link invalidateToolAvailability}.
+   * {@link refreshToolAvailability}.
    */
   toolAvailabilityChanged: undefined;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,6 +306,16 @@ export async function activate(context: vscode.ExtensionContext) {
       await refreshGitHubToken();
       await invalidateToolAvailability();
     }),
+    // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
+    // reflects the new state without the user clicking Re-check.
+    vscode.extensions.onDidChange(() => {
+      void invalidateToolAvailability();
+    }),
+    // Workspace folders opened/closed can flip `isGitRepository`, which
+    // gates the GitHub PR subscription tool group.
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      void invalidateToolAvailability();
+    }),
   );
   const disposeGitHubAuthListener = bus.on(
     'githubTokenInvalid',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,13 +298,13 @@ export async function activate(context: vscode.ExtensionContext) {
   setGitHubTokenProvider(() => cachedGitHubToken);
   void refreshGitHubToken();
   context.subscriptions.push(
-    context.secrets.onDidChange((e) => {
-      if (e.key === SecretManager.GITHUB_TOKEN_KEY) {
-        // Refresh the cached token first so availability checks see the
-        // new value, then re-probe so any subscribed UI (Tools tab) and
-        // the runtime cache pick up the change automatically.
-        void refreshGitHubToken().then(() => invalidateToolAvailability());
-      }
+    context.secrets.onDidChange(async (e) => {
+      if (e.key !== SecretManager.GITHUB_TOKEN_KEY) return;
+      // Refresh the cached token first so availability checks see the
+      // new value, then re-probe so any subscribed UI (Tools tab) and
+      // the runtime cache pick up the change automatically.
+      await refreshGitHubToken();
+      await invalidateToolAvailability();
     }),
   );
   const disposeGitHubAuthListener = bus.on(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,24 +297,40 @@ export async function activate(context: vscode.ExtensionContext) {
   };
   setGitHubTokenProvider(() => cachedGitHubToken);
   void refreshGitHubToken();
+  // VS Code's event emitters don't await async listeners, so we funnel
+  // fire-and-forget async work through this helper to log rejections
+  // instead of letting them become unhandled promise rejections.
+  const logRefreshFailure = (trigger: string) => (err: unknown) => {
+    logger.error(
+      'extension',
+      `Tool availability refresh failed (${trigger}): ${toErrorMessage(err)}`,
+    );
+  };
+
   context.subscriptions.push(
-    context.secrets.onDidChange(async (e) => {
+    context.secrets.onDidChange((e) => {
       if (e.key !== SecretManager.GITHUB_TOKEN_KEY) return;
       // Refresh the cached token first so availability checks see the
       // new value, then re-probe so any subscribed UI (Tools tab) and
       // the runtime cache pick up the change automatically.
-      await refreshGitHubToken();
-      await refreshToolAvailability();
+      void (async () => {
+        await refreshGitHubToken();
+        await refreshToolAvailability();
+      })().catch(logRefreshFailure('secret change'));
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.
     vscode.extensions.onDidChange(() => {
-      void refreshToolAvailability();
+      void refreshToolAvailability().catch(
+        logRefreshFailure('extension change'),
+      );
     }),
     // Workspace folders opened/closed can flip `isGitRepository`, which
     // gates the GitHub PR subscription tool group.
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      void refreshToolAvailability();
+      void refreshToolAvailability().catch(
+        logRefreshFailure('workspace folder change'),
+      );
     }),
   );
   const disposeGitHubAuthListener = bus.on(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ import { UsageLogService } from '@logger/UsageLogService';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { interruptAllCodexSessions } from '@tools/codex';
 import { setExtensionChecker } from '@tools/externalToolDefs';
-import { invalidateToolAvailability } from '@tools/toolAvailability';
+import { refreshToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
 import { getAuthStatus } from '@auth/authCommands';
 import { setGitHubTokenProvider, prPollingSource } from '@tools/github';
@@ -304,17 +304,17 @@ export async function activate(context: vscode.ExtensionContext) {
       // new value, then re-probe so any subscribed UI (Tools tab) and
       // the runtime cache pick up the change automatically.
       await refreshGitHubToken();
-      await invalidateToolAvailability();
+      await refreshToolAvailability();
     }),
     // Lean/LaTeX extension installed or removed → re-probe so the Tools tab
     // reflects the new state without the user clicking Re-check.
     vscode.extensions.onDidChange(() => {
-      void invalidateToolAvailability();
+      void refreshToolAvailability();
     }),
     // Workspace folders opened/closed can flip `isGitRepository`, which
     // gates the GitHub PR subscription tool group.
     vscode.workspace.onDidChangeWorkspaceFolders(() => {
-      void invalidateToolAvailability();
+      void refreshToolAvailability();
     }),
   );
   const disposeGitHubAuthListener = bus.on(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,7 @@ import { UsageLogService } from '@logger/UsageLogService';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
 import { interruptAllCodexSessions } from '@tools/codex';
 import { setExtensionChecker } from '@tools/externalToolDefs';
+import { invalidateToolAvailability } from '@tools/toolAvailability';
 import { setSetupPlatform } from '@tools/setup';
 import { getAuthStatus } from '@auth/authCommands';
 import { setGitHubTokenProvider, prPollingSource } from '@tools/github';
@@ -299,7 +300,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     context.secrets.onDidChange((e) => {
       if (e.key === SecretManager.GITHUB_TOKEN_KEY) {
-        void refreshGitHubToken();
+        // Refresh the cached token first so availability checks see the
+        // new value, then re-probe so any subscribed UI (Tools tab) and
+        // the runtime cache pick up the change automatically.
+        void refreshGitHubToken().then(() => invalidateToolAvailability());
       }
     }),
   );

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -92,7 +92,7 @@ import {
 } from '@tools/approval';
 import {
   getLastCheckResults,
-  onToolAvailabilityChanged,
+  invalidateToolAvailability,
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
 import {
@@ -323,11 +323,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     bus.on('prSubscriptionsChanged', ({ keys }) => {
       void this.withActiveWebview((w) => this.sendPRSubscriptions(w, keys));
     });
-
-    // Push a refreshed Tools tab whenever external tool availability
-    // changes (e.g. GitHub token set/removed in the Git tab). The probe
-    // already ran inside `invalidateToolAvailability`, so skip re-probing.
-    onToolAvailabilityChanged(() => {
+    bus.on('toolAvailabilityChanged', () => {
       void this.withActiveWebview((w) =>
         this.sendToolDashboardData(w, { skipChecks: true }),
       );
@@ -561,7 +557,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION]: (data) =>
         this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
-        this.withActiveWebview((w) => this.sendToolDashboardData(w)),
+        invalidateToolAvailability(),
       [SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL]: async (data) => {
         await setToolEnabled(data.toolId, data.enabled);
         refreshDisabledToolCache();
@@ -915,8 +911,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await SecretManager.set(SecretManager.GITHUB_TOKEN_KEY, token.trim());
       void vscode.window.showInformationMessage('GitHub token saved.');
       await this.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
-      // The Tools tab refreshes automatically via `onToolAvailabilityChanged`,
-      // triggered by the secret-storage change listener in extension.ts.
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -92,6 +92,7 @@ import {
 } from '@tools/approval';
 import {
   getLastCheckResults,
+  onToolAvailabilityChanged,
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
 import {
@@ -321,6 +322,15 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // Lifetime == extension; bus is process-global so no dispose needed.
     bus.on('prSubscriptionsChanged', ({ keys }) => {
       void this.withActiveWebview((w) => this.sendPRSubscriptions(w, keys));
+    });
+
+    // Push a refreshed Tools tab whenever external tool availability
+    // changes (e.g. GitHub token set/removed in the Git tab). The probe
+    // already ran inside `invalidateToolAvailability`, so skip re-probing.
+    onToolAvailabilityChanged(() => {
+      void this.withActiveWebview((w) =>
+        this.sendToolDashboardData(w, { skipChecks: true }),
+      );
     });
   }
 
@@ -905,9 +915,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await SecretManager.set(SecretManager.GITHUB_TOKEN_KEY, token.trim());
       void vscode.window.showInformationMessage('GitHub token saved.');
       await this.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
-      // Re-probe external tools so the Tools tab and the runtime
-      // availability cache pick up the new token without a manual recheck.
-      await this.withActiveWebview((w) => this.sendToolDashboardData(w));
+      // The Tools tab refreshes automatically via `onToolAvailabilityChanged`,
+      // triggered by the secret-storage change listener in extension.ts.
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
@@ -922,7 +931,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await SecretManager.delete(SecretManager.GITHUB_TOKEN_KEY);
       void vscode.window.showInformationMessage('GitHub token removed.');
       await this.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
-      await this.withActiveWebview((w) => this.sendToolDashboardData(w));
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -92,7 +92,7 @@ import {
 } from '@tools/approval';
 import {
   getLastCheckResults,
-  invalidateToolAvailability,
+  refreshToolAvailability,
   refreshDisabledToolCache,
 } from '@tools/toolAvailability';
 import {
@@ -557,7 +557,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION]: (data) =>
         this.handleInstallToolExtension(data),
       [SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS]: () =>
-        invalidateToolAvailability(),
+        refreshToolAvailability(),
       [SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL]: async (data) => {
         await setToolEnabled(data.toolId, data.enabled);
         refreshDisabledToolCache();

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -905,6 +905,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await SecretManager.set(SecretManager.GITHUB_TOKEN_KEY, token.trim());
       void vscode.window.showInformationMessage('GitHub token saved.');
       await this.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
+      // Re-probe external tools so the Tools tab and the runtime
+      // availability cache pick up the new token without a manual recheck.
+      await this.withActiveWebview((w) => this.sendToolDashboardData(w));
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
@@ -919,6 +922,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await SecretManager.delete(SecretManager.GITHUB_TOKEN_KEY);
       void vscode.window.showInformationMessage('GitHub token removed.');
       await this.withActiveWebview((w) => this.sendGitHubTokenStatus(w));
+      await this.withActiveWebview((w) => this.sendToolDashboardData(w));
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1591,8 +1591,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleInstallToolExtension(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.INSTALL_TOOL_EXTENSION>,
   ): Promise<void> {
-    await this.latexHandlers.installExtension(data.extensionId, (w) =>
-      this.sendToolDashboardData(w),
-    );
+    await this.latexHandlers.installExtension(data.extensionId);
   }
 }

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -279,10 +279,10 @@ export class LatexSettingsHandlers {
     }
   }
 
-  /** Install a VS Code extension and refresh the given view data. */
+  /** Install a VS Code extension and optionally refresh the given view data. */
   async installExtension(
     extensionId: string,
-    refresh: (w: vscode.Webview) => Promise<void>,
+    refresh?: (w: vscode.Webview) => Promise<void>,
   ): Promise<void> {
     try {
       await vscode.commands.executeCommand(
@@ -292,7 +292,9 @@ export class LatexSettingsHandlers {
       void vscode.window.showInformationMessage(
         `Extension "${extensionId}" installed`,
       );
-      await this.ctx.withActiveWebview(refresh);
+      if (refresh) {
+        await this.ctx.withActiveWebview(refresh);
+      }
     } catch (error) {
       await showLoggedErrorMessage(
         this.ctx.channel,

--- a/src/settingsView/utils/toolDashboardData.ts
+++ b/src/settingsView/utils/toolDashboardData.ts
@@ -17,7 +17,6 @@ import {
   type RegisteredToolName,
 } from '@tools/registry';
 import {
-  getLastCheckResults,
   runExternalToolChecks,
   type ExternalToolCheckResult,
 } from '@tools/toolAvailability';
@@ -140,14 +139,12 @@ const BUILTIN_TOOLS: (Omit<ToolDashboardItem, 'status' | 'tools'> & {
 // Public API
 // ============================================================
 
-/** Cached detail check results from the last full probe. */
-let lastDetailResults: (string | undefined)[] | null = null;
-
 /**
  * Build the complete tool dashboard items list.
  *
  * @param cachedResults — when provided, skips network probes and uses
- *   these results. Used by the toggle handler for instant UI updates.
+ *   these results (including their `statusDetail`). Used by the toggle
+ *   handler for instant UI updates.
  */
 export async function buildToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
@@ -162,26 +159,9 @@ export async function buildToolDashboardItems(
 
   const results = cachedResults ?? (await runExternalToolChecks());
 
-  // Skip detail checks when using cached results (toggle path)
-  const detailResults = cachedResults
-    ? (lastDetailResults ?? results.map(() => undefined))
-    : await Promise.all(
-        results.map(async ({ id }) => {
-          const def = findExternalToolDef(id);
-          if (!def?.detailCheck) return undefined;
-          try {
-            return await def.detailCheck();
-          } catch {
-            return undefined;
-          }
-        }),
-      );
-  lastDetailResults = detailResults;
-
   const disabledIds = getDisabledToolIds();
   const externalItems: ToolDashboardItem[] = [];
-  for (let i = 0; i < results.length; i++) {
-    const { id, tools, status } = results[i];
+  for (const { id, tools, status, statusDetail } of results) {
     const def = findExternalToolDef(id);
     if (!def || def.hideFromDashboard) continue;
     externalItems.push({
@@ -198,7 +178,7 @@ export async function buildToolDashboardItems(
       installCommand: def.installCommand,
       authCommand: def.authCommand,
       configNotes: def.configNotes,
-      statusDetail: detailResults[i],
+      statusDetail,
       authNote: def.authNote,
       toggleable: def.toggleable,
       enabled: !disabledIds.has(def.id),

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -1,8 +1,10 @@
 /**
  * External tool availability checks with caching.
  *
- * Pure service — runs checks, manages cache, returns results.
- * Tool definitions (what to check + UI metadata) live in
+ * Runs `check` (main probe) and `detailCheck` (human-readable detail) in
+ * parallel, caches the results, and broadcasts `toolAvailabilityChanged`
+ * when inputs change so subscribed UIs refresh without re-probing. Tool
+ * definitions (what to check + UI metadata) live in
  * {@link @tools/externalToolDefs}.
  *
  * Used by:
@@ -26,6 +28,8 @@ export interface ExternalToolCheckResult {
   readonly tools: readonly RegisteredToolName[];
   readonly name: string;
   readonly status: 'available' | 'not-found' | 'unknown';
+  /** Human-readable status detail from the group's `detailCheck`, if any. */
+  readonly statusDetail?: string;
 }
 
 // ============================================================
@@ -58,30 +62,41 @@ export function getDisabledToolNames(): ReadonlySet<string> {
 
 /**
  * Run all external tool checks in parallel.
- * Always performs fresh checks and updates the availability cache.
+ * Always performs fresh `check` + `detailCheck` probes and updates the
+ * availability cache.
  *
  * Called by the tool dashboard (needs per-group results).
  * Also populates the cache read by `getUnavailableToolNamesCached()`.
  *
- * @returns Per-group results with `available` / `not-found` / `unknown` status.
+ * @returns Per-group results with `available` / `not-found` / `unknown`
+ *   status and an optional human-readable `statusDetail`.
  */
 export async function runExternalToolChecks(): Promise<
   ExternalToolCheckResult[]
 > {
   const results = await Promise.all(
     EXTERNAL_TOOL_DEFS.map(
-      async ({ id, tools, name, check }): Promise<ExternalToolCheckResult> => {
-        try {
-          const available = await check();
-          return {
-            id,
-            tools,
-            name,
-            status: available ? 'available' : 'not-found',
-          };
-        } catch {
-          return { id, tools, name, status: 'unknown' };
+      async ({
+        id,
+        tools,
+        name,
+        check,
+        detailCheck,
+      }): Promise<ExternalToolCheckResult> => {
+        const [available, statusDetail] = await Promise.all([
+          check().catch(() => null),
+          detailCheck?.().catch(() => undefined),
+        ]);
+        if (available === null) {
+          return { id, tools, name, status: 'unknown', statusDetail };
         }
+        return {
+          id,
+          tools,
+          name,
+          status: available ? 'available' : 'not-found',
+          statusDetail,
+        };
       },
     ),
   );
@@ -120,7 +135,7 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * git-repo status, extension install state) — mutators don't have to know
  * which UIs depend on the result.
  */
-export async function invalidateToolAvailability(): Promise<void> {
+export async function refreshToolAvailability(): Promise<void> {
   await runExternalToolChecks();
   bus.emit('toolAvailabilityChanged', undefined);
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -62,19 +62,48 @@ export function getDisabledToolNames(): ReadonlySet<string> {
 
 /**
  * Run all external tool checks in parallel.
- * Always performs fresh `check` + `detailCheck` probes and updates the
+ * Always returns fresh `check` + `detailCheck` probes and updates the
  * availability cache.
  *
- * Called by the tool dashboard (needs per-group results).
- * Also populates the cache read by `getUnavailableToolNamesCached()`.
+ * Concurrent calls are coalesced: while a probe is in flight, additional
+ * callers share the same Promise and receive its results. If any caller
+ * arrives AFTER the active probe started reading inputs, a follow-up probe
+ * is scheduled so the cache ultimately reflects the most recent state and
+ * a stale probe can't overwrite a fresh one by finishing last.
+ *
+ * Called by the tool dashboard (needs per-group results) and
+ * {@link refreshToolAvailability}. Also populates the cache read by
+ * `getUnavailableToolNamesCached()`.
  *
  * @returns Per-group results with `available` / `not-found` / `unknown`
  *   status and an optional human-readable `statusDetail`.
  */
-export async function runExternalToolChecks(): Promise<
-  ExternalToolCheckResult[]
-> {
-  const results = await Promise.all(
+let inflightProbe: Promise<ExternalToolCheckResult[]> | null = null;
+let pendingRerun = false;
+export function runExternalToolChecks(): Promise<ExternalToolCheckResult[]> {
+  if (inflightProbe) {
+    pendingRerun = true;
+    return inflightProbe;
+  }
+  inflightProbe = (async () => {
+    let results: ExternalToolCheckResult[] = [];
+    try {
+      do {
+        pendingRerun = false;
+        results = await runProbes();
+        cached = buildUnavailableSet(results);
+        lastResults = results;
+      } while (pendingRerun);
+    } finally {
+      inflightProbe = null;
+    }
+    return results;
+  })();
+  return inflightProbe;
+}
+
+async function runProbes(): Promise<ExternalToolCheckResult[]> {
+  return Promise.all(
     EXTERNAL_TOOL_DEFS.map(
       async ({
         id,
@@ -104,11 +133,6 @@ export async function runExternalToolChecks(): Promise<
       },
     ),
   );
-
-  cached = buildUnavailableSet(results);
-  lastResults = results;
-
-  return results;
 }
 
 /** Build the set of unavailable tool names from external check results only. */
@@ -139,31 +163,13 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * git-repo status, extension install state) — mutators don't have to know
  * which UIs depend on the result.
  *
- * Concurrent calls are coalesced: while a probe is in flight, additional
- * callers share the same Promise. If any of those callers arrives AFTER
- * the probe started reading inputs, a follow-up probe is scheduled so the
- * final cache reflects the most recent state. A burst therefore produces
- * at most two probes and one `toolAvailabilityChanged` emission at the end.
+ * Coalescing and follow-up-probe scheduling happen inside
+ * `runExternalToolChecks`, so the dashboard-load probe and a refresh-triggered
+ * probe can't race.
  */
-let inflightRefresh: Promise<void> | null = null;
-let pendingRerun = false;
-export function refreshToolAvailability(): Promise<void> {
-  if (inflightRefresh) {
-    pendingRerun = true;
-    return inflightRefresh;
-  }
-  inflightRefresh = (async () => {
-    try {
-      do {
-        pendingRerun = false;
-        await runExternalToolChecks();
-      } while (pendingRerun);
-      bus.emit('toolAvailabilityChanged', undefined);
-    } finally {
-      inflightRefresh = null;
-    }
-  })();
-  return inflightRefresh;
+export async function refreshToolAvailability(): Promise<void> {
+  await runExternalToolChecks();
+  bus.emit('toolAvailabilityChanged', undefined);
 }
 
 /**

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -11,6 +11,7 @@
  */
 
 // Local imports
+import { bus } from '@eventBus/ProgressEventBus';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
@@ -112,43 +113,16 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
   return lastResults;
 }
 
-// ============================================================
-// Change notifications
-// ============================================================
-
-type AvailabilityChangeListener = () => void;
-const availabilityListeners = new Set<AvailabilityChangeListener>();
-
 /**
- * Subscribe to tool-availability changes. The listener fires after
- * {@link invalidateToolAvailability} completes a fresh probe.
- * Use this to refresh any UI that depends on external tool status
- * (e.g. the Tools tab in the settings view). Returns a disposer.
- */
-export function onToolAvailabilityChanged(
-  listener: AvailabilityChangeListener,
-): () => void {
-  availabilityListeners.add(listener);
-  return () => availabilityListeners.delete(listener);
-}
-
-/**
- * Re-probe external tools and notify listeners.
- *
- * Call this whenever an input to the availability checks changes
- * (GitHub token, workspace git-repo status, extension install state).
- * This is the single entry point for "tool inputs may have changed" —
- * mutators don't have to know which UIs or runtime caches are affected.
+ * Re-probe external tools and broadcast `toolAvailabilityChanged` so any
+ * subscribed UI (Tools tab) and runtime caches refresh. Call this whenever
+ * an input to the availability checks changes (GitHub token, workspace
+ * git-repo status, extension install state) — mutators don't have to know
+ * which UIs depend on the result.
  */
 export async function invalidateToolAvailability(): Promise<void> {
   await runExternalToolChecks();
-  for (const listener of availabilityListeners) {
-    try {
-      listener();
-    } catch {
-      // Listeners must not throw; swallow to protect siblings.
-    }
-  }
+  bus.emit('toolAvailabilityChanged', undefined);
 }
 
 /**

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -140,16 +140,24 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * which UIs depend on the result.
  *
  * Concurrent calls are coalesced: while a probe is in flight, additional
- * callers receive the same Promise. Bursts of events (e.g. workspace folder
- * and extension changes landing together) therefore trigger one probe and
- * one `toolAvailabilityChanged` emission.
+ * callers share the same Promise. If any of those callers arrives AFTER
+ * the probe started reading inputs, a follow-up probe is scheduled so the
+ * final cache reflects the most recent state. A burst therefore produces
+ * at most two probes and one `toolAvailabilityChanged` emission at the end.
  */
 let inflightRefresh: Promise<void> | null = null;
+let pendingRerun = false;
 export function refreshToolAvailability(): Promise<void> {
-  if (inflightRefresh) return inflightRefresh;
+  if (inflightRefresh) {
+    pendingRerun = true;
+    return inflightRefresh;
+  }
   inflightRefresh = (async () => {
     try {
-      await runExternalToolChecks();
+      do {
+        pendingRerun = false;
+        await runExternalToolChecks();
+      } while (pendingRerun);
       bus.emit('toolAvailabilityChanged', undefined);
     } finally {
       inflightRefresh = null;

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -112,6 +112,45 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
   return lastResults;
 }
 
+// ============================================================
+// Change notifications
+// ============================================================
+
+type AvailabilityChangeListener = () => void;
+const availabilityListeners = new Set<AvailabilityChangeListener>();
+
+/**
+ * Subscribe to tool-availability changes. The listener fires after
+ * {@link invalidateToolAvailability} completes a fresh probe.
+ * Use this to refresh any UI that depends on external tool status
+ * (e.g. the Tools tab in the settings view). Returns a disposer.
+ */
+export function onToolAvailabilityChanged(
+  listener: AvailabilityChangeListener,
+): () => void {
+  availabilityListeners.add(listener);
+  return () => availabilityListeners.delete(listener);
+}
+
+/**
+ * Re-probe external tools and notify listeners.
+ *
+ * Call this whenever an input to the availability checks changes
+ * (GitHub token, workspace git-repo status, extension install state).
+ * This is the single entry point for "tool inputs may have changed" —
+ * mutators don't have to know which UIs or runtime caches are affected.
+ */
+export async function invalidateToolAvailability(): Promise<void> {
+  await runExternalToolChecks();
+  for (const listener of availabilityListeners) {
+    try {
+      listener();
+    } catch {
+      // Listeners must not throw; swallow to protect siblings.
+    }
+  }
+}
+
 /**
  * Rebuild the availability cache from the last check results without
  * re-probing external tools. Called after toggling a tool on/off.

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -83,13 +83,17 @@ export async function runExternalToolChecks(): Promise<
         check,
         detailCheck,
       }): Promise<ExternalToolCheckResult> => {
-        const [available, statusDetail] = await Promise.all([
-          check().catch(() => null),
-          detailCheck?.().catch(() => undefined),
-        ]);
-        if (available === null) {
+        // Run check then detailCheck sequentially — some groups (Codex,
+        // Zotero, GitHub PR) share probe work between the two, so running
+        // them in parallel would duplicate that work.
+        let available: boolean;
+        try {
+          available = await check();
+        } catch {
+          const statusDetail = await detailCheck?.().catch(() => undefined);
           return { id, tools, name, status: 'unknown', statusDetail };
         }
+        const statusDetail = await detailCheck?.().catch(() => undefined);
         return {
           id,
           tools,
@@ -134,10 +138,24 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  * an input to the availability checks changes (GitHub token, workspace
  * git-repo status, extension install state) — mutators don't have to know
  * which UIs depend on the result.
+ *
+ * Concurrent calls are coalesced: while a probe is in flight, additional
+ * callers receive the same Promise. Bursts of events (e.g. workspace folder
+ * and extension changes landing together) therefore trigger one probe and
+ * one `toolAvailabilityChanged` emission.
  */
-export async function refreshToolAvailability(): Promise<void> {
-  await runExternalToolChecks();
-  bus.emit('toolAvailabilityChanged', undefined);
+let inflightRefresh: Promise<void> | null = null;
+export function refreshToolAvailability(): Promise<void> {
+  if (inflightRefresh) return inflightRefresh;
+  inflightRefresh = (async () => {
+    try {
+      await runExternalToolChecks();
+      bus.emit('toolAvailabilityChanged', undefined);
+    } finally {
+      inflightRefresh = null;
+    }
+  })();
+  return inflightRefresh;
 }
 
 /**


### PR DESCRIPTION
Setting or removing a GitHub personal access token in the Git tab
updated only the Git tab's status badge. The Tools tab continued to
show "GitHub PR Activity Subscription: Not Found" until the user
manually clicked Re-check, and the runtime tool-availability cache
stayed stale so subscribe_pr_activity / unsubscribe_pr_activity /
find_current_pr were filtered out of subsequent agent runs.

Re-run the external tool checks after the token mutation so both the
Tools tab UI and the runtime cache pick up the new token immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes shared tool-availability probing/caching with new coalescing logic and new event-driven refresh triggers, which could affect tool gating or introduce unexpected probe frequency/races if incorrect.
> 
> **Overview**
> Ensures the **Tools** dashboard and runtime tool-availability cache update automatically when the GitHub token (or other probe inputs) change, without requiring a manual *Re-check*.
> 
> Adds a new `toolAvailabilityChanged` bus event and a `refreshToolAvailability()` helper that re-runs external tool probes and notifies subscribed UIs. Extension activation now triggers refreshes on GitHub secret changes, extension install/uninstall, and workspace-folder changes (with error logging for async listener failures), and the Tools tab listens for the event and routes *Re-check* through the shared refresh path.
> 
> Simplifies dashboard data building by returning `statusDetail` directly from `runExternalToolChecks()` and removes ad-hoc detail-result caching; `runExternalToolChecks()` now coalesces concurrent probes and schedules a follow-up run if inputs change mid-flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8ac141d45fb6e5ab7d3f89a15763a5c7988e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->