### PR TITLE
Refine session description generation to use short labels

### DIFF
--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -15,8 +15,27 @@ import * as logger from '@agent/core/logger';
 import { bus } from '@eventBus/ProgressEventBus';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
+import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 const CHANNEL = 'SessionDescription';
+const MAX_DESCRIPTION_LENGTH = 80;
+
+/**
+ * Normalize a model-generated session description: collapse newlines,
+ * strip surrounding quotes/backticks, drop trailing sentence punctuation,
+ * and truncate to a UI-friendly length. Returns an empty string when the
+ * cleaned result has no meaningful content.
+ */
+export function cleanSessionDescription(text: string): string {
+  const cleaned = text
+    .trim()
+    .replaceAll(/\s*\n\s*/g, ' ')
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/[.!?…]+$/, '')
+    .trim();
+  if (!cleaned) return '';
+  return truncateWithEllipsis(cleaned, MAX_DESCRIPTION_LENGTH);
+}
 
 const SYSTEM_PROMPT = `You generate very short session labels for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
 
@@ -83,21 +102,8 @@ export async function generateSessionDescription(
     const { text } = handler.extractResponse(result.response, '');
 
     if (isNonEmptyString(text)) {
-      // Collapse newlines to prevent corrupting line-based tool output,
-      // strip surrounding quotes/trailing punctuation, and cap length so
-      // tab/history rows stay readable even if the model overshoots.
-      const cleaned = text
-        .trim()
-        .replaceAll(/\s*\n\s*/g, ' ')
-        .replace(/^["'`]+|["'`]+$/g, '')
-        .replace(/[.!?…]+$/, '')
-        .trim();
-      if (!cleaned) return;
-      const MAX_DESCRIPTION_LENGTH = 80;
-      const description =
-        cleaned.length > MAX_DESCRIPTION_LENGTH
-          ? cleaned.slice(0, MAX_DESCRIPTION_LENGTH - 1).trimEnd() + '…'
-          : cleaned;
+      const description = cleanSessionDescription(text);
+      if (!description) return;
       await writeSessionDescription(executionId, description);
       bus.emit('updateStreamDescription', { streamId, description });
       logger.info(CHANNEL, `Generated session description for ${executionId}`);

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -92,6 +92,7 @@ export async function generateSessionDescription(
         .replace(/^["'`]+|["'`]+$/g, '')
         .replace(/[.!?…]+$/, '')
         .trim();
+      if (!cleaned) return;
       const MAX_DESCRIPTION_LENGTH = 80;
       const description =
         cleaned.length > MAX_DESCRIPTION_LENGTH

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -18,7 +18,7 @@ import { isNonEmptyString } from '@utils/core';
 
 const CHANNEL = 'SessionDescription';
 
-const SYSTEM_PROMPT = `You generate concise session descriptions for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write 1-2 sentences summarizing what this session aims to accomplish. Be specific and informative. Do not include meta-commentary — just the summary. Write in present tense (e.g. "Reviews the introduction for...").`;
+const SYSTEM_PROMPT = `You generate very short session labels for a LaTeX research assistant tool. Given an agent name, its description, and the user's instruction, write a single short phrase (max ~10 words, no trailing period) that captures what the session aims to accomplish. Be specific but terse — no full sentences, no meta-commentary, no quotes. Use present-tense verb phrases (e.g. "Reviewing introduction for clarity", "Fixing TikZ arrow alignment").`;
 
 /**
  * Build a user prompt for session description generation.
@@ -83,8 +83,20 @@ export async function generateSessionDescription(
     const { text } = handler.extractResponse(result.response, '');
 
     if (isNonEmptyString(text)) {
-      // Collapse newlines to prevent corrupting line-based tool output.
-      const description = text.trim().replaceAll(/\s*\n\s*/g, ' ');
+      // Collapse newlines to prevent corrupting line-based tool output,
+      // strip surrounding quotes/trailing punctuation, and cap length so
+      // tab/history rows stay readable even if the model overshoots.
+      const cleaned = text
+        .trim()
+        .replaceAll(/\s*\n\s*/g, ' ')
+        .replace(/^["'`]+|["'`]+$/g, '')
+        .replace(/[.!?…]+$/, '')
+        .trim();
+      const MAX_DESCRIPTION_LENGTH = 80;
+      const description =
+        cleaned.length > MAX_DESCRIPTION_LENGTH
+          ? cleaned.slice(0, MAX_DESCRIPTION_LENGTH - 1).trimEnd() + '…'
+          : cleaned;
       await writeSessionDescription(executionId, description);
       bus.emit('updateStreamDescription', { streamId, description });
       logger.info(CHANNEL, `Generated session description for ${executionId}`);

--- a/src/test/agent/runtime/sessionDescription.test.ts
+++ b/src/test/agent/runtime/sessionDescription.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from 'assert';
+
+import { cleanSessionDescription } from '@agent/runtime/sessionDescription';
+
+describe('cleanSessionDescription', () => {
+  it('returns short text unchanged', () => {
+    assert.equal(
+      cleanSessionDescription('Reviewing introduction for clarity'),
+      'Reviewing introduction for clarity',
+    );
+  });
+
+  it('collapses newlines into single spaces', () => {
+    assert.equal(
+      cleanSessionDescription('Reviewing\nintroduction\n  for clarity'),
+      'Reviewing introduction for clarity',
+    );
+  });
+
+  it('strips surrounding quotes and backticks', () => {
+    assert.equal(cleanSessionDescription('"Fixing TikZ arrows"'), 'Fixing TikZ arrows');
+    assert.equal(cleanSessionDescription('`Fixing TikZ arrows`'), 'Fixing TikZ arrows');
+    assert.equal(cleanSessionDescription("'Fixing TikZ arrows'"), 'Fixing TikZ arrows');
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    assert.equal(cleanSessionDescription('Fixing arrows.'), 'Fixing arrows');
+    assert.equal(cleanSessionDescription('Fixing arrows!?'), 'Fixing arrows');
+    assert.equal(cleanSessionDescription('Fixing arrows…'), 'Fixing arrows');
+  });
+
+  it('returns empty string when input is only quotes/punctuation', () => {
+    assert.equal(cleanSessionDescription('"..."'), '');
+    assert.equal(cleanSessionDescription('``'), '');
+    assert.equal(cleanSessionDescription('   '), '');
+  });
+
+  it('truncates with ellipsis at 80 characters', () => {
+    const long = 'a'.repeat(120);
+    const result = cleanSessionDescription(long);
+    assert.equal(result.length, 80);
+    assert.ok(result.endsWith('…'));
+  });
+});

--- a/src/test/agent/runtime/sessionDescription.test.ts
+++ b/src/test/agent/runtime/sessionDescription.test.ts
@@ -18,9 +18,18 @@ describe('cleanSessionDescription', () => {
   });
 
   it('strips surrounding quotes and backticks', () => {
-    assert.equal(cleanSessionDescription('"Fixing TikZ arrows"'), 'Fixing TikZ arrows');
-    assert.equal(cleanSessionDescription('`Fixing TikZ arrows`'), 'Fixing TikZ arrows');
-    assert.equal(cleanSessionDescription("'Fixing TikZ arrows'"), 'Fixing TikZ arrows');
+    assert.equal(
+      cleanSessionDescription('"Fixing TikZ arrows"'),
+      'Fixing TikZ arrows',
+    );
+    assert.equal(
+      cleanSessionDescription('`Fixing TikZ arrows`'),
+      'Fixing TikZ arrows',
+    );
+    assert.equal(
+      cleanSessionDescription("'Fixing TikZ arrows'"),
+      'Fixing TikZ arrows',
+    );
   });
 
   it('strips trailing sentence punctuation', () => {


### PR DESCRIPTION
## Summary
Updated the session description generation to produce concise, terse labels instead of full sentences. This improves UI readability in tabs and history rows by keeping descriptions short and preventing overflow.

## Key Changes
- **Updated system prompt**: Changed instructions from generating "1-2 sentences" to generating "a single short phrase (max ~10 words)" with present-tense verb phrases as examples
- **Enhanced text processing**: Added multiple cleaning steps to the generated description:
  - Strip surrounding quotes and backticks that the model might add
  - Remove trailing punctuation (periods, exclamation marks, question marks, ellipses)
  - Enforce a maximum length of 80 characters with ellipsis truncation to prevent UI overflow
  - Preserve newline collapsing for tool output compatibility

## Implementation Details
The description processing now follows this pipeline:
1. Trim whitespace
2. Collapse internal newlines to spaces
3. Remove surrounding quotes/backticks
4. Strip trailing punctuation
5. Trim again
6. Truncate to 80 characters if needed, adding ellipsis

This ensures descriptions remain readable in constrained UI spaces while maintaining semantic clarity about session intent.

https://claude.ai/code/session_01GEHscL3BxqJpZaJ9AF4fgd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to prompt wording and deterministic string cleanup before persisting/emitting session descriptions, with added unit coverage; low impact beyond UI text formatting.
> 
> **Overview**
> Session description generation now asks the helper model for a *single short label* (terse verb phrase) instead of 1–2 sentence summaries, to better fit stream tabs/history UI.
> 
> The model output is now normalized via `cleanSessionDescription` (collapse newlines, strip surrounding quotes/backticks, remove trailing sentence punctuation, and truncate to 80 chars with an ellipsis) and skipped entirely if it cleans to empty; unit tests cover these cleaning/truncation rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6184dd8e236e62baebe1b4f9b9c4fc0190f36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->