### PR TITLE
fix: stop badging original workspace file before workflow output is accepted

### DIFF
--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
 
 import { bus } from '@eventBus/ProgressEventBus';
-import {
-  collectOutputFileLocations,
-  type OutputFileInfo,
-} from '@shared/schemas/output';
+import type { OutputFileInfo } from '@shared/schemas/output';
 
 // Session-scoped: the touched set is not persisted across window reloads so
 // the badges clear on restart and track only the current session's activity.
@@ -48,17 +45,15 @@ class TeXRAFileDecorationProvider implements vscode.FileDecorationProvider {
   }
 }
 
-// Decorate workspace files reachable from this output info — including the
-// original workspace file referenced via `lineage.original` for edit
-// workflows whose agent output sits under runStorage.
+// Only mark the primary output location. Lineage entries (original, diffBase,
+// diffFile) are reference points — marking them would badge the source file as
+// "Modified by TeXRA" before the user has actually accepted the workflow output.
 function collectWorkspacePaths(
   target: Set<string>,
   info: OutputFileInfo,
 ): void {
-  for (const loc of collectOutputFileLocations(info)) {
-    if (loc.kind === 'workspace') {
-      target.add(loc.absolutePath);
-    }
+  if (info.location.kind === 'workspace') {
+    target.add(info.location.absolutePath);
   }
 }
 

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -4,7 +4,6 @@ import { mapToRecord } from '@progressView/persistence/serializationUtils';
 import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
 import {
   CompileFailureSchema,
-  collectOutputFileLocations,
   OutputFileInfoListSchema,
   type CompileFailure,
   type OutputFileInfo,
@@ -154,10 +153,9 @@ export class OutputFilesManager {
     info: OutputFileInfo,
     workspaceOnly: boolean,
   ): void {
-    for (const loc of collectOutputFileLocations(info)) {
-      if (!workspaceOnly || loc.kind === 'workspace') {
-        target.add(loc.absolutePath);
-      }
+    const loc = info.location;
+    if (!workspaceOnly || loc.kind === 'workspace') {
+      target.add(loc.absolutePath);
     }
   }
 

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -93,32 +93,3 @@ export const RoundOutputSchema = z.strictObject({
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-/**
- * Return every `FileLocation` reachable from an `OutputFileInfo`: the primary
- * `location` plus any lineage entries (`original`, `diffBase`, `diffFile`).
- * Missing lineage entries (`null`/`undefined`) are skipped; defensively, any
- * entry with a falsy `absolutePath` is also dropped, though valid
- * `FileLocation`s always have one.
- *
- * Callers that only care about workspace files should filter the result by
- * `loc.kind === 'workspace'` themselves — the workspace-scope check is
- * platform-coupled and intentionally lives outside this VS Code-free module.
- */
-export function collectOutputFileLocations(
-  info: OutputFileInfo,
-): FileLocation[] {
-  const { lineage } = info;
-  const candidates: (FileLocation | null | undefined)[] = [
-    info.location,
-    lineage?.original,
-    lineage?.diffBase,
-    lineage?.diffFile,
-  ];
-  const result: FileLocation[] = [];
-  for (const loc of candidates) {
-    if (loc != null && loc.absolutePath) {
-      result.push(loc);
-    }
-  }
-  return result;
-}

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -92,4 +92,3 @@ export const RoundOutputSchema = z.strictObject({
   xmlSummary: OutputXmlSummarySchema,
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
-


### PR DESCRIPTION
collectWorkspacePaths was iterating all locations from collectOutputFileLocations,
which includes lineage.original. For workflow agents the primary output lives in
runStorage, but lineage.original points back to the original workspace source file —
so that unmodified file received the "Modified by TeXRA" badge immediately on agent
completion, making it look as though the output had been auto-accepted.

Now only the primary info.location is checked; lineage entries are reference points
for diffing, not files TeXRA has written.

https://claude.ai/code/session_01HNGUJEHDNXxRHGYy62ZQFM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how output paths are collected by ignoring lineage locations, which may affect any features that previously relied on those reference paths being included in known/modified sets. Scope is small but alters behavior in file tracking and VS Code decorations.
> 
> **Overview**
> Fixes premature VS Code “Modified by TeXRA” badges by only considering `OutputFileInfo.location` when marking workspace files, instead of also traversing lineage references (`original`/`diffBase`/`diffFile`).
> 
> Removes the shared `collectOutputFileLocations` helper and updates `OutputFilesManager.getKnownFilePaths` to likewise index only the primary output path, reducing path collection to a single location per output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c5c4694388a0af598ef8e10120493928e4c1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->