### PR TITLE
[codex] configure Codex approval policy

### DIFF
--- a/docs/guide/codex-cli.md
+++ b/docs/guide/codex-cli.md
@@ -34,6 +34,7 @@ All Codex options live on the Codex card in **Dashboard → Tools** and are scop
 | -------------------- | --------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
 | **Sandbox mode**     | `read-only`, `workspace-write`, `danger-full-access`                        | `workspace-write` | File-system access. Agents may override per call via `sandbox_mode`.       |
 | **Reasoning effort** | `low`, `medium`, `high`, `xhigh`                                            | `high`            | How deeply Codex deliberates. `xhigh` is capped to `high` before hand-off. |
+| **Approval policy**  | `auto approve`, `ask when requested`, `ask for untrusted`, `ask on failure` | `auto approve`    | When the Codex child process may stop to ask before running commands.      |
 | **Require approval** | checkbox under _Approval & Safety_ (<i class="codicon codicon-shield"></i>) | on                | Show a confirmation prompt before every Codex call.                        |
 
 TeXRA always drives Codex with the short model name `gpt-5.5` — OpenAI's latest flagship, well-suited to the planning, tool use, and multi-step execution Codex relies on. Everything else (providers, MCP servers, custom instructions) comes from Codex's own `~/.codex/config.toml`.

--- a/src/common/state/stateKeys.ts
+++ b/src/common/state/stateKeys.ts
@@ -42,6 +42,7 @@ export enum WorkspaceStateKey {
   // Codex settings
   CODEX_SANDBOX_MODE = 'texra.codexSandboxMode',
   CODEX_REASONING_EFFORT = 'texra.codexReasoningEffort',
+  CODEX_APPROVAL_POLICY = 'texra.codexApprovalPolicy',
 
   // Git commit author settings
   GIT_MARK_COMMITS = 'texra.git.markCommits',

--- a/src/common/webview/settingsViewCommands.ts
+++ b/src/common/webview/settingsViewCommands.ts
@@ -79,6 +79,7 @@ export const SETTINGS_VIEW_CMD = {
   SET_BASH_APPROVAL_ENABLED: 'setBashApprovalEnabled',
   SET_CODEX_SANDBOX_MODE: 'setCodexSandboxMode',
   SET_CODEX_REASONING_EFFORT: 'setCodexReasoningEffort',
+  SET_CODEX_APPROVAL_POLICY: 'setCodexApprovalPolicy',
   // Tool dashboard commands
   GET_TOOL_DASHBOARD_DATA: 'getToolDashboardData',
   OPEN_TOOL_INSTALL_URL: 'openToolInstallUrl',

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -106,6 +106,7 @@ import {
 import {
   parseCodexSandboxMode,
   parseCodexReasoningEffort,
+  parseCodexApprovalPolicy,
 } from '@tools/codexConfig';
 import { findExternalToolDef } from '@tools/externalToolDefs';
 import {
@@ -603,6 +604,11 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           WorkspaceStateKey.CODEX_REASONING_EFFORT,
           data.effort,
         ),
+      [SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY]: (data) =>
+        this.updateCodexSetting(
+          WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+          data.policy,
+        ),
 
       // Tool dashboard handlers
       [SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA]: () =>
@@ -1064,6 +1070,12 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
           WorkspaceStateKey.CODEX_REASONING_EFFORT,
           'high',
         ) ?? 'high',
+      ),
+      codexApprovalPolicy: parseCodexApprovalPolicy(
+        workspaceSM.get<string>(
+          WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+          'never',
+        ) ?? 'never',
       ),
     });
   }

