### PR TITLE
Add label taxonomy and umbrella sub-issue support

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,79 +1,96 @@
-# Source of truth for issue/PR labels. Synced to GitHub by .github/workflows/label-sync.yml.
-# Schema: EndBug/label-sync@v2. Use `aliases` for renames so existing usage is preserved.
+# Source of truth for issue/PR labels on lionsr/texra.
+# Reflects the merged scheme: existing curated organic labels (preserved as-is)
+# plus a small additive layer for axes the existing scheme doesn't cover.
+# Synced by .github/workflows/label-sync.yml.
 
-# ---- type: what kind of change (mutually exclusive in practice) ----
-- name: 'type:bug'
+# ---- type-equivalent (flat, GitHub-default-aligned) ----
+- name: 'bug'
   color: 'd73a4a'
-  description: 'Defect in shipped behavior'
-  aliases: ['bug']
+  description: "Something isn't working"
 
-- name: 'type:feature'
-  color: '0e8a16'
-  description: 'New user-facing capability'
-  aliases: ['enhancement']
+- name: 'enhancement'
+  color: 'a2eeef'
+  description: 'New feature or request'
 
-- name: 'type:refactor'
-  color: '5319e7'
-  description: 'Code restructure or tech-debt; no behavior change'
-  aliases: ['tech-debt']
+- name: 'tech-debt'
+  color: 'ededed'
+  description: 'Refactor or cleanup, no behavior change'
 
-- name: 'type:docs'
+- name: 'documentation'
   color: '0075ca'
-  description: 'Documentation only'
-  aliases: ['documentation']
-
-- name: 'type:chore'
-  color: 'cfd3d7'
-  description: 'Build, deps, tooling, CI'
+  description: 'Improvements or additions to documentation'
 
 # ---- area: which part of the codebase (multi-select) ----
-# Only the areas with proven issue/PR volume. Add more when they earn it.
-- name: 'area:agent'
-  color: '1d76db'
-  description: 'src/agent/** (core, flows, runtime)'
+# Five organic labels already in use, plus three additions for axes the
+# auto-labeller can derive cheaply from changed paths.
+- name: 'area:agent-runtime'
+  color: 'bfdadc'
+  description: 'Agent execution, flows, delegation, tools, task state, and orchestration'
 
-- name: 'area:model'
-  color: '1d76db'
-  description: 'src/model/**, src/agent/modelHandlers/**'
+- name: 'area:model-handlers'
+  color: 'c5def5'
+  description: 'Model providers, SDK handlers, streaming, pricing, and model registry behavior'
 
-- name: 'area:latex'
-  color: '1d76db'
-  description: 'src/latex/**'
+- name: 'area:progress-view'
+  color: 'd4c5f9'
+  description: 'Progress board, stream tabs, task groups, logs, and rendering behavior'
 
-- name: 'area:progress'
-  color: '1d76db'
-  description: 'src/progressView/**'
+- name: 'area:latex-workflow'
+  color: '5319e7'
+  description: 'LaTeX build, latexdiff, BibTeX, extraction, and document workflow behavior'
+
+- name: 'area:docs'
+  color: '0075ca'
+  description: 'Documentation, PRDs, walkthroughs, screenshots, and guides'
 
 - name: 'area:webview'
   color: '1d76db'
-  description: 'src/webview/**, src/settingsView/**'
+  description: 'Webview UI: agent panel, settings view, shared frontend components'
 
 - name: 'area:ci'
   color: '1d76db'
-  description: '.github/workflows/**, build configs'
+  description: 'GitHub Actions workflows and repo-root build/lint/tsconfig files'
 
 - name: 'area:deps'
   color: '1d76db'
-  description: 'Dependency bumps (Dependabot, package*.json)'
+  description: 'Dependency bumps and package manifests (Dependabot)'
+
+# ---- status: lifecycle (mutually exclusive in practice) ----
+- name: 'status:needs-triage'
+  color: 'd876e3'
+  description: 'Needs title/body cleanup or first-pass diagnosis before work is clear'
+
+- name: 'status:needs-validation'
+  color: 'fbca04'
+  description: 'Needs verification against API docs, CI, runtime behavior, or product intent'
+
+- name: 'status:ready-review'
+  color: '0e8a16'
+  description: 'Ready for human review or implementation'
+
+- name: 'status:blocked-external'
+  color: 'b60205'
+  description: 'Blocked on upstream provider behavior, docs, quota, or external system state'
+
+# ---- risk: blast radius ----
+- name: 'risk:low'
+  color: '0e8a16'
+  description: 'Small or low-blast-radius change'
+
+- name: 'risk:medium'
+  color: 'fbca04'
+  description: 'Moderate runtime, migration, or integration risk'
+
+- name: 'risk:high'
+  color: 'd93f0b'
+  description: 'High-blast-radius, architectural, schema, or stale-conflict risk'
 
 # ---- priority: only the one that means something ----
 - name: 'priority:p0'
   color: 'b60205'
   description: 'Drop everything: blocker, data loss, or security'
 
