### PR TITLE
fix: keep toggle icons stable

### DIFF
--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -28,7 +28,6 @@ import { getComposedPathElement } from '../utils';
 interface ToolbarButton {
   id: string;
   icon: string;
-  iconActive?: string;
   command: string;
   title: string;
   titleActive?: string;
@@ -389,14 +388,12 @@ export class StreamHeader extends LitElement {
                       ? this.superYoloActive
                       : this.yoloActive),
                   );
-                  const icon =
-                    isActive && btn.iconActive ? btn.iconActive : btn.icon;
                   const title =
                     isActive && btn.titleActive ? btn.titleActive : btn.title;
                   return html`
                     <vscode-toolbar-button
                       id=${btn.id}
-                      icon=${icon}
+                      icon=${btn.icon}
                       label=${title}
                       title=${title}
                       data-command=${btn.command}

--- a/src/progressView/frontend/constants.ts
+++ b/src/progressView/frontend/constants.ts
@@ -128,7 +128,6 @@ const WORKFLOW_TOOLBAR = [
 const YOLO_TOGGLE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.YOLO_TOGGLE_BTN,
   icon: 'shield',
-  iconActive: 'flame',
   command: PROGRESS_VIEW_COMMANDS.TOGGLE_TOOL_EDIT_APPROVAL_BYPASS,
   title: 'Skip edit approvals (auto-accept file changes)',
   titleActive: 'Edit auto-accept active — click to resume approval prompts',
@@ -139,7 +138,6 @@ const YOLO_TOGGLE_BUTTON = Object.freeze({
 const SUPER_YOLO_TOGGLE_BUTTON = Object.freeze({
   id: ELEMENT_IDS.SUPER_YOLO_TOGGLE_BTN,
   icon: 'rocket',
-  iconActive: 'zap',
   command: PROGRESS_VIEW_COMMANDS.TOGGLE_SUPER_YOLO_BYPASS,
   title: 'Auto-approve delegated tasks (skip task-by-task approval)',
   titleActive: 'Auto-approve active — click to resume manual approval',


### PR DESCRIPTION
## Summary

- Keep the tool-edit and delegated-task toggle icons fixed when the toggles are active.
- Preserve the active visual treatment and active tooltip text, so the state remains visible without changing the codicon glyph.

## Checks

- npx prettier --check src/progressView/frontend/components/StreamHeader.ts src/progressView/frontend/constants.ts
- npm run compile:fast
- npm run lint (passes with one pre-existing warning in src/agent/runtime/sessionDescription.ts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that affects icon rendering for toggle toolbar buttons; no data handling or command behavior changes.
> 
> **Overview**
> Prevents the progress view’s YOLO toggle buttons from swapping codicon glyphs when active by removing `iconActive` support and always rendering the configured `icon`.
> 
> Active state is now communicated solely via the existing `is-active` styling and `titleActive` tooltip text, keeping the visual highlight and state messaging without changing the icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c69975222bf0e7073a7a7add228dd49f7c766be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->