### PR TITLE
Improve setup flow and API key status handling

### DIFF
--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -172,16 +172,25 @@ let initPromise: Promise<void> | null = null;
 /**
  * Load all agents into cache. Call once at activation.
  * Thread-safe: concurrent calls share the same promise.
+ *
+ * On rejection, `initPromise` is cleared so a subsequent call (e.g. a
+ * "Retry" action surfaced to the user) can attempt the load again.
+ * Without this, a transient failure during activation would poison the
+ * registry for the rest of the session.
  */
 export async function loadAgents(): Promise<void> {
   if (initPromise) {
     return initPromise;
   }
 
-  initPromise = doLoad().then(() => {
-    initialized = true;
-    initPromise = null;
-  });
+  initPromise = (async () => {
+    try {
+      await doLoad();
+      initialized = true;
+    } finally {
+      initPromise = null;
+    }
+  })();
 
   return initPromise;
 }

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -172,25 +172,16 @@ let initPromise: Promise<void> | null = null;
 /**
  * Load all agents into cache. Call once at activation.
  * Thread-safe: concurrent calls share the same promise.
- *
- * On rejection, `initPromise` is cleared so a subsequent call (e.g. a
- * "Retry" action surfaced to the user) can attempt the load again.
- * Without this, a transient failure during activation would poison the
- * registry for the rest of the session.
  */
 export async function loadAgents(): Promise<void> {
   if (initPromise) {
     return initPromise;
   }
 
-  initPromise = (async () => {
-    try {
-      await doLoad();
-      initialized = true;
-    } finally {
-      initPromise = null;
-    }
-  })();
+  initPromise = doLoad().then(() => {
+    initialized = true;
+    initPromise = null;
+  });
 
   return initPromise;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,11 +99,9 @@ async function refreshApiKeyStatus() {
   }
 
   // `anyApiKeyExists()` already falls back to `canUseServerSideKeys()`
-  // internally, so a Researcher Access user with no local key is treated
-  // as set up. Don't catch here: a transient probe failure shouldn't
-  // regress a signed-in user back to the "Get Started" CTA. Let the
-  // outer `safeRefreshApiKeyStatus` log it and leave the pill in its
-  // prior state.
+  // internally. Don't catch here: a transient probe failure shouldn't
+  // regress a signed-in user to the "Get Started" CTA — let the outer
+  // wrapper log it and leave the pill in its prior state.
   const exists = await SecretManager.anyApiKeyExists();
   if (!exists) {
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
@@ -167,33 +165,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await refreshModelListIfNeeded();
 
-  const promptAgentLoadFailure = (err: unknown) => {
+  loadAgents().catch((err) => {
     logger.error(
       'extension',
       `Failed to initialize agent index: ${toErrorMessage(err)}`,
     );
-    // Silent failures here leave the agent dropdown empty with no
-    // explanation. Surface a one-shot, dismissible message so a brand-new
-    // user knows what's wrong and how to recover. Recurses on retry so a
-    // second failure re-prompts instead of looking like success.
-    void vscode.window
-      .showWarningMessage(
-        'TeXRA could not load its agent definitions. Some agents may be missing from the dropdown.',
-        'Retry',
-        'View Logs',
-      )
-      .then((choice) => {
-        if (choice === 'Retry') {
-          loadAgents().catch(promptAgentLoadFailure);
-        } else if (choice === 'View Logs') {
-          // `toggleOutput` would *hide* the panel if already visible —
-          // not what "View Logs" implies. Use `panel.output.focus` so
-          // the action consistently reveals the Output view.
-          void vscode.commands.executeCommand('workbench.panel.output.focus');
-        }
-      });
-  };
-  loadAgents().catch(promptAgentLoadFailure);
+  });
 
   try {
     setRuntimeExtensionId(context.extension.id);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,9 +100,10 @@ async function refreshApiKeyStatus() {
 
   const exists = await SecretManager.anyApiKeyExists();
   if (!exists) {
-    apiKeyStatusBarItem.text = '$(warning) TeXRA: API Key Required';
-    apiKeyStatusBarItem.tooltip = 'No API keys configured — click to set up';
-    apiKeyStatusBarItem.command = 'texra.setApiKey';
+    apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
+    apiKeyStatusBarItem.tooltip =
+      'Click to run the setup assistant — sign in for free or add an API key';
+    apiKeyStatusBarItem.command = 'texra.runSetupAssistant';
     apiKeyStatusBarItem.show();
   } else {
     apiKeyStatusBarItem.hide();
@@ -165,6 +166,22 @@ export async function activate(context: vscode.ExtensionContext) {
       'extension',
       `Failed to initialize agent index: ${toErrorMessage(err)}`,
     );
+    // Silent failures here leave the agent dropdown empty with no
+    // explanation. Surface a one-shot, dismissible message so a brand-new
+    // user knows what's wrong and how to recover.
+    void vscode.window
+      .showWarningMessage(
+        'TeXRA could not load its agent definitions. Some agents may be missing from the dropdown.',
+        'Retry',
+        'View Logs',
+      )
+      .then((choice) => {
+        if (choice === 'Retry') {
+          void loadAgents().catch(() => undefined);
+        } else if (choice === 'View Logs') {
+          void vscode.commands.executeCommand('workbench.action.output.toggleOutput');
+        }
+      });
   });
 
   try {
@@ -489,11 +506,28 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const welcomeKey = 'texra.welcomeShown';
   if (!context.globalState.get<boolean>(welcomeKey)) {
-    // Opening the VS Code walkthrough is enough — don't double up with a
-    // popup asking the user to open the walkthrough they just saw.
+    // Open the walkthrough AND surface a notification with a one-click
+    // path to the setup assistant. Walkthroughs can be dismissed or buried
+    // behind other tabs, leaving brand-new users with no obvious next
+    // step. The notification gives them an action button they can click
+    // immediately; the walkthrough is still there if they want the full
+    // tour.
     void vscode.commands
       .executeCommand('texra.openGettingStarted')
       .then(() => context.globalState.update(welcomeKey, true));
+    void vscode.window
+      .showInformationMessage(
+        'Welcome to TeXRA! The setup assistant can sign you in (free) or set up an API key in one go.',
+        'Run Setup Assistant',
+        'Open Walkthrough',
+      )
+      .then((choice) => {
+        if (choice === 'Run Setup Assistant') {
+          void vscode.commands.executeCommand('texra.runSetupAssistant');
+        } else if (choice === 'Open Walkthrough') {
+          void vscode.commands.executeCommand('texra.openGettingStarted');
+        }
+      });
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,14 +167,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await refreshModelListIfNeeded();
 
-  loadAgents().catch((err) => {
+  const promptAgentLoadFailure = (err: unknown) => {
     logger.error(
       'extension',
       `Failed to initialize agent index: ${toErrorMessage(err)}`,
     );
     // Silent failures here leave the agent dropdown empty with no
     // explanation. Surface a one-shot, dismissible message so a brand-new
-    // user knows what's wrong and how to recover.
+    // user knows what's wrong and how to recover. Recurses on retry so a
+    // second failure re-prompts instead of looking like success.
     void vscode.window
       .showWarningMessage(
         'TeXRA could not load its agent definitions. Some agents may be missing from the dropdown.',
@@ -183,7 +184,7 @@ export async function activate(context: vscode.ExtensionContext) {
       )
       .then((choice) => {
         if (choice === 'Retry') {
-          void loadAgents().catch(() => undefined);
+          loadAgents().catch(promptAgentLoadFailure);
         } else if (choice === 'View Logs') {
           // `toggleOutput` would *hide* the panel if already visible —
           // not what "View Logs" implies. Use `panel.output.focus` so
@@ -191,7 +192,8 @@ export async function activate(context: vscode.ExtensionContext) {
           void vscode.commands.executeCommand('workbench.panel.output.focus');
         }
       });
-  });
+  };
+  loadAgents().catch(promptAgentLoadFailure);
 
   try {
     setRuntimeExtensionId(context.extension.id);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,14 +98,13 @@ async function refreshApiKeyStatus() {
     return;
   }
 
-  const hasApiKey = await SecretManager.anyApiKeyExists();
-  // Researcher Access users have no local API key but can run models via
-  // server-side keys. Treat them as "set up" so the pill doesn't keep
-  // pestering them after sign-in.
-  const hasServerKeys = await getServerSideKeyService()
-    .canUseServerSideKeys()
-    .catch(() => false);
-  if (!hasApiKey && !hasServerKeys) {
+  // `anyApiKeyExists()` already falls back to `canUseServerSideKeys()`
+  // internally, so a Researcher Access user with no local key is treated
+  // as set up. Catch here so a transient server-key probe failure
+  // doesn't leave the pill stuck — better to hide than to show a stale
+  // CTA on top of a working credential.
+  const exists = await SecretManager.anyApiKeyExists().catch(() => false);
+  if (!exists) {
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =
       'Click to run the setup assistant — sign in for free or add an API key';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,10 +100,11 @@ async function refreshApiKeyStatus() {
 
   // `anyApiKeyExists()` already falls back to `canUseServerSideKeys()`
   // internally, so a Researcher Access user with no local key is treated
-  // as set up. Catch here so a transient server-key probe failure
-  // doesn't leave the pill stuck — better to hide than to show a stale
-  // CTA on top of a working credential.
-  const exists = await SecretManager.anyApiKeyExists().catch(() => false);
+  // as set up. Don't catch here: a transient probe failure shouldn't
+  // regress a signed-in user back to the "Get Started" CTA. Let the
+  // outer `safeRefreshApiKeyStatus` log it and leave the pill in its
+  // prior state.
+  const exists = await SecretManager.anyApiKeyExists();
   if (!exists) {
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,10 @@ export async function activate(context: vscode.ExtensionContext) {
         if (choice === 'Retry') {
           void loadAgents().catch(() => undefined);
         } else if (choice === 'View Logs') {
-          void vscode.commands.executeCommand('workbench.action.output.toggleOutput');
+          // `toggleOutput` would *hide* the panel if already visible —
+          // not what "View Logs" implies. Use `panel.output.focus` so
+          // the action consistently reveals the Output view.
+          void vscode.commands.executeCommand('workbench.panel.output.focus');
         }
       });
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,8 +98,14 @@ async function refreshApiKeyStatus() {
     return;
   }
 
-  const exists = await SecretManager.anyApiKeyExists();
-  if (!exists) {
+  const hasApiKey = await SecretManager.anyApiKeyExists();
+  // Researcher Access users have no local API key but can run models via
+  // server-side keys. Treat them as "set up" so the pill doesn't keep
+  // pestering them after sign-in.
+  const hasServerKeys = await getServerSideKeyService()
+    .canUseServerSideKeys()
+    .catch(() => false);
+  if (!hasApiKey && !hasServerKeys) {
     apiKeyStatusBarItem.text = '$(rocket) TeXRA: Get Started';
     apiKeyStatusBarItem.tooltip =
       'Click to run the setup assistant — sign in for free or add an API key';
@@ -423,11 +429,25 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.StatusBarAlignment.Left,
   );
   context.subscriptions.push(apiKeyStatusBarItem);
-  void refreshApiKeyStatus().catch((err) =>
-    logger.error(
-      'extension',
-      `API key status refresh failed: ${toErrorMessage(err)}`,
-    ),
+  const safeRefreshApiKeyStatus = () =>
+    refreshApiKeyStatus().catch((err) =>
+      logger.error(
+        'extension',
+        `API key status refresh failed: ${toErrorMessage(err)}`,
+      ),
+    );
+  void safeRefreshApiKeyStatus();
+  // Without these listeners the pill stayed on "Get Started" forever after
+  // a Researcher Access sign-in or after the first API key was stored.
+  context.subscriptions.push(
+    vscode.authentication.onDidChangeSessions((e) => {
+      if (e.provider.id === 'texra-supabase') {
+        void safeRefreshApiKeyStatus();
+      }
+    }),
+    getServerSideKeyService().onDidChangeModelAccess(() => {
+      void safeRefreshApiKeyStatus();
+    }),
   );
 
   const runningStreams = new Set<string>();
@@ -506,28 +526,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const welcomeKey = 'texra.welcomeShown';
   if (!context.globalState.get<boolean>(welcomeKey)) {
-    // Open the walkthrough AND surface a notification with a one-click
-    // path to the setup assistant. Walkthroughs can be dismissed or buried
-    // behind other tabs, leaving brand-new users with no obvious next
-    // step. The notification gives them an action button they can click
-    // immediately; the walkthrough is still there if they want the full
-    // tour.
+    // Opening the VS Code walkthrough is enough — its first step is the
+    // setup assistant CTA, so don't double up with a popup.
     void vscode.commands
       .executeCommand('texra.openGettingStarted')
       .then(() => context.globalState.update(welcomeKey, true));
-    void vscode.window
-      .showInformationMessage(
-        'Welcome to TeXRA! The setup assistant can sign you in (free) or set up an API key in one go.',
-        'Run Setup Assistant',
-        'Open Walkthrough',
-      )
-      .then((choice) => {
-        if (choice === 'Run Setup Assistant') {
-          void vscode.commands.executeCommand('texra.runSetupAssistant');
-        } else if (choice === 'Open Walkthrough') {
-          void vscode.commands.executeCommand('texra.openGettingStarted');
-        }
-      });
   }
 }
 

--- a/src/frontend/ui/welcomeView.ts
+++ b/src/frontend/ui/welcomeView.ts
@@ -43,6 +43,18 @@ function renderWelcomeHtml(): string {
     }
     p { margin: 0 0 12px; }
     .muted { color: var(--vscode-descriptionForeground); }
+    .step {
+      margin: 0 0 12px;
+      padding-left: 22px;
+      position: relative;
+    }
+    .step .num {
+      position: absolute;
+      left: 0;
+      top: 0;
+      font-weight: 600;
+      color: var(--vscode-textLink-foreground);
+    }
     .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }
     a {
       color: var(--vscode-textLink-foreground);
@@ -53,20 +65,23 @@ function renderWelcomeHtml(): string {
 </head>
 <body>
   <p>
-    TeXRA is a multi-agent orchestration system for LaTeX research. An
-    orchestrator coordinates specialized agents that derive results, verify
-    proofs, run symbolic computation, generate figures, and assemble
-    manuscripts &mdash; every step auditable, every citation grounded.
+    <strong>Welcome to TeXRA</strong> — an AI research assistant for LaTeX. It
+    coordinates specialized agents to edit manuscripts, derive results, draw
+    figures, and verify proofs.
   </p>
-  <p class="muted">
-    Open a folder to begin. The TeXRA tour and commands become available once
-    a workspace is open.
-  </p>
+  <p class="muted"><strong>To get started:</strong></p>
+  <div class="step"><span class="num">1.</span>Open a folder containing your LaTeX project (or create a sample).</div>
+  <div class="step"><span class="num">2.</span>TeXRA will reload and walk you through sign-in or API key setup.</div>
+  <div class="step"><span class="num">3.</span>Pick an input file, choose the orchestrator, and hit Execute.</div>
   <div class="actions">
     <a href="${openFolder}">Open Folder</a>
     <a href="${cloneRepo}">Clone Repository</a>
     <a href="${docs}">Read the docs</a>
   </div>
+  <p class="muted">
+    TeXRA needs a single-folder workspace. Multi-root workspaces aren't
+    supported &mdash; open one folder at a time.
+  </p>
 </body>
 </html>`;
 }

--- a/src/frontend/ui/welcomeView.ts
+++ b/src/frontend/ui/welcomeView.ts
@@ -43,18 +43,8 @@ function renderWelcomeHtml(): string {
     }
     p { margin: 0 0 12px; }
     .muted { color: var(--vscode-descriptionForeground); }
-    .step {
-      margin: 0 0 12px;
-      padding-left: 22px;
-      position: relative;
-    }
-    .step .num {
-      position: absolute;
-      left: 0;
-      top: 0;
-      font-weight: 600;
-      color: var(--vscode-textLink-foreground);
-    }
+    ol { margin: 0 0 12px; padding-left: 22px; }
+    li { margin-bottom: 6px; }
     .actions { display: flex; flex-direction: column; gap: 6px; margin: 16px 0; }
     a {
       color: var(--vscode-textLink-foreground);
@@ -70,9 +60,11 @@ function renderWelcomeHtml(): string {
     figures, and verify proofs.
   </p>
   <p class="muted"><strong>To get started:</strong></p>
-  <div class="step"><span class="num">1.</span>Open a folder containing your LaTeX project (or create a sample).</div>
-  <div class="step"><span class="num">2.</span>TeXRA will reload and walk you through sign-in or API key setup.</div>
-  <div class="step"><span class="num">3.</span>Pick an input file, choose the orchestrator, and hit Execute.</div>
+  <ol>
+    <li>Open a folder containing your LaTeX project (or create a sample).</li>
+    <li>TeXRA will reload and walk you through sign-in or API key setup.</li>
+    <li>Pick an input file, choose the orchestrator, and hit Execute.</li>
+  </ol>
   <div class="actions">
     <a href="${openFolder}">Open Folder</a>
     <a href="${cloneRepo}">Clone Repository</a>

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -78,8 +78,8 @@ export class GettingStartedBanner extends LitElement {
       <div id="gettingStartedBanner" class="getting-started-banner">
         <div class="getting-started-header">
           <span class="getting-started-text">
-            <strong>Welcome to TeXRA!</strong> Open a workspace with LaTeX
-            files, or get started with one of these:
+            <strong>Welcome to TeXRA!</strong> No LaTeX files here yet — pick
+            how you'd like to start:
           </span>
           <vscode-toolbar-button
             icon="close"


### PR DESCRIPTION
## Summary
This PR enhances the TeXRA setup experience by improving how the extension handles API key status, supporting server-side keys for Researcher Access users, and providing better guidance through the onboarding flow.

## Key Changes

- **API Key Status Indicator**: 
  - Renamed status bar item from "API Key Required" to "Get Started" with a more inviting rocket icon
  - Updated command to launch `texra.runSetupAssistant` instead of direct key setup
  - Changed tooltip to encourage sign-in or API key addition
  - Now considers both local API keys and server-side keys (for Researcher Access users) when determining setup status

- **Server-Side Key Support**:
  - Added check for `canUseServerSideKeys()` so users with server-side access don't see persistent "setup required" prompts
  - Added listeners for authentication changes and model access changes to refresh status appropriately

- **Agent Loading Error Handling**:
  - Added user-facing warning message when agent definitions fail to load
  - Provides "Retry" and "View Logs" options for troubleshooting
  - Prevents silent failures that would leave users confused with an empty agent dropdown

- **Welcome View Improvements**:
  - Redesigned welcome page with clearer, numbered steps for getting started
  - Added visual styling for step indicators
  - Improved messaging to guide users through opening a folder → sign-in/setup → execution
  - Added note about single-folder workspace requirement

- **Getting Started Banner**:
  - Updated banner text to be more contextual ("No LaTeX files here yet")
  - Simplified messaging about available options

## Implementation Details

- The `refreshApiKeyStatus()` function now checks both local and server-side keys before showing the setup prompt
- Added event listeners for `onDidChangeSessions` (authentication) and `onDidChangeModelAccess` (server keys) to keep status in sync
- Wrapped status refresh in a safe error handler to prevent unhandled promise rejections
- Enhanced error messaging for agent loading failures with actionable recovery options

https://claude.ai/code/session_01Dxe94WR3PnTstUoAjV7mBG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX/state-management changes limited to onboarding copy and when the status-bar setup CTA refreshes; main risk is minor regressions in status pill visibility/refresh timing.
> 
> **Overview**
> Updates the status-bar API-key reminder into a friendlier **“TeXRA: Get Started”** CTA that launches `texra.runSetupAssistant` (with updated tooltip) instead of sending users directly to API key setup.
> 
> Makes the CTA state more reliable by wrapping refresh in a shared safe handler and re-refreshing when Supabase auth sessions change or when server-side model access changes, avoiding the pill getting stuck after sign-in/key setup.
> 
> Improves onboarding messaging in the no-workspace welcome view (adds clear numbered steps and a single-folder workspace note) and tweaks the main webview “Getting Started” banner copy to better fit empty/non-LaTeX workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc316f158c83320ec4199ea989c22bd9ad6b9f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->