### PR TITLE
Add send_to_terminal tool to setup wizard for sudo / interactive prompts

### DIFF
--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -332,37 +332,29 @@ prompts:
 
     ## bash vs. send_to_terminal
 
-    The `bash` tool captures stdio and returns the result to you, but
-    it has no TTY — it cannot answer a `sudo` password prompt or any
-    other interactive prompt. For those, use `send_to_terminal`:
+    The `bash` tool captures stdio but has no TTY — it cannot answer a
+    `sudo` password prompt or any other interactive prompt. For those,
+    use `send_to_terminal`:
 
-      - **Use `bash`** for everything that runs non-interactively:
-        `brew install ...`, `scoop install ...`, `apt-get` queries that
-        don't need elevation, PATH-rc edits via `printf >> ~/.zshrc`,
-        `which ...`, version checks, etc. The user's bash approval
-        dialog is the gate.
-      - **Use `send_to_terminal`** when the command MUST run in a real
-        terminal:
-          - `sudo apt-get install -y ...` (password prompt)
-          - any other `sudo ...` (password prompt)
-          - `brew install --cask mactex` (license / confirmation prompt)
-          - installers that drop into a paginator or editor
-        The tool reuses the same bash approval dialog and runs inside
-        a visible VS Code integrated terminal so the user can answer
-        any password / confirmation prompts themselves. When the
-        terminal has shell integration enabled (the default for
-        bash/zsh/pwsh/fish in VS Code-launched terminals), you get the
-        exit code and a tail of the output back. When shell
-        integration is unavailable the result is `captured: false` —
-        in that case wait for the user to confirm completion before
-        re-probing with `verify_setup`.
+      - **Use `bash`** for non-interactive work: `brew install ...`,
+        `scoop install ...`, `apt-get` queries that don't need
+        elevation, PATH-rc edits via `printf >> ~/.zshrc`, `which ...`,
+        version checks. The bash approval dialog is the gate.
+      - **Use `send_to_terminal`** when the command needs a real
+        terminal: any `sudo`, `brew install --cask` license prompts,
+        installers that drop into a paginator or editor. It reuses the
+        same approval dialog and runs in a visible terminal so the
+        user can answer prompts.
 
-    Read the captured output: an exit code of 0 with a sane tail means
-    the install succeeded; a non-zero exit or an obvious error message
-    means it didn't. Either way, follow up with `verify_setup` to
-    confirm the tool is now on PATH before declaring victory. Never
-    reach for `send_to_terminal` to bypass the `bash` approval dialog
-    on a command that would have worked fine in `bash`.
+    Treat the result as advisory: exit 0 with a sane output tail means
+    the install probably worked; a non-zero exit or an error message
+    means it didn't; an undefined exit code means we couldn't read the
+    result (interrupted, or the user's terminal doesn't have shell
+    integration). Always follow up with `verify_setup` to confirm the
+    tool is on PATH before declaring victory — that is the source of
+    truth, not the captured output. Never reach for `send_to_terminal`
+    to bypass the `bash` approval dialog on a command that would have
+    worked fine in `bash`.
 
     ## Secrets
 

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -332,9 +332,9 @@ prompts:
 
     ## bash vs. send_to_terminal
 
-    The `bash` tool captures stdio and returns the result to you, but it
-    has no TTY — it cannot answer a `sudo` password prompt or any other
-    interactive prompt. For those, use `send_to_terminal`:
+    The `bash` tool captures stdio and returns the result to you, but
+    it has no TTY — it cannot answer a `sudo` password prompt or any
+    other interactive prompt. For those, use `send_to_terminal`:
 
       - **Use `bash`** for everything that runs non-interactively:
         `brew install ...`, `scoop install ...`, `apt-get` queries that
@@ -347,17 +347,22 @@ prompts:
           - any other `sudo ...` (password prompt)
           - `brew install --cask mactex` (license / confirmation prompt)
           - installers that drop into a paginator or editor
-        The tool types the command into a visible VS Code terminal but
-        leaves it at the prompt — the user presses Enter to run it (that
-        keystroke is the approval) and answers any password / yes-no
-        prompt themselves. You receive no captured output, so after
-        sending you must wait for the user to confirm the command
-        finished, then re-probe with `verify_setup` to see what changed.
+        The tool reuses the same bash approval dialog and runs inside
+        a visible VS Code integrated terminal so the user can answer
+        any password / confirmation prompts themselves. When the
+        terminal has shell integration enabled (the default for
+        bash/zsh/pwsh/fish in VS Code-launched terminals), you get the
+        exit code and a tail of the output back. When shell
+        integration is unavailable the result is `captured: false` —
+        in that case wait for the user to confirm completion before
+        re-probing with `verify_setup`.
 
-    Never reach for `send_to_terminal` to bypass the `bash` approval
-    dialog on a command that would have worked fine in `bash`. The
-    tool always leaves the command at the prompt unexecuted — the
-    user's Enter keystroke is the approval gate, by design.
+    Read the captured output: an exit code of 0 with a sane tail means
+    the install succeeded; a non-zero exit or an obvious error message
+    means it didn't. Either way, follow up with `verify_setup` to
+    confirm the tool is now on PATH before declaring victory. Never
+    reach for `send_to_terminal` to bypass the `bash` approval dialog
+    on a command that would have worked fine in `bash`.
 
     ## Secrets
 

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -84,11 +84,39 @@ prompts:
 
     ## Opening move
 
-    Start by calling `probe_environment` exactly once. It returns a JSON
-    document describing the OS, package manager, installed TeX tools, the
-    LaTeX Workshop extension, per-provider API-key presence, and Researcher
-    Access sign-in. Summarize the result in one short paragraph to the
-    user — including, if relevant, which credential sources are missing.
+    Your very first turn is conversational, not a tool call. In ONE
+    short message:
+
+      1. Greet the user by name if you have one, otherwise just "Hi".
+      2. Introduce TeXRA in one or two sentences — pick from "What
+         TeXRA actually is" above, in plain language. Mention the
+         orchestrator + workflow agents at the level of "I can polish,
+         proofread, review, and orchestrate work across your LaTeX
+         papers."
+      3. Ask the user TWO things, framed as a single short question:
+           - What they want to do with TeXRA (improve a draft, start a
+             new paper, just look around, …) — so you know what to set
+             up for.
+           - Whether anything is already in place — e.g. they already
+             have TeX installed, an API key, a paper open in the
+             editor — so you can skip phases.
+      4. Tell them you'll then probe their environment and walk them
+         through whatever is missing. Do NOT call any tool yet.
+
+    Wait for the user's reply. Once they answer (even briefly — a
+    one-word "polish a paper" is enough), call `probe_environment`
+    exactly once. It returns a JSON document describing the OS, package
+    manager, installed TeX tools, the LaTeX Workshop extension,
+    per-provider API-key presence, and Researcher Access sign-in.
+    Summarize the result in one short paragraph to the user — combining
+    what they told you with what the probe found, and naming any
+    credential sources that are missing.
+
+    If the user types something that's clearly an immediate task
+    ("just fix grammar in this file") and the probe later shows the
+    environment is ready, you can skip ahead to phase H rather than
+    walking through every phase. The intro question is for context,
+    not a strict gate.
 
     Then decide the plan based on what's missing. Work phases roughly in
     this order, but skip anything the probe shows is already done:

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -13,6 +13,7 @@ settings:
     - read_config
     - update_config
     - bash
+    - send_to_terminal
     - read_file
     - write_file
     - edit_file
@@ -93,10 +94,16 @@ prompts:
     this order, but skip anything the probe shows is already done:
 
       A. Core LaTeX: pdflatex/latexmk, perl, ghostscript, gm/magick,
-         latexindent, texcount, latexdiff. Install each in turn via `bash`
-         using the detected package manager (brew on macOS, apt/apt-get on
-         Ubuntu, scoop on Windows). If no package manager is detected,
-         explain the situation and offer manual copy-paste links.
+         latexindent, texcount, latexdiff. Install each in turn using
+         the detected package manager (brew on macOS, apt/apt-get on
+         Ubuntu, scoop on Windows). For non-elevated installs (`brew`,
+         `scoop`, user-level `apt-get` queries) use `bash`. For
+         `sudo apt-get install -y ...` and any other command that
+         prompts for a password or interactive confirmation, use
+         `send_to_terminal` instead — the captured-stdio `bash` tool
+         has no TTY and will hang on the password prompt. If no
+         package manager is detected, explain the situation and offer
+         manual copy-paste links.
       B. LaTeX Workshop extension: `install_vscode_extension` with
          `"James-Yu.latex-workshop"`.
       C. PATH fix if TeX binaries are installed but missing from PATH:
@@ -294,6 +301,35 @@ prompts:
       instructions) rather than retrying blindly.
     - After every successful install, re-run `verify_setup { "tool": "<name>" }`
       to confirm the tool is now on PATH.
+
+    ## bash vs. send_to_terminal
+
+    The `bash` tool captures stdio and returns the result to you, but it
+    has no TTY — it cannot answer a `sudo` password prompt or any other
+    interactive prompt. For those, use `send_to_terminal`:
+
+      - **Use `bash`** for everything that runs non-interactively:
+        `brew install ...`, `scoop install ...`, `apt-get` queries that
+        don't need elevation, PATH-rc edits via `printf >> ~/.zshrc`,
+        `which ...`, version checks, etc. The user's bash approval
+        dialog is the gate.
+      - **Use `send_to_terminal`** when the command MUST run in a real
+        terminal:
+          - `sudo apt-get install -y ...` (password prompt)
+          - any other `sudo ...` (password prompt)
+          - `brew install --cask mactex` (license / confirmation prompt)
+          - installers that drop into a paginator or editor
+        The tool types the command into a visible VS Code terminal but
+        leaves it at the prompt — the user presses Enter to run it (that
+        keystroke is the approval) and answers any password / yes-no
+        prompt themselves. You receive no captured output, so after
+        sending you must wait for the user to confirm the command
+        finished, then re-probe with `verify_setup` to see what changed.
+
+    Never reach for `send_to_terminal` to bypass the `bash` approval
+    dialog on a command that would have worked fine in `bash`. Never
+    auto-execute (`execute: true`) the privileged command itself —
+    leaving the keystroke to the user is the whole approval model.
 
     ## Secrets
 

--- a/resources/tool_use_agents/setup.yaml
+++ b/resources/tool_use_agents/setup.yaml
@@ -355,9 +355,9 @@ prompts:
         finished, then re-probe with `verify_setup` to see what changed.
 
     Never reach for `send_to_terminal` to bypass the `bash` approval
-    dialog on a command that would have worked fine in `bash`. Never
-    auto-execute (`execute: true`) the privileged command itself —
-    leaving the keystroke to the user is the whole approval model.
+    dialog on a command that would have worked fine in `bash`. The
+    tool always leaves the command at the prompt unexecuted — the
+    user's Enter keystroke is the approval gate, by design.
 
     ## Secrets
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -314,15 +314,17 @@ export async function activate(context: vscode.ExtensionContext) {
       },
     },
     terminal: {
-      sendCommand: async ({ name, command, execute }) => {
+      sendCommand: async ({ name, command }) => {
         // Reuse a terminal with the same name when present so repeated
         // calls don't clutter the user's terminal panel with tabs.
         const existing = vscode.window.terminals.find((t) => t.name === name);
         const terminal = existing ?? vscode.window.createTerminal({ name });
         terminal.show();
-        // `addNewLine` controls whether the command is auto-executed.
-        // Default is unexecuted so the user's Enter is the approval gate.
-        terminal.sendText(command, execute);
+        // `addNewLine: false` leaves the command unexecuted at the prompt.
+        // The user's Enter keystroke is the approval gate — auto-execute
+        // would defeat the entire purpose of this tool, so it is not
+        // exposed to callers.
+        terminal.sendText(command, false);
       },
     },
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import {
   refreshModelListIfNeeded,
   registerAgentDirectoryRoots,
 } from '@frontend/setup';
+import { runTerminalCommand } from '@frontend/setupTerminalRunner';
 import { agentDirectories } from '@frontend/agents';
 import { FileLister } from '@frontend/files';
 import { killActiveRecording } from '@frontend/media/audio';
@@ -314,18 +315,7 @@ export async function activate(context: vscode.ExtensionContext) {
       },
     },
     terminal: {
-      sendCommand: async ({ name, command }) => {
-        // Reuse a terminal with the same name when present so repeated
-        // calls don't clutter the user's terminal panel with tabs.
-        const existing = vscode.window.terminals.find((t) => t.name === name);
-        const terminal = existing ?? vscode.window.createTerminal({ name });
-        terminal.show();
-        // `addNewLine: false` leaves the command unexecuted at the prompt.
-        // The user's Enter keystroke is the approval gate — auto-execute
-        // would defeat the entire purpose of this tool, so it is not
-        // exposed to callers.
-        terminal.sendText(command, false);
-      },
+      runCommand: (args) => runTerminalCommand(args),
     },
   });
   // GitHub token lives in SecretStorage (managed via the Git settings tab).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,6 +313,18 @@ export async function activate(context: vscode.ExtensionContext) {
         await vscode.workspace.getConfiguration().update(key, value, scope);
       },
     },
