### PR TITLE
fix: align settings terminology

### DIFF
--- a/docs/prd/launcher-and-onboarding.md
+++ b/docs/prd/launcher-and-onboarding.md
@@ -68,7 +68,7 @@ Concretely:
 
 5. **The schema is fragile.** Custom teams reference agents by bare name,
    so renaming a custom agent silently breaks every team that referenced
-   it. Built-in presets ship without an explicit lead. Workflow defaults are
+   it. Built-in teams ship without an explicit lead. Workflow defaults are
    lumped into `workflowAgents` with no role distinction.
 
 6. **The launcher does not express intent.** Selecting `orchestrator` vs.

--- a/docs/prd/launcher-and-onboarding.md
+++ b/docs/prd/launcher-and-onboarding.md
@@ -54,20 +54,20 @@ Concretely:
    agent is `internal: true`.
 
 3. **Teams exist but read as flat badge clouds.** The Multi-Agent settings
-   tab (`MultiAgentTab.ts:420–574`) ships four built-in presets
+   tab (`MultiAgentTab.ts:420–574`) ships four built-in teams
    (Mathematician, Physicist, Lean Project, Computer Scientist (ML)). Each is
    rendered as a card with a single row of agent badges — the lead
    orchestrator is not visually distinguished from specialists or workflow
    agents.
 
 4. **Tweaking a team is a maze.** To customise a built-in team a user must
-   apply the preset (which silently overwrites their global enabled-agents
+   apply the team (which silently overwrites their global enabled-agents
    list — `agentHandlers.ts:589–592`), switch tabs to the Agents tab, toggle
-   agents, click "Save Preset", then name the result. The card that triggered
+   agents, click "Save Team", then name the result. The card that triggered
    the flow has no Edit, Duplicate, or inline tweak affordance.
 
-5. **The schema is fragile.** Custom presets reference agents by bare name,
-   so renaming a custom agent silently breaks every preset that referenced
+5. **The schema is fragile.** Custom teams reference agents by bare name,
+   so renaming a custom agent silently breaks every team that referenced
    it. Built-in presets ship without an explicit lead. Workflow defaults are
    lumped into `workflowAgents` with no role distinction.
 
@@ -1011,8 +1011,8 @@ responsibilities, which now live in the launcher and the Multi-Agent tab.
 
 ### Concrete deltas vs. today
 
-1. **`Save Preset` toolbar button removed.** Today's flow (toggle agents
-   here, click `Save Preset`, name in a `vscode.window.showInputBox`) lives
+1. **`Save Team` toolbar button removed.** Today's flow (toggle agents
+   here, click `Save Team`, name in a `vscode.window.showInputBox`) lives
    in `AgentsTab.ts:225–227` and `agentHandlers.ts:609–652`. It is replaced
    by the launcher's `Save as new team` (L2) and the Multi-Agent tab's
    `+ Save current setup as team` / `+ New team`. The Agents tab is no
@@ -1075,7 +1075,7 @@ affordance. This PRD defines the rules every tab must follow.
 | Agents tab "Tool Use" sub-tab          | renamed to **"Tool-Use Agents"** to disambiguate from the Tools tab (`AgentsTab.ts:259`)                                                                                                                                                                         |
 | Tools tab "Memory & Workflow" category | renamed to **"Workflow tools"** to disambiguate from the Memory tab (`ToolsTab.ts:66`)                                                                                                                                                                           |
 
-`AgentsTab.ts:269` ("Save current agent configuration as a preset") and
+`AgentsTab.ts:269` ("Save current agent configuration as a team") and
 similar tooltips are updated to use "team" everywhere the user sees them.
 The schema rename happens in one commit; tooltips and labels in another.
 
@@ -1084,7 +1084,7 @@ The schema rename happens in one commit; tooltips and labels in another.
 One rule: **every toggle saves immediately on change; every named entity
 (team, custom agent, GitHub token) is saved through an explicit modal**.
 
