### PR TITLE
[codex] Consolidate agent config and Google tool schema fixes

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -14,7 +14,7 @@ The **Dashboard** is your one-stop shop for managing everything in TeXRA. Open i
 - **Agents** - Turn agents on or off for the current workspace. Agents that support multiple output files are marked with a badge.
 - **Multi-Agent** - Configure multi-agent orchestration and presets.
 - **Tools** - Manage tool-use agent capabilities and approval settings.
-- **Git** - Set a GitHub personal access token (required for the `subscribe_pr_activity` tool) and optionally attribute TeXRA commits to a custom author.
+- **Git** - Set a GitHub personal access token (required for the `github_subscription` tool) and optionally attribute TeXRA commits to a custom author.
 - **LaTeX** - Configure LaTeX formatting, diff, and TikZ settings.
 
 ::: tip
@@ -245,7 +245,7 @@ The **Git tab** in the TeXRA Dashboard (`TeXRA: Show Dashboard` → **Git**) cov
 
 ### GitHub personal access token
 
-Several tool-use agents can call `subscribe_pr_activity` to watch a pull request and inject new comments, reviews, line comments, and failed CI runs into the current agent stream as follow-up messages — the same mechanism that handles user-typed follow-ups. The tool polls GitHub's REST API every 30 seconds and needs an authenticated token.
+Several tool-use agents can call `github_subscription` to watch a repo, pull request, or issue and inject new comments, reviews, line comments, failed CI runs, and merge-conflict events into the current agent stream as follow-up messages — the same mechanism that handles user-typed follow-ups. The tool polls GitHub's REST API every 30 seconds and needs an authenticated token.
 
 Setup:
 
@@ -259,7 +259,7 @@ Setup:
 
 The token is stored in VS Code's encrypted **Secret Storage** — never written to `settings.json`. Alternatively, export `GITHUB_TOKEN` in the shell VS Code is launched from and the tool will pick it up automatically (the Git tab will show **Env** as the status).
 
-Once a token is configured, an agent can run `subscribe_pr_activity owner=… repo=… pullNumber=…` and every new PR event arrives wrapped in a `<github-webhook-activity>` tag in the follow-up queue. Subscriptions auto-terminate when the PR closes or merges, and up to 25 PRs can be watched concurrently.
+Once a token is configured, an agent can run `github_subscription command=subscribe path=owner/repo/pulls/N` (or `path=owner/repo` for the whole repo, `path=owner/repo/issues/N` for a single issue) and every new event arrives wrapped in a `<github-webhook-activity>` tag in the follow-up queue. Use `command=unsubscribe` with the same path to stop, `command=list` to see active subscriptions, and `command=find_current` to resolve the current branch's PR. Subscriptions auto-terminate when the PR closes or merges, and up to 25 PRs can be watched concurrently.
 
 ### TeXRA commit author
 

