### PR TITLE
[codex] Inject progress sink into coordinators

### DIFF
--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -16,6 +16,7 @@ import {
   BasePromiseCoordinator,
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
+import type { ProgressSink } from './ProgressSink';
 
 // ============================================================================
 // Types
@@ -46,7 +47,7 @@ interface ProposalShowPayload extends Record<string, unknown> {
 // ============================================================================
 
 /** Manages pending agent proposals (workflow and tool-use). */
-class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
+export class AgentProposalCoordinator extends BasePromiseCoordinator<
   ProposalResult,
   ProposalShowPayload
 > {
@@ -85,5 +86,11 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
 // Singleton Export
 // ============================================================================
 
+export function createAgentProposalCoordinator(
+  progressSink: ProgressSink,
+): AgentProposalCoordinator {
+  return new AgentProposalCoordinator(progressSink);
+}
+
 /** Singleton coordinator instance. */
-export const proposalCoordinator = new AgentProposalCoordinatorImpl();
+export const proposalCoordinator = new AgentProposalCoordinator();

--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -11,8 +11,6 @@
  * 3. On resolution → emits 'resolveAgentProposal' to dismiss UI
  */
 
-// Local imports
-import { bus } from '@eventBus/ProgressEventBus';
 import type { AgentProposal } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -70,10 +68,10 @@ class AgentProposalCoordinatorImpl extends BasePromiseCoordinator<
     const { proposalId, proposal, timeoutMs } = options;
 
     // Request host to show progress view so user sees the proposal
-    bus.emit('requestEnsureProgressView', {});
+    this.progressSink.emit('requestEnsureProgressView', {});
 
     // Activate the stream that needs approval so user sees the prompt immediately
-    bus.emit('setActiveStream', { streamId });
+    this.progressSink.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
       proposalId,

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -18,7 +18,11 @@
  */
 
 // Local imports
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import {
+  defaultProgressSink,
+  type ProgressSink,
+} from '@agent/runtime/ProgressSink';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // ============================================================================
 // Types
@@ -61,6 +65,10 @@ export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
+  constructor(
+    protected readonly progressSink: ProgressSink = defaultProgressSink,
+  ) {}
+
   /** Single source of truth for all pending requests */
   protected readonly requests = new Map<string, RequestState<TResult>>();
 
@@ -112,7 +120,7 @@ export abstract class BasePromiseCoordinator<
       });
 
       // Emit show event (cast needed for generic base class)
-      bus.emit(this.config.showEventName, payload as any);
+      this.progressSink.emit(this.config.showEventName, payload as any);
     });
   }
 
@@ -177,7 +185,7 @@ export abstract class BasePromiseCoordinator<
     this.requests.set(id, { status: 'resolved' });
 
     // Emit resolve event (cast needed for generic base class)
-    bus.emit(this.config.resolveEventName, {
+    this.progressSink.emit(this.config.resolveEventName, {
       [this.config.idFieldName]: id,
     } as any);
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -12,6 +12,7 @@ import {
   BasePromiseCoordinator,
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
+import type { ProgressSink } from './ProgressSink';
 
 // ============================================================================
 // Types
@@ -42,7 +43,7 @@ interface PlanApprovalShowPayload extends Record<string, unknown> {
 // ============================================================================
 
 /** Manages pending plan approval requests. */
-class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
+export class PlanApprovalCoordinator extends BasePromiseCoordinator<
   PlanApprovalResult,
   PlanApprovalShowPayload
 > {
@@ -124,5 +125,11 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
 // Singleton Export
 // ============================================================================
 
+export function createPlanApprovalCoordinator(
+  progressSink: ProgressSink,
+): PlanApprovalCoordinator {
+  return new PlanApprovalCoordinator(progressSink);
+}
+
 /** Singleton coordinator instance. */
-export const planApprovalCoordinator = new PlanApprovalCoordinatorImpl();
+export const planApprovalCoordinator = new PlanApprovalCoordinator();

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -7,8 +7,6 @@
  * 3. On resolution → emits 'resolvePlanApproval' to dismiss UI
  */
 
-// Local imports
-import { bus } from '@eventBus/ProgressEventBus';
 import type { Plan } from '@shared/schemas';
 import {
   BasePromiseCoordinator,
@@ -74,10 +72,10 @@ class PlanApprovalCoordinatorImpl extends BasePromiseCoordinator<
     this.approvalStreamMap.set(approvalId, streamId);
 
     // Request host to show progress view so user sees the approval prompt
-    bus.emit('requestEnsureProgressView', {});
+    this.progressSink.emit('requestEnsureProgressView', {});
 
     // Activate the stream that needs approval so user sees the prompt immediately
-    bus.emit('setActiveStream', { streamId });
+    this.progressSink.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
       approvalId,

--- a/src/agent/runtime/ProgressSink.ts
+++ b/src/agent/runtime/ProgressSink.ts
@@ -1,0 +1,21 @@
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export interface ProgressSink {
+  emit<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void;
+}
+
+export class EventBusProgressSink implements ProgressSink {
+  constructor(private readonly eventBus: ProgressSink) {}
+
+  emit<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    this.eventBus.emit(event, payload);
+  }
+}
+
+export const defaultProgressSink: ProgressSink = new EventBusProgressSink(bus);

--- a/src/agent/runtime/ProgressSink.ts
+++ b/src/agent/runtime/ProgressSink.ts
@@ -7,15 +7,4 @@ export interface ProgressSink {
   ): void;
 }
 
-export class EventBusProgressSink implements ProgressSink {
-  constructor(private readonly eventBus: ProgressSink) {}
-
-  emit<K extends keyof ProgressEventPayloads>(
-    event: K,
-    payload: ProgressEventPayloads[K],
-  ): void {
-    this.eventBus.emit(event, payload);
-  }
-}
-
-export const defaultProgressSink: ProgressSink = new EventBusProgressSink(bus);
+export const defaultProgressSink: ProgressSink = bus;


### PR DESCRIPTION
## Summary
- add a typed ProgressSink port backed by the existing ProgressEventBus
- route promise-based plan/proposal coordinator progress events through the sink
- preserve current default behavior while making these runtime coordinators host-injectable

## PRD
- Part of prds/prd-electron-app.md §9 #20 AgentRuntimeHost / ProgressSink boundary

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session storage flows and refactors event/config abstractions to be host-injectable; mistakes could break login, token refresh, or runtime UI event wiring. Also introduces new ESLint enforcement that may block builds if edge cases in path detection/import patterns are missed.
> 
> **Overview**
> Refactors several extension subsystems to be more *host-neutral* by introducing explicit ports/adapters: a typed `ProgressSink` injected into promise-based runtime coordinators, a `ConfigProvider` interface with a VS Code-backed `VscodeConfigProvider`, and a generalized `WorkspaceProvider.watch` implementation (with a Node fallback watcher).
> 
> Hardens architecture boundaries with new ESLint rules that (1) restrict `initPlatform` imports to composition roots and (2) forbid direct `vscode` imports in designated platform-independent directories.
> 
> Reworks a few concrete features to use these adapters: bundled agent seeding is extracted into `BundledAgentDirectorySync`, tool-edit diff approval is routed through a new `DiffViewHost`/`VscodeDiffViewHost`, Supabase session parsing/token extraction moves into `SupabaseSession` with `AuthTokenProvider.getSessionTokens`, and webviews/styles migrate from `@shared/vscode`/VS Code CSS vars to `hostBridge` and `--texra-*` theme tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951146ac6ae67e3d1f3182ee136ee5df976e8c97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->