### PR TITLE
[codex] Avoid full terminal log rewrites

### DIFF
--- a/src/progressView/frontend/components/TaskGroupList.ts
+++ b/src/progressView/frontend/components/TaskGroupList.ts
@@ -159,6 +159,10 @@ export class TaskGroupList extends LitElement {
   @query(`#${ELEMENT_IDS.LOG_CONTENT}`)
   private scrollContainer?: HTMLElement;
 
+  /** Terminal committed-line node, managed imperatively to avoid full text rewrites. */
+  @query('.terminal-pre--committed')
+  private terminalCommittedPre?: HTMLPreElement;
+
   /**
    * Sticky scroll state: when true, new content auto-scrolls to bottom.
    * Flips false when user scrolls away, true when user scrolls back to bottom.
@@ -167,6 +171,15 @@ export class TaskGroupList extends LitElement {
 
   /** Threshold for detecting "near bottom" in scroll listener (px) */
   private static readonly STICKY_THRESHOLD = 150;
+
+  /** Text node currently attached to terminalCommittedPre. */
+  private terminalCommittedTextNode: Text | null = null;
+
+  /** Number of committed terminal characters already written to the DOM. */
+  private renderedTerminalLinesLength = 0;
+
+  /** True after a terminal cache rebuild, when incremental append is invalid. */
+  private terminalCommittedNeedsReset = true;
 
   /** Handle scroll events from vscode-scrollable to track user intent */
   private handleVscScroll = (): void => {
@@ -282,6 +295,17 @@ export class TaskGroupList extends LitElement {
     }
   }
 
+  override updated(): void {
+    if (this.terminal) {
+      this.syncTerminalCommittedText();
+      return;
+    }
+
+    this.terminalCommittedTextNode = null;
+    this.renderedTerminalLinesLength = 0;
+    this.terminalCommittedNeedsReset = true;
+  }
+
   /**
    * Incrementally classify messages appended since `startIndex`.
    * Avoids full tree rebuilds by classifying only new messages and inserting by timestamp.
@@ -379,6 +403,7 @@ export class TaskGroupList extends LitElement {
   private rebuildTerminalText(): void {
     this.cachedRawTail = '';
     this.cachedTerminalLines = '';
+    this.terminalCommittedNeedsReset = true;
     this.appendTerminalChunk(this.messages.map((m) => m.text).join(''));
   }
 
@@ -685,6 +710,54 @@ export class TaskGroupList extends LitElement {
     `;
   }
 
+  private renderTerminalOutput(): TemplateResult {
+    const tailText = processTerminalText(this.cachedRawTail);
+    const committedClass = 'terminal-pre terminal-pre--committed';
+    const tailClass = 'terminal-pre terminal-pre--tail';
+    const committed = html`<pre class=${committedClass}></pre>`;
+    const tail = html`<pre class=${tailClass}>${tailText}</pre>`;
+
+    return html`<div class="terminal-container">${[committed, tail]}</div>`;
+  }
+
+  private syncTerminalCommittedText(): void {
+    const pre = this.terminalCommittedPre;
+    if (!pre) return;
+
+    const next = this.cachedTerminalLines;
+    const hasAttachedNode = this.terminalCommittedTextNode?.parentNode === pre;
+    const shouldReset =
+      this.terminalCommittedNeedsReset ||
+      !hasAttachedNode ||
+      next.length < this.renderedTerminalLinesLength;
+
+    if (shouldReset) {
+      pre.textContent = '';
+      this.terminalCommittedTextNode =
+        next.length > 0 ? document.createTextNode(next) : null;
+      if (this.terminalCommittedTextNode) {
+        pre.append(this.terminalCommittedTextNode);
+      }
+      this.renderedTerminalLinesLength = next.length;
+      this.terminalCommittedNeedsReset = false;
+      return;
+    }
+
+    if (next.length > this.renderedTerminalLinesLength) {
+      if (!this.terminalCommittedTextNode) {
+        this.terminalCommittedTextNode = document.createTextNode('');
+        pre.append(this.terminalCommittedTextNode);
+      }
+
+      this.terminalCommittedTextNode.appendData(
+        next.slice(this.renderedTerminalLinesLength),
+      );
+      this.renderedTerminalLinesLength = next.length;
+    }
+
+    this.terminalCommittedNeedsReset = false;
+  }
+
   override render(): TemplateResult {
     // Show placeholder only when there are no streams in the current filter
     if (!this.hasStreams) {
@@ -706,9 +779,7 @@ export class TaskGroupList extends LitElement {
           class="log-container"
           @vsc-scrollable-scroll=${this.handleVscScroll}
         >
-          <pre class="terminal-pre">
-${this.cachedTerminalLines}${processTerminalText(this.cachedRawTail)}</pre
-          >
+          ${this.renderTerminalOutput()}
         </vscode-scrollable>
       `;
     }

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -314,9 +314,9 @@ export const logEntryStyles = css`
     color: var(--vscode-terminal-ansiRed, var(--color-error));
   }
 
-  /* Pre-formatted text block for terminal-mode streams.
-     Inherits font/color from the terminal .log-container. */
-  :host([terminal]) .terminal-pre {
+  /* Pre-formatted text nodes for terminal-mode streams.
+     Keep committed output and the live tail separate without changing text flow. */
+  :host([terminal]) .terminal-container {
     margin: 0;
     padding: 0;
     font-family: inherit;
@@ -324,5 +324,16 @@ export const logEntryStyles = css`
     color: inherit;
     white-space: pre-wrap;
     word-break: break-all;
+  }
+
+  :host([terminal]) .terminal-pre {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    white-space: inherit;
+    word-break: inherit;
   }
 `;


### PR DESCRIPTION
## Summary
- split terminal-mode log rendering into separate committed-output and live-tail DOM nodes
- manage the committed-output text node imperatively so complete-line appends add only the new suffix instead of asking Lit to rewrite the historical buffer
- keep the live tail declarative and bounded, preserving the existing ANSI stripping, carriage-return overwrite handling, and tail cap behavior

## Why
Issue #3141 identified that terminal mode had incremental text caching, but still handed Lit one growing concatenated text node. Every appended chunk could therefore replace the full rendered buffer and push browser rendering toward O(n²) behavior over long process streams.

A purely guarded committed `<pre>` is not enough for normal line-oriented terminal output, because `cachedTerminalLines` changes whenever a new complete line arrives. This version leaves the committed node out of Lit's text rendering path and appends only newly committed text, while the tail node continues to update normally within `MAX_TAIL`.

Fixes #3141.

## Validation
- `npx prettier --check src/progressView/frontend/components/TaskGroupList.ts src/progressView/frontend/styles/logEntryStyles.ts`
- `git diff --check`
- `npm run compile:safe`
- `npm run lint` (0 errors; 3 pre-existing warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces imperative DOM text-node management in terminal mode, which could cause rendering or reset edge cases, but is scoped to frontend log display (no data/auth changes).
> 
> **Overview**
> **Terminal-mode log rendering is refactored to avoid re-rendering the entire accumulated buffer on every update.** The UI now renders terminal output as two adjacent `<pre>` nodes (committed lines + live tail) and imperatively appends only the newly committed suffix via `syncTerminalCommittedText()`.
> 
> `TaskGroupList` tracks/reset state for the committed text node on cache rebuilds or mode toggles, and CSS is updated to keep the two `<pre>` elements visually flowing as a single pre-wrapped stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59ceb83a6c3073942a1ed391aa13acb229ac07b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->