### PR TITLE
[codex] Explain included access limits

### DIFF
--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -13,8 +13,8 @@ import {
   MODELS,
   MODEL_CONFIGS,
   ModelProvider,
+  ReasoningEffort,
   type ModelConfig,
-  type ReasoningEffort,
 } from 'llm-zoo';
 
 // Shared schemas and dispatchers
@@ -31,7 +31,7 @@ import { getHelperModelName } from '@agent/runtime/helperModel';
 import { LEVEL_TO_EFFORT } from '@agent/runtime/ModelFactory';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { ULTRA_TIER, MAX_TIER } from '@auth/config';
+import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';
 import { AUTH_COMMANDS } from '@auth/constants';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { runExecuteCommand } from '@commands/agent/executeCommand';
@@ -275,6 +275,23 @@ function supportsReasoningLevel(config: ModelConfig): boolean {
   );
 }
 
+function getIncludedAccessReasoningCap(
+  config: ModelConfig,
+): ReasoningLevel | undefined {
+  if (
+    !getServerSideKeyService().getUseIncludedModelAccess() ||
+    !config.name.startsWith('gpt5') ||
+    config.capabilities.reasoningEffort !== ReasoningEffort.XHIGH
+  ) {
+    return undefined;
+  }
+
+  const userTier = getServerSideKeyService().getUserTier();
+  if (userTier === MAX_TIER) return 'high';
+  if (userTier === FREE_TIER) return 'medium';
+  return undefined;
+}
+
 function buildModelSelectionItems(): ModelSelectionItem[] {
   const enabledSet = new Set(
     globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS, DEFAULT_MODELS),
@@ -306,6 +323,10 @@ function buildModelSelectionItems(): ModelSelectionItem[] {
       const defaultLevel = EFFORT_TO_LEVEL.get(reasoningEffort);
       if (defaultLevel) {
         item.defaultReasoningLevel = defaultLevel;
+      }
+      const includedAccessCap = getIncludedAccessReasoningCap(config);
+      if (includedAccessCap) {
+        item.includedAccessReasoningCap = includedAccessCap;
       }
       // Validate persisted override against the schema instead of blindly casting.
       const parsed = ReasoningLevelSchema.safeParse(reasoningOverrides[name]);
@@ -685,6 +706,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     if (view) await fn(view.webview);
   }
 
+  private async primeIncludedAccessIfAuthenticated(): Promise<void> {
+    const serverSideKeyService = getServerSideKeyService();
+    if (
+      serverSideKeyService.getUseIncludedModelAccess() &&
+      (await SupabaseClient.isAuthenticated())
+    ) {
+      await serverSideKeyService.canUseServerSideKeys();
+    }
+  }
+
   // ============================================================
   // Public methods for external access
   // ============================================================
@@ -694,6 +725,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // so it doesn't block the initial render. The frontend shows a loading
     // spinner until data arrives.
     void this.sendToolDashboardData(webview);
+
+    await this.primeIncludedAccessIfAuthenticated();
 
     await Promise.all([
       this.sendMemoryData(webview),
@@ -850,6 +883,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
+    await this.primeIncludedAccessIfAuthenticated();
     const models = buildModelSelectionItems();
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
@@ -1454,7 +1488,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     // Access mode affects model availability — invalidate cached options.
     invalidateModelOptionsCache();
-    await this.withActiveWebview((w) => this.sendProfileData(w));
+    await this.withActiveWebview(async (w) => {
+      await this.sendProfileData(w);
+      await this.sendModelSelectionData(w);
+    });
 
     const modeLabel =
       data.mode === 'included' ? 'Included Access' : 'My Own Keys';

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -727,13 +727,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     void this.sendToolDashboardData(webview);
 
     await this.primeIncludedAccessIfAuthenticated();
+    await this.sendProfileData(webview);
+    await this.sendModelSelectionData(webview);
 
     await Promise.all([
       this.sendMemoryData(webview),
       this.sendMemoryEnabled(webview),
       this.sendHistoryData(webview),
-      this.sendProfileData(webview),
-      this.sendModelSelectionData(webview),
       this.agentHandlers.sendAgentSelectionData(webview),
       this.agentHandlers.sendCustomAgentDir(webview),
       this.sendSuperYoloEnabled(webview),

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -706,14 +706,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     if (view) await fn(view.webview);
   }
 
-  private async primeIncludedAccessIfAuthenticated(): Promise<void> {
+  private async primeIncludedAccessIfAuthenticated(): Promise<boolean> {
     const serverSideKeyService = getServerSideKeyService();
     if (
-      serverSideKeyService.getUseIncludedModelAccess() &&
-      (await SupabaseClient.isAuthenticated())
+      !serverSideKeyService.getUseIncludedModelAccess() ||
+      !(await SupabaseClient.isAuthenticated())
     ) {
-      await serverSideKeyService.canUseServerSideKeys();
+      return false;
     }
+
+    return serverSideKeyService.canUseServerSideKeys();
   }
 
   // ============================================================
@@ -726,8 +728,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // spinner until data arrives.
     void this.sendToolDashboardData(webview);
 
-    await this.primeIncludedAccessIfAuthenticated();
-    await this.sendProfileData(webview);
+    const hasServerSideAccess = await this.primeIncludedAccessIfAuthenticated();
+    await this.sendProfileData(webview, { hasServerSideAccess });
     await this.sendModelSelectionData(webview);
 
     await Promise.all([
@@ -806,7 +808,10 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
-  public async sendProfileData(webview: vscode.Webview): Promise<void> {
+  public async sendProfileData(
+    webview: vscode.Webview,
+    options: { hasServerSideAccess?: boolean } = {},
+  ): Promise<void> {
     const isAuthenticated = await SupabaseClient.isAuthenticated();
     const providerKeyStatuses = await getProviderKeyStatuses();
 
@@ -834,7 +839,8 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     const serverSideKeyService = getServerSideKeyService();
     const hasServerSideAccess =
-      await serverSideKeyService.canUseServerSideKeys();
+      options.hasServerSideAccess ??
+      (await serverSideKeyService.canUseServerSideKeys());
 
     const user = await SupabaseClient.getUser();
     const authContext = await SupabaseClient.getUserAuthContext();
@@ -1487,8 +1493,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     // Access mode affects model availability — invalidate cached options.
     invalidateModelOptionsCache();
+    const hasServerSideAccess = await this.primeIncludedAccessIfAuthenticated();
     await this.withActiveWebview(async (w) => {
-      await this.sendProfileData(w);
+      await this.sendProfileData(w, { hasServerSideAccess });
       await this.sendModelSelectionData(w);
     });
 

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -883,7 +883,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendModelSelectionData(webview: vscode.Webview): Promise<void> {
-    await this.primeIncludedAccessIfAuthenticated();
     const models = buildModelSelectionItems();
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,

--- a/src/settingsView/frontend/components/profile/ApiAccessSection.ts
+++ b/src/settingsView/frontend/components/profile/ApiAccessSection.ts
@@ -3,11 +3,14 @@
  */
 
 // Third-party imports
-import { LitElement, html, type TemplateResult } from 'lit';
+import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { designTokens } from '@shared/styles';
+import { codiconStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared copy
+import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
 
 // Local imports - profile view styles
 import { profileViewStyles } from './styles';
@@ -17,7 +20,7 @@ import { ProfileViewEvents } from './events';
 
 @customElement('api-access-section')
 export class ApiAccessSection extends LitElement {
-  static override styles = [designTokens, profileViewStyles];
+  static override styles = [designTokens, codiconStyles, profileViewStyles];
 
   @property({ attribute: false }) mode: 'included' | 'personal' = 'personal';
 
@@ -46,7 +49,9 @@ export class ApiAccessSection extends LitElement {
               <span class="option-title">Use Included Access</span>
               <span class="option-description"
                 >Works automatically. No setup needed. Does not apply to
-                OpenRouter — those models always use your OpenRouter key.</span
+                OpenRouter — those models always use your OpenRouter key. Bring
+                your own provider API keys to use more of your own quota and
+                avoid relay caps.</span
               >
             </span>
           </label>
@@ -61,11 +66,36 @@ export class ApiAccessSection extends LitElement {
             <span class="option-content">
               <span class="option-title">Use My Own Keys</span>
               <span class="option-description"
-                >Provide your own API keys from OpenAI, Anthropic, etc.</span
+                >Provide your own API keys from OpenAI, Anthropic, etc. This
+                uses your provider account directly for higher limits and models
+                outside Included Access.</span
               >
             </span>
           </label>
         </div>
+        ${this.mode === 'included'
+          ? html`
+              <div class="api-access-support">
+                <span
+                  class="codicon codicon-heart api-access-support-icon"
+                  aria-hidden="true"
+                ></span>
+                <span class="api-access-support-copy">
+                  ${PROMO_NOTICE_LONG.supportLead}<a
+                    href=${PROMO_NOTICE_LONG.supportSponsorsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >${PROMO_NOTICE_LONG.supportSponsorsLabel}</a
+                  >${PROMO_NOTICE_LONG.supportMiddle}<a
+                    href=${PROMO_NOTICE_LONG.supportCoffeeUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >${PROMO_NOTICE_LONG.supportCoffeeLabel}</a
+                  >${PROMO_NOTICE_LONG.supportTail}
+                </span>
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -139,21 +139,40 @@ export class ModelSelectionList extends LitElement {
     );
   }
 
+  private getIncludedAccessReasoningCap(
+    model: ModelSelectionItem,
+  ): ReasoningLevel | null {
+    if (
+      !this.authenticated ||
+      this.apiAccessMode !== 'included' ||
+      !this.isRelayAvailable(model.name) ||
+      model.reasoningLevel ||
+      !model.includedAccessReasoningCap
+    ) {
+      return null;
+    }
+    return model.includedAccessReasoningCap;
+  }
+
   private renderReasoningDropdown(
     model: ModelSelectionItem,
   ): TemplateResult | typeof nothing {
     if (!model.supportsReasoningLevel) return nothing;
 
     const currentValue = model.reasoningLevel ?? '';
+    const includedAccessCap = this.getIncludedAccessReasoningCap(model);
     const defaultLabel = model.defaultReasoningLevel
       ? `Default (${REASONING_LEVEL_LABELS[model.defaultReasoningLevel]})`
       : 'Default';
+    const title = includedAccessCap
+      ? `Reasoning level. Included Access uses the TeXRA relay and caps this model's default Extra high reasoning to ${REASONING_LEVEL_LABELS[includedAccessCap]}. Use your own provider API key for uncapped provider-side access.`
+      : 'Reasoning level';
 
     return html`
       <vscode-single-select
         class="reasoning-level-select"
         .value=${currentValue}
-        title="Reasoning level"
+        title=${title}
         @change=${(e: Event) => this.handleReasoningLevelChange(model.name, e)}
       >
         <vscode-option value="" ?selected=${currentValue === ''}>
@@ -167,6 +186,13 @@ export class ModelSelectionList extends LitElement {
           `,
         )}
       </vscode-single-select>
+      ${includedAccessCap
+        ? html`<span
+            class="codicon codicon-warning model-row-icon model-row-icon--warning"
+            title=${title}
+            aria-hidden="true"
+          ></span>`
+        : nothing}
     `;
   }
 

--- a/src/settingsView/frontend/components/profile/styles.ts
+++ b/src/settingsView/frontend/components/profile/styles.ts
@@ -192,6 +192,32 @@ export const profileViewStyles: CSSResult = css`
     accent-color: var(--vscode-focusBorder);
   }
 
+  .api-access-support {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spacing-small);
+    padding: var(--spacing-small) var(--spacing-medium);
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-normal);
+  }
+
+  .api-access-support-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: var(--vscode-charts-red, var(--vscode-errorForeground));
+  }
+
+  .api-access-support a {
+    color: var(--vscode-textLink-foreground);
+    text-decoration: none;
+  }
+
+  .api-access-support a:hover {
+    color: var(--vscode-textLink-activeForeground);
+    text-decoration: underline;
+  }
+
   .option-content {
     display: flex;
     flex-direction: column;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -182,6 +182,8 @@ export const ModelSelectionItemSchema = z.object({
   defaultReasoningLevel: ReasoningLevelSchema.optional(),
   /** The user's chosen reasoning level override (undefined = use default). */
   reasoningLevel: ReasoningLevelSchema.optional(),
+  /** Included access relay cap applied to the default xhigh effort, if any. */
+  includedAccessReasoningCap: ReasoningLevelSchema.optional(),
   /** Whether this model qualifies as a "fast first response" pick (price-based). */
   isFast: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- show a settings warning when included access caps default GPT-5 xhigh reasoning
- refresh model selection after switching API access mode so cap state updates immediately
- add a compact support prompt for GitHub Sponsors and Buy Me a Coffee under Included Access

## Validation
- npm run typecheck
- npm run format
- npm run lint (passes with 3 unrelated existing warnings)
- npm run compile:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how model selection metadata is computed and when profile/model data is refreshed after auth/access-mode transitions, which can affect displayed availability and defaults. UI-only copy/styling additions are low risk but the tier-based cap logic could misclassify models or tiers if assumptions change.
> 
> **Overview**
> **Included Access limits are now explained inline.** The backend annotates model-selection items with an `includedAccessReasoningCap` when Included Access would down-cap default GPT-5 `XHIGH` reasoning based on user tier, and the schema is extended to carry this field.
> 
> **Settings UI reflects the cap state immediately.** Switching API access mode now primes server-side access (only when authenticated), refreshes profile data with that result, and re-sends model selection so the frontend can show a warning icon + tooltip on the reasoning dropdown when a cap applies. The Profile tab also adds a compact Sponsors/Buy Me a Coffee support callout when Included Access is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f75a929938ade9c7c75fce7b004ab888cfceb83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->