### PR TITLE
fix: prevent server-side relay from overriding OpenRouter routing (gpt-5.5 stream timeout)

### DIFF
--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -270,9 +270,10 @@ export abstract class ModelHandler<
    * - Both are defined in RELAY_MODELS, ensuring UI filtering matches API validation
    */
   protected shouldUseServerSideKeys(): boolean {
-    // Skip openRouterOnly models - these should always route through OpenRouter
-    // since their model IDs don't exist on provider APIs.
-    if (this.config.openRouterOnly) {
+    // Models routing through OpenRouter (openRouterOnly or global toggle) always use the
+    // OpenRouter API — the server-side relay is a direct-provider path, not an OpenRouter
+    // path, so it must never take precedence here.
+    if (shouldUseOpenRouter(this.config)) {
       return false;
     }
     // Pass short name (this.config.name) for client-side tier validation.
@@ -332,12 +333,12 @@ export abstract class ModelHandler<
       );
     }
 
-    // openRouterOnly models can NEVER use server-side relay - they always need OpenRouter key.
-    // Allow these even in "Use Included Access" mode since included access is never possible.
-    if (this.config.openRouterOnly) {
+    // Models routing through OpenRouter always need the OpenRouter key — included access
+    // is a direct-provider relay path and does not apply here.
+    if (shouldUseOpenRouter(this.config)) {
       return this.fetchApiKeyOrThrow(
         'openRouter',
-        `Model "${this.config.name}" requires an OpenRouter API key. Please set it using the "Set API Key" command.`,
+        'Missing API key for OpenRouter. Please set it using the "Set API Key" command.',
       );
     }
 
@@ -352,13 +353,6 @@ export abstract class ModelHandler<
       throw new Error(
         `Model "${this.config.name}" is not available with your current subscription tier. ` +
           `Switch to "Use My Own Keys" via the TeXRA Profile panel, or select a model included in your tier.`,
-      );
-    }
-
-    if (shouldUseOpenRouter(this.config)) {
-      return this.fetchApiKeyOrThrow(
-        'openRouter',
-        'Missing API key for OpenRouter. Please set it using the "Set API Key" command.',
       );
     }
 

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -257,8 +257,10 @@ export abstract class ModelHandler<
    * Centralizes the decision to avoid duplication between getApiKey() and getBaseUrl().
    * Both methods call this to ensure consistent routing decisions.
    *
-   * Returns true only if:
-   * 1. Model is not openRouterOnly (those always use OpenRouter)
+   * Returns true only if ALL of the following hold:
+   * 1. Model is NOT routing through OpenRouter (neither openRouterOnly nor global toggle).
+   *    OpenRouter always requires an OpenRouter API key; the server-side relay is a
+   *    direct-provider path that must not interfere.
    * 2. shouldUseServerSideKeysSync confirms access:
    *    - Setting enabled
    *    - Provider supported
@@ -301,8 +303,11 @@ export abstract class ModelHandler<
    * When server-side keys are enabled (experimental), returns the user's JWT token instead,
    * which the relay Edge Function will use for authentication.
    *
-   * When "Use Included Access" is enabled, only server-side keys are used - no fallback
+   * When "Use Included Access" is enabled, only server-side keys are used — no fallback
    * to personal API keys. This ensures runtime behavior matches dropdown availability.
