### PR TITLE
docs: add code-review skill and refresh outdated CLAUDE.md sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,8 @@ The project has two build systems with different trade-offs:
   - `utils/system/` - Shell command execution (`execUtils`)
   - `utils/text/` - Text and XML processing utilities
   - `utils/prompt/` - Prompt builder utilities
-- `src/explorer/` - VS Code file explorer integration and watchers
 - `src/settingsView/` - Unified settings webview combining History, Memory, Models, Agents, Multi-Agent, LaTeX, and Tools tabs
+- `src/platform/` - Platform abstraction layer (composition root). Hosts call `initPlatform()` once at startup; agnostic code uses `platform()` from `@platform`.
 
 ### Pragmatic implementations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Guidance for Claude Code when working with this repository. For detailed coding conventions and patterns, see [AGENTS.md](./AGENTS.md).
 
+## Code review
+
+When reviewing TeXRA code (whether invoked via `/review`, asked for a code review, or auditing a PR/branch), **load the project skill at [skills/code-review/SKILL.md](./skills/code-review/SKILL.md) first** and use [skills/code-review/references/review-checklist.md](./skills/code-review/references/review-checklist.md) as the targeted check list. A "no issues found" review on this repo is almost always wrong — the skill encodes the repo-specific rules (platform decoupling, Zod v4, PocketFlow, factory layering, render-time workarounds) that generic review passes miss. Always include a `Verified` section listing what you actually opened.
+
 ## Project Overview
 
 TeXRA is a VS Code extension that serves as an AI-powered LaTeX research assistant. It uses Large Language Models to help academics with writing, research, and document processing.
@@ -79,8 +83,9 @@ The core of TeXRA is its agent architecture in `src/agent/`:
 
 Key directories in `src/`:
 
-- `agent/` - Agent core, implementations, model handlers, runtime, tool-use
-  - `implementations/flows/` - PocketFlow-based flow implementations (reflection, tool-use)
+- `agent/` - Agent core, implementations, model handlers, runtime, toolUse, output, storage, remote, node
+  - `implementations/flows/` - PocketFlow-based flow implementations (reflection, tooluse)
+- `platform/` - Platform abstraction layer (composition root). Hosts (VS Code, future CLI/Electron) call `initPlatform()` once at startup; core code accesses host services via `platform()` from `@platform`. See `src/platform/platform.ts`.
 - `commands/` - Commands organized by domain (see below)
 - `common/` - Backend-only helpers (errors, state, files, webview base classes)
 - `frontend/` - Extension-host utilities for shared UI flows
@@ -98,6 +103,7 @@ Key directories in `src/`:
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules
+- `test/` - Mocha test suites (do NOT run via `npm test`; see Development Commands)
 
 Key documentation in `docs/`:
 
@@ -262,7 +268,8 @@ For good separation of concerns, testability, and platform independence, core bu
 
 **VS Code-allowed zones** — platform-specific wiring belongs here:
 
-- `src/extension.ts` (entry point)
+- `src/extension.ts` (entry point — calls `initPlatform()` exactly once with the VS Code-backed services)
+- `src/platform/` interfaces themselves (interface definitions; concrete VS Code implementations are wired from `extension.ts`)
 - `src/commands/` (VS Code command handlers)
 - `src/frontend/` (VS Code UI utilities)
 - `src/common/webview/` (webview base classes)
@@ -274,6 +281,7 @@ For good separation of concerns, testability, and platform independence, core bu
 
 **Patterns for keeping code platform-agnostic:**
 
+- Reach host services through `platform()` from `@platform` (config, state, log, fs, workspace, storage, secrets) — never import `vscode` in agnostic zones.
 - Use `isFile()` / `isDirectory()` from `@common/files/fsEntryType` instead of `vscode.FileType`
 - Use `isFileNotFoundError()` from `@common/errors` instead of `instanceof vscode.FileSystemError`
 - Return error results instead of calling `vscode.window.show*Message()` from business logic — let the caller (command layer) handle UI
@@ -287,6 +295,7 @@ Common aliases (full list in `tsconfig.json`):
 - `@model/*`, `@latex/*`, `@logger/*`, `@tools/*`, `@webview/*`
 - `@progressView/*`, `@settingsView/*`, `@shared/*`, `@eventBus/*`
 - `@replacement/*`, `@housekeeping/*`, `@auth/*`, `@types/*`
+- `@platform`, `@platform/*` (platform abstraction layer)
 
 ## Adding New Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Guidance for Claude Code when working with this repository. For detailed coding 
 
 ## Code review
 
-When reviewing TeXRA code (whether invoked via `/review`, asked for a code review, or auditing a PR/branch), **load the project skill at [skills/code-review/SKILL.md](./skills/code-review/SKILL.md) first** and use [skills/code-review/references/review-checklist.md](./skills/code-review/references/review-checklist.md) as the targeted check list. A "no issues found" review on this repo is almost always wrong — the skill encodes the repo-specific rules (platform decoupling, Zod v4, PocketFlow, factory layering, render-time workarounds) that generic review passes miss. Always include a `Verified` section listing what you actually opened.
+For `/review` or any code review on this repo, load [skills/code-review/SKILL.md](./skills/code-review/SKILL.md) first — generic passes miss the repo-specific rules below. Always include a `Verified` section listing what you opened.
 
 ## Project Overview
 

--- a/docs/proposals/unified-output-protocol.md
+++ b/docs/proposals/unified-output-protocol.md
@@ -86,7 +86,7 @@ Gate the rollout on **no statistically meaningful regression** on the N=1 path. 
 
 ### Phase 1: Protocol constants and parser
 
