### PR TITLE
[codex] fix stale subagent stream tabs

### DIFF
--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -62,6 +62,13 @@ export const StreamStatusService = {
     this.set(stream, STREAM_STATUS.READY);
   },
 
+  /** Reset every stream to READY. Used by ProgressViewState.clearAll(). */
+  clearAll(): void {
+    for (const stream of [...statusMemory.keys()]) {
+      this.clear(stream);
+    }
+  },
+
   entries(): IterableIterator<[StreamTabId, StreamStatus]> {
     return statusMemory.entries();
   },

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -145,6 +145,8 @@ interface ResolveAgentOptions {
   streamTabIdOverride?: StreamTabId;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
+  /** Fires after setActiveStream is emitted. */
+  onAfterActivation?: (streamId: StreamTabId) => void;
   /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
   enforceCategory?: boolean;
 }
@@ -224,6 +226,7 @@ async function resolveAgentBase(
     isRemote: isRemoteAgent(fullConfig.agent),
     hasMultipleOutputs: useMultipleOutputs,
   });
+  options?.onAfterActivation?.(streamId);
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
@@ -483,6 +486,18 @@ function buildFallbackNotification(config: AgentConfig) {
 // Shared Orchestration
 // ============================================================================
 
+function markActivatedStreamLaunchFailed(
+  streamId: StreamTabId,
+  configPayload: AgentConfigPayload,
+  err: unknown,
+): void {
+  const errorMsg = `Failed to start agent ${configPayload.agent}: ${getSdkErrorMessage(err)}`;
+  new AgentLogger(streamId, true).logError(errorMsg, err, {
+    operation: `start ${configPayload.agent}`,
+  });
+  StreamStatusService.set(streamId, STREAM_STATUS.ERROR);
+}
+
 /**
  * Resolves agent context and acquires stream lock, handling the preliminary→final
  * stream ID correction that occurs when useMultipleOutputs changes during resolution.
@@ -497,15 +512,30 @@ async function resolveAndAcquireStream(
     taskType?: string;
     onBeforeActivation?: (streamId: StreamTabId) => void;
     enforceCategory?: boolean;
+    suppressErrorNotification?: boolean;
   },
 ): Promise<ResolvedAgentBase> {
   if (options?.streamTabIdOverride) {
     // Direct resolution with known stream ID (e.g., resume from snapshot)
-    return resolveAgentBase(configPayload, executionId, {
-      streamTabIdOverride: options.streamTabIdOverride,
-      onBeforeActivation: options.onBeforeActivation,
-      enforceCategory: options.enforceCategory,
-    });
+    let activatedStreamId: StreamTabId | undefined;
+    try {
+      return await resolveAgentBase(configPayload, executionId, {
+        streamTabIdOverride: options.streamTabIdOverride,
+        onBeforeActivation: options.onBeforeActivation,
+        onAfterActivation: (streamId) => {
+          activatedStreamId = streamId;
+        },
+        enforceCategory: options.enforceCategory,
+      });
+    } catch (err) {
+      if (activatedStreamId) {
+        markActivatedStreamLaunchFailed(activatedStreamId, configPayload, err);
+      }
+      if (!options.suppressErrorNotification && !(err instanceof ZodError)) {
+        bus.emit('requestShowError', { message: toErrorMessage(err) });
+      }
+      throw err;
+    }
   }
 
   if (!configPayload.agent || !configPayload.model) {
@@ -520,14 +550,25 @@ async function resolveAndAcquireStream(
   acquireStreamOrThrow(preliminaryStreamId, options?.taskType);
 
   let ctx: ResolvedAgentBase;
+  let activatedStreamId: StreamTabId | undefined;
   try {
     ctx = await resolveAgentBase(configPayload, resolvedExecutionId, {
       onBeforeActivation: options?.onBeforeActivation,
+      onAfterActivation: (streamId) => {
+        activatedStreamId = streamId;
+      },
       enforceCategory: options?.enforceCategory,
     });
   } catch (err) {
-    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
-    if (!(err instanceof ZodError)) {
+    if (activatedStreamId) {
+      if (activatedStreamId !== preliminaryStreamId) {
+        StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+      }
+      markActivatedStreamLaunchFailed(activatedStreamId, configPayload, err);
+    } else {
+      StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+    }
+    if (!options?.suppressErrorNotification && !(err instanceof ZodError)) {
       bus.emit('requestShowError', { message: toErrorMessage(err) });
     }
     throw err;
@@ -580,6 +621,7 @@ export async function executeAgent(
   const ctx = await resolveAndAcquireStream(configPayload, executionId, {
     onBeforeActivation: options?.onStreamResolved,
     enforceCategory: options?.enforceCategory,
+    suppressErrorNotification: options?.isSubagent,
   });
   ctx.delegationDepth = options?.delegationDepth ?? 0;
   const { setting, streamId, config } = ctx;

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -145,8 +145,12 @@ interface ResolveAgentOptions {
   streamTabIdOverride?: StreamTabId;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
-  /** Fires after setActiveStream is emitted. */
-  onAfterActivation?: (streamId: StreamTabId) => void;
+  /**
+   * Fires immediately after setActiveStream is emitted. Marks the activation
+   * boundary: any subsequent failure should surface on this stream (the UI
+   * tab is now visible) rather than be dropped silently.
+   */
+  onActivated?: (streamId: StreamTabId) => void;
   /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
   enforceCategory?: boolean;
 }
