### PR TITLE
[codex] Use OpenAI SDK tool call assertion

### DIFF
--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -23,6 +23,7 @@ import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
   ChatCompletionMessageFunctionToolCall,
+  ChatCompletionMessageToolCall,
 } from 'openai/resources/chat/completions';
 import type {
   ResponseFunctionToolCallItem,
@@ -520,12 +521,17 @@ function getAssistantToolCalls(
     return [];
   }
 
-  try {
-    assertToolCallsAreChatCompletionFunctionToolCalls(message.tool_calls);
-    return message.tool_calls;
-  } catch {
-    return [];
+  const functionToolCalls: ChatCompletionMessageFunctionToolCall[] = [];
+  for (const toolCall of message.tool_calls) {
+    const candidate: ChatCompletionMessageToolCall[] = [toolCall];
+    try {
+      assertToolCallsAreChatCompletionFunctionToolCalls(candidate);
+      functionToolCalls.push(candidate[0]);
+    } catch {
+      // Skip non-function or malformed entries while preserving valid calls.
+    }
   }
+  return functionToolCalls;
 }
 
 // ============================================================

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -17,11 +17,12 @@ import {
   isAssistantMessage,
   isToolMessage,
 } from 'openai/lib/chatCompletionUtils';
+import { assertToolCallsAreChatCompletionFunctionToolCalls } from 'openai/lib/parser';
 import latexPreamble from '../../../resources/templates/chatExport.tex';
 import type { Part } from '@google/genai';
 import type {
   ChatCompletionMessageParam,
-  ChatCompletionMessageToolCall,
+  ChatCompletionMessageFunctionToolCall,
 } from 'openai/resources/chat/completions';
 import type {
   ResponseFunctionToolCallItem,
@@ -456,12 +457,11 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
 
       // OpenAI Chat Completions: tool_calls array on assistant messages
       for (const tc of getAssistantToolCalls(item)) {
-        const fn = tc.type === 'function' ? tc.function : undefined;
-        if (fn?.name) {
+        if (tc.function.name) {
           nodes.push({
             kind: 'tool-call',
-            name: fn.name,
-            input: fn.arguments ?? '{}',
+            name: tc.function.name,
+            input: tc.function.arguments ?? '{}',
           });
           lastAssistantHadToolUse = true;
         }
@@ -512,12 +512,20 @@ function toChatCompletionMessageParam(
   return item as ChatCompletionMessageParam;
 }
 
-function getAssistantToolCalls(item: unknown): ChatCompletionMessageToolCall[] {
+function getAssistantToolCalls(
+  item: unknown,
+): ChatCompletionMessageFunctionToolCall[] {
   const message = toChatCompletionMessageParam(item);
   if (!isAssistantMessage(message) || !Array.isArray(message.tool_calls)) {
     return [];
   }
-  return message.tool_calls;
+
+  try {
+    assertToolCallsAreChatCompletionFunctionToolCalls(message.tool_calls);
+    return message.tool_calls;
+  } catch {
+    return [];
+  }
 }
 
 // ============================================================

--- a/src/commands/history/chatExportFormatter.ts
+++ b/src/commands/history/chatExportFormatter.ts
@@ -458,11 +458,12 @@ function normalizeMessages(messages: unknown[]): ExportNode[] {
 
       // OpenAI Chat Completions: tool_calls array on assistant messages
       for (const tc of getAssistantToolCalls(item)) {
-        if (tc.function.name) {
+        const fn = tc.function;
+        if (fn?.name) {
           nodes.push({
             kind: 'tool-call',
-            name: tc.function.name,
-            input: tc.function.arguments ?? '{}',
+            name: fn.name,
+            input: fn.arguments ?? '{}',
           });
           lastAssistantHadToolUse = true;
         }

--- a/src/shared/constants/delegationPolicy.ts
+++ b/src/shared/constants/delegationPolicy.ts
@@ -44,9 +44,7 @@ export interface NestedDelegationConfig {
   maxDepth: number;
 }
 
-export type DelegationGateBlockReason =
-  | 'max_depth_reached'
-  | 'unknown_depth';
+export type DelegationGateBlockReason = 'max_depth_reached' | 'unknown_depth';
 
 export interface DelegationGateResult {
   depth: number | 'unknown';

--- a/src/test/commands/history/chatExportFormatter.test.ts
+++ b/src/test/commands/history/chatExportFormatter.test.ts
@@ -1,0 +1,49 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - commands
+import { formatChatAsMarkdown } from '@commands/history/chatExportFormatter';
+
+describe('formatChatAsMarkdown', () => {
+  it('preserves function tool calls in mixed tool_calls arrays', () => {
+    const markdown = formatChatAsMarkdown({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      config: {},
+      messages: [
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              id: 'call_first',
+              type: 'function',
+              function: {
+                name: 'first_tool',
+                arguments: '{"x":1}',
+              },
+            },
+            {
+              id: 'call_custom',
+              type: 'custom',
+              custom: {
+                name: 'custom_tool',
+                input: '{"skip":true}',
+              },
+            },
+            {
+              id: 'call_second',
+              type: 'function',
+              function: {
+                name: 'second_tool',
+                arguments: '{"y":2}',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    assert.match(markdown, /#### Tool: `first_tool`/);
+    assert.match(markdown, /#### Tool: `second_tool`/);
+    assert.doesNotMatch(markdown, /custom_tool/);
+  });
+});

--- a/src/test/commands/history/chatExportFormatter.test.ts
+++ b/src/test/commands/history/chatExportFormatter.test.ts
@@ -30,6 +30,10 @@ describe('formatChatAsMarkdown', () => {
               },
             },
             {
+              id: 'call_malformed',
+              type: 'function',
+            },
+            {
               id: 'call_second',
               type: 'function',
               function: {
@@ -45,5 +49,6 @@ describe('formatChatAsMarkdown', () => {
     assert.match(markdown, /#### Tool: `first_tool`/);
     assert.match(markdown, /#### Tool: `second_tool`/);
     assert.doesNotMatch(markdown, /custom_tool/);
+    assert.doesNotMatch(markdown, /call_malformed/);
   });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,7 @@
 // This file is loaded before all tests to configure the test environment
 
 // Standard library imports
+import * as fs from 'fs';
 import * as path from 'path';
 
 // Third-party imports
@@ -39,6 +40,10 @@ register({
     '@eventBus/*': ['eventBus/*', path.join(srcDir, 'eventBus/*')],
   },
 });
+
+require.extensions['.tex'] = (module, filename) => {
+  module.exports = fs.readFileSync(filename, 'utf8');
+};
 
 // Set longer timeout for VS Code extension tests
 if (typeof mocha !== 'undefined') {

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -54,13 +54,9 @@ export interface ExternalToolDef {
   /** Returns true if the external dependency is available. */
   readonly check: (probeResult?: unknown) => Promise<boolean>;
   /** Optional detailed status string resolved at check time (shown below description). */
-  readonly detailCheck?: (
-    probeResult?: unknown,
-  ) => Promise<string | undefined>;
+  readonly detailCheck?: (probeResult?: unknown) => Promise<string | undefined>;
   /** Optional short status label for the dashboard badge. */
-  readonly statusLabel?: (
-    probeResult?: unknown,
-  ) => Promise<string | undefined>;
+  readonly statusLabel?: (probeResult?: unknown) => Promise<string | undefined>;
   // Dashboard UI metadata
   readonly name: string;
   readonly category: ToolCategory;


### PR DESCRIPTION
## Summary
- Use OpenAI's native `assertToolCallsAreChatCompletionFunctionToolCalls` helper when exporting assistant tool calls.
- Return SDK-typed function tool calls so export rendering no longer needs manual `tc.type === "function"` narrowing.
- Preserve the existing malformed-payload behavior by skipping invalid tool-call arrays.

## Validation
- `npm run -s typecheck`
- `npm run -s lint` (passes with two existing unrelated import-order warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to export/rendering normalization and test harness wiring; main risk is subtle differences in which tool calls are included in exported chat output.
> 
> **Overview**
> Chat export formatting now validates OpenAI Chat Completions assistant `tool_calls` using the SDK’s `assertToolCallsAreChatCompletionFunctionToolCalls`, returning only well-formed *function* tool calls and avoiding manual `tc.type === 'function'` narrowing.
> 
> Adds a regression test to ensure mixed `tool_calls` arrays keep valid function calls while ignoring custom/malformed entries, and updates Mocha test setup to load `.tex` templates during formatter tests. Minor type/formatting-only cleanups are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b0e42d8e2b4fd6191a72ec37572219b584e167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->