### PR TITLE
feat(github): emit merge conflict events from PR/repo subscriptions

### DIFF
--- a/docs/proposals/unified-output-protocol.md
+++ b/docs/proposals/unified-output-protocol.md
@@ -86,7 +86,7 @@ Gate the rollout on **no statistically meaningful regression** on the N=1 path. 
 
 ### Phase 1: Protocol constants and parser
 
-Land the unified container parser as the *only* parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
+Land the unified container parser as the _only_ parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
 
 ### Phase 2: Migrate prompts and YAML
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -39,12 +39,13 @@ import {
   MAX_CONCURRENT_PR_SUBSCRIPTIONS,
   PR_POLL_INTERVAL_MS,
 } from './prSubscriptionConstants';
-import type {
-  GhCheckRun,
-  GhIssueComment,
-  GhPullRequest,
-  GhReview,
-  GhReviewComment,
+import {
+  isDefiniteMergeableState,
+  type GhCheckRun,
+  type GhIssueComment,
+  type GhPullRequest,
+  type GhReview,
+  type GhReviewComment,
 } from './prTypes';
 
 function createInitialState(pr: PRKey): SubscriptionState {
@@ -69,19 +70,6 @@ function createInitialState(pr: PRKey): SubscriptionState {
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
   };
-}
-
-/**
- * GitHub computes `mergeable_state` asynchronously after every push or base
- * change; until it stabilizes the field reads `unknown`. We deliberately
- * ignore that transient value when classifying transitions — recording
- * `unknown` as the "previous" state would let a clean→unknown→dirty
- * sequence look like clean→dirty (correct), but a dirty→unknown→clean
- * sequence would silently lose the resolved transition. Treating
- * `unknown` as "no observation" keeps both directions correct.
- */
-function isDefiniteMergeableState(s: string | undefined): s is string {
-  return s !== undefined && s !== 'unknown';
 }
 
 // Coalesce this many same-kind events in a single tick into a summary.
@@ -129,15 +117,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
   headSha: string | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
-  /**
-   * Last observed *definite* `mergeable_state` from GitHub (`undefined`
-   * before the first definite reading). Crucially we never store
-   * `'unknown'` here — that's the "still computing" placeholder GitHub
-   * returns right after a push or base change, and treating it as a real
-   * state would corrupt transition detection (a dirty→unknown→clean
-   * sequence would silently lose the "resolved" event because dirty would
-   * be overwritten by unknown before the clean reading arrived).
-   */
+  /** Last *definite* `mergeable_state`; see `isDefiniteMergeableState`. */
   mergeableState: string | undefined;
   etags: {
     pr?: string;
@@ -242,30 +222,19 @@ export class PRPollingSource extends PollingSourceBase<
       }
       state.headSha = newHead;
 
-      // Mergeable-state transitions. We only emit when we have a previous
-      // *definite* observation to compare against — `'unknown'` is the
-      // placeholder GitHub returns while mergeability is still being
-      // computed (right after a push or base change), and treating it as
-      // either a real state or the absence of one would corrupt detection:
-      //   - storing `'unknown'` as `prev` would mask a dirty→unknown→clean
-      //     sequence (the resolved guard `prev === 'dirty'` never fires);
-      //   - emitting on first definite reading after `prev === undefined`
-      //     would surface "merge conflict detected" for PRs that were
-      //     already dirty when we subscribed (or whose first reading just
-      //     happened to land on 'unknown' because mergeability had been
-      //     invalidated mid-poll).
-      // So: only the dirty/non-dirty *transition* between two definite
-      // observations counts. Anything before the first definite reading,
-      // including the seeding tick, is silent.
+      // Mergeable-state transitions: only definite-to-definite reads count,
+      // so the seeding tick (and any tick where GitHub returns `'unknown'`)
+      // is silent. See `isDefiniteMergeableState` for the rationale.
       if (isDefiniteMergeableState(newMergeable)) {
         const prev = state.mergeableState;
-        if (isDefiniteMergeableState(prev)) {
-          if (newMergeable === 'dirty' && prev !== 'dirty') {
+        state.mergeableState = newMergeable;
+        if (isDefiniteMergeableState(prev) && prev !== newMergeable) {
+          if (newMergeable === 'dirty') {
             this.emit(
               state,
               formatMergeConflictDetected(state.slug, pr.pullNumber, prev),
             );
-          } else if (prev === 'dirty' && newMergeable !== 'dirty') {
+          } else if (prev === 'dirty') {
             this.emit(
               state,
               formatMergeConflictResolved(
@@ -276,7 +245,6 @@ export class PRPollingSource extends PollingSourceBase<
             );
           }
         }
-        state.mergeableState = newMergeable;
       }
     }
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -20,6 +20,8 @@ import {
   formatCIComplete,
   formatCIPassed,
   formatIssueComment,
+  formatMergeConflictDetected,
+  formatMergeConflictResolved,
   formatPRClosed,
   formatReview,
   formatReviewComment,
@@ -60,12 +62,26 @@ function createInitialState(pr: PRKey): SubscriptionState {
     headSha: undefined,
     state: undefined,
     merged: false,
+    mergeableState: undefined,
     etags: {},
     sinceCursors: {},
     lastSuccessAt: Date.now(),
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
   };
+}
+
+/**
+ * GitHub computes `mergeable_state` asynchronously after every push or base
+ * change; until it stabilizes the field reads `unknown`. We deliberately
+ * ignore that transient value when classifying transitions — recording
+ * `unknown` as the "previous" state would let a clean→unknown→dirty
+ * sequence look like clean→dirty (correct), but a dirty→unknown→clean
+ * sequence would silently lose the resolved transition. Treating
+ * `unknown` as "no observation" keeps both directions correct.
+ */
+function isDefiniteMergeableState(s: string | undefined): s is string {
+  return s !== undefined && s !== 'unknown';
 }
 
 // Coalesce this many same-kind events in a single tick into a summary.
@@ -113,6 +129,16 @@ interface SubscriptionState extends BasePollSubscriptionState {
   headSha: string | undefined;
   state: 'open' | 'closed' | undefined;
   merged: boolean;
+  /**
+   * Last observed *definite* `mergeable_state` from GitHub (`undefined`
+   * before the first definite reading). Crucially we never store
+   * `'unknown'` here — that's the "still computing" placeholder GitHub
+   * returns right after a push or base change, and treating it as a real
+   * state would corrupt transition detection (a dirty→unknown→clean
+   * sequence would silently lose the "resolved" event because dirty would
+   * be overwritten by unknown before the clean reading arrived).
+   */
+  mergeableState: string | undefined;
   etags: {
     pr?: string;
     issueComments?: string;
@@ -189,6 +215,7 @@ export class PRPollingSource extends PollingSourceBase<
       const newHead = prRes.data.head.sha;
       const newState = prRes.data.state;
       const newMerged = prRes.data.merged;
+      const newMergeable = prRes.data.mergeable_state;
 
       // Detect close/merge on initialized subscriptions.
       if (
@@ -214,6 +241,43 @@ export class PRPollingSource extends PollingSourceBase<
         state.checkRunsCache = undefined;
       }
       state.headSha = newHead;
+
+      // Mergeable-state transitions. We only emit when we have a previous
+      // *definite* observation to compare against — `'unknown'` is the
+      // placeholder GitHub returns while mergeability is still being
+      // computed (right after a push or base change), and treating it as
+      // either a real state or the absence of one would corrupt detection:
+      //   - storing `'unknown'` as `prev` would mask a dirty→unknown→clean
+      //     sequence (the resolved guard `prev === 'dirty'` never fires);
+      //   - emitting on first definite reading after `prev === undefined`
+      //     would surface "merge conflict detected" for PRs that were
+      //     already dirty when we subscribed (or whose first reading just
+      //     happened to land on 'unknown' because mergeability had been
+      //     invalidated mid-poll).
+      // So: only the dirty/non-dirty *transition* between two definite
+      // observations counts. Anything before the first definite reading,
+      // including the seeding tick, is silent.
+      if (isDefiniteMergeableState(newMergeable)) {
+        const prev = state.mergeableState;
+        if (isDefiniteMergeableState(prev)) {
+          if (newMergeable === 'dirty' && prev !== 'dirty') {
+            this.emit(
+              state,
+              formatMergeConflictDetected(state.slug, pr.pullNumber, prev),
+            );
+          } else if (prev === 'dirty' && newMergeable !== 'dirty') {
+            this.emit(
+              state,
+              formatMergeConflictResolved(
+                state.slug,
+                pr.pullNumber,
+                newMergeable,
+              ),
+            );
+          }
+        }
+        state.mergeableState = newMergeable;
+      }
     }
 
     // Bail cleanly if the PR is already closed. On the first (initialization)

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -46,18 +46,19 @@ import {
   formatRepoReviewComment,
   formatRepoSubscriptionError,
 } from './formatRepoEvent';
-import { getNewestTimestamp, trimSet } from './formatUtils';
+import { getNewestTimestamp, trimMap, trimSet } from './formatUtils';
 import { ghGet } from './githubClient';
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,
   type Disposable,
 } from './PollingSourceBase';
-import type {
-  GhIssueComment,
-  GhPullRequest,
-  GhPullsListEntry,
-  GhReviewComment,
+import {
+  isDefiniteMergeableState,
+  type GhIssueComment,
+  type GhPullRequest,
+  type GhPullsListEntry,
+  type GhReviewComment,
 } from './prTypes';
 
 // We pull all "updated since" data; a sufficiently large window guarantees we
@@ -138,21 +139,12 @@ interface SubscriptionState extends BasePollSubscriptionState {
    */
   prStateByNumber: Map<number, 'open' | 'closed' | 'merged'>;
   /**
-   * Last seen `updated_at` from the pulls list per PR. Used to drive the
-   * holistic merge-conflict probe: an advanced `updated_at` is a (necessary
-   * but not sufficient) signal that head was pushed or the base shifted,
-   * either of which can change `mergeable_state`. We probe `/pulls/{N}`
-   * only for PRs whose updated_at advanced since the prior tick — which
-   * naturally covers head pushes, and catches base-branch effects via the
-   * comment / review activity that typically follows a merge into base.
+   * Per-PR `updated_at` cursor for the merge-conflict probe; only advanced
+   * after a successful probe so transient probe failures keep the PR as a
+   * candidate next tick. See `probeMergeableStates`.
    */
   prUpdatedAtByNumber: Map<number, string>;
-  /**
-   * Last observed *definite* `mergeable_state` per PR (we never store
-   * `'unknown'` — see `isDefiniteMergeableState` in PRPollingSource for
-   * the same reasoning). Indexed by PR number; entries roll off with
-   * `prStateByNumber` via shared FIFO eviction.
-   */
+  /** Per-PR last *definite* `mergeable_state`; see `isDefiniteMergeableState`. */
   prMergeableByNumber: Map<number, string>;
 }
 
@@ -272,11 +264,7 @@ export class RepoPollingSource extends PollingSourceBase<
         state.prStateByNumber.delete(pr.number);
         state.prStateByNumber.set(pr.number, next);
       }
-      while (state.prStateByNumber.size > MAX_PR_STATE_ENTRIES) {
-        const oldest = state.prStateByNumber.keys().next().value;
-        if (oldest === undefined) break;
-        state.prStateByNumber.delete(oldest);
-      }
+      trimMap(state.prStateByNumber, MAX_PR_STATE_ENTRIES);
     }
 
     if (issueRes.status === 200) {
@@ -343,63 +331,58 @@ export class RepoPollingSource extends PollingSourceBase<
     state: SubscriptionState,
     pulls: readonly GhPullsListEntry[],
   ): Promise<void> {
-    // Build the candidate list: open PRs whose updated_at advanced (or is
-    // first-seen as open). Order by updated_at desc so the freshest wins
-    // when the per-tick cap bites. The pulls list is already newest-first
-    // by sort=updated&direction=desc — preserve that order.
+    // Build the candidate list: open PRs whose updated_at advanced since
+    // our last definite observation. First-seen PRs are seeded silently —
+    // probing on first observation would surface "merge conflict detected"
+    // for PRs that were already dirty before we attached. We update the
+    // updated_at cursor only AFTER a successful probe so a transient probe
+    // failure leaves the PR as a candidate next tick rather than waiting
+    // for the next push to bring it back into scope.
     const candidates: GhPullsListEntry[] = [];
     for (const pr of pulls) {
       if (pr.state !== 'open') continue;
       if (shouldDropBotEvent(pr.user)) continue;
       const prevUpdatedAt = state.prUpdatedAtByNumber.get(pr.number);
-      // Always record the latest updated_at so the next tick's "advanced"
-      // detection is correct — but only QUEUE a probe when we observed an
-      // advance. Without this we'd probe every open PR every tick.
-      const advanced =
-        prevUpdatedAt === undefined || pr.updated_at > prevUpdatedAt;
-      state.prUpdatedAtByNumber.set(pr.number, pr.updated_at);
-      // First-seen-after-init: predates our subscription; record updated_at
-      // and the next pulls-list response with a real change will bring it
-      // back as a candidate. Probing on first observation would silently
-      // emit for PRs that were already dirty when we attached.
-      if (prevUpdatedAt === undefined) continue;
-      if (!advanced) continue;
-      candidates.push(pr);
+      if (prevUpdatedAt === undefined) {
+        state.prUpdatedAtByNumber.set(pr.number, pr.updated_at);
+        continue;
+      }
+      if (pr.updated_at > prevUpdatedAt) candidates.push(pr);
     }
     if (candidates.length === 0) return;
 
+    // Pulls list is already sorted by updated_at desc, so slicing yields
+    // the freshest candidates when the per-tick cap bites.
     const probes = candidates.slice(0, MAX_MERGEABLE_PROBES_PER_TICK);
-    // Run probes in parallel — each is one independent GET, the budget cap
-    // is small (<=5), and serializing would multiply tick latency.
     const probeResults = await Promise.allSettled(
       probes.map(async (pr) => {
         const path = `/repos/${state.owner}/${state.repo}/pulls/${pr.number}`;
         const res = await ghGet<GhPullRequest>(path);
         if (res.status !== 200) return undefined;
-        return { number: pr.number, mergeable: res.data.mergeable_state };
+        return {
+          number: pr.number,
+          updatedAt: pr.updated_at,
+          mergeable: res.data.mergeable_state,
+        };
       }),
     );
-    // Capture (number, prev, next) for newly-dirty PRs *before* writing back
-    // to the map — otherwise the per-PR formatter's "(was X)" hint would
-    // read the just-overwritten value.
+
     const newlyDirty: { number: number; prev: string }[] = [];
     for (const result of probeResults) {
       if (result.status !== 'fulfilled' || !result.value) continue;
-      const { number, mergeable } = result.value;
+      const { number, updatedAt, mergeable } = result.value;
+      // Probe succeeded — advance updated_at so we don't re-probe until
+      // the next external change.
+      state.prUpdatedAtByNumber.set(number, updatedAt);
       if (!isDefiniteMergeableState(mergeable)) continue;
       const prev = state.prMergeableByNumber.get(number);
       state.prMergeableByNumber.set(number, mergeable);
-      if (!isDefiniteMergeableState(prev)) {
-        // First definite reading — silent seed. Same reasoning as the per-PR
-        // poller: we don't want to surface "merge conflict detected" for a
-        // PR that was already dirty before we observed it.
-        continue;
-      }
+      // Silent seed on first definite reading; resolved transitions are
+      // intentionally not surfaced at the repo level (see method doc).
+      if (!isDefiniteMergeableState(prev)) continue;
       if (mergeable === 'dirty' && prev !== 'dirty') {
         newlyDirty.push({ number, prev });
       }
-      // Resolved transitions are intentionally not emitted at the repo level
-      // — see method-level comment.
     }
 
     if (newlyDirty.length >= MERGE_CONFLICT_COALESCE_THRESHOLD) {
@@ -418,21 +401,9 @@ export class RepoPollingSource extends PollingSourceBase<
         );
       }
     }
-    // Bound `prMergeableByNumber` against unbounded growth on long-lived
-    // subscriptions watching busy repos. FIFO mirrors `prStateByNumber`'s
-    // policy: closed-and-forgotten PRs roll off first because they stop
-    // being re-inserted by the probe loop. Cap matches MAX_PR_STATE_ENTRIES
-    // so the two maps age out at roughly the same rate.
-    while (state.prMergeableByNumber.size > MAX_PR_STATE_ENTRIES) {
-      const oldest = state.prMergeableByNumber.keys().next().value;
-      if (oldest === undefined) break;
-      state.prMergeableByNumber.delete(oldest);
-    }
-    while (state.prUpdatedAtByNumber.size > MAX_PR_STATE_ENTRIES) {
-      const oldest = state.prUpdatedAtByNumber.keys().next().value;
-      if (oldest === undefined) break;
-      state.prUpdatedAtByNumber.delete(oldest);
-    }
+
+    trimMap(state.prMergeableByNumber, MAX_PR_STATE_ENTRIES);
+    trimMap(state.prUpdatedAtByNumber, MAX_PR_STATE_ENTRIES);
   }
 }
 
