### PR TITLE
fix(progressView): hide default model on bash stream tabs

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -431,6 +431,9 @@ export class ProgressApp extends ProgressAppBase {
       isToolUse: this.activeIsToolUse$.get(),
       hasStreams,
       streamName: activeStreamInfo.name,
+      // `bash` child streams emit raw stdout/stderr; render them terminal-style
+      // (monospace, no timestamps, tight spacing) instead of as logger entries.
+      terminalMode: activeStreamInfo.agent === 'bash',
     };
   });
 

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -35,6 +35,7 @@ import {
   select,
   combine,
 } from '@shared/signals';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { sortStreams, StreamSortSchema } from '@shared/streams/streamSort';
 import { codiconStyles } from '@shared/styles/codiconStyles';
 
@@ -431,9 +432,9 @@ export class ProgressApp extends ProgressAppBase {
       isToolUse: this.activeIsToolUse$.get(),
       hasStreams,
       streamName: activeStreamInfo.name,
-      // `bash` child streams emit raw stdout/stderr; render them terminal-style
-      // (monospace, no timestamps, tight spacing) instead of as logger entries.
-      terminalMode: activeStreamInfo.agent === 'bash',
+      // Process agents emit raw stdout/stderr; render them terminal-style
+      // (monospace, no timestamps, tight spacing) rather than logger entries.
+      terminalMode: isProcessAgent(activeStreamInfo.agent),
     };
   });
 

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -63,6 +63,8 @@ interface CachedStream {
   messages: LogMessageData[];
   toggleStates: ToggleStateStore;
   ref: Ref<TaskGroupList>;
+  /** Whether to render this stream's logs in terminal style. */
+  terminalMode: boolean;
 }
 
 @customElement('log-list')
