### PR TITLE
Cap xhigh reasoning on GPT-5 for free tier users

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: texra-ai
+custom: https://buymeacoffee.com/texra.ai

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 > and more—plus a hosted **Orchestrator** and a roster of remote specialist
 > agents. Sign in through the Profile view to get started—no API keys
 > required.
+>
+> The relay runs on sponsor credits. If TeXRA helps your research, please
+> consider supporting it via
+> [GitHub Sponsors](https://github.com/sponsors/texra-ai) or
+> [Buy Me a Coffee](https://buymeacoffee.com/texra.ai) to keep the program
+> open for everyone.
 
 **TeXRA is a multi-agent research assistant for VS Code.** Instead of chatting
 with a single model, you direct an **Orchestrator** that delegates to a team of

--- a/src/agent/modelHandlers/ModelHandler.ts
+++ b/src/agent/modelHandlers/ModelHandler.ts
@@ -20,7 +20,7 @@ import { MediaEntry } from '@agent/utils/mediaTypes';
 import type { NormalizedUsage } from '@agent/types/NormalizedUsage';
 import { K_SLICE } from '@agent/core/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
-import { MAX_TIER } from '@auth/config';
+import { MAX_TIER, FREE_TIER } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
 
 // Local imports - platform
@@ -466,8 +466,8 @@ export abstract class ModelHandler<
 
   /**
    * Returns the effective reasoning effort for the current user and model.
-   * Max tier users should not receive xhigh reasoning on GPT-5 models when
-   * using included (server-side) access.
+   * On GPT-5 models accessed via included (server-side) keys, xhigh reasoning
+   * is capped: Max tier → high, free tier → medium.
    */
   protected getEffectiveReasoningEffort(): ReasoningEffort | null {
     const { supportsReasoningEffort, reasoningEffort } = this.capabilities;
@@ -488,6 +488,9 @@ export abstract class ModelHandler<
       const userTier = getServerSideKeyService().getUserTier();
       if (userTier === MAX_TIER) {
         return ReasoningEffort.HIGH;
+      }
+      if (userTier === FREE_TIER) {
+        return ReasoningEffort.MEDIUM;
       }
     }
 

--- a/src/settingsView/frontend/components/profile/ProfileInfo.ts
+++ b/src/settingsView/frontend/components/profile/ProfileInfo.ts
@@ -64,6 +64,19 @@ export class ProfileInfo extends LitElement {
           ${PROMO_NOTICE_LONG.promoLead}<code>${PROMO_NOTICE_LONG.promoCode}</code>${PROMO_NOTICE_LONG.promoTail}
           ${PROMO_NOTICE_LONG.privacyLead}<strong>${PROMO_NOTICE_LONG.privacyNot}</strong>${PROMO_NOTICE_LONG.privacyMiddle}<strong>${PROMO_NOTICE_LONG.privacyNever}</strong>${PROMO_NOTICE_LONG.privacyTrailing}
         </div>
+        <div class="profile-notice">
+          ${PROMO_NOTICE_LONG.supportLead}<a
+            href=${PROMO_NOTICE_LONG.supportSponsorsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            >${PROMO_NOTICE_LONG.supportSponsorsLabel}</a
+          >${PROMO_NOTICE_LONG.supportMiddle}<a
+            href=${PROMO_NOTICE_LONG.supportCoffeeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            >${PROMO_NOTICE_LONG.supportCoffeeLabel}</a
+          >${PROMO_NOTICE_LONG.supportTail}
+        </div>
         ${expiration
           ? html`
               <div class="info-row">

--- a/src/shared/copy/promoNotice.ts
+++ b/src/shared/copy/promoNotice.ts
@@ -33,4 +33,11 @@ export const PROMO_NOTICE_LONG = {
   privacyMiddle: ' store your prompts or responses, and they are ',
   privacyNever: 'never',
   privacyTrailing: ' used for training.',
+  supportLead: 'Help keep the relay running for everyone — support TeXRA via ',
+  supportSponsorsUrl: 'https://github.com/sponsors/texra-ai',
+  supportSponsorsLabel: 'GitHub Sponsors',
+  supportMiddle: ' or ',
+  supportCoffeeUrl: 'https://buymeacoffee.com/texra.ai',
+  supportCoffeeLabel: 'Buy Me a Coffee',
+  supportTail: '.',
 } as const;

--- a/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
@@ -1,0 +1,150 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Third-party imports
+import {
+  DEFAULT_MODEL_CAPABILITIES,
+  type ModelConfig,
+  ModelProvider,
+  ReasoningEffort,
+} from 'llm-zoo';
+
+// Local imports - handler under test (concrete subclass exercising base-class
+// `getEffectiveReasoningEffort` — OpenRouterNative does not override it)
+import { ModelHandlerOpenRouterNative } from '@agent/modelHandlers/modelHandlerOpenRouterNative';
+import { FREE_TIER, MAX_TIER, ULTRA_TIER } from '@auth/config';
+
+// Modules to monkey-patch
+import * as serverKeysModule from '@auth/serverKeys';
+import * as providerConfigModule from '@utils/config/providerConfig';
+
+function buildGpt5Config(
+  overrides: Partial<ModelConfig> = {},
+): ModelConfig {
+  return {
+    name: 'gpt5-mini',
+    label: 'GPT-5 Mini',
+    fullName: 'gpt-5-mini-2025-08-15',
+    shortName: 'gpt5-mini',
+    provider: ModelProvider.OPENAI,
+    maxOutputTokens: 16384,
+    inputPrice: 0,
+    outputPrice: 0,
+    contextWindow: 200000,
+    capabilities: {
+      ...DEFAULT_MODEL_CAPABILITIES,
+      supportsReasoningEffort: true,
+      reasoningEffort: ReasoningEffort.XHIGH,
+    },
+    openRouterOnly: false,
+    openrouterFullName: 'openai/gpt-5-mini',
+    ...overrides,
+  };
+}
+
+describe('ModelHandler.getEffectiveReasoningEffort tier caps', () => {
+  const originalGetUseOpenRouter = providerConfigModule.getUseOpenRouter;
+  const originalGetServerSideKeyService =
+    serverKeysModule.getServerSideKeyService;
+
+  function stubServerSideKeys(tier: string | null): void {
+    (
+      providerConfigModule as {
+        getUseOpenRouter: typeof originalGetUseOpenRouter;
+      }
+    ).getUseOpenRouter = () => false;
+
+    (
+      serverKeysModule as {
+        getServerSideKeyService: typeof originalGetServerSideKeyService;
+      }
+    ).getServerSideKeyService = () =>
+      ({
+        shouldUseServerSideKeysSync: () => true,
+        getUserTier: () => tier,
+        getUseIncludedModelAccess: () => true,
+        canUseServerSideKeys: async () => true,
+        getRelayBaseUrl: (provider: string) =>
+          `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+      }) as unknown as ReturnType<typeof originalGetServerSideKeyService>;
+  }
+
+  afterEach(() => {
+    (
+      providerConfigModule as {
+        getUseOpenRouter: typeof originalGetUseOpenRouter;
+      }
+    ).getUseOpenRouter = originalGetUseOpenRouter;
+    (
+      serverKeysModule as {
+        getServerSideKeyService: typeof originalGetServerSideKeyService;
+      }
+    ).getServerSideKeyService = originalGetServerSideKeyService;
+  });
+
+  it('caps xhigh to medium for free tier on GPT-5 with server-side keys', () => {
+    stubServerSideKeys(FREE_TIER);
+    const handler = new ModelHandlerOpenRouterNative(buildGpt5Config());
+    assert.equal(
+      (handler as any).getEffectiveReasoningEffort(),
+      ReasoningEffort.MEDIUM,
+    );
+  });
+
+  it('caps xhigh to high for Max tier on GPT-5 with server-side keys', () => {
+    stubServerSideKeys(MAX_TIER);
+    const handler = new ModelHandlerOpenRouterNative(buildGpt5Config());
+    assert.equal(
+      (handler as any).getEffectiveReasoningEffort(),
+      ReasoningEffort.HIGH,
+    );
+  });
+
+  it('does not cap xhigh for Ultra tier on GPT-5 with server-side keys', () => {
+    stubServerSideKeys(ULTRA_TIER);
+    const handler = new ModelHandlerOpenRouterNative(buildGpt5Config());
+    assert.equal(
+      (handler as any).getEffectiveReasoningEffort(),
+      ReasoningEffort.XHIGH,
+    );
+  });
+
+  it('does not cap when not using server-side keys (free tier, own key)', () => {
+    (
+      providerConfigModule as {
+        getUseOpenRouter: typeof originalGetUseOpenRouter;
+      }
+    ).getUseOpenRouter = () => false;
+
+    (
+      serverKeysModule as {
+        getServerSideKeyService: typeof originalGetServerSideKeyService;
+      }
+    ).getServerSideKeyService = () =>
+      ({
+        shouldUseServerSideKeysSync: () => false,
+        getUserTier: () => FREE_TIER,
+        getUseIncludedModelAccess: () => false,
+        canUseServerSideKeys: async () => false,
+        getRelayBaseUrl: (provider: string) =>
+          `https://relay.example.com/functions/v1/relay/${provider}/v1`,
+      }) as unknown as ReturnType<typeof originalGetServerSideKeyService>;
+
+    const handler = new ModelHandlerOpenRouterNative(buildGpt5Config());
+    assert.equal(
+      (handler as any).getEffectiveReasoningEffort(),
+      ReasoningEffort.XHIGH,
+    );
+  });
+
+  it('does not cap non-GPT-5 models even on free tier with server-side keys', () => {
+    stubServerSideKeys(FREE_TIER);
+    const handler = new ModelHandlerOpenRouterNative(
+      buildGpt5Config({ name: 'claude-sonnet-4-6', shortName: 'claude-sonnet-4-6' }),
+    );
+    assert.equal(
+      (handler as any).getEffectiveReasoningEffort(),
+      ReasoningEffort.XHIGH,
+    );
+  });
+});

--- a/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
+++ b/src/test/agent/modelHandlers/ModelHandlerReasoningCap.test.ts
@@ -18,9 +18,7 @@ import { FREE_TIER, MAX_TIER, ULTRA_TIER } from '@auth/config';
 import * as serverKeysModule from '@auth/serverKeys';
 import * as providerConfigModule from '@utils/config/providerConfig';
 
-function buildGpt5Config(
-  overrides: Partial<ModelConfig> = {},
-): ModelConfig {
+function buildGpt5Config(overrides: Partial<ModelConfig> = {}): ModelConfig {
   return {
     name: 'gpt5-mini',
     label: 'GPT-5 Mini',
@@ -140,7 +138,10 @@ describe('ModelHandler.getEffectiveReasoningEffort tier caps', () => {
   it('does not cap non-GPT-5 models even on free tier with server-side keys', () => {
     stubServerSideKeys(FREE_TIER);
     const handler = new ModelHandlerOpenRouterNative(
-      buildGpt5Config({ name: 'claude-sonnet-4-6', shortName: 'claude-sonnet-4-6' }),
+      buildGpt5Config({
+        name: 'claude-sonnet-4-6',
+        shortName: 'claude-sonnet-4-6',
+      }),
     );
     assert.equal(
       (handler as any).getEffectiveReasoningEffort(),

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -123,7 +123,7 @@ export const TIER_CONFIG: TierModelConfig = {
 export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
   free: 20, // $20/month - promo (bumped from $10)
   Max: 100, // $100/month - promo (bumped from $50)
-  Ultra: 1500, // $1500/month - sponsor access
+  Ultra: 200, // $200/month - sponsor access
 };
 
 // =============================================================================

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -123,7 +123,7 @@ export const TIER_CONFIG: TierModelConfig = {
 export const TIER_SPENDING_LIMITS: TierSpendingLimits = {
   free: 20, // $20/month - promo (bumped from $10)
   Max: 100, // $100/month - promo (bumped from $50)
-  Ultra: 200, // $200/month - sponsor access
+  Ultra: 300, // $300/month - sponsor access
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary
This PR adjusts tier-based caps and limits for the relay program, plus adds donation links.

## Key Changes
- **Reasoning effort capping for GPT-5**: When using included (server-side) access to GPT-5 models, xhigh reasoning is now capped based on user tier:
  - Max tier users: capped to `HIGH`
  - Free tier users: capped to `MEDIUM`
  - Other tiers: no restriction
- **Spending limit adjustment**: Reduced Ultra tier monthly spending limit from $1500 to $300.
- **Donation links**: Added `.github/FUNDING.yml`, a "Support TeXRA" line in Settings → Profile, and a brief mention in the README pointing to GitHub Sponsors and Buy Me a Coffee.
- **Tests**: Added regression coverage for the GPT-5 tier-based reasoning cap.

## Notes
- DeepSeek's API only accepts `high`/`max` (its handler already coerces all other levels), so no cap is needed for that provider.
- Anthropic's `effort` parameter is already adaptive — Claude self-scales depth — so no fixed cap is applied for Anthropic relay traffic.
- API-key (non-relay) mode is unchanged: user-selected reasoning effort is respected.

https://claude.ai/code/session_012RJH8Qhf9kQV169aRM9CCv