### PR TITLE
[codex] Add webview theme token shim

### DIFF
--- a/src/common/styles/common.css
+++ b/src/common/styles/common.css
@@ -2,16 +2,210 @@
  * Document-level styles for TeXRA webviews.
  * These styles target elements outside Shadow DOM (body, document root).
  *
- * Note: Custom design tokens are defined in litStyles.ts at :host level
- * for Lit components. Document-level styles use VS Code variables directly.
+ * Theme tokens map the extension host's VS Code variables to TeXRA-owned
+ * variables. Electron can provide the same --texra-* contract without VS Code.
  */
+
+:root {
+  --texra-activityBarBadge-background: var(
+    --vscode-activityBarBadge-background
+  );
+  --texra-badge-background: var(--vscode-badge-background);
+  --texra-badge-foreground: var(--vscode-badge-foreground);
+  --texra-button-background: var(--vscode-button-background);
+  --texra-button-border: var(--vscode-button-border);
+  --texra-button-foreground: var(--vscode-button-foreground);
+  --texra-button-hoverBackground: var(--vscode-button-hoverBackground);
+  --texra-button-secondaryBackground: var(--vscode-button-secondaryBackground);
+  --texra-button-secondaryForeground: var(--vscode-button-secondaryForeground);
+  --texra-button-secondaryHoverBackground: var(
+    --vscode-button-secondaryHoverBackground
+  );
+  --texra-button-separator: var(--vscode-button-separator);
+  --texra-charts-blue: var(--vscode-charts-blue);
+  --texra-charts-green: var(--vscode-charts-green);
+  --texra-charts-orange: var(--vscode-charts-orange);
+  --texra-charts-red: var(--vscode-charts-red);
+  --texra-charts-yellow: var(--vscode-charts-yellow);
+  --texra-contrastBorder: var(--vscode-contrastBorder);
+  --texra-debugTokenExpression-name: var(--vscode-debugTokenExpression-name);
+  --texra-debugTokenExpression-number: var(
+    --vscode-debugTokenExpression-number
+  );
+  --texra-debugTokenExpression-string: var(
+    --vscode-debugTokenExpression-string
+  );
+  --texra-descriptionForeground: var(--vscode-descriptionForeground);
+  --texra-diffEditor-insertedTextBackground: var(
+    --vscode-diffEditor-insertedTextBackground
+  );
+  --texra-diffEditor-removedTextBackground: var(
+    --vscode-diffEditor-removedTextBackground
+  );
+  --texra-dropdown-border: var(--vscode-dropdown-border);
+  --texra-editor-background: var(--vscode-editor-background);
+  --texra-editor-findMatchBackground: var(--vscode-editor-findMatchBackground);
+  --texra-editor-findMatchHighlightBackground: var(
+    --vscode-editor-findMatchHighlightBackground
+  );
+  --texra-editor-findMatchHighlightForeground: var(
+    --vscode-editor-findMatchHighlightForeground
+  );
+  --texra-editor-font-family: var(--vscode-editor-font-family);
+  --texra-editor-font-size: var(--vscode-editor-font-size);
+  --texra-editor-foreground: var(--vscode-editor-foreground);
+  --texra-editor-inactiveSelectionBackground: var(
+    --vscode-editor-inactiveSelectionBackground
+  );
+  --texra-editor-lineHighlightBackground: var(
+    --vscode-editor-lineHighlightBackground
+  );
+  --texra-editor-selectionBackground: var(--vscode-editor-selectionBackground);
+  --texra-editorError-foreground: var(--vscode-editorError-foreground);
+  --texra-editorGroupHeader-tabsBackground: var(
+    --vscode-editorGroupHeader-tabsBackground
+  );
+  --texra-editorGroupHeader-tabsBorder: var(
+    --vscode-editorGroupHeader-tabsBorder
+  );
+  --texra-editorHoverWidget-background: var(
+    --vscode-editorHoverWidget-background
+  );
+  --texra-editorHoverWidget-border: var(--vscode-editorHoverWidget-border);
+  --texra-editorHoverWidget-foreground: var(
+    --vscode-editorHoverWidget-foreground
+  );
+  --texra-editorInfo-background: var(--vscode-editorInfo-background);
+  --texra-editorInfo-foreground: var(--vscode-editorInfo-foreground);
+  --texra-editorWarning-background: var(--vscode-editorWarning-background);
+  --texra-editorWarning-foreground: var(--vscode-editorWarning-foreground);
+  --texra-editorWidget-background: var(--vscode-editorWidget-background);
+  --texra-editorWidget-border: var(--vscode-editorWidget-border);
+  --texra-errorForeground: var(--vscode-errorForeground);
+  --texra-focusBorder: var(--vscode-focusBorder);
+  --texra-font-family: var(--vscode-font-family);
+  --texra-font-size: var(--vscode-font-size);
+  --texra-font-weight: var(--vscode-font-weight);
+  --texra-foreground: var(--vscode-foreground);
+  --texra-gitDecoration-addedResourceForeground: var(
+    --vscode-gitDecoration-addedResourceForeground
+  );
+  --texra-gitDecoration-deletedResourceForeground: var(
+    --vscode-gitDecoration-deletedResourceForeground
+  );
+  --texra-gitDecoration-modifiedResourceForeground: var(
+    --vscode-gitDecoration-modifiedResourceForeground
+  );
+  --texra-icon-foreground: var(--vscode-icon-foreground);
+  --texra-input-background: var(--vscode-input-background);
+  --texra-input-border: var(--vscode-input-border);
+  --texra-input-foreground: var(--vscode-input-foreground);
+  --texra-input-placeholderForeground: var(
+    --vscode-input-placeholderForeground
+  );
+  --texra-inputValidation-errorBackground: var(
+    --vscode-inputValidation-errorBackground
+  );
+  --texra-inputValidation-infoBackground: var(
+    --vscode-inputValidation-infoBackground
+  );
+  --texra-inputValidation-infoBorder: var(--vscode-inputValidation-infoBorder);
+  --texra-inputValidation-infoForeground: var(
+    --vscode-inputValidation-infoForeground
+  );
+  --texra-inputValidation-warningBackground: var(
+    --vscode-inputValidation-warningBackground
+  );
+  --texra-inputValidation-warningBorder: var(
+    --vscode-inputValidation-warningBorder
+  );
+  --texra-inputValidation-warningForeground: var(
+    --vscode-inputValidation-warningForeground
+  );
+  --texra-list-activeSelectionBackground: var(
+    --vscode-list-activeSelectionBackground
+  );
+  --texra-list-activeSelectionForeground: var(
+    --vscode-list-activeSelectionForeground
+  );
+  --texra-list-hoverBackground: var(--vscode-list-hoverBackground);
+  --texra-list-warningForeground: var(--vscode-list-warningForeground);
+  --texra-menu-background: var(--vscode-menu-background);
+  --texra-menu-border: var(--vscode-menu-border);
+  --texra-menu-foreground: var(--vscode-menu-foreground);
+  --texra-notificationsInfoIcon-foreground: var(
+    --vscode-notificationsInfoIcon-foreground
+  );
+  --texra-panel-border: var(--vscode-panel-border);
+  --texra-panelSection-border: var(--vscode-panelSection-border);
+  --texra-progressBar-background: var(--vscode-progressBar-background);
+  --texra-sideBar-background: var(--vscode-sideBar-background);
+  --texra-sideBar-foreground: var(--vscode-sideBar-foreground);
+  --texra-sideBarSectionHeader-background: var(
+    --vscode-sideBarSectionHeader-background
+  );
+  --texra-sideBarTitle-foreground: var(--vscode-sideBarTitle-foreground);
+  --texra-statusBarItem-warningBackground: var(
+    --vscode-statusBarItem-warningBackground
+  );
+  --texra-symbolIcon-classForeground: var(--vscode-symbolIcon-classForeground);
+  --texra-symbolIcon-constantForeground: var(
+    --vscode-symbolIcon-constantForeground
+  );
+  --texra-symbolIcon-functionForeground: var(
+    --vscode-symbolIcon-functionForeground
+  );
+  --texra-symbolIcon-keywordForeground: var(
+    --vscode-symbolIcon-keywordForeground
+  );
+  --texra-symbolIcon-propertyForeground: var(
+    --vscode-symbolIcon-propertyForeground
+  );
+  --texra-symbolIcon-variableForeground: var(
+    --vscode-symbolIcon-variableForeground
+  );
+  --texra-terminal-ansiBlack: var(--vscode-terminal-ansiBlack);
+  --texra-terminal-ansiBlue: var(--vscode-terminal-ansiBlue);
+  --texra-terminal-ansiBrightBlack: var(--vscode-terminal-ansiBrightBlack);
+  --texra-terminal-ansiBrightBlue: var(--vscode-terminal-ansiBrightBlue);
+  --texra-terminal-ansiBrightCyan: var(--vscode-terminal-ansiBrightCyan);
+  --texra-terminal-ansiBrightGreen: var(--vscode-terminal-ansiBrightGreen);
+  --texra-terminal-ansiBrightMagenta: var(--vscode-terminal-ansiBrightMagenta);
+  --texra-terminal-ansiBrightRed: var(--vscode-terminal-ansiBrightRed);
+  --texra-terminal-ansiBrightWhite: var(--vscode-terminal-ansiBrightWhite);
+  --texra-terminal-ansiBrightYellow: var(--vscode-terminal-ansiBrightYellow);
+  --texra-terminal-ansiCyan: var(--vscode-terminal-ansiCyan);
+  --texra-terminal-ansiGreen: var(--vscode-terminal-ansiGreen);
+  --texra-terminal-ansiMagenta: var(--vscode-terminal-ansiMagenta);
+  --texra-terminal-ansiRed: var(--vscode-terminal-ansiRed);
+  --texra-terminal-ansiWhite: var(--vscode-terminal-ansiWhite);
+  --texra-terminal-ansiYellow: var(--vscode-terminal-ansiYellow);
+  --texra-terminal-background: var(--vscode-terminal-background);
+  --texra-terminal-foreground: var(--vscode-terminal-foreground);
+  --texra-terminal-selectionBackground: var(
+    --vscode-terminal-selectionBackground
+  );
+  --texra-terminalCursor-foreground: var(--vscode-terminalCursor-foreground);
+  --texra-testing-iconFailed: var(--vscode-testing-iconFailed);
+  --texra-testing-iconPassed: var(--vscode-testing-iconPassed);
+  --texra-textBlockQuote-background: var(--vscode-textBlockQuote-background);
+  --texra-textBlockQuote-border: var(--vscode-textBlockQuote-border);
+  --texra-textCodeBlock-background: var(--vscode-textCodeBlock-background);
+  --texra-textLink-activeForeground: var(--vscode-textLink-activeForeground);
+  --texra-textLink-foreground: var(--vscode-textLink-foreground);
+  --texra-textPreformat-foreground: var(--vscode-textPreformat-foreground);
+  --texra-toolbar-activeBackground: var(--vscode-toolbar-activeBackground);
+  --texra-toolbar-hoverBackground: var(--vscode-toolbar-hoverBackground);
+  --texra-widget-border: var(--vscode-widget-border);
+  --texra-widget-shadow: var(--vscode-widget-shadow);
+}
 
 body {
   margin: 0;
   padding: 20px;
-  font-family: var(--vscode-font-family);
-  font-size: var(--vscode-font-size);
-  color: var(--vscode-editor-foreground);
-  background-color: var(--vscode-editor-background);
+  font-family: var(--texra-font-family);
+  font-size: var(--texra-font-size);
+  color: var(--texra-editor-foreground);
+  background-color: var(--texra-editor-background);
   box-sizing: border-box;
 }