@@ -226,7 +230,7 @@ async function resolveAgentBase(
     isRemote: isRemoteAgent(fullConfig.agent),
     hasMultipleOutputs: useMultipleOutputs,
   });
-  options?.onAfterActivation?.(streamId);
+  options?.onActivated?.(streamId);
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
@@ -486,23 +490,48 @@ function buildFallbackNotification(config: AgentConfig) {
 // Shared Orchestration
 // ============================================================================
 
-function markActivatedStreamLaunchFailed(
-  streamId: StreamTabId,
-  configPayload: AgentConfigPayload,
-  err: unknown,
-): void {
-  const errorMsg = `Failed to start agent ${configPayload.agent}: ${getSdkErrorMessage(err)}`;
-  new AgentLogger(streamId, true).logError(errorMsg, err, {
-    operation: `start ${configPayload.agent}`,
-  });
-  StreamStatusService.set(streamId, STREAM_STATUS.ERROR);
+/**
+ * Saga-style compensation for a failed stream activation.
+ *
+ *  - Pre-activation failure (no `activatedStreamId`): the UI tab was never
+ *    registered. Release the preliminary lock if we held it; the caller
+ *    won't ever see a stream.
+ *
+ *  - Post-activation failure (`activatedStreamId` set): the UI tab is
+ *    visible. Surface the failure on it and transition to ERROR so the
+ *    tab doesn't hang in INITIALIZING. Release the preliminary lock only
+ *    when the activation switched to a different id (rare: when
+ *    `useMultipleOutputs` flips during resolution).
+ */
+function compensateFailedActivation(args: {
+  preliminaryStreamId?: StreamTabId;
+  activatedStreamId?: StreamTabId;
+  configPayload: AgentConfigPayload;
+  err: unknown;
+}): void {
+  const { preliminaryStreamId, activatedStreamId, configPayload, err } = args;
+
+  if (activatedStreamId) {
+    new AgentLogger(activatedStreamId, true).logError(
+      `Failed to start agent ${configPayload.agent}: ${getSdkErrorMessage(err)}`,
+      err,
+      { operation: `start ${configPayload.agent}` },
+    );
+    StreamStatusService.set(activatedStreamId, STREAM_STATUS.ERROR);
+  }
+
+  if (preliminaryStreamId && preliminaryStreamId !== activatedStreamId) {
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+  }
 }
 
 /**
  * Resolves agent context and acquires stream lock, handling the preliminary→final
  * stream ID correction that occurs when useMultipleOutputs changes during resolution.
  *
- * Consolidates the acquire → resolve → correct pattern duplicated across entry points.
+ * Treats the `setActiveStream` emission as a transactional commit point:
+ * resolution failures before that point release the lock silently; failures
+ * after surface on the visible tab via {@link compensateFailedActivation}.
  */
 async function resolveAndAcquireStream(
   configPayload: AgentConfigPayload,
@@ -512,69 +541,48 @@ async function resolveAndAcquireStream(
     taskType?: string;
     onBeforeActivation?: (streamId: StreamTabId) => void;
     enforceCategory?: boolean;
+    /** Skip the `requestShowError` toast — for callers that show their own UI. */
     suppressErrorNotification?: boolean;
   },
 ): Promise<ResolvedAgentBase> {
-  if (options?.streamTabIdOverride) {
-    // Direct resolution with known stream ID (e.g., resume from snapshot)
-    let activatedStreamId: StreamTabId | undefined;
-    try {
-      return await resolveAgentBase(configPayload, executionId, {
-        streamTabIdOverride: options.streamTabIdOverride,
-        onBeforeActivation: options.onBeforeActivation,
-        onAfterActivation: (streamId) => {
-          activatedStreamId = streamId;
-        },
-        enforceCategory: options.enforceCategory,
-      });
-    } catch (err) {
-      if (activatedStreamId) {
-        markActivatedStreamLaunchFailed(activatedStreamId, configPayload, err);
-      }
-      if (!options.suppressErrorNotification && !(err instanceof ZodError)) {
-        bus.emit('requestShowError', { message: toErrorMessage(err) });
-      }
-      throw err;
+  let preliminaryStreamId: StreamTabId | undefined;
+  let resolvedExecutionId = executionId;
+
+  if (!options?.streamTabIdOverride) {
+    if (!configPayload.agent || !configPayload.model) {
+      throw new Error('Missing required fields: model and/or agent');
     }
+    resolvedExecutionId = executionId ?? generateExecutionId();
+    preliminaryStreamId = getStreamTabId(
+      configPayload.agent,
+      configPayload.model,
+      { executionId: resolvedExecutionId },
+    );
+    acquireStreamOrThrow(preliminaryStreamId, options?.taskType);
   }
 
-  if (!configPayload.agent || !configPayload.model) {
-    throw new Error('Missing required fields: model and/or agent');
-  }
-  const resolvedExecutionId = executionId ?? generateExecutionId();
-  const preliminaryStreamId = getStreamTabId(
-    configPayload.agent,
-    configPayload.model,
-    { executionId: resolvedExecutionId },
-  );
-  acquireStreamOrThrow(preliminaryStreamId, options?.taskType);
-
-  let ctx: ResolvedAgentBase;
   let activatedStreamId: StreamTabId | undefined;
   try {
-    ctx = await resolveAgentBase(configPayload, resolvedExecutionId, {
+    return await resolveAgentBase(configPayload, resolvedExecutionId, {
+      streamTabIdOverride: options?.streamTabIdOverride,
       onBeforeActivation: options?.onBeforeActivation,
-      onAfterActivation: (streamId) => {
+      onActivated: (streamId) => {
         activatedStreamId = streamId;
       },
       enforceCategory: options?.enforceCategory,
     });
   } catch (err) {
-    if (activatedStreamId) {
-      if (activatedStreamId !== preliminaryStreamId) {
-        StreamStatusService.releaseIfInitializing(preliminaryStreamId);
-      }
-      markActivatedStreamLaunchFailed(activatedStreamId, configPayload, err);
-    } else {
-      StreamStatusService.releaseIfInitializing(preliminaryStreamId);
-    }
+    compensateFailedActivation({
+      preliminaryStreamId,
+      activatedStreamId,
+      configPayload,
+      err,
+    });
     if (!options?.suppressErrorNotification && !(err instanceof ZodError)) {
       bus.emit('requestShowError', { message: toErrorMessage(err) });
     }
     throw err;
   }
-
-  return ctx;
 }
 
 // ============================================================================
@@ -806,7 +814,12 @@ export async function resumeToolUseFromSnapshot(
   const ctx = await resolveAndAcquireStream(
     snapshot.agentConfig,
     snapshot.executionId,
-    { streamTabIdOverride: snapshot.streamId },
+    {
+      streamTabIdOverride: snapshot.streamId,
+      // resumeCommand surfaces its own warning toast on failure; skip the
+      // bus-level error to avoid double-notifying.
+      suppressErrorNotification: true,
+    },
   );
   // Recover delegation depth from the persisted parent-execution chain
   // so resumed subagents remain gated by the nested-delegation policy

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -284,6 +284,12 @@ export class StreamTab extends LitElement {
         padding: var(--spacing-small) var(--spacing-tiny);
       }
 
+      .tab-container.is-compact .tab-delete {
+        width: 20px;
+        min-width: 20px;
+        height: 20px;
+      }
+
       .tab-container.is-compact .tab-header {
         gap: var(--spacing-tiny);
       }
@@ -472,18 +478,14 @@ export class StreamTab extends LitElement {
                 </div>
               `}
         </button>
-        ${this.compact
-          ? nothing
-          : html`
-              <vscode-toolbar-button
-                class="tab-delete"
-                icon="close"
-                title="Delete stream"
-                aria-label="Delete stream"
-                data-stream=${stream.name}
-                data-action="delete"
-              ></vscode-toolbar-button>
-            `}
+        <vscode-toolbar-button
+          class="tab-delete"
+          icon="close"
+          title="Delete stream"
+          aria-label="Delete stream"
+          data-stream=${stream.name}
+          data-action="delete"
+        ></vscode-toolbar-button>
       </div>
     `;
   }

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -311,6 +311,7 @@ export class ProgressViewState {
 
   async clearStream(stream: StreamTabId): Promise<void> {
     // Clear in-memory state
+    StreamStatusService.clear(stream);
     this.outputFiles.evict(stream);
     this.usageStats.evict(stream);
     this.meta.evict(stream);

--- a/src/progressView/state/ProgressViewState.ts
+++ b/src/progressView/state/ProgressViewState.ts
@@ -339,6 +339,7 @@ export class ProgressViewState {
     );
 
     // Clear in-memory state
+    StreamStatusService.clearAll();
     this.outputFiles.evictAll();
     this.usageStats.evictAll();
     this.meta.evictAll();


### PR DESCRIPTION
## Summary

- Mark subagent streams as `ERROR` when startup fails after the stream tab has already been registered.
- Keep the per-stream close button available in compact stream-tab mode so orphaned tabs can still be removed.
- Clear runtime stream status when deleting a stream so removed tabs do not linger in status memory.

## Root Cause

Subagent startup could fail after `setActiveStream` registered the stream but before the normal execution lifecycle took over. That left a progress tab with no reliable terminal transition. In compact mode, the close control was also hidden, making these orphaned tabs difficult or impossible to remove from the UI.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

Note: `npm test` was not run per repository instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent stream activation/error-handling and lock release behavior; mistakes could cause incorrect status transitions or leaked locks, but the changes are localized and mainly affect failure paths and UI affordances.
> 
> **Overview**
> Fixes cases where a stream tab is created but agent startup fails, leaving the tab stuck in `INITIALIZING`.
> 
> `executeAgent` now treats `setActiveStream` as an activation boundary (via a new `onActivated` hook) and adds saga-style compensation: failures after activation are logged to the activated stream and force its status to `ERROR`, while pre-activation failures still release the preliminary stream lock. Callers can also suppress the global `requestShowError` toast (used for subagents and snapshot resume) to avoid double notifications.
> 
> Progress view cleanup is tightened: `ProgressViewState.clearStream()`/`clearAll()` now reset runtime stream statuses (`StreamStatusService.clear`/new `clearAll`), and the StreamTabs UI keeps the per-tab delete button available (and sized) in compact mode so orphaned tabs can be removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9c29dbc962c89a1dd3d495370b3bc818f594dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->