### PR TITLE
Add error handling for legacy instruction backfill and persisted state

### DIFF
--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { cleanupInactiveAgents } from '@agent/toolUse/ToolUseAgentRegistry';
+import { toErrorMessage } from '@common/errors';
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import { AgentLogger } from '@logger/AgentLogger';
 import { StreamLogStore } from '@logger/StreamLogStore';
@@ -468,7 +469,8 @@ export class ProgressViewState {
           restoredCount++;
         } catch (err) {
           this.logger.warn(
-            `[Persistence] Failed to backfill legacy instruction for ${streamId}: ${String(err)}`,
+            `[Persistence] Failed to backfill legacy instruction for ${streamId}: ${toErrorMessage(err)}`,
+            { data: err },
           );
         }
       }),

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -426,44 +426,51 @@ export class ProgressViewState {
 
     await Promise.all(
       this.streamLogs.keys().map(async (streamId) => {
-        const store = getStreamTabStore(streamId);
-        const legacyInstruction = await store.readPreferredLegacyInstruction();
-        if (!legacyInstruction) return;
+        try {
+          const store = getStreamTabStore(streamId);
+          const legacyInstruction =
+            await store.readPreferredLegacyInstruction();
+          if (!legacyInstruction) return;
 
-        const text = legacyInstruction.text.trim();
-        if (!text) return;
+          const text = legacyInstruction.text.trim();
+          if (!text) return;
 
-        const log = this.streamLogs.get(streamId);
-        if (!log) return;
+          const log = this.streamLogs.get(streamId);
+          if (!log) return;
 
-        const alreadyPresent = log
-          .getRange(0, log.head)
-          .some(
-            (entry) =>
-              entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
-              entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
-              entry.text?.trim() === text,
+          const alreadyPresent = log
+            .getRange(0, log.head)
+            .some(
+              (entry) =>
+                entry.type === STREAM_LOG_ENTRY_TYPES.LOG &&
+                entry.messageType === MESSAGE_TYPES.USER_MESSAGE &&
+                entry.text?.trim() === text,
+            );
+          if (alreadyPresent) return;
+
+          const firstTimestamp = log.firstTimestamp;
+          const baseTimestamp =
+            legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
+          const timestamp =
+            firstTimestamp == null
+              ? baseTimestamp
+              : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
+
+          this.streamLogs.append(streamId, {
+            id: `legacy-instruction:${streamId}:${timestamp}`,
+            type: STREAM_LOG_ENTRY_TYPES.LOG,
+            level: LOG_LEVELS.INFO,
+            timestamp,
+            messageType: MESSAGE_TYPES.USER_MESSAGE,
+            text: legacyInstruction.text,
+            data: { source: 'legacyInstruction' },
+          });
+          restoredCount++;
+        } catch (err) {
+          this.logger.warn(
+            `[Persistence] Failed to backfill legacy instruction for ${streamId}: ${String(err)}`,
           );
-        if (alreadyPresent) return;
-
-        const firstTimestamp = log.firstTimestamp;
-        const baseTimestamp =
-          legacyInstruction.timestamp ?? firstTimestamp ?? Date.now();
-        const timestamp =
-          firstTimestamp == null
-            ? baseTimestamp
-            : Math.max(0, Math.min(baseTimestamp, firstTimestamp - 1));
-
-        this.streamLogs.append(streamId, {
-          id: `legacy-instruction:${streamId}:${timestamp}`,
-          type: STREAM_LOG_ENTRY_TYPES.LOG,
-          level: LOG_LEVELS.INFO,
-          timestamp,
-          messageType: MESSAGE_TYPES.USER_MESSAGE,
-          text: legacyInstruction.text,
-          data: { source: 'legacyInstruction' },
-        });
-        restoredCount++;
+        }
       }),
     );
 

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -101,21 +101,34 @@ export class PersistedState<T extends Record<string, unknown>> {
     if (result.success) {
       return result.data;
     }
-    // Fall back to schema defaults (parse undefined/empty object). Wrap in
-    // try/catch so a schema whose defaults don't cover every field can't
-    // take down the caller — a stale or malformed PersistedState key must
-    // never block webview activation or extension startup.
+    // Fall back to schema defaults via safeParse so a schema whose defaults
+    // don't cover every field can't throw out of a caller's constructor — a
+    // stale or malformed PersistedState key must never block webview
+    // activation or extension startup. Also persist the reset so the bad
+    // value is replaced and the next load doesn't keep hitting this path.
     const defaultResult = this.schema.safeParse({});
     if (defaultResult.success) {
       console.warn(
         `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
+        {
+          storedType: describeStored(stored),
+          issues: summarizeIssues(result.error),
+        },
       );
+      this.storage.set(this.key, defaultResult.data);
       return defaultResult.data;
     }
     console.warn(
       `[PersistedState] Invalid stored data and no default for ${this.key}; using empty object.`,
+      {
+        storedType: describeStored(stored),
+        storedIssues: summarizeIssues(result.error),
+        defaultIssues: summarizeIssues(defaultResult.error),
+      },
     );
-    return {} as T;
+    const empty = {} as T;
+    this.storage.set(this.key, empty);
+    return empty;
   }
 
   /** Get current state (shallow copy) */
@@ -141,7 +154,16 @@ export class PersistedState<T extends Record<string, unknown>> {
 
   /** Reset to schema defaults */
   reset(): void {
-    this.state = this.schema.parse({});
+    const defaultResult = this.schema.safeParse({});
+    if (defaultResult.success) {
+      this.state = defaultResult.data;
+    } else {
+      console.warn(
+        `[PersistedState] Reset has no schema defaults for ${this.key}; using empty object.`,
+        { issues: summarizeIssues(defaultResult.error) },
+      );
+      this.state = {} as T;
+    }
     this.storage.set(this.key, this.state);
   }
 
@@ -149,4 +171,33 @@ export class PersistedState<T extends Record<string, unknown>> {
   reload(): void {
     this.state = this.load();
   }
+}
+
+/**
+ * Produce a compact, log-safe description of a stored value. Tiny fingerprint
+ * so we can tell "undefined" from "object with these keys" from "string of
+ * length N" without dumping user data into the console.
+ */
+function describeStored(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return `array(len=${value.length})`;
+  const type = typeof value;
+  if (type === 'object') {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const preview = keys.slice(0, 6).join(',');
+    const suffix = keys.length > 6 ? `,+${keys.length - 6}` : '';
+    return `object{${preview}${suffix}}`;
+  }
+  if (type === 'string') return `string(len=${(value as string).length})`;
+  return type;
+}
+
+/** First few zod issues, trimmed so the console stays readable. */
+function summarizeIssues(error: z.ZodError): Array<Record<string, unknown>> {
+  return error.issues.slice(0, 5).map((issue) => ({
+    path: issue.path.join('.') || '(root)',
+    code: issue.code,
+    message: issue.message,
+  }));
 }

--- a/src/shared/state/PersistedState.ts
+++ b/src/shared/state/PersistedState.ts
@@ -101,11 +101,21 @@ export class PersistedState<T extends Record<string, unknown>> {
     if (result.success) {
       return result.data;
     }
+    // Fall back to schema defaults (parse undefined/empty object). Wrap in
+    // try/catch so a schema whose defaults don't cover every field can't
+    // take down the caller — a stale or malformed PersistedState key must
+    // never block webview activation or extension startup.
+    const defaultResult = this.schema.safeParse({});
+    if (defaultResult.success) {
+      console.warn(
+        `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
+      );
+      return defaultResult.data;
+    }
     console.warn(
-      `[PersistedState] Invalid stored data for ${this.key}, resetting.`,
+      `[PersistedState] Invalid stored data and no default for ${this.key}; using empty object.`,
     );
-    // Fall back to schema defaults (parse undefined/empty object)
-    return this.schema.parse({});
+    return {} as T;
   }
 
   /** Get current state (shallow copy) */


### PR DESCRIPTION
## Summary
This PR improves error handling and resilience in two critical areas: legacy instruction backfilling and persisted state initialization. These changes prevent individual stream failures from blocking the entire backfill process and ensure the application can recover gracefully from corrupted or invalid stored data.

## Key Changes

- **Legacy instruction backfill error handling**: Wrapped the legacy instruction backfill logic in a try-catch block to isolate failures per stream. If backfilling fails for one stream, the process continues for others instead of failing entirely. Errors are logged as warnings for debugging.

- **Persisted state fallback strategy**: Enhanced the state initialization to attempt schema defaults before falling back to an empty object. This provides a more graceful degradation path:
  - First tries to parse the stored data
  - If that fails, attempts to parse an empty object against the schema to get defaults
  - Only if both fail does it return an empty object and log a warning
  - This prevents malformed or stale persisted state from blocking webview activation or extension startup

## Implementation Details

- The legacy instruction backfill now logs specific stream IDs when failures occur, making it easier to diagnose issues
- The persisted state fallback distinguishes between "invalid data with defaults available" and "invalid data with no defaults" scenarios with appropriate warning messages
- Both changes maintain backward compatibility while improving robustness against edge cases

https://claude.ai/code/session_01FN8p86a9WBk48jfVdGBfYA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to persistence initialization/backfill error handling and add logging plus safer fallbacks; main risk is inadvertently resetting stored state in edge cases.
> 
> **Overview**
> Improves resilience of progress-view persistence by making legacy workflow-instruction backfill fault-tolerant per stream: failures are caught, logged with stream context, and no longer abort the overall backfill.
> 
> Hardens `PersistedState` initialization/reset so invalid stored values no longer throw: it now attempts to hydrate schema defaults via `safeParse({})`, persists the reset value back to storage, and falls back to an empty object only when the schema provides no defaults, with compact, log-safe diagnostics about the bad stored value and Zod issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485efac5d0138b5370716c2907e910c9d5612a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->