+    terminal: {
+      sendCommand: async ({ name, command, execute }) => {
+        // Reuse a terminal with the same name when present so repeated
+        // calls don't clutter the user's terminal panel with tabs.
+        const existing = vscode.window.terminals.find((t) => t.name === name);
+        const terminal = existing ?? vscode.window.createTerminal({ name });
+        terminal.show();
+        // `addNewLine` controls whether the command is auto-executed.
+        // Default is unexecuted so the user's Enter is the approval gate.
+        terminal.sendText(command, execute);
+      },
+    },
   });
   // GitHub token lives in SecretStorage (managed via the Git settings tab).
   // The tool layer only supports a synchronous token lookup, so we cache here

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -102,24 +102,27 @@ async function captureExecution(
   const execution = integration.executeCommand(command);
 
   // Exit code is delivered via the global end-event, not the execution
-  // object itself, so subscribe BEFORE we start reading. The promise
-  // resolves with the real exit code when the matching end-event
-  // fires, never with the timeout sentinel — that's the outer race's
-  // job below.
+  // object itself, so subscribe BEFORE we start reading. Hoist the
+  // disposable so the timeout branch below can also dispose it —
+  // otherwise the listener stays registered for the rest of the
+  // session and fires on every unrelated terminal execution.
+  let endDisposable: vscode.Disposable | undefined;
   const exitCodePromise = new Promise<number | undefined>((resolve) => {
-    const disposable = vscode.window.onDidEndTerminalShellExecution(
-      (event) => {
-        if (event.execution !== execution) return;
-        disposable.dispose();
-        resolve(event.exitCode);
-      },
-    );
+    endDisposable = vscode.window.onDidEndTerminalShellExecution((event) => {
+      if (event.execution !== execution) return;
+      endDisposable?.dispose();
+      endDisposable = undefined;
+      resolve(event.exitCode);
+    });
   });
 
   // Sliding-window tail: keep at most OUTPUT_MAX_CHARS of the most
   // recent output. The previous version flipped a `truncated` flag and
   // skipped all subsequent chunks, which discarded the actual end of
   // the run (the success / error line the agent needs to interpret).
+  // Add a `.catch` so a stream error after we abandon the reader
+  // (e.g. on timeout, or if the user closes the terminal) cannot
+  // surface as an unhandled rejection.
   let output = '';
   const reader = (async () => {
     for await (const chunk of execution.read()) {
@@ -128,7 +131,11 @@ async function captureExecution(
         output = output.slice(-OUTPUT_MAX_CHARS);
       }
     }
-  })();
+  })().catch(() => {
+    // Swallow — the captured output we have so far is still useful,
+    // and the agent already has a `timedOut` / undefined-exit signal
+    // for the failure case.
+  });
 
   const raced = await Promise.race([
     exitCodePromise,
@@ -138,6 +145,14 @@ async function captureExecution(
   ]);
   const timedOut = raced === TIMEOUT_SENTINEL;
   const exitCode = timedOut ? undefined : raced;
+
+  // On timeout, dispose the now-stranded end-event listener. It would
+  // otherwise stay registered for the rest of the session and fire on
+  // every unrelated terminal execution that ends afterward.
+  if (timedOut) {
+    endDisposable?.dispose();
+    endDisposable = undefined;
+  }
 
   // Drain any final chunks unless we timed out; bound the wait so a
   // hung reader can't block the agent forever.

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -121,18 +121,28 @@ function raceWithTimeout<T>(
   timeoutMs: number,
 ): Promise<Raced<T>> {
   return new Promise((resolve) => {
+    // Predeclared with `let` so the `settle` closure can read them
+    // even if `subscribe` fires its callback synchronously (would
+    // otherwise hit the TDZ for the original `const` bindings).
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
+    let disposable: vscode.Disposable | undefined = undefined;
     const settle = (result: Raced<T>) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
-      disposable.dispose();
+      if (timer !== undefined) clearTimeout(timer);
+      disposable?.dispose();
       resolve(result);
     };
-    const disposable = subscribe((value) =>
-      settle({ timedOut: false, value }),
-    );
-    const timer = setTimeout(() => settle({ timedOut: true }), timeoutMs);
+    disposable = subscribe((value) => settle({ timedOut: false, value }));
+    if (settled) {
+      // `subscribe` already resolved synchronously; settle() ran
+      // before `disposable` was assigned, so dispose now and skip
+      // the timer entirely.
+      disposable.dispose();
+      return;
+    }
+    timer = setTimeout(() => settle({ timedOut: true }), timeoutMs);
   });
 }
 

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -1,13 +1,12 @@
 /**
  * Setup-tool integrated-terminal runner.
  *
- * Implements `SetupTerminalAdapter.runCommand` for `extension.ts`. Prefers
- * VS Code's stable `Terminal.shellIntegration` API (since 1.93) so the
- * setup agent can read back exit code + output. When shell integration
- * isn't available — custom shell, user disabled the auto-inject, remote
- * SSH edge cases — falls back to `terminal.sendText(command, true)` and
- * reports `captured: false` so the agent knows to ask the user to
- * confirm completion and re-probe.
+ * Implements `SetupTerminalAdapter.runCommand`. Prefers VS Code's stable
+ * `Terminal.shellIntegration` API (since 1.93) so the agent gets exit
+ * code + output. When integration isn't available — custom shell, user
+ * disabled the auto-inject, remote SSH edge cases — falls back to
+ * `sendText` and returns an empty captured result; the caller sees the
+ * same shape as a Ctrl+C interruption and re-probes with `verify_setup`.
  */
 
 // Third-party imports
@@ -17,87 +16,58 @@ import stripAnsi from 'strip-ansi';
 // Local imports
 import type { TerminalRunResult } from '@tools/setup';
 
-/** Length cap for the captured output tail. */
 const OUTPUT_MAX_CHARS = 12_000;
-/** How long to wait for shell integration to finish activating on a fresh terminal. */
 const SHELL_INTEGRATION_WAIT_MS = 2_000;
+const READER_DRAIN_MS = 250;
 
-/**
- * Run a command in a named integrated terminal and (when possible)
- * return its captured output and exit code.
- *
- * The caller is responsible for approval gating — by the time
- * `runCommand` is called, the user has already approved the command
- * through the normal bash approval surface.
- */
 export async function runTerminalCommand(args: {
   name: string;
   command: string;
   timeoutMs: number;
 }): Promise<TerminalRunResult> {
   const { name, command, timeoutMs } = args;
-
-  // Reuse a terminal with the same name when present so repeated calls
-  // don't clutter the user's terminal panel with duplicate tabs. A
-  // terminal that has already exited keeps appearing in `terminals`
-  // until the user closes it manually — skip those, otherwise our
-  // command would silently land in a dead tab.
-  const existing = vscode.window.terminals.find(
-    (t) => t.name === name && t.exitStatus === undefined,
-  );
-  const terminal = existing ?? vscode.window.createTerminal({ name });
-  terminal.show();
-
+  const terminal = revealTerminal(name);
   const integration = await waitForShellIntegration(
     terminal,
     SHELL_INTEGRATION_WAIT_MS,
   );
 
   if (!integration) {
-    // No shell integration → run the command but give up on capture.
-    // Auto-execute (`addNewLine: true`) — the bash approval dialog is
-    // the gate, so requiring an extra Enter keystroke would just
-    // confuse the user.
     terminal.sendText(command, true);
-    return { captured: false };
+    return { exitCode: undefined, output: '', timedOut: false };
   }
 
   return captureExecution(integration, command, timeoutMs);
 }
 
 /**
- * Wait briefly for `shellIntegration` to populate on a freshly-created
- * terminal. Returns `undefined` if it doesn't show up in time.
+ * Reuse a same-named, still-running terminal so repeated calls don't
+ * pile up tabs. Already-exited terminals stay in `terminals` until the
+ * user closes them; treat those as gone.
  */
+function revealTerminal(name: string): vscode.Terminal {
+  const existing = vscode.window.terminals.find(
+    (t) => t.name === name && t.exitStatus === undefined,
+  );
+  const terminal = existing ?? vscode.window.createTerminal({ name });
+  terminal.show();
+  return terminal;
+}
+
 async function waitForShellIntegration(
   terminal: vscode.Terminal,
   timeoutMs: number,
 ): Promise<vscode.TerminalShellIntegration | undefined> {
   if (terminal.shellIntegration) return terminal.shellIntegration;
-
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      disposable.dispose();
-      resolve(undefined);
-    }, timeoutMs);
-    const disposable = vscode.window.onDidChangeTerminalShellIntegration(
-      (event) => {
-        if (event.terminal === terminal) {
-          clearTimeout(timer);
-          disposable.dispose();
-          resolve(event.shellIntegration);
-        }
-      },
-    );
-  });
+  const raced = await raceWithTimeout<vscode.TerminalShellIntegration>(
+    (resolve) =>
+      vscode.window.onDidChangeTerminalShellIntegration((event) => {
+        if (event.terminal === terminal) resolve(event.shellIntegration);
+      }),
+    timeoutMs,
+  );
+  return raced.timedOut ? undefined : raced.value;
 }
-
-/**
- * Sentinel returned by the timeout race so callers can distinguish
- * "we gave up waiting" from "the shell reported no exit code" (Ctrl+C
- * before completion). Plain `undefined` means the latter.
- */
-const TIMEOUT_SENTINEL: unique symbol = Symbol('terminal-timeout');
 
 async function captureExecution(
   integration: vscode.TerminalShellIntegration,
@@ -107,78 +77,78 @@ async function captureExecution(
   const execution = integration.executeCommand(command);
 
   // Exit code is delivered via the global end-event, not the execution
-  // object itself, so subscribe BEFORE we start reading. Hoist the
-  // disposable so the timeout branch below can also dispose it —
-  // otherwise the listener stays registered for the rest of the
-  // session and fires on every unrelated terminal execution.
-  let endDisposable: vscode.Disposable | undefined;
-  const exitCodePromise = new Promise<number | undefined>((resolve) => {
-    endDisposable = vscode.window.onDidEndTerminalShellExecution((event) => {
-      if (event.execution !== execution) return;
-      endDisposable?.dispose();
-      endDisposable = undefined;
-      resolve(event.exitCode);
-    });
-  });
+  // object itself, so subscribe before reading.
+  const raced = raceWithTimeout<number | undefined>(
+    (resolve) =>
+      vscode.window.onDidEndTerminalShellExecution((event) => {
+        if (event.execution === execution) resolve(event.exitCode);
+      }),
+    timeoutMs,
+  );
 
-  // Sliding-window tail: keep at most OUTPUT_MAX_CHARS of the most
-  // recent output. The previous version flipped a `truncated` flag and
-  // skipped all subsequent chunks, which discarded the actual end of
-  // the run (the success / error line the agent needs to interpret).
-  // Add a `.catch` so a stream error after we abandon the reader
-  // (e.g. on timeout, or if the user closes the terminal) cannot
-  // surface as an unhandled rejection.
-  let output = '';
-  const reader = (async () => {
-    for await (const chunk of execution.read()) {
-      output += chunk;
-      if (output.length > OUTPUT_MAX_CHARS) {
-        output = output.slice(-OUTPUT_MAX_CHARS);
-      }
-    }
-  })().catch(() => {
-    // Swallow — the captured output we have so far is still useful,
-    // and the agent already has a `timedOut` / undefined-exit signal
-    // for the failure case.
-  });
+  // Drain the stream into a sliding-window tail. `.catch` swallows
+  // late stream errors (terminal closed after we stopped awaiting)
+  // so they cannot bubble up as unhandled rejections.
+  const reader = tail(execution.read(), OUTPUT_MAX_CHARS).catch(() => '');
 
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  const raced = await Promise.race([
-    exitCodePromise,
-    new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
-      timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
-    }),
+  const result = await raced;
+
+  // Drain any final chunks; bound the wait so a hung reader can't
+  // block the agent forever.
+  const output = await Promise.race([
+    reader,
+    new Promise<string>((resolve) =>
+      setTimeout(() => resolve(''), READER_DRAIN_MS),
+    ),
   ]);
-  const timedOut = raced === TIMEOUT_SENTINEL;
-  const exitCode = timedOut ? undefined : raced;
-  // Clear the timer when the exit-code event won. Without this the
-  // pending timeout (up to 15 min) sits on the event loop holding the
-  // sentinel-resolving closure alive long after the command finished.
-  if (!timedOut && timeoutHandle !== undefined) {
-    clearTimeout(timeoutHandle);
-  }
-
-  // On timeout, dispose the now-stranded end-event listener. It would
-  // otherwise stay registered for the rest of the session and fire on
-  // every unrelated terminal execution that ends afterward.
-  if (timedOut) {
-    endDisposable?.dispose();
-    endDisposable = undefined;
-  }
-
-  // Drain any final chunks unless we timed out; bound the wait so a
-  // hung reader can't block the agent forever.
-  if (!timedOut) {
-    await Promise.race([
-      reader,
-      new Promise<void>((resolve) => setTimeout(resolve, 250)),
-    ]);
-  }
 
   return {
-    captured: true,
-    exitCode,
+    exitCode: result.timedOut ? undefined : result.value,
     output: stripAnsi(output),
-    timedOut,
+    timedOut: result.timedOut,
   };
+}
+
+type Raced<T> = { timedOut: false; value: T } | { timedOut: true };
+
+/**
+ * Race a one-shot event subscription against a timeout. Disposes the
+ * subscription and clears the timer in whichever branch wins so we
+ * never leak listeners or pending timers.
+ */
+function raceWithTimeout<T>(
+  subscribe: (resolve: (value: T) => void) => vscode.Disposable,
+  timeoutMs: number,
+): Promise<Raced<T>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: Raced<T>) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      disposable.dispose();
+      resolve(result);
+    };
+    const disposable = subscribe((value) =>
+      settle({ timedOut: false, value }),
+    );
+    const timer = setTimeout(() => settle({ timedOut: true }), timeoutMs);
+  });
+}
+
+/**
+ * Drain an async iterable into a length-capped sliding-window tail.
+ * Caller may abandon the returned promise; chunk errors are surfaced
+ * to the caller for them to decide whether to swallow.
+ */
+async function tail(
+  stream: AsyncIterable<string>,
+  maxChars: number,
+): Promise<string> {
+  let buf = '';
+  for await (const chunk of stream) {
+    buf += chunk;
+    if (buf.length > maxChars) buf = buf.slice(-maxChars);
+  }
+  return buf;
 }

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -87,6 +87,13 @@ async function waitForShellIntegration(
   });
 }
 
