### PR TITLE
refactor(progressView): single source of truth for stream descriptions

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,4 +1,7 @@
-import { isActiveStatus } from '@common/constants/streamStatus';
+import {
+  isActiveStatus,
+  isInFlightStatus,
+} from '@common/constants/streamStatus';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
@@ -7,14 +10,6 @@ import {
 } from '@shared/schemas';
 
 const statusMemory = new Map<StreamTabId, StreamStatus>();
-
-/** Statuses that prevent acquiring a new stream lock. */
-const BLOCKED_STATUSES = new Set<StreamStatus>([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.RESUMING,
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.WAITING,
-]);
 
 interface SetOptions {
   emit?: boolean;
@@ -26,8 +21,7 @@ export const StreamStatusService = {
   },
 
   tryAcquire(stream: StreamTabId): boolean {
-    const current = statusMemory.get(stream);
-    if (current && BLOCKED_STATUSES.has(current)) {
+    if (isInFlightStatus(statusMemory.get(stream))) {
       return false;
     }
     this.set(stream, STREAM_STATUS.INITIALIZING);

--- a/src/common/constants/streamStatus.ts
+++ b/src/common/constants/streamStatus.ts
@@ -75,6 +75,23 @@ export function isActiveStatus(status: StreamStatus | undefined): boolean {
 }
 
 /**
+ * Statuses during which an agent cycle may still be appending to the stream
+ * and it must not be evicted from memory or acquired by a new run. Superset
+ * of {@link isActiveStatus} — also covers INITIALIZING (pre-start) and
+ * WAITING (paused on user input; follow-up appends to the same log).
+ */
+const IN_FLIGHT_STATUSES: ReadonlySet<StreamStatus> = new Set<StreamStatus>([
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.RESUMING,
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.WAITING,
+]);
+
+export function isInFlightStatus(status: StreamStatus | undefined): boolean {
+  return status !== undefined && IN_FLIGHT_STATUSES.has(status);
+}
+
+/**
  * Check if a status is terminal (execution ended).
  */
 export function isTerminalStatus(status: StreamStatus | undefined): boolean {

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -32,6 +32,19 @@ export class StreamLogStore {
   private readonly dirtyStreamIds = new Set<StreamTabId>();
   private readonly kv = new KVStore(STREAM_LOGS_DIR);
 
+  /**
+   * Lightweight summary per stream (first/last timestamp). Populated at load
+   * and refreshed on append/update. Survives `releaseEntries` so sidebar
+   * sorting keeps working for streams whose heavy entries have been evicted.
+   */
+  private readonly summaries = new Map<
+    StreamTabId,
+    { firstTimestamp?: number; lastTimestamp?: number }
+  >();
+
+  /** Deduplicates concurrent `ensureLoaded` calls for the same stream. */
+  private readonly pendingLoads = new Map<StreamTabId, Promise<void>>();
+
   /** Guards persistence — tests create store without calling load(). */
   private loaded = false;
 
@@ -50,20 +63,63 @@ export class StreamLogStore {
   }
 
   has(streamId: StreamTabId): boolean {
-    return this.logs.has(streamId);
+    return this.logs.has(streamId) || this.summaries.has(streamId);
   }
 
   keys(): StreamTabId[] {
-    return [...this.logs.keys()];
+    // Union of loaded + summary-only streams; Set dedupes.
+    return [...new Set([...this.logs.keys(), ...this.summaries.keys()])];
   }
 
   ensureStream(streamId: StreamTabId): StreamLog {
     return this.getOrCreate(streamId);
   }
 
+  /**
+   * Drop heavy entries from memory while keeping the on-disk copy authoritative.
+   * Skips streams with pending writes so `save()` can flush first. Subsequent
+   * access must go through `ensureLoaded` to rehydrate.
+   */
+  releaseEntries(streamId: StreamTabId): void {
+    const logInstance = this.logs.get(streamId);
+    if (!logInstance) return;
+    if (this.dirtyStreamIds.has(streamId)) return;
+    this.refreshSummary(streamId, logInstance);
+    this.logs.delete(streamId);
+  }
+
+  /**
+   * Async reload entries from disk if they were released. No-op when already
+   * resident or when the stream is unknown.
+   */
+  async ensureLoaded(streamId: StreamTabId): Promise<void> {
+    if (this.logs.has(streamId)) return;
+    if (!this.summaries.has(streamId)) return;
+    const existing = this.pendingLoads.get(streamId);
+    if (existing) return existing;
+    const work = (async () => {
+      try {
+        const raw = await this.kv.read<unknown[]>(streamId);
+        const entries = this.parsePersistedEntries(raw);
+        const logInstance = new StreamLog(entries);
+        this.logs.set(streamId, logInstance);
+        this.refreshSummary(streamId, logInstance);
+      } catch {
+        log.warn(LOG_TAG, `Failed to reload stream ${streamId} from disk`);
+      }
+    })();
+    this.pendingLoads.set(streamId, work);
+    try {
+      await work;
+    } finally {
+      this.pendingLoads.delete(streamId);
+    }
+  }
+
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
     const logInstance = this.getOrCreate(streamId);
     const appended = logInstance.append(entry);
+    this.refreshSummary(streamId, logInstance);
     this.markDirty(streamId);
     void this.save();
     this.notify(streamId);
@@ -81,6 +137,7 @@ export class StreamLogStore {
     const updated = logInstance.update(id, patch);
     if (!updated) return undefined;
 
+    this.refreshSummary(streamId, logInstance);
     this.markDirty(streamId);
     void this.save();
     this.notify(streamId);
@@ -92,15 +149,22 @@ export class StreamLogStore {
   }
 
   getFirstTimestamp(streamId: StreamTabId): number | undefined {
-    return this.logs.get(streamId)?.firstTimestamp;
+    return (
+      this.logs.get(streamId)?.firstTimestamp ??
+      this.summaries.get(streamId)?.firstTimestamp
+    );
   }
 
   getLastTimestamp(streamId: StreamTabId): number | undefined {
-    return this.logs.get(streamId)?.lastTimestamp;
+    return (
+      this.logs.get(streamId)?.lastTimestamp ??
+      this.summaries.get(streamId)?.lastTimestamp
+    );
   }
 
   async delete(streamId: StreamTabId): Promise<void> {
     this.logs.delete(streamId);
+    this.summaries.delete(streamId);
     this.dirtyStreamIds.delete(streamId);
     if (!this.loaded) return;
 
@@ -112,6 +176,7 @@ export class StreamLogStore {
   async clear(): Promise<void> {
     const count = this.logs.size;
     this.logs.clear();
+    this.summaries.clear();
     this.dirtyStreamIds.clear();
     if (!this.loaded) return;
 
@@ -159,6 +224,7 @@ export class StreamLogStore {
    */
   async load(migrationSource?: MementoStorage): Promise<void> {
     this.logs.clear();
+    this.summaries.clear();
     this.dirtyStreamIds.clear();
 
     // 1. Scan directory — filenames decode back to stream IDs
@@ -180,7 +246,9 @@ export class StreamLogStore {
       let totalEntries = 0;
       for (const [streamId, entries] of results) {
         if (entries.length > 0) {
-          this.logs.set(streamId as StreamTabId, new StreamLog(entries));
+          const logInstance = new StreamLog(entries);
+          this.logs.set(streamId as StreamTabId, logInstance);
+          this.refreshSummary(streamId as StreamTabId, logInstance);
           totalEntries += entries.length;
         }
       }
@@ -244,8 +312,16 @@ export class StreamLogStore {
     if (!logInstance) {
       logInstance = new StreamLog();
       this.logs.set(streamId, logInstance);
+      if (!this.summaries.has(streamId)) this.summaries.set(streamId, {});
     }
     return logInstance;
+  }
+
+  private refreshSummary(streamId: StreamTabId, logInstance: StreamLog): void {
+    this.summaries.set(streamId, {
+      firstTimestamp: logInstance.firstTimestamp,
+      lastTimestamp: logInstance.lastTimestamp,
+    });
   }
 
   private markDirty(streamId: StreamTabId): void {
@@ -329,7 +405,9 @@ export class StreamLogStore {
     for (const [streamId, rawEntries] of Object.entries(record)) {
       const entries = this.parsePersistedEntries(rawEntries);
       if (entries.length > 0) {
-        this.logs.set(streamId as StreamTabId, new StreamLog(entries));
+        const logInstance = new StreamLog(entries);
+        this.logs.set(streamId as StreamTabId, logInstance);
+        this.refreshSummary(streamId as StreamTabId, logInstance);
         totalEntries += entries.length;
       }
     }

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -182,8 +182,12 @@ export class StreamLogStore {
             }
           }
         }
-        // Load recovered — saves can persist this stream again.
+        // Load recovered — saves can persist this stream again. If a save
+        // was deferred while the load was in flight (dirty stream re-queued
+        // by executeWrite), flush it now so we don't wait for another
+        // append to unblock it.
         this.loadFailed.delete(streamId);
+        if (this.dirtyStreamIds.has(streamId)) void this.save();
       } catch {
         // Rehydrate failed. Mark so `executeWrite` skips this stream and
         // doesn't overwrite the on-disk history with whatever empty/partial
@@ -527,15 +531,16 @@ export class StreamLogStore {
       return Promise.resolve();
     }
 
-    // Skip streams whose rehydrate read failed — writing now would clobber
-    // the authoritative on-disk history with a fresh empty-plus-new-appends
-    // log. Keep them dirty so the next save retries once ensureLoaded has
-    // merged disk entries back in.
+    // Skip streams whose rehydrate is pending or errored — writing now
+    // would clobber the authoritative on-disk history with a fresh
+    // empty-plus-new-appends log before `ensureLoaded` merges disk entries
+    // back in. Keep them dirty so the next save retries after the load
+    // resolves.
     const allDirty = [...this.dirtyStreamIds];
     this.dirtyStreamIds.clear();
     const dirtyIds: StreamTabId[] = [];
     for (const streamId of allDirty) {
-      if (this.loadFailed.has(streamId)) {
+      if (this.loadFailed.has(streamId) || this.pendingLoads.has(streamId)) {
         this.dirtyStreamIds.add(streamId);
       } else {
         dirtyIds.push(streamId);

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -107,6 +107,10 @@ export class StreamLogStore {
     const work = (async () => {
       try {
         const raw = await this.kv.read<unknown[]>(streamId);
+        // A concurrent `append` (e.g. the agent writing to this stream)
+        // may have populated `logs` while we awaited the disk read; its
+        // in-memory entries are newer than the file, so don't clobber.
+        if (this.logs.has(streamId)) return;
         const entries = this.parsePersistedEntries(raw);
         const logInstance = new StreamLog(entries);
         this.logs.set(streamId, logInstance);

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -46,6 +46,14 @@ export class StreamLogStore {
   private readonly pendingLoads = new Map<StreamTabId, Promise<void>>();
 
   /**
+   * Streams currently being flushed by `executeWrite`. `dirtyStreamIds` is
+   * cleared before the async `kv.write` finishes, so we also have to treat
+   * these as non-evictable — dropping the in-memory log mid-flight would
+   * leave nothing to re-mark dirty if the write fails.
+   */
+  private readonly flushing = new Set<StreamTabId>();
+
+  /**
    * Streams that went stale while still dirty, so `releaseEntries` deferred
    * the memory drop until the next save flush. Reads + new appends clear the
    * entry so a reactivated stream isn't evicted out from under the agent.
@@ -109,7 +117,10 @@ export class StreamLogStore {
       }
       return;
     }
-    if (this.dirtyStreamIds.has(streamId)) {
+    if (
+      this.dirtyStreamIds.has(streamId) ||
+      this.flushing.has(streamId)
+    ) {
       this.pendingRelease.add(streamId);
       return;
     }
@@ -227,6 +238,7 @@ export class StreamLogStore {
     this.summaries.delete(streamId);
     this.dirtyStreamIds.delete(streamId);
     this.pendingRelease.delete(streamId);
+    this.flushing.delete(streamId);
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -240,6 +252,7 @@ export class StreamLogStore {
     this.summaries.clear();
     this.dirtyStreamIds.clear();
     this.pendingRelease.clear();
+    this.flushing.clear();
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -497,6 +510,11 @@ export class StreamLogStore {
 
     log.debug(LOG_TAG, `Writing ${dirtyIds.length} dirty stream(s)`);
 
+    // Mark these as mid-flush so `releaseEntries` defers — we need the
+    // in-memory copy preserved until the write resolves, otherwise a failed
+    // write can't re-mark the stream dirty (there'd be no log entries left).
+    for (const streamId of dirtyIds) this.flushing.add(streamId);
+
     const writes = dirtyIds.flatMap((streamId) => {
       const logInstance = this.logs.get(streamId);
       return logInstance ? [this.kv.write(streamId, logInstance.toJSON())] : [];
@@ -516,6 +534,7 @@ export class StreamLogStore {
         }
       })
       .finally(() => {
+        for (const streamId of dirtyIds) this.flushing.delete(streamId);
         if (this.inFlightWrite === writePromise) {
           this.inFlightWrite = null;
           if (!this.pendingResolve) {

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -411,6 +411,11 @@ export class StreamLogStore {
     // appends that landed on a resumed stream. Bound the loop by the set
     // of streams that could still make progress — if the only dirty
     // entries are persistently `loadFailed`, we can't persist them.
+    // Cap the write retries so a persistent write error (disk full, perm
+    // denied) doesn't hang shutdown forever — `executeWrite`'s catch
+    // re-marks failed streams dirty, which would otherwise spin.
+    const MAX_WRITE_RETRIES = 3;
+    let writeAttempts = 0;
     /* eslint-disable no-await-in-loop */
     while (true) {
       if (this.saveTimer !== null) {
@@ -419,6 +424,7 @@ export class StreamLogStore {
         const resolve = this.pendingResolve;
         this.pendingResolve = null;
         await this.executeWrite(resolve);
+        writeAttempts++;
       } else if (this.inFlightWrite) {
         await this.inFlightWrite;
       } else if (this.pendingLoads.size > 0) {
@@ -430,7 +436,16 @@ export class StreamLogStore {
           (id) => !this.loadFailed.has(id),
         );
         if (!canRetry) return;
+        if (writeAttempts >= MAX_WRITE_RETRIES) {
+          log.warn(
+            LOG_TAG,
+            `flush() gave up after ${MAX_WRITE_RETRIES} retries; ` +
+              `${this.dirtyStreamIds.size} stream(s) still dirty`,
+          );
+          return;
+        }
         await this.executeWrite(null);
+        writeAttempts++;
       }
     }
     /* eslint-enable no-await-in-loop */

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -301,6 +301,8 @@ export class StreamLogStore {
     this.logs.clear();
     this.summaries.clear();
     this.dirtyStreamIds.clear();
+    this.pendingRelease.clear();
+    this.flushing.clear();
 
     // 1. Scan directory — filenames decode back to stream IDs
     const streamIds = await this.kv.listKeys();

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -45,6 +45,13 @@ export class StreamLogStore {
   /** Deduplicates concurrent `ensureLoaded` calls for the same stream. */
   private readonly pendingLoads = new Map<StreamTabId, Promise<void>>();
 
+  /**
+   * Streams that went stale while still dirty, so `releaseEntries` deferred
+   * the memory drop until the next save flush. Reads + new appends clear the
+   * entry so a reactivated stream isn't evicted out from under the agent.
+   */
+  private readonly pendingRelease = new Set<StreamTabId>();
+
   /** Guards persistence — tests create store without calling load(). */
   private loaded = false;
 
@@ -86,13 +93,18 @@ export class StreamLogStore {
 
   /**
    * Drop heavy entries from memory while keeping the on-disk copy authoritative.
-   * Skips streams with pending writes so `save()` can flush first. Subsequent
-   * access must go through `ensureLoaded` to rehydrate.
+   * If there are pending writes, queue the release so `executeWrite` can flush
+   * first and actually evict afterwards; otherwise releases immediately.
+   * Subsequent access must go through `ensureLoaded` to rehydrate.
    */
   releaseEntries(streamId: StreamTabId): void {
     const logInstance = this.logs.get(streamId);
     if (!logInstance) return;
-    if (this.dirtyStreamIds.has(streamId)) return;
+    if (this.dirtyStreamIds.has(streamId)) {
+      this.pendingRelease.add(streamId);
+      return;
+    }
+    this.pendingRelease.delete(streamId);
     this.refreshSummary(streamId, logInstance);
     this.logs.delete(streamId);
   }
@@ -102,6 +114,9 @@ export class StreamLogStore {
    * resident or when the stream is unknown.
    */
   async ensureLoaded(streamId: StreamTabId): Promise<void> {
+    // Reactivation cancels any deferred release so the fresh agent work
+    // doesn't get evicted mid-run.
+    this.pendingRelease.delete(streamId);
     if (this.logs.has(streamId)) return;
     if (!this.summaries.has(streamId)) return;
     const existing = this.pendingLoads.get(streamId);
@@ -109,12 +124,25 @@ export class StreamLogStore {
     const work = (async () => {
       try {
         const raw = await this.kv.read<unknown[]>(streamId);
-        // A concurrent `append` (e.g. the agent writing to this stream)
-        // may have populated `logs` while we awaited the disk read; its
-        // in-memory entries are newer than the file, so don't clobber.
-        if (this.logs.has(streamId)) return;
-        const entries = this.parsePersistedEntries(raw);
-        const logInstance = new StreamLog(entries);
+        // If `delete` ran during the read, don't resurrect the stream.
+        if (!this.summaries.has(streamId)) return;
+        const diskEntries = this.parsePersistedEntries(raw);
+        const live = this.logs.get(streamId);
+        if (live && live.size > 0) {
+          // A concurrent `append` populated `logs` during the disk read.
+          // Merge disk (history) before the live appends so `save()` writes
+          // the union instead of clobbering the authoritative disk copy
+          // with just the new entries. StreamLog's constructor re-numbers
+          // seqNos so the merged view stays contiguous.
+          const merged = new StreamLog([...diskEntries, ...live.toJSON()]);
+          this.logs.set(streamId, merged);
+          this.refreshSummary(streamId, merged);
+          this.markDirty(streamId);
+          void this.save();
+          this.notify(streamId);
+          return;
+        }
+        const logInstance = new StreamLog(diskEntries);
         this.logs.set(streamId, logInstance);
         this.refreshSummary(streamId, logInstance);
       } catch {
@@ -130,6 +158,8 @@ export class StreamLogStore {
   }
 
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
+    // New writes mean the stream is live again — cancel any deferred release.
+    this.pendingRelease.delete(streamId);
     const logInstance = this.getOrCreate(streamId);
     const appended = logInstance.append(entry);
     this.refreshSummary(streamId, logInstance);
@@ -179,6 +209,7 @@ export class StreamLogStore {
     this.logs.delete(streamId);
     this.summaries.delete(streamId);
     this.dirtyStreamIds.delete(streamId);
+    this.pendingRelease.delete(streamId);
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -191,6 +222,7 @@ export class StreamLogStore {
     this.logs.clear();
     this.summaries.clear();
     this.dirtyStreamIds.clear();
+    this.pendingRelease.clear();
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -465,11 +497,30 @@ export class StreamLogStore {
             this.savePromise = null;
           }
         }
+        this.drainPendingReleases();
         resolve?.();
       });
 
     this.inFlightWrite = writePromise;
     return writePromise;
+  }
+
+  /**
+   * Evict streams whose release was deferred while they were dirty. Called
+   * after every write flush. Any reactivation (append / ensureLoaded /
+   * delete) will have cleared the pending entry, so only streams that stayed
+   * idle and clean through the flush are actually released here.
+   */
+  private drainPendingReleases(): void {
+    if (this.pendingRelease.size === 0) return;
+    for (const streamId of [...this.pendingRelease]) {
+      if (this.dirtyStreamIds.has(streamId)) continue;
+      this.pendingRelease.delete(streamId);
+      const logInstance = this.logs.get(streamId);
+      if (!logInstance) continue;
+      this.refreshSummary(streamId, logInstance);
+      this.logs.delete(streamId);
+    }
   }
 }
 

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -485,10 +485,18 @@ export class StreamLogStore {
       return logInstance ? [this.kv.write(streamId, logInstance.toJSON())] : [];
     });
 
+    let writeSucceeded = false;
     const writePromise = Promise.all(writes)
-      .then(() => {})
+      .then(() => {
+        writeSucceeded = true;
+      })
       .catch(() => {
-        // Keep writes non-throwing on hot path.
+        // Failed writes re-mark their streams dirty so the next save
+        // retries, and prevent eviction below (disk wouldn't have the
+        // entries yet; releasing memory would lose them).
+        for (const streamId of dirtyIds) {
+          if (this.logs.has(streamId)) this.dirtyStreamIds.add(streamId);
+        }
       })
       .finally(() => {
         if (this.inFlightWrite === writePromise) {
@@ -497,7 +505,7 @@ export class StreamLogStore {
             this.savePromise = null;
           }
         }
-        this.drainPendingReleases();
+        if (writeSucceeded) this.drainPendingReleases();
         resolve?.();
       });
 

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -63,12 +63,14 @@ export class StreamLogStore {
   }
 
   has(streamId: StreamTabId): boolean {
-    return this.logs.has(streamId) || this.summaries.has(streamId);
+    // `summaries` is the authoritative registry of known streams and is
+    // always a superset of `logs` (every entry we ever write to `logs`
+    // also lands in `summaries`; eviction drops `logs` but keeps summary).
+    return this.summaries.has(streamId);
   }
 
   keys(): StreamTabId[] {
-    // Union of loaded + summary-only streams; Set dedupes.
-    return [...new Set([...this.logs.keys(), ...this.summaries.keys()])];
+    return [...this.summaries.keys()];
   }
 
   ensureStream(streamId: StreamTabId): void {

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -99,7 +99,16 @@ export class StreamLogStore {
    */
   releaseEntries(streamId: StreamTabId): void {
     const logInstance = this.logs.get(streamId);
-    if (!logInstance) return;
+    if (!logInstance) {
+      // Can't drop what isn't resident — but if a rehydrate is in flight,
+      // queue the intent so it runs once the load completes. Otherwise the
+      // rapid in-flight → stale flip would finish the load into memory
+      // with no subsequent eviction trigger.
+      if (this.pendingLoads.has(streamId)) {
+        this.pendingRelease.add(streamId);
+      }
+      return;
+    }
     if (this.dirtyStreamIds.has(streamId)) {
       this.pendingRelease.add(streamId);
       return;
@@ -145,6 +154,14 @@ export class StreamLogStore {
         const logInstance = new StreamLog(diskEntries);
         this.logs.set(streamId, logInstance);
         this.refreshSummary(streamId, logInstance);
+        // A `releaseEntries` that arrived while the load was in flight gets
+        // queued; honor it now (unless a reactivation cleared the intent).
+        if (this.pendingRelease.has(streamId)) {
+          this.pendingRelease.delete(streamId);
+          if (!this.dirtyStreamIds.has(streamId)) {
+            this.logs.delete(streamId);
+          }
+        }
       } catch {
         log.warn(LOG_TAG, `Failed to reload stream ${streamId} from disk`);
       }

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -71,8 +71,15 @@ export class StreamLogStore {
     return [...new Set([...this.logs.keys(), ...this.summaries.keys()])];
   }
 
-  ensureStream(streamId: StreamTabId): StreamLog {
-    return this.getOrCreate(streamId);
+  ensureStream(streamId: StreamTabId): void {
+    // No-op if the stream is already known — either resident in `logs` or
+    // released with metadata in `summaries`. Creating a fresh empty log here
+    // for a released stream would shadow the on-disk copy from
+    // `ensureLoaded`, leaving switches to that stream showing an empty view.
+    if (this.logs.has(streamId) || this.summaries.has(streamId)) return;
+    const logInstance = new StreamLog();
+    this.logs.set(streamId, logInstance);
+    this.summaries.set(streamId, {});
   }
 
   /**

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -60,6 +60,15 @@ export class StreamLogStore {
    */
   private readonly pendingRelease = new Set<StreamTabId>();
 
+  /**
+   * Streams whose rehydrate read from disk failed. While marked, saves skip
+   * them so we never overwrite the authoritative disk copy with a fresh
+   * empty-log-plus-new-appends that would drop persisted history.
+   * Cleared when `ensureLoaded` eventually succeeds (subsequent `append`s
+   * opportunistically retry the load).
+   */
+  private readonly loadFailed = new Set<StreamTabId>();
+
   /** Guards persistence — tests create store without calling load(). */
   private loaded = false;
 
@@ -160,20 +169,27 @@ export class StreamLogStore {
           this.markDirty(streamId);
           void this.save();
           this.notify(streamId);
-          return;
-        }
-        const logInstance = new StreamLog(diskEntries);
-        this.logs.set(streamId, logInstance);
-        this.refreshSummary(streamId, logInstance);
-        // A `releaseEntries` that arrived while the load was in flight gets
-        // queued; honor it now (unless a reactivation cleared the intent).
-        if (this.pendingRelease.has(streamId)) {
-          this.pendingRelease.delete(streamId);
-          if (!this.dirtyStreamIds.has(streamId)) {
-            this.logs.delete(streamId);
+        } else {
+          const logInstance = new StreamLog(diskEntries);
+          this.logs.set(streamId, logInstance);
+          this.refreshSummary(streamId, logInstance);
+          // A `releaseEntries` that arrived while the load was in flight gets
+          // queued; honor it now (unless a reactivation cleared the intent).
+          if (this.pendingRelease.has(streamId)) {
+            this.pendingRelease.delete(streamId);
+            if (!this.dirtyStreamIds.has(streamId)) {
+              this.logs.delete(streamId);
+            }
           }
         }
+        // Load recovered — saves can persist this stream again.
+        this.loadFailed.delete(streamId);
       } catch {
+        // Rehydrate failed. Mark so `executeWrite` skips this stream and
+        // doesn't overwrite the on-disk history with whatever empty/partial
+        // log the agent may now be appending to. `append` retries the load
+        // in the background; once it succeeds the merge path runs.
+        this.loadFailed.add(streamId);
         log.warn(LOG_TAG, `Failed to reload stream ${streamId} from disk`);
       }
     })();
@@ -188,6 +204,12 @@ export class StreamLogStore {
   append(streamId: StreamTabId, entry: StreamLogAppendInput): StreamLogEntry {
     // New writes mean the stream is live again — cancel any deferred release.
     this.pendingRelease.delete(streamId);
+    // If a previous rehydrate errored, retry in the background so the
+    // eventual merge can combine disk history with these new entries
+    // before we're allowed to save.
+    if (this.loadFailed.has(streamId) && !this.logs.has(streamId)) {
+      void this.ensureLoaded(streamId);
+    }
     const logInstance = this.getOrCreate(streamId);
     const appended = logInstance.append(entry);
     this.refreshSummary(streamId, logInstance);
@@ -239,6 +261,7 @@ export class StreamLogStore {
     this.dirtyStreamIds.delete(streamId);
     this.pendingRelease.delete(streamId);
     this.flushing.delete(streamId);
+    this.loadFailed.delete(streamId);
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -253,6 +276,7 @@ export class StreamLogStore {
     this.dirtyStreamIds.clear();
     this.pendingRelease.clear();
     this.flushing.clear();
+    this.loadFailed.clear();
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -303,6 +327,7 @@ export class StreamLogStore {
     this.dirtyStreamIds.clear();
     this.pendingRelease.clear();
     this.flushing.clear();
+    this.loadFailed.clear();
 
     // 1. Scan directory — filenames decode back to stream IDs
     const streamIds = await this.kv.listKeys();
@@ -502,8 +527,20 @@ export class StreamLogStore {
       return Promise.resolve();
     }
 
-    const dirtyIds = [...this.dirtyStreamIds];
+    // Skip streams whose rehydrate read failed — writing now would clobber
+    // the authoritative on-disk history with a fresh empty-plus-new-appends
+    // log. Keep them dirty so the next save retries once ensureLoaded has
+    // merged disk entries back in.
+    const allDirty = [...this.dirtyStreamIds];
     this.dirtyStreamIds.clear();
+    const dirtyIds: StreamTabId[] = [];
+    for (const streamId of allDirty) {
+      if (this.loadFailed.has(streamId)) {
+        this.dirtyStreamIds.add(streamId);
+      } else {
+        dirtyIds.push(streamId);
+      }
+    }
 
     if (dirtyIds.length === 0) {
       resolve?.();

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -270,6 +270,7 @@ export class StreamLogStore {
     this.pendingRelease.delete(streamId);
     this.flushing.delete(streamId);
     this.loadFailed.delete(streamId);
+    this.pendingLoads.delete(streamId);
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -285,6 +286,7 @@ export class StreamLogStore {
     this.pendingRelease.clear();
     this.flushing.clear();
     this.loadFailed.clear();
+    this.pendingLoads.clear();
     if (!this.loaded) return;
 
     this.cancelPendingSave();
@@ -336,6 +338,7 @@ export class StreamLogStore {
     this.pendingRelease.clear();
     this.flushing.clear();
     this.loadFailed.clear();
+    this.pendingLoads.clear();
 
     // 1. Scan directory — filenames decode back to stream IDs
     const streamIds = await this.kv.listKeys();
@@ -563,23 +566,27 @@ export class StreamLogStore {
     // write can't re-mark the stream dirty (there'd be no log entries left).
     for (const streamId of dirtyIds) this.flushing.add(streamId);
 
-    const writes = dirtyIds.flatMap((streamId) => {
-      const logInstance = this.logs.get(streamId);
-      return logInstance ? [this.kv.write(streamId, logInstance.toJSON())] : [];
-    });
-
-    let writeSucceeded = false;
-    const writePromise = Promise.all(writes)
-      .then(() => {
-        writeSucceeded = true;
-      })
-      .catch(() => {
+    // `Promise.allSettled` keeps per-stream outcomes so a single failed
+    // write doesn't poison the drain for the other streams in the batch —
+    // `pendingRelease` entries for streams that wrote fine still get evicted.
+    const writePromise = Promise.allSettled(
+      dirtyIds.map((streamId) => {
+        const logInstance = this.logs.get(streamId);
+        return logInstance
+          ? this.kv.write(streamId, logInstance.toJSON())
+          : Promise.resolve();
+      }),
+    )
+      .then((results) => {
         // Failed writes re-mark their streams dirty so the next save
-        // retries, and prevent eviction below (disk wouldn't have the
-        // entries yet; releasing memory would lose them).
-        for (const streamId of dirtyIds) {
-          if (this.logs.has(streamId)) this.dirtyStreamIds.add(streamId);
-        }
+        // retries. Successful streams are now persisted and safe to evict
+        // (drainPendingReleases' dirtyStreamIds check excludes failed ones).
+        results.forEach((result, i) => {
+          if (result.status === 'rejected') {
+            const streamId = dirtyIds[i];
+            if (this.logs.has(streamId)) this.dirtyStreamIds.add(streamId);
+          }
+        });
       })
       .finally(() => {
         for (const streamId of dirtyIds) this.flushing.delete(streamId);
@@ -589,7 +596,7 @@ export class StreamLogStore {
             this.savePromise = null;
           }
         }
-        if (writeSucceeded) this.drainPendingReleases();
+        this.drainPendingReleases();
         resolve?.();
       });
 

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -405,18 +405,35 @@ export class StreamLogStore {
   async flush(): Promise<void> {
     if (!this.loaded) return;
 
-    if (this.saveTimer !== null) {
-      clearTimeout(this.saveTimer);
-      this.saveTimer = null;
-      const resolve = this.pendingResolve;
-      this.pendingResolve = null;
-      await this.executeWrite(resolve);
-      return;
+    // Drain iteratively: executeWrite may re-queue streams that are still
+    // rehydrating (`pendingLoads`) or whose prior load failed. Wait for
+    // those to resolve and then re-run the save, so shutdown doesn't lose
+    // appends that landed on a resumed stream. Bound the loop by the set
+    // of streams that could still make progress — if the only dirty
+    // entries are persistently `loadFailed`, we can't persist them.
+    /* eslint-disable no-await-in-loop */
+    while (true) {
+      if (this.saveTimer !== null) {
+        clearTimeout(this.saveTimer);
+        this.saveTimer = null;
+        const resolve = this.pendingResolve;
+        this.pendingResolve = null;
+        await this.executeWrite(resolve);
+      } else if (this.inFlightWrite) {
+        await this.inFlightWrite;
+      } else if (this.pendingLoads.size > 0) {
+        await Promise.allSettled([...this.pendingLoads.values()]);
+      } else {
+        // No in-flight work. Decide whether anything deferred can still
+        // be persisted in another save cycle.
+        const canRetry = [...this.dirtyStreamIds].some(
+          (id) => !this.loadFailed.has(id),
+        );
+        if (!canRetry) return;
+        await this.executeWrite(null);
+      }
     }
-
-    if (this.inFlightWrite) {
-      await this.inFlightWrite;
-    }
+    /* eslint-enable no-await-in-loop */
   }
 
   private getOrCreate(streamId: StreamTabId): StreamLog {

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -214,10 +214,9 @@ export class StreamLogStore {
     this.pendingRelease.delete(streamId);
     // If a previous rehydrate errored, retry in the background so the
     // eventual merge can combine disk history with these new entries
-    // before we're allowed to save.
-    if (this.loadFailed.has(streamId) && !this.logs.has(streamId)) {
-      void this.ensureLoaded(streamId);
-    }
+    // before we're allowed to save. `ensureLoaded` dedupes via
+    // `pendingLoads` so repeated appends don't spam overlapping reads.
+    if (this.loadFailed.has(streamId)) void this.ensureLoaded(streamId);
     const logInstance = this.getOrCreate(streamId);
     const appended = logInstance.append(entry);
     this.refreshSummary(streamId, logInstance);
@@ -431,10 +430,19 @@ export class StreamLogStore {
   }
 
   private refreshSummary(streamId: StreamTabId, logInstance: StreamLog): void {
-    this.summaries.set(streamId, {
-      firstTimestamp: logInstance.firstTimestamp,
-      lastTimestamp: logInstance.lastTimestamp,
-    });
+    // Mutate in place — no observer watches summary object identity, and
+    // this runs on the per-append hot path (~200/s during streaming), so
+    // avoiding the per-call allocation is worthwhile.
+    const existing = this.summaries.get(streamId);
+    if (existing) {
+      existing.firstTimestamp = logInstance.firstTimestamp;
+      existing.lastTimestamp = logInstance.lastTimestamp;
+    } else {
+      this.summaries.set(streamId, {
+        firstTimestamp: logInstance.firstTimestamp,
+        lastTimestamp: logInstance.lastTimestamp,
+      });
+    }
   }
 
   private markDirty(streamId: StreamTabId): void {

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -146,7 +146,11 @@ export class StreamLogStore {
     // Reactivation cancels any deferred release so the fresh agent work
     // doesn't get evicted mid-run.
     this.pendingRelease.delete(streamId);
-    if (this.logs.has(streamId)) return;
+    // Normally skip when already resident. But after a failed rehydrate a
+    // subsequent `append` may have populated a fresh empty log — we still
+    // need to retry the disk read so the merge path can reunite it with
+    // the persisted history before saves are re-enabled.
+    if (this.logs.has(streamId) && !this.loadFailed.has(streamId)) return;
     if (!this.summaries.has(streamId)) return;
     const existing = this.pendingLoads.get(streamId);
     if (existing) return existing;

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -390,7 +390,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     // Sync replacement active stream in the active progress target.
     if (wasActive && this.provider.state.activeStream) {
-      this.provider.setActiveStream(this.provider.state.activeStream);
+      await this.provider.setActiveStream(this.provider.state.activeStream);
     }
   }
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -4,8 +4,6 @@ import { computeAgentOptionsData } from '@agent/index';
 import type { IRunStorageService } from '@agent/runtime/RunStorageService';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
   BaseWebviewProvider,
   getSharedLocalResourceRoots,
@@ -454,9 +452,7 @@ export class ProgressViewProvider
     // release (the setStreamStatus guard excludes the active stream). Now
     // that the user has moved on, it's eligible.
     if (previous && previous !== streamId) {
-      if (!isInFlightStatus(StreamStatusService.get(previous))) {
-        this.state.streamLogs.releaseEntries(previous);
-      }
+      this.state.releasePreviousActive(previous);
     }
 
     if (!this.canSendToWebview()) return;

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -4,6 +4,8 @@ import { computeAgentOptionsData } from '@agent/index';
 import type { IRunStorageService } from '@agent/runtime/RunStorageService';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { detectWaitingStreams } from '@agent/storage/detectWaitingStreams';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import {
   BaseWebviewProvider,
   getSharedLocalResourceRoots,
@@ -433,7 +435,18 @@ export class ProgressViewProvider
   }
 
   public async setActiveStream(streamId: StreamTabId): Promise<void> {
+    const previous = this.state.activeStream;
     this.state.activeStream = streamId;
+
+    // Catches the "terminal-while-active" case: a stream that reached a
+    // non-in-flight status while it was the visible tab never triggered
+    // release (the setStreamStatus guard excludes the active stream). Now
+    // that the user has moved on, it's eligible.
+    if (previous && previous !== streamId) {
+      if (!isInFlightStatus(StreamStatusService.get(previous))) {
+        this.state.streamLogs.releaseEntries(previous);
+      }
+    }
 
     if (!this.canSendToWebview()) return;
 

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -441,6 +441,10 @@ export class ProgressViewProvider
     // newly-active tab shows its full log instead of an empty view.
     if (streamId) await this.state.streamLogs.ensureLoaded(streamId);
 
+    // Another setActiveStream may have run while we awaited rehydration;
+    // let the newer call own the webview sync so we don't overwrite it.
+    if (this.state.activeStream !== streamId) return;
+
     this.webviewUpdater.setActiveStream(streamId);
     // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata
     this.eventHandler.syncStreamContent(streamId, { includeActiveState: true });

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -432,10 +432,14 @@ export class ProgressViewProvider
     }
   }
 
-  public setActiveStream(streamId: StreamTabId): void {
+  public async setActiveStream(streamId: StreamTabId): Promise<void> {
     this.state.activeStream = streamId;
 
     if (!this.canSendToWebview()) return;
+
+    // Rehydrate entries released by the status-change eviction so the
+    // newly-active tab shows its full log instead of an empty view.
+    if (streamId) await this.state.streamLogs.ensureLoaded(streamId);
 
     this.webviewUpdater.setActiveStream(streamId);
     // Hydrate content (logs, todos, follow-ups, instruction, bypass state) + active-state metadata

--- a/src/progressView/ProgressViewProvider.ts
+++ b/src/progressView/ProgressViewProvider.ts
@@ -330,7 +330,18 @@ export class ProgressViewProvider
     // Skip content sync when streams exist but filter excludes all of them
     const hasStreams = this.state.streamLogs.keys().length > 0;
     if (activeStream || !hasStreams) {
-      this.eventHandler.syncStreamContent(activeStream);
+      // If the active stream's entries were released (e.g. filter change
+      // moved active to a previously-evicted stream), rehydrate before
+      // syncing so the webview doesn't render an empty log. Fall back to
+      // an immediate sync when the log is already resident.
+      if (activeStream && !this.state.streamLogs.get(activeStream)) {
+        void this.state.streamLogs.ensureLoaded(activeStream).then(() => {
+          if (this.state.activeStream !== activeStream) return;
+          this.eventHandler.syncStreamContent(activeStream);
+        });
+      } else {
+        this.eventHandler.syncStreamContent(activeStream);
+      }
     }
 
     this._pendingUpdateOptions = null;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -37,6 +37,20 @@ export type { UICallbacks };
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
 
+/**
+ * A stream is "in-flight" when any agent cycle may still append to its log.
+ * Non-in-flight streams have their entries released from memory (kept on
+ * disk) to bound session memory as many subagent tabs accumulate.
+ */
+function isInFlight(status: StreamStatus | undefined): boolean {
+  return (
+    status === STREAM_STATUS.RUNNING ||
+    status === STREAM_STATUS.RESUMING ||
+    status === STREAM_STATUS.INITIALIZING ||
+    status === STREAM_STATUS.WAITING
+  );
+}
+
 type StreamBadgeSnapshot = {
   activeSubagents: StreamExecutionState['activeSubagents'];
   finishedSubagentCount: StreamExecutionState['finishedSubagentCount'];
@@ -534,6 +548,13 @@ export class ProgressEventHandler {
   ): void {
     if (previousStatus === undefined) {
       StreamStatusService.set(streamId, status, { emit: false });
+    }
+
+    // Drop heavy entries from memory once a stream is no longer in-flight,
+    // unless the user is currently viewing it. Disk is authoritative; the
+    // next switch back triggers ensureLoaded to rehydrate.
+    if (!isInFlight(status) && streamId !== this.state.activeStream) {
+      this.state.streamLogs.releaseEntries(streamId);
     }
 
     if (!this.webviewUpdater.isAvailable()) return;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -245,11 +245,15 @@ export class ProgressEventHandler {
     }
   }
 
-  private handleSetActiveStream(
+  private async handleSetActiveStream(
     payload: ProgressEventPayloads['setActiveStream'],
-  ): void {
+  ): Promise<void> {
     const { streamId, isRemote, hasMultipleOutputs } = payload;
     if (!streamId) return;
+
+    // Rehydrate a potentially-evicted stream before syncing content,
+    // otherwise syncStreamContent hands an empty log to the webview.
+    await this.state.streamLogs.ensureLoaded(streamId);
 
     const wasKnownStream = this.state.streamLogs.has(streamId);
     const previousFilter = this.state.agentCategoryFilter;
@@ -288,7 +292,16 @@ export class ProgressEventHandler {
       // which may exclude the current stream and override state.activeStream —
       // completely bypassing the pending-permissions guard.
       this.maybeUpdateFilterForCategory(agentCategory);
+      const previous = this.state.activeStream;
       this.state.activeStream = streamId;
+      // Release the previously-active stream if it reached a terminal
+      // status while visible — setStreamStatus skips release for the
+      // active stream, so this switch is our only chance.
+      if (previous && previous !== streamId) {
+        if (!isInFlightStatus(StreamStatusService.get(previous))) {
+          this.state.streamLogs.releaseEntries(previous);
+        }
+      }
     }
 
     if (!this.webviewUpdater.isAvailable()) return;

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -537,10 +537,16 @@ export class ProgressEventHandler {
       StreamStatusService.set(streamId, status, { emit: false });
     }
 
-    // Drop heavy entries from memory once a stream is no longer in-flight,
-    // unless the user is currently viewing it. Disk is authoritative; the
-    // next switch back triggers ensureLoaded to rehydrate.
-    if (!isInFlightStatus(status) && streamId !== this.state.activeStream) {
+    // Keep memory bounded by stream status:
+    //  - returning to in-flight (e.g., background resume) eagerly rehydrates
+    //    previously-released entries so pending appends from the agent
+    //    runtime land on the full on-disk log instead of clobbering it via
+    //    an empty getOrCreate.
+    //  - leaving the in-flight set drops heavy entries; disk stays
+    //    authoritative and `setActiveStream` re-reads on demand.
+    if (isInFlightStatus(status)) {
+      void this.state.streamLogs.ensureLoaded(streamId);
+    } else if (streamId !== this.state.activeStream) {
       this.state.streamLogs.releaseEntries(streamId);
     }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -251,10 +251,6 @@ export class ProgressEventHandler {
     const { streamId, isRemote, hasMultipleOutputs } = payload;
     if (!streamId) return;
 
-    // Rehydrate a potentially-evicted stream before syncing content,
-    // otherwise syncStreamContent hands an empty log to the webview.
-    await this.state.streamLogs.ensureLoaded(streamId);
-
     const wasKnownStream = this.state.streamLogs.has(streamId);
     const previousFilter = this.state.agentCategoryFilter;
     this.state.streamLogs.ensureStream(streamId);
@@ -305,6 +301,16 @@ export class ProgressEventHandler {
     }
 
     if (!this.webviewUpdater.isAvailable()) return;
+
+    // Rehydrate a potentially-evicted stream before syncing content, so the
+    // webview doesn't get an empty log. All synchronous state mutations are
+    // already done above; the await here only gates webview delivery.
+    await this.state.streamLogs.ensureLoaded(streamId);
+
+    // A newer handleSetActiveStream may have resolved during our await and
+    // already taken over the active tab; skip webview sync so we don't
+    // overwrite its content with stale data.
+    if (shouldSwitch && this.state.activeStream !== streamId) return;
 
     const filterChanged = this.state.agentCategoryFilter !== previousFilter;
     if (!wasKnownStream || filterChanged) {

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -27,6 +27,7 @@ import {
   isApprovalBypassedForStream,
   isProposalBypassedForStream,
 } from '@tools/approval';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 
 import { registerHandlers } from './registerHandlers';
 import { registerUIEvents, type UICallbacks } from './UIEvents';
@@ -36,20 +37,6 @@ export type { UICallbacks };
 
 /** Throttle interval for conversation progress webview pushes (ms). */
 const PROGRESS_THROTTLE_MS = 500;
-
-/**
- * A stream is "in-flight" when any agent cycle may still append to its log.
- * Non-in-flight streams have their entries released from memory (kept on
- * disk) to bound session memory as many subagent tabs accumulate.
- */
-function isInFlight(status: StreamStatus | undefined): boolean {
-  return (
-    status === STREAM_STATUS.RUNNING ||
-    status === STREAM_STATUS.RESUMING ||
-    status === STREAM_STATUS.INITIALIZING ||
-    status === STREAM_STATUS.WAITING
-  );
-}
 
 type StreamBadgeSnapshot = {
   activeSubagents: StreamExecutionState['activeSubagents'];
@@ -553,7 +540,7 @@ export class ProgressEventHandler {
     // Drop heavy entries from memory once a stream is no longer in-flight,
     // unless the user is currently viewing it. Disk is authoritative; the
     // next switch back triggers ensureLoaded to rehydrate.
-    if (!isInFlight(status) && streamId !== this.state.activeStream) {
+    if (!isInFlightStatus(status) && streamId !== this.state.activeStream) {
       this.state.streamLogs.releaseEntries(streamId);
     }
 

--- a/src/progressView/events/ProgressEventHandler.ts
+++ b/src/progressView/events/ProgressEventHandler.ts
@@ -294,9 +294,7 @@ export class ProgressEventHandler {
       // status while visible — setStreamStatus skips release for the
       // active stream, so this switch is our only chance.
       if (previous && previous !== streamId) {
-        if (!isInFlightStatus(StreamStatusService.get(previous))) {
-          this.state.streamLogs.releaseEntries(previous);
-        }
+        this.state.releasePreviousActive(previous);
       }
     }
 

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -86,18 +86,18 @@ import {
 
 // Local imports - progress view contexts
 import {
-  EMPTY_DESCRIPTIONS,
   EMPTY_LOG_CONTEXT,
   EMPTY_PROCESS_OUTPUTS,
+  EMPTY_STREAM_BY_ID,
   EMPTY_STREAM_CONTEXT,
   permissionsContext,
   processOutputContext,
-  streamDescriptionsContext,
+  streamByIdContext,
   streamLogContext,
   streamStateContext,
   type ProcessOutputMap,
+  type StreamByIdMap,
   type StreamContextValue,
-  type StreamDescriptionMap,
   type StreamLogContextValue,
 } from './contexts/streamContexts';
 import type { FrontendEventHandlerContext } from './eventHandlers';
@@ -262,9 +262,9 @@ export class ProgressApp extends ProgressAppBase {
   @state()
   private processOutputContextValue: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
 
-  @provide({ context: streamDescriptionsContext })
+  @provide({ context: streamByIdContext })
   @state()
-  private descriptionsContextValue: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
+  private streamByIdContextValue: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
   // --- Selector computeds: extract fields, auto-memoized by Object.is ---
   private streamById$ = select(this.appState, (s) => s.streamById);
@@ -278,10 +278,6 @@ export class ProgressApp extends ProgressAppBase {
     (s) => s.followupOptionsByStream,
   );
   private processOutputs$ = select(this.appState, (s) => s.processOutputs);
-  private streamDescriptions$ = select(
-    this.appState,
-    (s) => s.streamDescriptions,
-  );
 
   // --- Derived computeds: only re-evaluate when selector inputs propagate ---
 
@@ -468,7 +464,7 @@ export class ProgressApp extends ProgressAppBase {
     this.streamLogContextValue = this.logContext$.get();
     this.permissionsContextValue = this.permissions$.get();
     this.processOutputContextValue = this.activeProcessOutputs$.get();
-    this.descriptionsContextValue = this.streamDescriptions$.get();
+    this.streamByIdContextValue = this.streamById$.get();
   }
 
   render(): TemplateResult {

--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -338,8 +338,14 @@ export class ProgressApp extends ProgressAppBase {
     return id ? (this.streamById$.get().get(id) ?? null) : null;
   });
 
+  /**
+   * True when the current filter yields at least one tab. Gates the
+   * "no streams match" placeholder — backend now sends every stream
+   * unfiltered, so `streamById.size` alone can't distinguish "nothing
+   * visible" from "everything hidden by filter".
+   */
   private hasStreams$ = new Signal.Computed(
-    () => this.streamById$.get().size > 0,
+    () => this.tabStreams$.get().length > 0,
   );
 
   /** Only changes when the ACTIVE stream's state changes, not any stream. */

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -33,12 +33,12 @@ import { ProgressEvents } from '../events';
 
 // Local imports - contexts
 import {
-  EMPTY_DESCRIPTIONS,
   EMPTY_PROCESS_OUTPUTS,
+  EMPTY_STREAM_BY_ID,
   processOutputContext,
-  streamDescriptionsContext,
+  streamByIdContext,
   type ProcessOutputMap,
-  type StreamDescriptionMap,
+  type StreamByIdMap,
 } from '../contexts/streamContexts';
 
 // Side-effect imports - sibling components
@@ -215,9 +215,9 @@ export class BackgroundTasksPanel extends LitElement {
   @state()
   private processOutputs: ProcessOutputMap = EMPTY_PROCESS_OUTPUTS;
 
-  @consume({ context: streamDescriptionsContext, subscribe: true })
+  @consume({ context: streamByIdContext, subscribe: true })
   @state()
-  private descriptions: StreamDescriptionMap = EMPTY_DESCRIPTIONS;
+  private streamById: StreamByIdMap = EMPTY_STREAM_BY_ID;
 
   /** Track previous active count to detect transitions. */
   private prevActiveCount = 0;
@@ -314,7 +314,7 @@ export class BackgroundTasksPanel extends LitElement {
     const entry = this.processOutputs.get(child.executionId);
     const isClickable = Boolean(child.childStreamId);
     const description = child.childStreamId
-      ? this.descriptions.get(child.childStreamId)
+      ? this.streamById.get(child.childStreamId)?.description
       : undefined;
     const waiting = isWaiting(child);
 

--- a/src/progressView/frontend/contexts/streamContexts.ts
+++ b/src/progressView/frontend/contexts/streamContexts.ts
@@ -94,13 +94,14 @@ export const processOutputContext = createContext<ProcessOutputMap>(
 );
 
 /**
- * Descriptions context: streamId → AI-generated session description.
+ * streamById context: Map<streamId, StreamTabInfo>. Single source of truth
+ * for per-stream metadata including AI-generated descriptions.
  * Consumed by BackgroundTasksPanel to label subagent entries.
  */
-export type StreamDescriptionMap = Map<StreamTabId, string>;
+export type StreamByIdMap = ReadonlyMap<StreamTabId, StreamTabInfo>;
 
-export const EMPTY_DESCRIPTIONS: StreamDescriptionMap = new Map();
+export const EMPTY_STREAM_BY_ID: StreamByIdMap = new Map();
 
-export const streamDescriptionsContext = createContext<StreamDescriptionMap>(
-  'progress-stream-descriptions',
+export const streamByIdContext = createContext<StreamByIdMap>(
+  'progress-stream-by-id',
 );

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -79,8 +79,15 @@ function updateStreamInfo(
     } else if (!existing) {
       mergedStates.set(stream.name, createStreamState(stream.agentCategory));
     }
-    const pending = stream.description ? undefined : takePendingDescription(stream.name);
-    newStreamById.set(stream.name, pending ? { ...stream, description: pending } : stream);
+    // Always drain the pending buffer so stale entries don't linger once the
+    // stream registers, even if the payload already carries a description.
+    // Stream-payload description wins (it's the authoritative value).
+    const pending = takePendingDescription(stream.name);
+    const description = stream.description ?? pending;
+    newStreamById.set(
+      stream.name,
+      description !== stream.description ? { ...stream, description } : stream,
+    );
   }
 
   return create(state, (draft) => {

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -90,13 +90,19 @@ function updateStreamInfo(
     );
   }
 
+  // Clean up removed streams' pending-description buffer outside the
+  // mutative draft callback so the side effect doesn't run if the draft
+  // later throws.
+  for (const key of state.streamStates.keys()) {
+    if (!newStreamById.has(key)) pendingDescriptions.delete(key);
+  }
+
   return create(state, (draft) => {
     for (const key of draft.streamStates.keys()) {
       if (!newStreamById.has(key)) {
         draft.streamStates.delete(key);
         draft.streamLogs.delete(key);
         draft.processOutputs.delete(key);
-        pendingDescriptions.delete(key);
       }
     }
 

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -11,6 +11,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import {
   createStreamState,
   type StreamMetadata,
+  type StreamTabId,
   type StreamTabInfo,
 } from '@shared/schemas';
 
@@ -121,16 +122,26 @@ function updateStreamInfo(
 export const streamLifecycleHandlers: HandlerRegistry = {
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS]: (data, ctx) => {
     const previousState = ctx.getState();
-    const activeStream = data.activeStream || null;
     const updated = updateStreamInfo(
       previousState,
       data.streams,
       data.streamStates,
     );
-    const nextActiveStreamId =
-      activeStream && updated.streamById.has(activeStream)
-        ? activeStream
-        : firstStreamId(updated.streamById);
+    // Honor explicit empty-string as "no selection" — backend sends this
+    // when the current filter excludes every stream. Since the backend now
+    // emits all streams unfiltered, falling back to firstStreamId would
+    // re-pick a filtered-out tab and render hidden-category content.
+    let nextActiveStreamId: StreamTabId | null;
+    if (data.activeStream === '') {
+      nextActiveStreamId = null;
+    } else if (
+      data.activeStream &&
+      updated.streamById.has(data.activeStream)
+    ) {
+      nextActiveStreamId = data.activeStream;
+    } else {
+      nextActiveStreamId = firstStreamId(updated.streamById);
+    }
 
     ctx.setState(() =>
       create(updated, (draft) => {

--- a/src/progressView/frontend/slices/streamLifecycleSlice.ts
+++ b/src/progressView/frontend/slices/streamLifecycleSlice.ts
@@ -16,6 +16,10 @@ import {
 
 import { firstStreamId, type ProgressState, type StreamState } from '../store';
 import { clearResolvedProposalIds } from './permissionSlice';
+import {
+  pendingDescriptions,
+  takePendingDescription,
+} from './streamMetaSlice';
 import { clearCopyContentStore } from '../formatters/copyContentStore';
 import { clearProposalInputStore } from '../formatters/proposalInputStore';
 import {
@@ -57,8 +61,11 @@ function updateStreamInfo(
   backendMetadata?: Record<string, StreamMetadata>,
 ): ProgressState {
   // Pre-compute merged states outside the draft (mergeBackendOwnedState uses
-  // create() internally, which cannot operate on draft proxies).
+  // create() internally, which cannot operate on draft proxies). Fold the
+  // pending-description drain into the same pass — no extra iteration.
+  // Explicit description on StreamTabInfo wins over the pending buffer.
   const mergedStates = new Map<string, StreamState>();
+  const newStreamById = new Map<string, StreamTabInfo>();
   for (const stream of streams) {
     const existing = state.streamStates.get(stream.name);
     const metadata = backendMetadata?.[stream.name];
@@ -72,9 +79,9 @@ function updateStreamInfo(
     } else if (!existing) {
       mergedStates.set(stream.name, createStreamState(stream.agentCategory));
     }
+    const pending = stream.description ? undefined : takePendingDescription(stream.name);
+    newStreamById.set(stream.name, pending ? { ...stream, description: pending } : stream);
   }
-
-  const newStreamById = new Map(streams.map((s) => [s.name, s]));
 
   return create(state, (draft) => {
     for (const key of draft.streamStates.keys()) {
@@ -82,21 +89,12 @@ function updateStreamInfo(
         draft.streamStates.delete(key);
         draft.streamLogs.delete(key);
         draft.processOutputs.delete(key);
-        draft.streamDescriptions.delete(key);
+        pendingDescriptions.delete(key);
       }
     }
 
     for (const [name, merged] of mergedStates) {
       draft.streamStates.set(name, merged);
-    }
-
-    // Hydrate streamDescriptions from StreamTabInfo (initial load / refresh).
-    // Only set — never delete here, because descriptions may have arrived via
-    // UPDATE_STREAM_DESCRIPTION before the stream payload carries them.
-    for (const stream of streams) {
-      if (stream.description) {
-        draft.streamDescriptions.set(stream.name, stream.description);
-      }
     }
 
     draft.streamById = newStreamById;
@@ -162,12 +160,12 @@ export const streamLifecycleHandlers: HandlerRegistry = {
     const cleaned = removePermissionsForStream(ctx.getPermissions(), streamId);
     ctx.setPermissions(cleaned);
 
+    pendingDescriptions.delete(streamId);
     ctx.setState((prev) =>
       create(prev, (draft) => {
         draft.streamStates.delete(streamId);
         draft.streamLogs.delete(streamId);
         draft.processOutputs.delete(streamId);
-        draft.streamDescriptions.delete(streamId);
         draft.streamById.delete(streamId);
         if (draft.activeStreamId === streamId) {
           draft.activeStreamId = null;
@@ -181,6 +179,7 @@ export const streamLifecycleHandlers: HandlerRegistry = {
     clearResolvedProposalIds();
     clearCopyContentStore();
     clearProposalInputStore();
+    pendingDescriptions.clear();
 
     // Clear all permissions — no streams means no valid permissions
     ctx.setPermissions([]);
@@ -191,7 +190,6 @@ export const streamLifecycleHandlers: HandlerRegistry = {
         draft.streamStates = new Map();
         draft.streamLogs = new Map();
         draft.processOutputs = new Map();
-        draft.streamDescriptions = new Map();
         draft.activeStreamId = null;
         draft.followupOptionsByStream = new Map();
       }),

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -99,14 +99,16 @@ export const streamMetaHandlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION]: (data, ctx) => {
     const { stream, description } = data;
-    ctx.setState((prev) => {
-      // If the stream isn't registered yet (subagent description racing
-      // UPDATE_STREAMS), buffer it; streamLifecycleSlice drains on arrival.
-      if (!prev.streamById.has(stream)) {
-        pendingDescriptions.set(stream, description);
-        return prev;
-      }
-      return create(prev, (draft) => {
+    // Subagent description can race its own UPDATE_STREAMS registration; if
+    // the stream isn't in streamById yet, buffer out-of-band so
+    // streamLifecycleSlice can drain it on arrival. Side effect lives
+    // outside the state updater so updater stays pure.
+    if (!ctx.getState().streamById.has(stream)) {
+      pendingDescriptions.set(stream, description);
+      return;
+    }
+    ctx.setState((prev) =>
+      create(prev, (draft) => {
         const existing = draft.streamById.get(stream);
         // Replace via set() so the Map value identity changes and selectors
         // observing streamById propagate the update (mirrors the pattern in
@@ -114,8 +116,8 @@ export const streamMetaHandlers: HandlerRegistry = {
         if (existing) {
           draft.streamById.set(stream, { ...existing, description });
         }
-      });
-    });
+      }),
+    );
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS]: (data, ctx) => {

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -6,13 +6,28 @@
 import { create } from 'mutative';
 
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
-import { STREAM_STATUS } from '@shared/schemas';
+import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 
 import { getStreamState, isToolUseState } from '../store';
 import type {
   HandlerRegistry,
   MessageHandlerContext,
 } from '../messageDispatcher';
+
+/**
+ * Buffer for subagent descriptions that race their own UPDATE_STREAMS
+ * registration. Lives as module state because it's purely transient plumbing
+ * between two slices, not state the UI needs to observe.
+ */
+export const pendingDescriptions = new Map<StreamTabId, string>();
+
+export function takePendingDescription(
+  streamId: StreamTabId,
+): string | undefined {
+  const desc = pendingDescriptions.get(streamId);
+  if (desc !== undefined) pendingDescriptions.delete(streamId);
+  return desc;
+}
 
 /** Max characters retained per output stream (stdout/stderr) per process. */
 const MAX_OUTPUT = 100_000;
@@ -84,14 +99,18 @@ export const streamMetaHandlers: HandlerRegistry = {
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION]: (data, ctx) => {
     const { stream, description } = data;
-    ctx.setState((prev) =>
-      create(prev, (draft) => {
-        draft.streamDescriptions.set(stream, description);
-        // Also update streamById entry if it exists (for consistency).
+    ctx.setState((prev) => {
+      // If the stream isn't registered yet (subagent description racing
+      // UPDATE_STREAMS), buffer it; streamLifecycleSlice drains on arrival.
+      if (!prev.streamById.has(stream)) {
+        pendingDescriptions.set(stream, description);
+        return prev;
+      }
+      return create(prev, (draft) => {
         const draftInfo = draft.streamById.get(stream);
         if (draftInfo) draftInfo.description = description;
-      }),
-    );
+      });
+    });
   },
 
   [PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS]: (data, ctx) => {

--- a/src/progressView/frontend/slices/streamMetaSlice.ts
+++ b/src/progressView/frontend/slices/streamMetaSlice.ts
@@ -107,8 +107,13 @@ export const streamMetaHandlers: HandlerRegistry = {
         return prev;
       }
       return create(prev, (draft) => {
-        const draftInfo = draft.streamById.get(stream);
-        if (draftInfo) draftInfo.description = description;
+        const existing = draft.streamById.get(stream);
+        // Replace via set() so the Map value identity changes and selectors
+        // observing streamById propagate the update (mirrors the pattern in
+        // stateUtils.updateParentStreamId).
+        if (existing) {
+          draft.streamById.set(stream, { ...existing, description });
+        }
       });
     });
   },

--- a/src/progressView/frontend/store.ts
+++ b/src/progressView/frontend/store.ts
@@ -68,10 +68,6 @@ export interface ProgressState {
   /** Background process outputs per stream — separated so output appends don't trigger meta context updates.
    *  Outer key: streamId, inner key: executionId → { stdout, stderr }. */
   processOutputs: Map<StreamTabId, ProcessOutputMap>;
-  /** AI-generated session descriptions keyed by stream ID.
-   *  Stored independently of streamById so descriptions arriving before
-   *  stream registration (common for subagents) are not dropped. */
-  streamDescriptions: Map<StreamTabId, string>;
 }
 
 /** Return the first stream ID from a streamById Map, or null if empty. */
@@ -91,7 +87,6 @@ export function createInitialState(): ProgressState {
     streamLogs: new Map(),
     followupOptionsByStream: new Map(),
     processOutputs: new Map(),
-    streamDescriptions: new Map(),
   };
 }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
 
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import {
@@ -374,12 +372,8 @@ export class WebviewUpdater {
       // setStreamStatus skipped release for the active tab, and the
       // filter-driven switch path doesn't go through setActiveStream.
       // Release here so the completed log doesn't stay pinned.
-      if (
-        previousActive &&
-        previousActive !== activeStream &&
-        !isInFlightStatus(StreamStatusService.get(previousActive))
-      ) {
-        state.streamLogs.releaseEntries(previousActive);
+      if (previousActive && previousActive !== activeStream) {
+        state.releasePreviousActive(previousActive);
       }
     }
 

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -345,7 +345,12 @@ export class WebviewUpdater {
     statuses?: Map<string, StreamStatus>,
     theme?: 'dark' | 'light',
   ): StreamTabId {
-    const streams = buildStreamInfos(state, state.agentCategoryFilter);
+    // Send every stream so streamById stays comprehensive for consumers like
+    // BackgroundTasksPanel that need to render cross-filter subagent children
+    // (e.g., tool-use subagents of a workflow orchestrator under a workflow
+    // filter). The frontend still applies `state.agentCategoryFilter` at the
+    // sidebar display layer via `tabStreams$`.
+    const streams = buildStreamInfos(state);
     const streamNames = streams.map((info) => info.name);
 
     // Compute valid active stream (pure query) and persist if changed

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -355,12 +355,9 @@ export class WebviewUpdater {
     // Active-stream validation still respects the filter so a filter change
     // auto-rotates to a matching tab instead of leaving a hidden tab selected.
     const filter = state.agentCategoryFilter;
-    const selectableNames =
-      filter === 'all'
-        ? streams.map((info) => info.name)
-        : streams
-            .filter((info) => info.agentCategory === filter)
-            .map((info) => info.name);
+    const selectableNames = streams
+      .filter((info) => filter === 'all' || info.agentCategory === filter)
+      .map((info) => info.name);
     const activeStream = state.pickValidActiveStream(selectableNames);
     if (activeStream !== state.activeStream) {
       state.activeStream = activeStream;

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import {
@@ -365,8 +367,20 @@ export class WebviewUpdater {
       selectableNames.length === 0
         ? ('' as StreamTabId)
         : state.pickValidActiveStream(selectableNames);
-    if (activeStream !== state.activeStream) {
+    const previousActive = state.activeStream;
+    if (activeStream !== previousActive) {
       state.activeStream = activeStream;
+      // The previously-active stream may have finished while visible —
+      // setStreamStatus skipped release for the active tab, and the
+      // filter-driven switch path doesn't go through setActiveStream.
+      // Release here so the completed log doesn't stay pinned.
+      if (
+        previousActive &&
+        previousActive !== activeStream &&
+        !isInFlightStatus(StreamStatusService.get(previousActive))
+      ) {
+        state.streamLogs.releaseEntries(previousActive);
+      }
     }
 
     if (!this.isAvailable()) {

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -351,10 +351,17 @@ export class WebviewUpdater {
     // filter). The frontend still applies `state.agentCategoryFilter` at the
     // sidebar display layer via `tabStreams$`.
     const streams = buildStreamInfos(state);
-    const streamNames = streams.map((info) => info.name);
 
-    // Compute valid active stream (pure query) and persist if changed
-    const activeStream = state.pickValidActiveStream(streamNames);
+    // Active-stream validation still respects the filter so a filter change
+    // auto-rotates to a matching tab instead of leaving a hidden tab selected.
+    const filter = state.agentCategoryFilter;
+    const selectableNames =
+      filter === 'all'
+        ? streams.map((info) => info.name)
+        : streams
+            .filter((info) => info.agentCategory === filter)
+            .map((info) => info.name);
+    const activeStream = state.pickValidActiveStream(selectableNames);
     if (activeStream !== state.activeStream) {
       state.activeStream = activeStream;
     }

--- a/src/progressView/managers/WebviewUpdater.ts
+++ b/src/progressView/managers/WebviewUpdater.ts
@@ -358,7 +358,13 @@ export class WebviewUpdater {
     const selectableNames = streams
       .filter((info) => filter === 'all' || info.agentCategory === filter)
       .map((info) => info.name);
-    const activeStream = state.pickValidActiveStream(selectableNames);
+    // When the filter excludes every stream, there's no valid tab to keep
+    // active; pickValidActiveStream's `[] || current` fallback would sticky
+    // on a hidden-category stream, so clear instead.
+    const activeStream =
+      selectableNames.length === 0
+        ? ('' as StreamTabId)
+        : state.pickValidActiveStream(selectableNames);
     if (activeStream !== state.activeStream) {
       state.activeStream = activeStream;
     }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { toErrorMessage } from '@common/errors';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -166,6 +168,18 @@ export class ProgressViewState {
       return current;
     }
     return availableStreams[0] || current;
+  }
+
+  /**
+   * Release a previously-active stream's entries if its status is not
+   * in-flight. `ProgressEventHandler.setStreamStatus` intentionally skips
+   * eviction for the active tab, so every active-stream switch path must
+   * call this on the stream being moved away from to close the loop.
+   */
+  releasePreviousActive(streamId: StreamTabId): void {
+    if (!isInFlightStatus(StreamStatusService.get(streamId))) {
+      this.streamLogs.releaseEntries(streamId);
+    }
   }
 
   get streamSortOrder(): StreamSort {


### PR DESCRIPTION
Collapse the duplicated `streamDescriptions` Map into
`streamById[name].description`. Descriptions now live on `StreamTabInfo`
only; consumers read them via the new `streamByIdContext`.

A module-level `pendingDescriptions` buffer handles the out-of-order case
(subagent `UPDATE_STREAM_DESCRIPTION` arriving before its stream is
registered in `streamById`); drained by `streamLifecycleSlice` when the
stream appears and cleared on stream/all delete.

https://claude.ai/code/session_01HMX2JEbhoPUiL52EyURbAk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches progress-view state/persistence and adds async rehydration/eviction paths for stream logs, which risks subtle race conditions (active-stream switching, flush/save, and disk read failures) affecting log visibility or persistence integrity.
> 
> **Overview**
> **Unifies stream metadata and descriptions** by removing the separate frontend `streamDescriptions` map and instead treating `streamById[streamId].description` as the single source of truth, exposed via a new `streamByIdContext`. A small `pendingDescriptions` buffer preserves out-of-order `UPDATE_STREAM_DESCRIPTION` events until the stream is registered, and is cleaned up on stream/all deletes.
> 
> **Adds bounded in-memory log eviction with safe rehydration**: `StreamLogStore` can now `releaseEntries()` to drop heavy log entries while retaining lightweight timestamp summaries for sorting, and `ensureLoaded()` to rehydrate from disk (deduped, merge-safe with concurrent appends, and guarded against load failures). Progress-view flow now rehydrates logs before syncing/rendering when switching streams or when a stream returns to an *in-flight* status, and evicts logs when a stream leaves the in-flight set (except the active tab), including closing a “terminal-while-active” gap via `ProgressViewState.releasePreviousActive()`.
> 
> **Adjusts metadata delivery and active-stream selection**: backend now sends all streams unfiltered to keep `streamById` comprehensive (e.g., for background subagent labels), while active-stream validation still respects the current filter and can explicitly clear selection when nothing matches (empty-string sentinel propagated to the frontend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d8e7eb9222e4f154d02a1b4c8cecce156ac4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->