-Land the unified container parser as the *only* parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
+Land the unified container parser as the _only_ parser path. Existing single-output agents temporarily emit the old container; the parser reads both. This is a non-breaking shim that lives for one release.
 
 ### Phase 2: Migrate prompts and YAML
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: code-review
+description: TeXRA-specific code review. Use when reviewing a PR, branch, or staged changes in this repository. Replaces a generic "looks good" pass with concrete, repo-aware checks against CLAUDE.md and AGENTS.md (platform decoupling, Zod v4 patterns, PocketFlow rules, factory anti-patterns, render-time workarounds, configuration/storage/log routing). The built-in /review skill should consult this skill first when reviewing TeXRA code.
+---
+
+# TeXRA Code Review
+
+A "no issues found" review on this repo is almost always wrong. This codebase has many narrow, project-specific conventions that generic review passes miss. Use this skill to ground review comments in real repo rules instead of vague style notes.
+
+## When to use this skill
+
+- The user runs `/review`, asks for a code review, or asks "what would you flag?"
+- A PR or branch needs an audit before merge.
+- Reviewing changes that touch `src/agent/`, `src/tools/`, `src/platform/`, `src/model/`, or any webview frontend.
+
+## How to run a review
+
+1. **Read [references/review-checklist.md](references/review-checklist.md) first.** It is the source of truth for repo-specific rules. Treat it as a search list, not a tickbox form — pick the categories that apply to the diff.
+2. **Identify the change surface.** Run `git diff` (or `git diff main...HEAD`) and group changed files by zone: VS Code-free zones (`agent/`, `model/`, `latex/`, `tools/`, `shared/`, `replacement/`, `eventBus/`, webview frontends), VS Code-allowed zones (`extension.ts`, `commands/`, `frontend/`, `common/webview`, `common/state`, `auth/`), and platform layer (`platform/`).
+3. **Run the targeted checks** from the checklist that match the zones touched. Most findings cluster around: platform coupling, Zod schemas, PocketFlow services, configuration/log routing, factory layering, and render-time workarounds.
+4. **Verify, don't speculate.** Before flagging, open the file and confirm the issue exists in the current diff, not in unrelated code. If something looks suspicious but you can't verify it, mark it as a question, not a finding.
+5. **Order findings by severity:** correctness/security first, then platform-decoupling violations, then API-contract issues, then style/maintainability. Cite `path:line` for every finding.
+6. **Skip the noise.** Don't comment on whitespace, missing JSDoc on private helpers, or anything CLAUDE.md says not to comment on. Don't propose new abstractions that the diff doesn't already justify.
+
+## Review output format
+
+Structure findings as:
+
+```
+## Findings
+
+### Critical
+- `path/file.ts:42` — <one-line summary>. <why it matters / what to do>.
+
+### Should fix
+- ...
+
+### Nits / questions
+- ...
+
+## Verified
+- <what you actually opened and checked, e.g. "Read src/tools/foo.ts:1-120; confirmed no `vscode` import">
+```
+
+Always include the **Verified** section. It forces honesty about what was actually inspected vs. skimmed, and it makes "no issues found" mean something — list what you checked.
+
+## Quality bar
+
+- A correct review either lists concrete findings tied to repo rules, or names what was inspected and why it's clean. Never both empty.
+- Prefer 3 well-grounded findings over 10 generic ones.
+- If the diff is large, narrow scope and say so ("Reviewed agent/ and tools/ paths; webview changes not yet reviewed").
+- For UI changes, the build doesn't validate behavior — say so explicitly if you couldn't run the extension.
+
+## Repo facts the review should know
+
+- **Platform abstraction**: core code reaches host services via `platform()` from `@platform` (see `src/platform/platform.ts`). Direct `vscode` imports are forbidden in `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`, `src/replacement/`, `src/eventBus/`, and webview frontends.
+- **Zod v4** with `.nullish()` (not `.optional()`) for tool input schemas; `.prefault()` for deserialization; `.catch()` for fallbacks; `.int()` / `.uuid()` / `.iso.datetime()` natively.
+- **PocketFlow**: services are immutable, set once via `flow.setServices()`; shared store holds only mutable state; transitions use `FlowTransition.*` constants; agents own lifecycle, flows own execution.
+- **Build commands**: `npm run compile:fast` / `package:fast` / `build:fast` skip type checking — `npm run typecheck` (or `compile:safe`) is required to catch type errors. **Never run `npm test`** (downloads VS Code test env; wastes time).
+- **Path aliases** (in `tsconfig.json`): `@agent/*`, `@commands/*`, `@common/*`, `@frontend/*`, `@utils/*`, `@model/*`, `@latex/*`, `@logger/*`, `@tools/*`, `@webview/*`, `@progressView/*`, `@settingsView/*`, `@shared/*`, `@eventBus/*`, `@replacement/*`, `@housekeeping/*`, `@auth/*`, `@types/*`, `@platform`, `@platform/*`.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: code-review
-description: TeXRA-specific code review. Use when reviewing a PR, branch, or staged changes in this repository. Replaces a generic "looks good" pass with concrete, repo-aware checks against CLAUDE.md and AGENTS.md (platform decoupling, Zod v4 patterns, PocketFlow rules, factory anti-patterns, render-time workarounds, configuration/storage/log routing). The built-in /review skill should consult this skill first when reviewing TeXRA code.
+description: TeXRA-aware code review. Use for /review, PR audits, or any code review of this repo. Catches platform-coupling, Zod v4, PocketFlow, factory, and webview-render rules that generic passes miss.
 ---
 
 # TeXRA Code Review
 
-A "no issues found" review on this repo is almost always wrong. This codebase has many narrow, project-specific conventions that generic review passes miss. Use this skill to ground review comments in real repo rules instead of vague style notes.
+A "no issues found" review on this repo is almost always wrong. CLAUDE.md and AGENTS.md encode many narrow conventions; this skill turns them into a targeted check list.
 
 ## When to use this skill
 
@@ -13,48 +13,27 @@ A "no issues found" review on this repo is almost always wrong. This codebase ha
 - A PR or branch needs an audit before merge.
 - Reviewing changes that touch `src/agent/`, `src/tools/`, `src/platform/`, `src/model/`, or any webview frontend.
 
-## How to run a review
+## Workflow
 
