### PR TITLE
[codex] Guard VS Code-free imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -179,6 +179,14 @@ const localRules = {
               });
             }
           },
+          ImportExpression(node) {
+            if (node.source?.value === 'vscode') {
+              context.report({
+                node: node.source,
+                messageId: 'forbiddenVscodeImport',
+              });
+            }
+          },
         };
       },
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,28 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'src/extension.ts'),
 ]);
 
+const VSCODE_FREE_ZONE_DIRS = [
+  'src/agent',
+  'src/model',
+  'src/latex',
+  'src/tools',
+  'src/shared',
+  'src/replacement',
+  'src/eventBus',
+  'src/webview/frontend',
+  'src/progressView/frontend',
+  'src/settingsView/frontend',
+].map((dir) => path.join(__dirname, dir));
+
+function isUnderDir(filename, dir) {
+  const relativePath = path.relative(dir, filename);
+  return (
+    relativePath !== '' &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
 const localRules = {
   rules: {
     'no-platform-init-outside-composition-root': {
@@ -98,6 +120,64 @@ const localRules = {
               node,
               messageId: 'forbidden',
             });
+          },
+        };
+      },
+    },
+    'no-vscode-import-in-free-zones': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Disallow direct VS Code imports in platform-independent source zones.',
+        },
+        messages: {
+          forbiddenVscodeImport:
+            'VS Code-free zones must not import "vscode"; route host access through platform or host adapters.',
+        },
+        schema: [],
+      },
+      create(context) {
+        const filename = context.filename;
+        if (!VSCODE_FREE_ZONE_DIRS.some((dir) => isUnderDir(filename, dir))) {
+          return {};
+        }
+
+        function reportIfVscodeSource(node) {
+          if (node.source?.value === 'vscode') {
+            context.report({
+              node: node.source,
+              messageId: 'forbiddenVscodeImport',
+            });
+          }
+        }
+
+        return {
+          ImportDeclaration: reportIfVscodeSource,
+          ExportAllDeclaration: reportIfVscodeSource,
+          ExportNamedDeclaration: reportIfVscodeSource,
+          TSImportEqualsDeclaration(node) {
+            const expression = node.moduleReference?.expression;
+            if (expression?.value === 'vscode') {
+              context.report({
+                node: expression,
+                messageId: 'forbiddenVscodeImport',
+              });
+            }
+          },
+          CallExpression(node) {
+            if (
+              node.callee.type === 'Identifier' &&
+              node.callee.name === 'require' &&
+              node.arguments.length === 1 &&
+              node.arguments[0]?.type === 'Literal' &&
+              node.arguments[0].value === 'vscode'
+            ) {
+              context.report({
+                node: node.arguments[0],
+                messageId: 'forbiddenVscodeImport',
+              });
+            }
           },
         };
       },
@@ -211,6 +291,7 @@ export default tseslint.config(
 
       // Keep useful rules, adjust if needed
       '@typescript-eslint/no-unused-vars': 'off',
+      'local/no-vscode-import-in-free-zones': 'error',
       'prefer-const': 'error',
     },
   },


### PR DESCRIPTION
## Summary
- add a local ESLint guard for direct `vscode` imports in the PRD's platform-independent source zones
- cover static imports, re-exports, TypeScript import-equals, and `require('vscode')`
- confirm the current baseline has no direct `vscode` imports in those zones

## PRD
- Implements `prds/prd-electron-app.md` §9 #11: CI guard for `vscode` imports in VS Code-free zones.

## Validation
- `npm run format`
- `npm run compile:safe`
- `npm run compile`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new lint-enforced boundaries around VS Code imports and refactors several auth and host-integration paths; mistakes could break authentication flows or webview/host interactions across environments.
> 
> **Overview**
> Adds **local ESLint rules** to enforce architectural boundaries: only composition roots may import `initPlatform`, and designated “VS Code-free” directories may not import `vscode` (covering static imports, re-exports, import-equals, `require`, and dynamic import).
> 
> Refactors **auth/session handling** to be more host-neutral: moves Supabase session parsing/token extraction into `SupabaseSession.ts`, introduces `AuthTokenProvider`/`SessionTokens`, shifts session-token retrieval into `SupabaseAuthProvider`, and updates `SupabaseClient` to rely on the provider (including a test reset hook and renamed “host provider registered” flag).
> 
> Decouples more code from VS Code by adding host-neutral interfaces/adapters: `ConfigProvider`/`VscodeConfigProvider` wired into `initPlatform`, a `WorkspaceProvider.watch` implementation for both VS Code and Node (`nodeWorkspace`), a `DiffViewHost` abstraction used by tool edit approval, and a Node-based event emitter/state wiring for `ServerSideKeyService`.
> 
> Updates webviews to use `@shared/hostBridge` and TeXRA-owned CSS variables (`--texra-*`) mapped from VS Code theme vars, plus small callsite adjustments (e.g., config update targets as `'global'`, audio binary lookup via `BinaryResolver`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f96a37609a3fe4f11ea4b408d8a07283f2b2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->