### PR TITLE
fix(deepseek): always emit reasoning_content in thinking-mode messages; reduce debug verbosity

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -760,14 +760,6 @@ export class ModelHandlerOpenAI<
       );
     }
 
-    normalizedMessages.forEach((msg, index) => {
-      const contentPreview =
-        typeof msg.content === 'string'
-          ? msg.content.substring(0, MESSAGE_PREVIEW_LENGTH)
-          : 'non-string content';
-      this.logger.debug(`Message ${index} (${msg.role}): ${contentPreview}...`);
-    });
-
     return normalizedMessages;
   }
 
@@ -896,12 +888,11 @@ export class ModelHandlerOpenAI<
       text,
     ) as ChatCompletionAssistantMessageParam & { reasoning_content?: string };
 
+    // Always include reasoning_content (even empty string) when the provider
+    // requires it, so all assistant messages stay consistent in thinking mode.
     if (this.shouldIncludeReasoningInAssistantMessages()) {
-      const reasoningContent =
-        this.extractReasoningFromResponse(responseObject);
-      if (reasoningContent) {
-        message.reasoning_content = reasoningContent;
-      }
+      message.reasoning_content =
+        this.extractReasoningFromResponse(responseObject) ?? '';
     }
 
     return message;
@@ -1575,15 +1566,15 @@ export class ModelHandlerOpenAI<
       tool_calls: toolCalls,
     };
 
-    // Include reasoning_content if this provider requires it for tool-use cycles
+    // Include reasoning_content if this provider requires it for tool-use cycles.
+    // Always include (even as empty string) to ensure consistency: once
+    // reasoning_content appears in the conversation history, DeepSeek's API
+    // requires it on every subsequent assistant message in thinking mode.
     if (this.shouldIncludeReasoningInToolCalls() && workspaceState) {
-      const reasoningContent =
-        workspaceState.reasoning.thinkingBlocks[0]?.thinking;
-      if (reasoningContent) {
-        callMsg.reasoning_content = reasoningContent;
-        // Clear after use to prevent stale reasoning in subsequent calls
-        workspaceState.resetReasoning();
-      }
+      callMsg.reasoning_content =
+        workspaceState.reasoning.thinkingBlocks[0]?.thinking ?? '';
+      // Clear after use to prevent stale reasoning in subsequent calls
+      workspaceState.resetReasoning();
     }
 
     if (text !== undefined || this.shouldIncludeEmptyAssistantToolContent()) {

--- a/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerDeepSeek.test.ts
@@ -311,6 +311,47 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
     assert.equal((messages[2] as any).tool_call_id, 'call_2');
   });
 
