### PR TITLE
[codex] Surface setup assistant walkthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -819,7 +819,7 @@
       },
       {
         "command": "texra.runSetupAssistant",
-        "title": "Run Setup Assistant",
+        "title": "Run Setup Assistant Agent (Setup Wizard)",
         "category": "TeXRA",
         "icon": "$(rocket)"
       },
@@ -1140,8 +1140,8 @@
         "steps": [
           {
             "id": "texra.gettingStarted.setupAssistant",
-            "title": "Let TeXRA set itself up",
-            "description": "One click. TeXRA's setup assistant will check your environment, install any missing LaTeX tools, add an API key or sign you in, and get you ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
+            "title": "Run the setup assistant agent",
+            "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
             "media": {
               "markdown": "resources/walkthroughs/getting-started.md"
             },

--- a/resources/walkthroughs/getting-started.md
+++ b/resources/walkthroughs/getting-started.md
@@ -8,9 +8,9 @@ You can also run individual agents yourself if you want to do one specific thing
 
 ## First-time setup
 
-**The quickest path:** run the **Setup Assistant**. It's a conversational agent that probes your environment, installs any missing LaTeX tools, sets up a credential, and verifies everything end-to-end.
+**The quickest path:** run the **Setup Assistant Agent**. It's a conversational agent that probes your environment, installs any missing LaTeX tools, sets up a credential, and verifies everything end-to-end.
 
-- Command Palette > **TeXRA: Run Setup Assistant**, or click **Run Setup Assistant** in the first step of the walkthrough on the left.
+- Command Palette > **TeXRA: Run Setup Assistant Agent (Setup Wizard)**, or click **Run Setup Assistant Agent** in the first step of the walkthrough on the left.
 - The assistant asks before every command and explains what it's about to do. You stay in control.
 - Already have LaTeX and a credential? It'll say so and skip straight to verification.
 
@@ -20,7 +20,7 @@ You can also run individual agents yourself if you want to do one specific thing
 
 Follow the checklist on the left. Each step links to the right command.
 
-1. **Let TeXRA set itself up** -- One click; the setup assistant handles the rest. (Or skip and follow the manual steps below.)
+1. **Let TeXRA set itself up** -- One click; the setup assistant agent handles the rest. (Or skip and follow the manual steps below.)
 2. **Try the sample project** -- A small LaTeX project you can play with safely.
 3. **Add your API key** -- You'll need one from Anthropic, OpenAI, Google, or similar. Chat subscriptions (ChatGPT Plus, Claude Pro) don't include API access.
 4. **Or just sign in** -- The Researcher Access Program gives you free model access, no API key needed. Signing in also unlocks extra agents.

--- a/resources/walkthroughs/getting-started.md
+++ b/resources/walkthroughs/getting-started.md
@@ -20,7 +20,7 @@ You can also run individual agents yourself if you want to do one specific thing
 
 Follow the checklist on the left. Each step links to the right command.
 
-1. **Let TeXRA set itself up** -- One click; the setup assistant agent handles the rest. (Or skip and follow the manual steps below.)
+1. **Run the setup assistant agent** -- One click; the setup assistant agent handles the rest. (Or skip and follow the manual steps below.)
 2. **Try the sample project** -- A small LaTeX project you can play with safely.
 3. **Add your API key** -- You'll need one from Anthropic, OpenAI, Google, or similar. Chat subscriptions (ChatGPT Plus, Claude Pro) don't include API access.
 4. **Or just sign in** -- The Researcher Access Program gives you free model access, no API key needed. Signing in also unlocks extra agents.

--- a/src/commands/system/mainViewCommands.ts
+++ b/src/commands/system/mainViewCommands.ts
@@ -141,6 +141,11 @@ export function registerMainViewCommands(
               command: sampleProjectCommands.createSampleProject,
             },
             {
+              label: '$(rocket) Run the setup assistant agent',
+              description: 'Check tools, credentials, and LaTeX setup',
+              command: 'texra.runSetupAssistant',
+            },
+            {
               label: '$(book) Walk me through setup',
               description: 'Open the getting started walkthrough',
               command: 'texra.openGettingStarted',

--- a/src/commands/system/walkthroughCommands.ts
+++ b/src/commands/system/walkthroughCommands.ts
@@ -1,6 +1,8 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+const GETTING_STARTED_WALKTHROUGH_ID = 'texra-ai.texra#texra.gettingStarted';
+
 export function registerWalkthroughCommands(
   context: vscode.ExtensionContext,
 ): void {
@@ -8,7 +10,7 @@ export function registerWalkthroughCommands(
     vscode.commands.registerCommand('texra.openGettingStarted', () =>
       vscode.commands.executeCommand(
         'workbench.action.openWalkthrough',
-        'texra.gettingStarted',
+        GETTING_STARTED_WALKTHROUGH_ID,
       ),
     ),
   );

--- a/src/commands/system/walkthroughCommands.ts
+++ b/src/commands/system/walkthroughCommands.ts
@@ -1,7 +1,7 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
-const GETTING_STARTED_WALKTHROUGH_ID = 'texra-ai.texra#texra.gettingStarted';
+const GETTING_STARTED_WALKTHROUGH_ID = 'texra.gettingStarted';
 
 export function registerWalkthroughCommands(
   context: vscode.ExtensionContext,
@@ -10,7 +10,7 @@ export function registerWalkthroughCommands(
     vscode.commands.registerCommand('texra.openGettingStarted', () =>
       vscode.commands.executeCommand(
         'workbench.action.openWalkthrough',
-        GETTING_STARTED_WALKTHROUGH_ID,
+        `${context.extension.id}#${GETTING_STARTED_WALKTHROUGH_ID}`,
       ),
     ),
   );

--- a/src/shared/utils/uiConstants.ts
+++ b/src/shared/utils/uiConstants.ts
@@ -1,5 +1,6 @@
 /** VS Code command URIs for use in anchor href attributes. */
 export const COMMAND_LINKS = {
+  RUN_SETUP_ASSISTANT: 'command:texra.runSetupAssistant',
   GETTING_STARTED: 'command:texra.openGettingStarted',
   CREATE_SAMPLE_PROJECT: 'command:texra.createSampleProject',
   CLONE_OVERLEAF: 'command:texra.cloneOverleafProject',
@@ -31,6 +32,7 @@ export const FEEDBACK_ELIGIBLE_KINDS = new Set<PermissionKind>([
 export function getGettingStartedHtml(prefix = ''): string {
   return (
     prefix +
+    `<a href="${COMMAND_LINKS.RUN_SETUP_ASSISTANT}">run the setup assistant agent</a>, ` +
     `<a href="${COMMAND_LINKS.GETTING_STARTED}">open the getting started walkthrough</a>, ` +
     `<a href="${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}">create a sample project</a>, ` +
     `<a href="${COMMAND_LINKS.CLONE_OVERLEAF}">clone an Overleaf project</a>, or ` +

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -90,6 +90,12 @@ export class GettingStartedBanner extends LitElement {
         </div>
         <ul class="getting-started-list">
           <li>
+            <a href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
+              >Run the setup assistant agent</a
+            >
+            -- checks tools, credentials, and LaTeX setup
+          </li>
+          <li>
             <a href=${COMMAND_LINKS.GETTING_STARTED}>Walk me through setup</a>
             -- takes a few minutes
           </li>


### PR DESCRIPTION
## Summary
- make the setup assistant easier to find by naming it as an agent/setup wizard in the Command Palette and walkthrough copy
- add a direct setup assistant action to the empty-workspace getting started banner and import/create project quick pick
- open the TeXRA walkthrough with the fully qualified VS Code walkthrough id so command links reliably resolve

## Validation
- npm run format
- npm run compile:safe
- npm run lint (0 errors; 3 pre-existing warnings in unrelated files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to onboarding copy and UI entry points plus a small tweak to how the walkthrough is opened; no core agent or data-handling logic is modified.
> 
> **Overview**
> **Improves setup assistant discoverability and wording.** Renames the `texra.runSetupAssistant` command title and updates getting-started walkthrough text/markdown to consistently present it as the “setup assistant agent / setup wizard”.
> 
> **Adds new UI entry points.** Surfaces “Run the setup assistant agent” in the empty-workspace getting-started banner and in the import/create project quick pick.
> 
> **Hardens walkthrough opening.** Updates `texra.openGettingStarted` to open the walkthrough via the fully-qualified `${extensionId}#texra.gettingStarted` id so command links resolve reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be18c5abe236dbc7b6eb54cef17f9177b6905e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->