### PR TITLE
refactor(agents): strip redundant scratchpad scaffolding from generic/polish/apply

### DIFF
--- a/reference-agents/apply.yaml
+++ b/reference-agents/apply.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: latex_document
   endTag: </latex_document>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -85,31 +82,7 @@ prompts:
 
   userRequest:
     - |
-      Apply all changes suggested in the inline annotations.
-
-      <scratchpad>
-      <annotation_analysis>
-      For each annotation, understand the issue and plan the fix:
-      \begin{enumerate}
-          \item Annotation: [text]
-              \begin{itemize}
-                  \item Location: [reference]
-                  \item Issue: [what is wrong or needed]
-                  \item Analysis: [work through if needed---derivations, reasoning, etc.]
-                  \item Fix: [what change to make]
-              \end{itemize}
-      \end{enumerate}
-      </annotation_analysis>
-
-      <implementation_plan>
-      All changes in document order:
-      \begin{enumerate}
-          \item [Location]: [Change]
-      \end{enumerate}
-      </implementation_plan>
-      </scratchpad>
-
-      Apply all changes and remove the original annotations:
+      Apply all changes suggested in the inline annotations and remove the original annotations.
 
       <latex_document>
       % DOCUMENT WITH CHANGES APPLIED
@@ -118,7 +91,7 @@ prompts:
     - |
       SECOND PHASE: Revise, condense, and finalize.
 
-      If extensive derivations were added in the first phase, revise them to match document level or +1 (unless instruction requests more detail).
+      If extensive derivations were added in the first phase, revise them to match the document's maturity level or +1 (unless the instruction requests more detail).
 
       Document Maturity Levels:
       \begin{itemize}
@@ -129,47 +102,7 @@ prompts:
           \item Level 5 - Publication Ready: Polished, journal-ready
       \end{itemize}
 
-      <scratchpad>
-      <document_assessment>
-      - Current document level: [1-5]
-      - Target level for revisions: [current or +1]
-      - Instruction requests more detail: [Yes / No]
-      </document_assessment>
-
-      <revision_plan>
-      \begin{enumerate}
-          \item Condensation targets (if derivations added):
-              \begin{itemize}
-                  \item [Location]: [Full derivation] $\rightarrow$ [Level-appropriate form]
-              \end{itemize}
-          \item Quality checks:
-              \begin{itemize}
-                  \item Notations defined before use
-                  \item Logical flow
-                  \item Smooth transitions
-              \end{itemize}
-      \end{enumerate}
-      </revision_plan>
-
-      <verification>
-      \begin{itemize}
-          \item All fixes correct: [Yes / Issues]
-          \item Logical flow preserved: [Yes / Issues]
-          \item Document complete: [Yes / Issues]
-      \end{itemize}
-      </verification>
-
-      <change_summary>
-      Summary of changes made:
-      \begin{enumerate}
-          \item [Location]: [What was changed and why]
-      \end{enumerate}
-
-      Comment style for documentation: [\criticize / \todo / \comment / %]
-      </change_summary>
-      </scratchpad>
-
-      Output the final revised document at appropriate level:
+      Verify before output: all fixes are correct, logical flow is preserved (no notation used before defined), and the document is complete. Match the document's existing comment style (\criticize / \todo / \comment / %) when annotating changes.
 
       <latex_document>
       % FINAL_REVISED_DOCUMENT

--- a/reference-agents/apply_multiple.yaml
+++ b/reference-agents/apply_multiple.yaml
@@ -90,41 +90,7 @@ prompts:
 
   userRequest:
     - |
-      Apply all changes suggested in the inline annotations across all documents.
-
-      <scratchpad>
-      <cross_document_analysis>
-      - Documents present: [list]
-      - Cross-document dependencies: [what results/definitions are shared]
-      - Consistency issues to watch: [notation, definitions that must align]
-      </cross_document_analysis>
-
-      <annotation_analysis>
-      For each annotation across all documents:
-      \begin{enumerate}
-          \item Document: [name], Annotation: [text]
-              \begin{itemize}
-                  \item Location: [reference]
-                  \item Issue: [what is wrong or needed]
-                  \item Analysis: [work through if needed]
-                  \item Fix: [what change to make]
-                  \item Cross-document impact: [affects other documents?]
-              \end{itemize}
-      \end{enumerate}
-      </annotation_analysis>
-
-      <implementation_plan>
-      All changes by document:
-      \begin{enumerate}
-          \item Document: [name]
-              \begin{itemize}
-                  \item [Location]: [Change]
-              \end{itemize}
-      \end{enumerate}
-      </implementation_plan>
-      </scratchpad>
-
-      Apply all changes and remove the original annotations:
+      Apply all changes suggested in the inline annotations across all documents and remove the original annotations. Watch for cross-document dependencies (shared results/definitions, consistent notation).
 
       <latex_documents>
       <document name="{{ OUTPUT_FILES_ORDER[0] }}">
@@ -139,7 +105,7 @@ prompts:
     - |
       SECOND PHASE: Revise, condense, and finalize.
 
-      If extensive derivations were added in the first phase, revise them to match document level or +1 (unless instruction requests more detail).
+      If extensive derivations were added in the first phase, revise them to match each document's maturity level or +1 (unless the instruction requests more detail).
 
       Document Maturity Levels:
       \begin{itemize}
@@ -150,53 +116,7 @@ prompts:
           \item Level 5 - Publication Ready: Polished, journal-ready
       \end{itemize}
 
-      <scratchpad>
-      <document_assessment>
-      For each document:
-      \begin{enumerate}
-          \item Document: [name]
-              \begin{itemize}
-                  \item Current level: [1-5]
-                  \item Target level: [current or +1]
-              \end{itemize}
-      \end{enumerate}
-      - Instruction requests more detail: [Yes / No]
-      </document_assessment>
-
-      <revision_plan>
-      \begin{enumerate}
-          \item Condensation targets by document:
-              \begin{itemize}
-                  \item [Document]: [Location]: [Full] $\rightarrow$ [Level-appropriate]
-              \end{itemize}
-          \item Cross-document consistency check:
-              \begin{itemize}
-                  \item Notation aligned: [Yes / Issues]
-                  \item Definitions consistent: [Yes / Issues]
-                  \item Results match: [Yes / Issues]
-              \end{itemize}
-      \end{enumerate}
-      </revision_plan>
-
-      <verification>
-      \begin{itemize}
-          \item All fixes correct: [Yes / Issues]
-          \item Logical flow preserved: [Yes / Issues]
-          \item All documents complete: [Yes / Issues]
-          \item Cross-document consistency: [Yes / Issues]
-      \end{itemize}
-      </verification>
-
-      <change_summary>
-      Summary of changes by document:
-      \begin{enumerate}
-          \item Document: [name]
-              \begin{itemize}
-                  \item [Location]: [What was changed and why]
-              \end{itemize}
-      \end{enumerate}
-      </change_summary>
-      </scratchpad>
+      Verify before output: all fixes are correct, logical flow is preserved (no notation used before defined), each document is complete, and cross-document consistency holds (aligned notation, consistent definitions, matching results).
 
       Output the final revised documents at appropriate levels:
 

--- a/reference-agents/apply_multiple.yaml
+++ b/reference-agents/apply_multiple.yaml
@@ -93,10 +93,10 @@ prompts:
       Apply all changes suggested in the inline annotations across all documents and remove the original annotations. Watch for cross-document dependencies (shared results/definitions, consistent notation).
 
       <latex_documents>
-      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      <document name="{OUTPUT_FILES_ORDER[0]}">
       % DOCUMENT_1 WITH CHANGES APPLIED
       </document>
-      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      <document name="{OUTPUT_FILES_ORDER[1]}">
       % DOCUMENT_2 WITH CHANGES APPLIED
       </document>
       ... (repeat for all output files)
@@ -121,10 +121,10 @@ prompts:
       Output the final revised documents at appropriate levels:
 
       <latex_documents>
-      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      <document name="{OUTPUT_FILES_ORDER[0]}">
       % FINAL_DOCUMENT_1
       </document>
-      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      <document name="{OUTPUT_FILES_ORDER[1]}">
       % FINAL_DOCUMENT_2
       </document>
       ... (repeat for all output files)

--- a/reference-agents/generic.yaml
+++ b/reference-agents/generic.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: latex_document
   endTag: </latex_document>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -65,79 +62,13 @@ prompts:
 
   userRequest:
     - |
