### PR TITLE
[codex] Fix agent tool status updates

### DIFF
--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -129,13 +129,6 @@ export function killExecution(executionId: string): boolean {
   const handle = registry.get(executionId);
   if (!handle) return false;
   const result = handle.terminate();
-  if (
-    result &&
-    handle instanceof AgentExecutionHandle &&
-    handle.parentStreamId !== handle.childStreamId
-  ) {
-    emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
-  }
   // Always notify waiters — even if terminate() returned false (e.g. PID not
   // yet assigned), callers blocking on this execution should be unblocked.
   notifyWaiters(executionId);

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -129,6 +129,13 @@ export function killExecution(executionId: string): boolean {
   const handle = registry.get(executionId);
   if (!handle) return false;
   const result = handle.terminate();
+  if (
+    result &&
+    handle instanceof AgentExecutionHandle &&
+    handle.parentStreamId !== handle.childStreamId
+  ) {
+    emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
+  }
   // Always notify waiters — even if terminate() returned false (e.g. PID not
   // yet assigned), callers blocking on this execution should be unblocked.
   notifyWaiters(executionId);

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -30,8 +30,8 @@ export function cleanSessionDescription(text: string): string {
   const cleaned = text
     .trim()
     .replaceAll(/\s*\n\s*/g, ' ')
-    .replace(/^["'`]+|["'`]+$/g, '')
-    .replace(/[.!?…]+$/, '')
+    .replaceAll(/^["'`]+|["'`]+$/g, '')
+    .replaceAll(/[.!?…]+$/g, '')
     .trim();
   if (!cleaned) return '';
   return truncateWithEllipsis(cleaned, MAX_DESCRIPTION_LENGTH);

--- a/src/commands/latex/compareCommands.ts
+++ b/src/commands/latex/compareCommands.ts
@@ -5,9 +5,9 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { bus } from '@eventBus/ProgressEventBus';
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 import { showLoggedErrorMessage, toErrorMessage } from '@common/errors';
+import { bus } from '@eventBus/ProgressEventBus';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import * as logger from '@logger/logUtils';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latex';

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -17,12 +17,12 @@ import { z } from 'zod';
 
 // Local imports - shared
 import { getExecutionStore } from '@agent/storage';
+import { bus } from '@eventBus/ProgressEventBus';
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
 import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
 
 // Local imports - tools
-import { bus } from '@eventBus/ProgressEventBus';
 import type { ExecutionId, FileLocation } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { formatResultCount, pluralize } from '@tools/formatting';

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -362,6 +362,24 @@ async function listOpenPullSuggestions(
   return `\n\nOpen PRs you can subscribe to directly:\n${lines.join('\n')}`;
 }
 
+async function getFindCurrentFallbackInfo(
+  owner: string,
+  repo: string,
+): Promise<{ defaultBranch?: string; suggestions: string }> {
+  const [defaultBranchResult, suggestionsResult] = await Promise.allSettled([
+    getDefaultBranch(owner, repo),
+    listOpenPullSuggestions(owner, repo),
+  ]);
+  return {
+    defaultBranch:
+      defaultBranchResult.status === 'fulfilled'
+        ? defaultBranchResult.value
+        : undefined,
+    suggestions:
+      suggestionsResult.status === 'fulfilled' ? suggestionsResult.value : '',
+  };
+}
+
 async function execFindCurrent(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
@@ -401,8 +419,7 @@ async function execFindCurrent(
   }
   const pr = res.data[0];
   if (!pr) {
-    const defaultBranch = await getDefaultBranch(remote.owner, remote.repo);
-    const suggestions = await listOpenPullSuggestions(
+    const { defaultBranch, suggestions } = await getFindCurrentFallbackInfo(
       remote.owner,
       remote.repo,
     );

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -391,16 +391,6 @@ async function execFindCurrent(
   if (branch === 'HEAD') {
     throw new ToolError('HEAD is detached — cannot infer a PR branch.');
   }
-  const defaultBranch = await getDefaultBranch(remote.owner, remote.repo);
-  if (branch === defaultBranch) {
-    const suggestions = await listOpenPullSuggestions(
-      remote.owner,
-      remote.repo,
-    );
-    throw new ToolError(
-      `Current branch is the default branch "${branch}", so command="find_current" cannot infer a single PR. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
-    );
-  }
   const apiPath = `/repos/${remote.owner}/${remote.repo}/pulls?state=open&head=${remote.owner}:${encodeURIComponent(branch)}&per_page=1`;
   const res =
     await ghGet<
@@ -411,10 +401,16 @@ async function execFindCurrent(
   }
   const pr = res.data[0];
   if (!pr) {
+    const defaultBranch = await getDefaultBranch(remote.owner, remote.repo);
     const suggestions = await listOpenPullSuggestions(
       remote.owner,
       remote.repo,
     );
+    if (branch === defaultBranch) {
+      throw new ToolError(
+        `Current branch is the default branch "${branch}", and no open PR uses it as the head branch. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
+      );
+    }
     throw new ToolError(
       `No open PR found for ${remote.owner}/${remote.repo} head ${branch}. Push this branch and open a PR, or pass command="subscribe" with an explicit path for an existing PR.${suggestions}`,
     );

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -374,7 +374,7 @@ async function getFindCurrentFallbackInfo(
     defaultBranch:
       defaultBranchResult.status === 'fulfilled'
         ? defaultBranchResult.value
-        : undefined,
+        : 'main',
     suggestions:
       suggestionsResult.status === 'fulfilled' ? suggestionsResult.value : '',
   };

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -374,7 +374,7 @@ async function getFindCurrentFallbackInfo(
     defaultBranch:
       defaultBranchResult.status === 'fulfilled'
         ? defaultBranchResult.value
-        : 'main',
+        : undefined,
     suggestions:
       suggestionsResult.status === 'fulfilled' ? suggestionsResult.value : '',
   };
@@ -426,6 +426,11 @@ async function execFindCurrent(
     if (branch === defaultBranch) {
       throw new ToolError(
         `Current branch is the default branch "${branch}", and no open PR uses it as the head branch. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
+      );
+    }
+    if (!defaultBranch && branch === 'main') {
+      throw new ToolError(
+        `Current branch is "main", no open PR uses it as the head branch, and the default branch could not be confirmed. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
       );
     }
     throw new ToolError(

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -328,6 +328,40 @@ async function gitInDir(args: string[], cwd: string): Promise<string> {
   return stdout.trim();
 }
 
+interface OpenPullSummary {
+  number: number;
+  title?: string;
+  head?: { ref?: string };
+}
+
+async function getDefaultBranch(owner: string, repo: string): Promise<string> {
+  const res = await ghGet<{ default_branch?: string }>(
+    `/repos/${owner}/${repo}`,
+  );
+  if (res.status !== 200) {
+    throw new ToolError(`Unexpected GitHub response status: ${res.status}`);
+  }
+  return res.data.default_branch ?? 'main';
+}
+
+async function listOpenPullSuggestions(
+  owner: string,
+  repo: string,
+): Promise<string> {
+  const res = await ghGet<OpenPullSummary[]>(
+    `/repos/${owner}/${repo}/pulls?state=open&per_page=5`,
+  );
+  if (res.status !== 200 || res.data.length === 0) {
+    return '';
+  }
+  const lines = res.data.map((pr) => {
+    const title = pr.title ? ` - ${pr.title}` : '';
+    const head = pr.head?.ref ? ` (${pr.head.ref})` : '';
+    return `- ${owner}/${repo}/pulls/${pr.number}${head}${title}`;
+  });
+  return `\n\nOpen PRs you can subscribe to directly:\n${lines.join('\n')}`;
+}
+
 async function execFindCurrent(
   input: GitHubSubscriptionInput,
 ): Promise<ToolResult> {
@@ -357,6 +391,16 @@ async function execFindCurrent(
   if (branch === 'HEAD') {
     throw new ToolError('HEAD is detached — cannot infer a PR branch.');
   }
+  const defaultBranch = await getDefaultBranch(remote.owner, remote.repo);
+  if (branch === defaultBranch) {
+    const suggestions = await listOpenPullSuggestions(
+      remote.owner,
+      remote.repo,
+    );
+    throw new ToolError(
+      `Current branch is the default branch "${branch}", so command="find_current" cannot infer a single PR. Pass command="subscribe" with an explicit path such as "${remote.owner}/${remote.repo}/pulls/N".${suggestions}`,
+    );
+  }
   const apiPath = `/repos/${remote.owner}/${remote.repo}/pulls?state=open&head=${remote.owner}:${encodeURIComponent(branch)}&per_page=1`;
   const res =
     await ghGet<
@@ -367,8 +411,12 @@ async function execFindCurrent(
   }
   const pr = res.data[0];
   if (!pr) {
+    const suggestions = await listOpenPullSuggestions(
+      remote.owner,
+      remote.repo,
+    );
     throw new ToolError(
-      `No open PR found for ${remote.owner}/${remote.repo} head ${branch}. Push the branch and open a PR first.`,
+      `No open PR found for ${remote.owner}/${remote.repo} head ${branch}. Push this branch and open a PR, or pass command="subscribe" with an explicit path for an existing PR.${suggestions}`,
     );
   }
   const path = `${remote.owner}/${remote.repo}/pulls/${pr.number}`;


### PR DESCRIPTION
## Summary

- Make `github_subscription find_current` explain when the current branch is the default branch instead of suggesting a bogus `main` PR.
- Include open PR path suggestions when `find_current` cannot resolve a branch-specific PR.
- Refresh the active-subagent display immediately after a successful `executions kill` so killed children show `STOPPED` promptly.

## Root Cause

`github_subscription find_current` only resolves the current git branch to a PR, but its no-match error implied the caller should always push/open a PR. That is misleading when the checkout is on the repository default branch and the intended target is an existing PR.

For `executions kill`, the runtime set the child stream status to `STOPPED` and notified waiters, but the progress UI active-child list was only refreshed later when the execution was untracked.

## Validation

- `npm run typecheck`
- `npm run lint` (passes with existing warnings in unrelated files)
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to string-cleanup behavior and improved `find_current` fallback/error messaging, with a couple extra GitHub GETs when no PR matches the current branch.
> 
> **Overview**
> Improves `github_subscription` `find_current` behavior when no PR matches the current branch by *detecting default-branch checkouts*, updating the guidance to use explicit `owner/repo/pulls/N` paths, and appending up to 5 open-PR suggestions for quick subscription.
> 
> Minor cleanup: switches session-description normalization to `replaceAll` for quote/punctuation stripping and reorders a couple imports (no functional change intended).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c7c02ff03724a0cabdbcace590d8d0aae3de42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->