### PR TITLE
fix: remove wait follow-up shortcut

### DIFF
--- a/src/progressView/frontend/ProgressApp.ts
+++ b/src/progressView/frontend/ProgressApp.ts
@@ -565,7 +565,6 @@ export class ProgressApp extends ProgressAppBase {
           @followup-polish=${this.onFollowUpPolish}
           @followup-clear=${this.onFollowUpClear}
           @followup-focus-complete=${this.onFollowUpFocusComplete}
-          @followup-focus-request=${this.onFollowUpFocusRequest}
         ></tool-use-stream-content>
       `;
     }
@@ -750,19 +749,6 @@ export class ProgressApp extends ProgressAppBase {
       e,
       this.getEventHandlerContext(),
     );
-
-  /** Focus the follow-up input (e.g. from the "Send Follow-up" button in log entries). */
-  private onFollowUpFocusRequest = (): void => {
-    const streamId = this.appState.get().activeStreamId;
-    if (!streamId) return;
-
-    this.setStreamState(streamId, (prev) => {
-      if (!isToolUseState(prev) || prev.ui.shouldFocusFollowUp) return prev;
-      return create(prev, (draft) => {
-        draft.ui.shouldFocusFollowUp = true;
-      });
-    });
-  };
 
   /**
    * Reset focus/polish/transcription triggers after they've been consumed.

--- a/src/progressView/frontend/components/LogList.ts
+++ b/src/progressView/frontend/components/LogList.ts
@@ -262,18 +262,6 @@ export class LogList extends LitElement {
       return;
     }
 
-    // Handle "Send Follow-up" button in executions wait entries
-    const breakWaitBtn = this.findTargetInPath<HTMLElement>(
-      event,
-      '.followup-break-wait',
-    );
-    if (breakWaitBtn) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.dispatchEvent(ProgressEvents.followupFocusRequest());
-      return;
-    }
-
     // Handle copy buttons - content is stored in the copy registry
     const copyButton = this.findTargetInPath<HTMLElement>(
       event,

--- a/src/progressView/frontend/events.ts
+++ b/src/progressView/frontend/events.ts
@@ -114,7 +114,4 @@ export const ProgressEvents = {
 
   followupFocusComplete: () =>
     createEvent('followup-focus-complete', undefined),
-
-  /** Request focus on the follow-up input (e.g. from the "Send Follow-up" button in log entries). */
-  followupFocusRequest: () => createEvent('followup-focus-request', undefined),
 } as const;

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -383,11 +383,9 @@ function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
 
   if (action === 'wait') {
     const timeout = execInput.timeout ?? 300;
-    // prettier-ignore
-    const waitContent = isInProgress
-      ? html`<pre>wait (timeout: ${timeout}s)</pre><span class="followup-break-wait" title="Focus the follow-up input to send a message and break this wait"><i class="codicon codicon-comment"></i> Send Follow-up</span>`
-      : wrapInPre(`wait (timeout: ${timeout}s)`);
-    sections.push(buildToolUseSection('Action:', waitContent));
+    sections.push(
+      buildToolUseSection('Action:', wrapInPre(`wait (timeout: ${timeout}s)`)),
+    );
   } else if (action === 'kill') {
     sections.push(buildToolUseSection('Action:', wrapInPre('kill')));
   }

--- a/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -368,7 +368,7 @@ function buildMemorySections(ctx: ToolSectionContext): TemplateResult[] {
 }
 
 function buildExecutionsSections(ctx: ToolSectionContext): TemplateResult[] {
-  const { input, isInProgress } = ctx;
+  const { input } = ctx;
   if (!isPlainObject(input)) return [];
   const execInput = input as ExecutionsToolInput;
   const execPath = execInput.path ?? '';

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -148,7 +148,7 @@ export const toolUseStyles = css`
   }
 
   /* Shared base for inline action links */
-  :is(.proposal-restore-link, .followup-break-wait) {
+  .proposal-restore-link {
     color: var(--color-text-link);
     cursor: pointer;
     font-size: var(--font-size-sm);
@@ -161,7 +161,7 @@ export const toolUseStyles = css`
       background-color var(--transition-fast);
   }
 
-  :is(.proposal-restore-link, .followup-break-wait):focus-visible {
+  .proposal-restore-link:focus-visible {
     outline: var(--border-thin) solid var(--vscode-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
@@ -174,22 +174,6 @@ export const toolUseStyles = css`
 
   .proposal-banner-setup {
     margin-left: auto;
-  }
-
-  /* Follow-up break-wait button (shown inside executions wait entries) */
-  .followup-break-wait {
-    margin-top: var(--spacing-small);
-    padding: var(--spacing-tiny) var(--spacing-small);
-    border: var(--border-thin) solid var(--color-text-link);
-    border-radius: var(--border-radius-small);
-  }
-
-  .followup-break-wait:hover {
-    background-color: color-mix(
-      in srgb,
-      var(--color-text-link) 15%,
-      transparent
-    );
   }
 
   /* Diff styles */

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -147,7 +147,7 @@ export const toolUseStyles = css`
     border: var(--border-thin) solid var(--color-border);
   }
 
-  /* Shared base for inline action links */
+  /* Proposal restore link */
   .proposal-restore-link {
     color: var(--color-text-link);
     cursor: pointer;


### PR DESCRIPTION
## Summary

- Removes the inline follow-up shortcut from in-progress `executions wait` log entries.
- Removes the now-unused event path, click handler, and styles for that control.
- Leaves wait entries as plain status displays, so the progress view no longer suggests a separate action whose only effect is to focus another input.

## Design note

The previous control introduced cognitive load: its label suggested that a follow-up would be sent, while the implementation only moved focus to the follow-up input. Removing the control keeps the status log passive and reserves user input for the dedicated follow-up area.

## Checks

- `npx prettier --write src/progressView/frontend/formatters/logFormatters/toolFormatters.ts src/progressView/frontend/components/LogList.ts src/progressView/frontend/events.ts src/progressView/frontend/ProgressApp.ts src/progressView/frontend/styles/toolUseStyles.ts`
- `npm run lint` (passes with one unrelated warning in `src/agent/runtime/sessionDescription.ts`)
- `npm run compile:fast` (passes with existing Vite warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of a shortcut and its unused event wiring; no impact on tool execution, backend behavior, or data handling.
> 
> **Overview**
> Progress view no longer renders an inline “Send Follow-up” control inside in-progress `executions` `wait` tool log entries; wait entries are now displayed as plain status text.
> 
> This removes the corresponding click handling in `LogList`, the `followup-focus-request` custom event, and the `ProgressApp` stream-state focus trigger path, along with the now-unused `.followup-break-wait` styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70484a459881ec7cd5ca7a32c38040baad01f2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->