### PR TITLE
fix: clarify delegation depth gating

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -795,6 +795,7 @@ class ToolUseDispatchNode<C> extends Node<
           agentName: options.agentName,
           workingDirectory: options.workingDirectory,
           delegationDepth: options.delegationDepth,
+          delegationConfig: options.delegationConfig,
           onExecutionReady,
           onToolOutput,
         },

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -4,6 +4,7 @@ import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/AgentCycleOptions';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { AgentLogger } from '@logger/AgentLogger';
+import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 export interface AgentCore<C = unknown> {
@@ -24,6 +25,12 @@ export interface AgentCore<C = unknown> {
    * to compute the child's depth.
    */
   delegationDepth?: number;
+  /**
+   * Delegation policy snapshot for this agent run. Tool-use flows set this once
+   * so the visible tool list and runtime delegation gate derive from the same
+   * max-depth setting without carrying a second depth value.
+   */
+  delegationConfig?: NestedDelegationConfig;
 }
 
 export interface BaseFlowContextInit<C = unknown> extends AgentCore<C> {

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -29,8 +29,8 @@ export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
   readonly isSubagent?: boolean;
   /**
    * True when the agent's YAML requested delegation tools but they were filtered
-   * out by the nested-delegation gate (disabled or depth cap reached). The
-   * prepare node uses this to tell the LLM it cannot delegate further.
+   * out by the current delegation-depth gate. The prepare node uses this to
+   * tell the LLM it cannot delegate further.
    */
   readonly delegationTrimmed?: boolean;
 }

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -25,11 +25,8 @@ import {
   type EndGroupStatus,
 } from '@shared/schemas';
 import type { SubagentProgressUpdate } from '@shared/schemas';
-import {
-  delegationAllowed,
-  type NestedDelegationConfig,
-} from '@shared/constants/delegationPolicy';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
+import { evaluateDelegationGate } from '@shared/constants/delegationPolicy';
 
 import { getDefaultToolRegistry } from '@tools/registry';
 import {
@@ -86,13 +83,11 @@ function resolveTools(
   tools: AgentToolUseSetting['tools'],
   registry: IToolRegistry,
   logger: { warn: (msg: string) => void },
-  delegationDepth: number,
-  nestedConfig: NestedDelegationConfig,
+  delegationBlocked: boolean,
 ): { tools: ToolDefinition[]; delegationTrimmed: boolean } {
   const disabled = getDisabledToolNames();
   const unavailable = getUnavailableToolNamesCached();
   const missingDependency: string[] = [];
-  const canDelegate = delegationAllowed(delegationDepth, nestedConfig);
 
   // Don't warn on routine filtering outcomes (user-disabled, unavailable,
   // not in registry): they fire on every tool-use cycle and drown out real
@@ -104,7 +99,7 @@ function resolveTools(
   const resolved = toolConfigs
     .map((config) => (typeof config === 'string' ? { name: config } : config))
     .filter((def) => {
-      if (DELEGATION_TOOLS.has(def.name) && !canDelegate) {
+      if (DELEGATION_TOOLS.has(def.name) && delegationBlocked) {
         delegationTrimmed = true;
         return false;
       }
@@ -148,13 +143,16 @@ export async function runToolUseFlow<C = unknown>(
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
   const delegationDepth = input.delegationDepth ?? 0;
-  const nestedConfig = readNestedDelegationConfig();
+  const delegationConfig = readNestedDelegationConfig();
+  const delegationGate = evaluateDelegationGate(
+    delegationDepth,
+    delegationConfig,
+  );
   const { tools: resolvedTools, delegationTrimmed } = resolveTools(
     setting.tools,
     registry,
     logger,
-    delegationDepth,
-    nestedConfig,
+    !delegationGate.allowed,
   );
 
   const kv = getExecutionStore(executionId);
@@ -168,6 +166,7 @@ export async function runToolUseFlow<C = unknown>(
     onRoundFinalized: input.onRoundFinalized ?? (async () => {}),
     persistTodos: (todos) => kv.writeTodos(todos),
     delegationDepth,
+    delegationConfig,
     delegationTrimmed,
   };
 

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -14,6 +14,7 @@ import type { ExecutionId } from '@shared/schemas';
 import {
   clampNestedDelegationDepth,
   type NestedDelegationConfig,
+  UNKNOWN_DELEGATION_DEPTH,
 } from '@shared/constants/delegationPolicy';
 
 /** Read the current delegation policy from workspace state. */
@@ -31,7 +32,7 @@ export function readNestedDelegationConfig(): NestedDelegationConfig {
  * `delegationAllowed(MAX_SAFE_INTEGER, { maxDepth })` is false for any
  * configured cap, so delegation is conservatively blocked.
  */
-const UNKNOWN_DEPTH_SENTINEL = Number.MAX_SAFE_INTEGER;
+const UNKNOWN_DEPTH_SENTINEL = UNKNOWN_DELEGATION_DEPTH;
 
 /**
  * Read meta without letting filesystem/IO errors bubble up — safeParse

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -4,6 +4,7 @@ import type {
   PlanState,
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
+import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 
 export interface ToolFileInteractionContext {
@@ -21,6 +22,12 @@ export interface ToolFileInteractionContext {
    * N for an agent N levels deep. Read by delegation tools to compute the child's depth.
    */
   delegationDepth?: number;
+  /**
+   * Delegation policy snapshot for the executing agent. Keeps delegation tool
+   * enforcement aligned with the tool list shown to the model without carrying
+   * a second depth value.
+   */
+  delegationConfig?: NestedDelegationConfig;
   tracker: FileInteractionState;
   /** Todo state for managing task lists. Optional for backward compatibility. */
   todoState?: TodoState;

--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -21,6 +21,12 @@ export const NESTED_DELEGATION_DEPTH_RANGE = {
   default: 1,
 } as const;
 
+/**
+ * Sentinel for resumed executions whose persisted parent lineage cannot be
+ * trusted. It must never pass the max-depth gate for any supported setting.
+ */
+export const UNKNOWN_DELEGATION_DEPTH = Number.MAX_SAFE_INTEGER;
+
 /** Clamp an arbitrary value to the supported max-depth range. */
 export function clampNestedDelegationDepth(value: unknown): number {
   const n =
@@ -38,6 +44,40 @@ export interface NestedDelegationConfig {
   maxDepth: number;
 }
 
+export type DelegationGateBlockReason =
+  | 'max_depth_reached'
+  | 'unknown_depth';
+
+export interface DelegationGateResult {
+  depth: number | 'unknown';
+  maxDepth: number;
+  allowed: boolean;
+  blockReason?: DelegationGateBlockReason;
+}
+
+/** Explain the delegation gate result without leaking sentinel logic. */
+export function evaluateDelegationGate(
+  depth: number,
+  config: NestedDelegationConfig,
+): DelegationGateResult {
+  if (depth === UNKNOWN_DELEGATION_DEPTH) {
+    return {
+      depth: 'unknown',
+      maxDepth: config.maxDepth,
+      allowed: false,
+      blockReason: 'unknown_depth',
+    };
+  }
+
+  const allowed = depth < config.maxDepth;
+  return {
+    depth,
+    maxDepth: config.maxDepth,
+    allowed,
+    ...(allowed ? {} : { blockReason: 'max_depth_reached' as const }),
+  };
+}
+
 /**
  * Delegation gate. An agent at depth `d` may delegate iff `d < maxDepth`.
  * Root (depth 0) with the default (maxDepth 1) can always delegate;
@@ -47,5 +87,5 @@ export function delegationAllowed(
   depth: number,
   config: NestedDelegationConfig,
 ): boolean {
-  return depth < config.maxDepth;
+  return evaluateDelegationGate(depth, config).allowed;
 }

--- a/src/test/shared/delegationPolicy.test.ts
+++ b/src/test/shared/delegationPolicy.test.ts
@@ -1,0 +1,46 @@
+// Node.js built-in imports
+import * as assert from 'assert';
+
+// Local imports - shared constants
+import {
+  delegationAllowed,
+  evaluateDelegationGate,
+  UNKNOWN_DELEGATION_DEPTH,
+} from '@shared/constants/delegationPolicy';
+
+describe('delegationPolicy', () => {
+  it('allows root delegation at the default max depth', () => {
+    const config = { maxDepth: 1 };
+
+    assert.strictEqual(delegationAllowed(0, config), true);
+    assert.deepStrictEqual(evaluateDelegationGate(0, config), {
+      depth: 0,
+      maxDepth: 1,
+      allowed: true,
+    });
+  });
+
+  it('blocks subagent delegation at the default max depth', () => {
+    const result = evaluateDelegationGate(1, { maxDepth: 1 });
+
+    assert.deepStrictEqual(result, {
+      depth: 1,
+      maxDepth: 1,
+      allowed: false,
+      blockReason: 'max_depth_reached',
+    });
+  });
+
+  it('distinguishes unknown resumed lineage from ordinary max-depth blocks', () => {
+    const result = evaluateDelegationGate(UNKNOWN_DELEGATION_DEPTH, {
+      maxDepth: 5,
+    });
+
+    assert.deepStrictEqual(result, {
+      depth: 'unknown',
+      maxDepth: 5,
+      allowed: false,
+      blockReason: 'unknown_depth',
+    });
+  });
+});

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -50,7 +50,10 @@ import {
   type StreamTabId,
   type SubagentProgressUpdate,
 } from '@shared/schemas';
-import { delegationAllowed } from '@shared/constants/delegationPolicy';
+import {
+  evaluateDelegationGate,
+  type NestedDelegationConfig,
+} from '@shared/constants/delegationPolicy';
 import { formatBytes } from '@shared/utils/string';
 
 // Local imports - tools
@@ -209,21 +212,56 @@ interface ApprovalMeta {
 }
 
 /**
- * Defense-in-depth depth gate shared by fresh delegations and resumes.
- * The tool-use flow already filters delegation tools from the toolset when
- * the cap is reached, but if a rogue agent calls through anyway (fresh or
- * via the execution_id resume path) we refuse here with a clear error so
- * the LLM can pivot.
- *
- * Delegates to the same `delegationAllowed` predicate the tool filter
- * uses so NaN / sentinel depths behave identically at both gates.
+ * Runtime depth gate shared by fresh delegations and resumes.
+ * Tool-use flows pass the same max-depth snapshot used for tool resolution so
+ * prompt pruning and runtime enforcement derive from one policy snapshot.
+ * Direct tool calls fall back to the current workspace policy.
  */
-function depthGateError(parentDelegationDepth: number): ToolResult | null {
-  const config = readNestedDelegationConfig();
-  if (delegationAllowed(parentDelegationDepth, config)) return null;
+function depthGateError(
+  parentDelegationDepth: number,
+  configSnapshot?: NestedDelegationConfig,
+): ToolResult | null {
+  const gate = evaluateDelegationGate(
+    parentDelegationDepth,
+    configSnapshot ?? readNestedDelegationConfig(),
+  );
+  if (gate.allowed) return null;
+
+  const unknownDepth = gate.blockReason === 'unknown_depth';
+  const reason = unknownDepth
+    ? [
+        'The current session was resumed from saved state,',
+        'but its delegation lineage could not be verified.',
+      ].join(' ')
+    : [
+        `This agent is already at delegation depth ${gate.depth},`,
+        'and agents may delegate only when their current depth is less than',
+        'the configured max depth.',
+      ].join(' ');
+  const remediation = unknownDepth
+    ? [
+        'Resume or restart from a valid parent session,',
+        'or complete this task directly without delegating.',
+      ].join(' ')
+    : [
+        'Raise Settings → Multi-Agent → Max delegation depth,',
+        'or complete this task directly without delegating.',
+      ].join(' ');
   return {
-    error: `Delegation depth cap reached (max depth ${config.maxDepth}). Raise Settings → Multi-Agent → Max delegation depth, or complete this task directly without delegating.`,
+    error: [
+      `Delegation depth cap reached (current depth ${gate.depth},`,
+      `max depth ${gate.maxDepth}).`,
+      reason,
+      remediation,
+    ].join(' '),
     isError: true,
+    diagnostics: {
+      type: 'delegation_depth_cap',
+      currentDepth: gate.depth,
+      currentDepthKnown: !unknownDepth,
+      maxDepth: gate.maxDepth,
+      blockReason: gate.blockReason,
+    },
   };
 }
 
@@ -247,7 +285,10 @@ async function executeSubagent(
   const parentExecutionId = parentContext?.executionId;
   const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
 
-  const gated = depthGateError(parentDelegationDepth);
+  const gated = depthGateError(
+    parentDelegationDepth,
+    parentContext?.delegationConfig,
+  );
   if (gated) return gated;
 
   const executionId = generateExecutionId();
@@ -894,9 +935,12 @@ Git worktree support: ${
     executionId: string,
     instruction: string,
   ): Promise<ToolResult> {
-    const parentDelegationDepth =
-      getCurrentToolFileInteractionContext()?.delegationDepth ?? 0;
-    const gated = depthGateError(parentDelegationDepth);
+    const parentContext = getCurrentToolFileInteractionContext();
+    const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
+    const gated = depthGateError(
+      parentDelegationDepth,
+      parentContext?.delegationConfig,
+    );
     if (gated) return gated;
 
     const handle = getHandle(executionId);

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -49,12 +49,18 @@ export interface ExternalToolDef {
   readonly id: string;
   /** Tool names belonging to this group — must match registry keys. */
   readonly tools: readonly RegisteredToolName[];
+  /** Optional shared probe result passed to check/status/detail callbacks. */
+  readonly probe?: () => Promise<unknown>;
   /** Returns true if the external dependency is available. */
-  readonly check: () => Promise<boolean>;
+  readonly check: (probeResult?: unknown) => Promise<boolean>;
   /** Optional detailed status string resolved at check time (shown below description). */
-  readonly detailCheck?: () => Promise<string | undefined>;
+  readonly detailCheck?: (
+    probeResult?: unknown,
+  ) => Promise<string | undefined>;
   /** Optional short status label for the dashboard badge. */
-  readonly statusLabel?: () => Promise<string | undefined>;
+  readonly statusLabel?: (
+    probeResult?: unknown,
+  ) => Promise<string | undefined>;
   // Dashboard UI metadata
   readonly name: string;
   readonly category: ToolCategory;
@@ -125,6 +131,18 @@ async function getGitHubPRPrerequisites(): Promise<{
   const tokenPresent = getGitHubToken() !== undefined;
   const inGitRepo = await isGitRepository();
   return { tokenPresent, inGitRepo };
+}
+
+type GitHubPRPrerequisites = Awaited<
+  ReturnType<typeof getGitHubPRPrerequisites>
+>;
+
+async function resolveGitHubPRPrerequisites(
+  probeResult: unknown,
+): Promise<GitHubPRPrerequisites> {
+  return probeResult === undefined
+    ? getGitHubPRPrerequisites()
+    : (probeResult as GitHubPRPrerequisites);
 }
 
 // ============================================================
@@ -263,19 +281,23 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
     toggleable: true,
     installActionCommand: 'texra.showGitSettings',
     installActionLabel: 'Open Git settings',
-    check: async () => {
-      const { tokenPresent, inGitRepo } = await getGitHubPRPrerequisites();
+    probe: getGitHubPRPrerequisites,
+    check: async (probeResult) => {
+      const { tokenPresent, inGitRepo } =
+        await resolveGitHubPRPrerequisites(probeResult);
       return tokenPresent && inGitRepo;
     },
-    statusLabel: async () => {
-      const { tokenPresent, inGitRepo } = await getGitHubPRPrerequisites();
+    statusLabel: async (probeResult) => {
+      const { tokenPresent, inGitRepo } =
+        await resolveGitHubPRPrerequisites(probeResult);
       if (tokenPresent && inGitRepo) return undefined;
       if (tokenPresent && !inGitRepo) return 'Needs git repo';
       if (!tokenPresent && inGitRepo) return 'Needs token';
       return 'Needs setup';
     },
-    detailCheck: async () => {
-      const { tokenPresent, inGitRepo } = await getGitHubPRPrerequisites();
+    detailCheck: async (probeResult) => {
+      const { tokenPresent, inGitRepo } =
+        await resolveGitHubPRPrerequisites(probeResult);
       if (tokenPresent && inGitRepo) {
         return 'GitHub token detected and workspace is a git repo. Ready to subscribe to PR activity.';
       }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -111,19 +111,28 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
         id,
         tools,
         name,
+        probe,
         check,
         statusLabel: getStatusLabel,
         detailCheck,
       }): Promise<ExternalToolCheckResult> => {
-        // Run check then detailCheck sequentially — some groups (Codex,
-        // Zotero, GitHub PR) share probe work between the two, so running
-        // them in parallel would duplicate that work.
+        // Run check/status/detail from one shared probe result. Some groups
+        // (Codex, Zotero, GitHub PR) touch async local state, so running the
+        // callbacks independently can duplicate the same probe work.
+        let probeResult: unknown;
         let available: boolean;
         try {
-          available = await check();
+          probeResult = await probe?.();
+          available = await check(probeResult);
         } catch {
-          const statusDetail = await detailCheck?.().catch(() => undefined);
-          const statusLabel = await getStatusLabel?.().catch(() => undefined);
+          const statusDetail = await resolveOptionalStatus(
+            detailCheck,
+            probeResult,
+          );
+          const statusLabel = await resolveOptionalStatus(
+            getStatusLabel,
+            probeResult,
+          );
           return {
             id,
             tools,
@@ -133,8 +142,14 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
             statusDetail,
           };
         }
-        const statusDetail = await detailCheck?.().catch(() => undefined);
-        const statusLabel = await getStatusLabel?.().catch(() => undefined);
+        const statusDetail = await resolveOptionalStatus(
+          detailCheck,
+          probeResult,
+        );
+        const statusLabel = await resolveOptionalStatus(
+          getStatusLabel,
+          probeResult,
+        );
         return {
           id,
           tools,
@@ -146,6 +161,16 @@ async function runProbes(): Promise<ExternalToolCheckResult[]> {
       },
     ),
   );
+}
+
+async function resolveOptionalStatus(
+  getStatus:
+    | ((probeResult?: unknown) => Promise<string | undefined>)
+    | undefined,
+  probeResult: unknown,
+): Promise<string | undefined> {
+  if (!getStatus) return undefined;
+  return getStatus(probeResult).catch(() => undefined);
 }
 
 /** Build the set of unavailable tool names from external check results only. */


### PR DESCRIPTION
## Summary

- evaluate delegation depth through a shared policy helper, snapshotting only the max-depth config at tool-use flow setup so prompt pruning and runtime enforcement derive from the same policy without carrying a second depth value
- tailor unknown-lineage remediation and diagnostics so unknown depth is reported as `unknown` instead of leaking the internal sentinel
- share external tool availability probe results across callers so duplicate GitHub prerequisite checks do not run during one refresh

## Validation

- `git diff --check`
- npm-based checks were not run because this worktree environment has no `npm` binary available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-agent delegation gating and resume behavior; incorrect policy snapshotting or sentinel handling could wrongly allow/block delegation. External tool availability probing changes could affect tool enable/disable reporting during refreshes.
> 
> **Overview**
> Clarifies and unifies nested-delegation depth enforcement by introducing `evaluateDelegationGate`, adding an explicit `UNKNOWN_DELEGATION_DEPTH` sentinel, and returning structured block reasons (`max_depth_reached` vs `unknown_depth`). Tool-use flow setup now snapshots `delegationConfig` and threads it through `ToolFileInteractionContext` so tool filtering and `DelegationTools` runtime checks use the *same* policy decision, with improved error text and diagnostics when delegation is blocked.
> 
> External tool availability checks now support an optional shared `probe` result that is reused across `check`, `statusLabel`, and `detailCheck` callbacks (notably for GitHub PR prerequisites), reducing duplicated async work during a single refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2d5f58848842a0f4504af79a93bb7253ef6a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->