-Today's outlier is the Agents tab `Save Preset` button
+Today's outlier is the Agents tab `Save Team` button
 (`AgentsTab.ts:225–227, 268–272`), which conflates "edit a list" with
 "persist a named entity". This PRD already removes that button from the
 Agents tab. The replacement flows are explicit (launcher footer's `Save as
@@ -1101,14 +1101,14 @@ and stays that way.
 Every tab follows the same rule: **primary action in the tab header, on
 the right; row-level actions on each row, on the right**.
 
-| Today                                                                         | After                                                                                     |
-| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| AgentsTab header right: `Save Preset` (removed), `From Template`, `New Agent` | header right: `+ New agent`, `+ From template`                                            |
-| MultiAgentTab: card-level delete on hover only (`MultiAgentTab.ts:288`)       | card-level `Use` / `Edit` / `Duplicate` / `Delete` always visible (delete still confirms) |
-| LaTeXTab: per-card `Apply` (right) and `Reset` (right)                        | unchanged — already follows the rule                                                      |
-| ToolsTab: `Re-check` button at top right                                      | unchanged                                                                                 |
-| ModelsTab: per-row toggles                                                    | unchanged                                                                                 |
-| Memory / History tabs: scattered                                              | header right gets a single primary action (`+ New memory`, `Clear all`)                   |
+| Today                                                                       | After                                                                                     |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| AgentsTab header right: `Save Team` (removed), `From Template`, `New Agent` | header right: `+ New agent`, `+ From template`                                            |
+| MultiAgentTab: card-level delete on hover only (`MultiAgentTab.ts:288`)     | card-level `Use` / `Edit` / `Duplicate` / `Delete` always visible (delete still confirms) |
+| LaTeXTab: per-card `Apply` (right) and `Reset` (right)                      | unchanged — already follows the rule                                                      |
+| ToolsTab: `Re-check` button at top right                                    | unchanged                                                                                 |
+| ModelsTab: per-row toggles                                                  | unchanged                                                                                 |
+| Memory / History tabs: scattered                                            | header right gets a single primary action (`+ New memory`, `Clear all`)                   |
 
 Buttons in row-actions read primary → destructive left-to-right with
 spacing token `var(--spacing-medium)` between them. Destructive actions
@@ -1546,7 +1546,7 @@ rewritten to the new `Team[]` schema with explicit lead/default/spec/wf
 splits — see the table above. No persistent state involved; this is
 shipped code.
 
-### Custom presets in workspace state
+### Custom teams in workspace state
 
 Today's `WorkspaceStateKey.CUSTOM_AGENT_PRESETS` is
 `Array<AgentModePreset>` with `workflowAgents: string[]`,
@@ -1675,7 +1675,7 @@ current workspace; it does not override an active workspace selection.
 10. **Render the new Multi-Agent tab** (Use/Edit/Duplicate/Delete
     actions, team editor side panel) behind the same flag.
 11. **Refresh the Agents tab** (role badges, "Used by teams",
-    visible-but-locked setup agents, removed `Save Preset` button).
+    visible-but-locked setup agents, removed `Save Team` button).
 12. **`SET_TAB` deep-link upgrade** — accept tab id + sub-section anchor
     alongside numeric `tabIndex` for one minor-version migration window.
 13. **Codex settings move** from Tools tab to Models tab (under helper

--- a/resources/walkthroughs/getting-started.md
+++ b/resources/walkthroughs/getting-started.md
@@ -26,7 +26,7 @@ Follow the checklist on the left. Each step links to the right command.
 4. **Or just sign in** -- The Researcher Access Program gives you free model access, no API key needed. Signing in also unlocks extra agents.
 5. **Pick your files** -- At minimum, just add your manuscript as an Input file.
 6. **Use the orchestrator** -- It plans a pipeline and dispatches agents. Ask it which agent to use, or leave the instruction blank and the orchestrator decides.
-7. **Pick your field** -- Choose a preset (Physicist, Mathematician, Lean) so the orchestrator has the right tools.
+7. **Pick your field** -- Choose a team (Physicist, Mathematician, Lean) so the orchestrator has the right tools.
 8. **Auto-extract figures** -- Optional. Pulls out figures and TikZ blocks before editing.
 9. **Hit Execute!** -- The orchestrator proposes tasks for you to approve in the Progress view. Press **y** to approve or **n** to reject.
 10. **Check what it did** -- Compare the output against your original with VS Code's diff view.

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -169,20 +169,20 @@ export class UserMessage extends LitElement {
     defaultTitle: 'Copy message',
   });
 
