### PR TITLE
[codex] fix CDATA workflow output extraction

### DIFF
--- a/src/test/utils/text/xmlUtils.test.ts
+++ b/src/test/utils/text/xmlUtils.test.ts
@@ -2,7 +2,13 @@
 import { strict as assert } from 'assert';
 
 // Local imports - utils
-import { extractScratchpad, formatContent } from '@utils/text/xmlUtils';
+import {
+  addCdataToTags,
+  addCdataToTagsMultiple,
+  extractScratchpad,
+  formatContent,
+  removeCDATA,
+} from '@utils/text/xmlUtils';
 
 describe('xmlUtils.formatContent', () => {
   it('converts HTML scratchpad content to markdown bullets', async () => {
@@ -53,5 +59,57 @@ describe('xmlUtils.extractScratchpad', () => {
     const result = await extractScratchpad(response);
 
     assert.equal(result, '## Plan\n\n- Step 1\n- Step 2');
+  });
+});
+
+describe('xmlUtils CDATA handling', () => {
+  it('does not double-wrap content that is already CDATA-wrapped', () => {
+    const input =
+      '<latex_document><![CDATA[Text with <xml-like> LaTeX & comments]]></latex_document>';
+
+    const result = addCdataToTags(input, ['latex_document']);
+
+    assert.equal(result, input);
+  });
+
+  it('does not double-wrap attributed tags that are already CDATA-wrapped', () => {
+    const input =
+      '<document name="main.tex"><![CDATA[Text with <xml-like> LaTeX & comments]]></document>';
+
+    const result = addCdataToTagsMultiple(input, ['document']);
+
+    assert.equal(result, input);
+  });
+
+  it('wraps malformed CDATA starts instead of treating them as complete', () => {
+    const input =
+      '<latex_document><![CDATA[Text with <xml-like> LaTeX</latex_document>';
+
+    const result = addCdataToTags(input, ['latex_document']);
+
+    assert.equal(
+      result,
+      '<latex_document><![CDATA[<![CDATA[Text with <xml-like> LaTeX]]></latex_document>',
+    );
+  });
+
+  it('wraps malformed CDATA starts in attributed tags', () => {
+    const input =
+      '<document name="main.tex"><![CDATA[Text with <xml-like> LaTeX</document>';
+
+    const result = addCdataToTagsMultiple(input, ['document']);
+
+    assert.equal(
+      result,
+      '<document name="main.tex"><![CDATA[<![CDATA[Text with <xml-like> LaTeX]]></document>',
+    );
+  });
+
+  it('removes nested CDATA wrappers left by legacy double-wrapping', () => {
+    const input = '<![CDATA[<![CDATA[Text with <xml-like> LaTeX]]>]]>';
+
+    const result = removeCDATA(input);
+
+    assert.equal(result, 'Text with <xml-like> LaTeX');
   });
 });

--- a/src/utils/text/xmlCdata.ts
+++ b/src/utils/text/xmlCdata.ts
@@ -9,6 +9,13 @@
  */
 const CDATA_PATTERN = /<!\[CDATA\[([\s\S]*?)\]\]>/g;
 
+function isCdataWrapped(content: string): boolean {
+  return (
+    content.trimStart().startsWith('<![CDATA[') &&
+    content.trimEnd().endsWith(']]>')
+  );
+}
+
 /**
  * Remove CDATA sections from content.
  * Centralized function to eliminate duplicate CDATA removal patterns.
@@ -17,7 +24,12 @@ const CDATA_PATTERN = /<!\[CDATA\[([\s\S]*?)\]\]>/g;
  * @returns Content with CDATA wrappers removed
  */
 export function removeCDATA(content: string): string {
-  return content.replaceAll(CDATA_PATTERN, '$1');
+  let current = content;
+  while (true) {
+    const cleaned = current.replaceAll(CDATA_PATTERN, '$1');
+    if (cleaned === current) return cleaned;
+    current = cleaned;
+  }
 }
 
 /**
@@ -26,7 +38,11 @@ export function removeCDATA(content: string): string {
 export function addCdataToTags(xmlData: string, tags: string[]): string {
   return tags.reduce((result, tag) => {
     const pattern = new RegExp(`(<${tag}>)(.*?)(</${tag}>)`, 'gs');
-    return result.replace(pattern, '$1<![CDATA[$2]]>$3');
+    return result.replace(pattern, (_, openTag, body, closeTag) =>
+      isCdataWrapped(body)
+        ? `${openTag}${body}${closeTag}`
+        : `${openTag}<![CDATA[${body}]]>${closeTag}`,
+    );
   }, xmlData);
 }
 
@@ -42,6 +58,10 @@ export function addCdataToTagsMultiple(
       `(<${tag}(?:\\s+[^>]*)?>)(.*?)(</${tag}>)`,
       'gs',
     );
-    return result.replace(pattern, '$1<![CDATA[$2]]>$3');
+    return result.replace(pattern, (_, openTag, body, closeTag) =>
+      isCdataWrapped(body)
+        ? `${openTag}${body}${closeTag}`
+        : `${openTag}<![CDATA[${body}]]>${closeTag}`,
+    );
   }, xmlData);
 }


### PR DESCRIPTION
## Summary
- make CDATA wrapping idempotent for workflow XML extraction
- recursively strip nested CDATA wrappers left by legacy double-wrapped outputs
- add focused regression coverage for both cases

## Root Cause
Workflow extraction wraps XML tag contents in CDATA before parsing so LaTeX with `<`, `>`, or `&` remains parser-safe. If a model already emitted CDATA, the helper double-wrapped the content, and the existing cleanup could leave a literal `<![CDATA[...]]>` wrapper in the extracted `.tex` file.

## Validation
- `npm run typecheck`
- `npm run lint` (passes with existing unrelated warnings)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches XML/CDATA sanitization used during workflow output extraction; mistakes could alter emitted document content or break parsing for edge-case XML/LaTeX inputs.
> 
> **Overview**
> **Improves CDATA safety in workflow XML extraction.** `addCdataToTags`/`addCdataToTagsMultiple` now detect already-wrapped tag bodies and skip re-wrapping, making CDATA insertion idempotent for both plain and attributed tags.
> 
> `removeCDATA` now repeatedly strips CDATA wrappers until stable, cleaning up legacy double-wrapped outputs. Adds regression tests covering idempotent wrapping, malformed/partial CDATA starts, and nested-wrapper removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5a454f8fe82b129668c439fe42216f0a3bd1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->