### PR TITLE
[codex] Guard platform initialization imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,6 +53,58 @@ const INTERNAL_ALIAS_PATH_GROUPS = INTERNAL_ALIAS_NAMES.flatMap((alias) => [
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const COMPOSITION_ROOT_FILES = new Set([
+  path.join(__dirname, 'src/extension.ts'),
+]);
+
+const localRules = {
+  rules: {
+    'no-platform-init-outside-composition-root': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Disallow initPlatform imports outside composition roots.',
+        },
+        messages: {
+          forbidden:
+            'initPlatform may only be imported by composition roots; use platform() elsewhere.',
+        },
+        schema: [],
+      },
+      create(context) {
+        const filename = path.normalize(context.filename);
+        const isAllowedFile =
+          COMPOSITION_ROOT_FILES.has(filename) ||
+          filename.includes(`${path.sep}src${path.sep}test${path.sep}`);
+
+        if (isAllowedFile) {
+          return {};
+        }
+
+        return {
+          ImportDeclaration(node) {
+            const importsInitPlatform = node.specifiers.some((specifier) => {
+              return (
+                specifier.type === 'ImportSpecifier' &&
+                specifier.imported.type === 'Identifier' &&
+                specifier.imported.name === 'initPlatform'
+              );
+            });
+
+            if (!importsInitPlatform) return;
+
+            context.report({
+              node,
+              messageId: 'forbidden',
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
 export default tseslint.config(
   // Global ignores specified in the old config
   {
@@ -75,9 +127,12 @@ export default tseslint.config(
     plugins: {
       '@stylistic': stylistic,
       import: importPlugin,
+      local: localRules,
       unicorn,
     },
     rules: {
+      'local/no-platform-init-outside-composition-root': 'error',
+
       // --- Unicorn modernization rules (ES2023+) ---
       'unicorn/prefer-string-replace-all': 'warn',
       'unicorn/prefer-at': 'warn',


### PR DESCRIPTION
## Summary
- add a local ESLint rule that forbids importing initPlatform outside composition roots
- allow the current VS Code composition root and test setup code to initialize platform fakes
- support the Electron PRD §9 #15 pre-refactoring by locking platform initialization to startup boundaries

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- targeted ESLint probe confirms the rule reports local/no-platform-init-outside-composition-root for an initPlatform import outside the composition root
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ESLint enforcement around `initPlatform` usage and refactors several core services (config, workspace watching, auth token/session handling) to be host-neutral, which could affect initialization order and authentication flows if miswired.
> 
> **Overview**
> **Guards platform initialization** by adding a local ESLint rule (`local/no-platform-init-outside-composition-root`) that forbids importing `initPlatform` outside `src/extension.ts` (and tests), pushing non-root code to use `platform()`.
> 
> **Continues the host-neutral platform refactor**: config access is routed through `platform.config` via a new `ConfigProvider` interface and `VscodeConfigProvider`, replacing direct VS Code config usage in `configUtils` and switching call sites to `target: 'global' | 'workspace'`. Workspace providers gain a `watch()` API with implementations for VS Code and a Node fallback (recursive glob watching).
> 
> **Auth/session plumbing is cleaned up and decoupled**: session parsing/token extraction is moved into `SupabaseSession.ts`, a shared `AuthTokenProvider`/`SessionTokens` contract is introduced, `SupabaseClient.getSessionTokens()` now delegates to the provider (with `resetForTests()`), and `ServerSideKeyService` drops VS Code `EventEmitter/Memento` in favor of host-provided state + a Node-backed emitter. Tool-edit approval diff handling is similarly abstracted behind a `DiffViewHost` with a VS Code implementation.
> 
> Adds focused unit tests covering the new session helpers, `SupabaseClient` token-provider behavior, and the refactored `ServerSideKeyService` initialization/events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c26b7e98825f8e45766e4cbf0097e029511c4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->