### PR TITLE
[codex] Route config helpers through platform

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,7 @@ import { VscodeFileSystem } from '@frontend/vscode/vscodeFileSystem';
 import { VscodeWorkspace } from '@frontend/vscode/vscodeWorkspace';
 import { VscodeStorage } from '@frontend/vscode/vscodeStorage';
 import { VscodeSecrets } from '@frontend/vscode/vscodeSecrets';
+import { VscodeConfigProvider } from '@frontend/vscode/vscodeConfig';
 import * as logger from '@logger/logUtils';
 import { UsageLogService } from '@logger/UsageLogService';
 import { STREAM_STATUS, type StreamStatus } from '@shared/schemas';
@@ -142,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext) {
   initializePolishModel(context.extensionPath);
   initializeStateManagers(context);
   initPlatform({
-    config: { get: getConfig },
+    config: new VscodeConfigProvider(),
     globalState: context.globalState,
     workspaceState: context.workspaceState,
     log: logger,

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -346,7 +346,7 @@ async function mergeNewModelsIfCustomized(
 
 /** Default options for global settings that should only be set if not already configured */
 const GLOBAL_IF_UNSET = {
-  target: vscode.ConfigurationTarget.Global,
+  target: 'global',
   prefix: false,
   ifUnset: true,
 } as const;

--- a/src/frontend/vscode/vscodeConfig.ts
+++ b/src/frontend/vscode/vscodeConfig.ts
@@ -15,6 +15,24 @@ interface VscodeConfigInspection<T> {
   workspaceFolderValue?: T;
 }
 
+function configKeys(key: string): string[] {
+  if (key.startsWith('texra.')) return [key];
+  return [key, `texra.${key}`];
+}
+
+function inspectKey<T>(key: string): VscodeConfigInspection<T> | undefined {
+  return vscode.workspace.getConfiguration().inspect<T>(key);
+}
+
+function resolveWriteKey(key: string): string {
+  if (key.startsWith('texra.')) return key;
+
+  if (inspectKey(key)) return key;
+
+  const texraKey = `texra.${key}`;
+  return inspectKey(texraKey) ? texraKey : key;
+}
+
 function toConfigurationTarget(
   target: ConfigTarget,
 ): vscode.ConfigurationTarget {
@@ -24,8 +42,8 @@ function toConfigurationTarget(
 }
 
 function normalizeInspection<T>(
-  key: string,
   inspection: VscodeConfigInspection<T> | undefined,
+  effectiveValue: T,
 ): ConfigInspection<T> | undefined {
   if (!inspection) return undefined;
   return {
@@ -33,7 +51,7 @@ function normalizeInspection<T>(
     globalValue: inspection.globalValue,
     workspaceValue: inspection.workspaceValue,
     workspaceFolderValue: inspection.workspaceFolderValue,
-    effectiveValue: vscode.workspace.getConfiguration().get<T>(key),
+    effectiveValue,
   };
 }
 
@@ -67,14 +85,15 @@ export class VscodeConfigProvider implements ConfigProvider {
   ): Promise<void> {
     await vscode.workspace
       .getConfiguration()
-      .update(key, value, toConfigurationTarget(target));
+      .update(resolveWriteKey(key), value, toConfigurationTarget(target));
   }
 
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
-    return normalizeInspection(
-      key,
-      vscode.workspace.getConfiguration().inspect<T>(key),
-    );
+    const inspection = configKeys(key)
+      .map((item) => inspectKey<T>(item))
+      .find((item) => item !== undefined);
+
+    return normalizeInspection(inspection, this.get<T>(key));
   }
 
   isExplicitlySet(key: string): boolean {
@@ -93,11 +112,21 @@ export class VscodeConfigProvider implements ConfigProvider {
   ): vscode.Disposable {
     return vscode.workspace.onDidChangeConfiguration((event) => {
       if (typeof key === 'string') {
-        if (event.affectsConfiguration(key)) listener();
+        if (configKeys(key).some((item) => event.affectsConfiguration(item))) {
+          listener();
+        }
         return;
       }
       if (Array.isArray(key)) {
-        if (key.some((item) => event.affectsConfiguration(item))) listener();
+        if (
+          key.some((item) =>
+            configKeys(item).some((candidate) =>
+              event.affectsConfiguration(candidate),
+            ),
+          )
+        ) {
+          listener();
+        }
         return;
       }
 

--- a/src/frontend/vscode/vscodeConfig.ts
+++ b/src/frontend/vscode/vscodeConfig.ts
@@ -1,0 +1,109 @@
+// Third-party imports
+import * as vscode from 'vscode';
+
+// Local imports
+import type {
+  ConfigInspection,
+  ConfigProvider,
+  ConfigTarget,
+} from '@platform/interfaces/config';
+
+interface VscodeConfigInspection<T> {
+  defaultValue?: T;
+  globalValue?: T;
+  workspaceValue?: T;
+  workspaceFolderValue?: T;
+}
+
+function toConfigurationTarget(
+  target: ConfigTarget,
+): vscode.ConfigurationTarget {
+  return target === 'global'
+    ? vscode.ConfigurationTarget.Global
+    : vscode.ConfigurationTarget.Workspace;
+}
+
+function normalizeInspection<T>(
+  key: string,
+  inspection: VscodeConfigInspection<T> | undefined,
+): ConfigInspection<T> | undefined {
+  if (!inspection) return undefined;
+  return {
+    defaultValue: inspection.defaultValue,
+    globalValue: inspection.globalValue,
+    workspaceValue: inspection.workspaceValue,
+    workspaceFolderValue: inspection.workspaceFolderValue,
+    effectiveValue: vscode.workspace.getConfiguration().get<T>(key),
+  };
+}
+
+/**
+ * VS Code-backed implementation of TeXRA's host-neutral config provider.
+ */
+export class VscodeConfigProvider implements ConfigProvider {
+  get<T>(key: string, defaultValue?: T): T {
+    const parts = key.split('.');
+
+    // Try multiple namespaces in order of priority (using === undefined to
+    // preserve null values).
+    let result: unknown = vscode.workspace
+      .getConfiguration(parts[0])
+      .get(parts.slice(1).join('.'));
+
+    if (result === undefined) {
+      result = vscode.workspace.getConfiguration('texra').get(key);
+    }
+    if (result === undefined) {
+      result = vscode.workspace.getConfiguration().get(`texra.${key}`);
+    }
+
+    return result !== undefined ? (result as T) : (defaultValue as T);
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    target: ConfigTarget = 'workspace',
+  ): Promise<void> {
+    await vscode.workspace
+      .getConfiguration()
+      .update(key, value, toConfigurationTarget(target));
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    return normalizeInspection(
+      key,
+      vscode.workspace.getConfiguration().inspect<T>(key),
+    );
+  }
+
+  isExplicitlySet(key: string): boolean {
+    const inspection = this.inspect(key);
+    if (!inspection) return false;
+    return (
+      inspection.globalValue !== undefined ||
+      inspection.workspaceValue !== undefined ||
+      inspection.workspaceFolderValue !== undefined
+    );
+  }
+
+  watch(
+    key: string | readonly string[] | RegExp,
+    listener: () => void,
+  ): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration((event) => {
+      if (typeof key === 'string') {
+        if (event.affectsConfiguration(key)) listener();
+        return;
+      }
+      if (Array.isArray(key)) {
+        if (key.some((item) => event.affectsConfiguration(item))) listener();
+        return;
+      }
+
+      // VS Code does not expose changed keys. Regex watchers are rare and
+      // should conservatively refresh on any configuration change.
+      listener();
+    });
+  }
+}

--- a/src/frontend/vscode/vscodeConfig.ts
+++ b/src/frontend/vscode/vscodeConfig.ts
@@ -24,15 +24,6 @@ function inspectKey<T>(key: string): VscodeConfigInspection<T> | undefined {
   return vscode.workspace.getConfiguration().inspect<T>(key);
 }
 
-function resolveWriteKey(key: string): string {
-  if (key.startsWith('texra.')) return key;
-
-  if (inspectKey(key)) return key;
-
-  const texraKey = `texra.${key}`;
-  return inspectKey(texraKey) ? texraKey : key;
-}
-
 function toConfigurationTarget(
   target: ConfigTarget,
 ): vscode.ConfigurationTarget {
@@ -83,9 +74,11 @@ export class VscodeConfigProvider implements ConfigProvider {
     value: T,
     target: ConfigTarget = 'workspace',
   ): Promise<void> {
+    // `configUtils.updateConfig` owns prefix policy, including explicit
+    // `prefix: false` writes. Preserve the exact key passed to this adapter.
     await vscode.workspace
       .getConfiguration()
-      .update(resolveWriteKey(key), value, toConfigurationTarget(target));
+      .update(key, value, toConfigurationTarget(target));
   }
 
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {

--- a/src/platform/interfaces/config.ts
+++ b/src/platform/interfaces/config.ts
@@ -1,6 +1,25 @@
+import type { Disposable } from './disposable';
+
+export type ConfigTarget = 'global' | 'workspace';
+
+export interface ConfigInspection<T = unknown> {
+  defaultValue?: T;
+  globalValue?: T;
+  workspaceValue?: T;
+  workspaceFolderValue?: T;
+  effectiveValue?: T;
+}
+
 /**
  * Platform configuration provider interface.
  */
 export interface ConfigProvider {
   get<T>(key: string, defaultValue?: T): T;
+  update<T>(key: string, value: T, target?: ConfigTarget): Promise<void>;
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined;
+  isExplicitlySet(key: string): boolean;
+  watch(
+    key: string | readonly string[] | RegExp,
+    listener: () => void,
+  ): Disposable;
 }

--- a/src/platform/interfaces/disposable.ts
+++ b/src/platform/interfaces/disposable.ts
@@ -1,0 +1,9 @@
+/**
+ * Host-neutral disposable resource.
+ *
+ * Structurally compatible with VS Code's Disposable and the unsubscribe
+ * callbacks used by Electron-side adapters.
+ */
+export interface Disposable {
+  dispose(): void;
+}

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -1124,7 +1124,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     enabled: boolean,
   ): Promise<void> {
     await updateConfig(configKey, enabled, {
-      target: vscode.ConfigurationTarget.Global,
+      target: 'global',
       prefix: false,
     });
     await this.withActiveWebview((w) => this.sendApprovalSettings(w));
@@ -1657,7 +1657,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       await globalSM?.update(def.globalStateKey, data.value);
     } else {
       await updateConfig(data.key, data.value, {
-        target: vscode.ConfigurationTarget.Global,
+        target: 'global',
         prefix: false,
       });
     }

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -146,7 +146,7 @@ export class LatexSettingsHandlers {
         }
 
         await updateConfig(key, resolvedValue, {
-          target: vscode.ConfigurationTarget.Global,
+          target: 'global',
           prefix: false,
         });
       }

--- a/src/test/tools/setup/SendToTerminalTool.test.ts
+++ b/src/test/tools/setup/SendToTerminalTool.test.ts
@@ -34,6 +34,10 @@ function installApprovalSkippingPlatform(): void {
     config: {
       get: <T>(key: string, defaultValue?: T): T =>
         key === BASH_APPROVAL_CONFIG_KEY ? (false as T) : (defaultValue as T),
+      update: async () => {},
+      inspect: () => undefined,
+      isExplicitlySet: () => false,
+      watch: () => ({ dispose: () => {} }),
     },
   };
   initPlatform(stub as Platform);

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -32,7 +32,8 @@ function configProvider() {
  * @returns The configuration value or default value
  */
 export function getConfig<T>(path: string, defaultValue?: T): T {
-  return configProvider()?.get(path, defaultValue) ?? (defaultValue as T);
+  const provider = configProvider();
+  return provider ? provider.get(path, defaultValue) : (defaultValue as T);
 }
 
 /**

--- a/src/utils/config/configUtils.ts
+++ b/src/utils/config/configUtils.ts
@@ -1,5 +1,21 @@
-// Third-party imports
-import * as vscode from 'vscode';
+// Local imports
+import { tryPlatform } from '@platform/platform';
+import type { ConfigTarget } from '@platform/interfaces/config';
+import type { Disposable } from '@platform/interfaces/disposable';
+
+interface ConfigSubscriptionContext {
+  subscriptions: Disposable[];
+}
+
+interface UpdateConfigOptions {
+  target?: ConfigTarget;
+  prefix?: boolean;
+  ifUnset?: boolean;
+}
+
+function configProvider() {
+  return tryPlatform()?.config;
+}
 
 /**
  * Gets a configuration value from VS Code settings.
@@ -16,21 +32,7 @@ import * as vscode from 'vscode';
  * @returns The configuration value or default value
  */
 export function getConfig<T>(path: string, defaultValue?: T): T {
-  const parts = path.split('.');
-
-  // Try multiple namespaces in order of priority (using === undefined to preserve null values)
-  let result: unknown = vscode.workspace
-    .getConfiguration(parts[0])
-    .get(parts.slice(1).join('.'));
-
-  if (result === undefined) {
-    result = vscode.workspace.getConfiguration('texra').get(path);
-  }
-  if (result === undefined) {
-    result = vscode.workspace.getConfiguration().get(`texra.${path}`);
-  }
-
-  return result !== undefined ? (result as T) : (defaultValue as T);
+  return configProvider()?.get(path, defaultValue) ?? (defaultValue as T);
 }
 
 /**
@@ -49,32 +51,19 @@ export function getConfig<T>(path: string, defaultValue?: T): T {
 export async function updateConfig<T>(
   path: string,
   value: T,
-  options: {
-    target?: vscode.ConfigurationTarget;
-    prefix?: boolean;
-    ifUnset?: boolean;
-  } = {},
+  options: UpdateConfigOptions = {},
 ): Promise<void> {
-  const {
-    target = vscode.ConfigurationTarget.Workspace,
-    prefix = true,
-    ifUnset = false,
-  } = options;
+  const { target = 'workspace', prefix = true, ifUnset = false } = options;
 
   const key = prefix && !path.startsWith('texra.') ? `texra.${path}` : path;
+  const provider = configProvider();
+  if (!provider) return;
 
-  if (ifUnset) {
-    const setting = vscode.workspace.getConfiguration().inspect(key);
-    if (
-      setting?.globalValue !== undefined ||
-      setting?.workspaceValue !== undefined ||
-      setting?.workspaceFolderValue !== undefined
-    ) {
-      return; // Setting already exists, don't update
-    }
+  if (ifUnset && provider.isExplicitlySet(key)) {
+    return; // Setting already exists, don't update
   }
 
-  await vscode.workspace.getConfiguration().update(key, value, target);
+  await provider.update(key, value, target);
 }
 
 /**
@@ -82,7 +71,7 @@ export async function updateConfig<T>(
  * (without VS Code defaults). Returns `undefined` if the key is not registered.
  */
 export function inspectConfig<T = unknown>(key: string) {
-  return vscode.workspace.getConfiguration().inspect<T>(key);
+  return configProvider()?.inspect<T>(key);
 }
 
 /**
@@ -90,13 +79,7 @@ export function inspectConfig<T = unknown>(key: string) {
  * (global, workspace, or workspace folder), rather than using defaults.
  */
 export function isConfigExplicitlySet(key: string): boolean {
-  const inspection = inspectConfig(key);
-  if (!inspection) return false;
-  return (
-    inspection.globalValue !== undefined ||
-    inspection.workspaceValue !== undefined ||
-    inspection.workspaceFolderValue !== undefined
-  );
+  return configProvider()?.isExplicitlySet(key) ?? false;
 }
 
 /**
@@ -108,17 +91,15 @@ export function isConfigExplicitlySet(key: string): boolean {
  * @returns Disposable for the registered listener
  */
 export function watchConfig(
-  context: vscode.ExtensionContext,
+  context: ConfigSubscriptionContext,
   keys: string | string[],
   callback: () => void,
-): vscode.Disposable {
+): Disposable {
   const keyArray = Array.isArray(keys) ? keys : [keys];
-
-  const disposable = vscode.workspace.onDidChangeConfiguration((e) => {
-    if (keyArray.some((key) => e.affectsConfiguration(key))) {
-      callback();
-    }
-  });
+  const provider = configProvider();
+  const disposable = provider?.watch(keyArray, callback) ?? {
+    dispose: () => {},
+  };
 
   context.subscriptions.push(disposable);
   return disposable;


### PR DESCRIPTION
## Summary
- expands ConfigProvider into a host-neutral settings store with get/update/inspect/isExplicitlySet/watch
- adds a VS Code-backed config provider that preserves the existing namespace fallback behavior
- routes configUtils.ts through the platform provider so shared config helpers no longer import vscode directly

PRD: prds/prd-electron-app.md §9 item 1

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors config and auth/session plumbing across core services, which can regress token refresh or settings persistence if adapters don’t exactly match prior VS Code behavior. Added unit tests reduce risk but the changes touch authentication and server-side key access flows.
> 
> **Overview**
> Decouples shared settings helpers from VS Code by expanding the platform `ConfigProvider` to support `get`/`update`/`inspect`/`isExplicitlySet`/`watch`, adding a VS Code-backed adapter (`VscodeConfigProvider`), and routing `configUtils` through `platform().config` (including changing callers to use host-neutral `target: 'global'`).
> 
> Refactors Supabase auth/session handling by extracting session schema + storage parsing and callback-token parsing into `SupabaseSession`, introducing a host-neutral `AuthTokenProvider` interface, and updating `SupabaseClient`/`SupabaseAuthProvider` to fetch/refresh tokens via the provider (plus adding test reset hooks).
> 
> Makes `ServerSideKeyService` host-neutral by replacing VS Code `EventEmitter`/`Memento` with a small Node-based emitter + `StateStore` injection for persistence, updating initialization wiring, and adding unit tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f630a2679171e999df247b8c520bfdbb0ef3814a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->