### PR TITLE
[codex] Remove polish spinner toolbar gap

### DIFF
--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -478,16 +478,17 @@ export class InstructionPanel extends LitElement {
               ?disabled=${session.isPolishing}
               data-action="polish"
             ></vscode-toolbar-button>
-            <vscode-progress-ring
-              id="polishProgressContainer"
-              style=${styleMap({
-                width: '16px',
-                height: '16px',
-                opacity: session.isPolishing ? '1' : '0',
-                transition: 'opacity var(--transition-normal)',
-                ...(session.isPolishing ? {} : { pointerEvents: 'none' }),
-              })}
-            ></vscode-progress-ring>
+            ${session.isPolishing
+              ? html`
+                  <vscode-progress-ring
+                    id="polishProgressContainer"
+                    style=${styleMap({
+                      width: '16px',
+                      height: '16px',
+                    })}
+                  ></vscode-progress-ring>
+                `
+              : nothing}
             <vscode-toolbar-button
               id="recordInstructionButton"
               icon=${session.isRecording ? 'stop-circle' : 'mic'}


### PR DESCRIPTION
## Summary
- Remove the hidden polish progress ring from the instruction toolbar when polishing is idle.
- Keep the progress ring visible while the polish request is actively running.

## Why
The idle progress ring used `opacity: 0`, which hid the spinner but still reserved toolbar width. That left an empty gap between the polish and microphone controls.

## Validation
- `npx prettier --check src/webview/frontend/components/InstructionPanel.ts`
- `npm run compile:fast`
- `npm run lint` (0 errors; existing import-order warnings remain)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: the polish progress ring is now conditionally rendered, which could slightly affect layout timing but does not touch business logic or data flow.
> 
> **Overview**
> Removes the *always-present but hidden* polish progress ring in `InstructionPanel` and instead renders it only while `session.isPolishing` is true, eliminating the idle toolbar spacing gap between the polish and mic controls.
> 
> Simplifies the spinner styling by dropping the opacity/transition/pointer-events workaround and keeping only fixed sizing when shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcdbfa99535048996aadba4ee9733d7dced95b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->