### PR TITLE
refactor: code-simplifier batch (7 parallel slices)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ slides/
 scripts/Heap-20260221T154935.heapsnapshot
 scripts/analyze_heap.py
 .claude/projects
+.claude/worktrees

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,6 @@ node_modules/
 
 # YAML templates with {{ }} placeholders - Prettier rewrites these as { { } }
 resources/templates/
+
+# Claude Code agent scratch space (worktrees contain unstaged template files)
+.claude/

--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -12,7 +12,6 @@ import {
   getDebugContext,
 } from '@agent/core/flows/CommonCycleTypes';
 import type { SdkToolCall } from '@agent/modelHandlers/types/IModelHandler';
-import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import type { ServerToolContentBlock } from '@agent/modelHandlers/types/ServerToolTypes';
 import type { ProviderStopReason } from '@agent/modelHandlers/types/StopReasonTypes';
 import {
@@ -199,33 +198,6 @@ export interface ToolUseCycleShared extends ToolUseCycleFields {
   toolCalls?: SdkToolCall[];
   /** Normalized usage with proper typing */
   cycleNormalizedUsage?: NormalizedUsage;
-}
-
-/**
- * Create a fresh ToolUseCycleShared with all fields initialized.
- *
- * Same pattern as ResponseCycleFlow's initializeCycleFields():
- * typed literal ensures compile-time checking — missing fields, typos,
- * and wrong types are all caught.
- */
-export function createToolUseCycleShared(
-  messages: ProviderMessage[],
-  cycleIndex: number,
-): ToolUseCycleShared {
-  return {
-    messages,
-    shouldStop: false,
-    endTurn: false,
-    responseTimeMs: undefined,
-    stopReason: undefined,
-    lastError: undefined,
-    response: undefined,
-    toolCalls: undefined,
-    text: undefined,
-    cycleIndex,
-    cycleResponseTimeMs: 0,
-    cycleNormalizedUsage: undefined,
-  };
 }
 
 /**

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -3,7 +3,7 @@ import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import {
   createToolUseCycleFlow,
-  createToolUseCycleShared,
+  type ToolUseCycleShared,
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { formatProviderHttpError } from '@common/errors';
@@ -57,10 +57,13 @@ export class ToolUseCycleNode<C> extends Node<
       return { outcome: 'skipped' };
     }
 
-    const cycleShared = createToolUseCycleShared(
-      prepRes.messages,
-      prepRes.runState.totalRounds,
-    );
+    const cycleShared: ToolUseCycleShared = {
+      messages: prepRes.messages,
+      shouldStop: false,
+      endTurn: false,
+      cycleIndex: prepRes.runState.totalRounds,
+      cycleResponseTimeMs: 0,
+    };
 
     const flow = createToolUseCycleFlow<C>();
     let client = await modelHandler.getClient();

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -605,7 +605,6 @@ async function loadRemoteAgents(): Promise<AgentEntry[]> {
 // KEY HELPERS
 // =============================================================================
 
-// Re-export for backward compatibility (local binding imported at top of file)
 export { createKey };
 
 /**

--- a/src/agent/modelHandlers/BaseReasoningStreamAggregator.ts
+++ b/src/agent/modelHandlers/BaseReasoningStreamAggregator.ts
@@ -6,8 +6,12 @@ import type {
   ChatCompletionMessageFunctionToolCall,
 } from 'openai/resources/chat/completions';
 
-// Local imports
-import type { StreamingAggregator } from './modelHandlerOpenAI';
+export interface StreamingAggregator {
+  appendContent(delta: string): void;
+  appendReasoning(delta: string): void;
+  consumeChunk(chunk: ChatCompletionChunk): void;
+  finalize(fallback?: ChatCompletion): ChatCompletion;
+}
 
 type ChatCompletionMessageWithReasoning = ChatCompletionMessage & {
   reasoning_content?: string;

--- a/src/agent/modelHandlers/modelHandlerDeepSeek.ts
+++ b/src/agent/modelHandlers/modelHandlerDeepSeek.ts
@@ -3,7 +3,6 @@ import { ReasoningEffort } from 'llm-zoo';
 
 // Local file imports
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
 // Type imports
@@ -31,6 +30,8 @@ import type { DeepSeekToolCall } from './types/IModelHandler';
  */
 export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
   // toolCallProvider and usageProvider inherit from base class via config.provider
+
+  protected override useReasoningStreamAggregator = true;
 
   /**
    * DeepSeek models don't support vision/attachments in tool results.
@@ -85,12 +86,6 @@ export class ModelHandlerDeepSeek extends ModelHandlerOpenAI<DeepSeekToolCall> {
    */
   protected override validateReasoningEffort(effort: string): string {
     return effort === ReasoningEffort.XHIGH ? 'max' : 'high';
-  }
-
-  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    return this.capabilities.supportsReasoning
-      ? new BaseReasoningStreamAggregator()
-      : null;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerGLM.ts
+++ b/src/agent/modelHandlers/modelHandlerGLM.ts
@@ -1,5 +1,4 @@
 // Local file imports
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
@@ -20,11 +19,7 @@ import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils'
  * @see https://open.bigmodel.cn/dev/api
  */
 export class ModelHandlerGLM extends ModelHandlerOpenAI {
-  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    return this.capabilities.supportsReasoning
-      ? new BaseReasoningStreamAggregator()
-      : null;
-  }
+  protected override useReasoningStreamAggregator = true;
 
   /**
    * GLM models require explicit `thinking` parameter to control reasoning.

--- a/src/agent/modelHandlers/modelHandlerKimi.ts
+++ b/src/agent/modelHandlers/modelHandlerKimi.ts
@@ -1,7 +1,6 @@
 // Local imports - agent
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import type { ToolDefinition } from '@model';
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
@@ -30,14 +29,10 @@ interface KimiTokenEstimateResponse {
  * @see https://platform.moonshot.cn/docs/guide/reasoning-model
  */
 export class ModelHandlerKimi extends ModelHandlerOpenAI {
+  protected override useReasoningStreamAggregator = true;
+
   protected override get usageProvider(): NormalizedUsage['provider'] {
     return 'moonshot';
-  }
-
-  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    return this.capabilities.supportsReasoning
-      ? new BaseReasoningStreamAggregator()
-      : null;
   }
 
   protected override getMessageNormalizationOptions():

--- a/src/agent/modelHandlers/modelHandlerMiniMax.ts
+++ b/src/agent/modelHandlers/modelHandlerMiniMax.ts
@@ -1,7 +1,6 @@
 // Local file imports
 import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import type { ToolDefinition } from '@model';
-import { BaseReasoningStreamAggregator } from './BaseReasoningStreamAggregator';
 import { ModelHandlerOpenAI } from './modelHandlerOpenAI';
 import type { NormalizeOpenAIMessageContentOptions } from './openAIMessageUtils';
 
@@ -38,14 +37,10 @@ function extractTextFromReasoningDetails(details: unknown): string | undefined {
  * @see https://platform.minimax.io/docs/guides/text-m2-function-call
  */
 export class ModelHandlerMiniMax extends ModelHandlerOpenAI {
+  protected override useReasoningStreamAggregator = true;
+
   protected override shouldIncludeReasoningInToolCalls(): boolean {
     return this.capabilities.supportsReasoning;
-  }
-
-  protected override createStreamingAggregator(): BaseReasoningStreamAggregator | null {
-    return this.capabilities.supportsReasoning
-      ? new BaseReasoningStreamAggregator()
-      : null;
   }
 
   /**

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -66,6 +66,10 @@ import {
 import { parseToolArguments } from './utils/parseArguments';
 import { ModelHandler } from './ModelHandler';
 import {
+  BaseReasoningStreamAggregator,
+  type StreamingAggregator,
+} from './BaseReasoningStreamAggregator';
+import {
   CLIENT_COMPACTION_SUMMARY_MAX_TOKENS,
   COMPACTION_SYSTEM_PROMPT,
   DEFAULT_COMPACTION_THRESHOLD_PERCENT,
@@ -104,13 +108,6 @@ function extractReasoningText(content: ReasoningContent | undefined): string {
 const DEEPSEEK_OFFICIAL_API_MAX_TOKENS = 8192;
 
 // COMPACTION_SYSTEM_PROMPT imported from contextManagementConstants
-
-export interface StreamingAggregator {
-  appendContent(delta: string): void;
-  appendReasoning(delta: string): void;
-  consumeChunk(chunk: ChatCompletionChunk): void;
-  finalize(fallback?: ChatCompletion): ChatCompletion;
-}
 
 /** Extracts `reasoning_content` from a streaming chunk delta. */
 function extractReasoningDelta(chunk: ChatCompletionChunk): string {
@@ -155,6 +152,8 @@ export class ModelHandlerOpenAI<
 
   /** Flag to force compaction on the next API call, set by requestCompaction(). */
   private compactionRequested = false;
+
+  protected useReasoningStreamAggregator: boolean = false;
 
   // ── Compaction interface overrides ────────────────────────────────────
 
@@ -346,6 +345,12 @@ export class ModelHandlerOpenAI<
    * Allows subclasses to provide a streaming aggregator implementation.
    */
   protected createStreamingAggregator(): StreamingAggregator | null {
+    if (
+      this.useReasoningStreamAggregator &&
+      this.capabilities.supportsReasoning
+    ) {
+      return new BaseReasoningStreamAggregator();
+    }
     return null;
   }
 

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -74,8 +74,6 @@ import {
   isOpenAIWebSearchCall,
   type ServerToolExtractionResult,
 } from './types/ServerToolTypes';
-import type { EventEmitter } from 'node:events';
-import type { ModelConfig } from 'llm-zoo';
 import type { InputTokenCountParams } from 'openai/resources/responses/input-tokens';
 import type { ProviderStopReason } from './types/StopReasonTypes';
 import type {
@@ -2677,10 +2675,6 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     return thoughtContent || null;
   }
 
-  private parseArguments(raw: unknown): unknown {
-    return parseToolArguments(raw, this.logger);
-  }
-
   extractToolUse(response: Response): OpenAIResponseToolCall[] {
     const items = response?.output;
     if (!Array.isArray(items)) return [];
@@ -2694,7 +2688,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       provider: 'openai-response',
       callId: call.call_id,
       name: call.name,
-      input: this.parseArguments(call.arguments),
+      input: parseToolArguments(call.arguments, this.logger),
       raw: call,
     }));
   }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -7,6 +7,8 @@ import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   validateExecutionRequest,

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -8,7 +8,6 @@ import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   validateExecutionRequest,
@@ -22,6 +21,7 @@ import {
   COMMON_COMMANDS,
   PROGRESS_VIEW_COMMANDS,
 } from '@common/webview';
+import { isInFlightStatus } from '@common/constants/streamStatus';
 import { RecordingManager } from '@common/managers/RecordingManager';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';

--- a/src/progressView/frontend/components/RequestPanels.ts
+++ b/src/progressView/frontend/components/RequestPanels.ts
@@ -171,6 +171,19 @@ export class RequestPanels extends LitElement {
   // Section rendering
   // ===========================================================================
 
+  private renderSectionHeader(
+    config: SectionConfig,
+    extra: TemplateResult | typeof nothing = nothing,
+  ): TemplateResult {
+    return html`
+      <div class="${config.cssClass}__header">
+        <i class="codicon codicon-${config.icon}"></i>
+        <span>${config.title}</span>
+        ${extra}
+      </div>
+    `;
+  }
+
   private renderSection(
     config: SectionConfig,
     permissions: PermissionState[],
@@ -179,10 +192,7 @@ export class RequestPanels extends LitElement {
 
     return html`
       <section class=${config.cssClass}>
-        <div class="${config.cssClass}__header">
-          <i class="codicon codicon-${config.icon}"></i>
-          <span>${config.title}</span>
-        </div>
+        ${this.renderSectionHeader(config)}
         <div class="${config.cssClass}__list">
           ${repeat(
             permissions,
@@ -214,34 +224,33 @@ export class RequestPanels extends LitElement {
 
     const config = SECTION_CONFIGS.externalInquiry;
     const current = perms[this._eiIndex];
+    const nav = html`
+      <div class="external-inquiry-requests__nav">
+        <button
+          class="external-inquiry-requests__nav-btn"
+          title="Previous inquiry"
+          ?disabled=${this._eiIndex === 0}
+          @click=${this._eiPrev}
+        >
+          <i class="codicon codicon-chevron-left"></i>
+        </button>
+        <span class="external-inquiry-requests__counter">
+          ${this._eiIndex + 1} / ${perms.length}
+        </span>
+        <button
+          class="external-inquiry-requests__nav-btn"
+          title="Next inquiry"
+          ?disabled=${this._eiIndex === perms.length - 1}
+          @click=${this._eiNext}
+        >
+          <i class="codicon codicon-chevron-right"></i>
+        </button>
+      </div>
+    `;
 
     return html`
       <section class=${config.cssClass}>
-        <div class="${config.cssClass}__header">
-          <i class="codicon codicon-${config.icon}"></i>
-          <span>${config.title}</span>
-          <div class="external-inquiry-requests__nav">
-            <button
-              class="external-inquiry-requests__nav-btn"
-              title="Previous inquiry"
-              ?disabled=${this._eiIndex === 0}
-              @click=${this._eiPrev}
-            >
-              <i class="codicon codicon-chevron-left"></i>
-            </button>
-            <span class="external-inquiry-requests__counter">
-              ${this._eiIndex + 1} / ${perms.length}
-            </span>
-            <button
-              class="external-inquiry-requests__nav-btn"
-              title="Next inquiry"
-              ?disabled=${this._eiIndex === perms.length - 1}
-              @click=${this._eiNext}
-            >
-              <i class="codicon codicon-chevron-right"></i>
-            </button>
-          </div>
-        </div>
+        ${this.renderSectionHeader(config, nav)}
         <div class="${config.cssClass}__list">
           ${keyed(getPermissionKey(current), config.renderPanel(current))}
         </div>

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -236,6 +236,424 @@ function isMcpTextBlock(
   );
 }
 
+type ToolSectionContext = {
+  toolName: string;
+  input: unknown;
+  filePath: string;
+  parsedOutput: unknown;
+  outputText: string;
+  isInProgress: boolean;
+};
+
+function buildEditDiffInputSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { input, filePath, parsedOutput } = ctx;
+  if (!isPlainObject(input)) return [];
+  const editInput = input as EditInput | TextEditorInput;
+  if (
+    typeof editInput.old_str !== 'string' ||
+    typeof editInput.new_str !== 'string'
+  ) {
+    return [];
+  }
+  const sections: TemplateResult[] = [];
+  const edits = getOutputEdits<{ startLine?: number }>(parsedOutput);
+  const startLine = edits?.[0]?.startLine;
+
+  if (filePath) {
+    sections.push(
+      buildToolUseSection(
+        'File:',
+        buildFileLinkWithLines(filePath, { startLine }),
+      ),
+    );
+  }
+  sections.push(
+    buildToolUseSection(
+      '',
+      buildEditDiffSection(editInput.old_str, editInput.new_str),
+    ),
+  );
+  return sections;
+}
+
+function buildFileLinkSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { input, filePath } = ctx;
+  if (!filePath) return [];
+  const readInput = input as ReadInput;
+  return [
+    buildToolUseSection(
+      'File:',
+      buildFileLinkWithLines(filePath, {
+        startLine: readInput.range?.start,
+        endLine: readInput.range?.end ?? undefined,
+      }),
+    ),
+  ];
+}
+
+function buildFileContentSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { toolName, input, filePath } = ctx;
+  if (!filePath) return [];
+  const writeInput = input as WriteInput;
+  const contentLanguage = getLanguageFromPath(filePath);
+  return [
+    buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
+    buildToolSection('', writeInput.content, {
+      toolName,
+      language: contentLanguage,
+    }),
+  ];
+}
+
+function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
+  const { input } = ctx;
+  if (!isPlainObject(input)) return [];
+  const memInput = input as MemoryToolInput;
+  const command = memInput.command;
+  const memPath = memInput.path ?? '';
+  const sections: TemplateResult[] = [];
+
+  if (memPath) {
+    sections.push(
+      buildToolUseSection('File:', buildMemoryPathDisplay(memPath)),
+    );
+  }
+
+  if (
+    command === 'str_replace' &&
+    memInput.old_str != null &&
+    memInput.new_str != null
+  ) {
+    sections.push(
+      buildToolUseSection(
+        '',
+        buildEditDiffSection(memInput.old_str, memInput.new_str),
+      ),
+    );
+  } else if (command === 'create' && memInput.file_text != null) {
+    const contentLanguage = memPath
+      ? getLanguageFromPath(memPath)
+      : 'plaintext';
+    sections.push(
+      buildToolSection('', memInput.file_text, {
+        language: contentLanguage,
+      }),
+    );
+  } else if (command === 'insert') {
+    const insertText = memInput.insert_text ?? memInput.new_str;
+    if (insertText != null) {
+      const lineLabel =
+        memInput.insert_line != null
+          ? `Insert at line ${memInput.insert_line}:`
+          : 'Insert:';
+      const contentLanguage = memPath
+        ? getLanguageFromPath(memPath)
+        : 'plaintext';
+      sections.push(
+        buildToolSection(lineLabel, insertText, {
+          language: contentLanguage,
+        }),
+      );
+    }
+  } else if (command === 'rename') {
+    const oldPath = memInput.old_path;
+    const newPath = memInput.new_path;
+    if (oldPath != null && newPath != null) {
+      sections.push(
+        buildToolUseSection('Rename:', wrapInPre(`${oldPath} → ${newPath}`)),
+      );
+    }
+  }
+  return sections;
+}
+
+function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { input, isInProgress } = ctx;
+  if (!isPlainObject(input)) return [];
+  const execInput = input as ExecutionsToolInput;
+  const execPath = execInput.path ?? '';
+  const action = execInput.action ?? EXECUTIONS_DEFAULT_ACTION;
+  const sections: TemplateResult[] = [];
+
+  if (execPath) {
+    sections.push(
+      buildToolUseSection('Path:', buildExecutionsPathDisplay(execPath)),
+    );
+  }
+
+  if (action === 'wait') {
+    const timeout = execInput.timeout ?? 300;
+    // prettier-ignore
+    const waitContent = isInProgress
+      ? html`<pre>wait (timeout: ${timeout}s)</pre><span class="followup-break-wait" title="Focus the follow-up input to send a message and break this wait"><i class="codicon codicon-comment"></i> Send Follow-up</span>`
+      : wrapInPre(`wait (timeout: ${timeout}s)`);
+    sections.push(buildToolUseSection('Action:', waitContent));
+  } else if (action === 'kill') {
+    sections.push(buildToolUseSection('Action:', wrapInPre('kill')));
+  }
+
+  if (execInput.view_range) {
+    const [start, end] = execInput.view_range;
+    sections.push(
+      buildToolUseSection('Range:', wrapInPre(`lines ${start}–${end}`)),
+    );
+  }
+  return sections;
+}
+
+function buildAcceptRunFilesSections(
+  ctx: ToolSectionContext,
+): TemplateResult[] {
+  const { input, parsedOutput } = ctx;
+  if (!isPlainObject(input)) return [];
+  const acceptInput = input as AcceptRunFilesInput;
+  const sections: TemplateResult[] = [];
+
+  if (acceptInput.execution_id) {
+    // prettier-ignore
+    sections.push(buildToolUseSection('Execution:', html`<code class="execution-id">${acceptInput.execution_id}</code>`));
+  }
+
+  const files = acceptInput.files;
+  if (Array.isArray(files) && files.length > 0) {
+    const edits = getOutputEdits<{
+      path?: string;
+      lineChanges?: { added: number; removed: number };
+    }>(parsedOutput);
+    const editsByPath = new Map(
+      (edits ?? []).filter((e) => e.path).map((e) => [e.path!, e] as const),
+    );
+
+    // prettier-ignore
+    const fileItems = html`${files.map((f) => {
+      const dest = f.original ?? f.path ?? '';
+      const source = f.path ?? '';
+      const isMapped = dest && source && dest !== source;
+      const edit = editsByPath.get(dest);
+      const diffStats = edit?.lineChanges
+        ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--spacing-small)">-${edit.lineChanges.removed}</span></span>`
+        : nothing;
+      // prettier-ignore
+      return html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
+    })}`;
+    // prettier-ignore
+    sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
+  }
+  return sections;
+}
+
+function buildDelegationSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { input } = ctx;
+  if (!isPlainObject(input)) return [];
+  const delegateInput = input as DelegateAgentInput | WorkflowAgentInput;
+  const sections: TemplateResult[] = [];
+
+  const execId =
+    'execution_id' in delegateInput
+      ? (delegateInput as DelegateAgentInput).execution_id
+      : undefined;
+  if (execId) {
+    // prettier-ignore
+    sections.push(buildToolUseSection('Resume:', html`<code class="execution-id">${execId}</code>`));
+  }
+
+  const agent = delegateInput.agent;
+  const model = delegateInput.model;
+  if (agent || model) {
+    const agentPart = agent ?? 'unknown';
+    const modelPart = model
+      ? html` <span class="file-source">(${model})</span>`
+      : nothing;
+    // prettier-ignore
+    sections.push(buildToolUseSection('Agent:', html`<code class="execution-id">${agentPart}</code>${modelPart}`));
+  }
+
+  const instruction = delegateInput.instruction;
+  if (instruction) {
+    sections.push(buildToolUseSection('Instruction:', wrapInPre(instruction)));
+  }
+
+  const extractFlags: string[] = [];
+  if ('extractFigures' in delegateInput && delegateInput.extractFigures)
+    extractFlags.push('Extract Figures');
+  if ('extractTikz' in delegateInput && delegateInput.extractTikz)
+    extractFlags.push('Extract TikZ');
+  if (extractFlags.length > 0) {
+    // prettier-ignore
+    sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><i class="codicon codicon-file-media"></i> ${f}</span>`)}`));
+  }
+
+  const fileGroups = getProposalFileGroups(delegateInput);
+  if (fileGroups.length > 0) {
+    // prettier-ignore
+    const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
+    // prettier-ignore
+    sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
+  }
+  return sections;
+}
+
+function buildSpecializedSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { toolName, input } = ctx;
+  const content =
+    SPECIALIZED_TOOL_SECTION_RENDERERS[
+      toolName as keyof typeof SPECIALIZED_TOOL_SECTION_RENDERERS
+    ](input);
+  if (content != null && content !== nothing) {
+    return [content];
+  }
+  return [];
+}
+
+function buildMcpSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { toolName, input, parsedOutput, outputText } = ctx;
+  const sections: TemplateResult[] = [];
+  let renderedMcpOutput = false;
+
+  if (input != null) {
+    const { text: inputValue, language: inputLanguage } =
+      stringifyWithLanguage(input);
+    if (inputValue) {
+      sections.push(
+        buildToolSection('Arguments:', inputValue, {
+          toolName,
+          language: inputLanguage,
+        }),
+      );
+    }
+  }
+
+  const mcpParsed = CodexMcpToolOutputSchema.safeParse(parsedOutput);
+  const mcpOutput: CodexMcpToolOutput | null = mcpParsed.success
+    ? mcpParsed.data
+    : null;
+  const contentBlocks = Array.isArray(mcpOutput?.contentBlocks)
+    ? mcpOutput.contentBlocks
+    : [];
+  const textBlocks = contentBlocks
+    .filter(isMcpTextBlock)
+    .map((block) => block.text);
+  const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
+
+  if (typeof mcpOutput?.status === 'string') {
+    let statusIcon: string;
+    if (mcpOutput.status === 'failed') {
+      statusIcon = 'codicon-error';
+    } else if (mcpOutput.status === 'in_progress') {
+      statusIcon = 'codicon-sync spin';
+    } else {
+      statusIcon = 'codicon-check';
+    }
+    // prettier-ignore
+    sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${statusIcon}"></i> ${mcpOutput.status}</span>`));
+    renderedMcpOutput = true;
+  }
+
+  if (textBlocks.length > 0) {
+    sections.push(buildToolSection('Response:', textBlocks.join('\n\n')));
+    renderedMcpOutput = true;
+  }
+
+  if (mcpOutput && 'structuredContent' in mcpOutput) {
+    const { text: structuredText, language: structuredLanguage } =
+      stringifyWithLanguage(mcpOutput.structuredContent);
+    if (structuredText) {
+      sections.push(
+        buildToolSection('Structured:', structuredText, {
+          toolName,
+          language: structuredLanguage,
+        }),
+      );
+      renderedMcpOutput = true;
+    }
+  }
+
+  if (otherBlocks.length > 0) {
+    const { text: contentText, language: contentLanguage } =
+      stringifyWithLanguage(otherBlocks);
+    if (contentText) {
+      sections.push(
+        buildToolSection('Content:', contentText, {
+          toolName,
+          language: contentLanguage,
+        }),
+      );
+      renderedMcpOutput = true;
+    }
+  }
+
+  if (!renderedMcpOutput && outputText) {
+    sections.push(
+      buildToolSection('Result:', outputText, {
+        toolName,
+        extraClass: 'tool-output-full',
+      }),
+    );
+  }
+  return sections;
+}
+
+function buildDefaultSections(ctx: ToolSectionContext): TemplateResult[] {
+  const { toolName, input } = ctx;
+  if (input == null) return [];
+  const codeLanguage = TOOL_CODE_LANGUAGES.get(toolName);
+  const { isCodeOnly, code } = codeLanguage
+    ? extractCodeOnlyInput(input)
+    : { isCodeOnly: false, code: '' };
+
+  if (isCodeOnly) {
+    return [buildToolSection('', code, { toolName, language: codeLanguage })];
+  }
+  const { text: inputValue, language: inputLanguage } =
+    stringifyWithLanguage(input);
+  if (inputValue) {
+    return [
+      buildToolSection('', inputValue, {
+        toolName,
+        language: inputLanguage,
+      }),
+    ];
+  }
+  return [];
+}
+
+const TOOL_SECTION_BUILDERS: Array<{
+  match: (toolName: string) => boolean;
+  build: (ctx: ToolSectionContext) => TemplateResult[];
+}> = [
+  {
+    match: (n) => TOOLS_WITH_DIFF_INPUT.has(n),
+    build: buildEditDiffInputSections,
+  },
+  {
+    match: (n) => TOOLS_WITH_FILE_LINK.has(n),
+    build: buildFileLinkSections,
+  },
+  {
+    match: (n) => TOOLS_WITH_FILE_CONTENT.has(n),
+    build: buildFileContentSections,
+  },
+  { match: (n) => n === 'memory', build: buildMemorySections },
+  { match: (n) => n === 'executions', build: buildExecutionsSections },
+  {
+    match: (n) => n === 'accept_run_files',
+    build: buildAcceptRunFilesSections,
+  },
+  { match: (n) => DELEGATION_TOOLS.has(n), build: buildDelegationSections },
+  {
+    match: (n) => Object.hasOwn(SPECIALIZED_TOOL_SECTION_RENDERERS, n),
+    build: buildSpecializedSections,
+  },
+  { match: (n) => n.startsWith('mcp:'), build: buildMcpSections },
+];
+
+function dispatchToolSections(ctx: ToolSectionContext): TemplateResult[] {
+  for (const { match, build } of TOOL_SECTION_BUILDERS) {
+    if (match(ctx.toolName)) return build(ctx);
+  }
+  return buildDefaultSections(ctx);
+}
+
 /** Format tool use log entry as TemplateResult. */
 export function formatToolUseTemplate(
   message: LogMessageData,
@@ -296,372 +714,17 @@ export function formatToolUseTemplate(
     ? `${titleBase} — ${headerSummary}`
     : titleBase;
 
-  // Build content sections
-  const sections: TemplateResult[] = [];
-
   const filePath =
     isPlainObject(input) && typeof input.path === 'string' ? input.path : '';
 
-  // Handle edit tools with diff display
-  if (TOOLS_WITH_DIFF_INPUT.has(toolName) && isPlainObject(input)) {
-    const editInput = input as EditInput | TextEditorInput;
-    if (
-      typeof editInput.old_str === 'string' &&
-      typeof editInput.new_str === 'string'
-    ) {
-      const edits = getOutputEdits<{ startLine?: number }>(parsed.output);
-      const startLine = edits?.[0]?.startLine;
-
-      if (filePath) {
-        sections.push(
-          buildToolUseSection(
-            'File:',
-            buildFileLinkWithLines(filePath, { startLine }),
-          ),
-        );
-      }
-      sections.push(
-        buildToolUseSection(
-          '',
-          buildEditDiffSection(editInput.old_str, editInput.new_str),
-        ),
-      );
-    }
-  }
-  // Handle read tools with file link
-  else if (TOOLS_WITH_FILE_LINK.has(toolName) && filePath) {
-    const readInput = input as ReadInput;
-    sections.push(
-      buildToolUseSection(
-        'File:',
-        buildFileLinkWithLines(filePath, {
-          startLine: readInput.range?.start,
-          endLine: readInput.range?.end ?? undefined,
-        }),
-      ),
-    );
-  }
-  // Handle write tools with file link + content
-  else if (TOOLS_WITH_FILE_CONTENT.has(toolName) && filePath) {
-    const writeInput = input as WriteInput;
-    sections.push(
-      buildToolUseSection('File:', buildFileLinkWithLines(filePath)),
-    );
-    const contentLanguage = getLanguageFromPath(filePath);
-    sections.push(
-      buildToolSection('', writeInput.content, {
-        toolName,
-        language: contentLanguage,
-      }),
-    );
-  }
-  // Handle memory tool with specialized formatting based on command
-  else if (toolName === 'memory' && isPlainObject(input)) {
-    const memInput = input as MemoryToolInput;
-    const command = memInput.command;
-    const memPath = memInput.path ?? '';
-
-    // Show memory file path for commands that operate on a single path
-    if (memPath) {
-      sections.push(
-        buildToolUseSection('File:', buildMemoryPathDisplay(memPath)),
-      );
-    }
-
-    if (
-      command === 'str_replace' &&
-      memInput.old_str != null &&
-      memInput.new_str != null
-    ) {
-      // str_replace: show diff (like edit_file)
-      sections.push(
-        buildToolUseSection(
-          '',
-          buildEditDiffSection(memInput.old_str, memInput.new_str),
-        ),
-      );
-    } else if (command === 'create' && memInput.file_text != null) {
-      // create: show file content (like write_file)
-      const contentLanguage = memPath
-        ? getLanguageFromPath(memPath)
-        : 'plaintext';
-      sections.push(
-        buildToolSection('', memInput.file_text, {
-          language: contentLanguage,
-        }),
-      );
-    } else if (command === 'insert') {
-      // insert: show inserted text at line number (tool accepts insert_text or new_str)
-      const insertText = memInput.insert_text ?? memInput.new_str;
-      if (insertText != null) {
-        const lineLabel =
-          memInput.insert_line != null
-            ? `Insert at line ${memInput.insert_line}:`
-            : 'Insert:';
-        const contentLanguage = memPath
-          ? getLanguageFromPath(memPath)
-          : 'plaintext';
-        sections.push(
-          buildToolSection(lineLabel, insertText, {
-            language: contentLanguage,
-          }),
-        );
-      }
-    } else if (command === 'rename') {
-      // rename: show old → new path (both required)
-      const oldPath = memInput.old_path;
-      const newPath = memInput.new_path;
-      if (oldPath != null && newPath != null) {
-        sections.push(
-          buildToolUseSection('Rename:', wrapInPre(`${oldPath} → ${newPath}`)),
-        );
-      }
-    }
-    // view and delete: file path section above is sufficient
-  }
-  // Handle executions tool with specialized formatting based on action
-  else if (toolName === 'executions' && isPlainObject(input)) {
-    const execInput = input as ExecutionsToolInput;
-    const execPath = execInput.path ?? '';
-    const action = execInput.action ?? EXECUTIONS_DEFAULT_ACTION;
-
-    // Show the virtual path being accessed
-    if (execPath) {
-      sections.push(
-        buildToolUseSection('Path:', buildExecutionsPathDisplay(execPath)),
-      );
-    }
-
-    if (action === 'wait') {
-      // wait: show timeout info and a button to break the wait via follow-up
-      const timeout = execInput.timeout ?? 300;
-      // prettier-ignore
-      const waitContent = isInProgress
-        ? html`<pre>wait (timeout: ${timeout}s)</pre><span class="followup-break-wait" title="Focus the follow-up input to send a message and break this wait"><i class="codicon codicon-comment"></i> Send Follow-up</span>`
-        : wrapInPre(`wait (timeout: ${timeout}s)`);
-      sections.push(buildToolUseSection('Action:', waitContent));
-    } else if (action === 'kill') {
-      // kill: show action
-      sections.push(buildToolUseSection('Action:', wrapInPre('kill')));
-    }
-    // view: path section above is sufficient
-
-    // Show view_range if specified
-    if (execInput.view_range) {
-      const [start, end] = execInput.view_range;
-      sections.push(
-        buildToolUseSection('Range:', wrapInPre(`lines ${start}–${end}`)),
-      );
-    }
-  }
-  // Handle accept_run_files with file list display
-  else if (toolName === 'accept_run_files' && isPlainObject(input)) {
-    const acceptInput = input as AcceptRunFilesInput;
-
-    // Show execution ID
-    if (acceptInput.execution_id) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Execution:', html`<code class="execution-id">${acceptInput.execution_id}</code>`));
-    }
-
-    // Show file mappings as a list with file links
-    const files = acceptInput.files;
-    if (Array.isArray(files) && files.length > 0) {
-      const edits = getOutputEdits<{
-        path?: string;
-        lineChanges?: { added: number; removed: number };
-      }>(parsed.output);
-      const editsByPath = new Map(
-        (edits ?? []).filter((e) => e.path).map((e) => [e.path!, e] as const),
-      );
-
-      // prettier-ignore
-      const fileItems = html`${files.map((f) => {
-        const dest = f.original ?? f.path ?? '';
-        const source = f.path ?? '';
-        const isMapped = dest && source && dest !== source;
-        const edit = editsByPath.get(dest);
-        const diffStats = edit?.lineChanges
-          ? html` <span class="file-stats"><span class="added">+${edit.lineChanges.added}</span><span class="removed" style="margin-left:var(--spacing-small)">-${edit.lineChanges.removed}</span></span>`
-          : nothing;
-        // prettier-ignore
-        return html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="file-link clickable-link" data-file=${dest}>${dest}</span>${isMapped ? html` <span class="file-source">(from ${source})</span>` : nothing}${diffStats}</li>`;
-      })}`;
-      // prettier-ignore
-      sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
-    }
-  }
-  // Handle delegation tools with structured display
-  else if (DELEGATION_TOOLS.has(toolName) && isPlainObject(input)) {
-    const delegateInput = input as DelegateAgentInput | WorkflowAgentInput;
-
-    // Resume mode: show execution ID
-    const execId =
-      'execution_id' in delegateInput
-        ? (delegateInput as DelegateAgentInput).execution_id
-        : undefined;
-    if (execId) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Resume:', html`<code class="execution-id">${execId}</code>`));
-    }
-
-    // Agent and model on one line
-    const agent = delegateInput.agent;
-    const model = delegateInput.model;
-    if (agent || model) {
-      const agentPart = agent ?? 'unknown';
-      const modelPart = model
-        ? html` <span class="file-source">(${model})</span>`
-        : nothing;
-      // prettier-ignore
-      sections.push(buildToolUseSection('Agent:', html`<code class="execution-id">${agentPart}</code>${modelPart}`));
-    }
-
-    // Instruction as readable text
-    const instruction = delegateInput.instruction;
-    if (instruction) {
-      sections.push(
-        buildToolUseSection('Instruction:', wrapInPre(instruction)),
-      );
-    }
-
-    // Extract figure flags (workflow delegation only)
-    const extractFlags: string[] = [];
-    if ('extractFigures' in delegateInput && delegateInput.extractFigures)
-      extractFlags.push('Extract Figures');
-    if ('extractTikz' in delegateInput && delegateInput.extractTikz)
-      extractFlags.push('Extract TikZ');
-    if (extractFlags.length > 0) {
-      // prettier-ignore
-      sections.push(buildToolUseSection('Extraction:', html`${extractFlags.map((f) => html`<span class="extract-flag"><i class="codicon codicon-file-media"></i> ${f}</span>`)}`));
-    }
-
-    // File groups (workflow file fields + memories for both delegation types)
-    const fileGroups = getProposalFileGroups(delegateInput);
-    if (fileGroups.length > 0) {
-      // prettier-ignore
-      const fileItems = html`${fileGroups.flatMap((g) => g.files.map((f) => html`<li class="detail-item"><i class="codicon codicon-file"></i> <span class="${g.clickable ? 'file-link clickable-link' : 'file-label'}" data-file=${ifDefined(g.clickable ? f : undefined)}>${f}</span> <span class="file-source">(${g.label})</span></li>`))}`;
-      // prettier-ignore
-      sections.push(buildToolUseSection('Files:', html`<ul class="detail-list">${fileItems}</ul>`));
-    }
-  }
-  // Handle specialized structured tool cards via renderer registry
-  else if (Object.hasOwn(SPECIALIZED_TOOL_SECTION_RENDERERS, toolName)) {
-    const content =
-      SPECIALIZED_TOOL_SECTION_RENDERERS[
-        toolName as keyof typeof SPECIALIZED_TOOL_SECTION_RENDERERS
-      ](input);
-    if (content != null && content !== nothing) {
-      sections.push(content);
-    }
-  }
-  // Handle MCP tool calls with richer result rendering
-  else if (toolName.startsWith('mcp:')) {
-    let renderedMcpOutput = false;
-
-    if (input != null) {
-      const { text: inputValue, language: inputLanguage } =
-        stringifyWithLanguage(input);
-      if (inputValue) {
-        sections.push(
-          buildToolSection('Arguments:', inputValue, {
-            toolName,
-            language: inputLanguage,
-          }),
-        );
-      }
-    }
-
-    const mcpParsed = CodexMcpToolOutputSchema.safeParse(parsed.output);
-    const mcpOutput: CodexMcpToolOutput | null = mcpParsed.success
-      ? mcpParsed.data
-      : null;
-    const contentBlocks = Array.isArray(mcpOutput?.contentBlocks)
-      ? mcpOutput.contentBlocks
-      : [];
-    const textBlocks = contentBlocks
-      .filter(isMcpTextBlock)
-      .map((block) => block.text);
-    const otherBlocks = contentBlocks.filter((block) => !isMcpTextBlock(block));
-
-    if (typeof mcpOutput?.status === 'string') {
-      const statusIcon =
-        mcpOutput.status === 'failed'
-          ? 'codicon-error'
-          : mcpOutput.status === 'in_progress'
-            ? 'codicon-sync spin'
-            : 'codicon-check';
-      // prettier-ignore
-      sections.push(buildToolUseSection('Status:', html`<span class="extract-flag"><i class="codicon ${statusIcon}"></i> ${mcpOutput.status}</span>`));
-      renderedMcpOutput = true;
-    }
-
-    if (textBlocks.length > 0) {
-      sections.push(buildToolSection('Response:', textBlocks.join('\n\n')));
-      renderedMcpOutput = true;
-    }
-
-    if (mcpOutput && 'structuredContent' in mcpOutput) {
-      const { text: structuredText, language: structuredLanguage } =
-        stringifyWithLanguage(mcpOutput.structuredContent);
-      if (structuredText) {
-        sections.push(
-          buildToolSection('Structured:', structuredText, {
-            toolName,
-            language: structuredLanguage,
-          }),
-        );
-        renderedMcpOutput = true;
-      }
-    }
-
-    if (otherBlocks.length > 0) {
-      const { text: contentText, language: contentLanguage } =
-        stringifyWithLanguage(otherBlocks);
-      if (contentText) {
-        sections.push(
-          buildToolSection('Content:', contentText, {
-            toolName,
-            language: contentLanguage,
-          }),
-        );
-        renderedMcpOutput = true;
-      }
-    }
-
-    if (!renderedMcpOutput && outputText) {
-      sections.push(
-        buildToolSection('Result:', outputText, {
-          toolName,
-          extraClass: 'tool-output-full',
-        }),
-      );
-    }
-  }
-  // Default handling for other tools
-  else if (input != null) {
-    const codeLanguage = TOOL_CODE_LANGUAGES.get(toolName);
-    const { isCodeOnly, code } = codeLanguage
-      ? extractCodeOnlyInput(input)
-      : { isCodeOnly: false, code: '' };
-
-    if (isCodeOnly) {
-      sections.push(
-        buildToolSection('', code, { toolName, language: codeLanguage }),
-      );
-    } else {
-      const { text: inputValue, language: inputLanguage } =
-        stringifyWithLanguage(input);
-      if (inputValue) {
-        sections.push(
-          buildToolSection('', inputValue, {
-            toolName,
-            language: inputLanguage,
-          }),
-        );
-      }
-    }
-  }
+  const sections: TemplateResult[] = dispatchToolSections({
+    toolName,
+    input,
+    filePath,
+    parsedOutput: parsed.output,
+    outputText,
+    isInProgress,
+  });
 
   // Show output if present
   const isWriteTool = TOOLS_WITH_FILE_CONTENT.has(toolName);

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -618,38 +618,47 @@ function buildDefaultSections(ctx: ToolSectionContext): TemplateResult[] {
 }
 
 const TOOL_SECTION_BUILDERS: Array<{
-  match: (toolName: string) => boolean;
+  match: (ctx: ToolSectionContext) => boolean;
   build: (ctx: ToolSectionContext) => TemplateResult[];
 }> = [
   {
-    match: (n) => TOOLS_WITH_DIFF_INPUT.has(n),
+    match: (ctx) => TOOLS_WITH_DIFF_INPUT.has(ctx.toolName),
     build: buildEditDiffInputSections,
   },
   {
-    match: (n) => TOOLS_WITH_FILE_LINK.has(n),
+    match: (ctx) =>
+      TOOLS_WITH_FILE_LINK.has(ctx.toolName) && Boolean(ctx.filePath),
     build: buildFileLinkSections,
   },
   {
-    match: (n) => TOOLS_WITH_FILE_CONTENT.has(n),
+    match: (ctx) =>
+      TOOLS_WITH_FILE_CONTENT.has(ctx.toolName) && Boolean(ctx.filePath),
     build: buildFileContentSections,
   },
-  { match: (n) => n === 'memory', build: buildMemorySections },
-  { match: (n) => n === 'executions', build: buildExecutionsSections },
+  { match: (ctx) => ctx.toolName === 'memory', build: buildMemorySections },
   {
-    match: (n) => n === 'accept_run_files',
+    match: (ctx) => ctx.toolName === 'executions',
+    build: buildExecutionsSections,
+  },
+  {
+    match: (ctx) => ctx.toolName === 'accept_run_files',
     build: buildAcceptRunFilesSections,
   },
-  { match: (n) => DELEGATION_TOOLS.has(n), build: buildDelegationSections },
   {
-    match: (n) => Object.hasOwn(SPECIALIZED_TOOL_SECTION_RENDERERS, n),
+    match: (ctx) => DELEGATION_TOOLS.has(ctx.toolName),
+    build: buildDelegationSections,
+  },
+  {
+    match: (ctx) =>
+      Object.hasOwn(SPECIALIZED_TOOL_SECTION_RENDERERS, ctx.toolName),
     build: buildSpecializedSections,
   },
-  { match: (n) => n.startsWith('mcp:'), build: buildMcpSections },
+  { match: (ctx) => ctx.toolName.startsWith('mcp:'), build: buildMcpSections },
 ];
 
 function dispatchToolSections(ctx: ToolSectionContext): TemplateResult[] {
   for (const { match, build } of TOOL_SECTION_BUILDERS) {
-    if (match(ctx.toolName)) return build(ctx);
+    if (match(ctx)) return build(ctx);
   }
   return buildDefaultSections(ctx);
 }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -622,7 +622,8 @@ const TOOL_SECTION_BUILDERS: Array<{
   build: (ctx: ToolSectionContext) => TemplateResult[];
 }> = [
   {
-    match: (ctx) => TOOLS_WITH_DIFF_INPUT.has(ctx.toolName),
+    match: (ctx) =>
+      TOOLS_WITH_DIFF_INPUT.has(ctx.toolName) && isPlainObject(ctx.input),
     build: buildEditDiffInputSections,
   },
   {
@@ -635,17 +636,22 @@ const TOOL_SECTION_BUILDERS: Array<{
       TOOLS_WITH_FILE_CONTENT.has(ctx.toolName) && Boolean(ctx.filePath),
     build: buildFileContentSections,
   },
-  { match: (ctx) => ctx.toolName === 'memory', build: buildMemorySections },
   {
-    match: (ctx) => ctx.toolName === 'executions',
+    match: (ctx) => ctx.toolName === 'memory' && isPlainObject(ctx.input),
+    build: buildMemorySections,
+  },
+  {
+    match: (ctx) => ctx.toolName === 'executions' && isPlainObject(ctx.input),
     build: buildExecutionsSections,
   },
   {
-    match: (ctx) => ctx.toolName === 'accept_run_files',
+    match: (ctx) =>
+      ctx.toolName === 'accept_run_files' && isPlainObject(ctx.input),
     build: buildAcceptRunFilesSections,
   },
   {
-    match: (ctx) => DELEGATION_TOOLS.has(ctx.toolName),
+    match: (ctx) =>
+      DELEGATION_TOOLS.has(ctx.toolName) && isPlainObject(ctx.input),
     build: buildDelegationSections,
   },
   {

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -26,6 +26,13 @@ import {
   clampNestedDelegationDepth,
 } from '@shared/constants/delegationPolicy';
 
+function clampSetting(value: number, min?: number, max?: number): number {
+  let result = value;
+  if (min != null) result = Math.max(min, result);
+  if (max != null) result = Math.min(max, result);
+  return result;
+}
+
 @customElement('multi-agent-tab')
 export class MultiAgentTab extends LitElement {
   static override styles = [
@@ -281,22 +288,6 @@ export class MultiAgentTab extends LitElement {
     );
   }
 
-  private handleToggle(event: Event): void {
-    this.emitToggle('super-yolo-toggle', event);
-  }
-
-  private handleKillToggle(event: Event): void {
-    this.emitToggle('allow-orchestrator-kill-toggle', event);
-  }
-
-  private handleDetachToggle(event: Event): void {
-    this.emitToggle('detach-subagents-on-stop-toggle', event);
-  }
-
-  private handleWorktreeSupportToggle(event: Event): void {
-    this.emitToggle('worktree-support-toggle', event);
-  }
-
   private handleNestedDelegationMaxDepthChange(input: HTMLInputElement): void {
     const parsed = Number(input.value);
     if (Number.isNaN(parsed)) {
@@ -333,9 +324,7 @@ export class MultiAgentTab extends LitElement {
       input.value = String(setting.value);
       return;
     }
-    let value = parsed;
-    if (setting.min != null) value = Math.max(setting.min, value);
-    if (setting.max != null) value = Math.min(setting.max, value);
+    const value = clampSetting(parsed, setting.min, setting.max);
     if (value !== parsed) input.value = String(value);
     this.dispatchEvent(
       createEvent('reliability-setting-change', { key: setting.key, value }),
@@ -501,7 +490,7 @@ export class MultiAgentTab extends LitElement {
           <vscode-checkbox
             ?checked=${this.superYoloEnabled}
             ?disabled=${this.toggleDisabled}
-            @change=${this.handleToggle}
+            @change=${(e: Event) => this.emitToggle('super-yolo-toggle', e)}
           >
             Auto-approve delegated tasks
           </vscode-checkbox>
@@ -516,7 +505,8 @@ export class MultiAgentTab extends LitElement {
         <div class="setting-block">
           <vscode-checkbox
             ?checked=${this.allowOrchestratorKill}
-            @change=${this.handleKillToggle}
+            @change=${(e: Event) =>
+              this.emitToggle('allow-orchestrator-kill-toggle', e)}
           >
             Let orchestrator stop agents early
           </vscode-checkbox>
@@ -530,7 +520,8 @@ export class MultiAgentTab extends LitElement {
         <div class="setting-block">
           <vscode-checkbox
             ?checked=${this.detachSubagentsOnStop}
-            @change=${this.handleDetachToggle}
+            @change=${(e: Event) =>
+              this.emitToggle('detach-subagents-on-stop-toggle', e)}
           >
             Keep agents running if I stop the orchestrator
           </vscode-checkbox>
@@ -543,7 +534,8 @@ export class MultiAgentTab extends LitElement {
         <div class="setting-block">
           <vscode-checkbox
             ?checked=${this.worktreeSupport}
-            @change=${this.handleWorktreeSupportToggle}
+            @change=${(e: Event) =>
+              this.emitToggle('worktree-support-toggle', e)}
           >
             Allow agents to work in git worktrees
           </vscode-checkbox>

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -46,6 +46,18 @@ const FEEDBACK_ACTIVE = selectorGroup(ITEM_NAMES, '--feedback-active');
 const BADGES = unsafeCSS(
   '.workflow-proposal__category-badge, .external-inquiry-request__mode-badge',
 );
+const SCROLLABLE_DETAILS = selectorGroup(
+  ITEM_NAMES.filter((n) => n !== 'workflow-proposal'),
+  '__details',
+);
+
+const sp = {
+  tiny: unsafeCSS('${sp.tiny}'),
+  small: unsafeCSS('${sp.small}'),
+  medium: unsafeCSS('${sp.medium}'),
+  large: unsafeCSS('${sp.large}'),
+  xlarge: unsafeCSS('${sp.xlarge}'),
+} as const;
 
 export const requestPanelStyles: CSSResult = css`
   /* ================================================================
@@ -53,21 +65,21 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   :is(${CONTAINERS}) {
-    margin: var(--spacing-large) 0;
-    padding: var(--spacing-large);
+    margin: ${sp.large} 0;
+    padding: ${sp.large};
     border: var(--border-thin) solid var(--vscode-input-border);
     border-radius: var(--border-radius-large);
     background: var(--vscode-editor-background);
     box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.12));
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
+    gap: ${sp.medium};
   }
 
   :is(${HEADERS}) {
     display: flex;
     align-items: center;
-    gap: var(--spacing-medium);
+    gap: ${sp.medium};
     font-weight: var(--font-weight-semibold);
     color: var(--vscode-editor-foreground);
   }
@@ -75,7 +87,7 @@ export const requestPanelStyles: CSSResult = css`
   :is(${LISTS}) {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-medium);
+    gap: ${sp.medium};
   }
 
   :is(${ITEMS}) {
@@ -84,25 +96,21 @@ export const requestPanelStyles: CSSResult = css`
     border-radius: var(--border-radius);
     border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
     background: var(--vscode-editorHoverWidget-background);
-    padding: var(--spacing-medium);
-    gap: var(--spacing-medium);
+    padding: ${sp.medium};
+    gap: ${sp.medium};
     position: relative;
   }
 
   :is(${DETAILS}) {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   /* Scroll constraint for panels with potentially long content.
      Excluded: workflow-proposal__details (has an absolutely-positioned
      dropdown that would be clipped by overflow-y: auto). */
