### PR TITLE
[codex] Remove deprecated models on upgrade

### DIFF
--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -299,10 +299,10 @@ async function mergeNewModelsIfCustomized(
     }
   }
 
-  // One-time strip for users upgrading past version 15:
-  // remove any enabled model that the registry now marks as deprecated. The
-  // Settings view still exposes deprecated models for deliberate opt-in, but
-  // upgraded users should not keep old defaults in normal model dropdowns.
+  // One-time strip for users upgrading past version 15: remove any currently
+  // enabled model that the registry now marks as deprecated. This can remove
+  // previous deliberate opt-ins during the upgrade so deprecated models do not
+  // stay in normal dropdowns by default; users can re-enable them from Settings.
   if ((previousVersion ?? 0) < 15) {
     for (const model of currentModels) {
       if (isDeprecatedModel(model)) strippedSet.add(model);

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -10,7 +10,11 @@ import { agentDirectories } from '@frontend/agents';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
-import { DEFAULT_MODELS, MODEL_LIST_VERSION } from '@model/computeModelOptions';
+import {
+  DEFAULT_MODELS,
+  MODEL_LIST_VERSION,
+  isDeprecatedModel,
+} from '@model/computeModelOptions';
 import { LATEX_WORKSHOP_EXT_ID } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { GlobalStorageFS } from '@utils/files';
@@ -294,10 +298,22 @@ async function mergeNewModelsIfCustomized(
       if (currentModels.includes(model)) strippedSet.add(model);
     }
   }
+
+  // One-time strip for users upgrading past version 15:
+  // remove any enabled model that the registry now marks as deprecated. The
+  // Settings view still exposes deprecated models for deliberate opt-in, but
+  // upgraded users should not keep old defaults in normal model dropdowns.
+  if ((previousVersion ?? 0) < 15) {
+    for (const model of currentModels) {
+      if (isDeprecatedModel(model)) strippedSet.add(model);
+    }
+  }
   const kept = currentModels.filter((model) => !strippedSet.has(model));
   const removed = [...strippedSet];
 
-  const added = DEFAULT_MODELS.filter((model) => !kept.includes(model));
+  const added = DEFAULT_MODELS.filter(
+    (model) => !kept.includes(model) && !isDeprecatedModel(model),
+  );
 
   if (added.length === 0 && removed.length === 0) {
     return;

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -23,6 +23,11 @@ import {
 // Local imports - sibling
 import { API_PROVIDERS, apiKeyExists, type ApiProvider } from './apiProviders';
 
+/** Return whether the registry marks a model as deprecated. */
+export function isDeprecatedModel(model: string): boolean {
+  return MODEL_CONFIGS[model]?.deprecated ?? false;
+}
+
 /**
  * Default models that should be present in every user's model list.
  * Update this list and increment MODEL_LIST_VERSION below when adding or
@@ -44,7 +49,7 @@ export const DEFAULT_MODELS = [
  * to get the updated defaults. A simple integer avoids hash-collision risks
  * and doesn't trigger on harmless reordering.
  */
-export const MODEL_LIST_VERSION = 14;
+export const MODEL_LIST_VERSION = 15;
 
 /**
  * Get the list of visible models from extension global state.

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -44,10 +44,11 @@ export const DEFAULT_MODELS = [
 ];
 
 /**
- * Version number for the default model list.
- * Increment this when adding or removing models to force existing users
- * to get the updated defaults. A simple integer avoids hash-collision risks
- * and doesn't trigger on harmless reordering.
+ * Version gate for model-list migrations.
+ * Increment this when adding/removing defaults or when existing users need
+ * their persisted enabled-model list reconciled with current model metadata.
+ * A simple integer avoids hash-collision risks and doesn't trigger on
+ * harmless reordering.
  */
 export const MODEL_LIST_VERSION = 15;
 

--- a/supabase/functions/auth-github/index.ts
+++ b/supabase/functions/auth-github/index.ts
@@ -14,8 +14,8 @@
  * - JWTs signed with Supabase's JWT secret
  */
 
-import { Hono } from 'jsr:@hono/hono@4.12.9';
-import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
+import { Hono } from 'jsr:@hono/hono@4.12.15';
+import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import { create, getNumericDate } from 'https://deno.land/x/djwt@v3.0.2/mod.ts';
 import { handleCors } from '../_shared/cors.ts';
 

--- a/supabase/functions/get-agent-config/index.ts
+++ b/supabase/functions/get-agent-config/index.ts
@@ -7,7 +7,7 @@
  * - POST /get-agent-config - Fetch agent YAML config by name
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
+import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================

--- a/supabase/functions/log-usage/index.ts
+++ b/supabase/functions/log-usage/index.ts
@@ -14,7 +14,7 @@
  * - RLS: Only SELECT policy for users, inserts use service role key
  */
 
-import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
+import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import { handleCors, getCorsHeaders } from '../_shared/cors.ts';
 
 // =============================================================================

--- a/supabase/functions/relay/index.ts
+++ b/supabase/functions/relay/index.ts
@@ -59,9 +59,9 @@
  * (SDKs send JWT in provider-specific headers, not the standard Authorization header).
  */
 
-import { Hono } from 'jsr:@hono/hono@4.12.9';
-import { cors } from 'jsr:@hono/hono@4.12.9/cors';
-import { createClient } from 'jsr:@supabase/supabase-js@2.100.1';
+import { Hono } from 'jsr:@hono/hono@4.12.15';
+import { cors } from 'jsr:@hono/hono@4.12.15/cors';
+import { createClient } from 'jsr:@supabase/supabase-js@2.104.1';
 import {
   TIER_CONFIG,
   TIER_SPENDING_LIMITS,

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -71,9 +71,9 @@ function toRelayModel(config: ModelConfig): RelayModel {
 // Model Definitions (derived from llm-zoo)
 // =============================================================================
 
-/** All current relay-compatible models from llm-zoo, converted to relay format. */
+/** All relay-compatible models from llm-zoo, converted to relay format. */
 const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
-  .filter((m) => !m.openRouterOnly && !m.deprecated)
+  .filter((m) => !m.openRouterOnly)
   .map(toRelayModel);
 
 /**

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -71,9 +71,9 @@ function toRelayModel(config: ModelConfig): RelayModel {
 // Model Definitions (derived from llm-zoo)
 // =============================================================================
 
-/** All models from llm-zoo, converted to relay format */
+/** All current relay-compatible models from llm-zoo, converted to relay format. */
 const RELAY_MODELS: RelayModel[] = Object.values(MODEL_CONFIGS)
-  .filter((m) => !m.openRouterOnly) // Exclude OpenRouter-only models
+  .filter((m) => !m.openRouterOnly && !m.deprecated)
   .map(toRelayModel);
 
 /**


### PR DESCRIPTION
## Summary

- Add a registry-backed helper for checking whether a model is marked deprecated in `llm-zoo`.
- Bump the model-list version so upgraded users run the model-list refresh.
- During that refresh, remove enabled models that are now deprecated while keeping deprecated models available in Settings for deliberate opt-in.

## Why

Users upgrading from an older release could keep deprecated model IDs in their normal model dropdown because the migration only removed a small hand-written set of old defaults. This makes the cleanup follow the current model registry instead.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint` (passes with existing warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user model-list migration logic by auto-removing any registry-deprecated models during an upgrade, which could surprise users or affect persisted preferences. Other changes are dependency bumps for Supabase edge functions with low behavioral risk.
> 
> **Overview**
> Updates the model-list migration to be **registry-driven**: on upgrade to `MODEL_LIST_VERSION = 15`, `refreshModelListIfNeeded` now removes any *currently enabled* models marked `deprecated` in `llm-zoo`, and also avoids auto-adding deprecated entries from `DEFAULT_MODELS`.
> 
> Adds a shared `isDeprecatedModel()` helper in `computeModelOptions.ts` to centralize the deprecation check.
> 
> Separately bumps Supabase edge-function dependencies (`hono` and `@supabase/supabase-js`) to newer versions without changing function logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f3fba080ba9a53347745e17237d87a9efab263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->