### PR TITLE
Add terminal mode support with ANSI code stripping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "shell-quote": "^1.8.3",
         "signal-polyfill": "^0.2.2",
         "sortablejs": "^1.15.7",
+        "strip-ansi": "^7.2.0",
         "tar": "^7.5.13",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "^1.0.2",
@@ -3609,7 +3610,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10849,7 +10849,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"

--- a/package.json
+++ b/package.json
@@ -1762,6 +1762,7 @@
     "shell-quote": "^1.8.3",
     "signal-polyfill": "^0.2.2",
     "sortablejs": "^1.15.7",
+    "strip-ansi": "^7.2.0",
     "tar": "^7.5.13",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -59,8 +59,12 @@ function processTerminalText(text: string): string {
     .map((line) => {
       const segs = line.split('\r');
       const last = segs.at(-1)!;
-      // Line ending with \r leaves cursor at start — show content before it
-      return last.length > 0 ? last : (segs.at(-2) ?? '');
+      if (last.length > 0) return last;
+      // One or more trailing \r leave cursor at start — find last written content
+      for (let i = segs.length - 2; i >= 0; i--) {
+        if (segs[i]!.length > 0) return segs[i]!;
+      }
+      return '';
     })
     .join('\n');
 }
@@ -341,7 +345,10 @@ export class TaskGroupList extends LitElement {
       this.cachedTerminalLines += processTerminalText(combined.slice(0, lastNl + 1));
       this.cachedRawTail = combined.slice(lastNl + 1);
     } else {
-      this.cachedRawTail = combined;
+      // No newline: collapse \r-overwritten content so the tail stays bounded
+      // (frequent \r updates without \n, e.g. progress bars, would otherwise
+      // grow the buffer and make every render O(n) on accumulated output)
+      this.cachedRawTail = processTerminalText(combined);
     }
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -75,12 +75,10 @@ function processTerminalText(text: string): string {
         const seg = segs[i]!;
         const eraseAt = seg.indexOf(ERASE_SENTINEL);
         if (eraseAt >= 0) {
-          // Overlay prefix up to the erase point, then clear the line from there.
+          // \r overlays the prefix up to the erase point; \x1b[K clears from there to EOL.
           const pre = seg.slice(0, eraseAt);
           const post = seg.slice(eraseAt + 1).split(ERASE_SENTINEL).join('');
-          const overlaid =
-            pre.length < current.length ? pre + current.slice(pre.length) : pre;
-          current = overlaid.slice(0, pre.length) + post;
+          current = pre + post;
         } else {
           // \r moves cursor to column 0 without clearing; shorter writes preserve the tail
           current = seg.length < current.length ? seg + current.slice(seg.length) : seg;

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -52,16 +52,17 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
 );
 
 // Null byte used as a sentinel for ANSI erase-line sequences inside processTerminalText.
-// \x00 won't appear in legitimate terminal text and is not touched by strip-ansi.
+// Real null bytes in the input are stripped first so the sentinel is unambiguous.
 const ERASE_SENTINEL = '\x00';
 
 /** Strip ANSI codes and simulate \r overwrite within each newline-delimited line. */
 function processTerminalText(text: string): string {
-  // Replace ANSI erase-line escapes (\x1b[K, \x1b[0K, \x1b[2K, …) with a sentinel
+  // Strip any real null bytes so \x00 is unambiguous as our internal sentinel.
+  // Then replace ANSI erase-line escapes (\x1b[K, \x1b[0K, \x1b[2K, …) with it
   // before stripping all ANSI so the overwrite loop can honour them: an erase clears
   // the line from that column onward instead of preserving the stale tail characters.
   // eslint-disable-next-line no-control-regex
-  const preprocessed = text.replace(/\x1b\[\d*K/g, ERASE_SENTINEL);
+  const preprocessed = text.split(ERASE_SENTINEL).join('').replace(/\x1b\[\d*K/g, ERASE_SENTINEL);
   return stripAnsi(preprocessed)
     .replace(/\r\n/g, '\n')
     .split('\n')

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -381,13 +381,14 @@ export class TaskGroupList extends LitElement {
     } else {
       // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
       // overwrites are handled correctly at render time.
-      // Only cap when there are confirmed standalone \r rewrites, i.e. \r is
-      // present AND the buffer does not end with \r (a trailing \r might be the
-      // first half of a \r\n split across chunks, so we defer the cap to avoid
-      // permanently dropping the preceding content before the \n arrives).
+      // Cap when there is at least one \r that is NOT the last character — that
+      // confirms standalone CR rewrites exist (progress-bar style). A trailing \r
+      // as the only/last CR is deferred: it may be the first half of a \r\n split
+      // across chunks, and capping would permanently drop the preceding content.
       const MAX_TAIL = 65536;
+      const crIdx = combined.indexOf('\r');
       this.cachedRawTail =
-        combined.includes('\r') && !combined.endsWith('\r') && combined.length > MAX_TAIL
+        crIdx >= 0 && crIdx < combined.length - 1 && combined.length > MAX_TAIL
           ? combined.slice(combined.length - MAX_TAIL)
           : combined;
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -50,6 +50,26 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
 
+/**
+ * Prepare raw process output for terminal-style display.
+ * Strips ANSI escape codes and simulates carriage-return overwrite so that
+ * progress lines (e.g. lake build's "● Building…\r✔ Built…") render like
+ * a real terminal instead of showing both the building and built indicators.
+ */
+function processTerminalText(text: string): string {
+  // Strip ANSI escape sequences (colors, cursor movement, etc.)
+  const stripped = text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+  // Within each newline-delimited segment, a bare \r moves back to the start.
+  // Split on \r and keep only the last segment per line.
+  const lines = stripped.split('\n');
+  return lines
+    .map((line) => {
+      const parts = line.split('\r');
+      return parts[parts.length - 1];
+    })
+    .join('\n');
+}
+
 /** Maps group status to codicon class (with optional animation) */
 function getStatusIcon(status: string): string {
   switch (status) {
@@ -92,6 +112,9 @@ export class TaskGroupList extends LitElement {
   /** Memoized tree output from buildGroupTree() - recomputed only when inputs change */
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
+
+  /** Memoized processed text for terminal mode rendering */
+  private cachedTerminalText = '';
 
   /** O(1) lookup from groupId → tree node. Built during buildGroupTree(). */
   private groupNodeIndex = new Map<string, GroupTree>();
@@ -145,6 +168,13 @@ export class TaskGroupList extends LitElement {
 
     const groupsChanged = changedProperties.has('groups');
     const messagesChanged = changedProperties.has('messages');
+    const terminalChanged = changedProperties.has('terminal');
+
+    if (this.terminal && (messagesChanged || terminalChanged)) {
+      this.cachedTerminalText = processTerminalText(
+        this.messages.map((m) => m.text).join(''),
+      );
+    }
     const prevMessages = messagesChanged
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;
@@ -582,6 +612,20 @@ export class TaskGroupList extends LitElement {
           @vsc-scrollable-scroll=${this.handleVscScroll}
         >
           <div class="log-placeholder">${unsafeHTML(PLACEHOLDER_HTML)}</div>
+        </vscode-scrollable>
+      `;
+    }
+
+    // Terminal mode: render raw process output as a single pre-formatted text
+    // block so carriage returns and ANSI codes behave like a real terminal.
+    if (this.terminal) {
+      return html`
+        <vscode-scrollable
+          id=${ELEMENT_IDS.LOG_CONTENT}
+          class="log-container"
+          @vsc-scrollable-scroll=${this.handleVscScroll}
+        >
+          <pre class="terminal-pre">${this.cachedTerminalText}</pre>
         </vscode-scrollable>
       `;
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -60,16 +60,16 @@ function processTerminalText(text: string): string {
   // Replace ANSI erase-line escapes (\x1b[K, \x1b[0K, \x1b[2K, …) with a sentinel
   // before stripping all ANSI so the overwrite loop can honour them: an erase clears
   // the line from that column onward instead of preserving the stale tail characters.
-  const preprocessed = text.replace(/\x1b\[\d*K/g, ERASE_SENTINEL);
+  // eslint-disable-next-line no-control-regex
+  const preprocessed = text.replace(/\[\d*K/g, ERASE_SENTINEL);
   return stripAnsi(preprocessed)
     .replace(/\r\n/g, '\n')
     .split('\n')
     .map((line) => {
       const segs = line.split('\r');
-      let current = segs[0]!;
-      // Erase sentinel in the initial (pre-\r) content clears from that column to EOL.
-      const firstErase = current.indexOf(ERASE_SENTINEL);
-      if (firstErase >= 0) current = current.slice(0, firstErase);
+      // On a fresh line (no preceding \r), \x1b[K has nothing to clear; text after
+      // the erase point is still written at the cursor, so just strip the markers.
+      let current = segs[0]!.split(ERASE_SENTINEL).join('');
 
       for (let i = 1; i < segs.length; i++) {
         const seg = segs[i]!;
@@ -77,7 +77,7 @@ function processTerminalText(text: string): string {
         if (eraseAt >= 0) {
           // Overlay prefix up to the erase point, then clear the line from there.
           const pre = seg.slice(0, eraseAt);
-          const post = seg.slice(eraseAt + 1).replace(/\x00/g, '');
+          const post = seg.slice(eraseAt + 1).split(ERASE_SENTINEL).join('');
           const overlaid =
             pre.length < current.length ? pre + current.slice(pre.length) : pre;
           current = overlaid.slice(0, pre.length) + post;
@@ -86,7 +86,7 @@ function processTerminalText(text: string): string {
           current = seg.length < current.length ? seg + current.slice(seg.length) : seg;
         }
       }
-      return current.replace(/\x00/g, '');
+      return current.split(ERASE_SENTINEL).join('');
     })
     .join('\n');
 }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -58,13 +58,13 @@ function processTerminalText(text: string): string {
     .split('\n')
     .map((line) => {
       const segs = line.split('\r');
-      const last = segs.at(-1)!;
-      if (last.length > 0) return last;
-      // One or more trailing \r leave cursor at start — find last written content
-      for (let i = segs.length - 2; i >= 0; i--) {
-        if (segs[i]!.length > 0) return segs[i]!;
+      let current = segs[0]!;
+      for (let i = 1; i < segs.length; i++) {
+        const seg = segs[i]!;
+        // \r moves cursor to column 0 without clearing; shorter writes preserve the tail
+        current = seg.length < current.length ? seg + current.slice(seg.length) : seg;
       }
-      return '';
+      return current;
     })
     .join('\n');
 }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -209,6 +209,10 @@ export class TaskGroupList extends LitElement {
       }
     }
 
+    // Group tree, message classification, and timeline are only used by the
+    // non-terminal render path — skip them when terminal mode is active.
+    if (this.terminal) return;
+
     const prevMessages = messagesChanged
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -51,20 +51,42 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
 
+// Null byte used as a sentinel for ANSI erase-line sequences inside processTerminalText.
+// \x00 won't appear in legitimate terminal text and is not touched by strip-ansi.
+const ERASE_SENTINEL = '\x00';
+
 /** Strip ANSI codes and simulate \r overwrite within each newline-delimited line. */
 function processTerminalText(text: string): string {
-  return stripAnsi(text)
+  // Replace ANSI erase-line escapes (\x1b[K, \x1b[0K, \x1b[2K, …) with a sentinel
+  // before stripping all ANSI so the overwrite loop can honour them: an erase clears
+  // the line from that column onward instead of preserving the stale tail characters.
+  const preprocessed = text.replace(/\x1b\[\d*K/g, ERASE_SENTINEL);
+  return stripAnsi(preprocessed)
     .replace(/\r\n/g, '\n')
     .split('\n')
     .map((line) => {
       const segs = line.split('\r');
       let current = segs[0]!;
+      // Erase sentinel in the initial (pre-\r) content clears from that column to EOL.
+      const firstErase = current.indexOf(ERASE_SENTINEL);
+      if (firstErase >= 0) current = current.slice(0, firstErase);
+
       for (let i = 1; i < segs.length; i++) {
         const seg = segs[i]!;
-        // \r moves cursor to column 0 without clearing; shorter writes preserve the tail
-        current = seg.length < current.length ? seg + current.slice(seg.length) : seg;
+        const eraseAt = seg.indexOf(ERASE_SENTINEL);
+        if (eraseAt >= 0) {
+          // Overlay prefix up to the erase point, then clear the line from there.
+          const pre = seg.slice(0, eraseAt);
+          const post = seg.slice(eraseAt + 1).replace(/\x00/g, '');
+          const overlaid =
+            pre.length < current.length ? pre + current.slice(pre.length) : pre;
+          current = overlaid.slice(0, pre.length) + post;
+        } else {
+          // \r moves cursor to column 0 without clearing; shorter writes preserve the tail
+          current = seg.length < current.length ? seg + current.slice(seg.length) : seg;
+        }
       }
-      return current;
+      return current.replace(/\x00/g, '');
     })
     .join('\n');
 }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -112,7 +112,7 @@ export class TaskGroupList extends LitElement {
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
 
-  /** Canonicalized partial-line buffer: visible display text, with trailing '\r' if cursor is at line start */
+  /** Raw partial-line buffer: unprocessed bytes after the last '\n', capped at 64 KiB */
   private cachedRawTail = '';
   /** Processed complete lines for terminal mode (up to and including the last '\n') */
   private cachedTerminalLines = '';
@@ -345,12 +345,12 @@ export class TaskGroupList extends LitElement {
       this.cachedTerminalLines += processTerminalText(combined.slice(0, lastNl + 1));
       this.cachedRawTail = combined.slice(lastNl + 1);
     } else {
-      // No newline: collapse to visible content to bound growth (progress bars
-      // can emit many \r-overwritten updates without ever emitting \n).
-      // Preserve a trailing '\r' as a cursor-at-start marker so the next chunk
-      // can still overwrite from column 0.
-      const visible = processTerminalText(combined);
-      this.cachedRawTail = combined.endsWith('\r') ? visible + '\r' : visible;
+      // No newline: keep raw bytes so that split ANSI sequences and cross-chunk
+      // \r overwrites are handled correctly at render time. Cap at 64 KiB to
+      // bound growth from progress bars that emit many \r updates without \n.
+      const MAX_TAIL = 65536;
+      this.cachedRawTail =
+        combined.length > MAX_TAIL ? combined.slice(combined.length - MAX_TAIL) : combined;
     }
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -347,11 +347,13 @@ export class TaskGroupList extends LitElement {
     } else {
       // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
       // overwrites are handled correctly at render time.
-      // Only apply a 64 KiB cap when the tail contains \r (progress-bar rewrites)
-      // to avoid silently dropping legitimate long-line output (e.g. JSON/base64).
+      // Only cap when there are confirmed standalone \r rewrites, i.e. \r is
+      // present AND the buffer does not end with \r (a trailing \r might be the
+      // first half of a \r\n split across chunks, so we defer the cap to avoid
+      // permanently dropping the preceding content before the \n arrives).
       const MAX_TAIL = 65536;
       this.cachedRawTail =
-        combined.includes('\r') && combined.length > MAX_TAIL
+        combined.includes('\r') && !combined.endsWith('\r') && combined.length > MAX_TAIL
           ? combined.slice(combined.length - MAX_TAIL)
           : combined;
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -112,7 +112,7 @@ export class TaskGroupList extends LitElement {
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
 
-  /** Raw text from last '\n' to end of received messages (partial-line buffer) */
+  /** Canonicalized partial-line buffer: visible display text, with trailing '\r' if cursor is at line start */
   private cachedRawTail = '';
   /** Processed complete lines for terminal mode (up to and including the last '\n') */
   private cachedTerminalLines = '';
@@ -345,10 +345,12 @@ export class TaskGroupList extends LitElement {
       this.cachedTerminalLines += processTerminalText(combined.slice(0, lastNl + 1));
       this.cachedRawTail = combined.slice(lastNl + 1);
     } else {
-      // No newline: collapse \r-overwritten content so the tail stays bounded
-      // (frequent \r updates without \n, e.g. progress bars, would otherwise
-      // grow the buffer and make every render O(n) on accumulated output)
-      this.cachedRawTail = processTerminalText(combined);
+      // No newline: collapse to visible content to bound growth (progress bars
+      // can emit many \r-overwritten updates without ever emitting \n).
+      // Preserve a trailing '\r' as a cursor-at-start marker so the next chunk
+      // can still overwrite from column 0.
+      const visible = processTerminalText(combined);
+      this.cachedRawTail = combined.endsWith('\r') ? visible + '\r' : visible;
     }
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -61,7 +61,7 @@ function processTerminalText(text: string): string {
   // before stripping all ANSI so the overwrite loop can honour them: an erase clears
   // the line from that column onward instead of preserving the stale tail characters.
   // eslint-disable-next-line no-control-regex
-  const preprocessed = text.replace(/\[\d*K/g, ERASE_SENTINEL);
+  const preprocessed = text.replace(/\x1b\[\d*K/g, ERASE_SENTINEL);
   return stripAnsi(preprocessed)
     .replace(/\r\n/g, '\n')
     .split('\n')

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -345,12 +345,15 @@ export class TaskGroupList extends LitElement {
       this.cachedTerminalLines += processTerminalText(combined.slice(0, lastNl + 1));
       this.cachedRawTail = combined.slice(lastNl + 1);
     } else {
-      // No newline: keep raw bytes so that split ANSI sequences and cross-chunk
-      // \r overwrites are handled correctly at render time. Cap at 64 KiB to
-      // bound growth from progress bars that emit many \r updates without \n.
+      // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
+      // overwrites are handled correctly at render time.
+      // Only apply a 64 KiB cap when the tail contains \r (progress-bar rewrites)
+      // to avoid silently dropping legitimate long-line output (e.g. JSON/base64).
       const MAX_TAIL = 65536;
       this.cachedRawTail =
-        combined.length > MAX_TAIL ? combined.slice(combined.length - MAX_TAIL) : combined;
+        combined.includes('\r') && combined.length > MAX_TAIL
+          ? combined.slice(combined.length - MAX_TAIL)
+          : combined;
     }
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -378,17 +378,12 @@ export class TaskGroupList extends LitElement {
       this.cachedRawTail = combined.slice(lastNl + 1);
     } else {
       // No newline: keep raw bytes so split ANSI sequences and cross-chunk \r
-      // overwrites are handled correctly at render time.
-      // Cap when there is at least one \r that is NOT the last character — that
-      // confirms standalone CR rewrites exist (progress-bar style). A trailing \r
-      // as the only/last CR is deferred: it may be the first half of a \r\n split
-      // across chunks, and capping would permanently drop the preceding content.
+      // overwrites are handled correctly at render time. Cap unconditionally:
+      // if the tail ends with \r (potential CRLF split) the cap still preserves
+      // that trailing \r, so the next arriving \n is correctly joined into \r\n.
       const MAX_TAIL = 65536;
-      const crIdx = combined.indexOf('\r');
       this.cachedRawTail =
-        crIdx >= 0 && crIdx < combined.length - 1 && combined.length > MAX_TAIL
-          ? combined.slice(combined.length - MAX_TAIL)
-          : combined;
+        combined.length > MAX_TAIL ? combined.slice(combined.length - MAX_TAIL) : combined;
     }
   }
 

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -13,6 +13,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { guard } from 'lit/directives/guard.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import stripAnsi from 'strip-ansi';
 
 // Local imports - shared schemas
 import { STREAM_STATUS } from '@shared/schemas';
@@ -50,22 +51,16 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
 
-/**
- * Prepare raw process output for terminal-style display.
- * Strips ANSI escape codes and simulates carriage-return overwrite so that
- * progress lines (e.g. lake build's "● Building…\r✔ Built…") render like
- * a real terminal instead of showing both the building and built indicators.
- */
+/** Strip ANSI codes and simulate \r overwrite within each newline-delimited line. */
 function processTerminalText(text: string): string {
-  // Strip ANSI escape sequences (colors, cursor movement, etc.)
-  const stripped = text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
-  // Within each newline-delimited segment, a bare \r moves back to the start.
-  // Split on \r and keep only the last segment per line.
-  const lines = stripped.split('\n');
-  return lines
+  return stripAnsi(text)
+    .replace(/\r\n/g, '\n')
+    .split('\n')
     .map((line) => {
-      const parts = line.split('\r');
-      return parts[parts.length - 1];
+      const segs = line.split('\r');
+      const last = segs.at(-1)!;
+      // Line ending with \r leaves cursor at start — show content before it
+      return last.length > 0 ? last : (segs.at(-2) ?? '');
     })
     .join('\n');
 }
@@ -113,8 +108,10 @@ export class TaskGroupList extends LitElement {
   private cachedTree: GroupTree[] = [];
   private cachedUngrouped: LogMessageData[] = [];
 
-  /** Memoized processed text for terminal mode rendering */
-  private cachedTerminalText = '';
+  /** Raw text from last '\n' to end of received messages (partial-line buffer) */
+  private cachedRawTail = '';
+  /** Processed complete lines for terminal mode (up to and including the last '\n') */
+  private cachedTerminalLines = '';
 
   /** O(1) lookup from groupId → tree node. Built during buildGroupTree(). */
   private groupNodeIndex = new Map<string, GroupTree>();
@@ -168,13 +165,24 @@ export class TaskGroupList extends LitElement {
 
     const groupsChanged = changedProperties.has('groups');
     const messagesChanged = changedProperties.has('messages');
-    const terminalChanged = changedProperties.has('terminal');
 
-    if (this.terminal && (messagesChanged || terminalChanged)) {
-      this.cachedTerminalText = processTerminalText(
-        this.messages.map((m) => m.text).join(''),
-      );
+    if (this.terminal) {
+      if (changedProperties.has('terminal')) {
+        this.rebuildTerminalText();
+      } else if (messagesChanged) {
+        const prevCount =
+          (changedProperties.get('messages') as LogMessageData[] | undefined)
+            ?.length ?? 0;
+        if (this.messages.length > prevCount) {
+          this.appendTerminalChunk(
+            this.messages.slice(prevCount).map((m) => m.text).join(''),
+          );
+        } else {
+          this.rebuildTerminalText();
+        }
+      }
     }
+
     const prevMessages = messagesChanged
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;
@@ -317,6 +325,23 @@ export class TaskGroupList extends LitElement {
     const idx = this.cachedUngrouped.findIndex((m) => m.id === msg.id);
     if (idx >= 0) {
       this.cachedUngrouped[idx] = msg;
+    }
+  }
+
+  private rebuildTerminalText(): void {
+    this.cachedRawTail = '';
+    this.cachedTerminalLines = '';
+    this.appendTerminalChunk(this.messages.map((m) => m.text).join(''));
+  }
+
+  private appendTerminalChunk(newRaw: string): void {
+    const combined = this.cachedRawTail + newRaw;
+    const lastNl = combined.lastIndexOf('\n');
+    if (lastNl >= 0) {
+      this.cachedTerminalLines += processTerminalText(combined.slice(0, lastNl + 1));
+      this.cachedRawTail = combined.slice(lastNl + 1);
+    } else {
+      this.cachedRawTail = combined;
     }
   }
 
@@ -616,8 +641,6 @@ export class TaskGroupList extends LitElement {
       `;
     }
 
-    // Terminal mode: render raw process output as a single pre-formatted text
-    // block so carriage returns and ANSI codes behave like a real terminal.
     if (this.terminal) {
       return html`
         <vscode-scrollable
@@ -625,7 +648,7 @@ export class TaskGroupList extends LitElement {
           class="log-container"
           @vsc-scrollable-scroll=${this.handleVscScroll}
         >
-          <pre class="terminal-pre">${this.cachedTerminalText}</pre>
+          <pre class="terminal-pre">${this.cachedTerminalLines}${processTerminalText(this.cachedRawTail)}</pre>
         </vscode-scrollable>
       `;
     }

--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -213,6 +213,14 @@ export class TaskGroupList extends LitElement {
     // non-terminal render path — skip them when terminal mode is active.
     if (this.terminal) return;
 
+    // If terminal just switched off, caches weren't maintained while it was on —
+    // do a full rebuild so the non-terminal render has accurate data.
+    if (changedProperties.get('terminal') === true) {
+      [this.cachedTree, this.cachedUngrouped] = this.buildGroupTree();
+      this.cachedTimeline = this.buildFullTimeline();
+      return;
+    }
+
     const prevMessages = messagesChanged
       ? (changedProperties.get('messages') as LogMessageData[] | undefined)
       : undefined;

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -313,4 +313,16 @@ export const logEntryStyles = css`
   :host([terminal]) .message-error {
     color: var(--vscode-terminal-ansiRed, var(--color-error));
   }
+
+  /* Pre-formatted text block for terminal-mode streams.
+     Inherits font/color from the terminal .log-container. */
+  :host([terminal]) .terminal-pre {
+    margin: 0;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
 `;


### PR DESCRIPTION
## Summary
This PR adds support for rendering log messages in a terminal mode that properly handles ANSI escape codes and carriage return (`\r`) characters commonly found in terminal output.

## Key Changes
- **Added `strip-ansi` dependency** to remove ANSI escape sequences from terminal output
- **Implemented `processTerminalText()` function** that:
  - Strips ANSI codes from text
  - Normalizes line endings (`\r\n` → `\n`)
  - Simulates carriage return behavior by showing only the last segment after `\r` within each line
- **Added terminal text caching** with two buffers:
  - `cachedTerminalLines`: Processed complete lines (up to the last newline)
  - `cachedRawTail`: Raw unprocessed text after the last newline (partial-line buffer)
- **Implemented incremental processing** in `willUpdate()`:
  - Detects when terminal mode is enabled or messages change
  - Appends new message chunks incrementally rather than reprocessing all messages
  - Falls back to full rebuild when necessary
- **Added terminal rendering** in the template that displays processed text in a `<pre>` element
- **Added CSS styling** for `.terminal-pre` class with proper formatting (no margins/padding, inherited fonts, word wrapping)

## Implementation Details
- The `appendTerminalChunk()` method efficiently handles streaming data by buffering incomplete lines and only processing complete lines
- Terminal mode uses a scrollable container consistent with the existing log UI
- The solution preserves the chronological order of messages while properly handling terminal control characters

https://claude.ai/code/session_01WvkbESZBwPDum6mmVCNBQe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the progress-view log rendering/update paths and introduces incremental buffering logic that could affect log correctness/performance, though it’s UI-only and not security- or data-critical.
> 
> **Overview**
> Adds a **terminal rendering mode** to the progress-view log list that displays raw stream output in a `<pre>` and processes terminal control sequences.
> 
> Introduces `strip-ansi` and a `processTerminalText()` pipeline to remove ANSI codes, normalize newlines, and simulate `\r` overwrites (including handling ANSI erase-line). Updates `TaskGroupList` to maintain terminal-specific buffers (`cachedTerminalLines` + a capped raw tail) and to incrementally append new message text in `willUpdate()`, while skipping the non-terminal group/timeline cache work when `terminal` is enabled. Adds `.terminal-pre` styling for the new `<pre>` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a466bbca7fa58f9ad8e1d37ad102415b910392b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->