+   * Exception: models routed through OpenRouter (openRouterOnly or global toggle) always
+   * use the OpenRouter API key regardless of included-access settings, because the
+   * server-side relay is a direct-provider path that does not apply to OpenRouter routing.
    *
    * @throws Error if required API key is missing from environment
    */

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -368,8 +368,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       const cleanup = (): void => {
-        ws.socket.removeListener('open', onOpen);
-        ws.socket.removeListener('error', onError);
+        ws.socket.off('open', onOpen);
+        ws.socket.off('error', onError);
         signal?.removeEventListener('abort', onAbort);
       };
       const onOpen = (): void => {

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1,5 +1,6 @@
 // Standard library imports
 import { Buffer } from 'node:buffer';
+import type { EventEmitter } from 'node:events';
 import * as path from 'path';
 
 // Third-party imports
@@ -368,8 +369,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
 
       const cleanup = (): void => {
-        ws.socket.off('open', onOpen);
-        ws.socket.off('error', onError);
+        (ws.socket as unknown as EventEmitter).removeListener('open', onOpen);
+        (ws.socket as unknown as EventEmitter).removeListener('error', onError);
         signal?.removeEventListener('abort', onAbort);
       };
       const onOpen = (): void => {

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -3,7 +3,7 @@ import type { AgentRunStateSnapshot } from '@agent/core/AgentState';
 import type { RunUsageTotals } from '@agent/core/RunUsageAccumulator';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { getUseOpenRouter } from '@utils/config/providerConfig';
+import { shouldUseOpenRouter } from '@agent/modelHandlers/support/ProxyConfigResolver';
 import {
   UsageLogService,
   type AgentLogger,
@@ -44,7 +44,10 @@ export interface UsageMonitorModelInfo {
     | 'supportsReasoning'
     | 'cacheDiscountFactor'
   >;
-  config: Pick<ModelConfig, 'provider' | 'name' | 'fullName' | 'inputPrice'>;
+  config: Pick<
+    ModelConfig,
+    'provider' | 'name' | 'fullName' | 'inputPrice' | 'openRouterOnly' | 'requiresResponsesAPI'
+  >;
 }
 
 /**
@@ -240,7 +243,7 @@ export class UsageMonitor {
         cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         reasoningTokens: usage.reasoningTokens ?? 0,
         usedRelay:
-          !getUseOpenRouter() &&
+          !shouldUseOpenRouter(config) &&
           getServerSideKeyService().shouldUseServerSideKeysSync(
             config.provider,
             config.name,

--- a/src/agent/utils/UsageMonitor.ts
+++ b/src/agent/utils/UsageMonitor.ts
@@ -3,6 +3,7 @@ import type { AgentRunStateSnapshot } from '@agent/core/AgentState';
 import type { RunUsageTotals } from '@agent/core/RunUsageAccumulator';
 import { UsageProviderSchema } from '@agent/types/NormalizedUsage';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { getUseOpenRouter } from '@utils/config/providerConfig';
 import {
   UsageLogService,
   type AgentLogger,
@@ -238,10 +239,12 @@ export class UsageMonitor {
         }),
         cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         reasoningTokens: usage.reasoningTokens ?? 0,
-        usedRelay: getServerSideKeyService().shouldUseServerSideKeysSync(
-          config.provider,
-          config.name,
-        ),
+        usedRelay:
+          !getUseOpenRouter() &&
+          getServerSideKeyService().shouldUseServerSideKeysSync(
+            config.provider,
+            config.name,
+          ),
         streamId: this.context.streamId,
       });
     } catch (error) {

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1440,14 +1440,28 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       data.mode === 'included',
     );
 
+    // Included Access routes through the TeXRA relay — OpenRouter bypasses it.
+    // Disable OpenRouter when switching to Included Access so routing is consistent.
+    let openRouterDisabled = false;
+    if (
+      data.mode === 'included' &&
+      globalSM?.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
+    ) {
+      await globalSM.update(GlobalStateKey.USE_OPENROUTER, false);
+      openRouterDisabled = true;
+    }
+
     // Access mode affects model availability — invalidate cached options.
     invalidateModelOptionsCache();
     await this.withActiveWebview((w) => this.sendProfileData(w));
 
     const modeLabel =
       data.mode === 'included' ? 'Included Access' : 'My Own Keys';
+    const suffix = openRouterDisabled
+      ? ' OpenRouter has been turned off (not compatible with Included Access).'
+      : '';
     void vscode.window.showInformationMessage(
-      `Model access changed to: ${modeLabel}`,
+      `Model access changed to: ${modeLabel}.${suffix}`,
     );
   }
 

--- a/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -45,7 +45,9 @@ export class ApiAccessSection extends LitElement {
             <span class="option-content">
               <span class="option-title">Use Included Access</span>
               <span class="option-description"
-                >Works automatically. No setup needed.</span
+                >Works automatically. No setup needed. Does not apply to
+                OpenRouter — those models always use your OpenRouter
+                key.</span
               >
             </span>
           </label>

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -246,7 +246,7 @@ export const PROVIDER_VSCODE_SETTINGS: Record<
       key: GlobalStateKey.USE_OPENROUTER,
       label: 'Use OpenRouter for All Models',
       description:
-        'Route all API calls through OpenRouter instead of direct provider APIs. Requires an OpenRouter API key.',
+        'Route all API calls through OpenRouter instead of direct provider APIs. Requires an OpenRouter API key. Note: OpenRouter bypasses Included Access — your OpenRouter key is always used directly.',
       globalStateKey: GlobalStateKey.USE_OPENROUTER,
     },
   ],

--- a/src/test/agent/modelHandlers/ModelHandlerOpenRouterNative.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerOpenRouterNative.test.ts
@@ -1,0 +1,111 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+} from 'llm-zoo';
+
+// Local imports - handler under test
+import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/modelHandlerOpenRouterNative';
+
+// Modules to monkey-patch
+import * as providerConfigModule from '@utils/config/providerConfig';
+import * as serverKeysModule from '@auth/serverKeys';
+
+function buildConfig(overrides: Partial<ModelConfig> = {}): ModelConfig {
+  return {
+    name: 'gpt-5.5',
+    label: 'GPT-5.5',
+    fullName: 'gpt-5.5-2026-04-15',
+    shortName: 'gpt-5.5',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 16384,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: { ...DEFAULT_MODEL_CAPABILITIES },
+    openRouterOnly: false,
+    openrouterFullName: 'openai/gpt-5.5',
+    ...overrides,
+  };
+}
+
+describe('ModelHandlerOpenRouterNative routing precedence', () => {
+  const originalGetUseOpenRouter = providerConfigModule.getUseOpenRouter;
+  const originalGetServerSideKeyService = serverKeysModule.getServerSideKeyService;
+
+  afterEach(() => {
+    (providerConfigModule as { getUseOpenRouter: typeof originalGetUseOpenRouter }).getUseOpenRouter =
+      originalGetUseOpenRouter;
+    (serverKeysModule as { getServerSideKeyService: typeof originalGetServerSideKeyService }).getServerSideKeyService =
+      originalGetServerSideKeyService;
+  });
+
+  it('shouldUseServerSideKeys returns false when getUseOpenRouter=true even if server-side keys are available', () => {
+    // Simulate: user has "Use Included Access" enabled with a valid server-side key service
+    (providerConfigModule as { getUseOpenRouter: typeof originalGetUseOpenRouter }).getUseOpenRouter =
+      () => true;
+
+    (serverKeysModule as { getServerSideKeyService: typeof originalGetServerSideKeyService }).getServerSideKeyService =
+      () =>
+        ({
+          shouldUseServerSideKeysSync: () => true,
+          getUseIncludedModelAccess: () => true,
+          canUseServerSideKeys: async () => true,
+          getRelayBaseUrl: (provider: string) =>
+            `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+        }) as unknown as ReturnType<typeof originalGetServerSideKeyService>;
+
+    const handler = new ModelHandlerOpenRouterNative(buildConfig());
+
+    // OpenRouter routing must take precedence — server-side relay does not apply here
+    assert.equal((handler as any).shouldUseServerSideKeys(), false);
+  });
+
+  it('shouldUseServerSideKeys returns false for openRouterOnly=true models regardless of server-side key availability', () => {
+    (providerConfigModule as { getUseOpenRouter: typeof originalGetUseOpenRouter }).getUseOpenRouter =
+      () => false;
+
+    (serverKeysModule as { getServerSideKeyService: typeof originalGetServerSideKeyService }).getServerSideKeyService =
+      () =>
+        ({
+          shouldUseServerSideKeysSync: () => true,
+          getUseIncludedModelAccess: () => true,
+          canUseServerSideKeys: async () => true,
+          getRelayBaseUrl: (provider: string) =>
+            `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+        }) as unknown as ReturnType<typeof originalGetServerSideKeyService>;
+
+    const handler = new ModelHandlerOpenRouterNative(
+      buildConfig({ openRouterOnly: true }),
+    );
+
+    assert.equal((handler as any).shouldUseServerSideKeys(), false);
+  });
+
+  it('shouldUseServerSideKeys respects server-side key service when NOT routing through OpenRouter', () => {
+    (providerConfigModule as { getUseOpenRouter: typeof originalGetUseOpenRouter }).getUseOpenRouter =
+      () => false;
+
+    (serverKeysModule as { getServerSideKeyService: typeof originalGetServerSideKeyService }).getServerSideKeyService =
+      () =>
+        ({
+          shouldUseServerSideKeysSync: () => true,
+          getUseIncludedModelAccess: () => true,
+          canUseServerSideKeys: async () => true,
+          getRelayBaseUrl: (provider: string) =>
+            `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+        }) as unknown as ReturnType<typeof originalGetServerSideKeyService>;
+
+    // Use a non-OpenRouter handler (base class logic), openRouterOnly=false, global toggle off
+    // shouldUseServerSideKeys should delegate to the service and return true
+    const handler = new ModelHandlerOpenRouterNative(
+      buildConfig({ openRouterOnly: false }),
+    );
+
+    assert.equal((handler as any).shouldUseServerSideKeys(), true);
+  });
+});


### PR DESCRIPTION
## Root Cause

When a user had **Included Access** + **Use OpenRouter** enabled and selected gpt-5.5 (`openRouterOnly: false`), the server-side relay was incorrectly taking precedence over OpenRouter routing. The relay used an OpenAI-format model name against the Anthropic endpoint, which caused a 400s Anthropic stream timeout: *"Stream closed before message_start after 400s (481 events)"*.

## Changes

### Core routing fix (`ModelHandler.ts`)
- `shouldUseServerSideKeys()`: now returns `false` whenever `shouldUseOpenRouter(config)` is true (global toggle **or** `openRouterOnly`). Previously only checked `openRouterOnly`.
- `getApiKey()`: moved the OpenRouter key fetch **before** the included-access tier guard, so OpenRouter models always use the OpenRouter API key regardless of access mode.

### Telemetry fix (`UsageMonitor.ts`)
- `usedRelay` was computed via `shouldUseServerSideKeysSync()` directly, which didn't account for OpenRouter precedence.
- Now uses `shouldUseOpenRouter(config)` (with `openRouterOnly` and `requiresResponsesAPI` added to the config Pick) to exactly mirror the routing decision, including the `requiresResponsesAPI` bypass case.

### WebSocket compatibility (`modelHandlerOpenAIResponse.ts`)
- `ws.socket.removeListener()` fails to type-check in newer `ws`/OpenAI SDK versions where the socket resolves to `NodeWebSocket`. Cast to `EventEmitter` explicitly, which is guaranteed correct regardless of the concrete ws type variant.

### UX (`SettingsViewMessageHandler.ts`, `ApiAccessSection.ts`, `providers.ts`)
- Switching to **Use Included Access** now auto-disables the **Use OpenRouter** toggle (they are mutually exclusive routing paths) and notifies the user with a clear explanation.
- Both the OpenRouter toggle description and the Included Access radio description now explicitly state that OpenRouter bypasses the relay.

### Tests & docs (`ModelHandlerOpenRouterNative.test.ts`)
- Three unit tests for `shouldUseServerSideKeys()` routing precedence: global toggle suppresses relay, `openRouterOnly` suppresses relay, relay respected when neither OpenRouter path is active.
- Updated JSDoc on `shouldUseServerSideKeys()` and `getApiKey()` to document the OpenRouter exception.

## Test plan
- [ ] Enable **Use Included Access** + **Use OpenRouter** → select gpt-5.5 → verify request routes to OpenRouter (no stream timeout)
- [ ] Enable **Use Included Access** with OpenRouter already on → verify OpenRouter is auto-disabled and notification appears
- [ ] `requiresResponsesAPI` model + global OpenRouter toggle on → verify `usedRelay` logs correctly
- [ ] Unit tests pass: `ModelHandlerOpenRouterNative.test.ts`

https://claude.ai/code/session_01SBmUjb4Ka1aFDCoZdm455N