### PR TITLE
[codex] Fix DeepSeek delegation tool parsing

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -18,7 +18,6 @@ import {
 import { isAssistantMessage } from 'openai/lib/chatCompletionUtils';
 import {
   assertToolCallsAreChatCompletionFunctionToolCalls,
-  validateInputTools,
 } from 'openai/lib/parser';
 
 // Local imports - agent components
@@ -420,8 +419,10 @@ export class ModelHandlerOpenAI<
       if (!parallelToolCalls) {
         baseParams.parallel_tool_calls = false;
       }
+      // These tools are parsed by TeXRA after the response. The SDK's
+      // auto-parse validator requires strict schemas, but several TeXRA tools
+      // intentionally expose nullable or optional fields.
       const convertedTools = toOpenAITools(tools);
-      validateInputTools(convertedTools);
       baseParams.tools = convertedTools;
       baseParams.tool_choice = 'auto';
     }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -70,7 +70,6 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
       name: d.name,
       description: d.description,
       parameters: convertToolSchema(d),
-      strict: true,
     },
   })) as ChatCompletionTool[];
 }

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -70,6 +70,7 @@ export function toOpenAITools(defs: ToolDefinition[]): ChatCompletionTool[] {
       name: d.name,
       description: d.description,
       parameters: convertToolSchema(d),
+      strict: true,
     },
   })) as ChatCompletionTool[];
 }

--- a/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
@@ -11,6 +11,10 @@ import {
 // Local imports - agent
 import { ModelHandlerDeepSeek } from '@agent/modelHandlers/modelHandlerDeepSeek';
 
+// Type imports
+import type { AgentLogger } from '@logger/AgentLogger';
+import type { ToolDefinition } from '@model';
+
 function thinkingFor(
   fullName: string,
   supportsReasoning: boolean,
@@ -21,6 +25,52 @@ function thinkingFor(
     capabilities: { ...DEFAULT_MODEL_CAPABILITIES, supportsReasoning },
   } as ModelConfig);
   return (handler as any).getThinkingParameter();
+}
+
+function buildConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    name: 'deepseek-chat',
+    fullName: 'deepseek-chat',
+    shortName: 'deepseek-chat',
+    provider: ModelProvider.DEEPSEEK,
+    maxOutputTokens: 1024,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoning: false,
+      supportsVision: false,
+      ...(overrides.capabilities ?? {}),
+    },
+    openRouterOnly: false,
+    label: 'DeepSeek Chat',
+    ...overrides,
+  };
+}
+
+function createLoggerStub(): Partial<AgentLogger> {
+  return {
+    streamId: 'test-channel',
+    debug: () => {
+      /* no-op */
+    },
+    info: () => {
+      /* no-op */
+    },
+    warn: () => {
+      /* no-op */
+    },
+    error: () => {
+      /* no-op */
+    },
+    withCurrentGroup: () => undefined,
+    runWithinCurrentGroup: async <T>(fn: () => T | Promise<T>) => fn(),
+    runWithGroup: async <T>(
+      _groupId: string | undefined,
+      fn: () => T | Promise<T>,
+    ) => fn(),
+  };
 }
 
 describe('ModelHandlerDeepSeek.getThinkingParameter', () => {
@@ -68,5 +118,59 @@ describe('ModelHandlerDeepSeek.getThinkingParameter', () => {
     assert.deepEqual(thinkingFor('deepseek-future', false), {
       type: 'disabled',
     });
+  });
+});
+
+describe('ModelHandlerDeepSeek tool conversion', () => {
+  it('sends nullable Chat Completions tools without SDK strict auto-parse validation', async () => {
+    const handler = new ModelHandlerDeepSeek(buildConfig());
+    handler.setLogger(createLoggerStub() as AgentLogger);
+    (handler as any).getStreamingConfig = () => false;
+
+    let capturedParams: any;
+    const client = {
+      chat: {
+        completions: {
+          create: async (params: any) => {
+            capturedParams = params;
+            return {
+              id: 'test-completion',
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'ok' },
+                  finish_reason: 'stop',
+                },
+              ],
+            };
+          },
+        },
+      },
+    };
+    const tools: ToolDefinition[] = [
+      {
+        name: 'delegate_workflow',
+        description: 'Delegate workflow',
+        parameters: {
+          type: 'object',
+          properties: {
+            instruction: { type: 'string' },
+            model: { type: 'string' },
+          },
+          required: ['instruction'],
+          additionalProperties: false,
+        },
+      },
+    ];
+
+    await handler.createResponse({
+      client: client as any,
+      messages: [{ role: 'user', content: 'delegate this' }],
+      temperature: 0,
+      tools,
+    });
+
+    assert.equal(capturedParams.tools[0].function.name, 'delegate_workflow');
+    assert.equal(capturedParams.tools[0].function.strict, undefined);
   });
 });

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -4,6 +4,7 @@ import { strict as assert } from 'assert';
 // Local imports - test
 import {
   toGoogleTools,
+  toOpenAITools,
   toOpenAIResponseTools,
 } from '@agent/modelHandlers/toolConversion';
 
