### PR TITLE
Replace vscode-button with custom styled buttons in GitTab

### DIFF
--- a/src/settingsView/frontend/tabs/GitTab.ts
+++ b/src/settingsView/frontend/tabs/GitTab.ts
@@ -350,15 +350,18 @@ export class GitTab extends LitElement {
                                         <span class="subscription-owner-label"
                                           >${owner.label}</span
                                         >
-                                        <vscode-button
-                                          appearance="secondary"
+                                        <button
+                                          class="tab-action-btn"
                                           @click=${() =>
                                             this.handleOpenPRSubscriptionStream(
                                               owner.streamId,
                                             )}
                                         >
+                                          <span
+                                            class="codicon codicon-comment-discussion"
+                                          ></span>
                                           Jump to agent
-                                        </vscode-button>
+                                        </button>
                                       </div>
                                     `,
                                   )}
@@ -370,13 +373,14 @@ export class GitTab extends LitElement {
                                 </p>
                               `}
                         </div>
-                        <vscode-button
-                          appearance="secondary"
+                        <button
+                          class="tab-action-btn"
                           @click=${() =>
                             this.handleUnsubscribePR(subscription.key)}
                         >
+                          <span class="codicon codicon-debug-stop"></span>
                           Stop
-                        </vscode-button>
+                        </button>
                       </li>
                     `,
                   )}


### PR DESCRIPTION
## Summary
Replaced VSCode button components with standard HTML buttons using custom styling in the GitTab PR subscription UI.

## Key Changes
- Replaced two `vscode-button` components with standard `<button>` elements
- Applied `tab-action-btn` class for consistent styling across both buttons
- Added Codicon icons to buttons:
  - "Jump to agent" button now displays a comment-discussion icon
  - "Stop" button now displays a debug-stop icon
- Removed `appearance="secondary"` attribute from both buttons (VSCode-specific styling)

## Implementation Details
- Icons are rendered using `<span>` elements with Codicon classes (`codicon-comment-discussion` and `codicon-debug-stop`)
- Button click handlers remain unchanged (`handleOpenPRSubscriptionStream` and `handleUnsubscribePR`)
- The custom `tab-action-btn` class should provide styling equivalent to the previous VSCode secondary button appearance

https://claude.ai/code/session_01S4pWBCkBQN7NQtTtS96Chh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps component types for two PR-subscription actions; primary risk is minor styling/accessibility regressions (focus/disabled states), with click behavior unchanged.
> 
> **Overview**
> Updates the GitTab PR subscription list UI to use standard `<button>` elements styled via `tab-action-btn` instead of `vscode-button`.
> 
> Adds Codicon icons to the *Jump to agent* and *Stop* actions while keeping the existing click handlers (`handleOpenPRSubscriptionStream`, `handleUnsubscribePR`) unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88501efec05311adba7feacf62adf13e166d4c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->