-1. **Read [references/review-checklist.md](references/review-checklist.md) first.** It is the source of truth for repo-specific rules. Treat it as a search list, not a tickbox form — pick the categories that apply to the diff.
-2. **Identify the change surface.** Run `git diff` (or `git diff main...HEAD`) and group changed files by zone: VS Code-free zones (`agent/`, `model/`, `latex/`, `tools/`, `shared/`, `replacement/`, `eventBus/`, webview frontends), VS Code-allowed zones (`extension.ts`, `commands/`, `frontend/`, `common/webview`, `common/state`, `auth/`), and platform layer (`platform/`).
-3. **Run the targeted checks** from the checklist that match the zones touched. Most findings cluster around: platform coupling, Zod schemas, PocketFlow services, configuration/log routing, factory layering, and render-time workarounds.
-4. **Verify, don't speculate.** Before flagging, open the file and confirm the issue exists in the current diff, not in unrelated code. If something looks suspicious but you can't verify it, mark it as a question, not a finding.
-5. **Order findings by severity:** correctness/security first, then platform-decoupling violations, then API-contract issues, then style/maintainability. Cite `path:line` for every finding.
-6. **Skip the noise.** Don't comment on whitespace, missing JSDoc on private helpers, or anything CLAUDE.md says not to comment on. Don't propose new abstractions that the diff doesn't already justify.
+1. **Read [references/review-checklist.md](references/review-checklist.md).** Pick the categories that match the diff — don't grind through all of them.
+2. **Identify the change surface.** Run `git diff` (or `git diff main...HEAD`) and group changed files by zone: VS Code-free zones (`agent/`, `model/`, `latex/`, `tools/`, `shared/`, `replacement/`, `eventBus/`, webview frontends) vs. VS Code-allowed zones (`extension.ts`, `commands/`, `frontend/`, `common/webview/`, `common/state/`, `auth/`, `platform/`).
+3. **Verify, don't speculate.** Open every file before flagging. If you can't verify, mark it as a question, not a finding.
+4. **Order by severity.** Correctness/security → platform-decoupling → API-contract → maintainability. Cite `path:line` for every finding.
+5. **Skip the noise.** Don't comment on whitespace, missing JSDoc on private helpers, or anything CLAUDE.md says not to comment on.
 
-## Review output format
-
-Structure findings as:
+## Output format
 
 ```
 ## Findings
-
 ### Critical
-- `path/file.ts:42` — <one-line summary>. <why it matters / what to do>.
-
+- `path/file.ts:42` — <one-line summary>. <why / fix>.
 ### Should fix
 - ...
-
 ### Nits / questions
 - ...
 
 ## Verified
-- <what you actually opened and checked, e.g. "Read src/tools/foo.ts:1-120; confirmed no `vscode` import">
+- <what you actually opened, e.g. "Read src/tools/foo.ts:1-120; confirmed no `vscode` import">
 ```
 
-Always include the **Verified** section. It forces honesty about what was actually inspected vs. skimmed, and it makes "no issues found" mean something — list what you checked.
-
-## Quality bar
-
-- A correct review either lists concrete findings tied to repo rules, or names what was inspected and why it's clean. Never both empty.
-- Prefer 3 well-grounded findings over 10 generic ones.
-- If the diff is large, narrow scope and say so ("Reviewed agent/ and tools/ paths; webview changes not yet reviewed").
-- For UI changes, the build doesn't validate behavior — say so explicitly if you couldn't run the extension.
-
-## Repo facts the review should know
-
-- **Platform abstraction**: core code reaches host services via `platform()` from `@platform` (see `src/platform/platform.ts`). Direct `vscode` imports are forbidden in `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`, `src/replacement/`, `src/eventBus/`, and webview frontends.
-- **Zod v4** with `.nullish()` (not `.optional()`) for tool input schemas; `.prefault()` for deserialization; `.catch()` for fallbacks; `.int()` / `.uuid()` / `.iso.datetime()` natively.
-- **PocketFlow**: services are immutable, set once via `flow.setServices()`; shared store holds only mutable state; transitions use `FlowTransition.*` constants; agents own lifecycle, flows own execution.
-- **Build commands**: `npm run compile:fast` / `package:fast` / `build:fast` skip type checking — `npm run typecheck` (or `compile:safe`) is required to catch type errors. **Never run `npm test`** (downloads VS Code test env; wastes time).
-- **Path aliases** (in `tsconfig.json`): `@agent/*`, `@commands/*`, `@common/*`, `@frontend/*`, `@utils/*`, `@model/*`, `@latex/*`, `@logger/*`, `@tools/*`, `@webview/*`, `@progressView/*`, `@settingsView/*`, `@shared/*`, `@eventBus/*`, `@replacement/*`, `@housekeeping/*`, `@auth/*`, `@types/*`, `@platform`, `@platform/*`.
+The `Verified` section is mandatory. Prefer 3 grounded findings over 10 generic ones.

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -1,122 +1,97 @@
 # TeXRA Review Checklist
 
-Targeted checks for this repo. Anchored in CLAUDE.md and AGENTS.md. Use the categories that match the diff — don't grind through the whole list.
+Targeted greps + concrete fixes. Pair with the design rules in `CLAUDE.md` (Zod, Flattening Abstraction Layers, Discouraged Factory Patterns, Render-Time Workarounds, Separation of Concerns) — don't restate those; consult them when the diff lands in their territory.
 
-## 1. Platform decoupling (highest-signal category)
+## 1. Platform decoupling (highest-signal)
 
-Search the diff for the patterns below.
+The full zone list lives in `CLAUDE.md` → "Separation of Concerns: VS Code Coupling". Run these greps on the diff:
 
