### PR TITLE
Display working directory in proposal and permission cards

### DIFF
--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -300,6 +300,11 @@ export class PermissionCard extends LitElement {
       <p><strong>Agent:</strong> ${data.agent}</p>
       <p><strong>Model:</strong> ${data.model}</p>
       <p><strong>Instruction:</strong> ${data.instruction}</p>
+      ${data.workingDirectory
+        ? html`<p>
+            <strong>Working directory:</strong> ${data.workingDirectory}
+          </p>`
+        : nothing}
       ${data.agentCategory === AGENT_CATEGORY.WORKFLOW
         ? this.renderExtractFlags(data)
         : nothing}

--- a/src/progressView/frontend/components/PermissionCard.ts
+++ b/src/progressView/frontend/components/PermissionCard.ts
@@ -302,7 +302,8 @@ export class PermissionCard extends LitElement {
       <p><strong>Instruction:</strong> ${data.instruction}</p>
       ${data.workingDirectory
         ? html`<p>
-            <strong>Working directory:</strong> ${data.workingDirectory}
+            <strong>Working directory:</strong>
+            <span class="file-path">${data.workingDirectory}</span>
           </p>`
         : nothing}
       ${data.agentCategory === AGENT_CATEGORY.WORKFLOW

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -207,11 +207,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
     >
       <span class="workflow-proposal__file-label">Working directory:</span>
       <span
-<<<<<<< HEAD
-        class="workflow-proposal__file-name workflow-proposal__file-name--readonly"
-=======
         class="workflow-proposal__file-name workflow-proposal__file-name--readonly workflow-proposal__file-name--wrap"
->>>>>>> 797f511 (fix: place working directory inside files block and wrap long paths)
         >${workingDirectory}</span
       >
     </div>`;

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -163,6 +163,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
           ${isWorkflow ? this.renderExtractFlags(data) : nothing}
+          ${this.renderWorkingDirectory(data)}
           ${this.renderProposalFiles(data)}
         </div>
         <vscode-toolbar-container class="workflow-proposal__actions">
@@ -195,6 +196,22 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
   // ===========================================================================
   // Proposal-specific rendering
   // ===========================================================================
+
+  private renderWorkingDirectory(
+    data: AgentProposalPermission,
+  ): TemplateResult | typeof nothing {
+    const workingDirectory = data.workingDirectory;
+    if (!workingDirectory) return nothing;
+    return html`<div
+      class="workflow-proposal__working-directory"
+      title=${workingDirectory}
+    >
+      <span class="workflow-proposal__file-label">Working directory:</span>
+      <span class="workflow-proposal__file-name workflow-proposal__file-name--readonly"
+        >${workingDirectory}</span
+      >
+    </div>`;
+  }
 
   private renderProposalFiles(
     data: AgentProposalPermission,

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -163,7 +163,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
           ${isWorkflow ? this.renderExtractFlags(data) : nothing}
-          ${this.renderWorkingDirectory(data)} ${this.renderProposalFiles(data)}
+          ${this.renderProposalFiles(data)}
         </div>
         <vscode-toolbar-container class="workflow-proposal__actions">
           <vscode-toolbar-button
@@ -207,7 +207,11 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
     >
       <span class="workflow-proposal__file-label">Working directory:</span>
       <span
+<<<<<<< HEAD
         class="workflow-proposal__file-name workflow-proposal__file-name--readonly"
+=======
+        class="workflow-proposal__file-name workflow-proposal__file-name--readonly workflow-proposal__file-name--wrap"
+>>>>>>> 797f511 (fix: place working directory inside files block and wrap long paths)
         >${workingDirectory}</span
       >
     </div>`;
@@ -217,8 +221,10 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
     data: AgentProposalPermission,
   ): TemplateResult | typeof nothing {
     const groups = getProposalFileGroups(data);
-    if (groups.length === 0) return nothing;
+    const workingDirectoryRow = this.renderWorkingDirectory(data);
+    if (groups.length === 0 && workingDirectoryRow === nothing) return nothing;
     return html`<div class="workflow-proposal__files">
+      ${workingDirectoryRow}
       ${repeat(
         groups,
         ({ label }) => label,

--- a/src/progressView/frontend/components/ProposalRequestPanel.ts
+++ b/src/progressView/frontend/components/ProposalRequestPanel.ts
@@ -163,8 +163,7 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
           </div>
           <div class="workflow-proposal__instruction">${data.instruction}</div>
           ${isWorkflow ? this.renderExtractFlags(data) : nothing}
-          ${this.renderWorkingDirectory(data)}
-          ${this.renderProposalFiles(data)}
+          ${this.renderWorkingDirectory(data)} ${this.renderProposalFiles(data)}
         </div>
         <vscode-toolbar-container class="workflow-proposal__actions">
           <vscode-toolbar-button
@@ -207,7 +206,8 @@ export class ProposalRequestPanel extends BaseFeedbackPanel {
       title=${workingDirectory}
     >
       <span class="workflow-proposal__file-label">Working directory:</span>
-      <span class="workflow-proposal__file-name workflow-proposal__file-name--readonly"
+      <span
+        class="workflow-proposal__file-name workflow-proposal__file-name--readonly"
         >${workingDirectory}</span
       >
     </div>`;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -513,6 +513,10 @@ export const requestPanelStyles: CSSResult = css`
     color: var(--color-text-secondary);
   }
 
+  .workflow-proposal__file-name--wrap {
+    word-break: break-word;
+  }
+
   .workflow-proposal__input-files .workflow-proposal__file-label {
     color: var(--vscode-editor-foreground);
   }


### PR DESCRIPTION
## Summary
Added display of the working directory field in both the proposal request panel and permission card components. This allows users to see which directory an agent proposal or permission will operate within.

## Key Changes
- **ProposalRequestPanel**: Added `renderWorkingDirectory()` method to display the working directory with appropriate styling and tooltip
  - Renders conditionally only when `workingDirectory` data is present
  - Uses consistent styling with other file-related fields in the proposal UI
  - Includes a title attribute for full path visibility on hover

- **PermissionCard**: Added working directory display in the permission details section
  - Conditionally renders the working directory field when present
  - Maintains consistent formatting with other permission metadata fields (agent, model, instruction)

## Implementation Details
- Both components check for the presence of `workingDirectory` before rendering to avoid displaying empty values
- The ProposalRequestPanel uses a dedicated styled div with class `workflow-proposal__working-directory` for consistent UI presentation
- The PermissionCard uses a simple paragraph format matching the existing metadata display pattern

https://claude.ai/code/session_01LY6CYwuPB25JXLpbXJMDsp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only rendering/styling changes gated on an optional `workingDirectory` field, with no behavior, security, or data-flow impact.
> 
> **Overview**
> Agent proposals now surface their `workingDirectory` in the UI.
> 
> `ProposalRequestPanel` adds a dedicated, tooltip-enabled “Working directory” row in the proposal files section and ensures the files block still renders when only a working directory is present. `PermissionCard` similarly shows the working directory in proposal permission details. Styling adds `workflow-proposal__file-name--wrap` to prevent long paths from overflowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9536e2866b7cd31cc2477f520cc55f0885de1950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->