### PR TITLE
ci: allow bot-opened PRs in issue tracker workflow

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
           claude_args: |
             --model claude-opus-4-7
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: '*'
+          allowed_bots: 'dependabot[bot],github-actions[bot],Copilot,chatgpt-codex-connector,claude[bot]'
           claude_args: |
             --model claude-opus-4-7
             --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"


### PR DESCRIPTION
The issue tracker's playbooks already handle bot-authored PRs (dependabot,
renovate, copilot, codex, etc.), but claude-code-action@v1 blocks bot
actors by default. Set allowed_bots: '*' so the tracker runs on PRs
opened by any bot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only expands `claude-code-action` execution to a defined list of bot accounts; main risk is unintended automation running on more PRs/events.
> 
> **Overview**
> Updates the `Issue Tracker` GitHub Actions workflow to allow `anthropics/claude-code-action@v1` to run when triggered by specific bot accounts by adding an `allowed_bots` allowlist (e.g. Dependabot/GitHub Actions/Copilot/Codex/Claude).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a49712ff30705ca9341a26ca08840f2b3cb3bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->