### PR TITLE
docs: correct GitHub token provider source

### DIFF
--- a/src/tools/github/githubAuth.ts
+++ b/src/tools/github/githubAuth.ts
@@ -2,8 +2,8 @@
  * Injectable GitHub token provider.
  *
  * This module is VS Code-free. The extension host registers an implementation
- * during activation (see `setGitHubTokenProvider`) that reads from
- * `texra.github.token` or other host-specific sources. Tools and the polling
+ * during activation (see `setGitHubTokenProvider`) that reads from VS Code's
+ * SecretStorage (or `GITHUB_TOKEN` env fallback). Tools and the polling
  * service read the token lazily via `getGitHubToken()` so they never depend on
  * VS Code APIs directly.
  */


### PR DESCRIPTION
The injected provider reads from VS Code SecretStorage (with GITHUB_TOKEN
env fallback), not the non-existent `texra.github.token` config key.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a module comment; no runtime logic is modified.
> 
> **Overview**
> Corrects the inline documentation in `src/tools/github/githubAuth.ts` to state that the injected GitHub token provider reads from VS Code `SecretStorage` (with `GITHUB_TOKEN` env fallback), replacing the outdated reference to a `texra.github.token` setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6838832ef86e9ad2e523b0ba1e24f467c707a9eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->