-- **Forbidden `vscode` imports.** `grep -nE "from ['\"]vscode['\"]"` in: `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`, `src/replacement/`, `src/eventBus/`, and any `**/frontend/` webview directory. Any hit is a finding — point to the corresponding `@platform` facade or `@common/files/fsEntryType` helper.
-- **Direct `vscode.workspace.getConfiguration` / `workspace.fs` calls** in agnostic code. Replace with `getConfig` / `updateConfig` / `watchConfig` from `@utils/config` and `WorkspaceFS` / `RelativeFS` / `StorageFS` / `GlobalStorageFS` / `AbsoluteFS` from `@utils/files`.
-- **`instanceof vscode.FileSystemError`** — should be `isFileNotFoundError(err)` from `@common/errors`.
-- **`vscode.FileType.File` / `Directory`** — should be `isFile()` / `isDirectory()` from `@common/files/fsEntryType`.
-- **`vscode.window.show*Message()` inside business logic.** Push UI side effects to the command/frontend layer. Business logic returns error results.
-- **Composition root abuses.** `initPlatform()` should only be called from the host entry point (`src/extension.ts` or future CLI/Electron host). `platform()` is for read access. `tryPlatform()` is reserved for module-init facades.
-- **Bypassing the platform.** `process.env`, `os.homedir()`, raw `fs/promises`, `child_process.exec` in agnostic zones — should go through the platform interfaces or `executeCommand` from `@utils/system/execUtils`.
+- **`grep -nE "from ['\"]vscode['\"]"`** in `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`, `src/replacement/`, `src/eventBus/`, or any webview `frontend/`. Any hit is a finding.
+- **Direct `vscode.workspace.getConfiguration` / `workspace.fs` / `secrets`** in agnostic code → use `platform().config`, `platform().fs`, `platform().secrets` (see `src/platform/platform.ts`). Note: `@utils/config` is the VS Code-allowed wrapper; agnostic code goes through `platform()`.
+- **`instanceof vscode.FileSystemError`** → `isFileNotFoundError(err)` from `@common/errors`.
+- **`vscode.FileType.File` / `.Directory`** → `isFile()` / `isDirectory()` from `@common/files/fsEntryType`.
+- **`vscode.window.show*Message()` in business logic** → return error results; let the command/frontend layer handle UI.
+- **`process.env`, `os.homedir()`, raw `fs/promises`, `child_process.exec`** in agnostic zones → platform interfaces or `executeCommand` from `@utils/system/execUtils`.
+- **`initPlatform()`** called outside the host entry point (`src/extension.ts`) → bug. Read access uses `platform()`; module-init facades use `tryPlatform()`.
 
 ## 2. Zod v4 schema correctness
 
-- **Tool input schemas use `.optional()`** instead of `.nullish()`. Breaks OpenAI-compatible structured output (DeepSeek, Kimi, etc.). Always `.nullish()` on optional fields, and use `== null` (not `=== undefined`) at use sites.
-- **Verbose old-style types**: `.string().int()`, `.string().uuid()`, `.string().datetime()`, `.nativeEnum(...)`, `.object({...}).passthrough()`. Should be `.int()`, `.uuid()`, `.iso.datetime()`, `.enum(...)`, `.looseObject({...})`.
-- **`z.custom<T>()`** when a real schema exists. Prefer `z.discriminatedUnion()` for unions; `z.custom` is a last resort and needs a comment justifying it.
-- **Duplicated field definitions** across schemas instead of `.extend()` / `.pick()` / `.partial()`.
-- **Manual `safeParse` + ternary** to provide a default — should be `Schema.catch(default).parse(data)`.
-- **Backward-compat handled via scattered `if`s** in consumers — should be a single `z.union([NewFormat, LegacyFormat.transform(...)])` at the entry point producing one canonical shape.
-- **Default value confusion**: `.prefault(v)` for normalizing inputs _before_ validation (deserialization); `.default(v)` for _after_ validation succeeds with missing field; `.catch(v)` for validation throw. Wrong choice silently corrupts state.
-- **Compile-time sync**: when a schema must mirror an external SDK type, a `satisfies` assertion should pin them together.
+Design rules in `CLAUDE.md` → "Schema and Type Guidelines" / "Backward Compatibility with Zod" and `AGENTS.md` → "Zod v4 Schema Patterns". Greps for the diff:
+
+- **Tool input schemas using `.optional()`** instead of `.nullish()` (breaks DeepSeek/Kimi/etc. structured output). At use sites, check for `=== undefined` (should be `== null`).
+- **Verbose old-style types**: `.string().int()`, `.string().uuid()`, `.string().datetime()`, `.nativeEnum`, `.passthrough()` → `.int()`, `.uuid()`, `.iso.datetime()`, `.enum()`, `.looseObject()`.
+- **Manual `safeParse` + ternary for defaults** → `Schema.catch(default).parse(data)`.
+- **`z.custom<T>()` without a comment** justifying why a real schema isn't possible.
+- **`.prefault` vs `.default` vs `.catch`** misuse: `.prefault` normalizes input _before_ validation (deserialization); `.default` fills in _after_ a missing field; `.catch` recovers from validation throws. Wrong choice silently corrupts state.
 
 ## 3. PocketFlow / agent runtime
 
-- **Mutable services.** `flow.setServices()` payload should be frozen-by-convention. Any field that gets reassigned during a run belongs in the shared store, not services.
-- **Magic transition strings**. `return 'continue'` / `'finalize'` / `'complete'` / `'default'` should use `FlowTransition.CONTINUE` / `FINALIZE` / `COMPLETE` / `DEFAULT`.
-- **Lifecycle leak**: flows or nodes calling agent init/finalize work. Agents own lifecycle; flows handle execution; nodes throw and let `agent.run()` catch.
-- **Wrapper-only files**. Anything whose only job is `createState() → flow.run() → interpret result` should be inlined into the calling node. CLAUDE.md cites `ResponseCycle.ts` / `ToolUseCycle.ts` as past offenders.
-- **`prep`/`exec`/`post` boundaries**: state mutations belong in `post`, not `exec`. Retry config goes through `maxRetries` / `retryDelay` getters, not ad-hoc loops.
-- **Missing `AgentLogger`**: agent flows should wrap `@logger/logUtils` with `AgentLogger` for grouped, tool-use-aware channels. Plain `console.log` or untagged `logger.info` is a finding.
-- **Unstructured log payloads**: file lists, missing outputs, latexdiff results, usage stats should go through the `data` argument, not interpolated into the message string. The progress view depends on structured payloads.
+- **`return 'continue' | 'finalize' | 'complete' | 'default'`** → use `FlowTransition.CONTINUE`/`FINALIZE`/`COMPLETE`/`DEFAULT` from `@agent/core/flows/FlowTransitions`.
+- **Mutable services**: anything passed to `flow.setServices()` that gets reassigned mid-run belongs in the shared store, not services.
+- **Lifecycle leak**: agent init/finalize logic appearing inside flows or nodes. Agents own lifecycle; flows execute; nodes throw and let `agent.run()` catch.
+- **`prep` / `exec` / `post` boundaries**: state mutations belong in `post`, not `exec`. Retries via `maxRetries` / `retryDelay` getters, not ad-hoc loops.
+- **Plain `console.log` or untagged `logger.info` in agent flows** → wrap with `AgentLogger` (`@logger`, exported from `src/logger/index.ts`) for grouped, tool-use-aware channels.
+- **Log payloads built by string interpolation** (file lists, missing outputs, latexdiff results, usage stats) → pass via the structured `data` argument so the progress view can render them.
+- **Commands invoking flow factories directly** → must launch via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters and resume actions stay coherent.
 
 ## 4. Configuration, storage, files
 
