### PR TITLE
Consolidate dismissible info notices

### DIFF
--- a/src/shared/schemas/mainView.ts
+++ b/src/shared/schemas/mainView.ts
@@ -27,6 +27,20 @@ import { ToolConfigFieldsSchema } from './toolConfig';
 export const SessionTypeSchema = z.enum(['toolUse', 'workflow']);
 export type SessionType = z.infer<typeof SessionTypeSchema>;
 
+export const SessionHintKeySchema = z.enum([
+  'toolUse',
+  'workflow',
+  'orchestrator',
+]);
+export type SessionHintKey = z.infer<typeof SessionHintKeySchema>;
+
+export const SessionHintDismissalsSchema = z.object({
+  toolUse: z.boolean().prefault(false),
+  workflow: z.boolean().prefault(false),
+  orchestrator: z.boolean().prefault(false),
+});
+export type SessionHintDismissals = z.infer<typeof SessionHintDismissalsSchema>;
+
 export const FileTypeSchema = z.enum([
   'input',
   'reference',
@@ -106,6 +120,7 @@ export const MainViewPersistedStateSchema = UIFileFieldsSchema.merge(
   outputFilesVisible: z.boolean().prefault(false),
   outputFilesActive: z.boolean().prefault(false),
   latexdiffsVisible: z.boolean().prefault(false),
+  dismissedSessionHints: SessionHintDismissalsSchema.prefault({}),
   openedFiles: z.array(z.string()).nullish(),
 });
 export type MainViewPersistedState = z.infer<
@@ -233,6 +248,7 @@ export const SessionContextSchema = z.object({
   isRecording: z.boolean(),
   isPolishing: z.boolean(),
   debugMode: z.boolean(),
+  dismissedSessionHints: SessionHintDismissalsSchema,
 });
 export type SessionContextValue = z.infer<typeof SessionContextSchema>;
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -18,6 +18,7 @@ register({
   paths: {
     '@/*': ['*', path.join(srcDir, '*')],
     '~/*': ['*', path.join(srcDir, '*')],
+    '@shared/*': ['shared/*', path.join(srcDir, 'shared/*')],
     '@common/*': ['common/*', path.join(srcDir, 'common/*')],
     '@webview/*': ['webview/*', path.join(srcDir, 'webview/*')],
     '@agent/*': ['agent/*', path.join(srcDir, 'agent/*')],

--- a/src/test/webview/sessionHints.test.ts
+++ b/src/test/webview/sessionHints.test.ts
@@ -1,0 +1,54 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { MainViewPersistedStateSchema } from '@shared/schemas';
+import { resolveSessionHintKey } from '@webview/frontend/sessionHints';
+
+describe('sessionHints', () => {
+  it('returns workflow for workflow mode', () => {
+    const hintKey = resolveSessionHintKey({
+      sessionType: 'workflow',
+      toolUseAgent: 'orchestrator',
+      toolUseAgentOptions: [],
+    });
+
+    assert.equal(hintKey, 'workflow');
+  });
+
+  it('returns toolUse for non-orchestrator tool-use agents', () => {
+    const hintKey = resolveSessionHintKey({
+      sessionType: 'toolUse',
+      toolUseAgent: 'chat',
+      toolUseAgentOptions: [{ value: 'chat', label: 'Chat' }],
+    });
+
+    assert.equal(hintKey, 'toolUse');
+  });
+
+  it('returns orchestrator for orchestrator tool-use agents', () => {
+    const hintKey = resolveSessionHintKey({
+      sessionType: 'toolUse',
+      toolUseAgent: 'orchestrator',
+      toolUseAgentOptions: [
+        {
+          value: 'orchestrator',
+          label: 'Orchestrator',
+          isOrchestrator: true,
+        },
+      ],
+    });
+
+    assert.equal(hintKey, 'orchestrator');
+  });
+
+  it('defaults dismissed session hints to visible', () => {
+    const state = MainViewPersistedStateSchema.parse({});
+
+    assert.deepEqual(state.dismissedSessionHints, {
+      toolUse: false,
+      workflow: false,
+      orchestrator: false,
+    });
+  });
+});

--- a/src/webview/frontend/MainApp.ts
+++ b/src/webview/frontend/MainApp.ts
@@ -19,6 +19,7 @@ import {
   type DependencyBannerState,
   type ModelOptionData,
   type AgentOptionData,
+  type SessionHintKey,
   type SingleFiles,
   type FileOptions,
   type MultiFiles,
@@ -74,6 +75,7 @@ import {
   dispatchMainViewMessage,
   type MainViewHandlerRegistry,
 } from './mainViewDispatcher';
+import { resolveSessionHintKey } from './sessionHints';
 import { SESSION_DEFAULTS } from './sessionDefaults';
 import {
   DEFAULT_STATE,
@@ -178,6 +180,9 @@ export class MainApp extends MainAppBase {
     visible: false,
   });
   private readonly gettingStartedVisible = signal(false);
+  private readonly dismissedSessionHints = signal(
+    DEFAULT_STATE.dismissedSessionHints,
+  );
   private readonly orchestratorBannerDismissed = signal(false);
   private readonly orchestratorBannerVisible$ = new Signal.Computed(() =>
     this.isSelectedAgentOrchestrator()
@@ -219,6 +224,7 @@ export class MainApp extends MainAppBase {
       isRecording: this.isRecording.get(),
       isPolishing: this.isPolishing.get(),
       debugMode: this.debugMode,
+      dismissedSessionHints: this.dismissedSessionHints.get(),
     }),
   );
 
@@ -435,6 +441,7 @@ export class MainApp extends MainAppBase {
       outputFilesVisible: mv.outputFiles,
       outputFilesActive: this.outputFilesActive.get(),
       latexdiffsVisible: this.latexdiffsVisible.get(),
+      dismissedSessionHints: this.dismissedSessionHints.get(),
       autoExtractFigure: cv.autoExtractFigure,
       autoExtractTikzFigure: cv.autoExtractTikzFigure,
       autoCompileInputPdf: cv.autoCompileInputPdf,
@@ -481,6 +488,7 @@ export class MainApp extends MainAppBase {
     });
     this.outputFilesActive.set(state.outputFilesActive);
     this.latexdiffsVisible.set(state.latexdiffsVisible);
+    this.dismissedSessionHints.set(state.dismissedSessionHints);
     this.checkboxValues.set({
       autoExtractFigure: state.autoExtractFigure,
       autoExtractTikzFigure: state.autoExtractTikzFigure,
@@ -1705,6 +1713,21 @@ export class MainApp extends MainAppBase {
     this.orchestratorBannerDismissed.set(true);
   }
 
+  private handleComponentDismissSessionHint(): void {
+    this.dismissSessionHint(resolveSessionHintKey(this.sessionContext$.get()));
+  }
+
+  private dismissSessionHint(hintKey: SessionHintKey): void {
+    const dismissed = this.dismissedSessionHints.get();
+    if (dismissed[hintKey]) return;
+
+    this.dismissedSessionHints.set({
+      ...dismissed,
+      [hintKey]: true,
+    });
+    this.saveState();
+  }
+
   private handleComponentLatexDiffsToggle(
     e: CustomEvent<LatexDiffsToggleDetail>,
   ): void {
@@ -1982,6 +2005,7 @@ export class MainApp extends MainAppBase {
             @agent-settings=${this.handleComponentAgentSettings}
             @model-settings=${this.handleComponentModelSettings}
             @focus-instruction=${this.handleComponentFocusInstruction}
+            @dismiss-session-hint=${this.handleComponentDismissSessionHint}
           ></instruction-panel>
 
           <banner-group

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -19,6 +19,8 @@ import { COMMAND_LINKS } from '@shared/utils/uiConstants';
 
 // Local imports - main view events
 import { MainViewEvents } from '../events';
+import { infoNoticeStyles } from '../styles/infoNoticeStyles';
+import { renderInfoNotice } from './infoNotice';
 
 @customElement('getting-started-banner')
 export class GettingStartedBanner extends LitElement {
@@ -26,28 +28,14 @@ export class GettingStartedBanner extends LitElement {
     designTokens,
     codiconStyles,
     commonViewStyles,
+    infoNoticeStyles,
     css`
-      :host {
-        display: block;
-      }
-
-      .getting-started-banner {
-        border-radius: var(--border-radius);
-        padding: var(--spacing-small) var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
-        background-color: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        line-height: var(--line-height-relaxed);
-      }
-
-      .getting-started-banner a {
+      .info-notice a {
         color: var(--color-text-link);
         text-decoration: none;
       }
 
-      .getting-started-banner a:hover {
+      .info-notice a:hover {
         text-decoration: underline;
       }
 
@@ -58,9 +46,7 @@ export class GettingStartedBanner extends LitElement {
       }
 
       .getting-started-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
+        font-weight: var(--font-weight-semibold);
       }
     `,
   ];
@@ -74,20 +60,17 @@ export class GettingStartedBanner extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (!this.visible) return nothing;
 
-    return html`
-      <div id="gettingStartedBanner" class="getting-started-banner">
-        <div class="getting-started-header">
-          <span class="getting-started-text">
-            <strong>Welcome to TeXRA!</strong> Open a workspace with LaTeX
-            files, or get started with one of these:
-          </span>
-          <vscode-toolbar-button
-            icon="close"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss getting started banner"
-            @click=${this.handleDismiss}
-          ></vscode-toolbar-button>
-        </div>
+    return renderInfoNotice({
+      id: 'gettingStartedBanner',
+      ariaLabel: 'Getting started guidance',
+      variant: 'banner',
+      content: html`
+        <span class="getting-started-header">
+          <strong>Welcome to TeXRA!</strong> Open a workspace with LaTeX files,
+          or get started with one of these:
+        </span>
+      `,
+      secondary: html`
         <ul class="getting-started-list">
           <li>
             <a href=${COMMAND_LINKS.GETTING_STARTED}>Walk me through setup</a>
@@ -108,8 +91,13 @@ export class GettingStartedBanner extends LitElement {
             -- download a paper's source
           </li>
         </ul>
-      </div>
-    `;
+      `,
+      dismiss: {
+        title: 'Dismiss (can be re-enabled in settings)',
+        ariaLabel: 'Dismiss getting started banner',
+        onDismiss: this.handleDismiss,
+      },
+    });
   }
 }
 

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -35,47 +35,13 @@ import {
   sessionContext,
   type SessionContextValue,
 } from '../contexts/mainViewContexts';
-
-type SessionHintKey = SessionType | 'orchestrator';
-
-const SESSION_HINT_COPY: Record<
-  SessionHintKey,
-  { lede: string; body: string; time: string; ariaLabel: string }
-> = {
-  workflow: {
-    lede: 'Deep pass.',
-    body: 'Drafts, reviews its own work, then revises — across your whole document.',
-    time: 'Typically 5–10 min on fast models, 10–30 min on frontier reasoning. Pick a smaller model if you need faster turnaround.',
-    ariaLabel: 'About workflow mode',
-  },
-  toolUse: {
-    lede: 'Conversational.',
-    body: 'Reads, edits, and searches in a running dialogue you steer turn by turn.',
-    time: 'Turns stream back in seconds; tool-heavy runs take a minute or two. Pick a stronger model for longer chains of reasoning.',
-    ariaLabel: 'About interactive mode',
-  },
-  orchestrator: {
-    lede: 'Orchestrator.',
-    body: 'Plans a pipeline of specialized agents and dispatches them for you.',
-    time: 'Name specific agents in your instruction (e.g., “use polish on the intro, then review the math”) to steer delegation — otherwise it picks. Approve tasks in Progress as they arrive.',
-    ariaLabel: 'About orchestrator mode',
-  },
-};
-
-function getSessionTitle(type: SessionType): string {
-  const copy = SESSION_HINT_COPY[type];
-  return `${copy.lede} ${copy.body}`;
-}
-
-function resolveSessionHintKey(session: SessionContextValue): SessionHintKey {
-  if (session.sessionType === SESSION_TYPES.TOOL_USE) {
-    const opt = session.toolUseAgentOptions.find(
-      (o) => o.value === session.toolUseAgent,
-    );
-    if (opt?.isOrchestrator) return 'orchestrator';
-  }
-  return session.sessionType;
-}
+import {
+  SESSION_HINT_COPY,
+  getSessionTitle,
+  resolveSessionHintKey,
+} from '../sessionHints';
+import { infoNoticeStyles } from '../styles/infoNoticeStyles';
+import { renderInfoNotice } from './infoNotice';
 
 @customElement('instruction-panel')
 export class InstructionPanel extends LitElement {
@@ -83,6 +49,7 @@ export class InstructionPanel extends LitElement {
     designTokens,
     commonViewStyles,
     selectStyles,
+    infoNoticeStyles,
     css`
       :host {
         display: block;
@@ -134,18 +101,6 @@ export class InstructionPanel extends LitElement {
 
       .instruction-session-toggle vscode-radio {
         font-size: var(--font-size-sm);
-      }
-
-      .session-hint {
-        display: flex;
-        gap: var(--spacing-small);
-        align-items: baseline;
-        margin-top: var(--spacing-small);
-        padding: var(--spacing-tiny) var(--spacing-small);
-        border-left: 2px solid var(--vscode-textLink-foreground);
-        color: var(--vscode-descriptionForeground);
-        font-size: var(--font-size-sm);
-        line-height: var(--line-height-relaxed);
       }
 
       .session-hint-lede {
@@ -289,17 +244,31 @@ export class InstructionPanel extends LitElement {
     return options.find((o) => o.value === selectedValue)?.hint ?? '';
   }
 
-  private renderSessionHint(session: SessionContextValue): TemplateResult {
-    const copy = SESSION_HINT_COPY[resolveSessionHintKey(session)];
-    return html`
-      <div class="session-hint" role="note" aria-label=${copy.ariaLabel}>
+  private renderSessionHint(
+    session: SessionContextValue,
+  ): TemplateResult | typeof nothing {
+    const hintKey = resolveSessionHintKey(session);
+    if (session.dismissedSessionHints[hintKey]) {
+      return nothing;
+    }
+
+    const copy = SESSION_HINT_COPY[hintKey];
+    return renderInfoNotice({
+      ariaLabel: copy.ariaLabel,
+      variant: 'inline',
+      content: html`
         <span class="session-hint-lede">${copy.lede}</span>
         <span class="session-hint-body">
           ${copy.body}
           <span class="session-hint-time">${copy.time}</span>
         </span>
-      </div>
-    `;
+      `,
+      dismiss: {
+        title: 'Hide this hint',
+        ariaLabel: 'Hide this hint',
+        onDismiss: this.handleDismissSessionHint,
+      },
+    });
   }
 
   private handleSessionTypeChange(event: Event): void {
@@ -384,6 +353,10 @@ export class InstructionPanel extends LitElement {
         text: 'Choose the AI model used by the selected agent.',
       }),
     );
+  }
+
+  private handleDismissSessionHint(): void {
+    this.dispatchEvent(MainViewEvents.dismissSessionHint());
   }
 
   override render(): TemplateResult | typeof nothing {

--- a/src/webview/frontend/components/LoginBanner.ts
+++ b/src/webview/frontend/components/LoginBanner.ts
@@ -20,6 +20,8 @@ import { PROMO_NOTICE_SHORT } from '@shared/copy/promoNotice';
 
 // Local imports - main view events
 import { MainViewEvents } from '../events';
+import { infoNoticeStyles } from '../styles/infoNoticeStyles';
+import { renderInfoNotice } from './infoNotice';
 
 @customElement('login-banner')
 export class LoginBanner extends LitElement {
@@ -27,32 +29,8 @@ export class LoginBanner extends LitElement {
     designTokens,
     codiconStyles,
     commonViewStyles,
+    infoNoticeStyles,
     css`
-      :host {
-        display: block;
-      }
-
-      .login-banner {
-        background: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        border-radius: var(--border-radius);
-        padding: var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: var(--spacing-medium);
-      }
-
-      .login-banner-content {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-medium);
-        flex: 1;
-      }
-
       .login-banner-icon {
         font-size: 1.5em;
         color: var(--vscode-button-background);
@@ -75,16 +53,6 @@ export class LoginBanner extends LitElement {
         font-size: var(--font-size-sm);
         opacity: var(--opacity-normal);
       }
-
-      .login-banner .actions {
-        flex-shrink: 0;
-      }
-
-      .actions {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-small);
-      }
     `,
   ];
 
@@ -101,38 +69,37 @@ export class LoginBanner extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (!this.visible) return nothing;
 
-    return html`
-      <div id="loginBanner" class="login-banner">
-        <div class="login-banner-content">
-          <span class="login-banner-icon"
-            ><i class="codicon codicon-sparkle"></i
-          ></span>
-          <div class="login-banner-text">
-            <span class="login-banner-title">Researcher Access Program</span>
-            <span class="login-banner-description">
-              ${PROMO_NOTICE_SHORT}
-            </span>
-          </div>
+    return renderInfoNotice({
+      id: 'loginBanner',
+      ariaLabel: 'Sign in to access researcher program features',
+      variant: 'banner',
+      leading: html`
+        <span class="login-banner-icon"
+          ><i class="codicon codicon-sparkle"></i
+        ></span>
+      `,
+      content: html`
+        <div class="login-banner-text">
+          <span class="login-banner-title">Researcher Access Program</span>
+          <span class="login-banner-description">${PROMO_NOTICE_SHORT}</span>
         </div>
-        <div class="actions">
-          <vscode-button
-            id="loginBannerButton"
-            appearance="primary"
-            @click=${this.handleSignIn}
-          >
-            <span slot="start" class="codicon codicon-sign-in"></span>
-            Sign In
-          </vscode-button>
-          <vscode-toolbar-button
-            id="loginBannerDismissButton"
-            icon="close"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss login banner"
-            @click=${this.handleDismiss}
-          ></vscode-toolbar-button>
-        </div>
-      </div>
-    `;
+      `,
+      actions: html`
+        <vscode-button
+          id="loginBannerButton"
+          appearance="primary"
+          @click=${this.handleSignIn}
+        >
+          <span slot="start" class="codicon codicon-sign-in"></span>
+          Sign In
+        </vscode-button>
+      `,
+      dismiss: {
+        title: 'Dismiss (can be re-enabled in settings)',
+        ariaLabel: 'Dismiss login banner',
+        onDismiss: this.handleDismiss,
+      },
+    });
   }
 }
 

--- a/src/webview/frontend/components/OrchestratorBanner.ts
+++ b/src/webview/frontend/components/OrchestratorBanner.ts
@@ -4,7 +4,7 @@
  * Appears when the orchestrator is selected. The conceptual explanation
  * lives in the InstructionPanel's session-hint; this banner adds only
  * complementary info: the approval keyboard shortcut and a shortcut
- * to Multi-Agent settings. Dismissable via "Got it".
+ * to Multi-Agent settings. Dismissable via the shared notice control.
  *
  * @fires dismiss-orchestrator - When dismiss button is clicked
  */
@@ -20,6 +20,8 @@ import { postMessage } from '@shared/vscode';
 
 // Local imports - main view events
 import { MainViewEvents } from '../events';
+import { infoNoticeStyles } from '../styles/infoNoticeStyles';
+import { renderInfoNotice } from './infoNotice';
 
 @customElement('orchestrator-banner')
 export class OrchestratorBanner extends LitElement {
@@ -27,58 +29,11 @@ export class OrchestratorBanner extends LitElement {
     designTokens,
     codiconStyles,
     commonViewStyles,
+    infoNoticeStyles,
     css`
-      :host {
-        display: block;
-      }
-
-      .orchestrator-banner {
-        border-radius: var(--border-radius);
-        padding: var(--spacing-small) var(--spacing-medium);
-        margin-bottom: var(--spacing-large);
-        background-color: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        line-height: var(--line-height-relaxed);
-        font-size: var(--font-size-sm);
-      }
-
-      .orchestrator-banner-footer {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        margin-top: var(--spacing-small);
-      }
-
       .orchestrator-tip {
         font-size: var(--font-size-xs);
         opacity: 0.8;
-      }
-
-      .got-it-btn {
-        flex-shrink: 0;
-        background: none;
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
-        color: var(--vscode-inputValidation-infoForeground);
-        cursor: pointer;
-        padding: var(--spacing-tiny) var(--spacing-medium);
-        border-radius: var(--border-radius);
-        font-size: var(--font-size-sm);
-      }
-
-      .got-it-btn:hover {
-        background: color-mix(
-          in srgb,
-          var(--vscode-inputValidation-infoBorder) 15%,
-          transparent
-        );
-      }
-
-      .got-it-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
-        outline-offset: 1px;
       }
 
       .settings-link {
@@ -110,8 +65,10 @@ export class OrchestratorBanner extends LitElement {
   override render(): TemplateResult | typeof nothing {
     if (!this.visible) return nothing;
 
-    return html`
-      <div class="orchestrator-banner">
+    return renderInfoNotice({
+      ariaLabel: 'Orchestrator approval guidance',
+      variant: 'banner',
+      content: html`
         <span class="orchestrator-tip">
           <strong>Tip:</strong> press <strong>y</strong>/<strong>n</strong> in
           the Progress board to approve or reject proposed tasks fast. Tune
@@ -123,17 +80,13 @@ export class OrchestratorBanner extends LitElement {
             Multi-Agent settings</button
           >.
         </span>
-        <div class="orchestrator-banner-footer">
-          <button
-            class="got-it-btn"
-            title="Dismiss (can be re-enabled in settings)"
-            @click=${this.handleDismiss}
-          >
-            Got it
-          </button>
-        </div>
-      </div>
-    `;
+      `,
+      dismiss: {
+        title: 'Dismiss (can be re-enabled in settings)',
+        ariaLabel: 'Dismiss orchestrator banner',
+        onDismiss: this.handleDismiss,
+      },
+    });
   }
 }
 

--- a/src/webview/frontend/components/infoNotice.ts
+++ b/src/webview/frontend/components/infoNotice.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared renderer for dismissible informational notices in the main view.
+ *
+ * Keeps inline hints and full-width help banners on the same structure so
+ * layout, dismiss controls, and ARIA roles stay consistent.
+ */
+
+// Third-party imports
+import { html, nothing, type TemplateResult } from 'lit';
+
+export type InfoNoticeVariant = 'banner' | 'inline';
+
+type InfoNoticeDismissConfig = {
+  title: string;
+  ariaLabel: string;
+  label?: string;
+  onDismiss: () => void;
+};
+
+type InfoNoticeOptions = {
+  ariaLabel: string;
+  content: TemplateResult;
+  variant: InfoNoticeVariant;
+  id?: string;
+  leading?: TemplateResult | typeof nothing;
+  actions?: TemplateResult | typeof nothing;
+  secondary?: TemplateResult | typeof nothing;
+  dismiss?: InfoNoticeDismissConfig;
+};
+
+function renderDismissControl(
+  dismiss: InfoNoticeDismissConfig,
+): TemplateResult {
+  if (dismiss.label) {
+    return html`
+      <button
+        class="info-notice__dismiss-button"
+        title=${dismiss.title}
+        aria-label=${dismiss.ariaLabel}
+        @click=${dismiss.onDismiss}
+      >
+        ${dismiss.label}
+      </button>
+    `;
+  }
+
+  return html`
+    <vscode-toolbar-button
+      class="info-notice__dismiss-icon"
+      icon="close"
+      title=${dismiss.title}
+      aria-label=${dismiss.ariaLabel}
+      @click=${dismiss.onDismiss}
+    ></vscode-toolbar-button>
+  `;
+}
+
+export function renderInfoNotice({
+  ariaLabel,
+  content,
+  variant,
+  id,
+  leading = nothing,
+  actions = nothing,
+  secondary = nothing,
+  dismiss,
+}: InfoNoticeOptions): TemplateResult {
+  const trailing =
+    actions !== nothing || dismiss
+      ? html`
+          <div class="info-notice__actions">
+            ${actions} ${dismiss ? renderDismissControl(dismiss) : nothing}
+          </div>
+        `
+      : nothing;
+
+  return html`
+    <div
+      id=${id ?? nothing}
+      class="info-notice info-notice--${variant}"
+      role="note"
+      aria-label=${ariaLabel}
+    >
+      <div class="info-notice__main">
+        ${leading !== nothing
+          ? html`<div class="info-notice__leading">${leading}</div>`
+          : nothing}
+        <div class="info-notice__content">${content}</div>
+        ${trailing}
+      </div>
+      ${secondary !== nothing
+        ? html`<div class="info-notice__secondary">${secondary}</div>`
+        : nothing}
+    </div>
+  `;
+}

--- a/src/webview/frontend/events.ts
+++ b/src/webview/frontend/events.ts
@@ -100,6 +100,8 @@ export const MainViewEvents = {
 
   dismissOrchestrator: () => createEvent('dismiss-orchestrator', undefined),
 
+  dismissSessionHint: () => createEvent('dismiss-session-hint', undefined),
+
   // LaTeXDiffs events
   latexDiffsToggle: (detail: LatexDiffsToggleDetail) =>
     createEvent('latexdiffs-toggle', detail),

--- a/src/webview/frontend/sessionHints.ts
+++ b/src/webview/frontend/sessionHints.ts
@@ -1,0 +1,69 @@
+// Local imports - shared schemas and types
+import type {
+  AgentOptionData,
+  SessionContextValue,
+  SessionHintKey,
+  SessionType,
+} from '@shared/schemas';
+
+// Local imports - main view
+import { SESSION_TYPES } from './constants';
+
+type SessionHintCopy = {
+  lede: string;
+  body: string;
+  time: string;
+  ariaLabel: string;
+};
+
+export const SESSION_HINT_COPY: Record<SessionHintKey, SessionHintCopy> = {
+  workflow: {
+    lede: 'Deep pass.',
+    body: 'Drafts, reviews its own work, then revises — across your whole document.',
+    time: 'Typically 5–10 min on fast models, 10–30 min on frontier reasoning. Pick a smaller model if you need faster turnaround.',
+    ariaLabel: 'About workflow mode',
+  },
+  toolUse: {
+    lede: 'Conversational.',
+    body: 'Reads, edits, and searches in a running dialogue you steer turn by turn.',
+    time: 'Turns stream back in seconds; tool-heavy runs take a minute or two. Pick a stronger model for longer chains of reasoning.',
+    ariaLabel: 'About interactive mode',
+  },
+  orchestrator: {
+    lede: 'Orchestrator.',
+    body: 'Plans a pipeline of specialized agents and dispatches them for you.',
+    time: 'Name specific agents in your instruction (e.g., “use polish on the intro, then review the math”) to steer delegation — otherwise it picks. Approve tasks in Progress as they arrive.',
+    ariaLabel: 'About orchestrator mode',
+  },
+};
+
+function isOrchestratorAgent(
+  options: AgentOptionData[],
+  selectedValue: string,
+): boolean {
+  return (
+    options.find((option) => option.value === selectedValue)?.isOrchestrator ===
+    true
+  );
+}
+
+export function resolveSessionHintKey(
+  session: Pick<
+    SessionContextValue,
+    'sessionType' | 'toolUseAgentOptions' | 'toolUseAgent'
+  >,
+): SessionHintKey {
+  if (
+    session.sessionType === SESSION_TYPES.TOOL_USE &&
+    isOrchestratorAgent(session.toolUseAgentOptions, session.toolUseAgent)
+  ) {
+    return 'orchestrator';
+  }
+
+  return session.sessionType;
+}
+
+export function getSessionTitle(type: SessionType): string {
+  const copy = SESSION_HINT_COPY[type];
+  return `${copy.lede} ${copy.body}`;
+}

--- a/src/webview/frontend/styles/infoNoticeStyles.ts
+++ b/src/webview/frontend/styles/infoNoticeStyles.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared styles for informational notices shown in the main view.
+ *
+ * Covers both full-width info banners and the inline session hint so
+ * dismissible user guidance uses one visual system and one layout model.
+ */
+
+// Third-party imports
+import { css, type CSSResult } from 'lit';
+
+export const infoNoticeStyles: CSSResult = css`
+  :host {
+    display: block;
+  }
+
+  .info-notice {
+    border-radius: var(--border-radius);
+  }
+
+  .info-notice__main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--spacing-small);
+  }
+
+  .info-notice__leading {
+    display: flex;
+    align-items: flex-start;
+    flex: 0 0 auto;
+  }
+
+  .info-notice__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    line-height: var(--line-height-relaxed);
+  }
+
+  .info-notice__actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: var(--spacing-small);
+    flex: 0 0 auto;
+    margin-left: auto;
+  }
+
+  .info-notice__secondary {
+    margin-top: var(--spacing-small);
+  }
+
+  .info-notice__dismiss-button {
+    flex-shrink: 0;
+    background: none;
+    border: var(--border-thin) solid var(--vscode-inputValidation-infoBorder);
+    color: inherit;
+    cursor: pointer;
+    padding: var(--spacing-tiny) var(--spacing-medium);
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-sm);
+  }
+
+  .info-notice__dismiss-button:hover {
+    background: color-mix(
+      in srgb,
+      var(--vscode-inputValidation-infoBorder) 15%,
+      transparent
+    );
+  }
+
+  .info-notice__dismiss-button:focus-visible {
+    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+  }
+
+  .info-notice--banner {
+    margin-bottom: var(--spacing-large);
+    padding: var(--spacing-small) var(--spacing-medium);
+    background-color: var(--vscode-inputValidation-infoBackground);
+    color: var(--vscode-inputValidation-infoForeground);
+    border: var(--border-thin) solid var(--vscode-inputValidation-infoBorder);
+  }
+
+  .info-notice--banner .info-notice__main {
+    gap: var(--spacing-medium);
+  }
+
+  .info-notice--inline {
+    margin-top: var(--spacing-small);
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border-left: 2px solid var(--vscode-textLink-foreground);
+    color: var(--vscode-descriptionForeground);
+    font-size: var(--font-size-sm);
+  }
+
+  .info-notice--inline .info-notice__content {
+    display: flex;
+    gap: var(--spacing-small);
+    align-items: baseline;
+  }
+`;


### PR DESCRIPTION
## Summary
- Add a shared info-notice renderer and style layer for main-view guidance UI.
- Reuse it for the session hint, login banner, getting-started banner, and orchestrator tip.
- Persist session-hint dismissal state per mode and keep it in the main-view schema/context.
- Add test coverage for hint-key resolution and default dismissal state, plus the test alias fix needed to run it.

## Testing
- `npm run compile:safe`
- `npm run compile-tests && npx mocha -r ./out/test/setup.js ./out/test/webview/sessionHints.test.js`
- `npm run lint` (passes with existing repo warnings, no new errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/state risk: refactors multiple banners to a shared renderer and adds new persisted `dismissedSessionHints` state, which could affect main-view rendering or state restore if mismatched.
> 
> **Overview**
> Adds a shared `renderInfoNotice` + `infoNoticeStyles` layer and migrates the getting-started, login, orchestrator, and inline session-hint UI to use it for consistent layout/dismiss controls and ARIA.
> 
> Introduces persisted per-mode session-hint dismissal (`dismissedSessionHints`) in the shared main-view schema/context, wires a new `dismiss-session-hint` event from `InstructionPanel` through `MainApp` to save the dismissal based on `resolveSessionHintKey`.
> 
> Extracts session-hint copy/key resolution into `sessionHints.ts`, updates tests/aliases to support `@shared/*`, and adds unit coverage for hint-key resolution and default dismissal state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deb56d1560a523c4c62efa490965a26985158ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->