### PR TITLE
Add Computer Scientist (ML) agent preset

### DIFF
--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -81,4 +81,22 @@ export const AGENT_MODE_PRESETS: AgentModePreset[] = [
       'orchestrator',
     ],
   },
+  {
+    id: 'cs-ml',
+    name: 'Computer Scientist (ML)',
+    description:
+      'For ML/CS papers -- algorithm design, experiments and ablations, literature search, critical review, and reproducibility.',
+    icon: 'codicon-symbol-method',
+    workflowAgents: ['criticize', 'generic', 'devise', 'apply', 'polish'],
+    toolUseAgents: [
+      'orchestrator',
+      'numerics',
+      'search',
+      'review',
+      'presenter',
+      'simplifier',
+      'latexFixer',
+      'progressCheck',
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
Added a new agent preset configuration for machine learning and computer science research workflows.

## Key Changes
- Added `cs-ml` preset to `AGENT_MODE_PRESETS` array in `agentPresets.ts`
- Configured with specialized workflow agents: `criticize`, `generic`, `devise`, `apply`, `polish`
- Configured with specialized tool-use agents: `orchestrator`, `numerics`, `search`, `review`, `presenter`, `simplifier`, `latexFixer`, `progressCheck`
- Preset is optimized for ML/CS paper analysis including algorithm design, experiments, ablations, literature search, critical review, and reproducibility assessment

## Implementation Details
The new preset follows the existing `AgentModePreset` structure and is designed to support comprehensive machine learning and computer science research workflows with agents specialized for numerical analysis, literature search, peer review, and LaTeX document handling.

https://claude.ai/code/session_019qFt24hsB3gSeyLJuAg69e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static `AGENT_MODE_PRESETS` entry without changing preset schema or runtime logic; impact is limited to making an additional preset available in settings.
> 
> **Overview**
> Adds a new built-in agent mode preset, `cs-ml` (“Computer Scientist (ML)”), to `AGENT_MODE_PRESETS` with a predefined set of workflow agents (`criticize`, `generic`, `devise`, `apply`, `polish`) and tool-use agents (e.g., `numerics`, `search`, `review`, `presenter`, plus LaTeX/progress helpers) for ML/CS research workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f40a1b49c666734bed70c2c3af96b6f3b46ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->