### PR TITLE
Adjust logging levels for diagnostic and progress messages

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -422,10 +422,6 @@ class ResponseProcessNode<C> extends BaseNode<
       .join(', ');
     logger.debug(`Usage summary: ${usageSummary}`);
 
-    logger.info(`Stop reason: ${result.stopReason}`, {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    });
-
     logger.debug(`Normalized usage: ${JSON.stringify(result.normalizedUsage)}`);
 
     logger.debug('Response preview:');
@@ -587,10 +583,6 @@ class ResponseContinuationNode<C> extends BaseNode<
         messageType: MESSAGE_TYPES.PROGRESS_STATUS,
       });
     }
-
-    logger.info('🧵 Added continuation prompt from partial XML output', {
-      messageType: MESSAGE_TYPES.PROGRESS_STATUS,
-    });
 
     if (modelHandler.capabilities.supportsAssistantPrefill) {
       modelHandler.addContinueMessageWithPrefill(

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -94,7 +94,9 @@ function parseToolInput(
   logger: AgentLogger,
 ): unknown {
   if (raw == null) {
-    logger.warn(`Tool call ${callId}: Received null input, using empty object`);
+    logger.debug(
+      `Tool call ${callId}: Received null input, using empty object`,
+    );
     return {};
   }
 
@@ -105,7 +107,7 @@ function parseToolInput(
   try {
     return JSON.parse(raw);
   } catch {
-    logger.warn(
+    logger.debug(
       `Tool call ${callId}: Failed to parse input as JSON, using raw string`,
     );
     return raw;

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1693,7 +1693,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
       return [true, messages];
     }
 
-    this.logger.warn(
+    this.logger.debug(
       'Output file exists but no end tag found - continuing from file',
     );
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -700,7 +700,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return null;
     }
 
-    this.logger.info(
+    this.logger.debug(
       `Resuming polling for pending background response ${pendingId}`,
     );
 
@@ -730,8 +730,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         throw err;
       }
       this.logger.warn(
-        `Failed to retrieve pending background response ${pendingId}: ${formatted.message}. ` +
-          'Will create new request.',
+        `Couldn't resume the pending OpenAI response; will start a new request. (${formatted.message})`,
         {
           data: {
             responseId: pendingId,
@@ -761,7 +760,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     if (pendingResponse.status === 'completed') {
       // Already completed while we were disconnected
-      this.logger.info(
+      this.logger.debug(
         `Pending background response ${pendingId} already completed`,
       );
       // Note: clearPendingBackgroundResponse() called by finalizeResponse() in caller
@@ -774,8 +773,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       pendingResponse.incomplete_details?.reason ??
       'no additional details';
     this.logger.warn(
-      `Pending background response ${pendingId} failed remotely ` +
-        `(status: ${pendingResponse.status}, reason: ${errorDetail}). Will create new request.`,
+      `OpenAI background response ended remotely (${pendingResponse.status}: ${errorDetail}); starting a new request.`,
       {
         data: {
           responseId: pendingId,
@@ -834,7 +832,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     } else {
       const errorDetail =
         response.error?.message ?? response.incomplete_details?.reason;
-      this.logger.warn(
+      this.logger.debug(
         `Response ${response.id} has status "${response.status}" - not safe for chaining`,
         {
           data: {
@@ -901,7 +899,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
     } else {
       // DIAGNOSTIC: Log when usage data is missing (streaming instability?)
-      this.logger.warn(
+      this.logger.debug(
         `[TOKEN_DIAG] response.usage.input_tokens MISSING - cannot track context usage`,
         {
           data: {
@@ -1838,7 +1836,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
         // Safety net: handle unexpected pending status (shouldn't happen without background mode)
         if (this.isBackgroundPending(response)) {
-          this.logger.warn(
+          this.logger.debug(
             `WebSocket response ${response.id} ended with pending status "${response.status}" — polling for completion`,
           );
           response = await this.waitForBackgroundCompletion(
@@ -1885,7 +1883,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // during slow GPT-5 requests), poll until it finishes instead of silently
         // returning an incomplete response.
         if (this.isBackgroundPending(response)) {
-          this.logger.warn(
+          this.logger.debug(
             `Streaming response ${response.id} ended with pending status "${response.status}" - polling for completion`,
           );
           response = await this.waitForBackgroundCompletion(
@@ -1926,7 +1924,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (this.isBackgroundPending(response)) {
         if (useBackgroundResponses) {
           this.logger.logProgress(
-            `Running OpenAI Responses in background mode for response ${response.id}; polling every 15s. Completion may take longer than usual.`,
+            'Running OpenAI in background mode; polling for completion (this may take longer than usual).',
           );
         } else {
           this.logger.debug(
@@ -1968,7 +1966,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // OpenAI: If the error indicates the response ID is invalid, clear it
       // This allows retry logic to recover by starting a fresh conversation
       if (isPreviousResponseIdError(error)) {
-        this.logger.info(
+        this.logger.debug(
           `Clearing previousResponseId=${this.previousResponseId} due to invalid/expired response - ` +
             'next retry will rebuild conversation from local history',
         );
@@ -1990,9 +1988,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         // hidden reasoning tokens) and compact client-side messages, then retry.
         // The guard !compactedThisCall prevents infinite recursion.
         this.logger.logProgress(
-          'Context window exceeded despite pre-flight check — ' +
-            'accumulated server-side reasoning tokens likely exceeded limit. ' +
-            'Clearing chained state and compacting for retry.',
+          'Context window exceeded — compacting conversation and retrying.',
         );
         this.previousResponseId = null;
         // Don't call resetConversationState() — it zeroes cumulativeInputTokens
@@ -2022,7 +2018,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // failure (tryResumeBackgroundResponse and waitForBackgroundCompletion).
       // If it survived to here, the next retry will try to resume the same ID.
       if (this.pendingBackgroundResponseId) {
-        this.logger.info(
+        this.logger.debug(
           `Retaining pendingBackgroundResponseId=${this.pendingBackgroundResponseId} for retry - ` +
             'next attempt will try to resume polling instead of creating new request',
         );
@@ -2062,7 +2058,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       output_tokens_details: { reasoning_tokens: 0 },
     };
     if (!responseObject.usage) {
-      this.logger.warn(
+      this.logger.debug(
         'Response missing usage information - token counts will show as 0',
         {
           data: {
@@ -2234,7 +2230,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         await delay(pollInterval, { signal });
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') {
-          this.logger.warn(
+          this.logger.debug(
             `Background polling aborted for response ${responseId} while waiting to poll.`,
             {
               data: {
@@ -2437,7 +2433,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       return [endTurn, messages];
     }
 
-    this.logger.warn(
+    this.logger.debug(
       'Output file exists but no end tag found - continuing from file',
     );
     // Only need to handle case where prefill needs to be prepended

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -570,7 +570,7 @@ export async function executeAgent(
       // Pre-execution UI setup
       if (executionId) await ensureRunDir(executionId);
       StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
-      logger.info('Starting task execution');
+      logger.info(`Starting task execution (streamId: ${streamId})`);
       logger.info(`Input file: ${config.inputFile}`);
       logger.debug(
         `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -570,7 +570,7 @@ export async function executeAgent(
       // Pre-execution UI setup
       if (executionId) await ensureRunDir(executionId);
       StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
-      logger.info(`Starting task execution for ${streamId}`);
+      logger.info('Starting task execution');
       logger.info(`Input file: ${config.inputFile}`);
       logger.debug(
         `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,


### PR DESCRIPTION
## Summary
This PR adjusts logging levels across the codebase to better categorize messages by severity and importance. Diagnostic messages, expected operational conditions, and verbose progress updates are downgraded from `warn` or `info` to `debug` level, while keeping truly important status updates at appropriate levels.

## Key Changes

- **ModelHandlerOpenAIResponse**: Downgraded 11 log statements from `warn`/`info` to `debug`:
  - Polling resumption and completion checks
  - Missing usage data diagnostics
  - WebSocket/streaming pending status handling
  - Background polling abortion
  - Output file continuation checks
  - Improved message clarity for context window and pending response scenarios

- **ResponseCycleFlow & ResponseContinuationNode**: Removed 2 `info`-level progress status messages that were redundant with other logging

- **ToolUseCycleFlow**: Downgraded 2 tool input parsing warnings to `debug` level (null input and JSON parse failures are expected edge cases)

- **ModelHandlerAnthropic**: Downgraded 1 output file continuation warning to `debug` level (consistency with OpenAI handler)

- **executeAgent**: Simplified startup log message to remove redundant stream ID from info-level log (moved to debug level)

## Implementation Details

- Messages that describe expected operational conditions (e.g., resuming pending responses, handling missing data) are now `debug` level
- Diagnostic messages (e.g., token tracking issues, polling diagnostics) are now `debug` level
- Verbose progress updates are removed or downgraded to reduce noise in user-facing logs
- Some messages were also improved for clarity and conciseness
- Critical operational status updates remain at `info` level

https://claude.ai/code/session_01HwBorRzCtgJZUcD1LRoxy6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to log levels/messages and removal of a couple redundant progress logs, with no functional logic or data-flow changes.
> 
> **Overview**
> Reduces log noise by downgrading several expected-condition/diagnostic messages from `info`/`warn` to `debug` across tool-use parsing and model handler resume/polling paths (notably `modelHandlerOpenAIResponse`, `ToolUseCycleFlow`, and `modelHandlerAnthropic`).
> 
> Removes a couple redundant `PROGRESS_STATUS` logs in `ResponseCycleFlow`, and tweaks startup logging in `executeAgent` to include `streamId` directly in the `info` message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a04f68fd5af4a756c223a5ae0270dc31896500b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->