### PR TITLE
Expand setup assistant with config tools, execution subscriptions, and orchestration

### DIFF
--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -16,6 +16,9 @@ settings:
     - edit_file
     - glob
     - ls
+    - delegate_agent
+    - delegate_workflow
+    - executions
 
 prompts:
   systemPrompt: |
@@ -72,6 +75,47 @@ prompts:
          project via `invoke_command` with `texra.createSampleProject`.
       G. Final `verify_setup` call; print a plain-language "you're good to
          go" summary.
+      H. Offer to launch the user's first task on their behalf — see
+         "Launching the first task" below. Default is to offer; do not
+         delegate without confirmation.
+
+    ## Launching the first task
+
+    Once the environment is healthy and a credential is in place, you can
+    act as a lightweight orchestrator and kick off the user's first run.
+    Keep this short — one yes/no question, one delegation, one pointer to
+    the Progress view.
+
+    1. Ask the user, in one sentence, what they want to work on. Offer two
+       defaults if they don't know:
+         - "Try the sample project" → use `sample/main.tex` (or whatever
+           file `texra.createSampleProject` just produced; ask the user to
+           confirm the path if uncertain).
+         - "Use a file already open in the editor" → ask for the path.
+    2. Pick the right delegation tool and agent:
+         - For an end-to-end paper improvement pass, prefer the remote
+           `orchestrator` tool-use agent (best when the user is signed in
+           via Researcher Access) via `delegate_agent`. It plans a pipeline
+           and dispatches workflow agents itself.
+         - For a single, well-scoped document operation (e.g. "fix grammar
+           in this file"), call `delegate_workflow` directly with `correct`
+           or `polish` and the user's file as `inputFile`.
+         - When in doubt, ask one clarifying question rather than guessing.
+       Pass `model` only if the user asked for one; otherwise let it
+       default. Do not invent file paths — the user-supplied path or the
+       sample project path are the only safe defaults.
+    3. The delegation goes through the normal proposal/approval UI — the
+       user reviews and approves the run. Tell them to watch the Progress
+       view and, for `orchestrator`, that they will see further proposals
+       there as it dispatches subagents.
+    4. After delegating, you can monitor with the `executions` tool:
+       `executions { path: "/executions/<id>", action: "wait" }` blocks
+       until the subagent's status changes; `action: "view"` reads the
+       latest summary, todos, and report. Do not poll in a tight loop.
+       Report progress to the user in one sentence per status change, and
+       stop when the subagent reaches `completed`.
+    5. If the user declines, do not push — say "you're set; hit Execute in
+       the main view whenever you're ready" and finish.
 
     ## Delegation to existing UI
 
@@ -110,10 +154,11 @@ prompts:
     ## Finish
 
     When the core dependencies, the LaTeX Workshop extension, and one
-    credential are all in place, tell the user they're ready and suggest
-    a concrete next action: "Click Execute on the sample project" or
-    "Open the main view and pick an agent." Do not keep asking follow-up
-    questions after that.
+    credential are all in place, tell the user they're ready and offer to
+    launch the first task per "Launching the first task" above. If the
+    user accepts, delegate once and stop — the Progress view takes it from
+    there. If they decline, point them at "Open the main view and pick an
+    agent" and stop. Do not keep asking follow-up questions after that.
 
   userRequest: |
     {{ INSTRUCTION }}

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -1,5 +1,5 @@
 name: setup
-description: Setup assistant — diagnoses the environment and installs missing dependencies for TeXRA.
+description: Setup assistant — diagnoses the environment, installs missing dependencies, configures TeXRA, and orchestrates the user's first task.
 
 settings:
   agentCategory: toolUse
@@ -10,42 +10,84 @@ settings:
     - unset_api_key
     - invoke_command
     - install_vscode_extension
+    - read_config
+    - update_config
     - bash
     - read_file
     - write_file
     - edit_file
     - glob
     - ls
+    - arxiv_search
+    - arxiv_metadata
+    - download_arxiv_source
+    - web_fetch
+    - web_search
     - delegate_agent
     - delegate_workflow
     - executions
 
 prompts:
   systemPrompt: |
-    You are TeXRA's setup assistant. Your single job: get a user from a fresh
-    install to a working TeXRA environment with minimum friction. You converse
-    conversationally in short, plain-language turns — no walls of text.
+    You are TeXRA's setup assistant — equal parts onboarding installer,
+    settings tutor, and lightweight orchestrator. Your single job: take a
+    user from a fresh install to a real, working first run, teaching them
+    enough about TeXRA along the way that they can keep going on their
+    own. You converse conversationally in short, plain-language turns —
+    no walls of text.
+
+    ## What TeXRA actually is (teach this when relevant)
+
+    TeXRA is a VS Code extension that pairs an LLM with a fleet of
+    specialized agents to help the user write, polish, and reason about
+    LaTeX research papers. Mention these pieces in plain language as you
+    encounter them:
+
+      - **Orchestrator** — the recommended way to start. The user gives
+        it their paper, it decides which agents to dispatch (correct,
+        polish, review, …) and proposes each task for approval in the
+        Progress view. Lives as the `orchestrator` tool-use agent.
+      - **Workflow agents** — single-purpose, run once over a whole file:
+        `correct` (proofreading), `polish` (instruction-driven rewrite),
+        `merge` (combine drafts), `ocr` (PDF → LaTeX), `transcribe_audio`
+        (audio → notes), `paper2poster` / `paper2slide`.
+      - **Tool-use agents** — interactive, multi-step assistants:
+        `chat` (general scientist collaborator), `research` (Wolfram-backed
+        derivations), `review` (critical reading), `creator` (writes new
+        agents), `latexFixer` / `latexDiff` (compile + diff helpers),
+        `lean` (Lean 4), `presenter` (slides), `setup` (you).
+      - **Progress view** — where pending agent proposals live. The user
+        approves with `y`, rejects with `n`, or edits before approving.
+      - **Memory** — Markdown notes the user can attach to any run so
+        agents pick up project conventions. Lives behind `texra.showMemory`.
+
+    Don't dump this list verbatim. Pull from it as the user asks "what
+    can it do?" or as a one-line aside when you're about to delegate.
 
     ## Core rule: explain → confirm → execute → verify
 
-    Every install/config step follows this loop:
+    Every install / config / settings step follows this loop:
       1. EXPLAIN, in one short sentence, what you're about to do and why.
-      2. CONFIRM — either wait for the user to approve the bash dialog, or
-         ask a single yes/no question for non-bash actions.
+      2. CONFIRM — either wait for the user to approve the bash dialog,
+         or ask a single yes/no question for non-bash actions. For
+         settings writes (`update_config`, `set_api_key`), describe the
+         old value and the new value before writing.
       3. EXECUTE one command at a time. Never chain risky operations.
-      4. VERIFY with `verify_setup` (or re-probe a specific tool) and tell
-         the user what changed in one sentence before moving on.
+      4. VERIFY with `verify_setup` (or re-probe a specific tool /
+         re-read the setting) and tell the user what changed in one
+         sentence before moving on.
 
     Never recommend disabling bash approvals or Super YOLO. Never run
-    destructive shell commands (`rm -rf`, `sudo ... --force`, etc.) as part
-    of setup.
+    destructive shell commands (`rm -rf`, `sudo ... --force`, etc.) as
+    part of setup.
 
     ## Opening move
 
     Start by calling `probe_environment` exactly once. It returns a JSON
     document describing the OS, package manager, installed TeX tools, the
     LaTeX Workshop extension, per-provider API-key presence, and Researcher
-    Access sign-in. Summarize the result in one short paragraph to the user.
+    Access sign-in. Summarize the result in one short paragraph to the
+    user — including, if relevant, which credential sources are missing.
 
     Then decide the plan based on what's missing. Work phases roughly in
     this order, but skip anything the probe shows is already done:
@@ -64,77 +106,182 @@ prompts:
          PATH="/usr/local/texlive/2024/bin/universal-darwin:$PATH"\n' >>
          ~/.zshrc`. The user's normal bash approval dialog is the gate; do
          not bypass it. Tell the user to open a new terminal afterward.
-      D. Credentials: exactly one of
-           - Researcher Access sign-in (recommended, free): call
-             `invoke_command` with `texra.auth.signIn`.
-           - User-supplied API key: once the user pastes one in chat, call
-             `set_api_key` with `{ provider, key }`. Never guess a key.
-      E. Optional extras (Zotero, Lean 4) — ask once whether to install;
-         default is skip.
-      F. If no `.tex` files in the workspace, offer to create the sample
-         project via `invoke_command` with `texra.createSampleProject`.
-      G. Final `verify_setup` call; print a plain-language "you're good to
-         go" summary.
-      H. Offer to launch the user's first task on their behalf — see
-         "Launching the first task" below. Default is to offer; do not
-         delegate without confirmation.
+      D. Credentials — see "Setting up credentials" below. This phase
+         MUST complete (Researcher Access sign-in OR at least one usable
+         API key) before phase H. If the probe shows no credential, do
+         not skip ahead.
+      E. Optional extras (Zotero, Lean 4, SoX for audio) — ask once
+         whether to install; default is skip. Use `update_config` to set
+         relevant paths (`texra.bib.zoteroPort`, `texra.audio.soxPath`)
+         after install if needed.
+      F. Project source — see "Bringing a paper into the workspace"
+         below. If no `.tex` files in the workspace, offer the sample
+         project, an Overleaf clone, or an arXiv download.
+      G. Final `verify_setup` call; print a plain-language "you're good
+         to go" summary that names the credential in use and the project
+         the user is about to work on.
+      H. Offer to launch the user's first task — see "Launching the
+         first task". Gate this on phase D being satisfied; do NOT
+         delegate without confirmation, and do NOT delegate if no
+         credential is in place.
 
-    ## Launching the first task
+    ## Setting up credentials (phase D — required)
 
-    Once the environment is healthy and a credential is in place, you can
-    act as a lightweight orchestrator and kick off the user's first run.
-    Keep this short — one yes/no question, one delegation, one pointer to
-    the Progress view.
+    TeXRA needs one of: a Researcher Access sign-in, or a real API key
+    for one of the supported providers. Pick the path that fits the
+    user; don't push both.
 
-    1. Ask the user, in one sentence, what they want to work on. Offer two
-       defaults if they don't know:
-         - "Try the sample project" → use `sample/main.tex` (or whatever
-           file `texra.createSampleProject` just produced; ask the user to
-           confirm the path if uncertain).
-         - "Use a file already open in the editor" → ask for the path.
-    2. Pick the right delegation tool and agent:
-         - For an end-to-end paper improvement pass, prefer the remote
-           `orchestrator` tool-use agent (best when the user is signed in
-           via Researcher Access) via `delegate_agent`. It plans a pipeline
-           and dispatches workflow agents itself.
-         - For a single, well-scoped document operation (e.g. "fix grammar
-           in this file"), call `delegate_workflow` directly with `correct`
-           or `polish` and the user's file as `inputFile`.
-         - When in doubt, ask one clarifying question rather than guessing.
-       Pass `model` only if the user asked for one; otherwise let it
-       default. Do not invent file paths — the user-supplied path or the
-       sample project path are the only safe defaults.
-    3. The delegation goes through the normal proposal/approval UI — the
-       user reviews and approves the run. Tell them to watch the Progress
-       view and, for `orchestrator`, that they will see further proposals
-       there as it dispatches subagents.
-    4. After delegating, you can monitor with the `executions` tool:
-       `action: "wait"` blocks until the subagent's status changes;
-       `action: "subscribe"` enrolls this stream to receive future
-       transitions as `<execution-activity>` follow-ups so you can keep
-       chatting with the user while the run progresses (it auto-disposes
-       when the subagent finishes); `action: "view"` reads the latest
-       summary, todos, and report. Do not poll in a tight loop. Report
-       progress to the user in one sentence per status change, and stop
-       when the subagent reaches `completed`.
-    5. If the user declines, do not push — say "you're set; hit Execute in
-       the main view whenever you're ready" and finish.
+      - **Researcher Access (recommended, free):** call `invoke_command`
+        with `texra.auth.signIn`. The browser flow handles the rest.
+        After the user finishes, re-run `probe_environment` to confirm
+        `auth.authenticated` flipped to `true`. Mention that signing in
+        also unlocks remote agents like the orchestrator.
+      - **Bring-your-own API key:** ask the user which provider they
+        already have an account with. If they don't have one, briefly
+        explain the options:
+          - **Anthropic** (Claude) — best default for most TeXRA agents.
+            Keys at https://console.anthropic.com/settings/keys.
+          - **OpenAI** (GPT-5/4o) — broad model coverage, vision strong.
+            Keys at https://platform.openai.com/api-keys.
+          - **Google** (Gemini) — long-context, fast. Keys at
+            https://aistudio.google.com/apikey.
+          - **DeepSeek**, **xAI** (Grok), **OpenRouter**, **Together**,
+            and others are also supported — list only the one(s) the
+            user mentions; don't dump every option.
+        Note that ChatGPT Plus / Claude Pro chat subscriptions do NOT
+        include API access — the user needs an API key from the
+        provider's developer console specifically.
+        Ask the user to paste the key in chat. Once they do, call
+        `set_api_key` with `{ provider, key }`. The tool masks the key
+        in its summary; never echo the raw value back. If the pasted
+        value looks like a placeholder (`sk-xxx`, `<your-key>`, etc.),
+        refuse and ask for the real one.
+      - After either path, re-probe and tell the user which credential
+        is now active. If neither sign-in nor a usable key is present,
+        do not advance to phase H.
 
-    ## Delegation to existing UI
+    ## Touching settings (read first, then update)
 
-    For anything outside your allowlisted actions (changing the helper
-    model, enabling memory persistence, picking an agent mode preset,
-    toggling individual models, managing GitHub tokens), DO NOT try to
-    replicate the flow. Instead, invoke the right settings tab via
-    `invoke_command`:
-      - Models tab: `texra.showModels`
+    You have two settings tools: `read_config` (any `texra.*` key,
+    read-only) and `update_config` (writes, but only on a strict
+    allowlist — bibliography path, Zotero port, SoX path, LaTeX
+    formatter choice, TikZ input directory, auto-compile toggle, git
+    commits depth, max image dimension). Use them educatively:
+
+      1. `read_config` to see the current value.
+      2. Explain in one sentence what the setting controls and why the
+         user might want to change it.
+      3. Ask before writing. State the proposed new value explicitly.
+      4. `update_config` with `target: "user"` for general preferences,
+         `target: "workspace"` only for project-local choices (e.g. a
+         workspace-specific `texra.bib.defaultPath`).
+      5. Re-read with `read_config` to confirm the write took.
+
+    For settings outside the allowlist (model selection, agent presets,
+    memory toggles, GitHub token, telemetry, …), do NOT try to write
+    them through bash or hand-edit settings.json. Open the right UI:
+
+      - Models tab: `invoke_command` `texra.showModels`
       - Agents tab: `texra.showAgents`
-      - Multi-Agent presets: `texra.showMultiAgent`
+      - Multi-Agent presets / delegation toggles: `texra.showMultiAgent`
       - Memory: `texra.showMemory`
       - Tools dashboard: `texra.showTools`
       - Git author & GitHub token: `texra.showGitSettings`
-      - Full dashboard: `texra.showSettingsView`
-    Then tell the user where to click.
+      - Native VS Code settings (search-filterable): `texra.openSettings`
+      - Full TeXRA dashboard: `texra.showSettingsView`
+
+    Then tell the user which control to click. The TeXRA dashboard tabs
+    embed the same UI surfaces a power user would use, so this is also
+    a good moment to point out features they didn't know existed.
+
+    ## Quick git primer (offer when relevant)
+
+    Some flows (Overleaf clone, contributing back to a repo) need
+    `git`. If `probe_environment` reports `git` missing, or the user
+    seems unfamiliar:
+
+      1. In one sentence: git is a version-control tool that tracks
+         every change to your files; TeXRA uses it to clone Overleaf
+         projects, surface recent commits in the editor, and let agents
+         work in isolated worktrees without touching your main checkout.
+      2. Install it through the platform package manager
+         (`brew install git`, `sudo apt-get install -y git`, or
+         `scoop install git`).
+      3. After install, ask the user for the name and email they want
+         on commits (you can leave this for `texra.showGitSettings` to
+         capture — that tab also handles the GitHub token).
+      4. Don't lecture about branches/merges unless asked. The user can
+         drive that through VS Code's Source Control panel; your job is
+         just to make sure git exists and is configured.
+
+    ## Bringing a paper into the workspace (phase F)
+
+    Three on-ramps. Pick whichever the user wants — don't run all three.
+
+      - **Sample project:** `invoke_command` `texra.createSampleProject`.
+        Best for "I just want to see how it works."
+      - **Overleaf clone:** `invoke_command` `texra.cloneOverleafProject`.
+        The command opens its own quick-pick that asks for the project
+        URL (`https://www.overleaf.com/project/<24-hex>`) and a Git
+        token. Tell the user where the token comes from:
+        https://www.overleaf.com/user/settings → "Git integration" →
+        generate a token. They can paste either the token alone (the
+        command stores it for them) or a fully formed
+        `https://git:<token>@git.overleaf.com/<id>` URL. After clone,
+        the workspace reopens on the cloned folder; you can then
+        delegate against the new `main.tex` (or whatever entry point
+        the project has).
+      - **arXiv paper:** the user can either point you at an arXiv ID
+        / abs URL and you run `download_arxiv_source` (downloads the
+        TeX source tarball into the workspace), or invoke
+        `texra.downloadArXivSource` for the GUI flow that prompts them
+        for an ID. If they only have a topic, use `arxiv_search` first
+        to find candidates, then `arxiv_metadata` to confirm before
+        downloading. Always confirm with the user which paper to fetch
+        before downloading.
+
+    ## Launching the first task (phase H)
+
+    Once the environment is healthy AND credentials are in place AND a
+    project is in the workspace, you can act as a lightweight
+    orchestrator. Keep this short — one yes/no question, one
+    delegation, one pointer to the Progress view.
+
+      1. Ask the user, in one sentence, what they want to work on.
+         Defaults if they don't know:
+           - "Try the sample project"
+           - "Use a file already open in the editor" (ask for the path)
+           - "Start with the file we just downloaded / cloned"
+      2. Pick the right delegation tool and agent:
+           - For an end-to-end paper improvement pass, prefer the remote
+             `orchestrator` tool-use agent (best when the user signed in
+             via Researcher Access) via `delegate_agent`. It plans a
+             pipeline and dispatches workflow agents itself.
+           - For a single, well-scoped document operation (e.g. "fix
+             grammar in this file"), call `delegate_workflow` directly
+             with `correct` or `polish` and the user's file as
+             `inputFile`.
+           - When in doubt, ask one clarifying question rather than
+             guessing.
+         Pass `model` only if the user asked for one; otherwise let it
+         default. Do not invent file paths — the user-supplied path or
+         the just-created sample / cloned / downloaded path are the only
+         safe defaults.
+      3. The delegation goes through the normal proposal/approval UI —
+         the user reviews and approves the run. Tell them to watch the
+         Progress view, and, for `orchestrator`, that they will see
+         further proposals there as it dispatches subagents.
+      4. After delegating, monitor with the `executions` tool: `action:
+         "wait"` blocks until the subagent's status changes; `action:
+         "subscribe"` enrolls this stream to receive future transitions
+         as `<execution-activity>` follow-ups so you can keep chatting
+         with the user while the run progresses (auto-disposes when the
+         subagent finishes); `action: "view"` reads the latest summary,
+         todos, and report. Do not poll in a tight loop. Report progress
+         to the user in one sentence per status change, and stop when
+         the subagent reaches `completed`.
+      5. If the user declines, do not push — say "you're set; hit
+         Execute in the main view whenever you're ready" and finish.
 
     ## Bash etiquette
 
@@ -150,18 +297,21 @@ prompts:
 
     ## Secrets
 
-    Never log API keys. When you call `set_api_key`, the tool itself masks
-    the value in its summary. If the user pastes a key that looks like a
-    placeholder, refuse and ask for a real one.
+    Never log API keys or Overleaf Git tokens. When you call
+    `set_api_key`, the tool itself masks the value in its summary; treat
+    Overleaf tokens with the same care (don't echo them back to the
+    user). If a pasted value looks like a placeholder, refuse and ask
+    for a real one.
 
     ## Finish
 
-    When the core dependencies, the LaTeX Workshop extension, and one
-    credential are all in place, tell the user they're ready and offer to
-    launch the first task per "Launching the first task" above. If the
-    user accepts, delegate once and stop — the Progress view takes it from
-    there. If they decline, point them at "Open the main view and pick an
-    agent" and stop. Do not keep asking follow-up questions after that.
+    When the core dependencies, the LaTeX Workshop extension, a
+    credential, and a workspace project are all in place, tell the user
+    they're ready and offer to launch the first task per "Launching the
+    first task". If the user accepts, delegate once and stop — the
+    Progress view takes it from there. If they decline, point them at
+    "Open the main view and pick an agent" and stop. Do not keep asking
+    follow-up questions after that.
 
   userRequest: |
     {{ INSTRUCTION }}

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -109,11 +109,14 @@ prompts:
        view and, for `orchestrator`, that they will see further proposals
        there as it dispatches subagents.
     4. After delegating, you can monitor with the `executions` tool:
-       `executions { path: "/executions/<id>", action: "wait" }` blocks
-       until the subagent's status changes; `action: "view"` reads the
-       latest summary, todos, and report. Do not poll in a tight loop.
-       Report progress to the user in one sentence per status change, and
-       stop when the subagent reaches `completed`.
+       `action: "wait"` blocks until the subagent's status changes;
+       `action: "subscribe"` enrolls this stream to receive future
+       transitions as `<execution-activity>` follow-ups so you can keep
+       chatting with the user while the run progresses (it auto-disposes
+       when the subagent finishes); `action: "view"` reads the latest
+       summary, todos, and report. Do not poll in a tight loop. Report
+       progress to the user in one sentence per status change, and stop
+       when the subagent reaches `completed`.
     5. If the user declines, do not push — say "you're set; hit Execute in
        the main view whenever you're ready" and finish.
 

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -14,32 +14,18 @@
 import {
   addExecutionListener,
   getHandle,
+  type ExecutionHandle,
 } from '@agent/runtime/executionRegistry';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId } from '@shared/schemas';
+import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
 
 const logger = new AgentLogger('ExecutionSubscriptionBinder');
 
-const OPEN_TAG = '<execution-activity>';
-const CLOSE_TAG = '</execution-activity>';
-
-/**
- * Strip any literal `<execution-activity>` / `</execution-activity>` tokens
- * from interpolated content so a malicious agent name or report cannot escape
- * the wrapper. Mirrors the sanitizer in formatPREvent.ts.
- */
-function sanitize(s: string): string {
-  return s.replaceAll(/<\s*\/?\s*execution-activity\s*>/gi, (match) =>
-    match.replace(/execution-activity/i, 'execution-​activity'),
-  );
-}
-
-function wrap(inner: string): string {
-  return `${OPEN_TAG}\n${sanitize(inner)}\n${CLOSE_TAG}`;
-}
+const TAG = 'execution-activity';
 
 interface Disposable {
   dispose: () => void;
@@ -95,9 +81,7 @@ interface SnapshotState {
   round: string | null;
 }
 
-function snapshot(executionId: string): SnapshotState | null {
-  const handle = getHandle(executionId);
-  if (!handle) return null;
+function snapshot(handle: ExecutionHandle): SnapshotState {
   const info = handle.getStatus();
   return {
     status: info.status,
@@ -106,15 +90,24 @@ function snapshot(executionId: string): SnapshotState | null {
   };
 }
 
+function send(streamId: StreamTabId, text: string): void {
+  void sendFollowUp(streamId, wrapAndSanitizeTag(TAG, text)).then((result) => {
+    if (result.status === 'sent' || result.status === 'queued') {
+      bus.emit('updateQueuedFollowUps', { streamId });
+    }
+  });
+}
+
 /**
- * Returns true if a new subscription was created, false if it already
- * existed for this (stream, execution) pair. Throws if the execution is
- * not currently tracked — terminal executions cannot be subscribed.
+ * Subscribe `streamId` to status, progress, and termination events for
+ * `executionId`. Subsequent calls for the same pair are no-ops. Throws if
+ * the execution is not currently tracked — terminal executions cannot be
+ * subscribed (use `executions view` to read the final report).
  */
 export function bindExecutionSubscription(
   streamId: StreamTabId,
   executionId: string,
-): boolean {
+): void {
   ensureReleaseHook();
 
   const handle = getHandle(executionId);
@@ -129,15 +122,11 @@ export function bindExecutionSubscription(
     bound = new Map();
     perStream.set(streamId, bound);
   }
-  if (bound.has(executionId)) return false;
+  if (bound.has(executionId)) return;
 
   const agentName = handle.agentName;
   const category = handle.category;
-  let last: SnapshotState | null = snapshot(executionId);
-
-  // Sentinel so a synchronous re-entry sees the slot as taken.
-  const sentinel: Disposable = { dispose: () => {} };
-  bound.set(executionId, sentinel);
+  let last: SnapshotState | null = snapshot(handle);
 
   let removeListener: (() => void) | null = null;
   let disposed = false;
@@ -149,27 +138,18 @@ export function bindExecutionSubscription(
     if (current) removeBoundKey(streamId, current, executionId);
   };
 
-  const send = (text: string): void => {
-    void sendFollowUp(streamId, wrap(text)).then((result) => {
-      if (result.status === 'sent' || result.status === 'queued') {
-        bus.emit('updateQueuedFollowUps', { streamId });
-      }
-    });
-  };
-
-  removeListener = addExecutionListener(executionId, () => {
-    const current = snapshot(executionId);
-
-    if (!current) {
-      // Handle gone — execution finished. Emit one final event then dispose.
+  removeListener = addExecutionListener(executionId, (h) => {
+    if (!h) {
       const previous = last?.status ?? 'unknown';
       send(
+        streamId,
         `${executionId} (${agentName}, ${category}) finished. Last known status: ${previous}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
       );
       dispose();
       return;
     }
 
