### PR TITLE
Update VS Code Marketplace badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # TeXRA: AI TeX Research Assistant for VS Code
 
 [![VS Code Marketplace](https://vsmarketplacebadges.dev/version-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+[![Installs](https://vsmarketplacebadges.dev/installs-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+[![Downloads](https://vsmarketplacebadges.dev/downloads-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+[![Rating](https://vsmarketplacebadges.dev/rating-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+[![Open VSX Version](https://img.shields.io/open-vsx/v/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
+[![Open VSX Downloads](https://img.shields.io/open-vsx/dt/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
+[![Latest Release](https://img.shields.io/github/v/release/LionSR/TeXRA)](https://github.com/LionSR/TeXRA/releases)
+[![Last Commit](https://img.shields.io/github/last-commit/LionSR/TeXRA)](https://github.com/LionSR/TeXRA/commits)
 [![License](https://img.shields.io/badge/license-Proprietary-blue)](LICENSE)
 
 > **🎓 Free for Researchers!** TeXRA now offers a **Researcher Access Program** with

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TeXRA: AI TeX Research Assistant for VS Code
 
-[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/texra-ai.texra)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+[![VS Code Marketplace](https://vsmarketplacebadges.dev/version-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![License](https://img.shields.io/badge/license-Proprietary-blue)](LICENSE)
 
 > **🎓 Free for Researchers!** TeXRA now offers a **Researcher Access Program** with


### PR DESCRIPTION
## Summary
Updated the VS Code Marketplace badge in the README to use a more reliable badge service.

## Changes
- Replaced the `img.shields.io` marketplace badge URL with `vsmarketplacebadges.dev` service
- The badge now points to the version-short endpoint for a cleaner display
- Maintains the same link destination to the TeXRA extension on the VS Code Marketplace

## Details
This change improves badge reliability by using a dedicated marketplace badge service (`vsmarketplacebadges.dev`) instead of the generic shields.io service, which may have inconsistent support for VS Code Marketplace metadata.

https://claude.ai/code/session_01Q8vtSSknS8BHznjxwoCsx6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code, build, or runtime behavior is modified.
> 
> **Overview**
> Updates `README.md` to swap the VS Code Marketplace badge source from `img.shields.io` to `vsmarketplacebadges.dev` and **adds additional Marketplace badges** for installs, downloads, and rating while keeping the Marketplace link target the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d2dd7774265ed591275f87ad9ad55f13680fd0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->