-# ---- status: lifecycle states the predictor and humans both consume ----
-- name: 'status:blocked'
-  color: '000000'
-  description: 'Waiting on external dependency or upstream'
-
-- name: 'status:needs-info'
-  color: 'd4c5f9'
-  description: 'Awaiting reporter clarification'
-  aliases: ['question']
-
-# ---- lifecycle: GitHub-recognized community labels ----
-# Names match GitHub's canonical defaults so contributor-surfacing features
-# (repo "Contribute" view, external discovery filters) recognize them.
+# ---- lifecycle: GitHub-recognized canonical community labels ----
 - name: 'good first issue'
   color: '7057ff'
   description: 'Onboarding-friendly'
@@ -82,10 +99,10 @@
   color: '008672'
   description: 'Maintainer welcomes external contributions'
 
-# ---- workflow hooks: consumed by automation ----
+# ---- workflow hooks ----
 - name: 'follow-up'
-  color: 'fbca04'
-  description: 'Created by post-merge agent from review feedback or deferred scope'
+  color: 'ededed'
+  description: 'Follow-up issue filed by post-merge agent from review feedback or deferred scope'
 
 - name: 'tracking'
   color: '8a2be2'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -72,14 +72,15 @@
   aliases: ['question']
 
 # ---- lifecycle: GitHub-recognized community labels ----
-- name: 'good-first-issue'
+# Names match GitHub's canonical defaults so contributor-surfacing features
+# (repo "Contribute" view, external discovery filters) recognize them.
+- name: 'good first issue'
   color: '7057ff'
   description: 'Onboarding-friendly'
 
-- name: 'help-wanted'
+- name: 'help wanted'
   color: '008672'
   description: 'Maintainer welcomes external contributions'
-  aliases: ['help wanted']
 
 # ---- workflow hooks: consumed by automation ----
 - name: 'follow-up'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,91 @@
+# Source of truth for issue/PR labels. Synced to GitHub by .github/workflows/label-sync.yml.
+# Schema: EndBug/label-sync@v2. Use `aliases` for renames so existing usage is preserved.
+
+# ---- type: what kind of change (mutually exclusive in practice) ----
+- name: 'type:bug'
+  color: 'd73a4a'
+  description: 'Defect in shipped behavior'
+  aliases: ['bug']
+
+- name: 'type:feature'
+  color: '0e8a16'
+  description: 'New user-facing capability'
+  aliases: ['enhancement']
+
+- name: 'type:refactor'
+  color: '5319e7'
+  description: 'Code restructure or tech-debt; no behavior change'
+  aliases: ['tech-debt']
+
+- name: 'type:docs'
+  color: '0075ca'
+  description: 'Documentation only'
+  aliases: ['documentation']
+
+- name: 'type:chore'
+  color: 'cfd3d7'
+  description: 'Build, deps, tooling, CI'
+
+# ---- area: which part of the codebase (multi-select) ----
+# Only the areas with proven issue/PR volume. Add more when they earn it.
+- name: 'area:agent'
+  color: '1d76db'
+  description: 'src/agent/** (core, flows, runtime)'
+
+- name: 'area:model'
+  color: '1d76db'
+  description: 'src/model/**, src/agent/modelHandlers/**'
+
+- name: 'area:latex'
+  color: '1d76db'
+  description: 'src/latex/**'
+
+- name: 'area:progress'
+  color: '1d76db'
+  description: 'src/progressView/**'
+
+- name: 'area:webview'
+  color: '1d76db'
+  description: 'src/webview/**, src/settingsView/**'
+
+- name: 'area:ci'
+  color: '1d76db'
+  description: '.github/workflows/**, build configs'
+
+- name: 'area:deps'
+  color: '1d76db'
+  description: 'Dependency bumps (Dependabot, package*.json)'
+
+# ---- priority: only the one that means something ----
+- name: 'priority:p0'
+  color: 'b60205'
+  description: 'Drop everything: blocker, data loss, or security'
+
+# ---- status: lifecycle states the predictor and humans both consume ----
+- name: 'status:blocked'
+  color: '000000'
+  description: 'Waiting on external dependency or upstream'
+
+- name: 'status:needs-info'
+  color: 'd4c5f9'
+  description: 'Awaiting reporter clarification'
+  aliases: ['question']
+
+# ---- lifecycle: GitHub-recognized community labels ----
+- name: 'good-first-issue'
+  color: '7057ff'
+  description: 'Onboarding-friendly'
+
+- name: 'help-wanted'
+  color: '008672'
+  description: 'Maintainer welcomes external contributions'
+  aliases: ['help wanted']
+
+# ---- workflow hooks: consumed by automation ----
+- name: 'follow-up'
+  color: 'fbca04'
+  description: 'Created by post-merge agent from review feedback or deferred scope'
+
+- name: 'tracking'
+  color: '8a2be2'
+  description: 'Umbrella issue with sub-issue children'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -49,7 +49,9 @@ jobs:
           shopt -u nocasematch
 
           # Area from changed file paths.
