### PR TITLE
fix: uniform user message bubble styling in progress view

### DIFF
--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -84,10 +84,6 @@ export class UserMessage extends LitElement {
         border-radius: var(--border-radius);
       }
 
-      .user-message--structured-delivery {
-        max-width: 100%;
-      }
-
       .user-message-header {
         display: flex;
         align-items: center;

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -192,8 +192,7 @@ export class UserMessage extends LitElement {
                   icon="code"
                   title=${rawMessageCopyState.title}
                   aria-label=${rawMessageCopyState.ariaLabel}
-                  @click=${() =>
-                    this.rawMessageCopyController.copy(this.text)}
+                  @click=${() => this.rawMessageCopyController.copy(this.text)}
                 ></vscode-toolbar-button>`
               : nothing}
           </div>

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -14,24 +14,11 @@ import { CopyButtonController } from '@shared/controllers';
 import { designTokens } from '@shared/styles/litStyles';
 import { codiconIconClasses } from '@shared/styles/codiconStyles';
 
-// Local imports - controllers
-
 // Local imports - formatter helpers
 import { formatTimestamp } from '../formatters/timestampUtils';
 
-const STRUCTURED_DELIVERY_TAGS = [
-  'background-result',
-  'background-error',
-  'codex-result',
-  'codex-error',
-  'execution-activity',
-  'github-webhook-activity',
-  'subagent-progress',
-  'subagent-result',
-  'subagent-error',
-] as const;
-
-const XML_ESCAPED_DELIVERY_TAGS = new Set<string>([
+// Tags whose text content is XML-entity-escaped and needs decoding for display.
+const XML_ESCAPED_TAGS = new Set([
   'background-result',
   'background-error',
   'codex-result',
@@ -40,13 +27,12 @@ const XML_ESCAPED_DELIVERY_TAGS = new Set<string>([
   'subagent-error',
 ]);
 
-const STRUCTURED_DELIVERY_PATTERN = new RegExp(
-  `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,
+const XML_ESCAPED_PATTERN = new RegExp(
+  `^\\s*<(${[...XML_ESCAPED_TAGS].join('|')})(\\s|>)`,
 );
 
-function getStructuredDeliveryTag(text: string): string | null {
-  const match = STRUCTURED_DELIVERY_PATTERN.exec(text);
-  return match?.[1] ?? null;
+function isXmlEscaped(text: string): boolean {
+  return XML_ESCAPED_PATTERN.test(text);
 }
 
 function decodeXmlEntitiesForDisplay(text: string): string {
@@ -125,28 +111,6 @@ export class UserMessage extends LitElement {
         font-size: var(--font-size-sm);
       }
 
-      .user-message--structured-delivery .user-message-content {
-        max-height: min(45vh, 520px);
-        overflow: auto;
-        padding: var(--spacing-small);
-        background: var(
-          --vscode-textCodeBlock-background,
-          var(--vscode-editor-background)
-        );
-        border-radius: var(--border-radius-small);
-        font-family: var(
-          --vscode-editor-font-family,
-          ui-monospace,
-          SFMono-Regular,
-          Consolas,
-          monospace
-        );
-        font-size: var(--vscode-editor-font-size, var(--font-size-sm));
-        line-height: 1.35;
-        white-space: pre;
-        word-wrap: normal;
-      }
-
       .user-message-timestamp {
         font-size: var(--font-size-xs);
       }
@@ -172,34 +136,21 @@ export class UserMessage extends LitElement {
 
   private displayCache = {
     text: '',
-    isStructuredDelivery: false,
     hasRawMessage: false,
     displayText: '',
   };
 
-  private getDisplayState(): {
-    isStructuredDelivery: boolean;
-    hasRawMessage: boolean;
-    displayText: string;
-  } {
+  private getDisplayState(): { hasRawMessage: boolean; displayText: string } {
     if (this.displayCache.text === this.text) {
       return this.displayCache;
     }
 
-    const structuredTag = getStructuredDeliveryTag(this.text);
-    const isStructuredDelivery = structuredTag != null;
-    const hasRawMessage =
-      structuredTag != null && XML_ESCAPED_DELIVERY_TAGS.has(structuredTag);
+    const hasRawMessage = isXmlEscaped(this.text);
     const displayText = hasRawMessage
       ? decodeXmlEntitiesForDisplay(this.text)
       : this.text;
 
-    this.displayCache = {
-      text: this.text,
-      isStructuredDelivery,
-      hasRawMessage,
-      displayText,
-    };
+    this.displayCache = { text: this.text, hasRawMessage, displayText };
     return this.displayCache;
   }
 
@@ -209,17 +160,11 @@ export class UserMessage extends LitElement {
     );
     const copyState = this.copyController.state;
     const rawMessageCopyState = this.rawMessageCopyController.state;
-    const { isStructuredDelivery, hasRawMessage, displayText } =
-      this.getDisplayState();
+    const { hasRawMessage, displayText } = this.getDisplayState();
 
     return html`
       <div class="user-message-container">
-        <div
-          class=${classMap({
-            'user-message': true,
-            'user-message--structured-delivery': isStructuredDelivery,
-          })}
-        >
+        <div class="user-message">
           <div class="user-message-header">
             <span class="user-message-header-left">
               <i class="codicon codicon-comment user-message-icon"></i>
@@ -247,7 +192,8 @@ export class UserMessage extends LitElement {
                   icon="code"
                   title=${rawMessageCopyState.title}
                   aria-label=${rawMessageCopyState.ariaLabel}
-                  @click=${() => this.rawMessageCopyController.copy(this.text)}
+                  @click=${() =>
+                    this.rawMessageCopyController.copy(this.text)}
                 ></vscode-toolbar-button>`
               : nothing}
           </div>

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -17,7 +17,19 @@ import { codiconIconClasses } from '@shared/styles/codiconStyles';
 // Local imports - formatter helpers
 import { formatTimestamp } from '../formatters/timestampUtils';
 
-// Tags whose text content is XML-entity-escaped and needs decoding for display.
+const STRUCTURED_DELIVERY_TAGS = [
+  'background-result',
+  'background-error',
+  'codex-result',
+  'codex-error',
+  'execution-activity',
+  'github-webhook-activity',
+  'subagent-progress',
+  'subagent-result',
+  'subagent-error',
+] as const;
+
+// Subset whose content is XML-entity-escaped and needs decoding for display.
 const XML_ESCAPED_TAGS = new Set([
   'background-result',
   'background-error',
@@ -27,12 +39,12 @@ const XML_ESCAPED_TAGS = new Set([
   'subagent-error',
 ]);
 
-const XML_ESCAPED_PATTERN = new RegExp(
-  `^\\s*<(${[...XML_ESCAPED_TAGS].join('|')})(\\s|>)`,
+const STRUCTURED_DELIVERY_PATTERN = new RegExp(
+  `^\\s*<(${STRUCTURED_DELIVERY_TAGS.join('|')})(\\s|>)`,
 );
 
-function isXmlEscaped(text: string): boolean {
-  return XML_ESCAPED_PATTERN.test(text);
+function getStructuredDeliveryTag(text: string): string | null {
+  return STRUCTURED_DELIVERY_PATTERN.exec(text)?.[1] ?? null;
 }
 
 function decodeXmlEntitiesForDisplay(text: string): string {
@@ -111,6 +123,26 @@ export class UserMessage extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      .user-message--structured-delivery .user-message-content {
+        max-height: min(45vh, 520px);
+        overflow: auto;
+        padding: var(--spacing-small);
+        background: var(
+          --vscode-textCodeBlock-background,
+          var(--vscode-editor-background)
+        );
+        border-radius: var(--border-radius-small);
+        font-family: var(
+          --vscode-editor-font-family,
+          ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          monospace
+        );
+        font-size: var(--vscode-editor-font-size, var(--font-size-sm));
+        line-height: 1.35;
+      }
+
       .user-message-timestamp {
         font-size: var(--font-size-xs);
       }
@@ -136,21 +168,33 @@ export class UserMessage extends LitElement {
 
   private displayCache = {
     text: '',
+    isStructuredDelivery: false,
     hasRawMessage: false,
     displayText: '',
   };
 
-  private getDisplayState(): { hasRawMessage: boolean; displayText: string } {
+  private getDisplayState(): {
+    isStructuredDelivery: boolean;
+    hasRawMessage: boolean;
+    displayText: string;
+  } {
     if (this.displayCache.text === this.text) {
       return this.displayCache;
     }
 
-    const hasRawMessage = isXmlEscaped(this.text);
+    const tag = getStructuredDeliveryTag(this.text);
+    const isStructuredDelivery = tag != null;
+    const hasRawMessage = tag != null && XML_ESCAPED_TAGS.has(tag);
     const displayText = hasRawMessage
       ? decodeXmlEntitiesForDisplay(this.text)
       : this.text;
 
-    this.displayCache = { text: this.text, hasRawMessage, displayText };
+    this.displayCache = {
+      text: this.text,
+      isStructuredDelivery,
+      hasRawMessage,
+      displayText,
+    };
     return this.displayCache;
   }
 
@@ -160,11 +204,17 @@ export class UserMessage extends LitElement {
     );
     const copyState = this.copyController.state;
     const rawMessageCopyState = this.rawMessageCopyController.state;
-    const { hasRawMessage, displayText } = this.getDisplayState();
+    const { isStructuredDelivery, hasRawMessage, displayText } =
+      this.getDisplayState();
 
     return html`
       <div class="user-message-container">
-        <div class="user-message">
+        <div
+          class=${classMap({
+            'user-message': true,
+            'user-message--structured-delivery': isStructuredDelivery,
+          })}
+        >
           <div class="user-message-header">
             <span class="user-message-header-left">
               <i class="codicon codicon-comment user-message-icon"></i>

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -30,11 +30,14 @@ const STRUCTURED_DELIVERY_TAGS = [
 ] as const;
 
 // Subset whose content is XML-entity-escaped and needs decoding for display.
+// subagent-progress is included because the "todos" variant runs todo text
+// through escapeText(), producing &amp;/&lt; entities in the body.
 const XML_ESCAPED_TAGS = new Set([
   'background-result',
   'background-error',
   'codex-result',
   'codex-error',
+  'subagent-progress',
   'subagent-result',
   'subagent-error',
 ]);

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -26,6 +26,7 @@ const STRUCTURED_DELIVERY_TAGS = [
   'codex-error',
   'execution-activity',
   'github-webhook-activity',
+  'subagent-progress',
   'subagent-result',
   'subagent-error',
 ] as const;


### PR DESCRIPTION
## Summary

- All user message bubbles are now uniformly 85% wide — structured-delivery messages no longer expand to 100%
- `subagent-progress` added to `STRUCTURED_DELIVERY_TAGS` so automatic progress payloads get the code-block treatment like other structured messages
- Structured-delivery content now wraps (`pre-wrap`) instead of scrolling horizontally (`pre`)
- Simplified the tag-detection logic: `XML_ESCAPED_TAGS` is now a plain `Set` used only for the two things that need it — entity decoding and the raw-copy button

## Test plan

- [ ] Send a plain follow-up message → renders as 85%-wide bubble with normal text style
- [ ] Trigger a subagent run → `<subagent-progress …/>` message appears as 85%-wide code-block bubble (monospace, capped height)
- [ ] Trigger a subagent result → `<subagent-result>` message same width and style as progress message
- [ ] Long multi-line structured-delivery content wraps within the bubble rather than scrolling horizontally
- [ ] Raw-copy button (code icon) still appears on `subagent-result`/`background-result`/`codex-result` messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/CSS and display-formatting tweaks in the progress view; low risk, with the main potential issue being misclassification/decoding of structured tags affecting wrapping and the raw-copy button.
> 
> **Overview**
> **Progress-view user message rendering is normalized.** Structured-delivery messages no longer expand to full width; all bubbles cap at `85%`, and structured content now wraps (`pre-wrap`) instead of forcing horizontal scrolling.
> 
> **Structured tag handling is updated.** `subagent-progress` is treated as a structured-delivery tag and included in the XML-entity decoding/raw-copy eligibility set, and the tag/escape detection logic is simplified (`XML_ESCAPED_TAGS`, streamlined `getStructuredDeliveryTag`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0ed0cdc826aa48d4366fd8355e43ce86ce14df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->