@@ -459,11 +430,6 @@ function createInitialState(owner: string, repo: string): SubscriptionState {
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
   };
-}
-
-/** Mirrors the PR poller's filter: anything but `'unknown'` is "definite". */
-function isDefiniteMergeableState(s: string | undefined): s is string {
-  return s !== undefined && s !== 'unknown';
 }
 
 function classifyPRState(pr: GhPullsListEntry): 'open' | 'closed' | 'merged' {

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -46,7 +46,7 @@ import {
   formatRepoReviewComment,
   formatRepoSubscriptionError,
 } from './formatRepoEvent';
-import { getNewestTimestamp, trimMap, trimSet } from './formatUtils';
+import { getNewestTimestamp, setRecent, trimMap, trimSet } from './formatUtils';
 import { ghGet } from './githubClient';
 import {
   PollingSourceBase,
@@ -259,10 +259,7 @@ export class RepoPollingSource extends PollingSourceBase<
             formatRepoPRClosed(state.slug, pr.number, next === 'merged'),
           );
         }
-        // FIFO eviction relies on Map insertion order; delete-then-set
-        // re-inserts at the tail so recently-touched PRs are kept.
-        state.prStateByNumber.delete(pr.number);
-        state.prStateByNumber.set(pr.number, next);
+        setRecent(state.prStateByNumber, pr.number, next);
       }
       trimMap(state.prStateByNumber, MAX_PR_STATE_ENTRIES);
     }
