### PR TITLE
docs: refresh README to reflect current TeXRA capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 with a single model, you direct an **Orchestrator** that delegates to a team of
 specialists—researchers, numericists, reviewers, formalizers, LaTeX
 fixers, presenters—each with their own tools, prompts, and model. The result
-is a coordinated lab in your editor that drafts, reviews, computes, formalizes,
-and ships rigorous scientific work alongside its LaTeX, code, figures, and PRs.
+is a coordinated lab in your editor that drafts, reviews, computes, and
+formalizes rigorous scientific work alongside its LaTeX, code, figures, and
+PRs.
 
 See [texra.ai](https://texra.ai) or the
 [full documentation](https://texra.ai/guide/) for tutorials, agent recipes, and
@@ -33,10 +34,10 @@ a web-based launch page.
   during delegation are queued, sub-agent runs can be inspected, waited on,
   resumed, or terminated, and the orchestrator builds long-term memory across
   sessions.
-- **Curated team presets** – ship as a **Physicist**, **Mathematician**,
-  **Computer Scientist (ML)**, or **Lean Project** team in one click—each a
-  preconfigured roster of workflow and tool-use agents tuned for that
-  discipline. Save your own teams from the Multi-Agent settings tab.
+- **Curated team presets** – switch to **Physicist**, **Mathematician**,
+  **Computer Scientist (ML)**, or **Lean Project** in one click from the
+  Multi-Agent settings tab. Each preset is a preconfigured roster of workflow
+  and tool-use agents tuned for that discipline; you can also save your own.
 - **A full cast of specialists** – locally bundled tool-use agents include
   `research`, `numerics`, `review`, `presenter`, `latexFixer`, `latexDiff`,
   `creator`, `lean`, `chat`, and the **Setup Wizard** (`setup`); workflow
@@ -47,12 +48,16 @@ a web-based launch page.
   `leanBlueprint` / `leanSearch` / `leanSimplifier` line.
 - **Tools that touch your project** – tool-use agents read and edit
   workspace files, run shell commands, drive LaTeX builds, work with Git and
-  GitHub PR subscriptions, and hand off to the Codex CLI for additional
-  reasoning surfaces—each call gated by an approval system you control.
-- **Live, replayable runs** – the **progress board** shows every active and
-  past run with streaming reasoning, sub-agent file diffs, cost and tool
-  metrics, and one-click replay. Pack a run into `History/` for a clean
-  audit trail.
+  GitHub PR subscriptions, and can delegate reasoning turns to the Codex
+  CLI—each tool call gated by per-stream approval (with an optional YOLO
+  bypass).
+- **Live, persistent runs** – the **progress board** streams reasoning, tool
+  calls, sub-agent file diffs, and per-run token usage and cost for active
+  and recently completed runs in your workspace. Saved task state can be
+  reopened later via **Show Agent Execution History**, tool-use agents can
+  be resumed via **Resume Tool-Use Agent**, and **Pack Output into History
+  Folder** archives a finished run's outputs into the workspace's `History/`
+  directory.
 - **Model flexibility with guardrails** – mix and match per agent: OpenAI
   (incl. GPT-5.5 and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google
   Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen (DashScope),

--- a/README.md
+++ b/README.md
@@ -78,12 +78,21 @@ configured for the providers those agents use.
 
 1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
    or [Open VSX](https://open-vsx.org/extension/texra-ai/texra).
-2. Run **`TeXRA: Run Setup Assistant Agent (Setup Wizard)`** from the command
-   palette, or click **Get Started** in the status bar. The Setup Wizard
-   diagnoses your environment, installs missing LaTeX tooling, helps you sign
-   in or add an API key, and verifies you're ready to run agents—asking
-   before every command and explaining what it's doing. It can hand off
-   interactive `sudo` prompts and installers to your VS Code terminal.
+2. Launch the **Setup Wizard**. Pick whichever is easiest:
+   - Click the **🚀 TeXRA: Get Started** pill in the status bar (shown
+     automatically until you sign in or add an API key).
+   - Click **Run the setup assistant agent** in the Getting Started banner
+     at the top of the TeXRA sidebar.
+   - Open VS Code's **Welcome / Walkthroughs** page and pick **TeXRA:
+     Getting Started** — Step 1 is a one-click button.
+   - Or, from the command palette, run
+     **`TeXRA: Run Setup Assistant Agent (Setup Wizard)`**.
+
+   The Setup Wizard diagnoses your environment, installs missing LaTeX
+   tooling, helps you sign in or add an API key, and verifies you're ready
+   to run agents—asking before every command and explaining what it's
+   doing. It can hand off interactive `sudo` prompts and installers to your
+   VS Code terminal.
 3. Pick an agent **team** in Settings → Multi-Agent (Physicist,
    Mathematician, CS/ML, or Lean Project), or stay with the default lineup.
 4. Open the TeXRA sidebar, select the **Orchestrator** (or any agent),
@@ -92,8 +101,9 @@ configured for the providers those agents use.
    and follow up at any time—messages are queued for whichever sub-agent
    needs them.
 
-New here? **`TeXRA: Create Sample Project`** spins up a fully configured
-workspace to experiment in.
+New here? Use the **Create Sample Project** button in the Getting Started
+banner (also available as `TeXRA: Create Sample Project` from the command
+palette) to spin up a fully configured workspace.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ a web-based launch page.
 
 ## Built-in Agent Teams
 
-| Team | What the team does |
-| --- | --- |
-| **Physicist** | Analytical derivations, numerical experiments, literature search, slide drafting, and critical review. |
-| **Mathematician** | Proofs, Lean 4 formalization, research, and LaTeX correction. |
-| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature search, critical review, and reproducibility. |
-| **Lean Project** | Lean 4 projects—theorem search, tactic simplification, and blueprint-driven formalization. |
+| Team                        | What the team does                                                                                     |
+| --------------------------- | ------------------------------------------------------------------------------------------------------ |
+| **Physicist**               | Analytical derivations, numerical experiments, literature search, slide drafting, and critical review. |
+| **Mathematician**           | Proofs, Lean 4 formalization, research, and LaTeX correction.                                          |
+| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature search, critical review, and reproducibility.  |
+| **Lean Project**            | Lean 4 projects—theorem search, tactic simplification, and blueprint-driven formalization.             |
 
 Switch teams from the Multi-Agent tab in Settings, or build your own roster of
 workflow and tool-use agents.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@
 > and more. Sign in through the Profile view to get started—no API keys
 > required.
 
-TeXRA brings large language models to rigorous scientific workflows. The
-extension embeds research-grade agents directly in VS Code so you can draft,
-review, and manage LaTeX projects—and the surrounding research code, figures,
-and pull requests—without leaving your editor.
+**TeXRA is a multi-agent research assistant for VS Code.** Instead of chatting
+with a single model, you direct an **Orchestrator** that delegates to a team of
+specialist agents—researchers, numericists, reviewers, formalizers, LaTeX
+fixers, presenters—each with their own tools, prompts, and model. The result
+is a coordinated lab in your editor that drafts, reviews, computes, formalizes,
+and ships rigorous scientific work alongside its LaTeX, code, figures, and PRs.
 
 See [texra.ai](https://texra.ai) or the
 [full documentation](https://texra.ai/guide/) for tutorials, agent recipes, and
@@ -24,28 +26,47 @@ a web-based launch page.
 
 ## Why TeXRA
 
-- **Reliable scientific workflow** – orchestrate literature review, drafting,
-  revision, and figure work with reproducible agent runs, structured logs, and
-  built-in verification tools like `latexdiff` and `texcount`.
-- **Specialized research agents** – built-in agents for correcting LaTeX,
-  polishing prose, generating TikZ figures, transcribing audio, OCR, slide and
-  poster authoring, intelligent merging, numerical experiments, and Lean proof
-  work.
-- **Multi-agent orchestration** – team presets (including a Computer Scientist
-  ML preset) coordinate research, numerics, review, and search agents with
-  clearer proposals and handoffs. The orchestrator delegates to the right
-  specialist and keeps follow-ups flowing while sub-agents work.
-- **Tool-use & MCP** – tool-use agents read and edit workspace files, run
-  shell commands, drive LaTeX builds, work with Git and GitHub PRs, and
-  connect to external Model Context Protocol servers.
-- **Transparent reasoning loops** – inspect live reasoning, replay sessions
-  from the progress board, and compare outputs across models to build trust in
-  the generated work.
-- **Model flexibility with guardrails** – connect to OpenAI (incl. GPT-5.5
-  and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google Gemini, DeepSeek,
-  xAI Grok, Moonshot Kimi, Alibaba Qwen, Zhipu GLM, MiniMax, OpenRouter, and
-  custom endpoints—while keeping API routing, context management, and cost
-  monitoring under your control.
+- **Orchestrator-first** – a built-in **Orchestrator** agent decomposes your
+  task, delegates to the right specialists in parallel, captures their outputs
+  as diffs, and presents proposals you approve before they touch your files.
+  Follow-ups during delegation are queued, sub-agents can be paused, resumed,
+  inspected, or terminated, and the orchestrator builds long-term memory
+  across sessions.
+- **Curated team presets** – ship as a **Physicist**, **Mathematician**,
+  **Computer Scientist (ML)**, or **Lean Project** team in one click—each a
+  preconfigured roster of workflow and tool-use agents tuned for that
+  discipline. Save your own teams from the Multi-Agent settings tab.
+- **A full cast of specialists** – `research`, `numerics`, `review`,
+  `search`, `presenter`, `simplifier`, `latexFixer`, `creator`, `lean` /
+  `leanSearch` / `leanSimplifier` / `leanBlueprint`, plus workflow agents for
+  `correct`, `polish`, `criticize`, `devise`, `apply`, `merge`, OCR, audio
+  transcription, paper-to-slide, and paper-to-poster.
+- **Tools & MCP** – every agent runs in a sandboxed tool-use loop with
+  workspace file edits, shell commands, LaTeX builds, `latexdiff` / `texcount`
+  / TikZ tooling, Git and GitHub PR workflows, Codex CLI handoff, web
+  research, and external Model Context Protocol servers.
+- **Live, replayable runs** – the **progress board** shows every active and
+  past run with streaming reasoning, sub-agent file diffs, cost and tool
+  metrics, and one-click replay. Pack a run into `History/` for a clean
+  audit trail.
+- **Model flexibility with guardrails** – mix and match per agent: OpenAI
+  (incl. GPT-5.5 and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google
+  Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen, Zhipu GLM,
+  MiniMax, OpenRouter, and custom endpoints—with context management,
+  retry/backoff, parallel-tool-call limits, and cost monitoring all
+  configurable.
+
+## Built-in Agent Teams
+
+| Team | What the team does |
+| --- | --- |
+| **Physicist** | Analytical derivations, numerical experiments, literature search, slide drafting, and critical review. |
+| **Mathematician** | Proofs, Lean 4 formalization, research, and LaTeX correction. |
+| **Computer Scientist (ML)** | Algorithm design, experiments and ablations, literature search, critical review, and reproducibility. |
+| **Lean Project** | Lean 4 projects—theorem search, tactic simplification, and blueprint-driven formalization. |
+
+Switch teams from the Multi-Agent tab in Settings, or build your own roster of
+workflow and tool-use agents.
 
 ## Quick Start
 
@@ -54,11 +75,15 @@ a web-based launch page.
 2. Run **`TeXRA: Run Setup Assistant Agent`** from the command palette, or
    click **Get Started** in the status bar, to walk through environment
    checks, missing tools, and model access.
-3. Run **`TeXRA: Create Sample Project`** to explore a fully configured
-   workspace, or open one of the built-in walkthroughs.
-4. Open the TeXRA sidebar, pick an agent, select your files, and click
-   **Execute**. Use chat for follow-ups with tool-use agents, and the
-   progress board to monitor and replay runs.
+3. Pick an agent **team** in Settings → Multi-Agent (Physicist, Mathematician,
+   CS/ML, or Lean Project), or stay with the default lineup.
+4. Open the TeXRA sidebar, select the **Orchestrator**, describe your task,
+   and approve the proposals it routes to specialists. Watch progress, file
+   diffs, and live reasoning on the **progress board**, and follow up at any
+   time—messages are queued for whichever sub-agent needs them.
+
+New here? **`TeXRA: Create Sample Project`** spins up a fully configured
+workspace to experiment in.
 
 ## Requirements
 
@@ -68,7 +93,7 @@ a web-based launch page.
 - **Perl** (required by `latexindent` and `latexdiff`)
 - **Optional**: GraphicsMagick/ImageMagick and Ghostscript for PDF and image
   processing; `git` for repository-aware features; `gh` and a Codex CLI for
-  GitHub PR and Codex integrations
+  GitHub PR and Codex integrations; Lean 4 + `lake` for the Lean Project team
 
 ## Configuring Models
 
@@ -84,17 +109,20 @@ XAI_API_KEY=your_xai_key_here
 OPENROUTER_API_KEY=your_openrouter_key_here
 ```
 
-TeXRA loads the `.env` file automatically at startup. For detailed setup
-instructions, see the [installation guide](https://texra.ai/guide/installation.html)
-and the [models guide](https://texra.ai/guide/models.html).
+TeXRA loads the `.env` file automatically at startup. Each agent in a team can
+use a different model, so you can pair a flagship reasoner for the orchestrator
+with cheaper, faster models for routine sub-tasks. See the
+[installation guide](https://texra.ai/guide/installation.html) and the
+[models guide](https://texra.ai/guide/models.html) for details.
 
 ## Customization
 
-Configure available agents, prompts, and model parameters in VS Code settings
+Configure agents, prompts, models, and reliability policy in VS Code settings
 or the unified Settings view (History, Memory, Models, Agents, Multi-Agent,
-LaTeX, Tools tabs). You can tailor directories, file types, output locations,
-and more to suit your workflow. Advanced users can define custom agents in
-YAML or extend the extension with new model handlers.
+LaTeX, Tools tabs). The Multi-Agent tab covers team presets, parallel
+tool-call limits, compaction thresholds, retry/backoff, and the orchestrator
+kill toggle. Power users can define new workflow or tool-use agents in YAML,
+register new model handlers, or wire up additional MCP servers.
 
 ## Support & Feedback
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ The Setup Wizard checks for and helps install most of the above for you.
 ## Configuring Models
 
 Sign in through the Profile view to use the Researcher Access Program (which
-also unlocks the hosted Orchestrator and remote specialists), or set your own
-API keys in VS Code settings or a workspace `.env` file:
+also unlocks the hosted Orchestrator and remote specialists), or store your
+own API keys via the **`TeXRA: Set API Key`** command (kept in VS Code's
+encrypted SecretStorage), or place them in a workspace `.env` file:
 
 ```env
 OPENAI_API_KEY=your_openai_key_here
@@ -150,8 +151,8 @@ the [installation guide](https://texra.ai/guide/installation.html) and the
 ## Customization
 
 Configure agents, prompts, models, and reliability policy in VS Code settings
-or the unified Settings view (History, Memory, Models, Agents, Multi-Agent,
-LaTeX, Tools tabs). The Multi-Agent tab covers team presets, parallel
+or the unified Settings view (Memory, History, Models, Agents, Multi-Agent,
+Tools, Git, LaTeX tabs). The Multi-Agent tab covers team presets, parallel
 tool-call limits, compaction thresholds, retry/backoff, and the orchestrator
 kill toggle. Power users can define new workflow or tool-use agents in YAML
 or register new model handlers.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ configured for the providers those agents use.
    to run agents—asking before every command and explaining what it's
    doing. It can hand off interactive `sudo` prompts and installers to your
    VS Code terminal.
+
 3. Pick an agent **team** in Settings → Multi-Agent (Physicist,
    Mathematician, CS/ML, or Lean Project), or stay with the default lineup.
 4. Open the TeXRA sidebar, select the **Orchestrator** (or any agent),

--- a/README.md
+++ b/README.md
@@ -8,65 +8,93 @@
 [![Open VSX Downloads](https://img.shields.io/open-vsx/dt/texra-ai/texra)](https://open-vsx.org/extension/texra-ai/texra)
 [![License](https://img.shields.io/badge/license-Proprietary-blue)](LICENSE)
 
-> **🎓 Free for Researchers!** TeXRA now offers a **Researcher Access Program** with
-> complimentary access to budget-friendly models from OpenAI, DeepSeek, Gemini, and more.
-> Sign in through the Profile view to get started—no API keys required.
+> **🎓 Free for Researchers!** TeXRA offers a **Researcher Access Program** with
+> complimentary access to budget-friendly models from OpenAI, DeepSeek, Gemini,
+> and more. Sign in through the Profile view to get started—no API keys
+> required.
 
 TeXRA brings large language models to rigorous scientific workflows. The
 extension embeds research-grade agents directly in VS Code so you can draft,
-review, and manage LaTeX projects without leaving your editor.
+review, and manage LaTeX projects—and the surrounding research code, figures,
+and pull requests—without leaving your editor.
 
 See [texra.ai](https://texra.ai) or the
-[full documentation](https://texra.ai/guide/) for tutorials and a web-based
-launch page.
+[full documentation](https://texra.ai/guide/) for tutorials, agent recipes, and
+a web-based launch page.
 
 ## Why TeXRA
 
 - **Reliable scientific workflow** – orchestrate literature review, drafting,
-  and revision with reproducible agent runs, structured logs, and built-in
-  verification tools like `latexdiff` and `texcount`.
-- **Specialized research agents** – deploy focused agents for correcting
-  LaTeX, polishing prose, generating figures, and document transformation—without
-  losing control over references and context.
-- **Transparent reasoning loops** – inspect live reasoning, replay sessions,
-  and compare outputs across models to build trust in the generated work.
-- **Model flexibility with guardrails** – connect to OpenAI, Anthropic,
-  DeepSeek, Gemini, Moonshot, Qwen, and custom endpoints while keeping
-  API routing and cost monitoring under your control.
+  revision, and figure work with reproducible agent runs, structured logs, and
+  built-in verification tools like `latexdiff` and `texcount`.
+- **Specialized research agents** – built-in agents for correcting LaTeX,
+  polishing prose, generating TikZ figures, transcribing audio, OCR, slide and
+  poster authoring, intelligent merging, numerical experiments, and Lean proof
+  work.
+- **Multi-agent orchestration** – team presets (including a Computer Scientist
+  ML preset) coordinate research, numerics, review, and search agents with
+  clearer proposals and handoffs. The orchestrator delegates to the right
+  specialist and keeps follow-ups flowing while sub-agents work.
+- **Tool-use & MCP** – tool-use agents read and edit workspace files, run
+  shell commands, drive LaTeX builds, work with Git and GitHub PRs, and
+  connect to external Model Context Protocol servers.
+- **Transparent reasoning loops** – inspect live reasoning, replay sessions
+  from the progress board, and compare outputs across models to build trust in
+  the generated work.
+- **Model flexibility with guardrails** – connect to OpenAI (incl. GPT-5.5
+  and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google Gemini, DeepSeek,
+  xAI Grok, Moonshot Kimi, Alibaba Qwen, Zhipu GLM, MiniMax, OpenRouter, and
+  custom endpoints—while keeping API routing, context management, and cost
+  monitoring under your control.
 
 ## Quick Start
 
-1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra).
-2. Run **`TeXRA: Create Sample Project`** from the command palette to explore a
-   fully configured workspace.
-3. Open the TeXRA sidebar, pick an agent, select your files, and click
-   **Execute**. Follow-up chat is available for tool-use agents.
+1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
+   or [Open VSX](https://open-vsx.org/extension/texra-ai/texra).
+2. Run **`TeXRA: Run Setup Assistant Agent`** from the command palette, or
+   click **Get Started** in the status bar, to walk through environment
+   checks, missing tools, and model access.
+3. Run **`TeXRA: Create Sample Project`** to explore a fully configured
+   workspace, or open one of the built-in walkthroughs.
+4. Open the TeXRA sidebar, pick an agent, select your files, and click
+   **Execute**. Use chat for follow-ups with tool-use agents, and the
+   progress board to monitor and replay runs.
 
 ## Requirements
 
-- **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX)
-- **Perl** (required for LaTeX formatting tools)
-- **Optional**: GraphicsMagick/ImageMagick and Ghostscript for PDF and image processing
+- **VS Code** 1.105+ (or a compatible editor such as VSCodium / Cursor)
+- **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX) for compilation and
+  related tooling
+- **Perl** (required by `latexindent` and `latexdiff`)
+- **Optional**: GraphicsMagick/ImageMagick and Ghostscript for PDF and image
+  processing; `git` for repository-aware features; `gh` and a Codex CLI for
+  GitHub PR and Codex integrations
 
-## Installation
+## Configuring Models
 
-Set your API keys in VS Code settings or create a workspace `.env` file:
+Sign in through the Profile view to use the Researcher Access Program, or set
+your own API keys in VS Code settings or a workspace `.env` file:
 
 ```env
 OPENAI_API_KEY=your_openai_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
 GEMINI_API_KEY=your_gemini_key_here
+DEEPSEEK_API_KEY=your_deepseek_key_here
+XAI_API_KEY=your_xai_key_here
+OPENROUTER_API_KEY=your_openrouter_key_here
 ```
 
 TeXRA loads the `.env` file automatically at startup. For detailed setup
-instructions, see the [installation guide](https://texra.ai/guide/installation.html).
+instructions, see the [installation guide](https://texra.ai/guide/installation.html)
+and the [models guide](https://texra.ai/guide/models.html).
 
 ## Customization
 
-Configure available agents, prompts, and model parameters in VS Code settings.
-You can tailor directories, file types, output locations, and more to suit your
-workflow. Advanced users can define custom agents in YAML or extend the
-extension with new model handlers.
+Configure available agents, prompts, and model parameters in VS Code settings
+or the unified Settings view (History, Memory, Models, Agents, Multi-Agent,
+LaTeX, Tools tabs). You can tailor directories, file types, output locations,
+and more to suit your workflow. Advanced users can define custom agents in
+YAML or extend the extension with new model handlers.
 
 ## Support & Feedback
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@
 
 > **🎓 Free for Researchers!** TeXRA offers a **Researcher Access Program** with
 > complimentary access to budget-friendly models from OpenAI, DeepSeek, Gemini,
-> and more. Sign in through the Profile view to get started—no API keys
+> and more—plus a hosted **Orchestrator** and a roster of remote specialist
+> agents. Sign in through the Profile view to get started—no API keys
 > required.
 
 **TeXRA is a multi-agent research assistant for VS Code.** Instead of chatting
 with a single model, you direct an **Orchestrator** that delegates to a team of
-specialist agents—researchers, numericists, reviewers, formalizers, LaTeX
+specialists—researchers, numericists, reviewers, formalizers, LaTeX
 fixers, presenters—each with their own tools, prompts, and model. The result
 is a coordinated lab in your editor that drafts, reviews, computes, formalizes,
 and ships rigorous scientific work alongside its LaTeX, code, figures, and PRs.
@@ -26,35 +27,38 @@ a web-based launch page.
 
 ## Why TeXRA
 
-- **Orchestrator-first** – a built-in **Orchestrator** agent decomposes your
-  task, delegates to the right specialists in parallel, captures their outputs
-  as diffs, and presents proposals you approve before they touch your files.
-  Follow-ups during delegation are queued, sub-agents can be paused, resumed,
-  inspected, or terminated, and the orchestrator builds long-term memory
-  across sessions.
+- **Orchestrator-first** – the **Orchestrator** decomposes your task,
+  delegates to specialists in parallel, captures their outputs as diffs, and
+  presents proposals you approve before they touch your files. Follow-ups
+  during delegation are queued, sub-agent runs can be inspected, waited on,
+  resumed, or terminated, and the orchestrator builds long-term memory across
+  sessions.
 - **Curated team presets** – ship as a **Physicist**, **Mathematician**,
   **Computer Scientist (ML)**, or **Lean Project** team in one click—each a
   preconfigured roster of workflow and tool-use agents tuned for that
   discipline. Save your own teams from the Multi-Agent settings tab.
-- **A full cast of specialists** – `research`, `numerics`, `review`,
-  `search`, `presenter`, `simplifier`, `latexFixer`, `creator`, `lean` /
-  `leanSearch` / `leanSimplifier` / `leanBlueprint`, plus workflow agents for
-  `correct`, `polish`, `criticize`, `devise`, `apply`, `merge`, OCR, audio
-  transcription, paper-to-slide, and paper-to-poster.
-- **Tools & MCP** – every agent runs in a sandboxed tool-use loop with
-  workspace file edits, shell commands, LaTeX builds, `latexdiff` / `texcount`
-  / TikZ tooling, Git and GitHub PR workflows, Codex CLI handoff, web
-  research, and external Model Context Protocol servers.
+- **A full cast of specialists** – locally bundled tool-use agents include
+  `research`, `numerics`, `review`, `presenter`, `latexFixer`, `latexDiff`,
+  `creator`, `lean`, `chat`, and the **Setup Wizard** (`setup`); workflow
+  agents include `correct`, `polish`, `merge`, `ocr`, `transcribe_audio`,
+  `paper2slide`, and `paper2poster`. Signing in unlocks remote specialists—
+  `orchestrator`, `search`, `simplifier`, `criticize`, `devise`, `apply`,
+  `generic`, `progressCheck`, and the Lean `leanOrchestrator` /
+  `leanBlueprint` / `leanSearch` / `leanSimplifier` line.
+- **Tools that touch your project** – tool-use agents read and edit
+  workspace files, run shell commands, drive LaTeX builds, work with Git and
+  GitHub PR subscriptions, and hand off to the Codex CLI for additional
+  reasoning surfaces—each call gated by an approval system you control.
 - **Live, replayable runs** – the **progress board** shows every active and
   past run with streaming reasoning, sub-agent file diffs, cost and tool
   metrics, and one-click replay. Pack a run into `History/` for a clean
   audit trail.
 - **Model flexibility with guardrails** – mix and match per agent: OpenAI
   (incl. GPT-5.5 and GPT Pro), Anthropic (incl. Claude Opus 4.7), Google
-  Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen, Zhipu GLM,
-  MiniMax, OpenRouter, and custom endpoints—with context management,
-  retry/backoff, parallel-tool-call limits, and cost monitoring all
-  configurable.
+  Gemini, DeepSeek, xAI Grok, Moonshot Kimi, Alibaba Qwen (DashScope),
+  Zhipu GLM, MiniMax, OpenRouter, and custom endpoints—with context
+  management, retry/backoff, parallel-tool-call limits, and cost monitoring
+  all configurable.
 
 ## Built-in Agent Teams
 
@@ -66,28 +70,34 @@ a web-based launch page.
 | **Lean Project**            | Lean 4 projects—theorem search, tactic simplification, and blueprint-driven formalization.             |
 
 Switch teams from the Multi-Agent tab in Settings, or build your own roster of
-workflow and tool-use agents.
+workflow and tool-use agents. Teams that include remote specialists (e.g. the
+Orchestrator, `search`, `simplifier`) require sign-in or your own API keys
+configured for the providers those agents use.
 
 ## Quick Start
 
 1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=texra-ai.texra)
    or [Open VSX](https://open-vsx.org/extension/texra-ai/texra).
-2. Run **`TeXRA: Run Setup Assistant Agent`** from the command palette, or
-   click **Get Started** in the status bar, to walk through environment
-   checks, missing tools, and model access.
-3. Pick an agent **team** in Settings → Multi-Agent (Physicist, Mathematician,
-   CS/ML, or Lean Project), or stay with the default lineup.
-4. Open the TeXRA sidebar, select the **Orchestrator**, describe your task,
-   and approve the proposals it routes to specialists. Watch progress, file
-   diffs, and live reasoning on the **progress board**, and follow up at any
-   time—messages are queued for whichever sub-agent needs them.
+2. Run **`TeXRA: Run Setup Assistant Agent (Setup Wizard)`** from the command
+   palette, or click **Get Started** in the status bar. The Setup Wizard
+   diagnoses your environment, installs missing LaTeX tooling, helps you sign
+   in or add an API key, and verifies you're ready to run agents—asking
+   before every command and explaining what it's doing. It can hand off
+   interactive `sudo` prompts and installers to your VS Code terminal.
+3. Pick an agent **team** in Settings → Multi-Agent (Physicist,
+   Mathematician, CS/ML, or Lean Project), or stay with the default lineup.
+4. Open the TeXRA sidebar, select the **Orchestrator** (or any agent),
+   describe your task, and approve the proposals it routes to specialists.
+   Watch progress, file diffs, and live reasoning on the **progress board**,
+   and follow up at any time—messages are queued for whichever sub-agent
+   needs them.
 
 New here? **`TeXRA: Create Sample Project`** spins up a fully configured
 workspace to experiment in.
 
 ## Requirements
 
-- **VS Code** 1.105+ (or a compatible editor such as VSCodium / Cursor)
+- **VS Code** 1.105+
 - **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX) for compilation and
   related tooling
 - **Perl** (required by `latexindent` and `latexdiff`)
@@ -95,24 +105,29 @@ workspace to experiment in.
   processing; `git` for repository-aware features; `gh` and a Codex CLI for
   GitHub PR and Codex integrations; Lean 4 + `lake` for the Lean Project team
 
+The Setup Wizard checks for and helps install most of the above for you.
+
 ## Configuring Models
 
-Sign in through the Profile view to use the Researcher Access Program, or set
-your own API keys in VS Code settings or a workspace `.env` file:
+Sign in through the Profile view to use the Researcher Access Program (which
+also unlocks the hosted Orchestrator and remote specialists), or set your own
+API keys in VS Code settings or a workspace `.env` file:
 
 ```env
 OPENAI_API_KEY=your_openai_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
-GEMINI_API_KEY=your_gemini_key_here
+GOOGLE_API_KEY=your_google_key_here
 DEEPSEEK_API_KEY=your_deepseek_key_here
 XAI_API_KEY=your_xai_key_here
 OPENROUTER_API_KEY=your_openrouter_key_here
 ```
 
-TeXRA loads the `.env` file automatically at startup. Each agent in a team can
-use a different model, so you can pair a flagship reasoner for the orchestrator
-with cheaper, faster models for routine sub-tasks. See the
-[installation guide](https://texra.ai/guide/installation.html) and the
+Other supported providers follow the same `<PROVIDER>_API_KEY` convention:
+`MOONSHOT_API_KEY`, `DASHSCOPE_API_KEY` (Qwen), `MINIMAX_API_KEY`,
+`GLM_API_KEY`. TeXRA loads the `.env` file automatically at startup. Each
+agent in a team can use a different model, so you can pair a flagship reasoner
+for the orchestrator with cheaper, faster models for routine sub-tasks. See
+the [installation guide](https://texra.ai/guide/installation.html) and the
 [models guide](https://texra.ai/guide/models.html) for details.
 
 ## Customization
@@ -121,8 +136,8 @@ Configure agents, prompts, models, and reliability policy in VS Code settings
 or the unified Settings view (History, Memory, Models, Agents, Multi-Agent,
 LaTeX, Tools tabs). The Multi-Agent tab covers team presets, parallel
 tool-call limits, compaction thresholds, retry/backoff, and the orchestrator
-kill toggle. Power users can define new workflow or tool-use agents in YAML,
-register new model handlers, or wire up additional MCP servers.
+kill toggle. Power users can define new workflow or tool-use agents in YAML
+or register new model handlers.
 
 ## Support & Feedback
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ workspace to experiment in.
 
 ## Requirements
 
-- **VS Code** 1.105+
+- **VS Code** 1.105+ (also runs in compatible editors such as Cursor,
+  Windsurf, and Google Antigravity)
 - **LaTeX distribution** (TeX Live, MiKTeX, or MacTeX) for compilation and
   related tooling
 - **Perl** (required by `latexindent` and `latexdiff`)

--- a/docs/proposals/unified-output-protocol.md
+++ b/docs/proposals/unified-output-protocol.md
@@ -86,7 +86,7 @@ Gate the rollout on **no statistically meaningful regression** on the N=1 path. 
 
 ### Phase 1: Protocol constants and parser
 
-Land the unified container parser as the *only* parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
+Land the unified container parser as the _only_ parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
 
 ### Phase 2: Migrate prompts and YAML
 


### PR DESCRIPTION
Update the user-facing README so it matches the modern feature set:
multi-agent orchestration, tool-use and MCP, GitHub PR work, the
expanded provider lineup (xAI Grok, GLM, MiniMax, OpenRouter, etc.),
the setup assistant, and the unified settings view. Also bump the
listed VS Code engine to match package.json (1.105+).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates (README and a minor markdown emphasis tweak) with no runtime or API behavior changes; risk is limited to potential user confusion if the described features/settings drift from implementation.
> 
> **Overview**
> Updates the `README.md` to reflect TeXRA’s current positioning as an **orchestrator-first, multi-agent** VS Code research assistant, including new sections for **built-in agent teams**, expanded quick-start via the **Setup Wizard**, and a more detailed feature list (tool-use approvals, progress board/history, Git/GitHub PR and Codex integrations).
> 
> Refreshes configuration guidance to emphasize sign-in vs API-key setup, expands the documented provider/API-key environment variables (e.g. `XAI_API_KEY`, `OPENROUTER_API_KEY`, plus additional provider conventions), and updates requirements to **VS Code 1.105+** with additional optional tooling notes. Also makes a small formatting change in `docs/proposals/unified-output-protocol.md` (markdown emphasis).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a046089a614e369c895008dabceedffabfa2458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->