### PR TITLE
[codex] Preserve response-chain token baseline

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -827,6 +827,13 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     };
   }
 
+  /** Drop server-side chain state while preserving local token history. */
+  private invalidateResponseChain(): void {
+    this.previousResponseId = null;
+    this.conversationState.sentMessages = 0;
+    this.conversationState.isCompacted = false;
+  }
+
   /**
    * Finalize response state after a successful API call.
    * Updates previousResponseId, conversation state, and token counts.
@@ -878,9 +885,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       // would lose its compaction baseline and fail hard on the next
       // turn, bypassing the context-window recovery below (which also
       // requires previousResponseId to be set).
-      this.previousResponseId = null;
-      this.conversationState.sentMessages = 0;
-      this.conversationState.isCompacted = false;
+      this.invalidateResponseChain();
     }
 
     // Clear any pending background response ID - a successful finalization means
@@ -2025,8 +2030,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           `Clearing previousResponseId=${this.previousResponseId} due to invalid/expired response - ` +
             'next retry will rebuild conversation from local history',
         );
-        this.previousResponseId = null;
-        this.resetConversationState();
+        this.invalidateResponseChain();
         // Also clear pending background response if present
         this.clearPendingBackgroundResponse();
       } else if (

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponse.test.ts
@@ -46,28 +46,31 @@ function createLoggerStub(): LoggerStub {
   };
 }
 
-function createConfig(): ModelConfig {
+function createConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
   return {
     name: 'gpt-4.1',
     fullName: 'gpt-4.1',
     shortName: 'gpt-4.1',
     label: 'GPT 4.1',
     provider: ModelProvider.OPENAI,
-    maxOutputTokens: 1024,
+    maxOutputTokens: overrides.maxOutputTokens ?? 1024,
     inputPrice: 0,
     outputPrice: 0,
-    contextWindow: 200000,
+    contextWindow: overrides.contextWindow ?? 200000,
     capabilities: {
       ...DEFAULT_MODEL_CAPABILITIES,
       supportsReasoning: false,
       supportsVision: false,
+      ...(overrides.capabilities ?? {}),
     },
-    openRouterOnly: true,
+    openRouterOnly: overrides.openRouterOnly ?? true,
   };
 }
 
-function createHandler(): ModelHandlerOpenAIResponse {
-  const handler = new ModelHandlerOpenAIResponse(createConfig());
+function createHandler(
+  configOverrides: Partial<ModelConfig> = {},
+): ModelHandlerOpenAIResponse {
+  const handler = new ModelHandlerOpenAIResponse(createConfig(configOverrides));
   handler.setLogger(createLoggerStub() as unknown as AgentLogger);
   handler.getStreamingConfig = () => false;
   return handler;
@@ -153,5 +156,69 @@ describe('ModelHandlerOpenAIResponse.createResponse', () => {
     assert.equal(requests[0].previous_response_id, undefined);
     assert.equal(requests[1].previous_response_id, undefined);
     assert.deepEqual(requests[1].input, secondTurnMessages);
+  });
+
+  it('uses the preserved token baseline after an invalid previous response id clears chaining', async () => {
+    const handler = createHandler({
+      openRouterOnly: false,
+      maxOutputTokens: 120000,
+      contextWindow: 200000,
+    });
+    const requests: any[] = [];
+    let tokenCountCalls = 0;
+    const client = {
+      responses: {
+        inputTokens: {
+          count: async () => {
+            tokenCountCalls += 1;
+            if (tokenCountCalls === 3) {
+              throw new Error('token counting unavailable');
+            }
+            return { input_tokens: 1000 };
+          },
+        },
+        create: async (params: any) => {
+          requests.push(params);
+          if (requests.length === 1) {
+            return createResponse('resp-baseline', { input_tokens: 100000 });
+          }
+          if (requests.length === 2) {
+            throw new Error(
+              "Previous response with id 'resp-baseline' not found.",
+            );
+          }
+          return createResponse('resp-rebuilt', { input_tokens: 100500 });
+        },
+      },
+    };
+    const firstTurnMessages = createMessages(2);
+    const rebuiltMessages = createMessages(3);
+
+    await handler.createResponse({
+      client: client as any,
+      messages: firstTurnMessages,
+      temperature: 0,
+    });
+
+    await assert.rejects(
+      handler.createResponse({
+        client: client as any,
+        messages: rebuiltMessages,
+        temperature: 0,
+      }),
+      /Previous response/,
+    );
+    await handler.createResponse({
+      client: client as any,
+      messages: rebuiltMessages,
+      temperature: 0,
+    });
+
+    assert.equal(requests.length, 3);
+    assert.equal(requests[1].previous_response_id, 'resp-baseline');
+    assert.equal(requests[2].previous_response_id, undefined);
+    assert.deepEqual(requests[2].input, rebuiltMessages);
+    assert.equal(tokenCountCalls, 3);
+    assert.equal(requests[2].max_output_tokens, 99990);
   });
 });


### PR DESCRIPTION
## Summary

Holistic follow-up to #3142. The missing-usage path correctly stopped dropping local history, but the invalid/expired `previous_response_id` path still used the full conversation reset helper.

This PR makes chain invalidation explicit: drop the server-side chain anchor and stale `sentMessages`, but preserve the local token baseline so the next retry can still trigger compaction before rebuilding from local history.

## Why

A stale response id usually means the next attempt must send local history without server-side context. If that local history is already large, zeroing `cumulativeInputTokens` disables the proactive compaction trigger at exactly the moment it is needed.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts retry/chaining state management in the OpenAI Responses handler, which can change when full history is resent and how `max_output_tokens` is capped during failures. Risk is mitigated by added unit coverage but affects core request/compaction behavior.
> 
> **Overview**
> Makes response-chain invalidation explicit in `ModelHandlerOpenAIResponse`: when chaining is deemed unsafe (e.g., missing usage) or `previous_response_id` is invalid/expired, it now clears the server-side chain anchor and stale message-slicing state **without** zeroing `cumulativeInputTokens`.
> 
> This preserves the token baseline used for proactive compaction/output budgeting on the next retry while forcing the next request to rebuild context from full local history.
> 
> Updates tests to allow config overrides and adds coverage ensuring an invalid `previous_response_id` clears chaining but still applies fallback `max_output_tokens` capping based on the preserved baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33bbf7554b3a3f741f53b9a5118153ed7a5ecce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->