@@ -371,12 +368,19 @@ export class RepoPollingSource extends PollingSourceBase<
     for (const result of probeResults) {
       if (result.status !== 'fulfilled' || !result.value) continue;
       const { number, updatedAt, mergeable } = result.value;
-      // Probe succeeded — advance updated_at so we don't re-probe until
-      // the next external change.
-      state.prUpdatedAtByNumber.set(number, updatedAt);
+      // Defer the cursor advance until we have a *definite* mergeable
+      // reading. GitHub commonly returns `'unknown'` for a few seconds
+      // after a push or base change while it computes mergeability;
+      // advancing updated_at on that response would drop the PR from the
+      // candidate set and let the subsequent dirty/clean transition slip
+      // by silently. Leaving the cursor unchanged keeps the PR a candidate
+      // next tick so we re-probe until GitHub resolves the state.
       if (!isDefiniteMergeableState(mergeable)) continue;
+      // setRecent (delete + set) refreshes insertion order so the
+      // FIFO trimMap below evicts least-recently-touched, not first-seen.
+      setRecent(state.prUpdatedAtByNumber, number, updatedAt);
       const prev = state.prMergeableByNumber.get(number);
-      state.prMergeableByNumber.set(number, mergeable);
+      setRecent(state.prMergeableByNumber, number, mergeable);
       // Silent seed on first definite reading; resolved transitions are
       // intentionally not surfaced at the repo level (see method doc).
       if (!isDefiniteMergeableState(prev)) continue;

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -39,6 +39,8 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatRepoIssueComment,
+  formatRepoMergeConflictDetected,
+  formatRepoMergeConflictSummary,
   formatRepoPRClosed,
   formatRepoPROpened,
   formatRepoReviewComment,
@@ -53,6 +55,7 @@ import {
 } from './PollingSourceBase';
 import type {
   GhIssueComment,
+  GhPullRequest,
   GhPullsListEntry,
   GhReviewComment,
 } from './prTypes';
@@ -75,6 +78,20 @@ const MAX_PR_STATE_ENTRIES = 500;
 // older than this fall out of the dedup window — but the `since` cursor
 // will normally have advanced past them by then anyway.
 const MAX_SEEN_IDS = 1000;
+// Holistic merge-conflict probing: each tick we GET `/pulls/{N}` for at
+// most this many open PRs whose `updated_at` advanced since the prior tick,
+// in newest-first order. Bounded so a busy repo can't fan out into one
+// extra GET per open PR — at 30s tick interval and 5 probes/tick we add
+// ~600 requests/hour per repo, well within the 5,000/hr token budget.
+// PRs that aren't probed this tick simply wait their turn: the next push
+// or comment will bubble them back to the top of the updated-at order.
+const MAX_MERGEABLE_PROBES_PER_TICK = 5;
+// Coalesce per-tick merge-conflict events into a single summary above this
+// threshold. Mirrors the PR-poller `COALESCE_THRESHOLD`: the typical cause
+// of many simultaneous transitions is a base-branch update invalidating
+// every open PR, and one summary message is more useful to an orchestrator
+// than five individual events.
+const MERGE_CONFLICT_COALESCE_THRESHOLD = 3;
 
 export type RepoKey = `${string}/${string}`;
 
@@ -120,6 +137,23 @@ interface SubscriptionState extends BasePollSubscriptionState {
    * time the PR shows up in the list endpoint.
    */
   prStateByNumber: Map<number, 'open' | 'closed' | 'merged'>;
+  /**
+   * Last seen `updated_at` from the pulls list per PR. Used to drive the
+   * holistic merge-conflict probe: an advanced `updated_at` is a (necessary
+   * but not sufficient) signal that head was pushed or the base shifted,
+   * either of which can change `mergeable_state`. We probe `/pulls/{N}`
+   * only for PRs whose updated_at advanced since the prior tick — which
+   * naturally covers head pushes, and catches base-branch effects via the
+   * comment / review activity that typically follows a merge into base.
+   */
+  prUpdatedAtByNumber: Map<number, string>;
+  /**
+   * Last observed *definite* `mergeable_state` per PR (we never store
+   * `'unknown'` — see `isDefiniteMergeableState` in PRPollingSource for
+   * the same reasoning). Indexed by PR number; entries roll off with
+   * `prStateByNumber` via shared FIFO eviction.
+   */
+  prMergeableByNumber: Map<number, string>;
 }
 
 export class RepoPollingSource extends PollingSourceBase<
@@ -187,6 +221,11 @@ export class RepoPollingSource extends PollingSourceBase<
       if (pullsRes.status === 200) {
         for (const pr of pullsRes.data) {
           state.prStateByNumber.set(pr.number, classifyPRState(pr));
+          // Seed the updated_at cursor so the next tick only treats real
+          // *advances* as probe triggers — without this the second tick
+          // would see every PR's updated_at as "advanced" relative to
+          // undefined and stampede MAX_PROBES probes on irrelevant PRs.
+          state.prUpdatedAtByNumber.set(pr.number, pr.updated_at);
         }
       }
       if (issueRes.status === 200) {
@@ -271,6 +310,129 @@ export class RepoPollingSource extends PollingSourceBase<
     // live only on /pulls/{n}/reviews, which is per-PR. An orchestrator that
     // needs that fidelity should delegate a worker that calls
     // github_subscription with path="owner/repo#N".
+
+    // Holistic merge-conflict detection. The list endpoint doesn't return
+    // `mergeable_state`, so we probe `/pulls/{N}` for a bounded number of
+    // open PRs whose `updated_at` advanced since the prior tick. That
+    // signal naturally covers head pushes (the most common cause of new
+    // conflicts) and surfaces base-branch conflicts via the comments /
+    // reviews that typically follow a base merge. PRs that don't make the
+    // per-tick cap roll over: the next tick re-evaluates the candidate set.
+    if (pullsRes.status === 200) {
+      await this.probeMergeableStates(state, pullsRes.data);
+    }
+  }
+
+  /**
+   * Probe up to `MAX_MERGEABLE_PROBES_PER_TICK` open PRs for
+   * `mergeable_state` changes, prioritizing ones whose `updated_at`
+   * advanced since the prior tick (with newest-first tie-breaking).
+   *
+   * Emits one event per PR that flipped to `'dirty'`, or a single coalesced
+   * summary if `>= MERGE_CONFLICT_COALESCE_THRESHOLD` PRs flipped on the
+   * same tick. We do NOT emit "resolved" notifications at the repo level —
+   * an orchestrator monitoring conflicts wants the alert, and the agent it
+   * delegates the fix to will run a per-PR subscription that surfaces the
+   * resolved transition. Adding it here would just spray noise.
+   *
+   * Skips bot-authored PRs end-to-end (mirrors the open/close gate above)
+   * and PRs we've already classified as `'dirty'` so we don't re-emit
+   * every time updated_at advances on an already-conflicted PR.
+   */
+  private async probeMergeableStates(
+    state: SubscriptionState,
+    pulls: readonly GhPullsListEntry[],
+  ): Promise<void> {
+    // Build the candidate list: open PRs whose updated_at advanced (or is
+    // first-seen as open). Order by updated_at desc so the freshest wins
+    // when the per-tick cap bites. The pulls list is already newest-first
+    // by sort=updated&direction=desc — preserve that order.
+    const candidates: GhPullsListEntry[] = [];
+    for (const pr of pulls) {
+      if (pr.state !== 'open') continue;
+      if (shouldDropBotEvent(pr.user)) continue;
+      const prevUpdatedAt = state.prUpdatedAtByNumber.get(pr.number);
+      // Always record the latest updated_at so the next tick's "advanced"
+      // detection is correct — but only QUEUE a probe when we observed an
+      // advance. Without this we'd probe every open PR every tick.
+      const advanced =
+        prevUpdatedAt === undefined || pr.updated_at > prevUpdatedAt;
+      state.prUpdatedAtByNumber.set(pr.number, pr.updated_at);
+      // First-seen-after-init: predates our subscription; record updated_at
+      // and the next pulls-list response with a real change will bring it
+      // back as a candidate. Probing on first observation would silently
+      // emit for PRs that were already dirty when we attached.
+      if (prevUpdatedAt === undefined) continue;
+      if (!advanced) continue;
+      candidates.push(pr);
+    }
+    if (candidates.length === 0) return;
+
+    const probes = candidates.slice(0, MAX_MERGEABLE_PROBES_PER_TICK);
+    // Run probes in parallel — each is one independent GET, the budget cap
+    // is small (<=5), and serializing would multiply tick latency.
+    const probeResults = await Promise.allSettled(
+      probes.map(async (pr) => {
+        const path = `/repos/${state.owner}/${state.repo}/pulls/${pr.number}`;
+        const res = await ghGet<GhPullRequest>(path);
+        if (res.status !== 200) return undefined;
+        return { number: pr.number, mergeable: res.data.mergeable_state };
+      }),
+    );
+    // Capture (number, prev, next) for newly-dirty PRs *before* writing back
+    // to the map — otherwise the per-PR formatter's "(was X)" hint would
+    // read the just-overwritten value.
+    const newlyDirty: { number: number; prev: string }[] = [];
+    for (const result of probeResults) {
+      if (result.status !== 'fulfilled' || !result.value) continue;
+      const { number, mergeable } = result.value;
+      if (!isDefiniteMergeableState(mergeable)) continue;
+      const prev = state.prMergeableByNumber.get(number);
+      state.prMergeableByNumber.set(number, mergeable);
+      if (!isDefiniteMergeableState(prev)) {
+        // First definite reading — silent seed. Same reasoning as the per-PR
+        // poller: we don't want to surface "merge conflict detected" for a
+        // PR that was already dirty before we observed it.
+        continue;
+      }
+      if (mergeable === 'dirty' && prev !== 'dirty') {
+        newlyDirty.push({ number, prev });
+      }
+      // Resolved transitions are intentionally not emitted at the repo level
+      // — see method-level comment.
+    }
+
+    if (newlyDirty.length >= MERGE_CONFLICT_COALESCE_THRESHOLD) {
+      this.emit(
+        state,
+        formatRepoMergeConflictSummary(
+          state.slug,
+          newlyDirty.map((d) => d.number),
+        ),
+      );
+    } else {
+      for (const { number, prev } of newlyDirty) {
+        this.emit(
+          state,
+          formatRepoMergeConflictDetected(state.slug, number, prev),
+        );
+      }
+    }
+    // Bound `prMergeableByNumber` against unbounded growth on long-lived
+    // subscriptions watching busy repos. FIFO mirrors `prStateByNumber`'s
+    // policy: closed-and-forgotten PRs roll off first because they stop
+    // being re-inserted by the probe loop. Cap matches MAX_PR_STATE_ENTRIES
+    // so the two maps age out at roughly the same rate.
+    while (state.prMergeableByNumber.size > MAX_PR_STATE_ENTRIES) {
+      const oldest = state.prMergeableByNumber.keys().next().value;
+      if (oldest === undefined) break;
+      state.prMergeableByNumber.delete(oldest);
+    }
+    while (state.prUpdatedAtByNumber.size > MAX_PR_STATE_ENTRIES) {
+      const oldest = state.prUpdatedAtByNumber.keys().next().value;
+      if (oldest === undefined) break;
+      state.prUpdatedAtByNumber.delete(oldest);
+    }
   }
 }
 
