### PR TITLE
[codex] Restore legacy workflow instructions

### DIFF
--- a/src/progressView/persistence/StreamTabStore.ts
+++ b/src/progressView/persistence/StreamTabStore.ts
@@ -11,9 +11,9 @@
  *       usageStats.json        → runId → TokenUsageStats
  *
  * Legacy data shapes (from before one-run-per-tab refactor) are transparently
- * migrated on read via preprocess helpers in streamTabSchemas.ts.
- * Instructions are rendered as user-message log entries now, so they are
- * stored in the log stream, not in this store.
+ * migrated on read via preprocess helpers in streamTabSchemas.ts. New workflow
+ * instructions live in the log stream; this store only retains archived legacy
+ * instruction records so older tabs can be backfilled during load.
  */
 
 import * as path from 'path';
@@ -27,11 +27,14 @@ import type {
 } from '@shared/schemas';
 import {
   StreamTabMetaSchema,
+  LegacyInstructionsDataSchema,
   OutputFilesDataSchema,
   MissingOutputsDataSchema,
   UsageDataSchema,
   flattenLegacyRuns,
   isLegacyNested,
+  selectPreferredLegacyInstruction,
+  type LegacyInstructionEntry,
   type StreamTabMeta,
   type OutputFilesRecord,
   type MissingOutputsRecord,
@@ -153,11 +156,29 @@ class StreamTabKVStore extends KVStore {
   /**
    * Persist legacy `{ runId: InstructionUpdate }` data verbatim so migrated
    * users don't lose the instruction text of older workflow tabs. The new
-   * UI logs instructions as user-message entries at run start, so this
-   * file is write-only here — readers must inspect it manually on disk.
+   * UI logs instructions as user-message entries at run start, so newer runs
+   * read from the log stream; legacy runs can still be backfilled from here.
    */
   async writeLegacyInstructions(data: unknown): Promise<void> {
     await this.write(KEYS.LEGACY_INSTRUCTIONS, data);
+  }
+
+  /**
+   * Read the archived legacy instruction record and pick the run users most
+   * likely expect to see. Prefers `meta.activeRunId` when that migration hint
+   * exists, otherwise falls back to the newest archived entry.
+   */
+  async readPreferredLegacyInstruction(): Promise<LegacyInstructionEntry | null> {
+    const raw = await this.read(KEYS.LEGACY_INSTRUCTIONS);
+    if (!raw) return null;
+
+    const result = LegacyInstructionsDataSchema.safeParse(raw);
+    if (!result.success || Object.keys(result.data).length === 0) {
+      return null;
+    }
+
+    const meta = await this.readMeta();
+    return selectPreferredLegacyInstruction(result.data, meta?.activeRunId);
   }
 
   /**

--- a/src/progressView/persistence/mementoMigration.ts
+++ b/src/progressView/persistence/mementoMigration.ts
@@ -212,7 +212,8 @@ async function migrateStreamToStore(
   const writes: Promise<void>[] = [];
 
   // Meta: taskState + executionId + parentStreamId.
-  // activeRunId is no longer persisted; one run per workflow tab.
+  // Preserve legacy activeRunId as a read-time migration hint so flattened
+  // outputs/instructions can still prefer the run users last selected.
   const taskStateEntry = data.taskStateEntries.find(
     ([key]) => key === streamId,
   );
@@ -220,6 +221,7 @@ async function migrateStreamToStore(
     ? TaskStateSchema.safeParse(taskStateEntry[1])
     : null;
   const executionId = extractFromRecord(data.executionIdsRaw, streamId);
+  const activeRunId = extractFromRecord(data.activeRunIdsRaw, streamId);
   const parentStreamId = extractFromRecord(data.parentStreamIdsRaw, streamId);
 
   const meta: StreamTabMeta = {};
@@ -228,6 +230,9 @@ async function migrateStreamToStore(
   }
   if (typeof executionId === 'string' && executionId.length > 0) {
     meta.executionId = executionId;
+  }
+  if (typeof activeRunId === 'string' && activeRunId.length > 0) {
+    meta.activeRunId = normalizeRunId(activeRunId);
   }
   if (typeof parentStreamId === 'string' && parentStreamId.length > 0) {
     meta.parentStreamId = parentStreamId;
@@ -276,8 +281,8 @@ async function migrateStreamToStore(
   // The new UI renders instructions as user-message log entries at run
   // start, but pre-refactor workflow runs never logged them — the text
   // only lived in this legacy memento record. Persist it verbatim as a
-  // `legacyInstructions.json` side file so no user-visible data is lost
-  // on upgrade; it isn't read by the UI but remains accessible on disk.
+  // `legacyInstructions.json` side file so load-time backfills can restore
+  // the visible instruction in archived workflow tabs.
   const runInstructionsData = extractFromRecord(
     data.runInstructionsRaw,
     streamId,

--- a/src/progressView/persistence/streamTabSchemas.ts
+++ b/src/progressView/persistence/streamTabSchemas.ts
@@ -46,6 +46,53 @@ export const StreamTabMetaSchema = z.object({
 export type StreamTabMeta = z.infer<typeof StreamTabMetaSchema>;
 
 // ============================================================================
+// Legacy instructions: { runId: { text, timestamp?, ... } }
+// ============================================================================
+
+export const LegacyInstructionEntrySchema = z.looseObject({
+  text: z.string(),
+  timestamp: z.number().optional(),
+});
+
+export type LegacyInstructionEntry = z.infer<
+  typeof LegacyInstructionEntrySchema
+>;
+
+export const LegacyInstructionsDataSchema = z
+  .record(z.string(), LegacyInstructionEntrySchema)
+  .catch({});
+
+/**
+ * Pick the legacy instruction that best matches the workflow run users most
+ * recently viewed. Prefer `preferredRunId` when available; otherwise fall back
+ * to the newest timestamp, breaking ties by later insertion order.
+ */
+export function selectPreferredLegacyInstruction(
+  record: Record<string, LegacyInstructionEntry>,
+  preferredRunId?: string | null,
+): LegacyInstructionEntry | null {
+  if (preferredRunId && record[preferredRunId]) {
+    return record[preferredRunId];
+  }
+
+  let selected: LegacyInstructionEntry | null = null;
+  for (const entry of Object.values(record)) {
+    if (!selected) {
+      selected = entry;
+      continue;
+    }
+
+    const nextTimestamp = entry.timestamp ?? Number.NEGATIVE_INFINITY;
+    const currentTimestamp = selected.timestamp ?? Number.NEGATIVE_INFINITY;
+    if (nextTimestamp >= currentTimestamp) {
+      selected = entry;
+    }
+  }
+
+  return selected;
+}
+
+// ============================================================================
 // Legacy detection + flattening
 // ============================================================================
 

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -20,6 +20,9 @@ import {
 import {
   AgentCategoryFilterSchema,
   ContextStateDataSchema,
+  LOG_LEVELS,
+  MESSAGE_TYPES,
+  STREAM_LOG_ENTRY_TYPES,
   TodoItemSchema,
   type ActiveChildInfo,
   type AgentCategoryFilter,
@@ -102,9 +105,9 @@ export function cleanupToolUseAgentRegistry(meta: StreamMetaManager): void {
  * Core state management for the progress view.
  *
  * Coordinates four persistence managers (streamLogs, outputFiles, usageStats,
- * meta) plus ephemeral in-memory state and preferences. Instructions are
- * emitted as user-message log entries, so they live inside the log stream
- * (not in state).
+ * meta) plus ephemeral in-memory state and preferences. Workflow instructions
+ * live in the log stream (new runs write them directly; legacy runs are
+ * backfilled there during load), not in separate progress-view state.
  */
 export class ProgressViewState {
   // -- Persistence managers ---------------------------------------------------
@@ -370,8 +373,8 @@ export class ProgressViewState {
 
     // Promote any pre-existing `runInstructions.json` disk files (from the
     // earlier memento→StreamTabStore migration) to the archival
-    // `legacyInstructions.json` so the instruction text survives on disk
-    // even though the new UI no longer displays it.
+    // `legacyInstructions.json` so older workflow tabs can still restore
+    // their original instruction into the log stream.
     await Promise.all(
       this.streamLogs.keys().map((id) =>
         getStreamTabStore(id)
@@ -379,6 +382,14 @@ export class ProgressViewState {
           .catch(() => {}),
       ),
     );
+
+    const restoredLegacyInstructionCount =
+      await this.backfillLegacyWorkflowInstructions();
+    if (restoredLegacyInstructionCount > 0) {
+      this.logger.info(
+        `[Persistence] Restored ${restoredLegacyInstructionCount} legacy workflow instruction(s) into stream logs`,
+      );
+    }
 
     this.logger.info('[Persistence] Managers loaded');
 
@@ -408,6 +419,55 @@ export class ProgressViewState {
       this.usageStats.load(streamIds),
       this.meta.load(streamIds),
     ]);
+  }
+
+  private async backfillLegacyWorkflowInstructions(): Promise<number> {
+    let restoredCount = 0;
+
+    await Promise.all(
+      this.streamLogs.keys().map(async (streamId) => {
+        const store = getStreamTabStore(streamId);
+        const legacyInstruction = await store.readPreferredLegacyInstruction();
+        if (!legacyInstruction) return;
+
+        const text = legacyInstruction.text.trim();
+        if (!text) return;
+
+        const log = this.streamLogs.get(streamId);
+        if (!log) return;
+
+        const alreadyPresent = log
+          .getRange(0, log.head)
+          .some(
+            (entry) =>
+              entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+              entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
+              entry.text?.trim() === text,
+          );
+        if (alreadyPresent) return;
+
+        const firstTimestamp = log.firstTimestamp;
+        const baseTimestamp =
+          legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
+        const timestamp =
+          firstTimestamp == null
+            ? baseTimestamp
+            : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
+
+        this.streamLogs.append(streamId, {
+          id: `legacy-instruction:${streamId}:${timestamp}`,
+          type: STREAM_LOG_ENTRY_TYPES.LOG,
+          level: LOG_LEVELS.INFO,
+          timestamp,
+          messageType: MESSAGE_TYPES.USER_MESSAGE,
+          text: legacyInstruction.text,
+          data: { source: 'legacyInstruction' },
+        });
+        restoredCount++;
+      }),
+    );
+
+    return restoredCount;
   }
 
   /** Validate activeStream against available streams after load */

--- a/src/test/progressView/streamTabSchemas.test.ts
+++ b/src/test/progressView/streamTabSchemas.test.ts
@@ -1,0 +1,43 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { selectPreferredLegacyInstruction } from '@progressView/persistence/streamTabSchemas';
+
+describe('selectPreferredLegacyInstruction', () => {
+  it('prefers the explicitly selected legacy run when available', () => {
+    const result = selectPreferredLegacyInstruction(
+      {
+        older: { text: 'older instruction', timestamp: 100 },
+        active: { text: 'active instruction', timestamp: 50 },
+      },
+      'active',
+    );
+
+    assert.equal(result?.text, 'active instruction');
+  });
+
+  it('falls back to the newest timestamp when no preferred run exists', () => {
+    const result = selectPreferredLegacyInstruction({
+      first: { text: 'first instruction', timestamp: 100 },
+      latest: { text: 'latest instruction', timestamp: 200 },
+    });
+
+    assert.equal(result?.text, 'latest instruction');
+  });
+
+  it('falls back to later insertion order when timestamps are absent', () => {
+    const result = selectPreferredLegacyInstruction({
+      first: { text: 'first instruction' },
+      second: { text: 'second instruction' },
+    });
+
+    assert.equal(result?.text, 'second instruction');
+  });
+
+  it('returns null when no legacy instructions exist', () => {
+    const result = selectPreferredLegacyInstruction({});
+
+    assert.equal(result, null);
+  });
+});


### PR DESCRIPTION
## Summary

Restores the original instruction display for older workflow sessions whose instruction text was preserved only in legacy per-run instruction storage after the one-run-per-tab progress-view refactor.

## Root Cause

New workflow runs log the user instruction as a `userMessage`, but pre-refactor workflow sessions stored that text in `runInstructions` instead. The migration preserved that data under `legacyInstructions.json`, but the current UI never read it back, so archived workflow tabs could lose their visible instruction box/message.

## Changes

- Parse archived legacy instruction records and select the instruction for the legacy active run when available.
- Backfill missing legacy instructions into the stream log during progress-state load, using a timestamp before the first existing log entry so the instruction stays pinned at the top.
- Preserve legacy `activeRunId` during memento migration as a read-time hint for both flattened outputs and restored instructions.
- Add focused tests for legacy instruction selection behavior.

## Validation

- `npm run compile:safe`
- `npm run compile-tests`
- `npm run lint` completed with 0 errors; existing repo-wide warning-class import/order and `replaceAll` warnings remain.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence/load behavior by injecting derived log entries from on-disk legacy data and by preserving `activeRunId` during migration; mistakes could cause missing/duplicated instructions or incorrect ordering in archived tabs.
> 
> **Overview**
> Restores visibility of **legacy workflow instructions** by selecting an appropriate entry from archived `legacyInstructions.json` and **backfilling it into the stream log** during `ProgressViewState.load()` when the log doesn’t already contain a matching `USER_MESSAGE`.
> 
> Adds schemas + selection logic (`selectPreferredLegacyInstruction`) to choose the best legacy instruction (prefer `meta.activeRunId`, else newest timestamp/insertion), exposes `StreamTabStore.readPreferredLegacyInstruction()`, and updates memento migration to persist legacy `activeRunId` into `meta.json` as a read-time hint. Includes unit tests covering the selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314d2074a06c21aac7dbee1b6452dd612db40441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->