### PR TITLE
Add support for using own API key when relay quota exhausted

### DIFF
--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -233,14 +233,17 @@ export abstract class RetryableInvocationNode<
     if (result.shouldRetry) {
       this._persistent401Error = null;
       this._hasAttemptedTokenRefresh = false;
-      const formatted = formatProviderHttpError(error);
-      if (formatted.isRelayError && formatted.statusCode === 401) {
-        await tryRefreshClient(
-          this.services.refreshClient,
-          this.services.logger,
-          'before manual retry after relay 401',
-        );
-      }
+      // Always refresh the client on manual retry. The user may have
+      // taken actions between failure and retry that change how the
+      // client should be built — setting a new API key (quota /
+      // credit-depletion flow), toggling included-access mode, rotating
+      // a token after a relay 401, etc. Refreshing is cheap and keeps
+      // the cached client in sync with current secrets/config.
+      await tryRefreshClient(
+        this.services.refreshClient,
+        this.services.logger,
+        'before manual retry',
+      );
     }
 
     return result.shouldRetry;

--- a/src/agent/core/flows/RetryState.ts
+++ b/src/agent/core/flows/RetryState.ts
@@ -196,9 +196,12 @@ export abstract class RetryableInvocationNode<
     }
   }
 
-  /** Auth/permission errors (401, 403) skip auto-retries — they need human attention. */
+  /** Auth/permission errors (401, 403) and credential-exhausted errors
+   *  (relay monthly limit, upstream credit depletion) skip auto-retries —
+   *  they need human attention (switching keys, topping up). */
   shouldAutoRetry(error: Error): boolean {
     const formatted = formatProviderHttpError(error);
+    if (formatted.isCredentialExhausted) return false;
     const code = formatted.statusCode;
     return code !== 401 && code !== 403;
   }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -573,6 +573,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     retryable,
     isRelayError: isRelay,
     isCredentialExhausted: isCredentialExhausted || undefined,
+    isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
     requestId,
     rawErrorBody,
     streamDiagnostics,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -454,11 +454,28 @@ function isRelayError(rawErrorBody: unknown): boolean {
   return isObject(nested) && '_relay' in nested;
 }
 