-  private payloadCopyController = new CopyButtonController(this, {
-    defaultTitle: 'Copy original payload',
+  private rawMessageCopyController = new CopyButtonController(this, {
+    defaultTitle: 'Copy raw message',
   });
 
   private displayCache = {
     text: '',
     isStructuredDelivery: false,
-    hasOriginalPayload: false,
+    hasRawMessage: false,
     displayText: '',
   };
 
   private getDisplayState(): {
     isStructuredDelivery: boolean;
-    hasOriginalPayload: boolean;
+    hasRawMessage: boolean;
     displayText: string;
   } {
     if (this.displayCache.text === this.text) {
@@ -191,16 +191,16 @@ export class UserMessage extends LitElement {
 
     const structuredTag = getStructuredDeliveryTag(this.text);
     const isStructuredDelivery = structuredTag != null;
-    const hasOriginalPayload =
+    const hasRawMessage =
       structuredTag != null && XML_ESCAPED_DELIVERY_TAGS.has(structuredTag);
-    const displayText = hasOriginalPayload
+    const displayText = hasRawMessage
       ? decodeXmlEntitiesForDisplay(this.text)
       : this.text;
 
     this.displayCache = {
       text: this.text,
       isStructuredDelivery,
-      hasOriginalPayload,
+      hasRawMessage,
       displayText,
     };
     return this.displayCache;
@@ -211,8 +211,8 @@ export class UserMessage extends LitElement {
       new Date(this.timestamp),
     );
     const copyState = this.copyController.state;
-    const payloadCopyState = this.payloadCopyController.state;
-    const { isStructuredDelivery, hasOriginalPayload, displayText } =
+    const rawMessageCopyState = this.rawMessageCopyController.state;
+    const { isStructuredDelivery, hasRawMessage, displayText } =
       this.getDisplayState();
 
     return html`
@@ -240,16 +240,17 @@ export class UserMessage extends LitElement {
               aria-label=${copyState.ariaLabel}
               @click=${() => this.copyController.copy(displayText)}
             ></vscode-toolbar-button>
-            ${hasOriginalPayload
+            ${hasRawMessage
               ? html`<vscode-toolbar-button
                   class=${classMap({
                     'user-message-copy': true,
-                    [payloadCopyState.successClass]: payloadCopyState.copied,
+                    [rawMessageCopyState.successClass]:
+                      rawMessageCopyState.copied,
                   })}
                   icon="code"
-                  title=${payloadCopyState.title}
-                  aria-label=${payloadCopyState.ariaLabel}
-                  @click=${() => this.payloadCopyController.copy(this.text)}
+                  title=${rawMessageCopyState.title}
+                  aria-label=${rawMessageCopyState.ariaLabel}
+                  @click=${() => this.rawMessageCopyController.copy(this.text)}
                 ></vscode-toolbar-button>`
               : nothing}
           </div>

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -5,7 +5,7 @@
  * into a single unified message handler.
  *
  * Domain-specific handlers are delegated to focused handler classes:
- * - AgentHandlers: agent selection, directories, and mode presets
+ * - AgentHandlers: agent selection, directories, and teams
  * - LatexSettingsHandlers: LaTeX tool detection and recommended settings
  */
 import * as vscode from 'vscode';
@@ -493,7 +493,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       [SETTINGS_VIEW_COMMANDS.RESET_CUSTOM_AGENT_DIR]: () =>
         this.agentHandlers.handleResetCustomAgentDir(),
 
-      // Agent mode presets
+      // Agent teams
       [SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS]: () =>
         this.withActiveWebview((w) =>
           this.agentHandlers.sendAgentModePresets(w),

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -177,7 +177,7 @@ export class SettingsApp extends SettingsAppBase {
   private readonly customAgentDirIsDefault = signal(true);
   private readonly agentSubTab = signal<AgentCategory | undefined>(undefined);
 
-  // Agent mode presets state
+  // Agent teams state
   private readonly customPresets = signal<AgentModePreset[]>([]);
 
   // Super YOLO / reliability state

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -74,5 +74,6 @@ export const AgentSelectionEvents = {
   }) => createEvent('agent-reveal-file', detail),
   viewRemotePrompt: (detail: { agentName: string }) =>
     createEvent('agent-view-remote-prompt', detail),
+  // Keep the event name stable because SettingsApp already listens for it.
   saveTeam: () => createEvent('save-agent-mode-preset', undefined),
 } as const;

--- a/src/settingsView/frontend/components/profile/events.ts
+++ b/src/settingsView/frontend/components/profile/events.ts
@@ -74,5 +74,5 @@ export const AgentSelectionEvents = {
   }) => createEvent('agent-reveal-file', detail),
   viewRemotePrompt: (detail: { agentName: string }) =>
     createEvent('agent-view-remote-prompt', detail),
-  savePreset: () => createEvent('save-agent-mode-preset', undefined),
+  saveTeam: () => createEvent('save-agent-mode-preset', undefined),
 } as const;

--- a/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -222,8 +222,8 @@ export class AgentsTab extends LitElement {
     this.dispatchEvent(AgentSelectionEvents.resetCustomDir());
   }
 
-  private handleSavePreset(): void {
-    this.dispatchEvent(AgentSelectionEvents.savePreset());
+  private handleSaveTeam(): void {
+    this.dispatchEvent(AgentSelectionEvents.saveTeam());
   }
 
   override render(): TemplateResult {
@@ -265,11 +265,11 @@ export class AgentsTab extends LitElement {
           <div class="agents-header-actions">
             <button
               class="tab-action-btn"
-              @click=${this.handleSavePreset}
-              title="Save current agent configuration as a preset"
+              @click=${this.handleSaveTeam}
+              title="Save current agent configuration as a team"
             >
               <span class="codicon codicon-save"></span>
-              Save Preset
+              Save Team
             </button>
             <button
               class="tab-action-btn"

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -1,6 +1,6 @@
 /**
  * MultiAgentTab component - multi-agent settings for the settings view.
- * Contains agent mode presets (built-in + custom) for quick configuration,
+ * Contains agent teams (built-in + custom) for quick configuration,
  * the auto-approve toggle for agent delegation proposals,
  * and reliability settings.
  */
@@ -68,7 +68,7 @@ export class MultiAgentTab extends LitElement {
         margin-top: var(--spacing-tiny);
       }
 
-      /* Preset cards */
+      /* Team cards */
       .preset-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -1,9 +1,9 @@
 /**
- * Agent selection, directory, and mode preset handlers.
+ * Agent selection, directory, and team handlers.
  *
  * Extracted from SettingsViewMessageHandler to improve cohesion.
  * Handles agent enable/disable, create/customize/delete, YAML editing,
- * custom agent directories, and agent mode presets.
+ * custom agent directories, and agent teams.
  */
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -91,7 +91,7 @@ export function buildAgentSelectionItems(): {
 }
 
 /**
- * Agent selection, directory, and mode preset handler delegate.
+ * Agent selection, directory, and team handler delegate.
  */
 export class AgentHandlers {
   constructor(
@@ -552,7 +552,7 @@ export class AgentHandlers {
     }
   }
 
-  // ── Agent mode preset handlers ──
+  // ── Agent team handlers ──
 
   async sendAgentModePresets(webview: vscode.Webview): Promise<void> {
     await webview.postMessage({
@@ -569,9 +569,7 @@ export class AgentHandlers {
         AGENT_MODE_PRESETS.find((p) => p.id === data.presetId) ??
         this.getCustomPresets().find((p) => p.id === data.presetId);
       if (!preset) {
-        await vscode.window.showErrorMessage(
-          `Unknown preset: ${data.presetId}`,
-        );
+        await vscode.window.showErrorMessage(`Unknown team: ${data.presetId}`);
         return;
       }
 
@@ -595,12 +593,12 @@ export class AgentHandlers {
       await this.refreshAfterAgentMutation();
 
       void vscode.window.showInformationMessage(
-        `Applied "${preset.name}" preset`,
+        `Applied "${preset.name}" team`,
       );
     } catch (error) {
       await showLoggedErrorMessage(
         this.ctx.channel,
-        'Failed to apply agent mode preset',
+        'Failed to apply agent team',
         error,
       );
     }
@@ -611,8 +609,8 @@ export class AgentHandlers {
   ): Promise<void> {
     try {
       const name = await vscode.window.showInputBox({
-        prompt: 'Name for the new preset',
-        placeHolder: 'e.g. My Research Setup',
+        prompt: 'Name for the new team',
+        placeHolder: 'e.g. My Research Team',
         validateInput: (v) => (v.trim() ? null : 'Name cannot be empty'),
       });
       if (!name) return; // cancelled
@@ -625,7 +623,7 @@ export class AgentHandlers {
       const preset: AgentModePreset = {
         id: `custom-${Date.now()}`,
         name: name.trim(),
-        description: `Custom preset: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
+        description: `Custom team: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
         icon: 'codicon-bookmark',
         workflowAgents,
         toolUseAgents,
@@ -639,13 +637,11 @@ export class AgentHandlers {
 
       await this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w));
 
-      void vscode.window.showInformationMessage(
-        `Saved preset "${name.trim()}"`,
-      );
+      void vscode.window.showInformationMessage(`Saved team "${name.trim()}"`);
     } catch (error) {
       await showLoggedErrorMessage(
         this.ctx.channel,
-        'Failed to save agent mode preset',
+        'Failed to save agent team',
         error,
       );
     }
@@ -660,7 +656,7 @@ export class AgentHandlers {
       if (!target) return;
 
       const confirm = await vscode.window.showWarningMessage(
-        `Delete preset "${target.name}"?`,
+        `Delete team "${target.name}"?`,
         { modal: true },
         'Delete',
       );
@@ -673,7 +669,7 @@ export class AgentHandlers {
     } catch (error) {
       await showLoggedErrorMessage(
         this.ctx.channel,
-        'Failed to delete agent mode preset',
+        'Failed to delete agent team',
         error,
       );
     }
@@ -759,7 +755,7 @@ export class AgentHandlers {
     ]);
   }
 
-  /** Read and validate custom presets from workspace state. */
+  /** Read and validate custom teams from workspace state. */
   private getCustomPresets(): AgentModePreset[] {
     const raw = workspaceSM.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []);
     const parsed = z.array(AgentModePresetSchema).safeParse(raw);

--- a/src/shared/schemas/agentPresets.ts
+++ b/src/shared/schemas/agentPresets.ts
@@ -1,15 +1,15 @@
 /**
- * Agent mode presets - predefined collections of enabled agents
+ * Agent teams - predefined collections of enabled agents
  * for different academic disciplines.
  *
- * Each preset specifies which workflow and tool-use agents to enable.
+ * Each team specifies which workflow and tool-use agents to enable.
  * Agent names are plain strings (not source-prefixed keys) so they
  * match across built-in and custom sources.
  */
 
 import { z } from 'zod';
 
-/** Schema for a single agent mode preset. */
+/** Schema for a single agent team. */
 export const AgentModePresetSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -22,7 +22,7 @@ export const AgentModePresetSchema = z.object({
 export type AgentModePreset = z.infer<typeof AgentModePresetSchema>;
 
 /**
- * Built-in agent mode presets.
+ * Built-in agent teams.
  *
  * Agent names listed here are matched by name (not source:name key)
  * so custom agents that override a built-in are included automatically.

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -231,10 +231,10 @@ export type UpdateSuperYoloEnabledMessage = z.infer<
 >;
 
 // ============================================================
-// Agent mode presets data schema
+// Agent team data schema
 // ============================================================
 
-/** Outbound: backend → frontend agent mode presets (built-in + custom) */
+/** Outbound: backend → frontend agent teams (built-in + custom) */
 export const UpdateAgentModePresetsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS),
   customPresets: z.array(AgentModePresetSchema),
@@ -612,7 +612,7 @@ const SetNestedDelegationMaxDepthMessageSchema = z.object({
     .max(NESTED_DELEGATION_DEPTH_RANGE.max),
 });
 
-// Agent mode preset inbound messages
+// Agent team inbound messages
 const GetAgentModePresetsMessageSchema = commandOnly(
   CMD.GET_AGENT_MODE_PRESETS,
 );
@@ -846,7 +846,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetBashApprovalEnabledMessageSchema,
     SetCodexSandboxModeMessageSchema,
     SetCodexReasoningEffortMessageSchema,
-    // Agent mode preset messages
+    // Agent team messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,
     SaveAgentModePresetMessageSchema,


### PR DESCRIPTION
## Summary
- rename the raw structured-message copy action from original payload to raw message
- align settings and onboarding copy around teams instead of presets
- update nearby developer comments so the team vocabulary is consistent while preserving existing schema identifiers

## Checks
- npm run lint (passes with one existing warning in src/agent/runtime/sessionDescription.ts)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily terminology/label updates across docs and settings UI; minimal behavioral impact aside from copy/tooltip changes in a few user-facing actions.
> 
> **Overview**
> Aligns user-facing vocabulary from *presets* to **teams** across the settings UI, handlers, and onboarding docs/walkthrough copy, while keeping existing message/schema identifiers (e.g., `AgentModePresetSchema`, `GET_AGENT_MODE_PRESETS`) stable.
> 
> Renames the Progress view structured-message copy affordance from “Copy original payload” to **“Copy raw message”** (including internal controller naming), and updates apply/save/delete notifications and prompts to refer to teams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c68c4264fe70e7beab68134d3e3fc0ab12acc47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->