### PR TITLE
refine: subtler dismiss button on session hint banner

### DIFF
--- a/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -40,18 +40,6 @@ export class WorkflowHintBanner extends LitElement {
       font-weight: 600;
       margin-right: 4px;
     }
-    button {
-      background: transparent;
-      border: none;
-      color: var(--vscode-foreground);
-      opacity: 0.7;
-      cursor: pointer;
-      padding: 0 4px;
-      font-size: 1em;
-    }
-    button:hover {
-      opacity: 1;
-    }
   `;
 
   @state()
@@ -71,14 +59,12 @@ export class WorkflowHintBanner extends LitElement {
           It reduces hallucinations and cuts fluff, so expect 10–30 minutes per
           run. Use Stop to cancel; pick Tool-Use mode for fast, iterative edits.
         </div>
-        <button
-          type="button"
-          @click=${this.handleDismiss}
-          title="Dismiss"
+        <vscode-toolbar-button
+          icon="close"
+          title="Dismiss this reminder"
           aria-label="Dismiss workflow mode reminder"
-        >
-          ✕
-        </button>
+          @click=${this.handleDismiss}
+        ></vscode-toolbar-button>
       </div>
     `;
   }

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -168,9 +168,6 @@ export class InstructionPanel extends LitElement {
       .session-hint-dismiss {
         flex: 0 0 auto;
         margin-left: var(--spacing-tiny);
-        font-size: 1em;
-        line-height: 1;
-        color: var(--vscode-descriptionForeground);
       }
 
       vscode-textarea#instruction {
@@ -313,15 +310,13 @@ export class InstructionPanel extends LitElement {
           ${copy.body}
           <span class="session-hint-time">${copy.time}</span>
         </span>
-        <button
-          type="button"
-          class="icon-btn-reset session-hint-dismiss"
+        <vscode-toolbar-button
+          icon="close"
+          class="session-hint-dismiss"
+          title="Dismiss this reminder"
           aria-label="Dismiss this reminder"
-          title="Dismiss"
           @click=${this.handleDismissSessionHint}
-        >
-          ✕
-        </button>
+        ></vscode-toolbar-button>
       </div>
     `;
   }

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -168,6 +168,8 @@ export class InstructionPanel extends LitElement {
       .session-hint-dismiss {
         flex: 0 0 auto;
         margin-left: var(--spacing-tiny);
+        font-size: 1em;
+        line-height: 1;
         color: var(--vscode-descriptionForeground);
       }
 
@@ -311,15 +313,15 @@ export class InstructionPanel extends LitElement {
           ${copy.body}
           <span class="session-hint-time">${copy.time}</span>
         </span>
-        <vscode-button
-          appearance="icon"
-          class="session-hint-dismiss"
+        <button
+          type="button"
+          class="icon-btn-reset session-hint-dismiss"
           aria-label="Dismiss this reminder"
-          title="Dismiss this reminder"
+          title="Dismiss"
           @click=${this.handleDismissSessionHint}
         >
-          <i class="codicon codicon-close"></i>
-        </vscode-button>
+          ✕
+        </button>
       </div>
     `;
   }


### PR DESCRIPTION
Match the WorkflowHintBanner reminder treatment — plain ✕ with
icon-btn-reset (transparent, opacity 0.7→1.0) — instead of the
prominent vscode-button icon that rendered as a large blue square.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps dismiss controls to `vscode-toolbar-button` icons; no logic, data, or security behavior changes beyond minor styling/layout differences.
> 
> **Overview**
> Standardizes the dismiss affordance for the workflow hint and session hint banners by replacing the custom/`vscode-button` close controls with a `vscode-toolbar-button` using the `close` icon and updated tooltip/ARIA text.
> 
> Removes the bespoke CSS styling previously used for the WorkflowHintBanner dismiss button and drops now-unneeded styling from the session hint dismiss class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81056da019fa2d33f8d0b714c113bfcbeccd40b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->