-          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+          # `gh pr view --json files` caps at 100 entries (cli/cli#5368), so paginate
+          # the REST API to get the full list for large PRs.
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].path')
           grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
 
           # area:model is broader than agent/modelHandlers + model/, so check it first.

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -29,6 +29,9 @@ jobs:
           # Strip leading bracketed bot tag like "[codex] " before prefix matching
           # so that "[codex] fix: ..." derives type:bug from the rest of the title.
           stripped="${TITLE#\[*\] }"
+          # Normalize Conventional Commits breaking-change marker so `feat!:` and
+          # `feat(scope)!:` are matched the same as `feat:` / `feat(scope):`.
+          stripped="${stripped/!:/:}"
 
           # Type from conventional-commit prefix in title.
           shopt -s nocasematch

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -26,10 +26,13 @@ jobs:
           set -euo pipefail
           labels=()
 
+          # Strip leading bracketed bot tag like "[codex] " before prefix matching
+          # so that "[codex] fix: ..." derives type:bug from the rest of the title.
+          stripped="${TITLE#\[*\] }"
+
           # Type from conventional-commit prefix in title.
-          # [codex] is intentionally not mapped; type comes from the rest of the title.
           shopt -s nocasematch
-          case "$TITLE" in
+          case "$stripped" in
             'fix:'*|'fix('*|'bug:'*)
               labels+=('type:bug') ;;
             'feat:'*|'feat('*)
@@ -49,9 +52,14 @@ jobs:
           files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
           grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
 
+          # area:model is broader than agent/modelHandlers + model/, so check it first.
           grep_files '^src/agent/(modelHandlers|modelRegistry)/' && labels+=('area:model') || true
           grep_files '^src/model/' && labels+=('area:model') || true
-          grep_files '^src/agent/' && labels+=('area:agent') || true
+          # area:agent excludes the model-handler subdirs so PRs that only touch
+          # modelHandlers don't double-tag as both area:agent and area:model.
+          if printf '%s\n' "$files" | grep -E '^src/agent/' | grep -qvE '^src/agent/(modelHandlers|modelRegistry)/'; then
+            labels+=('area:agent')
+          fi
           grep_files '^src/latex/' && labels+=('area:latex') || true
           grep_files '^src/progressView/' && labels+=('area:progress') || true
           grep_files '^src/(webview|settingsView)/' && labels+=('area:webview') || true

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -51,7 +51,7 @@ jobs:
           # Area from changed file paths.
           # `gh pr view --json files` caps at 100 entries (cli/cli#5368), so paginate
           # the REST API to get the full list for large PRs.
-          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].path')
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
           grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
 
           # area:model is broader than agent/modelHandlers + model/, so check it first.

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -57,7 +57,12 @@ jobs:
           # `gh pr view --json files` caps at 100 entries (cli/cli#5368), so paginate
           # the REST API to get the full list for large PRs.
           files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
-          grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
+          # Use here-strings (`<<<`) instead of `printf | grep` to avoid SIGPIPE
+          # bubbling under `set -o pipefail`: when `grep -q` matches early it
+          # closes the pipe, the upstream `printf` exits 141, and pipefail
+          # returns 141 — which the caller would misread as "no match". Here-
+          # strings avoid the pipeline entirely.
+          grep_files() { grep -qE "$1" <<<"$files"; }
 
           # area:model-handlers covers handlers + registry + the src/model/ tree.
           # Check it before area:agent-runtime so PRs that touch only modelHandlers