-      {% if INSTRUCTION %}
-      In the scratchpad below, develop a detailed plan for working on this document according to the instruction provided. Be specific about what sections need attention and what changes should be made. Think through the task systematically as a scientist would approach revising their own work.
-      {% else %}
-      In the scratchpad below, develop a detailed plan for working on this document. Analyze the content and structure, identify areas that could benefit from attention, and formulate a systematic approach. Think through the task as a scientist would approach revising their own work.
-      {% endif %}
-
-      <scratchpad>
-      \begin{enumerate}
-          \item [First consideration]
-              \begin{itemize}
-                  \item Analysis: [detailed analysis]
-                  \item Approach: [concrete steps]
-              \end{itemize}
-          \item [Second consideration]
-              \begin{itemize}
-                  \item Analysis: [detailed analysis]
-                  \item Approach: [concrete steps]
-              \end{itemize}
-          \item [Third consideration]
-              \begin{itemize}
-                  \item Analysis: [detailed analysis]
-                  \item Approach: [concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </scratchpad>
-
-      Then, following your plan in the scratchpad, please work on the \LaTeX document. Maintain professional academic standards and adhere to all \LaTeX formatting rules. Use the following format:
+      Work on the \LaTeX document. Maintain professional academic standards and adhere to all \LaTeX formatting rules. Use the following format:
       <latex_document>
       % 1ST_UPDATED_LATEX_DOCUMENT HERE
       </latex_document>
     - |
-      Now, critically reflect on the work you've just completed. As a scientist reviewing their own work, be thorough and honest in your assessment.
+      Now critically reflect on the work you've just completed and output a further refined version. Check for accuracy, notation consistency, structural coherence, formatting issues, and clarity. Include all the work from the previous step plus the new refinements.
 
-      In the scratchpad below, analyze your revisions and consider additional refinements. Be specific and point to concrete locations in your reflection.
-
-      <scratchpad>
-      <reflection>
-      \begin{enumerate}
-          \item How well does the revised document meet the requirements? Are there aspects that could be improved?
-          \item Is the mathematical content accurate and properly formatted according to \LaTeX best practices?
-          \item Are notations and terminology used consistently throughout?
-          \item Is the document structure logical and coherent? Do all parts flow naturally?
-          \item Are there any formatting issues that need attention (references, equations, figures, etc.)?
-          \item Have all custom math commands been used appropriately?
-          \item Are there any statements that could be more precise or clearer?
-      \end{enumerate}
-      </reflection>
-      <refinements>
-      \begin{enumerate}
-          \item [Refinement 1]
-              \begin{itemize}
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item [Refinement 2]
-              \begin{itemize}
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item [Refinement 3]
-              \begin{itemize}
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </refinements>
-      </scratchpad>
-
-      Based on this reflection, output a further refined version of the \LaTeX document, incorporating the improvements discussed in the scratchpad. Include all the work from the previous step plus the new refinements.
-
-      Use the following format:
       <latex_document>
       % 2ND_UPDATED_LATEX_DOCUMENT HERE
       </latex_document>

--- a/reference-agents/generic_multiple.yaml
+++ b/reference-agents/generic_multiple.yaml
@@ -64,10 +64,10 @@ prompts:
       Work on all \LaTeX documents. Maintain professional academic standards and adhere to all \LaTeX formatting rules. Maintain consistency across documents (notation, definitions, results). Use the following format:
 
       <latex_documents>
-      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      <document name="{OUTPUT_FILES_ORDER[0]}">
       % 1ST_UPDATED_LATEX_DOCUMENT_1 HERE
       </document>
-      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      <document name="{OUTPUT_FILES_ORDER[1]}">
       % 1ST_UPDATED_LATEX_DOCUMENT_2 HERE
       </document>
       ... (repeat for all output files)
@@ -78,10 +78,10 @@ prompts:
       Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}
 
       <latex_documents>
-      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      <document name="{OUTPUT_FILES_ORDER[0]}">
       % 2ND_UPDATED_LATEX_DOCUMENT_1 HERE
       </document>
-      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      <document name="{OUTPUT_FILES_ORDER[1]}">
       % 2ND_UPDATED_LATEX_DOCUMENT_2 HERE
       </document>
       ... (repeat for all output files)

--- a/reference-agents/generic_multiple.yaml
+++ b/reference-agents/generic_multiple.yaml
@@ -7,9 +7,6 @@ settings:
   documentTag: latex_documents
   endTag: </latex_documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -64,31 +61,7 @@ prompts:
 
   userRequest:
     - |
-      {% if INSTRUCTION %}
-      In the scratchpad below, develop a detailed plan for working on these documents according to the instruction provided. Be specific about what sections in which documents need attention and what changes should be made. Think through the task systematically as a scientist would approach revising their own work.
-      {% else %}
-      In the scratchpad below, develop a detailed plan for working on these documents. Analyze the content and structure of each, identify areas that could benefit from attention, and formulate a systematic approach. Think through the task as a scientist would approach revising their own work.
-      {% endif %}
-
-      <scratchpad>
-
-      1. [First consideration]
-          - Affected documents: [List of documents]
-          - Analysis: [detailed analysis]
-          - Approach: [concrete steps]
-      2. [Second consideration]
-          - Affected documents: [List of documents]
-          - Analysis: [detailed analysis]
-          - Approach: [concrete steps]
-      3. [Third consideration]
-          - Affected documents: [List of documents]
-          - Analysis: [detailed analysis]
-          - Approach: [concrete steps]
-      ...
-
-      </scratchpad>
-
-      Then, following your plan in the scratchpad, please work on all \LaTeX documents. Maintain professional academic standards and adhere to all \LaTeX formatting rules. Use the following format:
+      Work on all \LaTeX documents. Maintain professional academic standards and adhere to all \LaTeX formatting rules. Maintain consistency across documents (notation, definitions, results). Use the following format:
 
       <latex_documents>
       <document name="{{ OUTPUT_FILES_ORDER[0] }}">
@@ -100,50 +73,10 @@ prompts:
       ... (repeat for all output files)
       </latex_documents>
     - |
-      Now, critically reflect on the work you've just completed on all documents. As a scientist reviewing their own work, be thorough and honest in your assessment.
-
-      In the scratchpad below, analyze your revisions and consider additional refinements. Be specific and point to concrete locations in your reflection.
-
-      <scratchpad>
-      <reflection>
-      % Summary of Changes
-      \begin{enumerate}
-          \item [Summary of major changes made to each document]
-          \item [Evaluation of the effectiveness of these changes]
-          \item [Identification of any areas that may need further improvement]
-      \end{enumerate}
-      </reflection>
-      <refinements>
-      % Additional Improvements
-      \begin{enumerate}
-          \item [Refinement 1]
-              \begin{itemize}
-                  \item Affected documents: [List of documents]
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item [Refinement 2]
-              \begin{itemize}
-                  \item Affected documents: [List of documents]
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item [Refinement 3]
-              \begin{itemize}
-                  \item Affected documents: [List of documents]
-                  \item Rationale: [brief explanation]
-                  \item Implementation: [concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </refinements>
-      </scratchpad>
-
-      Based on this reflection, output further refined and complete versions of all \LaTeX documents, incorporating the improvements discussed in the scratchpad. Include all the work from the previous step plus the new refinements.
+      Now critically reflect on the work you've just completed across all documents and output further refined and complete versions. Check for accuracy, notation consistency within and across documents, structural coherence, formatting issues, and clarity. Include all the work from the previous step plus the new refinements.
 
       Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}
 
-      Use the following format:
       <latex_documents>
       <document name="{{ OUTPUT_FILES_ORDER[0] }}">
       % 2ND_UPDATED_LATEX_DOCUMENT_1 HERE

--- a/resources/agents/correct_multiple.yaml
+++ b/resources/agents/correct_multiple.yaml
@@ -6,6 +6,10 @@ settings:
   documentTag: latex_documents
   endTag: </latex_documents>
   outputExt: tex
+  # Override parent's singular-tag prefill so the model is primed with the
+  # plural <latex_documents> opening that this multi-document agent expects.
+  prefills:
+    - "Here are the revised \\LaTeX documents. <latex_documents>"
 
 prompts:
   systemPrompt: |
