### PR TITLE
Remove NODE_OPTIONS memory allocation requirement from build scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,18 +55,12 @@ Alternatively, use `npm run compile:safe` which runs type checking before buildi
 
 ### Legacy Webpack Builds
 
-The original webpack-based commands are still available but require increased memory:
+The original webpack-based commands are still available:
 
 ```bash
-# Set for webpack builds
-export NODE_OPTIONS=--max-old-space-size=8192
-
-# Or prefix individual commands
-NODE_OPTIONS=--max-old-space-size=8192 npm run compile
-NODE_OPTIONS=--max-old-space-size=8192 npm run package
+npm run compile
+npm run package
 ```
-
-Without this, webpack may fail with "JavaScript heap out of memory" errors during production builds.
 
 ## Architecture Overview
 

--- a/package.json
+++ b/package.json
@@ -1564,9 +1564,9 @@
   },
   "scripts": {
     "vscode:prepublish": "[ \"$SKIP_VSCE_PREPUBLISH\" = \"1\" ] || npm run package",
-    "compile": "NODE_OPTIONS=--max-old-space-size=8192 webpack",
-    "watch": "NODE_OPTIONS=--max-old-space-size=8192 webpack --watch",
-    "package": "NODE_OPTIONS=--max-old-space-size=8192 webpack --mode production --devtool hidden-source-map",
+    "compile": "webpack",
+    "watch": "webpack --watch",
+    "package": "webpack --mode production --devtool hidden-source-map",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",

--- a/prds/prd-progressview-modernization.md
+++ b/prds/prd-progressview-modernization.md
@@ -42,22 +42,6 @@ Rewrite ProgressView in Lit + TypeScript with type-safe IPC via relocated Zod sc
 
 ---
 
-## Build Requirements
-
-> **Important:** Due to growing codebase size and Lit component compilation, increased memory allocation is required.
-
-```bash
-# Required for compilation (prevents heap out of memory errors)
-NODE_OPTIONS=--max-old-space-size=8192 npm run compile
-
-# Or set in package.json scripts (recommended)
-"compile": "NODE_OPTIONS=--max-old-space-size=8192 webpack --mode production"
-```
-
-**Why:** Lit + TypeScript + Zod schema compilation creates significant memory pressure during webpack bundling, especially with 5 webview entry points.
-
----
-
 ## Goals & Phases
 
 | Phase       | Scope                                        | Status         | Doc                                                        |


### PR DESCRIPTION
## Summary
Removes the `NODE_OPTIONS=--max-old-space-size=8192` memory allocation requirement from webpack build scripts and related documentation. The build process no longer requires explicit heap size configuration.

## Changes
- **package.json**: Removed `NODE_OPTIONS=--max-old-space-size=8192` from `compile`, `watch`, and `package` npm scripts
- **CLAUDE.md**: Simplified webpack build documentation by removing memory allocation instructions and heap error warnings
- **prd-progressview-modernization.md**: Removed entire "Build Requirements" section that detailed memory allocation needs for Lit + TypeScript compilation

## Details
This change simplifies the developer experience by eliminating the need to manually configure Node.js heap memory for builds. The build process should now complete successfully with default memory settings, reducing friction for contributors and CI/CD pipelines.

https://claude.ai/code/session_01SuebSrvEfLyPW78XK1iQBZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low code risk but medium build/CI risk: webpack builds that previously relied on an 8GB heap may now fail with out-of-memory errors on larger workspaces or constrained environments.
> 
> **Overview**
> Removes the explicit Node heap-size override from the legacy webpack `compile`/`watch`/`package` npm scripts, relying on default Node memory settings.
> 
> Updates developer docs (`CLAUDE.md` and the ProgressView modernization PRD) to delete the old memory-allocation instructions and warnings so the documented webpack build path matches the simplified scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9dc35c939c6b8db9249c8b3d98bf477e63f881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->