--- a/src/progressView/frontend/components/BackgroundTasksPanel.ts
+++ b/src/progressView/frontend/components/BackgroundTasksPanel.ts
@@ -103,7 +103,7 @@ export class BackgroundTasksPanel extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .task-name--clickable {
@@ -114,7 +114,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .task-name--clickable:hover {
-        text-decoration-color: var(--vscode-foreground);
+        text-decoration-color: var(--texra-foreground);
       }
 
       .task-description {
@@ -162,7 +162,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       .section-label:hover {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .section-label .codicon {
@@ -191,7 +191,7 @@ export class BackgroundTasksPanel extends LitElement {
       }
 
       details.task-output > summary:hover {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .output-container {

--- a/src/progressView/frontend/components/ContextManagement.ts
+++ b/src/progressView/frontend/components/ContextManagement.ts
@@ -50,7 +50,7 @@ export class ContextManagement extends LitElement {
       summary,
       .context-icon,
       .context-title {
-        color: var(--accent-color, var(--vscode-foreground));
+        color: var(--accent-color, var(--texra-foreground));
       }
 
       .context-icon {
@@ -98,9 +98,9 @@ export class ContextManagement extends LitElement {
         padding: var(--spacing-small);
         white-space: pre-wrap;
         word-break: break-word;
-        border: var(--border-thin) solid var(--vscode-widget-border);
+        border: var(--border-thin) solid var(--texra-widget-border);
         border-radius: var(--border-radius-small);
-        background: var(--vscode-editorWidget-background);
+        background: var(--texra-editorWidget-background);
       }
     `,
   ];
@@ -112,7 +112,7 @@ export class ContextManagement extends LitElement {
   @property({ attribute: false }) config: ActionConfig = {
     icon: 'codicon-history',
     label: 'Context Management',
-    color: 'var(--vscode-foreground)',
+    color: 'var(--texra-foreground)',
   };
 
   /** Statistics items to display */

--- a/src/progressView/frontend/components/FileList.ts
+++ b/src/progressView/frontend/components/FileList.ts
@@ -57,7 +57,7 @@ export class FileList extends LitElement {
 
       .files-container {
         padding: 0;
-        font-size: var(--vscode-editor-font-size);
+        font-size: var(--texra-editor-font-size);
         overflow-y: auto;
         max-height: var(--height-large);
         flex-shrink: 0;
@@ -133,13 +133,13 @@ export class FileList extends LitElement {
       }
 
       .added {
-        color: var(--vscode-charts-green, green);
+        color: var(--texra-charts-green, green);
         margin-left: var(--spacing-small);
         font-size: var(--font-size-sm);
       }
 
       .removed {
-        color: var(--vscode-charts-red, red);
+        color: var(--texra-charts-red, red);
         margin-left: var(--spacing-small);
         font-size: var(--font-size-sm);
       }
@@ -177,7 +177,7 @@ export class FileList extends LitElement {
 
       .compile-warning {
         flex-shrink: 0;
-        color: var(--vscode-editorWarning-foreground, orange);
+        color: var(--texra-editorWarning-foreground, orange);
       }
 
       .compile-actions {

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -124,11 +124,11 @@ export class PlanView extends LitElement {
 
       .plan-step__file {
         font-size: var(--font-size-sm);
-        color: var(--vscode-textLink-foreground);
-        background: var(--vscode-badge-background);
+        color: var(--texra-textLink-foreground);
+        background: var(--texra-badge-background);
         padding: var(--border-thin) var(--spacing-medium);
         border-radius: var(--border-radius);
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
       }
 
       /* Status-specific styles */
@@ -141,11 +141,11 @@ export class PlanView extends LitElement {
       }
 
       .plan-step--in-progress .plan-step__icon {
-        color: var(--vscode-progressBar-background);
+        color: var(--texra-progressBar-background);
       }
 
       .plan-step--in-progress .plan-step__title {
-        color: var(--vscode-progressBar-background);
+        color: var(--texra-progressBar-background);
       }
 
       .plan-step--completed {

--- a/src/progressView/frontend/components/PlanView.ts
+++ b/src/progressView/frontend/components/PlanView.ts
@@ -128,7 +128,7 @@ export class PlanView extends LitElement {
         background: var(--texra-badge-background);
         padding: var(--border-thin) var(--spacing-medium);
         border-radius: var(--border-radius);
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
       }
 
       /* Status-specific styles */

--- a/src/progressView/frontend/components/QueuedFollowUps.ts
+++ b/src/progressView/frontend/components/QueuedFollowUps.ts
@@ -32,10 +32,9 @@ export class QueuedFollowUps extends LitElement {
 
       /* Info-style collapsible for queued messages */
       .queued-collapsible {
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
+        border: var(--border-thin) solid var(--texra-inputValidation-infoBorder);
         border-radius: var(--border-radius);
-        background-color: var(--vscode-inputValidation-infoBackground);
+        background-color: var(--texra-inputValidation-infoBackground);
       }
 
       .queued-collapsible::part(header) {
@@ -61,7 +60,7 @@ export class QueuedFollowUps extends LitElement {
         padding: var(--spacing-tiny) var(--spacing-small);
         font-size: var(--font-size);
         line-height: var(--line-height-normal);
-        background-color: var(--vscode-editor-background);
+        background-color: var(--texra-editor-background);
         border-radius: var(--border-radius-small);
         border: var(--border-thin) solid var(--color-border);
         min-width: 0;
@@ -72,7 +71,7 @@ export class QueuedFollowUps extends LitElement {
         font-size: var(--font-size-icon-sm);
         line-height: var(--line-height-normal);
         margin-top: var(--border-thin);
-        color: var(--vscode-inputValidation-infoBorder);
+        color: var(--texra-inputValidation-infoBorder);
       }
 
       .queued-follow-up-text {
@@ -80,7 +79,7 @@ export class QueuedFollowUps extends LitElement {
         min-width: 0;
         overflow-wrap: anywhere;
         white-space: pre-wrap;
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
     `,
   ];

--- a/src/progressView/frontend/components/StreamHeader.ts
+++ b/src/progressView/frontend/components/StreamHeader.ts
@@ -297,7 +297,7 @@ export class StreamHeader extends LitElement {
       }
 
       .parent-link:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }

--- a/src/progressView/frontend/components/StreamTabs.ts
+++ b/src/progressView/frontend/components/StreamTabs.ts
@@ -122,7 +122,7 @@ export class StreamTab extends LitElement {
 
       .tab-container.status-waiting,
       .tab-container.status-resuming {
-        border-left-color: var(--vscode-textLink-foreground);
+        border-left-color: var(--texra-textLink-foreground);
       }
 
       .tab-container.status-stopped,
@@ -138,7 +138,7 @@ export class StreamTab extends LitElement {
       @keyframes pulse-border {
         0%,
         100% {
-          border-left-color: var(--vscode-charts-orange, #d18616);
+          border-left-color: var(--texra-charts-orange, #d18616);
         }
         50% {
           border-left-color: transparent;
@@ -158,7 +158,7 @@ export class StreamTab extends LitElement {
         cursor: pointer;
         border: none;
         background: none;
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         text-align: left;
         font-family: var(--font-family);
         min-width: 0;
@@ -181,7 +181,7 @@ export class StreamTab extends LitElement {
 
       .tab-description {
         font-size: var(--font-size-sm);
-        color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+        color: var(--texra-descriptionForeground, var(--texra-foreground));
         opacity: 0.8;
         white-space: nowrap;
         overflow: hidden;
@@ -202,7 +202,7 @@ export class StreamTab extends LitElement {
         align-items: center;
         gap: var(--spacing-small);
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         opacity: var(--opacity-subtle);
         width: 100%;
       }
@@ -224,14 +224,14 @@ export class StreamTab extends LitElement {
         min-width: var(--height-control);
         height: var(--height-control);
         margin: 0;
-        color: var(--vscode-icon-foreground, var(--vscode-foreground));
+        color: var(--texra-icon-foreground, var(--texra-foreground));
         transition:
           color var(--transition-fast),
           background-color var(--transition-fast);
       }
 
       .tab-container:hover {
-        background-color: var(--vscode-list-hoverBackground);
+        background-color: var(--texra-list-hoverBackground);
       }
 
       /*
@@ -241,10 +241,10 @@ export class StreamTab extends LitElement {
        * color even when intermediate elements define their own.
        */
       .tab-container.is-active {
-        background-color: var(--vscode-list-activeSelectionBackground);
+        background-color: var(--texra-list-activeSelectionBackground);
         color: var(
-          --vscode-list-activeSelectionForeground,
-          var(--vscode-foreground)
+          --texra-list-activeSelectionForeground,
+          var(--texra-foreground)
         );
       }
 
@@ -256,8 +256,8 @@ export class StreamTab extends LitElement {
       .tab-container.is-active .tab-delete,
       .tab-container.is-active .tab-expand {
         color: var(
-          --vscode-list-activeSelectionForeground,
-          var(--vscode-foreground)
+          --texra-list-activeSelectionForeground,
+          var(--texra-foreground)
         );
       }
 
@@ -270,7 +270,7 @@ export class StreamTab extends LitElement {
       .tab-container.is-active .tab-delete:focus-within,
       .tab-container.is-active .tab-delete:hover *,
       .tab-container.is-active .tab-delete:focus-within * {
-        color: var(--vscode-errorForeground);
+        color: var(--texra-errorForeground);
       }
 
       /* Drop the dim-by-default opacity so the flipped foreground renders
@@ -305,19 +305,19 @@ export class StreamTab extends LitElement {
         border-radius: var(--border-radius-small);
         background-color: color-mix(
           in srgb,
-          var(--vscode-icon-foreground, var(--vscode-foreground)) 10%,
+          var(--texra-icon-foreground, var(--texra-foreground)) 10%,
           transparent
         );
       }
 
       .tab-delete:hover::part(control),
       .tab-delete:focus-within::part(control) {
-        background-color: var(--vscode-toolbar-hoverBackground);
+        background-color: var(--texra-toolbar-hoverBackground);
       }
 
       .tab-delete:hover,
       .tab-delete:focus-within {
-        color: var(--vscode-errorForeground);
+        color: var(--texra-errorForeground);
       }
 
       /* Expand/collapse chevron for parent tabs with children */
@@ -331,14 +331,14 @@ export class StreamTab extends LitElement {
         border: none;
         background: none;
         cursor: pointer;
-        color: var(--vscode-icon-foreground, var(--vscode-foreground));
+        color: var(--texra-icon-foreground, var(--texra-foreground));
         opacity: 0.6;
         padding: 0;
       }
 
       .tab-expand:hover {
         opacity: 1;
-        background-color: var(--vscode-toolbar-hoverBackground);
+        background-color: var(--texra-toolbar-hoverBackground);
       }
 
       .tab-expand .codicon {

--- a/src/progressView/frontend/components/TerminalCommandStrip.ts
+++ b/src/progressView/frontend/components/TerminalCommandStrip.ts
@@ -18,20 +18,20 @@ export class TerminalCommandStrip extends LitElement {
       padding: 6px 10px;
       margin: 0 0 8px 0;
       background: var(
-        --vscode-terminal-background,
-        var(--vscode-editor-background, transparent)
+        --texra-terminal-background,
+        var(--texra-editor-background, transparent)
       );
-      color: var(--vscode-terminal-foreground, var(--vscode-foreground));
-      border: 1px solid var(--vscode-panel-border, transparent);
+      color: var(--texra-terminal-foreground, var(--texra-foreground));
+      border: 1px solid var(--texra-panel-border, transparent);
       border-radius: 3px;
       font-family: var(
-        --vscode-editor-font-family,
+        --texra-editor-font-family,
         ui-monospace,
         SFMono-Regular,
         Consolas,
         monospace
       );
-      font-size: var(--vscode-editor-font-size, 12px);
+      font-size: var(--texra-editor-font-size, 12px);
       max-height: min(32vh, 320px);
       overflow: auto;
       white-space: pre;
@@ -44,7 +44,7 @@ export class TerminalCommandStrip extends LitElement {
     }
 
     .prompt {
-      color: var(--vscode-terminal-ansiGreen, var(--color-success, #0a0));
+      color: var(--texra-terminal-ansiGreen, var(--color-success, #0a0));
       font-weight: 600;
       user-select: none;
     }

--- a/src/progressView/frontend/components/TerminalOutput.ts
+++ b/src/progressView/frontend/components/TerminalOutput.ts
@@ -13,22 +13,22 @@ const DEFAULT_THEME = {
 
 /** VS Code terminal ANSI color CSS variables mapped to xterm.js theme keys. */
 const ANSI_COLOR_MAP = [
-  ['black', '--vscode-terminal-ansiBlack'],
-  ['red', '--vscode-terminal-ansiRed'],
-  ['green', '--vscode-terminal-ansiGreen'],
-  ['yellow', '--vscode-terminal-ansiYellow'],
-  ['blue', '--vscode-terminal-ansiBlue'],
-  ['magenta', '--vscode-terminal-ansiMagenta'],
-  ['cyan', '--vscode-terminal-ansiCyan'],
-  ['white', '--vscode-terminal-ansiWhite'],
-  ['brightBlack', '--vscode-terminal-ansiBrightBlack'],
-  ['brightRed', '--vscode-terminal-ansiBrightRed'],
-  ['brightGreen', '--vscode-terminal-ansiBrightGreen'],
-  ['brightYellow', '--vscode-terminal-ansiBrightYellow'],
-  ['brightBlue', '--vscode-terminal-ansiBrightBlue'],
-  ['brightMagenta', '--vscode-terminal-ansiBrightMagenta'],
-  ['brightCyan', '--vscode-terminal-ansiBrightCyan'],
-  ['brightWhite', '--vscode-terminal-ansiBrightWhite'],
+  ['black', '--texra-terminal-ansiBlack'],
+  ['red', '--texra-terminal-ansiRed'],
+  ['green', '--texra-terminal-ansiGreen'],
+  ['yellow', '--texra-terminal-ansiYellow'],
+  ['blue', '--texra-terminal-ansiBlue'],
+  ['magenta', '--texra-terminal-ansiMagenta'],
+  ['cyan', '--texra-terminal-ansiCyan'],
+  ['white', '--texra-terminal-ansiWhite'],
+  ['brightBlack', '--texra-terminal-ansiBrightBlack'],
+  ['brightRed', '--texra-terminal-ansiBrightRed'],
+  ['brightGreen', '--texra-terminal-ansiBrightGreen'],
+  ['brightYellow', '--texra-terminal-ansiBrightYellow'],
+  ['brightBlue', '--texra-terminal-ansiBrightBlue'],
+  ['brightMagenta', '--texra-terminal-ansiBrightMagenta'],
+  ['brightCyan', '--texra-terminal-ansiBrightCyan'],
+  ['brightWhite', '--texra-terminal-ansiBrightWhite'],
 ] as const;
 
 const MIN_SCROLLBACK = 4_000;
@@ -223,10 +223,10 @@ export class TerminalOutput extends LitElement {
 
     const theme: Record<string, string> = {
       background:
-        styles.getPropertyValue('--vscode-editor-background').trim() ||
+        styles.getPropertyValue('--texra-editor-background').trim() ||
         DEFAULT_THEME.background,
       foreground:
-        styles.getPropertyValue('--vscode-editor-foreground').trim() ||
+        styles.getPropertyValue('--texra-editor-foreground').trim() ||
         DEFAULT_THEME.foreground,
     };
 
@@ -236,17 +236,17 @@ export class TerminalOutput extends LitElement {
     }
 
     const cursor = styles
-      .getPropertyValue('--vscode-terminalCursor-foreground')
+      .getPropertyValue('--texra-terminalCursor-foreground')
       .trim();
     if (cursor) theme['cursor'] = cursor;
 
     const selectionBg = styles
-      .getPropertyValue('--vscode-terminal-selectionBackground')
+      .getPropertyValue('--texra-terminal-selectionBackground')
       .trim();
     if (selectionBg) theme['selectionBackground'] = selectionBg;
 
     const fontFamily =
-      styles.getPropertyValue('--vscode-editor-font-family').trim() ||
+      styles.getPropertyValue('--texra-editor-font-family').trim() ||
       DEFAULT_THEME.fontFamily;
 
     return { theme, fontFamily };

--- a/src/progressView/frontend/components/TodoList.ts
+++ b/src/progressView/frontend/components/TodoList.ts
@@ -83,7 +83,7 @@ export class TodoList extends LitElement {
       }
 
       .todo-item--in-progress .todo-item__icon {
-        color: var(--vscode-progressBar-background);
+        color: var(--texra-progressBar-background);
       }
 
       .todo-item--completed {

--- a/src/progressView/frontend/components/UsagePanel.ts
+++ b/src/progressView/frontend/components/UsagePanel.ts
@@ -22,9 +22,9 @@ const COMPACTION_THRESHOLD = 75;
 
 /** Solid fill color based on context utilization. */
 function fillColor(percent: number): string {
-  if (percent <= 65) return 'var(--vscode-testing-iconPassed, #73c991)';
-  if (percent <= 80) return 'var(--vscode-editorWarning-foreground, #cca700)';
-  return 'var(--vscode-testing-iconFailed, #f48771)';
+  if (percent <= 65) return 'var(--texra-testing-iconPassed, #73c991)';
+  if (percent <= 80) return 'var(--texra-editorWarning-foreground, #cca700)';
+  return 'var(--texra-testing-iconFailed, #f48771)';
 }
 
 @customElement('usage-panel')
@@ -43,7 +43,7 @@ export class UsagePanel extends LitElement {
 
       .usage-summary-footer {
         border-top: var(--border-thin) solid var(--color-border);
-        background-color: var(--vscode-sideBarSectionHeader-background);
+        background-color: var(--texra-sideBarSectionHeader-background);
         padding: var(--spacing-small) var(--spacing-medium);
         display: flex;
         justify-content: space-between;
@@ -77,7 +77,7 @@ export class UsagePanel extends LitElement {
         position: relative;
         width: 80px;
         height: 6px;
-        background: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.3));
+        background: var(--texra-editorWidget-border, rgba(128, 128, 128, 0.3));
         border-radius: var(--border-radius);
         overflow: hidden;
       }
@@ -95,7 +95,7 @@ export class UsagePanel extends LitElement {
         top: 0;
         bottom: 0;
         width: var(--border-thin);
-        background: var(--vscode-foreground);
+        background: var(--texra-foreground);
         opacity: var(--opacity-separator);
       }
 
@@ -109,7 +109,7 @@ export class UsagePanel extends LitElement {
       }
 
       :is(.run-summary__value, .context-state__value) {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
     `,
   ];

--- a/src/progressView/frontend/components/UserMessage.ts
+++ b/src/progressView/frontend/components/UserMessage.ts
@@ -80,8 +80,8 @@ export class UserMessage extends LitElement {
       .user-message {
         padding: var(--spacing-small);
         max-width: 85%;
-        background-color: var(--vscode-editor-selectionBackground);
-        border: var(--border-thin) solid var(--vscode-panel-border);
+        background-color: var(--texra-editor-selectionBackground);
+        border: var(--border-thin) solid var(--texra-panel-border);
         border-radius: var(--border-radius);
       }
 
@@ -91,7 +91,7 @@ export class UserMessage extends LitElement {
         gap: var(--spacing-tiny);
         margin-bottom: var(--spacing-tiny);
         font-size: var(--font-size-xs);
-        color: var(--vscode-descriptionForeground);
+        color: var(--texra-descriptionForeground);
       }
 
       .user-message-header-left {
@@ -119,7 +119,7 @@ export class UserMessage extends LitElement {
       }
 
       .user-message-content {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         white-space: pre-wrap;
         word-wrap: break-word;
         line-height: var(--line-height-relaxed);
@@ -131,18 +131,18 @@ export class UserMessage extends LitElement {
         overflow: auto;
         padding: var(--spacing-small);
         background: var(
-          --vscode-textCodeBlock-background,
-          var(--vscode-editor-background)
+          --texra-textCodeBlock-background,
+          var(--texra-editor-background)
         );
         border-radius: var(--border-radius-small);
         font-family: var(
-          --vscode-editor-font-family,
+          --texra-editor-font-family,
           ui-monospace,
           SFMono-Regular,
           Consolas,
           monospace
         );
-        font-size: var(--vscode-editor-font-size, var(--font-size-sm));
+        font-size: var(--texra-editor-font-size, var(--font-size-sm));
         line-height: 1.35;
       }
 

--- a/src/progressView/frontend/components/WorkflowHintBanner.ts
+++ b/src/progressView/frontend/components/WorkflowHintBanner.ts
@@ -26,11 +26,11 @@ export class WorkflowHintBanner extends LitElement {
       gap: 8px;
       padding: 8px 10px;
       margin: 0 0 8px 0;
-      background: var(--vscode-textBlockQuote-background);
-      border-left: 3px solid var(--vscode-textLink-foreground);
+      background: var(--texra-textBlockQuote-background);
+      border-left: 3px solid var(--texra-textLink-foreground);
       border-radius: 3px;
       font-size: 0.9em;
-      color: var(--vscode-foreground);
+      color: var(--texra-foreground);
     }
     .text {
       flex: 1;

--- a/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
+++ b/src/progressView/frontend/formatters/logFormatters/contextManagementFormatters.ts
@@ -47,27 +47,27 @@ const ACTION_CONFIG: Record<
   compaction: {
     icon: 'codicon-fold',
     label: 'Compacted',
-    color: 'var(--vscode-charts-blue)',
+    color: 'var(--texra-charts-blue)',
   },
   clear_tool_uses: {
     icon: 'codicon-trash',
     label: 'Cleared Tool Uses',
-    color: 'var(--vscode-charts-green)',
+    color: 'var(--texra-charts-green)',
   },
   clear_thinking: {
     icon: 'codicon-lightbulb',
     label: 'Cleared Thinking',
-    color: 'var(--vscode-charts-green)',
+    color: 'var(--texra-charts-green)',
   },
   truncation: {
     icon: 'codicon-ellipsis',
     label: 'Truncated',
-    color: 'var(--vscode-charts-orange)',
+    color: 'var(--texra-charts-orange)',
   },
   max_tokens_reduced: {
     icon: 'codicon-arrow-small-down',
     label: 'Max Tokens Reduced',
-    color: 'var(--vscode-charts-yellow)',
+    color: 'var(--texra-charts-yellow)',
   },
 };
 
@@ -82,7 +82,7 @@ function buildContextManagementItems(data: ContextManagementData): {
   const config: ActionConfig = ACTION_CONFIG[action] || {
     icon: 'codicon-history',
     label: action || 'Context Management',
-    color: 'var(--vscode-foreground)',
+    color: 'var(--texra-foreground)',
   };
 
   const items: ContextStatItem[] = [];

--- a/src/progressView/frontend/styles/codeBlockStyles.ts
+++ b/src/progressView/frontend/styles/codeBlockStyles.ts
@@ -17,13 +17,13 @@ export const codeBlockStyles = css`
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-tiny) var(--spacing-small);
-    background-color: var(--vscode-editorGroupHeader-tabsBackground);
+    background-color: var(--texra-editorGroupHeader-tabsBackground);
     border-bottom: var(--border-thin) solid var(--color-border);
     font-size: var(--font-size-xs);
   }
 
   .code-block-language {
-    color: var(--vscode-descriptionForeground, #888);
+    color: var(--texra-descriptionForeground, #888);
     text-transform: uppercase;
     letter-spacing: 0.5px;
     font-weight: var(--font-weight-medium);
@@ -32,8 +32,8 @@ export const codeBlockStyles = css`
   .code-block pre {
     margin: 0;
     padding: var(--spacing-small);
-    background-color: var(--vscode-editor-background);
-    border: var(--border-thin) solid var(--vscode-editorWidget-border);
+    background-color: var(--texra-editor-background);
+    border: var(--border-thin) solid var(--texra-editorWidget-border);
     border-radius: 0;
     overflow-x: auto;
   }
@@ -49,7 +49,7 @@ export const codeBlockStyles = css`
     padding: var(--spacing-small) var(--spacing-medium);
     border: none;
     background: transparent;
-    color: var(--vscode-descriptionForeground, #888);
+    color: var(--texra-descriptionForeground, #888);
     cursor: pointer;
     border-radius: var(--border-radius-small);
     transition:
@@ -59,25 +59,25 @@ export const codeBlockStyles = css`
 
     &:hover {
       background-color: var(
-        --vscode-toolbar-hoverBackground,
+        --texra-toolbar-hoverBackground,
         rgba(90, 93, 94, 0.31)
       );
-      color: var(--vscode-foreground);
+      color: var(--texra-foreground);
     }
 
     &:active {
       background-color: var(
-        --vscode-toolbar-activeBackground,
+        --texra-toolbar-activeBackground,
         rgba(99, 102, 103, 0.31)
       );
     }
 
     &.copied {
-      color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+      color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
     }
 
     &:focus-visible {
-      outline: var(--border-thin) solid var(--vscode-focusBorder);
+      outline: var(--border-thin) solid var(--texra-focusBorder);
       outline-offset: 1px;
     }
   }
@@ -96,13 +96,13 @@ export const codeBlockStyles = css`
   /* Highlight.js theme - VS Code colors for Shadow DOM */
   pre.hljs,
   .hljs {
-    background: var(--vscode-editor-background);
-    color: var(--vscode-editor-foreground);
+    background: var(--texra-editor-background);
+    color: var(--texra-editor-foreground);
   }
 
   .hljs-comment,
   .hljs-quote {
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     font-style: italic;
   }
 
@@ -110,8 +110,8 @@ export const codeBlockStyles = css`
   .hljs-selector-tag,
   .hljs-tag {
     color: var(
-      --vscode-symbolIcon-keywordForeground,
-      var(--vscode-textLink-foreground)
+      --texra-symbolIcon-keywordForeground,
+      var(--texra-textLink-foreground)
     );
   }
 
@@ -120,70 +120,70 @@ export const codeBlockStyles = css`
   .hljs-regexp,
   .hljs-template-tag,
   .hljs-template-variable {
-    color: var(--vscode-debugTokenExpression-string, #a31515);
+    color: var(--texra-debugTokenExpression-string, #a31515);
   }
 
   .hljs-number,
   .hljs-literal,
   .hljs-built_in,
   .hljs-type {
-    color: var(--vscode-debugTokenExpression-number, #098658);
+    color: var(--texra-debugTokenExpression-number, #098658);
   }
 
   .hljs-variable,
   .hljs-params,
   .hljs-attr {
     color: var(
-      --vscode-symbolIcon-variableForeground,
-      var(--vscode-editor-foreground)
+      --texra-symbolIcon-variableForeground,
+      var(--texra-editor-foreground)
     );
   }
 
   .hljs-function,
   .hljs-title,
   .hljs-title.function_ {
-    color: var(--vscode-symbolIcon-functionForeground, #795e26);
+    color: var(--texra-symbolIcon-functionForeground, #795e26);
   }
 
   .hljs-class .hljs-title,
   .hljs-title.class_,
   .hljs-title.class_.inherited__ {
-    color: var(--vscode-symbolIcon-classForeground, #267f99);
+    color: var(--texra-symbolIcon-classForeground, #267f99);
   }
 
   .hljs-property,
   .hljs-name {
     color: var(
-      --vscode-symbolIcon-propertyForeground,
-      var(--vscode-editor-foreground)
+      --texra-symbolIcon-propertyForeground,
+      var(--texra-editor-foreground)
     );
   }
 
   .hljs-operator,
   .hljs-punctuation {
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .hljs-section,
   .hljs-selector-class,
   .hljs-selector-id {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   .hljs-meta,
   .hljs-meta .hljs-keyword,
   .hljs-meta .hljs-string {
-    color: var(--vscode-symbolIcon-keywordForeground, #0000ff);
+    color: var(--texra-symbolIcon-keywordForeground, #0000ff);
   }
 
   .hljs-addition {
-    background-color: var(--vscode-diffEditor-insertedTextBackground);
-    color: var(--vscode-gitDecoration-addedResourceForeground, #22863a);
+    background-color: var(--texra-diffEditor-insertedTextBackground);
+    color: var(--texra-gitDecoration-addedResourceForeground, #22863a);
   }
 
   .hljs-deletion {
-    background-color: var(--vscode-diffEditor-removedTextBackground);
-    color: var(--vscode-gitDecoration-deletedResourceForeground, #b31d28);
+    background-color: var(--texra-diffEditor-removedTextBackground);
+    color: var(--texra-gitDecoration-deletedResourceForeground, #b31d28);
   }
 
   .hljs-emphasis {
@@ -196,11 +196,11 @@ export const codeBlockStyles = css`
 
   .hljs-symbol,
   .hljs-bullet {
-    color: var(--vscode-symbolIcon-constantForeground, #36acaa);
+    color: var(--texra-symbolIcon-constantForeground, #36acaa);
   }
 
   .hljs-link {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     text-decoration: underline;
   }
 `;

--- a/src/progressView/frontend/styles/groupStyles.ts
+++ b/src/progressView/frontend/styles/groupStyles.ts
@@ -20,27 +20,27 @@ export const groupStyles = css`
   }
 
   .log-group-header:hover {
-    background-color: var(--vscode-list-hoverBackground);
+    background-color: var(--texra-list-hoverBackground);
   }
 
   .log-group-header {
     &.is-running {
-      border-left-color: var(--vscode-statusBarItem-warningBackground);
+      border-left-color: var(--texra-statusBarItem-warningBackground);
     }
 
     &.is-error {
-      border-left-color: var(--vscode-errorForeground);
+      border-left-color: var(--texra-errorForeground);
     }
 
     &.is-stopped {
-      border-left-color: var(--vscode-testing-iconPassed);
+      border-left-color: var(--texra-testing-iconPassed);
     }
   }
 
   .log-group-content {
     padding-left: var(--spacing-small);
     border-left: var(--border-thin) dashed
-      var(--vscode-editorGroupHeader-tabsBorder);
+      var(--texra-editorGroupHeader-tabsBorder);
   }
 
   .log-run {

--- a/src/progressView/frontend/styles/logEntryStyles.ts
+++ b/src/progressView/frontend/styles/logEntryStyles.ts
@@ -38,8 +38,8 @@ export const logEntryStyles = css`
     gap: var(--spacing-small);
     padding: var(--spacing-small) var(--spacing-medium);
     margin: var(--spacing-small) 0;
-    background: var(--vscode-inputValidation-warningBackground);
-    border: var(--border-thin) solid var(--vscode-inputValidation-warningBorder);
+    background: var(--texra-inputValidation-warningBackground);
+    border: var(--border-thin) solid var(--texra-inputValidation-warningBorder);
     border-radius: var(--border-radius);
     color: var(--color-warning);
     font-style: italic;
@@ -82,7 +82,7 @@ export const logEntryStyles = css`
   .xml-link-container {
     margin-top: var(--spacing-small);
     padding-top: var(--spacing-small);
-    border-top: var(--border-thin) solid var(--vscode-widget-border);
+    border-top: var(--border-thin) solid var(--texra-widget-border);
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -131,7 +131,7 @@ export const logEntryStyles = css`
   }
 
   :is(.file-link, .web-search-link):focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -191,7 +191,7 @@ export const logEntryStyles = css`
   .banner-details:focus-within .banner-content-copy,
   .banner-content-copy:focus-visible {
     opacity: var(--opacity-full);
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
   }
 
   .banner-content-copy.copy-success {
@@ -209,11 +209,11 @@ export const logEntryStyles = css`
   }
 
   .level-debug {
-    color: var(--vscode-debugTokenExpression-name, #4b9ef9);
+    color: var(--texra-debugTokenExpression-name, #4b9ef9);
   }
 
   .level-info {
-    color: var(--vscode-notificationsInfoIcon-foreground, #75beff);
+    color: var(--texra-notificationsInfoIcon-foreground, #75beff);
   }
 
   .level-warn,
@@ -227,11 +227,11 @@ export const logEntryStyles = css`
   }
 
   .message-debug {
-    color: var(--vscode-textPreformat-foreground, #a9b7c6);
+    color: var(--texra-textPreformat-foreground, #a9b7c6);
   }
 
   .message-info {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .banner-summary {
@@ -264,8 +264,8 @@ export const logEntryStyles = css`
     font-weight: var(--font-weight-semibold);
     padding: var(--spacing-tiny) var(--spacing-small);
     border-radius: var(--border-radius);
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
     margin-right: var(--spacing-small);
   }
 
@@ -274,18 +274,18 @@ export const logEntryStyles = css`
      so their stdout/stderr reads like a terminal instead of a logger. */
   :host([terminal]) .log-container {
     font-family: var(
-      --vscode-editor-font-family,
+      --texra-editor-font-family,
       ui-monospace,
       SFMono-Regular,
       Consolas,
       monospace
     );
-    font-size: var(--vscode-editor-font-size, var(--font-size));
+    font-size: var(--texra-editor-font-size, var(--font-size));
     background-color: var(
-      --vscode-terminal-background,
-      var(--vscode-editor-background, transparent)
+      --texra-terminal-background,
+      var(--texra-editor-background, transparent)
     );
-    color: var(--vscode-terminal-foreground, var(--vscode-foreground));
+    color: var(--texra-terminal-foreground, var(--texra-foreground));
   }
 
   :host([terminal]) .log-line {
@@ -307,11 +307,11 @@ export const logEntryStyles = css`
   }
 
   :host([terminal]) .message-warn {
-    color: var(--vscode-terminal-ansiYellow, var(--color-warning));
+    color: var(--texra-terminal-ansiYellow, var(--color-warning));
   }
 
   :host([terminal]) .message-error {
-    color: var(--vscode-terminal-ansiRed, var(--color-error));
+    color: var(--texra-terminal-ansiRed, var(--color-error));
   }
 
   /* Pre-formatted text nodes for terminal-mode streams.

--- a/src/progressView/frontend/styles/toolUseStyles.ts
+++ b/src/progressView/frontend/styles/toolUseStyles.ts
@@ -8,7 +8,7 @@ export const toolUseStyles = css`
   .tool-use-section {
     margin: var(--spacing-small) 0;
     border-left: var(--border-medium) solid
-      color-mix(in srgb, var(--vscode-textLink-foreground) 30%, transparent);
+      color-mix(in srgb, var(--texra-textLink-foreground) 30%, transparent);
     padding-left: var(--spacing-medium);
   }
 
@@ -40,7 +40,7 @@ export const toolUseStyles = css`
 
   .tool-use-sublabel {
     font-weight: var(--font-weight-medium);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     opacity: var(--opacity-normal);
     font-size: var(--font-size-sm);
   }
@@ -63,7 +63,7 @@ export const toolUseStyles = css`
     margin: 0;
     padding: var(--spacing-small);
     background-color: var(
-      --vscode-inputValidation-errorBackground,
+      --texra-inputValidation-errorBackground,
       rgba(255, 0, 0, 0.1)
     );
     border-radius: var(--border-radius-small);
@@ -81,20 +81,20 @@ export const toolUseStyles = css`
     left: 0;
     inset-block: 0;
     width: var(--border-thick);
-    background: var(--vscode-editorWarning-foreground, #ff8c00);
+    background: var(--texra-editorWarning-foreground, #ff8c00);
     border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
   }
 
   .banner-details--relay-error > .details-summary .label {
-    color: var(--vscode-editorWarning-foreground, #ff8c00);
+    color: var(--texra-editorWarning-foreground, #ff8c00);
   }
 
   .tool-use-user-feedback > .details-summary :is(.tool-use-title, .codicon) {
-    color: var(--vscode-textLink-foreground, #3794ff);
+    color: var(--texra-textLink-foreground, #3794ff);
   }
 
   .tool-use-in-progress > .details-summary :is(.tool-use-title, .codicon) {
-    color: var(--vscode-charts-yellow, #cca700);
+    color: var(--texra-charts-yellow, #cca700);
   }
 
   /* Uses @keyframes spin from animationStyles (included via logStyles) */
@@ -103,7 +103,7 @@ export const toolUseStyles = css`
   }
 
   .tool-use-in-progress > .details-summary tool-timer {
-    color: var(--vscode-charts-yellow, #cca700);
+    color: var(--texra-charts-yellow, #cca700);
   }
 
   :is(.tool-user-feedback, .tool-error-content, .tool-output-full) {
@@ -119,15 +119,15 @@ export const toolUseStyles = css`
 
   .tool-user-feedback {
     background-color: var(
-      --vscode-inputValidation-infoBackground,
+      --texra-inputValidation-infoBackground,
       rgba(55, 148, 255, 0.1)
     );
-    border-left-color: var(--vscode-textLink-foreground, #3794ff);
+    border-left-color: var(--texra-textLink-foreground, #3794ff);
   }
 
   .tool-error-content {
     background-color: var(
-      --vscode-inputValidation-errorBackground,
+      --texra-inputValidation-errorBackground,
       rgba(255, 0, 0, 0.1)
     );
     border-left-color: var(--color-error);
@@ -143,7 +143,7 @@ export const toolUseStyles = css`
     display: block;
     border-radius: var(--border-radius-small);
     overflow: hidden;
-    background: var(--vscode-editor-background);
+    background: var(--texra-editor-background);
     border: var(--border-thin) solid var(--color-border);
   }
 
@@ -162,7 +162,7 @@ export const toolUseStyles = css`
   }
 
   .proposal-restore-link:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -178,15 +178,15 @@ export const toolUseStyles = css`
 
   /* Diff styles */
   .diff-add {
-    color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+    color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
   }
 
   .diff-remove {
-    color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+    color: var(--texra-gitDecoration-deletedResourceForeground, #f85149);
   }
 
   .diff-hunk {
-    color: var(--vscode-gitDecoration-modifiedResourceForeground, #d29922);
+    color: var(--texra-gitDecoration-modifiedResourceForeground, #d29922);
   }
 
   .edit-diff-container {
@@ -198,7 +198,7 @@ export const toolUseStyles = css`
     margin: 0;
     padding: var(--spacing-small);
     border-radius: var(--border-radius-small);
-    background-color: var(--vscode-editor-background);
+    background-color: var(--texra-editor-background);
     white-space: pre-wrap;
     word-break: break-word;
     line-height: var(--line-height-relaxed);
@@ -211,18 +211,18 @@ export const toolUseStyles = css`
 
   .diff-inline-del {
     background-color: var(
-      --vscode-diffEditor-removedTextBackground,
+      --texra-diffEditor-removedTextBackground,
       rgba(255, 0, 0, 0.2)
     );
-    color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+    color: var(--texra-gitDecoration-deletedResourceForeground, #f85149);
     text-decoration: line-through;
   }
 
   .diff-inline-add {
     background-color: var(
-      --vscode-diffEditor-insertedTextBackground,
+      --texra-diffEditor-insertedTextBackground,
       rgba(0, 255, 0, 0.2)
     );
-    color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
+    color: var(--texra-gitDecoration-addedResourceForeground, #3fb950);
   }
 `;

--- a/src/progressView/index.html
+++ b/src/progressView/index.html
@@ -19,7 +19,7 @@
         padding: 0;
         display: flex;
         height: 100vh;
-        background-color: var(--vscode-sideBar-background);
+        background-color: var(--texra-sideBar-background);
       }
     </style>
     <link

--- a/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -34,7 +34,7 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-path {
-        font-family: var(--texra-editor-font-family), monospace;
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
         color: var(--texra-textLink-foreground);

--- a/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -34,7 +34,7 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-path {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
         color: var(--texra-textLink-foreground);

--- a/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -34,10 +34,10 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-path {
-        font-family: var(--vscode-editor-font-family), monospace;
+        font-family: var(--texra-editor-font-family), monospace;
         font-size: var(--font-size);
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-textLink-foreground);
+        color: var(--texra-textLink-foreground);
         word-break: break-all;
       }
 
@@ -56,7 +56,7 @@ export class MemoryItem extends LitElement {
       }
 
       .memory-item.pinned {
-        border-left: 3px solid var(--vscode-textLink-foreground);
+        border-left: 3px solid var(--texra-textLink-foreground);
         padding-left: calc(var(--spacing-medium) - 3px);
       }
     `,

--- a/src/settingsView/frontend/components/memory/MemoryToggle.ts
+++ b/src/settingsView/frontend/components/memory/MemoryToggle.ts
@@ -23,7 +23,7 @@ export class MemoryToggle extends LitElement {
 
       .memory-settings {
         padding: var(--spacing-medium);
-        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
         margin-bottom: var(--spacing-small);
       }

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -88,7 +88,7 @@ export class AgentSelectionPanel extends LitElement {
         color: var(--color-text-secondary);
         text-transform: uppercase;
         letter-spacing: 0.05em;
-        background: var(--vscode-editor-background);
+        background: var(--texra-editor-background);
         border-bottom: var(--border-thin) solid var(--color-border);
         position: sticky;
         top: 0;
@@ -110,28 +110,28 @@ export class AgentSelectionPanel extends LitElement {
         padding: var(--spacing-small) var(--spacing-medium);
         cursor: pointer;
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         border-left: var(--border-medium) solid transparent;
         transition: background var(--transition-fast);
         outline: none;
       }
 
       .agent-list-item:hover {
-        background: var(--vscode-list-hoverBackground);
+        background: var(--texra-list-hoverBackground);
       }
 
       .agent-list-item:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: -1px;
       }
 
       .agent-list-item.selected {
-        background: var(--vscode-list-activeSelectionBackground);
+        background: var(--texra-list-activeSelectionBackground);
         color: var(
-          --vscode-list-activeSelectionForeground,
-          var(--vscode-foreground)
+          --texra-list-activeSelectionForeground,
+          var(--texra-foreground)
         );
-        border-left-color: var(--vscode-focusBorder);
+        border-left-color: var(--texra-focusBorder);
       }
 
       .agent-list-item.selected .agent-list-item-name,
@@ -144,7 +144,7 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-list-item-checkbox {
-        accent-color: var(--vscode-focusBorder);
+        accent-color: var(--texra-focusBorder);
         cursor: pointer;
         flex-shrink: 0;
       }
@@ -155,7 +155,7 @@ export class AgentSelectionPanel extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        font-family: var(--vscode-editor-font-family);
+        font-family: var(--texra-editor-font-family);
       }
 
       .agent-list-item-badges {
@@ -193,12 +193,12 @@ export class AgentSelectionPanel extends LitElement {
       .agent-detail-name {
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-semibold);
-        font-family: var(--vscode-editor-font-family);
-        color: var(--vscode-foreground);
+        font-family: var(--texra-editor-font-family);
+        color: var(--texra-foreground);
       }
 
       .agent-detail-description {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         line-height: var(--line-height-relaxed);
         margin-bottom: var(--spacing-large);
       }
@@ -218,7 +218,7 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-detail-meta-value {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .agent-detail-tools {
@@ -231,8 +231,8 @@ export class AgentSelectionPanel extends LitElement {
         display: inline-block;
         padding: var(--border-thin) var(--spacing-small);
         font-size: var(--font-size-xs);
-        font-family: var(--vscode-editor-font-family);
-        background: var(--vscode-textBlockQuote-background);
+        font-family: var(--texra-editor-font-family);
+        background: var(--texra-textBlockQuote-background);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         color: var(--color-text-secondary);
@@ -251,8 +251,8 @@ export class AgentSelectionPanel extends LitElement {
         padding: var(--spacing-small) var(--spacing-medium);
         font-size: var(--font-size-sm);
         font-family: inherit;
-        color: var(--vscode-foreground);
-        background: var(--vscode-input-background);
+        color: var(--texra-foreground);
+        background: var(--texra-input-background);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         cursor: pointer;
@@ -262,12 +262,12 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-action-btn:hover {
-        background: var(--vscode-list-hoverBackground);
-        border-color: var(--vscode-focusBorder);
+        background: var(--texra-list-hoverBackground);
+        border-color: var(--texra-focusBorder);
       }
 
       .agent-action-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
       }
 
@@ -279,13 +279,13 @@ export class AgentSelectionPanel extends LitElement {
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
         border-top: var(--border-thin) solid var(--color-border);
-        background: var(--vscode-editor-background);
+        background: var(--texra-editor-background);
       }
 
       .agent-count-link {
         font-size: var(--font-size-xs);
         font-family: inherit;
-        color: var(--vscode-textLink-foreground);
+        color: var(--texra-textLink-foreground);
         background: none;
         border: none;
         cursor: pointer;
@@ -298,7 +298,7 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-count-link:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }
@@ -314,13 +314,13 @@ export class AgentSelectionPanel extends LitElement {
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-medium);
         border-radius: var(--border-radius);
-        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
-        color: var(--vscode-badge-foreground);
+        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--texra-badge-foreground);
       }
 
       .agent-detail-path {
         font-size: var(--font-size-xs);
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         color: var(--color-text-secondary);
         margin-bottom: var(--spacing-large);
         overflow: hidden;
@@ -329,27 +329,27 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-action-btn--danger {
-        color: var(--vscode-errorForeground, #f44);
-        border-color: var(--vscode-errorForeground, #f44);
+        color: var(--texra-errorForeground, #f44);
+        border-color: var(--texra-errorForeground, #f44);
       }
 
       .agent-action-btn--danger:hover {
         background: var(
-          --vscode-inputValidation-errorBackground,
+          --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.1)
         );
-        border-color: var(--vscode-errorForeground, #f44);
+        border-color: var(--texra-errorForeground, #f44);
       }
 
       .agent-action-btn--primary {
-        color: var(--vscode-button-foreground, #fff);
-        background: var(--vscode-button-background);
-        border-color: var(--vscode-button-background);
+        color: var(--texra-button-foreground, #fff);
+        background: var(--texra-button-background);
+        border-color: var(--texra-button-background);
       }
 
       .agent-action-btn--primary:hover {
-        background: var(--vscode-button-hoverBackground);
-        border-color: var(--vscode-button-hoverBackground);
+        background: var(--texra-button-hoverBackground);
+        border-color: var(--texra-button-hoverBackground);
       }
 
       .agent-delete-confirm {
@@ -358,13 +358,13 @@ export class AgentSelectionPanel extends LitElement {
         gap: var(--spacing-medium);
         padding: var(--spacing-small) var(--spacing-medium);
         background: var(
-          --vscode-inputValidation-errorBackground,
+          --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.05)
         );
-        border: var(--border-thin) solid var(--vscode-errorForeground, #f44);
+        border: var(--border-thin) solid var(--texra-errorForeground, #f44);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .agent-delete-confirm-text {

--- a/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -320,7 +320,7 @@ export class AgentSelectionPanel extends LitElement {
 
       .agent-detail-path {
         font-size: var(--font-size-xs);
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         color: var(--color-text-secondary);
         margin-bottom: var(--spacing-large);
         overflow: hidden;

--- a/src/settingsView/frontend/components/profile/styles.ts
+++ b/src/settingsView/frontend/components/profile/styles.ts
@@ -57,7 +57,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .profile-notice code {
-    font-family: var(--texra-editor-font-family, monospace);
+    font-family: var(--texra-editor-font-family, monospace), monospace;
     font-size: 0.95em;
     padding: 0 var(--spacing-tiny);
     border-radius: var(--border-radius-small);

--- a/src/settingsView/frontend/components/profile/styles.ts
+++ b/src/settingsView/frontend/components/profile/styles.ts
@@ -3,7 +3,7 @@ import { css, type CSSResult } from 'lit';
 
 export const profileViewStyles: CSSResult = css`
   h2 {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     margin-top: var(--spacing-xlarge);
     margin-bottom: var(--spacing-medium);
     font-size: var(--font-size-lg);
@@ -35,12 +35,12 @@ export const profileViewStyles: CSSResult = css`
 
   .label {
     font-weight: var(--font-weight-bold);
-    color: var(--vscode-textPreformat-foreground);
+    color: var(--texra-textPreformat-foreground);
     min-width: 80px;
   }
 
   .value {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .tier-badge {
@@ -50,33 +50,33 @@ export const profileViewStyles: CSSResult = css`
 
   .profile-notice {
     margin: var(--spacing-small) 0 var(--spacing-medium);
-    color: var(--vscode-descriptionForeground, var(--color-text-secondary));
+    color: var(--texra-descriptionForeground, var(--color-text-secondary));
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
     max-width: 640px;
   }
 
   .profile-notice code {
-    font-family: var(--vscode-editor-font-family, monospace);
+    font-family: var(--texra-editor-font-family, monospace);
     font-size: 0.95em;
     padding: 0 var(--spacing-tiny);
     border-radius: var(--border-radius-small);
-    background: var(--vscode-textBlockQuote-background);
+    background: var(--texra-textBlockQuote-background);
   }
 
   .tier-badge.free {
-    background: var(--vscode-inputValidation-warningBackground);
-    color: var(--vscode-inputValidation-warningForeground);
+    background: var(--texra-inputValidation-warningBackground);
+    color: var(--texra-inputValidation-warningForeground);
   }
 
   .tier-badge.max {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .tier-badge.ultra {
-    background: var(--vscode-textLink-activeForeground);
-    color: var(--vscode-button-foreground);
+    background: var(--texra-textLink-activeForeground);
+    color: var(--texra-button-foreground);
   }
 
   .not-authenticated {
@@ -111,15 +111,15 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .provider-keys-table th {
-    background: var(--vscode-editor-background);
+    background: var(--texra-editor-background);
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     position: sticky;
     top: 0;
   }
 
   .provider-keys-table tbody tr:hover {
-    background: var(--vscode-list-hoverBackground);
+    background: var(--texra-list-hoverBackground);
   }
 
   /* Profile-specific badge modifiers (base category styles from @shared/styles) */
@@ -132,13 +132,13 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .badge.visibility-badge.public {
-    background: var(--vscode-testing-iconPassed);
-    color: var(--vscode-button-foreground);
+    background: var(--texra-testing-iconPassed);
+    color: var(--texra-button-foreground);
   }
 
   .badge.visibility-badge.custom {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .select-btn {
@@ -171,7 +171,7 @@ export const profileViewStyles: CSSResult = css`
     align-items: flex-start;
     gap: var(--spacing-medium);
     padding: var(--spacing-medium);
-    background: var(--vscode-input-background);
+    background: var(--texra-input-background);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
     cursor: pointer;
@@ -179,17 +179,17 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .api-access-option:hover {
-    border-color: var(--vscode-focusBorder);
+    border-color: var(--texra-focusBorder);
   }
 
   .api-access-option:has(input:checked) {
-    border-color: var(--vscode-focusBorder);
-    background: var(--vscode-list-hoverBackground);
+    border-color: var(--texra-focusBorder);
+    background: var(--texra-list-hoverBackground);
   }
 
   .api-access-option input[type='radio'] {
     margin-top: var(--spacing-tiny);
-    accent-color: var(--vscode-focusBorder);
+    accent-color: var(--texra-focusBorder);
   }
 
   .api-access-support {
@@ -205,16 +205,16 @@ export const profileViewStyles: CSSResult = css`
   .api-access-support-icon {
     flex-shrink: 0;
     margin-top: 2px;
-    color: var(--vscode-charts-red, var(--vscode-errorForeground));
+    color: var(--texra-charts-red, var(--texra-errorForeground));
   }
 
   .api-access-support a {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     text-decoration: none;
   }
 
   .api-access-support a:hover {
-    color: var(--vscode-textLink-activeForeground);
+    color: var(--texra-textLink-activeForeground);
     text-decoration: underline;
   }
 
@@ -226,7 +226,7 @@ export const profileViewStyles: CSSResult = css`
 
   .option-title {
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .option-description {
@@ -268,17 +268,17 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .key-status-badge.set {
-    background: var(--vscode-testing-iconPassed);
-    color: var(--vscode-button-foreground);
+    background: var(--texra-testing-iconPassed);
+    color: var(--texra-button-foreground);
   }
 
   .key-status-badge.env {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .key-status-badge.not-set {
-    background: var(--vscode-input-background);
+    background: var(--texra-input-background);
     color: var(--color-text-secondary);
     border: var(--border-thin) solid var(--color-border);
   }
@@ -296,7 +296,7 @@ export const profileViewStyles: CSSResult = css`
     gap: var(--spacing-medium);
     margin-bottom: var(--spacing-medium);
     padding: var(--spacing-medium);
-    background: var(--vscode-input-background);
+    background: var(--texra-input-background);
     border: var(--border-thin) solid var(--color-border);
     border-radius: var(--border-radius);
   }
@@ -326,11 +326,11 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .provider-expand-btn:hover {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .provider-expand-btn:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -356,7 +356,7 @@ export const profileViewStyles: CSSResult = css`
     flex-direction: column;
     gap: var(--spacing-medium);
     padding: var(--spacing-medium);
-    background: var(--vscode-textBlockQuote-background);
+    background: var(--texra-textBlockQuote-background);
     border-radius: var(--border-radius);
   }
 
@@ -368,7 +368,7 @@ export const profileViewStyles: CSSResult = css`
 
   .provider-setting label {
     font-size: var(--font-size-sm);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     min-width: 120px;
   }
 
@@ -392,8 +392,8 @@ export const profileViewStyles: CSSResult = css`
 
   .provider-setting-warning {
     color: var(
-      --vscode-inputValidation-warningForeground,
-      var(--vscode-editorWarning-foreground)
+      --texra-inputValidation-warningForeground,
+      var(--texra-editorWarning-foreground)
     );
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
@@ -406,7 +406,7 @@ export const profileViewStyles: CSSResult = css`
     padding: 0;
     font: inherit;
     font-size: var(--font-size-sm);
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     cursor: pointer;
     text-decoration: none;
     margin-left: var(--spacing-small);
@@ -448,7 +448,7 @@ export const profileViewStyles: CSSResult = css`
 
   .helper-model-row label {
     font-weight: var(--font-weight-medium);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     white-space: nowrap;
   }
 
@@ -469,9 +469,9 @@ export const profileViewStyles: CSSResult = css`
     align-items: center;
     width: 100%;
     padding: var(--spacing-medium);
-    background: var(--vscode-editor-background);
+    background: var(--texra-editor-background);
     border: none;
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
     cursor: pointer;
     font-size: var(--font-size-sm);
     font-family: inherit;
@@ -479,11 +479,11 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .provider-group-header:hover {
-    background: var(--vscode-list-hoverBackground);
+    background: var(--texra-list-hoverBackground);
   }
 
   .provider-group-header:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -527,7 +527,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .model-row:hover {
-    background: var(--vscode-list-hoverBackground);
+    background: var(--texra-list-hoverBackground);
   }
 
   .model-row vscode-checkbox {
@@ -550,7 +550,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .model-name {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     white-space: nowrap;
   }
 
@@ -590,19 +590,19 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .deprecated-toggle:hover {
-    color: var(--vscode-foreground);
-    background: var(--vscode-list-hoverBackground);
+    color: var(--texra-foreground);
+    background: var(--texra-list-hoverBackground);
   }
 
   .deprecated-toggle:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
 
   .deprecated-models {
     border-top: var(--border-thin) solid var(--color-border);
-    background: var(--vscode-textBlockQuote-background);
+    background: var(--texra-textBlockQuote-background);
   }
 
   /* Unavailable model rows (not in relay allowlist) */
@@ -623,8 +623,8 @@ export const profileViewStyles: CSSResult = css`
 
   .model-row-icon--warning {
     --_icon-color: var(
-      --vscode-list-warningForeground,
-      var(--vscode-editorWarning-foreground)
+      --texra-list-warningForeground,
+      var(--texra-editorWarning-foreground)
     );
   }
 `;

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -62,7 +62,7 @@ export class Pagination extends LitElement {
       }
 
       .pagination-status {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         letter-spacing: 0.02em;
       }
 
@@ -80,7 +80,7 @@ export class Pagination extends LitElement {
         height: var(--height-control);
         padding: 0 var(--spacing-small);
         font-size: var(--font-size-xs);
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         color: var(--color-text-secondary);
         background: none;
         border: var(--border-thin) solid var(--color-border);
@@ -92,13 +92,13 @@ export class Pagination extends LitElement {
       }
 
       .page-btn:hover:not(:disabled) {
-        color: var(--vscode-foreground);
-        border-color: var(--vscode-focusBorder);
+        color: var(--texra-foreground);
+        border-color: var(--texra-focusBorder);
       }
 
       .page-btn:active:not(:disabled) {
         background: var(
-          --vscode-toolbar-activeBackground,
+          --texra-toolbar-activeBackground,
           rgba(99, 102, 103, 0.31)
         );
       }
@@ -109,7 +109,7 @@ export class Pagination extends LitElement {
       }
 
       .page-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
       }
     `,

--- a/src/settingsView/frontend/components/shared/Pagination.ts
+++ b/src/settingsView/frontend/components/shared/Pagination.ts
@@ -62,7 +62,7 @@ export class Pagination extends LitElement {
       }
 
       .pagination-status {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         letter-spacing: 0.02em;
       }
 
@@ -80,7 +80,7 @@ export class Pagination extends LitElement {
         height: var(--height-control);
         padding: 0 var(--spacing-small);
         font-size: var(--font-size-xs);
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         color: var(--color-text-secondary);
         background: none;
         border: var(--border-thin) solid var(--color-border);

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -34,14 +34,14 @@ export class ToolCard extends LitElement {
         padding: var(--spacing-medium) var(--spacing-large);
         margin-bottom: var(--spacing-medium);
         background: var(
-          --vscode-editor-background,
-          var(--vscode-sideBar-background)
+          --texra-editor-background,
+          var(--texra-sideBar-background)
         );
         transition: border-color var(--transition-fast);
       }
 
       .tool-card:hover {
-        border-color: var(--vscode-focusBorder);
+        border-color: var(--texra-focusBorder);
       }
 
       .tool-header {
@@ -64,7 +64,7 @@ export class ToolCard extends LitElement {
       .tool-name {
         font-weight: var(--font-weight-medium);
         font-size: var(--font-size);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         white-space: nowrap;
       }
 
@@ -80,26 +80,26 @@ export class ToolCard extends LitElement {
       }
 
       .tool-badge--available {
-        color: var(--vscode-testing-iconPassed, #73c991);
+        color: var(--texra-testing-iconPassed, #73c991);
         background: color-mix(
           in srgb,
-          var(--vscode-testing-iconPassed, #73c991) 12%,
+          var(--texra-testing-iconPassed, #73c991) 12%,
           transparent
         );
       }
 
       .tool-badge--not-found {
-        color: var(--vscode-testing-iconFailed, #f48771);
+        color: var(--texra-testing-iconFailed, #f48771);
         background: color-mix(
           in srgb,
-          var(--vscode-testing-iconFailed, #f48771) 12%,
+          var(--texra-testing-iconFailed, #f48771) 12%,
           transparent
         );
       }
 
       .tool-badge--unknown {
-        color: var(--vscode-badge-foreground);
-        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--texra-badge-foreground);
+        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
       }
 
       .tool-description {
@@ -117,11 +117,11 @@ export class ToolCard extends LitElement {
       }
 
       .tool-id-tag {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size-xs);
         padding: var(--border-thin) var(--border-radius-large);
-        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
-        color: var(--vscode-badge-foreground);
+        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--texra-badge-foreground);
         border-radius: var(--border-radius);
       }
 
@@ -132,7 +132,7 @@ export class ToolCard extends LitElement {
         padding: var(--spacing-tiny) 0;
         font-size: var(--font-size-sm);
         font-family: inherit;
-        color: var(--vscode-textLink-foreground, #3794ff);
+        color: var(--texra-textLink-foreground, #3794ff);
         background: none;
         border: none;
         cursor: pointer;
@@ -144,7 +144,7 @@ export class ToolCard extends LitElement {
       }
 
       .tool-guide-toggle:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }
@@ -153,12 +153,12 @@ export class ToolCard extends LitElement {
         margin-top: var(--spacing-small);
         padding: var(--spacing-medium);
         background: var(
-          --vscode-textCodeBlock-background,
+          --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         line-height: var(--line-height-relaxed);
         white-space: pre-wrap;
       }
@@ -176,8 +176,8 @@ export class ToolCard extends LitElement {
         padding: var(--spacing-tiny) var(--spacing-medium);
         font-size: var(--font-size-sm);
         font-family: inherit;
-        color: var(--vscode-button-foreground, #fff);
-        background: var(--vscode-button-background, #0e639c);
+        color: var(--texra-button-foreground, #fff);
+        background: var(--texra-button-background, #0e639c);
         border: none;
         border-radius: var(--border-radius);
         cursor: pointer;
@@ -187,25 +187,25 @@ export class ToolCard extends LitElement {
       }
 
       .tool-action-btn:hover {
-        background: var(--vscode-button-hoverBackground, #1177bb);
+        background: var(--texra-button-hoverBackground, #1177bb);
       }
 
       .tool-action-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
       }
 
       .tool-action-btn--secondary {
-        color: var(--vscode-button-secondaryForeground, #ccc);
+        color: var(--texra-button-secondaryForeground, #ccc);
         background: var(
-          --vscode-button-secondaryBackground,
+          --texra-button-secondaryBackground,
           rgba(128, 128, 128, 0.2)
         );
       }
 
       .tool-action-btn--secondary:hover {
         background: var(
-          --vscode-button-secondaryHoverBackground,
+          --texra-button-secondaryHoverBackground,
           rgba(128, 128, 128, 0.3)
         );
       }
@@ -219,10 +219,10 @@ export class ToolCard extends LitElement {
         border-radius: var(--border-radius);
         white-space: nowrap;
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-charts-blue, #3794ff);
+        color: var(--texra-charts-blue, #3794ff);
         background: color-mix(
           in srgb,
-          var(--vscode-charts-blue, #3794ff) 12%,
+          var(--texra-charts-blue, #3794ff) 12%,
           transparent
         );
       }

--- a/src/settingsView/frontend/components/tools/ToolCard.ts
+++ b/src/settingsView/frontend/components/tools/ToolCard.ts
@@ -117,7 +117,7 @@ export class ToolCard extends LitElement {
       }
 
       .tool-id-tag {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-xs);
         padding: var(--border-thin) var(--border-radius-large);
         background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));

--- a/src/settingsView/frontend/styles.ts
+++ b/src/settingsView/frontend/styles.ts
@@ -11,7 +11,7 @@ const settingsHeaderStyles: CSSResult = css`
     align-items: center;
     justify-content: space-between;
     padding: var(--spacing-medium) var(--spacing-large);
-    background: var(--vscode-sideBar-background);
+    background: var(--texra-sideBar-background);
     border-bottom: var(--border-thin) solid var(--color-border);
     margin-bottom: var(--spacing-medium);
   }
@@ -35,7 +35,7 @@ const settingsHeaderStyles: CSSResult = css`
 
   .settings-header-email {
     font-weight: var(--font-weight-medium);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .settings-header-tier {
@@ -55,17 +55,14 @@ const settingsHeaderStyles: CSSResult = css`
 
   .settings-header-auth-button {
     min-height: var(--height-control);
-    color: var(--vscode-foreground);
-    background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+    color: var(--texra-foreground);
+    background: var(--texra-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
     border-color: var(--color-border);
   }
 
   .settings-header-auth-button:hover {
-    border-color: var(--vscode-focusBorder);
-    background: var(
-      --vscode-toolbar-activeBackground,
-      rgba(99, 102, 103, 0.31)
-    );
+    border-color: var(--texra-focusBorder);
+    background: var(--texra-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
   }
 `;
 

--- a/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -129,7 +129,7 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-dir-path {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         color: var(--texra-foreground);
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/settingsView/frontend/tabs/AgentsTab.ts
+++ b/src/settingsView/frontend/tabs/AgentsTab.ts
@@ -70,18 +70,18 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-sub-tab:hover {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .agents-sub-tab:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }
 
       .agents-sub-tab.active {
-        color: var(--vscode-foreground);
-        border-bottom-color: var(--vscode-focusBorder);
+        color: var(--texra-foreground);
+        border-bottom-color: var(--texra-focusBorder);
         font-weight: var(--font-weight-medium);
       }
 
@@ -99,8 +99,8 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-create-btn {
-        color: var(--vscode-foreground);
-        border-color: var(--vscode-focusBorder);
+        color: var(--texra-foreground);
+        border-color: var(--texra-focusBorder);
         font-weight: var(--font-weight-medium);
       }
 
@@ -113,7 +113,7 @@ export class AgentsTab extends LitElement {
         margin-bottom: var(--spacing-medium);
         font-size: var(--font-size-xs);
         color: var(--color-text-secondary);
-        background: var(--vscode-sideBar-background, rgba(128, 128, 128, 0.04));
+        background: var(--texra-sideBar-background, rgba(128, 128, 128, 0.04));
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
       }
@@ -129,8 +129,8 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-dir-path {
-        font-family: var(--vscode-editor-font-family, monospace);
-        color: var(--vscode-foreground);
+        font-family: var(--texra-editor-font-family, monospace);
+        color: var(--texra-foreground);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -141,8 +141,8 @@ export class AgentsTab extends LitElement {
         flex-shrink: 0;
         padding: 0 var(--spacing-small);
         font-size: var(--font-size-xs);
-        color: var(--vscode-badge-foreground);
-        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--texra-badge-foreground);
+        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
         border-radius: var(--border-radius);
       }
 
@@ -167,11 +167,11 @@ export class AgentsTab extends LitElement {
       }
 
       .agents-dir-icon-btn:hover {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .agents-dir-icon-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }

--- a/src/settingsView/frontend/tabs/GitTab.ts
+++ b/src/settingsView/frontend/tabs/GitTab.ts
@@ -47,14 +47,14 @@ export class GitTab extends LitElement {
 
       .setting-block {
         padding: var(--spacing-medium);
-        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
       }
 
       .setting-description {
         margin: var(--spacing-small) 0 0 0;
         font-size: var(--font-size-sm);
-        color: var(--vscode-descriptionForeground);
+        color: var(--texra-descriptionForeground);
       }
 
       .input-row {
@@ -88,7 +88,7 @@ export class GitTab extends LitElement {
 
       .token-row-label {
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .token-actions {
@@ -99,27 +99,27 @@ export class GitTab extends LitElement {
       }
 
       .token-remove-btn:hover {
-        color: var(--vscode-errorForeground);
-        border-color: var(--vscode-errorForeground);
+        color: var(--texra-errorForeground);
+        border-color: var(--texra-errorForeground);
       }
 
       .tinted-badge--ok {
         --_tint: var(
-          --vscode-testing-iconPassed,
-          var(--vscode-terminal-ansiGreen)
+          --texra-testing-iconPassed,
+          var(--texra-terminal-ansiGreen)
         );
       }
       .tinted-badge--warn {
-        --_tint: var(--vscode-editorWarning-foreground, #cca700);
+        --_tint: var(--texra-editorWarning-foreground, #cca700);
       }
       .tinted-badge--info {
-        --_tint: var(--vscode-badge-background);
+        --_tint: var(--texra-badge-background);
       }
 
       .instructions {
         margin: var(--spacing-small) 0 0 0;
         font-size: var(--font-size-sm);
-        color: var(--vscode-descriptionForeground);
+        color: var(--texra-descriptionForeground);
       }
       .instructions ol {
         margin: var(--spacing-tiny) 0 0 0;
@@ -129,7 +129,7 @@ export class GitTab extends LitElement {
         margin: 2px 0;
       }
       .instructions code {
-        background: var(--vscode-textBlockQuote-background);
+        background: var(--texra-textBlockQuote-background);
         padding: 0 var(--spacing-small);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
@@ -148,7 +148,7 @@ export class GitTab extends LitElement {
         padding: var(--spacing-tiny) 0;
       }
       .subscriptions-list code {
-        background: var(--vscode-textBlockQuote-background);
+        background: var(--texra-textBlockQuote-background);
         padding: var(--border-thin) var(--spacing-medium);
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
@@ -176,7 +176,7 @@ export class GitTab extends LitElement {
       .subscription-owner-label,
       .subscription-owner-placeholder {
         font-size: var(--font-size-sm);
-        color: var(--vscode-descriptionForeground);
+        color: var(--texra-descriptionForeground);
       }
       .subscription-owner-placeholder {
         margin: 0;

--- a/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -180,7 +180,7 @@ export class LaTeXTab extends LitElement {
         gap: var(--spacing-small);
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .latex-description {
@@ -195,7 +195,7 @@ export class LaTeXTab extends LitElement {
         margin-bottom: var(--spacing-medium);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
-        background: var(--vscode-editor-background);
+        background: var(--texra-editor-background);
       }
 
       .dependency-row {
@@ -210,11 +210,11 @@ export class LaTeXTab extends LitElement {
       }
 
       .dependency-icon.installed {
-        color: var(--vscode-testing-iconPassed, #73c991);
+        color: var(--texra-testing-iconPassed, #73c991);
       }
 
       .dependency-icon.missing {
-        color: var(--vscode-testing-iconFailed, #f48771);
+        color: var(--texra-testing-iconFailed, #f48771);
       }
 
       .dependency-info {
@@ -224,7 +224,7 @@ export class LaTeXTab extends LitElement {
 
       .dependency-name {
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .dependency-description {
@@ -241,7 +241,7 @@ export class LaTeXTab extends LitElement {
         margin-top: var(--spacing-small);
         font-size: var(--font-size-sm);
         font-family: inherit;
-        color: var(--vscode-textLink-foreground, #3794ff);
+        color: var(--texra-textLink-foreground, #3794ff);
         background: none;
         border: none;
         cursor: pointer;
@@ -256,19 +256,19 @@ export class LaTeXTab extends LitElement {
         margin-top: var(--spacing-small);
         padding: var(--spacing-medium);
         background: var(
-          --vscode-textCodeBlock-background,
+          --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius);
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         line-height: var(--line-height-relaxed);
         white-space: pre-wrap;
       }
 
       .dependency-path {
         margin-top: 4px;
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
       }
@@ -284,21 +284,21 @@ export class LaTeXTab extends LitElement {
         min-width: 0;
         padding: var(--spacing-small) var(--spacing-medium);
         background: var(
-          --vscode-textCodeBlock-background,
+          --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius-small);
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
 
       .copy-success {
-        color: var(--vscode-testing-iconPassed, #73c991) !important;
-        border-color: var(--vscode-testing-iconPassed, #73c991) !important;
+        color: var(--texra-testing-iconPassed, #73c991) !important;
+        border-color: var(--texra-testing-iconPassed, #73c991) !important;
       }
 
       .prerequisite-hint {
@@ -308,15 +308,15 @@ export class LaTeXTab extends LitElement {
         padding: var(--spacing-medium);
         margin-bottom: var(--spacing-medium);
         border: var(--border-thin) solid
-          var(--vscode-editorInfo-foreground, #3794ff);
+          var(--texra-editorInfo-foreground, #3794ff);
         border-radius: var(--border-radius);
-        background: var(--vscode-editor-background);
+        background: var(--texra-editor-background);
       }
 
       .prerequisite-hint .hint-icon {
         flex-shrink: 0;
         font-size: var(--font-size-lg);
-        color: var(--vscode-editorInfo-foreground, #3794ff);
+        color: var(--texra-editorInfo-foreground, #3794ff);
       }
 
       .prerequisite-hint .hint-body {
@@ -326,7 +326,7 @@ export class LaTeXTab extends LitElement {
 
       .prerequisite-hint .hint-title {
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         margin-bottom: var(--spacing-tiny);
       }
 
@@ -365,7 +365,7 @@ export class LaTeXTab extends LitElement {
         margin-bottom: var(--spacing-medium);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
-        background: var(--vscode-editor-background);
+        background: var(--texra-editor-background);
       }
 
       .setting-status-icon {
@@ -375,11 +375,11 @@ export class LaTeXTab extends LitElement {
       }
 
       .setting-status-icon.is-set {
-        color: var(--vscode-testing-iconPassed, #73c991);
+        color: var(--texra-testing-iconPassed, #73c991);
       }
 
       .setting-status-icon.not-set {
-        color: var(--vscode-testing-iconFailed, #f48771);
+        color: var(--texra-testing-iconFailed, #f48771);
       }
 
       .setting-info {
@@ -389,21 +389,21 @@ export class LaTeXTab extends LitElement {
 
       .setting-name {
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         margin-bottom: 2px;
       }
 
       .setting-config-key {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         margin-bottom: var(--spacing-small);
       }
 
       .setting-value {
-        font-family: var(--vscode-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace);
         font-size: var(--font-size-sm);
-        color: var(--vscode-textLink-foreground);
+        color: var(--texra-textLink-foreground);
       }
 
       .setting-description {
@@ -422,13 +422,13 @@ export class LaTeXTab extends LitElement {
       }
 
       .setting-badge.is-set {
-        background: var(--vscode-testing-iconPassed, #73c991);
-        color: var(--vscode-editor-background);
+        background: var(--texra-testing-iconPassed, #73c991);
+        color: var(--texra-editor-background);
       }
 
       .setting-badge.not-set {
-        background: var(--vscode-badge-background);
-        color: var(--vscode-badge-foreground);
+        background: var(--texra-badge-background);
+        color: var(--texra-badge-foreground);
       }
     `,
   ];

--- a/src/settingsView/frontend/tabs/LaTeXTab.ts
+++ b/src/settingsView/frontend/tabs/LaTeXTab.ts
@@ -268,7 +268,7 @@ export class LaTeXTab extends LitElement {
 
       .dependency-path {
         margin-top: 4px;
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
       }
@@ -288,7 +288,7 @@ export class LaTeXTab extends LitElement {
           rgba(128, 128, 128, 0.08)
         );
         border-radius: var(--border-radius-small);
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--texra-foreground);
         overflow: hidden;
@@ -394,14 +394,14 @@ export class LaTeXTab extends LitElement {
       }
 
       .setting-config-key {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--color-text-secondary);
         margin-bottom: var(--spacing-small);
       }
 
       .setting-value {
-        font-family: var(--texra-editor-font-family, monospace);
+        font-family: var(--texra-editor-font-family, monospace), monospace;
         font-size: var(--font-size-sm);
         color: var(--texra-textLink-foreground);
       }

--- a/src/settingsView/frontend/tabs/MultiAgentTab.ts
+++ b/src/settingsView/frontend/tabs/MultiAgentTab.ts
@@ -51,7 +51,7 @@ export class MultiAgentTab extends LitElement {
 
       .setting-block {
         padding: var(--spacing-medium);
-        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        background-color: var(--texra-editor-inactiveSelectionBackground);
         border-radius: var(--border-radius);
       }
 
@@ -80,7 +80,7 @@ export class MultiAgentTab extends LitElement {
         flex-direction: column;
         gap: var(--spacing-small);
         padding: var(--spacing-medium);
-        background-color: var(--vscode-editor-inactiveSelectionBackground);
+        background-color: var(--texra-editor-inactiveSelectionBackground);
         border: var(--border-thin) solid var(--color-border);
         border-radius: var(--border-radius);
         cursor: pointer;
@@ -90,25 +90,25 @@ export class MultiAgentTab extends LitElement {
       }
 
       .preset-card:hover {
-        border-color: var(--vscode-focusBorder);
+        border-color: var(--texra-focusBorder);
         background-color: var(
-          --vscode-list-hoverBackground,
+          --texra-list-hoverBackground,
           rgba(128, 128, 128, 0.1)
         );
       }
 
       .preset-card:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
       }
 
       .preset-card.active {
-        background-color: var(--vscode-list-activeSelectionBackground);
+        background-color: var(--texra-list-activeSelectionBackground);
         color: var(
-          --vscode-list-activeSelectionForeground,
-          var(--vscode-foreground)
+          --texra-list-activeSelectionForeground,
+          var(--texra-foreground)
         );
-        border-color: var(--vscode-focusBorder);
+        border-color: var(--texra-focusBorder);
       }
 
       .preset-card.active .preset-card-name,
@@ -125,10 +125,10 @@ export class MultiAgentTab extends LitElement {
         padding: var(--border-thin) var(--border-radius-large);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-focusBorder);
+        color: var(--texra-focusBorder);
         background: color-mix(
           in srgb,
-          var(--vscode-focusBorder) 15%,
+          var(--texra-focusBorder) 15%,
           transparent
         );
         border-radius: var(--border-radius-medium);
@@ -146,14 +146,14 @@ export class MultiAgentTab extends LitElement {
 
       .preset-card-icon {
         font-size: var(--font-size-lg);
-        color: var(--vscode-focusBorder);
+        color: var(--texra-focusBorder);
         flex-shrink: 0;
       }
 
       .preset-card-name {
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         flex: 1;
         min-width: 0;
         overflow: hidden;
@@ -188,16 +188,16 @@ export class MultiAgentTab extends LitElement {
         gap: var(--spacing-tiny);
         padding: var(--border-thin) var(--border-radius-large);
         font-size: var(--font-size-xs);
-        color: var(--vscode-badge-foreground);
-        background: var(--vscode-badge-background, rgba(128, 128, 128, 0.15));
+        color: var(--texra-badge-foreground);
+        background: var(--texra-badge-background, rgba(128, 128, 128, 0.15));
         border-radius: var(--border-radius);
       }
 
       .preset-agent-badge--orchestrator {
-        color: var(--vscode-button-foreground);
-        background: var(--vscode-button-background);
+        color: var(--texra-button-foreground);
+        background: var(--texra-button-background);
         border: var(--border-thin) solid
-          var(--vscode-button-background, var(--vscode-focusBorder));
+          var(--texra-button-background, var(--texra-focusBorder));
         font-weight: var(--font-weight-semibold);
       }
 
@@ -223,11 +223,11 @@ export class MultiAgentTab extends LitElement {
       }
 
       .preset-delete-btn:hover {
-        color: var(--vscode-errorForeground);
+        color: var(--texra-errorForeground);
       }
 
       .preset-delete-btn:focus-visible {
-        outline: var(--border-thin) solid var(--vscode-focusBorder);
+        outline: var(--border-thin) solid var(--texra-focusBorder);
         outline-offset: 1px;
         border-radius: var(--border-radius-small);
       }
@@ -247,7 +247,7 @@ export class MultiAgentTab extends LitElement {
       .reliability-row label {
         min-width: 140px;
         font-size: var(--font-size-sm);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .reliability-input {

--- a/src/settingsView/frontend/tabs/ToolsTab.ts
+++ b/src/settingsView/frontend/tabs/ToolsTab.ts
@@ -117,7 +117,7 @@ export class ToolsTab extends LitElement {
         gap: var(--spacing-small);
         font-size: var(--font-size-lg);
         font-weight: var(--font-weight-medium);
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       .tools-summary {
@@ -142,13 +142,13 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__track {
         fill: none;
-        stroke: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.25));
+        stroke: var(--texra-editorWidget-border, rgba(128, 128, 128, 0.25));
         stroke-width: 4;
       }
 
       .tools-health-ring__available {
         fill: none;
-        stroke: var(--vscode-testing-iconPassed, #73c991);
+        stroke: var(--texra-testing-iconPassed, #73c991);
         stroke-width: 4;
         stroke-linecap: round;
         transition: stroke-dashoffset var(--transition-slow);
@@ -156,7 +156,7 @@ export class ToolsTab extends LitElement {
 
       .tools-health-ring__missing {
         fill: none;
-        stroke: var(--vscode-testing-iconFailed, #f48771);
+        stroke: var(--texra-testing-iconFailed, #f48771);
         stroke-width: 4;
         stroke-linecap: round;
         transition: stroke-dashoffset var(--transition-slow);
@@ -179,11 +179,11 @@ export class ToolsTab extends LitElement {
       }
 
       .tools-stat-available {
-        color: var(--vscode-testing-iconPassed, #73c991);
+        color: var(--texra-testing-iconPassed, #73c991);
       }
 
       .tools-stat-missing {
-        color: var(--vscode-testing-iconFailed, #f48771);
+        color: var(--texra-testing-iconFailed, #f48771);
       }
 
       /* Base recheck-btn styles provided by .tab-action-btn in commonViewStyles */
@@ -237,7 +237,7 @@ export class ToolsTab extends LitElement {
         margin-bottom: var(--spacing-small);
         border-radius: var(--border-radius);
         background: var(
-          --vscode-textCodeBlock-background,
+          --texra-textCodeBlock-background,
           rgba(128, 128, 128, 0.08)
         );
       }

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -6,13 +6,13 @@ const TOOLTIP_SHOW_DELAY_MS = 500;
 const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
   padding: 'var(--spacing-small, 4px) var(--spacing-medium, 8px)',
-  fontSize: 'var(--vscode-font-size, 13px)',
-  fontFamily: 'var(--vscode-font-family)',
-  color: 'var(--vscode-editorHoverWidget-foreground, var(--vscode-foreground))',
+  fontSize: 'var(--texra-font-size, 13px)',
+  fontFamily: 'var(--texra-font-family)',
+  color: 'var(--texra-editorHoverWidget-foreground, var(--texra-foreground))',
   background:
-    'var(--vscode-editorHoverWidget-background, var(--vscode-editor-background))',
+    'var(--texra-editorHoverWidget-background, var(--texra-editor-background))',
   border:
-    '1px solid var(--vscode-editorHoverWidget-border, var(--vscode-contrastBorder, transparent))',
+    '1px solid var(--texra-editorHoverWidget-border, var(--texra-contrastBorder, transparent))',
   borderRadius: 'var(--border-radius, 3px)',
   whiteSpace: 'nowrap',
   pointerEvents: 'none',

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -7,7 +7,7 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
   padding: 'var(--spacing-small, 4px) var(--spacing-medium, 8px)',
   fontSize: 'var(--texra-font-size, 13px)',
-  fontFamily: 'var(--texra-font-family, system-ui)',
+  fontFamily: 'var(--texra-font-family, system-ui), system-ui',
   color: 'var(--texra-editorHoverWidget-foreground, var(--texra-foreground))',
   background:
     'var(--texra-editorHoverWidget-background, var(--texra-editor-background))',

--- a/src/shared/controllers/TooltipController.ts
+++ b/src/shared/controllers/TooltipController.ts
@@ -7,7 +7,7 @@ const TOOLTIP_STYLES: Partial<CSSStyleDeclaration> = {
   position: 'fixed',
   padding: 'var(--spacing-small, 4px) var(--spacing-medium, 8px)',
   fontSize: 'var(--texra-font-size, 13px)',
-  fontFamily: 'var(--texra-font-family)',
+  fontFamily: 'var(--texra-font-family, system-ui)',
   color: 'var(--texra-editorHoverWidget-foreground, var(--texra-foreground))',
   background:
     'var(--texra-editorHoverWidget-background, var(--texra-editor-background))',

--- a/src/shared/styles/badgeStyles.ts
+++ b/src/shared/styles/badgeStyles.ts
@@ -20,8 +20,8 @@ export const categoryBadgeStyles: CSSResult = css`
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-small);
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .category-badge .codicon,
@@ -32,37 +32,37 @@ export const categoryBadgeStyles: CSSResult = css`
   .category-workflow,
   .category-badge.workflow {
     background-color: var(
-      --vscode-editorInfo-background,
+      --texra-editorInfo-background,
       rgba(0, 127, 212, 0.15)
     );
-    color: var(--vscode-editorInfo-foreground, #3794ff);
+    color: var(--texra-editorInfo-foreground, #3794ff);
   }
 
   .category-tool-use,
   .category-badge.tooluse,
   .category-badge.tool-use {
     background-color: var(
-      --vscode-editorWarning-background,
+      --texra-editorWarning-background,
       rgba(255, 204, 0, 0.15)
     );
-    color: var(--vscode-editorWarning-foreground, #cca700);
+    color: var(--texra-editorWarning-foreground, #cca700);
   }
 `;
 
 export const searchHighlightStyles: CSSResult = css`
   mark {
     background-color: var(
-      --vscode-editor-findMatchHighlightBackground,
+      --texra-editor-findMatchHighlightBackground,
       #ffef0b80
     );
-    color: var(--vscode-editor-findMatchHighlightForeground, inherit);
+    color: var(--texra-editor-findMatchHighlightForeground, inherit);
     padding: 0;
     border-radius: var(--border-radius-small);
   }
 
   mark[data-current='true'] {
-    background-color: var(--vscode-editor-findMatchBackground, #ff8b0088);
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    background-color: var(--texra-editor-findMatchBackground, #ff8b0088);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
   }
 `;
 

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -18,18 +18,18 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .list-item {
-    border: var(--border-thin) solid var(--vscode-panelSection-border);
+    border: var(--border-thin) solid var(--texra-panelSection-border);
     border-radius: var(--border-radius-large);
     padding: var(--spacing-medium);
-    background-color: var(--vscode-editor-background);
+    background-color: var(--texra-editor-background);
   }
 
   .list-item:hover {
-    background-color: var(--vscode-list-hoverBackground);
+    background-color: var(--texra-list-hoverBackground);
   }
 
   .list-item:focus-within {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
   }
 
   .list-item-header {
@@ -60,11 +60,8 @@ export const commonViewStyles: CSSResult = css`
 
   .panel-collapsible::part(header) {
     padding: var(--spacing-small) var(--spacing-medium);
-    background-color: var(
-      --vscode-sideBarSectionHeader-background,
-      transparent
-    );
-    color: var(--vscode-sideBarTitle-foreground, var(--vscode-foreground));
+    background-color: var(--texra-sideBarSectionHeader-background, transparent);
+    color: var(--texra-sideBarTitle-foreground, var(--texra-foreground));
   }
 
   .panel-collapsible::part(body) {
@@ -95,7 +92,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .clickable-link:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -136,7 +133,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .details-summary:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -194,7 +191,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .btn-secondary:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -224,19 +221,16 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .tab-action-btn:hover {
-    color: var(--vscode-foreground);
-    border-color: var(--vscode-focusBorder);
+    color: var(--texra-foreground);
+    border-color: var(--texra-focusBorder);
   }
 
   .tab-action-btn:active {
-    background: var(
-      --vscode-toolbar-activeBackground,
-      rgba(99, 102, 103, 0.31)
-    );
+    background: var(--texra-toolbar-activeBackground, rgba(99, 102, 103, 0.31));
   }
 
   .tab-action-btn:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
   }
 
@@ -248,21 +242,21 @@ export const commonViewStyles: CSSResult = css`
     row-gap: var(--spacing-small);
     padding: var(--spacing-medium);
     margin-bottom: var(--spacing-large);
-    border: var(--border-thin) solid var(--vscode-focusBorder);
+    border: var(--border-thin) solid var(--texra-focusBorder);
     border-radius: var(--border-radius);
-    background: var(--vscode-editor-background);
+    background: var(--texra-editor-background);
   }
 
   .settings-reminder-icon {
     grid-row: 1 / -1;
     margin-top: 2px;
     font-size: var(--font-size-lg);
-    color: var(--vscode-focusBorder);
+    color: var(--texra-focusBorder);
   }
 
   .settings-reminder-title {
     font-weight: var(--font-weight-medium);
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .settings-reminder-description {
@@ -308,8 +302,8 @@ export const commonViewStyles: CSSResult = css`
     height: 18px;
     flex: 0 0 18px;
     border-radius: 50%;
-    color: var(--vscode-editor-background);
-    background: var(--vscode-focusBorder);
+    color: var(--texra-editor-background);
+    background: var(--texra-focusBorder);
     font-size: var(--font-size-xs);
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-tight);
@@ -345,7 +339,7 @@ export const commonViewStyles: CSSResult = css`
   }
 
   .icon-btn-reset:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -366,13 +360,13 @@ export const commonViewStyles: CSSResult = css`
  */
 export const focusRingStyles: CSSResult = css`
   .focus-ring:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
 
   .focus-ring--inset:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: -1px;
     border-radius: var(--border-radius-small);
   }
@@ -399,9 +393,9 @@ export const filledButtonStyles: CSSResult = css`
     padding: var(--spacing-small) var(--spacing-medium);
     font-size: var(--font-size);
     font-family: inherit;
-    color: var(--vscode-button-foreground);
-    background: var(--vscode-button-background);
-    border: var(--border-thin) solid var(--vscode-button-border, transparent);
+    color: var(--texra-button-foreground);
+    background: var(--texra-button-background);
+    border: var(--border-thin) solid var(--texra-button-border, transparent);
     border-radius: var(--border-radius);
     cursor: pointer;
     transition:
@@ -410,7 +404,7 @@ export const filledButtonStyles: CSSResult = css`
   }
 
   .filled-button:hover {
-    background: var(--vscode-button-hoverBackground);
+    background: var(--texra-button-hoverBackground);
   }
 
   .filled-button:active {
@@ -418,16 +412,16 @@ export const filledButtonStyles: CSSResult = css`
   }
 
   .filled-button:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
   }
 
   .filled-button--secondary {
-    color: var(--vscode-button-secondaryForeground, inherit);
-    background: var(--vscode-button-secondaryBackground, transparent);
+    color: var(--texra-button-secondaryForeground, inherit);
+    background: var(--texra-button-secondaryBackground, transparent);
   }
 
   .filled-button--secondary:hover {
-    background: var(--vscode-button-secondaryHoverBackground, transparent);
+    background: var(--texra-button-secondaryHoverBackground, transparent);
   }
 `;

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -76,11 +76,11 @@ export const historyListStyles: CSSResult = css`
 
   .history-label {
     font-weight: var(--font-weight-bold);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .history-value {
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     padding: var(--spacing-small) 0;
     word-break: break-word;
   }
@@ -101,7 +101,7 @@ export const historyListStyles: CSSResult = css`
 
   .history-description {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     font-style: italic;
     margin-top: var(--spacing-small);
     line-height: var(--line-height-normal);
@@ -111,7 +111,7 @@ export const historyListStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     gap: var(--spacing-small);
-    background-color: var(--vscode-editor-inactiveSelectionBackground);
+    background-color: var(--texra-editor-inactiveSelectionBackground);
     padding: var(--spacing-medium);
     border-radius: var(--border-radius);
     margin: var(--spacing-medium) 0;
@@ -125,14 +125,14 @@ export const historyListStyles: CSSResult = css`
 
   .config-key {
     font-weight: var(--font-weight-medium);
-    color: var(--vscode-editorInfo-foreground);
+    color: var(--texra-editorInfo-foreground);
     min-width: calc(
       var(--width-button-min) + var(--spacing-xlarge) + var(--spacing-xlarge)
     );
   }
 
   .config-value {
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     word-break: break-word;
   }
 `;

--- a/src/shared/styles/litStyles.ts
+++ b/src/shared/styles/litStyles.ts
@@ -3,34 +3,34 @@ import { css, type CSSResult } from 'lit';
 export const designTokens: CSSResult = css`
   :host {
     /* Text colors */
-    --color-text-secondary: var(--vscode-descriptionForeground);
-    --color-text-link: var(--vscode-textLink-foreground);
-    --color-text-link-active: var(--vscode-textLink-activeForeground);
+    --color-text-secondary: var(--texra-descriptionForeground);
+    --color-text-link: var(--texra-textLink-foreground);
+    --color-text-link-active: var(--texra-textLink-activeForeground);
 
     /* Background colors */
-    --color-bg-secondary: var(--vscode-sideBar-background);
+    --color-bg-secondary: var(--texra-sideBar-background);
 
     /* Border colors */
-    --color-border: var(--vscode-panel-border);
+    --color-border: var(--texra-panel-border);
 
     /* Status colors */
-    --color-success: var(--vscode-testing-iconPassed, #2ea043);
-    --color-error: var(--vscode-editorError-foreground, #f14c4c);
-    --color-warning: var(--vscode-editorWarning-foreground, #cca700);
-    --color-info: var(--vscode-charts-blue, #3794ff);
-    --color-added: var(--vscode-charts-green, #4caf50);
-    --color-removed: var(--vscode-charts-red, #f44336);
+    --color-success: var(--texra-testing-iconPassed, #2ea043);
+    --color-error: var(--texra-editorError-foreground, #f14c4c);
+    --color-warning: var(--texra-editorWarning-foreground, #cca700);
+    --color-info: var(--texra-charts-blue, #3794ff);
+    --color-added: var(--texra-charts-green, #4caf50);
+    --color-removed: var(--texra-charts-red, #f44336);
 
     /* Component aliases */
     --background-color: var(--color-bg-secondary);
-    --text-color: var(--vscode-sideBar-foreground);
-    --button-hover-background: var(--vscode-button-hoverBackground);
-    --dropdown-border: var(--vscode-dropdown-border);
+    --text-color: var(--texra-sideBar-foreground);
+    --button-hover-background: var(--texra-button-hoverBackground);
+    --dropdown-border: var(--texra-dropdown-border);
 
     /* Typography */
-    --font-size: var(--vscode-font-size);
-    --font-family: var(--vscode-font-family);
-    --font-weight: var(--vscode-font-weight);
+    --font-size: var(--texra-font-size);
+    --font-family: var(--texra-font-family);
+    --font-weight: var(--texra-font-weight);
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;

--- a/src/shared/styles/markdownStyles.ts
+++ b/src/shared/styles/markdownStyles.ts
@@ -45,7 +45,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content :is(h1, h2, h3, h4) {
-    color: var(--vscode-textLink-foreground, #3794ff);
+    color: var(--texra-textLink-foreground, #3794ff);
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-heading);
@@ -62,7 +62,7 @@ export const markdownStyles = css`
     margin-top: var(--spacing-large);
     margin-bottom: var(--spacing-small);
     border-left: var(--border-thick) solid
-      var(--vscode-activityBarBadge-background);
+      var(--texra-activityBarBadge-background);
     border-bottom: var(--border-thin) solid var(--color-border);
     padding-bottom: var(--spacing-tiny);
     border-radius: var(--border-radius) 0 0 var(--border-radius);
@@ -92,7 +92,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content code {
-    background-color: var(--vscode-textCodeBlock-background);
+    background-color: var(--texra-textCodeBlock-background);
     padding: var(--spacing-tiny) var(--spacing-small);
     border-radius: var(--border-radius);
     font-family: var(--font-family);
@@ -103,9 +103,9 @@ export const markdownStyles = css`
     padding: var(--spacing-medium) var(--spacing-large);
     margin: 0.5em 0;
     border-radius: var(--border-radius);
-    background-color: var(--vscode-textCodeBlock-background);
+    background-color: var(--texra-textCodeBlock-background);
     border-left: var(--spacing-tiny) solid
-      var(--vscode-activityBarBadge-background);
+      var(--texra-activityBarBadge-background);
     overflow-x: auto;
   }
 
@@ -118,7 +118,7 @@ export const markdownStyles = css`
 
   .markdown-content .latex-ref {
     font-family: var(--font-family);
-    color: var(--vscode-symbolIcon-keywordForeground);
+    color: var(--texra-symbolIcon-keywordForeground);
   }
 
   .markdown-content a {
@@ -132,7 +132,7 @@ export const markdownStyles = css`
 
   .markdown-content blockquote {
     border-left: var(--border-thick) solid
-      var(--vscode-activityBarBadge-background);
+      var(--texra-activityBarBadge-background);
     margin: var(--spacing-medium) 0;
     padding-left: var(--spacing-xlarge);
     color: var(--color-text-secondary);
@@ -150,7 +150,7 @@ export const markdownStyles = css`
     }
 
     th {
-      background-color: var(--vscode-editor-lineHighlightBackground);
+      background-color: var(--texra-editor-lineHighlightBackground);
       text-align: left;
     }
   }
@@ -160,7 +160,7 @@ export const markdownStyles = css`
   }
 
   .markdown-content strong {
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     font-weight: var(--font-weight-semibold);
   }
 
@@ -171,18 +171,18 @@ export const markdownStyles = css`
   .markdown-content hr {
     margin: 0.7em 0;
     height: var(--border-thin);
-    background-color: var(--vscode-editorWidget-border);
+    background-color: var(--texra-editorWidget-border);
     border: none;
   }
 
   .markdown-content em strong,
   .markdown-content strong em {
-    color: var(--vscode-editorInfo-foreground);
+    color: var(--texra-editorInfo-foreground);
   }
 
   .banner-content--scratchpad p:has(strong:first-child) {
     border-left: calc(var(--spacing-small) - 1px) solid
-      var(--vscode-notificationsInfoIcon-foreground);
+      var(--texra-notificationsInfoIcon-foreground);
     padding-left: var(--spacing-medium);
   }
 

--- a/src/shared/styles/permissionCardStyles.ts
+++ b/src/shared/styles/permissionCardStyles.ts
@@ -10,7 +10,7 @@ export const permissionCardStyles: CSSResult = css`
     z-index: 1000;
     background: color-mix(
       in srgb,
-      var(--vscode-editor-background) 70%,
+      var(--texra-editor-background) 70%,
       transparent
     );
   }
@@ -20,15 +20,15 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .permission-card {
-    background: var(--vscode-editor-background);
-    border: var(--border-thin) solid var(--vscode-panel-border);
+    background: var(--texra-editor-background);
+    border: var(--border-thin) solid var(--texra-panel-border);
     border-radius: var(--border-radius-large);
     padding: var(--spacing-xlarge);
     max-width: 600px;
     width: min(92vw, 600px);
     max-height: min(80vh, 44rem);
     overflow: hidden;
-    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.24));
+    box-shadow: 0 2px 8px var(--texra-widget-shadow, rgba(0, 0, 0, 0.24));
   }
 
   .permission-header {
@@ -50,10 +50,10 @@ export const permissionCardStyles: CSSResult = css`
   .code-block {
     display: block;
     padding: var(--spacing-medium);
-    background: var(--vscode-textCodeBlock-background);
+    background: var(--texra-textCodeBlock-background);
     border-radius: var(--border-radius);
-    color: var(--vscode-terminal-foreground);
-    font-family: var(--vscode-editor-font-family);
+    color: var(--texra-terminal-foreground);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size);
     white-space: pre-wrap;
     word-break: break-word;
@@ -79,9 +79,9 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .file-path {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-sm);
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     word-break: break-word;
   }
 
@@ -90,21 +90,21 @@ export const permissionCardStyles: CSSResult = css`
     align-items: baseline;
     gap: var(--spacing-small);
     font-size: var(--font-size-sm);
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
   }
 
   .diff-added {
-    color: var(--vscode-gitDecoration-addedResourceForeground, #89d185);
+    color: var(--texra-gitDecoration-addedResourceForeground, #89d185);
     font-weight: var(--font-weight-medium);
   }
 
   .diff-removed {
-    color: var(--vscode-gitDecoration-deletedResourceForeground, #f48771);
+    color: var(--texra-gitDecoration-deletedResourceForeground, #f48771);
     font-weight: var(--font-weight-medium);
   }
 
   .meta-text {
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     margin-left: var(--spacing-small);
   }
 
@@ -122,8 +122,8 @@ export const permissionCardStyles: CSSResult = css`
     font-weight: var(--font-weight-semibold);
     padding: var(--spacing-tiny) var(--spacing-small);
     border-radius: var(--border-radius);
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .file-list {
@@ -131,12 +131,12 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .file-list-label {
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     margin-right: var(--spacing-small);
   }
 
   .file-link {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     cursor: pointer;
     text-decoration: none;
     transition: color var(--transition-fast);
@@ -147,7 +147,7 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .file-link:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -169,16 +169,16 @@ export const permissionCardStyles: CSSResult = css`
     display: block;
     margin-bottom: var(--spacing-small);
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
   }
 
   .feedback-input {
     width: 100%;
     min-height: 60px;
     padding: var(--spacing-medium);
-    border: var(--border-thin) solid var(--vscode-input-border);
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
+    border: var(--border-thin) solid var(--texra-input-border);
+    background: var(--texra-input-background);
+    color: var(--texra-input-foreground);
     border-radius: var(--border-radius);
     font-family: inherit;
     font-size: var(--font-size);
@@ -187,6 +187,6 @@ export const permissionCardStyles: CSSResult = css`
   }
 
   .feedback-input:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
   }
 `;

--- a/src/shared/styles/requestPanelStyles.ts
+++ b/src/shared/styles/requestPanelStyles.ts
@@ -67,10 +67,10 @@ export const requestPanelStyles: CSSResult = css`
   :is(${CONTAINERS}) {
     margin: ${sp.large} 0;
     padding: ${sp.large};
-    border: var(--border-thin) solid var(--vscode-input-border);
+    border: var(--border-thin) solid var(--texra-input-border);
     border-radius: var(--border-radius-large);
-    background: var(--vscode-editor-background);
-    box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.12));
+    background: var(--texra-editor-background);
+    box-shadow: 0 2px 8px var(--texra-widget-shadow, rgba(0, 0, 0, 0.12));
     display: flex;
     flex-direction: column;
     gap: ${sp.medium};
@@ -81,7 +81,7 @@ export const requestPanelStyles: CSSResult = css`
     align-items: center;
     gap: ${sp.medium};
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   :is(${LISTS}) {
@@ -94,8 +94,8 @@ export const requestPanelStyles: CSSResult = css`
     display: flex;
     flex-direction: column;
     border-radius: var(--border-radius);
-    border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
-    background: var(--vscode-editorHoverWidget-background);
+    border: var(--border-thin) solid var(--texra-editorHoverWidget-border);
+    background: var(--texra-editorHoverWidget-background);
     padding: ${sp.medium};
     gap: ${sp.medium};
     position: relative;
@@ -150,17 +150,17 @@ export const requestPanelStyles: CSSResult = css`
   /* Shared action button colors */
   :is(${ACTIONS}) vscode-toolbar-button[data-action='approve']::part(control),
   :is(${ACTIONS}) vscode-toolbar-button[data-action='submit']::part(control) {
-    color: var(--vscode-testing-iconPassed);
+    color: var(--texra-testing-iconPassed);
   }
 
   :is(${ACTIONS}) vscode-toolbar-button[data-action='setup']::part(control) {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   :is(${FEEDBACK_ACTIVE})
     :is(${ACTIONS})
     vscode-toolbar-button[data-action='reject']::part(control) {
-    color: var(--vscode-inputValidation-warningBorder);
+    color: var(--texra-inputValidation-warningBorder);
   }
 
   /* Shared badge base */
@@ -176,22 +176,22 @@ export const requestPanelStyles: CSSResult = css`
 
   /* Type-specific item accent */
   .approval-request {
-    border-left: var(--border-thick) solid var(--vscode-editor-foreground);
+    border-left: var(--border-thick) solid var(--texra-editor-foreground);
   }
   .bash-approval-request {
-    border-left: var(--border-thick) solid var(--vscode-terminal-ansiYellow);
+    border-left: var(--border-thick) solid var(--texra-terminal-ansiYellow);
   }
   .retry-request {
     border-left: var(--border-thick) solid var(--color-warning);
   }
   .workflow-proposal {
-    border-left: var(--border-thick) solid var(--vscode-textLink-foreground);
+    border-left: var(--border-thick) solid var(--texra-textLink-foreground);
   }
   .plan-approval-request {
-    border-left: var(--border-thick) solid var(--vscode-textLink-foreground);
+    border-left: var(--border-thick) solid var(--texra-textLink-foreground);
   }
   .external-inquiry-request {
-    border-left: var(--border-thick) solid var(--vscode-focusBorder);
+    border-left: var(--border-thick) solid var(--texra-focusBorder);
   }
 
   /* Shared action button width — approval and bash use the same flex-basis */
@@ -205,11 +205,11 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .approval-requests__header .codicon {
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .approval-request__path {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-sm);
     color: var(--color-text-link);
     word-break: break-word;
@@ -261,7 +261,7 @@ export const requestPanelStyles: CSSResult = css`
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     border-left: var(--border-thin) solid
-      var(--vscode-button-separator, var(--vscode-input-border));
+      var(--texra-button-separator, var(--texra-input-border));
   }
 
   .approval-request__actions .diff-dropdown .diff-dropdown-menu {
@@ -288,16 +288,16 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .bash-approval-requests__header .codicon {
-    color: var(--vscode-terminal-ansiYellow);
+    color: var(--texra-terminal-ansiYellow);
   }
 
   .bash-approval-request__command {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-sm);
   }
 
   .bash-approval-request__command .code-block {
-    border-left: var(--border-thick) solid var(--vscode-terminal-ansiYellow);
+    border-left: var(--border-thick) solid var(--texra-terminal-ansiYellow);
   }
 
   .bash-approval-request__command .code-block pre {
@@ -318,9 +318,9 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .retry-request__operation {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-sm);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     font-weight: var(--font-weight-medium);
   }
 
@@ -340,7 +340,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .retry-request__error-summary {
     cursor: pointer;
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     display: flex;
     align-items: center;
     gap: ${sp.tiny};
@@ -348,7 +348,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .retry-request__error-summary:hover {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   /* Note: .toggle-icon rotation handled by commonViewStyles */
@@ -356,9 +356,9 @@ export const requestPanelStyles: CSSResult = css`
   .retry-request__error-body {
     margin-top: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-xs);
     white-space: pre-wrap;
     word-break: break-word;
@@ -367,7 +367,7 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .retry-request--relay .retry-request__operation {
-    color: var(--vscode-editorWarning-foreground, #ff8c00);
+    color: var(--texra-editorWarning-foreground, #ff8c00);
   }
 
   /* ================================================================
@@ -375,7 +375,7 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .workflow-proposals__header .codicon {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   .workflow-proposal__actions vscode-toolbar-button {
@@ -390,20 +390,20 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .workflow-proposal__category-badge--workflow {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .workflow-proposal__category-badge--tool-use {
-    background: var(--vscode-textLink-foreground);
-    color: var(--vscode-editor-background);
+    background: var(--texra-textLink-foreground);
+    color: var(--texra-editor-background);
   }
 
   .workflow-proposal__agent {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size);
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   .workflow-proposal__model {
@@ -425,7 +425,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposal__agent-select .codicon,
   .workflow-proposal__model-select .codicon {
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     flex-shrink: 0;
   }
 
@@ -446,14 +446,14 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposal__instruction {
     font-size: var(--font-size-sm);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     word-break: break-word;
     white-space: pre-wrap;
     max-height: 12em;
     overflow-y: auto;
     line-height: var(--line-height-normal);
     padding: ${sp.small} 0;
-    border-bottom: var(--border-thin) solid var(--vscode-editorWidget-border);
+    border-bottom: var(--border-thin) solid var(--texra-editorWidget-border);
   }
 
   .workflow-proposal__extract-flags {
@@ -480,7 +480,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .workflow-proposal__files > div {
     font-size: var(--font-size-sm);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     line-height: var(--line-height-normal);
   }
 
@@ -490,16 +490,16 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .workflow-proposal__file-name {
-    font-family: var(--vscode-editor-font-family);
-    color: var(--vscode-textLink-foreground);
+    font-family: var(--texra-editor-font-family);
+    color: var(--texra-textLink-foreground);
     cursor: pointer;
   }
 
   .workflow-proposal__file-name:hover {
     text-decoration: underline;
     color: var(
-      --vscode-textLink-activeForeground,
-      var(--vscode-textLink-foreground)
+      --texra-textLink-activeForeground,
+      var(--texra-textLink-foreground)
     );
   }
 
@@ -518,11 +518,11 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .workflow-proposal__input-files .workflow-proposal__file-label {
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .workflow-proposal__output-files .workflow-proposal__file-label {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   /* ================================================================
@@ -530,12 +530,12 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .plan-approval-requests__header .codicon {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   .plan-approval-request__summary {
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .plan-approval-request__steps {
@@ -553,14 +553,14 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .plan-approval-request__step-files {
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-xs);
     color: var(--color-text-secondary);
     margin-top: ${sp.tiny};
   }
 
   .plan-approval-request__file {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 
   .plan-approval-request__actions vscode-toolbar-button {
@@ -584,7 +584,7 @@ export const requestPanelStyles: CSSResult = css`
    * ================================================================ */
 
   .external-inquiry-requests__header .codicon {
-    color: var(--vscode-focusBorder);
+    color: var(--texra-focusBorder);
   }
 
   /* Carousel navigation for multiple external inquiries */
@@ -597,7 +597,7 @@ export const requestPanelStyles: CSSResult = css`
 
   .external-inquiry-requests__counter {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     font-variant-numeric: tabular-nums;
     min-width: 3ch;
     text-align: center;
@@ -613,12 +613,12 @@ export const requestPanelStyles: CSSResult = css`
     border: none;
     border-radius: var(--border-radius-small);
     background: transparent;
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     cursor: pointer;
   }
 
   .external-inquiry-requests__nav-btn:hover:not(:disabled) {
-    background: var(--vscode-toolbar-hoverBackground);
+    background: var(--texra-toolbar-hoverBackground);
   }
 
   .external-inquiry-requests__nav-btn:disabled {
@@ -627,24 +627,24 @@ export const requestPanelStyles: CSSResult = css`
   }
 
   .external-inquiry-request__mode-badge {
-    background: var(--vscode-badge-background);
-    color: var(--vscode-badge-foreground);
+    background: var(--texra-badge-background);
+    color: var(--texra-badge-foreground);
   }
 
   .external-inquiry-request__context {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     padding: ${sp.small} ${sp.medium};
-    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
     border-left: var(--border-thick) solid
-      var(--vscode-textBlockQuote-border, var(--vscode-focusBorder));
+      var(--texra-textBlockQuote-border, var(--texra-focusBorder));
     line-height: var(--line-height-normal);
   }
 
   .external-inquiry-request__question {
-    background: var(--vscode-textCodeBlock-background, rgba(0, 0, 0, 0.05));
-    border: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
+    background: var(--texra-textCodeBlock-background, rgba(0, 0, 0, 0.05));
+    border: var(--border-thin) solid var(--texra-editorHoverWidget-border);
     border-radius: var(--border-radius);
     padding: ${sp.medium};
     position: relative;
@@ -653,7 +653,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__question-text {
     font-size: var(--font-size);
     line-height: var(--line-height-relaxed, 1.6);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
     white-space: pre-wrap;
     word-break: break-word;
     max-height: min(22vh, 14rem);
@@ -666,7 +666,7 @@ export const requestPanelStyles: CSSResult = css`
     justify-content: flex-end;
     margin-top: ${sp.small};
     padding-top: ${sp.small};
-    border-top: var(--border-thin) solid var(--vscode-editorHoverWidget-border);
+    border-top: var(--border-thin) solid var(--texra-editorHoverWidget-border);
   }
 
   .external-inquiry-request__search-hint {
@@ -674,7 +674,7 @@ export const requestPanelStyles: CSSResult = css`
     align-items: center;
     gap: ${sp.small};
     font-size: var(--font-size-sm);
-    color: var(--vscode-editorInfo-foreground, var(--vscode-focusBorder));
+    color: var(--texra-editorInfo-foreground, var(--texra-focusBorder));
     padding: ${sp.small} 0;
   }
 
@@ -687,7 +687,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__attach-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
     display: flex;
     align-items: center;
     gap: ${sp.small};
@@ -698,7 +698,7 @@ export const requestPanelStyles: CSSResult = css`
     flex-direction: column;
     gap: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
 
@@ -707,8 +707,8 @@ export const requestPanelStyles: CSSResult = css`
     align-items: center;
     gap: ${sp.small};
     font-size: var(--font-size-sm);
-    font-family: var(--vscode-editor-font-family);
-    color: var(--vscode-textLink-foreground);
+    font-family: var(--texra-editor-font-family);
+    color: var(--texra-textLink-foreground);
   }
 
   .external-inquiry-request__answer-area {
@@ -733,7 +733,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__session-links-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .external-inquiry-request__session-links-list {
@@ -741,14 +741,14 @@ export const requestPanelStyles: CSSResult = css`
     flex-direction: column;
     gap: ${sp.tiny};
     padding: ${sp.small};
-    background: var(--vscode-textBlockQuote-background, rgba(0, 0, 0, 0.1));
+    background: var(--texra-textBlockQuote-background, rgba(0, 0, 0, 0.1));
     border-radius: var(--border-radius-small);
   }
 
   .external-inquiry-request__session-link-item {
     font-size: var(--font-size-sm);
-    font-family: var(--vscode-editor-font-family);
-    color: var(--vscode-textLink-foreground);
+    font-family: var(--texra-editor-font-family);
+    color: var(--texra-textLink-foreground);
     word-break: break-word;
   }
 
@@ -757,38 +757,38 @@ export const requestPanelStyles: CSSResult = css`
     min-height: 72px;
     max-height: min(18vh, 8rem);
     resize: vertical;
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size-sm);
     line-height: var(--line-height-normal);
     padding: ${sp.medium};
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: var(--border-thin) solid var(--vscode-input-border);
+    background: var(--texra-input-background);
+    color: var(--texra-input-foreground);
+    border: var(--border-thin) solid var(--texra-input-border);
     border-radius: var(--border-radius);
     outline: none;
     transition: border-color 0.15s ease;
   }
 
   .external-inquiry-request__session-links-input:focus {
-    border-color: var(--vscode-focusBorder);
+    border-color: var(--texra-focusBorder);
   }
 
   .external-inquiry-request__session-links-input::placeholder {
-    color: var(--vscode-input-placeholderForeground);
+    color: var(--texra-input-placeholderForeground);
   }
 
   .external-inquiry-request__session-links-hint {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
   }
 
   .external-inquiry-request__chat-links {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
   }
 
   .external-inquiry-request__chat-links a {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
     text-decoration: none;
   }
 
@@ -799,7 +799,7 @@ export const requestPanelStyles: CSSResult = css`
   .external-inquiry-request__answer-label {
     font-size: var(--font-size-sm);
     font-weight: var(--font-weight-semibold);
-    color: var(--vscode-editor-foreground);
+    color: var(--texra-editor-foreground);
   }
 
   .external-inquiry-request__answer-input {
@@ -807,29 +807,29 @@ export const requestPanelStyles: CSSResult = css`
     min-height: 96px;
     max-height: min(24vh, 12rem);
     resize: vertical;
-    font-family: var(--vscode-editor-font-family);
+    font-family: var(--texra-editor-font-family);
     font-size: var(--font-size);
     line-height: var(--line-height-normal);
     padding: ${sp.medium};
-    background: var(--vscode-input-background);
-    color: var(--vscode-input-foreground);
-    border: var(--border-thin) solid var(--vscode-input-border);
+    background: var(--texra-input-background);
+    color: var(--texra-input-foreground);
+    border: var(--border-thin) solid var(--texra-input-border);
     border-radius: var(--border-radius);
     outline: none;
     transition: border-color 0.15s ease;
   }
 
   .external-inquiry-request__answer-input:focus {
-    border-color: var(--vscode-focusBorder);
+    border-color: var(--texra-focusBorder);
   }
 
   .external-inquiry-request__answer-input::placeholder {
-    color: var(--vscode-input-placeholderForeground);
+    color: var(--texra-input-placeholderForeground);
   }
 
   .external-inquiry-request__answer-hint {
     font-size: var(--font-size-sm);
-    color: var(--vscode-descriptionForeground);
+    color: var(--texra-descriptionForeground);
   }
 
   @media (max-height: 900px) {

--- a/src/shared/styles/selectStyles.ts
+++ b/src/shared/styles/selectStyles.ts
@@ -9,7 +9,7 @@ export const selectStyles: CSSResult = css`
 
   .select-group .codicon {
     margin-right: var(--spacing-small);
-    color: var(--text-color, var(--vscode-foreground));
+    color: var(--text-color, var(--texra-foreground));
     vertical-align: text-bottom;
   }
 
@@ -33,14 +33,14 @@ export const selectStyles: CSSResult = css`
   }
 
   vscode-option {
-    font-family: var(--vscode-font-family);
+    font-family: var(--texra-font-family);
   }
 
   vscode-option.disabled-option,
   vscode-option.disabled-model,
   vscode-option.disabled-agent,
   vscode-option[data-requires-key='true'] {
-    color: var(--color-text-secondary, var(--vscode-descriptionForeground));
+    color: var(--color-text-secondary, var(--texra-descriptionForeground));
     opacity: var(--opacity-subtle, 0.7);
     font-style: italic;
   }
@@ -55,17 +55,17 @@ export const selectStyles: CSSResult = css`
   }
 
   .clickable:hover {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 
   .clickable:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
 
   .codicon.clickable:hover {
-    color: var(--button-hover-background, var(--vscode-button-hoverBackground));
+    color: var(--button-hover-background, var(--texra-button-hoverBackground));
   }
 
   vscode-single-select::part(listbox) {
@@ -73,7 +73,7 @@ export const selectStyles: CSSResult = css`
   }
 
   .api-key-missing {
-    color: var(--vscode-errorForeground);
+    color: var(--texra-errorForeground);
     opacity: var(--opacity-full);
     font-style: normal;
     margin-left: var(--spacing-tiny);

--- a/src/shared/styles/statusIndicatorStyles.ts
+++ b/src/shared/styles/statusIndicatorStyles.ts
@@ -8,7 +8,7 @@ export const statusIndicatorStyles: CSSResult = css`
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
-    background-color: var(--vscode-descriptionForeground);
+    background-color: var(--texra-descriptionForeground);
     opacity: var(--opacity-subtle, 0.7);
     transition:
       background-color var(--transition-slow),
@@ -25,7 +25,7 @@ export const statusIndicatorStyles: CSSResult = css`
 
   .status-indicator.is-stopped,
   .tab-status.is-stopped {
-    background-color: var(--vscode-descriptionForeground);
+    background-color: var(--texra-descriptionForeground);
     opacity: var(--opacity-subtle, 0.7);
   }
 
@@ -37,28 +37,28 @@ export const statusIndicatorStyles: CSSResult = css`
 
   .status-indicator.is-waiting,
   .tab-status.is-waiting {
-    background-color: var(--vscode-textLink-foreground);
+    background-color: var(--texra-textLink-foreground);
     opacity: var(--opacity-full);
     animation: pulse-scale 3s infinite;
   }
 
   .status-indicator.is-resuming,
   .tab-status.is-resuming {
-    background-color: var(--vscode-textLink-foreground);
+    background-color: var(--texra-textLink-foreground);
     opacity: var(--opacity-full);
     animation: pulse-scale 1.5s infinite;
   }
 
   .status-indicator.is-initializing,
   .tab-status.is-initializing {
-    background-color: var(--vscode-descriptionForeground);
+    background-color: var(--texra-descriptionForeground);
     opacity: var(--opacity-full);
     animation: pulse-scale 2.5s infinite;
   }
 
   .status-indicator.is-ready,
   .tab-status.is-ready {
-    background-color: var(--vscode-descriptionForeground);
+    background-color: var(--texra-descriptionForeground);
     opacity: var(--opacity-disabled, 0.5);
   }
 
@@ -72,7 +72,7 @@ export const statusIndicatorStyles: CSSResult = css`
   }
 
   .status-text.is-stopped {
-    color: var(--color-text-secondary, var(--vscode-descriptionForeground));
+    color: var(--color-text-secondary, var(--texra-descriptionForeground));
   }
 
   .status-text.is-error {
@@ -82,6 +82,6 @@ export const statusIndicatorStyles: CSSResult = css`
   .status-text.is-waiting,
   .status-text.is-resuming,
   .status-text.is-initializing {
-    color: var(--vscode-textLink-foreground);
+    color: var(--texra-textLink-foreground);
   }
 `;

--- a/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/src/webview/frontend/components/GettingStartedBanner.ts
@@ -35,10 +35,9 @@ export class GettingStartedBanner extends LitElement {
         border-radius: var(--border-radius);
         padding: var(--spacing-small) var(--spacing-medium);
         margin-bottom: var(--spacing-large);
-        background-color: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
+        background-color: var(--texra-inputValidation-infoBackground);
+        color: var(--texra-inputValidation-infoForeground);
+        border: var(--border-thin) solid var(--texra-inputValidation-infoBorder);
         line-height: var(--line-height-relaxed);
       }
 

--- a/src/webview/frontend/components/InstructionPanel.ts
+++ b/src/webview/frontend/components/InstructionPanel.ts
@@ -152,14 +152,14 @@ export class InstructionPanel extends LitElement {
         align-items: flex-start;
         margin-top: var(--spacing-small);
         padding: var(--spacing-tiny) var(--spacing-small);
-        border-left: 2px solid var(--vscode-textLink-foreground);
-        color: var(--vscode-descriptionForeground);
+        border-left: 2px solid var(--texra-textLink-foreground);
+        color: var(--texra-descriptionForeground);
         font-size: var(--font-size-sm);
         line-height: var(--line-height-relaxed);
       }
 
       .session-hint-lede {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
         font-weight: 600;
         letter-spacing: 0.01em;
         white-space: nowrap;
@@ -170,7 +170,7 @@ export class InstructionPanel extends LitElement {
       }
 
       .session-hint-time {
-        color: var(--vscode-descriptionForeground);
+        color: var(--texra-descriptionForeground);
         opacity: 0.85;
       }
 
@@ -182,7 +182,7 @@ export class InstructionPanel extends LitElement {
       vscode-textarea#instruction {
         width: 100%;
         margin: var(--spacing-medium) 0;
-        font-family: var(--vscode-editor-font-family);
+        font-family: var(--texra-editor-font-family);
         font-size: var(--font-size);
       }
 
@@ -305,7 +305,7 @@ export class InstructionPanel extends LitElement {
       }
 
       .recording {
-        color: var(--vscode-errorForeground);
+        color: var(--texra-errorForeground);
         animation: pulse 1s infinite;
       }
 

--- a/src/webview/frontend/components/LatexDiffsSection.ts
+++ b/src/webview/frontend/components/LatexDiffsSection.ts
@@ -42,7 +42,7 @@ export class LatexDiffsSection extends LitElement {
       .latexdiffs-section[data-expanded='true'] {
         background-color: var(--background-color);
         border: var(--border-thin) solid
-          var(--vscode-widget-border, var(--dropdown-border));
+          var(--texra-widget-border, var(--dropdown-border));
         border-radius: var(--border-radius);
         padding: var(--spacing-medium);
         overflow: visible;
@@ -61,7 +61,7 @@ export class LatexDiffsSection extends LitElement {
 
       .latexdiffs-section[data-expanded='true'] .optional-label,
       .latexdiffs-section[data-expanded='true'] .toggle-icon {
-        color: var(--vscode-foreground);
+        color: var(--texra-foreground);
       }
 
       #latexdiffsContent {

--- a/src/webview/frontend/components/LoginBanner.ts
+++ b/src/webview/frontend/components/LoginBanner.ts
@@ -33,10 +33,9 @@ export class LoginBanner extends LitElement {
       }
 
       .login-banner {
-        background: var(--vscode-inputValidation-infoBackground);
-        color: var(--vscode-inputValidation-infoForeground);
-        border: var(--border-thin) solid
-          var(--vscode-inputValidation-infoBorder);
+        background: var(--texra-inputValidation-infoBackground);
+        color: var(--texra-inputValidation-infoForeground);
+        border: var(--border-thin) solid var(--texra-inputValidation-infoBorder);
         border-radius: var(--border-radius);
         padding: var(--spacing-medium);
         margin-bottom: var(--spacing-large);
@@ -55,7 +54,7 @@ export class LoginBanner extends LitElement {
 
       .login-banner-icon {
         font-size: 1.5em;
-        color: var(--vscode-button-background);
+        color: var(--texra-button-background);
         display: flex;
         align-items: center;
       }

--- a/src/webview/frontend/styles.ts
+++ b/src/webview/frontend/styles.ts
@@ -54,7 +54,7 @@ export const mainViewStyles: CSSResult = css`
   .file-selection-group {
     background-color: var(--background-color);
     border: var(--border-thin) solid
-      var(--vscode-widget-border, var(--dropdown-border));
+      var(--texra-widget-border, var(--dropdown-border));
     border-radius: var(--border-radius);
     padding: var(--spacing-medium);
     margin-bottom: var(--spacing-large);

--- a/src/webview/frontend/styles/fileSelectStyles.ts
+++ b/src/webview/frontend/styles/fileSelectStyles.ts
@@ -133,14 +133,14 @@ export const toggleStyles = css`
   }
 
   .toggle-icon:focus-visible {
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
 
   .file-select[data-expanded='true'] .optional-label,
   .file-select[data-expanded='true'] .toggle-icon {
-    color: var(--vscode-foreground);
+    color: var(--texra-foreground);
   }
 `;
 
@@ -162,7 +162,7 @@ export const multiFilesStyles = css`
   .multiple-files-list {
     background-color: var(--background-color);
     border: var(--border-thin) solid
-      var(--vscode-widget-border, var(--dropdown-border));
+      var(--texra-widget-border, var(--dropdown-border));
     border-radius: var(--border-radius);
     padding: var(--spacing-small);
     font-size: var(--font-size);
@@ -180,7 +180,7 @@ export const multiFilesStyles = css`
   }
 
   .file-item:hover {
-    background-color: var(--vscode-list-hoverBackground);
+    background-color: var(--texra-list-hoverBackground);
   }
 
   .file-name {
@@ -191,7 +191,7 @@ export const multiFilesStyles = css`
   }
 
   .remove-button {
-    color: var(--vscode-icon-foreground, var(--vscode-foreground));
+    color: var(--texra-icon-foreground, var(--texra-foreground));
     cursor: pointer;
     flex-shrink: 0;
     opacity: var(--opacity-subtle);
@@ -209,7 +209,7 @@ export const multiFilesStyles = css`
 
   .remove-button:focus-visible {
     opacity: var(--opacity-full);
-    outline: var(--border-thin) solid var(--vscode-focusBorder);
+    outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
   }
@@ -235,7 +235,7 @@ export const dropdownStyles = css`
 
   .dropdown-container vscode-toolbar-button.has-options::part(control) {
     box-shadow: inset 0 0 0 1px
-      var(--vscode-inputValidation-infoBorder, var(--vscode-focusBorder));
+      var(--texra-inputValidation-infoBorder, var(--texra-focusBorder));
   }
 
   .dropdown-container .dropdown-menu {
@@ -245,9 +245,9 @@ export const dropdownStyles = css`
     right: auto;
     z-index: 100;
     display: block;
-    background-color: var(--vscode-menu-background);
-    color: var(--vscode-menu-foreground);
-    border: var(--border-thin) solid var(--vscode-menu-border);
+    background-color: var(--texra-menu-background);
+    color: var(--texra-menu-foreground);
+    border: var(--border-thin) solid var(--texra-menu-border);
     border-radius: var(--border-radius);
     min-width: 160px;
   }
@@ -276,7 +276,7 @@ export const dropdownStyles = css`
   }
 
   .dropdown-container .dropdown-menu vscode-checkbox:hover {
-    background: var(--vscode-list-hoverBackground);
+    background: var(--texra-list-hoverBackground);
   }
 `;
 

--- a/src/webview/frontend/styles/warningBannerStyles.ts
+++ b/src/webview/frontend/styles/warningBannerStyles.ts
@@ -16,9 +16,9 @@ export const warningBannerStyles: CSSResult = css`
     border-radius: var(--border-radius);
     padding: var(--spacing-small) var(--spacing-medium);
     margin-bottom: var(--spacing-large);
-    background-color: var(--vscode-inputValidation-warningBackground);
-    color: var(--vscode-inputValidation-warningForeground);
-    border: var(--border-thin) solid var(--vscode-inputValidation-warningBorder);
+    background-color: var(--texra-inputValidation-warningBackground);
+    color: var(--texra-inputValidation-warningForeground);
+    border: var(--border-thin) solid var(--texra-inputValidation-warningBorder);
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
## Summary
- add document-level `--texra-*` theme tokens mapped to the current VS Code theme variables
- rewrite shared, main, progress, and settings webview styles to consume `--texra-*` tokens
- leave VS Code variable references isolated to the common token mapping for the extension host

Supports `prds/prd-electron-app.md` §9 item 7.

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- git diff --check
- token audit: no direct `--vscode-*` references remain in webview/shared component styles; all `--texra-*` component tokens are mapped in `src/common/styles/common.css`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to refactors in authentication token/session handling and host-neutralization of services that touch secure storage, configuration, and file watching; regressions would surface as login/refresh or settings persistence issues.
> 
> **Overview**
> Adds a host-neutral theming layer by introducing document-level `--texra-*` CSS variables mapped from VS Code tokens and updates progress/settings webviews to consume `--texra-*` instead of `--vscode-*`.
> 
> Refactors platform boundaries to be less VS Code–coupled: introduces `ConfigProvider`/`WorkspaceProvider.watch` abstractions with a new `VscodeConfigProvider`, adds a Node workspace watcher implementation, and updates config writes to use host-neutral targets.
> 
> Hardens auth/service internals by extracting Supabase session parsing/token-callback parsing into `SupabaseSession`, formalizing `AuthTokenProvider`/`SessionTokens` (and wiring `SupabaseClient` to use it), and decoupling `ServerSideKeyService` from VS Code by swapping `vscode.EventEmitter/Memento` for host-neutral state and events.
> 
> Separately, adds a local ESLint rule enforcing that `initPlatform` is only imported from composition roots (and tests), and introduces a `DiffViewHost` abstraction with a VS Code implementation to encapsulate tool edit approval diff handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14957e79054f41f578d016a6b623b2c31bace5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->