--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -194,6 +194,7 @@ export class SettingsApp extends SettingsAppBase {
   private readonly bashApprovalEnabled = signal(true);
   private readonly codexSandboxMode = signal<string>('workspace-write');
   private readonly codexReasoningEffort = signal<string>('high');
+  private readonly codexApprovalPolicy = signal<string>('never');
 
   // Tool dashboard state
   private readonly toolDashboardItems = signal<ToolDashboardItem[]>([]);
@@ -345,6 +346,7 @@ export class SettingsApp extends SettingsAppBase {
         this.bashApprovalEnabled.set(data.bashApprovalEnabled);
         this.codexSandboxMode.set(data.codexSandboxMode);
         this.codexReasoningEffort.set(data.codexReasoningEffort);
+        this.codexApprovalPolicy.set(data.codexApprovalPolicy);
         return;
       }
 
@@ -637,6 +639,10 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT,
   );
 
+  private handleCodexApprovalPolicyChange = forwardDetail(
+    SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY,
+  );
+
   // Git settings event handlers
   private handleGitMarkCommitsToggle = forwardDetail(
     SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
@@ -894,6 +900,7 @@ export class SettingsApp extends SettingsAppBase {
               .bashApprovalEnabled=${this.bashApprovalEnabled.get()}
               .codexSandboxMode=${this.codexSandboxMode.get()}
               .codexReasoningEffort=${this.codexReasoningEffort.get()}
+              .codexApprovalPolicy=${this.codexApprovalPolicy.get()}
               @tool-open-url=${this.handleToolOpenUrl}
               @tool-install-extension=${this.handleToolInstallExtension}
               @tool-run-command=${this.handleToolRunCommand}
@@ -903,6 +910,8 @@ export class SettingsApp extends SettingsAppBase {
               @codex-sandbox-mode-change=${this.handleCodexSandboxModeChange}
               @codex-reasoning-effort-change=${this
                 .handleCodexReasoningEffortChange}
+              @codex-approval-policy-change=${this
+                .handleCodexApprovalPolicyChange}
             ></tools-tab>
           </vscode-tab-panel>
 

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -18,6 +18,7 @@ import type {
   ToolCategory,
   CodexSandboxMode,
   CodexReasoningEffort,
+  CodexApprovalPolicy,
 } from '@shared/schemas/settingsViewMessages';
 
 // Side-effect: register tool card component
@@ -42,6 +43,17 @@ const REASONING_EFFORT_OPTIONS: readonly {
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
   { value: 'xhigh', label: 'Extra high' },
+] as const;
+
+/** Codex approval policy display labels — single source of truth for the UI. */
+const APPROVAL_POLICY_OPTIONS: readonly {
+  value: CodexApprovalPolicy;
+  label: string;
+}[] = [
+  { value: 'never', label: 'Auto approve' },
+  { value: 'on-request', label: 'Ask when requested' },
+  { value: 'untrusted', label: 'Ask for untrusted' },
+  { value: 'on-failure', label: 'Ask on failure' },
 ] as const;
 
 /** Per-category display metadata. */
@@ -254,6 +266,7 @@ export class ToolsTab extends LitElement {
   @property({ type: Boolean }) bashApprovalEnabled = true;
   @property({ type: String }) codexSandboxMode = 'workspace-write';
   @property({ type: String }) codexReasoningEffort = 'high';
+  @property({ type: String }) codexApprovalPolicy = 'never';
 
   private handleRecheck(): void {
     this.dispatchEvent(createEvent('tool-recheck'));
@@ -283,6 +296,10 @@ export class ToolsTab extends LitElement {
 
   private handleCodexReasoningEffortChange = (e: Event): void => {
     this.emitSelect('codex-reasoning-effort-change', 'effort', e);
+  };
+
+  private handleCodexApprovalPolicyChange = (e: Event): void => {
+    this.emitSelect('codex-approval-policy-change', 'policy', e);
   };
 
   private renderApprovalSettings(): TemplateResult {
@@ -348,6 +365,12 @@ export class ToolsTab extends LitElement {
           this.codexReasoningEffort,
           REASONING_EFFORT_OPTIONS,
           this.handleCodexReasoningEffortChange,
+        )}
+        ${this.renderSelectRow(
+          'Approval policy',
+          this.codexApprovalPolicy,
+          APPROVAL_POLICY_OPTIONS,
+          this.handleCodexApprovalPolicyChange,
         )}
       </div>
     `;

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -329,12 +329,22 @@ export const CodexReasoningEffortSchema = z.enum([
 ]);
 export type CodexReasoningEffort = z.infer<typeof CodexReasoningEffortSchema>;
 
+/** Valid Codex approval policies (mirrors CODEX_APPROVAL_POLICIES in codexConfig.ts). */
+export const CodexApprovalPolicySchema = z.enum([
+  'never',
+  'on-request',
+  'on-failure',
+  'untrusted',
+]);
+export type CodexApprovalPolicy = z.infer<typeof CodexApprovalPolicySchema>;
+
 /** Outbound: backend → frontend approval settings */
 export const UpdateApprovalSettingsMessageSchema = z.object({
   command: z.literal(SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS),
   bashApprovalEnabled: z.boolean(),
   codexSandboxMode: CodexSandboxModeSchema,
   codexReasoningEffort: CodexReasoningEffortSchema,
+  codexApprovalPolicy: CodexApprovalPolicySchema,
 });
 export type UpdateApprovalSettingsMessage = z.infer<
   typeof UpdateApprovalSettingsMessageSchema
@@ -823,6 +833,10 @@ const SetCodexReasoningEffortMessageSchema = z.object({
   command: z.literal(CMD.SET_CODEX_REASONING_EFFORT),
   effort: CodexReasoningEffortSchema,
 });
+const SetCodexApprovalPolicyMessageSchema = z.object({
+  command: z.literal(CMD.SET_CODEX_APPROVAL_POLICY),
+  policy: CodexApprovalPolicySchema,
+});
 
 // Navigation inbound messages
 const OpenVscodeSettingsMessageSchema = commandOnly(CMD.OPEN_VSCODE_SETTINGS);
@@ -929,6 +943,7 @@ export const SettingsViewInboundMessageSchema = z.discriminatedUnion(
     SetBashApprovalEnabledMessageSchema,
     SetCodexSandboxModeMessageSchema,
     SetCodexReasoningEffortMessageSchema,
+    SetCodexApprovalPolicyMessageSchema,
     // Agent team messages
     GetAgentModePresetsMessageSchema,
     ApplyAgentModePresetMessageSchema,

--- a/src/test/tools/codexConfig.test.ts
+++ b/src/test/tools/codexConfig.test.ts
@@ -7,6 +7,7 @@ import { AgentCategory } from '@agent/core/AgentDataclass';
 import {
   buildCodexConfig,
   buildCodexWorkspaceOptions,
+  parseCodexApprovalPolicy,
   toCodexCliReasoningEffort,
 } from '@tools/codexConfig';
 import {
@@ -49,6 +50,19 @@ describe('toCodexCliReasoningEffort', () => {
     // 'xhigh' with `unknown variant 'xhigh', expected one of 'minimal',
     // 'low', 'medium', 'high' in 'model_reasoning_effort'`.
     assert.equal(toCodexCliReasoningEffort('xhigh'), 'high');
+  });
+});
+
+describe('parseCodexApprovalPolicy', () => {
+  it('accepts SDK approval policies', () => {
+    assert.equal(parseCodexApprovalPolicy('never'), 'never');
+    assert.equal(parseCodexApprovalPolicy('on-request'), 'on-request');
+    assert.equal(parseCodexApprovalPolicy('on-failure'), 'on-failure');
+    assert.equal(parseCodexApprovalPolicy('untrusted'), 'untrusted');
+  });
+
+  it('defaults to automatic approval for invalid persisted values', () => {
+    assert.equal(parseCodexApprovalPolicy('ask'), 'never');
   });
 });
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -73,6 +73,7 @@ import type {
   SandboxMode,
   Thread,
   ThreadItem,
+  ThreadOptions,
   TodoListItem,
   WebSearchItem,
 } from '@openai/codex-sdk';
@@ -173,10 +174,12 @@ export function interruptAllCodexSessions(): void {
 class CodexFollowUpSession implements IInterruptible {
   private interrupted = false;
   private queue: FollowUpQueue | null = null;
+  private turnAbortController: AbortController | null = null;
 
   interrupt(): void {
     this.interrupted = true;
     this.queue?.cancelWait();
+    this.turnAbortController?.abort();
   }
 
   setQueue(q: FollowUpQueue): void {
@@ -185,6 +188,15 @@ class CodexFollowUpSession implements IInterruptible {
 
   isInterrupted(): boolean {
     return this.interrupted;
+  }
+
+  startTurn(): AbortSignal {
+    this.turnAbortController = new AbortController();
+    return this.turnAbortController.signal;
+  }
+
+  finishTurn(): void {
+    this.turnAbortController = null;
   }
 }
 
@@ -305,9 +317,10 @@ async function runStreamedTurn(
   prompt: string,
   childStreamId: StreamTabId,
   logger: AgentLogger,
+  signal?: AbortSignal,
 ): Promise<RunResult> {
   logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
-  const { events } = await thread.runStreamed(prompt);
+  const { events } = await thread.runStreamed(prompt, { signal });
   const responseParts: string[] = [];
   let usage: RunResult['usage'] = null;
 
@@ -402,15 +415,24 @@ function startCodexLoop(params: {
         const prompt = messages.join('\n\n');
         StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
         const startedAt = Date.now();
+        const signal = session.startTurn();
 
         let turn: RunResult | null = null;
         let err: unknown = null;
         try {
-          turn = await runStreamedTurn(thread, prompt, childStreamId, logger);
+          turn = await runStreamedTurn(
+            thread,
+            prompt,
+            childStreamId,
+            logger,
+            signal,
+          );
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (caught) {
           err = caught;
           logger.error(toErrorMessage(caught));
+        } finally {
+          session.finishTurn();
         }
 
         const wallTimeMs = Date.now() - startedAt;
@@ -483,15 +505,16 @@ async function createCodexThread(
   const CodexClass = await importCodexClass();
   const codex = new CodexClass({ codexPathOverride: findCodexBinaryPath() });
   const config = await getCodexConfig();
-  const sandboxMode = input.sandbox_mode;
+  const sandboxMode = input.sandbox_mode ?? undefined;
   // Resumed threads keep their stored workspace unless explicitly overridden.
   const workspace =
     workingDir || !input.thread_id
       ? config.buildCodexWorkspaceOptions(workingDir)
       : {};
-  const threadOptions = {
+  const threadOptions: ThreadOptions = {
     ...workspace,
     sandboxMode,
+    approvalPolicy: config.getCodexApprovalPolicy(),
     model: config.CODEX_CLI_MODEL,
     modelReasoningEffort: config.getCodexCliReasoningEffort(),
     skipGitRepoCheck: true as const,

--- a/src/tools/codexConfig.ts
+++ b/src/tools/codexConfig.ts
@@ -8,6 +8,13 @@ import { getWorkspaceState } from '@agent/core/stateStore';
 import { WorkspaceFS } from '@utils/files';
 import { CODEX_AGENT_NAME, CODEX_DISPLAY_MODEL } from './codexShared';
 
+// Type-only imports
+import type {
+  ApprovalMode,
+  ModelReasoningEffort,
+  SandboxMode,
+} from '@openai/codex-sdk';
+
 // ============================================================================
 // Model config — the Codex CLI uses short model names, not versioned API IDs
 // ============================================================================
@@ -46,7 +53,10 @@ export function getCodexReasoningEffort(): CodexReasoningEffort {
  * extension used by providers like Anthropic Opus 'max'; cap it to 'high'
  * before handing the value to the Codex SDK.
  */
-export type CodexCliReasoningEffort = 'low' | 'medium' | 'high';
+export type CodexCliReasoningEffort = Extract<
+  ModelReasoningEffort,
+  'low' | 'medium' | 'high'
+>;
 
 export function toCodexCliReasoningEffort(
   effort: CodexReasoningEffort,
@@ -59,6 +69,37 @@ export function getCodexCliReasoningEffort(): CodexCliReasoningEffort {
 }
 
 // ============================================================================
+// Approval policy
+// ============================================================================
+
+const APPROVAL_POLICIES = [
+  'never',
+  'on-request',
+  'on-failure',
+  'untrusted',
+] as const;
+export const CODEX_APPROVAL_POLICIES =
+  APPROVAL_POLICIES satisfies readonly ApprovalMode[];
+export type CodexApprovalPolicy = ApprovalMode;
+
+const APPROVAL_POLICY_KEY = 'texra.codexApprovalPolicy';
+const APPROVAL_POLICY_DEFAULT: CodexApprovalPolicy = 'never';
+
+export function parseCodexApprovalPolicy(raw: string): CodexApprovalPolicy {
+  return (APPROVAL_POLICIES as readonly string[]).includes(raw)
+    ? (raw as CodexApprovalPolicy)
+    : APPROVAL_POLICY_DEFAULT;
+}
+
+export function getCodexApprovalPolicy(): CodexApprovalPolicy {
+  const raw = getWorkspaceState().get<string>(
+    APPROVAL_POLICY_KEY,
+    APPROVAL_POLICY_DEFAULT,
+  );
+  return parseCodexApprovalPolicy(raw);
+}
+
+// ============================================================================
 // Sandbox mode
 // ============================================================================
 
@@ -67,8 +108,9 @@ const SANDBOX_MODES = [
   'workspace-write',
   'danger-full-access',
 ] as const;
-export const CODEX_SANDBOX_MODES = SANDBOX_MODES;
-export type CodexSandboxMode = (typeof SANDBOX_MODES)[number];
+export const CODEX_SANDBOX_MODES =
+  SANDBOX_MODES satisfies readonly SandboxMode[];
+export type CodexSandboxMode = SandboxMode;
 
 const SANDBOX_MODE_KEY = 'texra.codexSandboxMode';
 const SANDBOX_MODE_DEFAULT: CodexSandboxMode = 'workspace-write';


### PR DESCRIPTION
## Summary

- Adds a Codex approval policy selector to the Tools settings UI, defaulting to auto approve.
- Persists the policy in workspace state and passes it to `@openai/codex-sdk` as `ThreadOptions.approvalPolicy`.
- Wires Codex turn interruption through `AbortSignal` so stopped/reloaded sessions actively signal the native child process.
- Uses SDK-native types for Codex thread options, approval policy, sandbox mode, and reasoning effort boundaries.

## Validation

- `npm run compile:safe`
- `npm run lint` (0 errors; 3 pre-existing unrelated warnings remain)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex session execution/interrupt paths and forwards a new `approvalPolicy` into `@openai/codex-sdk` thread options, which could affect command prompting and stop behavior. UI/state wiring is straightforward but impacts tool runtime behavior across workspaces.
> 
> **Overview**
> Adds a new workspace-scoped **Codex approval policy** setting (persisted as `texra.codexApprovalPolicy`) and surfaces it in the Tools tab UI and docs.
> 
> Wires the selected policy through settings view schemas/commands/handlers and into Codex thread creation as `ThreadOptions.approvalPolicy`, alongside tightening Codex config types to SDK-native enums.
> 
> Improves Codex session stopping by introducing per-turn `AbortSignal` cancellation so interrupting a session actively aborts an in-flight streamed turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63285a450a2c4fe740094ea88115873efbef86d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->