### PR TITLE
Raise PR subscription cap

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -259,7 +259,7 @@ Setup:
 
 The token is stored in VS Code's encrypted **Secret Storage** — never written to `settings.json`. Alternatively, export `GITHUB_TOKEN` in the shell VS Code is launched from and the tool will pick it up automatically (the Git tab will show **Env** as the status).
 
-Once a token is configured, an agent can run `subscribe_pr_activity owner=… repo=… pullNumber=…` and every new PR event arrives wrapped in a `<github-webhook-activity>` tag in the follow-up queue. Subscriptions auto-terminate when the PR closes or merges, and up to 10 PRs can be watched concurrently.
+Once a token is configured, an agent can run `subscribe_pr_activity owner=… repo=… pullNumber=…` and every new PR event arrives wrapped in a `<github-webhook-activity>` tag in the follow-up queue. Subscriptions auto-terminate when the PR closes or merges, and up to 25 PRs can be watched concurrently.
 
 ### TeXRA commit author
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -19,6 +19,10 @@ import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
 import { importCodexClass, findCodexBinaryPath } from '@tools/codexImport';
 import { getGitHubToken } from '@tools/github/githubAuth';
+import {
+  MAX_CONCURRENT_PR_SUBSCRIPTIONS,
+  PR_POLL_INTERVAL_MS,
+} from '@tools/github/prSubscriptionConstants';
 import { getZoteroPort } from '@tools/zotero/bbtClient';
 import { isGitRepository } from '@utils/system/isGitRepository';
 import { checkToolInstalled } from '@utils/system/toolUtils';