@@ -291,10 +453,17 @@ function createInitialState(owner: string, repo: string): SubscriptionState {
     seenIssueCommentIds: new Set(),
     seenReviewCommentIds: new Set(),
     prStateByNumber: new Map(),
+    prUpdatedAtByNumber: new Map(),
+    prMergeableByNumber: new Map(),
     lastSuccessAt: now,
     consecutiveFailures: 0,
     skipPollUntilMs: 0,
   };
+}
+
+/** Mirrors the PR poller's filter: anything but `'unknown'` is "definite". */
+function isDefiniteMergeableState(s: string | undefined): s is string {
+  return s !== undefined && s !== 'unknown';
 }
 
 function classifyPRState(pr: GhPullsListEntry): 'open' | 'closed' | 'merged' {

--- a/src/tools/github/formatIssueEvent.ts
+++ b/src/tools/github/formatIssueEvent.ts
@@ -1,10 +1,15 @@
 /**
  * Natural-language formatters for `IssuePollingSource`.
  *
- * Path form mirrors GitHub's REST URL shape: `owner/repo/issues/N`.
+ * Path form mirrors GitHub's REST URL shape: `owner/repo/issues/N`. Each
+ * formatter declares the message structure (headline + optional body +
+ * optional URL) via shared helpers from `formatUtils`.
  */
 
 import {
+  authorOf,
+  issueRef,
+  sections,
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
@@ -12,18 +17,20 @@ import type { GhIssue, GhIssueComment } from './prTypes';
 
 const MAX_BODY = 500;
 
-function truncate(s: string | null | undefined): string {
-  return truncateBody(s, MAX_BODY);
-}
+const truncate = (s: string | null | undefined): string =>
+  truncateBody(s, MAX_BODY);
 
 export function formatIssueComment(
   slug: string,
   issueNumber: number,
   c: GhIssueComment,
 ): string {
-  const author = c.user?.login ?? 'someone';
   return wrap(
-    `New comment on ${slug}/issues/${issueNumber} by @${author}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
+    sections(
+      `New comment on ${issueRef(slug, issueNumber)} by ${authorOf(c.user)}:`,
+      truncate(c.body),
+      c.html_url,
+    ),
   );
 }
 
@@ -36,7 +43,7 @@ export function formatIssueClosed(
     ? ` (state_reason: ${issue.state_reason})`
     : '';
   return wrap(
-    `${slug}/issues/${issueNumber} was closed${reason}. Subscription remains active in case the issue reopens.`,
+    `${issueRef(slug, issueNumber)} was closed${reason}. Subscription remains active in case the issue reopens.`,
   );
 }
 
@@ -46,7 +53,10 @@ export function formatIssueReopened(
   issue: GhIssue,
 ): string {
   return wrap(
-    `${slug}/issues/${issueNumber} was reopened: "${truncate(issue.title)}"\n\n${issue.html_url}`,
+    sections(
+      `${issueRef(slug, issueNumber)} was reopened: "${truncate(issue.title)}"`,
+      issue.html_url,
+    ),
   );
 }
 
@@ -56,6 +66,6 @@ export function formatIssueSubscriptionError(
   detail: string,
 ): string {
   return wrap(
-    `Issue subscription to ${slug}/issues/${issueNumber} halted: ${detail}`,
+    `Issue subscription to ${issueRef(slug, issueNumber)} halted: ${detail}`,
   );
 }

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -1,14 +1,19 @@
 /**
  * Natural-language formatting for PR webhook-style events.
  *
- * Output text is wrapped in a `<github-webhook-activity>` tag so the agent can
- * recognize that the follow-up came from an external subscription rather than
- * direct user typing. Keep text short and factual — the agent will fetch more
- * detail via its tools if needed.
+ * Each `format*` function declares a single message: a headline, optional
+ * body, optional URL, all composed via `sections(...)` and wrapped in the
+ * `<github-webhook-activity>` envelope. Variants (review verbs, passing
+ * conclusions, prefixes) live as data tables at the top of the file rather
+ * than inline ternary cascades — adding a new review state or passing
+ * conclusion is a one-line table edit.
  */
 
 import {
+  authorOf,
   formatPreviousStateHint,
+  prRef,
+  sections,
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
@@ -21,18 +26,54 @@ import type {
 
 const MAX_BODY = 500;
 
-function truncate(s: string | null | undefined): string {
-  return truncateBody(s, MAX_BODY);
+const truncate = (s: string | null | undefined): string =>
+  truncateBody(s, MAX_BODY);
+
+/** Verb fragments per `GhReview.state`. Unknown states fall back to "reviewed". */
+const REVIEW_VERBS: Readonly<Record<string, string>> = {
+  APPROVED: 'approved',
+  CHANGES_REQUESTED: 'requested changes on',
+  COMMENTED: 'commented on',
+  DISMISSED: 'dismissed a review on',
+};
+
+const FALLBACK_REVIEW_VERB = 'reviewed';
+
+/** Conclusions GitHub treats as non-blocking (success / advisory / skipped). */
+const PASSING_CONCLUSIONS: ReadonlySet<string> = new Set([
+  'success',
+  'neutral',
+  'skipped',
+]);
+
+export function isPassingConclusion(conclusion: string | null): boolean {
+  return conclusion !== null && PASSING_CONCLUSIONS.has(conclusion);
 }
+
+const reviewCommentLocation = (c: GhReviewComment): string => {
+  const line = c.line ?? c.original_line;
+  return line ? `${c.path}:${line}` : c.path;
+};
+
+const reviewCommentPrefix = (c: GhReviewComment): string =>
+  c.in_reply_to_id != null
+    ? 'Reply to inline review thread'
+    : 'New line review comment';
+
+const checkRunBlock = (run: GhCheckRun): string =>
+  `Check: ${run.name}\nConclusion: ${run.conclusion}\nDetails: ${run.html_url}`;
 
 export function formatIssueComment(
   slug: string,
   prNumber: number,
   c: GhIssueComment,
 ): string {
-  const author = c.user?.login ?? 'someone';
   return wrap(
-    `New comment on ${slug}/pulls/${prNumber} by @${author}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
+    sections(
+      `New comment on ${prRef(slug, prNumber)} by ${authorOf(c.user)}:`,
+      truncate(c.body),
+      c.html_url,
+    ),
   );
 }
 
@@ -41,15 +82,12 @@ export function formatReviewComment(
   prNumber: number,
   c: GhReviewComment,
 ): string {
-  const author = c.user?.login ?? 'someone';
-  const line = c.line ?? c.original_line;
-  const loc = line ? `${c.path}:${line}` : c.path;
-  const prefix =
-    c.in_reply_to_id != null
-      ? 'Reply to inline review thread'
-      : 'New line review comment';
   return wrap(
-    `${prefix} on ${slug}/pulls/${prNumber} by @${author} at ${loc}:\n\n${truncate(c.body)}\n\n${c.html_url}`,
+    sections(
+      `${reviewCommentPrefix(c)} on ${prRef(slug, prNumber)} by ${authorOf(c.user)} at ${reviewCommentLocation(c)}:`,
+      truncate(c.body),
+      c.html_url,
+    ),
   );
 }
 
@@ -58,20 +96,13 @@ export function formatReview(
   prNumber: number,
   r: GhReview,
 ): string {
-  const author = r.user?.login ?? 'someone';
-  const verb =
-    r.state === 'APPROVED'
-      ? 'approved'
-      : r.state === 'CHANGES_REQUESTED'
-        ? 'requested changes on'
-        : r.state === 'COMMENTED'
-          ? 'commented on'
-          : r.state === 'DISMISSED'
-            ? 'dismissed a review on'
-            : 'reviewed';
-  const body = r.body ? `\n\n${truncate(r.body)}` : '';
+  const verb = REVIEW_VERBS[r.state] ?? FALLBACK_REVIEW_VERB;
   return wrap(
-    `@${author} ${verb} ${slug}/pulls/${prNumber}.${body}\n\n${r.html_url}`,
+    sections(
+      `${authorOf(r.user)} ${verb} ${prRef(slug, prNumber)}.`,
+      r.body && truncate(r.body),
+      r.html_url,
+    ),
   );
 }
 
@@ -81,11 +112,10 @@ export function formatCheckFailure(
   run: GhCheckRun,
 ): string {
   return wrap(
-    `The following CI check failed on the PR. Investigate the failure and determine what action (if any) is needed.\n\n` +
-      `PR: ${slug}/pulls/${prNumber}\n` +
-      `Check: ${run.name}\n` +
-      `Conclusion: ${run.conclusion}\n` +
-      `Details: ${run.html_url}`,
+    sections(
+      'The following CI check failed on the PR. Investigate the failure and determine what action (if any) is needed.',
+      `PR: ${prRef(slug, prNumber)}\n${checkRunBlock(run)}`,
+    ),
   );
 }
 
@@ -94,25 +124,12 @@ export function formatCheckFailureSummary(
   prNumber: number,
   runs: GhCheckRun[],
 ): string {
-  const entries = runs
-    .map(
-      (r) =>
-        `Check: ${r.name}\nConclusion: ${r.conclusion}\nDetails: ${r.html_url}`,
-    )
-    .join('\n\n');
   return wrap(
-    `${runs.length} CI checks failed on the PR. Investigate the failures and determine what action (if any) is needed.\n\n` +
-      `PR: ${slug}/pulls/${prNumber}\n\n` +
-      entries,
-  );
-}
-
-/** Non-blocking conclusions: `success`, `neutral` (advisory), `skipped`. */
-export function isPassingConclusion(conclusion: string | null): boolean {
-  return (
-    conclusion === 'success' ||
-    conclusion === 'neutral' ||
-    conclusion === 'skipped'
+    sections(
+      `${runs.length} CI checks failed on the PR. Investigate the failures and determine what action (if any) is needed.`,
+      `PR: ${prRef(slug, prNumber)}`,
+      runs.map(checkRunBlock).join('\n\n'),
+    ),
   );
 }
 
@@ -123,7 +140,7 @@ export function formatCIPassed(
   runs: GhCheckRun[],
 ): string {
   return wrap(
-    `All ${runs.length} CI checks passed on ${slug}/pulls/${prNumber} (head ${sha.slice(0, 7)}).`,
+    `All ${runs.length} CI checks passed on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}).`,
   );
 }
 
@@ -136,7 +153,7 @@ export function formatCIComplete(
   const passed = runs.filter((r) => isPassingConclusion(r.conclusion)).length;
   const failed = runs.length - passed;
   return wrap(
-    `CI completed on ${slug}/pulls/${prNumber} (head ${sha.slice(0, 7)}): ${passed} passed, ${failed} failed.`,
+    `CI completed on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}): ${passed} passed, ${failed} failed.`,
   );
 }
 
@@ -145,8 +162,9 @@ export function formatPRClosed(
   prNumber: number,
   merged: boolean,
 ): string {
-  const verb = merged ? 'merged' : 'closed';
-  return wrap(`${slug}/pulls/${prNumber} was ${verb}. Subscription ended.`);
+  return wrap(
+    `${prRef(slug, prNumber)} was ${merged ? 'merged' : 'closed'}. Subscription ended.`,
+  );
 }
 
 /**
@@ -162,7 +180,7 @@ export function formatMergeConflictDetected(
   prevState: string | undefined,
 ): string {
   return wrap(
-    `Merge conflict detected on ${slug}/pulls/${prNumber}: GitHub now reports mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
+    `Merge conflict detected on ${prRef(slug, prNumber)}: GitHub now reports mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
       `The PR head no longer cleanly merges into its base — rebase or merge the base back in to resolve.`,
   );
 }
@@ -179,7 +197,7 @@ export function formatMergeConflictResolved(
   newState: string,
 ): string {
   return wrap(
-    `Merge conflict on ${slug}/pulls/${prNumber} is resolved: mergeable_state is now "${newState}".`,
+    `Merge conflict on ${prRef(slug, prNumber)} is resolved: mergeable_state is now "${newState}".`,
   );
 }
 
@@ -195,5 +213,5 @@ export function formatSubscriptionError(
   prNumber: number,
   detail: string,
 ): string {
-  return wrap(`PR subscription to ${slug}/pulls/${prNumber} halted: ${detail}`);
+  return wrap(`PR subscription to ${prRef(slug, prNumber)} halted: ${detail}`);
 }

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  formatPreviousStateHint,
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
@@ -160,9 +161,8 @@ export function formatMergeConflictDetected(
   prNumber: number,
   prevState: string | undefined,
 ): string {
-  const prevDetail = prevState ? ` (was "${prevState}")` : '';
   return wrap(
-    `Merge conflict detected on ${slug}/pulls/${prNumber}: GitHub now reports mergeable_state="dirty"${prevDetail}. ` +
+    `Merge conflict detected on ${slug}/pulls/${prNumber}: GitHub now reports mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
       `The PR head no longer cleanly merges into its base — rebase or merge the base back in to resolve.`,
   );
 }

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -149,6 +149,41 @@ export function formatPRClosed(
 }
 
 /**
+ * Emitted when GitHub flips `mergeable_state` to `dirty` (the head can no
+ * longer be merged into the base without conflict). Triggered by either a
+ * push to the head branch or a change to the base branch landing
+ * conflicting content. The agent typically wants to either rebase or merge
+ * the base branch back in.
+ */
+export function formatMergeConflictDetected(
+  slug: string,
+  prNumber: number,
+  prevState: string | undefined,
+): string {
+  const prevDetail = prevState ? ` (was "${prevState}")` : '';
+  return wrap(
+    `Merge conflict detected on ${slug}/pulls/${prNumber}: GitHub now reports mergeable_state="dirty"${prevDetail}. ` +
+      `The PR head no longer cleanly merges into its base — rebase or merge the base back in to resolve.`,
+  );
+}
+
+/**
+ * Emitted when a previously-dirty PR returns to a non-dirty state (typically
+ * after a rebase / merge of the base, or after the conflicting change is
+ * reverted). Pairs with `formatMergeConflictDetected` so an agent that acted
+ * on the conflict notification gets a clean "resolved" signal too.
+ */
+export function formatMergeConflictResolved(
+  slug: string,
+  prNumber: number,
+  newState: string,
+): string {
+  return wrap(
+    `Merge conflict on ${slug}/pulls/${prNumber} is resolved: mergeable_state is now "${newState}".`,
+  );
+}
+
+/**
  * Error events delivered into the follow-up queue when the poller hits an
  * unrecoverable condition (auth rejected, repeated failures). Same
  * `<github-webhook-activity>` envelope + sanitize path as every other event

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -72,6 +72,41 @@ export function formatRepoReviewComment(
   );
 }
 
+/**
+ * Single-PR merge-conflict notification, mirroring the per-PR formatter but
+ * keyed under the repo subscription. Triggered by the holistic probe in
+ * `RepoPollingSource` when an open PR's `mergeable_state` flips to `dirty`.
+ */
+export function formatRepoMergeConflictDetected(
+  slug: string,
+  prNumber: number,
+  prevState: string | undefined,
+): string {
+  const prevDetail = prevState ? ` (was "${prevState}")` : '';
+  return wrap(
+    `Merge conflict detected on ${slug}/pulls/${prNumber}: mergeable_state="dirty"${prevDetail}. ` +
+      `Subscribe to ${slug}/pulls/${prNumber} for nuanced events, or rebase / merge the base back in to resolve.`,
+  );
+}
+
+/**
+ * Coalesced "many PRs newly conflicted" notification — fires when the same
+ * tick discovers `>= COALESCE_THRESHOLD` PRs that flipped to dirty. Avoids
+ * spraying the orchestrator with one event per PR after a base-branch
+ * merge invalidates many PRs at once.
+ */
+export function formatRepoMergeConflictSummary(
+  slug: string,
+  prNumbers: readonly number[],
+): string {
+  const list = prNumbers.map((n) => `${slug}/pulls/${n}`).join('\n');
+  return wrap(
+    `Merge conflicts detected on ${prNumbers.length} PRs in ${slug} (mergeable_state="dirty"). ` +
+      `Likely caused by a recent base-branch update — subscribe per-PR for nuanced events, or rebase / merge the base back in.\n\n` +
+      list,
+  );
+}
+
 export function formatRepoSubscriptionError(
   slug: string,
   detail: string,

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -14,10 +14,19 @@
  *   surfaces both PR conversation comments and plain issue comments
  *   indistinguishably without an extra API call. The `html_url` in the
  *   message body resolves the actual type via GitHub's redirect.
+ *
+ * Each `format*` function reads as a description of the message rather than
+ * a string-building procedure: variant strings live in lookup tables, the
+ * recurring "headline + url on next line" pattern is unified, and reference
+ * paths / authors flow through shared helpers.
  */
 
 import {
+  authorOf,
   formatPreviousStateHint,
+  issueRef,
+  prRef,
+  sections,
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
@@ -29,14 +38,22 @@ import type {
 
 const MAX_BODY = 200;
 
-function truncate(s: string | null | undefined): string {
-  return truncateBody(s, MAX_BODY);
-}
+const truncate = (s: string | null | undefined): string =>
+  truncateBody(s, MAX_BODY);
+
+/** Repo-level events use a single newline + URL footer. */
+const withFooterUrl = (headline: string, url: string): string =>
+  `${headline}\n${url}`;
+
+const reviewCommentLabel = (c: GhReviewComment): string =>
+  c.in_reply_to_id != null ? 'review reply' : 'inline review comment';
 
 export function formatRepoPROpened(slug: string, pr: GhPullsListEntry): string {
-  const author = pr.user?.login ?? 'someone';
   return wrap(
-    `New pull request ${slug}/pulls/${pr.number} opened by @${author}: "${truncate(pr.title)}"\n${pr.html_url}`,
+    withFooterUrl(
+      `New pull request ${prRef(slug, pr.number)} opened by ${authorOf(pr.user)}: "${truncate(pr.title)}"`,
+      pr.html_url,
+    ),
   );
 }
 
@@ -45,8 +62,7 @@ export function formatRepoPRClosed(
   prNumber: number,
   merged: boolean,
 ): string {
-  const verb = merged ? 'merged' : 'closed';
-  return wrap(`${slug}/pulls/${prNumber} was ${verb}.`);
+  return wrap(`${prRef(slug, prNumber)} was ${merged ? 'merged' : 'closed'}.`);
 }
 
 export function formatRepoIssueComment(
@@ -54,9 +70,11 @@ export function formatRepoIssueComment(
   number: number,
   c: GhIssueComment,
 ): string {
-  const author = c.user?.login ?? 'someone';
   return wrap(
-    `New comment on ${slug}/issues/${number} by @${author}: "${truncate(c.body)}"\n${c.html_url}`,
+    withFooterUrl(
+      `New comment on ${issueRef(slug, number)} by ${authorOf(c.user)}: "${truncate(c.body)}"`,
+      c.html_url,
+    ),
   );
 }
 
@@ -65,11 +83,11 @@ export function formatRepoReviewComment(
   prNumber: number,
   c: GhReviewComment,
 ): string {
-  const author = c.user?.login ?? 'someone';
-  const reply =
-    c.in_reply_to_id != null ? 'review reply' : 'inline review comment';
   return wrap(
-    `New ${reply} on ${slug}/pulls/${prNumber} by @${author} (${c.path}): "${truncate(c.body)}"\n${c.html_url}`,
+    withFooterUrl(
+      `New ${reviewCommentLabel(c)} on ${prRef(slug, prNumber)} by ${authorOf(c.user)} (${c.path}): "${truncate(c.body)}"`,
+      c.html_url,
+    ),
   );
 }
 
@@ -84,8 +102,8 @@ export function formatRepoMergeConflictDetected(
   prevState: string | undefined,
 ): string {
   return wrap(
-    `Merge conflict detected on ${slug}/pulls/${prNumber}: mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
-      `Subscribe to ${slug}/pulls/${prNumber} for nuanced events, or rebase / merge the base back in to resolve.`,
+    `Merge conflict detected on ${prRef(slug, prNumber)}: mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
+      `Subscribe to ${prRef(slug, prNumber)} for nuanced events, or rebase / merge the base back in to resolve.`,
   );
 }
 
@@ -99,11 +117,11 @@ export function formatRepoMergeConflictSummary(
   slug: string,
   prNumbers: readonly number[],
 ): string {
-  const list = prNumbers.map((n) => `${slug}/pulls/${n}`).join('\n');
   return wrap(
-    `Merge conflicts detected on ${prNumbers.length} PRs in ${slug} (mergeable_state="dirty"). ` +
-      `Likely caused by a recent base-branch update — subscribe per-PR for nuanced events, or rebase / merge the base back in.\n\n` +
-      list,
+    sections(
+      `Merge conflicts detected on ${prNumbers.length} PRs in ${slug} (mergeable_state="dirty"). Likely caused by a recent base-branch update — subscribe per-PR for nuanced events, or rebase / merge the base back in.`,
+      prNumbers.map((n) => prRef(slug, n)).join('\n'),
+    ),
   );
 }
 

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -109,9 +109,9 @@ export function formatRepoMergeConflictDetected(
 
 /**
  * Coalesced "many PRs newly conflicted" notification — fires when the same
- * tick discovers `>= COALESCE_THRESHOLD` PRs that flipped to dirty. Avoids
- * spraying the orchestrator with one event per PR after a base-branch
- * merge invalidates many PRs at once.
+ * tick discovers enough PRs flipping to dirty to cross the repo poller's
+ * coalescing threshold. Avoids spraying the orchestrator with one event
+ * per PR after a base-branch update invalidates many PRs at once.
  */
 export function formatRepoMergeConflictSummary(
   slug: string,

--- a/src/tools/github/formatRepoEvent.ts
+++ b/src/tools/github/formatRepoEvent.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  formatPreviousStateHint,
   truncate as truncateBody,
   wrapWebhookEvent as wrap,
 } from './formatUtils';
@@ -82,9 +83,8 @@ export function formatRepoMergeConflictDetected(
   prNumber: number,
   prevState: string | undefined,
 ): string {
-  const prevDetail = prevState ? ` (was "${prevState}")` : '';
   return wrap(
-    `Merge conflict detected on ${slug}/pulls/${prNumber}: mergeable_state="dirty"${prevDetail}. ` +
+    `Merge conflict detected on ${slug}/pulls/${prNumber}: mergeable_state="dirty"${formatPreviousStateHint(prevState)}. ` +
       `Subscribe to ${slug}/pulls/${prNumber} for nuanced events, or rebase / merge the base back in to resolve.`,
   );
 }

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -98,6 +98,11 @@ export function trimSet<T>(set: Set<T>, maxSize: number): void {
  * FIFO-trim a Map to `maxSize` entries by deleting the oldest keys (Map
  * iteration is insertion order, so deleting `keys().next().value` repeatedly
  * evicts oldest-first). Mirrors `trimSet` for the Map case.
+ *
+ * Pair with `setRecent` on the write side so "oldest" reflects "least
+ * recently touched" rather than "earliest first inserted" — `Map.set` on
+ * an existing key does NOT refresh insertion order, so a plain `set` would
+ * let `trimMap` evict actively-touched entries.
  */
 export function trimMap<K, V>(map: Map<K, V>, maxSize: number): void {
   while (map.size > maxSize) {
@@ -105,4 +110,15 @@ export function trimMap<K, V>(map: Map<K, V>, maxSize: number): void {
     if (oldest === undefined) break;
     map.delete(oldest);
   }
+}
+
+/**
+ * Set `key` → `value` with LRU-style ordering: an existing entry is
+ * deleted first so `set` re-inserts at the tail, keeping `trimMap`'s
+ * eviction aligned with "least recently touched". Use this whenever a
+ * Map is paired with `trimMap` and entries can be updated.
+ */
+export function setRecent<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.delete(key);
+  map.set(key, value);
 }

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -30,6 +30,38 @@ export function formatPreviousStateHint(prevState: string | undefined): string {
   return prevState ? ` (was "${prevState}")` : '';
 }
 
+/** Canonical PR reference path, e.g. `owner/repo/pulls/42`. */
+export function prRef(slug: string, prNumber: number): string {
+  return `${slug}/pulls/${prNumber}`;
+}
+
+/** Canonical issue reference path, e.g. `owner/repo/issues/42`. */
+export function issueRef(slug: string, issueNumber: number): string {
+  return `${slug}/issues/${issueNumber}`;
+}
+
+/**
+ * `@login` for an author, falling back to `@someone` for anonymous /
+ * deleted-account events. Centralized so the fallback string stays
+ * consistent across every formatter.
+ */
+export function authorOf(user: { login: string } | null | undefined): string {
+  return `@${user?.login ?? 'someone'}`;
+}
+
+/**
+ * Compose paragraph-separated sections, dropping empty / falsy entries so
+ * a missing comment body or URL doesn't produce a stray blank paragraph.
+ * Each non-empty entry becomes a paragraph separated by a blank line.
+ */
+export function sections(
+  ...parts: ReadonlyArray<string | null | undefined | false>
+): string {
+  return parts
+    .filter((s): s is string => typeof s === 'string' && s.length > 0)
+    .join('\n\n');
+}
+
 export function truncate(s: string | null | undefined, max: number): string {
   const body = (s ?? '').trim();
   if (body.length <= max) return body;

--- a/src/tools/github/formatUtils.ts
+++ b/src/tools/github/formatUtils.ts
@@ -21,6 +21,15 @@ export function wrapWebhookEvent(inner: string): string {
   return wrapAndSanitizeTag(WEBHOOK_TAG, inner);
 }
 
+/**
+ * Renders an optional " (was \"X\")" hint for transition messages, or empty
+ * string when no prior state is known. Used by both PR and repo merge-
+ * conflict formatters.
+ */
+export function formatPreviousStateHint(prevState: string | undefined): string {
+  return prevState ? ` (was "${prevState}")` : '';
+}
+
 export function truncate(s: string | null | undefined, max: number): string {
   const body = (s ?? '').trim();
   if (body.length <= max) return body;
@@ -51,4 +60,17 @@ export function trimSet<T>(set: Set<T>, maxSize: number): void {
   if (excess <= 0) return;
   const iter = set.values();
   for (let i = 0; i < excess; i += 1) set.delete(iter.next().value as T);
+}
+
+/**
+ * FIFO-trim a Map to `maxSize` entries by deleting the oldest keys (Map
+ * iteration is insertion order, so deleting `keys().next().value` repeatedly
+ * evicts oldest-first). Mirrors `trimSet` for the Map case.
+ */
+export function trimMap<K, V>(map: Map<K, V>, maxSize: number): void {
+  while (map.size > maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
 }

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -158,7 +158,7 @@ async function execSubscribe(
         ? `Subscribed to repo ${slug}`
         : `Already subscribed to repo ${slug}`,
       output: created
-        ? `Subscribed to repo ${slug}. PR opens/closes/merges, conversation comments on PRs and issues, and inline review comments arrive as <github-webhook-activity> follow-ups. Each event uses GitHub's URL form (${slug}/pulls/N or ${slug}/issues/N) — pass that path back to command="subscribe" to delegate a worker.`
+        ? `Subscribed to repo ${slug}. PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, and newly-detected merge conflicts on open PRs arrive as <github-webhook-activity> follow-ups. Each event uses GitHub's URL form (${slug}/pulls/N or ${slug}/issues/N) — pass that path back to command="subscribe" to delegate a worker.`
         : `Already subscribed to repo ${slug}. Activity continues until command="unsubscribe".`,
     };
   }
@@ -170,7 +170,7 @@ async function execSubscribe(
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, and failed CI checks arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
+        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
         : `Already subscribed to ${slug}. Activity continues until command="unsubscribe" or the PR closes.`,
     };
   }
@@ -207,7 +207,7 @@ async function execSubscribe(
           : `Subscribed to ${prSlug}`
         : `Already subscribed to ${prSlug}`,
       output: created
-        ? `${prSlug} is a PR. New comments, reviews, line comments, and failed CI checks arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
+        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${prSlug}.`,
     };
   }
@@ -384,7 +384,7 @@ export class GitHubSubscriptionTool extends defineTool({
     'Manage GitHub activity subscriptions for the current agent stream.',
     'Path mirrors GitHub\'s REST URL shape and encodes the hierarchy: "owner/repo" addresses the whole repo (coarse, orchestrator-friendly); "owner/repo/pulls/N" addresses a specific pull request and "owner/repo/issues/N" addresses a specific issue (nuanced, worker-friendly).',
     'Commands:',
-    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments. For PRs: comments, reviews, line comments, failed CI checks (auto-unsubscribes on close/merge). For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
+    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
     '- unsubscribe: stop watching the path.',
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -65,6 +65,18 @@ export interface GhPullRequest {
 }
 
 /**
+ * GitHub computes `mergeable_state` asynchronously after every push or base
+ * change; until it stabilizes the field reads `'unknown'`. Both polling
+ * sources filter out that transient value so a clean→unknown→dirty (or
+ * dirty→unknown→clean) sequence registers as a single transition rather
+ * than two — recording `'unknown'` as the prior state would mask the
+ * resolved-side transition.
+ */
+export function isDefiniteMergeableState(s: string | undefined): s is string {
+  return s !== undefined && s !== 'unknown';
+}
+
+/**
  * Subset of `GET /repos/{o}/{r}/issues/{n}` we consume. The `pull_request`
  * field is GitHub's discriminator: present (with a `url`) iff this issue
  * record is actually a PR. The disambiguator on subscribe uses it.


### PR DESCRIPTION
PR-level: detect dirty/non-dirty transitions of mergeable_state on the
subscribed PR and emit "merge conflict detected" / "resolved" events.
'unknown' is filtered out so transient mid-computation states don't
corrupt transition detection.

Repo-level: holistic probe of /pulls/{N} for up to 5 open PRs whose
updated_at advanced since the last tick, with FIFO bookkeeping bounded
by MAX_PR_STATE_ENTRIES. Newly-dirty PRs surface as one event each,
or a coalesced summary when several flip together (typical after a
base-branch update).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new polling-based detection of `mergeable_state` transitions (including extra per-PR API probes at the repo level), which could affect rate limits and event noise if the heuristics misfire.
> 
> **Overview**
> PR and repo GitHub subscriptions now emit **merge conflict notifications** based on `mergeable_state` changes: per-PR subscriptions report *detected* (`dirty`) and *resolved* transitions, while repo subscriptions run a bounded per-tick probe of recently-updated open PRs and emit either per-PR conflict events or a coalesced summary.
> 
> Event formatting was refactored to use shared helpers in `formatUtils` (e.g. `sections`, `authorOf`, `prRef`/`issueRef`, `trimMap`/`setRecent`) for more consistent message structure and to support the new conflict messages, and tool descriptions were updated to document the added events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f546f971b08ad5e1438f4499a865ed36a7fcda62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->