+/** True when the relay rejected the request due to the user's monthly
+ *  spending limit being reached (supabase/functions/relay marks this with
+ *  `limitReached: true` in the error body). */
+function isRelayQuotaExhaustedBody(rawErrorBody: unknown): boolean {
+  if (!isObject(rawErrorBody)) return false;
+  if ((rawErrorBody as { limitReached?: unknown }).limitReached === true) {
+    return true;
+  }
+  const nested = (rawErrorBody as { error?: unknown }).error;
+  return (
+    isObject(nested) &&
+    (nested as { limitReached?: unknown }).limitReached === true
+  );
+}
+
 export function formatProviderHttpError(err: unknown): ProviderError {
   const rawErrorBody = detectRawErrorBody(err);
   const streamDiagnostics = detectStreamDiagnostics(err);
   const partialText = detectPartialText(err);
   const isRelay = isRelayError(rawErrorBody);
+  const isRelayQuotaExhausted =
+    isRelay && isRelayQuotaExhaustedBody(rawErrorBody);
 
   // Handle DOMException AbortError (from AbortController.abort())
   if (err instanceof DOMException && err.name === 'AbortError') {
@@ -479,6 +496,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       ...sdkMatch,
       retryable: isRelay || sdkMatch.retryable,
       isRelayError: isRelay,
+      isRelayQuotaExhausted: isRelayQuotaExhausted || undefined,
       rawErrorBody,
       streamDiagnostics,
       partialText,
@@ -516,6 +534,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     provider,
     retryable,
     isRelayError: isRelay,
+    isRelayQuotaExhausted: isRelayQuotaExhausted || undefined,
     requestId,
     rawErrorBody,
     streamDiagnostics,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -457,7 +457,7 @@ function isRelayError(rawErrorBody: unknown): boolean {
 /** True when the relay rejected the request due to the user's monthly
  *  spending limit being reached (supabase/functions/relay marks this with
  *  `limitReached: true` in the error body). */
-function isRelayQuotaExhaustedBody(rawErrorBody: unknown): boolean {
+function isRelayMonthlyLimitBody(rawErrorBody: unknown): boolean {
   if (!isObject(rawErrorBody)) return false;
   if ((rawErrorBody as { limitReached?: unknown }).limitReached === true) {
     return true;
@@ -469,13 +469,49 @@ function isRelayQuotaExhaustedBody(rawErrorBody: unknown): boolean {
   );
 }
 
+/** True when the upstream provider (Anthropic today) returned a credit-
+ *  balance-depleted 400. Match on the message prefix because Anthropic's
+ *  type is generic `invalid_request_error` — the message is the reliable
+ *  signal. Covers both the direct format and the enveloped format. */
+function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
+  if (!isObject(rawErrorBody)) return false;
+  const body = rawErrorBody as { type?: unknown; message?: unknown; error?: unknown };
+  const pick = (v: unknown): { type?: string; message?: string } | undefined =>
+    isObject(v)
+      ? {
+          type: isString((v as { type?: unknown }).type)
+            ? ((v as { type: string }).type)
+            : undefined,
+          message: isString((v as { message?: unknown }).message)
+            ? ((v as { message: string }).message)
+            : undefined,
+        }
+      : undefined;
+  const candidates = [pick(body), pick(body.error)];
+  return candidates.some(
+    (c) =>
+      c?.type === 'invalid_request_error' &&
+      typeof c.message === 'string' &&
+      c.message.toLowerCase().includes('credit balance is too low'),
+  );
+}
+
+function isCredentialExhaustedBody(rawErrorBody: unknown): boolean {
+  return (
+    isRelayMonthlyLimitBody(rawErrorBody) ||
+    isUpstreamCreditDepletedBody(rawErrorBody)
+  );
+}
+
 export function formatProviderHttpError(err: unknown): ProviderError {
   const rawErrorBody = detectRawErrorBody(err);
   const streamDiagnostics = detectStreamDiagnostics(err);
   const partialText = detectPartialText(err);
   const isRelay = isRelayError(rawErrorBody);
-  const isRelayQuotaExhausted =
-    isRelay && isRelayQuotaExhaustedBody(rawErrorBody);
+  // Credit exhaustion matches regardless of relay status: a direct
+  // Anthropic 400 "credit balance is too low" still wants the "Use your
+  // own API key" affordance so the user can switch credentials.
+  const isCredentialExhausted = isCredentialExhaustedBody(rawErrorBody);
 
   // Handle DOMException AbortError (from AbortController.abort())
   if (err instanceof DOMException && err.name === 'AbortError') {
@@ -494,9 +530,13 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   if (sdkMatch) {
     return {
       ...sdkMatch,
-      retryable: isRelay || sdkMatch.retryable,
+      // Credential-exhausted errors are not auto-retried (see
+      // RetryableInvocationNode.shouldAutoRetry) but the retry panel
+      // still surfaces with the "Use your own API key" button, so the
+      // `retryable` flag stays true here.
+      retryable: isRelay || sdkMatch.retryable || isCredentialExhausted,
       isRelayError: isRelay,
-      isRelayQuotaExhausted: isRelayQuotaExhausted || undefined,
+      isCredentialExhausted: isCredentialExhausted || undefined,
       rawErrorBody,
       streamDiagnostics,
       partialText,
@@ -517,7 +557,9 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // No status code on an unrecognized error likely means a network-level failure
   // (DNS, proxy, TLS, etc.) — treat as retryable for safety.
   const retryable =
-    isRelay || (statusCode ? isRetryableStatusCode(statusCode) : true);
+    isRelay ||
+    isCredentialExhausted ||
+    (statusCode ? isRetryableStatusCode(statusCode) : true);
 
   let message = finalMessage;
   if (statusCode) {
@@ -534,7 +576,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
     provider,
     retryable,
     isRelayError: isRelay,
-    isRelayQuotaExhausted: isRelayQuotaExhausted || undefined,
+    isCredentialExhausted: isCredentialExhausted || undefined,
     requestId,
     rawErrorBody,
     streamDiagnostics,

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -265,9 +265,15 @@ function detectProvider(err: unknown): string | undefined {
   const lowered = candidate.constructor?.name?.toLowerCase();
   if (!lowered) return undefined;
 
-  return (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+  // Match SDK class-name fragments, then normalize aliases to the
+  // canonical API-provider names used by SecretManager / model handlers.
+  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
+  // (class name contains "kimi") maps to "moonshot".
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (p) => lowered.includes(p),
   );
+  if (match === 'kimi') return 'moonshot';
+  return match;
 }
 
 /** Extract request ID from SDK errors (property or headers). */

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -496,13 +496,6 @@ function isUpstreamCreditDepletedBody(rawErrorBody: unknown): boolean {
   );
 }
 
-function isCredentialExhaustedBody(rawErrorBody: unknown): boolean {
-  return (
-    isRelayMonthlyLimitBody(rawErrorBody) ||
-    isUpstreamCreditDepletedBody(rawErrorBody)
-  );
-}
-
 export function formatProviderHttpError(err: unknown): ProviderError {
   const rawErrorBody = detectRawErrorBody(err);
   const streamDiagnostics = detectStreamDiagnostics(err);
@@ -511,7 +504,9 @@ export function formatProviderHttpError(err: unknown): ProviderError {
   // Credit exhaustion matches regardless of relay status: a direct
   // Anthropic 400 "credit balance is too low" still wants the "Use your
   // own API key" affordance so the user can switch credentials.
-  const isCredentialExhausted = isCredentialExhaustedBody(rawErrorBody);
+  const isUpstreamCreditDepleted = isUpstreamCreditDepletedBody(rawErrorBody);
+  const isCredentialExhausted =
+    isRelayMonthlyLimitBody(rawErrorBody) || isUpstreamCreditDepleted;
 
   // Handle DOMException AbortError (from AbortController.abort())
   if (err instanceof DOMException && err.name === 'AbortError') {
@@ -537,6 +532,7 @@ export function formatProviderHttpError(err: unknown): ProviderError {
       retryable: isRelay || sdkMatch.retryable || isCredentialExhausted,
       isRelayError: isRelay,
       isCredentialExhausted: isCredentialExhausted || undefined,
+      isUpstreamCreditDepleted: isUpstreamCreditDepleted || undefined,
       rawErrorBody,
       streamDiagnostics,
       partialText,

--- a/src/common/webview/progressViewCommands.ts
+++ b/src/common/webview/progressViewCommands.ts
@@ -36,6 +36,7 @@ export const PROGRESS_VIEW_COMMANDS = {
   COMPACT_RESPONSE: 'compactResponse',
   RETRY_STREAM_REQUEST: 'retryStreamRequest',
   CANCEL_RETRY_REQUEST: 'cancelRetryRequest',
+  USE_OWN_API_KEY: 'useOwnApiKey',
   DIFF_STREAM: 'diffStream',
   PACK_STREAM: 'packStream',
   SORT_STREAMS: 'sortStreams',

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -12,6 +12,8 @@ import {
   validateExecutionRequest,
   type ExecutionRequest,
 } from '@agent/core/executionRequests';
+import { getServerSideKeyService } from '@auth/serverKeys';
+import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
 import {
   BaseViewMessageHandler,
@@ -19,6 +21,7 @@ import {
   PROGRESS_VIEW_COMMANDS,
 } from '@common/webview';
 import { RecordingManager } from '@common/managers/RecordingManager';
+import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
@@ -190,6 +193,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.CANCEL_RETRY_REQUEST]: (data) => {
         retryCoordinator.cancelRetry(data.stream);
       },
+      [PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY]: (data) =>
+        this.handleUseOwnApiKey(data),
       [PROGRESS_VIEW_COMMANDS.RESTORE_STATE]: async (data) => {
         const taskState = this.provider.state.meta.getTaskState(data.stream);
         if (taskState) {
@@ -468,6 +473,36 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         'No retryable request is available for this stream yet.',
       );
     }
+  }
+
+  private async handleUseOwnApiKey(
+    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY>,
+  ): Promise<void> {
+    const providerArg = (SecretManager.API_PROVIDERS as readonly string[]).includes(
+      data.provider ?? '',
+    )
+      ? (data.provider as ApiProvider)
+      : undefined;
+
+    await vscode.commands.executeCommand(
+      apiKeyCommands.setApiKey,
+      providerArg,
+    );
+
+    // Check whether a usable key is available for the offending provider.
+    // If so, disable server-side relay so the retry uses the user's key and
+    // resolve the waiting retry prompt. Otherwise leave the panel open — the
+    // user can still choose Retry or Dismiss.
+    const hasKey = providerArg
+      ? await SecretManager.hasUsableApiKey(providerArg)
+      : await SecretManager.anyApiKeyExists();
+
+    if (!hasKey) {
+      return;
+    }
+
+    await getServerSideKeyService().setUseIncludedModelAccess(false);
+    retryCoordinator.triggerRetry(data.stream);
   }
 
   private async handleDiffStream(

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -489,15 +489,14 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       providerArg,
     );
 
-    // Check whether a usable key is available for the offending provider.
-    // If so, disable server-side relay so the retry uses the user's key and
-    // resolve the waiting retry prompt. Otherwise leave the panel open — the
-    // user can still choose Retry or Dismiss.
-    const hasKey = providerArg
-      ? await SecretManager.hasUsableApiKey(providerArg)
-      : await SecretManager.anyApiKeyExists();
-
-    if (!hasKey) {
+    // Only auto-resume when the user has a usable personal key for the
+    // offending provider. `anyApiKeyExists()` is deliberately NOT used as a
+    // fallback: it also returns true when relay/included access is available,
+    // which would let a user who cancelled the key picker silently flip off
+    // server-side access and strand the stream with no usable credential.
+    // If we can't identify the provider or verify the key, leave the panel
+    // open — the user can click Retry explicitly.
+    if (!providerArg || !(await SecretManager.hasUsableApiKey(providerArg))) {
       return;
     }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -485,30 +485,53 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       ? (data.provider as ApiProvider)
       : undefined;
 
+    // Snapshot all per-provider key values so we can detect which
+    // provider the user set or changed when providerArg is unknown.
+    // `anyApiKeyExists()` is deliberately NOT used — it also returns true
+    // when only relay access is available, which would let a user who
+    // cancelled without any personal key silently flip off server-side
+    // access.
+    const snapshotKeys = async () =>
+      new Map(
+        await Promise.all(
+          SecretManager.API_PROVIDERS.map(
+            async (p) =>
+              [
+                p,
+                await SecretManager.get(SecretManager.getApiKeySecretName(p)),
+              ] as const,
+          ),
+        ),
+      );
+    const before = providerArg ? undefined : await snapshotKeys();
+
     await vscode.commands.executeCommand(
       apiKeyCommands.setApiKey,
       providerArg,
     );
 
-    // Auto-resume when a usable personal key exists. If the offending
-    // provider is known we check it specifically; otherwise (relay errors
-    // without a provider attribution, or setApiKey ran with the provider
-    // picker) we accept any usable personal key as consent to flip off
-    // server-side access. `anyApiKeyExists()` is deliberately NOT used —
-    // it also returns true when only relay access is available, which
-    // would let a user who cancelled without any personal key silently
-    // flip off server-side access.
-    const hasUsableKey = providerArg
-      ? await SecretManager.hasUsableApiKey(providerArg)
-      : (
-          await Promise.all(
-            SecretManager.API_PROVIDERS.map((p) =>
-              SecretManager.hasUsableApiKey(p),
-            ),
-          )
-        ).some(Boolean);
+    let shouldProceed: boolean;
+    if (providerArg) {
+      // Known provider: any usable key for THAT provider counts as
+      // consent to switch modes (the button label advertises the flip).
+      shouldProceed = await SecretManager.hasUsableApiKey(providerArg);
+    } else {
+      // Unknown provider: require evidence that the user actually stored
+      // or changed a per-provider key in this flow. Without this check
+      // a stale key for an unrelated provider would satisfy the gate
+      // and strand the stream with no credential for the failing one.
+      const after = await snapshotKeys();
+      shouldProceed = SecretManager.API_PROVIDERS.some((p) => {
+        const next = after.get(p);
+        return (
+          typeof next === 'string' &&
+          next.trim().length > 0 &&
+          next !== before!.get(p)
+        );
+      });
+    }
 
-    if (!hasUsableKey) {
+    if (!shouldProceed) {
       return;
     }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -539,8 +539,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    await getServerSideKeyService().setUseIncludedModelAccess(false);
-    invalidateModelOptionsCache();
+    // Only disable relay access when the failing call actually went
+    // through relay. If the error came from a direct-key call (e.g.
+    // user's own Anthropic key ran out of credit on a tier that
+    // routes Anthropic directly while other providers still go via
+    // relay), flipping the global mode would revoke relay for the
+    // other providers too.
+    if (data.viaRelay === true) {
+      await getServerSideKeyService().setUseIncludedModelAccess(false);
+      invalidateModelOptionsCache();
+    }
     const retried = retryCoordinator.triggerRetry(data.stream);
     if (!retried) {
       await vscode.window.showInformationMessage(

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -30,6 +30,7 @@ import {
   type TaskState,
   type WorkflowTaskState,
 } from '@logger/TaskState';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import {
   CHAT_INSTRUCTION_TEMPLATE,
@@ -484,23 +485,36 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       ? (data.provider as ApiProvider)
       : undefined;
 
+    // Snapshot the per-provider key before the picker so we can tell whether
+    // the user actually stored a new credential. Without a known provider we
+    // skip the snapshot + auto-resume path entirely — the user can still set
+    // a key via the picker and click Retry explicitly.
+    const secretName = providerArg
+      ? SecretManager.getApiKeySecretName(providerArg)
+      : undefined;
+    const keyBefore = secretName
+      ? await SecretManager.get(secretName)
+      : undefined;
+
     await vscode.commands.executeCommand(
       apiKeyCommands.setApiKey,
       providerArg,
     );
 
-    // Only auto-resume when the user has a usable personal key for the
-    // offending provider. `anyApiKeyExists()` is deliberately NOT used as a
-    // fallback: it also returns true when relay/included access is available,
-    // which would let a user who cancelled the key picker silently flip off
-    // server-side access and strand the stream with no usable credential.
-    // If we can't identify the provider or verify the key, leave the panel
-    // open — the user can click Retry explicitly.
-    if (!providerArg || !(await SecretManager.hasUsableApiKey(providerArg))) {
+    if (!providerArg || !secretName) {
+      return;
+    }
+
+    // Auto-resume only when the key value actually changed. Cancelling the
+    // picker leaves secrets unchanged even if a stale key existed, so this
+    // avoids a spurious retry after explicit cancellation.
+    const keyAfter = await SecretManager.get(secretName);
+    if (!keyAfter || keyAfter === keyBefore) {
       return;
     }
 
     await getServerSideKeyService().setUseIncludedModelAccess(false);
+    invalidateModelOptionsCache();
     retryCoordinator.triggerRetry(data.stream);
   }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -485,25 +485,28 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       ? (data.provider as ApiProvider)
       : undefined;
 
-    // Snapshot all per-provider key values so we can detect which
-    // provider the user set or changed when providerArg is unknown.
-    // `anyApiKeyExists()` is deliberately NOT used — it also returns true
-    // when only relay access is available, which would let a user who
-    // cancelled without any personal key silently flip off server-side
-    // access.
-    const snapshotKeys = async () =>
-      new Map(
-        await Promise.all(
-          SecretManager.API_PROVIDERS.map(
-            async (p) =>
-              [
-                p,
-                await SecretManager.get(SecretManager.getApiKeySecretName(p)),
-              ] as const,
+    // The gate depends on WHICH credential is exhausted:
+    //   - Upstream credit depletion (Anthropic 400 "credit balance is
+    //     too low"): the STORED key is the broken one, so we require
+    //     evidence of a key change.
+    //   - Relay monthly limit (or unknown provider): the stored key is
+    //     fine, so any usable key counts as consent.
+    // `anyApiKeyExists()` is deliberately NOT used — it also returns
+    // true when only relay access is available.
+    const providersToCheck = providerArg
+      ? [providerArg]
+      : SecretManager.API_PROVIDERS;
+    const readKey = (p: ApiProvider) =>
+      SecretManager.get(SecretManager.getApiKeySecretName(p));
+
+    const requireChange = data.upstreamCreditDepleted === true;
+    const before = requireChange
+      ? new Map(
+          await Promise.all(
+            providersToCheck.map(async (p) => [p, await readKey(p)] as const),
           ),
-        ),
-      );
-    const before = providerArg ? undefined : await snapshotKeys();
+        )
+      : undefined;
 
     await vscode.commands.executeCommand(
       apiKeyCommands.setApiKey,
@@ -511,17 +514,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
 
     let shouldProceed: boolean;
-    if (providerArg) {
-      // Known provider: any usable key for THAT provider counts as
-      // consent to switch modes (the button label advertises the flip).
-      shouldProceed = await SecretManager.hasUsableApiKey(providerArg);
-    } else {
-      // Unknown provider: require evidence that the user actually stored
-      // or changed a per-provider key in this flow. Without this check
-      // a stale key for an unrelated provider would satisfy the gate
-      // and strand the stream with no credential for the failing one.
-      const after = await snapshotKeys();
-      shouldProceed = SecretManager.API_PROVIDERS.some((p) => {
+    if (requireChange) {
+      const after = new Map(
+        await Promise.all(
+          providersToCheck.map(async (p) => [p, await readKey(p)] as const),
+        ),
+      );
+      shouldProceed = providersToCheck.some((p) => {
         const next = after.get(p);
         return (
           typeof next === 'string' &&
@@ -529,6 +528,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           next !== before!.get(p)
         );
       });
+    } else {
+      const usable = await Promise.all(
+        providersToCheck.map((p) => SecretManager.hasUsableApiKey(p)),
+      );
+      shouldProceed = usable.some(Boolean);
     }
 
     if (!shouldProceed) {

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -490,15 +490,25 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       providerArg,
     );
 
-    // Auto-resume when a usable personal key exists for the offending
-    // provider — including the case where the user already had one stored
-    // and simply confirmed (or cancelled) the picker. The button label
-    // "Use your own API key" advertises the mode switch, so treating an
-    // existing stored key as consent is the behaviour users expect.
-    // `anyApiKeyExists()` is deliberately NOT used: it also returns true
-    // when relay access is available, which would let a user who cancelled
-    // without any personal key flip off server-side access.
-    if (!providerArg || !(await SecretManager.hasUsableApiKey(providerArg))) {
+    // Auto-resume when a usable personal key exists. If the offending
+    // provider is known we check it specifically; otherwise (relay errors
+    // without a provider attribution, or setApiKey ran with the provider
+    // picker) we accept any usable personal key as consent to flip off
+    // server-side access. `anyApiKeyExists()` is deliberately NOT used —
+    // it also returns true when only relay access is available, which
+    // would let a user who cancelled without any personal key silently
+    // flip off server-side access.
+    const hasUsableKey = providerArg
+      ? await SecretManager.hasUsableApiKey(providerArg)
+      : (
+          await Promise.all(
+            SecretManager.API_PROVIDERS.map((p) =>
+              SecretManager.hasUsableApiKey(p),
+            ),
+          )
+        ).some(Boolean);
+
+    if (!hasUsableKey) {
       return;
     }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -485,31 +485,20 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       ? (data.provider as ApiProvider)
       : undefined;
 
-    // Snapshot the per-provider key before the picker so we can tell whether
-    // the user actually stored a new credential. Without a known provider we
-    // skip the snapshot + auto-resume path entirely — the user can still set
-    // a key via the picker and click Retry explicitly.
-    const secretName = providerArg
-      ? SecretManager.getApiKeySecretName(providerArg)
-      : undefined;
-    const keyBefore = secretName
-      ? await SecretManager.get(secretName)
-      : undefined;
-
     await vscode.commands.executeCommand(
       apiKeyCommands.setApiKey,
       providerArg,
     );
 
-    if (!providerArg || !secretName) {
-      return;
-    }
-
-    // Auto-resume only when the key value actually changed. Cancelling the
-    // picker leaves secrets unchanged even if a stale key existed, so this
-    // avoids a spurious retry after explicit cancellation.
-    const keyAfter = await SecretManager.get(secretName);
-    if (!keyAfter || keyAfter === keyBefore) {
+    // Auto-resume when a usable personal key exists for the offending
+    // provider — including the case where the user already had one stored
+    // and simply confirmed (or cancelled) the picker. The button label
+    // "Use your own API key" advertises the mode switch, so treating an
+    // existing stored key as consent is the behaviour users expect.
+    // `anyApiKeyExists()` is deliberately NOT used: it also returns true
+    // when relay access is available, which would let a user who cancelled
+    // without any personal key flip off server-side access.
+    if (!providerArg || !(await SecretManager.hasUsableApiKey(providerArg))) {
       return;
     }
 

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -514,7 +514,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     await getServerSideKeyService().setUseIncludedModelAccess(false);
     invalidateModelOptionsCache();
-    retryCoordinator.triggerRetry(data.stream);
+    const retried = retryCoordinator.triggerRetry(data.stream);
+    if (!retried) {
+      await vscode.window.showInformationMessage(
+        'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
+      );
+    }
   }
 
   private async handleDiffStream(

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -37,10 +37,17 @@ export class RetryRequestPanel extends BaseRequestPanel {
   ];
 
   override handleKeyboardShortcut(key: string): boolean {
+    const data = this.permission.data as RetryPermission;
     switch (key) {
       case 'r':
         this.emitAction('retry');
         return true;
+      case 'k':
+        if (data.errorDetails?.isRelayQuotaExhausted) {
+          this.emitAction('useOwnApiKey');
+          return true;
+        }
+        return false;
       case 'escape':
         this.emitAction('cancel');
         return true;
@@ -52,6 +59,8 @@ export class RetryRequestPanel extends BaseRequestPanel {
   override render(): TemplateResult {
     const data = this.permission.data as RetryPermission;
     const isRelay = data.errorDetails?.isRelayError === true;
+    const isQuotaExhausted =
+      data.errorDetails?.isRelayQuotaExhausted === true;
     const retryable = data.errorDetails?.retryable !== false;
     const metaParts = [
       data.model ? `Model: ${data.model}` : null,
@@ -94,6 +103,18 @@ export class RetryRequestPanel extends BaseRequestPanel {
             : nothing}
         </div>
         <vscode-toolbar-container class="retry-request__actions">
+          ${when(
+            isQuotaExhausted,
+            () => html`
+              <vscode-toolbar-button
+                icon="key"
+                label="Use your own API key"
+                title="Use your own API key (k)"
+                @click=${() => this.emitAction('useOwnApiKey')}
+                >Use your own API key</vscode-toolbar-button
+              >
+            `,
+          )}
           <vscode-toolbar-button
             icon="refresh"
             label="Retry"

--- a/src/progressView/frontend/components/RetryRequestPanel.ts
+++ b/src/progressView/frontend/components/RetryRequestPanel.ts
@@ -43,7 +43,7 @@ export class RetryRequestPanel extends BaseRequestPanel {
         this.emitAction('retry');
         return true;
       case 'k':
-        if (data.errorDetails?.isRelayQuotaExhausted) {
+        if (data.errorDetails?.isCredentialExhausted) {
           this.emitAction('useOwnApiKey');
           return true;
         }
@@ -59,8 +59,8 @@ export class RetryRequestPanel extends BaseRequestPanel {
   override render(): TemplateResult {
     const data = this.permission.data as RetryPermission;
     const isRelay = data.errorDetails?.isRelayError === true;
-    const isQuotaExhausted =
-      data.errorDetails?.isRelayQuotaExhausted === true;
+    const isCredentialExhausted =
+      data.errorDetails?.isCredentialExhausted === true;
     const retryable = data.errorDetails?.retryable !== false;
     const metaParts = [
       data.model ? `Model: ${data.model}` : null,
@@ -104,7 +104,7 @@ export class RetryRequestPanel extends BaseRequestPanel {
         </div>
         <vscode-toolbar-container class="retry-request__actions">
           ${when(
-            isQuotaExhausted,
+            isCredentialExhausted,
             () => html`
               <vscode-toolbar-button
                 icon="key"

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -285,6 +285,16 @@ export function handlePermissionAction(
       break;
     }
     case PERMISSION_KIND.RETRY:
+      if (action === 'useOwnApiKey') {
+        // Non-terminal: panel stays open. The extension handler will
+        // trigger retry on success, or leave the panel for the user
+        // to choose Retry/Dismiss if the user cancels the key picker.
+        postMessage(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
+          stream: permission.data.streamId,
+          provider: permission.data.errorDetails?.provider,
+        });
+        break;
+      }
       if (action === 'retry') {
         postMessage(PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST, {
           stream: permission.data.streamId,

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -296,6 +296,10 @@ export function handlePermissionAction(
             permission.data.errorDetails?.isUpstreamCreditDepleted === true
               ? true
               : undefined,
+          viaRelay:
+            permission.data.errorDetails?.isRelayError === true
+              ? true
+              : undefined,
         });
         break;
       }

--- a/src/progressView/frontend/eventHandlers.ts
+++ b/src/progressView/frontend/eventHandlers.ts
@@ -292,6 +292,10 @@ export function handlePermissionAction(
         postMessage(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY, {
           stream: permission.data.streamId,
           provider: permission.data.errorDetails?.provider,
+          upstreamCreditDepleted:
+            permission.data.errorDetails?.isUpstreamCreditDepleted === true
+              ? true
+              : undefined,
         });
         break;
       }

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -33,12 +33,15 @@ const ProviderErrorSchema = z.object({
   isRelayError: z.boolean(),
   /** True when the credential (relay monthly limit OR upstream provider
    *  account) has been exhausted. Auto-retry is skipped for these errors
-   *  and the retry panel offers a "Use your own API key" button. Covers:
-   *   - relay 429 with limitReached=true (relay's own monthly cap)
-   *   - Anthropic 400 invalid_request_error with "credit balance is too
-   *     low" (upstream account out of credit — same whether the request
-   *     came via relay or a direct key). */
+   *  and the retry panel offers a "Use your own API key" button. */
   isCredentialExhausted: z.boolean().optional(),
+  /** True when the upstream provider account itself is out of credit
+   *  (Anthropic 400 "credit balance is too low"). Distinguishes the
+   *  "the key I have IS the broken one" case from relay monthly limit,
+   *  where the stored personal key is fine. The auto-resume handler
+   *  uses this to require a new key rather than reusing the depleted
+   *  stored credential. */
+  isUpstreamCreditDepleted: z.boolean().optional(),
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -31,6 +31,10 @@ const ProviderErrorSchema = z.object({
   provider: z.string().optional(),
   retryable: z.boolean(),
   isRelayError: z.boolean(),
+  /** True when the relay returned a monthly-spending-limit 429 (limitReached).
+   *  Distinguishes quota-exhausted from transient upstream rate limits so the
+   *  UI can offer switching to a user-owned API key. */
+  isRelayQuotaExhausted: z.boolean().optional(),
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),

--- a/src/shared/schemas/errors.ts
+++ b/src/shared/schemas/errors.ts
@@ -31,10 +31,14 @@ const ProviderErrorSchema = z.object({
   provider: z.string().optional(),
   retryable: z.boolean(),
   isRelayError: z.boolean(),
-  /** True when the relay returned a monthly-spending-limit 429 (limitReached).
-   *  Distinguishes quota-exhausted from transient upstream rate limits so the
-   *  UI can offer switching to a user-owned API key. */
-  isRelayQuotaExhausted: z.boolean().optional(),
+  /** True when the credential (relay monthly limit OR upstream provider
+   *  account) has been exhausted. Auto-retry is skipped for these errors
+   *  and the retry panel offers a "Use your own API key" button. Covers:
+   *   - relay 429 with limitReached=true (relay's own monthly cap)
+   *   - Anthropic 400 invalid_request_error with "credit balance is too
+   *     low" (upstream account out of credit — same whether the request
+   *     came via relay or a direct key). */
+  isCredentialExhausted: z.boolean().optional(),
   requestId: z.string().optional(),
   rawErrorBody: z.unknown().optional(),
   streamDiagnostics: StreamDiagnosticsSchema.optional(),

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -544,6 +544,11 @@ const UseOwnApiKeyMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY),
   stream: StreamTabIdSchema,
   provider: z.string().optional(),
+  /** True when the underlying cause is an upstream provider credit
+   *  depletion (Anthropic 400 "credit balance is too low"), meaning the
+   *  stored key IS the depleted credential. The handler requires a new
+   *  key for these rather than reusing the stored one. */
+  upstreamCreditDepleted: z.boolean().optional(),
 });
 
 const ToggleToolEditApprovalBypassMessageSchema = z.object({

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -549,6 +549,11 @@ const UseOwnApiKeyMessageSchema = z.object({
    *  stored key IS the depleted credential. The handler requires a new
    *  key for these rather than reusing the stored one. */
   upstreamCreditDepleted: z.boolean().optional(),
+  /** True when the failing request went through the TeXRA relay. When
+   *  false, relay wasn't in the path (direct-key call) and the handler
+   *  must not globally disable relay access — other providers may still
+   *  be served successfully by relay. */
+  viaRelay: z.boolean().optional(),
 });
 
 const ToggleToolEditApprovalBypassMessageSchema = z.object({

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -540,6 +540,12 @@ const CancelRetryRequestMessageSchema = z.object({
   stream: StreamTabIdSchema,
 });
 
+const UseOwnApiKeyMessageSchema = z.object({
+  command: z.literal(PROGRESS_VIEW_COMMANDS.USE_OWN_API_KEY),
+  stream: StreamTabIdSchema,
+  provider: z.string().optional(),
+});
+
 const ToggleToolEditApprovalBypassMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS),
   stream: StreamTabIdSchema,
@@ -717,6 +723,7 @@ export const ProgressViewInboundMessageSchema = z.discriminatedUnion(
     PolishFollowUpMessageSchema,
     RetryStreamRequestMessageSchema,
     CancelRetryRequestMessageSchema,
+    UseOwnApiKeyMessageSchema,
     StartRecordingMessageSchema,
     StopRecordingMessageSchema,
     PopOutMessageSchema,


### PR DESCRIPTION
## Summary
This PR adds functionality to allow users to switch to their own API key when the relay service has exhausted their monthly spending limit. When a relay quota exhaustion error occurs, users can now press 'k' or click a "Use your own API key" button to configure their own API credentials and automatically retry the request.

## Key Changes

- **Error Detection**: Added `isRelayQuotaExhaustedBody()` function to detect when relay returns a quota exhaustion error (marked by `limitReached: true` in the error body)
- **Error Schema**: Extended `ProviderError` schema with new optional `isRelayQuotaExhausted` field to distinguish quota exhaustion from transient rate limits
- **UI Components**: 
  - Added keyboard shortcut 'k' in `RetryRequestPanel` to trigger the "Use your own API key" action
  - Added conditional "Use your own API key" button that appears only when quota is exhausted
- **Message Handling**: 
  - Added new `USE_OWN_API_KEY` command to `PROGRESS_VIEW_COMMANDS`
  - Implemented `handleUseOwnApiKey()` handler that validates the provider, opens the API key picker, and automatically triggers retry if a valid key is configured
- **Server-side Integration**: Disables server-side relay access (`setUseIncludedModelAccess(false)`) when user provides their own key, ensuring the retry uses the user's credentials
- **Schema Updates**: Added `UseOwnApiKeyMessageSchema` to validate the new message type with stream ID and optional provider

## Implementation Details

The flow works as follows:
1. When a relay quota exhaustion error is detected, the error details include `isRelayQuotaExhausted: true`
2. The retry panel displays the "Use your own API key" button and enables the 'k' keyboard shortcut
3. User action triggers the `USE_OWN_API_KEY` command with the affected provider
4. The handler validates the provider, opens the API key configuration dialog
5. If a usable key is configured, server-side relay is disabled and retry is automatically triggered
6. If the user cancels the key picker, the panel remains open for manual retry/dismiss

https://claude.ai/code/session_01KqL1Zdr7qG7Fdigt1dnBEh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recovery path that changes retry behavior and can toggle off included/relay access based on error classification, which could affect how subsequent model requests are authenticated. Risk is mitigated by gating on detected exhaustion signals and only disabling relay when the failing call actually went through relay.
> 
> **Overview**
> Enables a new *"Use your own API key"* escape hatch when requests fail due to **credential exhaustion** (relay monthly limit or upstream credit depletion), wiring this through error formatting, schemas, webview commands, and the retry UI.
> 
> `formatProviderHttpError` now detects relay monthly-limit (`limitReached: true`) and Anthropic credit-depletion messages, surfaces `isCredentialExhausted`/`isUpstreamCreditDepleted`, and maps `kimi` SDK errors to canonical provider `moonshot`. Auto-retry is skipped for these exhaustion cases, while manual retry always refreshes the cached model client.
> 
> The retry panel adds a conditional button and `k` shortcut that sends a new `USE_OWN_API_KEY` message; the extension handler opens the API key picker, validates that a usable key (or a changed key for upstream depletion) exists, optionally disables included/relay access (only if the failed call used relay) and then triggers an automatic retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f295bb4f4efd57dffffbda8060ba20539a2dee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->