@@ -46,10 +50,10 @@ prompts:
     Output updated versions of all \LaTeX documents with targeted corrections that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
 
     <latex_documents>
-    <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+    <document name="{OUTPUT_FILES_ORDER[0]}">
     % 1ST_UPDATED_LATEX_DOCUMENT_1 HERE
     </document>
-    <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+    <document name="{OUTPUT_FILES_ORDER[1]}">
     % 1ST_UPDATED_LATEX_DOCUMENT_2 HERE
     </document>
     ... (repeat for all output files)

--- a/resources/agents/correct_multiple.yaml
+++ b/resources/agents/correct_multiple.yaml
@@ -6,8 +6,6 @@ settings:
   documentTag: latex_documents
   endTag: </latex_documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -45,33 +43,14 @@ prompts:
     {% endif %}
 
   userRequest: |
-    In the scratchpad below, brainstorm concrete ways to significantly improve the quality of all latex documents that are directly relevant to the instruction above. Do not consider any other aspects of the papers. Be as concrete as to change what in which section of which paper in what ways. Use the scratchpad as an opportunity to formulate as detailed as possible action plans so that a graduate student can also perform the revisions. In the scratchpad, list the planned changes, the rationale for each change, and the concrete steps to be taken to implement the changes starting from the beginning of each document.
-
-    <scratchpad>
-
-    1. [Specific improvement 1 addressing the instruction]
-        - Affected documents: [List of documents]
-        - Rationale: [explanation]
-        - Implementation: [Concrete steps]
-    2. [Specific improvement 2 addressing the instruction]
-        - Affected documents: [List of documents]
-        - Rationale: [explanation]
-        - Implementation: [Concrete steps]
-    3. [Specific improvement 3 addressing the instruction]
-        - Affected documents: [List of documents]
-        - Rationale: [explanation]
-        - Implementation: [Concrete steps]
-
-    </scratchpad>
-
-    Then, following your plan in the scratchpad, please output updated versions of all \LaTeX documents with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
+    Output updated versions of all \LaTeX documents with targeted corrections that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
 
     <latex_documents>
-    <document name="{OUTPUT_FILES_ORDER[0]}">
+    <document name="{{ OUTPUT_FILES_ORDER[0] }}">
     % 1ST_UPDATED_LATEX_DOCUMENT_1 HERE
     </document>
-    <document name="{OUTPUT_FILES_ORDER[1]}">
-    {{ 1ST_UPDATED_LATEX_DOCUMENT_2 }}
+    <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+    % 1ST_UPDATED_LATEX_DOCUMENT_2 HERE
     </document>
     ... (repeat for all output files)
     </latex_documents>

--- a/resources/agents/ocr.yaml
+++ b/resources/agents/ocr.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: latex_document
   endTag: </latex_document>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -49,75 +46,22 @@ prompts:
       {{ INSTRUCTION }}
       </instruction>
 
-      Please analyze the document to understand the notation conventions and mathematical style before processing the handwritten content.
-
-      First, analyze the handwritten content and document context in the scratchpad. Identify key mathematical elements and how they should be represented consistently with the existing document.
-
-      <scratchpad>
-      \begin{enumerate}
-          \item [Document Analysis]
-              \begin{itemize}
-                  \item Notation conventions used
-                  \item Mathematical environments employed
-                  \item Symbol definitions and usage
-                  \item Equation numbering style
-              \end{itemize}
-          \item [Image Content Analysis]
-              \begin{itemize}
-                  \item Mathematical expressions identified
-                  \item Special symbols and their LaTeX equivalents
-                  \item Structure and alignment requirements
-                  \item Required mathematical environments
-              \end{itemize}
-          \item [Integration Plan]
-              \begin{itemize}
-                  \item Notation adjustments needed
-                  \item Environment selection
-                  \item Symbol consistency checks
-                  \item Required definitions or references
-              \end{itemize}
-      \end{enumerate}
-      </scratchpad>
-
-      Now, generate the LaTeX code for the handwritten content, ensuring it integrates seamlessly with the existing document:
+      Analyze the document to understand its notation conventions and mathematical style, then generate the LaTeX code for the handwritten content. Ensure it integrates seamlessly with the existing document --- match notation, mathematical environments, and symbol usage:
 
       <latex_document>
       {LATEX_OCR_CONTENT}
       </latex_document>
       Use the same documentclass as the existing document. Include \begin{document} and \end{document} tags so that the standalonefile can be compiled.
     - |
-      Let's review the OCR conversion and integration. Consider these aspects in the scratchpad:
-
-      <scratchpad>
-      <reflection>
-      Find the three most likely OCR errors or misinterpretations in your output. For each:
-      \begin{enumerate}
-          \item What did the handwriting show vs. what you produced?
-          \item Why is this likely wrong? (Ambiguous symbol, inconsistent with document notation, unusual expression, etc.)
-          \item What is the correct interpretation?
-      \end{enumerate}
-
-      Then check:
+      Critically review the OCR conversion and output a refined version. Find the three most likely OCR errors or misinterpretations and check the following, fixing any issues found:
       \begin{itemize}
-          \item Are there any symbols that differ from the document's conventions? (e.g., you used $\alpha$ but the document uses $a$ for the same quantity)
-          \item Are there any mathematical environments that don't match the document's style?
-          \item Are subscripts/superscripts correctly ordered and nested?
+          \item Likely OCR errors --- for each: what the handwriting showed vs. what you produced, why it is likely wrong (ambiguous symbol, inconsistent with document notation, unusual expression), and the correct interpretation.
+          \item Symbols that differ from the document's conventions (e.g., you used $\alpha$ but the document uses $a$ for the same quantity).
+          \item Mathematical environments that do not match the document's style.
+          \item Subscripts/superscripts correctly ordered and nested.
       \end{itemize}
-      </reflection>
-      <improvements>
-      Based on the problems found above, list concrete fixes:
-      \begin{enumerate}
-          \item [Fix 1]
-              \begin{itemize}
-                  \item Issue: [Description]
-                  \item Solution: [Specific changes needed]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </improvements>
-      </scratchpad>
 
-      Based on this reflection, continue to finish and output the refined LaTeX content with improved notation consistency and integration:
+      Output the refined LaTeX content with improved notation consistency and integration:
 
       <latex_document>
       {REFINED_LATEX_OCR_CONTENT}

--- a/resources/agents/polish.yaml
+++ b/resources/agents/polish.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: latex_document
   endTag: </latex_document>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -18,7 +15,7 @@ prompts:
     {{ LATEX_STYLE_RULES }}
     Additional rules for polishing:
     \begin{itemize}
-        \item When writing formal \LaTeX documents rather than thinking in the scratchpad, never barely list things like 1.\ 2.\ 3.\ \ldots{} as in markdown.
+        \item In the final \LaTeX output, never bare-list things like 1.\ 2.\ 3.\ \ldots{} as in markdown --- use proper \LaTeX environments such as enumerate or itemize.
         \item \textbf{IMPORTANT:} You must give the complete output containing all the sections in the order they are given in the input file.
     \end{itemize}
 
@@ -45,68 +42,24 @@ prompts:
 
   userRequest:
     - |
