### PR TITLE
Add nested delegation depth gating for multi-agent workflows

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -787,6 +787,7 @@ class ToolUseDispatchNode<C> extends Node<
           model: options.modelName ?? options.config.model,
           agentName: options.agentName,
           workingDirectory: options.workingDirectory,
+          delegationDepth: options.delegationDepth,
           onExecutionReady,
           onToolOutput,
         },

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -17,6 +17,13 @@ export interface AgentCore<C = unknown> {
   userVarChannels: UserVariableChannels;
   /** Working directory override for subagent tool calls (e.g. a git worktree). */
   workingDirectory?: string;
+  /**
+   * Delegation depth: 0 for root (user-initiated), N for a subagent N levels deep.
+   * Set by executeAgent from ExecuteAgentOptions.delegationDepth. Used by the
+   * tool-use flow to gate delegation tools and by the delegation tool itself
+   * to compute the child's depth.
+   */
+  delegationDepth?: number;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -3,7 +3,6 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
-import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 import type {
   BaseFlowContextInit,
   FlowParams,
@@ -28,8 +27,6 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
   /** True when this agent was launched as a subagent by an orchestrator. */
   readonly isSubagent?: boolean;
-  /** Nested delegation policy snapshot, read once at flow entry. */
-  readonly nestedDelegationConfig?: NestedDelegationConfig;
   /**
    * True when the agent's YAML requested delegation tools but they were filtered
    * out by the nested-delegation gate (disabled or depth cap reached). The

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -10,6 +10,12 @@ import type {
 import type { IToolUseSession } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
+/** Snapshot of nested-delegation settings, read once per tool-use flow entry. */
+export interface NestedDelegationConfig {
+  enabled: boolean;
+  maxDepth: number;
+}
+
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly setting: AgentToolUseSetting;
   readonly session: IToolUseSession;
@@ -27,6 +33,14 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly persistTodos?: (todos: TodoItem[]) => Promise<void>;
   /** True when this agent was launched as a subagent by an orchestrator. */
   readonly isSubagent?: boolean;
+  /** Nested delegation policy snapshot, read once at flow entry. */
+  readonly nestedDelegationConfig?: NestedDelegationConfig;
+  /**
+   * True when the agent's YAML requested delegation tools but they were filtered
+   * out by the nested-delegation gate (disabled or depth cap reached). The
+   * prepare node uses this to tell the LLM it cannot delegate further.
+   */
+  readonly delegationTrimmed?: boolean;
 }
 
 export type { FlowParams as ToolUseFlowParams };

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -3,18 +3,13 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
+import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 import type {
   BaseFlowContextInit,
   FlowParams,
 } from '../common/BaseFlowServices';
 import type { IToolUseSession } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
-
-/** Snapshot of nested-delegation settings, read once per tool-use flow entry. */
-export interface NestedDelegationConfig {
-  enabled: boolean;
-  maxDepth: number;
-}
 
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly setting: AgentToolUseSetting;

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -2,6 +2,7 @@ import { Node } from '@agent/node';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { createRunState } from '@agent/core/AgentState';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { buildInitialToolUsePrompts } from '@utils/prompt';
 
@@ -21,13 +22,41 @@ export class ToolUsePrepareNode<C> extends Node<
     _prepRes: void,
   ): Promise<{ kind: 'success'; result: PrepareResult }> {
     const { userVarChannels, logger, snapshot } = this.services;
+    const memoryEnabled = this.services.resolvedTools.some(
+      (t) => t.name === 'memory',
+    );
+    const hasDelegationTools = this.services.resolvedTools.some((t) =>
+      DELEGATION_TOOLS.has(t.name),
+    );
+    const promptOptions = {
+      memoryEnabled,
+      hasDelegationTools,
+      isSubagent: this.services.isSubagent,
+      nestedDelegationBlocked: this.services.delegationTrimmed === true,
+    };
 
     if (snapshot) {
       logger.debug('Resuming tool-use session from saved state.');
+      // The persisted system message may reflect stale policy (e.g. the user
+      // changed Max delegation depth between sessions). Rebuild the current
+      // system text and swap it into any role='system' entry in the message
+      // list. Providers that pass `system` per-call (Anthropic) don't store
+      // it in messages, so this is a no-op there — the tool-use flow for
+      // those providers doesn't currently persist the system prompt at all.
+      const messages = await refreshPersistedSystemMessage(
+        snapshot.messages,
+        () =>
+          buildInitialToolUsePrompts(
+            this.services.prompt,
+            userVarChannels.transient,
+            logger,
+            promptOptions,
+          ),
+      );
       return {
         kind: 'success',
         result: {
-          messages: snapshot.messages,
+          messages,
           runState: snapshot.run,
           workspaceState: AgentWorkspaceState.fromSnapshot(snapshot.workspace),
           userChannels: {
@@ -41,24 +70,13 @@ export class ToolUsePrepareNode<C> extends Node<
 
     const runState = createRunState();
     const workspaceState = AgentWorkspaceState.create();
-    const memoryEnabled = this.services.resolvedTools.some(
-      (t) => t.name === 'memory',
-    );
-    const hasDelegationTools = this.services.resolvedTools.some((t) =>
-      DELEGATION_TOOLS.has(t.name),
-    );
 
     const { systemPrompt, userPrefix, userRequest, instructionSuffix } =
       await buildInitialToolUsePrompts(
         this.services.prompt,
         userVarChannels.transient,
         logger,
-        {
-          memoryEnabled,
-          hasDelegationTools,
-          isSubagent: this.services.isSubagent,
-          nestedDelegationBlocked: this.services.delegationTrimmed === true,
-        },
+        promptOptions,
       );
 
     const systemMessage = systemPrompt
@@ -121,4 +139,48 @@ export class ToolUsePrepareNode<C> extends Node<
 
     return FlowTransition.DEFAULT;
   }
+}
+
+/**
+ * Rebuild the persisted system message on resume so it reflects the current
+ * policy (e.g. Max delegation depth) rather than whatever was frozen at
+ * snapshot time. Only OpenAI-family providers keep system in the messages
+ * array; everything else is a no-op on the message list.
+ */
+async function refreshPersistedSystemMessage(
+  persisted: ProviderMessage[],
+  rebuild: () => Promise<{ systemPrompt: string; instructionSuffix: string }>,
+): Promise<ProviderMessage[]> {
+  const systemIdx = persisted.findIndex(
+    (m) =>
+      typeof m === 'object' && m !== null && (m as { role?: unknown }).role === 'system',
+  );
+  if (systemIdx < 0) return persisted;
+
+  const { systemPrompt, instructionSuffix } = await rebuild();
+  const systemText = systemPrompt
+    ? `${systemPrompt}\n${instructionSuffix}`
+    : instructionSuffix;
+
+  const updated = [...persisted];
+  const existing = updated[systemIdx] as Record<string, unknown>;
+  const prevContent = existing.content;
+  // Preserve the existing content shape: if it was an array of text blocks,
+  // keep the array form; otherwise use a plain string. This keeps us
+  // compatible across OpenAI / OpenAI Responses / OpenRouter without
+  // hard-coding any one shape.
+  let content: unknown;
+  if (
+    Array.isArray(prevContent) &&
+    prevContent.length > 0 &&
+    typeof prevContent[0] === 'object' &&
+    prevContent[0] !== null &&
+    'type' in (prevContent[0] as object)
+  ) {
+    content = [{ type: 'text', text: systemText }];
+  } else {
+    content = systemText;
+  }
+  updated[systemIdx] = { ...existing, content } as ProviderMessage;
+  return updated;
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -39,10 +39,12 @@ export class ToolUsePrepareNode<C> extends Node<
       logger.debug('Resuming tool-use session from saved state.');
       // The persisted system message may reflect stale policy (e.g. the user
       // changed Max delegation depth between sessions). Rebuild the current
-      // system text and swap it into any role='system' entry in the message
-      // list. Providers that pass `system` per-call (Anthropic) don't store
-      // it in messages, so this is a no-op there — the tool-use flow for
-      // those providers doesn't currently persist the system prompt at all.
+      // system text and swap it into the persisted first-message slot that
+      // holds the systemPrompt. For providers that pass `system` per-call
+      // (Anthropic) this is a no-op: the systemPrompt was never stored in
+      // messages to begin with.
+      const supportsSystemPrompt =
+        this.services.modelHandler.capabilities?.supportsSystemPrompt !== false;
       const messages = await refreshPersistedSystemMessage(
         snapshot.messages,
         () =>
@@ -52,6 +54,7 @@ export class ToolUsePrepareNode<C> extends Node<
             logger,
             promptOptions,
           ),
+        supportsSystemPrompt,
       );
       return {
         kind: 'success',
@@ -144,28 +147,36 @@ export class ToolUsePrepareNode<C> extends Node<
 /**
  * Rebuild the persisted system message on resume so it reflects the current
  * policy (e.g. Max delegation depth) rather than whatever was frozen at
- * snapshot time. Only OpenAI-family providers keep system in the messages
- * array; everything else is a no-op on the message list.
+ * snapshot time.
  *
- * Only the FIRST message is examined: when the persisted prompt exists it
- * always lives at index 0 (see `initializeMessages` across providers).
- * Later role='system' entries — e.g. the OpenAI `supportsIntermDevMsgs`
- * path stores the user request as a developer/system message at index 1 —
- * must not be touched, otherwise resume would overwrite the task with
- * system text.
+ * Two message-shape conventions are handled, keyed on the model's
+ * supportsSystemPrompt capability:
+ *
+ * - `supportsSystemPrompt !== false` (OpenAI Chat/Responses/OpenRouter
+ *   with a real system role): the persisted systemPrompt is at
+ *   `messages[0]` with role='system'. Later role='system' entries
+ *   (the OpenAI supportsIntermDevMsgs developer-message path at
+ *   index 1) must NOT be touched — they hold the task userRequest.
+ *
+ * - `supportsSystemPrompt === false` (o1-mini, o1-preview): the
+ *   systemPrompt is the FIRST CONTENT BLOCK of `messages[0]` with
+ *   role='user'. We replace only that block's text and leave any
+ *   subsequent blocks (userPrefix, userRequest) untouched.
+ *
+ * Providers that pass `system` per-call (Anthropic) never store the
+ * systemPrompt in `messages`, so both branches are a no-op there.
  */
 async function refreshPersistedSystemMessage(
   persisted: ProviderMessage[],
   rebuild: () => Promise<{ systemPrompt: string; instructionSuffix: string }>,
+  supportsSystemPrompt: boolean,
 ): Promise<ProviderMessage[]> {
   const first = persisted[0];
-  if (
-    !first ||
-    typeof first !== 'object' ||
-    (first as { role?: unknown }).role !== 'system'
-  ) {
-    return persisted;
-  }
+  if (!first || typeof first !== 'object') return persisted;
+
+  const role = (first as { role?: unknown }).role;
+  const expectedRole = supportsSystemPrompt ? 'system' : 'user';
+  if (role !== expectedRole) return persisted;
 
   const { systemPrompt, instructionSuffix } = await rebuild();
   const systemText = systemPrompt
@@ -173,21 +184,49 @@ async function refreshPersistedSystemMessage(
     : instructionSuffix;
 
   const existing = first as Record<string, unknown>;
-  // Preserve the existing content shape AND block type: OpenAI Chat uses
-  // { type: 'text' }, OpenAI Responses uses { type: 'input_text' }. If we
-  // unconditionally stamped 'text', resumed Responses snapshots would be
-  // rejected by the API.
-  const content = buildSystemContent(existing.content, systemText);
   const updated = [...persisted];
-  updated[0] = { ...existing, content } as ProviderMessage;
+  updated[0] = (
+    supportsSystemPrompt
+      ? { ...existing, content: buildSystemContent(existing.content, systemText) }
+      : withFirstBlockReplaced(existing, systemText)
+  ) as ProviderMessage;
   return updated;
 }
 
+/**
+ * For system-role messages: replace the whole content. Preserves the
+ * existing content shape AND block type (OpenAI Chat uses `'text'`,
+ * OpenAI Responses uses `'input_text'`); stamping the wrong type would
+ * make the resumed snapshot invalid for Responses providers.
+ */
 function buildSystemContent(prevContent: unknown, systemText: string): unknown {
   const firstBlockType = readFirstBlockType(prevContent);
   return firstBlockType
     ? [{ type: firstBlockType, text: systemText }]
     : systemText;
+}
+
+/**
+ * For the o1-style user-role case: replace the text of just the first
+ * content block, leaving userPrefix / userRequest blocks alongside it
+ * untouched. If the content isn't a shape we recognize (e.g. string
+ * content, empty array, non-text first block), leave the message alone.
+ */
+function withFirstBlockReplaced(
+  existing: Record<string, unknown>,
+  systemText: string,
+): Record<string, unknown> {
+  const content = existing.content;
+  if (!Array.isArray(content) || content.length === 0) return existing;
+  const firstBlock = content[0];
+  if (typeof firstBlock !== 'object' || firstBlock === null) return existing;
+  const type = (firstBlock as { type?: unknown }).type;
+  if (typeof type !== 'string') return existing;
+  const newContent = [
+    { ...(firstBlock as Record<string, unknown>), text: systemText },
+    ...content.slice(1),
+  ];
+  return { ...existing, content: newContent };
 }
 
 function readFirstBlockType(prevContent: unknown): string | null {

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -146,30 +146,40 @@ export class ToolUsePrepareNode<C> extends Node<
  * policy (e.g. Max delegation depth) rather than whatever was frozen at
  * snapshot time. Only OpenAI-family providers keep system in the messages
  * array; everything else is a no-op on the message list.
+ *
+ * Only the FIRST message is examined: when the persisted prompt exists it
+ * always lives at index 0 (see `initializeMessages` across providers).
+ * Later role='system' entries — e.g. the OpenAI `supportsIntermDevMsgs`
+ * path stores the user request as a developer/system message at index 1 —
+ * must not be touched, otherwise resume would overwrite the task with
+ * system text.
  */
 async function refreshPersistedSystemMessage(
   persisted: ProviderMessage[],
   rebuild: () => Promise<{ systemPrompt: string; instructionSuffix: string }>,
 ): Promise<ProviderMessage[]> {
-  const systemIdx = persisted.findIndex(
-    (m) =>
-      typeof m === 'object' && m !== null && (m as { role?: unknown }).role === 'system',
-  );
-  if (systemIdx < 0) return persisted;
+  const first = persisted[0];
+  if (
+    !first ||
+    typeof first !== 'object' ||
+    (first as { role?: unknown }).role !== 'system'
+  ) {
+    return persisted;
+  }
 
   const { systemPrompt, instructionSuffix } = await rebuild();
   const systemText = systemPrompt
     ? `${systemPrompt}\n${instructionSuffix}`
     : instructionSuffix;
 
-  const existing = persisted[systemIdx] as Record<string, unknown>;
+  const existing = first as Record<string, unknown>;
   // Preserve the existing content shape AND block type: OpenAI Chat uses
   // { type: 'text' }, OpenAI Responses uses { type: 'input_text' }. If we
   // unconditionally stamped 'text', resumed Responses snapshots would be
   // rejected by the API.
   const content = buildSystemContent(existing.content, systemText);
   const updated = [...persisted];
-  updated[systemIdx] = { ...existing, content } as ProviderMessage;
+  updated[0] = { ...existing, content } as ProviderMessage;
   return updated;
 }
 

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -165,10 +165,10 @@ async function refreshPersistedSystemMessage(
   const updated = [...persisted];
   const existing = updated[systemIdx] as Record<string, unknown>;
   const prevContent = existing.content;
-  // Preserve the existing content shape: if it was an array of text blocks,
-  // keep the array form; otherwise use a plain string. This keeps us
-  // compatible across OpenAI / OpenAI Responses / OpenRouter without
-  // hard-coding any one shape.
+  // Preserve the existing content shape AND block type: OpenAI Chat uses
+  // { type: 'text' }, OpenAI Responses uses { type: 'input_text' }. If we
+  // unconditionally stamped 'text', resumed Responses snapshots would be
+  // rejected by the API. Read the existing block's type and reuse it.
   let content: unknown;
   if (
     Array.isArray(prevContent) &&
@@ -177,7 +177,8 @@ async function refreshPersistedSystemMessage(
     prevContent[0] !== null &&
     'type' in (prevContent[0] as object)
   ) {
-    content = [{ type: 'text', text: systemText }];
+    const firstBlock = prevContent[0] as { type: string };
+    content = [{ type: firstBlock.type, text: systemText }];
   } else {
     content = systemText;
   }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -162,26 +162,28 @@ async function refreshPersistedSystemMessage(
     ? `${systemPrompt}\n${instructionSuffix}`
     : instructionSuffix;
 
-  const updated = [...persisted];
-  const existing = updated[systemIdx] as Record<string, unknown>;
-  const prevContent = existing.content;
+  const existing = persisted[systemIdx] as Record<string, unknown>;
   // Preserve the existing content shape AND block type: OpenAI Chat uses
   // { type: 'text' }, OpenAI Responses uses { type: 'input_text' }. If we
   // unconditionally stamped 'text', resumed Responses snapshots would be
-  // rejected by the API. Read the existing block's type and reuse it.
-  let content: unknown;
-  if (
-    Array.isArray(prevContent) &&
-    prevContent.length > 0 &&
-    typeof prevContent[0] === 'object' &&
-    prevContent[0] !== null &&
-    'type' in (prevContent[0] as object)
-  ) {
-    const firstBlock = prevContent[0] as { type: string };
-    content = [{ type: firstBlock.type, text: systemText }];
-  } else {
-    content = systemText;
-  }
+  // rejected by the API.
+  const content = buildSystemContent(existing.content, systemText);
+  const updated = [...persisted];
   updated[systemIdx] = { ...existing, content } as ProviderMessage;
   return updated;
+}
+
+function buildSystemContent(prevContent: unknown, systemText: string): unknown {
+  const firstBlockType = readFirstBlockType(prevContent);
+  return firstBlockType
+    ? [{ type: firstBlockType, text: systemText }]
+    : systemText;
+}
+
+function readFirstBlockType(prevContent: unknown): string | null {
+  if (!Array.isArray(prevContent) || prevContent.length === 0) return null;
+  const first = prevContent[0];
+  if (typeof first !== 'object' || first === null) return null;
+  const type = (first as { type?: unknown }).type;
+  return typeof type === 'string' ? type : null;
 }

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUsePrepareNode.ts
@@ -57,6 +57,7 @@ export class ToolUsePrepareNode<C> extends Node<
           memoryEnabled,
           hasDelegationTools,
           isSubagent: this.services.isSubagent,
+          nestedDelegationBlocked: this.services.delegationTrimmed === true,
         },
       );
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -168,7 +168,6 @@ export async function runToolUseFlow<C = unknown>(
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     delegationDepth,
-    nestedDelegationConfig: nestedConfig,
     delegationTrimmed,
   };
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -14,8 +14,8 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { getGlobalState } from '@agent/core/stateStore';
-import { GlobalStateKey } from '@common/state';
+import { getGlobalState, getWorkspaceState } from '@agent/core/stateStore';
+import { GlobalStateKey, WorkspaceStateKey } from '@common/state';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import {
@@ -43,7 +43,10 @@ import {
 } from './nodes/types';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
-import type { ToolUseServices } from './ToolUseServices';
+import type {
+  NestedDelegationConfig,
+  ToolUseServices,
+} from './ToolUseServices';
 
 export interface RunToolUseFlowInput<
   C = unknown,
@@ -77,15 +80,43 @@ export interface ToolUseFlowContext {
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
 
+export function readNestedDelegationConfig(): NestedDelegationConfig {
+  const state = getWorkspaceState();
+  const enabled = state.get<boolean>(
+    WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
+    false,
+  );
+  const raw = state.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, 2);
+  const maxDepth = Math.min(
+    5,
+    Math.max(1, Number.isFinite(raw) ? Math.round(raw) : 2),
+  );
+  return { enabled, maxDepth };
+}
+
+/**
+ * Delegation gate. Root (depth 0) can always delegate; subagents can only
+ * delegate when nesting is enabled and their depth is below the cap.
+ */
+export function delegationAllowed(
+  depth: number,
+  config: NestedDelegationConfig,
+): boolean {
+  if (depth <= 0) return true;
+  return config.enabled && depth < config.maxDepth;
+}
+
 function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
-  isSubagent?: boolean,
-): ToolDefinition[] {
+  delegationDepth: number,
+  nestedConfig: NestedDelegationConfig,
+): { tools: ToolDefinition[]; delegationTrimmed: boolean } {
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
   const missingDependency: string[] = [];
+  const canDelegate = delegationAllowed(delegationDepth, nestedConfig);
 
   // Don't warn on routine filtering outcomes (user-disabled, unavailable,
   // not in registry): they fire on every tool-use cycle and drown out real
@@ -93,10 +124,14 @@ function resolveTools(
   // `resolveToolDefinitions`; missing external deps are surfaced via
   // `notifyUnavailableTools` below.
   const toolConfigs = Array.isArray(tools) ? tools : [];
+  let delegationTrimmed = false;
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
-      if (isSubagent && DELEGATION_TOOLS.has(def.name)) return false;
+      if (DELEGATION_TOOLS.has(def.name) && !canDelegate) {
+        delegationTrimmed = true;
+        return false;
+      }
       if (disabled.has(def.name)) return false;
       if (unavailable.has(def.name)) {
         missingDependency.push(def.name);
@@ -125,7 +160,7 @@ function resolveTools(
     notifyUnavailableTools(missingDependency);
   }
 
-  return resolved;
+  return { tools: resolved, delegationTrimmed };
 }
 
 export async function runToolUseFlow<C = unknown>(
@@ -136,11 +171,14 @@ export async function runToolUseFlow<C = unknown>(
   const { logger, streamId, executionId, setting, onInterrupt } = input;
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
-  const resolvedTools = resolveTools(
+  const delegationDepth = input.delegationDepth ?? 0;
+  const nestedConfig = readNestedDelegationConfig();
+  const { tools: resolvedTools, delegationTrimmed } = resolveTools(
     setting.tools,
     registry,
     logger,
-    input.isSubagent,
+    delegationDepth,
+    nestedConfig,
   );
 
   const kv = getExecutionStore(executionId);
@@ -153,6 +191,9 @@ export async function runToolUseFlow<C = unknown>(
     snapshot: input.resumeSnapshot ?? null,
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
+    delegationDepth,
+    nestedDelegationConfig: nestedConfig,
+    delegationTrimmed,
   };
 
   const flowContext: ToolUseFlowContext = {

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -14,8 +14,9 @@ import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
-import { getGlobalState, getWorkspaceState } from '@agent/core/stateStore';
-import { GlobalStateKey, WorkspaceStateKey } from '@common/state';
+import { getGlobalState } from '@agent/core/stateStore';
+import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
+import { GlobalStateKey } from '@common/state';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import {
@@ -24,6 +25,10 @@ import {
   type EndGroupStatus,
 } from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
+import {
+  delegationAllowed,
+  type NestedDelegationConfig,
+} from '@shared/constants/delegationPolicy';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 
 import { getDefaultToolRegistry } from '@tools/registry';
@@ -43,10 +48,7 @@ import {
 } from './nodes/types';
 import { ToolUseSessionLifecycle } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
-import type {
-  NestedDelegationConfig,
-  ToolUseServices,
-} from './ToolUseServices';
+import type { ToolUseServices } from './ToolUseServices';
 
 export interface RunToolUseFlowInput<
   C = unknown,
@@ -79,32 +81,6 @@ export interface ToolUseFlowContext {
 }
 
 export type ToolUseFlowSetupCallback = (context: ToolUseFlowContext) => void;
-
-export function readNestedDelegationConfig(): NestedDelegationConfig {
-  const state = getWorkspaceState();
-  const enabled = state.get<boolean>(
-    WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
-    false,
-  );
-  const raw = state.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, 2);
-  const maxDepth = Math.min(
-    5,
-    Math.max(1, Number.isFinite(raw) ? Math.round(raw) : 2),
-  );
-  return { enabled, maxDepth };
-}
-
-/**
- * Delegation gate. Root (depth 0) can always delegate; subagents can only
- * delegate when nesting is enabled and their depth is below the cap.
- */
-export function delegationAllowed(
-  depth: number,
-  config: NestedDelegationConfig,
-): boolean {
-  if (depth <= 0) return true;
-  return config.enabled && depth < config.maxDepth;
-}
 
 function resolveTools(
   tools: AgentToolUseSetting['tools'],

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -34,6 +34,22 @@ export function readNestedDelegationConfig(): NestedDelegationConfig {
 const UNKNOWN_DEPTH_SENTINEL = Number.MAX_SAFE_INTEGER;
 
 /**
+ * Read meta without letting filesystem/IO errors bubble up — safeParse
+ * already handles malformed JSON by returning null, but the underlying
+ * storage layer can throw on permission or IO failures. Resume must
+ * not hard-fail on a single corrupted ancestor.
+ */
+async function readMetaSafely(
+  executionId: ExecutionId,
+): Promise<ExecutionMeta | null | 'error'> {
+  try {
+    return await getExecutionStore(executionId).readMeta();
+  } catch {
+    return 'error';
+  }
+}
+
+/**
  * Recover the delegation depth for a persisted execution on resume, where
  * the in-memory depth that executeAgent would normally carry is unavailable.
  *
@@ -43,14 +59,15 @@ const UNKNOWN_DEPTH_SENTINEL = Number.MAX_SAFE_INTEGER;
  * field persisted yet.
  *
  * Returns 0 when no parent is stored (root execution) or the persisted
- * depth is 0. Returns `UNKNOWN_DEPTH_SENTINEL` when the chain walk encounters
- * a missing ancestor mid-chain — we can't safely undercount, so callers
- * will see it as past the cap.
+ * depth is 0. Returns `UNKNOWN_DEPTH_SENTINEL` when the chain walk
+ * encounters a missing or unreadable ancestor mid-chain — we can't safely
+ * undercount, so callers will see it as past the cap.
  */
 export async function computeDelegationDepthFromStorage(
   executionId: ExecutionId,
 ): Promise<number> {
-  const rootMeta = await getExecutionStore(executionId).readMeta();
+  const rootMeta = await readMetaSafely(executionId);
+  if (rootMeta === 'error') return UNKNOWN_DEPTH_SENTINEL;
   if (!rootMeta) return 0;
   if (rootMeta.delegationDepth !== undefined) return rootMeta.delegationDepth;
   if (!rootMeta.parentExecutionId) return 0;
@@ -63,12 +80,11 @@ export async function computeDelegationDepthFromStorage(
   const MAX_WALK = 32;
   while (current && !visited.has(current) && depth < MAX_WALK) {
     visited.add(current);
-    const meta: ExecutionMeta | null = await getExecutionStore(
-      current,
-    ).readMeta();
-    // Ancestor meta missing or corrupted: we can't tell how deep we are.
-    // Return a sentinel that fails the gate for any configured cap.
-    if (!meta) return UNKNOWN_DEPTH_SENTINEL;
+    const meta = await readMetaSafely(current);
+    // Ancestor meta missing, corrupted, or unreadable: we can't tell how
+    // deep we are. Return a sentinel that fails the gate for any configured
+    // cap. Preserves resumability; conservatively blocks delegation.
+    if (meta === 'error' || meta === null) return UNKNOWN_DEPTH_SENTINEL;
     if (meta.delegationDepth !== undefined) return meta.delegationDepth + depth;
     const parent: ExecutionId | undefined = meta.parentExecutionId;
     if (!parent) break;

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -75,23 +75,25 @@ export async function computeDelegationDepthFromStorage(
   if (!rootMeta.parentExecutionId) return 0;
 
   // Legacy fallback: walk the chain for snapshots created before
-  // delegationDepth was persisted.
+  // delegationDepth was persisted. All loop-exit corruption signals
+  // (cycle, MAX_WALK) fail closed via the sentinel; only a clean walk
+  // that terminates at a root (no parentExecutionId) returns the depth.
   const visited = new Set<string>([executionId]);
   let current: ExecutionId | undefined = rootMeta.parentExecutionId;
   let depth = 1;
   const MAX_WALK = 32;
-  while (current && !visited.has(current) && depth < MAX_WALK) {
+  while (depth < MAX_WALK) {
+    if (!current) return depth; // clean terminus
+    if (visited.has(current)) return UNKNOWN_DEPTH_SENTINEL; // cycle
     visited.add(current);
     const meta = await readMetaSafely(current);
-    // Ancestor meta missing, corrupted, or unreadable: we can't tell how
-    // deep we are. Return a sentinel that fails the gate for any configured
-    // cap. Preserves resumability; conservatively blocks delegation.
     if (meta === 'error' || meta === null) return UNKNOWN_DEPTH_SENTINEL;
     if (meta.delegationDepth !== undefined) return meta.delegationDepth + depth;
     const parent: ExecutionId | undefined = meta.parentExecutionId;
-    if (!parent) break;
+    if (!parent) return depth; // clean terminus
     depth++;
     current = parent;
   }
-  return depth;
+  // MAX_WALK exceeded: chain longer than any legitimate depth — treat as corrupt.
+  return UNKNOWN_DEPTH_SENTINEL;
 }

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -16,17 +16,13 @@ import {
   type NestedDelegationConfig,
 } from '@shared/constants/delegationPolicy';
 
-/** Read the current nested-delegation policy from workspace state. */
+/** Read the current delegation policy from workspace state. */
 export function readNestedDelegationConfig(): NestedDelegationConfig {
   const state = getWorkspaceState();
-  const enabled = state.get<boolean>(
-    WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
-    false,
-  );
   const maxDepth = clampNestedDelegationDepth(
     state.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, undefined),
   );
-  return { enabled, maxDepth };
+  return { maxDepth };
 }
 
 /**

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -58,17 +58,19 @@ async function readMetaSafely(
  * `parentExecutionId` chain for pre-feature snapshots that don't have the
  * field persisted yet.
  *
- * Returns 0 when no parent is stored (root execution) or the persisted
- * depth is 0. Returns `UNKNOWN_DEPTH_SENTINEL` when the chain walk
- * encounters a missing or unreadable ancestor mid-chain — we can't safely
- * undercount, so callers will see it as past the cap.
+ * Fail-closed: any corrupted, unreadable, or missing meta in the lineage —
+ * including the resumed execution's own meta — returns
+ * `UNKNOWN_DEPTH_SENTINEL`. A valid resumable snapshot always has a valid
+ * `meta.json`, so `null` here is corruption, not a legitimate root. Treating
+ * it as depth 0 would let a broken-meta subagent bypass the delegation gate.
+ * Resume itself still succeeds on the surviving message snapshot; the LLM
+ * just can't delegate from that session.
  */
 export async function computeDelegationDepthFromStorage(
   executionId: ExecutionId,
 ): Promise<number> {
   const rootMeta = await readMetaSafely(executionId);
-  if (rootMeta === 'error') return UNKNOWN_DEPTH_SENTINEL;
-  if (!rootMeta) return 0;
+  if (rootMeta === 'error' || rootMeta === null) return UNKNOWN_DEPTH_SENTINEL;
   if (rootMeta.delegationDepth !== undefined) return rootMeta.delegationDepth;
   if (!rootMeta.parentExecutionId) return 0;
 

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -26,27 +26,51 @@ export function readNestedDelegationConfig(): NestedDelegationConfig {
 }
 
 /**
- * Recover the delegation depth for a persisted execution by walking the
- * parentExecutionId chain in its metadata. Used on resume, where the
- * in-memory depth that executeAgent would normally carry is unavailable.
+ * Sentinel returned when a resumed snapshot's lineage can't be trusted
+ * (e.g. an ancestor's meta was deleted while a descendant survived).
+ * `delegationAllowed(MAX_SAFE_INTEGER, { maxDepth })` is false for any
+ * configured cap, so delegation is conservatively blocked.
+ */
+const UNKNOWN_DEPTH_SENTINEL = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Recover the delegation depth for a persisted execution on resume, where
+ * the in-memory depth that executeAgent would normally carry is unavailable.
  *
- * Returns 0 when no parent is stored (root execution or pre-feature data)
- * or if a cycle is detected defensively.
+ * Preferred source is `meta.delegationDepth`, written at register-time by
+ * `DelegationTools.executeSubagent`. Falls back to walking the
+ * `parentExecutionId` chain for pre-feature snapshots that don't have the
+ * field persisted yet.
+ *
+ * Returns 0 when no parent is stored (root execution) or the persisted
+ * depth is 0. Returns `UNKNOWN_DEPTH_SENTINEL` when the chain walk encounters
+ * a missing ancestor mid-chain — we can't safely undercount, so callers
+ * will see it as past the cap.
  */
 export async function computeDelegationDepthFromStorage(
   executionId: ExecutionId,
 ): Promise<number> {
-  const visited = new Set<string>();
-  let current: ExecutionId | undefined = executionId;
-  let depth = 0;
-  // Cap the walk as a belt-and-suspenders against corrupted chains.
+  const rootMeta = await getExecutionStore(executionId).readMeta();
+  if (!rootMeta) return 0;
+  if (rootMeta.delegationDepth !== undefined) return rootMeta.delegationDepth;
+  if (!rootMeta.parentExecutionId) return 0;
+
+  // Legacy fallback: walk the chain for snapshots created before
+  // delegationDepth was persisted.
+  const visited = new Set<string>([executionId]);
+  let current: ExecutionId | undefined = rootMeta.parentExecutionId;
+  let depth = 1;
   const MAX_WALK = 32;
   while (current && !visited.has(current) && depth < MAX_WALK) {
     visited.add(current);
     const meta: ExecutionMeta | null = await getExecutionStore(
       current,
     ).readMeta();
-    const parent: ExecutionId | undefined = meta?.parentExecutionId;
+    // Ancestor meta missing or corrupted: we can't tell how deep we are.
+    // Return a sentinel that fails the gate for any configured cap.
+    if (!meta) return UNKNOWN_DEPTH_SENTINEL;
+    if (meta.delegationDepth !== undefined) return meta.delegationDepth + depth;
+    const parent: ExecutionId | undefined = meta.parentExecutionId;
     if (!parent) break;
     depth++;
     current = parent;

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -1,0 +1,59 @@
+/**
+ * Agent-side nested-delegation helpers. Reads workspace state and
+ * walks the persisted parent-execution chain to recover delegation
+ * depth on resume. Kept here (not in a flow-specific file) so the
+ * tool layer and resume path can import it without creating a cycle
+ * back through the tool registry.
+ */
+
+import { getExecutionStore } from '@agent/storage';
+import type { ExecutionMeta } from '@agent/storage/ExecutionKVStore';
+import { getWorkspaceState } from '@agent/core/stateStore';
+import { WorkspaceStateKey } from '@common/state';
+import type { ExecutionId } from '@shared/schemas';
+import {
+  clampNestedDelegationDepth,
+  type NestedDelegationConfig,
+} from '@shared/constants/delegationPolicy';
+
+/** Read the current nested-delegation policy from workspace state. */
+export function readNestedDelegationConfig(): NestedDelegationConfig {
+  const state = getWorkspaceState();
+  const enabled = state.get<boolean>(
+    WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
+    false,
+  );
+  const maxDepth = clampNestedDelegationDepth(
+    state.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, undefined),
+  );
+  return { enabled, maxDepth };
+}
+
+/**
+ * Recover the delegation depth for a persisted execution by walking the
+ * parentExecutionId chain in its metadata. Used on resume, where the
+ * in-memory depth that executeAgent would normally carry is unavailable.
+ *
+ * Returns 0 when no parent is stored (root execution or pre-feature data)
+ * or if a cycle is detected defensively.
+ */
+export async function computeDelegationDepthFromStorage(
+  executionId: ExecutionId,
+): Promise<number> {
+  const visited = new Set<string>();
+  let current: ExecutionId | undefined = executionId;
+  let depth = 0;
+  // Cap the walk as a belt-and-suspenders against corrupted chains.
+  const MAX_WALK = 32;
+  while (current && !visited.has(current) && depth < MAX_WALK) {
+    visited.add(current);
+    const meta: ExecutionMeta | null = await getExecutionStore(
+      current,
+    ).readMeta();
+    const parent: ExecutionId | undefined = meta?.parentExecutionId;
+    if (!parent) break;
+    depth++;
+    current = parent;
+  }
+  return depth;
+}

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -531,6 +531,12 @@ export interface ExecuteAgentOptions {
   enforceCategory?: boolean;
   /** Parent stream ID for subagent lineage tracking. Defaults to own streamId. */
   parentStreamId?: StreamTabId;
+  /**
+   * Depth of this execution in the delegation chain. Root (user-initiated) is 0;
+   * each delegate_agent / delegate_workflow call increments it. Used to gate
+   * nested delegation based on the Multi-Agent settings. Defaults to 0.
+   */
+  delegationDepth?: number;
   /** Fires with the real streamId before the stream is activated (before UI sync). */
   onStreamResolved?: (streamId: StreamTabId) => void;
   /** Fires before a tool-use subagent enters WAITING, delivering interim result to orchestrator. */
@@ -553,6 +559,7 @@ export async function executeAgent(
     onBeforeActivation: options?.onStreamResolved,
     enforceCategory: options?.enforceCategory,
   });
+  ctx.delegationDepth = options?.delegationDepth ?? 0;
   const { setting, streamId, config } = ctx;
   const { agent: agentName } = config;
   const { isSubagent } = options ?? {};

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -37,6 +37,7 @@ import {
   type AgentLoadOptions,
 } from '@agent/runtime/agentLoad';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
+import { computeDelegationDepthFromStorage } from '@agent/runtime/delegationPolicy';
 import { buildUserVars } from '@agent/utils/userVars';
 import { UsageMonitor } from '@agent/utils/UsageMonitor';
 import { normalizeRunId } from '@common/constants/runIds';
@@ -741,6 +742,12 @@ export async function resumeToolUseFromSnapshot(
     snapshot.agentConfig,
     snapshot.executionId,
     { streamTabIdOverride: snapshot.streamId },
+  );
+  // Recover delegation depth from the persisted parent-execution chain
+  // so resumed subagents remain gated by the nested-delegation policy
+  // instead of silently promoting to root.
+  ctx.delegationDepth = await computeDelegationDepthFromStorage(
+    snapshot.executionId,
   );
   const { setting, streamId } = ctx;
 

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -772,6 +772,11 @@ export async function resumeToolUseFromSnapshot(
             ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
           setting: setting as AgentToolUseSetting,
           resumeSnapshot: snapshot,
+          // Derive from the recovered parent chain: any execution with a
+          // parent is a subagent. Without this, the rebuilt system prompt
+          // would drop subagent-specific instructions (e.g. the shared
+          // /memories protocol) that the fresh run had included.
+          isSubagent: (ctx.delegationDepth ?? 0) > 0,
           onFollowUpConsumed: () =>
             bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
         },

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -42,6 +42,13 @@ export const ExecutionMetaSchema = z.object({
   category: z.string().optional(),
   /** AI-generated summary of what the session aimed to accomplish. */
   description: z.string().optional(),
+  /**
+   * Delegation depth at launch time: 0 for user-initiated, N for an agent
+   * N levels deep. Optional so pre-feature snapshots don't fail validation.
+   * Read on resume to enforce the nested-delegation cap without having to
+   * walk a potentially broken parent chain.
+   */
+  delegationDepth: z.number().int().nonnegative().optional(),
 });
 export type ExecutionMeta = z.infer<typeof ExecutionMetaSchema>;
 

--- a/src/agent/storage/executionLifecycle.ts
+++ b/src/agent/storage/executionLifecycle.ts
@@ -60,12 +60,14 @@ export async function registerExecution(
   agentName: string,
   parentExecutionId?: ExecutionId,
   category?: string,
+  delegationDepth?: number,
 ): Promise<void> {
   const timestamp = new Date().toISOString();
   const store = getExecutionStore(executionId);
 
   const meta: ExecutionMeta = { timestamp, parentExecutionId };
   if (category) meta.category = category;
+  if (delegationDepth !== undefined) meta.delegationDepth = delegationDepth;
 
   const writes: Promise<void>[] = [
     store.writeConfig(config),

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -16,6 +16,11 @@ export interface ToolFileInteractionContext {
   agentName?: string;
   /** Working directory override for tool calls (e.g. a git worktree path). */
   workingDirectory?: string;
+  /**
+   * Delegation depth of the agent executing this tool call. 0 for root (user-initiated),
+   * N for an agent N levels deep. Read by delegation tools to compute the child's depth.
+   */
+  delegationDepth?: number;
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */
   todoState?: TodoState;

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -23,7 +23,6 @@ export enum WorkspaceStateKey {
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
   ALLOW_ORCHESTRATOR_KILL = 'texra.allowOrchestratorKill',
   DETACH_SUBAGENTS_ON_STOP = 'texra.detachSubagentsOnStop',
-  NESTED_DELEGATION_ENABLED = 'texra.nestedDelegationEnabled',
   NESTED_DELEGATION_MAX_DEPTH = 'texra.nestedDelegationMaxDepth',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -23,6 +23,8 @@ export enum WorkspaceStateKey {
   SUPER_YOLO_ENABLED = 'texra.superYoloEnabled',
   ALLOW_ORCHESTRATOR_KILL = 'texra.allowOrchestratorKill',
   DETACH_SUBAGENTS_ON_STOP = 'texra.detachSubagentsOnStop',
+  NESTED_DELEGATION_ENABLED = 'texra.nestedDelegationEnabled',
+  NESTED_DELEGATION_MAX_DEPTH = 'texra.nestedDelegationMaxDepth',
   CUSTOM_AGENT_PRESETS = 'texra.customAgentPresets',
 
   // Codex settings

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -69,7 +69,6 @@ export const SETTINGS_VIEW_CMD = {
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
   SET_ALLOW_ORCHESTRATOR_KILL: 'setAllowOrchestratorKill',
   SET_DETACH_SUBAGENTS_ON_STOP: 'setDetachSubagentsOnStop',
-  SET_NESTED_DELEGATION_ENABLED: 'setNestedDelegationEnabled',
   SET_NESTED_DELEGATION_MAX_DEPTH: 'setNestedDelegationMaxDepth',
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -69,6 +69,8 @@ export const SETTINGS_VIEW_CMD = {
   SET_SUPER_YOLO_ENABLED: 'setSuperYoloEnabled',
   SET_ALLOW_ORCHESTRATOR_KILL: 'setAllowOrchestratorKill',
   SET_DETACH_SUBAGENTS_ON_STOP: 'setDetachSubagentsOnStop',
+  SET_NESTED_DELEGATION_ENABLED: 'setNestedDelegationEnabled',
+  SET_NESTED_DELEGATION_MAX_DEPTH: 'setNestedDelegationMaxDepth',
   APPLY_AGENT_MODE_PRESET: 'applyAgentModePreset',
   SAVE_AGENT_MODE_PRESET: 'saveAgentModePreset',
   DELETE_AGENT_MODE_PRESET: 'deleteAgentModePreset',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -428,11 +428,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
           data,
         ),
-      [SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_ENABLED]: (data) =>
-        this.updateBooleanAndSendSuperYolo(
-          WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
-          data,
-        ),
       [SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_MAX_DEPTH]: (data) =>
         this.handleSetNestedDelegationMaxDepth(data),
 
@@ -833,10 +828,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
       false,
     );
-    const nestedDelegationEnabled = workspaceSM.get<boolean>(
-      WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
-      false,
-    );
     const nestedDelegationMaxDepth = clampNestedDelegationDepth(
       workspaceSM.get<number>(
         WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
@@ -849,7 +840,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       reliabilitySettings: getReliabilitySettings(),
       allowOrchestratorKill,
       detachSubagentsOnStop,
-      nestedDelegationEnabled,
       nestedDelegationMaxDepth,
     });
   }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -80,6 +80,10 @@ import {
   PROVIDER_VSCODE_SETTINGS,
 } from '@shared/constants/providers';
 import { isFastFirstResponseModel } from '@shared/constants/fastModels';
+import {
+  NESTED_DELEGATION_DEPTH_RANGE,
+  clampNestedDelegationDepth,
+} from '@shared/constants/delegationPolicy';
 import type {
   RemoteAgent,
   ProviderKeyStatus,
@@ -177,12 +181,6 @@ const ALLOWED_VSCODE_SETTING_KEYS = new Set([
     .map((s) => s.key),
   ...RELIABILITY_SETTINGS.map((s) => s.key),
 ]);
-
-/** Clamp nested delegation max depth to the supported range. */
-function clampNestedMaxDepth(value: unknown): number {
-  const n = typeof value === 'number' && Number.isFinite(value) ? value : 2;
-  return Math.min(5, Math.max(1, Math.round(n)));
-}
 
 function getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {
   const defs = PROVIDER_VSCODE_SETTINGS[provider.toLowerCase()];
@@ -839,8 +837,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
       false,
     );
-    const nestedDelegationMaxDepth = clampNestedMaxDepth(
-      workspaceSM.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, 2),
+    const nestedDelegationMaxDepth = clampNestedDelegationDepth(
+      workspaceSM.get<number>(
+        WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
+        NESTED_DELEGATION_DEPTH_RANGE.default,
+      ),
     );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
@@ -888,7 +889,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   ): Promise<void> {
     await workspaceSM.update(
       WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
-      clampNestedMaxDepth(data.value),
+      clampNestedDelegationDepth(data.value),
     );
     await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
   }

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -178,6 +178,12 @@ const ALLOWED_VSCODE_SETTING_KEYS = new Set([
   ...RELIABILITY_SETTINGS.map((s) => s.key),
 ]);
 
+/** Clamp nested delegation max depth to the supported range. */
+function clampNestedMaxDepth(value: unknown): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : 2;
+  return Math.min(5, Math.max(1, Math.round(n)));
+}
+
 function getProviderVscodeSettings(provider: string): ProviderVscodeSetting[] {
   const defs = PROVIDER_VSCODE_SETTINGS[provider.toLowerCase()];
   if (!defs) return [];
@@ -424,6 +430,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
           data,
         ),
+      [SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_ENABLED]: (data) =>
+        this.updateBooleanAndSendSuperYolo(
+          WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
+          data,
+        ),
+      [SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_MAX_DEPTH]: (data) =>
+        this.handleSetNestedDelegationMaxDepth(data),
 
       // ── Delegated to AgentHandlers ──
 
@@ -822,12 +835,21 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
       false,
     );
+    const nestedDelegationEnabled = workspaceSM.get<boolean>(
+      WorkspaceStateKey.NESTED_DELEGATION_ENABLED,
+      false,
+    );
+    const nestedDelegationMaxDepth = clampNestedMaxDepth(
+      workspaceSM.get<number>(WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH, 2),
+    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
       enabled,
       reliabilitySettings: getReliabilitySettings(),
       allowOrchestratorKill,
       detachSubagentsOnStop,
+      nestedDelegationEnabled,
+      nestedDelegationMaxDepth,
     });
   }
 
@@ -858,6 +880,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     data: { enabled: boolean },
   ): Promise<void> {
     await workspaceSM.update(key, data.enabled);
+    await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
+  }
+
+  private async handleSetNestedDelegationMaxDepth(
+    data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_NESTED_DELEGATION_MAX_DEPTH>,
+  ): Promise<void> {
+    await workspaceSM.update(
+      WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
+      clampNestedMaxDepth(data.value),
+    );
     await this.withActiveWebview((w) => this.sendSuperYoloEnabled(w));
   }
 

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -184,6 +184,8 @@ export class SettingsApp extends SettingsAppBase {
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
   private readonly allowOrchestratorKill = signal(true);
   private readonly detachSubagentsOnStop = signal(false);
+  private readonly nestedDelegationEnabled = signal(false);
+  private readonly nestedDelegationMaxDepth = signal(2);
 
   // Approval settings state
   private readonly bashApprovalEnabled = signal(true);
@@ -345,6 +347,8 @@ export class SettingsApp extends SettingsAppBase {
         this.reliabilitySettings.set(data.reliabilitySettings);
         this.allowOrchestratorKill.set(data.allowOrchestratorKill);
         this.detachSubagentsOnStop.set(data.detachSubagentsOnStop);
+        this.nestedDelegationEnabled.set(data.nestedDelegationEnabled);
+        this.nestedDelegationMaxDepth.set(data.nestedDelegationMaxDepth);
         return;
       }
 
@@ -602,6 +606,14 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleDetachSubagentsOnStopToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP,
+  );
+
+  private handleAllowNestedDelegationToggle = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_ENABLED,
+  );
+
+  private handleNestedDelegationMaxDepthChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_MAX_DEPTH,
   );
 
   private handleApplyAgentModePreset = forwardDetail(
@@ -874,12 +886,18 @@ export class SettingsApp extends SettingsAppBase {
               .allowOrchestratorKill=${this.allowOrchestratorKill.get()}
               .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
               .worktreeSupport=${this.gitWorktreeSupport.get()}
+              .nestedDelegationEnabled=${this.nestedDelegationEnabled.get()}
+              .nestedDelegationMaxDepth=${this.nestedDelegationMaxDepth.get()}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @allow-orchestrator-kill-toggle=${this
                 .handleAllowOrchestratorKillToggle}
               @detach-subagents-on-stop-toggle=${this
                 .handleDetachSubagentsOnStopToggle}
               @worktree-support-toggle=${this.handleWorktreeSupportToggle}
+              @allow-nested-delegation-toggle=${this
+                .handleAllowNestedDelegationToggle}
+              @nested-delegation-max-depth-change=${this
+                .handleNestedDelegationMaxDepthChange}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -184,8 +184,7 @@ export class SettingsApp extends SettingsAppBase {
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
   private readonly allowOrchestratorKill = signal(true);
   private readonly detachSubagentsOnStop = signal(false);
-  private readonly nestedDelegationEnabled = signal(false);
-  private readonly nestedDelegationMaxDepth = signal(2);
+  private readonly nestedDelegationMaxDepth = signal(1);
 
   // Approval settings state
   private readonly bashApprovalEnabled = signal(true);
@@ -347,7 +346,6 @@ export class SettingsApp extends SettingsAppBase {
         this.reliabilitySettings.set(data.reliabilitySettings);
         this.allowOrchestratorKill.set(data.allowOrchestratorKill);
         this.detachSubagentsOnStop.set(data.detachSubagentsOnStop);
-        this.nestedDelegationEnabled.set(data.nestedDelegationEnabled);
         this.nestedDelegationMaxDepth.set(data.nestedDelegationMaxDepth);
         return;
       }
@@ -606,10 +604,6 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleDetachSubagentsOnStopToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP,
-  );
-
-  private handleAllowNestedDelegationToggle = forwardDetail(
-    SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_ENABLED,
   );
 
   private handleNestedDelegationMaxDepthChange = forwardDetail(
@@ -886,7 +880,6 @@ export class SettingsApp extends SettingsAppBase {
               .allowOrchestratorKill=${this.allowOrchestratorKill.get()}
               .detachSubagentsOnStop=${this.detachSubagentsOnStop.get()}
               .worktreeSupport=${this.gitWorktreeSupport.get()}
-              .nestedDelegationEnabled=${this.nestedDelegationEnabled.get()}
               .nestedDelegationMaxDepth=${this.nestedDelegationMaxDepth.get()}
               @super-yolo-toggle=${this.handleSuperYoloToggle}
               @allow-orchestrator-kill-toggle=${this
@@ -894,8 +887,6 @@ export class SettingsApp extends SettingsAppBase {
               @detach-subagents-on-stop-toggle=${this
                 .handleDetachSubagentsOnStopToggle}
               @worktree-support-toggle=${this.handleWorktreeSupportToggle}
-              @allow-nested-delegation-toggle=${this
-                .handleAllowNestedDelegationToggle}
               @nested-delegation-max-depth-change=${this
                 .handleNestedDelegationMaxDepthChange}
               @reliability-setting-change=${this.handleSetProviderVscodeSetting}

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -59,6 +59,7 @@ import {
   DEFAULT_GIT_MARK_COMMITS,
 } from '@shared/constants/git';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+import { NESTED_DELEGATION_DEPTH_RANGE } from '@shared/constants/delegationPolicy';
 
 // Local imports - settings view
 import type { AgentCategory } from '@shared/schemas/agent';
@@ -184,7 +185,9 @@ export class SettingsApp extends SettingsAppBase {
   private readonly reliabilitySettings = signal<NumberVscodeSetting[]>([]);
   private readonly allowOrchestratorKill = signal(true);
   private readonly detachSubagentsOnStop = signal(false);
-  private readonly nestedDelegationMaxDepth = signal(1);
+  private readonly nestedDelegationMaxDepth = signal<number>(
+    NESTED_DELEGATION_DEPTH_RANGE.default,
+  );
 
   // Approval settings state
   private readonly bashApprovalEnabled = signal(true);

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -275,6 +275,8 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) allowOrchestratorKill = true;
   @property({ attribute: false }) detachSubagentsOnStop = false;
   @property({ attribute: false }) worktreeSupport = false;
+  @property({ attribute: false }) nestedDelegationEnabled = false;
+  @property({ attribute: false }) nestedDelegationMaxDepth = 2;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
@@ -301,6 +303,23 @@ export class MultiAgentTab extends LitElement {
 
   private handleWorktreeSupportToggle(event: Event): void {
     this.emitToggle('worktree-support-toggle', event);
+  }
+
+  private handleNestedDelegationToggle(event: Event): void {
+    this.emitToggle('allow-nested-delegation-toggle', event);
+  }
+
+  private handleNestedDelegationMaxDepthChange(input: HTMLInputElement): void {
+    const parsed = Number(input.value);
+    if (Number.isNaN(parsed)) {
+      input.value = String(this.nestedDelegationMaxDepth);
+      return;
+    }
+    const clamped = Math.min(5, Math.max(1, Math.round(parsed)));
+    if (clamped !== parsed) input.value = String(clamped);
+    this.dispatchEvent(
+      createEvent('nested-delegation-max-depth-change', { value: clamped }),
+    );
   }
 
   private handlePresetClick(preset: AgentModePreset): void {
@@ -510,6 +529,39 @@ export class MultiAgentTab extends LitElement {
             When enabled, delegated agents can operate in git worktrees outside
             the main workspace. All tool calls within the subagent automatically
             use the worktree as their root directory.
+          </p>
+        </div>
+
+        <div class="setting-block">
+          <vscode-checkbox
+            ?checked=${this.nestedDelegationEnabled}
+            @change=${this.handleNestedDelegationToggle}
+          >
+            Allow nested delegation
+          </vscode-checkbox>
+          <p class="text-secondary setting-description">
+            Let a delegated agent delegate further (orchestrator →
+            sub-orchestrator → leaf agent). When off, subagents cannot call
+            delegation tools.
+          </p>
+          <div class="reliability-row">
+            <label>Max nesting depth</label>
+            <vscode-textfield
+              class="reliability-input"
+              type="number"
+              .value=${String(this.nestedDelegationMaxDepth)}
+              min="1"
+              max="5"
+              ?disabled=${!this.nestedDelegationEnabled}
+              @change=${(e: Event) =>
+                this.handleNestedDelegationMaxDepthChange(
+                  e.target as HTMLInputElement,
+                )}
+            ></vscode-textfield>
+          </div>
+          <p class="reliability-description">
+            Depth 2 allows one grandchild (orchestrator → orchestrator → leaf).
+            Only applies when nested delegation is on.
           </p>
         </div>
 

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -21,6 +21,10 @@ import {
   type AgentModePreset,
 } from '@shared/schemas/agentPresets';
 import type { NumberVscodeSetting } from '@shared/schemas/settingsViewMessages';
+import {
+  NESTED_DELEGATION_DEPTH_RANGE,
+  clampNestedDelegationDepth,
+} from '@shared/constants/delegationPolicy';
 
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
@@ -276,7 +280,8 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) detachSubagentsOnStop = false;
   @property({ attribute: false }) worktreeSupport = false;
   @property({ attribute: false }) nestedDelegationEnabled = false;
-  @property({ attribute: false }) nestedDelegationMaxDepth = 2;
+  @property({ attribute: false }) nestedDelegationMaxDepth =
+    NESTED_DELEGATION_DEPTH_RANGE.default;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
     [];
   @property({ attribute: false }) customPresets: AgentModePreset[] = [];
@@ -315,7 +320,7 @@ export class MultiAgentTab extends LitElement {
       input.value = String(this.nestedDelegationMaxDepth);
       return;
     }
-    const clamped = Math.min(5, Math.max(1, Math.round(parsed)));
+    const clamped = clampNestedDelegationDepth(parsed);
     if (clamped !== parsed) input.value = String(clamped);
     this.dispatchEvent(
       createEvent('nested-delegation-max-depth-change', { value: clamped }),
@@ -550,8 +555,8 @@ export class MultiAgentTab extends LitElement {
               class="reliability-input"
               type="number"
               .value=${String(this.nestedDelegationMaxDepth)}
-              min="1"
-              max="5"
+              min=${NESTED_DELEGATION_DEPTH_RANGE.min}
+              max=${NESTED_DELEGATION_DEPTH_RANGE.max}
               ?disabled=${!this.nestedDelegationEnabled}
               @change=${(e: Event) =>
                 this.handleNestedDelegationMaxDepthChange(

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -279,7 +279,6 @@ export class MultiAgentTab extends LitElement {
   @property({ attribute: false }) allowOrchestratorKill = true;
   @property({ attribute: false }) detachSubagentsOnStop = false;
   @property({ attribute: false }) worktreeSupport = false;
-  @property({ attribute: false }) nestedDelegationEnabled = false;
   @property({ attribute: false }) nestedDelegationMaxDepth =
     NESTED_DELEGATION_DEPTH_RANGE.default;
   @property({ attribute: false }) reliabilitySettings: NumberVscodeSetting[] =
@@ -308,10 +307,6 @@ export class MultiAgentTab extends LitElement {
 
   private handleWorktreeSupportToggle(event: Event): void {
     this.emitToggle('worktree-support-toggle', event);
-  }
-
-  private handleNestedDelegationToggle(event: Event): void {
-    this.emitToggle('allow-nested-delegation-toggle', event);
   }
 
   private handleNestedDelegationMaxDepthChange(input: HTMLInputElement): void {
@@ -538,26 +533,14 @@ export class MultiAgentTab extends LitElement {
         </div>
 
         <div class="setting-block">
-          <vscode-checkbox
-            ?checked=${this.nestedDelegationEnabled}
-            @change=${this.handleNestedDelegationToggle}
-          >
-            Allow nested delegation
-          </vscode-checkbox>
-          <p class="text-secondary setting-description">
-            Let a delegated agent delegate further (orchestrator →
-            sub-orchestrator → leaf agent). When off, subagents cannot call
-            delegation tools.
-          </p>
           <div class="reliability-row">
-            <label>Max nesting depth</label>
+            <label>Max delegation depth</label>
             <vscode-textfield
               class="reliability-input"
               type="number"
               .value=${String(this.nestedDelegationMaxDepth)}
               min=${NESTED_DELEGATION_DEPTH_RANGE.min}
               max=${NESTED_DELEGATION_DEPTH_RANGE.max}
-              ?disabled=${!this.nestedDelegationEnabled}
               @change=${(e: Event) =>
                 this.handleNestedDelegationMaxDepthChange(
                   e.target as HTMLInputElement,
@@ -565,8 +548,10 @@ export class MultiAgentTab extends LitElement {
             ></vscode-textfield>
           </div>
           <p class="reliability-description">
-            Depth 2 allows one grandchild (orchestrator → orchestrator → leaf).
-            Only applies when nested delegation is on.
+            Depth 1 (default): only the top-level orchestrator may delegate;
+            subagents cannot delegate further. Depth 2 lets a sub-orchestrator
+            delegate once more (orchestrator → sub-orchestrator → leaf).
+            Higher values allow deeper chains.
           </p>
         </div>
 

--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -1,17 +1,24 @@
 /**
- * Nested-delegation policy: range constants, clamping, and the pure
- * depth gate. No VS Code or Node dependencies so it can be imported
- * from both the extension host and the webview bundles.
+ * Delegation depth policy: range constants, clamping, and the pure gate.
+ * No VS Code or Node dependencies so it can be imported from both the
+ * extension host and the webview bundles. The state read lives in the
+ * agent runtime module so this file stays pure.
  *
- * The state read (`readNestedDelegationConfig`) lives in the agent
- * runtime module so this file stays pure.
+ * Semantics of `maxDepth`:
+ *
+ * - Root orchestrator starts at depth 0. Each `delegate_agent` /
+ *   `delegate_workflow` call increments the child's depth by 1.
+ * - An agent at depth `d` may delegate iff `d < maxDepth`.
+ * - Default is 1: only the root may delegate, subagents cannot delegate
+ *   further. Raise to 2 to allow one layer of nested delegation
+ *   (orchestrator → sub-orchestrator → leaf agent), and so on.
  */
 
 /** Supported range for the max-depth setting and its default. */
 export const NESTED_DELEGATION_DEPTH_RANGE = {
   min: 1,
   max: 5,
-  default: 2,
+  default: 1,
 } as const;
 
 /** Clamp an arbitrary value to the supported max-depth range. */
@@ -26,20 +33,19 @@ export function clampNestedDelegationDepth(value: unknown): number {
   );
 }
 
-/** Snapshot of nested-delegation settings, read once per tool-use flow entry. */
+/** Snapshot of delegation policy, read once per tool-use flow entry. */
 export interface NestedDelegationConfig {
-  enabled: boolean;
   maxDepth: number;
 }
 
 /**
- * Delegation gate. Root (depth 0) can always delegate; subagents can only
- * delegate when nesting is enabled and their depth is below the cap.
+ * Delegation gate. An agent at depth `d` may delegate iff `d < maxDepth`.
+ * Root (depth 0) with the default (maxDepth 1) can always delegate;
+ * subagents (depth ≥ 1) can only delegate when the user raises the cap.
  */
 export function delegationAllowed(
   depth: number,
   config: NestedDelegationConfig,
 ): boolean {
-  if (depth <= 0) return true;
-  return config.enabled && depth < config.maxDepth;
+  return depth < config.maxDepth;
 }

--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -1,0 +1,45 @@
+/**
+ * Nested-delegation policy: range constants, clamping, and the pure
+ * depth gate. No VS Code or Node dependencies so it can be imported
+ * from both the extension host and the webview bundles.
+ *
+ * The state read (`readNestedDelegationConfig`) lives in the agent
+ * runtime module so this file stays pure.
+ */
+
+/** Supported range for the max-depth setting and its default. */
+export const NESTED_DELEGATION_DEPTH_RANGE = {
+  min: 1,
+  max: 5,
+  default: 2,
+} as const;
+
+/** Clamp an arbitrary value to the supported max-depth range. */
+export function clampNestedDelegationDepth(value: unknown): number {
+  const n =
+    typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : NESTED_DELEGATION_DEPTH_RANGE.default;
+  return Math.min(
+    NESTED_DELEGATION_DEPTH_RANGE.max,
+    Math.max(NESTED_DELEGATION_DEPTH_RANGE.min, Math.round(n)),
+  );
+}
+
+/** Snapshot of nested-delegation settings, read once per tool-use flow entry. */
+export interface NestedDelegationConfig {
+  enabled: boolean;
+  maxDepth: number;
+}
+
+/**
+ * Delegation gate. Root (depth 0) can always delegate; subagents can only
+ * delegate when nesting is enabled and their depth is below the cap.
+ */
+export function delegationAllowed(
+  depth: number,
+  config: NestedDelegationConfig,
+): boolean {
+  if (depth <= 0) return true;
+  return config.enabled && depth < config.maxDepth;
+}

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -216,7 +216,6 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
   allowOrchestratorKill: z.boolean().prefault(true),
   detachSubagentsOnStop: z.boolean().prefault(false),
-  nestedDelegationEnabled: z.boolean().prefault(false),
   nestedDelegationMaxDepth: z
     .number()
     .int()
@@ -588,11 +587,6 @@ const SetDetachSubagentsOnStopMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
-const SetNestedDelegationEnabledMessageSchema = z.object({
-  command: z.literal(CMD.SET_NESTED_DELEGATION_ENABLED),
-  enabled: z.boolean(),
-});
-
 const SetNestedDelegationMaxDepthMessageSchema = z.object({
   command: z.literal(CMD.SET_NESTED_DELEGATION_MAX_DEPTH),
   value: z
@@ -809,7 +803,6 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetSuperYoloEnabledMessageSchema,
     SetAllowOrchestratorKillMessageSchema,
     SetDetachSubagentsOnStopMessageSchema,
-    SetNestedDelegationEnabledMessageSchema,
     SetNestedDelegationMaxDepthMessageSchema,
     // Git author settings messages
     GetGitAuthorSettingsMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -215,6 +215,8 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   reliabilitySettings: z.array(NumberVscodeSettingSchema).prefault([]),
   allowOrchestratorKill: z.boolean().prefault(true),
   detachSubagentsOnStop: z.boolean().prefault(false),
+  nestedDelegationEnabled: z.boolean().prefault(false),
+  nestedDelegationMaxDepth: z.number().int().min(1).max(5).prefault(2),
 });
 export type UpdateSuperYoloEnabledMessage = z.infer<
   typeof UpdateSuperYoloEnabledMessageSchema
@@ -580,6 +582,16 @@ const SetDetachSubagentsOnStopMessageSchema = z.object({
   enabled: z.boolean(),
 });
 
+const SetNestedDelegationEnabledMessageSchema = z.object({
+  command: z.literal(CMD.SET_NESTED_DELEGATION_ENABLED),
+  enabled: z.boolean(),
+});
+
+const SetNestedDelegationMaxDepthMessageSchema = z.object({
+  command: z.literal(CMD.SET_NESTED_DELEGATION_MAX_DEPTH),
+  value: z.number().int().min(1).max(5),
+});
+
 // Agent mode preset inbound messages
 const GetAgentModePresetsMessageSchema = commandOnly(
   CMD.GET_AGENT_MODE_PRESETS,
@@ -787,6 +799,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetSuperYoloEnabledMessageSchema,
     SetAllowOrchestratorKillMessageSchema,
     SetDetachSubagentsOnStopMessageSchema,
+    SetNestedDelegationEnabledMessageSchema,
+    SetNestedDelegationMaxDepthMessageSchema,
     // Git author settings messages
     GetGitAuthorSettingsMessageSchema,
     SetGitMarkCommitsMessageSchema,

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -23,6 +23,7 @@ import {
   AgentSourceSchema,
 } from './agent';
 import { AgentModePresetSchema } from './agentPresets';
+import { NESTED_DELEGATION_DEPTH_RANGE } from '../constants/delegationPolicy';
 import {
   DeleteMemoryMessageSchema,
   GetMemoryDataMessageSchema,
@@ -216,7 +217,12 @@ export const UpdateSuperYoloEnabledMessageSchema = z.object({
   allowOrchestratorKill: z.boolean().prefault(true),
   detachSubagentsOnStop: z.boolean().prefault(false),
   nestedDelegationEnabled: z.boolean().prefault(false),
-  nestedDelegationMaxDepth: z.number().int().min(1).max(5).prefault(2),
+  nestedDelegationMaxDepth: z
+    .number()
+    .int()
+    .min(NESTED_DELEGATION_DEPTH_RANGE.min)
+    .max(NESTED_DELEGATION_DEPTH_RANGE.max)
+    .prefault(NESTED_DELEGATION_DEPTH_RANGE.default),
 });
 export type UpdateSuperYoloEnabledMessage = z.infer<
   typeof UpdateSuperYoloEnabledMessageSchema
@@ -589,7 +595,11 @@ const SetNestedDelegationEnabledMessageSchema = z.object({
 
 const SetNestedDelegationMaxDepthMessageSchema = z.object({
   command: z.literal(CMD.SET_NESTED_DELEGATION_MAX_DEPTH),
-  value: z.number().int().min(1).max(5),
+  value: z
+    .number()
+    .int()
+    .min(NESTED_DELEGATION_DEPTH_RANGE.min)
+    .max(NESTED_DELEGATION_DEPTH_RANGE.max),
 });
 
 // Agent mode preset inbound messages

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -225,21 +225,13 @@ async function executeSubagent(
   const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
 
   // Defense-in-depth: the tool-use flow already filters delegation tools out
-  // of the toolset when nesting is disabled or capped, but if a rogue agent
-  // invokes the tool anyway we refuse here with a clear message so the LLM
-  // can pivot. The root orchestrator (depth 0) is never blocked.
+  // of the toolset when the depth cap is reached, but if a rogue agent calls
+  // the tool anyway we refuse here with a clear message so the LLM can pivot.
   if (parentDelegationDepth > 0) {
-    const nested = readNestedDelegationConfig();
-    if (!nested.enabled) {
+    const { maxDepth } = readNestedDelegationConfig();
+    if (parentDelegationDepth >= maxDepth) {
       return {
-        error:
-          'Nested delegation is disabled. Enable Settings → Multi-Agent → Allow nested delegation, or complete this task directly without delegating.',
-        isError: true,
-      };
-    }
-    if (parentDelegationDepth >= nested.maxDepth) {
-      return {
-        error: `Nested delegation depth cap reached (${nested.maxDepth}). Increase Settings → Multi-Agent → Max nesting depth, or complete this task directly without delegating.`,
+        error: `Delegation depth cap reached (max depth ${maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
         isError: true,
       };
     }

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -205,6 +205,25 @@ interface ApprovalMeta {
 }
 
 /**
+ * Defense-in-depth depth gate shared by fresh delegations and resumes.
+ * The tool-use flow already filters delegation tools from the toolset when
+ * the cap is reached, but if a rogue agent calls through anyway (fresh or
+ * via the execution_id resume path) we refuse here with a clear error so
+ * the LLM can pivot. The root orchestrator (depth 0) is never blocked.
+ */
+function depthGateError(parentDelegationDepth: number): ToolResult | null {
+  if (parentDelegationDepth <= 0) return null;
+  const { maxDepth } = readNestedDelegationConfig();
+  if (parentDelegationDepth >= maxDepth) {
+    return {
+      error: `Delegation depth cap reached (max depth ${maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
+      isError: true,
+    };
+  }
+  return null;
+}
+
+/**
  * Execute a subagent asynchronously.
  * Pre-generates executionId so all IDs (tool return, XML delivery, error)
  * are consistent and usable with the executions tool.
@@ -224,18 +243,8 @@ async function executeSubagent(
   const parentExecutionId = parentContext?.executionId;
   const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
 
-  // Defense-in-depth: the tool-use flow already filters delegation tools out
-  // of the toolset when the depth cap is reached, but if a rogue agent calls
-  // the tool anyway we refuse here with a clear message so the LLM can pivot.
-  if (parentDelegationDepth > 0) {
-    const { maxDepth } = readNestedDelegationConfig();
-    if (parentDelegationDepth >= maxDepth) {
-      return {
-        error: `Delegation depth cap reached (max depth ${maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
-        isError: true,
-      };
-    }
-  }
+  const gated = depthGateError(parentDelegationDepth);
+  if (gated) return gated;
 
   const executionId = generateExecutionId();
   const startedAt = Date.now();
@@ -829,6 +838,11 @@ Git worktree support: ${
     executionId: string,
     instruction: string,
   ): Promise<ToolResult> {
+    const parentDelegationDepth =
+      getCurrentToolFileInteractionContext()?.delegationDepth ?? 0;
+    const gated = depthGateError(parentDelegationDepth);
+    if (gated) return gated;
+
     const handle = getHandle(executionId);
     if (!(handle instanceof AgentExecutionHandle)) {
       throw new Error(

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -19,7 +19,7 @@ import {
 } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { executeAgent } from '@agent/runtime/executeAgent';
-import { readNestedDelegationConfig } from '@agent/implementations/flows/tooluse/runToolUseFlow';
+import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   getHandle,

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -255,6 +255,8 @@ async function executeSubagent(
     syntheticConfig,
     agentName,
     parentExecutionId,
+    undefined,
+    parentDelegationDepth + 1,
   );
 
   // Track delivery state in the module-level map so delegate_agent (resume) can reset it.

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -20,6 +20,7 @@ import {
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { executeAgent } from '@agent/runtime/executeAgent';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
+import { delegationAllowed } from '@shared/constants/delegationPolicy';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   getHandle,
@@ -209,18 +210,18 @@ interface ApprovalMeta {
  * The tool-use flow already filters delegation tools from the toolset when
  * the cap is reached, but if a rogue agent calls through anyway (fresh or
  * via the execution_id resume path) we refuse here with a clear error so
- * the LLM can pivot. The root orchestrator (depth 0) is never blocked.
+ * the LLM can pivot.
+ *
+ * Delegates to the same `delegationAllowed` predicate the tool filter
+ * uses so NaN / sentinel depths behave identically at both gates.
  */
 function depthGateError(parentDelegationDepth: number): ToolResult | null {
-  if (parentDelegationDepth <= 0) return null;
-  const { maxDepth } = readNestedDelegationConfig();
-  if (parentDelegationDepth >= maxDepth) {
-    return {
-      error: `Delegation depth cap reached (max depth ${maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
-      isError: true,
-    };
-  }
-  return null;
+  const config = readNestedDelegationConfig();
+  if (delegationAllowed(parentDelegationDepth, config)) return null;
+  return {
+    error: `Delegation depth cap reached (max depth ${config.maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
+    isError: true,
+  };
 }
 
 /**

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -19,6 +19,7 @@ import {
 } from '@agent/core/AgentConfig';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { executeAgent } from '@agent/runtime/executeAgent';
+import { readNestedDelegationConfig } from '@agent/implementations/flows/tooluse/runToolUseFlow';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import {
   getHandle,
@@ -219,10 +220,34 @@ async function executeSubagent(
   orchestratorStreamId: StreamTabId,
   options?: { enableYoloOnChild?: boolean; approvalMeta?: ApprovalMeta },
 ): Promise<ToolResult> {
+  const parentContext = getCurrentToolFileInteractionContext();
+  const parentExecutionId = parentContext?.executionId;
+  const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
+
+  // Defense-in-depth: the tool-use flow already filters delegation tools out
+  // of the toolset when nesting is disabled or capped, but if a rogue agent
+  // invokes the tool anyway we refuse here with a clear message so the LLM
+  // can pivot. The root orchestrator (depth 0) is never blocked.
+  if (parentDelegationDepth > 0) {
+    const nested = readNestedDelegationConfig();
+    if (!nested.enabled) {
+      return {
+        error:
+          'Nested delegation is disabled. Enable Settings → Multi-Agent → Allow nested delegation, or complete this task directly without delegating.',
+        isError: true,
+      };
+    }
+    if (parentDelegationDepth >= nested.maxDepth) {
+      return {
+        error: `Nested delegation depth cap reached (${nested.maxDepth}). Increase Settings → Multi-Agent → Max nesting depth, or complete this task directly without delegating.`,
+        isError: true,
+      };
+    }
+  }
+
   const executionId = generateExecutionId();
   const startedAt = Date.now();
 
-  const parentExecutionId = getCurrentToolFileInteractionContext()?.executionId;
   const syntheticConfig = AgentConfigSchema.parse(configPayload);
   await registerExecution(
     executionId,
@@ -249,6 +274,7 @@ async function executeSubagent(
     isSubagent: true,
     enforceCategory: true,
     parentStreamId: orchestratorStreamId,
+    delegationDepth: parentDelegationDepth + 1,
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       if (options?.enableYoloOnChild) {

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -64,6 +64,17 @@ The /memories directory is shared with the orchestrator and other subagents. Che
 </subagent_memory_protocol>`;
 
 /**
+ * Notice injected into a delegated subagent's system suffix when its YAML
+ * requested delegation tools but the nested-delegation gate removed them
+ * (either the global switch is off, or the depth cap is reached). Without
+ * this, the LLM keeps trying to call delegate_agent / delegate_workflow
+ * and fails confusingly.
+ */
+const NESTED_DELEGATION_BLOCKED_INSTRUCTIONS = `<nested_delegation_disabled>
+You are a delegated subagent. Nested delegation is disabled for this execution, so the delegation tools (delegate_agent, delegate_workflow, resume_agent, propose_agent, propose_workflow) are unavailable to you. Do not attempt to call them. Complete the task directly using the tools you have, or report back to the orchestrator if the task truly requires further delegation.
+</nested_delegation_disabled>`;
+
+/**
  * Combine the base system prompt with optional rules from `.texrarules`.
  *
  * @param systemPrompt Base system prompt template
@@ -216,6 +227,12 @@ export async function buildInitialToolUsePrompts(
     memoryEnabled?: boolean;
     hasDelegationTools?: boolean;
     isSubagent?: boolean;
+    /**
+     * True when the agent's YAML requested delegation tools but they were
+     * filtered out by the nested-delegation gate. Triggers a notice telling
+     * the LLM it cannot delegate further.
+     */
+    nestedDelegationBlocked?: boolean;
   },
 ): Promise<InitialPrompts & { instructionSuffix: string }> {
   const builder = new PromptBuilder(
@@ -236,6 +253,9 @@ export async function buildInitialToolUsePrompts(
     } else if (options.isSubagent) {
       suffixParts.push(SUBAGENT_MEMORY_INSTRUCTIONS);
     }
+  }
+  if (options?.nestedDelegationBlocked) {
+    suffixParts.push(NESTED_DELEGATION_BLOCKED_INSTRUCTIONS);
   }
   suffixParts.push(await buildWorkspaceInfoBlock());
 

--- a/src/utils/prompt/PromptBuilder.ts
+++ b/src/utils/prompt/PromptBuilder.ts
@@ -65,14 +65,13 @@ The /memories directory is shared with the orchestrator and other subagents. Che
 
 /**
  * Notice injected into a delegated subagent's system suffix when its YAML
- * requested delegation tools but the nested-delegation gate removed them
- * (either the global switch is off, or the depth cap is reached). Without
- * this, the LLM keeps trying to call delegate_agent / delegate_workflow
- * and fails confusingly.
+ * requested delegation tools but the max-delegation-depth gate removed
+ * them. Without this, the LLM keeps trying to call delegate_agent /
+ * delegate_workflow and fails confusingly.
  */
-const NESTED_DELEGATION_BLOCKED_INSTRUCTIONS = `<nested_delegation_disabled>
-You are a delegated subagent. Nested delegation is disabled for this execution, so the delegation tools (delegate_agent, delegate_workflow, resume_agent, propose_agent, propose_workflow) are unavailable to you. Do not attempt to call them. Complete the task directly using the tools you have, or report back to the orchestrator if the task truly requires further delegation.
-</nested_delegation_disabled>`;
+const NESTED_DELEGATION_BLOCKED_INSTRUCTIONS = `<delegation_depth_reached>
+You are a delegated subagent. The configured delegation depth does not allow you to delegate further, so the delegation tools (delegate_agent, delegate_workflow, resume_agent, propose_agent, propose_workflow) are unavailable to you. Do not attempt to call them. Complete the task directly using the tools you have, or report back to the orchestrator if the task truly requires further delegation.
+</delegation_depth_reached>`;
 
 /**
  * Combine the base system prompt with optional rules from `.texrarules`.


### PR DESCRIPTION
## Summary
Implements a configurable nested delegation system that allows orchestrators to control whether delegated subagents can further delegate tasks, and to what depth. This prevents runaway delegation chains while maintaining flexibility for complex multi-agent workflows.

## Key Changes

- **Nested Delegation Configuration**: Added `NESTED_DELEGATION_ENABLED` and `NESTED_DELEGATION_MAX_DEPTH` workspace state keys with UI controls in the Multi-Agent settings tab
  - Depth 0 (root orchestrator) can always delegate
  - Subagents can only delegate when nesting is enabled and their depth is below the configured cap (1-5, default 2)

- **Tool-Use Flow Integration**: Modified `runToolUseFlow` to:
  - Read nested delegation config once at flow entry via `readNestedDelegationConfig()`
  - Track delegation depth through the execution chain
  - Filter out delegation tools (`delegate_agent`, `delegate_workflow`, etc.) when nesting is disabled or depth cap is reached
  - Pass `delegationTrimmed` flag to prompt builder to notify the LLM when delegation tools are unavailable

- **Delegation Tool Gating**: Enhanced `executeSubagent` with defense-in-depth validation:
  - Checks if nested delegation is enabled before allowing subagent delegation
  - Validates depth hasn't exceeded the configured cap
  - Returns clear error messages directing users to settings or suggesting direct task completion

- **Execution Context Propagation**: 
  - Added `delegationDepth` field to `ExecuteAgentOptions`, `AgentCore`, and `ToolFileInteractionContext`
  - Increments depth when creating subagents via delegation tools
  - Allows delegation tools to compute child agent depth

- **LLM Awareness**: Added `NESTED_DELEGATION_BLOCKED_INSTRUCTIONS` notice injected into system prompt when delegation tools are filtered out, preventing the LLM from repeatedly attempting unavailable delegation calls

- **Settings UI**: Added toggle and numeric input for nested delegation configuration with validation (clamped to 1-5 range)

## Implementation Details

- Depth clamping is consistent across frontend, backend, and tool-use flow (1-5 range, default 2)
- Root orchestrators (depth 0) bypass all delegation checks
- Configuration is read once per tool-use flow entry for consistency
- Tool filtering happens at resolution time, before the LLM sees the toolset
- Error messages guide users to either enable nesting or complete tasks directly

https://claude.ai/code/session_017VTc5AniSHtjrqdNrjwu81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes multi-agent delegation behavior and tool availability, and adds new persisted metadata used during resume which could affect existing snapshots and subagent workflows if miscomputed.
> 
> **Overview**
> Adds a configurable *nested delegation depth* policy that limits whether an agent can call delegation tools based on its `delegationDepth` and a new workspace setting (`NESTED_DELEGATION_MAX_DEPTH`).
> 
> Tool-use flows now compute depth, filter out `delegate_*`/`resume_*` tools when the cap is reached, and inject a prompt notice when delegation was trimmed; resumed sessions also refresh their persisted system message so policy changes (like max depth) take effect.
> 
> Delegation execution now propagates and persists depth (`ExecutionMeta.delegationDepth`), recovers depth on resume via storage lineage walking (fail-closed), and enforces the cap again inside `DelegationTools` as defense-in-depth; settings UI/schema are extended to edit and validate the max-depth value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75d71aa5cafe1f4b39478f222f2baa819e16879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->