### PR TITLE
[codex] Fix Anthropic workflow prefill output

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1,6 +1,6 @@
 // Standard library imports
 import { Buffer } from 'node:buffer';
-import { basename } from 'node:path';
+import { basename, dirname } from 'node:path';
 
 // Third-party imports
 import {
@@ -13,11 +13,7 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
-import {
-  type AgentSetting,
-  hasEndTag,
-  requireWorkflowSetting,
-} from '@agent/core/AgentDataclass';
+import { type AgentSetting, hasEndTag } from '@agent/core/AgentDataclass';
 import {
   AnthropicAPIResponseUsage,
   AnthropicUsage,
@@ -50,7 +46,7 @@ import replacementEngine from '@replacement/engine';
 import type { ToolFileAttachment } from '@tools/result';
 
 // Local imports - utils
-import { flexibleFS, type FileLocation } from '@utils/files';
+import { AbsoluteFS, flexibleFS, type FileLocation } from '@utils/files';
 import { getAnthropicDynamicFiltering } from '@utils/config/providerConfig';
 import { objectToLogString } from '@utils/text/stringUtils';
 
@@ -1636,19 +1632,15 @@ export class ModelHandlerAnthropic extends ModelHandler<
     outputLocation: FileLocation,
     prefill: string,
   ): Promise<[boolean, MessageParam[]]> {
-    const workflowSetting = requireWorkflowSetting(agentSetting);
-
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
       if (this.capabilities.supportsAssistantPrefill) {
         this.logger.debug(`Adding prefill message:\n${prefill}`);
-        if (
-          workspaceState.assembly.accumulatedOutput.includes('<scratchpad>') &&
-          prefill === '<scratchpad>' // this is not so neat
-        ) {
-          await flexibleFS.write(outputLocation, prefill);
-        } else if (workflowSetting.outputExt === 'xml') {
-          await flexibleFS.write(outputLocation, prefill + '\n');
-        }
+        workspaceState.assembly.accumulatedOutput = `${prefill}\n`;
+        await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));
+        await flexibleFS.write(
+          outputLocation,
+          workspaceState.assembly.accumulatedOutput,
+        );
         messages.push({
           role: 'assistant',
           content: [{ type: 'text', text: prefill }],

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1,5 +1,8 @@
 // Standard library imports
 import { strict as assert } from 'assert';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Third-party imports
 import { APIUserAbortError as AnthropicUserAbortError } from '@anthropic-ai/sdk';
@@ -12,7 +15,9 @@ import {
   ModelProvider,
   ReasoningEffort,
 } from 'llm-zoo';
-import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory, AgentSettingSchema } from '@agent/core/AgentDataclass';
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 
 // Type imports
@@ -1299,6 +1304,57 @@ describe('ModelHandlerAnthropic message guards', () => {
     assert.equal(eventData.tokensBefore, 185000);
     assert.equal(eventData.tokensAfter, 25600);
     assert.equal(eventData.summary, '<summary>state</summary>');
+  });
+});
+
+describe('ModelHandlerAnthropic output prefill initialization', () => {
+  it('writes assistant prefills for non-XML workflow outputs', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'anthropic-prefill-'),
+    );
+    const outputPath = path.join(tempDir, 'r0', 'output.xml');
+
+    try {
+      const handler = createAnthropicHandler({
+        supportsAssistantPrefill: true,
+      });
+      stubHandlerForTest(handler);
+
+      const agentSetting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'latex_document',
+        endTag: '</latex_document>',
+        outputExt: 'tex',
+      });
+      const messages: MessageParam[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'revise the document' }],
+        },
+      ];
+      const prefill = '<latex_document>';
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          agentSetting,
+          messages,
+          workspaceState,
+          pathToLocation(outputPath),
+          prefill,
+        );
+
+      assert.equal(isComplete, false);
+      assert.equal(fs.readFileSync(outputPath, 'utf8'), `${prefill}\n`);
+      assert.equal(workspaceState.assembly.accumulatedOutput, `${prefill}\n`);
+      assert.equal(updatedMessages.at(-1)?.role, 'assistant');
+      assert.deepEqual(updatedMessages.at(-1)?.content, [
+        { type: 'text', text: prefill },
+      ]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Make the Anthropic handler write assistant prefills into the raw workflow output file for every assistant-prefill run.
- Remove the old `scratchpad` / `outputExt === 'xml'` special case so non-scratchpad workflow agents keep their opening XML document tag.
- Add a regression test covering the `outputExt: 'tex'` workflow case with a `<latex_document>` prefill.

## Surface-area review
- The behavioral change is deliberately confined to `ModelHandlerAnthropic.initializeOutputAndPrefill()` when the output file does not yet exist and the model supports assistant prefill.
- Resume/continuation behavior is unchanged: existing non-trivial output still flows through `prepareExistingOutputContent()`, end-tag detection, and continuation handling.
- The response cycle already re-checks whether the raw output file exists after initialization, so the prefill write causes later response text to append instead of replacing the opening tag.
- I did not remove `outputExt` from `AgentWorkflowSetting`; that is a separate schema/config cleanup with wider migration surface than this bug fix.

Fixes #3135.

## Validation
- `npm run compile-tests`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 pre-existing warnings outside touched files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes initial workflow output file initialization and directory creation, which could affect resume/append behavior across workflow agents.
> 
> **Overview**
> Ensures `ModelHandlerAnthropic.initializeOutputAndPrefill()` always writes the assistant prefill into the raw workflow output file (and `workspaceState.assembly.accumulatedOutput`) whenever the output file doesn’t yet exist and the model supports assistant prefill, removing the prior `scratchpad`/`outputExt === 'xml'` special-casing.
> 
> Adds a regression test covering a workflow with `outputExt: 'tex'` to verify the prefill is written (with a trailing newline) and an assistant prefill message is appended to `messages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4cc87ed663891c4e22ced3065740bbeee09e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->