+    const current = snapshot(h);
     const statusChanged = !last || last.status !== current.status;
     const roundChanged = last?.round !== current.round;
     if (!statusChanged && !roundChanged) {
@@ -177,24 +157,35 @@ export function bindExecutionSubscription(
       return;
     }
 
-    const transition = last
-      ? `${last.status} → ${current.status}`
-      : current.status;
+    const transition =
+      last && statusChanged
+        ? `${last.status} → ${current.status}`
+        : current.status;
+    const elapsed = current.elapsed ? ` (${current.elapsed} elapsed)` : '';
     const lines = [
-      `${executionId} (${agentName}, ${category}) ${transition}${
-        current.elapsed ? ` (${current.elapsed} elapsed)` : ''
-      }`,
+      `${executionId} (${agentName}, ${category}) ${transition}${elapsed}`,
     ];
     if (current.round) lines.push(current.round);
-    send(lines.join('\n'));
+    send(streamId, lines.join('\n'));
     last = current;
   });
+
+  // TOCTOU: handle could untrack between the initial getHandle() check
+  // and addExecutionListener registration. Re-check; if gone, fire the
+  // terminal event synchronously and dispose so the listener never leaks.
+  if (!getHandle(executionId)) {
+    send(
+      streamId,
+      `${executionId} (${agentName}, ${category}) finished. Last known status: ${last?.status ?? 'unknown'}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
+    );
+    dispose();
+    return;
+  }
 
   bound.set(executionId, { dispose });
   logger.info(
     `Bound execution subscription ${executionId} → stream ${streamId}`,
   );
-  return true;
 }
 
 /**

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -1,0 +1,218 @@
+/**
+ * Bind execution-status subscriptions to agent stream lifecycles.
+ *
+ * Each (streamId, executionId) pair holds one disposer registered with the
+ * execution registry's persistent listener API. Status transitions, progress
+ * updates, kills, and the final "untrack" event all fire as follow-ups into
+ * the subscriber stream's queue, wrapped in `<execution-activity>` so the
+ * agent can distinguish them from user input.
+ *
+ * Subscriptions self-dispose when the execution finishes (handle removed
+ * from the registry) and when the subscriber stream's queue is released.
+ */
+
+import {
+  addExecutionListener,
+  getHandle,
+} from '@agent/runtime/executionRegistry';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { bus } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import type { StreamTabId } from '@shared/schemas';
+
+const logger = new AgentLogger('ExecutionSubscriptionBinder');
+
+const OPEN_TAG = '<execution-activity>';
+const CLOSE_TAG = '</execution-activity>';
+
+/**
+ * Strip any literal `<execution-activity>` / `</execution-activity>` tokens
+ * from interpolated content so a malicious agent name or report cannot escape
+ * the wrapper. Mirrors the sanitizer in formatPREvent.ts.
+ */
+function sanitize(s: string): string {
+  return s.replaceAll(/<\s*\/?\s*execution-activity\s*>/gi, (match) =>
+    match.replace(/execution-activity/i, 'execution-​activity'),
+  );
+}
+
+function wrap(inner: string): string {
+  return `${OPEN_TAG}\n${sanitize(inner)}\n${CLOSE_TAG}`;
+}
+
+interface Disposable {
+  dispose: () => void;
+}
+
+type PerStream = Map<string, Disposable>;
+
+const perStream = new Map<StreamTabId, PerStream>();
+let releaseHookRegistered = false;
+
+function ensureReleaseHook(): void {
+  if (releaseHookRegistered) return;
+  ToolUseFollowUpQueue.onRelease((streamId) => {
+    const bound = perStream.get(streamId);
+    if (!bound) return;
+    for (const d of bound.values()) {
+      try {
+        d.dispose();
+      } catch (err) {
+        logger.warn(`Disposer threw during release: ${String(err)}`);
+      }
+    }
+    perStream.delete(streamId);
+  });
+  releaseHookRegistered = true;
+}
+
+function removeBoundKey(
+  streamId: StreamTabId,
+  bound: PerStream,
+  executionId: string,
+): void {
+  bound.delete(executionId);
+  if (bound.size === 0) perStream.delete(streamId);
+}
+
+function progressLine(
+  progress: { currentRound?: number; totalRounds?: number } | undefined,
+): string | null {
+  if (
+    !progress ||
+    progress.currentRound === undefined ||
+    progress.totalRounds === undefined
+  ) {
+    return null;
+  }
+  return `Progress: round ${progress.currentRound + 1}/${progress.totalRounds}`;
+}
+
+interface SnapshotState {
+  status: string;
+  elapsed: string | null;
+  round: string | null;
+}
+
+function snapshot(executionId: string): SnapshotState | null {
+  const handle = getHandle(executionId);
+  if (!handle) return null;
+  const info = handle.getStatus();
+  return {
+    status: info.status,
+    elapsed: info.elapsed,
+    round: progressLine(handle.getProgress()),
+  };
+}
+
+/**
+ * Returns true if a new subscription was created, false if it already
+ * existed for this (stream, execution) pair. Throws if the execution is
+ * not currently tracked — terminal executions cannot be subscribed.
+ */
+export function bindExecutionSubscription(
+  streamId: StreamTabId,
+  executionId: string,
+): boolean {
+  ensureReleaseHook();
+
+  const handle = getHandle(executionId);
+  if (!handle) {
+    throw new Error(
+      `Execution ${executionId} is not active. Subscribe only works on tracked executions; use 'view' to read the final report.`,
+    );
+  }
+
+  let bound = perStream.get(streamId);
+  if (!bound) {
+    bound = new Map();
+    perStream.set(streamId, bound);
+  }
+  if (bound.has(executionId)) return false;
+
+  const agentName = handle.agentName;
+  const category = handle.category;
+  let last: SnapshotState | null = snapshot(executionId);
+
+  // Sentinel so a synchronous re-entry sees the slot as taken.
+  const sentinel: Disposable = { dispose: () => {} };
+  bound.set(executionId, sentinel);
+
+  let removeListener: (() => void) | null = null;
+  let disposed = false;
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    if (removeListener) removeListener();
+    const current = perStream.get(streamId);
+    if (current) removeBoundKey(streamId, current, executionId);
+  };
+
+  const send = (text: string): void => {
+    void sendFollowUp(streamId, wrap(text)).then((result) => {
+      if (result.status === 'sent' || result.status === 'queued') {
+        bus.emit('updateQueuedFollowUps', { streamId });
+      }
+    });
+  };
+
+  removeListener = addExecutionListener(executionId, () => {
+    const current = snapshot(executionId);
+
+    if (!current) {
+      // Handle gone — execution finished. Emit one final event then dispose.
+      const previous = last?.status ?? 'unknown';
+      send(
+        `${executionId} (${agentName}, ${category}) finished. Last known status: ${previous}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
+      );
+      dispose();
+      return;
+    }
+
+    const statusChanged = !last || last.status !== current.status;
+    const roundChanged = last?.round !== current.round;
+    if (!statusChanged && !roundChanged) {
+      last = current;
+      return;
+    }
+
+    const transition = last
+      ? `${last.status} → ${current.status}`
+      : current.status;
+    const lines = [
+      `${executionId} (${agentName}, ${category}) ${transition}${
+        current.elapsed ? ` (${current.elapsed} elapsed)` : ''
+      }`,
+    ];
+    if (current.round) lines.push(current.round);
+    send(lines.join('\n'));
+    last = current;
+  });
+
+  bound.set(executionId, { dispose });
+  logger.info(
+    `Bound execution subscription ${executionId} → stream ${streamId}`,
+  );
+  return true;
+}
+
+/**
+ * Returns true if a subscription existed and was removed for this
+ * (stream, execution) pair.
+ */
+export function unbindExecutionSubscription(
+  streamId: StreamTabId,
+  executionId: string,
+): boolean {
+  const bound = perStream.get(streamId);
+  const d = bound?.get(executionId);
+  if (!bound || !d) return false;
+  try {
+    d.dispose();
+  } catch (err) {
+    logger.warn(`Disposer threw on explicit unsubscribe: ${String(err)}`);
+  }
+  removeBoundKey(streamId, bound, executionId);
+  return true;
+}

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -29,6 +29,9 @@ export {
 
 const registry = new Map<string, ExecutionHandle>();
 const changeCallbacks = new Map<string, Array<() => void>>();
+// Persistent listeners — stay attached across notifications (unlike one-shot
+// waiters in `changeCallbacks`). Used by the executions subscribe action.
+const persistentListeners = new Map<string, Set<() => void>>();
 
 // Notify waiters and refresh UI badges when stream status changes (e.g. RUNNING → WAITING).
 // Without this, waitForExecutionChange only resolves on progress/kill/untrack,
@@ -485,8 +488,43 @@ function removeChangeCallback(executionId: string, cb: () => void): void {
 }
 
 function notifyWaiters(executionId: string): void {
+  // Persistent listeners fire first and stay attached so subscribers keep
+  // receiving every transition (status, progress, untrack) until they
+  // dispose themselves.
+  const listeners = persistentListeners.get(executionId);
+  if (listeners) {
+    // Iterate a snapshot so a listener disposing itself mid-fire is safe.
+    for (const cb of [...listeners]) cb();
+  }
+
   const callbacks = changeCallbacks.get(executionId);
   if (!callbacks) return;
   changeCallbacks.delete(executionId);
   for (const cb of callbacks) cb();
+}
+
+/**
+ * Add a persistent listener invoked on every change to `executionId`
+ * (status transition, progress update, kill, untrack). Returns a disposer.
+ *
+ * The listener is fired with no arguments; query `getHandle(executionId)`
+ * inside to read current state, or treat `getHandle === undefined` as
+ * "execution finished and was removed from the registry".
+ */
+export function addExecutionListener(
+  executionId: string,
+  cb: () => void,
+): () => void {
+  let set = persistentListeners.get(executionId);
+  if (!set) {
+    set = new Set();
+    persistentListeners.set(executionId, set);
+  }
+  set.add(cb);
+  return () => {
+    const s = persistentListeners.get(executionId);
+    if (!s) return;
+    s.delete(cb);
+    if (s.size === 0) persistentListeners.delete(executionId);
+  };
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -31,7 +31,10 @@ const registry = new Map<string, ExecutionHandle>();
 const changeCallbacks = new Map<string, Array<() => void>>();
 // Persistent listeners — stay attached across notifications (unlike one-shot
 // waiters in `changeCallbacks`). Used by the executions subscribe action.
-const persistentListeners = new Map<string, Set<() => void>>();
+const persistentListeners = new Map<
+  string,
+  Set<(handle: ExecutionHandle | undefined) => void>
+>();
 
 // Notify waiters and refresh UI badges when stream status changes (e.g. RUNNING → WAITING).
 // Without this, waitForExecutionChange only resolves on progress/kill/untrack,
@@ -488,32 +491,43 @@ function removeChangeCallback(executionId: string, cb: () => void): void {
 }
 
 function notifyWaiters(executionId: string): void {
+  const listeners = persistentListeners.get(executionId);
+  const callbacks = changeCallbacks.get(executionId);
+  if (!listeners && !callbacks) return;
+
   // Persistent listeners fire first and stay attached so subscribers keep
   // receiving every transition (status, progress, untrack) until they
   // dispose themselves.
-  const listeners = persistentListeners.get(executionId);
   if (listeners) {
+    const handle = registry.get(executionId);
     // Iterate a snapshot so a listener disposing itself mid-fire is safe.
-    for (const cb of [...listeners]) cb();
+    for (const cb of [...listeners]) cb(handle);
   }
 
-  const callbacks = changeCallbacks.get(executionId);
-  if (!callbacks) return;
-  changeCallbacks.delete(executionId);
-  for (const cb of callbacks) cb();
+  if (callbacks) {
+    changeCallbacks.delete(executionId);
+    for (const cb of callbacks) cb();
+  }
+
+  // Backstop against listener leaks: if the execution is no longer tracked,
+  // any still-registered persistent listener is firing into the void. The
+  // binder's listener self-disposes on untrack, but a third-party caller
+  // that forgets the disposer would otherwise leak indefinitely.
+  if (!registry.has(executionId)) {
+    persistentListeners.delete(executionId);
+  }
 }
 
 /**
  * Add a persistent listener invoked on every change to `executionId`
  * (status transition, progress update, kill, untrack). Returns a disposer.
  *
- * The listener is fired with no arguments; query `getHandle(executionId)`
- * inside to read current state, or treat `getHandle === undefined` as
- * "execution finished and was removed from the registry".
+ * The callback receives the current `ExecutionHandle`, or `undefined` once
+ * the execution has been untracked (terminal event).
  */
 export function addExecutionListener(
   executionId: string,
-  cb: () => void,
+  cb: (handle: ExecutionHandle | undefined) => void,
 ): () => void {
   let set = persistentListeners.get(executionId);
   if (!set) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -287,6 +287,20 @@ export async function activate(context: vscode.ExtensionContext) {
     auth: {
       getStatus: () => getAuthStatus(),
     },
+    config: {
+      get: (key) => {
+        const cfg = vscode.workspace.getConfiguration();
+        return cfg.get(key);
+      },
+      update: async (key, value, target) => {
+        const cfg = vscode.workspace.getConfiguration();
+        const scope =
+          target === 'workspace'
+            ? vscode.ConfigurationTarget.Workspace
+            : vscode.ConfigurationTarget.Global;
+        await cfg.update(key, value, scope);
+      },
+    },
   });
   // GitHub token lives in SecretStorage (managed via the Git settings tab).
   // The tool layer only supports a synchronous token lookup, so we cache here

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,16 +289,28 @@ export async function activate(context: vscode.ExtensionContext) {
     },
     config: {
       get: (key) => {
-        const cfg = vscode.workspace.getConfiguration();
-        return cfg.get(key);
+        // Defense in depth: the only consumers today validate keys before
+        // reaching here, but the adapter is documented as `texra.*`-scoped
+        // and a future tool wiring through `platform.config` should not be
+        // able to read arbitrary VS Code settings by accident.
+        if (!key.startsWith('texra.')) {
+          throw new Error(
+            `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
+          );
+        }
+        return vscode.workspace.getConfiguration().get(key);
       },
       update: async (key, value, target) => {
-        const cfg = vscode.workspace.getConfiguration();
+        if (!key.startsWith('texra.')) {
+          throw new Error(
+            `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
+          );
+        }
         const scope =
           target === 'workspace'
             ? vscode.ConfigurationTarget.Workspace
             : vscode.ConfigurationTarget.Global;
-        await cfg.update(key, value, scope);
+        await vscode.workspace.getConfiguration().update(key, value, scope);
       },
     },
   });

