### PR TITLE
[codex] Extract bundled agent directory sync

### DIFF
--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -8,9 +8,13 @@ import { glob } from 'glob';
 // Local imports
 import { GlobalStorageFS } from '@utils/files';
 
-const BUNDLED_AGENT_DIRECTORY_NAMES = ['agents', 'tool_use_agents'] as const;
+export const BUNDLED_AGENT_DIRECTORY_NAMES = [
+  'agents',
+  'tool_use_agents',
+] as const;
 
-type BundledAgentDirectoryName = (typeof BUNDLED_AGENT_DIRECTORY_NAMES)[number];
+export type BundledAgentDirectoryName =
+  (typeof BUNDLED_AGENT_DIRECTORY_NAMES)[number];
 
 const LEGACY_AGENT_FILES = [
   'agents/generic.yaml',
@@ -36,7 +40,7 @@ export interface AgentDirectoryStorage {
 
 export interface AgentDirectoryVersionStore {
   get(): string | undefined;
-  update(version: string | undefined): Promise<void>;
+  update(version: string | undefined): PromiseLike<void>;
 }
 
 export interface AgentDirectorySyncLogger {

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -1,0 +1,160 @@
+// Standard library imports
+import * as path from 'path';
+
+// Third-party imports
+import fsExtra from 'fs-extra';
+import { glob } from 'glob';
+
+// Local imports
+import { GlobalStorageFS } from '@utils/files';
+
+const BUNDLED_AGENT_DIRECTORY_NAMES = ['agents', 'tool_use_agents'] as const;
+
+type BundledAgentDirectoryName = (typeof BUNDLED_AGENT_DIRECTORY_NAMES)[number];
+
+const LEGACY_AGENT_FILES = [
+  'agents/generic.yaml',
+  'agents/generic_multiple.yaml',
+  'agents/write/paper2cover.yaml',
+  'agents/write/write_slide.yaml',
+];
+
+export interface AgentDirectoryBundleSource {
+  listYamlFiles(directoryName: BundledAgentDirectoryName): Promise<string[]>;
+  copyDirectory(
+    directoryName: BundledAgentDirectoryName,
+    destinationPath: string,
+  ): Promise<void>;
+}
+
+export interface AgentDirectoryStorage {
+  ensureDir(relativePath: string): Promise<void>;
+  exists(relativePath: string): Promise<boolean>;
+  delete(relativePath: string): Promise<void>;
+  fullPath(relativePath: string): string;
+}
+
+export interface AgentDirectoryVersionStore {
+  get(): string | undefined;
+  update(version: string | undefined): Promise<void>;
+}
+
+export interface AgentDirectorySyncLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+export interface BundledAgentDirectorySyncOptions {
+  bundleSource: AgentDirectoryBundleSource;
+  storage: AgentDirectoryStorage;
+  versionStore: AgentDirectoryVersionStore;
+  logger: AgentDirectorySyncLogger;
+}
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export class PathAgentDirectoryBundleSource implements AgentDirectoryBundleSource {
+  constructor(private readonly resourcesBasePath: string) {}
+
+  listYamlFiles(directoryName: BundledAgentDirectoryName): Promise<string[]> {
+    return glob('**/*.yaml', {
+      cwd: path.join(this.resourcesBasePath, directoryName),
+      nodir: true,
+    });
+  }
+
+  async copyDirectory(
+    directoryName: BundledAgentDirectoryName,
+    destinationPath: string,
+  ): Promise<void> {
+    await fsExtra.copy(
+      path.join(this.resourcesBasePath, directoryName),
+      destinationPath,
+      { overwrite: true },
+    );
+  }
+}
+
+export class GlobalStorageAgentDirectoryStorage implements AgentDirectoryStorage {
+  ensureDir(relativePath: string): Promise<void> {
+    return GlobalStorageFS.ensureDir(relativePath);
+  }
+
+  exists(relativePath: string): Promise<boolean> {
+    return GlobalStorageFS.exists(relativePath);
+  }
+
+  delete(relativePath: string): Promise<void> {
+    return GlobalStorageFS.delete(relativePath);
+  }
+
+  fullPath(relativePath: string): string {
+    return GlobalStorageFS.fullPath(relativePath);
+  }
+}
+
+export class BundledAgentDirectorySync {
+  constructor(private readonly options: BundledAgentDirectorySyncOptions) {}
+
+  async reconcile(currentVersion: string | undefined): Promise<boolean> {
+    await this.deleteLegacyAgentFiles();
+
+    const lastKnownVersion = this.options.versionStore.get();
+    if (
+      currentVersion === lastKnownVersion &&
+      !(await this.hasMissingBundledAgentFiles())
+    ) {
+      return false;
+    }
+
+    for (const directoryName of BUNDLED_AGENT_DIRECTORY_NAMES) {
+      await this.options.storage.ensureDir(directoryName);
+      await this.options.bundleSource.copyDirectory(
+        directoryName,
+        this.options.storage.fullPath(directoryName),
+      );
+    }
+
+    await this.options.versionStore.update(currentVersion);
+    return true;
+  }
+
+  private async hasMissingBundledAgentFiles(): Promise<boolean> {
+    for (const directoryName of BUNDLED_AGENT_DIRECTORY_NAMES) {
+      const bundledFiles =
+        await this.options.bundleSource.listYamlFiles(directoryName);
+
+      for (const relativePath of bundledFiles) {
+        const storagePath = path.join(directoryName, relativePath);
+        if (await this.options.storage.exists(storagePath)) {
+          continue;
+        }
+
+        this.options.logger.info(
+          `Bundled agent missing from global storage, re-syncing defaults: ${storagePath}`,
+        );
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async deleteLegacyAgentFiles(): Promise<void> {
+    for (const legacyFile of LEGACY_AGENT_FILES) {
+      if (!(await this.options.storage.exists(legacyFile))) {
+        continue;
+      }
+      try {
+        await this.options.storage.delete(legacyFile);
+        this.options.logger.info(`Deleted legacy agent file: ${legacyFile}`);
+      } catch (error) {
+        this.options.logger.warn(
+          `Failed to delete legacy agent file ${legacyFile}: ${toMessage(error)}`,
+        );
+      }
+    }
+  }
+}

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -1,9 +1,12 @@
 import * as path from 'path';
 
-import fsExtra from 'fs-extra';
-import { glob } from 'glob';
 import * as vscode from 'vscode';
 
+import {
+  BundledAgentDirectorySync,
+  GlobalStorageAgentDirectoryStorage,
+  PathAgentDirectoryBundleSource,
+} from '@agent/index/AgentDirectorySync';
 import { toErrorMessage } from '@common/errors';
 import {
   GlobalStateKey,
@@ -27,7 +30,6 @@ import {
   type LatexConfigField,
 } from '@shared/constants/latex';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
-import { GlobalStorageFS } from '@utils/files';
 import { isConfigExplicitlySet, updateConfig } from '@utils/config';
 import { registerExternalRoot } from '@utils/files/externalRoots';
 import { extendEnvPath } from '@utils/system/platformPaths';
@@ -37,17 +39,6 @@ import { extendEnvPath } from '@utils/system/platformPaths';
  * Increment this when changing which settings are auto-configured.
  */
 const LATEX_CONFIG_VERSION = 2;
-
-/**
- * Legacy agent files that should be deleted from GlobalStorage.
- * These agents have been removed or renamed and should not exist locally.
- */
-const LEGACY_AGENT_FILES = [
-  'agents/generic.yaml',
-  'agents/generic_multiple.yaml',
-  'agents/write/paper2cover.yaml',
-  'agents/write/write_slide.yaml',
-];
 
 /**
  * Seed the disabled-tool list for first-time users only.
@@ -89,92 +80,33 @@ export async function initializeToolDefaults(): Promise<void> {
 export async function copyDefaultAgents(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  await deleteLegacyAgentFiles();
-
   const currentVersion = vscode.extensions.getExtension(context.extension.id)
     ?.packageJSON.version;
-  const lastKnownVersion = globalSM.get<string>(
-    GlobalStateKey.LAST_KNOWN_VERSION,
-  );
-
-  if (
-    currentVersion === lastKnownVersion &&
-    !(await hasMissingBundledAgentFiles(context))
-  ) {
-    return;
-  }
+  const sync = new BundledAgentDirectorySync({
+    bundleSource: new PathAgentDirectoryBundleSource(
+      path.join(context.extensionPath, 'resources'),
+    ),
+    storage: new GlobalStorageAgentDirectoryStorage(),
+    versionStore: {
+      get: () => globalSM.get<string>(GlobalStateKey.LAST_KNOWN_VERSION),
+      update: (version) =>
+        Promise.resolve(
+          globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
+        ),
+    },
+    logger: {
+      info: (message) => logger.info('extension', message),
+      warn: (message) => logger.warn('extension', message),
+    },
+  });
 
   try {
-    await GlobalStorageFS.ensureDir('agents');
-    await GlobalStorageFS.ensureDir('tool_use_agents');
-
-    const resourcesBase = path.join(context.extensionPath, 'resources');
-    await fsExtra.copy(
-      path.join(resourcesBase, 'agents'),
-      GlobalStorageFS.fullPath('agents'),
-      { overwrite: true },
-    );
-    await fsExtra.copy(
-      path.join(resourcesBase, 'tool_use_agents'),
-      GlobalStorageFS.fullPath('tool_use_agents'),
-      { overwrite: true },
-    );
-
-    await globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, currentVersion);
+    await sync.reconcile(currentVersion);
   } catch (err) {
     logger.error(
       'extension',
       `Error copying default agents: ${toErrorMessage(err)}`,
     );
-  }
-}
-
-async function hasMissingBundledAgentFiles(
-  context: vscode.ExtensionContext,
-): Promise<boolean> {
-  const resourcesBase = path.join(context.extensionPath, 'resources');
-  const bundledRoots = ['agents', 'tool_use_agents'] as const;
-
-  for (const root of bundledRoots) {
-    const bundledFiles = await glob('**/*.yaml', {
-      cwd: path.join(resourcesBase, root),
-      nodir: true,
-    });
-
-    for (const relativePath of bundledFiles) {
-      const storagePath = path.join(root, relativePath);
-      if (await GlobalStorageFS.exists(storagePath)) {
-        continue;
-      }
-
-      logger.info(
-        'extension',
-        `Bundled agent missing from global storage, re-syncing defaults: ${storagePath}`,
-      );
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/**
- * Deletes legacy agent files that have moved to remote-only
- */
-async function deleteLegacyAgentFiles(): Promise<void> {
-  for (const legacyFile of LEGACY_AGENT_FILES) {
-    if (!(await GlobalStorageFS.exists(legacyFile))) {
-      continue;
-    }
-    try {
-      await GlobalStorageFS.delete(legacyFile);
-      logger.info('extension', `Deleted legacy agent file: ${legacyFile}`);
-    } catch (err) {
-      logger.warn(
-        'extension',
-        `Failed to delete legacy agent file ${legacyFile}: ${toErrorMessage(err)}`,
-      );
-    }
   }
 }
 

--- a/src/frontend/setup.ts
+++ b/src/frontend/setup.ts
@@ -90,9 +90,7 @@ export async function copyDefaultAgents(
     versionStore: {
       get: () => globalSM.get<string>(GlobalStateKey.LAST_KNOWN_VERSION),
       update: (version) =>
-        Promise.resolve(
-          globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
-        ),
+        globalSM.update(GlobalStateKey.LAST_KNOWN_VERSION, version),
     },
     logger: {
       info: (message) => logger.info('extension', message),


### PR DESCRIPTION
## Summary
- move bundled agent copy/version/missing-file reconciliation into a host-neutral `BundledAgentDirectorySync`
- add injectable bundle-source, storage, version-store, and logger adapters for future Electron wiring
- keep the VS Code activation path behavior-preserving by wiring extension resources and global storage into the new sync class

## PRD
- Advances `prds/prd-electron-app.md` §9 #19 by extracting the bundled-agent resource bootstrap policy away from VS Code setup code.

## Validation
- `npm run format`
- `npm run compile:safe`
- `npm run compile`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session handling and host integration boundaries (config, workspace watching, server-side key events), which could impact login/token refresh and settings persistence if wiring is wrong. Most changes are refactors/extractions but span many files and webviews, increasing integration risk.
> 
> **Overview**
> Refactors several VS Code-coupled services into **host-neutral adapters** to support non-VS Code hosts: bundled agent seeding is extracted into `BundledAgentDirectorySync` with injectable bundle/storage/version/logging, VS Code config access is wrapped by `VscodeConfigProvider`, and workspace providers gain a `watch()` API (implemented in both VS Code and Node).
> 
> Auth code is reorganized to reduce coupling: Supabase session parsing/callback token extraction moves into `SupabaseSession`, `SupabaseAuthProvider` now implements a shared `AuthTokenProvider` (`getSessionTokens`), and `SupabaseClient` delegates token retrieval while renaming provider-registration state and adding `resetForTests()`.
> 
> UI/host decoupling continues in webviews and tools: tool edit approval diff handling is abstracted behind `DiffViewHost` with a VS Code implementation, settings webview message handling is dispatched via a new `settingsViewDispatcher`, and progress/settings webviews switch from `@shared/vscode` to `@shared/hostBridge` while CSS is updated to use `--texra-*` theme variables mapped from VS Code tokens.
> 
> Adds ESLint local rules to enforce architecture boundaries: restrict `initPlatform` imports to composition roots and forbid direct `vscode` imports in designated platform-independent directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fe001f8e79de633b0133af8949ad3db40e6f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->