-      In the scratchpad below, brainstorm concrete ways to significantly improve the quality of the paper that are directly relevant to the instruction above. Do not consider any other aspects of the paper. Be as concrete as to change what in which section in what ways. Use the scratchpad as an opportunity to formulate a as detailed as possible action plans so that a graduate student can also perform the revisions. In the scratchpad, list the planned changes, the rationale for each change and the concrete steps to be taken to implement the changes starting from the beginning of the document.
-      <scratchpad>
-      \begin{enumerate}
-          \item [Specific improvement 1 addressing the instruction]
-              \begin{itemize}
-                  \item Rationale: [explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item [Specific improvement 2 addressing the instruction]
-              \begin{itemize}
-                  \item Rationale: [explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item [Specific improvement 3 addressing the instruction]
-              \begin{itemize}
-                  \item Rationale: [explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-      \end{enumerate}
-      </scratchpad>
-
-      Then, following your plan in the scratchpad, please output an updated version of the \LaTeX document with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
+      Output an updated version of the \LaTeX document with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
       <latex_document>
       % 1ST_UPDATED_LATEX_DOCUMENT HERE
       </latex_document>
     - |
-      Let's critically reflect on the changes made according to the given instructions.
-      Now it is time to be brutally honest with yourself. For example, if I asked you to add equations, but you did not add any equations, you should absolutely criticize yourself for not following the instruction.
+      Now critically reflect on the changes made and output a further enhanced version. Be brutally honest --- if I asked you to add equations but you did not add any, criticize yourself for not following the instruction.
 
-      <scratchpad>
-      <reflection>
-      Find the three weakest changes you made. For each:
-      \begin{enumerate}
-          \item What was the change? Quote the specific before/after text.
-          \item Why is it weak? (Inaccurate, unnecessary, introduces inconsistency, adds fluff, damages flow, etc.)
-          \item How would you fix it?
-      \end{enumerate}
-
-      Then check for these specific failure modes:
+      Check for these failure modes and fix any you find:
       \begin{itemize}
+          \item Find the three weakest changes you made --- what was changed, why it is weak (inaccurate, unnecessary, introduces inconsistency, adds fluff, damages flow), and how to fix.
           \item Are there any mathematical reasonings or equations from the original version that are now missing?
           \item Are there any notations or quantities used before being defined?
           \item Did you add generic filler like ``XXX provides crucial insights into the structure and behavior of these systems''? Every added sentence must say something specific and substantive --- use ``show not tell.''
           \item Did you change anything NOT required by the instruction? If so, revert it.
       \end{itemize}
-      </reflection>
-      <idea>
-      Based on the problems found above, list concrete fixes:
-      \begin{enumerate}
-          \item [Fix or additional improvement 1]
-              \begin{itemize}
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item [Fix or additional improvement 2]
-              \begin{itemize}
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </idea>
-      </scratchpad>
 
-      Then, output a further enhanced version of the \LaTeX document based on the previous version you just revised, incorporating the reflections and additional improvements discussed in the scratchpad. Include all the changes you added in the previous step. Remember to stay laser-focused on the specific instruction provided or the additional plan in the scratchpad. For example, in the instruction, if I ask you to revise section A, you do not need to revise section B, unless changes (such as notations or symbols) in section A directly demands a change in section B. If I did not ask you to add a conclusion section, please refrain from adding one.
+      Output the further enhanced version based on the previous version, incorporating the fixes above. Include all the changes you added in the previous step. Stay laser-focused on the specific instruction --- if asked to revise section A, do not modify section B unless a change in A (such as notation or symbols) directly demands it. If a conclusion section was not requested, do not add one.
+
+      <latex_document>
+      % 2ND_UPDATED_LATEX_DOCUMENT HERE
+      </latex_document>

--- a/resources/agents/polish_multiple.yaml
+++ b/resources/agents/polish_multiple.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: latex_documents
   endTag: </latex_documents>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -18,7 +15,7 @@ prompts:
     {{ LATEX_STYLE_RULES }}
     Additional rules for polishing:
     \begin{itemize}
-        \item When writing formal \LaTeX documents rather than thinking in the scratchpad, never barely list things like 1.\ 2.\ 3.\ \ldots{} as in markdown.
+        \item In the final \LaTeX output, never bare-list things like 1.\ 2.\ 3.\ \ldots{} as in markdown --- use proper \LaTeX environments such as enumerate or itemize.
         \item \textbf{IMPORTANT:} You must give the complete output containing all the sections in the order they are given in each input file.
         \item Ensure that you maintain the structure and formatting of each individual paper while making improvements.
     \end{itemize}
@@ -51,34 +48,7 @@ prompts:
       The output files should be in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}.
       {% endif %}
 
-      In the scratchpad below, brainstorm concrete ways to significantly improve the quality of all papers that are directly relevant to the instruction above. Do not consider any other aspects of the papers. Be as concrete as to change what in which section of which paper in what ways. Use the scratchpad as an opportunity to formulate as detailed as possible action plans so that a graduate student can also perform the revisions. In the scratchpad, list the planned changes, the rationale for each change, and the concrete steps to be taken to implement the changes starting from the beginning of each document.
-
-      <scratchpad>
-      \begin{enumerate}
-          \item [Specific improvement 1 addressing the instruction]
-          \begin{itemize}
-              \item Affected documents: [List of documents]
-              \item Rationale: [explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-          
-          \item [Specific improvement 2 addressing the instruction]
-          \begin{itemize}
-              \item Affected documents: [List of documents]
-              \item Rationale: [explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-          
-          \item [Specific improvement 3 addressing the instruction]
-          \begin{itemize}
-              \item Affected document: [Name of the document]
-              \item Rationale: [explanation]
-              \item Implementation: [Concrete steps]
-          \end{itemize}
-      \end{enumerate}
-      </scratchpad>
-
-      Then, following your plan in the scratchpad, please output updated versions of all \LaTeX documents with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
+      Output updated versions of all \LaTeX documents with targeted corrections and enhancements that laser-focus on addressing the specific instruction provided. Refrain from making any changes that are not directly related to the instruction. Use the following format:
 
       <latex_documents>
       <document name="{OUTPUT_FILES_ORDER[0]}">
@@ -90,40 +60,18 @@ prompts:
       ... (repeat for all output files)
       </latex_documents>
     - |
-      Now it is time to be brutally honest with yourself.
+      Now critically reflect on the changes across all documents and output further enhanced versions. Be brutally honest with yourself.
 
-      <scratchpad>
-      <reflection>
-      Find the three weakest changes you made across all documents. For each:
-      \begin{enumerate}
-          \item What was the change? Quote the specific before/after text and which document.
-          \item Why is it weak? (Inaccurate, unnecessary, introduces inconsistency, adds fluff, damages flow, etc.)
-          \item How would you fix it?
-      \end{enumerate}
-
-      Then check for these specific failure modes:
+      Check for these failure modes and fix any you find:
       \begin{itemize}
+          \item Find the three weakest changes you made across all documents --- what was changed (quote before/after and which document), why it is weak (inaccurate, unnecessary, introduces inconsistency, adds fluff, damages flow), and how to fix.
           \item Are there any mathematical reasonings or equations from the originals that are now missing?
           \item Are there any notations or quantities used before being defined?
           \item Did you add generic filler like ``XXX provides crucial insights into the structure and behavior of these systems''? Every added sentence must say something specific and substantive --- use ``show not tell.''
           \item Did you change anything NOT required by the instruction? If so, revert it.
           \item Did later documents receive less attention than earlier ones? Re-read the last document now.
       \end{itemize}
-      </reflection>
-      <idea>
-      Based on the problems found above, list concrete fixes:
-      \begin{enumerate}
-          \item [Fix or additional improvement 1]
-              \begin{itemize}
-                  \item Affected documents: [List of documents]
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </idea>
-      </scratchpad>
 
-      Then, output further enhanced and complete versions of all \LaTeX documents in the <latex_documents> tag, incorporating the fixes and additional improvements discussed above. Include all the changes you added in the previous step. Remember to stay laser-focused on the specific instruction or the additional plan in the scratchpad. Only modify sections explicitly mentioned in the instruction or the additional plan in the scratchpad, unless changes in one section directly necessitate adjustments in another for consistency.
+      Output further enhanced and complete versions of all \LaTeX documents in the <latex_documents> tag, incorporating the fixes above. Include all the changes you added in the previous step. Only modify sections explicitly mentioned in the instruction, unless changes in one section directly necessitate adjustments in another for consistency.
 
       Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}

--- a/resources/agents/polish_multiple.yaml
+++ b/resources/agents/polish_multiple.yaml
@@ -77,10 +77,10 @@ prompts:
       Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}
 
       <latex_documents>
-      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      <document name="{OUTPUT_FILES_ORDER[0]}">
       % 2ND_UPDATED_LATEX_DOCUMENT_1 HERE
       </document>
-      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      <document name="{OUTPUT_FILES_ORDER[1]}">
       % 2ND_UPDATED_LATEX_DOCUMENT_2 HERE
       </document>
       ... (repeat for all output files)

--- a/resources/agents/polish_multiple.yaml
+++ b/resources/agents/polish_multiple.yaml
@@ -75,3 +75,13 @@ prompts:
       Output further enhanced and complete versions of all \LaTeX documents in the <latex_documents> tag, incorporating the fixes above. Include all the changes you added in the previous step. Only modify sections explicitly mentioned in the instruction, unless changes in one section directly necessitate adjustments in another for consistency.
 
       Ensure that the output documents are in the following order: OUTPUT_FILES_ORDER={{ OUTPUT_FILES_ORDER }}
+
+      <latex_documents>
+      <document name="{{ OUTPUT_FILES_ORDER[0] }}">
+      % 2ND_UPDATED_LATEX_DOCUMENT_1 HERE
+      </document>
+      <document name="{{ OUTPUT_FILES_ORDER[1] }}">
+      % 2ND_UPDATED_LATEX_DOCUMENT_2 HERE
+      </document>
+      ... (repeat for all output files)
+      </latex_documents>

--- a/resources/agents/transcribe_audio.yaml
+++ b/resources/agents/transcribe_audio.yaml
@@ -6,9 +6,6 @@ settings:
   documentTag: audio_transcript
   endTag: </audio_transcript>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
 
 prompts:
   systemPrompt: |
@@ -50,105 +47,25 @@ prompts:
       {{ INSTRUCTION }}
       </instruction>
 
-      Please analyze the attached audio content and any provided context.
-
-      First, perform the initial analysis, planning, and generate a summary in the scratchpad:
-
-      <scratchpad>
-      \begin{enumerate}
-          \item [Audio Content Analysis]
-              \begin{itemize}
-                  \item Estimated number of speakers.
-                  \item Key topics or themes identified.
-                  \item Mention of mathematical equations.
-                  \item Potential challenges (e.g., background noise, accents, overlapping speech).
-              \end{itemize}
-          \item [Speaker Identification Plan]
-              \begin{itemize}
-                  \item Strategy for distinguishing speakers.
-                  \item How speakers will be labeled (Identified names or Speaker A, B, C...). List identified names if any.
-              \end{itemize}
-          \item [Equation Translation Plan]
-               \begin{itemize}
-                   \item Approach for identifying and translating spoken equations to LaTeX.
-               \end{itemize}
-          \item [Sectioning Plan]
-              \begin{itemize}
-                  \item Criteria for dividing the transcript into sections.
-                  \item Potential section titles or themes.
-              \end{itemize}
-          \item [Generated Meeting Summary]
-              \begin{itemize}
-                  \item [Write the concise summary of the main points discussed in the audio here.]
-              \end{itemize}
-      \end{enumerate}
-
-      <summary>
-      % generate a sumnary of the audio content here
-      </summary>
-      </scratchpad>
-
-      Now, generate the initial audio transcript with timestamps, speaker identification, and LaTeX equations in the specified format. Do not use markdown. Use the following format:
+      Analyze the attached audio content and any provided context, then generate the initial audio transcript with timestamps, speaker identification, sectioning, and LaTeX equations. Do not use markdown. Use the following format:
 
       <audio_transcript>
       [HH:MM:SS:MS] SpeakerName: INITIAL_TRANSCRIPT_WITH_SPEAKERS_AND_EQUATIONS
       </audio_transcript>
     - |
-      Let's review the initial transcription, summary, structure, and equation translation. Consider these aspects in the scratchpad:
+      Critically review the initial transcription and produce a final, refined transcript. Check the following aspects and fix any issues found:
+      \begin{itemize}
+          \item Transcription accuracy --- noticeable word errors.
+          \item Speaker identification correct and consistent --- speakers labeled with names or letters as planned.
+          \item Timestamps included for each utterance in [HH:MM:SS] format and accurate.
+          \item Output follows required format: `[HH:MM:SS] SpeakerName: Text`.
+          \item Spoken mathematical equations correctly identified and translated into LaTeX (inline `\(...\)` or display `\[...\]`).
+          \item Transcript well-divided into logical sections with appropriate section breaks.
+          \item Punctuation and formatting clear and readable; no unintended markdown formatting (bold, italics).
+          \item Uncertain or unintelligible parts handled appropriately (e.g., `[unintelligible]`).
+      \end{itemize}
 
-      <scratchpad>
-      <reflection>
-      \begin{enumerate}
-          \item How accurate is the transcription? Are there noticeable word errors?
-          \item Is the speaker identification correct and consistent? Are speakers labeled with names or letters as planned?
-          \item Are timestamps included for each utterance in the correct [HH:MM:SS] format? Are they accurate?
-          \item Does the output follow the required format: `[HH:MM:SS] SpeakerName: Text`?
-          \item Is the generated summary accurate and comprehensive? Does it capture the key points effectively?
-          \item Are spoken mathematical equations correctly identified and translated into appropriate LaTeX format?
-          \item Is the transcript well-divided into logical sections? Are the section breaks appropriate?
-          \item Is the punctuation and formatting clear and readable? Is there any unintended markdown formatting?
-          \item Are uncertain or unintelligible parts handled appropriately?
-      \end{enumerate}
-      </reflection>
-      <improvements>
-      \begin{enumerate}
-          \item [Accuracy Corrections]
-              \begin{itemize}
-                  \item Issue: [Specific transcription error or unintelligible segment]
-                  \item Solution: [Correction or improved handling]
-              \end{itemize}
-          \item [Speaker/Timestamp Format Refinements]
-              \begin{itemize}
-                  \item Issue: [Speaker misattribution, incorrect labeling (name/letter), incorrect timestamp, or wrong format]
-                  \item Solution: [Correction to speaker labels, timestamps, or format]
-              \end{itemize}
-          \item [Equation Translation Corrections]
-               \begin{itemize}
-                   \item Issue: [Incorrect or missing LaTeX translation for a spoken equation]
-                   \item Solution: [Provide the correct LaTeX translation]
-               \end{itemize}
-          \item [Sectioning Adjustments]
-              \begin{itemize}
-                  \item Issue: [Poor section break, missing section, unclear topic flow]
-                  \item Solution: [Adjust section breaks, add titles, improve structure]
-              \end{itemize}
-          \item [Summary Enhancements]
-              \begin{itemize}
-                  \item Issue: [Missing key point, inaccurate summary statement]
-                  \item Solution: [Refine summary content]
-              \end{itemize}
-          \item [Markdown Removal]
-               \begin{itemize}
-                   \item Issue: [Unwanted markdown (bold, italics) found in transcript]
-                   \item Solution: [Remove markdown formatting]
-               \end{itemize}
-      \end{enumerate}
-      </improvements>
-
-      In this scratchpad, you may also go through the timeline of the audio and output one by one what improvements you made to the transcript.
-      </scratchpad>
-
-      Based on this reflection, produce the final, refined audio transcript with improved accuracy, correct speaker identification with timestamps, LaTeX equations, sectioning, and formatting. Ensure no markdown is used. Use the following format:
+      Output the final, refined audio transcript with improved accuracy, correct speaker identification with timestamps, LaTeX equations, sectioning, and formatting. Ensure no markdown is used. Use the following format:
 
       <audio_transcript>
       [HH:MM:SS:MS] SpeakerName: REFINED_TRANSCRIPT_WITH_SECTIONS_SPEAKERS_AND_EQUATIONS

--- a/resources/agents/write/paper2poster.yaml
+++ b/resources/agents/write/paper2poster.yaml
@@ -5,9 +5,6 @@ settings:
   endTag: </beamer_poster>
   outputExt: tex
   isRewrite: False
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
   requiredFilesInternal:
     TEMPLATE_POSTER: template_poster.tex
     TEMPLATE_POSTER_STYLE: beamercolorthemempi.sty
@@ -76,58 +73,29 @@ prompts:
 
   userRequest:
     - |
-      Based on the research paper provided, please create a detailed, mathematically rich LaTeX Beamer poster for a scientific audience in A5 format. In the scratchpad below, outline the key points and structure you plan to include in the poster.
-
-      <scratchpad>
-      \begin{enumerate}
-          \item Title, author information, and abstract
-          \item Introduction and motivation
-          \item Theoretical Framework
-          \item Methods and experimental setup
-          \item Key Results and data analysis
-          \item Discussion of findings
-          \item Conclusions and future work
-          \item References
-      \end{enumerate}
-      </scratchpad>
-
-      Then, please create the LaTeX Beamer poster, incorporating the key points outlined in the scratchpad. The poster should be professional, mathematically detailed, and effectively highlight the main aspects of the research paper. Use the following format:
+      Create a detailed, mathematically rich LaTeX Beamer poster for a scientific audience in A5 format. The poster should be professional, mathematically detailed, and effectively highlight the main aspects of the research paper. Use the following format:
 
       <beamer_poster>
       {{ TEMPLATE_POSTER_CONTENT }}
       </beamer_poster>
     - |
-      Please review your draft LaTeX Beamer poster critically, focusing on the following points:
-      <scratchpad>
-      <reflection>
-      1. Mathematical Depth: Have you included sufficient mathematical detail, including key equations, derivations, and explanations?
-      2. Content Coverage: Have you effectively summarized the key points of the research paper, including theoretical framework and methodology?
-      3. Structure and Layout: Is the poster well-structured with clear sections? Ensure there's a logical flow between sections and that the layout is visually appealing for A5 format.
-      4. Visual Representations: Have you included appropriate figures, tables, or diagrams to illustrate key concepts and results?
-      5. Balance: Is there a good balance between textual explanations, mathematical content, and visual elements?
-      6. Conciseness vs Detail: Despite the increased detail, is the content presented concisely and effectively for a poster format?
-      7. Physics Terminology: Is the use of notation and terminology consistent and appropriate for the target audience?
-      8. Mathematical Rigor: Are equations and mathematical concepts presented clearly and accurately? Ensure they are properly formatted using LaTeX commands.
-      9. Readability: Despite the increased content, is the text size appropriate for A5 format? Ensure all content is easily readable.
-      10. Color Usage: Have you effectively used the provided color scheme to enhance readability and visual appeal, especially for mathematical content?
-      11. References: Have you included necessary citations in a compact format using biblatex?
-      </reflection>
+      Critically review your draft and output a revised version. Check these aspects and fix any issues found:
+      \begin{enumerate}
+          \item Mathematical Depth: sufficient mathematical detail, key equations, derivations, and explanations.
+          \item Content Coverage: effectively summarizes key points including theoretical framework and methodology.
+          \item Structure and Layout: clear sections, logical flow, visually appealing for A5 format.
+          \item Visual Representations: appropriate figures, tables, or diagrams illustrating key concepts and results.
+          \item Balance: good balance between textual explanations, mathematical content, and visual elements.
+          \item Conciseness vs Detail: content presented concisely and effectively for a poster format.
+          \item Physics Terminology: notation and terminology consistent and appropriate for the target audience.
+          \item Mathematical Rigor: equations and mathematical concepts presented clearly and accurately, properly formatted using LaTeX commands.
+          \item Readability: text size appropriate for A5 format; all content easily readable.
+          \item Color Usage: effective use of the provided color scheme to enhance readability and visual appeal, especially for mathematical content.
+          \item References: necessary citations in a compact format using biblatex.
+      \end{enumerate}
 
-      <improvements>
+      Output the revised poster based on the previous version, balancing detailed mathematical content with visual appeal:
 
-      1. [Specific Improvement 1]
-          - Rationale: [Brief explanation]
-          - Implementation: [Concrete steps]
-      2. [Specific Improvement 2]
-          - Rationale: [Brief explanation]
-          - Implementation: [Concrete steps]
-      3. [Specific Improvement 3]
-          - Rationale: [Brief explanation]
-          - Implementation: [Concrete steps]
-
-      </improvements>
-      </scratchpad>
-
-      Based on this reflection, please revise the LaTeX Beamer poster to enhance its mathematical content, overall structure, and visual quality. Ensure that the poster effectively communicates the key aspects of the research paper to a scientific audience in an A5 format, balancing detailed mathematical content with visual appeal. Output the new version based on the previous version you just wrote.
-
-      Output your revised poster within the <beamer_poster> tags. Include
+      <beamer_poster>
+      % Complete revised LaTeX Beamer poster here
+      </beamer_poster>

--- a/resources/agents/write/paper2slide.yaml
+++ b/resources/agents/write/paper2slide.yaml
@@ -4,9 +4,6 @@ settings:
   documentTag: beamer_presentation
   endTag: </beamer_presentation>
   outputExt: tex
-  prefills:
-    - <scratchpad>
-    - <scratchpad>
   requiredFilesInternal:
     TEMPLATE_SLIDE: template_slide.tex
 
@@ -66,23 +63,7 @@ prompts:
       </instruction>
       {% endif %}
 
-      Based on the research paper provided, please create a professional LaTeX Beamer presentation for a scientific audience. The presentation should consist of 10-15 slides that effectively communicate the paper's key findings. In the scratchpad below, outline the structure and key points you plan to include in each section of the presentation.
-
-      <scratchpad>
-
-      1. [Title slide content]
-      2. [Introduction/Motivation]
-      3. [Key point 1]
-      4. [Key point 2]
-      5. [Key point 3]
-      6. [Methodology]
-      7. [Results]
-      8. [Conclusions]
-      9. [Future work]
-
-      </scratchpad>
-
-      Then, please create a complete, self-contained LaTeX Beamer presentation, incorporating the key points outlined in the scratchpad. The presentation should be professional, condensed, and effectively highlight the main aspects of the research paper. Use the following format:
+      Create a complete, self-contained LaTeX Beamer presentation that effectively communicates the paper's key findings in 10-15 slides. The presentation should be professional, condensed, and highlight the main aspects of the research paper. Use the following format:
 
       <beamer_presentation>
       \documentclass{beamer}
@@ -125,10 +106,7 @@ prompts:
       \end{document}
       </beamer_presentation>
     - |
-      Please review your draft LaTeX Beamer presentation critically, focusing on the following points:
-
-      <scratchpad>
-      <reflection>
+      Critically review your draft and output a revised version. Check these aspects and fix any issues found:
       \begin{enumerate}
           \item Does the presentation effectively communicate the key findings and methodology?
           \item Are the slides well-organized and logically structured?
@@ -139,31 +117,8 @@ prompts:
           \item Are transitions between slides smooth and logical?
           \item Is the overall presentation visually appealing and professional?
       \end{enumerate}
-      </reflection>
 
-      <improvements>
-      \begin{enumerate}
-          \item [Potential improvement 1]
-              \begin{itemize}
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item [Potential improvement 2]
-              \begin{itemize}
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item [Potential improvement 3]
-              \begin{itemize}
-                  \item Rationale: [Brief explanation]
-                  \item Implementation: [Concrete steps]
-              \end{itemize}
-          \item[\ldots]
-      \end{enumerate}
-      </improvements>
-      </scratchpad>
-
-      Based on this reflection, please revise your presentation to address any identified issues while maintaining its professional quality and technical accuracy. Output the complete, self-contained revised version based on the previous version you just wrote. Use the following format:
+      Output the complete, self-contained revised version based on the previous version, maintaining its professional quality and technical accuracy. Use the following format:
 
       <beamer_presentation>
       % Complete revised LaTeX Beamer presentation here

--- a/resources/templates/agentCreatorWorkflow.yaml
+++ b/resources/templates/agentCreatorWorkflow.yaml
@@ -14,8 +14,8 @@ prompts:
     You are an expert on the TeXRA codebase, a VS Code extension that runs YAML-defined AI agents.
     When generating workflow agent YAML definitions, follow the schema below exactly.
     Workflow agents process LaTeX documents in fixed rounds (default 2), producing output
-    wrapped in a documentTag. They use a chain-of-thought workflow with <scratchpad>
-    planning before the final output, and support single or multiple output files.
+    wrapped in a documentTag. Modern thinking-capable models reason natively before
+    producing the final output --- do not add scratchpad scaffolding by default.
 
     CRITICAL RULES:
     - agentCategory MUST be "workflow" (not "toolUse"). Workflow agents do NOT call tools.
@@ -26,10 +26,10 @@ prompts:
       - isRewrite: true when the agent edits/revises/corrects existing documents, false when it creates new content.
       - temperature: low (0.1) for editing/correction tasks, higher (0.5-0.8) for creative/generation tasks.
       - rounds: 1 for simple single-pass tasks, 2 for tasks that benefit from reflection.
-    - The number of prefills entries, userRequest entries, and rounds MUST all match:
-      - For rounds: 1 → exactly 1 prefill entry and 1 userRequest entry.
-      - For rounds: 2 → exactly 2 prefill entries and 2 userRequest entries.
-      If rounds is omitted (default 2), provide 2 entries for both.
+    - userRequest is an array with exactly as many entries as rounds (1 or 2).
+    - prefills is OPTIONAL. Omit it unless the agent should skip preamble and force
+      the response to start with a specific token (e.g., - "<latex_document>").
+      If you do include prefills, the array length MUST equal the number of rounds.
     - All fields with defaults can be omitted if the default value is acceptable,
       BUT outputExt defaults to "txt" so it must always be set explicitly to "tex".
     Respond only with the YAML wrapped in <yaml> tags.
@@ -65,9 +65,6 @@ prompts:
       outputExt: tex
       isRewrite: <true if editing existing docs, false if creating new>
       temperature: <0.1 for precise editing, 0.5-0.8 for creative>
-      prefills:
-        - "<scratchpad>"          # one entry per round
-        # - "<scratchpad>"        # add second entry only if rounds: 2
     prompts:
       systemPrompt: |
         <Role and task description. Written in LaTeX style using \begin{itemize} for lists.
@@ -80,10 +77,11 @@ prompts:
          Should include an <instruction>{{ INSTRUCTION }}</instruction> block.>
       userRequest:
         - |
-          <Round 1: Ask for brainstorming in <scratchpad>, then output in <latex_document> tags.>
+          <Round 1: Direct instruction to produce the output wrapped in <latex_document> tags.>
         # For 2-round agents, add a second entry:
         # - |
-        #   <Round 2: Ask for reflection and refinement in <scratchpad>, then updated <latex_document>.>
+        #   <Round 2: Reflection and refinement instruction with bullet-form failure-mode probes,
+        #    then output the updated <latex_document>.>
 
     Here is a complete real-world example for reference (the "polish" agent):
 
@@ -94,9 +92,6 @@ prompts:
       documentTag: latex_document
       endTag: </latex_document>
       outputExt: tex
-      prefills:
-        - <scratchpad>
-        - <scratchpad>
     prompts:
       systemPrompt: |
         You are a professional scientist. Your task is to improve a LaTeX research paper
@@ -121,15 +116,24 @@ prompts:
         <instruction>{{ INSTRUCTION }}</instruction>
       userRequest:
         - |
-          Brainstorm in <scratchpad>, then output revised \LaTeX in <latex_document> tags.
+          Output the revised \LaTeX wrapped in <latex_document> tags, focusing solely on the instruction.
         - |
-          Reflect on changes in <scratchpad>, then output improved <latex_document>.
+          Critically reflect on the changes and output a further enhanced version. Check for these
+          failure modes and fix any you find:
+          \begin{itemize}
+              \item Find the three weakest changes you made and how to fix them.
+              \item Are any equations or notations from the original now missing or used before defined?
+              \item Did you add generic filler sentences? Use ``show not tell.''
+              \item Did you change anything NOT required by the instruction? If so, revert it.
+          \end{itemize}
+          Output the further enhanced <latex_document>.
 
     IMPORTANT REMINDERS:
     - outputExt MUST be "tex", never "md" or "txt".
     - The documentTag in prompts must match the settings.documentTag.
     - userRequest must be an array with exactly as many entries as rounds (1 or 2).
-    - prefills must have the same number of entries as userRequest.
+    - Omit prefills by default; only add it (with one entry per round) when the agent should
+      skip preamble and force the response to start with a specific token like "<latex_document>".
     - Include {{ INSTRUCTION }} somewhere in the prompts so the user's instructions are passed through.
     - Write prompt text in LaTeX style (\begin{itemize}, \textbf{}, etc.), not markdown.
 

--- a/resources/templates/agentTemplate-workflowMultiple.yaml
+++ b/resources/templates/agentTemplate-workflowMultiple.yaml
@@ -14,9 +14,10 @@ settings:
   defaultOutputFiles:
     {{ OUTPUT_FILES }}
   outputExt: tex
-  prefills:
-    - "<scratchpad>"
-    - "<scratchpad>"
+  # Optional: `prefills` can force the assistant turn to start with a specific
+  # token (e.g., - "<latex_documents>") for agents that should skip preamble
+  # and jump straight to output. Most workflow agents do not need this --- modern
+  # thinking-capable models reason natively before producing the final output.
 
 # --- Agent Prompts ---
 prompts:
@@ -26,8 +27,9 @@ prompts:
     You are operating inside **TeXRA**, a VS Code extension that orchestrates
     AI agents defined in YAML. TeXRA loads selected files and exposes them as
     variables, allowing prompts to reference {{ INPUT_CONTENT }},
-    {{ ALL_INPUTS }}, or {{ OUTPUT_FILES_ORDER }}. Agents think in
-    <scratchpad> before writing the final output inside the documentTag.
+    {{ ALL_INPUTS }}, or {{ OUTPUT_FILES_ORDER }}. Each agent runs one or
+    more rounds and produces its final output wrapped in the configured
+    documentTag.
 
     Variable Retrieval (VR) exposes runtime data as variables in these prompts:
       - {{ INPUT_FILE }} / {{ INPUT_CONTENT }}: main file path and text
@@ -68,8 +70,8 @@ prompts:
 
   userRequest:
     - |
-        Brainstorm your plan in <scratchpad> with bullet points.
-        Then wrap each output in <latex_documents> with <document name="..."> blocks
+        Wrap each output in <latex_documents> with <document name="..."> blocks
         following the order in OUTPUT_FILES_ORDER.
     - |
-        Review the draft outputs and note targeted refinements for each document in <scratchpad>. Apply the improvements and emit the updated <latex_documents> content in the same order.
+        Review the draft outputs, apply targeted refinements for each document,
+        and emit the updated <latex_documents> content in the same order.

--- a/resources/templates/agentTemplate-workflowSingle.yaml
+++ b/resources/templates/agentTemplate-workflowSingle.yaml
@@ -11,9 +11,10 @@ settings:
   documentTag: latex_document
   endTag: </latex_document>
   outputExt: tex
-  prefills:
-    - '<scratchpad>'
-    - '<scratchpad>'
+  # Optional: `prefills` can force the assistant turn to start with a specific
+  # token (e.g., - "<latex_document>") for agents that should skip preamble
+  # and jump straight to output. Most workflow agents do not need this --- modern
+  # thinking-capable models reason natively before producing the final output.
 
 # --- Agent Prompts ---
 prompts:
@@ -23,8 +24,8 @@ prompts:
     You are operating inside **TeXRA**, a VS Code extension that orchestrates
     AI agents using YAML files. TeXRA loads selected documents and exposes them
     as variables, so prompts can reference data like {{ INPUT_CONTENT }} or
-    {{ ALL_INPUTS }}. Agents follow a chain-of-thought workflow with
-    <scratchpad> planning and a final output wrapped in the documentTag.
+    {{ ALL_INPUTS }}. Each agent runs one or more rounds and produces its
+    final output wrapped in the configured documentTag.
 
     Variable Retrieval (VR) exposes runtime data as variables in these prompts:
       - {{ INPUT_FILE }} / {{ INPUT_CONTENT }}: main file path and text
@@ -63,7 +64,7 @@ prompts:
 
   userRequest:
     - |
-      Brainstorm your plan in <scratchpad> with bullet points.
-      Then output the revised \LaTeX wrapped in <latex_document> tags.
+      Output the revised \LaTeX wrapped in <latex_document> tags.
     - |
-      Reflect on your previous revision and describe the most impactful follow-up edits in <scratchpad> before producing the updated <latex_document> output.
+      Critically reflect on your previous revision, identify the most impactful
+      follow-up edits, and output the updated <latex_document>.

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1634,6 +1634,13 @@ export class ModelHandlerAnthropic extends ModelHandler<
   ): Promise<[boolean, MessageParam[]]> {
     if (!(await flexibleFS.existsAndNonTrivial(outputLocation))) {
       if (this.capabilities.supportsAssistantPrefill) {
+        if (prefill.length === 0) {
+          // Anthropic rejects assistant messages with empty text content blocks.
+          // When an agent declares no prefill, skip pushing the assistant turn
+          // entirely so the model produces its response from a clean slate.
+          this.logger.debug('No prefill provided; skipping assistant prefill message');
+          return [false, messages];
+        }
         this.logger.debug(`Adding prefill message:\n${prefill}`);
         workspaceState.assembly.accumulatedOutput = `${prefill}\n`;
         await AbsoluteFS.ensureDir(dirname(outputLocation.absolutePath));

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -1653,19 +1653,27 @@ export class ModelHandlerAnthropic extends ModelHandler<
           content: [{ type: 'text', text: prefill }],
         });
       } else {
-        // For thinking-enabled models that don't support assistant prefill,
-        // add prefill as part of the user message like OpenAI handler
-        const pseudoPrefillText = `Start your response with:\n${prefill}`;
-        const lastMsg = messages.at(-1);
-        if (lastMsg && Array.isArray(lastMsg.content)) {
-          lastMsg.content.push({
-            type: 'text',
-            text: pseudoPrefillText,
-          } as ContentBlockParam);
+        if (prefill.length === 0) {
+          // No prefill declared --- skip the pseudo-prefill instruction so the
+          // model isn't told `Start your response with:\n` (an empty directive).
+          this.logger.debug(
+            'No prefill provided; skipping pseudo-prefill instruction',
+          );
+        } else {
+          // For thinking-enabled models that don't support assistant prefill,
+          // add prefill as part of the user message like OpenAI handler
+          const pseudoPrefillText = `Start your response with:\n${prefill}`;
+          const lastMsg = messages.at(-1);
+          if (lastMsg && Array.isArray(lastMsg.content)) {
+            lastMsg.content.push({
+              type: 'text',
+              text: pseudoPrefillText,
+            } as ContentBlockParam);
+          }
+          this.logger.debug(
+            `Added pseudo prefill message to messages:\n${pseudoPrefillText}`,
+          );
         }
-        this.logger.debug(
-          `Added pseudo prefill message to messages:\n${pseudoPrefillText}`,
-        );
       }
       return [false, messages];
     }
@@ -1864,6 +1872,19 @@ export class ModelHandlerAnthropic extends ModelHandler<
           } as ContentBlockParam,
         ];
       }
