### PR TITLE
Remove GitHub badges from README; add quick-links to External Inquiry panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Rating](https://vsmarketplacebadges.dev/rating-short/texra-ai.texra.svg)](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
 [![Open VSX Version](https://img.shields.io/open-vsx/v/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
-[![Latest Release](https://img.shields.io/github/v/release/LionSR/TeXRA)](https://github.com/LionSR/TeXRA/releases)
-[![Last Commit](https://img.shields.io/github/last-commit/LionSR/TeXRA)](https://github.com/LionSR/TeXRA/commits)
 [![License](https://img.shields.io/badge/license-Proprietary-blue)](LICENSE)
 
 > **🎓 Free for Researchers!** TeXRA now offers a **Researcher Access Program** with

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -279,6 +279,14 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           <div class="external-inquiry-request__session-links-label">
             External chat/thread links (optional):
           </div>
+          <div class="external-inquiry-request__chat-links">
+            Open:
+            <a href="https://chatgpt.com/" target="_blank">ChatGPT Pro</a>
+            &nbsp;·&nbsp;
+            <a href="https://gemini.google.com/" target="_blank"
+              >Gemini Deep Think</a
+            >
+          </div>
           <textarea
             class="external-inquiry-request__session-links-input"
             placeholder="Paste one ChatGPT/Claude/Gemini thread link per line..."

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -281,9 +281,9 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           </div>
           <div class="external-inquiry-request__chat-links">
             Open:
-            <a href="https://chatgpt.com/" target="_blank">ChatGPT Pro</a>
+            <a href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">ChatGPT Pro</a>
             &nbsp;·&nbsp;
-            <a href="https://gemini.google.com/" target="_blank"
+            <a href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer"
               >Gemini Deep Think</a
             >
           </div>

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -281,7 +281,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
           </div>
           <div class="external-inquiry-request__chat-links">
             Open:
-            <a href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">ChatGPT Pro</a>
+            <a href="https://chatgpt.com/plans/pro/" target="_blank" rel="noopener noreferrer">ChatGPT Pro</a>
             &nbsp;·&nbsp;
             <a href="https://deepmind.google/models/gemini/deep-think/" target="_blank" rel="noopener noreferrer"
               >Gemini Deep Think</a

--- a/src/progressView/frontend/components/ExternalInquiryPanel.ts
+++ b/src/progressView/frontend/components/ExternalInquiryPanel.ts
@@ -283,7 +283,7 @@ export class ExternalInquiryPanel extends BaseFeedbackPanel {
             Open:
             <a href="https://chatgpt.com/" target="_blank" rel="noopener noreferrer">ChatGPT Pro</a>
             &nbsp;·&nbsp;
-            <a href="https://gemini.google.com/" target="_blank" rel="noopener noreferrer"
+            <a href="https://deepmind.google/models/gemini/deep-think/" target="_blank" rel="noopener noreferrer"
               >Gemini Deep Think</a
             >
           </div>

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -770,6 +770,20 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-descriptionForeground);
   }
 
+  .external-inquiry-request__chat-links {
+    font-size: var(--font-size-sm);
+    color: var(--vscode-descriptionForeground);
+  }
+
+  .external-inquiry-request__chat-links a {
+    color: var(--vscode-textLink-foreground);
+    text-decoration: none;
+  }
+
+  .external-inquiry-request__chat-links a:hover {
+    text-decoration: underline;
+  }
+
   .external-inquiry-request__answer-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);


### PR DESCRIPTION
## Summary
- Removed the "Latest Release" and "Last Commit" GitHub badges from `README.md` (the repo is private, so these badges don't render correctly)
- Added "ChatGPT Pro" and "Gemini Deep Think" quick-links to the External Inquiry panel above the session-links textarea, with matching styles in `requestPanelStyles.ts`

https://claude.ai/code/session_012u3hGUJU6CmHnsaragW7c2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/UI-only changes that add outbound links and styling without altering any backend logic or data handling.
> 
> **Overview**
> Removes the GitHub *Latest Release* and *Last Commit* badges from `README.md`.
> 
> Updates the External Inquiry panel to show quick links for opening **ChatGPT Pro** and **Gemini Deep Think** above the session-links textarea, with matching `.external-inquiry-request__chat-links` styling added to `requestPanelStyles.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5211235829756fb3779ac1193d1d01a913181678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->