-- **Config strings sprinkled inline.** Settings reads should funnel through `getConfig` from `@utils/config` so `watchConfig` can react to changes. Keys should match what's declared in `package.json`'s `contributes.configuration`.
-- **Direct path joins on workspace files**. Use `WorkspaceFS.getPath()` and friends; don't reach into `vscode.workspace.workspaceFolders` from agnostic code.
-- **Pasted-image paths** generated/resolved manually instead of via `pastedImageUtils`.
-- **Cleanup**: long-running data writers should use `RelativeFS.cleanupOldFiles` (or equivalent) rather than rolling their own retention.
-- **Session/run directories**: agents must launch via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters and resume actions stay coherent. Direct calls into flow factories from commands skip that wiring.
+- **Inline config strings** sprinkled across modules → use the typed accessors (`platform().config` in agnostic code; `getConfig`/`watchConfig` from `@utils/config` in VS Code-allowed code) so `watchConfig` can react. Verify keys exist in `package.json`'s `contributes.configuration`.
+- **Manual workspace path joining** → `WorkspaceFS.getPath()` and the helpers in `@utils/files`.
+- **Pasted-image paths** generated/resolved manually → `pastedImageUtils`.
+- **Long-running writers without retention** → `RelativeFS.cleanupOldFiles` (or equivalent).
 
-## 5. Factory and abstraction layering
+## 5. Webview / render-time
 
-- **Two-layer factories called once**: `createX → buildY` where `buildY` has one caller. Inline.
-- **Trivial identity factories**: `createOptions(o) { return { ...o }; }`. Use the literal.
-- **Re-export shims** for renamed/removed code (`export * from './X.removed'`, "// removed" comments, `_unused` placeholder vars). CLAUDE.md says: delete cleanly, don't leave breadcrumbs.
-- **Dead wrappers**: function calls only one underlying call and adds no logic. Inline at the call site if there's only one consumer.
+`CLAUDE.md` → "Render-Time Workarounds" already lists the anti-patterns. Greps for the diff:
 
-## 6. Render-time workarounds (webviews)
+- **`Date.now()` or synthetic IDs inside render functions** → move ID/timestamp creation to the producer.
+- **Lit components mutating shared state** → dispatch events; let the manager handle (`StreamTabs`, `LogList`, `OutputFilesManager`, `WebviewUpdater`, `UsageStatsManager`).
+- **Direct DOM manipulation alongside Lit components** → extend the existing component instead.
+- **Webview providers/handlers not extending `BaseViewContentProvider` / `BaseViewMessageHandler`** (`src/common/webview/`).
+- **String literals for webview commands** → constants in `src/common/webview/commands.ts`.
+- **New shared module path referenced without updating `localResourceRoots`** → 401 at runtime.
 
-- **`Date.now()` / synthetic IDs in render functions.** Move ID/timestamp creation to the producer.
-- **DOM queries to check whether data exists** before rendering. Means upstream data is incomplete.
-- **Deduplication after rendering** (comparing rendered HTML or text). Means the data path isn't deduped.
-- **Lit components mutating shared state** instead of dispatching events the manager handles.
-- **Direct DOM manipulation alongside Lit components**: prefer extending the existing component or manager (`StreamTabs`, `LogList`, `UsagePanel`, `OutputFilesManager`, `WebviewUpdater`, `UsageStatsManager`).
+## 6. Error handling and logging
 
-## 7. Webview consistency
+- **Ad-hoc `vscode.window.showErrorMessage`** → `logErrorMessage` / `showLoggedErrorMessage` / `showLoggedMessageWithDocs` from `@common/errors/errorHandlingUtils`.
+- **Swallowed errors** (`catch {}` / `catch (_) {}`) without a comment explaining why.
+- **`instanceof Error`** narrowing where the standard helpers above apply.
 
-- **Provider/handler not extending base classes**: every webview should extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `src/common/webview/`.
-- **String literals for webview commands**: use the constants in `src/common/webview/commands.ts`.
-- **Missing `localResourceRoots`** entries when a new shared module path is referenced — causes 401s at runtime.
-- **Naming**: `[Domain]View[Component]` (`MainViewContentProvider`, `SettingsViewMessageHandler`).
-- **CSS sprawl**: per-component styles should live as TypeScript in each view's `frontend/`, with shared tokens in `src/common/styles/common.css`.
-- **CDN vs local**: complex deps (markdown-it, KaTeX, highlight.js) should be CDN-loaded; lightweight bundles (split.js, codicons) local.
+## 7. Bash, exec, and security
 
-## 8. Error handling and logging
+- **`child_process.exec` direct calls** → `executeCommand` from `@utils/system/execUtils`.
+- **String-interpolated shell commands** → arg arrays; flag command-injection risk on any user/LLM-derived data.
+- **`path.join(workspaceRoot, userInput)`** without canonicalization → path-traversal risk; use `WorkspaceFS` / `RelativeFS`. Workspace contents are LLM-influenced; treat as untrusted.
 
-- **Ad-hoc `vscode.window.showErrorMessage`** instead of `logErrorMessage` / `showLoggedErrorMessage` / `showLoggedMessageWithDocs` from `@common/errors/errorHandlingUtils.ts`.
-- **Swallowed errors** (`catch {}` or `catch (_) {}`) without comment explaining why.
-- **Silent failure paths**: returning `undefined` / `null` on error without logging at the right level. Routine events use debug; outcomes use info/error.
-- **Error type narrowing**: `instanceof Error` checks instead of repo-standard helpers.
+## 8. Build, lint, dead code
 
-## 9. Naming and style
+- **`npm test` invocations** added anywhere (scripts, CI, docs) → must not exist; downloads VS Code test env.
+- **Type-sensitive changes without mention of `npm run typecheck` / `compile:safe`** → `compile:fast`/`package:fast`/`build:fast` skip type checks.
+- **Long relative imports** (`../../../../`) where a path alias exists.
+- **Re-export shims** for renamed/removed code, "// removed" comments, `_unused` placeholder vars — delete cleanly per `CLAUDE.md` Flattening rules.
+- **Dead exports** (declared, no consumer). `grep -r "exportedSymbol" src/`.
 
