### PR TITLE
[codex] Remove VS Code EventEmitter from server keys

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -61,7 +61,7 @@ export interface ServerSideKeyServiceContext {
 }
 
 class NodeEvent<T> {
-  private readonly emitter = new EventEmitter();
+  private readonly emitter = new EventEmitter().setMaxListeners(0);
 
   readonly event: Event<T> = (listener) => {
     this.emitter.on('event', listener);
@@ -70,8 +70,19 @@ class NodeEvent<T> {
     };
   };
 
-  fire(event: T): void {
-    this.emitter.emit('event', event);
+  fire(this: NodeEvent<void>): void;
+  fire(event: T): void;
+  fire(event?: T): void {
+    const listeners = this.emitter.listeners('event') as Array<
+      (event: T) => void
+    >;
+    for (const listener of listeners) {
+      try {
+        listener(event as T);
+      } catch (error) {
+        logger.error(CHANNEL, 'Event listener failed.', { data: error });
+      }
+    }
   }
 
   dispose(): void {
@@ -128,7 +139,7 @@ export class ServerSideKeyService {
   }
 
   /**
-   * Initialize the service with VS Code extension context.
+   * Initialize the service with a host-provided persistence context.
    * This enables settings persistence.
    */
   initialize(context: ServerSideKeyServiceContext): void {

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,7 +14,7 @@
  * - free tier: Budget models only (under $1/M input)
  */
 
-import * as vscode from 'vscode';
+import { EventEmitter } from 'events';
 import * as logger from '@logger/logUtils';
 import {
   SERVER_SIDE_CACHE_TTL_MS,
@@ -40,6 +40,44 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
 
 /** Global state key for the "use included model access" preference. */
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export interface Event<T> {
+  (listener: (event: T) => void): Disposable;
+}
+
+export interface MementoStore {
+  get<T>(key: string, defaultValue: T): T;
+  get<T>(key: string): T | undefined;
+  update<T>(key: string, value: T): PromiseLike<void>;
+}
+
+export interface ServerSideKeyServiceContext {
+  subscriptions: Disposable[];
+  globalState: MementoStore;
+}
+
+class NodeEvent<T> {
+  private readonly emitter = new EventEmitter();
+
+  readonly event: Event<T> = (listener) => {
+    this.emitter.on('event', listener);
+    return {
+      dispose: () => this.emitter.off('event', listener),
+    };
+  };
+
+  fire(event: T): void {
+    this.emitter.emit('event', event);
+  }
+
+  dispose(): void {
+    this.emitter.removeAllListeners();
+  }
+}
 
 /**
  * Interface for authentication provider that can check auth state and get user tier.
@@ -71,10 +109,10 @@ export class ServerSideKeyService {
 
   // Settings
   private useIncludedModelAccess = true;
-  private globalState: vscode.Memento | null = null;
-  private readonly _onDidChangeModelAccess = new vscode.EventEmitter<boolean>();
-  private readonly _onCacheCleared = new vscode.EventEmitter<void>();
-  private readonly _tierServiceClearSubscription: vscode.Disposable;
+  private globalState: MementoStore | null = null;
+  private readonly _onDidChangeModelAccess = new NodeEvent<boolean>();
+  private readonly _onCacheCleared = new NodeEvent<void>();
+  private readonly _tierServiceClearSubscription: Disposable;
 
   readonly onDidChangeModelAccess = this._onDidChangeModelAccess.event;
   readonly onCacheCleared = this._onCacheCleared.event;
@@ -93,7 +131,7 @@ export class ServerSideKeyService {
    * Initialize the service with VS Code extension context.
    * This enables settings persistence.
    */
-  initialize(context: vscode.ExtensionContext): void {
+  initialize(context: ServerSideKeyServiceContext): void {
     context.subscriptions.push(this._onDidChangeModelAccess);
     context.subscriptions.push(this._onCacheCleared);
     context.subscriptions.push(this._tierServiceClearSubscription);

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -13,19 +13,24 @@
  * - free tier: Budget models only (under $1/M input)
  */
 
-import * as vscode from 'vscode';
 import { SUPABASE_CUSTOM_DOMAIN } from '../config';
 import { getTierService } from '../tier';
 import {
   ServerSideKeyService,
   type AuthProvider,
+  type ServerSideKeyServiceContext,
 } from './ServerSideKeyService';
+import type * as vscode from 'vscode';
 
 // Types
 export { SERVER_SIDE_PROVIDERS, type ServerSideProvider } from './types';
 
 // Service class
-export { ServerSideKeyService, type AuthProvider };
+export {
+  ServerSideKeyService,
+  type AuthProvider,
+  type ServerSideKeyServiceContext,
+};
 
 // ==========================================================================
 // Singleton Instance


### PR DESCRIPTION
## Summary
- Replace `vscode.EventEmitter` usage in `ServerSideKeyService` with a small Node `EventEmitter` adapter.
- Introduce structural event, disposable, memento, and initialization context types so the service no longer needs a runtime `vscode` import.
- Keep the existing singleton initializer accepting the VS Code extension context through a type-only boundary.

## Electron PRD series
This is PR 1 from `prds/prd-electron-app.md` section 9 suggested ordering: start with the mechanical host-coupling reduction before larger platform/controller extractions.

Likely next PRs in the series:
1. Expand `ConfigProvider` and route `configUtils.ts` through it.
2. Add `WorkspaceProvider.watch` and a host-neutral `Disposable`.
3. Introduce `DiffViewHost` around the native VS Code diff approval call.
4. Define the agent runtime progress sink boundary.
5. Extract host-neutral auth/session and controller layers before the desktop shell.

## Validation
- `npx prettier --write src/auth/serverKeys/ServerSideKeyService.ts src/auth/serverKeys/index.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces `vscode.EventEmitter`/`vscode.Memento` usage with a custom Node-based event adapter and structural context types, which could subtly affect event delivery or disposal behavior if the adapter differs from VS Code semantics.
> 
> **Overview**
> Removes the runtime dependency on `vscode` from `ServerSideKeyService` by introducing host-neutral `Disposable`, `Event`, `MementoStore`, and `ServerSideKeyServiceContext` types and a small `NodeEvent` wrapper around Node’s `EventEmitter`.
> 
> Updates initialization to accept the new context shape while keeping the VS Code entrypoint in `src/auth/serverKeys/index.ts` behind a type-only `vscode` import and exporting the new context type for non-VS Code hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a6574023ff6a9b35a7c2add17608d10de92347. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->