--- a/docs/supabase/SYNC_REFERENCE_AGENTS.sql
+++ b/docs/supabase/SYNC_REFERENCE_AGENTS.sql
@@ -203,6 +203,22 @@ ON CONFLICT (name) DO UPDATE SET
 
 INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
 VALUES (
+  'humanize',
+  'Removes LLM stylistic tells from research prose. Phase 1 annotates problems; phase 2 directly rewrites for natural voice while strictly preserving meaning.',
+  'researcher/humanize.yaml',
+  ARRAY['researcher'],
+  'workflow',
+  NULL
+)
+ON CONFLICT (name) DO UPDATE SET
+  description    = EXCLUDED.description,
+  storage_path   = EXCLUDED.storage_path,
+  visibility     = EXCLUDED.visibility,
+  agent_category = EXCLUDED.agent_category,
+  tools          = EXCLUDED.tools;
+
+INSERT INTO remote_agents (name, description, storage_path, visibility, agent_category, tools)
+VALUES (
   'logic',
   'Logical flow analyzer for research papers. Improves argument structure and coherence.',
   'researcher/logic.yaml',
@@ -308,7 +324,7 @@ VALUES (
   'tool-use/orchestrator.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'external_inquiry', 'codex', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'extract_figures', 'extract_bib_entries', 'texcount', 'external_inquiry', 'codex', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -340,7 +356,7 @@ VALUES (
   'tool-use/progressCheck.yaml',
   ARRAY['public'],
   'toolUse',
-  ARRAY['executions', 'read_file', 'glob', 'grep', 'ls', 'bash', 'memory', 'find_current_pr', 'web_fetch', 'external_inquiry']
+  ARRAY['executions', 'read_file', 'glob', 'grep', 'ls', 'bash', 'memory', 'github_subscription', 'web_fetch', 'external_inquiry']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -392,7 +408,7 @@ VALUES (
   'tool-use-lean/lean.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['todo_write', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
+  ARRAY['todo_write', 'lean_diagnostics', 'lean_file', 'lean_project', 'lean_inspect', 'lean_loogle', 'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep', 'ls', 'memory', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,
@@ -424,7 +440,7 @@ VALUES (
   'tool-use-lean/leanOrchestrator.yaml',
   ARRAY['researcher', 'lean'],
   'toolUse',
-  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'subscribe_pr_activity', 'unsubscribe_pr_activity', 'find_current_pr']
+  ARRAY['delegate_workflow', 'delegate_agent', 'executions', 'accept_run_files', 'todo_write', 'plan', 'read_file', 'write_file', 'edit_file', 'bash', 'glob', 'grep', 'ls', 'codex', 'lean_diagnostics', 'lean_inspect', 'lean_loogle', 'lean_file', 'lean_project', 'github_subscription']
 )
 ON CONFLICT (name) DO UPDATE SET
   description    = EXCLUDED.description,

--- a/docs/supabase/remote-agents.config.json
+++ b/docs/supabase/remote-agents.config.json
@@ -29,6 +29,7 @@
     "enhance_multiple": { "folder": "whitelist", "visibility": ["public"] },
     "generic": { "folder": "public", "visibility": ["public"] },
     "generic_multiple": { "folder": "public", "visibility": ["public"] },
+    "humanize": { "folder": "researcher", "visibility": ["researcher"] },
     "logic": { "folder": "researcher", "visibility": ["public"] },
     "logic_multiple": { "folder": "researcher", "visibility": ["public"] },
     "notation": { "folder": "researcher", "visibility": ["public"] },

--- a/reference-agents/Lean4/lean.yaml
+++ b/reference-agents/Lean4/lean.yaml
@@ -18,16 +18,14 @@ settings:
     - grep
     - ls
     - memory
-    # GitHub PR subscription — opt-in. Disabled by default; enable in
-    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
-    # When disabled by the user, resolveTools() strips these from the
-    # model's tool list. When enabled but the token/git-repo check has
-    # not yet populated the availability cache (i.e. before the Tools
-    # dashboard has run its checks), the tools may still appear and
-    # calls will fail at runtime with a setup-pointing ToolError.
-    - subscribe_pr_activity
-    - unsubscribe_pr_activity
-    - find_current_pr
+    # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
+    # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
+    # Git. When disabled by the user, resolveTools() strips this from the
+    # model's tool list. When enabled but the token/git-repo check has not yet
+    # populated the availability cache (i.e. before the Tools dashboard has
+    # run its checks), the tool may still appear and calls will fail at
+    # runtime with a setup-pointing ToolError.
+    - github_subscription
 
 prompts:
   systemPrompt: |

--- a/reference-agents/Lean4/leanOrchestrator.yaml
+++ b/reference-agents/Lean4/leanOrchestrator.yaml
@@ -28,16 +28,14 @@ settings:
     - lean_loogle
     - lean_file
     - lean_project
-    # GitHub PR subscription — opt-in. Disabled by default; enable in
-    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
-    # When disabled by the user, resolveTools() strips these from the
-    # model's tool list. When enabled but the token/git-repo check has
-    # not yet populated the availability cache (i.e. before the Tools
-    # dashboard has run its checks), the tools may still appear and
-    # calls will fail at runtime with a setup-pointing ToolError.
-    - subscribe_pr_activity
-    - unsubscribe_pr_activity
-    - find_current_pr
+    # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
+    # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
+    # Git. When disabled by the user, resolveTools() strips this from the
+    # model's tool list. When enabled but the token/git-repo check has not yet
+    # populated the availability cache (i.e. before the Tools dashboard has
+    # run its checks), the tool may still appear and calls will fail at
+    # runtime with a setup-pointing ToolError.
+    - github_subscription
 
 prompts:
   systemPrompt: |

--- a/reference-agents/orchestrator.yaml
+++ b/reference-agents/orchestrator.yaml
@@ -22,16 +22,14 @@ settings:
     - texcount
     - external_inquiry
     - codex
-    # GitHub PR subscription — opt-in. Disabled by default; enable in
-    # Dashboard → Tools and configure a GitHub token in Dashboard → Git.
-    # When disabled by the user, resolveTools() strips these from the
-    # model's tool list. When enabled but the token/git-repo check has
-    # not yet populated the availability cache (i.e. before the Tools
-    # dashboard has run its checks), the tools may still appear and
-    # calls will fail at runtime with a setup-pointing ToolError.
-    - subscribe_pr_activity
-    - unsubscribe_pr_activity
-    - find_current_pr
+    # GitHub subscription (repos, PRs, issues) — opt-in. Disabled by default;
+    # enable in Dashboard → Tools and configure a GitHub token in Dashboard →
+    # Git. When disabled by the user, resolveTools() strips this from the
+    # model's tool list. When enabled but the token/git-repo check has not yet
+    # populated the availability cache (i.e. before the Tools dashboard has
+    # run its checks), the tool may still appear and calls will fail at
+    # runtime with a setup-pointing ToolError.
+    - github_subscription
 prompts:
   systemPrompt: |
     You are an AI scientist assistant that stewards the long-term development of LaTeX research projects. Think beyond individual tasks—consider whether the project structure scales, conventions stay consistent, and accumulated work builds toward a coherent whole. Maintain modular folder organization: keep sources, figures, bibliography, and build artifacts in separate directories so the project stays navigable as it grows. Proactively propose cleanup when you see duplicated logic, dead code, or inconsistent patterns. Every change should leave the project in a better structural state, not just fulfill the immediate request.

--- a/reference-agents/progressCheck.yaml
+++ b/reference-agents/progressCheck.yaml
@@ -11,7 +11,7 @@ settings:
     - ls
     - bash
     - memory
-    - find_current_pr
+    - github_subscription
     - web_fetch
     - external_inquiry
 prompts:
@@ -24,7 +24,7 @@ prompts:
 
     (2) The overall goal. Find the user's standing intent, not just the latest request. Check in order of likelihood, stop at the first hit: `/memories/goals.md` via the memory tool (use action `view` only — never create/str_replace/insert/delete/rename/pin), then `TODO.md` / `README.md` at the workspace root, then any live plan on `/executions/P` (the orchestrator's record). Most sessions have none of these — that is fine; say so and treat the latest request as the goal. Do not invent one.
 
-    (3) Git and PR state. If the workspace is a git repo, a single `git log --oneline -n 20` plus `git status` via bash is usually enough; add `git diff --stat HEAD~1` only when the session intended to commit and you want to confirm the working tree is clean. Try `find_current_pr` once — if the tool is unavailable (GitHub integration not enabled), errors, or returns no PR, skip GitHub lookups entirely and proceed with the local git review. If a PR is attached and `gh` is on PATH, `gh pr view <n>` surfaces the body and recent review comments — that is usually the only `gh` call needed. Only escalate to `gh issue view <n>` or `gh issue list --state open --limit 10` when the PR body references an issue, or to `gh pr list --state merged --limit 10` when a delivery or commit mentions a recently merged PR you need to read. Prefer `gh` over `web_fetch` for repo data; reserve `web_fetch` for off-host references (arXiv, doc sites). Closed-but-not-fully-resolved PRs often leave dangling follow-ups in the body ("follow-up in #NNN", "TODO before release"); recently merged PRs often unblock work that was previously deferred.
+    (3) Git and PR state. If the workspace is a git repo, a single `git log --oneline -n 20` plus `git status` via bash is usually enough; add `git diff --stat HEAD~1` only when the session intended to commit and you want to confirm the working tree is clean. Try `github_subscription` with `command: find_current` once — if the tool is unavailable (GitHub integration not enabled), errors, or returns no PR, skip GitHub lookups entirely and proceed with the local git review. If a PR is attached and `gh` is on PATH, `gh pr view <n>` surfaces the body and recent review comments — that is usually the only `gh` call needed. Only escalate to `gh issue view <n>` or `gh issue list --state open --limit 10` when the PR body references an issue, or to `gh pr list --state merged --limit 10` when a delivery or commit mentions a recently merged PR you need to read. Prefer `gh` over `web_fetch` for repo data; reserve `web_fetch` for off-host references (arXiv, doc sites). Closed-but-not-fully-resolved PRs often leave dangling follow-ups in the body ("follow-up in #NNN", "TODO before release"); recently merged PRs often unblock work that was previously deferred.
 
     (4) Unblocked follow-ups. Work that was blocked on something just merged, fixed, or answered. Signals: an earlier delivery said "couldn't finish X because Y wasn't available" and Y is now in place; a PR closed a dependency issue that made a deferred task feasible; the user said "later" on an item that depended on a merge that has since landed.
 

--- a/src/agent/modelHandlers/toolConversion.ts
+++ b/src/agent/modelHandlers/toolConversion.ts
@@ -7,11 +7,7 @@ import type {
   Tool as AnthropicTool,
   ToolUnion,
 } from '@anthropic-ai/sdk/resources/messages';
-import type {
-  Tool as GeminiTool,
-  FunctionDeclaration,
-  Schema,
-} from '@google/genai';
+import type { Tool as GeminiTool, FunctionDeclaration } from '@google/genai';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
 import type {
   FunctionTool,
@@ -229,7 +225,7 @@ export function toGoogleTools(defs: ToolDefinition[]): GeminiTool[] {
   const declarations: FunctionDeclaration[] = defs.map((d) => ({
     name: d.name,
     description: d.description,
-    parameters: convertToolSchema(d) as Schema | undefined,
+    parametersJsonSchema: convertToolSchema(d) ?? undefined,
   }));
 
   return [{ functionDeclarations: declarations }];


### PR DESCRIPTION
## Summary
- migrate reference agent configs to the unified github_subscription tool and register the humanize agent
- update generated Supabase remote-agent sync metadata for those config changes
- send Google function tool schemas via parametersJsonSchema instead of casting JSON Schema into the SDK Schema field

## Validation
- npm run typecheck
- npm run compile:fast
- npm run lint (passes with 3 unrelated existing warnings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how Gemini function tool schemas are serialized (`parametersJsonSchema`), which can affect tool-calling behavior at runtime; the rest is largely documentation/config sync for agent/tool registration.
> 
> **Overview**
> Updates agent and docs configuration to standardize on the unified `github_subscription` tool (replacing prior PR-only subscription tooling) and refreshes Supabase sync metadata accordingly.
> 
> Registers a new `humanize` workflow agent in the remote-agent config/sync lists.
> 
> Fixes Google/Gemini tool conversion by sending tool schemas via `parametersJsonSchema` (JSON Schema) instead of casting into the SDK `Schema` field, aligning payloads with the Gemini function declaration API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c3f987b8655e17ccd85d4b816dd48d325ddf3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->