@@ -11,6 +12,29 @@ import {
 import type { ToolDefinition } from '@model';
 import type { Tool as GeminiTool } from '@google/genai';
 import type { FunctionTool } from 'openai/resources/responses/responses';
+
+describe('toOpenAITools', () => {
+  it('marks Chat Completions function tools as strict for SDK validation', () => {
+    const defs: ToolDefinition[] = [
+      {
+        name: 'delegate_workflow',
+        description: 'Delegate workflow',
+        parameters: {
+          type: 'object',
+          properties: { instruction: { type: 'string' } },
+          required: ['instruction'],
+          additionalProperties: false,
+        },
+      },
+    ];
+
+    const tools = toOpenAITools(defs);
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].type, 'function');
+    assert.equal(tools[0].function.name, 'delegate_workflow');
+    assert.equal(tools[0].function.strict, true);
+  });
+});
 
 describe('toOpenAIResponseTools', () => {
   it('converts tool definitions to Response API format', () => {

--- a/src/test/modelHandlers/ResponseToolConversion.test.ts
+++ b/src/test/modelHandlers/ResponseToolConversion.test.ts
@@ -14,7 +14,7 @@ import type { Tool as GeminiTool } from '@google/genai';
 import type { FunctionTool } from 'openai/resources/responses/responses';
 
 describe('toOpenAITools', () => {
-  it('marks Chat Completions function tools as strict for SDK validation', () => {
+  it('leaves Chat Completions function tools non-strict', () => {
     const defs: ToolDefinition[] = [
       {
         name: 'delegate_workflow',
@@ -32,7 +32,7 @@ describe('toOpenAITools', () => {
     assert.equal(tools.length, 1);
     assert.equal(tools[0].type, 'function');
     assert.equal(tools[0].function.name, 'delegate_workflow');
-    assert.equal(tools[0].function.strict, true);
+    assert.equal(tools[0].function.strict, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

- Stop running the OpenAI SDK's Chat Completions `validateInputTools()` helper on TeXRA tool definitions.
- Keep Chat Completions function tools non-strict so nullable/optional TeXRA tool fields can be sent to DeepSeek and other OpenAI-compatible providers.
- Add DeepSeek-specific regression coverage for `delegate_workflow`-style tools with optional fields.

## Root Cause

DeepSeek uses the OpenAI-compatible Chat Completions path. TeXRA parses tool-call arguments itself after the model response, but the handler was still calling the OpenAI SDK's auto-parse validator before sending tools. That SDK validator is only appropriate for strict auto-parse tools and rejects schemas like `delegate_workflow` because they contain optional or nullable fields.

The fix is not to force `strict: true`; that would break existing TeXRA tools with optional fields. The fix is to bypass the SDK auto-parse validator for Chat Completions tools and leave the schemas in the non-strict form TeXRA already uses.

## Validation

- `npm install`
- `npm run compile:fast`
- `npm run lint -- --quiet`
- `npm run typecheck`
- DeepSeek regression test: `ModelHandlerDeepSeek.createResponse()` forwards a `delegate_workflow`-style tool with an optional `model` field without strict SDK validation blocking the request.
