### PR TITLE
[codex] reject oversized BibTeX attachments

### DIFF
--- a/src/test/tools/DelegationTools.test.ts
+++ b/src/test/tools/DelegationTools.test.ts
@@ -6,7 +6,7 @@ import { FileType, type FileStat } from '@platform/interfaces/filesystem';
 
 // Local imports - tools
 import {
-  rejectOversizedLibraryBibAuxiliary,
+  rejectOversizedBibAttachments,
   type WorkflowAgentInput,
 } from '@tools/DelegationTools';
 import { WorkspaceFS } from '@utils/files';
@@ -46,33 +46,50 @@ describe('DelegationTools', () => {
     WorkspaceFS.stat = originalStat;
   });
 
-  it('rejects auxiliary library.bib files larger than 100KB', async () => {
+  it('rejects auxiliary .bib files larger than 100KB', async () => {
     WorkspaceFS.stat = async () => stat(100 * 1024 + 1);
 
-    const result = await rejectOversizedLibraryBibAuxiliary({
+    const result = await rejectOversizedBibAttachments({
       ...BASE_INPUT,
-      auxiliaryFile: 'library.bib',
+      auxiliaryFile: 'references.bib',
     });
 
     assert.strictEqual(result?.isError, true);
-    assert.strictEqual(result?.summary, 'Rejected oversized library.bib');
+    assert.strictEqual(result?.summary, 'Rejected oversized BibTeX attachment');
     assert.strictEqual(
       result?.error,
-      'library.bib is 102401 bytes (100.0 KB), over the 102400 byte (100.0 KB) limit. Call extract_bib_entries first if citations are needed, then re-propose without library.bib.',
+      'references.bib is 102401 bytes (100.0 KB), over the 102400 byte (100.0 KB) limit. Call extract_bib_entries first if citations are needed, then re-propose without the full .bib file.',
     );
     assert.strictEqual(result?.output, result?.error);
     assert.deepStrictEqual(result?.diagnostics, {
-      type: 'oversized_library_bib',
-      path: 'library.bib',
+      type: 'oversized_bib_attachment',
+      path: 'references.bib',
       sizeBytes: 102401,
       limitBytes: 102400,
     });
   });
 
-  it('allows auxiliary library.bib files at the 100KB limit', async () => {
+  it('rejects reference .bib files larger than 100KB', async () => {
+    WorkspaceFS.stat = async () => stat(150 * 1024);
+
+    const result = await rejectOversizedBibAttachments({
+      ...BASE_INPUT,
+      referenceFiles: ['paper.tex', 'bibliography/main.bib'],
+    });
+
+    assert.strictEqual(result?.isError, true);
+    assert.deepStrictEqual(result?.diagnostics, {
+      type: 'oversized_bib_attachment',
+      path: 'bibliography/main.bib',
+      sizeBytes: 153600,
+      limitBytes: 102400,
+    });
+  });
+
+  it('allows .bib files at the 100KB limit', async () => {
     WorkspaceFS.stat = async () => stat(100 * 1024);
 
-    const result = await rejectOversizedLibraryBibAuxiliary({
+    const result = await rejectOversizedBibAttachments({
       ...BASE_INPUT,
       auxiliaryFiles: ['library.bib'],
     });
@@ -80,16 +97,17 @@ describe('DelegationTools', () => {
     assert.strictEqual(result, null);
   });
 
-  it('ignores non-library auxiliary files', async () => {
+  it('ignores non-bib reference and auxiliary files', async () => {
     let statCalled = false;
     WorkspaceFS.stat = async () => {
       statCalled = true;
       return stat(500 * 1024);
     };
 
-    const result = await rejectOversizedLibraryBibAuxiliary({
+    const result = await rejectOversizedBibAttachments({
       ...BASE_INPUT,
-      auxiliaryFiles: ['references.bib'],
+      referenceFiles: ['paper.tex'],
+      auxiliaryFiles: ['preamble.tex'],
     });
 
     assert.strictEqual(result, null);

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -88,8 +88,7 @@ import { generateExecutionId } from '@utils/core/executionId';
 const LOG_CHANNEL = 'DelegationTools';
 logger.initialize(LOG_CHANNEL);
 
-const LARGE_LIBRARY_BIB_LIMIT_BYTES = 100 * 1024;
-const LARGE_LIBRARY_BIB_NAME = 'library.bib';
+const LARGE_BIB_LIMIT_BYTES = 100 * 1024;
 
 // ============================================================================
 // Subagent delivery state tracking
@@ -642,38 +641,43 @@ const WorkflowAgentInputSchema = z.object({
 
 export type WorkflowAgentInput = z.infer<typeof WorkflowAgentInputSchema>;
 
-function isLibraryBib(filePath: string): boolean {
+function isBibFile(filePath: string): boolean {
   const basename = filePath.replaceAll('\\', '/').split('/').at(-1);
-  return basename?.toLowerCase() === LARGE_LIBRARY_BIB_NAME;
+  return basename?.toLowerCase().endsWith('.bib') ?? false;
 }
 
-function getAuxiliaryFiles(input: WorkflowAgentInput): string[] {
-  return [input.auxiliaryFile, ...input.auxiliaryFiles].filter(
+function getReferenceAndAuxiliaryFiles(input: WorkflowAgentInput): string[] {
+  return [
+    input.referenceFile,
+    ...input.referenceFiles,
+    input.auxiliaryFile,
+    ...input.auxiliaryFiles,
+  ].filter(
     (path): path is string => typeof path === 'string' && path.length > 0,
   );
 }
 
-/** Reject workflow proposals that attach an oversized default bibliography. */
-export async function rejectOversizedLibraryBibAuxiliary(
+/** Reject workflow proposals that attach oversized bibliography files. */
+export async function rejectOversizedBibAttachments(
   input: WorkflowAgentInput,
 ): Promise<ToolResult | null> {
-  const libraryBibFiles = getAuxiliaryFiles(input).filter(isLibraryBib);
+  const bibFiles = getReferenceAndAuxiliaryFiles(input).filter(isBibFile);
 
-  for (const libraryBib of libraryBibFiles) {
-    const stats = await WorkspaceFS.stat(libraryBib);
-    if (stats.size <= LARGE_LIBRARY_BIB_LIMIT_BYTES) continue;
+  for (const bibFile of bibFiles) {
+    const stats = await WorkspaceFS.stat(bibFile);
+    if (stats.size <= LARGE_BIB_LIMIT_BYTES) continue;
 
-    const message = `${libraryBib} is ${stats.size} bytes (${formatBytes(stats.size)}), over the ${LARGE_LIBRARY_BIB_LIMIT_BYTES} byte (${formatBytes(LARGE_LIBRARY_BIB_LIMIT_BYTES)}) limit. Call extract_bib_entries first if citations are needed, then re-propose without ${LARGE_LIBRARY_BIB_NAME}.`;
+    const message = `${bibFile} is ${stats.size} bytes (${formatBytes(stats.size)}), over the ${LARGE_BIB_LIMIT_BYTES} byte (${formatBytes(LARGE_BIB_LIMIT_BYTES)}) limit. Call extract_bib_entries first if citations are needed, then re-propose without the full .bib file.`;
     return {
-      summary: `Rejected oversized ${LARGE_LIBRARY_BIB_NAME}`,
+      summary: `Rejected oversized BibTeX attachment`,
       error: message,
       output: message,
       isError: true,
       diagnostics: {
-        type: 'oversized_library_bib',
-        path: libraryBib,
+        type: 'oversized_bib_attachment',
+        path: bibFile,
         sizeBytes: stats.size,
-        limitBytes: LARGE_LIBRARY_BIB_LIMIT_BYTES,
+        limitBytes: LARGE_BIB_LIMIT_BYTES,
       },
     };
   }
@@ -753,8 +757,8 @@ Example: agent=correct, inputFile=paper.tex, extractFigures=true, instruction="T
       throw new Error(`${missing.label} not found: ${missing.path}`);
     }
 
-    const libraryBibRejection = await rejectOversizedLibraryBibAuxiliary(input);
-    if (libraryBibRejection) return libraryBibRejection;
+    const oversizedBibRejection = await rejectOversizedBibAttachments(input);
+    if (oversizedBibRejection) return oversizedBibRejection;
 
     // Extraction flags map to toolConfig, flowing through the proposal UI and
     // into MediaExtractionNode → LatexMediaManager at runtime.


### PR DESCRIPTION
## Summary

- Generalize the workflow delegation preflight from only `library.bib` auxiliaries to any `.bib` file attached as a reference or auxiliary.
- Keep the 100KB limit and guide orchestrators to call `extract_bib_entries` before re-proposing without the full bibliography file.
- Update tests for oversized auxiliary `.bib`, oversized reference `.bib`, exactly-at-limit `.bib`, and non-`.bib` reference/auxiliary files.

## Context

Follow-up to #3150 after broadening the policy from the default `library.bib` file to all BibTeX attachments passed through reference or auxiliary fields.

## Validation

- `npm run typecheck`
- `npm run compile-tests`
- `npm run lint` (passes with existing unrelated warnings in `StreamLogStore.ts`, `ProgressEventHandler.ts`, and `ProgressViewState.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow delegation preflight validation to reject any oversized `.bib` passed via reference/auxiliary fields, which could block previously-allowed delegations if file selection is wrong. Logic is simple and well-tested, but it sits on the critical path for `delegate_workflow` execution.
> 
> **Overview**
> Generalizes the workflow delegation preflight from rejecting only `library.bib` auxiliaries to rejecting **any** `.bib` file attached via `reference*` or `auxiliary*` when it exceeds the 100KB limit, returning updated error messaging and diagnostics.
> 
> Updates `WorkflowAgentTool` to use the new `rejectOversizedBibAttachments` check and expands tests to cover oversized auxiliary/reference `.bib` files, the exact-limit case, and ensuring non-`.bib` attachments are ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa5abf7cd62d04861523c6b9d6c0e8fb3d122ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->