@@ -271,8 +275,7 @@ export const EXTERNAL_TOOL_DEFS: readonly ExternalToolDef[] = [
       '  4. Copy the token back into TeXRA via "Set token".\n\n' +
       'Alternatively, export GITHUB_TOKEN in the environment VS Code is launched from.',
     installUrl: 'https://github.com/settings/tokens',
-    configNotes:
-      'Token stored in VS Code SecretStorage (managed from Git tab). Requires a git repository in the workspace. Polls every 30s; subscription cap: 10 concurrent PRs.',
+    configNotes: `Token stored in VS Code SecretStorage (managed from Git tab). Requires a git repository in the workspace. Polls every ${PR_POLL_INTERVAL_MS / 1000}s; subscription cap: ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs.`,
     authNote: 'Uses personal access token',
     toggleable: true,
     installActionCommand: 'texra.showGitSettings',

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -2,8 +2,8 @@
  * Poll-based event source for GitHub PR activity.
  *
  * Each subscribed PR maintains per-resource cursors (last-seen ID) and ETags.
- * A single shared timer ticks every `POLL_INTERVAL_MS` and iterates all active
- * subscriptions. Events are converted to natural-language text via
+ * A single shared timer ticks every `PR_POLL_INTERVAL_MS` and iterates all
+ * active subscriptions. Events are converted to natural-language text via
  * `formatPREvent` and dispatched to per-caller listeners.
  *
  * Transport is polling for v1; swapping to a push transport (e.g. a Supabase
@@ -33,6 +33,10 @@ import {
   type ConditionalResponse,
   ghGet,
 } from './githubClient';
+import {
+  MAX_CONCURRENT_PR_SUBSCRIPTIONS,
+  PR_POLL_INTERVAL_MS,
+} from './prSubscriptionConstants';
 import type {
   GhCheckRun,
   GhIssueComment,
@@ -45,8 +49,6 @@ export interface Disposable {
   dispose(): void;
 }
 
-const POLL_INTERVAL_MS = 30_000;
-const MAX_CONCURRENT_SUBSCRIPTIONS = 10;
 // Coalesce this many same-kind events in a single tick into a summary.
 const COALESCE_THRESHOLD = 3;
 // Exponential backoff on transient poll failures. After each failure the
@@ -200,9 +202,9 @@ export class PRPollingSource {
 
     let state = this.subscriptions.get(key);
     if (!state) {
-      if (this.subscriptions.size >= MAX_CONCURRENT_SUBSCRIPTIONS) {
+      if (this.subscriptions.size >= MAX_CONCURRENT_PR_SUBSCRIPTIONS) {
         throw new Error(
-          `Too many active PR subscriptions (max ${MAX_CONCURRENT_SUBSCRIPTIONS}). Unsubscribe from one before adding another.`,
+          `Too many active PR subscriptions (max ${MAX_CONCURRENT_PR_SUBSCRIPTIONS}). Unsubscribe from one before adding another.`,
         );
       }
       state = {
@@ -257,7 +259,7 @@ export class PRPollingSource {
     if (this.timer) return;
     this.timer = setInterval(() => {
       void this.tick();
-    }, POLL_INTERVAL_MS);
+    }, PR_POLL_INTERVAL_MS);
     // Fire an immediate tick so first-subscribe initializes cursors without
     // waiting a full interval.
     void this.tick();
@@ -272,7 +274,7 @@ export class PRPollingSource {
   private tickInFlight = false;
 
   private async tick(): Promise<void> {
-    // setInterval fires every POLL_INTERVAL_MS regardless of prior
+    // setInterval fires every PR_POLL_INTERVAL_MS regardless of prior
     // completion; with N subscriptions and 15s per-request timeouts a tick
     // can outlast the interval. Without this guard overlapping ticks would
     // double-emit events for the same new items.

--- a/src/tools/github/prSubscriptionConstants.ts
+++ b/src/tools/github/prSubscriptionConstants.ts
@@ -1,0 +1,2 @@
+export const PR_POLL_INTERVAL_MS = 30_000;
+export const MAX_CONCURRENT_PR_SUBSCRIPTIONS = 25;

--- a/src/tools/github/subscribePRTool.ts
+++ b/src/tools/github/subscribePRTool.ts
@@ -15,6 +15,10 @@ import { ToolError, type ToolResult } from '@tools/result';
 import { defineTool } from '../core/define';
 import { bindPRSubscription } from './PRSubscriptionBinder';
 import { getGitHubToken } from './githubAuth';
+import {
+  MAX_CONCURRENT_PR_SUBSCRIPTIONS,
+  PR_POLL_INTERVAL_MS,
+} from './prSubscriptionConstants';
 
 const SubscribePRInputSchema = z.strictObject({
   owner: z.string().min(1).describe('Repository owner (user or org)'),
@@ -32,7 +36,7 @@ export class SubscribePRTool extends defineTool({
     'When such a follow-up arrives, treat it like user input: investigate what it refers to, fix it if the action is small and unambiguous, ask the user if the change is architecturally significant or the request is ambiguous, or skip the event if no action is needed.',
     'Do NOT re-post the event text as a comment on GitHub — that would create a self-loop; your job is to react to events, not echo them.',
     'The subscription is scoped to the current stream: sub-agents spawned via delegate_agent do not inherit it. Delegation results come through their own follow-up channel.',
-    'Subscriptions auto-terminate when the PR is closed or merged. Poll interval ≈ 30s. Up to 10 concurrent PRs. Requires a GitHub token — set it in TeXRA settings → Git tab, or via the GITHUB_TOKEN environment variable.',
+    `Subscriptions auto-terminate when the PR is closed or merged. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Up to ${MAX_CONCURRENT_PR_SUBSCRIPTIONS} concurrent PRs. Requires a GitHub token — set it in TeXRA settings → Git tab, or via the GITHUB_TOKEN environment variable.`,
   ].join(' '),
   schema: SubscribePRInputSchema,
 }) {
@@ -55,7 +59,7 @@ export class SubscribePRTool extends defineTool({
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, and failed CI checks will arrive as follow-up messages wrapped in <github-webhook-activity>. Poll interval ≈ 30s. Auto-unsubscribes on close/merge.`
+        ? `Subscribed to ${slug}. New comments, reviews, line comments, and failed CI checks will arrive as follow-up messages wrapped in <github-webhook-activity>. Poll interval ≈ ${PR_POLL_INTERVAL_MS / 1000}s. Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${slug}. You will continue to receive PR activity as follow-up messages until the PR closes or you call unsubscribe_pr_activity.`,
     };
   }


### PR DESCRIPTION
## Summary
- raise the PR activity subscription limit from 10 to 25 concurrent PRs
- share the PR subscription cap and polling interval through one constants module
- update tool metadata and user documentation to report the new limit

## Checks
- npm run compile:fast
- npm run typecheck
- npm run lint (passes with one existing warning in src/agent/runtime/sessionDescription.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases the maximum concurrent PR poll subscriptions, which can raise GitHub API traffic and amplify rate-limit/performance issues when many PRs are watched at once.
> 
> **Overview**
> Raises the `subscribe_pr_activity` concurrent subscription cap from **10 → 25**.
> 
> Centralizes the poll interval and subscription cap into a new `prSubscriptionConstants` module and updates the poller (`PRPollingSource`), tool metadata (`externalToolDefs`), tool descriptions/output text (`subscribePRTool`), and user docs to reference the shared constants and new limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442bf88e4b810bd8e4b2e1b1e2ff8f45416ced4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->