-  .approval-request__details,
-  .bash-approval-request__details,
-  .retry-request__details,
-  .plan-approval-request__details,
-  .external-inquiry-request__details {
+  :is(${SCROLLABLE_DETAILS}) {
     max-height: min(34vh, 26rem);
     overflow-y: auto;
     scrollbar-gutter: stable;
@@ -114,20 +122,20 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--color-text-secondary);
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
     flex-wrap: wrap;
   }
 
   :is(${ACTIONS}) {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   :is(${ACTIONS})::part(container) {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   :is(${ACTIONS}) vscode-toolbar-button {
@@ -136,7 +144,7 @@ export const requestPanelStyles: CSSResult = css`
 
   :is(${ACTIONS}) vscode-toolbar-button::part(control) {
     justify-content: flex-start;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   /* Shared action button colors */
@@ -161,7 +169,7 @@ export const requestPanelStyles: CSSResult = css`
     font-weight: var(--font-weight-semibold);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    padding: var(--spacing-tiny) var(--border-radius-large);
+    padding: ${sp.tiny} var(--border-radius-large);
     border-radius: var(--border-radius);
     white-space: nowrap;
   }
@@ -210,7 +218,7 @@ export const requestPanelStyles: CSSResult = css`
   .approval-request__diff {
     display: inline-flex;
     align-items: baseline;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .approval-request__diff-added,
@@ -258,7 +266,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .approval-request__actions .diff-dropdown .diff-dropdown-menu {
     position: absolute;
-    top: calc(100% + var(--spacing-tiny));
+    top: calc(100% + ${sp.tiny});
     left: 0;
     z-index: 100;
     min-width: 150px;
@@ -326,7 +334,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .retry-request__error-details {
-    margin-top: var(--spacing-tiny);
+    margin-top: ${sp.tiny};
     font-size: var(--font-size-xs);
   }
 
@@ -335,7 +343,7 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-descriptionForeground);
     display: flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: ${sp.tiny};
     user-select: none;
   }
 
@@ -346,8 +354,8 @@ export const requestPanelStyles: CSSResult = css`
   /* Note: .toggle-icon rotation handled by commonViewStyles */
 
   .retry-request__error-body {
-    margin-top: var(--spacing-tiny);
-    padding: var(--spacing-small);
+    margin-top: ${sp.tiny};
+    padding: ${sp.small};
     background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     font-family: var(--vscode-editor-font-family);
@@ -377,7 +385,7 @@ export const requestPanelStyles: CSSResult = css`
   .workflow-proposal__header-row {
     display: flex;
     align-items: baseline;
-    gap: var(--spacing-medium);
+    gap: ${sp.medium};
     flex-wrap: wrap;
   }
 
@@ -405,14 +413,14 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposal__model::before {
     content: '\u2022';
-    margin-right: var(--spacing-small);
+    margin-right: ${sp.small};
   }
 
   .workflow-proposal__agent-select,
   .workflow-proposal__model-select {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .workflow-proposal__agent-select .codicon,
@@ -444,21 +452,21 @@ export const requestPanelStyles: CSSResult = css`
     max-height: 12em;
     overflow-y: auto;
     line-height: var(--line-height-normal);
-    padding: var(--spacing-small) 0;
+    padding: ${sp.small} 0;
     border-bottom: var(--border-thin) solid var(--vscode-editorWidget-border);
   }
 
   .workflow-proposal__extract-flags {
     display: flex;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
     flex-wrap: wrap;
-    margin-top: var(--spacing-small);
+    margin-top: ${sp.small};
   }
 
   .workflow-proposal__extract-flag {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-tiny);
+    gap: ${sp.tiny};
     text-transform: none;
     letter-spacing: normal;
   }
@@ -466,8 +474,8 @@ export const requestPanelStyles: CSSResult = css`
   .workflow-proposal__files {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
-    margin-top: var(--spacing-small);
+    gap: ${sp.small};
+    margin-top: ${sp.small};
   }
 
   .workflow-proposal__files > div {
@@ -527,12 +535,12 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .plan-approval-request__steps {
-    margin: var(--spacing-small) 0;
-    padding-left: var(--spacing-xlarge);
+    margin: ${sp.small} 0;
+    padding-left: ${sp.xlarge};
   }
 
   .plan-approval-request__steps li {
-    margin-bottom: var(--spacing-small);
+    margin-bottom: ${sp.small};
   }
 
   .plan-approval-request__step-desc {
@@ -544,7 +552,7 @@ export const requestPanelStyles: CSSResult = css`
     font-family: var(--vscode-editor-font-family);
     font-size: var(--font-size-xs);
     color: var(--color-text-secondary);
-    margin-top: var(--spacing-tiny);
+    margin-top: ${sp.tiny};
   }
 
   .plan-approval-request__file {
@@ -560,7 +568,7 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   :is(${FEEDBACKS}) {
-    margin-top: var(--spacing-small);
+    margin-top: ${sp.small};
   }
 
   :is(${FEEDBACK_INPUTS}) {
@@ -579,7 +587,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-requests__nav {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
     margin-left: auto;
   }
 
@@ -622,7 +630,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__context {
     font-size: var(--font-size-sm);
     color: var(--vscode-descriptionForeground);
-    padding: var(--spacing-small) var(--spacing-medium);
+    padding: ${sp.small} ${sp.medium};
     background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     border-left: var(--border-thick) solid
@@ -634,7 +642,7 @@ export const requestPanelStyles: CSSResult = css`
     background: var(--vscode-textCodeBlock-background, rgba(0, 0, 0, 0.05));
     border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
     border-radius: var(--border-radius);
-    padding: var(--spacing-medium);
+    padding: ${sp.medium};
     position: relative;
   }
 
@@ -652,24 +660,24 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__question-actions {
     display: flex;
     justify-content: flex-end;
-    margin-top: var(--spacing-small);
-    padding-top: var(--spacing-small);
+    margin-top: ${sp.small};
+    padding-top: ${sp.small};
     border-top: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
   }
 
   .external-inquiry-request__search-hint {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
     font-size: var(--font-size-sm);
     color: var(--vscode-editorInfo-foreground, var(--vscode-focusBorder));
-    padding: var(--spacing-small) 0;
+    padding: ${sp.small} 0;
   }
 
   .external-inquiry-request__attach-files {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .external-inquiry-request__attach-label {
@@ -678,14 +686,14 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--vscode-descriptionForeground);
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .external-inquiry-request__file-list {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-tiny);
-    padding: var(--spacing-small);
+    gap: ${sp.tiny};
+    padding: ${sp.small};
     background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
@@ -693,7 +701,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__file-item {
     display: flex;
     align-items: center;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
     font-size: var(--font-size-sm);
     font-family: var(--vscode-editor-font-family);
     color: var(--vscode-textLink-foreground);
@@ -702,20 +710,20 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__answer-area {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .external-inquiry-request__session-links {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .external-inquiry-request__session-links-known,
   .external-inquiry-request__session-links-input-group {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-small);
+    gap: ${sp.small};
   }
 
   .external-inquiry-request__session-links-label {
@@ -727,8 +735,8 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__session-links-list {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-tiny);
-    padding: var(--spacing-small);
+    gap: ${sp.tiny};
+    padding: ${sp.small};
     background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
@@ -748,7 +756,7 @@ export const requestPanelStyles: CSSResult = css`
     font-family: var(--vscode-editor-font-family);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
-    padding: var(--spacing-medium);
+    padding: ${sp.medium};
     background: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
     border: var(--border-thin) solid var(--vscode-input-border);
@@ -798,7 +806,7 @@ export const requestPanelStyles: CSSResult = css`
     font-family: var(--vscode-editor-font-family);
     font-size: var(--font-size);
     line-height: var(--line-height-normal);
-    padding: var(--spacing-medium);
+    padding: ${sp.medium};
     background: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
     border: var(--border-thin) solid var(--vscode-input-border);
@@ -821,11 +829,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   @media (max-height: 900px) {
-    .approval-request__details,
-    .bash-approval-request__details,
-    .retry-request__details,
-    .plan-approval-request__details,
-    .external-inquiry-request__details {
+    :is(${SCROLLABLE_DETAILS}) {
       max-height: min(28vh, 20rem);
     }
 

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -52,11 +52,11 @@ const SCROLLABLE_DETAILS = selectorGroup(
 );
 
 const sp = {
-  tiny: unsafeCSS('${sp.tiny}'),
-  small: unsafeCSS('${sp.small}'),
-  medium: unsafeCSS('${sp.medium}'),
-  large: unsafeCSS('${sp.large}'),
-  xlarge: unsafeCSS('${sp.xlarge}'),
+  tiny: unsafeCSS('var(--spacing-tiny)'),
+  small: unsafeCSS('var(--spacing-small)'),
+  medium: unsafeCSS('var(--spacing-medium)'),
+  large: unsafeCSS('var(--spacing-large)'),
+  xlarge: unsafeCSS('var(--spacing-xlarge)'),
 } as const;
 
 export const requestPanelStyles: CSSResult = css`

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -62,10 +62,10 @@ import {
   isSuperYoloFeatureEnabled,
   isProposalBypassedForStream,
   isApprovalBypassedForStream,
-  setToolEditApprovalSessionBypass,
+  enableYoloOnChildStream,
 } from '@tools/approval';
+import { computeAndWriteWorkflowDiffs } from '@tools/subagentDiffs';
 import {
-  computeAndWriteWorkflowDiffs,
   formatSubagentDelivery,
   formatSubagentError,
   formatSubagentProgress,
@@ -327,11 +327,7 @@ async function executeSubagent(
     onStreamResolved: (resolvedStreamId) => {
       childStreamId = resolvedStreamId;
       if (options?.enableYoloOnChild) {
-        // Silent: fires before stream activation so the UI notification would
-        // be dropped. The subsequent SYNC_STREAM_CONTENT reads from the map.
-        setToolEditApprovalSessionBypass(resolvedStreamId, true, {
-          silent: true,
-        });
+        enableYoloOnChildStream(resolvedStreamId);
       }
     },
     onProgress,

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -15,16 +15,12 @@ import { z } from 'zod';
 // Local imports - agent
 import {
   getExecutionStore,
-  type ExecutionListingEntry,
   type ChildRecord,
-  type TodoEntry,
   listExecutions,
 } from '@agent/storage';
 import { flowKey } from '@agent/node/persistedFlow';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import {
-  type ExecutionHandle,
-  type ExecutionStatusInfo,
   ACTIVE_STATUSES,
   AgentExecutionHandle,
   ProcessExecutionHandle,
@@ -45,7 +41,6 @@ import { isDirectory } from '@common/files/fsEntryType';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
-  EXECUTION_STATUS,
   ExecutionIdSchema,
   type ExecutionId,
 } from '@shared/schemas';
@@ -53,6 +48,15 @@ import { StorageFS } from '@utils/files';
 import { resolveStoragePath } from '@utils/files/taskRunStorage';
 import { getPathSegments } from '@utils/core/pathCore';
 import { splitContentLines } from '@utils/text/stringUtils';
+import {
+  formatListingLine,
+  formatProgressLine,
+  formatStatusInfo,
+  formatTodoHeader,
+  formatTodoSection,
+  getAvailablePaths,
+  getExecutionStatusInfo,
+} from './executionFormatters';
 import { ToolError, type ToolResult } from './result';
 import { defineTool } from './core/define';
 import {
@@ -83,22 +87,6 @@ const WORKFLOW_ONLY_FIELDS = new Set([
 
 /** Config fields only relevant to toolUse agents — hidden for workflow. */
 const TOOL_USE_ONLY_FIELDS = new Set(['toolConfig']);
-
-/** Return paths available for a given agent category. */
-function getAvailablePaths(category?: string, hasChildren?: boolean): string[] {
-  const common = ['config', 'report'];
-  if (hasChildren) common.push('children');
-  switch (category) {
-    case 'toolUse':
-      return [...common, 'conversation', 'todos'];
-    case 'workflow':
-      return [...common, 'files'];
-    case 'process':
-      return [...common, 'output'];
-    default:
-      return [...common, 'conversation', 'todos', 'files', 'output'];
-  }
-}
 
 /**
  * Listen for follow-up messages on the current stream and abort the given
@@ -207,26 +195,6 @@ export type ExecutionsToolInput = z.infer<typeof ExecutionsToolInputSchema>;
 // Helpers
 // ============================================================================
 
-/** Format status info as a display string. */
-function formatStatusInfo(info: ExecutionStatusInfo): string {
-  return info.elapsed
-    ? `${info.status} (${info.elapsed} elapsed)`
-    : info.status;
-}
-
-/** Resolve the runtime status for an execution ID, using persisted terminal status as fallback. */
-function getExecutionStatusInfo(
-  executionId: string,
-  terminalStatus?: string,
-): ExecutionStatusInfo {
-  const handle = getHandle(executionId);
-  if (handle) return handle.getStatus();
-  return {
-    status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,
-    elapsed: null,
-  };
-}
-
 /**
  * Single-pass check: should the wait endpoint skip blocking on this execution?
  *
@@ -261,51 +229,6 @@ function shouldSkipWait(executionId: string): boolean {
   }
 
   return false;
-}
-
-/** Format round progress as a display line, or empty string if unavailable. */
-function formatProgressLine(handle: ExecutionHandle | undefined): string {
-  const progress = handle?.getProgress();
-  if (
-    progress?.currentRound === undefined ||
-    progress.totalRounds === undefined
-  ) {
-    return '';
-  }
-  return `Progress: round ${progress.currentRound + 1}/${progress.totalRounds}`;
-}
-
-/** Format a listing entry as a single summary line. */
-function formatListingLine(entry: ExecutionListingEntry): string {
-  const ts = entry.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
-  const info = getExecutionStatusInfo(entry.id, entry.terminalStatus);
-  const categoryTag = entry.category ? `  ${entry.category}` : '';
-  const parentSuffix = entry.parentExecutionId
-    ? `  parent=${entry.parentExecutionId}`
-    : '';
-  const descSuffix = entry.description ? `  — ${entry.description}` : '';
-  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
-}
-
-const TODO_ICON: Record<string, string> = {
-  completed: '[x]',
-  in_progress: '[>]',
-  pending: '[ ]',
-};
-
-/** Format todo items as a checklist. */
-function formatTodoSection(todos: TodoEntry[]): string[] {
-  return todos.map((t) => {
-    const icon = TODO_ICON[t.status ?? ''] ?? '[ ]';
-    return `${icon} ${t.content ?? '(no description)'}`;
-  });
-}
-
-/** Format a todo header with counts. */
-function formatTodoHeader(executionId: string, todos: TodoEntry[]): string {
-  const completed = todos.filter((t) => t.status === 'completed').length;
-  const inProgress = todos.filter((t) => t.status === 'in_progress').length;
-  return `Tasks for ${executionId} (${completed} done, ${inProgress} active, ${todos.length - completed - inProgress} pending):`;
 }
 
 export class ExecutionsTool extends defineTool({

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -8,6 +8,7 @@ import type { ToolResult } from '@tools/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
 import { createStreamApprovalController } from './streamApprovalQueue';
+import { isApprovalBypassedForStream } from './toolEditApproval';
 
 export const BashApprovalRequestSchema = z.object({
   command: z.string(),
@@ -44,7 +45,7 @@ export async function requestBashApproval(
 
   if (
     !approvalsEnabled ||
-    (streamId && bashApprovalController.isBypassed(streamId))
+    (streamId && isApprovalBypassedForStream(streamId))
   ) {
     return { accepted: true };
   }
@@ -58,7 +59,7 @@ async function showApprovalPrompt(
   request: BashApprovalRequest,
   streamId?: StreamTabId,
 ): Promise<BashApprovalResult> {
-  if (streamId && bashApprovalController.isBypassed(streamId)) {
+  if (streamId && isApprovalBypassedForStream(streamId)) {
     return { accepted: true };
   }
 

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,21 +1,25 @@
+import { z } from 'zod';
+
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
 import { bus } from '@eventBus/ProgressEventBus';
-import type { StreamTabId } from '@shared/schemas';
+import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import type { ToolResult } from '@tools/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
 
-import { isApprovalBypassedForStream } from './toolEditApproval';
+import { createStreamApprovalController } from './streamApprovalQueue';
 
-export interface BashApprovalRequest {
-  command: string;
-  streamId?: StreamTabId;
-}
+export const BashApprovalRequestSchema = z.object({
+  command: z.string(),
+  streamId: StreamTabIdSchema.optional(),
+});
+export type BashApprovalRequest = z.infer<typeof BashApprovalRequestSchema>;
 
-export interface BashApprovalResult {
-  accepted: boolean;
-  userMessage?: string;
-}
+export const BashApprovalResultSchema = z.object({
+  accepted: z.boolean(),
+  userMessage: z.string().optional(),
+});
+export type BashApprovalResult = z.infer<typeof BashApprovalResultSchema>;
 
 export const BASH_APPROVAL_CONFIG_KEY = 'texra.toolUse.requireBashApproval';
 
@@ -23,34 +27,12 @@ export const BASH_APPROVAL_ACTIONS = ['approve', 'reject'] as const;
 
 export type BashApprovalAction = (typeof BASH_APPROVAL_ACTIONS)[number];
 
-export interface RejectablePendingEntry {
-  streamId?: StreamTabId;
-  isSettled: () => boolean;
-  settle: (result: { accepted: false }) => void;
-}
+export const bashApprovalController =
+  createStreamApprovalController<BashApprovalResult>({
+    rejectionResult: () => ({ accepted: false }),
+  });
 
-export function rejectPendingEntries<T extends RejectablePendingEntry>(
-  entries: Iterable<T>,
-  streamId?: StreamTabId,
-): void {
-  for (const entry of entries) {
-    const matches = streamId === undefined || entry.streamId === streamId;
-    if (matches && !entry.isSettled()) {
-      entry.settle({ accepted: false });
-    }
-  }
-}
-
-let queue: Promise<void> = Promise.resolve();
 let approvalCounter = 0;
-const pendingApprovals = new Map<
-  string,
-  {
-    streamId?: StreamTabId;
-    settle: (result: BashApprovalResult) => void;
-    isSettled: () => boolean;
-  }
->();
 
 export async function requestBashApproval(
   request: BashApprovalRequest,
@@ -62,24 +44,21 @@ export async function requestBashApproval(
 
   if (
     !approvalsEnabled ||
-    (streamId && isApprovalBypassedForStream(streamId))
+    (streamId && bashApprovalController.isBypassed(streamId))
   ) {
     return { accepted: true };
   }
 
-  const operation = queue.then(() => showApprovalPrompt(request, streamId));
-  queue = operation.then(
-    () => {},
-    () => {},
+  return bashApprovalController.enqueue(() =>
+    showApprovalPrompt(request, streamId),
   );
-  return operation;
 }
 
 async function showApprovalPrompt(
   request: BashApprovalRequest,
   streamId?: StreamTabId,
 ): Promise<BashApprovalResult> {
-  if (streamId && isApprovalBypassedForStream(streamId)) {
+  if (streamId && bashApprovalController.isBypassed(streamId)) {
     return { accepted: true };
   }
 
@@ -94,7 +73,7 @@ async function showApprovalPrompt(
         resolve(result);
       };
 
-      pendingApprovals.set(requestId, {
+      bashApprovalController.registerPending(requestId, {
         streamId,
         settle,
         isSettled: () => settled,
@@ -115,7 +94,7 @@ async function showApprovalPrompt(
       });
     });
   } finally {
-    pendingApprovals.delete(requestId);
+    bashApprovalController.unregisterPending(requestId);
     bus.emit('resolveBashPermission', { requestId });
   }
 }
@@ -125,7 +104,7 @@ export async function handleProgressViewBashApprovalAction(payload: {
   action: BashApprovalAction;
   feedback?: string;
 }): Promise<void> {
-  const entry = pendingApprovals.get(payload.requestId);
+  const entry = bashApprovalController.getPending(payload.requestId);
   if (!entry || entry.isSettled()) return;
 
   entry.settle({
@@ -133,18 +112,6 @@ export async function handleProgressViewBashApprovalAction(payload: {
     userMessage:
       payload.action === 'reject' ? payload.feedback?.trim() : undefined,
   });
-}
-
-/** @internal Called by unified cleanup in toolEditApproval.ts */
-export function _rejectPendingBashApprovalsForStream(
-  streamId: StreamTabId,
-): void {
-  rejectPendingEntries(pendingApprovals.values(), streamId);
-}
-
-/** @internal Called by unified cleanup in toolEditApproval.ts */
-export function _rejectAllPendingBashApprovals(): void {
-  rejectPendingEntries(pendingApprovals.values());
 }
 
 export function buildBashApprovalRejectedResult(

--- a/src/tools/approval/index.ts
+++ b/src/tools/approval/index.ts
@@ -1,33 +1,27 @@
 /**
  * Unified approval system exports.
  *
- * This module serves as the coordination point for approval cleanup,
- * breaking the circular dependency between bashApproval and toolEditApproval.
+ * This module is the coordination point for approval cleanup so that
+ * bash and tool-edit modules don't form a circular dependency.
  *
- * Import cleanup functions from here, not from individual modules.
+ * Import cleanup helpers from here, not from individual modules.
  */
 
-// Local file imports - individual approval modules
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import type { StreamTabId } from '@shared/schemas';
 import {
   _rejectAllPendingInquiries,
   _rejectPendingInquiriesForStream,
 } from '@tools/inquiry';
-import {
-  _rejectAllPendingBashApprovals,
-  _rejectPendingBashApprovalsForStream,
-} from './bashApproval';
+
+import { bashApprovalController } from './bashApproval';
 import {
   _clearAllProposalBypass,
   _clearProposalBypassForStream,
-  _disableAllProposalBypasses,
 } from './proposalApproval';
 import {
-  _clearAllApprovalBypass,
-  _clearApprovalBypassForStream,
-  _rejectAllPendingToolEditApprovals,
-  _rejectPendingToolEditApprovalsForStream,
+  toolEditApprovalController,
+  enableYoloOnChildStream,
 } from './toolEditApproval';
 
 /**
@@ -35,10 +29,10 @@ import {
  * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
  */
 export function cleanupApprovalsForStream(streamId: StreamTabId): void {
-  _rejectPendingToolEditApprovalsForStream(streamId);
-  _rejectPendingBashApprovalsForStream(streamId);
+  toolEditApprovalController.rejectPendingForStream(streamId);
+  bashApprovalController.rejectPendingForStream(streamId);
   _rejectPendingInquiriesForStream(streamId);
-  _clearApprovalBypassForStream(streamId);
+  toolEditApprovalController.clearBypassForStream(streamId);
   _clearProposalBypassForStream(streamId);
   planApprovalCoordinator.clearForStream(streamId);
 }
@@ -48,13 +42,15 @@ export function cleanupApprovalsForStream(streamId: StreamTabId): void {
  * Handles pending approvals (tool edits + bash), plan approvals, and YOLO mode state.
  */
 export function cleanupAllApprovals(): void {
-  _rejectAllPendingToolEditApprovals();
-  _rejectAllPendingBashApprovals();
+  toolEditApprovalController.rejectAllPending();
+  bashApprovalController.rejectAllPending();
   _rejectAllPendingInquiries();
-  _clearAllApprovalBypass();
+  toolEditApprovalController.clearAllBypass();
   _clearAllProposalBypass();
   planApprovalCoordinator.clearAll();
 }
+
+export { enableYoloOnChildStream };
 
 // Re-export commonly used functions from individual modules
 export {

--- a/src/tools/approval/streamApprovalQueue.ts
+++ b/src/tools/approval/streamApprovalQueue.ts
@@ -1,0 +1,114 @@
+/**
+ * Generic stream-scoped approval controller.
+ *
+ * Encapsulates the shared concerns of bash and tool-edit approvals:
+ *   - serialized request queue (one prompt at a time)
+ *   - registry of in-flight pending approvals keyed by request id
+ *   - per-stream bypass state with optional UI notification hook
+ *   - rejection on stream cleanup
+ *
+ * Parameterized by the approval result type so each controller can carry
+ * domain-specific result fields (e.g. tool-edit appliedContent / userPatch).
+ */
+
+import type { StreamTabId } from '@shared/schemas';
+
+export interface PendingApproval<R extends { accepted: boolean }> {
+  streamId?: StreamTabId;
+  isSettled: () => boolean;
+  settle: (result: R) => void;
+}
+
+export interface StreamApprovalController<R extends { accepted: boolean }> {
+  registerPending(id: string, entry: PendingApproval<R>): void;
+  unregisterPending(id: string): void;
+  getPending(id: string): PendingApproval<R> | undefined;
+  isBypassed(streamId: StreamTabId): boolean;
+  setBypass(
+    streamId: StreamTabId,
+    enabled: boolean,
+    options?: { silent?: boolean },
+  ): void;
+  toggleBypass(streamId: StreamTabId): boolean;
+  enqueue<T>(run: () => Promise<T>): Promise<T>;
+  rejectPendingForStream(streamId: StreamTabId): void;
+  rejectAllPending(): void;
+  clearBypassForStream(streamId: StreamTabId): void;
+  clearAllBypass(): void;
+}
+
+export interface StreamApprovalControllerOptions<
+  R extends { accepted: boolean },
+> {
+  rejectionResult: () => R;
+  notifyBypassChange?: (streamId: StreamTabId, bypassActive: boolean) => void;
+}
+
+export function createStreamApprovalController<R extends { accepted: boolean }>(
+  options: StreamApprovalControllerOptions<R>,
+): StreamApprovalController<R> {
+  const pending = new Map<string, PendingApproval<R>>();
+  const bypassedByStream = new Map<StreamTabId, boolean>();
+  let queue: Promise<void> = Promise.resolve();
+
+  function notify(streamId: StreamTabId): void {
+    options.notifyBypassChange?.(
+      streamId,
+      bypassedByStream.get(streamId) ?? false,
+    );
+  }
+
+  function rejectMatching(streamId?: StreamTabId): void {
+    for (const entry of pending.values()) {
+      const matches = streamId === undefined || entry.streamId === streamId;
+      if (matches && !entry.isSettled()) {
+        entry.settle(options.rejectionResult());
+      }
+    }
+  }
+
+  return {
+    registerPending(id, entry) {
+      pending.set(id, entry);
+    },
+    unregisterPending(id) {
+      pending.delete(id);
+    },
+    getPending(id) {
+      return pending.get(id);
+    },
+    isBypassed(streamId) {
+      return bypassedByStream.get(streamId) ?? false;
+    },
+    setBypass(streamId, enabled, opts) {
+      bypassedByStream.set(streamId, enabled);
+      if (!opts?.silent) notify(streamId);
+    },
+    toggleBypass(streamId) {
+      const next = !(bypassedByStream.get(streamId) ?? false);
+      bypassedByStream.set(streamId, next);
+      notify(streamId);
+      return next;
+    },
+    enqueue(run) {
+      const operation = queue.then(run);
+      queue = operation.then(
+        () => {},
+        () => {},
+      );
+      return operation;
+    },
+    rejectPendingForStream(streamId) {
+      rejectMatching(streamId);
+    },
+    rejectAllPending() {
+      rejectMatching();
+    },
+    clearBypassForStream(streamId) {
+      bypassedByStream.delete(streamId);
+    },
+    clearAllBypass() {
+      bypassedByStream.clear();
+    },
+  };
+}

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -4,37 +4,45 @@ import {
   DIFF_EQUAL,
   DIFF_INSERT,
 } from 'diff-match-patch';
+import { z } from 'zod';
 
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
 import { bus } from '@eventBus/ProgressEventBus';
-import type { StreamTabId } from '@shared/schemas';
-import { type LineChanges, type ToolResult } from '@tools/result';
+import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
+import {
+  LineChangesSchema,
+  type LineChanges,
+  type ToolResult,
+} from '@tools/result';
 import { WorkspaceFS } from '@utils/files';
 import { countLines } from '@utils/text/stringUtils';
 
-import {
-  type RejectablePendingEntry,
-  rejectPendingEntries,
-} from './bashApproval';
+import { createStreamApprovalController } from './streamApprovalQueue';
 
-export interface ToolEditApprovalRequest {
-  path: string;
-  originalContent: string;
-  proposedContent: string;
-  sourceTool: string;
-  streamId?: StreamTabId;
-}
+export const ToolEditApprovalRequestSchema = z.object({
+  path: z.string(),
+  originalContent: z.string(),
+  proposedContent: z.string(),
+  sourceTool: z.string(),
+  streamId: StreamTabIdSchema.optional(),
+});
+export type ToolEditApprovalRequest = z.infer<
+  typeof ToolEditApprovalRequestSchema
+>;
 
-export interface ToolEditApprovalResult {
-  accepted: boolean;
-  userMessage?: string;
-  appliedContent?: string;
-  userPatch?: string;
-  lineChanges?: LineChanges;
+export const ToolEditApprovalResultSchema = z.object({
+  accepted: z.boolean(),
+  userMessage: z.string().optional(),
+  appliedContent: z.string().optional(),
+  userPatch: z.string().optional(),
+  lineChanges: LineChangesSchema.optional(),
   /** 1-based line number where the first change occurs (for navigation) */
-  startLine?: number;
-}
+  startLine: z.number().optional(),
+});
+export type ToolEditApprovalResult = z.infer<
+  typeof ToolEditApprovalResultSchema
+>;
 
 export const TOOL_EDIT_APPROVAL_CONFIG_KEY =
   'texra.toolUse.requireEditApproval';
@@ -52,89 +60,54 @@ export const TOOL_EDIT_APPROVAL_ACTIONS = [
 export type ToolEditApprovalAction =
   (typeof TOOL_EDIT_APPROVAL_ACTIONS)[number];
 
-let queue: Promise<void> = Promise.resolve();
+export const toolEditApprovalController =
+  createStreamApprovalController<ToolEditApprovalResult>({
+    rejectionResult: () => ({ accepted: false }),
+    notifyBypassChange: (streamId, bypassActive) => {
+      bus.emit('updateToolEditApprovalBypassState', {
+        streamId,
+        bypassActive,
+      });
+    },
+  });
+
 let customHandler:
   | ((request: ToolEditApprovalRequest) => Promise<ToolEditApprovalResult>)
   | undefined;
-const bypassedByStream = new Map<StreamTabId, boolean>();
-
-/**
- * Abstract pending approval registry for rejection tracking.
- * The native handler (in @frontend/approval) registers entries here
- * so that stream cleanup can reject them without vscode dependencies.
- */
-const pendingApprovals = new Map<string, RejectablePendingEntry>();
 
 /** Register a pending approval entry for rejection tracking. */
 export function registerPendingApproval(
   id: string,
-  entry: RejectablePendingEntry,
+  entry: {
+    streamId?: StreamTabId;
+    isSettled: () => boolean;
+    settle: (result: ToolEditApprovalResult) => void;
+  },
 ): void {
-  pendingApprovals.set(id, entry);
+  toolEditApprovalController.registerPending(id, entry);
 }
 
 /** Unregister a pending approval entry after it has been resolved. */
 export function unregisterPendingApproval(id: string): void {
-  pendingApprovals.delete(id);
+  toolEditApprovalController.unregisterPending(id);
 }
 
-function notifyBypassState(streamId: StreamTabId): void {
-  bus.emit('updateToolEditApprovalBypassState', {
-    streamId,
-    bypassActive: bypassedByStream.get(streamId) ?? false,
-  });
-}
-
-/**
- * Set YOLO bypass state for a stream.
- * @param silent - Skip UI notification. Use when the bypass is set before
- *   the stream is activated (the subsequent SYNC_STREAM_CONTENT will carry
- *   the correct state from isApprovalBypassedForStream).
- */
 export function setToolEditApprovalSessionBypass(
   streamId: StreamTabId,
   enabled: boolean,
   options?: { silent?: boolean },
 ): void {
-  bypassedByStream.set(streamId, enabled);
-  if (!options?.silent) {
-    notifyBypassState(streamId);
-  }
+  toolEditApprovalController.setBypass(streamId, enabled, options);
 }
 
 export function toggleToolEditApprovalSessionBypass(
   streamId: StreamTabId,
 ): boolean {
-  const newState = !(bypassedByStream.get(streamId) ?? false);
-  bypassedByStream.set(streamId, newState);
-  notifyBypassState(streamId);
-  return newState;
+  return toolEditApprovalController.toggleBypass(streamId);
 }
 
 export function isApprovalBypassedForStream(streamId: StreamTabId): boolean {
-  return bypassedByStream.get(streamId) ?? false;
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _rejectPendingToolEditApprovalsForStream(
-  streamId: StreamTabId,
-): void {
-  rejectPendingEntries(pendingApprovals.values(), streamId);
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _rejectAllPendingToolEditApprovals(): void {
-  rejectPendingEntries(pendingApprovals.values());
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _clearApprovalBypassForStream(streamId: StreamTabId): void {
-  bypassedByStream.delete(streamId);
-}
-
-/** @internal Called by unified cleanup in index.ts */
-export function _clearAllApprovalBypass(): void {
-  bypassedByStream.clear();
+  return toolEditApprovalController.isBypassed(streamId);
 }
 
 export function setToolEditApprovalHandler(
@@ -238,22 +211,14 @@ export function computeUserPatch(
 async function enqueueApproval(
   request: ToolEditApprovalRequest,
 ): Promise<ToolEditApprovalResult> {
-  // Note: YOLO bypass is checked in requestToolEditApproval before enqueueing
-  const run = async () => {
+  return toolEditApprovalController.enqueue(async () => {
     if (!customHandler) {
       throw new Error(
         'No approval handler registered. Call initializeNativeToolEditApproval first.',
       );
     }
     return customHandler(request);
-  };
-
-  const operation = queue.then(run);
-  queue = operation.then(
-    () => {},
-    () => {},
-  );
-  return operation;
+  });
 }
 
 export async function requestToolEditApproval(
@@ -270,9 +235,9 @@ export async function requestToolEditApproval(
       ? request
       : { ...request, streamId: context.streamId };
 
-  // Check global config and per-stream YOLO mode
   const streamId = preparedRequest.streamId;
-  const isStreamBypassed = streamId && isApprovalBypassedForStream(streamId);
+  const isStreamBypassed =
+    streamId && toolEditApprovalController.isBypassed(streamId);
   if (!approvalsEnabled || isStreamBypassed) {
     return finalizeApprovalResult({ accepted: true }, preparedRequest);
   }
@@ -393,4 +358,15 @@ export function buildApprovalRejectedResult(
     result.userInstruction = feedback;
   }
   return result;
+}
+
+/**
+ * Enable tool-edit YOLO on a freshly resolved child subagent stream.
+ *
+ * Used by DelegationTools when launching a subagent that should inherit the
+ * parent's auto-approval. Silent because it fires before the child stream is
+ * activated; the subsequent SYNC_STREAM_CONTENT carries the bypass state.
+ */
+export function enableYoloOnChildStream(childStreamId: StreamTabId): void {
+  toolEditApprovalController.setBypass(childStreamId, true, { silent: true });
 }

--- a/src/tools/executionFormatters.ts
+++ b/src/tools/executionFormatters.ts
@@ -1,0 +1,96 @@
+import type { ExecutionListingEntry, TodoEntry } from '@agent/storage';
+import {
+  type ExecutionHandle,
+  type ExecutionStatusInfo,
+  getHandle,
+} from '@agent/runtime/executionRegistry';
+import { EXECUTION_STATUS } from '@shared/schemas';
+
+/** Return paths available for a given agent category. */
+export function getAvailablePaths(
+  category?: string,
+  hasChildren?: boolean,
+): string[] {
+  const common = ['config', 'report'];
+  if (hasChildren) common.push('children');
+  switch (category) {
+    case 'toolUse':
+      return [...common, 'conversation', 'todos'];
+    case 'workflow':
+      return [...common, 'files'];
+    case 'process':
+      return [...common, 'output'];
+    default:
+      return [...common, 'conversation', 'todos', 'files', 'output'];
+  }
+}
+
+/** Format status info as a display string. */
+export function formatStatusInfo(info: ExecutionStatusInfo): string {
+  return info.elapsed
+    ? `${info.status} (${info.elapsed} elapsed)`
+    : info.status;
+}
+
+/** Resolve the runtime status for an execution ID, using persisted terminal status as fallback. */
+export function getExecutionStatusInfo(
+  executionId: string,
+  terminalStatus?: string,
+): ExecutionStatusInfo {
+  const handle = getHandle(executionId);
+  if (handle) return handle.getStatus();
+  return {
+    status: terminalStatus ?? EXECUTION_STATUS.COMPLETED,
+    elapsed: null,
+  };
+}
+
+/** Format round progress as a display line, or empty string if unavailable. */
+export function formatProgressLine(
+  handle: ExecutionHandle | undefined,
+): string {
+  const progress = handle?.getProgress();
+  if (
+    progress?.currentRound === undefined ||
+    progress.totalRounds === undefined
+  ) {
+    return '';
+  }
+  return `Progress: round ${progress.currentRound + 1}/${progress.totalRounds}`;
+}
+
+/** Format a listing entry as a single summary line. */
+export function formatListingLine(entry: ExecutionListingEntry): string {
+  const ts = entry.timestamp.replace('T', ' ').replace(/\.\d+Z$/, '');
+  const info = getExecutionStatusInfo(entry.id, entry.terminalStatus);
+  const categoryTag = entry.category ? `  ${entry.category}` : '';
+  const parentSuffix = entry.parentExecutionId
+    ? `  parent=${entry.parentExecutionId}`
+    : '';
+  const descSuffix = entry.description ? `  — ${entry.description}` : '';
+  return `${entry.id}  ${ts}  ${entry.agent}${categoryTag}  ${entry.model}  [${formatStatusInfo(info)}]${parentSuffix}${descSuffix}`;
+}
+
+const TODO_ICON: Record<string, string> = {
+  completed: '[x]',
+  in_progress: '[>]',
+  pending: '[ ]',
+};
+
+/** Format todo items as a checklist. */
+export function formatTodoSection(todos: TodoEntry[]): string[] {
+  return todos.map((t) => {
+    const icon = TODO_ICON[t.status ?? ''] ?? '[ ]';
+    return `${icon} ${t.content ?? '(no description)'}`;
+  });
+}
+
+/** Format a todo header with counts. */
+export function formatTodoHeader(
+  executionId: string,
+  todos: TodoEntry[],
+): string {
+  const completed = todos.filter((t) => t.status === 'completed').length;
+  const inProgress = todos.filter((t) => t.status === 'in_progress').length;
+  return `Tasks for ${executionId} (${completed} done, ${inProgress} active, ${todos.length - completed - inProgress} pending):`;
+}

--- a/src/tools/result.ts
+++ b/src/tools/result.ts
@@ -40,7 +40,7 @@ export const ToolFileAttachmentSchema = FileReferenceSchema.extend({
   /** Base64 encoded payload when inline transport is supported */
   base64Data: z.string().optional(),
   /** Raw bytes for providers that require binary uploads */
-  bytes: z.custom<Uint8Array>((val) => val instanceof Uint8Array).optional(),
+  bytes: z.instanceof(Uint8Array).optional(),
 });
 export type ToolFileAttachment = z.infer<typeof ToolFileAttachmentSchema>;
 

--- a/src/tools/subagentDiffs.ts
+++ b/src/tools/subagentDiffs.ts
@@ -1,0 +1,152 @@
+import path from 'path';
+
+import { diff_match_patch } from 'diff-match-patch';
+
+import type { OutputFileSummary } from '@agent/runtime/AgentFlowResult';
+import type { ExecutionId } from '@shared/schemas';
+import { AbsoluteFS } from '@utils/files';
+import { getRunDir, ensureRunDir } from '@utils/files/taskRunStorage';
+import { countLines } from '@utils/text/stringUtils';
+
+/** Maximum lines of diff to include per file in deliveries. */
+const MAX_DIFF_LINES = 200;
+
+/** Shorter truncation limit for large changes (>40% of file modified). */
+const LARGE_CHANGE_DIFF_LINES = 80;
+
+/**
+ * When the changed lines (added + removed) exceed this fraction of the
+ * original file's line count, the diff is flagged as a large change.
+ * The orchestrator still gets a diff file but truncated shorter.
+ */
+const LARGE_CHANGE_RATIO = 0.4;
+
+/**
+ * Compute a human-readable line-level diff between two strings.
+ * Uses diff-match-patch's line-mode diffing (diff_linesToChars_ /
+ * diff_charsToLines_) to produce clean whole-line diffs with +/- prefixes.
+ * Returns null if the strings are identical.
+ */
+function computeReadableDiff(
+  original: string,
+  modified: string,
+): string | null {
+  const dmp = new diff_match_patch();
+
+  // Convert to line-mode: each line becomes a single "character" so
+  // diff_main operates on whole lines, not individual characters.
+  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(
+    original,
+    modified,
+  );
+  const diffs = dmp.diff_main(chars1, chars2, false);
+  dmp.diff_charsToLines_(diffs, lineArray);
+
+  // Check if there are any actual changes.
+  if (diffs.every(([op]) => op === 0)) return null;
+
+  const PREFIX: Record<number, string> = { 1: '+', [-1]: '-', 0: ' ' };
+  const lines: string[] = [];
+  for (const [op, text] of diffs) {
+    const prefix = PREFIX[op] ?? ' ';
+    // Each chunk is one or more complete lines (with trailing \n).
+    // Split and prefix each line, dropping the trailing empty entry from split.
+    const chunkLines = text.split('\n');
+    for (let i = 0; i < chunkLines.length; i++) {
+      // Skip the empty string after the final \n
+      if (i === chunkLines.length - 1 && chunkLines[i] === '') continue;
+      lines.push(`${prefix}${chunkLines[i]}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Truncate diff text to a maximum number of lines.
+ * Appends a truncation notice if the diff exceeds the limit.
+ */
+function truncateDiff(diff: string, maxLines: number): string {
+  const lines = diff.split('\n');
+  if (lines.length <= maxLines) return diff;
+  return lines.slice(0, maxLines).join('\n') + '\n[... diff truncated]';
+}
+
+/** Info about a diff file written to the execution's run directory. */
+export interface DiffFileInfo {
+  /** The relative path within the run directory (e.g. "diffs/chapter1.tex.diff"). */
+  diffRelPath: string;
+  /** True when the change ratio exceeded the large-change threshold. */
+  largeChange: boolean;
+}
+
+/**
+ * Compute diffs for workflow output files and write them to the execution's
+ * run directory as `.diff` files. Returns a map from output absolutePath to
+ * diff file info, so the delivery formatter can reference them by path.
+ *
+ * All diffs are written regardless of change size. Large changes (ratio above
+ * {@link LARGE_CHANGE_RATIO}) are flagged so the orchestrator knows the diff
+ * may be truncated and can read the full output file for context.
+ *
+ * Files without an original (new files) or where reading fails are omitted.
+ */
+export async function computeAndWriteWorkflowDiffs(
+  executionId: ExecutionId,
+  outputs: OutputFileSummary[],
+): Promise<Map<string, DiffFileInfo>> {
+  const results = new Map<string, DiffFileInfo>();
+  const diffsToWrite: Array<{ diffRelPath: string; content: string }> = [];
+
+  // First pass: compute diffs and decide which to write.
+  await Promise.all(
+    outputs.map(async (o) => {
+      if (!o.originalPath) return;
+      try {
+        const [original, modified] = await Promise.all([
+          AbsoluteFS.read(o.originalPath),
+          AbsoluteFS.read(o.absolutePath),
+        ]);
+
+        // Flag large changes so the orchestrator knows to also read the
+        // full output file — the diff alone may not capture everything.
+        let largeChange = false;
+        const originalLines = countLines(original);
+        if (originalLines > 0 && o.added !== null && o.removed !== null) {
+          const changedLines = (o.added ?? 0) + (o.removed ?? 0);
+          largeChange = changedLines / originalLines > LARGE_CHANGE_RATIO;
+        }
+
+        const diff = computeReadableDiff(original, modified);
+        if (diff) {
+          const limit = largeChange ? LARGE_CHANGE_DIFF_LINES : MAX_DIFF_LINES;
+          const truncated = truncateDiff(diff, limit);
+          // Use full relativePath (with separators replaced) to avoid collisions
+          // when multiple files share the same basename in different directories.
+          const safeName = o.relativePath.replaceAll(/[\\/]/g, '_');
+          const diffRelPath = `diffs/${safeName}.diff`;
+          results.set(o.absolutePath, { diffRelPath, largeChange });
+          diffsToWrite.push({ diffRelPath, content: truncated });
+        }
+      } catch {
+        // File read failure is non-fatal — skip diff for this file.
+      }
+    }),
+  );
+
+  // Second pass: write diff files to disk.
+  if (diffsToWrite.length > 0) {
+    const runDir = getRunDir(executionId);
+    await ensureRunDir(executionId);
+    const diffsDir = path.join(runDir, 'diffs');
+    await AbsoluteFS.ensureDir(diffsDir);
+
+    await Promise.all(
+      diffsToWrite.map(async ({ diffRelPath, content }) => {
+        const fullPath = path.join(runDir, diffRelPath);
+        await AbsoluteFS.write(fullPath, content);
+      }),
+    );
+  }
+
+  return results;
+}

--- a/src/tools/subagentResults.ts
+++ b/src/tools/subagentResults.ts
@@ -8,10 +8,6 @@
  * (just before injection into model context via FollowUpQueue).
  */
 
-import path from 'path';
-
-import { diff_match_patch } from 'diff-match-patch';
-
 import type {
   AgentFlowResult,
   OutputFileSummary,
@@ -23,160 +19,10 @@ import type {
   TodoItem,
   Plan,
 } from '@shared/schemas';
-import type { ExecutionId } from '@shared/schemas';
 import { TODO_STATUS } from '@shared/schemas/todo';
 import { countByStatus } from '@shared/schemas/todoDisplay';
 import { formatDuration } from '@utils/core';
-import { AbsoluteFS } from '@utils/files';
-import { getRunDir, ensureRunDir } from '@utils/files/taskRunStorage';
-import { countLines } from '@utils/text/stringUtils';
-
-// ============================================================================
-// Diff computation for workflow deliveries
-// ============================================================================
-
-/** Maximum lines of diff to include per file in deliveries. */
-const MAX_DIFF_LINES = 200;
-
-/** Shorter truncation limit for large changes (>40% of file modified). */
-const LARGE_CHANGE_DIFF_LINES = 80;
-
-/**
- * When the changed lines (added + removed) exceed this fraction of the
- * original file's line count, the diff is flagged as a large change.
- * The orchestrator still gets a diff file but truncated shorter.
- */
-const LARGE_CHANGE_RATIO = 0.4;
-
-/**
- * Compute a human-readable line-level diff between two strings.
- * Uses diff-match-patch's line-mode diffing (diff_linesToChars_ /
- * diff_charsToLines_) to produce clean whole-line diffs with +/- prefixes.
- * Returns null if the strings are identical.
- */
-function computeReadableDiff(
-  original: string,
-  modified: string,
-): string | null {
-  const dmp = new diff_match_patch();
-
-  // Convert to line-mode: each line becomes a single "character" so
-  // diff_main operates on whole lines, not individual characters.
-  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(
-    original,
-    modified,
-  );
-  const diffs = dmp.diff_main(chars1, chars2, false);
-  dmp.diff_charsToLines_(diffs, lineArray);
-
-  // Check if there are any actual changes.
-  if (diffs.every(([op]) => op === 0)) return null;
-
-  const PREFIX: Record<number, string> = { 1: '+', [-1]: '-', 0: ' ' };
-  const lines: string[] = [];
-  for (const [op, text] of diffs) {
-    const prefix = PREFIX[op] ?? ' ';
-    // Each chunk is one or more complete lines (with trailing \n).
-    // Split and prefix each line, dropping the trailing empty entry from split.
-    const chunkLines = text.split('\n');
-    for (let i = 0; i < chunkLines.length; i++) {
-      // Skip the empty string after the final \n
-      if (i === chunkLines.length - 1 && chunkLines[i] === '') continue;
-      lines.push(`${prefix}${chunkLines[i]}`);
-    }
-  }
-  return lines.join('\n');
-}
-
-/**
- * Truncate diff text to a maximum number of lines.
- * Appends a truncation notice if the diff exceeds the limit.
- */
-function truncateDiff(diff: string, maxLines: number): string {
-  const lines = diff.split('\n');
-  if (lines.length <= maxLines) return diff;
-  return lines.slice(0, maxLines).join('\n') + '\n[... diff truncated]';
-}
-
-/** Info about a diff file written to the execution's run directory. */
-export interface DiffFileInfo {
-  /** The relative path within the run directory (e.g. "diffs/chapter1.tex.diff"). */
-  diffRelPath: string;
-  /** True when the change ratio exceeded the large-change threshold. */
-  largeChange: boolean;
-}
-
-/**
- * Compute diffs for workflow output files and write them to the execution's
- * run directory as `.diff` files. Returns a map from output absolutePath to
- * diff file info, so the delivery formatter can reference them by path.
- *
- * All diffs are written regardless of change size. Large changes (ratio above
- * {@link LARGE_CHANGE_RATIO}) are flagged so the orchestrator knows the diff
- * may be truncated and can read the full output file for context.
- *
- * Files without an original (new files) or where reading fails are omitted.
- */
-export async function computeAndWriteWorkflowDiffs(
-  executionId: ExecutionId,
-  outputs: OutputFileSummary[],
-): Promise<Map<string, DiffFileInfo>> {
-  const results = new Map<string, DiffFileInfo>();
-  const diffsToWrite: Array<{ diffRelPath: string; content: string }> = [];
-
-  // First pass: compute diffs and decide which to write.
-  await Promise.all(
-    outputs.map(async (o) => {
-      if (!o.originalPath) return;
-      try {
-        const [original, modified] = await Promise.all([
-          AbsoluteFS.read(o.originalPath),
-          AbsoluteFS.read(o.absolutePath),
-        ]);
-
-        // Flag large changes so the orchestrator knows to also read the
-        // full output file — the diff alone may not capture everything.
-        let largeChange = false;
-        const originalLines = countLines(original);
-        if (originalLines > 0 && o.added !== null && o.removed !== null) {
-          const changedLines = (o.added ?? 0) + (o.removed ?? 0);
-          largeChange = changedLines / originalLines > LARGE_CHANGE_RATIO;
-        }
-
-        const diff = computeReadableDiff(original, modified);
-        if (diff) {
-          const limit = largeChange ? LARGE_CHANGE_DIFF_LINES : MAX_DIFF_LINES;
-          const truncated = truncateDiff(diff, limit);
-          // Use full relativePath (with separators replaced) to avoid collisions
-          // when multiple files share the same basename in different directories.
-          const safeName = o.relativePath.replaceAll(/[\\/]/g, '_');
-          const diffRelPath = `diffs/${safeName}.diff`;
-          results.set(o.absolutePath, { diffRelPath, largeChange });
-          diffsToWrite.push({ diffRelPath, content: truncated });
-        }
-      } catch {
-        // File read failure is non-fatal — skip diff for this file.
-      }
-    }),
-  );
-
-  // Second pass: write diff files to disk.
-  if (diffsToWrite.length > 0) {
-    const runDir = getRunDir(executionId);
-    await ensureRunDir(executionId);
-    const diffsDir = path.join(runDir, 'diffs');
-    await AbsoluteFS.ensureDir(diffsDir);
-
-    await Promise.all(
-      diffsToWrite.map(async ({ diffRelPath, content }) => {
-        const fullPath = path.join(runDir, diffRelPath);
-        await AbsoluteFS.write(fullPath, content);
-      }),
-    );
-  }
-
-  return results;
-}
+import type { DiffFileInfo } from './subagentDiffs';
 
 // ============================================================================
 // Formatting helpers


### PR DESCRIPTION
## Summary

Consolidates 7 parallel `code-simplifier` passes into one branch. **+95 LoC across 23 files** — 4 new shared modules (+365) trade against ~−270 lines of duplicated controllers, factories, and inline branch chains.

## Slices (per-area diff)

| # | Area | Net LoC | Notes |
|---|---|---|---|
| 1 | `modelHandlers/` reasoning aggregator | −11 | Collapsed 4 identical `createStreamingAggregator` overrides (DeepSeek/Kimi/MiniMax/GLM) into a `useReasoningStreamAggregator` flag; relocated `StreamingAggregator` interface to break a type-only import cycle |
| 2 | `ToolUseCycleFlow` factory | −28 | Inlined `createToolUseCycleShared` (one caller); matches `ResponseCycleNode` precedent |
| 3 | Approval subsystem unification | structural | New `streamApprovalQueue.ts` factors out the controller logic shared by `bashApproval` + `toolEditApproval`; Zod-derived request/result types replace hand-written interfaces; `enableYoloOnChildStream` helper removes `setToolEditApprovalSessionBypass` leakage from `DelegationTools`; `z.custom<Uint8Array>` → `z.instanceof` |
| 4 | `toolFormatters` lookup table | **+65** | Per-tool builders dispatched via `TOOL_SECTION_BUILDERS` with first-match-wins semantics. ⚠️ This slice **grew** the file — per-builder signatures and `ToolSectionContext` destructuring outweighed savings from removing the if/else chain. Easy to drop from the PR if the architectural win isn't worth the LoC cost. |
| 5 | `ExecutionsTool` / `subagentResults` split | structural | Pure formatters → new `executionFormatters.ts`. Diff computation → new `subagentDiffs.ts`. `subagentResults` keeps formatting only. |
| 6 | `modelHandlerOpenAIResponse` | −7 | Dropped 2 unused imports (`EventEmitter`, `ModelConfig`); inlined `parseArguments` one-liner. Conservative pass — predecessor agent left ~30 helpers untouched given recent fixes. |
| 7 | `requestPanelStyles` consolidation | ~neutral | `sp` token map for 52 `var(--spacing-*)` occurrences; shared `SCROLLABLE_DETAILS` selector group at both duplicated sites |

Plus: `.gitignore` and `.prettierignore` extended to skip `.claude/worktrees/` (agent scratch space contains unstaged Jinja templates that prettier mis-parses).

## Rejected on inspection

The reconnaissance scout overestimated several simplification targets. After analysis these were left alone:

- **Cycle-node inlining (`ToolUseCycleNode`, `ResponseCycleNode`).** Snapshot↔hydration, `setOnUpdate`/`clearOnUpdate` lifecycle in try/finally, persist-chain draining, prefill short-circuit, outcome→`FlowTransition` mapping, and `recordRound`/`onRoundFinalized` on error are real logic — not pass-through wrappers.
- **Provider reasoning-content merge consolidation.** `mergeReasoningContent` and `BaseReasoningStreamAggregator.finalize()` use different join semantics; per-handler overrides differ where MiniMax uses `reasoning_details` (array) vs `reasoning_content` (string) — genuine field-shape differences.
- **Broader `modelHandlerOpenAIResponse` refactor.** Hot-path file with 81 commits in 3 months; recent fixes for WebSocket keepalive, response-chain token baseline, GPT-5.5 streaming, concurrency guards. Most of the ~30 private helpers analyzed were judged either multi-caller, real abstractions, or load-bearing for recent fixes.
- **Over-defensive null guards in `ToolUseCycleFlow`.** Guards at lines 96/248/688 are over genuinely nullable types per their schemas (`raw: unknown` from model output, optional `services.session`, optional `shared.toolCalls`). Removing them would regress.

## Test plan

- [x] `npm run typecheck` — only the 2 pre-existing `ProgressViewMessageHandler.ts` errors (`isInFlightStatus`, `StreamStatusService`); confirmed by stashing.
- [x] `npm run lint` — clean.
- [ ] Manual smoke: run a tool-use agent, confirm bash approval prompts still gate edits, confirm `enableYoloOnChild` delegation still bypasses correctly.
- [ ] Manual smoke: progress view rendering for each tool type (edit, bash, read, write, memory, executions, accept_run_files, delegation, codex, mcp) — #4's lookup table changed dispatch, semantics should be identical.
- [ ] Manual smoke: open a request panel and verify spacing/styles are visually identical pre/post #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactors, but it touches tool-edit/bash approval gating, tool-use log rendering dispatch, and model streaming aggregation paths, so regressions would affect core agent interaction flows.
> 
> **Overview**
> Refactors multiple subsystems to reduce duplicated logic and centralize shared behavior. OpenAI-compatible model handlers (DeepSeek/GLM/Kimi/MiniMax) now enable a shared reasoning streaming aggregator via a `useReasoningStreamAggregator` flag, and the `StreamingAggregator` interface is moved to `BaseReasoningStreamAggregator` to avoid type-only coupling.
> 
> Unifies bash and tool-edit approval flows behind a new `createStreamApprovalController` (shared queueing, pending registry, and per-stream bypass), switches request/result types to Zod schemas, and updates delegation to inherit YOLO via `enableYoloOnChildStream`. Splits execution listing/todo formatting into `executionFormatters.ts` and workflow diff generation into `subagentDiffs.ts`, and restructures tool-use log rendering to a dispatch table of section builders; also factors request panel headers/styles and updates ignore rules for `.claude/` scratch/worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda0ae64845ce0a8cfa41d715c06dab97ca8a1db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->