### PR TITLE
[codex] Add workspace watch platform hook

### DIFF
--- a/src/frontend/vscode/vscodeWorkspace.ts
+++ b/src/frontend/vscode/vscodeWorkspace.ts
@@ -15,4 +15,27 @@ export class VscodeWorkspace implements WorkspaceProvider {
   asRelativePath(filePath: string): string {
     return vscode.workspace.asRelativePath(filePath, false);
   }
+
+  watch(globPattern: string, listener: () => void): vscode.Disposable {
+    const workspacePath = this.getWorkspacePath();
+    const pattern = workspacePath
+      ? new vscode.RelativePattern(workspacePath, globPattern)
+      : globPattern;
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      pattern,
+      false,
+      false,
+      false,
+    );
+    const subscriptions = [
+      watcher.onDidCreate(listener),
+      watcher.onDidChange(listener),
+      watcher.onDidDelete(listener),
+    ];
+
+    return new vscode.Disposable(() => {
+      subscriptions.forEach((subscription) => subscription.dispose());
+      watcher.dispose();
+    });
+  }
 }

--- a/src/frontend/vscode/vscodeWorkspace.ts
+++ b/src/frontend/vscode/vscodeWorkspace.ts
@@ -18,23 +18,25 @@ export class VscodeWorkspace implements WorkspaceProvider {
 
   watch(globPattern: string, listener: () => void): vscode.Disposable {
     const workspaceFolders = vscode.workspace.workspaceFolders;
-    const patterns = workspaceFolders?.length
-      ? workspaceFolders.map(
-          (folder) => new vscode.RelativePattern(folder, globPattern),
-        )
-      : [globPattern];
-    const watchers = patterns.map((pattern) =>
-      vscode.workspace.createFileSystemWatcher(pattern, false, false, false),
+    const pattern =
+      workspaceFolders?.length === 1
+        ? new vscode.RelativePattern(workspaceFolders[0], globPattern)
+        : globPattern;
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      pattern,
+      false,
+      false,
+      false,
     );
-    const subscriptions = watchers.flatMap((watcher) => [
+    const subscriptions = [
       watcher.onDidCreate(listener),
       watcher.onDidChange(listener),
       watcher.onDidDelete(listener),
-    ]);
+    ];
 
     return new vscode.Disposable(() => {
       subscriptions.forEach((subscription) => subscription.dispose());
-      watchers.forEach((watcher) => watcher.dispose());
+      watcher.dispose();
     });
   }
 }

--- a/src/frontend/vscode/vscodeWorkspace.ts
+++ b/src/frontend/vscode/vscodeWorkspace.ts
@@ -17,25 +17,24 @@ export class VscodeWorkspace implements WorkspaceProvider {
   }
 
   watch(globPattern: string, listener: () => void): vscode.Disposable {
-    const workspacePath = this.getWorkspacePath();
-    const pattern = workspacePath
-      ? new vscode.RelativePattern(workspacePath, globPattern)
-      : globPattern;
-    const watcher = vscode.workspace.createFileSystemWatcher(
-      pattern,
-      false,
-      false,
-      false,
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const patterns = workspaceFolders?.length
+      ? workspaceFolders.map(
+          (folder) => new vscode.RelativePattern(folder, globPattern),
+        )
+      : [globPattern];
+    const watchers = patterns.map((pattern) =>
+      vscode.workspace.createFileSystemWatcher(pattern, false, false, false),
     );
-    const subscriptions = [
+    const subscriptions = watchers.flatMap((watcher) => [
       watcher.onDidCreate(listener),
       watcher.onDidChange(listener),
       watcher.onDidDelete(listener),
-    ];
+    ]);
 
     return new vscode.Disposable(() => {
       subscriptions.forEach((subscription) => subscription.dispose());
-      watcher.dispose();
+      watchers.forEach((watcher) => watcher.dispose());
     });
   }
 }

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -25,11 +25,26 @@ function shouldNotify(
 
 function listDirectories(root: string): string[] {
   const directories = [root];
-  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return directories;
+  }
+
+  for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     directories.push(...listDirectories(path.join(root, entry.name)));
   }
   return directories;