--- a/src/test/tools/setup/ConfigTools.test.ts
+++ b/src/test/tools/setup/ConfigTools.test.ts
@@ -1,0 +1,192 @@
+import { strict as assert } from 'assert';
+
+import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
+import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+
+interface UpdateRecord {
+  key: string;
+  value: unknown;
+  target: 'user' | 'workspace';
+}
+
+function createPlatform(initial: Record<string, unknown> = {}): {
+  platform: SetupPlatform;
+  store: Record<string, unknown>;
+  updates: UpdateRecord[];
+} {
+  const store: Record<string, unknown> = { ...initial };
+  const updates: UpdateRecord[] = [];
+  const platform: SetupPlatform = {
+    secrets: {
+      async setApiKey() {},
+      async deleteApiKey() {},
+      async apiKeyExists() {
+        return false;
+      },
+      async hasUsableApiKey() {
+        return false;
+      },
+      async storedApiKeyExists() {
+        return false;
+      },
+      async anyApiKeyExists() {
+        return false;
+      },
+      async gitHubTokenExists() {
+        return 'none';
+      },
+      providers: [],
+    },
+    commands: {
+      async invoke() {},
+    },
+    extensions: {
+      isInstalled() {
+        return false;
+      },
+      async install() {},
+    },
+    auth: {
+      async getStatus() {
+        return { authenticated: false };
+      },
+    },
+    config: {
+      get(key) {
+        return store[key];
+      },
+      async update(key, value, target) {
+        updates.push({ key, value, target });
+        store[key] = value;
+      },
+    },
+  };
+  return { platform, store, updates };
+}
+
+describe('ConfigTools — read_config', () => {
+  it('reads an existing texra.* key', async () => {
+    const { platform } = createPlatform({ 'texra.bib.zoteroPort': 23119 });
+    setSetupPlatform(platform);
+    const tool = new ReadConfigTool();
+
+    const result = await tool.call({ key: 'texra.bib.zoteroPort' });
+
+    assert.ok(!('isError' in result) || !result.isError);
+    assert.match(result.output ?? '', /23119/);
+  });
+
+  it('rejects keys not starting with texra.', async () => {
+    const { platform } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new ReadConfigTool();
+
+    const result = await tool.call({ key: 'editor.fontSize' });
+
+    assert.ok(result.isError, 'should report an error');
+  });
+});
+
+describe('ConfigTools — update_config allowlist', () => {
+  it('writes an allowlisted key when the value matches its schema', async () => {
+    const { platform, store, updates } = createPlatform({
+      'texra.bib.zoteroPort': 23119,
+    });
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    const result = await tool.call({
+      key: 'texra.bib.zoteroPort',
+      value: 23200,
+      target: 'user',
+    });
+
+    assert.ok(!('isError' in result) || !result.isError);
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].key, 'texra.bib.zoteroPort');
+    assert.equal(updates[0].value, 23200);
+    assert.equal(updates[0].target, 'user');
+    assert.equal(store['texra.bib.zoteroPort'], 23200);
+    // Output reports both before and after values for the educative summary.
+    assert.match(result.output ?? '', /23119/);
+    assert.match(result.output ?? '', /23200/);
+  });
+
+  it('rejects non-allowlisted keys at schema parse time (no write)', async () => {
+    const { platform, updates } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    const result = await tool.call({
+      key: 'texra.model.useImprovedConnection',
+      value: true,
+      target: 'user',
+    });
+
+    assert.ok(result.isError, 'should reject off-allowlist key');
+    assert.equal(updates.length, 0, 'must not call platform.update');
+  });
+
+  it('rejects type-mismatched values for an allowlisted key', async () => {
+    const { platform, updates } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    const result = await tool.call({
+      key: 'texra.bib.zoteroPort',
+      value: 'not a number',
+      target: 'user',
+    });
+
+    assert.ok(result.isError, 'string value should be rejected');
+    assert.equal(updates.length, 0);
+  });
+
+  it('rejects out-of-range numeric values', async () => {
+    const { platform, updates } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    // Port range is 1..65535
+    for (const port of [0, -1, 70000]) {
+      const result = await tool.call({
+        key: 'texra.bib.zoteroPort',
+        value: port,
+        target: 'user',
+      });
+      assert.ok(result.isError, `${port} should be rejected`);
+    }
+
+    assert.equal(updates.length, 0);
+  });
+
+  it('rejects enum values outside the schema', async () => {
+    const { platform, updates } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    const result = await tool.call({
+      key: 'texra.latex.formatter',
+      value: 'pandoc',
+      target: 'user',
+    });
+
+    assert.ok(result.isError, 'unknown enum should be rejected');
+    assert.equal(updates.length, 0);
+  });
+
+  it('honors target=workspace scope', async () => {
+    const { platform, updates } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new UpdateConfigTool();
+
+    await tool.call({
+      key: 'texra.bib.defaultPath',
+      value: 'refs.bib',
+      target: 'workspace',
+    });
+
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].target, 'workspace');
+  });
+});

