### PR TITLE
[codex] treat Codex abort as clean interruption

### DIFF
--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -200,6 +200,18 @@ class CodexFollowUpSession implements IInterruptible {
   }
 }
 
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+function isCleanCodexInterruption(
+  err: unknown,
+  signal: AbortSignal,
+  session: CodexFollowUpSession,
+): boolean {
+  return signal.aborted || session.isInterrupted() || isAbortError(err);
+}
+
 // ============================================================================
 // Result formatting
 // ============================================================================
@@ -429,6 +441,7 @@ function startCodexLoop(params: {
           );
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
         } catch (caught) {
+          if (isCleanCodexInterruption(caught, signal, session)) break;
           err = caught;
           logger.error(toErrorMessage(caught));
         } finally {


### PR DESCRIPTION
## Summary

- Detect Codex streamed-turn aborts as intentional interruptions.
- Skip error logging and avoid enqueueing a `<codex-error>` for user stop/reload aborts.

Closes #3265.

## Validation

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to Codex session loop error handling to suppress logging/error delivery on aborts; main risk is accidentally masking genuine failures if misclassified as an interruption.
> 
> **Overview**
> Codex streamed-turn aborts are now treated as a *clean interruption* (user stop/reload) rather than an error.
> 
> This adds helpers to detect abort-like conditions (`AbortSignal.aborted`, `session.isInterrupted()`, or `AbortError`) and uses them in the session loop to break without logging the error or enqueueing a `<codex-error>` follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df45279f75423f2c5178fbe63281c990a7bc3775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->