### PR TITLE
fix: release DeepSeek pricing update as 0.37.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.37.8] - 2026-05-01
+
+### Bug Fixes
+
+- **Current DeepSeek V4 pricing** — DeepSeek V4 Flash and Pro now use DeepSeek's current cache-hit pricing, and V4 Pro reflects the active discounted input and output rates.
+
 ## [0.37.7] - 2026-05-01
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "texra",
-  "version": "0.37.7",
+  "version": "0.37.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "texra",
-      "version": "0.37.7",
+      "version": "0.37.8",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
@@ -43,7 +43,7 @@
         "identifiers-arxiv": "^0.1.1",
         "katex": "^0.16.45",
         "lit": "^3.3.2",
-        "llm-zoo": "^1.6.0",
+        "llm-zoo": "^1.6.1",
         "mark.js": "^8.11.1",
         "markdown-it": "^14.1.1",
         "markdown-it-texmath": "^1.0.0",
@@ -7779,9 +7779,9 @@
       }
     },
     "node_modules/llm-zoo": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.6.0.tgz",
-      "integrity": "sha512-M54xZghJ7TbH1Lvg/5AJbveFy4l5Hhfw17g4pcINnlJF58MwHTcVi7r4leBzmR2mHSWmbm+upMEVAyFwdGqAHA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/llm-zoo/-/llm-zoo-1.6.1.tgz",
+      "integrity": "sha512-bZuat5sMXJrWEejuyAT1UWvrBUIz97MK3hh85vMHQNxqkXM1NOQS6pwG3BGNgvblooMwTCbkIusBSrLpY/uQBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "texra",
   "displayName": "TeXRA",
   "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
-  "version": "0.37.7",
+  "version": "0.37.8",
   "publisher": "texra-ai",
   "engines": {
     "vscode": "^1.105.0"
@@ -1637,7 +1637,7 @@
     "identifiers-arxiv": "^0.1.1",
     "katex": "^0.16.45",
     "lit": "^3.3.2",
-    "llm-zoo": "^1.6.0",
+    "llm-zoo": "^1.6.1",
     "mark.js": "^8.11.1",
     "markdown-it": "^14.1.1",
     "markdown-it-texmath": "^1.0.0",

--- a/supabase/functions/relay/models.ts
+++ b/supabase/functions/relay/models.ts
@@ -8,7 +8,7 @@
  * - Ultra: All models including premium ($3+/M input)
  */
 
-import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.6.0';
+import { MODEL_CONFIGS, type ModelConfig } from 'npm:llm-zoo@^1.6.1';
 
 // =============================================================================
 // Types


### PR DESCRIPTION
## Summary
- bump TeXRA to 0.37.8 for the DeepSeek pricing update
- update llm-zoo to 1.6.1 so TeXRA uses current DeepSeek V4 pricing and max thinking defaults from the model catalog
- align the Supabase relay import with llm-zoo 1.6.1
- add the DeepSeek pricing correction under a new 0.37.8 changelog section

## Validation
- npm run format
- npm run compile:safe
- npm run lint (passes with 3 existing warnings in unrelated files)
- npm ls llm-zoo --depth=0
- verified llm-zoo metadata reports DeepSeek V4 Flash cache hit /bin/zsh.0028/M, V4 Pro discounted input/output /bin/zsh.435//bin/zsh.87/M, and thinking variants default to xhigh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the `llm-zoo` catalog dependency to update model pricing metadata, which can change relay tier gating and cost calculations for DeepSeek V4 models. Scope is small but impacts user-facing billing/pricing behavior.
> 
> **Overview**
> Updates TeXRA to `0.37.8` and bumps `llm-zoo` to `^1.6.1` so the model catalog reflects **current DeepSeek V4 Flash/Pro cache-hit and discounted input/output pricing**.
> 
> Aligns the Supabase relay’s `MODEL_CONFIGS` import to the new `llm-zoo` version and records the pricing correction in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee4e3d07ca17c7befbb39d35854bf8f476af58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->