@@ -115,6 +117,7 @@ export class LogList extends LitElement {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
       entry.messages = this.streamContext.logs;
+      entry.terminalMode = this.streamContext.terminalMode;
 
       // Evict oldest non-active entries when cache exceeds cap
       this.evictStaleCacheEntries();
@@ -139,6 +142,7 @@ export class LogList extends LitElement {
           .messages=${data.messages}
           .hasStreams=${this.streamContext.hasStreams}
           .toggleStates=${data.toggleStates}
+          ?terminal=${data.terminalMode}
         ></task-group-list>
       `,
     )}`;
@@ -214,6 +218,7 @@ export class LogList extends LitElement {
       messages: [],
       toggleStates,
       ref: createRef<TaskGroupList>(),
+      terminalMode: false,
     };
     this.streamCache.set(streamId, entry);
     return entry;

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -80,6 +80,12 @@ export class TaskGroupList extends LitElement {
   /** Toggle state store for persistence */
   @property({ attribute: false }) toggleStates: ToggleStateStore | null = null;
 
+  /**
+   * Render log output in terminal style (monospace, no bullets/timestamps).
+   * Reflected to the host attribute so scoped CSS can target it.
+   */
+  @property({ type: Boolean, reflect: true }) terminal = false;
+
   /** Track previous group statuses to detect completion (not rendered — no @state needed) */
   private previousStatuses = new Map<string, string>();
 

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -54,6 +54,8 @@ export interface StreamLogContextValue {
   hasStreams: boolean;
   /** Stream name for switch detection in LogList */
   streamName: string | null;
+  /** Render log output in terminal style (monospace, no timestamps, etc). */
+  terminalMode: boolean;
 }
 
 export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
@@ -62,6 +64,7 @@ export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   isToolUse: false,
   hasStreams: false,
   streamName: null,
+  terminalMode: false,
 };
 
 export const streamLogContext = createContext<StreamLogContextValue>(

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -268,4 +268,49 @@ export const logEntryStyles = css`
     color: var(--vscode-badge-foreground);
     margin-right: var(--spacing-small);
   }
+
+  /* Terminal-style output: monospace font, tighter spacing, no log bullets.
+     Applied to streams that proxy raw process output (e.g. bash child streams)
+     so their stdout/stderr reads like a terminal instead of a logger. */
+  :host([terminal]) .log-container {
+    font-family: var(
+      --vscode-editor-font-family,
+      ui-monospace,
+      SFMono-Regular,
+      Consolas,
+      monospace
+    );
+    font-size: var(--vscode-editor-font-size, var(--font-size));
+    background-color: var(
+      --vscode-terminal-background,
+      var(--vscode-editor-background, transparent)
+    );
+    color: var(--vscode-terminal-foreground, var(--vscode-foreground));
+  }
+
+  :host([terminal]) .log-line {
+    padding: 0;
+    line-height: 1.35;
+    word-break: normal;
+    overflow-wrap: anywhere;
+  }
+
+  /* Bullet/timestamp prefix is noisy for raw process output. */
+  :host([terminal]) .log-line .timestamp {
+    display: none;
+  }
+
+  /* stdout renders at terminal foreground; stderr keeps a warn tint. */
+  :host([terminal]) .message-info,
+  :host([terminal]) .message-debug {
+    color: inherit;
+  }
+
+  :host([terminal]) .message-warn {
+    color: var(--vscode-terminal-ansiYellow, var(--color-warning));
+  }
+
+  :host([terminal]) .message-error {
+    color: var(--vscode-terminal-ansiRed, var(--color-error));
+  }
 `;

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { getCleanAgentName, isRemoteAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import type { AgentCategoryFilter, StreamTabInfo } from '@shared/schemas';
+import { isProcessAgent } from '@shared/streams/agentKind';
 import { sortStreams } from '@shared/streams/streamSort';
 import type { ProgressViewState } from './state/ProgressViewState';
 
@@ -60,15 +61,15 @@ function buildStreamInfo(
       ? `${agentName}: ${path.basename(inputFile)}`
       : agentName;
 
-  // `bash` child streams carry a synthetic AgentConfig whose `model` is the
-  // schema's prefault, not a model actually used for inference. Hide it so
-  // the tab doesn't display a misleading model label.
-  const isBashSession = config?.agent === 'bash';
+  // Process agents (e.g. bash) carry a synthetic AgentConfig whose `model` is
+  // the schema's prefault, not a model actually used for inference — omit it
+  // so the tab doesn't display a misleading label.
+  const processAgent = isProcessAgent(config?.agent);
 
   return {
     name: id,
     label,
-    model: isBashSession ? undefined : config?.model,
+    model: processAgent ? undefined : config?.model,
     agent: config?.agent,
     agentCategory: category,
     hasMultipleOutputs:

--- a/src/progressView/streamInfoUtils.ts
+++ b/src/progressView/streamInfoUtils.ts
@@ -60,10 +60,15 @@ function buildStreamInfo(
       ? `${agentName}: ${path.basename(inputFile)}`
       : agentName;
 
+  // `bash` child streams carry a synthetic AgentConfig whose `model` is the
+  // schema's prefault, not a model actually used for inference. Hide it so
+  // the tab doesn't display a misleading model label.
+  const isBashSession = config?.agent === 'bash';
+
   return {
     name: id,
     label,
-    model: config?.model,
+    model: isBashSession ? undefined : config?.model,
     agent: config?.agent,
     agentCategory: category,
     hasMultipleOutputs:

--- a/src/shared/streams/agentKind.ts
+++ b/src/shared/streams/agentKind.ts
@@ -1,0 +1,18 @@
+/**
+ * Agent-kind classification for stream presentation.
+ *
+ * A "process agent" runs as a raw OS process (e.g. the `bash` tool) rather
+ * than an LLM-driven reasoning session. Its stream carries no meaningful
+ * model and its log entries are unstructured stdout/stderr, so info builders
+ * and UI components render it differently than regular agents.
+ *
+ * Keeping the classification here — rather than open-coded against the agent
+ * name at each site — lets callers express their own concern (hide the model,
+ * render terminal-style, etc.) without knowing which specific tools qualify.
+ */
+
+const PROCESS_AGENTS: ReadonlySet<string> = new Set(['bash']);
+
+export function isProcessAgent(agent: string | undefined): boolean {
+  return agent !== undefined && PROCESS_AGENTS.has(agent);
+}


### PR DESCRIPTION
Bash tool child streams carry a synthetic AgentConfig whose `model` is
the schema's prefault (gemini31p), not a model ever used for inference.
Omit the field in StreamTabInfo for bash sessions so the tab meta and
tooltip stop showing a misleading model label.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to progress view presentation logic (tab metadata and log rendering) and don’t affect execution, permissions, or data persistence beyond adding a new UI flag.
> 
> **Overview**
> **Improves presentation of `bash` child streams in the Progress view.** Stream metadata now classifies certain agents as *process agents* and omits the `model` field for them so tab labels/tooltips don’t show a misleading default model.
> 
> For process-agent streams, the frontend also switches log rendering into a terminal-style mode (monospace, tighter spacing, hides timestamps/bullets, terminal-like colors) by threading a new `terminalMode` flag through `streamLogContext` into `TaskGroupList` styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50baffcfd27f6762588f792d3822b86f5e3e08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->