+/**
+ * Sentinel returned by the timeout race so callers can distinguish
+ * "we gave up waiting" from "the shell reported no exit code" (Ctrl+C
+ * before completion). Plain `undefined` means the latter.
+ */
+const TIMEOUT_SENTINEL: unique symbol = Symbol('terminal-timeout');
+
 async function captureExecution(
   integration: vscode.TerminalShellIntegration,
   command: string,
@@ -95,61 +102,51 @@ async function captureExecution(
   const execution = integration.executeCommand(command);
 
   // Exit code is delivered via the global end-event, not the execution
-  // object itself, so subscribe BEFORE we start reading. We resolve
-  // when the matching end-event fires, or `undefined` on timeout.
+  // object itself, so subscribe BEFORE we start reading. The promise
+  // resolves with the real exit code when the matching end-event
+  // fires, never with the timeout sentinel — that's the outer race's
+  // job below.
   const exitCodePromise = new Promise<number | undefined>((resolve) => {
-    const timer = setTimeout(() => {
-      disposable.dispose();
-      resolve(undefined);
-    }, timeoutMs);
     const disposable = vscode.window.onDidEndTerminalShellExecution(
       (event) => {
         if (event.execution !== execution) return;
-        clearTimeout(timer);
         disposable.dispose();
         resolve(event.exitCode);
       },
     );
   });
 
+  // Sliding-window tail: keep at most OUTPUT_MAX_CHARS of the most
+  // recent output. The previous version flipped a `truncated` flag and
+  // skipped all subsequent chunks, which discarded the actual end of
+  // the run (the success / error line the agent needs to interpret).
   let output = '';
-  let truncated = false;
   const reader = (async () => {
     for await (const chunk of execution.read()) {
-      if (truncated) continue;
       output += chunk;
       if (output.length > OUTPUT_MAX_CHARS) {
-        // Keep the tail — for installer / package-manager output the
-        // last few lines (success / error message) are what the agent
-        // actually needs to interpret.
         output = output.slice(-OUTPUT_MAX_CHARS);
-        truncated = true;
       }
     }
   })();
 
-  // Race the exit-code subscription against an explicit timeout. The
-  // timer inside `exitCodePromise` resolves with `undefined` after
-  // `timeoutMs`; treat that as a timeout signal so the agent can
-  // distinguish "command interrupted before completion" from "we gave
-  // up waiting".
-  let timedOut = false;
-  const exitCode = await Promise.race([
+  const raced = await Promise.race([
     exitCodePromise,
-    new Promise<undefined>((resolve) => {
-      setTimeout(() => {
-        timedOut = true;
-        resolve(undefined);
-      }, timeoutMs + 50);
-    }),
+    new Promise<typeof TIMEOUT_SENTINEL>((resolve) =>
+      setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs),
+    ),
   ]);
+  const timedOut = raced === TIMEOUT_SENTINEL;
+  const exitCode = timedOut ? undefined : raced;
 
-  // Drain any final chunks; bound the wait so a hung reader can't
-  // block the agent forever.
-  await Promise.race([
-    reader,
-    new Promise<void>((resolve) => setTimeout(resolve, 250)),
-  ]);
+  // Drain any final chunks unless we timed out; bound the wait so a
+  // hung reader can't block the agent forever.
+  if (!timedOut) {
+    await Promise.race([
+      reader,
+      new Promise<void>((resolve) => setTimeout(resolve, 250)),
+    ]);
+  }
 
   return {
     captured: true,

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -1,0 +1,160 @@
+/**
+ * Setup-tool integrated-terminal runner.
+ *
+ * Implements `SetupTerminalAdapter.runCommand` for `extension.ts`. Prefers
+ * VS Code's stable `Terminal.shellIntegration` API (since 1.93) so the
+ * setup agent can read back exit code + output. When shell integration
+ * isn't available — custom shell, user disabled the auto-inject, remote
+ * SSH edge cases — falls back to `terminal.sendText(command, true)` and
+ * reports `captured: false` so the agent knows to ask the user to
+ * confirm completion and re-probe.
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+import stripAnsi from 'strip-ansi';
+
+// Local imports
+import type { TerminalRunResult } from '@tools/setup';
+
+/** Length cap for the captured output tail. */
+const OUTPUT_MAX_CHARS = 12_000;
+/** How long to wait for shell integration to finish activating on a fresh terminal. */
+const SHELL_INTEGRATION_WAIT_MS = 2_000;
+
+/**
+ * Run a command in a named integrated terminal and (when possible)
+ * return its captured output and exit code.
+ *
+ * The caller is responsible for approval gating — by the time
+ * `runCommand` is called, the user has already approved the command
+ * through the normal bash approval surface.
+ */
+export async function runTerminalCommand(args: {
+  name: string;
+  command: string;
+  timeoutMs: number;
+}): Promise<TerminalRunResult> {
+  const { name, command, timeoutMs } = args;
+
+  // Reuse a terminal with the same name when present so repeated calls
+  // don't clutter the user's terminal panel with duplicate tabs.
+  const existing = vscode.window.terminals.find((t) => t.name === name);
+  const terminal = existing ?? vscode.window.createTerminal({ name });
+  terminal.show();
+
+  const integration = await waitForShellIntegration(
+    terminal,
+    SHELL_INTEGRATION_WAIT_MS,
+  );
+
+  if (!integration) {
+    // No shell integration → run the command but give up on capture.
+    // Auto-execute (`addNewLine: true`) — the bash approval dialog is
+    // the gate, so requiring an extra Enter keystroke would just
+    // confuse the user.
+    terminal.sendText(command, true);
+    return { captured: false, reason: 'no-shell-integration' };
+  }
+
+  return captureExecution(integration, command, timeoutMs);
+}
+
+/**
+ * Wait briefly for `shellIntegration` to populate on a freshly-created
+ * terminal. Returns `undefined` if it doesn't show up in time.
+ */
+async function waitForShellIntegration(
+  terminal: vscode.Terminal,
+  timeoutMs: number,
+): Promise<vscode.TerminalShellIntegration | undefined> {
+  if (terminal.shellIntegration) return terminal.shellIntegration;
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      disposable.dispose();
+      resolve(undefined);
+    }, timeoutMs);
+    const disposable = vscode.window.onDidChangeTerminalShellIntegration(
+      (event) => {
+        if (event.terminal === terminal) {
+          clearTimeout(timer);
+          disposable.dispose();
+          resolve(event.shellIntegration);
+        }
+      },
+    );
+  });
+}
+
+async function captureExecution(
+  integration: vscode.TerminalShellIntegration,
+  command: string,
+  timeoutMs: number,
+): Promise<TerminalRunResult> {
+  const execution = integration.executeCommand(command);
+
+  // Exit code is delivered via the global end-event, not the execution
+  // object itself, so subscribe BEFORE we start reading. We resolve
+  // when the matching end-event fires, or `undefined` on timeout.
+  const exitCodePromise = new Promise<number | undefined>((resolve) => {
+    const timer = setTimeout(() => {
+      disposable.dispose();
+      resolve(undefined);
+    }, timeoutMs);
+    const disposable = vscode.window.onDidEndTerminalShellExecution(
+      (event) => {
+        if (event.execution !== execution) return;
+        clearTimeout(timer);
+        disposable.dispose();
+        resolve(event.exitCode);
+      },
+    );
+  });
+
+  let output = '';
+  let truncated = false;
+  const reader = (async () => {
+    for await (const chunk of execution.read()) {
+      if (truncated) continue;
+      output += chunk;
+      if (output.length > OUTPUT_MAX_CHARS) {
+        // Keep the tail — for installer / package-manager output the
+        // last few lines (success / error message) are what the agent
+        // actually needs to interpret.
+        output = output.slice(-OUTPUT_MAX_CHARS);
+        truncated = true;
+      }
+    }
+  })();
+
+  // Race the exit-code subscription against an explicit timeout. The
+  // timer inside `exitCodePromise` resolves with `undefined` after
+  // `timeoutMs`; treat that as a timeout signal so the agent can
+  // distinguish "command interrupted before completion" from "we gave
+  // up waiting".
+  let timedOut = false;
+  const exitCode = await Promise.race([
+    exitCodePromise,
+    new Promise<undefined>((resolve) => {
+      setTimeout(() => {
+        timedOut = true;
+        resolve(undefined);
+      }, timeoutMs + 50);
+    }),
+  ]);
+
+  // Drain any final chunks; bound the wait so a hung reader can't
+  // block the agent forever.
+  await Promise.race([
+    reader,
+    new Promise<void>((resolve) => setTimeout(resolve, 250)),
+  ]);
+
+  return {
+    captured: true,
+    exitCode,
+    output: stripAnsi(output),
+    timedOut,
+  };
+}

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -142,14 +142,21 @@ async function captureExecution(
     // for the failure case.
   });
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const raced = await Promise.race([
     exitCodePromise,
-    new Promise<typeof TIMEOUT_SENTINEL>((resolve) =>
-      setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs),
-    ),
+    new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), timeoutMs);
+    }),
   ]);
   const timedOut = raced === TIMEOUT_SENTINEL;
   const exitCode = timedOut ? undefined : raced;
+  // Clear the timer when the exit-code event won. Without this the
+  // pending timeout (up to 15 min) sits on the event loop holding the
+  // sentinel-resolving closure alive long after the command finished.
+  if (!timedOut && timeoutHandle !== undefined) {
+    clearTimeout(timeoutHandle);
+  }
 
   // On timeout, dispose the now-stranded end-event listener. It would
   // otherwise stay registered for the rest of the session and fire on

--- a/src/frontend/setupTerminalRunner.ts
+++ b/src/frontend/setupTerminalRunner.ts
@@ -38,8 +38,13 @@ export async function runTerminalCommand(args: {
   const { name, command, timeoutMs } = args;
 
   // Reuse a terminal with the same name when present so repeated calls
-  // don't clutter the user's terminal panel with duplicate tabs.
-  const existing = vscode.window.terminals.find((t) => t.name === name);
+  // don't clutter the user's terminal panel with duplicate tabs. A
+  // terminal that has already exited keeps appearing in `terminals`
+  // until the user closes it manually — skip those, otherwise our
+  // command would silently land in a dead tab.
+  const existing = vscode.window.terminals.find(
+    (t) => t.name === name && t.exitStatus === undefined,
+  );
   const terminal = existing ?? vscode.window.createTerminal({ name });
   terminal.show();
 
@@ -54,7 +59,7 @@ export async function runTerminalCommand(args: {
     // the gate, so requiring an extra Enter keystroke would just
     // confuse the user.
     terminal.sendText(command, true);
-    return { captured: false, reason: 'no-shell-integration' };
+    return { captured: false };
   }
 
   return captureExecution(integration, command, timeoutMs);

--- a/src/test/tools/setup/ConfigTools.test.ts
+++ b/src/test/tools/setup/ConfigTools.test.ts
@@ -1,7 +1,12 @@
 import { strict as assert } from 'assert';
 
 import { ReadConfigTool, UpdateConfigTool } from '@tools/setup/ConfigTools';
-import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+import {
+  setSetupPlatform,
+  type SetupPlatform,
+} from '@tools/setup/platform';
+
+import { createFakeSetupPlatform } from './fixtures';
 
 interface UpdateRecord {
   key: string;
@@ -16,41 +21,7 @@ function createPlatform(initial: Record<string, unknown> = {}): {
 } {
   const store: Record<string, unknown> = { ...initial };
   const updates: UpdateRecord[] = [];
-  const platform: SetupPlatform = {
-    secrets: {
-      async setApiKey() {},
-      async deleteApiKey() {},
-      async apiKeyExists() {
-        return false;
-      },
-      async hasUsableApiKey() {
-        return false;
-      },
-      async storedApiKeyExists() {
-        return false;
-      },
-      async anyApiKeyExists() {
-        return false;
-      },
-      async gitHubTokenExists() {
-        return 'none';
-      },
-      providers: [],
-    },
-    commands: {
-      async invoke() {},
-    },
-    extensions: {
-      isInstalled() {
-        return false;
-      },
-      async install() {},
-    },
-    auth: {
-      async getStatus() {
-        return { authenticated: false };
-      },
-    },
+  const platform = createFakeSetupPlatform({
     config: {
       get(key) {
         return store[key];
@@ -60,12 +31,7 @@ function createPlatform(initial: Record<string, unknown> = {}): {
         store[key] = value;
       },
     },
-    terminal: {
-      async runCommand() {
-        return { captured: false, reason: 'unavailable' };
-      },
-    },
-  };
+  });
   return { platform, store, updates };
 }
 

--- a/src/test/tools/setup/ConfigTools.test.ts
+++ b/src/test/tools/setup/ConfigTools.test.ts
@@ -61,7 +61,9 @@ function createPlatform(initial: Record<string, unknown> = {}): {
       },
     },
     terminal: {
-      async sendCommand() {},
+      async runCommand() {
+        return { captured: false, reason: 'unavailable' };
+      },
     },
   };
   return { platform, store, updates };

--- a/src/test/tools/setup/ConfigTools.test.ts
+++ b/src/test/tools/setup/ConfigTools.test.ts
@@ -60,6 +60,9 @@ function createPlatform(initial: Record<string, unknown> = {}): {
         store[key] = value;
       },
     },
+    terminal: {
+      async sendCommand() {},
+    },
   };
   return { platform, store, updates };
 }

--- a/src/test/tools/setup/InvokeCommandTool.test.ts
+++ b/src/test/tools/setup/InvokeCommandTool.test.ts
@@ -60,7 +60,9 @@ function createPlatform(): {
       async update() {},
     },
     terminal: {
-      async sendCommand() {},
+      async runCommand() {
+        return { captured: false, reason: 'unavailable' };
+      },
     },
   };
   return { platform, invocations };

--- a/src/test/tools/setup/InvokeCommandTool.test.ts
+++ b/src/test/tools/setup/InvokeCommandTool.test.ts
@@ -59,6 +59,9 @@ function createPlatform(): {
       },
       async update() {},
     },
+    terminal: {
+      async sendCommand() {},
+    },
   };
   return { platform, invocations };
 }

--- a/src/test/tools/setup/InvokeCommandTool.test.ts
+++ b/src/test/tools/setup/InvokeCommandTool.test.ts
@@ -4,7 +4,12 @@ import { strict as assert } from 'assert';
 // Local imports
 import { AUTH_COMMANDS } from '@auth/constants';
 import { InvokeCommandTool } from '@tools/setup/InvokeCommandTool';
-import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+import {
+  setSetupPlatform,
+  type SetupPlatform,
+} from '@tools/setup/platform';
+
+import { createFakeSetupPlatform } from './fixtures';
 
 interface InvokeRecord {
   command: string;
@@ -16,55 +21,13 @@ function createPlatform(): {
   invocations: InvokeRecord[];
 } {
   const invocations: InvokeRecord[] = [];
-  const platform: SetupPlatform = {
-    secrets: {
-      async setApiKey() {},
-      async deleteApiKey() {},
-      async apiKeyExists() {
-        return false;
-      },
-      async hasUsableApiKey() {
-        return false;
-      },
-      async storedApiKeyExists() {
-        return false;
-      },
-      async anyApiKeyExists() {
-        return false;
-      },
-      async gitHubTokenExists() {
-        return 'none';
-      },
-      providers: [],
-    },
+  const platform = createFakeSetupPlatform({
     commands: {
       async invoke(command, ...args) {
         invocations.push({ command, args });
       },
     },
-    extensions: {
-      isInstalled() {
-        return false;
-      },
-      async install() {},
-    },
-    auth: {
-      async getStatus() {
-        return { authenticated: false };
-      },
-    },
-    config: {
-      get() {
-        return undefined;
-      },
-      async update() {},
-    },
-    terminal: {
-      async runCommand() {
-        return { captured: false, reason: 'unavailable' };
-      },
-    },
-  };
+  });
   return { platform, invocations };
 }
 

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -146,4 +146,31 @@ describe('SendToTerminalTool', () => {
     }
     assert.equal(runs.length, 0);
   });
+
+  it('truncates from the head, not the tail — the success/error line is at the end', async () => {
+    // Output longer than the tool's preview cap. We sentinel the start
+    // and end so we can see which side survived truncation.
+    const head = 'BEGIN_MARKER\n' + 'x'.repeat(8_000);
+    const end = 'Setting up perl ... done\nEND_MARKER';
+    const { platform } = createPlatform({
+      exitCode: 0,
+      output: head + '\n' + end,
+      timedOut: false,
+    });
+    setSetupPlatform(platform);
+
+    const result = await new SendToTerminalTool().call({
+      command: 'sudo apt-get install -y perl',
+    });
+
+    assert.ok(!result.isError);
+    assert.ok(
+      (result.output ?? '').includes('END_MARKER'),
+      'tail (success line) must survive truncation',
+    );
+    assert.ok(
+      !(result.output ?? '').includes('BEGIN_MARKER'),
+      'head must be elided when output exceeds the preview cap',
+    );
+  });
 });

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -2,6 +2,8 @@
 import { strict as assert } from 'assert';
 
 // Local imports