@@ -66,13 +71,20 @@ jobs:
           grep_files '^src/model/' && labels+=('area:model-handlers') || true
           # area:agent-runtime: src/agent/ (excluding modelHandlers/modelRegistry)
           # plus src/tools/ (per the label description: "...delegation, tools...").
-          if printf '%s\n' "$files" | grep -E '^src/agent/' | grep -qvE '^src/agent/(modelHandlers|modelRegistry)/'; then
+          # Filter into an intermediate variable so the two-stage check has no
+          # internal pipe (same SIGPIPE concern as above).
+          non_model_agent=$(grep -vE '^src/agent/(modelHandlers|modelRegistry)/' <<<"$files" || true)
+          if grep -qE '^src/agent/' <<<"$non_model_agent"; then
             labels+=('area:agent-runtime')
           fi
           grep_files '^src/tools/' && labels+=('area:agent-runtime') || true
           grep_files '^src/latex/' && labels+=('area:latex-workflow') || true
           grep_files '^src/progressView/' && labels+=('area:progress-view') || true
-          grep_files '^src/(webview|settingsView)/' && labels+=('area:webview') || true
+          # area:webview covers all webview-side and webview-adjacent UI code:
+          # webview frontends, the settings view, extension-host UI orchestration
+          # (src/frontend/), and the shared webview base classes.
+          grep_files '^src/(webview|settingsView|frontend)/' && labels+=('area:webview') || true
+          grep_files '^src/common/webview/' && labels+=('area:webview') || true
           grep_files '^(docs/|README\.md|CHANGELOG\.md|resources/walkthroughs/)' && labels+=('area:docs') || true
           grep_files '^\.github/workflows/' && labels+=('area:ci') || true
           # Build/lint/tsconfig at the repo root also belong to area:ci.

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -27,27 +27,29 @@ jobs:
           labels=()
 
           # Strip leading bracketed bot tag like "[codex] " before prefix matching
-          # so that "[codex] fix: ..." derives type:bug from the rest of the title.
+          # so that "[codex] fix: ..." derives bug from the rest of the title.
           stripped="${TITLE#\[*\] }"
           # Normalize Conventional Commits breaking-change marker so `feat!:` and
-          # `feat(scope)!:` are matched the same as `feat:` / `feat(scope):`.
+          # `feat(scope)!:` match the same as `feat:` / `feat(scope):`.
           stripped="${stripped/!:/:}"
 
-          # Type from conventional-commit prefix in title.
+          # Type from conventional-commit prefix in title. The repo uses flat
+          # type labels (bug / enhancement / tech-debt / documentation) rather
+          # than a `type:*` prefix, matching GitHub's default labels.
+          # chore/ci/test/style/build prefixes get no type label — those PRs
+          # rely on area labels alone.
           shopt -s nocasematch
           case "$stripped" in
             'fix:'*|'fix('*|'bug:'*)
-              labels+=('type:bug') ;;
+              labels+=('bug') ;;
             'feat:'*|'feat('*)
-              labels+=('type:feature') ;;
+              labels+=('enhancement') ;;
             'refactor:'*|'refactor('*|'perf:'*|'perf('*)
-              labels+=('type:refactor') ;;
+              labels+=('tech-debt') ;;
             'docs:'*|'docs('*)
-              labels+=('type:docs') ;;
+              labels+=('documentation') ;;
             'chore(deps'*|'build(deps'*)
-              labels+=('type:chore' 'area:deps') ;;
-            'chore:'*|'chore('*|'ci:'*|'ci('*|'test:'*|'test('*|'style:'*|'style('*|'build:'*|'build('*)
-              labels+=('type:chore') ;;
+              labels+=('area:deps') ;;
           esac
           shopt -u nocasematch
 
@@ -57,19 +59,23 @@ jobs:
           files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
           grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
 
-          # area:model is broader than agent/modelHandlers + model/, so check it first.
-          grep_files '^src/agent/(modelHandlers|modelRegistry)/' && labels+=('area:model') || true
-          grep_files '^src/model/' && labels+=('area:model') || true
-          # area:agent excludes the model-handler subdirs so PRs that only touch
-          # modelHandlers don't double-tag as both area:agent and area:model.
+          # area:model-handlers covers handlers + registry + the src/model/ tree.
+          # Check it before area:agent-runtime so PRs that touch only modelHandlers
+          # don't double-tag.
+          grep_files '^src/agent/(modelHandlers|modelRegistry)/' && labels+=('area:model-handlers') || true
+          grep_files '^src/model/' && labels+=('area:model-handlers') || true
+          # area:agent-runtime: src/agent/ (excluding modelHandlers/modelRegistry)
+          # plus src/tools/ (per the label description: "...delegation, tools...").
           if printf '%s\n' "$files" | grep -E '^src/agent/' | grep -qvE '^src/agent/(modelHandlers|modelRegistry)/'; then
