### PR TITLE
Remove xmlStructureMode and simplify XML processing logic

### DIFF
--- a/src/agent/core/AgentDataclass.ts
+++ b/src/agent/core/AgentDataclass.ts
@@ -36,8 +36,6 @@ export const AgentSettingBaseSchema = z.strictObject({
   internal: z.boolean().optional(),
 });
 
-const XmlStructureMode = z.enum(['never', 'scratchpadOnly', 'always']);
-
 export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   agentCategory: z
     .literal(AgentCategory.Workflow)
@@ -47,7 +45,6 @@ export const AgentWorkflowSettingSchema = AgentSettingBaseSchema.extend({
   prefills: z.array(z.string()).prefault([]),
   outputExt: z.string().prefault('txt'),
   isMultipleOutput: z.boolean().prefault(false),
-  xmlStructureMode: XmlStructureMode.prefault('scratchpadOnly'),
 });
 
 export const AgentToolUseSettingSchema = AgentSettingBaseSchema.extend({
@@ -61,7 +58,8 @@ function normalizeAgentSettingInput(input: unknown): unknown {
   if (typeof input !== 'object' || input === null) {
     return input;
   }
-  const { agentType, maxRounds, ...rest } = input as Record<string, unknown>;
+  const { agentType, maxRounds, xmlStructureMode: _xmlStructureMode, ...rest } =
+    input as Record<string, unknown>;
 
   // Migrate legacy maxRounds → rounds
   if (maxRounds !== undefined && rest.rounds === undefined) {

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -26,7 +26,6 @@ export interface ReflectionServices<
   readonly promptBuilder: PromptBuilder;
   readonly fileService: TaskRunFileService;
   readonly getOutputFileLocation: (round: number) => AgentFileLocation;
-  readonly shouldEnsureXmlStructure: boolean;
   readonly baseFiles: WorkspaceFileLocation[];
   readonly onRoundFinalized: RoundFinalizedCallback;
 }

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -68,15 +68,8 @@ export class OutputNode<C = unknown> extends Node<
   }
 
   async exec(prepRes: OutputPrepInput): Promise<OutputExecResult> {
-    const {
-      outputState,
-      xmlManager,
-      diffManager,
-      setting,
-      logger,
-      baseFiles,
-      shouldEnsureXmlStructure: shouldEnsureXml,
-    } = this.services;
+    const { outputState, xmlManager, diffManager, setting, logger, baseFiles } =
+      this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
 
     let mapping: RoundFileMapping | undefined;
@@ -85,17 +78,15 @@ export class OutputNode<C = unknown> extends Node<
     if (endTurn) {
       logger.debug(`Processing output for round ${currentRound}`);
 
-      if (shouldEnsureXml) {
-        await tryOperation(
-          'XML structure',
-          () =>
-            xmlManager.ensureCorrectXmlStructure(
-              outputLocation,
-              setting.documentTag,
-            ),
-          logger,
-        );
-      }
+      await tryOperation(
+        'XML structure',
+        () =>
+          xmlManager.ensureCorrectXmlStructure(
+            outputLocation,
+            setting.documentTag,
+          ),
+        logger,
+      );
 
       await tryOperation(
         'Output processing',

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -73,10 +73,7 @@ function deriveConfig(
   prompt: RunReflectionFlowInput['prompt'],
 ): {
   totalRounds: number;
-  outputExt: string;
 } {
-  const useScratchpad = setting.prefills.includes('<scratchpad>');
-
   const { userRequest } = prompt;
   let requestCount: number;
   if (Array.isArray(userRequest)) {
@@ -86,10 +83,7 @@ function deriveConfig(
   }
   const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
 
-  return {
-    totalRounds,
-    outputExt: useScratchpad ? 'xml' : setting.outputExt,
-  };
+  return { totalRounds };
 }
 
 export async function runReflectionFlow<C = unknown>(
@@ -145,7 +139,7 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  const { totalRounds, outputExt } = deriveConfig(setting, prompt);
+  const { totalRounds } = deriveConfig(setting, prompt);
 
   const getOutputFileLocation =
     input.getOutputFileLocation ??
@@ -159,7 +153,7 @@ export async function runReflectionFlow<C = unknown>(
           'runReflectionFlow requires a TaskRunFileService bound to an executionId for default output-path resolution.',
         );
       }
-      const fileName = getOutputFileName(outputExt, round);
+      const fileName = getOutputFileName(setting.outputExt, round);
       return fileService.createLocation(fileName) as AgentFileLocation;
     });
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -144,16 +144,16 @@ export async function runReflectionFlow<C = unknown>(
   const getOutputFileLocation =
     input.getOutputFileLocation ??
     ((round: number): AgentFileLocation => {
-      // The default `r{round}/output.{ext}` filename is only collision-safe
+      // The default `r{round}/output.xml` filename is only collision-safe
       // when resolved through a run-storage-bound fileService. Enforce the
       // invariant so a misconfigured TaskRunFileService can't silently
-      // route outputs to a shared `<workspace>/r{round}/output.tex` path.
+      // route outputs to a shared `<workspace>/r{round}/output.xml` path.
       if (!fileService.hasRunDirectory()) {
         throw new Error(
           'runReflectionFlow requires a TaskRunFileService bound to an executionId for default output-path resolution.',
         );
       }
-      const fileName = getOutputFileName(setting.outputExt, round);
+      const fileName = getOutputFileName('xml', round);
       return fileService.createLocation(fileName) as AgentFileLocation;
     });
 

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -72,28 +72,10 @@ function deriveConfig(
   setting: AgentWorkflowSetting,
   prompt: RunReflectionFlowInput['prompt'],
 ): {
-  shouldEnsureXmlStructure: boolean;
   totalRounds: number;
   outputExt: string;
 } {
   const useScratchpad = setting.prefills.includes('<scratchpad>');
-
-  let shouldEnsureXmlStructure: boolean;
-  switch (setting.xmlStructureMode) {
-    case 'always':
-      shouldEnsureXmlStructure = true;
-      break;
-    case 'never':
-      shouldEnsureXmlStructure = false;
-      break;
-    case 'scratchpadOnly':
-      shouldEnsureXmlStructure = useScratchpad;
-      break;
-    default: {
-      const _exhaustive: never = setting.xmlStructureMode;
-      throw new Error(`Unknown xmlStructureMode: ${_exhaustive}`);
-    }
-  }
 
   const { userRequest } = prompt;
   let requestCount: number;
@@ -105,7 +87,6 @@ function deriveConfig(
   const totalRounds = Math.max(setting.rounds ?? 2, requestCount);
 
   return {
-    shouldEnsureXmlStructure,
     totalRounds,
     outputExt: useScratchpad ? 'xml' : setting.outputExt,
   };
@@ -164,10 +145,7 @@ export async function runReflectionFlow<C = unknown>(
 
   const latexMediaManager = new LatexMediaManager(logger, fileService);
 
-  const { shouldEnsureXmlStructure, totalRounds, outputExt } = deriveConfig(
-    setting,
-    prompt,
-  );
+  const { totalRounds, outputExt } = deriveConfig(setting, prompt);
 
   const getOutputFileLocation =
     input.getOutputFileLocation ??
@@ -281,7 +259,6 @@ export async function runReflectionFlow<C = unknown>(
       promptBuilder,
       fileService,
       getOutputFileLocation,
-      shouldEnsureXmlStructure,
       baseFiles,
     };
     pf.setServices(services);

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -33,6 +33,7 @@ import {
   type StorageKey,
 } from '@shared/schemas';
 import {
+  AbsoluteFS,
   TaskRunFileService,
   WorkspaceFS,
   createWorkspaceLocation,
@@ -153,8 +154,22 @@ export async function runReflectionFlow<C = unknown>(
           'runReflectionFlow requires a TaskRunFileService bound to an executionId for default output-path resolution.',
         );
       }
-      const fileName = getOutputFileName('xml', round);
-      return fileService.createLocation(fileName) as AgentFileLocation;
+      const canonical = fileService.createLocation(
+        getOutputFileName('xml', round),
+      ) as AgentFileLocation;
+      // Resume-from-pre-refactor compat: if a round was partially written on an
+      // older build that used `.tex` for non-scratchpad agents, keep using that
+      // file on resume so initializeOutputAndPrefill sees the existing content
+      // instead of starting a fresh round at output.xml.
+      if (!AbsoluteFS.existsSync(canonical.absolutePath)) {
+        const legacy = fileService.createLocation(
+          getOutputFileName('tex', round),
+        ) as AgentFileLocation;
+        if (AbsoluteFS.existsSync(legacy.absolutePath)) {
+          return legacy;
+        }
+      }
+      return canonical;
     });
 
   const interruptible: IInterruptible = {

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import { bus } from '@eventBus/ProgressEventBus';
@@ -19,8 +17,6 @@ import {
 
 import { indentLatexFile, indentLatexFiles } from './LatexOutputUtils';
 import type { XmlOutputManager } from './XmlOutputManager';
-
-const SCRATCHPAD_TAG_PATTERN = /<scratchpad\s*>/i;
 
 export interface ProcessingContext {
   agentSetting: AgentWorkflowSetting;
@@ -82,23 +78,6 @@ export class OutputFileProcessor {
     }
   }
 
-  /**
-   * Derive a meaningful source name for a non-XML single output.
-   * When there is exactly one base file, use its filename so that
-   * FileLineageCalculator can find the workspace original (which powers
-   * the diff display and the "Compare with base" buttons). Falls back to
-   * the raw output basename when there are multiple base files.
-   */
-  private getSourceForSingleOutput(outputLocation: FileLocation): string {
-    if (this.ctx.baseFiles.length === 1) {
-      const base = this.ctx.baseFiles[0];
-      return path.basename(
-        base.kind !== 'external' ? base.relativePath : base.absolutePath,
-      );
-    }
-    return path.basename(outputLocation.absolutePath);
-  }
-
   private handleEmptyOutput(
     round: number,
     rawLocation: FileLocation,
@@ -117,19 +96,10 @@ export class OutputFileProcessor {
     logger.debug(`Processing single output for ${outputLocation.absolutePath}`);
 
     try {
-      const shouldProcessXml = this.shouldProcessXml(agentSetting);
-      const processed = shouldProcessXml
-        ? await this.ctx.xmlManager.processSingleXmlOutput(
-            outputLocation,
-            currRound,
-          )
-        : {
-            source: this.getSourceForSingleOutput(outputLocation),
-            round: currRound,
-            location: rawLocation ?? outputLocation,
-            lineage: null,
-            diff: null,
-          };
+      const processed = await this.ctx.xmlManager.processSingleXmlOutput(
+        outputLocation,
+        currRound,
+      );
 
       if (!processed.location.absolutePath) {
         logger.debug(
@@ -248,22 +218,6 @@ export class OutputFileProcessor {
         { messageType: MESSAGE_TYPES.INTERNAL },
       );
       data.xmlSummary = { ...emptySummary };
-    }
-  }
-
-  private shouldProcessXml(agentSetting: AgentWorkflowSetting): boolean {
-    switch (agentSetting.xmlStructureMode ?? 'scratchpadOnly') {
-      case 'always':
-        return true;
-      case 'scratchpadOnly':
-        return (
-          Boolean(agentSetting.documentTag) ||
-          Boolean(
-            agentSetting.prefills?.some((p) => SCRATCHPAD_TAG_PATTERN.test(p)),
-          )
-        );
-      default:
-        return false;
     }
   }
 }

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -34,11 +34,12 @@ function getCompileDisplayName(file: OutputFileInfo): string {
   const rawBase = path.basename(file.location.absolutePath);
   const src = file.source;
   if (!src || src === rawBase) return rawBase;
-  // Avoid leaking the generic stem that replaced the old descriptive names
+  // Avoid leaking the generic raw-wrapper stem (`output`, `output.xml`, or the
+  // pre-refactor `output.tex`) as a display name — those are run-storage
+  // internals, not the meaningful document name.
   const srcBase = path.basename(src);
-  return srcBase && srcBase !== 'output' && srcBase !== 'output.tex'
-    ? srcBase
-    : rawBase;
+  const GENERIC_STEMS = new Set(['output', 'output.xml', 'output.tex']);
+  return srcBase && !GENERIC_STEMS.has(srcBase) ? srcBase : rawBase;
 }
 
 /**

--- a/src/agent/output/compileCheck.ts
+++ b/src/agent/output/compileCheck.ts
@@ -28,7 +28,7 @@ const MIN_TIMEOUT_MS = 10000;
 /**
  * Return a human-readable display name for an output file in compile messages.
  * Prefers the `source` field (which carries the original document name, e.g.
- * "constrained_note.tex") over the raw run-storage basename ("output.tex").
+ * "constrained_note.tex") over the extracted-file basename.
  */
 function getCompileDisplayName(file: OutputFileInfo): string {
   const rawBase = path.basename(file.location.absolutePath);

--- a/src/commands/latex/latexdiffCommands.ts
+++ b/src/commands/latex/latexdiffCommands.ts
@@ -462,11 +462,6 @@ async function scanRunDirForOutputs(
       // Collect .tex files recursively — extracted docs may live in subdirs
       // (e.g. r0/chapters/main.tex) when source names include path segments.
       const allTexFiles = await collectTexFiles(roundDirAbsolute);
-      // Strip diff artifacts before the output.tex decision so a round with
-      // only output.tex + one artifact doesn't lose output.tex (artifacts
-      // are filtered first, then the raw stem is dropped only when real
-      // extracted outputs remain alongside it).
-      const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
       // Between-round artifacts written to run storage always carry both round
       // numbers (e.g. output_diffr1r0.tex). The bare _diff suffix only appears
       // in workspace-side diffs, never here, so a legitimately-named source
@@ -474,9 +469,10 @@ async function scanRunDirForOutputs(
       const nonArtifact = allTexFiles.filter(
         (f) => !/_diffr\d+r\d+$/.test(path.parse(f).name),
       );
-      // For XML-mode agents, the round dir has both output.tex (raw wrapper)
-      // and extracted files (e.g. paper.tex).  Drop the raw stem only when
-      // real extracted outputs exist alongside it.
+      // Raw round output is output.xml (never collected by collectTexFiles).
+      // Guard for pre-refactor runs where non-scratchpad agents wrote output.tex
+      // as the raw wrapper: drop it when real extracted outputs exist alongside.
+      const rawStem = `${WORKFLOW_OUTPUT_BASENAME}.tex`;
       const texFiles =
         nonArtifact.length > 1 && nonArtifact.includes(rawStem)
           ? nonArtifact.filter((f) => f !== rawStem)

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -314,7 +314,13 @@ export class FileList extends LitElement {
    * Returns empty string for generic names that shouldn't override the fallback.
    */
   private getSourceDisplayPath(source: string | undefined): string {
-    if (!source || source === 'output' || source === 'output.tex') return '';
+    if (
+      !source ||
+      source === 'output' ||
+      source === 'output.xml' ||
+      source === 'output.tex'
+    )
+      return '';
     // Treat a trailing all-alpha suffix as a real extension (.tex, .txt, .bib…).
     // Suffixes containing digits (.v2, .r3) are version qualifiers, not
     // extensions, so .tex is appended in those cases.

--- a/src/test/agent/utils/promptBuilder.test.ts
+++ b/src/test/agent/utils/promptBuilder.test.ts
@@ -26,7 +26,6 @@ describe('PromptBuilder', () => {
     isMultipleOutput: false,
     filePatternsContain: [],
     tools: [],
-    xmlStructureMode: 'scratchpadOnly',
   };
 
   it('uses array-based userRequest entries for reflections', async () => {

--- a/src/test/agent/utils/userVars.test.ts
+++ b/src/test/agent/utils/userVars.test.ts
@@ -25,7 +25,6 @@ const baseSetting: AgentSetting = {
   isMultipleOutput: false,
   filePatternsContain: [],
   tools: [],
-  xmlStructureMode: 'scratchpadOnly',
 };
 
 const basePrompt: AgentPrompt = {


### PR DESCRIPTION
## Summary
This PR removes the `xmlStructureMode` configuration option and simplifies the XML processing logic throughout the codebase. The system now always processes outputs through the XML manager, eliminating conditional logic based on scratchpad detection and structure mode settings.

## Key Changes

- **Removed `xmlStructureMode` configuration**: Deleted the `XmlStructureMode` enum and `xmlStructureMode` field from `AgentWorkflowSetting` schema, along with migration logic for the deprecated field
- **Simplified output processing**: Removed the `shouldProcessXml()` method and conditional XML processing in `OutputFileProcessor`. All single outputs now go through `xmlManager.processSingleXmlOutput()`
- **Removed helper methods**: Deleted `getSourceForSingleOutput()` method that was only used in non-XML processing paths
- **Simplified reflection flow configuration**: Removed `shouldEnsureXmlStructure` and `outputExt` derivation from `deriveConfig()`. Output files are now always generated as `.xml` format
- **Unconditional XML structure validation**: In `OutputNode`, XML structure validation now always runs via `xmlManager.ensureCorrectXmlStructure()` instead of being conditional
- **Removed unused imports**: Cleaned up `path` module import and `SCRATCHPAD_TAG_PATTERN` constant from `OutputFileProcessor`
- **Updated comments**: Adjusted documentation in `latexdiffCommands.ts` and `compileCheck.ts` to reflect the new XML-only output approach
- **Removed service parameter**: Deleted `shouldEnsureXmlStructure` from `ReflectionServices` interface
- **Updated test fixtures**: Removed `xmlStructureMode` from test settings in `promptBuilder.test.ts` and `userVars.test.ts`

## Implementation Details

The refactoring consolidates the output processing pipeline to always use XML-based processing, removing the complexity of conditional logic that determined whether to process outputs as XML based on scratchpad presence or explicit configuration. This simplifies the codebase while maintaining the same XML processing capabilities for all workflow outputs.

https://claude.ai/code/session_01Cc6EKJtYy47vxu4xFxLjZp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow output handling to always write/process `output.xml` and always enforce XML structure, which can affect extraction/diff/compile behavior and resume compatibility for existing runs.
> 
> **Overview**
> Removes the `xmlStructureMode` workflow setting and strips legacy `xmlStructureMode` input during settings normalization.
> 
> Simplifies the reflection workflow/output pipeline to **always** validate XML structure and process outputs via `XmlOutputManager`, with default round output paths now using `output.xml` (plus resume compatibility for older `.tex` raw-wrapper runs). Updates latexdiff/compile-check/UI display-name logic to treat `output.xml`/`output.tex` as generic internal stems, and adjusts tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab3b763cf9dea77c71584b999f21bd7c46804ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->