### PR TITLE
[codex] Enable inline Claude PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,26 +3,19 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
+      actions: read
       id-token: write
 
     steps:
@@ -36,9 +29,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude,chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-7 --allowed-tools Bash(gh pr:*)'
+          claude_args: |
+            --model claude-opus-4-7
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,mcp__github__*,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude,chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
+          allowed_bots: 'claude[bot],chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
@@ -37,4 +37,4 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
             --model claude-opus-4-7
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,mcp__github__*,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api graphql:*)"
+            --allowedTools "Read" "Glob" "Grep" "mcp__github_inline_comment__create_inline_comment" "mcp__github__*" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh api graphql:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude[bot],chatgpt-codex-connector,cursor[bot],cursor,copilot-pull-request-reviewer'
+          allowed_bots: 'claude[bot],chatgpt-codex-connector[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
@@ -37,4 +37,4 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
             --model claude-opus-4-7
-            --allowedTools "Read" "Glob" "Grep" "mcp__github_inline_comment__create_inline_comment" "mcp__github__*" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh api graphql:*)"
+            --allowedTools "Read" "Glob" "Grep" "mcp__github_inline_comment__create_inline_comment" "mcp__github__*" "Bash(gh pr diff:*)" "Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

This updates the Claude Code Review workflow so the stock `/code-review:code-review` command can publish inline PR review comments.

## Changes

- Adds PR-scoped concurrency without cancelling in-progress review runs.
- Grants the review job write access to pull requests and issues, plus read access to Actions.
- Runs `/code-review:code-review ... --comment`.
- Allows the GitHub MCP tools, including `mcp__github_inline_comment__create_inline_comment`, while keeping `gh` access limited to read-oriented PR diff/view commands.
- Uses exact bot actor names in `allowed_bots` so bot-authored synchronize events are not skipped.

## Validation

- Parsed `.github/workflows/claude-code-review.yml` with Ruby's YAML parser: `YAML OK`.
- Commit hook ran `npm run format` successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants the workflow write access to PRs/issues and broader GitHub MCP capabilities, so misconfiguration could result in unintended commenting or metadata changes despite the `gh` command scope being read-oriented.
> 
> **Overview**
> Updates the `Claude Code Review` GitHub Actions workflow to support *inline PR review comments*: adds PR-scoped `concurrency`, switches the `/code-review:code-review` prompt to include `--comment`, and expands tool access to GitHub MCP inline-comment creation plus read-only `gh` commands.
> 
> The job’s permissions are adjusted to allow writing to `pull-requests` and `issues` (and reading `actions`) to enable comment publication, and an `allowed_bots` allowlist is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae2cf9ceb6bc12e4f6256ca777bb2137d3b61b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->