-            labels+=('area:agent')
+            labels+=('area:agent-runtime')
           fi
-          grep_files '^src/latex/' && labels+=('area:latex') || true
-          grep_files '^src/progressView/' && labels+=('area:progress') || true
+          grep_files '^src/tools/' && labels+=('area:agent-runtime') || true
+          grep_files '^src/latex/' && labels+=('area:latex-workflow') || true
+          grep_files '^src/progressView/' && labels+=('area:progress-view') || true
           grep_files '^src/(webview|settingsView)/' && labels+=('area:webview') || true
+          grep_files '^(docs/|README\.md|CHANGELOG\.md|resources/walkthroughs/)' && labels+=('area:docs') || true
           grep_files '^\.github/workflows/' && labels+=('area:ci') || true
-          # Build/lint/tsconfig at the repo root also belong to area:ci per labels.yml.
+          # Build/lint/tsconfig at the repo root also belong to area:ci.
           grep_files '^(esbuild|vite|webpack|eslint|prettier|babel|jest|rollup)\.config\.(mjs|cjs|js|ts)$' && labels+=('area:ci') || true
           grep_files '^tsconfig(\..+)?\.json$' && labels+=('area:ci') || true
           grep_files '^(package(-lock)?\.json|\.github/dependabot\.yml)$' && labels+=('area:deps') || true
@@ -82,18 +88,19 @@ jobs:
           # Dedupe.
           mapfile -t unique < <(printf '%s\n' "${labels[@]}" | sort -u)
 
-          # type:* is mutually exclusive. If we computed a desired type, strip any
-          # currently-applied type:* that doesn't match it — this handles retitles
-          # like `chore:` -> `fix:` without leaving stale labels behind. If we
-          # computed no type (bare title), leave existing type:* alone so a manual
-          # override is preserved. area:* is multi-select; never strip those.
+          # Type labels (bug/enhancement/tech-debt/documentation) are mutually
+          # exclusive in practice. If we computed a desired type, strip any of
+          # the other three currently applied so retitles like `chore:` -> `fix:`
+          # don't leave stale labels. If we computed no type (bare title or chore),
+          # leave existing type labels alone so a manual override is preserved.
+          # area:* and risk:*/status:*/etc. are multi-select; never strip those.
           desired_type=""
           for l in "${unique[@]}"; do
-            case "$l" in type:*) desired_type="$l"; break ;; esac
+            case "$l" in bug|enhancement|tech-debt|documentation) desired_type="$l"; break ;; esac
           done
           if [ -n "$desired_type" ]; then
             current_types=$(gh pr view "$PR" --repo "$REPO" --json labels \
-              --jq '.labels[].name | select(startswith("type:"))')
+              --jq '.labels[] | select(.name == "bug" or .name == "enhancement" or .name == "tech-debt" or .name == "documentation") | .name')
             while IFS= read -r t; do
               [ -z "$t" ] && continue
               if [ "$t" != "$desired_type" ]; then

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,72 @@
+name: Auto-label PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply type and area labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          labels=()
+
+          # Type from conventional-commit prefix in title.
+          # [codex] is intentionally not mapped; type comes from the rest of the title.
+          shopt -s nocasematch
+          case "$TITLE" in
+            'fix:'*|'fix('*|'bug:'*)
+              labels+=('type:bug') ;;
+            'feat:'*|'feat('*)
+              labels+=('type:feature') ;;
+            'refactor:'*|'refactor('*|'perf:'*|'perf('*)
+              labels+=('type:refactor') ;;
+            'docs:'*|'docs('*)
+              labels+=('type:docs') ;;
+            'chore(deps'*|'build(deps'*)
+              labels+=('type:chore' 'area:deps') ;;
+            'chore:'*|'chore('*|'ci:'*|'ci('*|'test:'*|'test('*|'style:'*|'style('*)
+              labels+=('type:chore') ;;
+          esac
+          shopt -u nocasematch
+
+          # Area from changed file paths.
+          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+          grep_files() { printf '%s\n' "$files" | grep -qE "$1"; }
+
+          grep_files '^src/agent/(modelHandlers|modelRegistry)/' && labels+=('area:model') || true
+          grep_files '^src/model/' && labels+=('area:model') || true
+          grep_files '^src/agent/' && labels+=('area:agent') || true
+          grep_files '^src/latex/' && labels+=('area:latex') || true
+          grep_files '^src/progressView/' && labels+=('area:progress') || true
+          grep_files '^src/(webview|settingsView)/' && labels+=('area:webview') || true
+          grep_files '^\.github/workflows/' && labels+=('area:ci') || true
+          grep_files '^(package(-lock)?\.json|\.github/dependabot\.yml)$' && labels+=('area:deps') || true
+
+          if [ ${#labels[@]} -eq 0 ]; then
+            echo "No labels matched."
+            exit 0
+          fi
+
+          # Dedupe.
+          mapfile -t unique < <(printf '%s\n' "${labels[@]}" | sort -u)
+
+          # Apply each label individually so a single missing label doesn't abort the rest.
+          for l in "${unique[@]}"; do
+            gh pr edit "$PR" --repo "$REPO" --add-label "$l" 2>&1 | sed "s/^/[$l] /" || true
+          done

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -43,7 +43,7 @@ jobs:
               labels+=('type:docs') ;;
             'chore(deps'*|'build(deps'*)
               labels+=('type:chore' 'area:deps') ;;
-            'chore:'*|'chore('*|'ci:'*|'ci('*|'test:'*|'test('*|'style:'*|'style('*)
+            'chore:'*|'chore('*|'ci:'*|'ci('*|'test:'*|'test('*|'style:'*|'style('*|'build:'*|'build('*)
               labels+=('type:chore') ;;
           esac
           shopt -u nocasematch

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: Auto-label PR
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -73,6 +73,26 @@ jobs:
 
           # Dedupe.
           mapfile -t unique < <(printf '%s\n' "${labels[@]}" | sort -u)
