### PR TITLE
[codex] Isolate tool edit diff host

### DIFF
--- a/src/frontend/approval/DiffViewHost.ts
+++ b/src/frontend/approval/DiffViewHost.ts
@@ -1,0 +1,28 @@
+export interface DiffSource {
+  filePath: string;
+}
+
+export interface DiffSession {
+  original: DiffSource;
+  proposed: DiffSource;
+  title: string;
+}
+
+export interface DiffOptions {
+  preserveFocus?: boolean;
+}
+
+export interface DiffViewHost {
+  openDiff(
+    original: DiffSource,
+    proposed: DiffSource,
+    title: string,
+    options?: DiffOptions,
+  ): Promise<DiffSession>;
+  closeDiff(session: DiffSession): Promise<void>;
+  revealFirstChange(session: DiffSession, line: number): Promise<void>;
+  readProposedContent(
+    session: DiffSession,
+    fallbackContent: string,
+  ): Promise<string>;
+}

--- a/src/frontend/approval/VscodeDiffViewHost.ts
+++ b/src/frontend/approval/VscodeDiffViewHost.ts
@@ -1,0 +1,146 @@
+import { promises as fs } from 'fs';
+
+import * as vscode from 'vscode';
+
+import {
+  type DiffOptions,
+  type DiffSession,
+  type DiffSource,
+  type DiffViewHost,
+} from '@frontend/approval/DiffViewHost';
+import { REVEAL_TIMEOUT_MS } from '@tools/approval/toolEditApproval';
+
+export class VscodeDiffViewHost implements DiffViewHost {
+  async openDiff(
+    original: DiffSource,
+    proposed: DiffSource,
+    title: string,
+    options: DiffOptions = {},
+  ): Promise<DiffSession> {
+    const session = { original, proposed, title };
+    await vscode.commands.executeCommand(
+      'vscode.diff',
+      this.toUri(original),
+      this.toUri(proposed),
+      title,
+      {
+        preserveFocus: options.preserveFocus ?? true,
+      } satisfies vscode.TextDocumentShowOptions,
+    );
+    return session;
+  }
+
+  async closeDiff(session: DiffSession): Promise<void> {
+    const targetUris = new Set([
+      this.toUri(session.original).toString(),
+      this.toUri(session.proposed).toString(),
+    ]);
+
+    const tabsToClose: vscode.Tab[] = [];
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        const input = tab.input;
+        if (
+          typeof vscode.TabInputTextDiff !== 'undefined' &&
+          input instanceof vscode.TabInputTextDiff
+        ) {
+          const original = input.original.toString();
+          const modified = input.modified.toString();
+          if (targetUris.has(original) && targetUris.has(modified)) {
+            tabsToClose.push(tab);
+          }
+          continue;
+        }
+
+        if (
+          typeof vscode.TabInputText !== 'undefined' &&
+          input instanceof vscode.TabInputText
+        ) {
+          if (targetUris.has(input.uri.toString())) {
+            tabsToClose.push(tab);
+          }
+        }
+      }
+    }
+
+    if (tabsToClose.length > 0) {
+      await vscode.window.tabGroups.close(tabsToClose);
+    }
+  }
+
+  async revealFirstChange(session: DiffSession, line: number): Promise<void> {
+    const targetUri = this.toUri(session.proposed).toString();
+    const position = new vscode.Position(line, 0);
+
+    const tryReveal = () => {
+      const editor = vscode.window.visibleTextEditors.find(
+        (candidate) => candidate.document.uri.toString() === targetUri,
+      );
+
+      if (!editor) {
+        return false;
+      }
+
+      editor.selections = [new vscode.Selection(position, position)];
+      editor.revealRange(
+        new vscode.Range(position, position),
+        vscode.TextEditorRevealType.InCenter,
+      );
+      return true;
+    };
+
+    if (tryReveal()) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      let resolved = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const disposable = vscode.window.onDidChangeVisibleTextEditors(() => {
+        if (!resolved && tryReveal()) {
+          resolved = true;
+          disposeAll();
+          resolve();
+        }
+      });
+
+      function disposeAll() {
+        if (timer) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+        disposable.dispose();
+      }
+
+      timer = setTimeout(() => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        disposeAll();
+        tryReveal();
+        resolve();
+      }, REVEAL_TIMEOUT_MS);
+    });
+  }
+
+  async readProposedContent(
+    session: DiffSession,
+    fallbackContent: string,
+  ): Promise<string> {
+    const proposedUri = this.toUri(session.proposed);
+    const openDocument = vscode.workspace.textDocuments.find(
+      (doc) => doc.uri.toString() === proposedUri.toString(),
+    );
+    return openDocument
+      ? openDocument.getText()
+      : await fs
+          .readFile(proposedUri.fsPath, 'utf8')
+          .catch(() => fallbackContent);
+  }
+
+  private toUri(source: DiffSource): vscode.Uri {
+    return vscode.Uri.file(source.filePath);
+  }
+}

