### PR TITLE
fix: preserve reasoning_content when merging assistant messages

### DIFF
--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -11,11 +11,7 @@ type MessageLike = {
   content?: unknown;
   tool_calls?: unknown;
   tool_call_id?: unknown;
-  /**
-   * DeepSeek/Kimi/GLM thinking-mode reasoning that must round-trip with the
-   * assistant turn. Tracked here so message normalization preserves it instead
-   * of dropping it when consecutive assistant messages merge.
-   */
+  /** Tracked so merging assistant messages preserves DeepSeek-style reasoning that must round-trip to the API. */
   reasoning_content?: unknown;
 };
 
@@ -45,10 +41,11 @@ function mergeReasoningContent(
     return;
   }
   if (typeof prevReasoning === 'string' && typeof currReasoning === 'string') {
-    previous.reasoning_content =
-      prevReasoning && currReasoning
-        ? `${prevReasoning}\n${currReasoning}`
-        : prevReasoning || currReasoning;
+    if (prevReasoning === '' || currReasoning === '') {
+      previous.reasoning_content = prevReasoning || currReasoning;
+    } else {
+      previous.reasoning_content = `${prevReasoning}\n${currReasoning}`;
+    }
   }
 }
 

--- a/src/agent/modelHandlers/openAIMessageUtils.ts
+++ b/src/agent/modelHandlers/openAIMessageUtils.ts
@@ -11,6 +11,12 @@ type MessageLike = {
   content?: unknown;
   tool_calls?: unknown;
   tool_call_id?: unknown;
+  /**
+   * DeepSeek/Kimi/GLM thinking-mode reasoning that must round-trip with the
+   * assistant turn. Tracked here so message normalization preserves it instead
+   * of dropping it when consecutive assistant messages merge.
+   */
+  reasoning_content?: unknown;
 };
 
 type ContentArray = Array<Record<string, unknown>>;
@@ -27,10 +33,31 @@ function isTextContentItem(
   );
 }
 
+function mergeReasoningContent(
+  previous: MessageLike,
+  current: MessageLike,
+): void {
+  const prevReasoning = previous.reasoning_content;
+  const currReasoning = current.reasoning_content;
+  if (currReasoning == null) return;
+  if (prevReasoning == null) {
+    previous.reasoning_content = currReasoning;
+    return;
+  }
+  if (typeof prevReasoning === 'string' && typeof currReasoning === 'string') {
+    previous.reasoning_content =
+      prevReasoning && currReasoning
+        ? `${prevReasoning}\n${currReasoning}`
+        : prevReasoning || currReasoning;
+  }
+}
+
 function mergeMessageContent(
   previous: MessageLike,
   current: MessageLike,
 ): void {
+  mergeReasoningContent(previous, current);
+
   const prevContent = previous.content;
   const currContent = current.content;
 

--- a/src/test/agent/modelHandlers/OpenAIMessageUtils.test.ts
+++ b/src/test/agent/modelHandlers/OpenAIMessageUtils.test.ts
@@ -106,6 +106,56 @@ describe('normalizeOpenAIMessageContent', () => {
     );
   });
 
+  it('preserves reasoning_content when merging consecutive assistant messages', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'first thought',
+      },
+      {
+        role: 'assistant',
+        content: 'second thought',
+        reasoning_content: 'thinking step',
+      },
+    ];
+
+    const normalized = normalizeOpenAIMessageContent(messages, {
+      mergeConsecutiveRoles: true,
+    });
+
+    assert.equal(normalized.length, 1);
+    assert.equal(
+      (normalized[0] as { reasoning_content?: string }).reasoning_content,
+      'thinking step',
+      'reasoning_content from later message should survive merge',
+    );
+  });
+
+  it('concatenates reasoning_content from both merged messages', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: 'first',
+        reasoning_content: 'earlier reasoning',
+      },
+      {
+        role: 'assistant',
+        content: 'second',
+        reasoning_content: 'later reasoning',
+      },
+    ];
+
+    const normalized = normalizeOpenAIMessageContent(messages, {
+      mergeConsecutiveRoles: true,
+    });
+
+    assert.equal(normalized.length, 1);
+    assert.equal(
+      (normalized[0] as { reasoning_content?: string }).reasoning_content,
+      'earlier reasoning\nlater reasoning',
+    );
+  });
+
   it('does not merge tool-call protocol messages', () => {
     const messages = [
       {


### PR DESCRIPTION
DeepSeek thinking models 400 with "The reasoning_content in the
thinking mode must be passed back to the API" if the assistant message
that produced reasoning is sent back without that field.

The DeepSeek handler enables `mergeConsecutiveRoles: true`, which
collapses adjacent same-role messages via `mergeMessageContent()`. That
helper only touched `content`, so when two consecutive assistant
messages were merged and only the later one carried `reasoning_content`,
the field was silently dropped and the next request failed.

Track `reasoning_content` on the merge type and copy it onto the
surviving message (concatenating when both sides carry reasoning) so the
field round-trips through normalization. Add unit tests covering both
the "only later message has reasoning" and "both have reasoning" paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to message normalization/merge behavior and adds tests; main risk is unintended formatting/concatenation differences for `reasoning_content` in edge cases.
> 
> **Overview**
> **Fixes loss of `reasoning_content` during message normalization.** When `mergeConsecutiveRoles` collapses adjacent assistant messages, the survivor now retains `reasoning_content` from later messages and concatenates it (newline-delimited) when both messages include it.
> 
> Adds unit tests covering the “only later message has reasoning” and “both have reasoning” merge scenarios to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64b84e81622e0aa5658728f71ea2049574739f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->