### PR TITLE
[codex] Make bash stream results scrollable

### DIFF
--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -587,14 +587,11 @@ export class StreamTabs extends LitElement {
         color: var(--color-removed);
       }
 
-      /* Child stream nesting */
+      /* Recursive child stream nesting */
       .child-streams {
         padding-left: var(--spacing-medium, 12px);
         border-left: var(--border-thin) solid var(--color-border);
         margin-left: var(--spacing-small);
-        max-height: 12rem;
-        overflow-y: auto;
-        scrollbar-gutter: stable;
       }
 
       .child-streams stream-tab {
@@ -658,8 +655,8 @@ export class StreamTabs extends LitElement {
    * Single source of truth for "is this parent's child list expanded?".
    * Rules (top to bottom):
    *   1. Honor user intent if set.
-   *   2. Expand if any child is actively running.
-   *   3. Collapse once all children have reached a terminal status.
+   *   2. Expand if any child or descendant is actively running.
+   *   3. Collapse once every child branch has reached a terminal status.
    *   4. Otherwise (mixed / still-unknown), keep expanded — default on
    *      first appearance before status events arrive.
    */
@@ -673,7 +670,10 @@ export class StreamTabs extends LitElement {
     let anyActive = false;
     let anyUnknown = false;
     for (const child of children) {
-      const activity = classifyChild(this.streamStates, child.name);
+      const activity = this.classifyChildBranch(
+        child.name,
+        new Set([parentId]),
+      );
       if (activity === 'active') anyActive = true;
       else if (activity === 'unknown') anyUnknown = true;
     }
@@ -690,6 +690,81 @@ export class StreamTabs extends LitElement {
     return this.streamStates.get(name)?.lastTimestamp;
   }
 
+  /**
+   * Classify an entire child branch, not just the direct row. This keeps a
+   * parent expanded while a deeper descendant (for example subagent → bash) is
+   * still running, and avoids dimming a completed intermediate child that has
+   * active descendants.
+   */
+  private classifyChildBranch(
+    streamId: StreamTabId,
+    visited: Set<string>,
+  ): ChildActivity {
+    const ownActivity = classifyChild(this.streamStates, streamId);
+    if (ownActivity === 'active') return 'active';
+    if (visited.has(streamId)) return ownActivity;
+
+    visited.add(streamId);
+
+    let anyUnknown = ownActivity === 'unknown';
+    const children = this.childStreamsByParent.get(streamId) ?? [];
+    for (const child of children) {
+      const childActivity = this.classifyChildBranch(child.name, visited);
+      if (childActivity === 'active') return 'active';
+      if (childActivity === 'unknown') anyUnknown = true;
+    }
+
+    return anyUnknown ? 'unknown' : 'finished';
+  }
+
+  private renderStreamNode(
+    stream: StreamTabInfo,
+    options: { compact: boolean; visited: Set<string> },
+  ): TemplateResult {
+    const nextVisited = new Set(options.visited);
+    nextVisited.add(stream.name);
+
+    const children = (this.childStreamsByParent.get(stream.name) ?? []).filter(
+      (child) => !nextVisited.has(child.name),
+    );
+    const childCount = children.length;
+    const expanded =
+      !options.compact &&
+      childCount > 0 &&
+      this.expandedParents.has(stream.name);
+    const isFinished =
+      stream.parentStreamId != null &&
+      this.classifyChildBranch(stream.name, new Set(options.visited)) ===
+        'finished';
+
+    return html`
+      <stream-tab
+        class=${isFinished ? 'is-finished' : ''}
+        .info=${stream}
+        .compact=${options.compact}
+        .status=${this.getStatus(stream.name)}
+        .lastTimestamp=${this.getTimestamp(stream.name)}
+        ?active=${stream.name === this.activeStreamId}
+        .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)}
+        .childCount=${childCount}
+        ?expanded=${expanded}
+      ></stream-tab>
+      ${!options.compact && childCount > 0
+        ? html`<div class="child-streams" ?hidden=${!expanded}>
+            ${repeat(
+              children,
+              (child) => child.name,
+              (child) =>
+                this.renderStreamNode(child, {
+                  compact: false,
+                  visited: nextVisited,
+                }),
+            )}
+          </div>`
+        : nothing}
+    `;
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="tabs">
@@ -698,29 +773,11 @@ export class StreamTabs extends LitElement {
             ${repeat(
               this.streams,
               (stream) => stream.name,
-              (stream) => {
-                const children = this.childStreamsByParent.get(stream.name);
-                const rawChildCount = children?.length ?? 0;
-                // In compact mode, force childCount to 0 so the entire
-                // <div class="child-streams"> subtree is unmounted (saves
-                // memory on sessions with many child streams). In non-compact
-                // mode, the div always mounts with ?hidden tied to `expanded`
-                // so DOM is preserved across user-driven toggles (the common
-                // case PR #2984 optimized for). Compact toggles come from
-                // sidebar resize, which is infrequent enough that
-                // unmount/remount is acceptable and frees memory.
-                const childCount = !this.compact ? rawChildCount : 0;
-                const expanded =
-                  childCount > 0 && this.expandedParents.has(stream.name);
-
-                // prettier-ignore
-                return html`<stream-tab .info=${stream} .compact=${this.compact} .status=${this.getStatus(stream.name)} .lastTimestamp=${this.getTimestamp(stream.name)} ?active=${stream.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(stream.name)} .childCount=${rawChildCount} ?expanded=${expanded}></stream-tab>${children && childCount > 0 ? html`<div class="child-streams" ?hidden=${!expanded}>${repeat(children, (child) => child.name, (child) => {
-                  const childStatus = this.getStatus(child.name);
-                  const isFinished = classifyChild(this.streamStates, child.name) === 'finished';
-                  // prettier-ignore
-                  return html`<stream-tab class=${isFinished ? 'is-finished' : ''} .info=${child} .compact=${false} .status=${childStatus} .lastTimestamp=${this.getTimestamp(child.name)} ?active=${child.name === this.activeStreamId} .hasPendingApproval=${this.pendingApprovalStreamIds.has(child.name)}></stream-tab>`;
-                })}</div>` : nothing}`;
-              },
+              (stream) =>
+                this.renderStreamNode(stream, {
+                  compact: this.compact,
+                  visited: new Set(),
+                }),
             )}
           </div>
           ${when(

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -632,10 +632,13 @@ export class StreamTabs extends LitElement {
    * `manuallyCollapsed` + `finishedCollapseHandled` sets.
    */
   private userOverride: Map<string, 'expanded' | 'collapsed'> = new Map();
+  private branchActivityCache: Map<StreamTabId, ChildActivity> = new Map();
 
   protected override willUpdate(changed: import('lit').PropertyValues): void {
     if (!changed.has('childStreamsByParent') && !changed.has('streamStates'))
       return;
+
+    this.branchActivityCache.clear();
 
     for (const parentId of this.userOverride.keys()) {
       if (!this.childStreamsByParent.has(parentId)) {
@@ -670,10 +673,7 @@ export class StreamTabs extends LitElement {
     let anyActive = false;
     let anyUnknown = false;
     for (const child of children) {
-      const activity = this.classifyChildBranch(
-        child.name,
-        new Set([parentId]),
-      );
+      const activity = this.getBranchActivity(child.name, new Set([parentId]));
       if (activity === 'active') anyActive = true;
       else if (activity === 'unknown') anyUnknown = true;
     }
@@ -691,30 +691,43 @@ export class StreamTabs extends LitElement {
   }
 
   /**
-   * Classify an entire child branch, not just the direct row. This keeps a
-   * parent expanded while a deeper descendant (for example subagent → bash) is
-   * still running, and avoids dimming a completed intermediate child that has
-   * active descendants.
+   * Classify an entire child branch, not just the direct row. Results are
+   * memoized for each reactive update so deep child trees are traversed once
+   * even though expansion and dimming both ask for branch activity.
    */
-  private classifyChildBranch(
+  private getBranchActivity(
     streamId: StreamTabId,
     visited: Set<string>,
   ): ChildActivity {
-    const ownActivity = classifyChild(this.streamStates, streamId);
-    if (ownActivity === 'active') return 'active';
-    if (visited.has(streamId)) return ownActivity;
+    if (visited.has(streamId))
+      return classifyChild(this.streamStates, streamId);
 
-    visited.add(streamId);
+    const cached = this.branchActivityCache.get(streamId);
+    if (cached) return cached;
+
+    const ownActivity = classifyChild(this.streamStates, streamId);
+    if (ownActivity === 'active') {
+      this.branchActivityCache.set(streamId, 'active');
+      return 'active';
+    }
+
+    const nextVisited = new Set(visited);
+    nextVisited.add(streamId);
 
     let anyUnknown = ownActivity === 'unknown';
     const children = this.childStreamsByParent.get(streamId) ?? [];
     for (const child of children) {
-      const childActivity = this.classifyChildBranch(child.name, visited);
-      if (childActivity === 'active') return 'active';
+      const childActivity = this.getBranchActivity(child.name, nextVisited);
+      if (childActivity === 'active') {
+        this.branchActivityCache.set(streamId, 'active');
+        return 'active';
+      }
       if (childActivity === 'unknown') anyUnknown = true;
     }
 
-    return anyUnknown ? 'unknown' : 'finished';
+    const activity = anyUnknown ? 'unknown' : 'finished';
+    this.branchActivityCache.set(streamId, activity);
+    return activity;
   }
 
   private renderStreamNode(
@@ -734,8 +747,7 @@ export class StreamTabs extends LitElement {
       this.expandedParents.has(stream.name);
     const isFinished =
       stream.parentStreamId != null &&
-      this.classifyChildBranch(stream.name, new Set(options.visited)) ===
-        'finished';
+      this.getBranchActivity(stream.name, options.visited) === 'finished';
 
     return html`
       <stream-tab

--- a/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -32,7 +32,8 @@ export class TerminalCommandStrip extends LitElement {
         monospace
       );
       font-size: var(--vscode-editor-font-size, 12px);
-      overflow-x: auto;
+      max-height: min(32vh, 320px);
+      overflow: auto;
       white-space: pre;
     }
 

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -52,6 +52,8 @@ function decodeXmlEntitiesForDisplay(text: string): string {
   if (!text.includes('&')) return text;
 
   return text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&amp;', '&');

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -30,18 +30,28 @@ const STRUCTURED_DELIVERY_TAGS = [
   'subagent-error',
 ] as const;
 
+const XML_ESCAPED_DELIVERY_TAGS = new Set<string>([
+  'background-result',
+  'background-error',
+  'codex-result',
+  'codex-error',
+  'subagent-result',
+  'subagent-error',
+]);
+
 const STRUCTURED_DELIVERY_PATTERN = new RegExp(
   `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,
 );
 
-function isStructuredDeliveryMessage(text: string): boolean {
-  return STRUCTURED_DELIVERY_PATTERN.test(text);
+function getStructuredDeliveryTag(text: string): string | null {
+  const match = STRUCTURED_DELIVERY_PATTERN.exec(text);
+  return match?.[1] ?? null;
 }
 
-function decodeXmlEntities(text: string): string {
+function decodeXmlEntitiesForDisplay(text: string): string {
+  if (!text.includes('&')) return text;
+
   return text
-    .replaceAll('&quot;', '"')
-    .replaceAll('&apos;', "'")
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&amp;', '&');
@@ -157,15 +167,41 @@ export class UserMessage extends LitElement {
     defaultTitle: 'Copy message',
   });
 
+  private displayCache = {
+    text: '',
+    isStructuredDelivery: false,
+    displayText: '',
+  };
+
+  private getDisplayState(): {
+    isStructuredDelivery: boolean;
+    displayText: string;
+  } {
+    if (this.displayCache.text === this.text) {
+      return this.displayCache;
+    }
+
+    const structuredTag = getStructuredDeliveryTag(this.text);
+    const isStructuredDelivery = structuredTag != null;
+    const displayText =
+      structuredTag != null && XML_ESCAPED_DELIVERY_TAGS.has(structuredTag)
+        ? decodeXmlEntitiesForDisplay(this.text)
+        : this.text;
+
+    this.displayCache = {
+      text: this.text,
+      isStructuredDelivery,
+      displayText,
+    };
+    return this.displayCache;
+  }
+
   override render(): TemplateResult {
     const { timeDisplay, tooltipTimestamp } = formatTimestamp(
       new Date(this.timestamp),
     );
     const copyState = this.copyController.state;
-    const isStructuredDelivery = isStructuredDeliveryMessage(this.text);
-    const displayText = isStructuredDelivery
-      ? decodeXmlEntities(this.text)
-      : this.text;
+    const { isStructuredDelivery, displayText } = this.getDisplayState();
 
     return html`
       <div class="user-message-container">
@@ -190,7 +226,7 @@ export class UserMessage extends LitElement {
               icon="copy"
               title=${copyState.title}
               aria-label=${copyState.ariaLabel}
-              @click=${() => this.copyController.copy(displayText)}
+              @click=${() => this.copyController.copy(this.text)}
             ></vscode-toolbar-button>
           </div>
           <div

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -5,7 +5,7 @@
  */
 
 // Third-party imports
-import { LitElement, html, css, type TemplateResult } from 'lit';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -167,14 +167,20 @@ export class UserMessage extends LitElement {
     defaultTitle: 'Copy message',
   });
 
+  private payloadCopyController = new CopyButtonController(this, {
+    defaultTitle: 'Copy original payload',
+  });
+
   private displayCache = {
     text: '',
     isStructuredDelivery: false,
+    hasOriginalPayload: false,
     displayText: '',
   };
 
   private getDisplayState(): {
     isStructuredDelivery: boolean;
+    hasOriginalPayload: boolean;
     displayText: string;
   } {
     if (this.displayCache.text === this.text) {
@@ -183,14 +189,16 @@ export class UserMessage extends LitElement {
 
     const structuredTag = getStructuredDeliveryTag(this.text);
     const isStructuredDelivery = structuredTag != null;
-    const displayText =
-      structuredTag != null && XML_ESCAPED_DELIVERY_TAGS.has(structuredTag)
-        ? decodeXmlEntitiesForDisplay(this.text)
-        : this.text;
+    const hasOriginalPayload =
+      structuredTag != null && XML_ESCAPED_DELIVERY_TAGS.has(structuredTag);
+    const displayText = hasOriginalPayload
+      ? decodeXmlEntitiesForDisplay(this.text)
+      : this.text;
 
     this.displayCache = {
       text: this.text,
       isStructuredDelivery,
+      hasOriginalPayload,
       displayText,
     };
     return this.displayCache;
@@ -201,7 +209,9 @@ export class UserMessage extends LitElement {
       new Date(this.timestamp),
     );
     const copyState = this.copyController.state;
-    const { isStructuredDelivery, displayText } = this.getDisplayState();
+    const payloadCopyState = this.payloadCopyController.state;
+    const { isStructuredDelivery, hasOriginalPayload, displayText } =
+      this.getDisplayState();
 
     return html`
       <div class="user-message-container">
@@ -226,8 +236,20 @@ export class UserMessage extends LitElement {
               icon="copy"
               title=${copyState.title}
               aria-label=${copyState.ariaLabel}
-              @click=${() => this.copyController.copy(this.text)}
+              @click=${() => this.copyController.copy(displayText)}
             ></vscode-toolbar-button>
+            ${hasOriginalPayload
+              ? html`<vscode-toolbar-button
+                  class=${classMap({
+                    'user-message-copy': true,
+                    [payloadCopyState.successClass]: payloadCopyState.copied,
+                  })}
+                  icon="code"
+                  title=${payloadCopyState.title}
+                  aria-label=${payloadCopyState.ariaLabel}
+                  @click=${() => this.payloadCopyController.copy(this.text)}
+                ></vscode-toolbar-button>`
+              : nothing}
           </div>
           <div
             class="user-message-content"

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -19,6 +19,34 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 // Local imports - formatter helpers
 import { formatTimestamp } from '../formatters/timestampUtils';
 
+const STRUCTURED_DELIVERY_TAGS = [
+  'background-result',
+  'background-error',
+  'codex-result',
+  'codex-error',
+  'execution-activity',
+  'github-webhook-activity',
+  'subagent-result',
+  'subagent-error',
+] as const;
+
+const STRUCTURED_DELIVERY_PATTERN = new RegExp(
+  `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,
+);
+
+function isStructuredDeliveryMessage(text: string): boolean {
+  return STRUCTURED_DELIVERY_PATTERN.test(text);
+}
+
+function decodeXmlEntities(text: string): string {
+  return text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
+}
+
 @customElement('user-message')
 export class UserMessage extends LitElement {
   static override styles = [
@@ -41,6 +69,10 @@ export class UserMessage extends LitElement {
         background-color: var(--vscode-editor-selectionBackground);
         border: var(--border-thin) solid var(--vscode-panel-border);
         border-radius: var(--border-radius);
+      }
+
+      .user-message--structured-delivery {
+        max-width: 100%;
       }
 
       .user-message-header {
@@ -84,6 +116,28 @@ export class UserMessage extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      .user-message--structured-delivery .user-message-content {
+        max-height: min(45vh, 520px);
+        overflow: auto;
+        padding: var(--spacing-small);
+        background: var(
+          --vscode-textCodeBlock-background,
+          var(--vscode-editor-background)
+        );
+        border-radius: var(--border-radius-small);
+        font-family: var(
+          --vscode-editor-font-family,
+          ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          monospace
+        );
+        font-size: var(--vscode-editor-font-size, var(--font-size-sm));
+        line-height: 1.35;
+        white-space: pre;
+        word-wrap: normal;
+      }
+
       .user-message-timestamp {
         font-size: var(--font-size-xs);
       }
@@ -108,10 +162,19 @@ export class UserMessage extends LitElement {
       new Date(this.timestamp),
     );
     const copyState = this.copyController.state;
+    const isStructuredDelivery = isStructuredDeliveryMessage(this.text);
+    const displayText = isStructuredDelivery
+      ? decodeXmlEntities(this.text)
+      : this.text;
 
     return html`
       <div class="user-message-container">
-        <div class="user-message">
+        <div
+          class=${classMap({
+            'user-message': true,
+            'user-message--structured-delivery': isStructuredDelivery,
+          })}
+        >
           <div class="user-message-header">
             <span class="user-message-header-left">
               <i class="codicon codicon-comment user-message-icon"></i>
@@ -127,13 +190,13 @@ export class UserMessage extends LitElement {
               icon="copy"
               title=${copyState.title}
               aria-label=${copyState.ariaLabel}
-              @click=${() => this.copyController.copy(this.text)}
+              @click=${() => this.copyController.copy(displayText)}
             ></vscode-toolbar-button>
           </div>
           <div
             class="user-message-content"
             data-log-id=${this.logId}
-            .textContent=${this.text}
+            .textContent=${displayText}
           ></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Make long bash stream commands scroll within the command strip instead of expanding the tab.
- Render structured tool follow-up deliveries as scrollable monospace blocks in the progress timeline.
- Decode XML entities for display and copy in those structured deliveries while preserving the model-facing escaped payload.

## Root Cause

Long process commands and structured follow-up payloads were displayed as normal wrapping message content. Background bash delivery payloads are XML-escaped for safe agent delivery, and the progress UI was showing that serialized form directly.

## Validation

- `prettier --write src/progressView/frontend/components/TerminalCommandStrip.ts src/progressView/frontend/components/UserMessage.ts`
- `npm run compile:fast`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to new recursive stream-tree rendering and activity classification logic that could affect expand/collapse behavior and performance on large/degenerate trees; other changes are UI-only styling/copy behavior.
> 
> **Overview**
> Improves progress UI handling of large payloads by making `terminal-command-strip` and structured follow-up deliveries in `user-message` render as scrollable monospace blocks instead of expanding the layout.
> 
> Adds detection for structured delivery tags, decodes XML entities for *display* (while preserving the original escaped payload for copying), and introduces an extra copy action for the original payload when applicable.
> 
> Refactors `StreamTabs` child rendering to be **fully recursive**, with memoized branch activity so parent expand/collapse and finished-dimming consider descendant activity (and removes the child-list max-height/scroll styling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33b9d4b68c77afbe43915d958304aedf8604e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->