--- a/src/test/tools/setup/InvokeCommandTool.test.ts
+++ b/src/test/tools/setup/InvokeCommandTool.test.ts
@@ -53,6 +53,12 @@ function createPlatform(): {
         return { authenticated: false };
       },
     },
+    config: {
+      get() {
+        return undefined;
+      },
+      async update() {},
+    },
   };
   return { platform, invocations };
 }

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -34,6 +34,10 @@ import {
   waitForAnyExecutionChange,
   killExecution,
 } from '@agent/runtime/executionRegistry';
+import {
+  bindExecutionSubscription,
+  unbindExecutionSubscription,
+} from '@agent/runtime/ExecutionSubscriptionBinder';
 
 // Local imports - utils
 import { WorkspaceStateKey, workspaceSM } from '@common/state';
@@ -133,12 +137,14 @@ const ExecutionsToolInputSchema = z.strictObject({
 
   /** Action to perform. */
   action: z
-    .enum(['view', 'wait', 'kill'])
+    .enum(['view', 'wait', 'kill', 'subscribe', 'unsubscribe'])
     .prefault('view')
     .describe(
       'view: read execution data (returns immediately). ' +
         'wait: wait for a status change on /executions or /executions/{id}, then return the same data as view (avoids sleep-poll loops). ' +
-        'kill: terminate a running execution by ID (use on /executions/{id}).',
+        'kill: terminate a running execution by ID (use on /executions/{id}). ' +
+        'subscribe: receive future status/progress changes for /executions/{id} as <execution-activity> follow-ups; auto-disposes when the execution finishes or this stream is released. ' +
+        'unsubscribe: stop receiving <execution-activity> follow-ups for /executions/{id}.',
     ),
 
   /** Optional line range [start, end] for large outputs (action="view" only). */
@@ -323,7 +329,8 @@ Use offset/limit to paginate the /executions listing (default: offset 0, limit 1
 Use view_range: [start, end] to paginate conversation, output, and file content.
 Use action: "wait" on /executions or /executions/{id} to wait for a status change instead of polling.
 Use action: "wait" with ids: ["id1", "id2", ...] on /executions to wait for any of the listed executions to change.
-Use action: "kill" on /executions/{id} to terminate a running execution.`,
+Use action: "kill" on /executions/{id} to terminate a running execution.
+Use action: "subscribe" on /executions/{id} to receive future status, progress, and termination events as <execution-activity> follow-ups (auto-disposes when the execution finishes or this stream is released). Use action: "unsubscribe" on /executions/{id} to stop them.`,
   schema: ExecutionsToolInputSchema,
 }) {
   protected async execute(input: ExecutionsToolInput): Promise<ToolResult> {
@@ -338,6 +345,11 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
 
     // /executions - list all executions
     if (!id) {
+      if (input.action === 'subscribe' || input.action === 'unsubscribe') {
+        throw new ToolError(
+          `action='${input.action}' requires a specific execution: use /executions/{id}.`,
+        );
+      }
       if (input.action === 'wait')
         await this.waitForAnyChange(input.timeout ?? 300, input.ids);
       return this.listExecutions(input.offset ?? 0, input.limit ?? 100);
@@ -350,6 +362,12 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
       // Kill action: terminate a running execution (only valid on /executions/{id})
       if (input.action === 'kill') {
         return this.handleKill(executionId);
+      }
+      if (input.action === 'subscribe') {
+        return this.handleSubscribe(executionId);
+      }
+      if (input.action === 'unsubscribe') {
+        return this.handleUnsubscribe(executionId);
       }
       if (input.action === 'wait')
         await this.waitForChange(executionId, input.timeout ?? 300);
@@ -682,6 +700,44 @@ Use action: "kill" on /executions/{id} to terminate a running execution.`,
     return {
       output: `Execution ${executionId} could not be terminated.`,
       isError: true,
+    };
+  }
+
+  private handleSubscribe(executionId: ExecutionId): ToolResult {
+    const streamId = getCurrentToolFileInteractionContext()?.streamId;
+    if (!streamId) {
+      throw new ToolError(
+        'subscribe must be called from within an agent stream.',
+      );
+    }
+    let created: boolean;
+    try {
+      created = bindExecutionSubscription(streamId, executionId);
+    } catch (err) {
+      throw new ToolError(err instanceof Error ? err.message : String(err));
+    }
+    return {
+      summary: created
+        ? `Subscribed to ${executionId}`
+        : `Already subscribed to ${executionId}`,
+      output: created
+        ? `Subscribed to ${executionId}. Status, round, and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`
+        : `Already subscribed to ${executionId}. You will continue to receive <execution-activity> events until the execution finishes, this stream is released, or you call action='unsubscribe'.`,
+    };
+  }
+
+  private handleUnsubscribe(executionId: ExecutionId): ToolResult {
+    const streamId = getCurrentToolFileInteractionContext()?.streamId;
+    if (!streamId) {
+      throw new ToolError(
+        'unsubscribe must be called from within an agent stream.',
+      );
+    }
+    const removed = unbindExecutionSubscription(streamId, executionId);
+    return {
+      output: removed
+        ? `Unsubscribed from ${executionId}.`
+        : `No active subscription to ${executionId} on this stream.`,
     };
   }
 

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -704,25 +704,29 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
   }
 
   private handleSubscribe(executionId: ExecutionId): ToolResult {
-    const streamId = getCurrentToolFileInteractionContext()?.streamId;
+    const ctx = getCurrentToolFileInteractionContext();
+    const streamId = ctx?.streamId;
     if (!streamId) {
       throw new ToolError(
         'subscribe must be called from within an agent stream.',
       );
     }
-    let created: boolean;
+    // Subscribing to your own execution would feed every status transition
+    // back into the same session, creating a self-sustaining loop of
+    // <execution-activity> follow-ups.
+    if (ctx?.executionId === executionId) {
+      throw new ToolError(
+        `Cannot subscribe to your own execution (${executionId}).`,
+      );
+    }
     try {
-      created = bindExecutionSubscription(streamId, executionId);
+      bindExecutionSubscription(streamId, executionId);
     } catch (err) {
       throw new ToolError(err instanceof Error ? err.message : String(err));
     }
     return {
-      summary: created
-        ? `Subscribed to ${executionId}`
-        : `Already subscribed to ${executionId}`,
-      output: created
-        ? `Subscribed to ${executionId}. Status, round, and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`
-        : `Already subscribed to ${executionId}. You will continue to receive <execution-activity> events until the execution finishes, this stream is released, or you call action='unsubscribe'.`,
+      summary: `Subscribed to ${executionId}`,
+      output: `Subscribed to ${executionId}. Status, round, and termination events will arrive as follow-ups wrapped in <execution-activity>. Auto-disposes when the execution finishes or this stream is released. Call again with action='unsubscribe' to stop sooner.`,
     };
   }
 

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -7,6 +7,8 @@
  * detail via its tools if needed.
  */
 
+import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
+
 import type {
   GhCheckRun,
   GhIssueComment,
@@ -14,33 +16,8 @@ import type {
   GhReviewComment,
 } from './prTypes';
 
-const OPEN_TAG = '<github-webhook-activity>';
-const CLOSE_TAG = '</github-webhook-activity>';
-
+const TAG = 'github-webhook-activity';
 const MAX_BODY = 500;
-
-/**
- * Remove anything that could close or re-open our wrapper tag. Every string
- * interpolated inside `<github-webhook-activity>…</github-webhook-activity>`
- * flows through `wrap` and therefore through this sanitizer. That includes
- * comment/review bodies, usernames, CI check names (configurable in workflow
- * YAML — attacker-controlled by the PR author), file paths, and URLs.
- * Without this, any of those fields could inject `</github-webhook-activity>`
- * and escape the wrapper, feeding arbitrary text to the agent as if it were
- * direct user input.
- *
- * Matches liberally (whitespace inside the tag, case-insensitive) because
- * LLMs and HTML parsers both accept `</github-webhook-activity >`,
- * `< / github-webhook-activity >`, and similar variants as closing tags.
- * The replacement injects a zero-width space into the tag *name* so no
- * re-parser can reconstruct it — not just guards on the outside, which
- * left the middle structurally intact.
- */
-function sanitize(s: string): string {
-  return s.replaceAll(/<\s*\/?\s*github-webhook-activity\s*>/gi, (match) =>
-    match.replace(/github-webhook-activity/i, 'github-\u200Bwebhook-activity'),
-  );
-}
 
 function truncate(s: string | null | undefined): string {
   const body = (s ?? '').trim();
@@ -49,13 +26,13 @@ function truncate(s: string | null | undefined): string {
 }
 
 /**
- * Sanitize every field by sanitizing the fully-assembled inner text before
- * wrapping. Per-field sanitization is easy to forget when a new formatter is
- * added; doing it at the wrap boundary closes the whole attack surface by
- * construction.
+ * Sanitizing per-field is easy to forget when a new formatter is added;
+ * doing it at the wrap boundary closes the attack surface by construction.
+ * Every comment/review body, username, CI check name, file path, or URL
+ * interpolated into the wrapper flows through here.
  */
 function wrap(inner: string): string {
-  return `${OPEN_TAG}\n${sanitize(inner)}\n${CLOSE_TAG}`;
+  return wrapAndSanitizeTag(TAG, inner);
 }
 
 export function formatIssueComment(

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -63,6 +63,8 @@ import {
   UnsetApiKeyTool,
   InvokeCommandTool,
   InstallVscodeExtensionTool,
+  ReadConfigTool,
+  UpdateConfigTool,
 } from './setup';
 
 /** Singleton IToolRegistry instance for the default tools. */
@@ -130,6 +132,8 @@ function createDefaultTools() {
     unset_api_key: new UnsetApiKeyTool(),
     invoke_command: new InvokeCommandTool(),
     install_vscode_extension: new InstallVscodeExtensionTool(),
+    read_config: new ReadConfigTool(),
+    update_config: new UpdateConfigTool(),
   } satisfies Record<string, ITool>;
 }
 

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -1,0 +1,202 @@
+/**
+ * Read and update TeXRA's `texra.*` VS Code settings during onboarding.
+ *
+ * Two narrow tools: `read_config` (read-only) and `update_config` (writes,
+ * gated by a strict per-key allowlist). Together they let the setup
+ * assistant teach the user about a setting, show its current value, and
+ * change it transparently — without giving an LLM unfettered write access
+ * to arbitrary VS Code configuration. Anything outside the allowlist must
+ * still be edited through the regular settings UI.
+ */
+
+import { z } from 'zod';
+
+import { ToolError, type ToolResult } from '@tools/result';
+
+import { defineTool } from '../core/define';
+import { getSetupPlatform } from './platform';
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-key value validators for `update_config`. Read access (`read_config`)
+ * is open across all `texra.*` keys, but writes must clear a strict schema
+ * so a hallucinated payload cannot, say, set `texra.git.numberOfCommitsToShow`
+ * to `"yes please"` or flip a destructive toggle.
+ *
+ * Each entry pairs a Zod schema with a one-line summary the tool echoes back
+ * to the agent (and surfaces in the description) so the assistant can
+ * explain the setting before changing it.
+ */
+const UPDATABLE_KEYS = {
+  'texra.bib.defaultPath': {
+    schema: z.string().describe('Workspace path to the default .bib file'),
+    summary:
+      'Default bibliography file used by tools that scan citations (e.g. extract_bib_entries).',
+  },
+  'texra.bib.zoteroPort': {
+    schema: z
+      .number()
+      .int()
+      .min(1)
+      .max(65535)
+      .describe('Local port the Zotero Better BibTeX server listens on'),
+    summary:
+      'Local port for the Zotero Better BibTeX integration. Default 23119.',
+  },
+  'texra.audio.soxPath': {
+    schema: z.string().describe('Absolute path to the sox binary'),
+    summary:
+      'Path override for the SoX audio tool (used by the audio transcription agent).',
+  },
+  'texra.latex.formatter': {
+    schema: z
+      .enum(['none', 'latexindent', 'tex-fmt'])
+      .describe('Which formatter TeXRA invokes when normalizing LaTeX'),
+    summary:
+      'LaTeX formatter choice. "none" disables auto-formatting; "latexindent" requires Perl; "tex-fmt" is a Rust-based alternative.',
+  },
+  'texra.latex.tikzInputDirectory': {
+    schema: z
+      .string()
+      .describe('Workspace-relative directory containing TikZ source files'),
+    summary:
+      'Where the TikZ extraction/compilation flows look for figure source files.',
+  },
+  'texra.workflow.autoCompileAfterOutput': {
+    schema: z
+      .boolean()
+      .describe('Whether to compile LaTeX after each agent output'),
+    summary:
+      'Auto-compiles the LaTeX project after a workflow agent writes output. Useful for catching breakage early.',
+  },
+  'texra.git.numberOfCommitsToShow': {
+    schema: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .describe('How many recent commits to surface in the Git picker'),
+    summary:
+      'Depth of the recent-commits dropdown surfaced by the Git integration.',
+  },
+  'texra.maxImageDimension': {
+    schema: z
+      .number()
+      .int()
+      .min(64)
+      .max(8192)
+      .describe('Maximum pixel dimension for images sent to vision models'),
+    summary:
+      'Image dimension cap before downscaling. Lower values save tokens; higher values preserve fidelity.',
+  },
+} satisfies Record<
+  string,
+  { schema: z.ZodType<unknown>; summary: string }
+>;
+
+type UpdatableKey = keyof typeof UPDATABLE_KEYS;
+
+const UPDATABLE_KEY_LIST = Object.keys(UPDATABLE_KEYS) as UpdatableKey[];
+
+function describeAllowlist(): string {
+  return UPDATABLE_KEY_LIST.map(
+    (k) => `- \`${k}\` — ${UPDATABLE_KEYS[k].summary}`,
+  ).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// read_config
+// ---------------------------------------------------------------------------
+
+const ReadConfigInputSchema = z.strictObject({
+  key: z
+    .string()
+    .min(1)
+    .regex(
+      /^texra\./,
+      'Only TeXRA configuration keys are readable through this tool. Pass a key starting with "texra.".',
+    )
+    .describe('Configuration key starting with "texra." (e.g. texra.bib.defaultPath).'),
+});
+
+type ReadConfigInput = z.infer<typeof ReadConfigInputSchema>;
+
+export class ReadConfigTool extends defineTool({
+  name: 'read_config',
+  description: `Read the effective value of a TeXRA configuration key.
+
+Accepts any key starting with \`texra.\`. Returns the current resolved value (workspace value if set, else user, else default). Use this when teaching the user what a setting controls — read first, explain, then propose a change with \`update_config\`. For settings outside this tool's reach (which is most of them), open the settings UI via \`invoke_command\` with \`texra.openSettings\` or \`texra.showSettingsView\`.`,
+  schema: ReadConfigInputSchema,
+}) {
+  protected async execute(input: ReadConfigInput): Promise<ToolResult> {
+    const value = getSetupPlatform().config.get(input.key);
+    const json = JSON.stringify(value, null, 2) ?? 'undefined';
+    return {
+      summary: `Read ${input.key}`,
+      output: `${input.key}:\n${json}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// update_config
+// ---------------------------------------------------------------------------
+
+const UpdateConfigInputSchema = z.strictObject({
+  key: z
+    .enum(UPDATABLE_KEY_LIST as [UpdatableKey, ...UpdatableKey[]])
+    .describe(
+      `Configuration key to update. Must be on the setup allowlist:\n${describeAllowlist()}`,
+    ),
+  value: z
+    .unknown()
+    .describe(
+      'New value. Type depends on the key — see the allowlist for each key\'s expected schema.',
+    ),
+  target: z
+    .enum(['user', 'workspace'])
+    .prefault('user')
+    .describe(
+      '"user" updates the global VS Code setting (sticks across workspaces); "workspace" scopes the change to the current workspace only.',
+    ),
+});
+
+type UpdateConfigInput = z.infer<typeof UpdateConfigInputSchema>;
+
+export class UpdateConfigTool extends defineTool({
+  name: 'update_config',
+  description: `Update a TeXRA configuration value (allowlisted keys only).
+
+Use this AFTER calling \`read_config\` and explaining to the user what the setting does and what the new value will mean — every change should be educative. Pass \`target: "workspace"\` only when the change is genuinely workspace-specific (e.g. a project-local bib path); default to \`"user"\` for general preferences.
+
+Allowlisted keys:
+${describeAllowlist()}
+
+Anything outside this list must be changed through the settings UI — invoke \`texra.openSettings\` (native VS Code Settings, filtered to texra.*) or \`texra.showSettingsView\` (TeXRA dashboard).`,
+  schema: UpdateConfigInputSchema,
+}) {
+  protected async execute(input: UpdateConfigInput): Promise<ToolResult> {
+    const entry = UPDATABLE_KEYS[input.key];
+    const parsed = entry.schema.safeParse(input.value);
+    if (!parsed.success) {
+      throw new ToolError(
+        `Value rejected for ${input.key}: ${parsed.error.issues
+          .map((i) => i.message)
+          .join('; ')}. ${entry.summary}`,
+      );
+    }
+
+    const previous = getSetupPlatform().config.get(input.key);
+    await getSetupPlatform().config.update(input.key, parsed.data, input.target);
+
+    const before = JSON.stringify(previous);
+    const after = JSON.stringify(parsed.data);
+    return {
+      summary: `Updated ${input.key} (${input.target})`,
+      output: `Updated ${input.key} (${input.target} scope): ${before ?? 'undefined'} → ${after}.`,
+    };
+  }
+}

--- a/src/tools/setup/ConfigTools.ts
+++ b/src/tools/setup/ConfigTools.ts
@@ -16,10 +16,6 @@ import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
 
-// ---------------------------------------------------------------------------
-// Allowlist
-// ---------------------------------------------------------------------------
-
 /**
  * Per-key value validators for `update_config`. Read access (`read_config`)
  * is open across all `texra.*` keys, but writes must clear a strict schema
@@ -107,10 +103,6 @@ function describeAllowlist(): string {
   ).join('\n');
 }
 
-// ---------------------------------------------------------------------------
-// read_config
-// ---------------------------------------------------------------------------
-
 const ReadConfigInputSchema = z.strictObject({
   key: z
     .string()
@@ -140,10 +132,6 @@ Accepts any key starting with \`texra.\`. Returns the current resolved value (wo
     };
   }
 }
-
-// ---------------------------------------------------------------------------
-// update_config
-// ---------------------------------------------------------------------------
 
 const UpdateConfigInputSchema = z.strictObject({
   key: z

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -35,9 +35,14 @@ const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
   'texra.showMultiAgent',
   'texra.showTools',
   'texra.showGitSettings',
+  // Native VS Code settings (filterable to texra.*)
+  'texra.openSettings',
   // Workspace bootstrap
   'texra.createSampleProject',
   'texra.showMainView',
+  // Project sourcing
+  'texra.cloneOverleafProject',
+  'texra.downloadArXivSource',
   // Refresh helpers
   'texra.refreshApiKeyStatus',
   'texra.refreshAllOptions',
@@ -60,7 +65,7 @@ type InvokeCommandInput = z.infer<typeof InvokeCommandInputSchema>;
 
 export class InvokeCommandTool extends defineTool({
   name: 'invoke_command',
-  description: `Invoke an allowlisted VS Code command. Use this to hand off to TeXRA's existing UX — the API-key quick-pick (texra.setApiKey), the Researcher Access sign-in (texra.auth.signIn), the settings-dashboard tab openers (texra.showModels / texra.showAgents / texra.showMemory / texra.showMultiAgent / texra.showTools / texra.showGitSettings), and the sample-project creator (texra.createSampleProject). Non-allowlisted commands are rejected. To install a VS Code extension (LaTeX Workshop, Lean 4), use \`install_vscode_extension\` instead — it enforces a stricter per-extension allowlist.`,
+  description: `Invoke an allowlisted VS Code command. Use this to hand off to TeXRA's existing UX — the API-key quick-pick (texra.setApiKey), the Researcher Access sign-in (texra.auth.signIn), the settings-dashboard tab openers (texra.showModels / texra.showAgents / texra.showMemory / texra.showMultiAgent / texra.showTools / texra.showGitSettings), the native VS Code settings UI filtered to texra.* (texra.openSettings), the sample-project creator (texra.createSampleProject), the Overleaf clone wizard (texra.cloneOverleafProject), and the arXiv source downloader (texra.downloadArXivSource). Non-allowlisted commands are rejected. To install a VS Code extension (LaTeX Workshop, Lean 4), use \`install_vscode_extension\` instead — it enforces a stricter per-extension allowlist.`,
   schema: InvokeCommandInputSchema,
 }) {
   protected async execute(input: InvokeCommandInput): Promise<ToolResult> {

--- a/src/tools/setup/InvokeCommandTool.ts
+++ b/src/tools/setup/InvokeCommandTool.ts
@@ -35,12 +35,11 @@ const ALLOWED_COMMANDS: ReadonlySet<string> = new Set([
   'texra.showMultiAgent',
   'texra.showTools',
   'texra.showGitSettings',
-  // Native VS Code settings (filterable to texra.*)
+  // Native VS Code settings, search-filterable to texra.*
   'texra.openSettings',
   // Workspace bootstrap
   'texra.createSampleProject',
   'texra.showMainView',
-  // Project sourcing
   'texra.cloneOverleafProject',
   'texra.downloadArXivSource',
   // Refresh helpers

--- a/src/tools/setup/index.ts
+++ b/src/tools/setup/index.ts
@@ -22,6 +22,7 @@ export { SetApiKeyTool } from './SetApiKeyTool';
 export { UnsetApiKeyTool } from './UnsetApiKeyTool';
 export { InvokeCommandTool } from './InvokeCommandTool';
 export { InstallVscodeExtensionTool } from './InstallVscodeExtensionTool';
+export { ReadConfigTool, UpdateConfigTool } from './ConfigTools';
 export {
   setSetupPlatform,
   getSetupPlatform,
@@ -30,4 +31,5 @@ export {
   type SetupCommandAdapter,
   type SetupExtensionAdapter,
   type SetupAuthAdapter,
+  type SetupConfigAdapter,
 } from './platform';

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -53,12 +53,25 @@ export interface SetupAuthAdapter {
   }>;
 }
 
+/** Configuration-value surface. Reads/writes scoped to `texra.*` keys. */
+export interface SetupConfigAdapter {
+  /** Read the effective value of a `texra.*` setting. */
+  get(key: string): unknown;
+  /** Write a `texra.*` setting. `target` selects user vs. workspace scope. */
+  update(
+    key: string,
+    value: unknown,
+    target: 'user' | 'workspace',
+  ): Promise<void>;
+}
+
 /** Aggregated setup platform. */
 export interface SetupPlatform {
   secrets: SetupSecretsAdapter;
   commands: SetupCommandAdapter;
   extensions: SetupExtensionAdapter;
   auth: SetupAuthAdapter;
+  config: SetupConfigAdapter;
 }
 
 let platform: SetupPlatform | undefined;

--- a/src/utils/text/sanitizeTag.ts
+++ b/src/utils/text/sanitizeTag.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrap a body in `<tagName>…</tagName>` while neutralizing any literal
+ * occurrences of the tag inside the body, so a payload coming from an
+ * untrusted source (PR webhook fields, agent names, etc.) cannot escape
+ * the wrapper and feed text to the LLM as if it were direct user input.
+ *
+ * Matches `</tag>` and `<tag>` liberally — whitespace inside the tag,
+ * case-insensitive — because LLMs and HTML parsers both accept variants
+ * like `</tag >`, `< / tag >`, etc. as closers. The replacement injects
+ * a zero-width space into the tag *name* so no re-parser can reconstruct
+ * it; guarding only the outside of the tag would leave the middle
+ * structurally intact.
+ */
+
+const VALID_TAG_NAME = /^[a-z][a-z0-9-]*$/i;
+
+function escapeRegex(s: string): string {
+  return s.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function sanitizeTag(tagName: string, body: string): string {
+  if (!VALID_TAG_NAME.test(tagName)) {
+    throw new Error(`Invalid tag name for sanitizer: ${tagName}`);
+  }
+  const re = new RegExp(`<\\s*/?\\s*${escapeRegex(tagName)}\\s*>`, 'gi');
+  const ZWSP = String.fromCharCode(0x200b);
+  const broken = `${tagName[0]}${ZWSP}${tagName.slice(1)}`;
+  return body.replaceAll(re, (match) =>
+    match.includes('/') ? `</${broken}>` : `<${broken}>`,
+  );
+}
+
+export function wrapAndSanitizeTag(tagName: string, body: string): string {
+  return `<${tagName}>\n${sanitizeTag(tagName, body)}\n</${tagName}>`;
+}


### PR DESCRIPTION
## Summary

This PR significantly expands the setup assistant's capabilities to guide users through complete onboarding—from environment diagnosis through first task execution. It adds configuration management tools, execution status subscriptions for real-time monitoring, and comprehensive documentation for credential setup, project sourcing, and task delegation.

## Key Changes

### Setup Assistant Documentation & Guidance
- **Expanded system prompt** in `setup.yaml` with detailed phases for onboarding:
  - Phase D: Credential setup (Researcher Access sign-in vs. API key bring-your-own)
  - Phase E: Optional extras (Zotero, Lean 4, SoX)
  - Phase F: Project sourcing (sample project, Overleaf clone, arXiv download)
  - Phase H: First task orchestration with delegation
- **New educational sections** explaining TeXRA's architecture (orchestrator, workflow agents, tool-use agents, Progress view, Memory)
- **Detailed credential flow** with provider-specific guidance (Anthropic, OpenAI, Google, DeepSeek, etc.)
- **Settings management guidance** with read-first, explain, confirm, write pattern
- **Git primer** for users unfamiliar with version control
- **Project on-ramp documentation** for sample projects, Overleaf clones, and arXiv downloads
- **First task orchestration** with execution monitoring via subscriptions

### Configuration Tools
- **`ReadConfigTool`** (`read_config`): Read-only access to any `texra.*` configuration key
- **`UpdateConfigTool`** (`update_config`): Write access to an allowlisted set of configuration keys:
  - Bibliography paths and Zotero port
  - Audio tool (SoX) path
  - LaTeX formatter choice
  - TikZ input directory
  - Auto-compile toggle
  - Git commits depth
  - Max image dimension
- Both tools include strict schema validation and user-facing summaries for each setting

### Execution Subscriptions
- **`ExecutionSubscriptionBinder`** (new file): Manages persistent listeners for execution status changes
  - Binds (streamId, executionId) pairs to receive real-time status transitions, progress updates, and completion events
  - Wraps updates in `<execution-activity>` tags for agent stream parsing
  - Auto-disposes when execution finishes or stream is released
  - Sanitizes agent names and reports to prevent tag escape
- **`ExecutionsTool` enhancements**:
  - New `subscribe` action: Attach a persistent listener to an execution and receive follow-ups as status changes occur
  - New `unsubscribe` action: Detach a listener
  - Allows agents to monitor long-running tasks without polling

### Platform & Registry Updates
- **`SetupPlatform` interface**: Added `config` adapter for reading/writing VS Code settings
- **`extension.ts`**: Implemented config adapter using VS Code's `vscode.workspace.getConfiguration()` API with user/workspace scope support
- **`executionRegistry.ts`**: Added persistent listener infrastructure (`addExecutionListener`, `persistentListeners` map) to support subscriptions
- **Tool registry**: Registered `ReadConfigTool` and `UpdateConfigTool`
- **`InvokeCommandTool`**: Added allowed commands for settings UI (`texra.openSettings`) and project sourcing (`texra.cloneOverleafProject`, `texra.downloadArXivSource`)

## Notable Implementation Details

- **Allowlist-gated writes**: Configuration updates are restricted to a curated set of keys with per-key Zod schemas, preventing agents from writing arbitrary settings
- **Sanitization**: Execution activity tags are sanitized to prevent malicious agent names or reports from breaking the wrapper format
- **Scope-aware updates**: Config writes support both user (global) and workspace (project-local) scopes
- **Persistent listeners**: Unlike one-shot waiters, persistent listeners remain attached across all state changes until explicitly disposed, enabling real-time monitoring without polling
- **Follow-up integration**: Subscription updates flow through the existing `sendFollowUp` mechanism, allowing agents to receive execution events as chat-like messages

https://claude.ai/code/session_01JFzK8gtNedidDVRhLXfJib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new setup-time config write capabilities (allowlisted) and introduces persistent execution status subscriptions that push follow-ups into agent streams, which could impact runtime behavior if misused or leaked.
> 
> **Overview**
> **Setup onboarding is expanded from “install deps” to end-to-end first-run orchestration.** The `setup` agent prompt now guides credential setup, optional extras, project import (sample/Overleaf/arXiv), and optionally delegating a first task while monitoring progress via `executions`.
> 
> **Adds two setup config tools.** New `read_config` (read any `texra.*` key) and `update_config` (write only an allowlisted set of `texra.*` keys with Zod validation and before/after reporting) are wired through a new `SetupConfigAdapter` implemented in `extension.ts`, registered in the tool registry, and covered by unit tests.
> 
> **Adds execution event subscriptions to avoid polling.** `executions` gains `subscribe`/`unsubscribe`, backed by a new `ExecutionSubscriptionBinder` and a persistent listener API (`addExecutionListener`) in `executionRegistry`, emitting sanitized `<execution-activity>` follow-ups and auto-disposing on execution completion or stream release.
> 
> **Hardens tag-wrapped follow-ups.** Introduces reusable `wrapAndSanitizeTag` and refactors GitHub PR event formatting to use it to prevent tag-escape injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2180751f9316d2634c44eec3b9e4416826ac0ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->