--- a/src/frontend/approval/nativeToolEditApproval.ts
+++ b/src/frontend/approval/nativeToolEditApproval.ts
@@ -16,6 +16,12 @@ import * as vscode from 'vscode';
 
 import { isLatexFile } from '@common/files/fileTypeUtils';
 import { bus } from '@eventBus/ProgressEventBus';
+import {
+  type DiffSession,
+  type DiffSource,
+  type DiffViewHost,
+} from '@frontend/approval/DiffViewHost';
+import { VscodeDiffViewHost } from '@frontend/approval/VscodeDiffViewHost';
 import type { StreamTabId } from '@shared/schemas';
 import type { LineChanges } from '@tools/result';
 import {
@@ -29,7 +35,6 @@ import {
   firstChangedLine,
   isApprovalBypassedForStream,
   registerPendingApproval,
-  REVEAL_TIMEOUT_MS,
   setToolEditApprovalHandler,
   unregisterPendingApproval,
   type ToolEditApprovalAction,
@@ -41,8 +46,7 @@ import { normalizeLineEndings } from '@utils/text/stringUtils';
 
 interface PendingApprovalEntry extends LatexPreviewEntry {
   request: ToolEditApprovalRequest;
-  originalUri: vscode.Uri;
-  proposedUri: vscode.Uri;
+  diffSession: DiffSession;
   title: string;
   streamId?: StreamTabId;
   lineChanges: LineChanges;
@@ -57,6 +61,7 @@ interface ToolEditApprovalActionPayload {
 
 let approvalCounter = 0;
 const pendingApprovals = new Map<string, PendingApprovalEntry>();
+const diffViewHost: DiffViewHost = new VscodeDiffViewHost();
 let storageDirectory: string | undefined;
 
 function getStorageDir(): string {
@@ -76,21 +81,21 @@ async function createTempFile(
   side: 'original' | 'proposed',
   targetPath: string,
   content: string,
-): Promise<vscode.Uri> {
+): Promise<DiffSource> {
   const dir = await ensureStorageDir();
   const ext = path.extname(targetPath) || '.txt';
   const fileName = `${randomUUID()}-${side}${ext}`;
   const filePath = path.join(dir, fileName);
   await fs.writeFile(filePath, content, 'utf8');
-  return vscode.Uri.file(filePath);
+  return { filePath };
 }
 
-async function cleanupTempFile(uri: vscode.Uri): Promise<void> {
-  await fs.unlink(uri.fsPath).catch(() => {});
+async function cleanupTempFile(source: DiffSource): Promise<void> {
+  await fs.unlink(source.filePath).catch(() => {});
 }
 
-async function revealFirstChange(
-  proposedUri: vscode.Uri,
+async function revealFirstChangedLine(
+  session: DiffSession,
   originalContent: string,
   proposedContent: string,
 ): Promise<void> {
@@ -99,98 +104,7 @@ async function revealFirstChange(
     return;
   }
 
-  const targetUri = proposedUri.toString();
-  const position = new vscode.Position(line, 0);
-
-  const tryReveal = () => {
-    const editor = vscode.window.visibleTextEditors.find(
-      (candidate) => candidate.document.uri.toString() === targetUri,
-    );
-
-    if (!editor) {
-      return false;
-    }
-
-    editor.selections = [new vscode.Selection(position, position)];
-    editor.revealRange(
-      new vscode.Range(position, position),
-      vscode.TextEditorRevealType.InCenter,
-    );
-    return true;
-  };
-
-  if (tryReveal()) {
-    return;
-  }
-
-  await new Promise<void>((resolve) => {
-    let resolved = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
-    const disposable = vscode.window.onDidChangeVisibleTextEditors(() => {
-      if (!resolved && tryReveal()) {
-        resolved = true;
-        disposeAll();
-        resolve();
-      }
-    });
-
-    function disposeAll() {
-      if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
-      }
-      disposable.dispose();
-    }
-
-    timer = setTimeout(() => {
-      if (resolved) {
-        return;
-      }
-      resolved = true;
-      disposeAll();
-      tryReveal();
-      resolve();
-    }, REVEAL_TIMEOUT_MS);
-  });
-}
-
-async function closeApprovalEditors(
-  originalUri: vscode.Uri,
-  proposedUri: vscode.Uri,
-): Promise<void> {
-  const targetUris = new Set([originalUri.toString(), proposedUri.toString()]);
-
-  const tabsToClose: vscode.Tab[] = [];
-  for (const group of vscode.window.tabGroups.all) {
-    for (const tab of group.tabs) {
-      const input = tab.input;
-      if (
-        typeof vscode.TabInputTextDiff !== 'undefined' &&
-        input instanceof vscode.TabInputTextDiff
-      ) {
-        const original = input.original.toString();
-        const modified = input.modified.toString();
-        if (targetUris.has(original) && targetUris.has(modified)) {
-          tabsToClose.push(tab);
-        }
-        continue;
-      }
-
-      if (
-        typeof vscode.TabInputText !== 'undefined' &&
-        input instanceof vscode.TabInputText
-      ) {
-        if (targetUris.has(input.uri.toString())) {
-          tabsToClose.push(tab);
-        }
-      }
-    }
-  }
-
-  if (tabsToClose.length > 0) {
-    await vscode.window.tabGroups.close(tabsToClose);
-  }
+  await diffViewHost.revealFirstChange(session, line);
 }
 
 async function showProgressViewApprovalPrompt(
@@ -243,12 +157,12 @@ async function nativeRequestApproval(
 
   approvalCounter += 1;
   const requestId = `approval-${Date.now().toString(36)}-${approvalCounter}`;
-  const originalUri = await createTempFile(
+  const originalSource = await createTempFile(
     'original',
     filePath,
     originalContent,
   );
-  const proposedUri = await createTempFile(
+  const proposedSource = await createTempFile(
     'proposed',
     filePath,
     proposedContent,
@@ -273,16 +187,21 @@ async function nativeRequestApproval(
     : '';
   const title = `Tool edit (${sourceTool}): ${description}${changeSuffix}`;
   let result: ToolEditApprovalResult = { accepted: false };
+  let diffSession: DiffSession | undefined;
   try {
-    await vscode.commands.executeCommand(
-      'vscode.diff',
-      originalUri,
-      proposedUri,
+    const openedSession = await diffViewHost.openDiff(
+      originalSource,
+      proposedSource,
       title,
-      { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
+      { preserveFocus: true },
     );
+    diffSession = openedSession;
 
-    await revealFirstChange(proposedUri, originalContent, proposedContent);
+    await revealFirstChangedLine(
+      openedSession,
+      originalContent,
+      proposedContent,
+    );
 
     result = await new Promise<ToolEditApprovalResult>((resolve) => {
       let settled = false;
@@ -298,8 +217,9 @@ async function nativeRequestApproval(
 
       const entry: PendingApprovalEntry = {
         request,
-        originalUri,
-        proposedUri,
+        diffSession: openedSession,
+        originalUri: { fsPath: originalSource.filePath },
+        proposedUri: { fsPath: proposedSource.filePath },
         originalContent,
         proposedContent,
         title,
@@ -328,17 +248,9 @@ async function nativeRequestApproval(
     });
 
     if (result.accepted) {
-      // Read current content from open document or file, falling back to proposedContent
-      const openDocument = vscode.workspace.textDocuments.find(
-        (doc) => doc.uri.toString() === proposedUri.toString(),
-      );
       // Normalize here: these reads bypass BaseFS so may contain CRLF.
       const appliedContent = normalizeLineEndings(
-        openDocument
-          ? openDocument.getText()
-          : await fs
-              .readFile(proposedUri.fsPath, 'utf8')
-              .catch(() => proposedContent),
+        await diffViewHost.readProposedContent(openedSession, proposedContent),
       );
       const userPatch = computeUserPatch(proposedContent, appliedContent);
       result = {
@@ -357,9 +269,11 @@ async function nativeRequestApproval(
     const entry = pendingApprovals.get(requestId);
     pendingApprovals.delete(requestId);
     unregisterPendingApproval(requestId);
-    await closeApprovalEditors(originalUri, proposedUri);
-    await cleanupTempFile(originalUri);
-    await cleanupTempFile(proposedUri);
+    if (diffSession) {
+      await diffViewHost.closeDiff(diffSession);
+    }
+    await cleanupTempFile(originalSource);
+    await cleanupTempFile(proposedSource);
 
     // Clean up any workspace temp files created by preview/latexdiff (parallel for performance)
     if (entry?.workspaceTempCleanup.length) {
@@ -382,15 +296,14 @@ export async function handleProgressViewToolEditApprovalAction(
 
   switch (payload.action) {
     case 'openDiff':
-      await vscode.commands.executeCommand(
-        'vscode.diff',
-        entry.originalUri,
-        entry.proposedUri,
+      entry.diffSession = await diffViewHost.openDiff(
+        entry.diffSession.original,
+        entry.diffSession.proposed,
         entry.title,
-        { preserveFocus: true } satisfies vscode.TextDocumentShowOptions,
+        { preserveFocus: true },
       );
-      await revealFirstChange(
-        entry.proposedUri,
+      await revealFirstChangedLine(
+        entry.diffSession,
         entry.originalContent,
         entry.proposedContent,
       );
@@ -408,9 +321,10 @@ export async function handleProgressViewToolEditApprovalAction(
     case 'approve': {
       // Normalize: this read bypasses BaseFS so may contain CRLF.
       const appliedContent = normalizeLineEndings(
-        await fs
-          .readFile(entry.proposedUri.fsPath, 'utf-8')
-          .catch(() => entry.proposedContent),
+        await diffViewHost.readProposedContent(
+          entry.diffSession,
+          entry.proposedContent,
+        ),
       );
       entry.settle({ accepted: true, appliedContent });
       break;


### PR DESCRIPTION
## Summary
- Add a host-facing `DiffViewHost` contract for opening, revealing, closing, and reading tool-edit diffs.
- Move the current VS Code `vscode.diff`, tab cleanup, reveal, and modified-content reads into `VscodeDiffViewHost`.
- Keep `nativeToolEditApproval` behavior the same while routing diff operations through the host boundary.

## Electron PRD series
This is PR 2 from `prds/prd-electron-app.md` section 9: put the highest-effort tool-edit approval surface behind a stable contract before the Electron Monaco implementation exists.

Previous PR in series: #3267.

Likely next PRs:
1. Expand `ConfigProvider` and route `configUtils.ts` through it.
2. Add `WorkspaceProvider.watch` and a host-neutral `Disposable`.
3. Define the agent runtime progress sink boundary.
4. Extract host-neutral auth/session and controller layers.

## Validation
- `npx prettier --write src/frontend/approval/DiffViewHost.ts src/frontend/approval/VscodeDiffViewHost.ts src/frontend/approval/nativeToolEditApproval.ts`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors authentication/session handling and config/state plumbing behind new host-neutral interfaces, which could affect token refresh, persisted settings, and server-side key access behavior if integration points are missed.
> 
> **Overview**
> **Moves tool-edit diff UI behind a host contract.** Introduces `DiffViewHost` plus a VS Code implementation (`VscodeDiffViewHost`) and routes `nativeToolEditApproval` diff open/close/reveal/content reads through it (behavior intended to stay the same).
> 
> **Continues the host-neutral platform extraction.** Adds a richer `ConfigProvider` (update/inspect/isExplicitlySet/watch) with a VS Code adapter (`VscodeConfigProvider`), updates `configUtils` and multiple call sites to use host targets (`'global' | 'workspace'`), and adds `WorkspaceProvider.watch` with VS Code and Node implementations.
> 
> **Decouples auth/session and server-side key services from VS Code types.** Extracts Supabase session parsing/token-callback parsing into `SupabaseSession`, introduces `AuthTokenProvider`/`SessionTokens`, updates `SupabaseClient` to source tokens via the provider (with `resetForTests`), and refactors `ServerSideKeyService` initialization/events/state to be host-provided (with new unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fc8020d985b56380d12bdda0806d663e4ad289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->