+  it('includes empty reasoning_content in tool-call messages when model generated none', async () => {
+    const handler = new ModelHandlerDeepSeek(
+      buildConfig({
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+          supportsVision: false,
+        },
+      }),
+    );
+    const workspace = {
+      reasoning: {
+        thinkingBlocks: [] as Array<{ type: string; thinking: string }>,
+      },
+      resetReasoning() {
+        this.reasoning.thinkingBlocks = [];
+      },
+    };
+
+    const messages = await handler.createBatchedToolUseFollowUpMessages(
+      [
+        {
+          raw: {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'some_tool', arguments: '{}' },
+          },
+        },
+      ] as any,
+      [{ output: 'result' }],
+      [[]],
+      workspace as any,
+      '',
+    );
+
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].role, 'assistant');
+    // reasoning_content must always be present in thinking mode, even as empty string
+    assert.equal((messages[0] as any).reasoning_content, '');
+  });
+
   it('passes back response reasoning_content on final assistant messages', () => {
     const handler = new ModelHandlerDeepSeek(
       buildConfig({
@@ -344,6 +385,38 @@ describe('ModelHandlerDeepSeek tool conversion', () => {
       (message as any).reasoning_content,
       'Tool result is sufficient.',
     );
+  });
+
+  it('includes empty reasoning_content on final assistant messages when model generated none', () => {
+    const handler = new ModelHandlerDeepSeek(
+      buildConfig({
+        capabilities: {
+          ...DEFAULT_MODEL_CAPABILITIES,
+          supportsReasoning: true,
+          supportsVision: false,
+        },
+      }),
+    );
+    const response = {
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: 'final answer',
+            // no reasoning_content
+          },
+        },
+      ],
+    };
+
+    const message = handler.createAssistantMessageFromResponse(
+      response as any,
+      'final answer',
+    );
+
+    assert.equal(message.role, 'assistant');
+    // reasoning_content must always be present in thinking mode, even as empty string
+    assert.equal((message as any).reasoning_content, '');
   });
 
   it('sends nullable Chat Completions tools without SDK strict auto-parse validation', async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -16,6 +16,8 @@ const srcDir = path.resolve(__dirname, '..', '..', 'src');
 register({
   baseUrl: outDir,
   paths: {
+    // Map 'vscode' to a stub so unit tests run outside the VS Code test host.
+    'vscode': [path.join(outDir, 'test/support/vscode-mock')],
     '@/*': ['*', path.join(srcDir, '*')],
     '~/*': ['*', path.join(srcDir, '*')],
     '@common/*': ['common/*', path.join(srcDir, 'common/*')],
@@ -37,6 +39,10 @@ register({
     '@tools/*': ['tools/*', path.join(srcDir, 'tools/*')],
     '@types/*': ['types/*', path.join(srcDir, 'types/*')],
     '@eventBus/*': ['eventBus/*', path.join(srcDir, 'eventBus/*')],
+    '@shared/*': ['shared/*', path.join(srcDir, 'shared/*')],
+    '@auth/*': ['auth/*', path.join(srcDir, 'auth/*')],
+    '@platform': ['platform', path.join(srcDir, 'platform')],
+    '@platform/*': ['platform/*', path.join(srcDir, 'platform/*')],
   },
 });
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,11 +13,17 @@ import { register } from 'tsconfig-paths';
 const outDir = path.resolve(__dirname, '..');
 const srcDir = path.resolve(__dirname, '..', '..', 'src');
 
+// Only stub 'vscode' when running outside the VS Code extension host.
+// Inside the host, VSCODE_PID is set and the real vscode API is available.
+const standaloneMode = !process.env['VSCODE_PID'];
+const extraPaths: Record<string, string[]> = standaloneMode
+  ? { vscode: [path.join(outDir, 'test/support/vscode-mock')] }
+  : {};
+
 register({
   baseUrl: outDir,
   paths: {
-    // Map 'vscode' to a stub so unit tests run outside the VS Code test host.
-    'vscode': [path.join(outDir, 'test/support/vscode-mock')],
+    ...extraPaths,
     '@/*': ['*', path.join(srcDir, '*')],
     '~/*': ['*', path.join(srcDir, '*')],
     '@common/*': ['common/*', path.join(srcDir, 'common/*')],

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -13,10 +13,18 @@ import { register } from 'tsconfig-paths';
 const outDir = path.resolve(__dirname, '..');
 const srcDir = path.resolve(__dirname, '..', '..', 'src');
 
-// Only stub 'vscode' when running outside the VS Code extension host.
-// Inside the host, VSCODE_PID is set and the real vscode API is available.
-const standaloneMode = !process.env['VSCODE_PID'];
-const extraPaths: Record<string, string[]> = standaloneMode
+// Only stub 'vscode' when the real module is not available.
+// Probing with require.resolve() works correctly in all environments:
+// the real vscode module is available inside the VS Code extension host
+// (vscode-test runner), but not in plain Node.js / standalone Mocha runs
+// — regardless of whether VSCODE_PID happens to be set in the shell.
+let vscodeMissing = false;
+try {
+  require.resolve('vscode');
+} catch {
+  vscodeMissing = true;
+}
+const extraPaths: Record<string, string[]> = vscodeMissing
   ? { vscode: [path.join(outDir, 'test/support/vscode-mock')] }
   : {};
 

--- a/src/test/support/vscode-mock.ts
+++ b/src/test/support/vscode-mock.ts
@@ -1,0 +1,63 @@
+/**
+ * Minimal vscode module stub for unit tests running outside VS Code.
+ * Only mocks the APIs that production code calls at module load time or
+ * in paths exercised by the test suite.
+ */
+
+export const window = {
+  showErrorMessage: async (..._: unknown[]) => undefined,
+  showInformationMessage: async (..._: unknown[]) => undefined,
+  showWarningMessage: async (..._: unknown[]) => undefined,
+  createOutputChannel: (_name: string) => ({
+    appendLine: (_text: string) => {},
+    append: (_text: string) => {},
+    show: () => {},
+    dispose: () => {},
+  }),
+};
+
+export const workspace = {
+  getConfiguration: (_section?: string) => ({
+    get: <T>(_key: string, defaultValue?: T): T | undefined => defaultValue,
+  }),
+  onDidChangeConfiguration: () => ({ dispose: () => {} }),
+};
+
+export const commands = {
+  executeCommand: async (..._: unknown[]) => undefined,
+};
+
+export const Uri = {
+  file: (p: string) => ({ fsPath: p, toString: () => p, path: p }),
+  parse: (s: string) => ({ fsPath: s, toString: () => s, path: s }),
+};
+
+export const FileType = {
+  Unknown: 0,
+  File: 1,
+  Directory: 2,
+  SymbolicLink: 64,
+};
+
+export class EventEmitter<T> {
+  event = (_listener: (e: T) => unknown) => ({ dispose: () => {} });
+  fire(_data: T) {}
+  dispose() {}
+}
+
+export class Disposable {
+  static from(..._: { dispose(): unknown }[]): Disposable {
+    return new Disposable(() => {});
+  }
+  constructor(private callOnDispose: () => unknown) {}
+  dispose() {
+    this.callOnDispose();
+  }
+}
+
+export const ThemeColor = class {
+  constructor(public id: string) {}
+};
+
+export const ProgressLocation = { Notification: 15, Window: 10, SourceControl: 1 };
+export const StatusBarAlignment = { Left: 1, Right: 2 };


### PR DESCRIPTION
Two bugs fixed in the DeepSeek/OpenAI model handler:

1. Excessive debug logging: removed the per-message debug loop in
   `prepareNormalizedMessages` that emitted one line per message on every
   API call (80+ lines per call in long sessions). The count-change summary
   log is kept.

2. DeepSeek 400 "reasoning_content must be passed back" error: the
   `if (reasoningContent)` guard in `buildAssistantMessageWithToolCalls`
   and `createAssistantMessageFromResponse` silently omitted
   `reasoning_content` when the model returned no reasoning for a turn.
   DeepSeek's API requires the field on every assistant message once it
   appears anywhere in the conversation history — even as an empty string.
   Removed the guard; both methods now always set
   `reasoning_content = ... ?? ''` when the provider requires it.

Also adds two regression tests covering the empty-reasoning case and
improves test setup with @shared/* / @platform / vscode path aliases plus
a minimal vscode stub module for running unit tests standalone.

https://claude.ai/code/session_01Kz84QrHc2gwJnT6NVjpfuF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the OpenAI/DeepSeek message construction to always send `reasoning_content` (including empty strings) in thinking mode, which affects API request payloads and could impact tool-use conversation continuity if incorrect.
> 
> **Overview**
> **Fixes DeepSeek thinking-mode conversation formatting and trims noisy logs.**
> 
> DeepSeek/OpenAI tool-use and final assistant message builders now always set `reasoning_content` to a string (defaulting to `''`) whenever the provider requires it, preventing DeepSeek 400s when a turn produces no reasoning.
> 
> Removes per-message debug logging in `prepareNormalizedMessages` (keeps only the summary log), adds regression tests for the empty-reasoning cases, and updates test setup to conditionally stub `vscode` plus add additional tsconfig path aliases for standalone unit test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5411999c76907dc1d2f1830c61b184f2776e73a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->