### PR TITLE
[codex] Extract settings view dispatcher

### DIFF
--- a/src/settingsView/frontend/SettingsApp.ts
+++ b/src/settingsView/frontend/SettingsApp.ts
@@ -25,30 +25,12 @@ import {
 
 // Local imports - shared schemas and constants
 import {
-  UpdateMemoryEnabledMessageSchema,
-  UpdateMemoryMessageSchema,
   type MemoryViewItem,
-  UpdateHistoryMessageSchema,
-  HistoryClearedMessageSchema,
   type HistoryItem,
-  UpdateProfileMessageSchema,
   type ProviderKeyStatus,
   type ModelSelectionItem,
-  UpdateModelSelectionMessageSchema,
-  SetTabMessageSchema,
 } from '@shared/schemas';
 import {
-  UpdateAgentSelectionMessageSchema,
-  UpdateCustomAgentDirMessageSchema,
-  UpdateSuperYoloEnabledMessageSchema,
-  UpdateAgentModePresetsMessageSchema,
-  UpdateApprovalSettingsMessageSchema,
-  UpdateToolDashboardMessageSchema,
-  UpdateGitAuthorSettingsMessageSchema,
-  UpdateGitHubTokenStatusMessageSchema,
-  UpdatePRSubscriptionsMessageSchema,
-  UpdateLatexSettingsStatusMessageSchema,
-  UpdateLatexConfigValuesMessageSchema,
   type AgentSelectionItem,
   type LatexConfigValues,
   type NumberVscodeSetting,
@@ -68,6 +50,10 @@ import { NESTED_DELEGATION_DEPTH_RANGE } from '@shared/constants/delegationPolic
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
 import { settingsViewStyles } from './styles';
+import {
+  dispatchSettingsViewMessage,
+  type SettingsMessageHandlerContext,
+} from './settingsViewDispatcher';
 import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Side-effect: register tab components
@@ -219,213 +205,59 @@ export class SettingsApp extends SettingsAppBase {
   private readonly latexConfigValues = signal<LatexConfigValues>({});
   private readonly latexConfigValuesLoaded = signal(false);
 
-  private parseMessage<T>(
-    raw: unknown,
-    schema: {
-      safeParse(
-        data: unknown,
-      ): { success: true; data: T } | { success: false; error: unknown };
-    },
-  ): T | null {
-    const result = schema.safeParse(raw);
-    if (!result.success) {
-      this.logSchemaError(
-        '[SettingsApp] Message validation failed.',
-        result.error,
-      );
-      return null;
-    }
-    return result.data;
+  private getMessageHandlerContext(): SettingsMessageHandlerContext {
+    return {
+      selectedTabIndex: this.selectedTabIndex,
+      memoryItems: this.memoryItems,
+      memoryEnabled: this.memoryEnabled,
+      memoryToggleDisabled: this.memoryToggleDisabled,
+      historyItems: this.historyItems,
+      authenticated: this.authenticated,
+      userEmail: this.userEmail,
+      userId: this.userId,
+      tier: this.tier,
+      apiAccessMode: this.apiAccessMode,
+      allowedModels: this.allowedModels,
+      accessExpiresAt: this.accessExpiresAt,
+      providerKeyStatuses: this.providerKeyStatuses,
+      globalStreamingDefault: this.globalStreamingDefault,
+      modelSelectionItems: this.modelSelectionItems,
+      helperModel: this.helperModel,
+      preferShortModelNames: this.preferShortModelNames,
+      workflowAgents: this.workflowAgents,
+      toolUseAgents: this.toolUseAgents,
+      customAgentDir: this.customAgentDir,
+      customAgentDirIsDefault: this.customAgentDirIsDefault,
+      agentSubTab: this.agentSubTab,
+      customPresets: this.customPresets,
+      reliabilitySettings: this.reliabilitySettings,
+      allowOrchestratorKill: this.allowOrchestratorKill,
+      detachSubagentsOnStop: this.detachSubagentsOnStop,
+      nestedDelegationMaxDepth: this.nestedDelegationMaxDepth,
+      bashApprovalEnabled: this.bashApprovalEnabled,
+      codexSandboxMode: this.codexSandboxMode,
+      codexReasoningEffort: this.codexReasoningEffort,
+      codexApprovalPolicy: this.codexApprovalPolicy,
+      toolDashboardItems: this.toolDashboardItems,
+      toolDashboardLoaded: this.toolDashboardLoaded,
+      gitMarkCommits: this.gitMarkCommits,
+      gitAuthorName: this.gitAuthorName,
+      gitAuthorEmail: this.gitAuthorEmail,
+      gitWorktreeSupport: this.gitWorktreeSupport,
+      gitSettingsLoaded: this.gitSettingsLoaded,
+      githubTokenStatus: this.githubTokenStatus,
+      prSubscriptions: this.prSubscriptions,
+      latexSettingsStatus: this.latexSettingsStatus,
+      latexSettingsLoaded: this.latexSettingsLoaded,
+      latexConfigValues: this.latexConfigValues,
+      latexConfigValuesLoaded: this.latexConfigValuesLoaded,
+      clearHistorySearch: () => this.historyTab?.clearSearch(),
+      logSchemaError: (message, error) => this.logSchemaError(message, error),
+    };
   }
 
   protected override handleMessage(raw: unknown): void {
-    if (!raw || typeof raw !== 'object' || !('command' in raw)) {
-      return;
-    }
-
-    const command = (raw as { command: string }).command;
-
-    switch (command) {
-      case SETTINGS_VIEW_COMMANDS.SET_TAB: {
-        const data = this.parseMessage(raw, SetTabMessageSchema);
-        if (!data) return;
-        this.selectedTabIndex.set(data.tabIndex);
-        this.agentSubTab.set(data.agentSubTab);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY: {
-        const data = this.parseMessage(raw, UpdateMemoryMessageSchema);
-        if (!data) return;
-        this.memoryItems.set(data.items ?? []);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED: {
-        const data = this.parseMessage(raw, UpdateMemoryEnabledMessageSchema);
-        if (!data) return;
-        this.memoryEnabled.set(data.enabled);
-        this.memoryToggleDisabled.set(false);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY: {
-        const data = this.parseMessage(raw, UpdateHistoryMessageSchema);
-        if (!data) return;
-        this.historyItems.set(
-          [...data.historyItems].sort(
-            (a, b) =>
-              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-          ),
-        );
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED: {
-        const data = this.parseMessage(raw, HistoryClearedMessageSchema);
-        if (!data) return;
-        this.historyItems.set([]);
-        this.historyTab?.clearSearch();
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION: {
-        const data = this.parseMessage(raw, UpdateModelSelectionMessageSchema);
-        if (!data) return;
-        this.modelSelectionItems.set(data.models);
-        this.helperModel.set(data.helperModel);
-        this.preferShortModelNames.set(data.preferShortModelNames);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION: {
-        const data = this.parseMessage(raw, UpdateAgentSelectionMessageSchema);
-        if (!data) return;
-        this.workflowAgents.set(data.workflow);
-        this.toolUseAgents.set(data.toolUse);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_CUSTOM_AGENT_DIR: {
-        const data = this.parseMessage(raw, UpdateCustomAgentDirMessageSchema);
-        if (!data) return;
-        this.customAgentDir.set(data.path);
-        this.customAgentDirIsDefault.set(data.isDefault);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED: {
-        const data = this.parseMessage(
-          raw,
-          UpdateSuperYoloEnabledMessageSchema,
-        );
-        if (!data) return;
-        this.reliabilitySettings.set(data.reliabilitySettings);
-        this.allowOrchestratorKill.set(data.allowOrchestratorKill);
-        this.detachSubagentsOnStop.set(data.detachSubagentsOnStop);
-        this.nestedDelegationMaxDepth.set(data.nestedDelegationMaxDepth);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS: {
-        const data = this.parseMessage(
-          raw,
-          UpdateAgentModePresetsMessageSchema,
-        );
-        if (!data) return;
-        this.customPresets.set(data.customPresets);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS: {
-        const data = this.parseMessage(
-          raw,
-          UpdateApprovalSettingsMessageSchema,
-        );
-        if (!data) return;
-        this.bashApprovalEnabled.set(data.bashApprovalEnabled);
-        this.codexSandboxMode.set(data.codexSandboxMode);
-        this.codexReasoningEffort.set(data.codexReasoningEffort);
-        this.codexApprovalPolicy.set(data.codexApprovalPolicy);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD: {
-        const data = this.parseMessage(raw, UpdateToolDashboardMessageSchema);
-        if (!data) return;
-        this.toolDashboardItems.set(data.items);
-        this.toolDashboardLoaded.set(true);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS: {
-        const data = this.parseMessage(
-          raw,
-          UpdateGitAuthorSettingsMessageSchema,
-        );
-        if (!data) return;
-        this.gitMarkCommits.set(data.markCommits);
-        this.gitAuthorName.set(data.authorName);
-        this.gitAuthorEmail.set(data.authorEmail);
-        this.gitWorktreeSupport.set(data.worktreeSupport);
-        this.gitSettingsLoaded.set(true);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_GITHUB_TOKEN_STATUS: {
-        const data = this.parseMessage(
-          raw,
-          UpdateGitHubTokenStatusMessageSchema,
-        );
-        if (!data) return;
-        this.githubTokenStatus.set(data.status);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_PR_SUBSCRIPTIONS: {
-        const data = this.parseMessage(raw, UpdatePRSubscriptionsMessageSchema);
-        if (!data) return;
-        this.prSubscriptions.set(data.subscriptions);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS: {
-        const data = this.parseMessage(
-          raw,
-          UpdateLatexSettingsStatusMessageSchema,
-        );
-        if (!data) return;
-        this.latexSettingsStatus.set(data.settings);
-        this.latexSettingsLoaded.set(true);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES: {
-        const data = this.parseMessage(
-          raw,
-          UpdateLatexConfigValuesMessageSchema,
-        );
-        if (!data) return;
-        this.latexConfigValues.set(data.values);
-        this.latexConfigValuesLoaded.set(true);
-        return;
-      }
-
-      case SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE: {
-        const data = this.parseMessage(raw, UpdateProfileMessageSchema);
-        if (!data) return;
-        this.authenticated.set(data.authenticated);
-        this.userEmail.set(data.user?.email ?? 'N/A');
-        this.userId.set(data.user?.id ?? '');
-        this.tier.set(data.tier ?? 'free');
-        this.apiAccessMode.set(data.apiAccessMode);
-        this.allowedModels.set(data.allowedModels ?? null);
-        this.accessExpiresAt.set(data.accessExpiresAt ?? null);
-        this.providerKeyStatuses.set(data.providerKeyStatuses ?? []);
-        this.globalStreamingDefault.set(data.globalStreamingDefault ?? true);
-        return;
-      }
-    }
+    dispatchSettingsViewMessage(raw, this.getMessageHandlerContext());
   }
 
   private handleTabSelect(event: VscTabsSelectEvent): void {

--- a/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -1,0 +1,286 @@
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/commands';
+import {
+  HistoryClearedMessageSchema,
+  SetTabMessageSchema,
+  UpdateAgentModePresetsMessageSchema,
+  UpdateAgentSelectionMessageSchema,
+  UpdateApprovalSettingsMessageSchema,
+  UpdateCustomAgentDirMessageSchema,
+  UpdateGitAuthorSettingsMessageSchema,
+  UpdateGitHubTokenStatusMessageSchema,
+  UpdateHistoryMessageSchema,
+  UpdateLatexConfigValuesMessageSchema,
+  UpdateLatexSettingsStatusMessageSchema,
+  UpdateMemoryEnabledMessageSchema,
+  UpdateMemoryMessageSchema,
+  UpdateModelSelectionMessageSchema,
+  UpdatePRSubscriptionsMessageSchema,
+  UpdateProfileMessageSchema,
+  UpdateSuperYoloEnabledMessageSchema,
+  UpdateToolDashboardMessageSchema,
+  type AgentSelectionItem,
+  type HistoryItem,
+  type LatexConfigValues,
+  type LatexSettingsStatus,
+  type MemoryViewItem,
+  type ModelSelectionItem,
+  type NumberVscodeSetting,
+  type PRSubscriptionEntry,
+  type ProviderKeyStatus,
+  type ToolDashboardItem,
+} from '@shared/schemas';
+import type { AgentCategory } from '@shared/schemas/agent';
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+
+interface WritableSignal<T> {
+  set(value: T): void;
+}
+
+interface MessageSchema<T> {
+  safeParse(
+    data: unknown,
+  ): { success: true; data: T } | { success: false; error: unknown };
+}
+
+export interface SettingsMessageHandlerContext {
+  selectedTabIndex: WritableSignal<number>;
+  memoryItems: WritableSignal<MemoryViewItem[]>;
+  memoryEnabled: WritableSignal<boolean>;
+  memoryToggleDisabled: WritableSignal<boolean>;
+  historyItems: WritableSignal<HistoryItem[]>;
+  authenticated: WritableSignal<boolean>;
+  userEmail: WritableSignal<string>;
+  userId: WritableSignal<string>;
+  tier: WritableSignal<string>;
+  apiAccessMode: WritableSignal<'included' | 'personal'>;
+  allowedModels: WritableSignal<string[] | null>;
+  accessExpiresAt: WritableSignal<string | null>;
+  providerKeyStatuses: WritableSignal<ProviderKeyStatus[]>;
+  globalStreamingDefault: WritableSignal<boolean>;
+  modelSelectionItems: WritableSignal<ModelSelectionItem[]>;
+  helperModel: WritableSignal<string>;
+  preferShortModelNames: WritableSignal<boolean>;
+  workflowAgents: WritableSignal<AgentSelectionItem[]>;
+  toolUseAgents: WritableSignal<AgentSelectionItem[]>;
+  customAgentDir: WritableSignal<string>;
+  customAgentDirIsDefault: WritableSignal<boolean>;
+  agentSubTab: WritableSignal<AgentCategory | undefined>;
+  customPresets: WritableSignal<AgentModePreset[]>;
+  reliabilitySettings: WritableSignal<NumberVscodeSetting[]>;
+  allowOrchestratorKill: WritableSignal<boolean>;
+  detachSubagentsOnStop: WritableSignal<boolean>;
+  nestedDelegationMaxDepth: WritableSignal<number>;
+  bashApprovalEnabled: WritableSignal<boolean>;
+  codexSandboxMode: WritableSignal<string>;
+  codexReasoningEffort: WritableSignal<string>;
+  codexApprovalPolicy: WritableSignal<string>;
+  toolDashboardItems: WritableSignal<ToolDashboardItem[]>;
+  toolDashboardLoaded: WritableSignal<boolean>;
+  gitMarkCommits: WritableSignal<boolean>;
+  gitAuthorName: WritableSignal<string>;
+  gitAuthorEmail: WritableSignal<string>;
+  gitWorktreeSupport: WritableSignal<boolean>;
+  gitSettingsLoaded: WritableSignal<boolean>;
+  githubTokenStatus: WritableSignal<'secret' | 'env' | 'none'>;
+  prSubscriptions: WritableSignal<readonly PRSubscriptionEntry[]>;
+  latexSettingsStatus: WritableSignal<LatexSettingsStatus>;
+  latexSettingsLoaded: WritableSignal<boolean>;
+  latexConfigValues: WritableSignal<LatexConfigValues>;
+  latexConfigValuesLoaded: WritableSignal<boolean>;
+  clearHistorySearch(): void;
+  logSchemaError(message: string, error: unknown): void;
+}
+
+function parseMessage<T>(
+  raw: unknown,
+  schema: MessageSchema<T>,
+  ctx: SettingsMessageHandlerContext,
+): T | null {
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    ctx.logSchemaError(
+      '[SettingsApp] Message validation failed.',
+      result.error,
+    );
+    return null;
+  }
+  return result.data;
+}
+
+export function dispatchSettingsViewMessage(
+  raw: unknown,
+  ctx: SettingsMessageHandlerContext,
+): boolean {
+  if (!raw || typeof raw !== 'object' || !('command' in raw)) {
+    return false;
+  }
+
+  const command = (raw as { command: string }).command;
+
+  switch (command) {
+    case SETTINGS_VIEW_COMMANDS.SET_TAB: {
+      const data = parseMessage(raw, SetTabMessageSchema, ctx);
+      if (!data) return false;
+      ctx.selectedTabIndex.set(data.tabIndex);
+      ctx.agentSubTab.set(data.agentSubTab);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY: {
+      const data = parseMessage(raw, UpdateMemoryMessageSchema, ctx);
+      if (!data) return false;
+      ctx.memoryItems.set(data.items ?? []);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED: {
+      const data = parseMessage(raw, UpdateMemoryEnabledMessageSchema, ctx);
+      if (!data) return false;
+      ctx.memoryEnabled.set(data.enabled);
+      ctx.memoryToggleDisabled.set(false);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_HISTORY: {
+      const data = parseMessage(raw, UpdateHistoryMessageSchema, ctx);
+      if (!data) return false;
+      ctx.historyItems.set(
+        [...data.historyItems].sort(
+          (a, b) =>
+            new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        ),
+      );
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.HISTORY_CLEARED: {
+      const data = parseMessage(raw, HistoryClearedMessageSchema, ctx);
+      if (!data) return false;
+      ctx.historyItems.set([]);
+      ctx.clearHistorySearch();
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION: {
+      const data = parseMessage(raw, UpdateModelSelectionMessageSchema, ctx);
+      if (!data) return false;
+      ctx.modelSelectionItems.set(data.models);
+      ctx.helperModel.set(data.helperModel);
+      ctx.preferShortModelNames.set(data.preferShortModelNames);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION: {
+      const data = parseMessage(raw, UpdateAgentSelectionMessageSchema, ctx);
+      if (!data) return false;
+      ctx.workflowAgents.set(data.workflow);
+      ctx.toolUseAgents.set(data.toolUse);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_CUSTOM_AGENT_DIR: {
+      const data = parseMessage(raw, UpdateCustomAgentDirMessageSchema, ctx);
+      if (!data) return false;
+      ctx.customAgentDir.set(data.path);
+      ctx.customAgentDirIsDefault.set(data.isDefault);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED: {
+      const data = parseMessage(raw, UpdateSuperYoloEnabledMessageSchema, ctx);
+      if (!data) return false;
+      ctx.reliabilitySettings.set(data.reliabilitySettings);
+      ctx.allowOrchestratorKill.set(data.allowOrchestratorKill);
+      ctx.detachSubagentsOnStop.set(data.detachSubagentsOnStop);
+      ctx.nestedDelegationMaxDepth.set(data.nestedDelegationMaxDepth);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS: {
+      const data = parseMessage(raw, UpdateAgentModePresetsMessageSchema, ctx);
+      if (!data) return false;
+      ctx.customPresets.set(data.customPresets);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS: {
+      const data = parseMessage(raw, UpdateApprovalSettingsMessageSchema, ctx);
+      if (!data) return false;
+      ctx.bashApprovalEnabled.set(data.bashApprovalEnabled);
+      ctx.codexSandboxMode.set(data.codexSandboxMode);
+      ctx.codexReasoningEffort.set(data.codexReasoningEffort);
+      ctx.codexApprovalPolicy.set(data.codexApprovalPolicy);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD: {
+      const data = parseMessage(raw, UpdateToolDashboardMessageSchema, ctx);
+      if (!data) return false;
+      ctx.toolDashboardItems.set(data.items);
+      ctx.toolDashboardLoaded.set(true);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS: {
+      const data = parseMessage(raw, UpdateGitAuthorSettingsMessageSchema, ctx);
+      if (!data) return false;
+      ctx.gitMarkCommits.set(data.markCommits);
+      ctx.gitAuthorName.set(data.authorName);
+      ctx.gitAuthorEmail.set(data.authorEmail);
+      ctx.gitWorktreeSupport.set(data.worktreeSupport);
+      ctx.gitSettingsLoaded.set(true);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_GITHUB_TOKEN_STATUS: {
+      const data = parseMessage(raw, UpdateGitHubTokenStatusMessageSchema, ctx);
+      if (!data) return false;
+      ctx.githubTokenStatus.set(data.status);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_PR_SUBSCRIPTIONS: {
+      const data = parseMessage(raw, UpdatePRSubscriptionsMessageSchema, ctx);
+      if (!data) return false;
+      ctx.prSubscriptions.set(data.subscriptions);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS: {
+      const data = parseMessage(
+        raw,
+        UpdateLatexSettingsStatusMessageSchema,
+        ctx,
+      );
+      if (!data) return false;
+      ctx.latexSettingsStatus.set(data.settings);
+      ctx.latexSettingsLoaded.set(true);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES: {
+      const data = parseMessage(raw, UpdateLatexConfigValuesMessageSchema, ctx);
+      if (!data) return false;
+      ctx.latexConfigValues.set(data.values);
+      ctx.latexConfigValuesLoaded.set(true);
+      return true;
+    }
+
+    case SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE: {
+      const data = parseMessage(raw, UpdateProfileMessageSchema, ctx);
+      if (!data) return false;
+      ctx.authenticated.set(data.authenticated);
+      ctx.userEmail.set(data.user?.email ?? 'N/A');
+      ctx.userId.set(data.user?.id ?? '');
+      ctx.tier.set(data.tier ?? 'free');
+      ctx.apiAccessMode.set(data.apiAccessMode);
+      ctx.allowedModels.set(data.allowedModels ?? null);
+      ctx.accessExpiresAt.set(data.accessExpiresAt ?? null);
+      ctx.providerKeyStatuses.set(data.providerKeyStatuses ?? []);
+      ctx.globalStreamingDefault.set(data.globalStreamingDefault ?? true);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/settingsView/frontend/settingsViewDispatcher.ts
+++ b/src/settingsView/frontend/settingsViewDispatcher.ts
@@ -98,8 +98,12 @@ function parseMessage<T>(
 ): T | null {
   const result = schema.safeParse(raw);
   if (!result.success) {
+    const command =
+      raw && typeof raw === 'object' && 'command' in raw
+        ? String((raw as { command: unknown }).command)
+        : 'unknown';
     ctx.logSchemaError(
-      '[SettingsApp] Message validation failed.',
+      `[settingsViewDispatcher] Message validation failed for command "${command}".`,
       result.error,
     );
     return null;


### PR DESCRIPTION
## Summary
- move SettingsApp backend-message parsing and command dispatch into settingsViewDispatcher
- keep SettingsApp as the state/rendering owner through an explicit handler context
- align settings with the existing main/progress dispatcher pattern for Electron IPC reuse

Electron PRD slice: prds/prd-electron-app.md §9 Tier 3 #13.

## Validation
- npm run format
- npm run compile:safe
- npm run compile (passes with existing Nunjucks critical-dependency warning)
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session token plumbing and server-side key access events while introducing host-neutral platform abstractions; regressions could break sign-in, token refresh, or included-model access toggles across hosts.
> 
> **Overview**
> Refactors several VS Code-coupled areas toward *host-neutral* interfaces.
> 
> Auth is reorganized by extracting Supabase session parsing/token extraction into `SupabaseSession` and introducing a shared `AuthTokenProvider`/`SessionTokens` contract; `SupabaseClient.getSessionTokens()` now delegates to the registered provider, and `SupabaseAuthProvider` exposes `getSessionTokens()` and uses the shared parsers for callback/session storage.
> 
> Server-side key access is decoupled from VS Code types by replacing `vscode.EventEmitter`/`ExtensionContext` dependencies with a small disposable/event abstraction and host-provided state/subscriptions; initialization wiring is updated accordingly and covered by new unit tests.
> 
> On the frontend/platform side, settings/config access is routed through a new `ConfigProvider` (`VscodeConfigProvider` in the extension) and `configUtils` now uses `platform.config` for get/update/inspect/watch; `WorkspaceProvider` gains a `watch()` API with new implementations for VS Code and Node. The Settings webview message handling is extracted into `settingsViewDispatcher`, and tool-edit approval diff handling is similarly abstracted via `DiffViewHost` with a VS Code implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0141ae3e6dcec5ed014d84ed4efd602f78cdd6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->