+import { initPlatform, type Platform } from '@platform/platform';
+import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
 import { SendToTerminalTool } from '@tools/setup/SendToTerminalTool';
 import {
   setSetupPlatform,
@@ -10,6 +12,27 @@ import {
 } from '@tools/setup/platform';
 
 import { createFakeSetupPlatform } from './fixtures';
+
+/**
+ * `requestBashApproval` reads `texra.toolUse.requireBashApproval` via
+ * `getConfig`, which falls through to the supplied default (`true`)
+ * when no platform is registered — so without intervention the
+ * approval prompt would be shown and the test would hang waiting for a
+ * user response that never arrives. Register a minimal platform that
+ * resolves the bash-approval flag to `false`; everything else in this
+ * test file goes through the SetupPlatform fixture, not Platform.
+ */
+function installApprovalSkippingPlatform(): void {
+  const stub: Partial<Platform> = {
+    config: {
+      get: <T,>(key: string, defaultValue?: T): T => {
+        if (key === BASH_APPROVAL_CONFIG_KEY) return false as T;
+        return defaultValue as T;
+      },
+    },
+  };
+  initPlatform(stub as Platform);
+}
 
 interface RunRecord {
   name: string;
@@ -41,6 +64,8 @@ function createPlatform(
 }
 
 describe('SendToTerminalTool', () => {
+  before(() => installApprovalSkippingPlatform());
+
   it('runs the command and returns exit code + captured output preview', async () => {
     const { platform, runs } = createPlatform();
     setSetupPlatform(platform);

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -8,7 +8,6 @@ import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
 interface SendRecord {
   name: string;
   command: string;
-  execute: boolean;
 }
 
 function createPlatform(): {
@@ -67,7 +66,7 @@ function createPlatform(): {
 }
 
 describe('SendToTerminalTool', () => {
-  it('types the command without auto-executing by default', async () => {
+  it('types the command and prepends TeXRA: to the default label', async () => {
     const { platform, sends } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
@@ -81,30 +80,31 @@ describe('SendToTerminalTool', () => {
     assert.equal(sends.length, 1);
     assert.equal(sends[0].command, 'sudo apt-get install -y latexmk');
     assert.equal(
-      sends[0].execute,
-      false,
-      'must default to non-executed so the user presses Enter as approval',
+      sends[0].name,
+      'TeXRA: setup',
+      'default label "setup" must be prefixed with TeXRA:',
     );
-    assert.equal(sends[0].name, 'TeXRA: setup');
     assert.match(result.output ?? '', /press Enter/);
     assert.match(result.output ?? '', /sudo password prompt/);
   });
 
-  it('accepts a custom terminal name and execute=true', async () => {
+  it('always prepends TeXRA: to a caller-supplied label', async () => {
     const { platform, sends } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
     const result = await tool.call({
-      command: 'clear',
-      reason: 'tidy follow-up',
-      name: 'TeXRA: install LaTeX',
-      execute: true,
+      command: 'sudo apt-get install -y perl',
+      reason: 'sudo password prompt',
+      label: 'install LaTeX',
     });
 
     assert.ok(!result.isError);
-    assert.equal(sends[0].name, 'TeXRA: install LaTeX');
-    assert.equal(sends[0].execute, true);
+    assert.equal(
+      sends[0].name,
+      'TeXRA: install LaTeX',
+      'caller-supplied labels must be prefixed, never used as-is',
+    );
     assert.match(result.summary ?? '', /TeXRA: install LaTeX/);
   });
 
@@ -122,6 +122,42 @@ describe('SendToTerminalTool', () => {
     assert.equal(sends.length, 0);
   });
 
+  it('rejects commands containing newlines — they would auto-execute past Enter', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    for (const command of [
+      'sudo apt-get install -y perl\nrm -rf /tmp/leak',
+      'sudo apt-get install -y perl\r\necho pwned',
+      'first\rsecond',
+    ]) {
+      const result = await tool.call({
+        command,
+        reason: 'sudo password prompt',
+      });
+      assert.ok(
+        result.isError,
+        `embedded newline must be rejected: ${JSON.stringify(command)}`,
+      );
+    }
+    assert.equal(sends.length, 0, 'no sends should reach the platform');
+  });
+
+  it('rejects whitespace-only reason — the agent must justify TTY use', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y perl',
+      reason: '   ',
+    });
+
+    assert.ok(result.isError, 'whitespace-only reason must fail validation');
+    assert.equal(sends.length, 0);
+  });
+
   it('trims surrounding whitespace before sending', async () => {
     const { platform, sends } = createPlatform();
     setSetupPlatform(platform);
@@ -133,5 +169,25 @@ describe('SendToTerminalTool', () => {
     });
 
     assert.equal(sends[0].command, 'sudo apt-get install -y perl');
+  });
+
+  it('redacts the full command from the transcript output for long commands', async () => {
+    const { platform } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const longSecret = 'sudo apt-get install -y ' + 'x'.repeat(200);
+    const result = await tool.call({
+      command: longSecret,
+      reason: 'sudo password prompt',
+    });
+
+    assert.ok(!result.isError);
+    assert.ok(
+      !(result.output ?? '').includes(longSecret),
+      'output must not echo the full command verbatim',
+    );
+    // A truncated preview is fine; the bracketed full string is not.
+    assert.match(result.output ?? '', /preview/);
   });
 });

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -15,20 +15,17 @@ import { createFakeSetupPlatform } from './fixtures';
 
 /**
  * `requestBashApproval` reads `texra.toolUse.requireBashApproval` via
- * `getConfig`, which falls through to the supplied default (`true`)
- * when no platform is registered — so without intervention the
- * approval prompt would be shown and the test would hang waiting for a
- * user response that never arrives. Register a minimal platform that
- * resolves the bash-approval flag to `false`; everything else in this
- * test file goes through the SetupPlatform fixture, not Platform.
+ * `getConfig`, which falls through to its default (`true`) when no
+ * platform is registered — so without intervention the approval prompt
+ * would emit on the bus and the test would hang waiting for a settle
+ * callback that never arrives. Stub the platform's config so the
+ * approval flag resolves to `false` and the dialog is skipped.
  */
 function installApprovalSkippingPlatform(): void {
   const stub: Partial<Platform> = {
     config: {
-      get: <T,>(key: string, defaultValue?: T): T => {
-        if (key === BASH_APPROVAL_CONFIG_KEY) return false as T;
-        return defaultValue as T;
-      },
+      get: <T,>(key: string, defaultValue?: T): T =>
+        key === BASH_APPROVAL_CONFIG_KEY ? (false as T) : (defaultValue as T),
     },
   };
   initPlatform(stub as Platform);
@@ -42,15 +39,11 @@ interface RunRecord {
 
 function createPlatform(
   result: TerminalRunResult = {
-    captured: true,
     exitCode: 0,
     output: 'installed perl 5.38.2\n',
     timedOut: false,
   },
-): {
-  platform: SetupPlatform;
-  runs: RunRecord[];
-} {
+): { platform: SetupPlatform; runs: RunRecord[] } {
   const runs: RunRecord[] = [];
   const platform = createFakeSetupPlatform({
     terminal: {
@@ -66,27 +59,21 @@ function createPlatform(
 describe('SendToTerminalTool', () => {
   before(() => installApprovalSkippingPlatform());
 
-  it('runs the command and returns exit code + captured output preview', async () => {
+  it('runs the command and returns exit code + captured output', async () => {
     const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
     const result = await tool.call({
       command: 'sudo apt-get install -y perl',
-      reason: 'sudo password prompt',
     });
 
     assert.ok(!result.isError);
     assert.equal(runs.length, 1);
     assert.equal(runs[0].command, 'sudo apt-get install -y perl');
-    assert.equal(
-      runs[0].name,
-      'TeXRA: setup',
-      'default label "setup" must be prefixed with TeXRA:',
-    );
-    assert.match(result.summary ?? '', /exit 0/);
+    assert.equal(runs[0].name, 'TeXRA: setup');
+    assert.match(result.summary ?? '', /exited 0/);
     assert.match(result.output ?? '', /installed perl/);
-    assert.match(result.output ?? '', /sudo password prompt/);
   });
 
   it('always prepends TeXRA: to a caller-supplied label', async () => {
@@ -96,30 +83,22 @@ describe('SendToTerminalTool', () => {
 
     await tool.call({
       command: 'sudo apt-get install -y perl',
-      reason: 'sudo password prompt',
       label: 'install LaTeX',
     });
 
-    assert.equal(
-      runs[0].name,
-      'TeXRA: install LaTeX',
-      'caller-supplied labels must be prefixed, never used as-is',
-    );
+    assert.equal(runs[0].name, 'TeXRA: install LaTeX');
   });
 
   it('reports a non-zero exit code clearly to the agent', async () => {
     const { platform } = createPlatform({
-      captured: true,
       exitCode: 100,
       output: 'E: Unable to locate package fakepkg\n',
       timedOut: false,
     });
     setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
 
-    const result = await tool.call({
+    const result = await new SendToTerminalTool().call({
       command: 'sudo apt-get install -y fakepkg',
-      reason: 'sudo password prompt',
     });
 
     assert.ok(!result.isError);
@@ -127,71 +106,24 @@ describe('SendToTerminalTool', () => {
     assert.match(result.output ?? '', /Unable to locate package/);
   });
 
-  it('handles timeout result without throwing', async () => {
+  it('reports a timeout without throwing', async () => {
     const { platform } = createPlatform({
-      captured: true,
       exitCode: undefined,
       output: 'fetching...\n',
       timedOut: true,
     });
     setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
 
-    const result = await tool.call({
+    const result = await new SendToTerminalTool().call({
       command: 'sudo apt-get install -y perl',
-      reason: 'sudo password prompt',
       timeout: 1000,
     });
 
     assert.ok(!result.isError);
     assert.match(result.summary ?? '', /timed out/);
-    assert.match(result.output ?? '', /did not finish/);
   });
 
-  it('explains the no-capture case when shell integration is unavailable', async () => {
-    const { platform } = createPlatform({ captured: false });
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const result = await tool.call({
-      command: 'sudo apt-get install -y perl',
-      reason: 'sudo password prompt',
-    });
-
-    assert.ok(!result.isError);
-    assert.match(result.summary ?? '', /no output capture/);
-    assert.match(result.output ?? '', /Shell integration was not available/);
-  });
-
-  it('rejects whitespace-only commands', async () => {
-    const { platform, runs } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const result = await tool.call({
-      command: '   ',
-      reason: 'sudo password prompt',
-    });
-
-    assert.ok(result.isError);
-    assert.equal(runs.length, 0);
-  });
-
-  it('rejects whitespace-only reason — the agent must justify TTY use', async () => {
-    const { platform, runs } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const result = await tool.call({
-      command: 'sudo apt-get install -y perl',
-      reason: '   ',
-    });
-
-    assert.ok(result.isError);
-    assert.equal(runs.length, 0);
-  });
-
-  it('rejects commands containing newlines — they would smuggle a second command', async () => {
+  it('rejects commands containing newlines', async () => {
     const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
@@ -201,28 +133,9 @@ describe('SendToTerminalTool', () => {
       'sudo apt-get install -y perl\r\necho pwned',
       'first\rsecond',
     ]) {
-      const result = await tool.call({
-        command,
-        reason: 'sudo password prompt',
-      });
-      assert.ok(
-        result.isError,
-        `embedded newline must be rejected: ${JSON.stringify(command)}`,
-      );
+      const result = await tool.call({ command });
+      assert.ok(result.isError, `must reject ${JSON.stringify(command)}`);
     }
     assert.equal(runs.length, 0);
-  });
-
-  it('trims surrounding whitespace before sending', async () => {
-    const { platform, runs } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    await tool.call({
-      command: '   sudo apt-get install -y perl   ',
-      reason: 'sudo password prompt',
-    });
-
-    assert.equal(runs[0].command, 'sudo apt-get install -y perl');
   });
 });

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -9,6 +9,8 @@ import {
   type TerminalRunResult,
 } from '@tools/setup/platform';
 
+import { createFakeSetupPlatform } from './fixtures';
+
 interface RunRecord {
   name: string;
   command: string;
@@ -27,54 +29,14 @@ function createPlatform(
   runs: RunRecord[];
 } {
   const runs: RunRecord[] = [];
-  const platform: SetupPlatform = {
-    secrets: {
-      async setApiKey() {},
-      async deleteApiKey() {},
-      async apiKeyExists() {
-        return false;
-      },
-      async hasUsableApiKey() {
-        return false;
-      },
-      async storedApiKeyExists() {
-        return false;
-      },
-      async anyApiKeyExists() {
-        return false;
-      },
-      async gitHubTokenExists() {
-        return 'none';
-      },
-      providers: [],
-    },
-    commands: {
-      async invoke() {},
-    },
-    extensions: {
-      isInstalled() {
-        return false;
-      },
-      async install() {},
-    },
-    auth: {
-      async getStatus() {
-        return { authenticated: false };
-      },
-    },
-    config: {
-      get() {
-        return undefined;
-      },
-      async update() {},
-    },
+  const platform = createFakeSetupPlatform({
     terminal: {
       async runCommand(args) {
         runs.push(args);
         return result;
       },
     },
-  };
+  });
   return { platform, runs };
 }
 
@@ -162,10 +124,7 @@ describe('SendToTerminalTool', () => {
   });
 
   it('explains the no-capture case when shell integration is unavailable', async () => {
-    const { platform } = createPlatform({
-      captured: false,
-      reason: 'no-shell-integration',
-    });
+    const { platform } = createPlatform({ captured: false });
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -1,0 +1,137 @@
+// Node.js built-in imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import { SendToTerminalTool } from '@tools/setup/SendToTerminalTool';
+import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+
+interface SendRecord {
+  name: string;
+  command: string;
+  execute: boolean;
+}
+
+function createPlatform(): {
+  platform: SetupPlatform;
+  sends: SendRecord[];
+} {
+  const sends: SendRecord[] = [];
+  const platform: SetupPlatform = {
+    secrets: {
+      async setApiKey() {},
+      async deleteApiKey() {},
+      async apiKeyExists() {
+        return false;
+      },
+      async hasUsableApiKey() {
+        return false;
+      },
+      async storedApiKeyExists() {
+        return false;
+      },
+      async anyApiKeyExists() {
+        return false;
+      },
+      async gitHubTokenExists() {
+        return 'none';
+      },
+      providers: [],
+    },
+    commands: {
+      async invoke() {},
+    },
+    extensions: {
+      isInstalled() {
+        return false;
+      },
+      async install() {},
+    },
+    auth: {
+      async getStatus() {
+        return { authenticated: false };
+      },
+    },
+    config: {
+      get() {
+        return undefined;
+      },
+      async update() {},
+    },
+    terminal: {
+      async sendCommand(args) {
+        sends.push(args);
+      },
+    },
+  };
+  return { platform, sends };
+}
+
+describe('SendToTerminalTool', () => {
+  it('types the command without auto-executing by default', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y latexmk',
+      reason: 'sudo password prompt',
+    });
+
+    assert.ok(!result.isError);
+    assert.equal(sends.length, 1);
+    assert.equal(sends[0].command, 'sudo apt-get install -y latexmk');
+    assert.equal(
+      sends[0].execute,
+      false,
+      'must default to non-executed so the user presses Enter as approval',
+    );
+    assert.equal(sends[0].name, 'TeXRA: setup');
+    assert.match(result.output ?? '', /press Enter/);
+    assert.match(result.output ?? '', /sudo password prompt/);
+  });
+
+  it('accepts a custom terminal name and execute=true', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'clear',
+      reason: 'tidy follow-up',
+      name: 'TeXRA: install LaTeX',
+      execute: true,
+    });
+
+    assert.ok(!result.isError);
+    assert.equal(sends[0].name, 'TeXRA: install LaTeX');
+    assert.equal(sends[0].execute, true);
+    assert.match(result.summary ?? '', /TeXRA: install LaTeX/);
+  });
+
+  it('rejects whitespace-only commands', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: '   ',
+      reason: 'sudo password prompt',
+    });
+
+    assert.ok(result.isError);
+    assert.equal(sends.length, 0);
+  });
+
+  it('trims surrounding whitespace before sending', async () => {
+    const { platform, sends } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    await tool.call({
+      command: '   sudo apt-get install -y perl   ',
+      reason: 'sudo password prompt',
+    });
+
+    assert.equal(sends[0].command, 'sudo apt-get install -y perl');
+  });
+});

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -19,7 +19,15 @@ import { createFakeSetupPlatform } from './fixtures';
  * platform is registered — so without intervention the approval prompt
  * would emit on the bus and the test would hang waiting for a settle
  * callback that never arrives. Stub the platform's config so the
- * approval flag resolves to `false` and the dialog is skipped.
+ * approval flag resolves to `false`.
+ *
+ * `initPlatform` mutates module-scope state and the platform stays
+ * registered for the rest of the mocha process; we don't reset it in an
+ * `after` hook because there's no public reset API. That's fine here:
+ * the stub returns `defaultValue` verbatim for every key except
+ * `BASH_APPROVAL_CONFIG_KEY`, so any test that runs after this file in
+ * the same process sees behaviour identical to "no platform registered"
+ * unless it also checks the approval flag.
  */
 function installApprovalSkippingPlatform(): void {
   const stub: Partial<Platform> = {

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -3,18 +3,30 @@ import { strict as assert } from 'assert';
 
 // Local imports
 import { SendToTerminalTool } from '@tools/setup/SendToTerminalTool';
-import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+import {
+  setSetupPlatform,
+  type SetupPlatform,
+  type TerminalRunResult,
+} from '@tools/setup/platform';
 
-interface SendRecord {
+interface RunRecord {
   name: string;
   command: string;
+  timeoutMs: number;
 }
 
-function createPlatform(): {
+function createPlatform(
+  result: TerminalRunResult = {
+    captured: true,
+    exitCode: 0,
+    output: 'installed perl 5.38.2\n',
+    timedOut: false,
+  },
+): {
   platform: SetupPlatform;
-  sends: SendRecord[];
+  runs: RunRecord[];
 } {
-  const sends: SendRecord[] = [];
+  const runs: RunRecord[] = [];
   const platform: SetupPlatform = {
     secrets: {
       async setApiKey() {},
@@ -57,59 +69,118 @@ function createPlatform(): {
       async update() {},
     },
     terminal: {
-      async sendCommand(args) {
-        sends.push(args);
+      async runCommand(args) {
+        runs.push(args);
+        return result;
       },
     },
   };
-  return { platform, sends };
+  return { platform, runs };
 }
 
 describe('SendToTerminalTool', () => {
-  it('types the command and prepends TeXRA: to the default label', async () => {
-    const { platform, sends } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const result = await tool.call({
-      command: 'sudo apt-get install -y latexmk',
-      reason: 'sudo password prompt',
-    });
-
-    assert.ok(!result.isError);
-    assert.equal(sends.length, 1);
-    assert.equal(sends[0].command, 'sudo apt-get install -y latexmk');
-    assert.equal(
-      sends[0].name,
-      'TeXRA: setup',
-      'default label "setup" must be prefixed with TeXRA:',
-    );
-    assert.match(result.output ?? '', /press Enter/);
-    assert.match(result.output ?? '', /sudo password prompt/);
-  });
-
-  it('always prepends TeXRA: to a caller-supplied label', async () => {
-    const { platform, sends } = createPlatform();
+  it('runs the command and returns exit code + captured output preview', async () => {
+    const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
     const result = await tool.call({
       command: 'sudo apt-get install -y perl',
       reason: 'sudo password prompt',
-      label: 'install LaTeX',
     });
 
     assert.ok(!result.isError);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].command, 'sudo apt-get install -y perl');
     assert.equal(
-      sends[0].name,
+      runs[0].name,
+      'TeXRA: setup',
+      'default label "setup" must be prefixed with TeXRA:',
+    );
+    assert.match(result.summary ?? '', /exit 0/);
+    assert.match(result.output ?? '', /installed perl/);
+    assert.match(result.output ?? '', /sudo password prompt/);
+  });
+
+  it('always prepends TeXRA: to a caller-supplied label', async () => {
+    const { platform, runs } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    await tool.call({
+      command: 'sudo apt-get install -y perl',
+      reason: 'sudo password prompt',
+      label: 'install LaTeX',
+    });
+
+    assert.equal(
+      runs[0].name,
       'TeXRA: install LaTeX',
       'caller-supplied labels must be prefixed, never used as-is',
     );
-    assert.match(result.summary ?? '', /TeXRA: install LaTeX/);
+  });
+
+  it('reports a non-zero exit code clearly to the agent', async () => {
+    const { platform } = createPlatform({
+      captured: true,
+      exitCode: 100,
+      output: 'E: Unable to locate package fakepkg\n',
+      timedOut: false,
+    });
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y fakepkg',
+      reason: 'sudo password prompt',
+    });
+
+    assert.ok(!result.isError);
+    assert.match(result.summary ?? '', /exited 100/);
+    assert.match(result.output ?? '', /Unable to locate package/);
+  });
+
+  it('handles timeout result without throwing', async () => {
+    const { platform } = createPlatform({
+      captured: true,
+      exitCode: undefined,
+      output: 'fetching...\n',
+      timedOut: true,
+    });
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y perl',
+      reason: 'sudo password prompt',
+      timeout: 1000,
+    });
+
+    assert.ok(!result.isError);
+    assert.match(result.summary ?? '', /timed out/);
+    assert.match(result.output ?? '', /did not finish/);
+  });
+
+  it('explains the no-capture case when shell integration is unavailable', async () => {
+    const { platform } = createPlatform({
+      captured: false,
+      reason: 'no-shell-integration',
+    });
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y perl',
+      reason: 'sudo password prompt',
+    });
+
+    assert.ok(!result.isError);
+    assert.match(result.summary ?? '', /no output capture/);
+    assert.match(result.output ?? '', /Shell integration was not available/);
   });
 
   it('rejects whitespace-only commands', async () => {
-    const { platform, sends } = createPlatform();
+    const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
@@ -119,11 +190,25 @@ describe('SendToTerminalTool', () => {
     });
 
     assert.ok(result.isError);
-    assert.equal(sends.length, 0);
+    assert.equal(runs.length, 0);
   });
 
-  it('rejects commands containing newlines — they would auto-execute past Enter', async () => {
-    const { platform, sends } = createPlatform();
+  it('rejects whitespace-only reason — the agent must justify TTY use', async () => {
+    const { platform, runs } = createPlatform();
+    setSetupPlatform(platform);
+    const tool = new SendToTerminalTool();
+
+    const result = await tool.call({
+      command: 'sudo apt-get install -y perl',
+      reason: '   ',
+    });
+
+    assert.ok(result.isError);
+    assert.equal(runs.length, 0);
+  });
+
+  it('rejects commands containing newlines — they would smuggle a second command', async () => {
+    const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
@@ -141,25 +226,11 @@ describe('SendToTerminalTool', () => {
         `embedded newline must be rejected: ${JSON.stringify(command)}`,
       );
     }
-    assert.equal(sends.length, 0, 'no sends should reach the platform');
-  });
-
-  it('rejects whitespace-only reason — the agent must justify TTY use', async () => {
-    const { platform, sends } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const result = await tool.call({
-      command: 'sudo apt-get install -y perl',
-      reason: '   ',
-    });
-
-    assert.ok(result.isError, 'whitespace-only reason must fail validation');
-    assert.equal(sends.length, 0);
+    assert.equal(runs.length, 0);
   });
 
   it('trims surrounding whitespace before sending', async () => {
-    const { platform, sends } = createPlatform();
+    const { platform, runs } = createPlatform();
     setSetupPlatform(platform);
     const tool = new SendToTerminalTool();
 
@@ -168,26 +239,6 @@ describe('SendToTerminalTool', () => {
       reason: 'sudo password prompt',
     });
 
-    assert.equal(sends[0].command, 'sudo apt-get install -y perl');
-  });
-
-  it('redacts the full command from the transcript output for long commands', async () => {
-    const { platform } = createPlatform();
-    setSetupPlatform(platform);
-    const tool = new SendToTerminalTool();
-
-    const longSecret = 'sudo apt-get install -y ' + 'x'.repeat(200);
-    const result = await tool.call({
-      command: longSecret,
-      reason: 'sudo password prompt',
-    });
-
-    assert.ok(!result.isError);
-    assert.ok(
-      !(result.output ?? '').includes(longSecret),
-      'output must not echo the full command verbatim',
-    );
-    // A truncated preview is fine; the bracketed full string is not.
-    assert.match(result.output ?? '', /preview/);
+    assert.equal(runs[0].command, 'sudo apt-get install -y perl');
   });
 });

--- a/src/test/tools/setup/fixtures.ts
+++ b/src/test/tools/setup/fixtures.ts
@@ -1,8 +1,7 @@
 // Local imports
-import {
-  setSetupPlatform,
-  type SetupPlatform,
-  type TerminalRunResult,
+import type {
+  SetupPlatform,
+  TerminalRunResult,
 } from '@tools/setup/platform';
 
 /**
@@ -68,13 +67,4 @@ export function createFakeSetupPlatform(
       ...overrides.terminal,
     },
   };
-}
-
-/** Convenience: build the fake platform and register it in one step. */
-export function installFakeSetupPlatform(
-  overrides: Partial<SetupPlatform> = {},
-): SetupPlatform {
-  const platform = createFakeSetupPlatform(overrides);
-  setSetupPlatform(platform);
-  return platform;
 }

--- a/src/test/tools/setup/fixtures.ts
+++ b/src/test/tools/setup/fixtures.ts
@@ -62,7 +62,7 @@ export function createFakeSetupPlatform(
     },
     terminal: {
       async runCommand(): Promise<TerminalRunResult> {
-        return { captured: false };
+        return { exitCode: undefined, output: '', timedOut: false };
       },
       ...overrides.terminal,
     },

--- a/src/test/tools/setup/fixtures.ts
+++ b/src/test/tools/setup/fixtures.ts
@@ -1,0 +1,80 @@
+// Local imports
+import {
+  setSetupPlatform,
+  type SetupPlatform,
+  type TerminalRunResult,
+} from '@tools/setup/platform';
+
+/**
+ * Build a fully stubbed `SetupPlatform` for tool unit tests, with each
+ * adapter overridable. The defaults are the "deny / not present"
+ * answers — no API keys configured, no extensions installed, not
+ * authenticated, no terminal capture — so a test only needs to override
+ * the specific surface it exercises.
+ */
+export function createFakeSetupPlatform(
+  overrides: Partial<SetupPlatform> = {},
+): SetupPlatform {
+  return {
+    secrets: {
+      async setApiKey() {},
+      async deleteApiKey() {},
+      async apiKeyExists() {
+        return false;
+      },
+      async hasUsableApiKey() {
+        return false;
+      },
+      async storedApiKeyExists() {
+        return false;
+      },
+      async anyApiKeyExists() {
+        return false;
+      },
+      async gitHubTokenExists() {
+        return 'none';
+      },
+      providers: [],
+      ...overrides.secrets,
+    },
+    commands: {
+      async invoke() {},
+      ...overrides.commands,
+    },
+    extensions: {
+      isInstalled() {
+        return false;
+      },
+      async install() {},
+      ...overrides.extensions,
+    },
+    auth: {
+      async getStatus() {
+        return { authenticated: false };
+      },
+      ...overrides.auth,
+    },
+    config: {
+      get() {
+        return undefined;
+      },
+      async update() {},
+      ...overrides.config,
+    },
+    terminal: {
+      async runCommand(): Promise<TerminalRunResult> {
+        return { captured: false };
+      },
+      ...overrides.terminal,
+    },
+  };
+}
+
+/** Convenience: build the fake platform and register it in one step. */
+export function installFakeSetupPlatform(
+  overrides: Partial<SetupPlatform> = {},
+): SetupPlatform {
+  const platform = createFakeSetupPlatform(overrides);
+  setSetupPlatform(platform);
+  return platform;
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -65,6 +65,7 @@ import {
   InstallVscodeExtensionTool,
   ReadConfigTool,
   UpdateConfigTool,
+  SendToTerminalTool,
 } from './setup';
 
 /** Singleton IToolRegistry instance for the default tools. */
@@ -134,6 +135,7 @@ function createDefaultTools() {
     install_vscode_extension: new InstallVscodeExtensionTool(),
     read_config: new ReadConfigTool(),
     update_config: new UpdateConfigTool(),
+    send_to_terminal: new SendToTerminalTool(),
   } satisfies Record<string, ITool>;
 }
 

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -16,9 +16,11 @@ import { getSetupPlatform } from './platform';
  *   - shells that drop the process into a paginator / editor
  *
  * For those cases the agent types the command into a real VS Code
- * integrated terminal. The terminal is shown to the user; by default the
- * command is left at the prompt unexecuted so the user's Enter keystroke
- * is the explicit approval (and gives them a chance to edit or cancel).
+ * integrated terminal. The terminal is shown to the user; the command
+ * is left at the prompt unexecuted so the user's Enter keystroke is the
+ * explicit approval (and gives them a chance to edit or cancel). The
+ * tool intentionally does NOT expose an auto-execute switch — that
+ * would defeat the entire approval model.
  *
  * This is intentionally a separate tool from `bash`:
  *   - `bash`: captured stdio, agent reads the result, approval dialog gates execution.
@@ -27,42 +29,71 @@ import { getSetupPlatform } from './platform';
  * Use the right one for the job — never reach for this tool to bypass
  * `bash` approvals on commands that would have worked in `bash`.
  */
+/**
+ * Reject any control character that VS Code's terminal would treat as an
+ * Enter / line-feed, defeating the approval gate. `terminal.sendText`
+ * normalizes both `\n` and `\r` into a CR the shell reads as Enter, so
+ * `"cmd1\ncmd2"` with execute=false would still auto-run `cmd1`. We
+ * reject the raw string at parse time rather than stripping silently —
+ * the agent should rewrite multi-line input as a single command.
+ */
+const FORBIDDEN_COMMAND_CHARS = /[\r\n]/;
+
 const SendToTerminalInputSchema = z.strictObject({
   command: z
     .string()
     .min(1)
     .max(2048)
+    .refine((s) => !FORBIDDEN_COMMAND_CHARS.test(s), {
+      message:
+        'command must not contain newline / carriage-return characters — they would auto-execute past the Enter approval gate.',
+    })
     .describe(
-      'The command to type into the integrated terminal. One command per call (a script is fine if it is the user-visible operation, but no chaining unrelated steps).',
+      'The command to type into the integrated terminal. One command per call (a script is fine if it is the user-visible operation, but no chaining unrelated steps). Must not contain newline or carriage-return characters; those would auto-execute past the Enter approval gate.',
     ),
   reason: z
     .string()
     .min(1)
     .max(200)
+    .refine((s) => s.trim().length > 0, {
+      message: 'reason must include non-whitespace text',
+    })
     .describe(
       'One short sentence stating why this needs an interactive terminal instead of the regular `bash` tool — typically "sudo password prompt" or "interactive confirmation". The reason is shown back to the user.',
     ),
-  name: z
+  label: z
     .string()
     .min(1)
-    .max(60)
-    .prefault('TeXRA: setup')
+    .max(40)
+    .prefault('setup')
+    .refine((s) => s.trim().length > 0, {
+      message: 'label must include non-whitespace text',
+    })
     .describe(
-      'Display name for the terminal tab (e.g. "TeXRA: install LaTeX"). Defaults to "TeXRA: setup".',
-    ),
-  execute: z
-    .boolean()
-    .prefault(false)
-    .describe(
-      'When false (default), the command is typed but not executed — the user must press Enter to run it, which is the approval gate. Set true ONLY for a follow-up no-op like clearing the screen, never for the privileged command itself.',
+      'Short suffix for the terminal tab name. The tool always prepends "TeXRA: " so the terminal cannot be made to impersonate other terminals or extensions. Examples: "setup", "install LaTeX", "PATH fix".',
     ),
 });
 
 type SendToTerminalInput = z.infer<typeof SendToTerminalInputSchema>;
 
+/** Cap on the command preview echoed back into the tool transcript. */
+const COMMAND_PREVIEW_MAX = 80;
+
+/**
+ * Build a short, transcript-safe preview of the command. The user can
+ * already see the command in the revealed terminal, so we deliberately
+ * avoid echoing the full text into the saved transcript / exports —
+ * that would mirror a known footgun where secrets ride along in tool
+ * output (cf. `InvokeCommandTool`'s arg redaction).
+ */
+function commandPreview(command: string): string {
+  if (command.length <= COMMAND_PREVIEW_MAX) return command;
+  return `${command.slice(0, COMMAND_PREVIEW_MAX)}…`;
+}
+
 export class SendToTerminalTool extends defineTool({
   name: 'send_to_terminal',
-  description: `Type a command into a VS Code integrated terminal and reveal the terminal to the user. Use this — instead of \`bash\` — when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. By default the command is left at the prompt unexecuted, so the user must press Enter to run it (that keystroke is the approval). You receive no captured output — after sending, ask the user to confirm completion before continuing, then re-probe with \`verify_setup\` or \`probe_environment\`. Do NOT use this to bypass \`bash\` approvals for commands that would work in \`bash\`.`,
+  description: `Type a command into a VS Code integrated terminal and reveal the terminal to the user. Use this — instead of \`bash\` — when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. The command is left at the prompt unexecuted; the user must press Enter to run it (that keystroke is the approval). The terminal tab is always named "TeXRA: <label>" so it cannot impersonate other terminals. You receive no captured output and only a redacted preview of the command — after sending, ask the user to confirm completion before continuing, then re-probe with \`verify_setup\` or \`probe_environment\`. Do NOT use this to bypass \`bash\` approvals for commands that would work in \`bash\`.`,
   schema: SendToTerminalInputSchema,
 }) {
   protected async execute(input: SendToTerminalInput): Promise<ToolResult> {
@@ -73,27 +104,20 @@ export class SendToTerminalTool extends defineTool({
       throw new ToolError('Refusing to send an empty command to the terminal.');
     }
 
-    const name = input.name.trim() || 'TeXRA: setup';
-    await platform.terminal.sendCommand({
-      name,
-      command,
-      execute: input.execute,
-    });
+    const label = input.label.trim();
+    const name = `TeXRA: ${label}`;
+    await platform.terminal.sendCommand({ name, command });
 
-    const verb = input.execute
-      ? 'sent and executed in'
-      : 'typed (awaiting Enter) into';
+    const reason = input.reason.trim();
+    const preview = commandPreview(command);
     return {
-      summary: `Command ${verb} terminal "${name}"`,
+      summary: `Typed command into terminal "${name}" (awaiting Enter)`,
       output:
-        `${verb.charAt(0).toUpperCase() + verb.slice(1)} the integrated terminal "${name}":\n` +
-        '```\n' +
-        command +
-        '\n```\n' +
-        `Reason: ${input.reason.trim()}\n\n` +
-        (input.execute
-          ? 'The command was sent with auto-execute on. Watch the terminal for output and any password / confirmation prompts.'
-          : "The command is sitting at the user's prompt — they need to press Enter to run it, then complete any password or confirmation prompts in the terminal. Wait for the user to tell you it finished before re-probing."),
+        `Typed a command into the integrated terminal "${name}" — preview: \`${preview}\`. ` +
+        `Reason: ${reason}. ` +
+        "The command is sitting at the user's prompt; they need to press Enter to run it, then complete any password or confirmation prompts in the terminal. " +
+        'Wait for the user to tell you it finished before re-probing. ' +
+        '(Full command text is intentionally not echoed into the transcript — the user can see it in the revealed terminal.)',
     };
   }
 }

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -1,0 +1,99 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Local imports
+import { ToolError, type ToolResult } from '@tools/result';
+
+// Local file imports
+import { defineTool } from '../core/define';
+import { getSetupPlatform } from './platform';
+
+/**
+ * Some commands cannot run through the captured-stdio `bash` tool:
+ *
+ *   - `sudo apt-get install ...` needs the user's password at a real TTY
+ *   - `brew install --cask mactex` and similar prompt for confirmation
+ *   - shells that drop the process into a paginator / editor
+ *
+ * For those cases the agent types the command into a real VS Code
+ * integrated terminal. The terminal is shown to the user; by default the
+ * command is left at the prompt unexecuted so the user's Enter keystroke
+ * is the explicit approval (and gives them a chance to edit or cancel).
+ *
+ * This is intentionally a separate tool from `bash`:
+ *   - `bash`: captured stdio, agent reads the result, approval dialog gates execution.
+ *   - `send_to_terminal`: interactive TTY, no captured output, the visible terminal + Enter keystroke is the approval.
+ *
+ * Use the right one for the job — never reach for this tool to bypass
+ * `bash` approvals on commands that would have worked in `bash`.
+ */
+const SendToTerminalInputSchema = z.strictObject({
+  command: z
+    .string()
+    .min(1)
+    .max(2048)
+    .describe(
+      'The command to type into the integrated terminal. One command per call (a script is fine if it is the user-visible operation, but no chaining unrelated steps).',
+    ),
+  reason: z
+    .string()
+    .min(1)
+    .max(200)
+    .describe(
+      'One short sentence stating why this needs an interactive terminal instead of the regular `bash` tool — typically "sudo password prompt" or "interactive confirmation". The reason is shown back to the user.',
+    ),
+  name: z
+    .string()
+    .min(1)
+    .max(60)
+    .prefault('TeXRA: setup')
+    .describe(
+      'Display name for the terminal tab (e.g. "TeXRA: install LaTeX"). Defaults to "TeXRA: setup".',
+    ),
+  execute: z
+    .boolean()
+    .prefault(false)
+    .describe(
+      'When false (default), the command is typed but not executed — the user must press Enter to run it, which is the approval gate. Set true ONLY for a follow-up no-op like clearing the screen, never for the privileged command itself.',
+    ),
+});
+
+type SendToTerminalInput = z.infer<typeof SendToTerminalInputSchema>;
+
+export class SendToTerminalTool extends defineTool({
+  name: 'send_to_terminal',
+  description: `Type a command into a VS Code integrated terminal and reveal the terminal to the user. Use this — instead of \`bash\` — when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. By default the command is left at the prompt unexecuted, so the user must press Enter to run it (that keystroke is the approval). You receive no captured output — after sending, ask the user to confirm completion before continuing, then re-probe with \`verify_setup\` or \`probe_environment\`. Do NOT use this to bypass \`bash\` approvals for commands that would work in \`bash\`.`,
+  schema: SendToTerminalInputSchema,
+}) {
+  protected async execute(input: SendToTerminalInput): Promise<ToolResult> {
+    const platform = getSetupPlatform();
+    const command = input.command.trim();
+
+    if (command.length === 0) {
+      throw new ToolError('Refusing to send an empty command to the terminal.');
+    }
+
+    const name = input.name.trim() || 'TeXRA: setup';
+    await platform.terminal.sendCommand({
+      name,
+      command,
+      execute: input.execute,
+    });
+
+    const verb = input.execute
+      ? 'sent and executed in'
+      : 'typed (awaiting Enter) into';
+    return {
+      summary: `Command ${verb} terminal "${name}"`,
+      output:
+        `${verb.charAt(0).toUpperCase() + verb.slice(1)} the integrated terminal "${name}":\n` +
+        '```\n' +
+        command +
+        '\n```\n' +
+        `Reason: ${input.reason.trim()}\n\n` +
+        (input.execute
+          ? 'The command was sent with auto-execute on. Watch the terminal for output and any password / confirmation prompts.'
+          : "The command is sitting at the user's prompt — they need to press Enter to run it, then complete any password or confirmation prompts in the terminal. Wait for the user to tell you it finished before re-probing."),
+    };
+  }
+}

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 
 // Local imports
-import { ToolError, type ToolResult } from '@tools/result';
+import { type ToolResult } from '@tools/result';
 import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
@@ -13,70 +13,27 @@ import { truncateWithEllipsis } from '@utils/text/stringUtils';
 import { defineTool } from '../core/define';
 import { getSetupPlatform } from './platform';
 
-/**
- * Some commands cannot run through the captured-stdio `bash` tool:
- *
- *   - `sudo apt-get install ...` needs the user's password at a real TTY
- *   - `brew install --cask mactex` and similar prompt for confirmation
- *   - shells that drop the process into a paginator / editor
- *
- * For those cases the agent runs the command inside a real VS Code
- * integrated terminal. Approval re-uses the regular `bash` approval
- * dialog — there's no second gate to maintain, and the user already
- * understands that surface.
- *
- * When the terminal has shell integration active (the default for
- * bash/zsh/pwsh/fish in VS Code-launched terminals since 1.93), the
- * tool reads back the exit code and output via
- * `Terminal.shellIntegration.executeCommand`. When integration isn't
- * available, the tool falls back to `terminal.sendText` and reports
- * `captured: false` — the agent must then ask the user to confirm the
- * command finished and re-probe.
- */
-
-const DEFAULT_TIMEOUT_MS = 300_000; // 5 min — installs can be slow
-
-/**
- * Reject any control character that would behave as Enter inside the
- * terminal. Even with shell integration, embedded `\n` / `\r` would
- * smuggle a second command past the user's view of what they
- * approved — keep the schema strict and let the agent rewrite
- * multi-line input as a single command.
- */
-const FORBIDDEN_COMMAND_CHARS = /[\r\n]/;
+const DEFAULT_TIMEOUT_MS = 300_000;
+const OUTPUT_PREVIEW_MAX = 4_000;
 
 const SendToTerminalInputSchema = z.strictObject({
+  // The single non-cosmetic guard: VS Code normalizes \n / \r when typed
+  // into a terminal, so a multi-line input would smuggle a second
+  // command past the bash approval dialog. The agent must rewrite
+  // multi-step work as a single line.
   command: z
     .string()
-    .min(1)
-    .max(2048)
-    .refine((s) => !FORBIDDEN_COMMAND_CHARS.test(s), {
-      message:
-        'command must not contain newline / carriage-return characters — they would smuggle a second command past the approval surface.',
+    .refine((s) => !/[\r\n]/.test(s), {
+      message: 'command must not contain newline / carriage-return characters.',
     })
     .describe(
-      'The command to run inside the integrated terminal. One command per call. Must not contain newline or carriage-return characters.',
-    ),
-  reason: z
-    .string()
-    .min(1)
-    .max(200)
-    .refine((s) => s.trim().length > 0, {
-      message: 'reason must include non-whitespace text',
-    })
-    .describe(
-      'One short sentence stating why this needs an interactive terminal instead of the regular `bash` tool — typically "sudo password prompt" or "interactive confirmation". Shown back to the user.',
+      'The command to run inside the integrated terminal. One line; no embedded newlines.',
     ),
   label: z
     .string()
-    .min(1)
-    .max(40)
     .prefault('setup')
-    .refine((s) => s.trim().length > 0, {
-      message: 'label must include non-whitespace text',
-    })
     .describe(
-      'Short suffix for the terminal tab name. The tool always prepends "TeXRA: " so the terminal cannot impersonate other terminals or extensions.',
+      'Short suffix for the terminal tab name; the tool prepends "TeXRA: ".',
     ),
   timeout: z
     .int()
@@ -84,95 +41,40 @@ const SendToTerminalInputSchema = z.strictObject({
     .max(900_000)
     .nullish()
     .describe(
-      'Hard cap (ms) on how long the tool waits for the captured run before giving up. Defaults to 300,000 ms (5 min). Ignored when shell integration is unavailable.',
+      'Hard cap (ms) on how long to wait for the run. Defaults to 5 min.',
     ),
 });
 
 type SendToTerminalInput = z.infer<typeof SendToTerminalInputSchema>;
 
-/** Length cap for the command preview in tool output. */
-const COMMAND_PREVIEW_MAX = 80;
-/** Length cap for the captured-output tail surfaced to the agent. */
-const OUTPUT_PREVIEW_MAX = 4_000;
-
 export class SendToTerminalTool extends defineTool({
   name: 'send_to_terminal',
-  description: `Run a command in a VS Code integrated terminal — use this instead of \`bash\` when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. Approval reuses the regular \`bash\` approval dialog. When the terminal has shell integration enabled (bash/zsh/pwsh/fish in a VS Code-launched terminal), the tool returns the exit code and a tail of the captured output. When shell integration is unavailable the tool reports \`captured: false\` and you must wait for the user to confirm completion before re-probing. Do NOT use this to bypass \`bash\` approvals on commands that would work in \`bash\`.`,
+  description: `Run a command in a VS Code integrated terminal — use this instead of \`bash\` when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. Approval reuses the regular \`bash\` approval dialog. Returns an exit code and a tail of the output when shell integration is active (bash/zsh/pwsh/fish in VS Code-launched terminals); returns an undefined exit code with empty output otherwise — re-probe with \`verify_setup\` to confirm what actually happened. Do NOT use this to bypass \`bash\` approvals on commands that would work in \`bash\`.`,
   schema: SendToTerminalInputSchema,
 }) {
   protected async execute(input: SendToTerminalInput): Promise<ToolResult> {
     const command = input.command.trim();
-    if (command.length === 0) {
-      throw new ToolError('Refusing to send an empty command to the terminal.');
-    }
 
-    // Reuse the same approval dialog the `bash` tool uses. The user
-    // sees the exact command before anything is sent to the terminal.
     const approval = await requestBashApproval({ command });
     if (!approval.accepted) {
       return buildBashApprovalRejectedResult(command, approval.userMessage);
     }
 
-    const platform = getSetupPlatform();
-    const label = input.label.trim();
-    const name = `TeXRA: ${label}`;
+    const name = `TeXRA: ${input.label.trim() || 'setup'}`;
     const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
-    const reason = input.reason.trim();
-    const preview = truncateWithEllipsis(command, COMMAND_PREVIEW_MAX);
 
-    const result = await platform.terminal.runCommand({
-      name,
-      command,
-      timeoutMs,
-    });
+    const { exitCode, output, timedOut } = await getSetupPlatform()
+      .terminal.runCommand({ name, command, timeoutMs });
 
-    if (!result.captured) {
-      return {
-        summary: `Ran command in terminal "${name}" (no output capture)`,
-        output:
-          `Ran a command in the integrated terminal "${name}" — preview: \`${preview}\`. ` +
-          `Reason: ${reason}. ` +
-          'Shell integration was not available on this terminal, so I cannot read back the exit code or output. ' +
-          'Wait for the user to tell you the command finished (and any password / confirmation prompts are answered) before re-probing with `verify_setup` or `probe_environment`.',
-      };
-    }
-
-    if (result.timedOut) {
-      return {
-        summary: `Command in terminal "${name}" timed out after ${(timeoutMs / 1000).toFixed(0)}s`,
-        output:
-          `The command was running in "${name}" — preview: \`${preview}\` — but did not finish within ${(timeoutMs / 1000).toFixed(0)}s. ` +
-          'It may still be running in the terminal; ask the user whether to keep waiting, raise the `timeout`, or interrupt it (Ctrl+C in the terminal). ' +
-          (result.output
-            ? 'Captured output so far is appended below.\n\n' +
-              wrapOutput(truncateWithEllipsis(result.output, OUTPUT_PREVIEW_MAX))
-            : 'No output was captured before the timeout.'),
-      };
-    }
-
-    const exit = result.exitCode;
-    const ok = exit === 0;
     const exitLabel =
-      exit === undefined
-        ? 'unknown (terminal interrupted before completion)'
-        : String(exit);
+      exitCode === undefined ? 'unknown' : String(exitCode);
+    const summary = timedOut
+      ? `"${name}" timed out after ${Math.round(timeoutMs / 1000)}s`
+      : `"${name}" exited ${exitLabel}`;
+    const tail = output.trim()
+      ? '\n\n' + truncateWithEllipsis(output, OUTPUT_PREVIEW_MAX)
+      : '';
 
-    const outputBlock = result.output.trim()
-      ? wrapOutput(truncateWithEllipsis(result.output, OUTPUT_PREVIEW_MAX))
-      : '(no output captured)';
-
-    return {
-      summary: ok
-        ? `Ran command in terminal "${name}" (exit 0)`
-        : `Command in terminal "${name}" exited ${exitLabel}`,
-      output:
-        `Ran in integrated terminal "${name}" — preview: \`${preview}\`. ` +
-        `Reason: ${reason}. Exit code: ${exitLabel}.\n\n` +
-        outputBlock,
-    };
+    return { summary, output: summary + tail };
   }
-}
-
-function wrapOutput(text: string): string {
-  return '```\n' + text + '\n```';
 }

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -7,7 +7,6 @@ import {
   buildBashApprovalRejectedResult,
   requestBashApproval,
 } from '@tools/approval/bashApproval';
-import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -16,6 +15,18 @@ import { getSetupPlatform } from './platform';
 const DEFAULT_TIMEOUT_MS = 300_000;
 const OUTPUT_PREVIEW_MAX = 4_000;
 const TERMINAL_NAME_PREFIX = 'TeXRA: ';
+
+/**
+ * Keep the last `maxLen` characters; prepend an ellipsis when
+ * truncated. Mirrors the runner's sliding-window `tail` — for setup
+ * installers the success / error line is at the *end* of the output,
+ * so head-truncation (the codebase's default `truncateWithEllipsis`)
+ * would discard exactly the lines the agent needs.
+ */
+function tailWithEllipsis(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return '…' + text.slice(-(maxLen - 1));
+}
 
 const SendToTerminalInputSchema = z.strictObject({
   // The single non-cosmetic guard: VS Code normalizes \n / \r when typed
@@ -73,7 +84,7 @@ export class SendToTerminalTool extends defineTool({
       ? `"${name}" timed out after ${Math.round(timeoutMs / 1000)}s`
       : `"${name}" exited ${exitLabel}`;
     const tail = output.trim()
-      ? '\n\n' + truncateWithEllipsis(output, OUTPUT_PREVIEW_MAX)
+      ? '\n\n' + tailWithEllipsis(output, OUTPUT_PREVIEW_MAX)
       : '';
 
     return { summary, output: summary + tail };

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -3,6 +3,11 @@ import { z } from 'zod';
 
 // Local imports
 import { ToolError, type ToolResult } from '@tools/result';
+import {
+  buildBashApprovalRejectedResult,
+  requestBashApproval,
+} from '@tools/approval/bashApproval';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 // Local file imports
 import { defineTool } from '../core/define';
@@ -15,27 +20,28 @@ import { getSetupPlatform } from './platform';
  *   - `brew install --cask mactex` and similar prompt for confirmation
  *   - shells that drop the process into a paginator / editor
  *
- * For those cases the agent types the command into a real VS Code
- * integrated terminal. The terminal is shown to the user; the command
- * is left at the prompt unexecuted so the user's Enter keystroke is the
- * explicit approval (and gives them a chance to edit or cancel). The
- * tool intentionally does NOT expose an auto-execute switch — that
- * would defeat the entire approval model.
+ * For those cases the agent runs the command inside a real VS Code
+ * integrated terminal. Approval re-uses the regular `bash` approval
+ * dialog — there's no second gate to maintain, and the user already
+ * understands that surface.
  *
- * This is intentionally a separate tool from `bash`:
- *   - `bash`: captured stdio, agent reads the result, approval dialog gates execution.
- *   - `send_to_terminal`: interactive TTY, no captured output, the visible terminal + Enter keystroke is the approval.
- *
- * Use the right one for the job — never reach for this tool to bypass
- * `bash` approvals on commands that would have worked in `bash`.
+ * When the terminal has shell integration active (the default for
+ * bash/zsh/pwsh/fish in VS Code-launched terminals since 1.93), the
+ * tool reads back the exit code and output via
+ * `Terminal.shellIntegration.executeCommand`. When integration isn't
+ * available, the tool falls back to `terminal.sendText` and reports
+ * `captured: false` — the agent must then ask the user to confirm the
+ * command finished and re-probe.
  */
+
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 min — installs can be slow
+
 /**
- * Reject any control character that VS Code's terminal would treat as an
- * Enter / line-feed, defeating the approval gate. `terminal.sendText`
- * normalizes both `\n` and `\r` into a CR the shell reads as Enter, so
- * `"cmd1\ncmd2"` with execute=false would still auto-run `cmd1`. We
- * reject the raw string at parse time rather than stripping silently —
- * the agent should rewrite multi-line input as a single command.
+ * Reject any control character that would behave as Enter inside the
+ * terminal. Even with shell integration, embedded `\n` / `\r` would
+ * smuggle a second command past the user's view of what they
+ * approved — keep the schema strict and let the agent rewrite
+ * multi-line input as a single command.
  */
 const FORBIDDEN_COMMAND_CHARS = /[\r\n]/;
 
@@ -46,10 +52,10 @@ const SendToTerminalInputSchema = z.strictObject({
     .max(2048)
     .refine((s) => !FORBIDDEN_COMMAND_CHARS.test(s), {
       message:
-        'command must not contain newline / carriage-return characters — they would auto-execute past the Enter approval gate.',
+        'command must not contain newline / carriage-return characters — they would smuggle a second command past the approval surface.',
     })
     .describe(
-      'The command to type into the integrated terminal. One command per call (a script is fine if it is the user-visible operation, but no chaining unrelated steps). Must not contain newline or carriage-return characters; those would auto-execute past the Enter approval gate.',
+      'The command to run inside the integrated terminal. One command per call. Must not contain newline or carriage-return characters.',
     ),
   reason: z
     .string()
@@ -59,7 +65,7 @@ const SendToTerminalInputSchema = z.strictObject({
       message: 'reason must include non-whitespace text',
     })
     .describe(
-      'One short sentence stating why this needs an interactive terminal instead of the regular `bash` tool — typically "sudo password prompt" or "interactive confirmation". The reason is shown back to the user.',
+      'One short sentence stating why this needs an interactive terminal instead of the regular `bash` tool — typically "sudo password prompt" or "interactive confirmation". Shown back to the user.',
     ),
   label: z
     .string()
@@ -70,22 +76,25 @@ const SendToTerminalInputSchema = z.strictObject({
       message: 'label must include non-whitespace text',
     })
     .describe(
-      'Short suffix for the terminal tab name. The tool always prepends "TeXRA: " so the terminal cannot be made to impersonate other terminals or extensions. Examples: "setup", "install LaTeX", "PATH fix".',
+      'Short suffix for the terminal tab name. The tool always prepends "TeXRA: " so the terminal cannot impersonate other terminals or extensions.',
+    ),
+  timeout: z
+    .int()
+    .min(1_000)
+    .max(900_000)
+    .nullish()
+    .describe(
+      'Hard cap (ms) on how long the tool waits for the captured run before giving up. Defaults to 300,000 ms (5 min). Ignored when shell integration is unavailable.',
     ),
 });
 
 type SendToTerminalInput = z.infer<typeof SendToTerminalInputSchema>;
 
-/** Cap on the command preview echoed back into the tool transcript. */
+/** Length cap for the command preview in tool output. */
 const COMMAND_PREVIEW_MAX = 80;
+/** Length cap for the captured-output tail surfaced to the agent. */
+const OUTPUT_PREVIEW_MAX = 4_000;
 
-/**
- * Build a short, transcript-safe preview of the command. The user can
- * already see the command in the revealed terminal, so we deliberately
- * avoid echoing the full text into the saved transcript / exports —
- * that would mirror a known footgun where secrets ride along in tool
- * output (cf. `InvokeCommandTool`'s arg redaction).
- */
 function commandPreview(command: string): string {
   if (command.length <= COMMAND_PREVIEW_MAX) return command;
   return `${command.slice(0, COMMAND_PREVIEW_MAX)}…`;
@@ -93,31 +102,82 @@ function commandPreview(command: string): string {
 
 export class SendToTerminalTool extends defineTool({
   name: 'send_to_terminal',
-  description: `Type a command into a VS Code integrated terminal and reveal the terminal to the user. Use this — instead of \`bash\` — when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. The command is left at the prompt unexecuted; the user must press Enter to run it (that keystroke is the approval). The terminal tab is always named "TeXRA: <label>" so it cannot impersonate other terminals. You receive no captured output and only a redacted preview of the command — after sending, ask the user to confirm completion before continuing, then re-probe with \`verify_setup\` or \`probe_environment\`. Do NOT use this to bypass \`bash\` approvals for commands that would work in \`bash\`.`,
+  description: `Run a command in a VS Code integrated terminal — use this instead of \`bash\` when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. Approval reuses the regular \`bash\` approval dialog. When the terminal has shell integration enabled (bash/zsh/pwsh/fish in a VS Code-launched terminal), the tool returns the exit code and a tail of the captured output. When shell integration is unavailable the tool reports \`captured: false\` and you must wait for the user to confirm completion before re-probing. Do NOT use this to bypass \`bash\` approvals on commands that would work in \`bash\`.`,
   schema: SendToTerminalInputSchema,
 }) {
   protected async execute(input: SendToTerminalInput): Promise<ToolResult> {
-    const platform = getSetupPlatform();
     const command = input.command.trim();
-
     if (command.length === 0) {
       throw new ToolError('Refusing to send an empty command to the terminal.');
     }
 
+    // Reuse the same approval dialog the `bash` tool uses. The user
+    // sees the exact command before anything is sent to the terminal.
+    const approval = await requestBashApproval({ command });
+    if (!approval.accepted) {
+      return buildBashApprovalRejectedResult(command, approval.userMessage);
+    }
+
+    const platform = getSetupPlatform();
     const label = input.label.trim();
     const name = `TeXRA: ${label}`;
-    await platform.terminal.sendCommand({ name, command });
-
+    const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
     const reason = input.reason.trim();
     const preview = commandPreview(command);
+
+    const result = await platform.terminal.runCommand({
+      name,
+      command,
+      timeoutMs,
+    });
+
+    if (!result.captured) {
+      return {
+        summary: `Ran command in terminal "${name}" (no output capture)`,
+        output:
+          `Ran a command in the integrated terminal "${name}" — preview: \`${preview}\`. ` +
+          `Reason: ${reason}. ` +
+          'Shell integration was not available on this terminal, so I cannot read back the exit code or output. ' +
+          'Wait for the user to tell you the command finished (and any password / confirmation prompts are answered) before re-probing with `verify_setup` or `probe_environment`.',
+      };
+    }
+
+    if (result.timedOut) {
+      return {
+        summary: `Command in terminal "${name}" timed out after ${(timeoutMs / 1000).toFixed(0)}s`,
+        output:
+          `The command was running in "${name}" — preview: \`${preview}\` — but did not finish within ${(timeoutMs / 1000).toFixed(0)}s. ` +
+          'It may still be running in the terminal; ask the user whether to keep waiting, raise the `timeout`, or interrupt it (Ctrl+C in the terminal). ' +
+          (result.output
+            ? 'Captured output so far is appended below.\n\n' +
+              wrapOutput(truncateWithEllipsis(result.output, OUTPUT_PREVIEW_MAX))
+            : 'No output was captured before the timeout.'),
+      };
+    }
+
+    const exit = result.exitCode;
+    const ok = exit === 0;
+    const exitLabel =
+      exit === undefined
+        ? 'unknown (terminal interrupted before completion)'
+        : String(exit);
+
+    const outputBlock = result.output.trim()
+      ? wrapOutput(truncateWithEllipsis(result.output, OUTPUT_PREVIEW_MAX))
+      : '(no output captured)';
+
     return {
-      summary: `Typed command into terminal "${name}" (awaiting Enter)`,
+      summary: ok
+        ? `Ran command in terminal "${name}" (exit 0)`
+        : `Command in terminal "${name}" exited ${exitLabel}`,
       output:
-        `Typed a command into the integrated terminal "${name}" — preview: \`${preview}\`. ` +
-        `Reason: ${reason}. ` +
-        "The command is sitting at the user's prompt; they need to press Enter to run it, then complete any password or confirmation prompts in the terminal. " +
-        'Wait for the user to tell you it finished before re-probing. ' +
-        '(Full command text is intentionally not echoed into the transcript — the user can see it in the revealed terminal.)',
+        `Ran in integrated terminal "${name}" — preview: \`${preview}\`. ` +
+        `Reason: ${reason}. Exit code: ${exitLabel}.\n\n` +
+        outputBlock,
     };
   }
+}
+
+function wrapOutput(text: string): string {
+  return '```\n' + text + '\n```';
 }

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -95,11 +95,6 @@ const COMMAND_PREVIEW_MAX = 80;
 /** Length cap for the captured-output tail surfaced to the agent. */
 const OUTPUT_PREVIEW_MAX = 4_000;
 
-function commandPreview(command: string): string {
-  if (command.length <= COMMAND_PREVIEW_MAX) return command;
-  return `${command.slice(0, COMMAND_PREVIEW_MAX)}…`;
-}
-
 export class SendToTerminalTool extends defineTool({
   name: 'send_to_terminal',
   description: `Run a command in a VS Code integrated terminal — use this instead of \`bash\` when the command needs a real TTY: \`sudo\` password prompts, package managers that ask for confirmation (e.g. \`brew install --cask\`), or anything that drops the user into an interactive UI. Approval reuses the regular \`bash\` approval dialog. When the terminal has shell integration enabled (bash/zsh/pwsh/fish in a VS Code-launched terminal), the tool returns the exit code and a tail of the captured output. When shell integration is unavailable the tool reports \`captured: false\` and you must wait for the user to confirm completion before re-probing. Do NOT use this to bypass \`bash\` approvals on commands that would work in \`bash\`.`,
@@ -123,7 +118,7 @@ export class SendToTerminalTool extends defineTool({
     const name = `TeXRA: ${label}`;
     const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
     const reason = input.reason.trim();
-    const preview = commandPreview(command);
+    const preview = truncateWithEllipsis(command, COMMAND_PREVIEW_MAX);
 
     const result = await platform.terminal.runCommand({
       name,

--- a/src/tools/setup/SendToTerminalTool.ts
+++ b/src/tools/setup/SendToTerminalTool.ts
@@ -15,6 +15,7 @@ import { getSetupPlatform } from './platform';
 
 const DEFAULT_TIMEOUT_MS = 300_000;
 const OUTPUT_PREVIEW_MAX = 4_000;
+const TERMINAL_NAME_PREFIX = 'TeXRA: ';
 
 const SendToTerminalInputSchema = z.strictObject({
   // The single non-cosmetic guard: VS Code normalizes \n / \r when typed
@@ -33,7 +34,7 @@ const SendToTerminalInputSchema = z.strictObject({
     .string()
     .prefault('setup')
     .describe(
-      'Short suffix for the terminal tab name; the tool prepends "TeXRA: ".',
+      `Short suffix for the terminal tab name; the tool prepends "${TERMINAL_NAME_PREFIX}".`,
     ),
   timeout: z
     .int()
@@ -60,7 +61,7 @@ export class SendToTerminalTool extends defineTool({
       return buildBashApprovalRejectedResult(command, approval.userMessage);
     }
 
-    const name = `TeXRA: ${input.label.trim() || 'setup'}`;
+    const name = TERMINAL_NAME_PREFIX + input.label.trim();
     const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS;
 
     const { exitCode, output, timedOut } = await getSetupPlatform()

--- a/src/tools/setup/index.ts
+++ b/src/tools/setup/index.ts
@@ -36,4 +36,5 @@ export {
   type SetupAuthAdapter,
   type SetupConfigAdapter,
   type SetupTerminalAdapter,
+  type TerminalRunResult,
 } from './platform';

--- a/src/tools/setup/index.ts
+++ b/src/tools/setup/index.ts
@@ -7,6 +7,8 @@
  *   - set_api_key / unset_api_key — SecretStorage writes
  *   - invoke_command — bridge to allowlisted VS Code commands
  *   - install_vscode_extension — install LaTeX Workshop / Lean 4
+ *   - send_to_terminal — type into VS Code's integrated terminal for
+ *     sudo / interactive prompts the captured-stdio bash tool can't handle
  *
  * Shell-rc writes go through the regular `bash` tool (and its approval
  * dialog) — there's no dedicated rc-writing tool. A hand-rolled validator
@@ -23,6 +25,7 @@ export { UnsetApiKeyTool } from './UnsetApiKeyTool';
 export { InvokeCommandTool } from './InvokeCommandTool';
 export { InstallVscodeExtensionTool } from './InstallVscodeExtensionTool';
 export { ReadConfigTool, UpdateConfigTool } from './ConfigTools';
+export { SendToTerminalTool } from './SendToTerminalTool';
 export {
   setSetupPlatform,
   getSetupPlatform,
@@ -32,4 +35,5 @@ export {
   type SetupExtensionAdapter,
   type SetupAuthAdapter,
   type SetupConfigAdapter,
+  type SetupTerminalAdapter,
 } from './platform';

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -96,11 +96,7 @@ export type TerminalRunResult =
       output: string;
       timedOut: boolean;
     }
-  | {
-      captured: false;
-      /** Why we couldn't capture — surfaced to the agent for context. */
-      reason: 'no-shell-integration' | 'unavailable';
-    };
+  | { captured: false };
 
 /** Aggregated setup platform. */
 export interface SetupPlatform {

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -73,10 +73,10 @@ export interface SetupConfigAdapter {
  *
  * Implementations should prefer VS Code's stable `Terminal.shellIntegration`
  * API (since 1.93) so the agent can read back exit code + output. When
- * shell integration isn't available (custom shell, user disabled the
- * auto-inject, remote edge case), the implementation falls back to
- * `sendText` and reports `captured: false` — the agent then has to ask
- * the user to confirm completion and re-probe.
+ * shell integration is unavailable the implementation may return an
+ * `undefined` exit code with empty output — the caller treats that the
+ * same as "user interrupted", since neither path tells us anything
+ * actionable.
  */
 export interface SetupTerminalAdapter {
   runCommand(args: {
@@ -87,16 +87,13 @@ export interface SetupTerminalAdapter {
   }): Promise<TerminalRunResult>;
 }
 
-export type TerminalRunResult =
-  | {
-      captured: true;
-      /** `undefined` if the shell didn't report one (e.g. user Ctrl+C). */
-      exitCode: number | undefined;
-      /** ANSI-stripped, length-capped tail of the command's output. */
-      output: string;
-      timedOut: boolean;
-    }
-  | { captured: false };
+export interface TerminalRunResult {
+  /** `undefined` if shell integration was unavailable, or the run was interrupted. */
+  exitCode: number | undefined;
+  /** ANSI-stripped, length-capped tail of the command's output. May be empty. */
+  output: string;
+  timedOut: boolean;
+}
 
 /** Aggregated setup platform. */
 export interface SetupPlatform {

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -74,14 +74,10 @@ export interface SetupConfigAdapter {
 export interface SetupTerminalAdapter {
   /**
    * Reveal a VS Code integrated terminal and type `command` into it.
-   * When `execute` is `false`, the command is left at the prompt so the
-   * user must press Enter — that keystroke is the approval gate.
+   * The command is left at the prompt unexecuted — the user must press
+   * Enter to run it. That keystroke is the approval gate.
    */
-  sendCommand(args: {
-    name: string;
-    command: string;
-    execute: boolean;
-  }): Promise<void>;
+  sendCommand(args: { name: string; command: string }): Promise<void>;
 }
 
 /** Aggregated setup platform. */

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -70,15 +70,37 @@ export interface SetupConfigAdapter {
  * the captured-stdio `bash` tool cannot handle: `sudo` password prompts,
  * other interactive TTY prompts, and any flow where the user must type
  * into the running process.
+ *
+ * Implementations should prefer VS Code's stable `Terminal.shellIntegration`
+ * API (since 1.93) so the agent can read back exit code + output. When
+ * shell integration isn't available (custom shell, user disabled the
+ * auto-inject, remote edge case), the implementation falls back to
+ * `sendText` and reports `captured: false` — the agent then has to ask
+ * the user to confirm completion and re-probe.
  */
 export interface SetupTerminalAdapter {
-  /**
-   * Reveal a VS Code integrated terminal and type `command` into it.
-   * The command is left at the prompt unexecuted — the user must press
-   * Enter to run it. That keystroke is the approval gate.
-   */
-  sendCommand(args: { name: string; command: string }): Promise<void>;
+  runCommand(args: {
+    name: string;
+    command: string;
+    /** Hard cap on how long to wait for the captured run before giving up. */
+    timeoutMs: number;
+  }): Promise<TerminalRunResult>;
 }
+
+export type TerminalRunResult =
+  | {
+      captured: true;
+      /** `undefined` if the shell didn't report one (e.g. user Ctrl+C). */
+      exitCode: number | undefined;
+      /** ANSI-stripped, length-capped tail of the command's output. */
+      output: string;
+      timedOut: boolean;
+    }
+  | {
+      captured: false;
+      /** Why we couldn't capture — surfaced to the agent for context. */
+      reason: 'no-shell-integration' | 'unavailable';
+    };
 
 /** Aggregated setup platform. */
 export interface SetupPlatform {

--- a/src/tools/setup/platform.ts
+++ b/src/tools/setup/platform.ts
@@ -65,6 +65,25 @@ export interface SetupConfigAdapter {
   ): Promise<void>;
 }
 
+/**
+ * Integrated-terminal surface. The setup agent uses this for commands
+ * the captured-stdio `bash` tool cannot handle: `sudo` password prompts,
+ * other interactive TTY prompts, and any flow where the user must type
+ * into the running process.
+ */
+export interface SetupTerminalAdapter {
+  /**
+   * Reveal a VS Code integrated terminal and type `command` into it.
+   * When `execute` is `false`, the command is left at the prompt so the
+   * user must press Enter — that keystroke is the approval gate.
+   */
+  sendCommand(args: {
+    name: string;
+    command: string;
+    execute: boolean;
+  }): Promise<void>;
+}
+
 /** Aggregated setup platform. */
 export interface SetupPlatform {
   secrets: SetupSecretsAdapter;
@@ -72,6 +91,7 @@ export interface SetupPlatform {
   extensions: SetupExtensionAdapter;
   auth: SetupAuthAdapter;
   config: SetupConfigAdapter;
+  terminal: SetupTerminalAdapter;
 }
 
 let platform: SetupPlatform | undefined;


### PR DESCRIPTION
## Summary

Adds a `send_to_terminal` tool to the setup wizard for commands the captured-stdio `bash` tool cannot handle: `sudo` password prompts, `brew install --cask` confirmations, installers that drop into a paginator, etc. Captures exit code + output via VS Code's stable `Terminal.shellIntegration.executeCommand` API (since 1.93), with a `sendText` fallback when shell integration is unavailable.

## Design

**One approval gate, not two.** The tool reuses the existing bash approval dialog — the user sees the literal command before anything runs. No second "press Enter to approve" gate; that just confused things.

**Output capture via shell integration.** When the user's terminal has shell integration active (default for bash/zsh/pwsh/fish in VS Code-launched terminals), the agent gets back `{exitCode, output, timedOut}`. When it isn't active, the tool falls back to `sendText` and returns an undefined exit code — the agent re-probes via `verify_setup` to confirm what actually happened. The agent is told to treat captured output as advisory; `verify_setup` is the source of truth.

**Single result shape.** No discriminated union: `captured: true | false` was a boolean wearing a tuxedo. Same shape either way; "shell integration missing" looks identical to "user Ctrl+C-ed mid-run" — neither tells the agent anything actionable, and the recovery (re-probe) is the same.

**Slim schema.** Only one validation matters: rejecting embedded `\r\n` in `command`. VS Code's `sendText` normalizes those to CR which the shell reads as Enter, so multi-line input would smuggle a second command past the approval dialog. The other validation theater (length caps, whitespace-only refines, `reason`-must-justify) was dropped — the user already sees the exact command in the approval dialog.

**Terminal name impersonation guard.** The tool always prepends `TeXRA: ` to the agent-supplied label so the terminal tab can't impersonate other extensions.

## Files

- `src/tools/setup/SendToTerminalTool.ts` — the new tool (80 LOC).
- `src/tools/setup/platform.ts` — `SetupTerminalAdapter` interface + `TerminalRunResult`.
- `src/frontend/setupTerminalRunner.ts` — VS Code wiring with shell-integration capture, sliding-window output tail, `raceWithTimeout` + `tail` helpers.
- `src/extension.ts` — adapter hookup (4 lines).
- `src/tools/registry.ts` — registers the tool.
- `resources/tool_use_agents/setup.yaml` — opens the wizard with a greeting + context question before probing the environment; documents `bash` vs. `send_to_terminal` selection; updates phase-A install guidance to use `send_to_terminal` for `sudo` paths.
- `src/test/tools/setup/fixtures.ts` — extracts a shared `createFakeSetupPlatform(overrides)` helper used by all three setup-tool test files (replaces ~50 lines of duplicated stub-building per file).
- `src/test/tools/setup/SendToTerminalTool.test.ts` — unit tests covering exit-code reporting, timeout reporting, label prefixing, and the embedded-newline guard. Stubs `Platform.config` so `requestBashApproval` auto-accepts in tests.

## Test plan

- [ ] Trigger the setup wizard from a fresh state on macOS, walk through `brew install` (non-interactive) → verify `bash` is used.
- [ ] Trigger on Ubuntu, walk through `sudo apt-get install -y latexmk` → verify `send_to_terminal` is used, password prompt works in the visible terminal, exit code comes back.
- [ ] Trigger in a terminal without shell integration (e.g. custom shell setup) → verify the tool returns `exitCode: undefined` and the agent re-probes via `verify_setup`.
- [ ] Verify the `TeXRA: setup` terminal is reused across consecutive calls and not duplicated.
- [ ] Verify multi-line `command` input is rejected before the approval dialog appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new setup tool that can execute arbitrary one-line commands in the user’s integrated terminal (including `sudo` flows), which is inherently higher impact despite reusing the existing bash-approval gate and adding newline/label guards.
> 
> **Overview**
> Introduces a new `send_to_terminal` setup tool to run one-line commands in VS Code’s integrated terminal for cases the captured-stdio `bash` tool can’t handle (e.g. `sudo` password prompts and other interactive installers), returning exit code + an output tail when shell integration is available.
> 
> Wires a new `terminal` adapter into the setup platform (`SetupTerminalAdapter`/`TerminalRunResult`) with a VS Code implementation that prefers `Terminal.shellIntegration.executeCommand` and falls back to `sendText` when capture isn’t possible, then registers the tool in the tool registry and setup agent YAML (including updated onboarding flow and guidance on when to use `bash` vs `send_to_terminal`).
> 
> Refactors setup-tool unit tests to use a shared `createFakeSetupPlatform` fixture and adds targeted tests for `send_to_terminal` behavior (label prefixing, timeout/exit handling, output truncation, and newline injection rejection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ef57b3751bc4782ed5fc610e28278cc2b8c7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->