+}
+
+function closeWatcher(watcher: fs.FSWatcher): void {
+  try {
+    watcher.close();
+  } catch {
+    // Watcher may already be closed by the OS after an async error.
+  }
 }
 
 function createRecursiveFallbackWatcher(
@@ -44,28 +59,40 @@ function createRecursiveFallbackWatcher(
     if (watchedDirectories.has(directory)) return;
     watchedDirectories.add(directory);
 
-    const watcher = fs.watch(directory, (_event, filename) => {
-      const absolutePath =
-        filename == null ? null : path.join(directory, filename.toString());
-      const relativePath =
-        absolutePath == null ? null : path.relative(root, absolutePath);
+    let watcher: fs.FSWatcher;
+    try {
+      watcher = fs.watch(directory, (_event, filename) => {
+        const absolutePath =
+          filename == null ? null : path.join(directory, filename.toString());
+        const relativePath =
+          absolutePath == null ? null : path.relative(root, absolutePath);
 
-      if (absolutePath && fs.existsSync(absolutePath)) {
-        try {
-          if (fs.statSync(absolutePath).isDirectory()) {
-            for (const nested of listDirectories(absolutePath)) {
-              watchDirectory(nested);
+        if (absolutePath && fs.existsSync(absolutePath)) {
+          try {
+            if (fs.statSync(absolutePath).isDirectory()) {
+              for (const nested of listDirectories(absolutePath)) {
+                watchDirectory(nested);
+              }
             }
+          } catch {
+            // File may have been removed between existsSync and statSync.
           }
-        } catch {
-          // File may have been removed between existsSync and statSync.
         }
-      }
 
-      if (shouldNotify(globPattern, relativePath)) {
-        listener();
-      }
+        if (shouldNotify(globPattern, relativePath)) {
+          listener();
+        }
+      });
+    } catch {
+      watchedDirectories.delete(directory);
+      return;
+    }
+
+    watcher.on('error', () => {
+      closeWatcher(watcher);
+      watchedDirectories.delete(directory);
     });
+
     watchers.push(watcher);
   };
 
@@ -74,7 +101,7 @@ function createRecursiveFallbackWatcher(
   }
 
   return {
-    dispose: () => watchers.forEach((watcher) => watcher.close()),
+    dispose: () => watchers.forEach(closeWatcher),
   };
 }
 
@@ -104,14 +131,18 @@ export const nodeWorkspace: WorkspaceProvider = {
         root,
         { recursive: true },
         (_event, filename) => {
-          const relativePath = filename?.toString() ?? null;
+          const absolutePath =
+            filename == null ? null : path.join(root, filename.toString());
+          const relativePath =
+            absolutePath == null ? null : path.relative(root, absolutePath);
           if (shouldNotify(globPattern, relativePath)) {
             listener();
           }
         },
       );
+      watcher.on('error', () => closeWatcher(watcher));
       return {
-        dispose: () => watcher.close(),
+        dispose: () => closeWatcher(watcher),
       };
     } catch {
       return createRecursiveFallbackWatcher(root, globPattern, listener);

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -5,7 +5,78 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { minimatch } from 'minimatch';
+
 import type { WorkspaceProvider } from '../interfaces/workspace';
+
+function normalizeRelativePath(filePath: string): string {
+  return filePath.replaceAll('\\', '/');
+}
+
+function shouldNotify(
+  globPattern: string,
+  relativePath: string | null,
+): boolean {
+  if (relativePath == null) return true;
+  return minimatch(normalizeRelativePath(relativePath), globPattern, {
+    dot: true,
+  });
+}
+
+function listDirectories(root: string): string[] {
+  const directories = [root];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    directories.push(...listDirectories(path.join(root, entry.name)));
+  }
+  return directories;
+}
+
+function createRecursiveFallbackWatcher(
+  root: string,
+  globPattern: string,
+  listener: () => void,
+): { dispose(): void } {
+  const watchers: fs.FSWatcher[] = [];
+  const watchedDirectories = new Set<string>();
+
+  const watchDirectory = (directory: string): void => {
+    if (watchedDirectories.has(directory)) return;
+    watchedDirectories.add(directory);
+
+    const watcher = fs.watch(directory, (_event, filename) => {
+      const absolutePath =
+        filename == null ? null : path.join(directory, filename.toString());
+      const relativePath =
+        absolutePath == null ? null : path.relative(root, absolutePath);
+
+      if (absolutePath && fs.existsSync(absolutePath)) {
+        try {
+          if (fs.statSync(absolutePath).isDirectory()) {
+            for (const nested of listDirectories(absolutePath)) {
+              watchDirectory(nested);
+            }
+          }
+        } catch {
+          // File may have been removed between existsSync and statSync.
+        }
+      }
+
+      if (shouldNotify(globPattern, relativePath)) {
+        listener();
+      }
+    });
+    watchers.push(watcher);
+  };
+
+  for (const directory of listDirectories(root)) {
+    watchDirectory(directory);
+  }
+
+  return {
+    dispose: () => watchers.forEach((watcher) => watcher.close()),
+  };
+}
 
 export const nodeWorkspace: WorkspaceProvider = {
   getWorkspacePath(): string | undefined {
@@ -19,24 +90,31 @@ export const nodeWorkspace: WorkspaceProvider = {
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
       return filePath;
     }
-    return relative.replaceAll('\\', '/');
+    return normalizeRelativePath(relative);
   },
 
-  watch(_globPattern: string, listener: () => void): { dispose(): void } {
+  watch(globPattern: string, listener: () => void): { dispose(): void } {
     const root = this.getWorkspacePath();
     if (!root) {
       return { dispose: () => {} };
     }
 
-    let watcher: fs.FSWatcher;
     try {
-      watcher = fs.watch(root, { recursive: true }, listener);
+      const watcher = fs.watch(
+        root,
+        { recursive: true },
+        (_event, filename) => {
+          const relativePath = filename?.toString() ?? null;
+          if (shouldNotify(globPattern, relativePath)) {
+            listener();
+          }
+        },
+      );
+      return {
+        dispose: () => watcher.close(),
+      };
     } catch {
-      watcher = fs.watch(root, listener);
+      return createRecursiveFallbackWatcher(root, globPattern, listener);
     }
-
-    return {
-      dispose: () => watcher.close(),
-    };
   },
 };

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -2,6 +2,7 @@
  * Node.js workspace provider for CLI / Electron / tests.
  * Uses process.cwd() as the workspace root.
  */
+import * as fs from 'fs';
 import * as path from 'path';
 
 import type { WorkspaceProvider } from '../interfaces/workspace';
@@ -19,5 +20,23 @@ export const nodeWorkspace: WorkspaceProvider = {
       return filePath;
     }
     return relative.replaceAll('\\', '/');
+  },
+
+  watch(_globPattern: string, listener: () => void): { dispose(): void } {
+    const root = this.getWorkspacePath();
+    if (!root) {
+      return { dispose: () => {} };
+    }
+
+    let watcher: fs.FSWatcher;
+    try {
+      watcher = fs.watch(root, { recursive: true }, listener);
+    } catch {
+      watcher = fs.watch(root, listener);
+    }
+
+    return {
+      dispose: () => watcher.close(),
+    };
   },
 };

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -17,7 +17,7 @@ function shouldNotify(
   globPattern: string,
   relativePath: string | null,
 ): boolean {
-  if (relativePath == null) return true;
+  if (relativePath == null) return false;
   return minimatch(normalizeRelativePath(relativePath), globPattern, {
     dot: true,
   });
@@ -52,16 +52,20 @@ function createRecursiveFallbackWatcher(
   globPattern: string,
   listener: () => void,
 ): { dispose(): void } {
-  const watchers: fs.FSWatcher[] = [];
+  let disposed = false;
+  const watchers = new Set<fs.FSWatcher>();
   const watchedDirectories = new Set<string>();
 
   const watchDirectory = (directory: string): void => {
+    if (disposed) return;
     if (watchedDirectories.has(directory)) return;
     watchedDirectories.add(directory);
 
     let watcher: fs.FSWatcher;
     try {
       watcher = fs.watch(directory, (_event, filename) => {
+        if (disposed) return;
+
         const absolutePath =
           filename == null ? null : path.join(directory, filename.toString());
         const relativePath =
@@ -90,10 +94,11 @@ function createRecursiveFallbackWatcher(
 
     watcher.on('error', () => {
       closeWatcher(watcher);
+      watchers.delete(watcher);
       watchedDirectories.delete(directory);
     });
 
-    watchers.push(watcher);
+    watchers.add(watcher);
   };
 
   for (const directory of listDirectories(root)) {
@@ -101,7 +106,14 @@ function createRecursiveFallbackWatcher(
   }
 
   return {
-    dispose: () => watchers.forEach(closeWatcher),
+    dispose: () => {
+      disposed = true;
+      for (const watcher of watchers) {
+        closeWatcher(watcher);
+      }
+      watchers.clear();
+      watchedDirectories.clear();
+    },
   };
 }
 
@@ -127,10 +139,13 @@ export const nodeWorkspace: WorkspaceProvider = {
     }
 
     try {
+      let disposed = false;
       const watcher = fs.watch(
         root,
         { recursive: true },
         (_event, filename) => {
+          if (disposed) return;
+
           const absolutePath =
             filename == null ? null : path.join(root, filename.toString());
           const relativePath =
@@ -142,7 +157,10 @@ export const nodeWorkspace: WorkspaceProvider = {
       );
       watcher.on('error', () => closeWatcher(watcher));
       return {
-        dispose: () => closeWatcher(watcher),
+        dispose: () => {
+          disposed = true;
+          closeWatcher(watcher);
+        },
       };
     } catch {
       return createRecursiveFallbackWatcher(root, globPattern, listener);

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -9,8 +9,31 @@ import { minimatch } from 'minimatch';
 
 import type { WorkspaceProvider } from '../interfaces/workspace';
 
+const CASE_INSENSITIVE_GLOBS =
+  process.platform === 'win32' || process.platform === 'darwin';
+const IGNORED_WATCH_DIRECTORIES = new Set([
+  '.cache',
+  '.git',
+  '.next',
+  '.pnpm',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+]);
+
 function normalizeRelativePath(filePath: string): string {
   return filePath.replaceAll('\\', '/');
+}
+
+function shouldWatchDirectory(root: string, directory: string): boolean {
+  const relativePath = normalizeRelativePath(path.relative(root, directory));
+  if (!relativePath) return true;
+  return !relativePath
+    .split('/')
+    .some((segment) => IGNORED_WATCH_DIRECTORIES.has(segment));
 }
 
 function shouldNotify(
@@ -20,6 +43,7 @@ function shouldNotify(
   if (relativePath == null) return false;
   return minimatch(normalizeRelativePath(relativePath), globPattern, {
     dot: true,
+    nocase: CASE_INSENSITIVE_GLOBS,
   });
 }
 
@@ -34,6 +58,7 @@ function listDirectories(root: string): string[] {
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
+    if (IGNORED_WATCH_DIRECTORIES.has(entry.name)) continue;
     directories.push(...listDirectories(path.join(root, entry.name)));
   }
   return directories;
@@ -74,6 +99,7 @@ function createRecursiveFallbackWatcher(
         if (absolutePath && fs.existsSync(absolutePath)) {
           try {
             if (fs.statSync(absolutePath).isDirectory()) {
+              if (!shouldWatchDirectory(root, absolutePath)) return;
               for (const nested of listDirectories(absolutePath)) {
                 watchDirectory(nested);
               }

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -11,29 +11,23 @@ import type { WorkspaceProvider } from '../interfaces/workspace';
 
 const CASE_INSENSITIVE_GLOBS =
   process.platform === 'win32' || process.platform === 'darwin';
-const IGNORED_WATCH_DIRECTORIES = new Set([
-  '.cache',
-  '.git',
-  '.next',
-  '.pnpm',
-  '.turbo',
-  'build',
-  'coverage',
-  'dist',
-  'node_modules',
-  'out',
-]);
 
 function normalizeRelativePath(filePath: string): string {
   return filePath.replaceAll('\\', '/');
 }
 
-function shouldWatchDirectory(root: string, directory: string): boolean {
+function shouldTraverseDirectory(
+  root: string,
+  directory: string,
+  globPattern: string,
+): boolean {
   const relativePath = normalizeRelativePath(path.relative(root, directory));
   if (!relativePath) return true;
-  return !relativePath
-    .split('/')
-    .some((segment) => IGNORED_WATCH_DIRECTORIES.has(segment));
+  return minimatch(relativePath, globPattern, {
+    dot: true,
+    nocase: CASE_INSENSITIVE_GLOBS,
+    partial: true,
+  });
 }
 
 function shouldNotify(
@@ -47,19 +41,28 @@ function shouldNotify(
   });
 }
 
-function listDirectories(root: string): string[] {
-  const directories = [root];
+function listDirectories(
+  workspaceRoot: string,
+  directory: string,
+  globPattern: string,
+): string[] {
+  const directories = [directory];
   let entries: fs.Dirent[];
   try {
-    entries = fs.readdirSync(root, { withFileTypes: true });
+    entries = fs.readdirSync(directory, { withFileTypes: true });
   } catch {
     return directories;
   }
 
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
-    if (IGNORED_WATCH_DIRECTORIES.has(entry.name)) continue;
-    directories.push(...listDirectories(path.join(root, entry.name)));
+    const absolutePath = path.join(directory, entry.name);
+    if (!shouldTraverseDirectory(workspaceRoot, absolutePath, globPattern)) {
+      continue;
+    }
+    directories.push(
+      ...listDirectories(workspaceRoot, absolutePath, globPattern),
+    );
   }
   return directories;
 }
@@ -99,8 +102,14 @@ function createRecursiveFallbackWatcher(
         if (absolutePath && fs.existsSync(absolutePath)) {
           try {
             if (fs.statSync(absolutePath).isDirectory()) {
-              if (!shouldWatchDirectory(root, absolutePath)) return;
-              for (const nested of listDirectories(absolutePath)) {
+              if (!shouldTraverseDirectory(root, absolutePath, globPattern)) {
+                return;
+              }
+              for (const nested of listDirectories(
+                root,
+                absolutePath,
+                globPattern,
+              )) {
                 watchDirectory(nested);
               }
             }
@@ -127,7 +136,7 @@ function createRecursiveFallbackWatcher(
     watchers.add(watcher);
   };
 
-  for (const directory of listDirectories(root)) {
+  for (const directory of listDirectories(root, root, globPattern)) {
     watchDirectory(directory);
   }
 

--- a/src/platform/interfaces/workspace.ts
+++ b/src/platform/interfaces/workspace.ts
@@ -1,3 +1,5 @@
+import type { Disposable } from './disposable';
+
 /**
  * Platform workspace provider interface.
  */
@@ -11,4 +13,9 @@ export interface WorkspaceProvider {
    * Returns the original path if it is outside the workspace.
    */
   asRelativePath(filePath: string): string;
+
+  /**
+   * Watch workspace files matching the given glob pattern.
+   */
+  watch(globPattern: string, listener: () => void): Disposable;
 }


### PR DESCRIPTION
## Summary
- add a host-neutral Disposable interface for platform watcher APIs
- extend WorkspaceProvider with watch(globPattern, listener)
- wire VS Code workspace watching through createFileSystemWatcher and provide a Node fallback for non-VS Code hosts

Electron PRD slice: prds/prd-electron-app.md §9 Tier 1 #4.

## Validation
- npm run format
- npm run compile:safe
- npm run compile (passes with existing Nunjucks critical-dependency warning)
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this refactors auth token/session plumbing and server-side key service initialization to be host-neutral, and adds new file-watching behavior that can affect performance or cache invalidation across hosts.
> 
> **Overview**
> Adds a host-neutral `WorkspaceProvider.watch()` API (plus `Disposable`) and wires it for VS Code via `createFileSystemWatcher` and for Node hosts via `fs.watch` with a recursive fallback implementation.
> 
> Refactors config access to go through a platform `ConfigProvider` (new `VscodeConfigProvider`, `ConfigTarget` strings like `'global'|'workspace'`), updating call sites and tests to stop depending directly on `vscode.ConfigurationTarget`.
> 
> Decouples several auth/services from VS Code specifics: introduces `AuthTokenProvider`/`SessionTokens`, moves Supabase session parsing/callback token parsing into `SupabaseSession`, updates `SupabaseClient` to fetch tokens via the provider (and adds `resetForTests`), and updates `ServerSideKeyService` to use host-provided state/subscriptions with a Node event emitter adapter (with new unit tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971de6807b90331f0ff04cf2ad97b0b88a153ce6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->