### PR TITLE
feat: surface \criticize annotations as inline diagnostics (experimental)

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -45,6 +45,13 @@
             "description": "When a workflow run completes, automatically preview the final revised file in a new editor tab. Disable for batch runs when you don't want a tab to steal focus.",
             "scope": "resource",
             "order": 51
+          },
+          "texra.inlineCriticism.enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Experimental: parse \\criticize{message}{severity}{confidence} annotations from agent-revised LaTeX files and surface them as VS Code diagnostics (squiggles + Problems panel). Severity 5→Error, 4→Warning, 3→Info, 1–2→Hint. Tool-use agents may also push diagnostics directly via the add_criticism tool.",
+            "scope": "resource",
+            "order": 52
           }
         }
       },

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -61,6 +61,10 @@ import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgent
 import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
 import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 import { getLinterMessages } from '@frontend/latex/linter';
+import {
+  pushManualCriticism,
+  registerInlineCriticism,
+} from '@frontend/latex/inlineCriticism';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import { VscodeFileSystem } from '@frontend/vscode/vscodeFileSystem';
 import { VscodeWorkspace } from '@frontend/vscode/vscodeWorkspace';
@@ -82,10 +86,11 @@ import {
   issuePollingSource,
 } from '@tools/github';
 import { setToolNotificationHandler } from '@tools/toolUnavailableNotification';
+import { setAddCriticismSink } from '@tools/AddCriticismTool';
 import { setLinterProvider } from '@tools/DiagnosticsTool';
 import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
