### PR TITLE
Add auto-close functionality for short-lived child streams

### DIFF
--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -147,6 +147,10 @@ export interface ProgressEventPayloads {
    *  Listened by blocking tools (e.g. ExecutionsTool wait) to abort early. */
   followUpSent: { streamId: StreamTabId };
 
+  /** Request the progress view to remove a stream tab (used by short-lived
+   *  child streams that should auto-close once their work is done). */
+  removeStream: { streamId: StreamTabId };
+
   extensionDeactivating: undefined;
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -374,8 +374,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       return;
     }
 
-    // Stop the agent if it is still running so the process does not leak
-    await vscode.commands.executeCommand('texra.stopAgent', streamId);
+    // Stop the agent if it is still running so the process does not leak.
+    // Skip for already-finished streams to avoid spurious STOPPED status
+    // transitions and child interrupts on naturally completed work.
+    if (isInFlightStatus(StreamStatusService.get(streamId))) {
+      await vscode.commands.executeCommand('texra.stopAgent', streamId);
+    }
 
     // Clear pending approvals, retry requests, queued follow-ups, and YOLO state
     cleanupApprovalsForStream(streamId);

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -16,7 +16,6 @@ import {
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   BaseViewMessageHandler,
   COMMON_COMMANDS,
@@ -24,6 +23,7 @@ import {
 } from '@common/webview';
 import { isInFlightStatus } from '@common/constants/streamStatus';
 import { RecordingManager } from '@common/managers/RecordingManager';
+import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
@@ -124,12 +124,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     this.handlerRegistry = this.createHandlerRegistry();
 
-    bus.on('removeStream', ({ streamId }) => {
+    const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
       void this.handleDeleteStream({
         command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
         stream: streamId,
       });
     });
+    context.subscriptions.push({ dispose: unsubscribeRemoveStream });
   }
 
   /**

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -16,6 +16,7 @@ import {
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { apiKeyCommands } from '@commands/api/apiKeyCommands';
 import { toErrorMessage } from '@common/errors';
+import { bus } from '@eventBus/ProgressEventBus';
 import {
   BaseViewMessageHandler,
   COMMON_COMMANDS,
@@ -122,6 +123,13 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
 
     this.handlerRegistry = this.createHandlerRegistry();
+
+    bus.on('removeStream', ({ streamId }) => {
+      void this.handleDeleteStream({
+        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        stream: streamId,
+      });
+    });
   }
 
   /**

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -282,6 +282,7 @@ export class BashTool extends defineTool({
         });
         const terminalStatus = result.success ? 'completed' : 'error';
         await writeTerminalStatus(executionId, terminalStatus).catch(() => {});
+        unregisterInterruptible(childStreamId);
         finalizeChildStream(childStreamId, executionId, logger, {
           wallTimeMs,
           error: result.success
@@ -291,7 +292,6 @@ export class BashTool extends defineTool({
               ),
           autoClose: true,
         });
-        unregisterInterruptible(childStreamId);
 
         const msg = formatBashDelivery(
           executionId,
@@ -306,11 +306,11 @@ export class BashTool extends defineTool({
       })
       .catch(async (err: unknown) => {
         await writeTerminalStatus(executionId, 'error').catch(() => {});
+        unregisterInterruptible(childStreamId);
         finalizeChildStream(childStreamId, executionId, logger, {
           error: err,
           autoClose: true,
         });
-        unregisterInterruptible(childStreamId);
 
         const msg = formatBashError(executionId, command, err);
         await getExecutionStore(executionId).writeReport(msg);

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -196,6 +196,7 @@ export class BashTool extends defineTool({
     const syntheticConfig = AgentConfigSchema.parse({
       agent: 'bash',
       instruction: command,
+      agentCategory: AgentCategory.ToolUse,
     });
 
     try {
@@ -288,6 +289,7 @@ export class BashTool extends defineTool({
             : new ToolError(
                 `Background bash failed with exit code ${result.exitCode ?? 'unknown'}.`,
               ),
+          autoClose: true,
         });
         unregisterInterruptible(childStreamId);
 
@@ -306,6 +308,7 @@ export class BashTool extends defineTool({
         await writeTerminalStatus(executionId, 'error').catch(() => {});
         finalizeChildStream(childStreamId, executionId, logger, {
           error: err,
+          autoClose: true,
         });
         unregisterInterruptible(childStreamId);
 

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -42,6 +42,8 @@ interface FinalizeChildStreamOptions {
   } | null;
   error?: unknown;
   errorMessage?: string;
+  /** Remove the child stream tab from the progress view once finalized. */
+  autoClose?: boolean;
 }
 
 /** Create a child stream tab and execution handle for a background child task. */
@@ -113,4 +115,8 @@ export function finalizeChildStream(
     );
   }
   untrackExecution(executionId);
+
+  if (options?.autoClose) {
+    bus.emit('removeStream', { streamId: childStreamId });
+  }
 }


### PR DESCRIPTION
## Summary
This PR adds automatic cleanup of short-lived child stream tabs in the progress view. When a background task completes, its stream tab can now be automatically removed instead of remaining open indefinitely.

## Key Changes
- **Event Bus Enhancement**: Added a new `removeStream` event to `ProgressEventBus` that allows requesting removal of a stream tab from the progress view
- **Progress View Handler**: Updated `ProgressViewMessageHandler` to listen for `removeStream` events and handle stream deletion
- **Child Stream Finalization**: Extended `finalizeChildStream()` with an optional `autoClose` parameter that emits the `removeStream` event when enabled
- **Bash Tool Integration**: Updated `BashTool` to:
  - Set `agentCategory: AgentCategory.ToolUse` in synthetic agent config for background bash execution
  - Enable `autoClose: true` when finalizing child streams for both success and error cases

## Implementation Details
- The `removeStream` event is emitted from `finalizeChildStream()` only when `options.autoClose` is explicitly set to `true`
- The progress view handler receives the event and calls `handleDeleteStream()` with the appropriate stream ID
- This provides a clean separation of concerns: child stream management handles the event emission, while the progress view handles the UI cleanup

https://claude.ai/code/session_01KXocKENP3FWSXxbxqDHYR8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/lifecycle cleanup changes with limited scope; main risk is unintended stream/tab removal or missed cleanup due to the new auto-close path.
> 
> **Overview**
> Adds an explicit `removeStream` event to `ProgressEventBus` and wires `ProgressViewMessageHandler` to consume it by deleting the requested stream tab.
> 
> Extends `finalizeChildStream()` with an `autoClose` option that emits `removeStream` on completion, and enables it for background `bash` child streams (also tagging the synthetic config with `agentCategory: ToolUse`). Stream deletion now only issues `texra.stopAgent` when the stream is still in-flight, avoiding unnecessary STOPPED transitions for already-finished work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c865609a631ab2867e3def0cbced50bdee01695e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->