### PR TITLE
feat(settings): add API config hint banner to Models tab

### DIFF
--- a/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -9,7 +9,7 @@ import { LitElement, html, nothing, css, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { commonViewStyles, designTokens } from '@shared/styles';
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
 
 // Local imports - shared schemas
 import type {
@@ -27,12 +27,82 @@ export class ModelsTab extends LitElement {
   static override styles = [
     designTokens,
     commonViewStyles,
+    codiconStyles,
     css`
       :host {
         display: block;
       }
 
       /* max-width and centering provided by .tab-content-container */
+
+      .models-tab-hint {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--spacing-medium);
+        padding: var(--spacing-medium);
+        margin-bottom: var(--spacing-large);
+        border: var(--border-thin) solid
+          var(--vscode-editorInfo-foreground, #3794ff);
+        border-radius: var(--border-radius);
+        background: var(--vscode-editor-background);
+      }
+
+      .models-tab-hint .codicon-info {
+        flex-shrink: 0;
+        font-size: var(--font-size-lg);
+        color: var(--vscode-editorInfo-foreground, #3794ff);
+        margin-top: 2px;
+      }
+
+      .models-tab-hint-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-small);
+      }
+
+      .models-tab-hint-title {
+        font-weight: var(--font-weight-medium);
+        color: var(--vscode-foreground);
+      }
+
+      .models-tab-hint-description {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        line-height: var(--line-height-normal);
+      }
+
+      .models-tab-hint-actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--spacing-small);
+      }
+
+      .models-tab-hint-link {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-tiny);
+        padding: var(--spacing-tiny) var(--spacing-small);
+        background: none;
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius-small);
+        color: var(--vscode-textLink-foreground);
+        font: inherit;
+        font-size: var(--font-size-sm);
+        cursor: pointer;
+      }
+
+      .models-tab-hint-link:hover {
+        background: var(--vscode-list-hoverBackground);
+        border-color: var(--vscode-focusBorder);
+      }
+
+      .models-tab-hint-link:focus-visible {
+        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline-offset: 1px;
+      }
     `,
   ];
 
@@ -47,6 +117,55 @@ export class ModelsTab extends LitElement {
   @property({ attribute: false }) helperModel = '';
   @property({ type: Boolean }) preferShortModelNames = false;
 
+  private scrollToSection(tagName: string): void {
+    const el = this.shadowRoot?.querySelector(tagName);
+    if (el instanceof HTMLElement) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  private renderTabHint(): TemplateResult | typeof nothing {
+    if (this.providerKeyStatuses.length === 0) {
+      return nothing;
+    }
+
+    const description =
+      this.apiAccessMode === 'included'
+        ? 'Personal provider API keys are optional overrides—configure them in the API Configuration section below.'
+        : 'To use your own keys for OpenAI, Anthropic, Google, and other providers, scroll to the API Configuration section below.';
+
+    const accessJump = this.authenticated
+      ? html`<button
+          class="models-tab-hint-link"
+          @click=${() => this.scrollToSection('api-access-section')}
+        >
+          Model Access
+        </button>`
+      : nothing;
+
+    return html`
+      <div class="models-tab-hint" role="note">
+        <span class="codicon codicon-info"></span>
+        <div class="models-tab-hint-body">
+          <div class="models-tab-hint-title">
+            Looking for API key settings?
+          </div>
+          <div class="models-tab-hint-description">${description}</div>
+          <div class="models-tab-hint-actions">
+            ${accessJump}
+            <button
+              class="models-tab-hint-link"
+              @click=${() => this.scrollToSection('provider-key-list')}
+            >
+              <span class="codicon codicon-key"></span>
+              Jump to API Configuration
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
   override render(): TemplateResult {
     const apiAccessSection = this.authenticated
       ? html`<api-access-section
@@ -56,7 +175,7 @@ export class ModelsTab extends LitElement {
 
     return html`
       <div class="models-container tab-content-container">
-        ${apiAccessSection}
+        ${this.renderTabHint()} ${apiAccessSection}
         <model-selection-list
           .models=${this.modelSelectionItems}
           .helperModel=${this.helperModel}

--- a/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -36,9 +36,10 @@ export class ModelsTab extends LitElement {
       /* max-width and centering provided by .tab-content-container */
 
       .models-tab-hint {
-        display: flex;
-        align-items: flex-start;
-        gap: var(--spacing-medium);
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: var(--spacing-medium);
+        row-gap: var(--spacing-small);
         padding: var(--spacing-medium);
         margin-bottom: var(--spacing-large);
         border: var(--border-thin) solid
@@ -48,18 +49,10 @@ export class ModelsTab extends LitElement {
       }
 
       .models-tab-hint .codicon-info {
-        flex-shrink: 0;
+        grid-row: 1 / span 3;
         font-size: var(--font-size-lg);
         color: var(--vscode-editorInfo-foreground, #3794ff);
         margin-top: 2px;
-      }
-
-      .models-tab-hint-body {
-        flex: 1;
-        min-width: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--spacing-small);
       }
 
       .models-tab-hint-title {
@@ -79,30 +72,6 @@ export class ModelsTab extends LitElement {
         align-items: center;
         gap: var(--spacing-small);
       }
-
-      .models-tab-hint-link {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-tiny);
-        padding: var(--spacing-tiny) var(--spacing-small);
-        background: none;
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius-small);
-        color: var(--vscode-textLink-foreground);
-        font: inherit;
-        font-size: var(--font-size-sm);
-        cursor: pointer;
-      }
-
-      .models-tab-hint-link:hover {
-        background: var(--vscode-list-hoverBackground);
-        border-color: var(--vscode-focusBorder);
-      }
-
-      .models-tab-hint-link:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
-        outline-offset: 1px;
-      }
     `,
   ];
 
@@ -117,12 +86,20 @@ export class ModelsTab extends LitElement {
   @property({ attribute: false }) helperModel = '';
   @property({ type: Boolean }) preferShortModelNames = false;
 
-  private scrollToSection(tagName: string): void {
+  private scrollToSection(
+    tagName: 'api-access-section' | 'provider-key-list',
+  ): void {
     const el = this.shadowRoot?.querySelector(tagName);
     if (el instanceof HTMLElement) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   }
+
+  private readonly handleScrollToApiAccess = (): void =>
+    this.scrollToSection('api-access-section');
+
+  private readonly handleScrollToApiConfig = (): void =>
+    this.scrollToSection('provider-key-list');
 
   private renderTabHint(): TemplateResult | typeof nothing {
     if (this.providerKeyStatuses.length === 0) {
@@ -136,31 +113,27 @@ export class ModelsTab extends LitElement {
 
     const accessJump = this.authenticated
       ? html`<button
-          class="models-tab-hint-link"
-          @click=${() => this.scrollToSection('api-access-section')}
+          class="tab-action-btn"
+          @click=${this.handleScrollToApiAccess}
         >
           Model Access
         </button>`
       : nothing;
 
     return html`
-      <div class="models-tab-hint" role="note">
+      <div class="models-tab-hint">
         <span class="codicon codicon-info"></span>
-        <div class="models-tab-hint-body">
-          <div class="models-tab-hint-title">
-            Looking for API key settings?
-          </div>
-          <div class="models-tab-hint-description">${description}</div>
-          <div class="models-tab-hint-actions">
-            ${accessJump}
-            <button
-              class="models-tab-hint-link"
-              @click=${() => this.scrollToSection('provider-key-list')}
-            >
-              <span class="codicon codicon-key"></span>
-              Jump to API Configuration
-            </button>
-          </div>
+        <div class="models-tab-hint-title">Looking for API key settings?</div>
+        <div class="models-tab-hint-description">${description}</div>
+        <div class="models-tab-hint-actions">
+          ${accessJump}
+          <button
+            class="tab-action-btn"
+            @click=${this.handleScrollToApiConfig}
+          >
+            <span class="codicon codicon-key"></span>
+            Jump to API Configuration
+          </button>
         </div>
       </div>
     `;


### PR DESCRIPTION
The Models tab opens with the model selection list visible, leaving the
API Configuration section below the fold. New users could miss where to
set provider API keys. Add an info-level hint banner at the top with
quick-jump buttons to the API Configuration section (and Model Access
when authenticated) so the entry point for key setup is obvious without
disrupting the existing layout.

https://claude.ai/code/session_012g5Y4E1DhihhDx2ndiTAuk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a conditional banner and scroll-to-section buttons; main risk is minor layout/scroll behavior regressions in the settings webview.
> 
> **Overview**
> Adds an info hint banner at the top of the Models tab that points users to API key configuration, with quick-jump buttons that smoothly scroll to `provider-key-list` (and `api-access-section` when authenticated).
> 
> The banner is only shown when `providerKeyStatuses` is non-empty, and it includes new Codicon-based styling via `codiconStyles` plus the new banner CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a06ba0065f6a3c1bdcee27bb39e3f154514b442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->