-import { StorageFS } from '@utils/files';
+import { StorageFS, WorkspaceFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { setToolMissingHandler } from '@utils/system';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
@@ -458,6 +463,23 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push({ dispose: disposeGitHubAuthListener });
   setLinterProvider(getLinterMessages);
   setOpenBuildDisplay(openBuildDisplayIfTex);
+  registerInlineCriticism(context);
+  setAddCriticismSink((payload) => {
+    let resolvedPath = payload.path;
+    try {
+      resolvedPath = WorkspaceFS.toAbsolute(payload.path);
+    } catch {
+      // No workspace open — fall back to the raw path.
+    }
+    const accepted = pushManualCriticism({
+      absolutePath: resolvedPath,
+      line: payload.line,
+      message: payload.message,
+      severity: payload.severity,
+      confidence: payload.confidence,
+    });
+    return { accepted, resolvedPath };
+  });
   applyGitAuthorConfig();
 
   setToolNotificationHandler((message, actionCommand, actionLabel) => {

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -90,7 +90,7 @@ import { setAddCriticismSink } from '@tools/AddCriticismTool';
 import { setLinterProvider } from '@tools/DiagnosticsTool';
 import { setLeanVscodeServices } from '@tools/lean/leanVscodeServices';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
-import { StorageFS, WorkspaceFS } from '@utils/files';
+import { StorageFS } from '@utils/files';
 import { getConfig } from '@utils/config';
 import { setToolMissingHandler } from '@utils/system';
 import { TASK_RUNS_DIR } from '@utils/files/taskRunStorage';
@@ -465,20 +465,14 @@ export async function activate(context: vscode.ExtensionContext) {
   setOpenBuildDisplay(openBuildDisplayIfTex);
   registerInlineCriticism(context);
   setAddCriticismSink((payload) => {
-    let resolvedPath = payload.path;
-    try {
-      resolvedPath = WorkspaceFS.toAbsolute(payload.path);
-    } catch {
-      // No workspace open — fall back to the raw path.
-    }
     const accepted = pushManualCriticism({
-      absolutePath: resolvedPath,
+      absolutePath: payload.absolutePath,
       line: payload.line,
       message: payload.message,
       severity: payload.severity,
       confidence: payload.confidence,
     });
-    return { accepted, resolvedPath };
+    return { accepted, resolvedPath: payload.absolutePath };
   });
   applyGitAuthorConfig();
 

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -1,16 +1,14 @@
 /**
  * Experimental: surface `\criticize{message}{severity}{confidence}` annotations
  * inserted by critique-style agents (criticize, notation, elevate, verifyFix,
- * ...) as VS Code diagnostics, so they show up as squiggles in the editor and
- * entries in the Problems panel — like a linter.
+ * ...) as VS Code diagnostics — squiggles in the editor and entries in the
+ * Problems panel, like a linter.
  *
  * Two ingest paths:
- *   1. Bus event hook: every time an agent round emits `addOutputFiles`, we
- *      read each output file and brute-force parse `\criticize{...}` macros
- *      out of it. Universal — any agent that writes the macro participates.
- *   2. Tool sink (`add_criticism` tool): tool-use agents that want to flag an
- *      issue without literally writing `\criticize{...}` into the document
- *      can call the tool, which routes through `pushManualCriticism` here.
+ *   1. Bus event hook on `addOutputFiles` parses each output `.tex` file.
+ *      Universal — any agent that writes the macro participates.
+ *   2. `add_criticism` tool routes through `pushManualCriticism` here for
+ *      tool-use agents that want to flag issues without inserting the macro.
  *
  * Gated on `texra.inlineCriticism.enabled` (default: false).
  */
@@ -23,30 +21,21 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
-import { getConfig } from '@utils/config';
+import type { ManualCriticismEntry } from '@tools/AddCriticismTool';
+import { getConfig, watchConfig } from '@utils/config';
+import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'InlineCriticism';
 const SETTING_KEY = 'inlineCriticism.enabled';
 const COLLECTION_NAME = 'texra-criticism';
 const SOURCE_LABEL = 'TeXRA';
-
-/** Manual criticism entry pushed by tool-use agents via `add_criticism`. */
-export interface ManualCriticismEntry {
-  /** Absolute path to the file the criticism applies to. */
-  absolutePath: string;
-  /** 1-based line number (matches editor gutter). */
-  line: number;
-  message: string;
-  /** 1–5; mapped to DiagnosticSeverity. */
-  severity: number;
-  /** 1–5; appended to the message as `(S/C)`. */
-  confidence: number;
-}
+const CODE_PARSED = 'criticize';
+const CODE_TOOL = 'criticize:tool';
 
 let collection: vscode.DiagnosticCollection | undefined;
 let busUnsubscribe: (() => void) | undefined;
 
-/** Severity 5 → Error, 4 → Warning, 3 → Info, 1–2 → Hint. */
+/** Criticism severity (1–5) → VS Code DiagnosticSeverity. */
 function mapSeverity(severity: number): vscode.DiagnosticSeverity {
   if (severity >= 5) return vscode.DiagnosticSeverity.Error;
   if (severity >= 4) return vscode.DiagnosticSeverity.Warning;
@@ -58,19 +47,21 @@ function isEnabled(): boolean {
   return getConfig<boolean>(SETTING_KEY, false) === true;
 }
 
-async function readFileText(absolutePath: string): Promise<string | null> {
-  try {
-    const bytes = await vscode.workspace.fs.readFile(
-      vscode.Uri.file(absolutePath),
-    );
-    return Buffer.from(bytes).toString('utf8');
-  } catch (error) {
-    logger.error(
-      CHANNEL,
-      `Failed to read ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    return null;
-  }
+function buildDiagnostic(
+  range: vscode.Range,
+  message: string,
+  severity: number,
+  confidence: number,
+  code: string,
+): vscode.Diagnostic {
+  const diag = new vscode.Diagnostic(
+    range,
+    `${message} (S${severity}/C${confidence})`,
+    mapSeverity(severity),
+  );
+  diag.source = SOURCE_LABEL;
+  diag.code = code;
+  return diag;
 }
 
 async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
@@ -78,8 +69,16 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
   const absolutePath = file.location.absolutePath;
   if (!absolutePath.toLowerCase().endsWith('.tex')) return;
 
-  const text = await readFileText(absolutePath);
-  if (text === null) return;
+  let text: string;
+  try {
+    text = await AbsoluteFS.read(absolutePath);
+  } catch (error) {
+    logger.error(
+      CHANNEL,
+      `Failed to read ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return;
+  }
 
   const annotations = parseCriticismAnnotations(text);
   const uri = vscode.Uri.file(absolutePath);
@@ -89,23 +88,18 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
     return;
   }
 
-  const diagnostics = annotations.map((a) => {
-    const range = new vscode.Range(
-      a.line,
-      a.column,
-      a.line,
-      a.column + a.length,
-    );
-    const diag = new vscode.Diagnostic(
-      range,
-      `${a.message} (S${a.severity}/C${a.confidence})`,
-      mapSeverity(a.severity),
-    );
-    diag.source = SOURCE_LABEL;
-    diag.code = 'criticize';
-    return diag;
-  });
-  collection.set(uri, diagnostics);
+  collection.set(
+    uri,
+    annotations.map((a) =>
+      buildDiagnostic(
+        new vscode.Range(a.line, a.column, a.line, a.column + a.length),
+        a.message,
+        a.severity,
+        a.confidence,
+        CODE_PARSED,
+      ),
+    ),
+  );
 }
 
 function handleAddOutputFiles(payload: {
@@ -145,42 +139,41 @@ function disable(): void {
 }
 
 /**
- * Push a single criticism entry from a tool-use agent. Returns false if the
- * feature is disabled (no diagnostic collection is registered). Appends to
- * (rather than replacing) the file's diagnostics so a tool can add multiple
- * entries across multiple calls.
+ * Append a criticism entry from a tool-use agent. Returns false when the
+ * feature is disabled so the tool can report the no-op back to the agent.
  */
 export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
   if (!collection) return false;
 
   const uri = vscode.Uri.file(entry.absolutePath);
   const lineIndex = Math.max(0, Math.floor(entry.line) - 1);
-  const range = new vscode.Range(lineIndex, 0, lineIndex, Number.MAX_SAFE_INTEGER);
-  const diag = new vscode.Diagnostic(
-    range,
-    `${entry.message} (S${entry.severity}/C${entry.confidence})`,
-    mapSeverity(entry.severity),
+  const range = new vscode.Range(
+    lineIndex,
+    0,
+    lineIndex,
+    Number.MAX_SAFE_INTEGER,
   );
-  diag.source = SOURCE_LABEL;
-  diag.code = 'criticize:tool';
+  const diag = buildDiagnostic(
+    range,
+    entry.message,
+    entry.severity,
+    entry.confidence,
+    CODE_TOOL,
+  );
 
   const existing = collection.get(uri) ?? [];
   collection.set(uri, [...existing, diag]);
   return true;
 }
 
-/**
- * Register the inline-criticism subsystem. Honors the setting at activation
- * and re-evaluates on configuration changes.
- */
-export function registerInlineCriticism(context: vscode.ExtensionContext): void {
+export function registerInlineCriticism(
+  context: vscode.ExtensionContext,
+): void {
   if (isEnabled()) enable(context);
 
-  const watcher = vscode.workspace.onDidChangeConfiguration((event) => {
-    if (!event.affectsConfiguration(`texra.${SETTING_KEY}`)) return;
+  watchConfig(context, `texra.${SETTING_KEY}`, () => {
     if (isEnabled()) enable(context);
     else disable();
   });
-  context.subscriptions.push(watcher);
   context.subscriptions.push({ dispose: disable });
 }

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -1,0 +1,186 @@
+/**
+ * Experimental: surface `\criticize{message}{severity}{confidence}` annotations
+ * inserted by critique-style agents (criticize, notation, elevate, verifyFix,
+ * ...) as VS Code diagnostics, so they show up as squiggles in the editor and
+ * entries in the Problems panel — like a linter.
+ *
+ * Two ingest paths:
+ *   1. Bus event hook: every time an agent round emits `addOutputFiles`, we
+ *      read each output file and brute-force parse `\criticize{...}` macros
+ *      out of it. Universal — any agent that writes the macro participates.
+ *   2. Tool sink (`add_criticism` tool): tool-use agents that want to flag an
+ *      issue without literally writing `\criticize{...}` into the document
+ *      can call the tool, which routes through `pushManualCriticism` here.
+ *
+ * Gated on `texra.inlineCriticism.enabled` (default: false).
+ */
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import { bus } from '@eventBus/ProgressEventBus';
+import { parseCriticismAnnotations } from '@latex/criticismParser';
+import * as logger from '@logger/logUtils';
+import type { OutputFileInfo } from '@shared/schemas';
+import { getConfig } from '@utils/config';
+
+const CHANNEL = 'InlineCriticism';
+const SETTING_KEY = 'inlineCriticism.enabled';
+const COLLECTION_NAME = 'texra-criticism';
+const SOURCE_LABEL = 'TeXRA';
+
+/** Manual criticism entry pushed by tool-use agents via `add_criticism`. */
+export interface ManualCriticismEntry {
+  /** Absolute path to the file the criticism applies to. */
+  absolutePath: string;
+  /** 1-based line number (matches editor gutter). */
+  line: number;
+  message: string;
+  /** 1–5; mapped to DiagnosticSeverity. */
+  severity: number;
+  /** 1–5; appended to the message as `(S/C)`. */
+  confidence: number;
+}
+
+let collection: vscode.DiagnosticCollection | undefined;
+let busUnsubscribe: (() => void) | undefined;
+
+/** Severity 5 → Error, 4 → Warning, 3 → Info, 1–2 → Hint. */
+function mapSeverity(severity: number): vscode.DiagnosticSeverity {
+  if (severity >= 5) return vscode.DiagnosticSeverity.Error;
+  if (severity >= 4) return vscode.DiagnosticSeverity.Warning;
+  if (severity >= 3) return vscode.DiagnosticSeverity.Information;
+  return vscode.DiagnosticSeverity.Hint;
+}
+
+function isEnabled(): boolean {
+  return getConfig<boolean>(SETTING_KEY, false) === true;
+}
+
+async function readFileText(absolutePath: string): Promise<string | null> {
+  try {
+    const bytes = await vscode.workspace.fs.readFile(
+      vscode.Uri.file(absolutePath),
+    );
+    return Buffer.from(bytes).toString('utf8');
+  } catch (error) {
+    logger.error(
+      CHANNEL,
+      `Failed to read ${absolutePath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
+  if (!collection) return;
+  const absolutePath = file.location.absolutePath;
+  if (!absolutePath.toLowerCase().endsWith('.tex')) return;
+
+  const text = await readFileText(absolutePath);
+  if (text === null) return;
+
+  const annotations = parseCriticismAnnotations(text);
+  const uri = vscode.Uri.file(absolutePath);
+
+  if (annotations.length === 0) {
+    collection.delete(uri);
+    return;
+  }
+
+  const diagnostics = annotations.map((a) => {
+    const range = new vscode.Range(
+      a.line,
+      a.column,
+      a.line,
+      a.column + a.length,
+    );
+    const diag = new vscode.Diagnostic(
+      range,
+      `${a.message} (S${a.severity}/C${a.confidence})`,
+      mapSeverity(a.severity),
+    );
+    diag.source = SOURCE_LABEL;
+    diag.code = 'criticize';
+    return diag;
+  });
+  collection.set(uri, diagnostics);
+}
+
+function handleAddOutputFiles(payload: {
+  filesByRound: { [key: number]: OutputFileInfo[] };
+}): void {
+  if (!collection) return;
+  const allFiles = Object.values(payload.filesByRound).flat();
+  void Promise.all(allFiles.map((f) => refreshFileDiagnostics(f))).catch(
+    (error: unknown) => {
+      logger.error(
+        CHANNEL,
+        `Failed to refresh criticism diagnostics: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    },
+  );
+}
+
+function enable(context: vscode.ExtensionContext): void {
+  if (collection) return;
+  collection = vscode.languages.createDiagnosticCollection(COLLECTION_NAME);
+  context.subscriptions.push(collection);
+  busUnsubscribe = bus.on('addOutputFiles', handleAddOutputFiles);
+  logger.info(CHANNEL, 'Inline criticism diagnostics enabled');
+}
+
+function disable(): void {
+  if (busUnsubscribe) {
+    busUnsubscribe();
+    busUnsubscribe = undefined;
+  }
+  if (collection) {
+    collection.clear();
+    collection.dispose();
+    collection = undefined;
+  }
+  logger.info(CHANNEL, 'Inline criticism diagnostics disabled');
+}
+
+/**
+ * Push a single criticism entry from a tool-use agent. Returns false if the
+ * feature is disabled (no diagnostic collection is registered). Appends to
+ * (rather than replacing) the file's diagnostics so a tool can add multiple
+ * entries across multiple calls.
+ */
+export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
+  if (!collection) return false;
+
+  const uri = vscode.Uri.file(entry.absolutePath);
+  const lineIndex = Math.max(0, Math.floor(entry.line) - 1);
+  const range = new vscode.Range(lineIndex, 0, lineIndex, Number.MAX_SAFE_INTEGER);
+  const diag = new vscode.Diagnostic(
+    range,
+    `${entry.message} (S${entry.severity}/C${entry.confidence})`,
+    mapSeverity(entry.severity),
+  );
+  diag.source = SOURCE_LABEL;
+  diag.code = 'criticize:tool';
+
+  const existing = collection.get(uri) ?? [];
+  collection.set(uri, [...existing, diag]);
+  return true;
+}
+
+/**
+ * Register the inline-criticism subsystem. Honors the setting at activation
+ * and re-evaluates on configuration changes.
+ */
+export function registerInlineCriticism(context: vscode.ExtensionContext): void {
+  if (isEnabled()) enable(context);
+
+  const watcher = vscode.workspace.onDidChangeConfiguration((event) => {
+    if (!event.affectsConfiguration(`texra.${SETTING_KEY}`)) return;
+    if (isEnabled()) enable(context);
+    else disable();
+  });
+  context.subscriptions.push(watcher);
+  context.subscriptions.push({ dispose: disable });
+}

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -10,23 +10,23 @@
  *   2. `add_criticism` tool routes through `pushManualCriticism` here for
  *      tool-use agents that want to flag issues without inserting the macro.
  *
- * Gated on `texra.inlineCriticism.enabled` (default: false).
+ * Gated on the `INLINE_CRITICISM_ENABLED` global state key, surfaced as a
+ * toggle in the LaTeX settings tab (default: false).
  */
 
 // Third-party imports
 import * as vscode from 'vscode';
 
 // Local imports
+import { globalSM, GlobalStateKey } from '@common/state';
 import { bus } from '@eventBus/ProgressEventBus';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
 import type { ManualCriticismEntry } from '@tools/AddCriticismTool';
-import { getConfig, watchConfig } from '@utils/config';
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'InlineCriticism';
-const SETTING_KEY = 'inlineCriticism.enabled';
 const COLLECTION_NAME = 'texra-criticism';
 const SOURCE_LABEL = 'TeXRA';
 const CODE_PARSED = 'criticize';
@@ -34,6 +34,7 @@ const CODE_TOOL = 'criticize:tool';
 
 let collection: vscode.DiagnosticCollection | undefined;
 let busUnsubscribe: (() => void) | undefined;
+let extensionContext: vscode.ExtensionContext | undefined;
 
 /** Criticism severity (1–5) → VS Code DiagnosticSeverity. */
 function mapSeverity(severity: number): vscode.DiagnosticSeverity {
@@ -43,8 +44,9 @@ function mapSeverity(severity: number): vscode.DiagnosticSeverity {
   return vscode.DiagnosticSeverity.Hint;
 }
 
-function isEnabled(): boolean {
-  return getConfig<boolean>(SETTING_KEY, false) === true;
+export function isInlineCriticismEnabled(): boolean {
+  return globalSM?.get<boolean>(GlobalStateKey.INLINE_CRITICISM_ENABLED, false)
+    === true;
 }
 
 function buildDiagnostic(
@@ -169,11 +171,20 @@ export function pushManualCriticism(entry: ManualCriticismEntry): boolean {
 export function registerInlineCriticism(
   context: vscode.ExtensionContext,
 ): void {
-  if (isEnabled()) enable(context);
-
-  watchConfig(context, `texra.${SETTING_KEY}`, () => {
-    if (isEnabled()) enable(context);
-    else disable();
-  });
+  extensionContext = context;
+  if (isInlineCriticismEnabled()) enable(context);
   context.subscriptions.push({ dispose: disable });
+}
+
+/**
+ * Persist the new setting value and reconcile the active subsystem. Called
+ * from the settings webview handler when the user toggles the checkbox.
+ */
+export async function setInlineCriticismEnabled(
+  enabled: boolean,
+): Promise<void> {
+  await globalSM?.update(GlobalStateKey.INLINE_CRITICISM_ENABLED, enabled);
+  if (!extensionContext) return;
+  if (enabled) enable(extensionContext);
+  else disable();
 }

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -184,7 +184,11 @@ export async function setInlineCriticismEnabled(
   enabled: boolean,
 ): Promise<void> {
   await globalSM?.update(GlobalStateKey.INLINE_CRITICISM_ENABLED, enabled);
-  if (!extensionContext) return;
+  if (!extensionContext) {
+    throw new Error(
+      'setInlineCriticismEnabled called before registerInlineCriticism',
+    );
+  }
   if (enabled) enable(extensionContext);
   else disable();
 }

--- a/packages/extension/src/frontend/latex/inlineCriticism.ts
+++ b/packages/extension/src/frontend/latex/inlineCriticism.ts
@@ -19,7 +19,7 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { globalSM, GlobalStateKey } from '@common/state';
-import { bus } from '@eventBus/ProgressEventBus';
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { parseCriticismAnnotations } from '@latex/criticismParser';
 import * as logger from '@logger/logUtils';
 import type { OutputFileInfo } from '@shared/schemas';
@@ -36,7 +36,7 @@ let collection: vscode.DiagnosticCollection | undefined;
 let busUnsubscribe: (() => void) | undefined;
 let extensionContext: vscode.ExtensionContext | undefined;
 
-/** Criticism severity (1–5) → VS Code DiagnosticSeverity. */
+/** Criticism severity (0–5) → VS Code DiagnosticSeverity. */
 function mapSeverity(severity: number): vscode.DiagnosticSeverity {
   if (severity >= 5) return vscode.DiagnosticSeverity.Error;
   if (severity >= 4) return vscode.DiagnosticSeverity.Warning;
@@ -45,8 +45,10 @@ function mapSeverity(severity: number): vscode.DiagnosticSeverity {
 }
 
 export function isInlineCriticismEnabled(): boolean {
-  return globalSM?.get<boolean>(GlobalStateKey.INLINE_CRITICISM_ENABLED, false)
-    === true;
+  return (
+    globalSM?.get<boolean>(GlobalStateKey.INLINE_CRITICISM_ENABLED, false) ===
+    true
+  );
 }
 
 function buildDiagnostic(
@@ -66,8 +68,15 @@ function buildDiagnostic(
   return diag;
 }
 
+function keepToolDiagnostics(
+  diagnostics: readonly vscode.Diagnostic[],
+): vscode.Diagnostic[] {
+  return diagnostics.filter((diag) => diag.code === CODE_TOOL);
+}
+
 async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
-  if (!collection) return;
+  const activeCollection = collection;
+  if (!activeCollection) return;
   const absolutePath = file.location.absolutePath;
   if (!absolutePath.toLowerCase().endsWith('.tex')) return;
 
@@ -82,17 +91,26 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
     return;
   }
 
+  if (collection !== activeCollection) return;
+
   const annotations = parseCriticismAnnotations(text);
   const uri = vscode.Uri.file(absolutePath);
+  const manualDiagnostics = keepToolDiagnostics(
+    activeCollection.get(uri) ?? [],
+  );
 
   if (annotations.length === 0) {
-    collection.delete(uri);
+    if (manualDiagnostics.length > 0) {
+      activeCollection.set(uri, manualDiagnostics);
+    } else {
+      activeCollection.delete(uri);
+    }
     return;
   }
 
-  collection.set(
-    uri,
-    annotations.map((a) =>
+  activeCollection.set(uri, [
+    ...manualDiagnostics,
+    ...annotations.map((a) =>
       buildDiagnostic(
         new vscode.Range(a.line, a.column, a.line, a.column + a.length),
         a.message,
@@ -101,12 +119,12 @@ async function refreshFileDiagnostics(file: OutputFileInfo): Promise<void> {
         CODE_PARSED,
       ),
     ),
-  );
+  ]);
 }
 
-function handleAddOutputFiles(payload: {
-  filesByRound: { [key: number]: OutputFileInfo[] };
-}): void {
+function handleAddOutputFiles(
+  payload: ProgressEventPayloads['addOutputFiles'],
+): void {
   if (!collection) return;
   const allFiles = Object.values(payload.filesByRound).flat();
   void Promise.all(allFiles.map((f) => refreshFileDiagnostics(f))).catch(

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -63,6 +63,10 @@ import {
 } from '@frontend/git/gitAuthorSetup';
 import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
+import {
+  isInlineCriticismEnabled,
+  setInlineCriticismEnabled,
+} from '@frontend/latex/inlineCriticism';
 import { compileLatex2Pdf } from '@latex/texTools';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import {
@@ -555,6 +559,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
         ),
       [SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE]: (data) =>
         this.latexHandlers.handleSetLatexConfigValue(data),
+      [SETTINGS_VIEW_COMMANDS.GET_INLINE_CRITICISM_ENABLED]: () =>
+        this.withActiveWebview((w) => this.sendInlineCriticismEnabled(w)),
+      [SETTINGS_VIEW_COMMANDS.SET_INLINE_CRITICISM_ENABLED]: (data) =>
+        this.handleSetInlineCriticismEnabled(data.enabled),
 
       // Approval settings handlers
       [SETTINGS_VIEW_COMMANDS.GET_APPROVAL_SETTINGS]: () =>
@@ -698,6 +706,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       this.sendApprovalSettings(webview),
       this.latexHandlers.sendLatexSettingsStatus(webview),
       this.latexHandlers.sendLatexConfigValues(webview),
+      this.sendInlineCriticismEnabled(webview),
     ]);
   }
 
@@ -709,6 +718,22 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
   public async sendMemoryEnabled(webview: vscode.Webview): Promise<void> {
     await webview.postMessage(this.memoryController.getMemoryEnabledMessage());
+  }
+
+  public async sendInlineCriticismEnabled(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    await webview.postMessage({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_INLINE_CRITICISM_ENABLED,
+      enabled: isInlineCriticismEnabled(),
+    });
+  }
+
+  private async handleSetInlineCriticismEnabled(
+    enabled: boolean,
+  ): Promise<void> {
+    await setInlineCriticismEnabled(enabled);
+    await this.withActiveWebview((w) => this.sendInlineCriticismEnabled(w));
   }
 
   public async sendHistoryData(webview: vscode.Webview): Promise<void> {

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -267,6 +267,7 @@ export class SettingsApp extends SettingsAppBase {
   private readonly latexSettingsLoaded = signal(false);
   private readonly latexConfigValues = signal<LatexConfigValues>({});
   private readonly latexConfigValuesLoaded = signal(false);
+  private readonly inlineCriticismEnabled = signal(false);
 
   private getMessageHandlerContext(): SettingsMessageHandlerContext {
     return {
@@ -316,6 +317,7 @@ export class SettingsApp extends SettingsAppBase {
       latexSettingsLoaded: this.latexSettingsLoaded,
       latexConfigValues: this.latexConfigValues,
       latexConfigValuesLoaded: this.latexConfigValuesLoaded,
+      inlineCriticismEnabled: this.inlineCriticismEnabled,
       clearHistorySearch: () => this.historyTab?.clearSearch(),
       logSchemaError: (message, error) => this.logSchemaError(message, error),
     };
@@ -675,6 +677,10 @@ export class SettingsApp extends SettingsAppBase {
 
   private handleSetLatexConfigValue = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+  );
+
+  private handleSetInlineCriticismEnabled = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_INLINE_CRITICISM_ENABLED,
   );
 
   private handleRunInstallCommand = forwardDetail(
@@ -1062,11 +1068,13 @@ export class SettingsApp extends SettingsAppBase {
               .loaded=${this.latexSettingsLoaded.get()}
               .configValues=${this.latexConfigValues.get()}
               .configLoaded=${this.latexConfigValuesLoaded.get()}
+              .inlineCriticismEnabled=${this.inlineCriticismEnabled.get()}
               .desktopHost=${desktopHost}
               @latex-apply-settings=${this.handleApplyLatexSettings}
               @latex-install-workshop=${this.handleInstallLatexWorkshop}
               @latex-run-install-command=${this.handleRunInstallCommand}
               @latex-set-config-value=${this.handleSetLatexConfigValue}
+              @inline-criticism-toggle=${this.handleSetInlineCriticismEnabled}
             ></latex-tab>
           </wa-tab-panel>
         </wa-tab-group>

--- a/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/packages/extension/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -11,6 +11,7 @@ import {
   UpdateGitHubTokenStatusMessageSchema,
   UpdateHistoryMessageSchema,
   UpdateLatexConfigValuesMessageSchema,
+  UpdateInlineCriticismEnabledMessageSchema,
   UpdateLatexSettingsStatusMessageSchema,
   UpdateMemoryEnabledMessageSchema,
   UpdateMemoryMessageSchema,
@@ -90,6 +91,7 @@ export interface SettingsMessageHandlerContext {
   latexSettingsLoaded: WritableSignal<boolean>;
   latexConfigValues: WritableSignal<LatexConfigValues>;
   latexConfigValuesLoaded: WritableSignal<boolean>;
+  inlineCriticismEnabled: WritableSignal<boolean>;
   clearHistorySearch(): void;
   logSchemaError(message: string, error: unknown): void;
 }
@@ -282,6 +284,17 @@ export function dispatchSettingsViewMessage(
       if (!data) return false;
       ctx.latexConfigValues.set(data.values);
       ctx.latexConfigValuesLoaded.set(true);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_INLINE_CRITICISM_ENABLED: {
+      const data = parseMessage(
+        raw,
+        UpdateInlineCriticismEnabledMessageSchema,
+        ctx,
+      );
+      if (!data) return false;
+      ctx.inlineCriticismEnabled.set(data.enabled);
       return true;
     }
 

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -387,6 +387,13 @@ export class LaTeXTab extends LitElement {
         min-width: 0;
       }
 
+      .setting-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        white-space: nowrap;
+      }
+
       .setting-name {
         font-weight: var(--font-weight-medium);
         color: var(--texra-foreground);
@@ -442,6 +449,7 @@ export class LaTeXTab extends LitElement {
   configValues: LatexConfigValues = {};
 
   @property({ type: Boolean, attribute: 'config-loaded' }) configLoaded = false;
+  @property({ type: Boolean }) inlineCriticismEnabled = false;
   @property({ type: Boolean, attribute: 'desktop-host' }) desktopHost = false;
 
   @state() private expandedGuides = new Set<string>();
@@ -455,6 +463,14 @@ export class LaTeXTab extends LitElement {
 
   private handleApply(field?: SettingInfo['key'], reset = false): void {
     this.dispatchEvent(createEvent('latex-apply-settings', { field, reset }));
+  }
+
+  private handleInlineCriticismToggle(event: Event): void {
+    this.dispatchEvent(
+      createEvent('inline-criticism-toggle', {
+        enabled: (event.target as HTMLInputElement).checked,
+      }),
+    );
   }
 
   private allSettingsSet(): boolean {
@@ -777,7 +793,39 @@ export class LaTeXTab extends LitElement {
                 this.renderSettingCard(info),
               )}
             `}
+        ${this.renderInlineCriticismSetting()}
         ${this.renderCompileDiffSettings()}
+      </div>
+    `;
+  }
+
+  private renderInlineCriticismSetting(): TemplateResult {
+    return html`
+      <div class="section-header" style="margin-top:var(--spacing-large)">
+        <span class="codicon codicon-comment-discussion"></span>
+        Inline Criticism
+      </div>
+      <div class="setting-card">
+        <span
+          class="codicon setting-status-icon ${this.inlineCriticismEnabled
+            ? 'is-set codicon-check'
+            : 'not-set codicon-circle-slash'}"
+        ></span>
+        <div class="setting-info">
+          <div class="setting-name">Surface \\criticize annotations</div>
+          <div class="setting-description">
+            Parse \\criticize{message}{severity}{confidence} annotations from
+            agent-revised LaTeX files and show them as editor diagnostics.
+          </div>
+        </div>
+        <label class="setting-toggle">
+          <input
+            type="checkbox"
+            .checked=${this.inlineCriticismEnabled}
+            @change=${this.handleInlineCriticismToggle}
+          />
+          <span>${this.inlineCriticismEnabled ? 'On' : 'Off'}</span>
+        </label>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -437,6 +437,14 @@ export class LaTeXTab extends LitElement {
         background: var(--texra-badge-background);
         color: var(--texra-badge-foreground);
       }
+
+      .checkbox-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        margin-top: var(--spacing-small);
+        cursor: pointer;
+      }
     `,
   ];
 

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,7 +17,10 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": ["onStartupFinished", "onColorTheme"],
+    "activationEvents": [
+      "onStartupFinished",
+      "onColorTheme"
+    ],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -361,6 +364,13 @@
               "order": 51,
               "scope": "resource",
               "type": "boolean"
+            },
+            "texra.inlineCriticism.enabled": {
+              "default": false,
+              "description": "Experimental: parse \\criticize{message}{severity}{confidence} annotations from agent-revised LaTeX files and surface them as VS Code diagnostics (squiggles + Problems panel). Severity 5→Error, 4→Warning, 3→Info, 1–2→Hint. Tool-use agents may also push diagnostics directly via the add_criticism tool.",
+              "order": 52,
+              "scope": "resource",
+              "type": "boolean"
             }
           },
           "title": "TeXRA"
@@ -587,7 +597,13 @@
               "type": "array"
             },
             "texra.files.included.auxiliaryExtensions": {
-              "default": [".txt", ".tex", ".cls", ".md", ".sty"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".cls",
+                ".md",
+                ".sty"
+              ],
               "description": "File extensions to include when searching for auxiliary files",
               "editPresentation": "multilineText",
               "items": {
@@ -597,7 +613,10 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [".txt", ".tex"],
+              "default": [
+                ".txt",
+                ".tex"
+              ],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -607,7 +626,11 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [".txt", ".tex", ".md"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md"
+              ],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -647,7 +670,13 @@
               "type": "array"
             },
             "texra.files.included.referenceExtensions": {
-              "default": [".txt", ".tex", ".md", ".bib", ".bbl"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md",
+                ".bib",
+                ".bbl"
+              ],
               "description": "File extensions to include when searching for reference files",
               "editPresentation": "multilineText",
               "items": {
@@ -843,7 +872,10 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": ["sameDirectory", "workspaceTemp"],
+              "enum": [
+                "sameDirectory",
+                "workspaceTemp"
+              ],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1343,7 +1375,9 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": ["onCommand:texra.runSetupAssistant"],
+              "completionEvents": [
+                "onCommand:texra.runSetupAssistant"
+              ],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1352,7 +1386,9 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": ["onCommand:texra.createSampleProject"],
+              "completionEvents": [
+                "onCommand:texra.createSampleProject"
+              ],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1361,7 +1397,9 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": ["onCommand:texra.setApiKey"],
+              "completionEvents": [
+                "onCommand:texra.setApiKey"
+              ],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1371,7 +1409,9 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": ["onCommand:texra.auth.signIn"],
+              "completionEvents": [
+                "onCommand:texra.auth.signIn"
+              ],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1381,7 +1421,9 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": ["onCommand:texra.showMainView"],
+              "completionEvents": [
+                "onCommand:texra.showMainView"
+              ],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Reference** -- papers or notes for context (optional)\n- **Auxiliary** -- bib files, style files, preambles (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1400,7 +1442,9 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": ["onCommand:texra.showDashboard"],
+              "completionEvents": [
+                "onCommand:texra.showDashboard"
+              ],
               "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
@@ -1423,7 +1467,9 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": ["onCommand:texra.execute"],
+              "completionEvents": [
+                "onCommand:texra.execute"
+              ],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,10 +17,7 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": [
-      "onStartupFinished",
-      "onColorTheme"
-    ],
+    "activationEvents": ["onStartupFinished", "onColorTheme"],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -597,13 +594,7 @@
               "type": "array"
             },
             "texra.files.included.auxiliaryExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".cls",
-                ".md",
-                ".sty"
-              ],
+              "default": [".txt", ".tex", ".cls", ".md", ".sty"],
               "description": "File extensions to include when searching for auxiliary files",
               "editPresentation": "multilineText",
               "items": {
@@ -613,10 +604,7 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [
-                ".txt",
-                ".tex"
-              ],
+              "default": [".txt", ".tex"],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -626,11 +614,7 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md"
-              ],
+              "default": [".txt", ".tex", ".md"],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -670,13 +654,7 @@
               "type": "array"
             },
             "texra.files.included.referenceExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md",
-                ".bib",
-                ".bbl"
-              ],
+              "default": [".txt", ".tex", ".md", ".bib", ".bbl"],
               "description": "File extensions to include when searching for reference files",
               "editPresentation": "multilineText",
               "items": {
@@ -872,10 +850,7 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": [
-                "sameDirectory",
-                "workspaceTemp"
-              ],
+              "enum": ["sameDirectory", "workspaceTemp"],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1375,9 +1350,7 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": [
-                "onCommand:texra.runSetupAssistant"
-              ],
+              "completionEvents": ["onCommand:texra.runSetupAssistant"],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1386,9 +1359,7 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.createSampleProject"
-              ],
+              "completionEvents": ["onCommand:texra.createSampleProject"],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1397,9 +1368,7 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.setApiKey"
-              ],
+              "completionEvents": ["onCommand:texra.setApiKey"],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1409,9 +1378,7 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.auth.signIn"
-              ],
+              "completionEvents": ["onCommand:texra.auth.signIn"],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1421,9 +1388,7 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMainView"
-              ],
+              "completionEvents": ["onCommand:texra.showMainView"],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Reference** -- papers or notes for context (optional)\n- **Auxiliary** -- bib files, style files, preambles (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1442,9 +1407,7 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showDashboard"
-              ],
+              "completionEvents": ["onCommand:texra.showDashboard"],
               "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
@@ -1467,9 +1430,7 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.execute"
-              ],
+              "completionEvents": ["onCommand:texra.execute"],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -133,6 +133,9 @@ export enum GlobalStateKey {
 
   // Desktop-only crash reporting
   DESKTOP_CRASH_REPORTING_ENABLED = 'texra.desktop.crashReporting.enabled',
+
+  // Experimental
+  INLINE_CRITICISM_ENABLED = 'texra.inlineCriticism.enabled',
 }
 
 /** Prefix used for per-instruction suppression flags */

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -115,6 +115,9 @@ export const SETTINGS_VIEW_CMD = {
   // LaTeX/compile/diff config (storage-backed, migrated from VS Code config)
   GET_LATEX_CONFIG_VALUES: 'getLatexConfigValues',
   SET_LATEX_CONFIG_VALUE: 'setLatexConfigValue',
+  // Experimental settings
+  GET_INLINE_CRITICISM_ENABLED: 'getInlineCriticismEnabled',
+  SET_INLINE_CRITICISM_ENABLED: 'setInlineCriticismEnabled',
 } as const;
 
 // Settings view specific commands (combines Memory, History, and Profile views)
@@ -138,4 +141,5 @@ export const SETTINGS_VIEW_COMMANDS = {
   UPDATE_GIT_AUTHOR_SETTINGS: 'updateGitAuthorSettings',
   UPDATE_LATEX_SETTINGS_STATUS: 'updateLatexSettingsStatus',
   UPDATE_LATEX_CONFIG_VALUES: 'updateLatexConfigValues',
+  UPDATE_INLINE_CRITICISM_ENABLED: 'updateInlineCriticismEnabled',
 } as const;

--- a/src/latex/criticismParser.ts
+++ b/src/latex/criticismParser.ts
@@ -21,6 +21,7 @@ export interface CriticismAnnotation {
 }
 
 const MACRO = '\\criticize';
+const INTEGER = /^\d+$/;
 
 function readBraceGroup(
   source: string,
@@ -46,6 +47,12 @@ function readBraceGroup(
     i++;
   }
   return null;
+}
+
+function skipWhitespace(source: string, index: number): number {
+  let i = index;
+  while (i < source.length && /\s/.test(source[i])) i++;
+  return i;
 }
 
 /**
@@ -82,35 +89,45 @@ export function parseCriticismAnnotations(
     const macroAt = source.indexOf(MACRO, searchFrom);
     if (macroAt === -1) break;
 
+    const afterMacro = source[macroAt + MACRO.length];
     // Guard against partial matches like `\criticizeFoo`.
-    if (source[macroAt + MACRO.length] !== '{') {
+    if (afterMacro && /[A-Za-z]/.test(afterMacro)) {
       searchFrom = macroAt + MACRO.length;
       continue;
     }
 
-    const arg1 = readBraceGroup(source, macroAt + MACRO.length);
+    const arg1Start = skipWhitespace(source, macroAt + MACRO.length);
+    const arg1 = readBraceGroup(source, arg1Start);
     if (!arg1) {
       searchFrom = macroAt + MACRO.length;
       continue;
     }
-    const arg2 = readBraceGroup(source, arg1.end);
+    const arg2 = readBraceGroup(source, skipWhitespace(source, arg1.end));
     if (!arg2) {
       searchFrom = arg1.end;
       continue;
     }
-    const arg3 = readBraceGroup(source, arg2.end);
+    const arg3 = readBraceGroup(source, skipWhitespace(source, arg2.end));
     if (!arg3) {
       searchFrom = arg2.end;
       continue;
     }
 
-    const severity = Number.parseInt(arg2.content.trim(), 10);
-    const confidence = Number.parseInt(arg3.content.trim(), 10);
+    const severityText = arg2.content.trim();
+    const confidenceText = arg3.content.trim();
+    const severity = INTEGER.test(severityText)
+      ? Number.parseInt(severityText, 10)
+      : NaN;
+    const confidence = INTEGER.test(confidenceText)
+      ? Number.parseInt(confidenceText, 10)
+      : NaN;
     if (
       Number.isFinite(severity) &&
       Number.isFinite(confidence) &&
-      severity >= 1 &&
-      severity <= 5
+      severity >= 0 &&
+      severity <= 5 &&
+      confidence >= 1 &&
+      confidence <= 5
     ) {
       const { line, column } = cursor.advanceTo(macroAt);
       out.push({

--- a/src/latex/criticismParser.ts
+++ b/src/latex/criticismParser.ts
@@ -1,14 +1,11 @@
 /**
- * Parser for `\criticize{message}{severity}{confidence}` annotations inserted
- * by critique-style agents (criticize, notation, elevate, verifyFix, ...).
+ * Brace-balanced parser for `\criticize{message}{severity}{confidence}`.
  *
- * Returns each occurrence with its position so the extension host can surface
- * them as VS Code diagnostics. Brace-balanced so `\criticize{...\cref{x}...}`
- * style nesting is handled correctly (the regex in `replacement/advanced.ts`
- * only allows one level of nesting).
+ * Needed in addition to the regex in `replacement/advanced.ts` because that
+ * one only handles a single level of brace nesting, while messages routinely
+ * contain `\cref{...}` and similar nested macros.
  *
- * Pure text in / data out — no `vscode` import so this stays usable in the
- * agent core too.
+ * No `vscode` import — usable from agent core too.
  */
 
 export interface CriticismAnnotation {
@@ -25,11 +22,6 @@ export interface CriticismAnnotation {
 
 const MACRO = '\\criticize';
 
-/**
- * Read one brace-balanced `{...}` argument starting at `source[index]`.
- * Returns the inner text and the index of the character after the closing `}`.
- * Returns null if the argument is malformed (unbalanced braces, no opening `{`).
- */
 function readBraceGroup(
   source: string,
   index: number,
@@ -56,44 +48,42 @@ function readBraceGroup(
   return null;
 }
 
-/** Convert a 0-based char offset into 0-based (line, column). */
-function offsetToLineCol(
-  source: string,
-  offset: number,
-): { line: number; column: number } {
-  let line = 0;
-  let lineStart = 0;
-  for (let i = 0; i < offset; i++) {
-    if (source[i] === '\n') {
-      line++;
-      lineStart = i + 1;
+/**
+ * Running line/column cursor: advances forward through `source` so the total
+ * cost of converting many offsets stays O(N) instead of O(N × matches).
+ */
+class LineColCursor {
+  private offset = 0;
+  private line = 0;
+  private lineStart = 0;
+  constructor(private readonly source: string) {}
+
+  advanceTo(target: number): { line: number; column: number } {
+    while (this.offset < target) {
+      if (this.source[this.offset] === '\n') {
+        this.line++;
+        this.lineStart = this.offset + 1;
+      }
+      this.offset++;
     }
+    return { line: this.line, column: this.offset - this.lineStart };
   }
-  return { line, column: offset - lineStart };
 }
 
-/**
- * Parse all `\criticize{message}{severity}{confidence}` occurrences in `source`.
- *
- * Severity/confidence are parsed as integers. If the second/third arg isn't
- * a clean integer (e.g. older single-arg form `\criticize{Fixed: ...}`), the
- * occurrence is skipped — those agents render visually but don't carry the
- * severity metadata diagnostics need.
- */
 export function parseCriticismAnnotations(
   source: string,
 ): CriticismAnnotation[] {
   if (!source.includes(MACRO)) return [];
 
   const out: CriticismAnnotation[] = [];
+  const cursor = new LineColCursor(source);
   let searchFrom = 0;
   while (searchFrom < source.length) {
     const macroAt = source.indexOf(MACRO, searchFrom);
     if (macroAt === -1) break;
 
     // Guard against partial matches like `\criticizeFoo`.
-    const after = source[macroAt + MACRO.length];
-    if (after !== '{') {
+    if (source[macroAt + MACRO.length] !== '{') {
       searchFrom = macroAt + MACRO.length;
       continue;
     }
@@ -122,7 +112,7 @@ export function parseCriticismAnnotations(
       severity >= 1 &&
       severity <= 5
     ) {
-      const { line, column } = offsetToLineCol(source, macroAt);
+      const { line, column } = cursor.advanceTo(macroAt);
       out.push({
         message: arg1.content,
         severity,

--- a/src/latex/criticismParser.ts
+++ b/src/latex/criticismParser.ts
@@ -1,0 +1,140 @@
+/**
+ * Parser for `\criticize{message}{severity}{confidence}` annotations inserted
+ * by critique-style agents (criticize, notation, elevate, verifyFix, ...).
+ *
+ * Returns each occurrence with its position so the extension host can surface
+ * them as VS Code diagnostics. Brace-balanced so `\criticize{...\cref{x}...}`
+ * style nesting is handled correctly (the regex in `replacement/advanced.ts`
+ * only allows one level of nesting).
+ *
+ * Pure text in / data out — no `vscode` import so this stays usable in the
+ * agent core too.
+ */
+
+export interface CriticismAnnotation {
+  message: string;
+  severity: number;
+  confidence: number;
+  /** 0-based line index in the source */
+  line: number;
+  /** 0-based UTF-16 column on `line` */
+  column: number;
+  /** Length of the matched `\criticize{...}{...}{...}` substring */
+  length: number;
+}
+
+const MACRO = '\\criticize';
+
+/**
+ * Read one brace-balanced `{...}` argument starting at `source[index]`.
+ * Returns the inner text and the index of the character after the closing `}`.
+ * Returns null if the argument is malformed (unbalanced braces, no opening `{`).
+ */
+function readBraceGroup(
+  source: string,
+  index: number,
+): { content: string; end: number } | null {
+  if (source[index] !== '{') return null;
+  let depth = 1;
+  let i = index + 1;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\\' && i + 1 < source.length) {
+      // Skip escaped character (handles `\{`, `\}`, `\\`)
+      i += 2;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return { content: source.slice(index + 1, i), end: i + 1 };
+      }
+    }
+    i++;
+  }
+  return null;
+}
+
+/** Convert a 0-based char offset into 0-based (line, column). */
+function offsetToLineCol(
+  source: string,
+  offset: number,
+): { line: number; column: number } {
+  let line = 0;
+  let lineStart = 0;
+  for (let i = 0; i < offset; i++) {
+    if (source[i] === '\n') {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return { line, column: offset - lineStart };
+}
+
+/**
+ * Parse all `\criticize{message}{severity}{confidence}` occurrences in `source`.
+ *
+ * Severity/confidence are parsed as integers. If the second/third arg isn't
+ * a clean integer (e.g. older single-arg form `\criticize{Fixed: ...}`), the
+ * occurrence is skipped — those agents render visually but don't carry the
+ * severity metadata diagnostics need.
+ */
+export function parseCriticismAnnotations(
+  source: string,
+): CriticismAnnotation[] {
+  if (!source.includes(MACRO)) return [];
+
+  const out: CriticismAnnotation[] = [];
+  let searchFrom = 0;
+  while (searchFrom < source.length) {
+    const macroAt = source.indexOf(MACRO, searchFrom);
+    if (macroAt === -1) break;
+
+    // Guard against partial matches like `\criticizeFoo`.
+    const after = source[macroAt + MACRO.length];
+    if (after !== '{') {
+      searchFrom = macroAt + MACRO.length;
+      continue;
+    }
+
+    const arg1 = readBraceGroup(source, macroAt + MACRO.length);
+    if (!arg1) {
+      searchFrom = macroAt + MACRO.length;
+      continue;
+    }
+    const arg2 = readBraceGroup(source, arg1.end);
+    if (!arg2) {
+      searchFrom = arg1.end;
+      continue;
+    }
+    const arg3 = readBraceGroup(source, arg2.end);
+    if (!arg3) {
+      searchFrom = arg2.end;
+      continue;
+    }
+
+    const severity = Number.parseInt(arg2.content.trim(), 10);
+    const confidence = Number.parseInt(arg3.content.trim(), 10);
+    if (
+      Number.isFinite(severity) &&
+      Number.isFinite(confidence) &&
+      severity >= 1 &&
+      severity <= 5
+    ) {
+      const { line, column } = offsetToLineCol(source, macroAt);
+      out.push({
+        message: arg1.content,
+        severity,
+        confidence,
+        line,
+        column,
+        length: arg3.end - macroAt,
+      });
+    }
+
+    searchFrom = arg3.end;
+  }
+
+  return out;
+}

--- a/src/latex/index.ts
+++ b/src/latex/index.ts
@@ -55,6 +55,15 @@ export { LatexMediaManager } from './LatexMediaManager';
 export { ArxivSourceProcessor, arxivProcessor } from './arxivProcessor';
 
 // -----------------------------------------------------------------------------
+// Criticism Annotations
+// -----------------------------------------------------------------------------
+
+export {
+  parseCriticismAnnotations,
+  type CriticismAnnotation,
+} from './criticismParser';
+
+// -----------------------------------------------------------------------------
 // Core Utilities
 // -----------------------------------------------------------------------------
 

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -508,6 +508,15 @@ export type UpdateLatexConfigValuesMessage = z.infer<
   typeof UpdateLatexConfigValuesMessageSchema
 >;
 
+/** Outbound: backend → frontend inline criticism toggle state */
+export const UpdateInlineCriticismEnabledMessageSchema = z.object({
+  command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_INLINE_CRITICISM_ENABLED),
+  enabled: z.boolean(),
+});
+export type UpdateInlineCriticismEnabledMessage = z.infer<
+  typeof UpdateInlineCriticismEnabledMessageSchema
+>;
+
 // ============================================================
 // Inbound message schemas (frontend → backend)
 // ============================================================
@@ -849,6 +858,15 @@ const SetLatexConfigValueMessageSchema = z.object({
   value: z.union([z.boolean(), z.number(), z.string(), z.null()]).optional(),
 });
 
+// Experimental settings inbound messages
+const GetInlineCriticismEnabledMessageSchema = commandOnly(
+  CMD.GET_INLINE_CRITICISM_ENABLED,
+);
+const SetInlineCriticismEnabledMessageSchema = z.object({
+  command: z.literal(CMD.SET_INLINE_CRITICISM_ENABLED),
+  enabled: z.boolean(),
+});
+
 // Approval settings inbound messages
 const GetApprovalSettingsMessageSchema = commandOnly(CMD.GET_APPROVAL_SETTINGS);
 const SetBashApprovalEnabledMessageSchema = z.object({
@@ -896,6 +914,8 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     RunInstallCommandMessageSchema,
     GetLatexConfigValuesMessageSchema,
     SetLatexConfigValueMessageSchema,
+    GetInlineCriticismEnabledMessageSchema,
+    SetInlineCriticismEnabledMessageSchema,
     // Memory messages
     GetMemoryDataMessageSchema,
     OpenMemoryFileMessageSchema,

--- a/src/test-kernel/latex/CriticismParser.vitest.mts
+++ b/src/test-kernel/latex/CriticismParser.vitest.mts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCriticismAnnotations } from '@latex/criticismParser';
+import { AddCriticismInputSchema } from '@tools/AddCriticismTool';
+
+describe('parseCriticismAnnotations', () => {
+  it('accepts whitespace before arguments and severity zero', () => {
+    const annotations = parseCriticismAnnotations(
+      'before\n\\criticize {verified \\textbf{step}} {0} {5}\nafter',
+    );
+
+    expect(annotations).toMatchObject([
+      {
+        message: 'verified \\textbf{step}',
+        severity: 0,
+        confidence: 5,
+        line: 1,
+        column: 0,
+      },
+    ]);
+  });
+
+  it('rejects non-integer and out-of-range confidence values', () => {
+    expect(parseCriticismAnnotations('\\criticize{bad}{3}{999}')).toEqual([]);
+    expect(parseCriticismAnnotations('\\criticize{bad}{3}{4.5}')).toEqual([]);
+  });
+
+  it('does not parse partial macro names', () => {
+    expect(parseCriticismAnnotations('\\criticizeFoo{x}{3}{5}')).toEqual([]);
+  });
+});
+
+describe('AddCriticismInputSchema', () => {
+  it('rejects empty paths and accepts severity zero', () => {
+    expect(() =>
+      AddCriticismInputSchema.parse({
+        path: '   ',
+        line: 1,
+        message: 'x',
+        severity: 1,
+        confidence: 5,
+      }),
+    ).toThrow();
+
+    expect(
+      AddCriticismInputSchema.parse({
+        path: 'paper.tex',
+        line: 1,
+        message: 'verified',
+        severity: 0,
+        confidence: 5,
+      }).severity,
+    ).toBe(0);
+  });
+});

--- a/src/tools/AddCriticismTool.ts
+++ b/src/tools/AddCriticismTool.ts
@@ -1,0 +1,104 @@
+// Third-party imports
+import { z } from 'zod';
+
+// Internal imports
+import * as logger from '@agent/core/logger';
+import { toErrorMessage } from '@common/errors';
+
+// Local file imports
+import { defineTool } from './core/define';
+import { type ToolResult, ToolError } from './result';
+
+const CHANNEL = 'AddCriticismTool';
+logger.initialize(CHANNEL);
+
+/**
+ * Sink injected by the extension host. Receives one criticism entry and
+ * routes it to the inline-criticism `DiagnosticCollection`. Returns
+ * `accepted: false` when the experimental setting is disabled — the tool
+ * surfaces this back to the agent so it knows the call was a no-op.
+ */
+export interface AddCriticismSinkPayload {
+  path: string;
+  line: number;
+  message: string;
+  severity: number;
+  confidence: number;
+}
+
+export type AddCriticismSink = (payload: AddCriticismSinkPayload) => {
+  accepted: boolean;
+  resolvedPath: string;
+};
+
+let sink: AddCriticismSink = () => ({
+  accepted: false,
+  resolvedPath: '',
+});
+
+/**
+ * Inject the sink that pushes criticism entries to the VS Code diagnostic
+ * collection. Wired in `extension.ts` once at activation.
+ */
+export function setAddCriticismSink(provider: AddCriticismSink): void {
+  sink = provider;
+}
+
+export const AddCriticismInputSchema = z.strictObject({
+  path: z
+    .string()
+    .describe(
+      'Absolute or workspace-relative path to the file the criticism applies to.',
+    ),
+  line: z
+    .number()
+    .int()
+    .min(1)
+    .describe('1-based line number where the issue occurs.'),
+  message: z.string().min(1).describe('Description of the issue.'),
+  severity: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .describe(
+      'Severity 1–5: 5=desk-rejection risk, 4=significantly weakens, 3=worth addressing, 2=minor polish, 1=cosmetic.',
+    ),
+  confidence: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .describe(
+      'Confidence 1–5: 5=certain, 4=high certainty with minor subjectivity, 3=reasonable but field-dependent, 2=subjective, 1=speculative.',
+    ),
+});
+
+export type AddCriticismInput = z.infer<typeof AddCriticismInputSchema>;
+
+export class AddCriticismTool extends defineTool({
+  name: 'add_criticism',
+  description:
+    'Push a critique annotation as a VS Code diagnostic (squiggle + Problems panel entry) for the given file and line. Use this to flag issues without inserting a literal \\criticize{...}{...}{...} macro into the document. Requires the experimental "texra.inlineCriticism.enabled" setting; the tool reports "not accepted" if disabled.',
+  schema: AddCriticismInputSchema,
+}) {
+  protected async execute(input: AddCriticismInput): Promise<ToolResult> {
+    try {
+      const result = sink(input);
+      if (!result.accepted) {
+        return {
+          summary: 'Criticism not accepted',
+          output:
+            'Inline criticism diagnostics are disabled. Enable "texra.inlineCriticism.enabled" in settings to surface critiques as diagnostics.',
+        };
+      }
+      const where = result.resolvedPath || input.path;
+      const summary = `Added criticism for ${where}:${input.line} (S${input.severity}/C${input.confidence})`;
+      return { summary, output: summary };
+    } catch (error) {
+      const detail = toErrorMessage(error);
+      logger.error(CHANNEL, `Failed to add criticism: ${detail}`);
+      throw new ToolError(`Failed to add criticism: ${detail}`);
+    }
+  }
+}

--- a/src/tools/AddCriticismTool.ts
+++ b/src/tools/AddCriticismTool.ts
@@ -13,33 +13,36 @@ const CHANNEL = 'AddCriticismTool';
 logger.initialize(CHANNEL);
 
 /**
- * Sink injected by the extension host. Receives one criticism entry and
- * routes it to the inline-criticism `DiagnosticCollection`. Returns
- * `accepted: false` when the experimental setting is disabled — the tool
- * surfaces this back to the agent so it knows the call was a no-op.
+ * Shared shape for a single criticism entry. The tool emits this with `path`
+ * (which the host resolves to `absolutePath`) and the host re-emits the same
+ * shape into the diagnostic collection.
  */
-export interface AddCriticismSinkPayload {
+export interface ManualCriticismEntry {
+  /** Absolute path resolved by the host. */
+  absolutePath: string;
+  /** 1-based line number. */
+  line: number;
+  message: string;
+  /** 1–5; mapped to DiagnosticSeverity. */
+  severity: number;
+  /** 1–5; appended to the message as `(S/C)`. */
+  confidence: number;
+}
+
+/**
+ * Sink injected by the extension host. Returns `accepted: false` when the
+ * experimental setting is disabled so the tool can surface that to the agent.
+ */
+export type AddCriticismSink = (input: {
   path: string;
   line: number;
   message: string;
   severity: number;
   confidence: number;
-}
+}) => { accepted: boolean; resolvedPath: string };
 
-export type AddCriticismSink = (payload: AddCriticismSinkPayload) => {
-  accepted: boolean;
-  resolvedPath: string;
-};
+let sink: AddCriticismSink = () => ({ accepted: false, resolvedPath: '' });
 
-let sink: AddCriticismSink = () => ({
-  accepted: false,
-  resolvedPath: '',
-});
-
-/**
- * Inject the sink that pushes criticism entries to the VS Code diagnostic
- * collection. Wired in `extension.ts` once at activation.
- */
 export function setAddCriticismSink(provider: AddCriticismSink): void {
   sink = provider;
 }

--- a/src/tools/AddCriticismTool.ts
+++ b/src/tools/AddCriticismTool.ts
@@ -2,8 +2,10 @@
 import { z } from 'zod';
 
 // Internal imports
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import * as logger from '@agent/core/logger';
 import { toErrorMessage } from '@common/errors';
+import { resolveWorkspaceRelativePath } from '@tools/pathResolution';
 
 // Local file imports
 import { defineTool } from './core/define';
@@ -13,9 +15,9 @@ const CHANNEL = 'AddCriticismTool';
 logger.initialize(CHANNEL);
 
 /**
- * Shared shape for a single criticism entry. The tool emits this with `path`
- * (which the host resolves to `absolutePath`) and the host re-emits the same
- * shape into the diagnostic collection.
+ * Host-resolved shape for a single criticism entry. Tool input uses `path`;
+ * `execute` resolves it against the active working directory before handing the
+ * entry to the extension host as `absolutePath`.
  */
 export interface ManualCriticismEntry {
   /** Absolute path resolved by the host. */
@@ -23,7 +25,7 @@ export interface ManualCriticismEntry {
   /** 1-based line number. */
   line: number;
   message: string;
-  /** 1–5; mapped to DiagnosticSeverity. */
+  /** 0–5; mapped to DiagnosticSeverity. */
   severity: number;
   /** 1–5; appended to the message as `(S/C)`. */
   confidence: number;
@@ -34,7 +36,7 @@ export interface ManualCriticismEntry {
  * experimental setting is disabled so the tool can surface that to the agent.
  */
 export type AddCriticismSink = (input: {
-  path: string;
+  absolutePath: string;
   line: number;
   message: string;
   severity: number;
@@ -50,6 +52,8 @@ export function setAddCriticismSink(provider: AddCriticismSink): void {
 export const AddCriticismInputSchema = z.strictObject({
   path: z
     .string()
+    .trim()
+    .min(1)
     .describe(
       'Absolute or workspace-relative path to the file the criticism applies to.',
     ),
@@ -62,10 +66,10 @@ export const AddCriticismInputSchema = z.strictObject({
   severity: z
     .number()
     .int()
-    .min(1)
+    .min(0)
     .max(5)
     .describe(
-      'Severity 1–5: 5=desk-rejection risk, 4=significantly weakens, 3=worth addressing, 2=minor polish, 1=cosmetic.',
+      'Severity 0–5: 5=desk-rejection risk, 4=significantly weakens, 3=worth addressing, 2=minor polish, 1=cosmetic, 0=verified/correct.',
     ),
   confidence: z
     .number()
@@ -87,7 +91,13 @@ export class AddCriticismTool extends defineTool({
 }) {
   protected async execute(input: AddCriticismInput): Promise<ToolResult> {
     try {
-      const result = sink(input);
+      const workingDirectory =
+        getCurrentToolFileInteractionContext()?.workingDirectory;
+      const resolved = resolveWorkspaceRelativePath(
+        input.path,
+        workingDirectory,
+      );
+      const result = sink({ ...input, absolutePath: resolved.absolute });
       if (!result.accepted) {
         return {
           summary: 'Criticism not accepted',
@@ -95,7 +105,7 @@ export class AddCriticismTool extends defineTool({
             'Inline criticism diagnostics are disabled. Enable "texra.inlineCriticism.enabled" in settings to surface critiques as diagnostics.',
         };
       }
-      const where = result.resolvedPath || input.path;
+      const where = result.resolvedPath || resolved.absolute;
       const summary = `Added criticism for ${where}:${input.line} (S${input.severity}/C${input.confidence})`;
       return { summary, output: summary };
     } catch (error) {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,6 +9,7 @@ import {
 } from '@model/ToolDefinition';
 
 // Local imports - tools
+import { AddCriticismTool } from './AddCriticismTool';
 import { BashTool } from './bash';
 import { DiagnosticsTool } from './DiagnosticsTool';
 import { ApplyPathTool } from './applyPath';
@@ -82,6 +83,7 @@ function createDefaultTools() {
   return {
     str_replace_editor: new TextEditorTool(),
     diagnostics: new DiagnosticsTool(),
+    add_criticism: new AddCriticismTool(),
     bash: new BashTool(),
     read_file: new ReadFileTool(),
     write_file: new WriteFileTool(),


### PR DESCRIPTION
Experimental: parse `\criticize{message}{severity}{confidence}` macros from
agent-revised LaTeX files (criticize, notation, elevate, verifyFix, …) and
surface them as VS Code diagnostics — squiggles in the editor and entries
in the Problems panel. Severity 5→Error, 4→Warning, 3→Info, 1–2→Hint.

## Ingest paths

- **Bus hook on `addOutputFiles`** — universal, no agent changes required.
  Each output `.tex` file is read with `AbsoluteFS.read` and brace-balanced
  parsed by `criticismParser.ts` (handles nested `\cref{...}` etc., which the
  existing single-level regex in `replacement/advanced.ts` can't). The file's
  diagnostics are then replaced wholesale in the collection.

- **`add_criticism` tool** — for tool-use agents that want to flag an issue
  without inserting the literal macro into the document. Pushed via an
  injectable sink wired in `extension.ts` (vscode-free in `src/tools/`).

## Settings location

No VS Code `texra.inlineCriticism.enabled` config. The toggle is a
`GlobalStateKey.INLINE_CRITICISM_ENABLED` global memento, surfaced in a new
**Experimental** section of the LaTeX settings tab. Matches the storage
pattern used by `MEMORY_ENABLED`, `SUPER_YOLO_ENABLED`, etc.

Toggling the checkbox calls `setInlineCriticismEnabled`, which persists to
`globalSM` and reconciles the diagnostic collection live (subscribes/clears
+ disposes the bus listener). Default off.

## Files

- `src/latex/criticismParser.ts` — pure parser, single-pass `LineColCursor`
  for O(N) line/column conversion regardless of match count.
- `src/frontend/latex/inlineCriticism.ts` — owns the `DiagnosticCollection`,
  bus listener, manual-push sink.
- `src/tools/AddCriticismTool.ts` — the tool, vscode-free.
- Settings plumbing across `stateManager.ts`, `settingsViewCommands.ts`,
  `settingsViewMessages.ts`, `SettingsViewMessageHandler.ts`,
  `SettingsApp.ts`, `LaTeXTab.ts`.

## Test plan

- [ ] Toggle "Inline criticism diagnostics" in the LaTeX settings tab, confirm checkbox state persists across reloads
- [ ] Run a critique-style agent (e.g. `criticize`) on a `.tex` file with the toggle on; verify squiggles appear at each `\criticize{...}{...}{...}` and the Problems panel groups them by severity
- [ ] Disable the toggle mid-session; confirm diagnostics clear and re-enabling does not re-flood from buffered events
- [ ] Run an `add_criticism` tool call from a tool-use agent; verify the diagnostic appears at the requested file/line with `(S/C)` suffix
- [ ] Call `add_criticism` while the toggle is off; verify the tool reports "not accepted" without throwing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new diagnostics pipeline that reads and parses generated `.tex` output files and exposes results via VS Code’s Problems/diagnostics APIs; incorrect parsing or event handling could create noisy/incorrect squiggles or performance overhead on large outputs. Also introduces a new tool (`add_criticism`) wired through an injected sink, which affects agent tool behavior when enabled.
> 
> **Overview**
> **Adds an experimental inline-diagnostics feature for agent critiques.** When enabled, the extension now parses `\\criticize{message}{severity}{confidence}` annotations in agent-produced `.tex` output files (via the `addOutputFiles` bus event) and surfaces them as VS Code diagnostics (squiggles + Problems), mapping severity 0–5 to hint→error.
> 
> Also introduces a brace-balanced `parseCriticismAnnotations` parser (exported from `src/latex`) plus a new tool-use entrypoint, `add_criticism`, which resolves paths and pushes per-line diagnostics through an injected host sink.
> 
> Wires a new toggle (`texra.inlineCriticism.enabled`) end-to-end: VS Code contribution metadata, persisted global state key, settings-view commands/messages/dispatcher plumbing, and a new control in the LaTeX settings tab; enabling/disabling live creates/clears the diagnostic collection and bus listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff80f6d21d7fc9b1d5fc236e50f4f5a46388368a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->