### PR TITLE
Add subagent indicator to compact stream tabs

### DIFF
--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -425,6 +425,8 @@ export class StreamTab extends LitElement {
             ${hasChildrenCompact
               ? html`<i
                   class="codicon codicon-chevron-right compact-subagent-hint"
+                  role="img"
+                  aria-label="${this.childCount} child stream${this.childCount > 1 ? 's' : ''}"
                   title="${this.childCount} child stream${this.childCount > 1 ? 's' : ''}"
                 ></i>`
               : nothing}

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -288,6 +288,12 @@ export class StreamTab extends LitElement {
         gap: var(--spacing-tiny);
       }
 
+      .compact-subagent-hint {
+        font-size: var(--font-size-xs);
+        opacity: 0.35;
+        flex-shrink: 0;
+      }
+
       .tab-delete::part(control) {
         padding: 0;
         border-radius: var(--border-radius-small);
@@ -378,6 +384,7 @@ export class StreamTab extends LitElement {
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
+    const hasChildrenCompact = this.childCount > 0 && this.compact;
 
     return html`
       <div
@@ -415,6 +422,12 @@ export class StreamTab extends LitElement {
               >${stream.parentStreamId ? '↳ ' : ''}${stream.label ||
               stream.name}</span
             >
+            ${hasChildrenCompact
+              ? html`<i
+                  class="codicon codicon-chevron-right compact-subagent-hint"
+                  title="${this.childCount} subagent${this.childCount > 1 ? 's' : ''}"
+                ></i>`
+              : nothing}
           </div>
           ${this.compact
             ? nothing

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -672,6 +672,7 @@ export class StreamTabs extends LitElement {
               (stream) => stream.name,
               (stream) => {
                 const children = this.childStreamsByParent.get(stream.name);
+                const rawChildCount = children?.length ?? 0;
                 // In compact mode, force childCount to 0 so the entire
                 // <div class="child-streams"> subtree is unmounted (saves
                 // memory on sessions with many child streams). In non-compact
@@ -680,12 +681,12 @@ export class StreamTabs extends LitElement {
                 // case PR #2984 optimized for). Compact toggles come from
                 // sidebar resize, which is infrequent enough that
                 // unmount/remount is acceptable and frees memory.
-                const childCount = !this.compact ? (children?.length ?? 0) : 0;
+                const childCount = !this.compact ? rawChildCount : 0;
                 const expanded =
                   childCount > 0 && this.expandedParents.has(stream.name);
 
                 // prettier-ignore
-                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.getStatus(stream.name)} .lastTimestamp=${this.getTimestamp(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${childCount} ?expanded=${expanded}></stream-tab>${children && childCount > 0 ? html`<div class="child-streams" ?hidden=${!expanded}>${repeat(children, (child) => child.name, (child) => {
+                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.getStatus(stream.name)} .lastTimestamp=${this.getTimestamp(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${rawChildCount} ?expanded=${expanded}></stream-tab>${children && childCount > 0 ? html`<div class="child-streams" ?hidden=${!expanded}>${repeat(children, (child) => child.name, (child) => {
                   const childStatus = this.getStatus(child.name);
                   const isFinished = classifyChild(this.streamStates, child.name) === 'finished';
                   // prettier-ignore

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -425,7 +425,7 @@ export class StreamTab extends LitElement {
             ${hasChildrenCompact
               ? html`<i
                   class="codicon codicon-chevron-right compact-subagent-hint"
-                  title="${this.childCount} subagent${this.childCount > 1 ? 's' : ''}"
+                  title="${this.childCount} child stream${this.childCount > 1 ? 's' : ''}"
                 ></i>`
               : nothing}
           </div>

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -384,7 +384,7 @@ export class StreamTab extends LitElement {
     const tooltip = this._tooltip;
     const agentDecorator = this._agentDecorator;
     const hasChildren = this.childCount > 0 && !this.compact;
-    const hasChildrenCompact = this.childCount > 0 && this.compact;
+    const childStreamLabel = `${this.childCount} child stream${this.childCount > 1 ? 's' : ''}`;
 
     return html`
       <div
@@ -403,9 +403,7 @@ export class StreamTab extends LitElement {
               class="tab-expand"
               data-stream=${stream.name}
               data-action="toggle-children"
-              title=${this.expanded
-                ? 'Collapse child streams'
-                : `${this.childCount} child stream${this.childCount > 1 ? 's' : ''}`}
+              title=${this.expanded ? 'Collapse child streams' : childStreamLabel}
               aria-expanded=${this.expanded ? 'true' : 'false'}
             >
               <i class="codicon codicon-chevron-right"></i>
@@ -422,12 +420,12 @@ export class StreamTab extends LitElement {
               >${stream.parentStreamId ? '↳ ' : ''}${stream.label ||
               stream.name}</span
             >
-            ${hasChildrenCompact
+            ${this.childCount > 0 && this.compact
               ? html`<i
                   class="codicon codicon-chevron-right compact-subagent-hint"
                   role="img"
-                  aria-label="${this.childCount} child stream${this.childCount > 1 ? 's' : ''}"
-                  title="${this.childCount} child stream${this.childCount > 1 ? 's' : ''}"
+                  aria-label=${childStreamLabel}
+                  title=${childStreamLabel}
                 ></i>`
               : nothing}
           </div>


### PR DESCRIPTION
## Summary
Added a visual indicator to stream tabs in compact mode to show when a stream has child streams (subagents), improving discoverability of nested stream hierarchies.

## Key Changes
- Added new `.compact-subagent-hint` CSS class with subtle styling (small font size, low opacity, no shrinking)
- Introduced `hasChildrenCompact` computed variable to detect streams with children in compact mode
- Added a chevron icon indicator that displays next to the stream label when in compact mode and the stream has child streams
- Icon includes a tooltip showing the count of subagents

## Implementation Details
- The indicator uses a right-pointing chevron icon (`codicon-chevron-right`) to suggest expandable content
- Styling is intentionally subtle (35% opacity) to avoid visual clutter while remaining discoverable
- Tooltip dynamically pluralizes "subagent" based on child count for better UX

https://claude.ai/code/session_01Ud8uGJm9gM1Vp5dzZ9HyZt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds a subtle compact-mode chevron/tooltip to indicate streams with children while preserving existing expand/collapse behavior. Minor risk of small layout/ARIA regressions in the tab header.
> 
> **Overview**
> Adds a compact-mode visual hint for parent streams: `stream-tab` now renders a subtle chevron icon next to the title (with tooltip/`aria-label` showing the pluralized child count) when a stream has child streams but the nested list is unmounted.
> 
> Refactors child-count handling so `StreamTabs` still passes the *raw* child count to each tab in compact mode (for the indicator) while continuing to treat the count as `0` for mounting the `.child-streams` subtree, and reuses the same `childStreamLabel` string for tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995aa31a9786893882ffcf7a71d67480db539d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->