+    } else if (lastMessage?.role === 'user') {
+      // No prefill was pushed (agent declared empty prefill). Add the model's
+      // response as a new assistant message so multi-round conversation history
+      // is preserved.
+      messages.push({
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: bestConnector + newResponse,
+          } as ContentBlockParam,
+        ],
+      });
     }
   }
 

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1356,6 +1356,51 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('skips assistant prefill message when prefill is empty', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'anthropic-prefill-empty-'),
+    );
+    const outputPath = path.join(tempDir, 'r0', 'output.xml');
+
+    try {
+      const handler = createAnthropicHandler({
+        supportsAssistantPrefill: true,
+      });
+      stubHandlerForTest(handler);
+
+      const agentSetting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'latex_document',
+        endTag: '</latex_document>',
+        outputExt: 'tex',
+      });
+      const userMessage: MessageParam = {
+        role: 'user',
+        content: [{ type: 'text', text: 'revise the document' }],
+      };
+      const messages: MessageParam[] = [userMessage];
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [isComplete, updatedMessages] =
+        await handler.initializeOutputAndPrefill(
+          {} as AgentConfig,
+          agentSetting,
+          messages,
+          workspaceState,
+          pathToLocation(outputPath),
+          '',
+        );
+
+      assert.equal(isComplete, false);
+      assert.equal(fs.existsSync(outputPath), false);
+      assert.equal(workspaceState.assembly.accumulatedOutput, '');
+      assert.equal(updatedMessages.length, 1);
+      assert.equal(updatedMessages.at(-1)?.role, 'user');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('ModelHandlerAnthropic pre-message_start error handling', () => {

--- a/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerAnthropic.test.ts
@@ -1401,6 +1401,102 @@ describe('ModelHandlerAnthropic output prefill initialization', () => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('skips pseudo-prefill instruction when prefill is empty (thinking-only models)', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'anthropic-pseudo-empty-'),
+    );
+    const outputPath = path.join(tempDir, 'r0', 'output.xml');
+
+    try {
+      const handler = createAnthropicHandler({
+        supportsAssistantPrefill: false,
+      });
+      stubHandlerForTest(handler);
+
+      const agentSetting = AgentSettingSchema.parse({
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'latex_document',
+        endTag: '</latex_document>',
+        outputExt: 'tex',
+      });
+      const userText = 'revise the document';
+      const messages: MessageParam[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: userText }],
+        },
+      ];
+      const workspaceState = AgentWorkspaceState.create();
+
+      const [, updatedMessages] = await handler.initializeOutputAndPrefill(
+        {} as AgentConfig,
+        agentSetting,
+        messages,
+        workspaceState,
+        pathToLocation(outputPath),
+        '',
+      );
+
+      assert.equal(updatedMessages.length, 1);
+      const last = updatedMessages.at(-1);
+      assert.equal(last?.role, 'user');
+      assert.deepEqual(last?.content, [{ type: 'text', text: userText }]);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ModelHandlerAnthropic updateMessageContentWithPrefill', () => {
+  it('creates a new assistant message when no prefill assistant turn exists', () => {
+    const handler = createAnthropicHandler({ supportsAssistantPrefill: true });
+    stubHandlerForTest(handler);
+
+    const messages: MessageParam[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'revise the document' }],
+      },
+    ];
+    const workspaceState = AgentWorkspaceState.create();
+
+    handler.updateMessageContentWithPrefill(
+      messages,
+      '',
+      '<latex_document>...</latex_document>',
+      workspaceState,
+    );
+
+    assert.equal(messages.length, 2);
+    assert.equal(messages.at(-1)?.role, 'assistant');
+    assert.deepEqual(messages.at(-1)?.content, [
+      { type: 'text', text: '<latex_document>...</latex_document>' },
+    ]);
+  });
+
+  it('appends to existing assistant prefill message', () => {
+    const handler = createAnthropicHandler({ supportsAssistantPrefill: true });
+    stubHandlerForTest(handler);
+
+    const messages: MessageParam[] = [
+      { role: 'user', content: [{ type: 'text', text: 'revise' }] },
+      { role: 'assistant', content: [{ type: 'text', text: '<latex_document>' }] },
+    ];
+    const workspaceState = AgentWorkspaceState.create();
+
+    handler.updateMessageContentWithPrefill(
+      messages,
+      '',
+      'body</latex_document>',
+      workspaceState,
+    );
+
+    assert.equal(messages.length, 2);
+    const assistantContent = messages.at(-1)?.content;
+    assert.equal(Array.isArray(assistantContent), true);
+    assert.equal((assistantContent as MessageParam['content'])!.length, 2);
+  });
 });
 
 describe('ModelHandlerAnthropic pre-message_start error handling', () => {


### PR DESCRIPTION
Modern thinking-capable models reason natively in their own thinking blocks,
which already render as a distinct UI banner (lightbulb icon) separate from
scratchpad banners (pencil icon). The scratchpad templates in these three
agents were pure CoT scaffolding — empty enumerate/itemize placeholders like
"Improvement 1/2/3 → Rationale/Implementation" — without domain rubrics worth
preserving.

- generic, generic_multiple: drop both rounds of scratchpad and prefills.
- polish, polish_multiple: drop round-1 scaffolding; convert round-2 reflection
  failure-mode probes (weakest-changes, show-not-tell, filler check, instruction
  scope) from scratchpad shell to plain bullet instructions.
- apply, apply_multiple: drop round-1 scaffolding; keep the Document Maturity
  Levels (1-5) rubric in round 2 as instruction text instead of a scratchpad
  with empty placeholders.

Code paths are already null-safe: extractScratchpad() returns null when tag is
absent, and both call sites (ResponseCycleFlow, fileContentUtils) guard with
if (scratchpad) before logging. Empty/missing prefills array is handled
gracefully by PromptBuilder. No code changes needed.

https://claude.ai/code/session_01GpuqLrWsg9p5uEd3kSPbsw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly prompt/template refactors, but it also changes Anthropic model-handler behavior around prefills and message history, which could affect multi-round agent execution if incorrect.
> 
> **Overview**
> Removes redundant `<scratchpad>` planning/placeholder scaffolding from several workflow agents (`generic`, `polish`, `apply`, plus multi-document variants) and updates prompts to give direct instructions plus explicit verification/failure-mode checklists.
> 
> Standardizes multi-document prompt examples to use `{OUTPUT_FILES_ORDER[i]}` placeholders and updates workflow agent templates/agent-creator guidance to make `prefills` optional by default.
> 
> Fixes `ModelHandlerAnthropic` to *skip* creating assistant/pseudo-prefill messages when `prefill` is empty (avoiding Anthropic API rejection and empty directives), and ensures multi-round history is preserved by pushing a new assistant message when no prefill turn exists; adds unit tests covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49b9e4013a8d572f159447242a3bb29631dec6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->