### PR TITLE
feat: share repo-level workspace state across git worktrees

### DIFF
--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -60,6 +60,7 @@ import { registerAgentEventListeners } from '@frontend/events/agentEventListener
 import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
 import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
+import { resolveGitCommonRoot } from '@frontend/git/resolveGitRoot';
 import { getLinterMessages } from '@frontend/latex/linter';
 import {
   pushManualCriticism,
@@ -149,6 +150,7 @@ export async function activate(context: vscode.ExtensionContext) {
     path: path.join(workspaceRoot, '.env'),
   });
   await setActiveSidebarView(SIDEBAR_VIEWS.MAIN);
+  const gitRepoRoot = await resolveGitCommonRoot(workspaceRoot);
 
   SecretManager.initialize(context);
   agentDirectories.initialize(context);
@@ -157,11 +159,11 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.createOutputChannel(name),
   );
   initializePolishModel(context.extensionPath);
-  initializeStateManagers(context);
+  initializeStateManagers(context, gitRepoRoot);
   initPlatform({
     config: new VscodeConfigProvider(),
     globalState: context.globalState,
-    workspaceState: context.workspaceState,
+    workspaceState: workspaceSM,
     log: logger,
     fs: new VscodeFileSystem(),
     workspace: new VscodeWorkspace(),

--- a/packages/extension/src/frontend/git/resolveGitRoot.ts
+++ b/packages/extension/src/frontend/git/resolveGitRoot.ts
@@ -1,0 +1,98 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import * as vscode from 'vscode';
+
+/** Minimal types for the vscode.git extension public API (version 1). */
+interface GitRepository {
+  readonly rootUri: vscode.Uri;
+}
+
+interface GitAPI {
+  getRepository(uri: vscode.Uri): GitRepository | null;
+}
+
+interface GitExtension {
+  getAPI(version: 1): GitAPI;
+}
+
+function hasFileType(stat: vscode.FileStat, type: vscode.FileType): boolean {
+  return (stat.type & type) !== 0;
+}
+
+export function resolveCommonRootFromGitdir(
+  repoRoot: string,
+  gitdir: string,
+): string {
+  const normalizedGitdir = path.normalize(gitdir);
+  const worktreesDir = path.dirname(normalizedGitdir);
+  const commonGitDir = path.dirname(worktreesDir);
+
+  if (
+    path.basename(worktreesDir) === 'worktrees' &&
+    path.basename(commonGitDir) === '.git'
+  ) {
+    return path.dirname(commonGitDir);
+  }
+
+  return repoRoot;
+}
+
+/**
+ * Resolve the git common-directory root for a workspace path.
+ *
+ * For a main worktree the common root is the repository root. For additional
+ * worktrees, `.git` is a file pointing into `.git/worktrees/<name>`, so this
+ * returns the main repository root. Submodule `.git/modules/...` layouts fall
+ * back to the submodule root to avoid namespace collisions.
+ */
+export async function resolveGitCommonRoot(
+  workspacePath: string,
+): Promise<string | undefined> {
+  try {
+    const ext = vscode.extensions.getExtension<GitExtension>('vscode.git');
+    if (!ext) {
+      return undefined;
+    }
+
+    const exports = ext.isActive ? ext.exports : await ext.activate();
+    const git = exports.getAPI(1);
+    const repo = git.getRepository(vscode.Uri.file(workspacePath));
+    if (!repo) {
+      return undefined;
+    }
+
+    const gitEntryUri = vscode.Uri.joinPath(repo.rootUri, '.git');
+    let stat: vscode.FileStat;
+    try {
+      stat = await vscode.workspace.fs.stat(gitEntryUri);
+    } catch {
+      return undefined;
+    }
+
+    if (hasFileType(stat, vscode.FileType.Directory)) {
+      return repo.rootUri.fsPath;
+    }
+
+    if (!hasFileType(stat, vscode.FileType.File)) {
+      return undefined;
+    }
+
+    const bytes = await vscode.workspace.fs.readFile(gitEntryUri);
+    const content = Buffer.from(bytes).toString('utf8').trim();
+    const match = /^gitdir:\s*(.+)$/m.exec(content);
+    if (!match) {
+      return undefined;
+    }
+
+    const gitdirValue = match[1].trim();
+    const gitdir = path.isAbsolute(gitdirValue)
+      ? gitdirValue
+      : path.resolve(repo.rootUri.fsPath, gitdirValue);
+
+    return resolveCommonRootFromGitdir(repo.rootUri.fsPath, gitdir);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/common/state/stateManager.ts
+++ b/src/common/state/stateManager.ts
@@ -1,6 +1,9 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - state
+import { WorktreeMemento } from './worktreeMemento';
+
 // Re-export pure-data state keys so existing `@common/state/stateManager`
 // imports keep working. The actual definitions live in stateKeys.ts so
 // vscode-free zones can import them via `@common/state/stateKeys` without
@@ -10,6 +13,30 @@ export {
   GlobalStateKey,
   INSTRUCTION_PREFIX,
 } from './stateKeys';
+import { WorkspaceStateKey } from './stateKeys';
+
+/**
+ * WorkspaceStateKeys that represent repository-level configuration rather
+ * than per-workspace run data. These are shared across git worktrees of the
+ * same repository by routing them through globalState with a repo namespace.
+ */
+const WORKTREE_SHARED_KEYS: ReadonlySet<WorkspaceStateKey> =
+  new Set<WorkspaceStateKey>([
+    WorkspaceStateKey.ENABLED_AGENTS,
+    WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+    WorkspaceStateKey.SUPER_YOLO_ENABLED,
+    WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+    WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+    WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
+    WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+    WorkspaceStateKey.CODEX_SANDBOX_MODE,
+    WorkspaceStateKey.CODEX_REASONING_EFFORT,
+    WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+    WorkspaceStateKey.GIT_MARK_COMMITS,
+    WorkspaceStateKey.GIT_AUTHOR_NAME,
+    WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+    WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+  ]);
 
 /** Workspace state manager (initialized via initializeStateManagers) */
 export let workspaceSM: vscode.Memento;
@@ -17,10 +44,24 @@ export let workspaceSM: vscode.Memento;
 /** Global state manager (initialized via initializeStateManagers) */
 export let globalSM: vscode.Memento;
 
-/** Initialize the state managers with the extension context */
+/**
+ * Initialize the state managers with the extension context.
+ *
+ * When `repoRoot` is available, selected repository-level workspace keys are
+ * shared across all git worktrees for that repository. All run/session keys
+ * remain in VS Code's normal workspaceState.
+ */
 export function initializeStateManagers(
   context: vscode.ExtensionContext,
+  repoRoot?: string,
 ): void {
-  workspaceSM = context.workspaceState;
   globalSM = context.globalState;
+  workspaceSM = repoRoot
+    ? new WorktreeMemento(
+        context.workspaceState,
+        context.globalState,
+        repoRoot,
+        WORKTREE_SHARED_KEYS,
+      )
+    : context.workspaceState;
 }

--- a/src/common/state/worktreeMemento.ts
+++ b/src/common/state/worktreeMemento.ts
@@ -1,0 +1,69 @@
+// Third-party imports
+import type * as vscode from 'vscode';
+
+/**
+ * A `vscode.Memento`-compatible wrapper that transparently shares selected
+ * repository-level workspace keys across git worktrees.
+ */
+export class WorktreeMemento implements vscode.Memento {
+  constructor(
+    private readonly workspaceState: vscode.Memento,
+    private readonly globalState: vscode.Memento,
+    private readonly repoRoot: string,
+    private readonly sharedKeys: ReadonlySet<string>,
+  ) {}
+
+  keys(): readonly string[] {
+    const all = new Set(this.workspaceState.keys());
+    for (const key of this.sharedKeys) {
+      if (
+        this.globalState.get(this.namespacedKey(key)) !== undefined ||
+        this.workspaceState.get(key) !== undefined
+      ) {
+        all.add(key);
+      }
+    }
+    return [...all];
+  }
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (!this.sharedKeys.has(key)) {
+      return defaultValue === undefined
+        ? this.workspaceState.get<T>(key)
+        : this.workspaceState.get<T>(key, defaultValue);
+    }
+
+    const namespacedKey = this.namespacedKey(key);
+    const sharedValue = this.globalState.get<T>(namespacedKey);
+    if (sharedValue !== undefined) {
+      return sharedValue;
+    }
+
+    const legacyValue = this.workspaceState.get<T>(key);
+    if (legacyValue !== undefined) {
+      void this.update(key, legacyValue);
+      return legacyValue;
+    }
+
+    return defaultValue;
+  }
+
+  update(key: string, value: unknown): Thenable<void> {
+    if (!this.sharedKeys.has(key)) {
+      return this.workspaceState.update(key, value);
+    }
+
+    return this.updateSharedKey(key, value);
+  }
+
+  private namespacedKey(key: string): string {
+    return `worktree:${this.repoRoot}:${key}`;
+  }
+
+  private async updateSharedKey(key: string, value: unknown): Promise<void> {
+    await this.globalState.update(this.namespacedKey(key), value);
+    await this.workspaceState.update(key, undefined);
+  }
+}

--- a/src/test-kernel/common/WorktreeMemento.vitest.ts
+++ b/src/test-kernel/common/WorktreeMemento.vitest.ts
@@ -1,0 +1,120 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - common state
+import { WorktreeMemento } from '@common/state/worktreeMemento';
+
+class FakeMemento {
+  readonly writes: Array<[string, unknown]> = [];
+
+  constructor(private readonly values = new Map<string, unknown>()) {}
+
+  keys(): readonly string[] {
+    return [...this.values.keys()];
+  }
+
+  get<T>(key: string): T | undefined;
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.values.has(key) ? (this.values.get(key) as T) : defaultValue;
+  }
+
+  update(key: string, value: unknown): Thenable<void> {
+    this.writes.push([key, value]);
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+    return Promise.resolve();
+  }
+}
+
+describe('WorktreeMemento', () => {
+  const sharedKey = 'texra.enabledAgents';
+  const localKey = 'texra.taskStates';
+  const repoRoot = '/repo/main';
+  const namespacedKey = `worktree:${repoRoot}:${sharedKey}`;
+
+  it('reads and writes shared keys through repo-namespaced global state', async () => {
+    const workspaceState = new FakeMemento();
+    const globalState = new FakeMemento(new Map([[namespacedKey, ['review']]]));
+    const memento = new WorktreeMemento(
+      workspaceState,
+      globalState,
+      repoRoot,
+      new Set([sharedKey]),
+    );
+
+    expect(memento.get(sharedKey, [])).toEqual(['review']);
+    await memento.update(sharedKey, ['latexFixer']);
+    expect(globalState.get(namespacedKey)).toEqual(['latexFixer']);
+    expect(workspaceState.get(sharedKey)).toBeUndefined();
+  });
+
+  it('migrates legacy workspace values before returning defaults', async () => {
+    const workspaceState = new FakeMemento(new Map([[sharedKey, ['correct']]]));
+    const globalState = new FakeMemento();
+    const memento = new WorktreeMemento(
+      workspaceState,
+      globalState,
+      repoRoot,
+      new Set([sharedKey]),
+    );
+
+    expect(memento.get(sharedKey, [])).toEqual(['correct']);
+    expect(globalState.get(namespacedKey)).toEqual(['correct']);
+    await Promise.resolve();
+    expect(workspaceState.get(sharedKey)).toBeUndefined();
+  });
+
+  it('clears legacy workspace values when shared keys are updated', async () => {
+    const workspaceState = new FakeMemento(new Map([[sharedKey, ['stale']]]));
+    const globalState = new FakeMemento(
+      new Map([[namespacedKey, ['current']]]),
+    );
+    const memento = new WorktreeMemento(
+      workspaceState,
+      globalState,
+      repoRoot,
+      new Set([sharedKey]),
+    );
+
+    await memento.update(sharedKey, undefined);
+
+    expect(globalState.get(namespacedKey)).toBeUndefined();
+    expect(workspaceState.get(sharedKey)).toBeUndefined();
+    expect(memento.get(sharedKey, [])).toEqual([]);
+  });
+
+  it('leaves non-shared keys in workspace state', async () => {
+    const workspaceState = new FakeMemento(
+      new Map([[localKey, { one: true }]]),
+    );
+    const globalState = new FakeMemento();
+    const memento = new WorktreeMemento(
+      workspaceState,
+      globalState,
+      repoRoot,
+      new Set([sharedKey]),
+    );
+
+    expect(memento.get(localKey)).toEqual({ one: true });
+    await memento.update(localKey, { two: true });
+    expect(workspaceState.get(localKey)).toEqual({ two: true });
+    expect(globalState.keys()).toEqual([]);
+  });
+
+  it('reports only keys with stored values', () => {
+    const workspaceState = new FakeMemento(new Map([[localKey, true]]));
+    const globalState = new FakeMemento();
+    const memento = new WorktreeMemento(
+      workspaceState,
+      globalState,
+      repoRoot,
+      new Set([sharedKey]),
+    );
+
+    expect(memento.keys()).toEqual([localKey]);
+  });
+});

--- a/src/test-kernel/frontend/ResolveGitRoot.vitest.ts
+++ b/src/test-kernel/frontend/ResolveGitRoot.vitest.ts
@@ -1,0 +1,33 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('vscode', () => ({
+  default: {},
+  extensions: {},
+  workspace: {},
+  Uri: {},
+  FileType: { File: 1, Directory: 2 },
+}));
+
+// Local imports - extension frontend
+import { resolveCommonRootFromGitdir } from '@frontend/git/resolveGitRoot';
+
+describe('resolveCommonRootFromGitdir', () => {
+  it('uses the main repository root for git worktree gitdir files', () => {
+    expect(
+      resolveCommonRootFromGitdir(
+        '/repo/feature-worktree',
+        '/repo/main/.git/worktrees/feature-worktree',
+      ),
+    ).toBe('/repo/main');
+  });
+
+  it('keeps submodules scoped to their own repository root', () => {
+    expect(
+      resolveCommonRootFromGitdir(
+        '/repo/main/deps/submodule',
+        '/repo/main/.git/modules/deps/submodule',
+      ),
+    ).toBe('/repo/main/deps/submodule');
+  });
+});


### PR DESCRIPTION
Uses the built-in vscode.git extension API and vscode.workspace.fs to
resolve the git common root at activation time, then wraps workspaceSM
in a new WorktreeMemento. The 13 repository-level keys (agent config,
git author settings, worktree support, Codex settings) are transparently
routed to globalState under a `worktree:<repoRoot>:<key>` namespace so
every worktree of the same repo reads and writes the same value.
Per-run / per-workspace keys (stream logs, task states, etc.) are
unaffected. No callers required changes.

https://claude.ai/code/session_01W6UnHUzCt75wc6QNBqKfW6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how selected workspace settings are persisted by routing them through repo-namespaced `globalState`, which could affect migration/consistency of user configuration across workspaces and worktrees.
> 
> **Overview**
> Adds git worktree awareness so *repository-level* workspace settings are shared across all worktrees of the same repo.
> 
> On activation, the extension resolves the repo’s git “common root” via the `vscode.git` API and wraps `workspaceState` in a new `WorktreeMemento` that transparently stores a fixed set of config keys in `globalState` under `worktree:<repoRoot>:<key>`, including legacy migration/cleanup behavior. Includes new unit tests for the git-root resolution helper and `WorktreeMemento` read/write/migration semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8186984605cfbc5a29983cdfc9ef31d75c27576c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->