### PR TITLE
[codex] Tighten OpenAI background fallback diagnostics

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -216,15 +216,26 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
   /**
    * Check if background mode is active for this handler.
-   * Background mode is enabled when the config toggle is on AND
-   * this model/agent is eligible for background execution.
+   * Background mode is enabled when this handler supports it, the config
+   * toggle is on, and this model/agent is eligible for background execution.
    */
   public override isBackgroundModeActive(): boolean {
-    const useBackgroundResponses = getConfig<boolean>(
-      'texra.model.useBackgroundResponses',
-      true,
+    return this.shouldUseBackgroundResponses();
+  }
+
+  private isBackgroundModeToggleEnabled(): boolean {
+    return getConfig<boolean>('texra.model.useBackgroundResponses', true);
+  }
+
+  private shouldUseBackgroundResponses(
+    backgroundToggleEnabled = this.isBackgroundModeToggleEnabled(),
+    backgroundModeEligible = this.isBackgroundModeEligible(),
+  ): boolean {
+    return (
+      this.backgroundModeSupported &&
+      backgroundToggleEnabled &&
+      backgroundModeEligible
     );
-    return useBackgroundResponses && this.isBackgroundModeEligible();
   }
 
   protected override backgroundModeSupported = true;
@@ -1597,25 +1608,26 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     const { client, messages, temperature, systemPrompt, signal, tools } =
       options;
-    const streamingToggleEnabled = this.getStreamingConfig();
-    const backgroundToggleEnabled = getConfig<boolean>(
-      'texra.model.useBackgroundResponses',
-      true,
+    const backgroundToggleEnabled = this.isBackgroundModeToggleEnabled();
+    const backgroundModeEligible = this.isBackgroundModeEligible();
+    const useBackgroundResponses = this.shouldUseBackgroundResponses(
+      backgroundToggleEnabled,
+      backgroundModeEligible,
     );
-    const useBackgroundResponses =
-      this.backgroundModeSupported &&
-      backgroundToggleEnabled &&
-      this.isBackgroundModeEligible();
+    const streamingToggleEnabled = useBackgroundResponses
+      ? super.getStreamingConfig()
+      : this.getStreamingConfig();
     const useStreaming = streamingToggleEnabled && !useBackgroundResponses;
     const useWebSocket =
       this.isWebSocketModeEnabled() && !useBackgroundResponses;
 
-    if (backgroundToggleEnabled && !useBackgroundResponses) {
-      const reason = !this.backgroundModeSupported
-        ? 'this handler does not support background execution'
-        : 'not eligible for this model/agent type (requires a GPT model with a workflow agent)';
+    if (
+      backgroundToggleEnabled &&
+      backgroundModeEligible &&
+      !useBackgroundResponses
+    ) {
       this.logger.debug(
-        `Background mode toggle is enabled but ${reason}. Falling back to synchronous requests.`,
+        'Background mode toggle is enabled but this handler does not support background execution. Proceeding without background mode.',
       );
     } else if (streamingToggleEnabled && useBackgroundResponses) {
       this.logger.debug(

--- a/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenAIResponseBackground.test.ts
@@ -1,0 +1,95 @@
+// Node.js built-in imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import * as configModule from '@agent/core/config';
+import { ModelHandlerOpenAIResponse } from '@agent/modelHandlers/modelHandlerOpenAIResponse';
+
+class UnsupportedBackgroundHandler extends ModelHandlerOpenAIResponse {
+  protected override backgroundModeSupported = false;
+}
+
+function createOpenAIConfig(name: string): ModelConfig {
+  return {
+    name,
+    label: name,
+    fullName: name,
+    shortName: name,
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 10,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 1000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+  };
+}
+
+describe('ModelHandlerOpenAIResponse background mode', () => {
+  const originalGetConfig = configModule.getConfig;
+
+  afterEach(() => {
+    (configModule as { getConfig: typeof originalGetConfig }).getConfig =
+      originalGetConfig;
+  });
+
+  it('enables background mode by default only for GPT workflow agents', () => {
+    const handler = new ModelHandlerOpenAIResponse(createOpenAIConfig('gpt-5'));
+    handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.isBackgroundModeActive(), true);
+    assert.equal(handler.getStreamingConfig(), false);
+  });
+
+  it('keeps GPT tool-use agents on streaming requests by default', () => {
+    const handler = new ModelHandlerOpenAIResponse(createOpenAIConfig('gpt-5'));
+    handler.setAgentCategory(AgentCategory.ToolUse);
+
+    assert.equal(handler.isBackgroundModeActive(), false);
+    assert.equal(handler.getStreamingConfig(), true);
+  });
+
+  it('keeps non-GPT workflow agents on streaming requests by default', () => {
+    const handler = new ModelHandlerOpenAIResponse(createOpenAIConfig('o3'));
+    handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.isBackgroundModeActive(), false);
+    assert.equal(handler.getStreamingConfig(), true);
+  });
+
+  it('respects the background-mode toggle for GPT workflow agents', () => {
+    (configModule as { getConfig: typeof originalGetConfig }).getConfig = (<T>(
+      key: string,
+      defaultValue?: T,
+    ): T => {
+      if (key === 'texra.model.useBackgroundResponses') {
+        return false as T;
+      }
+      return originalGetConfig(key, defaultValue);
+    }) as typeof originalGetConfig;
+
+    const handler = new ModelHandlerOpenAIResponse(createOpenAIConfig('gpt-5'));
+    handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.isBackgroundModeActive(), false);
+    assert.equal(handler.getStreamingConfig(), true);
+  });
+
+  it('keeps streaming enabled when an eligible handler cannot use background mode', () => {
+    const handler = new UnsupportedBackgroundHandler(
+      createOpenAIConfig('gpt-5'),
+    );
+    handler.setAgentCategory(AgentCategory.Workflow);
+
+    assert.equal(handler.isBackgroundModeActive(), false);
+    assert.equal(handler.getStreamingConfig(), true);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize OpenAI Responses background-mode activation behind one helper
- avoid emitting the "Falling back to synchronous requests" debug log for non-GPT models and tool-use agents that are not background-mode candidates
- keep the streaming-suppression diagnostic reachable by reading the raw streaming preference only when background mode is active
- add regression coverage for GPT workflow, GPT tool-use, non-GPT workflow, disabled-toggle, and unsupported-handler cases

## Root Cause
`createResponse()` used `this.getStreamingConfig()` after the OpenAI Responses handler had already overridden that accessor to disable streaming whenever background mode was active. That made the "skipping streaming" diagnostic dead. The same block also logged fallback diagnostics for every request where the default background toggle was true but the request was ineligible, which made normal tool-use and non-GPT requests look like failed background requests.

## Validation
- `npm run compile:safe`
- `npm run lint` (0 errors; existing unrelated warnings remain in `StreamLogStore.ts`, `ProgressEventHandler.ts`, and `ProgressViewState.ts`)

Closes #3099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how OpenAI Responses chooses between background polling and streaming, which can change runtime transport behavior and debug logging for some requests. Scope is contained to one handler with added unit coverage to reduce regression risk.
> 
> **Overview**
> Tightens OpenAI Responses background-mode decisioning by centralizing activation behind `shouldUseBackgroundResponses()` and splitting the config toggle lookup into `isBackgroundModeToggleEnabled()`.
> 
> Updates `createResponseImpl()` to read the *raw* streaming preference (`super.getStreamingConfig()`) when background mode is active, making the "skipping streaming" diagnostic reachable again, and narrows the "toggle enabled but unsupported" debug log to only fire for background-eligible requests.
> 
> Adds `ModelHandlerOpenAIResponseBackground.test.ts` coverage for GPT workflow vs tool-use agents, non-GPT workflow agents, disabled toggle behavior, and handlers that explicitly don’t support background execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3676f6c5bc9e408bad490777360b4b83b7004adf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->