### PR TITLE
fix: stop workflow output from premature workspace file badging and path pollution

### DIFF
--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
+import { bus } from '@eventBus/ProgressEventBus';
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
@@ -192,6 +193,12 @@ async function handleAcceptEdited(
 
     const editedContent = await flexibleFS.read(editedLocation);
     await flexibleFS.write(targetLocation, editedContent);
+
+    if (targetLocation.kind === 'workspace') {
+      bus.emit('workspaceFilesWritten', {
+        absolutePaths: [targetLocation.absolutePath],
+      });
+    }
 
     const operation = isNewFile && !targetExists ? 'created' : 'replaced';
     const successMessage = `Successfully ${operation} '${targetFileName}' with content from '${editedFileName}'`;

--- a/src/eventBus/ProgressEventBus.ts
+++ b/src/eventBus/ProgressEventBus.ts
@@ -179,6 +179,12 @@ export interface ProgressEventPayloads {
    */
   toolAvailabilityChanged: undefined;
 
+  /**
+   * One or more files were written directly to the workspace (e.g. via
+   * accept_run_files). Listened by fileDecorations to badge the files.
+   */
+  workspaceFilesWritten: { absolutePaths: string[] };
+
   // ── Frontend-bound events ──
   // Emitted by agent core/runtime; consumed by frontend listeners.
   // Keeps @agent/ free of @frontend/ imports.

--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -62,17 +62,20 @@ export function registerFileDecorations(
 ): void {
   const provider = new TeXRAFileDecorationProvider();
 
-  const unsubscribeOutputFiles = bus.on('addOutputFiles', ({ filesByRound }) => {
-    const paths = new Set<string>();
-    for (const roundFiles of Object.values(filesByRound)) {
-      for (const info of roundFiles) {
-        collectWorkspacePaths(paths, info);
+  const unsubscribeOutputFiles = bus.on(
+    'addOutputFiles',
+    ({ filesByRound }) => {
+      const paths = new Set<string>();
+      for (const roundFiles of Object.values(filesByRound)) {
+        for (const info of roundFiles) {
+          collectWorkspacePaths(paths, info);
+        }
       }
-    }
-    if (paths.size > 0) {
-      provider.markTouched(paths);
-    }
-  });
+      if (paths.size > 0) {
+        provider.markTouched(paths);
+      }
+    },
+  );
 
   const unsubscribeWritten = bus.on(
     'workspaceFilesWritten',

--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -62,7 +62,7 @@ export function registerFileDecorations(
 ): void {
   const provider = new TeXRAFileDecorationProvider();
 
-  const unsubscribe = bus.on('addOutputFiles', ({ filesByRound }) => {
+  const unsubscribeOutputFiles = bus.on('addOutputFiles', ({ filesByRound }) => {
     const paths = new Set<string>();
     for (const roundFiles of Object.values(filesByRound)) {
       for (const info of roundFiles) {
@@ -74,9 +74,17 @@ export function registerFileDecorations(
     }
   });
 
+  const unsubscribeWritten = bus.on(
+    'workspaceFilesWritten',
+    ({ absolutePaths }) => {
+      provider.markTouched(absolutePaths);
+    },
+  );
+
   context.subscriptions.push(
     vscode.window.registerFileDecorationProvider(provider),
     provider,
-    { dispose: unsubscribe },
+    { dispose: unsubscribeOutputFiles },
+    { dispose: unsubscribeWritten },
   );
 }

--- a/src/frontend/ui/fileDecorations.ts
+++ b/src/frontend/ui/fileDecorations.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
 
 import { bus } from '@eventBus/ProgressEventBus';
-import {
-  collectOutputFileLocations,
-  type OutputFileInfo,
-} from '@shared/schemas/output';
+import type { OutputFileInfo } from '@shared/schemas/output';
 
 // Session-scoped: the touched set is not persisted across window reloads so
 // the badges clear on restart and track only the current session's activity.
@@ -48,17 +45,15 @@ class TeXRAFileDecorationProvider implements vscode.FileDecorationProvider {
   }
 }
 
-// Decorate workspace files reachable from this output info — including the
-// original workspace file referenced via `lineage.original` for edit
-// workflows whose agent output sits under runStorage.
+// Only mark the primary output location. Lineage entries (original, diffBase,
+// diffFile) are reference points — marking them would badge the source file as
+// "Modified by TeXRA" before the user has actually accepted the workflow output.
 function collectWorkspacePaths(
   target: Set<string>,
   info: OutputFileInfo,
 ): void {
-  for (const loc of collectOutputFileLocations(info)) {
-    if (loc.kind === 'workspace') {
-      target.add(loc.absolutePath);
-    }
+  if (info.location.kind === 'workspace') {
+    target.add(info.location.absolutePath);
   }
 }
 

--- a/src/progressView/managers/OutputFilesManager.ts
+++ b/src/progressView/managers/OutputFilesManager.ts
@@ -4,7 +4,6 @@ import { mapToRecord } from '@progressView/persistence/serializationUtils';
 import { getStreamTabStore } from '@progressView/persistence/StreamTabStore';
 import {
   CompileFailureSchema,
-  collectOutputFileLocations,
   OutputFileInfoListSchema,
   type CompileFailure,
   type OutputFileInfo,
@@ -154,10 +153,9 @@ export class OutputFilesManager {
     info: OutputFileInfo,
     workspaceOnly: boolean,
   ): void {
-    for (const loc of collectOutputFileLocations(info)) {
-      if (!workspaceOnly || loc.kind === 'workspace') {
-        target.add(loc.absolutePath);
-      }
+    const loc = info.location;
+    if (!workspaceOnly || loc.kind === 'workspace') {
+      target.add(loc.absolutePath);
     }
   }
 

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -93,32 +93,3 @@ export const RoundOutputSchema = z.strictObject({
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
 
-/**
- * Return every `FileLocation` reachable from an `OutputFileInfo`: the primary
- * `location` plus any lineage entries (`original`, `diffBase`, `diffFile`).
- * Missing lineage entries (`null`/`undefined`) are skipped; defensively, any
- * entry with a falsy `absolutePath` is also dropped, though valid
- * `FileLocation`s always have one.
- *
- * Callers that only care about workspace files should filter the result by
- * `loc.kind === 'workspace'` themselves — the workspace-scope check is
- * platform-coupled and intentionally lives outside this VS Code-free module.
- */
-export function collectOutputFileLocations(
-  info: OutputFileInfo,
-): FileLocation[] {
-  const { lineage } = info;
-  const candidates: (FileLocation | null | undefined)[] = [
-    info.location,
-    lineage?.original,
-    lineage?.diffBase,
-    lineage?.diffFile,
-  ];
-  const result: FileLocation[] = [];
-  for (const loc of candidates) {
-    if (loc != null && loc.absolutePath) {
-      result.push(loc);
-    }
-  }
-  return result;
-}

--- a/src/shared/schemas/output.ts
+++ b/src/shared/schemas/output.ts
@@ -92,4 +92,3 @@ export const RoundOutputSchema = z.strictObject({
   xmlSummary: OutputXmlSummarySchema,
 });
 export type RoundOutput = z.infer<typeof RoundOutputSchema>;
-

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -22,6 +22,7 @@ import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 // Local imports - tools
+import { bus } from '@eventBus/ProgressEventBus';
 import type { ExecutionId, FileLocation } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatResultCount, pluralize } from '@tools/formatting';
@@ -182,6 +183,7 @@ Optional:
         return {
           path: mapping.path,
           original: dest.relativePath,
+          destAbsolutePath: dest.absolutePath,
           proposedContent,
           originalContent,
           destExists,
@@ -193,7 +195,11 @@ Optional:
     // Phase 2: Request approval and write each file
     const results: string[] = [];
     const edits: ToolResult['edits'] = [];
-    const acceptedEntries: { outputPath: string; originalPath: string }[] = [];
+    const acceptedEntries: {
+      outputPath: string;
+      originalPath: string;
+      destAbsolutePath: string;
+    }[] = [];
     let rejected = 0;
     const rejectionMessages: string[] = [];
 
@@ -239,6 +245,14 @@ Optional:
       acceptedEntries.push({
         outputPath: entry.path,
         originalPath: entry.original,
+        destAbsolutePath: entry.destAbsolutePath,
+      });
+    }
+
+    // Badge all accepted workspace files
+    if (acceptedEntries.length > 0) {
+      bus.emit('workspaceFilesWritten', {
+        absolutePaths: acceptedEntries.map((e) => e.destAbsolutePath),
       });
     }
 


### PR DESCRIPTION
## Summary

- `collectOutputFileLocations` walked all lineage entries (`original`, `diffBase`, `diffFile`) in addition to the primary output location. Two call sites used it where only the primary `info.location` was correct, causing workspace source files to be treated as TeXRA-generated outputs before the user ever clicked Accept.
- `fileDecorations.ts` — the original workspace source file received the "Modified by TeXRA" badge immediately on agent completion, making it appear as if the workflow output had been auto-accepted.
- `OutputFilesManager.collectPaths` — pack/clean gathered source files into the "generated outputs" set, so they could be operated on before acceptance.
- `collectOutputFileLocations` is deleted entirely (zero callers remain); both sites now read `info.location` directly.

## Test plan

- [ ] Run a workflow agent to completion; verify the "Modified by TeXRA" (`T`) badge does **not** appear on the original source file until after clicking Accept
- [ ] Click Accept; verify the badge then appears on the (now-modified) workspace file
- [ ] Trigger pack/clean on a completed workflow stream; verify the source file is not included in the operated-on file set before acceptance

https://claude.ai/code/session_01HNGUJEHDNXxRHGYy62ZQFM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNGUJEHDNXxRHGYy62ZQFM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how workspace output paths are collected and when VS Code file decorations are applied, which can affect pack/clean behavior and user-visible file state. Risk is limited to workflow output tracking and UI badging, with no auth or data-format changes.
> 
> **Overview**
> Prevents workflow source files from being treated as generated outputs before the user accepts changes by **stopping lineage paths (`original`, `diffBase`, `diffFile`) from being included** in output path collection.
> 
> Deletes `collectOutputFileLocations` and updates file decoration and output-file path tracking to use only `OutputFileInfo.location`. Adds a new bus event, `workspaceFilesWritten`, emitted by `accept_run_files` and `texra.acceptEdited`, and listened to by `fileDecorations` to badge files *only after* they are actually written to the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e75fe8586202655b36644311f5aa17601fe23c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->