+
+          # type:* is mutually exclusive. If we computed a desired type, strip any
+          # currently-applied type:* that doesn't match it — this handles retitles
+          # like `chore:` -> `fix:` without leaving stale labels behind. If we
+          # computed no type (bare title), leave existing type:* alone so a manual
+          # override is preserved. area:* is multi-select; never strip those.
+          desired_type=""
+          for l in "${unique[@]}"; do
+            case "$l" in type:*) desired_type="$l"; break ;; esac
+          done
+          if [ -n "$desired_type" ]; then
+            current_types=$(gh pr view "$PR" --repo "$REPO" --json labels \
+              --jq '.labels[].name | select(startswith("type:"))')
+            while IFS= read -r t; do
+              [ -z "$t" ] && continue
+              if [ "$t" != "$desired_type" ]; then
+                gh pr edit "$PR" --repo "$REPO" --remove-label "$t" 2>&1 | sed "s/^/[remove $t] /" || true
+              fi
+            done <<< "$current_types"
+          fi
 
           # Apply each label individually so a single missing label doesn't abort the rest.
           for l in "${unique[@]}"; do

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -64,6 +64,9 @@ jobs:
           grep_files '^src/progressView/' && labels+=('area:progress') || true
           grep_files '^src/(webview|settingsView)/' && labels+=('area:webview') || true
           grep_files '^\.github/workflows/' && labels+=('area:ci') || true
