### PR TITLE
fix: restore display names, diff stats, and latexdiff recovery after output-rename refactor

### DIFF
--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -82,6 +82,23 @@ export class OutputFileProcessor {
     }
   }
 
+  /**
+   * Derive a meaningful source name for a non-XML single output.
+   * When there is exactly one base file, use its filename so that
+   * FileLineageCalculator can find the workspace original (which powers
+   * the diff display and the "Compare with base" buttons). Falls back to
+   * the raw output basename when there are multiple base files.
+   */
+  private getSourceForSingleOutput(outputLocation: FileLocation): string {
+    if (this.ctx.baseFiles.length === 1) {
+      const base = this.ctx.baseFiles[0];
+      return path.basename(
+        base.kind !== 'external' ? base.relativePath : base.absolutePath,
+      );
+    }
+    return path.basename(outputLocation.absolutePath);
+  }
+
   private handleEmptyOutput(
     round: number,
     rawLocation: FileLocation,
@@ -107,7 +124,7 @@ export class OutputFileProcessor {
             currRound,
           )
         : {
-            source: path.basename(outputLocation.absolutePath),
+            source: this.getSourceForSingleOutput(outputLocation),
             round: currRound,
             location: rawLocation ?? outputLocation,
             lineage: null,

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -104,7 +104,10 @@ export class XmlOutputManager {
     // name and the extracted content are always in sync.  For agents without an
     // inputFile, the XML document name gives a human-readable fallback.
     const inputFileStem = path.parse(this.agentConfig.inputFile).name;
-    const texStem = inputFileStem || sourceName || rawStem;
+    // Sanitize the stem derived from model output to prevent path traversal:
+    // strip all directory components and take only the filename stem.
+    const rawTexStem = inputFileStem || sourceName || rawStem;
+    const texStem = path.parse(path.basename(rawTexStem)).name || rawStem;
     const texRelativePath = outputDir
       ? path.join(outputDir, `${texStem}.tex`)
       : `${texStem}.tex`;

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -104,10 +104,9 @@ export class XmlOutputManager {
     // name and the extracted content are always in sync.  For agents without an
     // inputFile, the XML document name gives a human-readable fallback.
     const inputFileStem = path.parse(this.agentConfig.inputFile).name;
-    // Sanitize the stem derived from model output to prevent path traversal:
-    // strip all directory components and take only the filename stem.
-    const rawTexStem = inputFileStem || sourceName || rawStem;
-    const texStem = path.parse(path.basename(rawTexStem)).name || rawStem;
+    const texStem =
+      path.parse(path.basename(inputFileStem || sourceName || rawStem)).name ||
+      rawStem;
     const texRelativePath = outputDir
       ? path.join(outputDir, `${texStem}.tex`)
       : `${texStem}.tex`;

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -89,17 +89,27 @@ export class XmlOutputManager {
     documentTag: string,
     thinkingTag: string = 'scratchpad',
   ): Promise<{ location: FileLocation; sourceName: string }> {
-    const { name } = path.parse(outputLocation.absolutePath);
+    const { name: rawStem } = path.parse(outputLocation.absolutePath);
     const outputDir = getFileDirectory(outputLocation);
-    const texRelativePath = outputDir
-      ? path.join(outputDir, `${name}.tex`)
-      : `${name}.tex`;
 
-    const texLocation = this.fileService.createLocation(texRelativePath);
-
+    // Read content first so we can derive the destination name from the
+    // XML document-name attribute before creating the output location.
     let outputContent = await AbsoluteFS.read(outputLocation.absolutePath);
     const sourceName =
       outputContent.match(DOCUMENT_NAME_REGEX)?.[1]?.trim() ?? '';
+
+    // Name the extracted .tex after the document (XML name attr), then the
+    // input file, then fall back to the raw stem ("output").  This keeps the
+    // extracted LaTeX readable ("constrained_note.tex") while the raw model
+    // response stays at its fixed "output.*" path.
+    const inputFileStem = path.parse(this.agentConfig.inputFile).name;
+    const texStem = sourceName || inputFileStem || rawStem;
+    const texRelativePath = outputDir
+      ? path.join(outputDir, `${texStem}.tex`)
+      : `${texStem}.tex`;
+
+    const texLocation = this.fileService.createLocation(texRelativePath);
+
     const tagsToWrap = [documentTag, thinkingTag];
     outputContent = addCdataToTags(outputContent, tagsToWrap);
 

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -98,12 +98,13 @@ export class XmlOutputManager {
     const sourceName =
       outputContent.match(DOCUMENT_NAME_REGEX)?.[1]?.trim() ?? '';
 
-    // Name the extracted .tex after the document (XML name attr), then the
-    // input file, then fall back to the raw stem ("output").  This keeps the
-    // extracted LaTeX readable ("constrained_note.tex") while the raw model
-    // response stays at its fixed "output.*" path.
+    // Name the extracted .tex after: input file stem → first XML document name
+    // → raw output stem.  Input file takes priority because extractDocument()
+    // also uses agentConfig.inputFile as its matching hint, so the destination
+    // name and the extracted content are always in sync.  For agents without an
+    // inputFile, the XML document name gives a human-readable fallback.
     const inputFileStem = path.parse(this.agentConfig.inputFile).name;
-    const texStem = sourceName || inputFileStem || rawStem;
+    const texStem = inputFileStem || sourceName || rawStem;
     const texRelativePath = outputDir
       ? path.join(outputDir, `${texStem}.tex`)
       : `${texStem}.tex`;

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -5,6 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import { AgentSetting } from '@agent/core/AgentDataclass';
 import { getExtractedDocOutputFileName } from '@agent/utils/outputFileUtils';
+import { WORKFLOW_OUTPUT_BASENAME } from '@agent/output/workflowOutputLayout';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { AgentLogger } from '@logger/AgentLogger';
 import replacementEngine, { applyReplacements } from '@replacement/engine';
@@ -109,7 +110,12 @@ export class XmlOutputManager {
     const safeSourceName = sourceName
       ? path.parse(path.basename(sourceName)).name
       : '';
-    const texStem = inputFileStem || safeSourceName || rawStem;
+    const stemCandidate = inputFileStem || safeSourceName || rawStem;
+    // Guard: don't write the extracted .tex to the same path as the raw output.
+    const texStem =
+      stemCandidate === WORKFLOW_OUTPUT_BASENAME
+        ? `${WORKFLOW_OUTPUT_BASENAME}_extracted`
+        : stemCandidate;
     const texRelativePath = outputDir
       ? path.join(outputDir, `${texStem}.tex`)
       : `${texStem}.tex`;

--- a/src/agent/output/XmlOutputManager.ts
+++ b/src/agent/output/XmlOutputManager.ts
@@ -104,9 +104,12 @@ export class XmlOutputManager {
     // name and the extracted content are always in sync.  For agents without an
     // inputFile, the XML document name gives a human-readable fallback.
     const inputFileStem = path.parse(this.agentConfig.inputFile).name;
-    const texStem =
-      path.parse(path.basename(inputFileStem || sourceName || rawStem)).name ||
-      rawStem;
+    // sourceName comes from model XML and may carry path components or a .tex
+    // extension — strip both.  inputFileStem and rawStem are already clean stems.
+    const safeSourceName = sourceName
+      ? path.parse(path.basename(sourceName)).name
+      : '';
+    const texStem = inputFileStem || safeSourceName || rawStem;
     const texRelativePath = outputDir
       ? path.join(outputDir, `${texStem}.tex`)
       : `${texStem}.tex`;

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -91,7 +91,7 @@ export async function runCompileCheck(
   for (const outputFile of texOutputs) {
     const displayName = getCompileDisplayName(outputFile);
     try {
-      await compileOne(ctx, outputFile, currentRound, {
+      await compileOne(ctx, outputFile, currentRound, displayName, {
         compileRoot,
         runDirectory,
         timeoutMs,
@@ -114,9 +114,9 @@ async function compileOne(
   ctx: CompileCheckContext,
   outputFile: OutputFileInfo,
   currentRound: number,
+  displayName: string,
   opts: PerFileOptions,
 ): Promise<void> {
-  const displayName = getCompileDisplayName(outputFile);
   // compiledBasename is the actual on-disk filename LaTeX engines use when
   // naming their .log; it may differ from displayName when file.source is set.
   const compiledBasename = path.basename(outputFile.location.absolutePath);

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -157,7 +157,10 @@ async function compileOne(
     return;
   }
 
-  const tail = await readLogTail(buildDir, displayName);
+  // LaTeX engines name their log after the actual compiled file, not the
+  // cosmetic display name, so pass the real basename for log path lookup.
+  const compiledBasename = path.basename(outputFile.location.absolutePath);
+  const tail = await readLogTail(buildDir, compiledBasename);
   await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
   await flexibleFS.write(
     logDest,

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -173,13 +173,13 @@ async function compileOne(
 
 async function readLogTail(
   buildDir: string,
-  displayName: string,
+  compiledBasename: string,
 ): Promise<string> {
   // LaTeX engines drop `<basename-without-ext>.log`; strip .tex
   // case-insensitively so .TEX/.Tex map to the same file.
   const latexLogAbs = path.join(
     buildDir,
-    `${displayName.replace(/\.tex$/i, '')}.log`,
+    `${compiledBasename.replace(/\.tex$/i, '')}.log`,
   );
   try {
     const full = await flexibleFS.read(pathToLocation(latexLogAbs));

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -26,6 +26,22 @@ const LOG_TAIL_LINES = 200;
 const MIN_TIMEOUT_MS = 10000;
 
 /**
+ * Return a human-readable display name for an output file in compile messages.
+ * Prefers the `source` field (which carries the original document name, e.g.
+ * "constrained_note.tex") over the raw run-storage basename ("output.tex").
+ */
+function getCompileDisplayName(file: OutputFileInfo): string {
+  const rawBase = path.basename(file.location.absolutePath);
+  const src = file.source;
+  if (!src || src === rawBase) return rawBase;
+  // Avoid leaking the generic stem that replaced the old descriptive names
+  const srcBase = path.basename(src);
+  return srcBase && srcBase !== 'output' && srcBase !== 'output.tex'
+    ? srcBase
+    : rawBase;
+}
+
+/**
  * Compile each .tex output of a round to verify the workflow produced a
  * buildable document. Success is silent; failures write the log tail to
  * `<runDir>/compile/<safe>.log`. Missing toolchains, runs without a run
@@ -73,7 +89,7 @@ export async function runCompileCheck(
   const compileRoot = path.join(runDirectory, 'compile');
 
   for (const outputFile of texOutputs) {
-    const displayName = path.basename(outputFile.location.absolutePath);
+    const displayName = getCompileDisplayName(outputFile);
     try {
       await compileOne(ctx, outputFile, currentRound, {
         compileRoot,
@@ -100,7 +116,7 @@ async function compileOne(
   currentRound: number,
   opts: PerFileOptions,
 ): Promise<void> {
-  const displayName = path.basename(outputFile.location.absolutePath);
+  const displayName = getCompileDisplayName(outputFile);
   // Full relative path keeps two outputs sharing a basename distinct
   // (ch1/main.tex vs ch2/main.tex).
   const safeName = getComparablePath(outputFile.location).replaceAll(

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -157,8 +157,6 @@ async function compileOne(
     return;
   }
 
-  // LaTeX engines name their log after the actual compiled file, not the
-  // cosmetic display name, so pass the real basename for log path lookup.
   const compiledBasename = path.basename(outputFile.location.absolutePath);
   const tail = await readLogTail(buildDir, compiledBasename);
   await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -117,6 +117,9 @@ async function compileOne(
   opts: PerFileOptions,
 ): Promise<void> {
   const displayName = getCompileDisplayName(outputFile);
+  // compiledBasename is the actual on-disk filename LaTeX engines use when
+  // naming their .log; it may differ from displayName when file.source is set.
+  const compiledBasename = path.basename(outputFile.location.absolutePath);
   // Full relative path keeps two outputs sharing a basename distinct
   // (ch1/main.tex vs ch2/main.tex).
   const safeName = getComparablePath(outputFile.location).replaceAll(
@@ -157,7 +160,6 @@ async function compileOne(
     return;
   }
 
-  const compiledBasename = path.basename(outputFile.location.absolutePath);
   const tail = await readLogTail(buildDir, compiledBasename);
   await flexibleFS.ensureDir(pathToLocation(opts.compileRoot));
   await flexibleFS.write(

--- a/src/agent/output/diffComputation.ts
+++ b/src/agent/output/diffComputation.ts
@@ -83,12 +83,24 @@ export async function computeOutputDiffStats(
 
       // Use original as diff base when there's no direct base mapping
       // and the original is a different file (not self-referencing)
-      const diffBaseLocation =
+      let diffBaseLocation =
         baseLocation ??
         (originalLocation &&
         getComparablePath(originalLocation) !== locationPath
           ? originalLocation
           : null);
+
+      // Fallback for single-input multi-output: when an agent extracts N
+      // documents from one base file, the extracted doc names (e.g. "chapter1",
+      // "methods") don't match the base filename via basename strategies.
+      // If no diff base was found but there is exactly one base file, use it
+      // so the diff stats reflect real changes against the original.
+      if (!diffBaseLocation && !originalLocation && baseFiles.length === 1) {
+        const candidate = baseFiles[0];
+        if (getComparablePath(candidate) !== locationPath) {
+          diffBaseLocation = candidate;
+        }
+      }
 
       const effectiveOriginal = suppressLineage ? null : originalLocation;
       const effectiveDiffBase = suppressLineage ? null : diffBaseLocation;

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -418,7 +418,12 @@ async function scanRunDirForOutputs(
         // than the fixed "output.tex" stem, so filtering by basename would
         // silently drop them.  Skip non-LaTeX files (.xml raw outputs, .log
         // compile artefacts, etc.) by extension only.
-        if (parsed.ext !== '.tex') {
+        if (
+          parsed.ext !== '.tex' ||
+          // Exclude latexdiff artifacts written to round dirs by LatexDiffManager
+          // (e.g. "foo_diff.tex", "foo_diffr1r0.tex").
+          /_diff(r\d+r\d+)?$/.test(parsed.name)
+        ) {
           continue;
         }
 

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -498,11 +498,14 @@ async function scanRunDirForOutputs(
           sourceNoExt === WORKFLOW_OUTPUT_BASENAME
             ? path.basename(inputFile)
             : sourceNoExt;
-        // Match recovered file to its base by relative path; fall back to the
-        // primary inputFile so single-output rounds always have a valid original.
+        // Match recovered file to its base by relative path. Fall back to the
+        // single configured base only when there's no ambiguity (one candidate);
+        // in multi-file runs an unmatched file gets null so it surfaces as a
+        // "missing base" error rather than silently diffing against the wrong doc.
         const fileKey = fileRelToRound.replace(/\\/g, '/').replace(/\.tex$/i, '');
         const originalLocation =
-          baseLocationByRelPath.get(fileKey) ?? defaultBaseLocation;
+          baseLocationByRelPath.get(fileKey) ??
+          (baseLocationByRelPath.size === 1 ? defaultBaseLocation : null);
         outputs.push({
           source,
           round,

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -451,17 +451,22 @@ async function scanRunDirForOutputs(
       // Collect .tex files recursively — extracted docs may live in subdirs
       // (e.g. r0/chapters/main.tex) when source names include path segments.
       const allTexFiles = await collectTexFiles(roundDirAbsolute);
-      // For XML-mode agents, the round dir has both output.tex (raw wrapper)
-      // and extracted files (e.g. paper.tex).  Drop the raw stem when extracted
-      // files are present so latexdiff doesn't operate on XML-wrapped content.
+      // Strip diff artifacts before the output.tex decision so a round with
+      // only output.tex + one artifact doesn't lose output.tex (artifacts
+      // are filtered first, then the raw stem is dropped only when real
+      // extracted outputs remain alongside it).
       const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
+      const nonArtifact = allTexFiles.filter(
+        (f) => !LATEXDIFF_ARTIFACT_RE.test(path.parse(f).name),
+      );
+      // For XML-mode agents, the round dir has both output.tex (raw wrapper)
+      // and extracted files (e.g. paper.tex).  Drop the raw stem only when
+      // real extracted outputs exist alongside it.
       const texFiles =
-        allTexFiles.length > 1 && allTexFiles.includes(rawStem)
-          ? allTexFiles.filter((f) => f !== rawStem)
-          : allTexFiles;
+        nonArtifact.length > 1 && nonArtifact.includes(rawStem)
+          ? nonArtifact.filter((f) => f !== rawStem)
+          : nonArtifact;
       for (const fileRelToRound of texFiles) {
-        const parsed = path.parse(fileRelToRound);
-        if (LATEXDIFF_ARTIFACT_RE.test(parsed.name)) continue;
 
         const relativePath = path.join(entryName, fileRelToRound);
         const location = createRunStorageLocation(

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -52,6 +52,9 @@ import { checkToolInstalled } from '@utils/system';
 import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
+
+/** Matches latexdiff artifact stems: foo_diff or foo_diffr1r0 */
+const LATEXDIFF_ARTIFACT_RE = /_diff(r\d+r\d+)?$/;
 logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);
@@ -422,7 +425,7 @@ async function scanRunDirForOutputs(
           parsed.ext !== '.tex' ||
           // Exclude latexdiff artifacts written to round dirs by LatexDiffManager
           // (e.g. "foo_diff.tex", "foo_diffr1r0.tex").
-          /_diff(r\d+r\d+)?$/.test(parsed.name)
+          LATEXDIFF_ARTIFACT_RE.test(parsed.name)
         ) {
           continue;
         }

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -469,8 +469,12 @@ async function scanRunDirForOutputs(
       // are filtered first, then the raw stem is dropped only when real
       // extracted outputs remain alongside it).
       const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
+      // Between-round artifacts written to run storage always carry both round
+      // numbers (e.g. output_diffr1r0.tex). The bare _diff suffix only appears
+      // in workspace-side diffs, never here, so a legitimately-named source
+      // like "chapter_diff.tex" is not mistakenly dropped.
       const nonArtifact = allTexFiles.filter(
-        (f) => !LATEXDIFF_ARTIFACT_RE.test(path.parse(f).name),
+        (f) => !/_diffr\d+r\d+$/.test(path.parse(f).name),
       );
       // For XML-mode agents, the round dir has both output.tex (raw wrapper)
       // and extracted files (e.g. paper.tex).  Drop the raw stem only when

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -413,11 +413,12 @@ async function scanRunDirForOutputs(
       for (const [fileName, nestedType] of roundEntries) {
         if (nestedType !== vscode.FileType.File) continue;
         const parsed = path.parse(fileName);
-        // Only the canonical round output `output.tex` is a valid latexdiff
-        // target — scratchpad artifacts like `output.xml` and multi-document
-        // extracted files (which carry their own source-derived names) must
-        // not be fed into latexdiff via this fallback.
-        if (parsed.name !== WORKFLOW_OUTPUT_BASENAME || parsed.ext !== '.tex') {
+        // Accept any .tex file as a latexdiff target.  Extracted documents
+        // now carry source-derived names (e.g. "constrained_note.tex") rather
+        // than the fixed "output.tex" stem, so filtering by basename would
+        // silently drop them.  Skip non-LaTeX files (.xml raw outputs, .log
+        // compile artefacts, etc.) by extension only.
+        if (parsed.ext !== '.tex') {
           continue;
         }
 
@@ -428,7 +429,9 @@ async function scanRunDirForOutputs(
           executionId,
         );
         outputs.push({
-          source: inputFile,
+          // Use the file's own stem as source so FileLineageCalculator can
+          // match it back to the workspace original (e.g. "constrained_note").
+          source: parsed.name,
           round,
           location,
           lineage: {

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -424,6 +424,7 @@ async function collectTexFiles(
 async function scanRunDirForOutputs(
   executionId: ExecutionId,
   inputFile: string,
+  extraBaseFiles?: string[],
 ): Promise<Map<number, OutputFileInfo[]> | null> {
   try {
     const runDirAbsolute = await resolveRunDir(executionId);
@@ -433,11 +434,17 @@ async function scanRunDirForOutputs(
       vscode.Uri.file(runDirAbsolute),
     );
 
-    const baseLocation = pathToLocation(
-      path.isAbsolute(inputFile)
-        ? inputFile
-        : path.join(WorkspaceFS.getPath() ?? '', inputFile),
-    );
+    const workspacePath = WorkspaceFS.getPath() ?? '';
+    const toAbs = (f: string): string =>
+      path.isAbsolute(f) ? f : path.join(workspacePath, f);
+
+    // Build a basename → workspace location map from all configured base files
+    // so multi-output runs can match each recovered file to its correct original.
+    const baseLocationByBasename = new Map<string, FileLocation>();
+    for (const bf of [inputFile, ...(extraBaseFiles ?? [])]) {
+      baseLocationByBasename.set(path.basename(bf), pathToLocation(toAbs(bf)));
+    }
+    const defaultBaseLocation = pathToLocation(toAbs(inputFile));
 
     const rounds = new Map<number, OutputFileInfo[]>();
 
@@ -483,12 +490,17 @@ async function scanRunDirForOutputs(
           sourceNoExt === WORKFLOW_OUTPUT_BASENAME
             ? path.basename(inputFile)
             : sourceNoExt;
+        // Match each recovered file to its base by basename; fall back to the
+        // primary inputFile so single-output rounds always have a valid original.
+        const originalLocation =
+          baseLocationByBasename.get(path.basename(fileRelToRound)) ??
+          defaultBaseLocation;
         outputs.push({
           source,
           round,
           location,
           lineage: {
-            original: baseLocation,
+            original: originalLocation,
             diffBase: null,
             diffFile: null,
           },
@@ -633,7 +645,11 @@ async function handleRunLatexdiff(
     if (!outputsByRound && runId) {
       const parsedRunId = ExecutionIdSchema.safeParse(runId);
       if (parsedRunId.success) {
-        const scanned = await scanRunDirForOutputs(parsedRunId.data, inputFile);
+        const scanned = await scanRunDirForOutputs(
+          parsedRunId.data,
+          inputFile,
+          outputFiles,
+        );
         if (scanned) {
           outputsByRound = scanned;
           discoveredExecutionId = parsedRunId.data;

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -54,8 +54,6 @@ import { hasExtension } from '@utils/core/pathCore';
 
 const CHANNEL = 'LaTeXCommands';
 
-/** Matches latexdiff artifact stems: foo_diff or foo_diffr1r0 */
-const LATEXDIFF_ARTIFACT_RE = /_diff(r\d+r\d+)?$/;
 logger.initialize(CHANNEL);
 
 const service = new LaTeXdiffService(CHANNEL);

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
@@ -383,13 +384,25 @@ async function collectTexFiles(
   }
   const results: string[] = [];
   for (const [name, type] of entries) {
-    if (type === vscode.FileType.File) {
+    const absPath = path.join(dir, name);
+    // Skip symlinks — they are mirrored dependency copies placed by
+    // ensureMirroredInRoundDir, not revised outputs.  Use lstat because
+    // some vscode.workspace.fs implementations don't set the SymbolicLink
+    // flag in the returned FileType bitmask.
+    try {
+      if ((await fs.promises.lstat(absPath)).isSymbolicLink()) continue;
+    } catch {
+      // lstat failed; fall through and include the entry
+    }
+    const isFile = (type & vscode.FileType.File) !== 0;
+    const isDir = (type & vscode.FileType.Directory) !== 0;
+    if (isFile) {
       if (hasExtension(name, '.tex')) {
         results.push(prefix ? `${prefix}/${name}` : name);
       }
-    } else if (type === vscode.FileType.Directory) {
+    } else if (isDir) {
       const sub = await collectTexFiles(
-        path.join(dir, name),
+        absPath,
         prefix ? `${prefix}/${name}` : name,
       );
       results.push(...sub);
@@ -437,7 +450,15 @@ async function scanRunDirForOutputs(
       const outputs: OutputFileInfo[] = [];
       // Collect .tex files recursively — extracted docs may live in subdirs
       // (e.g. r0/chapters/main.tex) when source names include path segments.
-      const texFiles = await collectTexFiles(roundDirAbsolute);
+      const allTexFiles = await collectTexFiles(roundDirAbsolute);
+      // For XML-mode agents, the round dir has both output.tex (raw wrapper)
+      // and extracted files (e.g. paper.tex).  Drop the raw stem when extracted
+      // files are present so latexdiff doesn't operate on XML-wrapped content.
+      const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
+      const texFiles =
+        allTexFiles.length > 1 && allTexFiles.includes(rawStem)
+          ? allTexFiles.filter((f) => f !== rawStem)
+          : allTexFiles;
       for (const fileRelToRound of texFiles) {
         const parsed = path.parse(fileRelToRound);
         if (LATEXDIFF_ARTIFACT_RE.test(parsed.name)) continue;

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -368,6 +368,37 @@ interface DiffOperation {
 }
 
 /**
+ * Recursively collect all `.tex` file paths under `dir`, returned as paths
+ * relative to `dir` using forward slashes (e.g. `"chapters/main.tex"`).
+ */
+async function collectTexFiles(
+  dir: string,
+  prefix = '',
+): Promise<string[]> {
+  let entries: [string, vscode.FileType][];
+  try {
+    entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(dir));
+  } catch {
+    return [];
+  }
+  const results: string[] = [];
+  for (const [name, type] of entries) {
+    if (type === vscode.FileType.File) {
+      if (hasExtension(name, '.tex')) {
+        results.push(prefix ? `${prefix}/${name}` : name);
+      }
+    } else if (type === vscode.FileType.Directory) {
+      const sub = await collectTexFiles(
+        path.join(dir, name),
+        prefix ? `${prefix}/${name}` : name,
+      );
+      results.push(...sub);
+    }
+  }
+  return results;
+}
+
+/**
  * Read `executions/{runId}/r{round}/output.*` directly from disk and build
  * `OutputFileInfo[]` per round. Used as a recovery fallback when the caller
  * supplies a `runId` but stream-tab metadata is missing or stale — in that
@@ -403,43 +434,25 @@ async function scanRunDirForOutputs(
       if (round == null) continue;
 
       const roundDirAbsolute = path.join(runDirAbsolute, entryName);
-      let roundEntries: [string, vscode.FileType][];
-      try {
-        roundEntries = await vscode.workspace.fs.readDirectory(
-          vscode.Uri.file(roundDirAbsolute),
-        );
-      } catch {
-        continue;
-      }
-
       const outputs: OutputFileInfo[] = [];
-      for (const [fileName, nestedType] of roundEntries) {
-        if (nestedType !== vscode.FileType.File) continue;
-        const parsed = path.parse(fileName);
-        // Accept any .tex file as a latexdiff target.  Extracted documents
-        // now carry source-derived names (e.g. "constrained_note.tex") rather
-        // than the fixed "output.tex" stem, so filtering by basename would
-        // silently drop them.  Skip non-LaTeX files (.xml raw outputs, .log
-        // compile artefacts, etc.) by extension only.
-        if (
-          parsed.ext !== '.tex' ||
-          // Exclude latexdiff artifacts written to round dirs by LatexDiffManager
-          // (e.g. "foo_diff.tex", "foo_diffr1r0.tex").
-          LATEXDIFF_ARTIFACT_RE.test(parsed.name)
-        ) {
-          continue;
-        }
+      // Collect .tex files recursively — extracted docs may live in subdirs
+      // (e.g. r0/chapters/main.tex) when source names include path segments.
+      const texFiles = await collectTexFiles(roundDirAbsolute);
+      for (const fileRelToRound of texFiles) {
+        const parsed = path.parse(fileRelToRound);
+        if (LATEXDIFF_ARTIFACT_RE.test(parsed.name)) continue;
 
-        const relativePath = path.join(entryName, fileName);
+        const relativePath = path.join(entryName, fileRelToRound);
         const location = createRunStorageLocation(
           path.join(runDirAbsolute, relativePath),
           relativePath,
           executionId,
         );
+        // Preserve subdirectory in source (e.g. "chapters/main") so
+        // FileLineageCalculator can match it back to the workspace original.
+        const sourceNoExt = fileRelToRound.replace(/\.tex$/i, '');
         outputs.push({
-          // Use the file's own stem as source so FileLineageCalculator can
-          // match it back to the workspace original (e.g. "constrained_note").
-          source: parsed.name,
+          source: sourceNoExt,
           round,
           location,
           lineage: {

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -438,11 +438,17 @@ async function scanRunDirForOutputs(
     const toAbs = (f: string): string =>
       path.isAbsolute(f) ? f : path.join(workspacePath, f);
 
-    // Build a basename → workspace location map from all configured base files
-    // so multi-output runs can match each recovered file to its correct original.
-    const baseLocationByBasename = new Map<string, FileLocation>();
+    // Build a relative-path (no extension) → workspace location map so
+    // multi-output runs with duplicate basenames (e.g. chapters/main.tex and
+    // appendix/main.tex) don't collide. fileRelToRound mirrors the workspace
+    // relative path for XML-extracted files, so the keys match directly.
+    const baseLocationByRelPath = new Map<string, FileLocation>();
     for (const bf of [inputFile, ...(extraBaseFiles ?? [])]) {
-      baseLocationByBasename.set(path.basename(bf), pathToLocation(toAbs(bf)));
+      const abs = toAbs(bf);
+      const rel = (workspacePath ? path.relative(workspacePath, abs) : bf)
+        .replace(/\\/g, '/')
+        .replace(/\.tex$/i, '');
+      baseLocationByRelPath.set(rel, pathToLocation(abs));
     }
     const defaultBaseLocation = pathToLocation(toAbs(inputFile));
 
@@ -490,11 +496,11 @@ async function scanRunDirForOutputs(
           sourceNoExt === WORKFLOW_OUTPUT_BASENAME
             ? path.basename(inputFile)
             : sourceNoExt;
-        // Match each recovered file to its base by basename; fall back to the
+        // Match recovered file to its base by relative path; fall back to the
         // primary inputFile so single-output rounds always have a valid original.
+        const fileKey = fileRelToRound.replace(/\\/g, '/').replace(/\.tex$/i, '');
         const originalLocation =
-          baseLocationByBasename.get(path.basename(fileRelToRound)) ??
-          defaultBaseLocation;
+          baseLocationByRelPath.get(fileKey) ?? defaultBaseLocation;
         outputs.push({
           source,
           round,

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -476,9 +476,15 @@ async function scanRunDirForOutputs(
         );
         // Preserve subdirectory in source (e.g. "chapters/main") so
         // FileLineageCalculator can match it back to the workspace original.
+        // For the generic "output" stem, fall back to the input file basename
+        // so progress labels show the meaningful name instead of "output".
         const sourceNoExt = fileRelToRound.replace(/\.tex$/i, '');
+        const source =
+          sourceNoExt === WORKFLOW_OUTPUT_BASENAME
+            ? path.basename(inputFile)
+            : sourceNoExt;
         outputs.push({
-          source: sourceNoExt,
+          source,
           round,
           location,
           lineage: {

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -315,7 +315,10 @@ export class FileList extends LitElement {
    */
   private getSourceDisplayPath(source: string | undefined): string {
     if (!source || source === 'output' || source === 'output.tex') return '';
-    const hasExt = /\.tex$/i.test(source);
+    // Treat a trailing all-alpha suffix as a real extension (.tex, .txt, .bib…).
+    // Suffixes containing digits (.v2, .r3) are version qualifiers, not
+    // extensions, so .tex is appended in those cases.
+    const hasExt = /\.[a-zA-Z]+$/.test(source);
     return hasExt ? source : `${source}.tex`;
   }
 

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -315,7 +315,7 @@ export class FileList extends LitElement {
    */
   private getSourceDisplayPath(source: string | undefined): string {
     if (!source || source === 'output' || source === 'output.tex') return '';
-    const hasExt = /\.[^/\\]+$/.test(source);
+    const hasExt = /\.tex$/i.test(source);
     return hasExt ? source : `${source}.tex`;
   }
 

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -315,7 +315,7 @@ export class FileList extends LitElement {
    */
   private getSourceDisplayPath(source: string | undefined): string {
     if (!source || source === 'output' || source === 'output.tex') return '';
-    const hasExt = source.includes('.');
+    const hasExt = /\.[^/\\]+$/.test(source);
     return hasExt ? source : `${source}.tex`;
   }
 

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -224,7 +224,11 @@ export class FileList extends LitElement {
     if (!file?.location) return nothing;
 
     const location = file.location;
-    const displayPath = this.getDisplayPath(file.lineage?.original ?? location);
+    // Prefer: workspace original → source doc name → run-storage relative path
+    const displayPath =
+      this.getDisplayPath(file.lineage?.original) ||
+      this.getSourceDisplayPath(file.source) ||
+      this.getDisplayPath(location);
     const { dir, basename } = parsePath(displayPath);
     const tooltipPath = this.getDisplayPath(location);
     const effectiveBase =
@@ -295,11 +299,24 @@ export class FileList extends LitElement {
       .sort((a, b) => a[0] - b[0]);
   }
 
-  private getDisplayPath(loc: OutputFileInfo['location']): string {
+  private getDisplayPath(
+    loc: OutputFileInfo['location'] | null | undefined,
+  ): string {
     if (!loc) return '';
     return loc.kind === 'workspace' || loc.kind === 'runStorage'
       ? loc.relativePath
       : loc.absolutePath;
+  }
+
+  /**
+   * Derive a display path from the source document name when lineage.original
+   * is absent (e.g. multi-doc extractions whose names don't match a base file).
+   * Returns empty string for generic names that shouldn't override the fallback.
+   */
+  private getSourceDisplayPath(source: string | undefined): string {
+    if (!source || source === 'output' || source === 'output.tex') return '';
+    const hasExt = source.includes('.');
+    return hasExt ? source : `${source}.tex`;
   }
 
   private renderDiffStats(


### PR DESCRIPTION
Commit e4df4c2 renamed workflow outputs from descriptive filenames to the fixed path `r{n}/output.tex`. Several downstream systems that relied on the old filename encoding broke; this PR fixes them all.

## Core fixes (original scope)

**1. OutputFileProcessor — source field for non-XML single output**
When there is exactly one base file, derive `source` from its name so `FileLineageCalculator.findMatchingBaseFile` can match the workspace original. Previously `source = "output.tex"` caused the Generated Files list to fall back to showing the run-storage path `r0/output.tex`.

**2. XmlOutputManager — extracted file naming**
Name extracted `.tex` files after the input file stem or XML `<document name>` attribute (with collision guards and path sanitization) instead of the raw output stem. Fixes compound-stem double-parsing and prevents raw `output.tex` from being co-mingled with real extracted documents.

**3. compileCheck — display name vs compiled basename**
Prefer `outputFile.source` (human-readable document name) for user-facing log messages. Keep `compiledBasename = path.basename(outputFile.location.absolutePath)` as the key for reading LaTeX `.log` files, since engines name logs after the real on-disk filename. Pass `displayName` as a parameter to `compileOne` to avoid a duplicate `getCompileDisplayName` call; rename `readLogTail`'s parameter from `displayName` to `compiledBasename` to make the distinction explicit.

**4. diffComputation — diff-base fallback for multi-output single-input runs**
When an agent extracts N documents from one `.tex` input, extracted names (`chapter1`, `methods`, …) don't match the base file via basename strategy, leaving `diffBase = null` and showing only `+N` with no removal count. Fix: when no diff base is found and there is exactly one base file, use it as the diff base (without touching `lineage.original`, so display is unaffected).

**5. FileList — source-field display fallback**
For run-storage outputs whose `lineage.original` is null, fall back to the `source` field (e.g. `"chapter1"` → `"chapter1.tex"`) before the generic run-storage relative path. Use an all-alpha extension check (`/\.[a-zA-Z]+$/`) to distinguish real extensions (`.tex`, `.txt`, `.bib`) from version qualifiers (`.v2`, `.r3`) when deciding whether to append `.tex`.

## latexdiff run-dir recovery improvements

**6. Recursive `.tex` discovery in `scanRunDirForOutputs`**
Accept any `.tex` file under a round directory (not just `output.tex`), skipping dependency symlinks. Extracted docs may live in subdirectories (e.g. `r0/chapters/main.tex`).

**7. Artifact filter ordering**
Pre-filter between-round latexdiff artifacts (`/_diffr\d+r\d+$/`) before deciding whether to drop the raw `output.tex` stem. The previous order could eliminate both when only `output.tex` + one artifact existed.

**8. Artifact filter scope**
Use `/_diffr\d+r\d+$/` (requires both round numbers) instead of the broader `/_diff(r\d+r\d+)?$/` in run-storage scans. Between-round artifacts always carry both numbers; bare `_diff` outputs go to the workspace, not run storage, so a legitimate source file named `chapter_diff.tex` is never falsely excluded.

**9. Multi-file base matching by relative path**
Pass `outputFiles` (all configured base files) into `scanRunDirForOutputs` and map each recovered file to its correct workspace original by workspace-relative path (without extension). Keying by relative path rather than basename prevents `chapters/main.tex` and `appendix/main.tex` from colliding on `"main"`. When multiple bases are configured and a recovered file matches none, set `lineage.original = null` so it surfaces as a "missing base" error rather than silently diffing against the wrong document.

**10. Progress labels for single-output rounds**
When the only recovered file is `output.tex`, use `path.basename(inputFile)` as `source` so latexdiff progress messages show the meaningful input document name (e.g. `"paper.tex (r0)"`) instead of `"output (r0)"`.

https://claude.ai/code/session_017TXS8YUsv71qbRf41iqk89