### PR TITLE
Trim default models: strip gpt54pro and opus46T on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Improvements
+
+- **GPT-5.4 Pro now off by default** — `gpt54pro` is no longer part of the default model list and is stripped from existing users' enabled models on upgrade. It remains available to manually re-enable in the Models settings tab.
+
 ## [0.37.4] - 2026-04-21
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Improvements
 
-- **GPT-5.4 Pro now off by default** — `gpt54pro` is no longer part of the default model list and is stripped from existing users' enabled models on upgrade. It remains available to manually re-enable in the Models settings tab.
+- **Default model list trimmed** — `gpt54pro` and `opus46T` (superseded by `opus47T`) are no longer part of the default model list and are stripped from existing users' enabled models on upgrade. Both remain available to manually re-enable in the Models settings tab.
 
 ## [0.37.4] - 2026-04-21
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -218,7 +218,7 @@ export async function refreshModelListIfNeeded(): Promise<void> {
   );
 
   try {
-    await mergeNewModelsIfCustomized();
+    await mergeNewModelsIfCustomized(storedVersion);
     await globalSM.update(
       GlobalStateKey.MODEL_LIST_VERSION,
       MODEL_LIST_VERSION,
@@ -235,9 +235,11 @@ export async function refreshModelListIfNeeded(): Promise<void> {
 /**
  * Reconciles the user's enabled-models list with the current defaults: adds
  * any new DEFAULT_MODELS entries and applies per-version one-off removals
- * (see inline comments for rationale).
+ * gated on previousVersion so they run on the intended upgrade only.
  */
-async function mergeNewModelsIfCustomized(): Promise<void> {
+async function mergeNewModelsIfCustomized(
+  previousVersion: number | undefined,
+): Promise<void> {
   const currentModels = globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS);
   if (!currentModels) {
     logger.info(
@@ -247,28 +249,27 @@ async function mergeNewModelsIfCustomized(): Promise<void> {
     return;
   }
 
-  // gpt54pro was a default for 0.36.5–0.36.x, then removed as duplicative with
-  // gpt54. Strip it once on upgrade so it is off by default for all users; they
-  // can still re-enable it manually in the Models settings tab.
-  const stripped = currentModels.filter((model) => model !== 'gpt54pro');
+  // One-time strip of gpt54pro for users upgrading past version 13. It was a
+  // default for 0.36.5–0.36.x, then removed as duplicative with gpt54. The
+  // (previousVersion ?? 0) < 13 gate ensures users who manually re-enable it
+  // after this release don't lose it again on future unrelated version bumps.
+  const strippedSet = new Set<string>();
+  if ((previousVersion ?? 0) < 13 && currentModels.includes('gpt54pro')) {
+    strippedSet.add('gpt54pro');
+  }
+  const kept = currentModels.filter((model) => !strippedSet.has(model));
+  const removed = [...strippedSet];
 
-  const modelsToAdd = DEFAULT_MODELS.filter(
-    (model) => !stripped.includes(model),
-  );
+  const added = DEFAULT_MODELS.filter((model) => !kept.includes(model));
 
-  if (modelsToAdd.length === 0 && stripped.length === currentModels.length) {
+  if (added.length === 0 && removed.length === 0) {
     return;
   }
 
-  await globalSM.update(GlobalStateKey.ENABLED_MODELS, [
-    ...stripped,
-    ...modelsToAdd,
-  ]);
+  await globalSM.update(GlobalStateKey.ENABLED_MODELS, [...kept, ...added]);
   logger.info(
     'extension',
-    `Refreshed enabled models: added [${modelsToAdd.join(', ')}], removed [${currentModels
-      .filter((m) => !stripped.includes(m))
-      .join(', ')}]`,
+    `Refreshed enabled models: added [${added.join(', ')}], removed [${removed.join(', ')}]`,
   );
 }
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -9,11 +9,7 @@ import { agentDirectories } from '@frontend/agents';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import {
-  DEFAULT_MODELS,
-  FORCE_DISABLED_MODELS,
-  MODEL_LIST_VERSION,
-} from '@model/computeModelOptions';
+import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/computeModelOptions';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { GlobalStorageFS } from '@utils/files';
@@ -237,8 +233,9 @@ export async function refreshModelListIfNeeded(): Promise<void> {
 }
 
 /**
- * Merges new default models into the user's enabled list and strips any models
- * listed in FORCE_DISABLED_MODELS.
+ * Reconciles the user's enabled-models list with the current defaults: adds
+ * any new DEFAULT_MODELS entries and applies per-version one-off removals
+ * (see inline comments for rationale).
  */
 async function mergeNewModelsIfCustomized(): Promise<void> {
   const currentModels = globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS);
@@ -250,35 +247,29 @@ async function mergeNewModelsIfCustomized(): Promise<void> {
     return;
   }
 
-  const forceDisabled = new Set(FORCE_DISABLED_MODELS);
-  const kept = currentModels.filter((model) => !forceDisabled.has(model));
-  const removed = currentModels.filter((model) => forceDisabled.has(model));
+  // gpt54pro was a default for 0.36.5–0.36.x, then removed as duplicative with
+  // gpt54. Strip it once on upgrade so it is off by default for all users; they
+  // can still re-enable it manually in the Models settings tab.
+  const stripped = currentModels.filter((model) => model !== 'gpt54pro');
 
   const modelsToAdd = DEFAULT_MODELS.filter(
-    (model) => !kept.includes(model),
+    (model) => !stripped.includes(model),
   );
 
-  if (modelsToAdd.length === 0 && removed.length === 0) {
+  if (modelsToAdd.length === 0 && stripped.length === currentModels.length) {
     return;
   }
 
   await globalSM.update(GlobalStateKey.ENABLED_MODELS, [
-    ...kept,
+    ...stripped,
     ...modelsToAdd,
   ]);
-
-  if (modelsToAdd.length > 0) {
-    logger.info(
-      'extension',
-      `Merged ${modelsToAdd.length} new models into user's list: ${modelsToAdd.join(', ')}`,
-    );
-  }
-  if (removed.length > 0) {
-    logger.info(
-      'extension',
-      `Removed ${removed.length} force-disabled models from user's list: ${removed.join(', ')}`,
-    );
-  }
+  logger.info(
+    'extension',
+    `Refreshed enabled models: added [${modelsToAdd.join(', ')}], removed [${currentModels
+      .filter((m) => !stripped.includes(m))
+      .join(', ')}]`,
+  );
 }
 
 /** Default options for global settings that should only be set if not already configured */

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -249,13 +249,17 @@ async function mergeNewModelsIfCustomized(
     return;
   }
 
-  // One-time strip of gpt54pro for users upgrading past version 13. It was a
-  // default for 0.36.5–0.36.x, then removed as duplicative with gpt54. The
-  // (previousVersion ?? 0) < 13 gate ensures users who manually re-enable it
-  // after this release don't lose it again on future unrelated version bumps.
+  // One-time strip for users upgrading past version 13:
+  // - gpt54pro: default for 0.36.5–0.36.x, then removed as duplicative with gpt54.
+  // - opus46T: default before opus47T landed and superseded it.
+  // The (previousVersion ?? 0) < 13 gate ensures users who manually re-enable
+  // either after this release don't lose it again on future unrelated bumps.
+  const V13_REMOVALS = ['gpt54pro', 'opus46T'];
   const strippedSet = new Set<string>();
-  if ((previousVersion ?? 0) < 13 && currentModels.includes('gpt54pro')) {
-    strippedSet.add('gpt54pro');
+  if ((previousVersion ?? 0) < 13) {
+    for (const model of V13_REMOVALS) {
+      if (currentModels.includes(model)) strippedSet.add(model);
+    }
   }
   const kept = currentModels.filter((model) => !strippedSet.has(model));
   const removed = [...strippedSet];

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -9,7 +9,11 @@ import { agentDirectories } from '@frontend/agents';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/computeModelOptions';
+import {
+  DEFAULT_MODELS,
+  FORCE_DISABLED_MODELS,
+  MODEL_LIST_VERSION,
+} from '@model/computeModelOptions';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { GlobalStorageFS } from '@utils/files';
@@ -233,7 +237,8 @@ export async function refreshModelListIfNeeded(): Promise<void> {
 }
 
 /**
- * Merges new default models into user's existing enabled models list.
+ * Merges new default models into the user's enabled list and strips any models
+ * listed in FORCE_DISABLED_MODELS.
  */
 async function mergeNewModelsIfCustomized(): Promise<void> {
   const currentModels = globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS);
@@ -245,22 +250,35 @@ async function mergeNewModelsIfCustomized(): Promise<void> {
     return;
   }
 
+  const forceDisabled = new Set(FORCE_DISABLED_MODELS);
+  const kept = currentModels.filter((model) => !forceDisabled.has(model));
+  const removed = currentModels.filter((model) => forceDisabled.has(model));
+
   const modelsToAdd = DEFAULT_MODELS.filter(
-    (model) => !currentModels.includes(model),
+    (model) => !kept.includes(model),
   );
 
-  if (modelsToAdd.length === 0) {
+  if (modelsToAdd.length === 0 && removed.length === 0) {
     return;
   }
 
   await globalSM.update(GlobalStateKey.ENABLED_MODELS, [
-    ...currentModels,
+    ...kept,
     ...modelsToAdd,
   ]);
-  logger.info(
-    'extension',
-    `Merged ${modelsToAdd.length} new models into user's list: ${modelsToAdd.join(', ')}`,
-  );
+
+  if (modelsToAdd.length > 0) {
+    logger.info(
+      'extension',
+      `Merged ${modelsToAdd.length} new models into user's list: ${modelsToAdd.join(', ')}`,
+    );
+  }
+  if (removed.length > 0) {
+    logger.info(
+      'extension',
+      `Removed ${removed.length} force-disabled models from user's list: ${removed.join(', ')}`,
+    );
+  }
 }
 
 /** Default options for global settings that should only be set if not already configured */

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -37,12 +37,19 @@ export const DEFAULT_MODELS = [
 ];
 
 /**
+ * Models that must be off by default for all users. Any entry here is stripped
+ * from existing users' enabled-model lists when MODEL_LIST_VERSION advances.
+ * Users can still re-enable these manually in settings.
+ */
+export const FORCE_DISABLED_MODELS = ['gpt54pro'];
+
+/**
  * Version number for the default model list.
  * Increment this when adding or removing models to force existing users
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 12;
+export const MODEL_LIST_VERSION = 13;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -25,7 +25,8 @@ import { API_PROVIDERS, apiKeyExists, type ApiProvider } from './apiProviders';
 
 /**
  * Default models that should be present in every user's model list.
- * Update this list and increment MODEL_LIST_VERSION below when adding new models.
+ * Update this list and increment MODEL_LIST_VERSION below when adding or
+ * removing models.
  */
 export const DEFAULT_MODELS = [
   'gemini31p',

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -37,13 +37,6 @@ export const DEFAULT_MODELS = [
 ];
 
 /**
- * Models that must be off by default for all users. Any entry here is stripped
- * from existing users' enabled-model lists when MODEL_LIST_VERSION advances.
- * Users can still re-enable these manually in settings.
- */
-export const FORCE_DISABLED_MODELS = ['gpt54pro'];
-
-/**
  * Version number for the default model list.
  * Increment this when adding or removing models to force existing users
  * to get the updated defaults. A simple integer avoids hash-collision risks


### PR DESCRIPTION
## Summary
This PR makes both `gpt54pro` and `opus46T` off by default. Neither is in `DEFAULT_MODELS`, but both lingered in existing users' enabled lists since the migration logic only added new defaults — it never removed stale ones. Both remain available to manually re-enable in the Models settings tab.

- `gpt54pro` was a default for 0.36.5–0.36.x and is duplicative with `gpt54`.
- `opus46T` was a default before `opus47T` landed and superseded it.

## Key Changes
- **`mergeNewModelsIfCustomized()`** now accepts the previous stored `MODEL_LIST_VERSION` and applies a `V13_REMOVALS` list (`gpt54pro`, `opus46T`) only when upgrading from `< 13`. The version gate ensures users who manually re-enable either model after this release don't lose it on future unrelated bumps.
- **`MODEL_LIST_VERSION`** bumped from 12 → 13 to trigger the migration.
- **Logging** reports both added and removed models in a single message; `removed[]` is computed once and reused.
- **`DEFAULT_MODELS` doc comment** aligned with the `MODEL_LIST_VERSION` doc comment (both additions and removals require a version bump).
- **CHANGELOG.md** documents the trim.

## Test plan
- [ ] Fresh install: `ENABLED_MODELS` is unset → migration is a no-op, defaults apply (no `gpt54pro` / `opus46T`).
- [ ] Upgrade from `MODEL_LIST_VERSION` < 13 with `gpt54pro` and/or `opus46T` enabled → both stripped, log line reports the removals.
- [ ] User manually re-enables `gpt54pro` after upgrading to v13, then `MODEL_LIST_VERSION` later bumps to 14 → `gpt54pro` is preserved (no double-strip).
- [ ] `npm run typecheck` passes.

https://claude.ai/code/session_01HTpf7iXRnS3LyeyxLM2fMq