+          # Build/lint/tsconfig at the repo root also belong to area:ci per labels.yml.
+          grep_files '^(esbuild|vite|webpack|eslint|prettier|babel|jest|rollup)\.config\.(mjs|cjs|js|ts)$' && labels+=('area:ci') || true
+          grep_files '^tsconfig(\..+)?\.json$' && labels+=('area:ci') || true
           grep_files '^(package(-lock)?\.json|\.github/dependabot\.yml)$' && labels+=('area:deps') || true
 
           if [ ${#labels[@]} -eq 0 ]; then

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -152,11 +152,15 @@ jobs:
               - PR: #<PR-number>
               - <Related issues or review comments>
               ```
-            - **Labels**: always `follow-up`, plus exactly one `type:*` label
-              (`type:bug`, `type:feature`, `type:refactor`, `type:docs`, `type:chore`),
-              plus any `area:*` labels that match the parent PR's changed paths
-              (`area:agent`, `area:model`, `area:latex`, `area:progress`,
-              `area:webview`, `area:ci`, `area:deps`).
+            - **Labels**: always `follow-up`. Plus, when applicable:
+              - One type-equivalent: `bug`, `enhancement`, `tech-debt`, or `documentation`.
+              - Any matching `area:*` from the parent PR's changed paths:
+                `area:agent-runtime`, `area:model-handlers`, `area:progress-view`,
+                `area:latex-workflow`, `area:docs`, `area:webview`, `area:ci`, `area:deps`.
+              - One `risk:*` (`risk:low`, `risk:medium`, `risk:high`) reflecting blast radius.
+              - One `status:*` (`status:needs-triage`, `status:needs-validation`,
+                `status:ready-review`, `status:blocked-external`) reflecting current state.
+              - `priority:p0` only for blocker / data-loss / security follow-ups.
 
             **Umbrella vs flat decision.**
 
@@ -172,7 +176,8 @@ jobs:
                  - **Capture both `number` AND `id` from the response** — `id` is the
                    global node ID needed by sub_issue_write below.
               2. For each child, call `mcp__github__issue_write` (method=create) with
-                 the body, `follow-up` + one `type:*` + matching `area:*` labels.
+                 the body and labels (`follow-up` + applicable type/area/risk/status
+                 from the list above).
                  **Capture both `number` AND `id` from each child response.**
               3. For each child, attach to the umbrella:
                  `mcp__github__sub_issue_write` with method=`add`,

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -4,7 +4,10 @@ on:
   issues:
     types: [closed]
   pull_request:
-    types: [closed, opened, labeled, review_requested]
+    # `labeled` is intentionally omitted — Playbook C does nothing for label
+    # events, and auto-label.yml fires labeled events on every push, which
+    # otherwise cascades into duplicate, costly track runs.
+    types: [closed, opened, review_requested]
   pull_request_review:
     types: [submitted]
 

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -39,7 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'dependabot[bot],github-actions[bot],Copilot,chatgpt-codex-connector,claude[bot]'
+          allowed_bots: 'dependabot[bot],github-actions[bot],Copilot,chatgpt-codex-connector,claude[bot],cursor[bot]'
           claude_args: |
             --model claude-opus-4-7
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -132,7 +132,7 @@ jobs:
             - Speculative future work not discussed in the PR
             - Bot suggestions already addressed or dismissed
 
-            For each genuine follow-up, draft an issue with:
+            For each genuine follow-up, create an issue with:
             - **Title**: Short, imperative (e.g. "Add error handling for X")
             - **Body**:
               ```

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -173,16 +173,18 @@ jobs:
                  - Title: `Tracking: follow-ups from #<PR-number> (<short PR title>)`
                  - Body: brief context + bulleted preview of child titles + link to parent PR
                  - Labels: `tracking`, plus the parent PR's `area:*` labels
-                 - **Capture both `number` AND `id` from the response** — `id` is the
-                   global node ID needed by sub_issue_write below.
+                 - **Capture both `number` AND `id` from the response.** `id` is the
+                   numeric REST database id (integer), NOT `node_id` (the GraphQL
+                   string). `sub_issue_write` below requires the integer `id`.
               2. For each child, call `mcp__github__issue_write` (method=create) with
                  the body and labels (`follow-up` + applicable type/area/risk/status
                  from the list above).
-                 **Capture both `number` AND `id` from each child response.**
+                 **Capture both `number` AND `id` (integer) from each child response.**
               3. For each child, attach to the umbrella:
                  `mcp__github__sub_issue_write` with method=`add`,
                  `issue_number=<umbrella-number>`, `sub_issue_id=<child-id>`.
-                 Note: `sub_issue_id` is the child's global `id`, NOT its `number`.
+                 Note: `sub_issue_id` is the child's numeric REST `id` (integer),
+                 NOT its issue `number` and NOT its `node_id`.
 
             Then add new issues to relevant tracking issue checklists:
             - For flat (1 follow-up): append `- [ ] #<issue> - <title>` to the relevant section

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -132,7 +132,7 @@ jobs:
             - Speculative future work not discussed in the PR
             - Bot suggestions already addressed or dismissed
 
-            For each genuine follow-up, create an issue:
+            For each genuine follow-up, draft an issue with:
             - **Title**: Short, imperative (e.g. "Add error handling for X")
             - **Body**:
               ```
@@ -148,15 +148,41 @@ jobs:
               - PR: #<PR-number>
               - <Related issues or review comments>
               ```
-            - **Labels**: "follow-up" plus any relevant labels ("bug", "enhancement",
-              "tech-debt", "documentation")
+            - **Labels**: always `follow-up`, plus exactly one `type:*` label
+              (`type:bug`, `type:feature`, `type:refactor`, `type:docs`, `type:chore`),
+              plus any `area:*` labels that match the parent PR's changed paths
+              (`area:agent`, `area:model`, `area:latex`, `area:progress`,
+              `area:webview`, `area:ci`, `area:deps`).
+
+            **Umbrella vs flat decision.**
+
+            - **0 follow-ups**: skip B2 entirely.
+            - **1 follow-up**: create the issue flat. Reference the parent PR in the body.
+              Do NOT create an umbrella — sub-issue overhead is not worth it for a single child.
+            - **2+ follow-ups from the same PR**: create a tracking umbrella first,
+              then create each child as a native sub-issue of the umbrella:
+              1. Create umbrella with `mcp__github__issue_write` (method=create):
+                 - Title: `Tracking: follow-ups from #<PR-number> (<short PR title>)`
+                 - Body: brief context + bulleted preview of child titles + link to parent PR
+                 - Labels: `tracking`, plus the parent PR's `area:*` labels
+                 - **Capture both `number` AND `id` from the response** — `id` is the
+                   global node ID needed by sub_issue_write below.
+              2. For each child, call `mcp__github__issue_write` (method=create) with
+                 the body, `follow-up` + one `type:*` + matching `area:*` labels.
+                 **Capture both `number` AND `id` from each child response.**
+              3. For each child, attach to the umbrella:
+                 `mcp__github__sub_issue_write` with method=`add`,
+                 `issue_number=<umbrella-number>`, `sub_issue_id=<child-id>`.
+                 Note: `sub_issue_id` is the child's global `id`, NOT its `number`.
 
             Then add new issues to relevant tracking issue checklists:
-            - Append `- [ ] #<issue> - <title>` to the relevant section
-            - Comment: "📋 Added follow-up issues from #<PR>: #<issue1>, #<issue2>, ..."
+            - For flat (1 follow-up): append `- [ ] #<issue> - <title>` to the relevant section
+            - For umbrella (2+): append `- [ ] #<umbrella> - Tracking: ...` (single line for the umbrella)
+            - Comment on the parent PR: "📋 Filed follow-ups from this PR: #<umbrella-or-issue>"
 
             **Be conservative.** Only create issues for genuine, actionable follow-ups.
-            When in doubt, skip it. False positives create noise.
+            When in doubt, skip it. False positives create noise. Two real follow-ups
+            justify an umbrella; two speculative ones do not.
 
             ---
 

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml
-          # Keep legacy labels (Later, ambitious) until manually deleted.
-          # Renames are handled via the `aliases` field in labels.yml.
+          # Don't delete labels that aren't in labels.yml; the repo carries
+          # legacy labels (Later, ambitious, question, help wanted spelling
+          # variants) that should be removed manually if at all.
           delete-other-labels: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,23 @@
+name: Label Sync
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/labels.yml', '.github/workflows/label-sync.yml']
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          # Keep legacy labels (Later, ambitious) until manually deleted.
+          # Renames are handled via the `aliases` field in labels.yml.
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduces a minimal evidence-driven label scheme (16 labels across type,
area, priority, status, lifecycle, workflow axes), a sync workflow keyed
off .github/labels.yml, an auto-labeller that derives type from title
prefix and area from changed paths, and updates Playbook B2 to file
multiple follow-ups under a Tracking umbrella as native sub-issues.

Migrations are handled via EndBug/label-sync aliases:
  enhancement     -> type:feature
  bug             -> type:bug
  tech-debt       -> type:refactor
  documentation   -> type:docs
  question        -> status:needs-info
  "help wanted"   -> help-wanted

Legacy labels Later and ambitious are left in place for manual deletion
(delete-other-labels is false).

Sub-issue rule: 0 follow-ups -> skip; 1 follow-up -> flat issue (today's
behavior); 2+ follow-ups from one PR -> Tracking umbrella with native
sub-issue children. Audit confirmed PR #3088 (3 children) and #3097
(2 children) as the modal cluster pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes GitHub Actions automation that mutates PR/issue labels and creates issues, which could cause noisy or incorrect repo state if the labeling rules or triggers misfire.
> 
> **Overview**
> Introduces a repo-wide label taxonomy via `.github/labels.yml` and adds a `label-sync` workflow to keep GitHub labels in sync (without deleting legacy labels).
> 
> Adds an `auto-label` workflow that derives PR **type** labels from conventional-commit title prefixes and **area** labels from changed paths, with logic to avoid stale type labels on retitles.
> 
> Updates the `issue-tracker` workflow to avoid running on `labeled` events, expands allowed bot list, and extends the follow-up playbook to optionally create a `tracking` umbrella issue and attach multiple follow-ups as native sub-issues with standardized labels (type/area/risk/status/priority).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0e31d386dd3158f88a073ace7251058ff4d09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->