-- Service singletons that hold state and behavior: **PascalCase** (`StreamStatusService`, `ModelRegistry`).
-- Simple command/function namespaces: **camelCase** (`agentCommands`, `latexCommands`).
-- True constants: **UPPER_SNAKE_CASE** (`MAX_ERROR_LENGTH`).
-- Long relative imports (`../../../../`) where a path alias exists.
-- Dead exports (declared, no consumer). `grep -r "exportedSymbol" src/` to verify.
+## 9. Comments
 
-## 10. Bash, exec, and security
+- **WHAT comments** on well-named code → delete.
+- **Process tags** ("// added for issue #123", "// per Codex review") → belong in PR description; delete from code.
+- **Multi-paragraph docstrings on private helpers** → one short line max.
 
-- **`bash` / `child_process.exec` direct calls** instead of `executeCommand` from `@utils/system/execUtils`.
-- **Unescaped interpolation** in shell strings — command injection risk. Prefer arg arrays.
-- **Path traversal**: workspace-relative paths should pass through `WorkspaceFS` / `RelativeFS`, never raw `path.join(workspaceRoot, userInput)` without canonicalization.
-- **Untrusted workspaces**: TeXRA disables them in `package.json`. Code should still treat workspace contents as untrusted input (LLM-influenced data).
+## 10. Concurrency and resources
 
-## 11. Build, test, lint hygiene
+- **Shared mutable state held across `await`** → race risk; capture locals before `await`.
+- **Webview disposes that don't unregister listeners / FS watchers** → leak.
+- **Long-running model handlers / tool calls without `signal.aborted` checks** between awaits.
 
-- **`npm test` invocations** in scripts, CI, or docs — must be removed. Use `npm run typecheck` and `npm run lint`.
-- **Build script picks**: a PR adding type-sensitive code should mention running `npm run typecheck` or `compile:safe`. esbuild/vite paths skip type checks.
-- **Lint must pass** before commit. Don't commit through lint failures.
+## 11. Common backward-compat traps
 
-## 12. Comments and changelog
-
-- **WHAT comments** on well-named code ("// store the user list"). Delete.
-- **Process tags** ("// added for issue #123", "// per Codex review"). Move to PR description; delete from code.
-- **Multi-paragraph docstrings** in private helpers. One short line max for non-public helpers.
-- **CHANGELOG.md churn**: only user-visible changes; never document intermediate bugs fixed within the same PR. Group as Features / Bug Fixes / Improvements.
-
-## 13. Concurrency and resources
-
-- **Shared mutable state across `await`** boundaries — race risk. Capture locals before `await`.
-- **Listener / watcher leaks**: webview disposes should unregister event listeners and FS watchers.
-- **`AbortController`** signals: long-running model handlers and tool calls should respect cancellation; check for `signal.aborted` after each `await`.
-- **`FollowUpQueue` / `ToolUseFollowUpQueueManager`**: queue semantics changed recently — verify ordering and cancellation interactions if touched.
-
-## 14. Common backward-compat traps
-
-- **Migrating settings to storage**: when a setting moves from `package.json` config to storage, both must read fall back to the legacy config until the migration window closes. Schema should be `z.union([NewSchema, LegacyConfigSchema.transform(...)])`.
-- **Renamed fields in persisted state**: persisted `TaskState`, run records, and session storage must `prefault` missing fields and tolerate the old shape — see `c9f8b2b` (validate persisted TaskState) for the canonical pattern.
-- **Provider handler exhaustiveness**: switches over provider unions should compile-fail when a new provider is added; check for `assertNever` / `satisfies never` on the default branch.
+- **Settings migrating from `package.json` config to storage** → schema must be `z.union([NewSchema, LegacyConfigSchema.transform(...)])` so the legacy shape still loads during the migration window.
+- **Renamed fields in persisted state** (`TaskState`, run records, session storage) → use `.prefault()` and tolerate the old shape (canonical pattern in `c9f8b2b`).
+- **Provider-handler `switch` over a discriminated union** → default branch should `assertNever` / `satisfies never` so adding a provider compile-fails.
 
 ## Final pass
 
-- Re-read your findings list. Cut anything not tied to a real file:line in the diff.
+- Cut findings not tied to a real `path:line` in the diff.
 - Add the **Verified** section that names what you actually opened.
-- If the diff is small and clean, say so and explain _what you checked_. "No issues found" alone is never a sufficient review on this repo.
+- If the diff is small and clean, say so and explain _what you checked_. "No issues found" alone is never sufficient on this repo.

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -22,7 +22,7 @@ Search the diff for the patterns below.
 - **Duplicated field definitions** across schemas instead of `.extend()` / `.pick()` / `.partial()`.
 - **Manual `safeParse` + ternary** to provide a default — should be `Schema.catch(default).parse(data)`.
 - **Backward-compat handled via scattered `if`s** in consumers — should be a single `z.union([NewFormat, LegacyFormat.transform(...)])` at the entry point producing one canonical shape.
-- **Default value confusion**: `.prefault(v)` for normalizing inputs *before* validation (deserialization); `.default(v)` for *after* validation succeeds with missing field; `.catch(v)` for validation throw. Wrong choice silently corrupts state.
+- **Default value confusion**: `.prefault(v)` for normalizing inputs _before_ validation (deserialization); `.default(v)` for _after_ validation succeeds with missing field; `.catch(v)` for validation throw. Wrong choice silently corrupts state.
 - **Compile-time sync**: when a schema must mirror an external SDK type, a `satisfies` assertion should pin them together.
 
 ## 3. PocketFlow / agent runtime
@@ -119,4 +119,4 @@ Search the diff for the patterns below.
 
 - Re-read your findings list. Cut anything not tied to a real file:line in the diff.
 - Add the **Verified** section that names what you actually opened.
-- If the diff is small and clean, say so and explain *what you checked*. "No issues found" alone is never a sufficient review on this repo.
+- If the diff is small and clean, say so and explain _what you checked_. "No issues found" alone is never a sufficient review on this repo.

--- a/skills/code-review/references/review-checklist.md
+++ b/skills/code-review/references/review-checklist.md
@@ -1,0 +1,122 @@
+# TeXRA Review Checklist
+
+Targeted checks for this repo. Anchored in CLAUDE.md and AGENTS.md. Use the categories that match the diff — don't grind through the whole list.
+
+## 1. Platform decoupling (highest-signal category)
+
+Search the diff for the patterns below.
+
+- **Forbidden `vscode` imports.** `grep -nE "from ['\"]vscode['\"]"` in: `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`, `src/replacement/`, `src/eventBus/`, and any `**/frontend/` webview directory. Any hit is a finding — point to the corresponding `@platform` facade or `@common/files/fsEntryType` helper.
+- **Direct `vscode.workspace.getConfiguration` / `workspace.fs` calls** in agnostic code. Replace with `getConfig` / `updateConfig` / `watchConfig` from `@utils/config` and `WorkspaceFS` / `RelativeFS` / `StorageFS` / `GlobalStorageFS` / `AbsoluteFS` from `@utils/files`.
+- **`instanceof vscode.FileSystemError`** — should be `isFileNotFoundError(err)` from `@common/errors`.
+- **`vscode.FileType.File` / `Directory`** — should be `isFile()` / `isDirectory()` from `@common/files/fsEntryType`.
+- **`vscode.window.show*Message()` inside business logic.** Push UI side effects to the command/frontend layer. Business logic returns error results.
+- **Composition root abuses.** `initPlatform()` should only be called from the host entry point (`src/extension.ts` or future CLI/Electron host). `platform()` is for read access. `tryPlatform()` is reserved for module-init facades.
+- **Bypassing the platform.** `process.env`, `os.homedir()`, raw `fs/promises`, `child_process.exec` in agnostic zones — should go through the platform interfaces or `executeCommand` from `@utils/system/execUtils`.
+
+## 2. Zod v4 schema correctness
+
+- **Tool input schemas use `.optional()`** instead of `.nullish()`. Breaks OpenAI-compatible structured output (DeepSeek, Kimi, etc.). Always `.nullish()` on optional fields, and use `== null` (not `=== undefined`) at use sites.
+- **Verbose old-style types**: `.string().int()`, `.string().uuid()`, `.string().datetime()`, `.nativeEnum(...)`, `.object({...}).passthrough()`. Should be `.int()`, `.uuid()`, `.iso.datetime()`, `.enum(...)`, `.looseObject({...})`.
+- **`z.custom<T>()`** when a real schema exists. Prefer `z.discriminatedUnion()` for unions; `z.custom` is a last resort and needs a comment justifying it.
+- **Duplicated field definitions** across schemas instead of `.extend()` / `.pick()` / `.partial()`.
+- **Manual `safeParse` + ternary** to provide a default — should be `Schema.catch(default).parse(data)`.
+- **Backward-compat handled via scattered `if`s** in consumers — should be a single `z.union([NewFormat, LegacyFormat.transform(...)])` at the entry point producing one canonical shape.
+- **Default value confusion**: `.prefault(v)` for normalizing inputs *before* validation (deserialization); `.default(v)` for *after* validation succeeds with missing field; `.catch(v)` for validation throw. Wrong choice silently corrupts state.
+- **Compile-time sync**: when a schema must mirror an external SDK type, a `satisfies` assertion should pin them together.
+
+## 3. PocketFlow / agent runtime
+
+- **Mutable services.** `flow.setServices()` payload should be frozen-by-convention. Any field that gets reassigned during a run belongs in the shared store, not services.
+- **Magic transition strings**. `return 'continue'` / `'finalize'` / `'complete'` / `'default'` should use `FlowTransition.CONTINUE` / `FINALIZE` / `COMPLETE` / `DEFAULT`.
+- **Lifecycle leak**: flows or nodes calling agent init/finalize work. Agents own lifecycle; flows handle execution; nodes throw and let `agent.run()` catch.
+- **Wrapper-only files**. Anything whose only job is `createState() → flow.run() → interpret result` should be inlined into the calling node. CLAUDE.md cites `ResponseCycle.ts` / `ToolUseCycle.ts` as past offenders.
+- **`prep`/`exec`/`post` boundaries**: state mutations belong in `post`, not `exec`. Retry config goes through `maxRetries` / `retryDelay` getters, not ad-hoc loops.
+- **Missing `AgentLogger`**: agent flows should wrap `@logger/logUtils` with `AgentLogger` for grouped, tool-use-aware channels. Plain `console.log` or untagged `logger.info` is a finding.
+- **Unstructured log payloads**: file lists, missing outputs, latexdiff results, usage stats should go through the `data` argument, not interpolated into the message string. The progress view depends on structured payloads.
+
+## 4. Configuration, storage, files
+
+- **Config strings sprinkled inline.** Settings reads should funnel through `getConfig` from `@utils/config` so `watchConfig` can react to changes. Keys should match what's declared in `package.json`'s `contributes.configuration`.
+- **Direct path joins on workspace files**. Use `WorkspaceFS.getPath()` and friends; don't reach into `vscode.workspace.workspaceFolders` from agnostic code.
+- **Pasted-image paths** generated/resolved manually instead of via `pastedImageUtils`.
+- **Cleanup**: long-running data writers should use `RelativeFS.cleanupOldFiles` (or equivalent) rather than rolling their own retention.
+- **Session/run directories**: agents must launch via `executeAgent` (`src/agent/runtime/executeAgent.ts`) so session filters and resume actions stay coherent. Direct calls into flow factories from commands skip that wiring.
+
+## 5. Factory and abstraction layering
+
+- **Two-layer factories called once**: `createX → buildY` where `buildY` has one caller. Inline.
+- **Trivial identity factories**: `createOptions(o) { return { ...o }; }`. Use the literal.
+- **Re-export shims** for renamed/removed code (`export * from './X.removed'`, "// removed" comments, `_unused` placeholder vars). CLAUDE.md says: delete cleanly, don't leave breadcrumbs.
+- **Dead wrappers**: function calls only one underlying call and adds no logic. Inline at the call site if there's only one consumer.
+
+## 6. Render-time workarounds (webviews)
+
+- **`Date.now()` / synthetic IDs in render functions.** Move ID/timestamp creation to the producer.
+- **DOM queries to check whether data exists** before rendering. Means upstream data is incomplete.
+- **Deduplication after rendering** (comparing rendered HTML or text). Means the data path isn't deduped.
+- **Lit components mutating shared state** instead of dispatching events the manager handles.
+- **Direct DOM manipulation alongside Lit components**: prefer extending the existing component or manager (`StreamTabs`, `LogList`, `UsagePanel`, `OutputFilesManager`, `WebviewUpdater`, `UsageStatsManager`).
+
+## 7. Webview consistency
+
+- **Provider/handler not extending base classes**: every webview should extend `BaseViewContentProvider` and `BaseViewMessageHandler` from `src/common/webview/`.
+- **String literals for webview commands**: use the constants in `src/common/webview/commands.ts`.
+- **Missing `localResourceRoots`** entries when a new shared module path is referenced — causes 401s at runtime.
+- **Naming**: `[Domain]View[Component]` (`MainViewContentProvider`, `SettingsViewMessageHandler`).
+- **CSS sprawl**: per-component styles should live as TypeScript in each view's `frontend/`, with shared tokens in `src/common/styles/common.css`.
+- **CDN vs local**: complex deps (markdown-it, KaTeX, highlight.js) should be CDN-loaded; lightweight bundles (split.js, codicons) local.
+
+## 8. Error handling and logging
+
+- **Ad-hoc `vscode.window.showErrorMessage`** instead of `logErrorMessage` / `showLoggedErrorMessage` / `showLoggedMessageWithDocs` from `@common/errors/errorHandlingUtils.ts`.
+- **Swallowed errors** (`catch {}` or `catch (_) {}`) without comment explaining why.
+- **Silent failure paths**: returning `undefined` / `null` on error without logging at the right level. Routine events use debug; outcomes use info/error.
+- **Error type narrowing**: `instanceof Error` checks instead of repo-standard helpers.
+
+## 9. Naming and style
+
+- Service singletons that hold state and behavior: **PascalCase** (`StreamStatusService`, `ModelRegistry`).
+- Simple command/function namespaces: **camelCase** (`agentCommands`, `latexCommands`).
+- True constants: **UPPER_SNAKE_CASE** (`MAX_ERROR_LENGTH`).
+- Long relative imports (`../../../../`) where a path alias exists.
+- Dead exports (declared, no consumer). `grep -r "exportedSymbol" src/` to verify.
+
+## 10. Bash, exec, and security
+
+- **`bash` / `child_process.exec` direct calls** instead of `executeCommand` from `@utils/system/execUtils`.
+- **Unescaped interpolation** in shell strings — command injection risk. Prefer arg arrays.
+- **Path traversal**: workspace-relative paths should pass through `WorkspaceFS` / `RelativeFS`, never raw `path.join(workspaceRoot, userInput)` without canonicalization.
+- **Untrusted workspaces**: TeXRA disables them in `package.json`. Code should still treat workspace contents as untrusted input (LLM-influenced data).
+
+## 11. Build, test, lint hygiene
+
+- **`npm test` invocations** in scripts, CI, or docs — must be removed. Use `npm run typecheck` and `npm run lint`.
+- **Build script picks**: a PR adding type-sensitive code should mention running `npm run typecheck` or `compile:safe`. esbuild/vite paths skip type checks.
+- **Lint must pass** before commit. Don't commit through lint failures.
+
+## 12. Comments and changelog
+
+- **WHAT comments** on well-named code ("// store the user list"). Delete.
+- **Process tags** ("// added for issue #123", "// per Codex review"). Move to PR description; delete from code.
+- **Multi-paragraph docstrings** in private helpers. One short line max for non-public helpers.
+- **CHANGELOG.md churn**: only user-visible changes; never document intermediate bugs fixed within the same PR. Group as Features / Bug Fixes / Improvements.
+
+## 13. Concurrency and resources
+
+- **Shared mutable state across `await`** boundaries — race risk. Capture locals before `await`.
+- **Listener / watcher leaks**: webview disposes should unregister event listeners and FS watchers.
+- **`AbortController`** signals: long-running model handlers and tool calls should respect cancellation; check for `signal.aborted` after each `await`.
+- **`FollowUpQueue` / `ToolUseFollowUpQueueManager`**: queue semantics changed recently — verify ordering and cancellation interactions if touched.
+
+## 14. Common backward-compat traps
+
+- **Migrating settings to storage**: when a setting moves from `package.json` config to storage, both must read fall back to the legacy config until the migration window closes. Schema should be `z.union([NewSchema, LegacyConfigSchema.transform(...)])`.
+- **Renamed fields in persisted state**: persisted `TaskState`, run records, and session storage must `prefault` missing fields and tolerate the old shape — see `c9f8b2b` (validate persisted TaskState) for the canonical pattern.
+- **Provider handler exhaustiveness**: switches over provider unions should compile-fail when a new provider is added; check for `assertNever` / `satisfies never` on the default branch.
+
+## Final pass
+
+- Re-read your findings list. Cut anything not tied to a real file:line in the diff.
+- Add the **Verified** section that names what you actually opened.
+- If the diff is small and clean, say so and explain *what you checked*. "No issues found" alone is never a sufficient review on this repo.


### PR DESCRIPTION
Adds skills/code-review/ with a TeXRA-specific review checklist (platform
decoupling, Zod v4, PocketFlow, factory anti-patterns, render-time
workarounds, etc.) so /review produces grounded findings instead of
"no issues found." Wires the skill in from CLAUDE.md.

Also fixes outdated docs:
- Documents src/platform/ (composition root) and @platform aliases
- Drops dead src/explorer/ reference from AGENTS.md
- Notes src/test/ exists but must not be run via npm test

https://claude.ai/code/session_01XJFUfnfdjjYrXj96kwjxBX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that add guidance/checklists and refresh references; no runtime code paths are affected.
> 
> **Overview**
> Adds a new TeXRA-specific `/review` skill (`skills/code-review/`) with a concrete review checklist focused on platform decoupling, Zod v4 patterns, PocketFlow/runtime pitfalls, and webview render-time anti-patterns.
> 
> Updates repository docs to point reviewers to the new skill and refreshes architecture notes (documents `src/platform/`/`@platform` usage, removes the stale `src/explorer/` mention, and notes `src/test/` exists but shouldn’t be run via `npm test`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6feda94dc89b50a7ca1ed23c6611c112c3f08b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->