### PR TITLE
[codex] Add fake platform test harness

### DIFF
--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -42,6 +42,16 @@ describe('FakePlatform', () => {
     );
   });
 
+  it('can model a missing workspace root', () => {
+    const platform = createFakePlatform({ workspacePath: undefined });
+
+    assert.equal(platform.workspace.getWorkspacePath(), undefined);
+    assert.equal(
+      platform.workspace.asRelativePath('/outside/main.tex'),
+      '/outside/main.tex',
+    );
+  });
+
   it('records log entries and supports custom overrides', () => {
     const log = new RecordingLogBackend();
     const fs = new FakeFileSystemProvider();

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -256,21 +256,17 @@ describe('FakePlatform', () => {
     assert.equal(fs.exists('/workspace/missing'), false);
   });
 
-  it('rejects directory copy when destination parent is missing', async () => {
+  it('creates missing destination parents when copying directories', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/a.txt': 'A',
     });
 
-    await assert.rejects(
-      () =>
-        fs.copy('/workspace/source', '/workspace/missing/dest', {
-          overwrite: true,
-        }),
-      /Parent directory not found/,
-    );
+    await fs.copy('/workspace/source', '/workspace/missing/dest', {
+      overwrite: true,
+    });
 
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
-    assert.equal(fs.exists('/workspace/missing'), false);
+    assert.equal(fs.getText('/workspace/missing/dest/a.txt'), 'A');
   });
 
   it('rejects directory copy onto itself with overwrite', async () => {

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -170,6 +170,27 @@ describe('FakePlatform', () => {
     assert.equal(stat.type, FileType.Directory);
   });
 
+  it('preserves file timestamps when renaming files', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/docs/a.txt': 'A',
+    });
+    const records = (
+      fs as unknown as {
+        records: Map<string, { type: number; ctime: number; mtime: number }>;
+      }
+    ).records;
+    const sourceRecord = records.get('/workspace/docs/a.txt');
+    assert.ok(sourceRecord);
+    sourceRecord.ctime = 1;
+    sourceRecord.mtime = 2;
+
+    await fs.rename('/workspace/docs/a.txt', '/workspace/docs/b.txt');
+
+    const renamed = await fs.stat('/workspace/docs/b.txt');
+    assert.equal(renamed.ctime, 1);
+    assert.equal(renamed.mtime, 2);
+  });
+
   it('matches real writeFile parent directory semantics', async () => {
     const fs = new FakeFileSystemProvider();
 

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -98,20 +98,21 @@ describe('FakePlatform', () => {
     assert.equal(changes, 1);
   });
 
-  it('updates existing config aliases without duplicating keys', async () => {
+  it('writes config aliases to the exact caller key', async () => {
     const platform = createFakePlatform();
 
     await platform.config.update('texra.files.exclude', ['dist']);
     await platform.config.update('files.exclude', ['node_modules']);
 
-    assert.deepEqual(platform.config.get('texra.files.exclude', []), [
+    assert.deepEqual(platform.config.get('files.exclude', []), [
       'node_modules',
     ]);
+    assert.deepEqual(platform.config.get('texra.files.exclude', []), ['dist']);
 
     await platform.config.update('files.exclude', undefined);
 
-    assert.deepEqual(platform.config.get('files.exclude', []), []);
-    assert.equal(platform.config.isExplicitlySet('texra.files.exclude'), false);
+    assert.deepEqual(platform.config.get('files.exclude', []), ['dist']);
+    assert.equal(platform.config.isExplicitlySet('texra.files.exclude'), true);
   });
 
   it('does not notify texra watchers for unprefixed config changes', async () => {
@@ -277,6 +278,31 @@ describe('FakePlatform', () => {
 
     assert.equal(fs.getText('/workspace/dest/a.txt'), 'A');
     assert.equal(fs.getText('/workspace/dest/existing.txt'), 'existing');
+  });
+
+  it('assigns fresh timestamps when copying directory children', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+      '/workspace/source/nested/b.txt': 'B',
+    });
+    const records = (
+      fs as unknown as {
+        records: Map<string, { type: number; ctime: number; mtime: number }>;
+      }
+    ).records;
+    for (const record of records.values()) {
+      record.ctime = 1;
+      record.mtime = 1;
+    }
+
+    await fs.copy('/workspace/source', '/workspace/dest');
+
+    assert.equal((await fs.stat('/workspace/dest/a.txt')).mtime > 1, true);
+    assert.equal((await fs.stat('/workspace/dest/nested')).mtime > 1, true);
+    assert.equal(
+      (await fs.stat('/workspace/dest/nested/b.txt')).mtime > 1,
+      true,
+    );
   });
 
   it('rejects directory copy when a destination file already exists', async () => {

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -98,6 +98,36 @@ describe('FakePlatform', () => {
     assert.equal(changes, 1);
   });
 
+  it('updates existing config aliases without duplicating keys', async () => {
+    const platform = createFakePlatform();
+
+    await platform.config.update('texra.files.exclude', ['dist']);
+    await platform.config.update('files.exclude', ['node_modules']);
+
+    assert.deepEqual(platform.config.get('texra.files.exclude', []), [
+      'node_modules',
+    ]);
+
+    await platform.config.update('files.exclude', undefined);
+
+    assert.deepEqual(platform.config.get('files.exclude', []), []);
+    assert.equal(platform.config.isExplicitlySet('texra.files.exclude'), false);
+  });
+
+  it('does not notify texra watchers for unprefixed config changes', async () => {
+    const platform = createFakePlatform();
+    let changes = 0;
+
+    platform.config.watch('texra.files', () => {
+      changes += 1;
+    });
+
+    await platform.config.update('files.exclude', ['node_modules']);
+    await platform.config.update('texra.files.include', ['src']);
+
+    assert.equal(changes, 1);
+  });
+
   it('records log entries and supports custom overrides', () => {
     const log = new RecordingLogBackend();
     const fs = new FakeFileSystemProvider();

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -217,6 +217,22 @@ describe('FakePlatform', () => {
     assert.equal(fs.getText('/workspace/dest/a.txt'), 'existing');
   });
 
+  it('keeps earlier directory copy writes when a later child fails', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+      '/workspace/source/z.txt': 'Z',
+      '/workspace/dest/z.txt': 'existing',
+    });
+
+    await assert.rejects(
+      () => fs.copy('/workspace/source', '/workspace/dest'),
+      /Target already exists/,
+    );
+
+    assert.equal(fs.getText('/workspace/dest/a.txt'), 'A');
+    assert.equal(fs.getText('/workspace/dest/z.txt'), 'existing');
+  });
+
   it('rejects file copy onto itself with overwrite', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/a.txt': 'A',

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -196,4 +196,40 @@ describe('FakePlatform', () => {
 
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
   });
+
+  it('rejects directory copy when a destination file blocks a source directory', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/item/a.txt': 'A',
+      '/workspace/dest/item': 'existing file',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.copy('/workspace/source', '/workspace/dest', { overwrite: true }),
+      /Path is a file/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/item/a.txt'), 'A');
+    assert.equal(fs.getText('/workspace/dest/item'), 'existing file');
+    assert.equal(fs.exists('/workspace/dest/item/a.txt'), false);
+  });
+
+  it('rejects directory copy when a destination directory blocks a source file', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/item': 'source file',
+      '/workspace/dest/item/existing.txt': 'existing nested file',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.copy('/workspace/source', '/workspace/dest', { overwrite: true }),
+      /Path is a directory/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/item'), 'source file');
+    assert.equal(
+      fs.getText('/workspace/dest/item/existing.txt'),
+      'existing nested file',
+    );
+  });
 });

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -207,6 +207,15 @@ describe('FakePlatform', () => {
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
   });
 
+  it('rejects same-path rename when the source is missing', async () => {
+    const fs = new FakeFileSystemProvider();
+
+    await assert.rejects(
+      () => fs.rename('/workspace/missing.txt', '/workspace/missing.txt'),
+      /File not found/,
+    );
+  });
+
   it('rejects directory copy when a destination file blocks a source directory', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/item/a.txt': 'A',

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -191,6 +191,32 @@ describe('FakePlatform', () => {
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
   });
 
+  it('copies directories into existing destination directories', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+      '/workspace/dest/existing.txt': 'existing',
+    });
+
+    await fs.copy('/workspace/source', '/workspace/dest');
+
+    assert.equal(fs.getText('/workspace/dest/a.txt'), 'A');
+    assert.equal(fs.getText('/workspace/dest/existing.txt'), 'existing');
+  });
+
+  it('rejects directory copy when a destination file already exists', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+      '/workspace/dest/a.txt': 'existing',
+    });
+
+    await assert.rejects(
+      () => fs.copy('/workspace/source', '/workspace/dest'),
+      /Target already exists/,
+    );
+
+    assert.equal(fs.getText('/workspace/dest/a.txt'), 'existing');
+  });
+
   it('rejects file copy onto itself with overwrite', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/a.txt': 'A',

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -1,0 +1,84 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - platform
+import { FileType } from '@platform/interfaces/filesystem';
+
+// Local imports - test support
+import {
+  FakeFileSystemProvider,
+  RecordingLogBackend,
+  createFakePlatform,
+} from '../support/FakePlatform';
+
+describe('FakePlatform', () => {
+  it('provides overridable platform services for tests', async () => {
+    const platform = createFakePlatform({
+      config: { enabled: true },
+      globalState: { version: 2 },
+      workspaceState: { task: 'active' },
+      files: { '/workspace/src/main.tex': 'hello' },
+      secrets: { token: 'secret-value' },
+    });
+
+    assert.equal(platform.config.get('enabled', false), true);
+    assert.equal(platform.globalState.get('version', 0), 2);
+    assert.equal(platform.workspaceState.get('task', 'idle'), 'active');
+    assert.equal(
+      platform.workspace.asRelativePath('/workspace/src/main.tex'),
+      'src/main.tex',
+    );
+    assert.equal(
+      platform.storage.getStoragePath(),
+      '/workspace/.texra/storage',
+    );
+    assert.equal(await platform.secrets.get('token'), 'secret-value');
+    assert.equal(
+      Buffer.from(
+        await platform.fs.readFile('/workspace/src/main.tex'),
+      ).toString('utf8'),
+      'hello',
+    );
+  });
+
+  it('records log entries and supports custom overrides', () => {
+    const log = new RecordingLogBackend();
+    const fs = new FakeFileSystemProvider();
+    const platform = createFakePlatform({}, { fs, log });
+
+    platform.log.initialize('TeXRA');
+    platform.log.info('TeXRA', 'ready', { data: { count: 1 } });
+
+    assert.equal(platform.fs, fs);
+    assert.deepEqual(log.initializedChannels, [
+      { channel: 'TeXRA', isAgent: undefined },
+    ]);
+    assert.deepEqual(log.entries, [
+      {
+        level: 'info',
+        channel: 'TeXRA',
+        message: 'ready',
+        options: { data: { count: 1 } },
+      },
+    ]);
+  });
+
+  it('implements in-memory filesystem operations', async () => {
+    const fs = new FakeFileSystemProvider();
+
+    await fs.createDirectory('/workspace/docs');
+    await fs.writeFile('/workspace/docs/a.txt', Buffer.from('A'));
+    await fs.copy('/workspace/docs/a.txt', '/workspace/docs/b.txt');
+    await fs.rename('/workspace/docs/b.txt', '/workspace/docs/c.txt');
+
+    assert.equal(fs.exists('/workspace/docs/b.txt'), false);
+    assert.equal(fs.getText('/workspace/docs/c.txt'), 'A');
+    assert.deepEqual(await fs.readDirectory('/workspace/docs'), [
+      ['a.txt', FileType.File],
+      ['c.txt', FileType.File],
+    ]);
+
+    const stat = await fs.stat('/workspace/docs');
+    assert.equal(stat.type, FileType.Directory);
+  });
+});

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -148,6 +148,23 @@ describe('FakePlatform', () => {
     assert.equal(fs.exists('/workspace/missing'), false);
   });
 
+  it('rejects directory copy when destination parent is missing', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.copy('/workspace/source', '/workspace/missing/dest', {
+          overwrite: true,
+        }),
+      /Parent directory not found/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+    assert.equal(fs.exists('/workspace/missing'), false);
+  });
+
   it('rejects directory copy onto itself with overwrite', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/a.txt': 'A',
@@ -159,6 +176,22 @@ describe('FakePlatform', () => {
           overwrite: true,
         }),
       /Cannot copy a directory onto itself/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+  });
+
+  it('rejects file copy onto itself with overwrite', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.copy('/workspace/source/a.txt', '/workspace/source/a.txt', {
+          overwrite: true,
+        }),
+      /Cannot copy a file onto itself/,
     );
 
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -75,6 +75,29 @@ describe('FakePlatform', () => {
     assert.equal(changes, 1);
   });
 
+  it('mirrors texra config aliases and nested watcher matching', async () => {
+    const platform = createFakePlatform();
+    let changes = 0;
+    const subscription = platform.config.watch('files', () => {
+      changes += 1;
+    });
+
+    await platform.config.update('texra.files.exclude', ['node_modules']);
+    subscription.dispose();
+    await platform.config.update('texra.files.include', ['src']);
+
+    assert.deepEqual(platform.config.get('files.exclude', []), [
+      'node_modules',
+    ]);
+    assert.equal(platform.config.isExplicitlySet('files.exclude'), true);
+    assert.deepEqual(platform.config.inspect('files.exclude'), {
+      globalValue: undefined,
+      workspaceValue: ['node_modules'],
+      effectiveValue: ['node_modules'],
+    });
+    assert.equal(changes, 1);
+  });
+
   it('records log entries and supports custom overrides', () => {
     const log = new RecordingLogBackend();
     const fs = new FakeFileSystemProvider();

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -96,4 +96,71 @@ describe('FakePlatform', () => {
 
     assert.equal(fs.getText('/workspace/missing/a.txt'), 'updated');
   });
+
+  it('rejects directory operations into self descendants', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () => fs.copy('/workspace/source', '/workspace/source/nested'),
+      /Cannot copy a directory into itself/,
+    );
+    await assert.rejects(
+      () => fs.rename('/workspace/source', '/workspace/source/nested'),
+      /Cannot rename a directory into itself/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+    assert.equal(fs.exists('/workspace/source/nested'), false);
+  });
+
+  it('rejects directory rename over non-empty targets', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+      '/workspace/dest/existing.txt': 'B',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.rename('/workspace/source', '/workspace/dest', { overwrite: true }),
+      /Directory is not empty/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+    assert.equal(fs.getText('/workspace/dest/existing.txt'), 'B');
+  });
+
+  it('rejects directory rename when destination parent is missing', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.rename('/workspace/source', '/workspace/missing/dest', {
+          overwrite: true,
+        }),
+      /Parent directory not found/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+    assert.equal(fs.exists('/workspace/missing'), false);
+  });
+
+  it('rejects directory copy onto itself with overwrite', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () =>
+        fs.copy('/workspace/source', '/workspace/source', {
+          overwrite: true,
+        }),
+      /Cannot copy a directory onto itself/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+  });
 });

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -52,6 +52,29 @@ describe('FakePlatform', () => {
     );
   });
 
+  it('supports fake config updates and watchers', async () => {
+    const platform = createFakePlatform({
+      config: { enabled: true },
+    });
+    let changes = 0;
+    const subscription = platform.config.watch('enabled', () => {
+      changes += 1;
+    });
+
+    await platform.config.update('enabled', false, 'global');
+    subscription.dispose();
+    await platform.config.update('enabled', true, 'global');
+
+    assert.equal(platform.config.get('enabled', true), true);
+    assert.equal(platform.config.isExplicitlySet('enabled'), true);
+    assert.deepEqual(platform.config.inspect('enabled'), {
+      globalValue: true,
+      workspaceValue: undefined,
+      effectiveValue: true,
+    });
+    assert.equal(changes, 1);
+  });
+
   it('records log entries and supports custom overrides', () => {
     const log = new RecordingLogBackend();
     const fs = new FakeFileSystemProvider();

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -229,6 +229,29 @@ describe('FakePlatform', () => {
     assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
   });
 
+  it('reports implicit readDirectory path prefixes as directories', async () => {
+    const fs = new FakeFileSystemProvider();
+    await fs.createDirectory('/workspace');
+    const records = (
+      fs as unknown as {
+        records: Map<
+          string,
+          { type: number; ctime: number; mtime: number; content?: Uint8Array }
+        >;
+      }
+    ).records;
+    records.set('/workspace/implicit/file.txt', {
+      type: FileType.File,
+      ctime: Date.now(),
+      mtime: Date.now(),
+      content: Buffer.from('A'),
+    });
+
+    assert.deepEqual(await fs.readDirectory('/workspace'), [
+      ['implicit', FileType.Directory],
+    ]);
+  });
+
   it('rejects directory copy when a destination file blocks a source directory', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/item/a.txt': 'A',

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -28,6 +28,7 @@ describe('FakePlatform', () => {
       platform.workspace.asRelativePath('/workspace/src/main.tex'),
       'src/main.tex',
     );
+    assert.equal(platform.workspace.asRelativePath('/workspace'), '');
     assert.equal(
       platform.storage.getStoragePath(),
       '/workspace/.texra/storage',
@@ -80,5 +81,19 @@ describe('FakePlatform', () => {
 
     const stat = await fs.stat('/workspace/docs');
     assert.equal(stat.type, FileType.Directory);
+  });
+
+  it('matches real writeFile parent directory semantics', async () => {
+    const fs = new FakeFileSystemProvider();
+
+    await assert.rejects(
+      () => fs.writeFile('/workspace/missing/a.txt', Buffer.from('A')),
+      /Parent directory not found/,
+    );
+
+    fs.setFile('/workspace/missing/a.txt', 'seed');
+    await fs.writeFile('/workspace/missing/a.txt', Buffer.from('updated'));
+
+    assert.equal(fs.getText('/workspace/missing/a.txt'), 'updated');
   });
 });

--- a/src/test/platform/FakePlatform.test.ts
+++ b/src/test/platform/FakePlatform.test.ts
@@ -216,6 +216,19 @@ describe('FakePlatform', () => {
     );
   });
 
+  it('rejects deleting the filesystem root', async () => {
+    const fs = new FakeFileSystemProvider({
+      '/workspace/source/a.txt': 'A',
+    });
+
+    await assert.rejects(
+      () => fs.delete('/', { recursive: true }),
+      /Cannot delete filesystem root/,
+    );
+
+    assert.equal(fs.getText('/workspace/source/a.txt'), 'A');
+  });
+
   it('rejects directory copy when a destination file blocks a source directory', async () => {
     const fs = new FakeFileSystemProvider({
       '/workspace/source/item/a.txt': 'A',

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -271,6 +271,14 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     const normalizedSource = normalizePath(source);
     const normalizedDest = normalizePath(dest);
     const sourceRecord = this.requireRecord(normalizedSource);
+    if (normalizedSource === normalizedDest) {
+      throw fakeFsError(
+        'EINVAL',
+        sourceRecord.type === FileType.Directory
+          ? `Cannot copy a directory onto itself: ${source} -> ${dest}`
+          : `Cannot copy a file onto itself: ${source} -> ${dest}`,
+      );
+    }
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {
@@ -281,12 +289,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     }
 
     this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
-    if (normalizedSource === normalizedDest) {
-      throw fakeFsError(
-        'EINVAL',
-        `Cannot copy a directory onto itself: ${source} -> ${dest}`,
-      );
-    }
+    this.assertParentDirectoryExists(normalizedDest);
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
       const relative = path.posix.relative(normalizedSource, child);

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -127,10 +127,11 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 
   get<T>(key: string, defaultValue?: T): T {
-    if (!this.values.has(key)) {
+    const resolvedKey = this.resolveExistingKey(key);
+    if (resolvedKey === undefined) {
       return defaultValue as T;
     }
-    return this.values.get(key) as T;
+    return this.values.get(resolvedKey) as T;
   }
 
   set(key: string, value: unknown): void {
@@ -155,11 +156,12 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
-    if (!this.values.has(key)) {
+    const resolvedKey = this.resolveExistingKey(key);
+    if (resolvedKey === undefined) {
       return undefined;
     }
-    const value = this.values.get(key) as T;
-    const target = this.targets.get(key) ?? 'workspace';
+    const value = this.values.get(resolvedKey) as T;
+    const target = this.targets.get(resolvedKey) ?? 'workspace';
     return {
       globalValue: target === 'global' ? value : undefined,
       workspaceValue: target === 'workspace' ? value : undefined,
@@ -168,7 +170,7 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 
   isExplicitlySet(key: string): boolean {
-    return this.values.has(key);
+    return this.resolveExistingKey(key) !== undefined;
   }
 
   watch(
@@ -197,12 +199,39 @@ export class FakeConfigProvider implements ConfigProvider {
     changedKey: string,
   ): boolean {
     if (watchedKey instanceof RegExp) {
-      return watchedKey.test(changedKey);
+      return true;
     }
     if (typeof watchedKey === 'string') {
-      return watchedKey === changedKey;
+      return this.affectsConfiguration(watchedKey, changedKey);
     }
-    return watchedKey.includes(changedKey);
+    return watchedKey.some((key) => this.affectsConfiguration(key, changedKey));
+  }
+
+  private resolveExistingKey(key: string): string | undefined {
+    return this.configKeys(key).find((candidate) => this.values.has(candidate));
+  }
+
+  private configKeys(key: string): string[] {
+    return key.startsWith('texra.') ? [key] : [key, `texra.${key}`];
+  }
+
+  private affectsConfiguration(
+    watchedKey: string,
+    changedKey: string,
+  ): boolean {
+    return this.configKeys(watchedKey).some((watchedCandidate) =>
+      this.configKeys(changedKey).some((changedCandidate) =>
+        this.isSameOrNestedKey(watchedCandidate, changedCandidate),
+      ),
+    );
+  }
+
+  private isSameOrNestedKey(first: string, second: string): boolean {
+    return (
+      first === second ||
+      first.startsWith(`${second}.`) ||
+      second.startsWith(`${first}.`)
+    );
   }
 }
 

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -280,6 +280,13 @@ export class FakeFileSystemProvider implements FileSystemProvider {
       return;
     }
 
+    this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
+    if (normalizedSource === normalizedDest) {
+      throw fakeFsError(
+        'EINVAL',
+        `Cannot copy a directory onto itself: ${source} -> ${dest}`,
+      );
+    }
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
       const relative = path.posix.relative(normalizedSource, child);
@@ -295,6 +302,10 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   ): Promise<void> {
     const normalizedSource = normalizePath(source);
     const normalizedDest = normalizePath(dest);
+    if (normalizedSource === normalizedDest) {
+      return;
+    }
+
     const sourceRecord = this.requireRecord(normalizedSource);
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
@@ -306,6 +317,9 @@ export class FakeFileSystemProvider implements FileSystemProvider {
       return;
     }
 
+    this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'rename');
+    this.assertDirectoryRenameTarget(normalizedDest);
+    this.assertParentDirectoryExists(normalizedDest);
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
       const relative = path.posix.relative(normalizedSource, child);
@@ -428,6 +442,43 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   private assertWritableTarget(target: string, overwrite?: boolean): void {
     if (!overwrite && this.records.has(target)) {
       throw fakeFsError('EEXIST', `Target already exists: ${target}`);
+    }
+  }
+
+  private assertNotSelfDescendant(
+    source: string,
+    dest: string,
+    operation: string,
+  ): void {
+    if (hasChildPath(source, dest)) {
+      throw fakeFsError(
+        'EINVAL',
+        `Cannot ${operation} a directory into itself: ${source} -> ${dest}`,
+      );
+    }
+  }
+
+  private assertDirectoryRenameTarget(dest: string): void {
+    const destRecord = this.records.get(dest);
+    if (destRecord?.type === FileType.File) {
+      throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
+    }
+    if (
+      destRecord?.type === FileType.Directory &&
+      this.childPaths(dest).length > 0
+    ) {
+      throw fakeFsError('ENOTEMPTY', `Directory is not empty: ${dest}`);
+    }
+  }
+
+  private assertParentDirectoryExists(target: string): void {
+    const parent = parentPath(target);
+    const parentRecord = this.records.get(parent);
+    if (!parentRecord) {
+      throw fakeFsError('ENOENT', `Parent directory not found: ${parent}`);
+    }
+    if (parentRecord.type !== FileType.Directory) {
+      throw fakeFsError('ENOTDIR', `Parent path is not a directory: ${parent}`);
     }
   }
 }

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -50,17 +50,19 @@ function cloneBytes(content: Uint8Array): Uint8Array {
 }
 
 function normalizePath(target: string): string {
-  return path.resolve('/', target);
+  return path.posix.resolve('/', target.replaceAll('\\', '/'));
 }
 
 function parentPath(target: string): string {
-  return path.dirname(normalizePath(target));
+  return path.posix.dirname(normalizePath(target));
 }
 
 function hasChildPath(parent: string, candidate: string): boolean {
-  const relative = path.relative(parent, candidate);
+  const relative = path.posix.relative(parent, candidate);
   return (
-    relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+    relative !== '' &&
+    !relative.startsWith('..') &&
+    !path.posix.isAbsolute(relative)
   );
 }
 
@@ -68,15 +70,15 @@ function directChildName(
   parent: string,
   candidate: string,
 ): string | undefined {
-  const relative = path.relative(parent, candidate);
+  const relative = path.posix.relative(parent, candidate);
   if (
     relative === '' ||
     relative.startsWith('..') ||
-    path.isAbsolute(relative)
+    path.posix.isAbsolute(relative)
   ) {
     return undefined;
   }
-  return relative.split(path.sep).at(0);
+  return relative.split(path.posix.sep).at(0);
 }
 
 function fileSize(record: FakeFileRecord): number {
@@ -190,7 +192,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   constructor(files: Record<string, string | Uint8Array> = {}) {
     this.createDirectorySync('/');
     for (const [target, content] of Object.entries(files)) {
-      this.writeFileSync(target, stringToBytes(content));
+      this.setFile(target, content);
     }
   }
 
@@ -207,7 +209,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   }
 
   async writeFile(target: string, content: Uint8Array): Promise<void> {
-    this.writeFileSync(target, content);
+    this.writeFileSync(target, content, { overwrite: true });
   }
 
   async delete(
@@ -252,7 +254,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     for (const [candidate, candidateRecord] of this.records) {
       const name = directChildName(normalized, candidate);
       if (name == null) continue;
-      const childPath = path.join(normalized, name);
+      const childPath = path.posix.join(normalized, name);
       const childRecord = this.records.get(childPath) ?? candidateRecord;
       entries.set(name, childRecord.type);
     }
@@ -272,14 +274,16 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {
-      this.writeFileSync(normalizedDest, sourceRecord.content);
+      this.writeFileSync(normalizedDest, sourceRecord.content, {
+        overwrite: options?.overwrite,
+      });
       return;
     }
 
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
-      const relative = path.relative(normalizedSource, child);
-      const childDest = path.join(normalizedDest, relative);
+      const relative = path.posix.relative(normalizedSource, child);
+      const childDest = path.posix.join(normalizedDest, relative);
       this.records.set(childDest, cloneRecord(this.requireRecord(child)));
     }
   }
@@ -295,15 +299,17 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {
-      this.writeFileSync(normalizedDest, sourceRecord.content);
+      this.writeFileSync(normalizedDest, sourceRecord.content, {
+        overwrite: options?.overwrite,
+      });
       this.records.delete(normalizedSource);
       return;
     }
 
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
-      const relative = path.relative(normalizedSource, child);
-      const childDest = path.join(normalizedDest, relative);
+      const relative = path.posix.relative(normalizedSource, child);
+      const childDest = path.posix.join(normalizedDest, relative);
       this.records.set(childDest, cloneRecord(this.requireRecord(child)));
     }
     await this.delete(normalizedSource, { recursive: true });
@@ -314,7 +320,10 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   }
 
   setFile(target: string, content: string | Uint8Array): void {
-    this.writeFileSync(target, stringToBytes(content));
+    this.writeFileSync(target, stringToBytes(content), {
+      createParent: true,
+      overwrite: true,
+    });
   }
 
   getText(target: string): string {
@@ -340,13 +349,36 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     return record;
   }
 
-  private writeFileSync(target: string, content: Uint8Array): void {
+  private writeFileSync(
+    target: string,
+    content: Uint8Array,
+    options: { createParent?: boolean; overwrite?: boolean } = {},
+  ): void {
     const normalized = normalizePath(target);
     const existing = this.records.get(normalized);
     if (existing?.type === FileType.Directory) {
       throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
     }
-    this.createDirectorySync(parentPath(normalized));
+    if (existing && !options.overwrite) {
+      throw fakeFsError('EEXIST', `Target already exists: ${target}`);
+    }
+
+    const parent = parentPath(normalized);
+    if (options.createParent) {
+      this.createDirectorySync(parent);
+    } else {
+      const parentRecord = this.records.get(parent);
+      if (!parentRecord) {
+        throw fakeFsError('ENOENT', `Parent directory not found: ${parent}`);
+      }
+      if (parentRecord.type !== FileType.Directory) {
+        throw fakeFsError(
+          'ENOTDIR',
+          `Parent path is not a directory: ${parent}`,
+        );
+      }
+    }
+
     const timestamp = now();
     this.records.set(normalized, {
       type: FileType.File,
@@ -363,11 +395,11 @@ export class FakeFileSystemProvider implements FileSystemProvider {
       throw fakeFsError('ENOTDIR', `Path is a file: ${target}`);
     }
 
-    const parts = normalized.split(path.sep).filter(Boolean);
-    let current: string = path.sep;
+    const parts = normalized.split(path.posix.sep).filter(Boolean);
+    let current: string = path.posix.sep;
     this.ensureDirectoryRecord(current);
     for (const part of parts) {
-      current = path.join(current, part);
+      current = path.posix.join(current, part);
       this.ensureDirectoryRecord(current);
     }
   }
@@ -397,23 +429,6 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     if (!overwrite && this.records.has(target)) {
       throw fakeFsError('EEXIST', `Target already exists: ${target}`);
     }
-    if (overwrite && this.records.has(target)) {
-      this.deleteSync(target);
-    }
-  }
-
-  private deleteSync(target: string): void {
-    const record = this.records.get(target);
-    if (!record) return;
-
-    if (record.type === FileType.Directory) {
-      for (const child of this.childPaths(target)) {
-        this.records.delete(child);
-      }
-    }
-    if (target !== '/') {
-      this.records.delete(target);
-    }
   }
 }
 
@@ -427,15 +442,11 @@ export class FakeWorkspaceProvider implements WorkspaceProvider {
   asRelativePath(filePath: string): string {
     const workspacePath = normalizePath(this.workspacePath);
     const normalized = normalizePath(filePath);
-    const relative = path.relative(workspacePath, normalized);
-    if (
-      relative === '' ||
-      relative.startsWith('..') ||
-      path.isAbsolute(relative)
-    ) {
+    const relative = path.posix.relative(workspacePath, normalized);
+    if (relative.startsWith('..') || path.posix.isAbsolute(relative)) {
       return filePath;
     }
-    return relative;
+    return relative.replaceAll('\\', '/');
   }
 }
 

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -307,11 +307,11 @@ export class FakeFileSystemProvider implements FileSystemProvider {
   ): Promise<void> {
     const normalizedSource = normalizePath(source);
     const normalizedDest = normalizePath(dest);
+    const sourceRecord = this.requireRecord(normalizedSource);
     if (normalizedSource === normalizedDest) {
       return;
     }
 
-    const sourceRecord = this.requireRecord(normalizedSource);
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -450,9 +450,12 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {
-      this.writeFileSync(normalizedDest, sourceRecord.content, {
-        overwrite: options?.overwrite,
-      });
+      const existing = this.records.get(normalizedDest);
+      if (existing?.type === FileType.Directory) {
+        throw fakeFsError('EISDIR', `Path is a directory: ${dest}`);
+      }
+      this.assertParentDirectoryExists(normalizedDest);
+      this.records.set(normalizedDest, cloneRecord(sourceRecord));
       this.records.delete(normalizedSource);
       return;
     }

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -109,6 +109,23 @@ function cloneRecord(record: FakeFileRecord): FakeFileRecord {
   return { ...record };
 }
 
+function copyRecord(record: FakeFileRecord): FakeFileRecord {
+  const timestamp = now();
+  if (record.type === FileType.File) {
+    return {
+      type: FileType.File,
+      ctime: timestamp,
+      mtime: timestamp,
+      content: cloneBytes(record.content),
+    };
+  }
+  return {
+    type: FileType.Directory,
+    ctime: timestamp,
+    mtime: timestamp,
+  };
+}
+
 export class FakeConfigProvider implements ConfigProvider {
   private readonly values = new Map<string, unknown>();
 
@@ -135,9 +152,8 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 
   set(key: string, value: unknown): void {
-    const storageKey = this.storageKeyForWrite(key);
-    this.values.set(storageKey, value);
-    this.targets.set(storageKey, 'workspace');
+    this.values.set(key, value);
+    this.targets.set(key, 'workspace');
     this.notifyWatchers(key);
   }
 
@@ -146,13 +162,12 @@ export class FakeConfigProvider implements ConfigProvider {
     value: T,
     target: ConfigTarget = 'workspace',
   ): Promise<void> {
-    const storageKey = this.storageKeyForWrite(key);
     if (value === undefined) {
-      this.values.delete(storageKey);
-      this.targets.delete(storageKey);
+      this.values.delete(key);
+      this.targets.delete(key);
     } else {
-      this.values.set(storageKey, value);
-      this.targets.set(storageKey, target);
+      this.values.set(key, value);
+      this.targets.set(key, target);
     }
     this.notifyWatchers(key);
   }
@@ -213,10 +228,6 @@ export class FakeConfigProvider implements ConfigProvider {
 
   private resolveExistingKey(key: string): string | undefined {
     return this.configKeys(key).find((candidate) => this.values.has(candidate));
-  }
-
-  private storageKeyForWrite(key: string): string {
-    return this.resolveExistingKey(key) ?? key;
   }
 
   private configKeys(key: string): string[] {
@@ -370,7 +381,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     }
 
     const entries = new Map<string, number>();
-    for (const [candidate, candidateRecord] of this.records) {
+    for (const candidate of this.records.keys()) {
       const name = directChildName(normalized, candidate);
       if (name == null) continue;
       const childPath = path.posix.join(normalized, name);
@@ -420,7 +431,7 @@ export class FakeFileSystemProvider implements FileSystemProvider {
         childRecord,
         options?.overwrite,
       );
-      this.records.set(childDest, cloneRecord(childRecord));
+      this.records.set(childDest, copyRecord(childRecord));
     }
   }
 

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -135,8 +135,9 @@ export class FakeConfigProvider implements ConfigProvider {
   }
 
   set(key: string, value: unknown): void {
-    this.values.set(key, value);
-    this.targets.set(key, 'workspace');
+    const storageKey = this.storageKeyForWrite(key);
+    this.values.set(storageKey, value);
+    this.targets.set(storageKey, 'workspace');
     this.notifyWatchers(key);
   }
 
@@ -145,12 +146,13 @@ export class FakeConfigProvider implements ConfigProvider {
     value: T,
     target: ConfigTarget = 'workspace',
   ): Promise<void> {
+    const storageKey = this.storageKeyForWrite(key);
     if (value === undefined) {
-      this.values.delete(key);
-      this.targets.delete(key);
+      this.values.delete(storageKey);
+      this.targets.delete(storageKey);
     } else {
-      this.values.set(key, value);
-      this.targets.set(key, target);
+      this.values.set(storageKey, value);
+      this.targets.set(storageKey, target);
     }
     this.notifyWatchers(key);
   }
@@ -199,6 +201,8 @@ export class FakeConfigProvider implements ConfigProvider {
     changedKey: string,
   ): boolean {
     if (watchedKey instanceof RegExp) {
+      // Match VscodeConfigProvider: VS Code does not expose changed keys for
+      // regex watchers, so regex subscriptions conservatively refresh.
       return true;
     }
     if (typeof watchedKey === 'string') {
@@ -211,6 +215,10 @@ export class FakeConfigProvider implements ConfigProvider {
     return this.configKeys(key).find((candidate) => this.values.has(candidate));
   }
 
+  private storageKeyForWrite(key: string): string {
+    return this.resolveExistingKey(key) ?? key;
+  }
+
   private configKeys(key: string): string[] {
     return key.startsWith('texra.') ? [key] : [key, `texra.${key}`];
   }
@@ -220,9 +228,7 @@ export class FakeConfigProvider implements ConfigProvider {
     changedKey: string,
   ): boolean {
     return this.configKeys(watchedKey).some((watchedCandidate) =>
-      this.configKeys(changedKey).some((changedCandidate) =>
-        this.isSameOrNestedKey(watchedCandidate, changedCandidate),
-      ),
+      this.isSameOrNestedKey(watchedCandidate, changedKey),
     );
   }
 

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -420,7 +420,6 @@ export class FakeFileSystemProvider implements FileSystemProvider {
 
     this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
     this.assertDirectoryCopyRootTarget(normalizedDest);
-    this.assertParentDirectoryExists(normalizedDest);
     this.createDirectorySync(normalizedDest);
     for (const child of this.childPaths(normalizedSource)) {
       const relative = path.posix.relative(normalizedSource, child);

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -258,8 +258,8 @@ export class FakeFileSystemProvider implements FileSystemProvider {
       const name = directChildName(normalized, candidate);
       if (name == null) continue;
       const childPath = path.posix.join(normalized, name);
-      const childRecord = this.records.get(childPath) ?? candidateRecord;
-      entries.set(name, childRecord.type);
+      const childRecord = this.records.get(childPath);
+      entries.set(name, childRecord?.type ?? FileType.Directory);
     }
     return [...entries.entries()].sort(([left], [right]) =>
       left.localeCompare(right),

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -294,18 +294,17 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
     this.assertDirectoryCopyRootTarget(normalizedDest);
     this.assertParentDirectoryExists(normalizedDest);
-    const children = this.childPaths(normalizedSource);
-    this.assertDirectoryCopyTargets(
-      normalizedSource,
-      normalizedDest,
-      children,
-      options?.overwrite,
-    );
     this.createDirectorySync(normalizedDest);
-    for (const child of children) {
+    for (const child of this.childPaths(normalizedSource)) {
       const relative = path.posix.relative(normalizedSource, child);
       const childDest = path.posix.join(normalizedDest, relative);
-      this.records.set(childDest, cloneRecord(this.requireRecord(child)));
+      const childRecord = this.requireRecord(child);
+      this.assertDirectoryCopyChildTarget(
+        childDest,
+        childRecord,
+        options?.overwrite,
+      );
+      this.records.set(childDest, cloneRecord(childRecord));
     }
   }
 
@@ -492,31 +491,25 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     }
   }
 
-  private assertDirectoryCopyTargets(
-    source: string,
+  private assertDirectoryCopyChildTarget(
     dest: string,
-    children: string[],
+    sourceRecord: FakeFileRecord,
     overwrite?: boolean,
   ): void {
-    for (const child of children) {
-      const relative = path.posix.relative(source, child);
-      const childDest = path.posix.join(dest, relative);
-      const sourceRecord = this.requireRecord(child);
-      const destRecord = this.records.get(childDest);
-      if (!destRecord) {
-        continue;
-      }
-      if (destRecord.type === sourceRecord.type) {
-        if (sourceRecord.type === FileType.File && !overwrite) {
-          throw fakeFsError('EEXIST', `Target already exists: ${childDest}`);
-        }
-        continue;
-      }
-      if (destRecord.type === FileType.Directory) {
-        throw fakeFsError('EISDIR', `Path is a directory: ${childDest}`);
-      }
-      throw fakeFsError('ENOTDIR', `Path is a file: ${childDest}`);
+    const destRecord = this.records.get(dest);
+    if (!destRecord) {
+      return;
     }
+    if (destRecord.type === sourceRecord.type) {
+      if (sourceRecord.type === FileType.File && !overwrite) {
+        throw fakeFsError('EEXIST', `Target already exists: ${dest}`);
+      }
+      return;
+    }
+    if (destRecord.type === FileType.Directory) {
+      throw fakeFsError('EISDIR', `Path is a directory: ${dest}`);
+    }
+    throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
   }
 
   private assertParentDirectoryExists(target: string): void {

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -509,13 +509,16 @@ export class FakeFileSystemProvider implements FileSystemProvider {
 }
 
 export class FakeWorkspaceProvider implements WorkspaceProvider {
-  constructor(private readonly workspacePath = '/workspace') {}
+  constructor(private readonly workspacePath: string | undefined) {}
 
   getWorkspacePath(): string | undefined {
     return this.workspacePath;
   }
 
   asRelativePath(filePath: string): string {
+    if (!this.workspacePath) {
+      return filePath;
+    }
     const workspacePath = normalizePath(this.workspacePath);
     const normalized = normalizePath(filePath);
     const relative = path.posix.relative(workspacePath, normalized);
@@ -569,7 +572,7 @@ export interface FakePlatformOptions {
   workspaceState?: Record<string, unknown>;
   files?: Record<string, string | Uint8Array>;
   secrets?: Record<string, string>;
-  workspacePath?: string;
+  workspacePath?: string | undefined;
   storagePath?: string;
   globalStoragePath?: string;
 }
@@ -578,13 +581,17 @@ export function createFakePlatform(
   options: FakePlatformOptions = {},
   overrides: Partial<Platform> = {},
 ): Platform {
+  const workspacePath = Object.hasOwn(options, 'workspacePath')
+    ? options.workspacePath
+    : '/workspace';
+
   return {
     config: new FakeConfigProvider(options.config),
     globalState: new FakeStateStore(options.globalState),
     workspaceState: new FakeStateStore(options.workspaceState),
     log: new RecordingLogBackend(),
     fs: new FakeFileSystemProvider(options.files),
-    workspace: new FakeWorkspaceProvider(options.workspacePath),
+    workspace: new FakeWorkspaceProvider(workspacePath),
     storage: new FakeStorageProvider(
       options.storagePath,
       options.globalStoragePath,

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -1,0 +1,515 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - platform
+import {
+  FileType,
+  type FileStat,
+  type FileSystemProvider,
+} from '@platform/interfaces/filesystem';
+import type { ConfigProvider } from '@platform/interfaces/config';
+import type { LogBackend, LogUtilsOptions } from '@platform/interfaces/log';
+import type { StateStore } from '@platform/interfaces/state';
+import type { StorageProvider } from '@platform/interfaces/storage';
+import type { WorkspaceProvider } from '@platform/interfaces/workspace';
+import type { Platform } from '@platform/platform';
+import type { PlatformSecrets } from '@platform/secrets';
+
+type FakeFileRecord =
+  | {
+      type: typeof FileType.Directory;
+      ctime: number;
+      mtime: number;
+    }
+  | {
+      type: typeof FileType.File;
+      ctime: number;
+      mtime: number;
+      content: Uint8Array;
+    };
+
+export type RecordingLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface RecordingLogEntry {
+  level: RecordingLogLevel;
+  channel: string;
+  message: string;
+  options?: LogUtilsOptions;
+}
+
+function fakeFsError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function cloneBytes(content: Uint8Array): Uint8Array {
+  return new Uint8Array(content);
+}
+
+function normalizePath(target: string): string {
+  return path.resolve('/', target);
+}
+
+function parentPath(target: string): string {
+  return path.dirname(normalizePath(target));
+}
+
+function hasChildPath(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative)
+  );
+}
+
+function directChildName(
+  parent: string,
+  candidate: string,
+): string | undefined {
+  const relative = path.relative(parent, candidate);
+  if (
+    relative === '' ||
+    relative.startsWith('..') ||
+    path.isAbsolute(relative)
+  ) {
+    return undefined;
+  }
+  return relative.split(path.sep).at(0);
+}
+
+function fileSize(record: FakeFileRecord): number {
+  return record.type === FileType.File ? record.content.byteLength : 0;
+}
+
+function fileStat(record: FakeFileRecord): FileStat {
+  return {
+    type: record.type,
+    ctime: record.ctime,
+    mtime: record.mtime,
+    size: fileSize(record),
+  };
+}
+
+function cloneRecord(record: FakeFileRecord): FakeFileRecord {
+  if (record.type === FileType.File) {
+    return {
+      ...record,
+      content: cloneBytes(record.content),
+    };
+  }
+  return { ...record };
+}
+
+export class FakeConfigProvider implements ConfigProvider {
+  private readonly values = new Map<string, unknown>();
+
+  constructor(values: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(values)) {
+      this.values.set(key, value);
+    }
+  }
+
+  get<T>(key: string, defaultValue?: T): T {
+    if (!this.values.has(key)) {
+      return defaultValue as T;
+    }
+    return this.values.get(key) as T;
+  }
+
+  set(key: string, value: unknown): void {
+    this.values.set(key, value);
+  }
+}
+
+export class FakeStateStore implements StateStore {
+  private readonly values = new Map<string, unknown>();
+
+  constructor(values: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(values)) {
+      this.values.set(key, value);
+    }
+  }
+
+  get<T>(key: string, defaultValue?: T): T {
+    if (!this.values.has(key)) {
+      return defaultValue as T;
+    }
+    return this.values.get(key) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      return;
+    }
+    this.values.set(key, value);
+  }
+}
+
+export class RecordingLogBackend implements LogBackend {
+  readonly initializedChannels: Array<{ channel: string; isAgent?: boolean }> =
+    [];
+
+  readonly entries: RecordingLogEntry[] = [];
+
+  initialize(channel: string, isAgent?: boolean): void {
+    this.initializedChannels.push({ channel, isAgent });
+  }
+
+  debug(channel: string, message: string, options?: LogUtilsOptions): void {
+    this.record('debug', channel, message, options);
+  }
+
+  info(channel: string, message: string, options?: LogUtilsOptions): void {
+    this.record('info', channel, message, options);
+  }
+
+  warn(channel: string, message: string, options?: LogUtilsOptions): void {
+    this.record('warn', channel, message, options);
+  }
+
+  error(channel: string, message: string, options?: LogUtilsOptions): void {
+    this.record('error', channel, message, options);
+  }
+
+  private record(
+    level: RecordingLogLevel,
+    channel: string,
+    message: string,
+    options?: LogUtilsOptions,
+  ): void {
+    this.entries.push({ level, channel, message, options });
+  }
+}
+
+export class FakeFileSystemProvider implements FileSystemProvider {
+  private readonly records = new Map<string, FakeFileRecord>();
+
+  constructor(files: Record<string, string | Uint8Array> = {}) {
+    this.createDirectorySync('/');
+    for (const [target, content] of Object.entries(files)) {
+      this.writeFileSync(target, stringToBytes(content));
+    }
+  }
+
+  async stat(target: string): Promise<FileStat> {
+    return fileStat(this.requireRecord(target));
+  }
+
+  async readFile(target: string): Promise<Uint8Array> {
+    const record = this.requireRecord(target);
+    if (record.type !== FileType.File) {
+      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
+    }
+    return cloneBytes(record.content);
+  }
+
+  async writeFile(target: string, content: Uint8Array): Promise<void> {
+    this.writeFileSync(target, content);
+  }
+
+  async delete(
+    target: string,
+    options?: { recursive?: boolean },
+  ): Promise<void> {
+    const normalized = normalizePath(target);
+    const record = this.records.get(normalized);
+    if (!record) {
+      return;
+    }
+
+    if (record.type === FileType.File) {
+      this.records.delete(normalized);
+      return;
+    }
+
+    const children = this.childPaths(normalized);
+    if (children.length > 0 && !options?.recursive) {
+      throw fakeFsError('ENOTEMPTY', `Directory is not empty: ${target}`);
+    }
+    for (const child of children) {
+      this.records.delete(child);
+    }
+    if (normalized !== '/') {
+      this.records.delete(normalized);
+    }
+  }
+
+  async createDirectory(target: string): Promise<void> {
+    this.createDirectorySync(target);
+  }
+
+  async readDirectory(target: string): Promise<[string, number][]> {
+    const normalized = normalizePath(target);
+    const record = this.requireRecord(normalized);
+    if (record.type !== FileType.Directory) {
+      throw fakeFsError('ENOTDIR', `Path is not a directory: ${target}`);
+    }
+
+    const entries = new Map<string, number>();
+    for (const [candidate, candidateRecord] of this.records) {
+      const name = directChildName(normalized, candidate);
+      if (name == null) continue;
+      const childPath = path.join(normalized, name);
+      const childRecord = this.records.get(childPath) ?? candidateRecord;
+      entries.set(name, childRecord.type);
+    }
+    return [...entries.entries()].sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+  }
+
+  async copy(
+    source: string,
+    dest: string,
+    options?: { overwrite?: boolean },
+  ): Promise<void> {
+    const normalizedSource = normalizePath(source);
+    const normalizedDest = normalizePath(dest);
+    const sourceRecord = this.requireRecord(normalizedSource);
+    this.assertWritableTarget(normalizedDest, options?.overwrite);
+
+    if (sourceRecord.type === FileType.File) {
+      this.writeFileSync(normalizedDest, sourceRecord.content);
+      return;
+    }
+
+    this.createDirectorySync(normalizedDest);
+    for (const child of this.childPaths(normalizedSource)) {
+      const relative = path.relative(normalizedSource, child);
+      const childDest = path.join(normalizedDest, relative);
+      this.records.set(childDest, cloneRecord(this.requireRecord(child)));
+    }
+  }
+
+  async rename(
+    source: string,
+    dest: string,
+    options?: { overwrite?: boolean },
+  ): Promise<void> {
+    const normalizedSource = normalizePath(source);
+    const normalizedDest = normalizePath(dest);
+    const sourceRecord = this.requireRecord(normalizedSource);
+    this.assertWritableTarget(normalizedDest, options?.overwrite);
+
+    if (sourceRecord.type === FileType.File) {
+      this.writeFileSync(normalizedDest, sourceRecord.content);
+      this.records.delete(normalizedSource);
+      return;
+    }
+
+    this.createDirectorySync(normalizedDest);
+    for (const child of this.childPaths(normalizedSource)) {
+      const relative = path.relative(normalizedSource, child);
+      const childDest = path.join(normalizedDest, relative);
+      this.records.set(childDest, cloneRecord(this.requireRecord(child)));
+    }
+    await this.delete(normalizedSource, { recursive: true });
+  }
+
+  exists(target: string): boolean {
+    return this.records.has(normalizePath(target));
+  }
+
+  setFile(target: string, content: string | Uint8Array): void {
+    this.writeFileSync(target, stringToBytes(content));
+  }
+
+  getText(target: string): string {
+    return Buffer.from(this.requireFile(target).content).toString('utf8');
+  }
+
+  private requireRecord(target: string): FakeFileRecord {
+    const normalized = normalizePath(target);
+    const record = this.records.get(normalized);
+    if (!record) {
+      throw fakeFsError('ENOENT', `File not found: ${target}`);
+    }
+    return record;
+  }
+
+  private requireFile(
+    target: string,
+  ): Extract<FakeFileRecord, { content: Uint8Array }> {
+    const record = this.requireRecord(target);
+    if (record.type !== FileType.File) {
+      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
+    }
+    return record;
+  }
+
+  private writeFileSync(target: string, content: Uint8Array): void {
+    const normalized = normalizePath(target);
+    const existing = this.records.get(normalized);
+    if (existing?.type === FileType.Directory) {
+      throw fakeFsError('EISDIR', `Path is a directory: ${target}`);
+    }
+    this.createDirectorySync(parentPath(normalized));
+    const timestamp = now();
+    this.records.set(normalized, {
+      type: FileType.File,
+      ctime: timestamp,
+      mtime: timestamp,
+      content: cloneBytes(content),
+    });
+  }
+
+  private createDirectorySync(target: string): void {
+    const normalized = normalizePath(target);
+    const existing = this.records.get(normalized);
+    if (existing?.type === FileType.File) {
+      throw fakeFsError('ENOTDIR', `Path is a file: ${target}`);
+    }
+
+    const parts = normalized.split(path.sep).filter(Boolean);
+    let current: string = path.sep;
+    this.ensureDirectoryRecord(current);
+    for (const part of parts) {
+      current = path.join(current, part);
+      this.ensureDirectoryRecord(current);
+    }
+  }
+
+  private ensureDirectoryRecord(target: string): void {
+    const existing = this.records.get(target);
+    if (existing?.type === FileType.File) {
+      throw fakeFsError('ENOTDIR', `Path is a file: ${target}`);
+    }
+    if (!existing) {
+      const timestamp = now();
+      this.records.set(target, {
+        type: FileType.Directory,
+        ctime: timestamp,
+        mtime: timestamp,
+      });
+    }
+  }
+
+  private childPaths(parent: string): string[] {
+    return [...this.records.keys()].filter((candidate) =>
+      hasChildPath(parent, candidate),
+    );
+  }
+
+  private assertWritableTarget(target: string, overwrite?: boolean): void {
+    if (!overwrite && this.records.has(target)) {
+      throw fakeFsError('EEXIST', `Target already exists: ${target}`);
+    }
+    if (overwrite && this.records.has(target)) {
+      this.deleteSync(target);
+    }
+  }
+
+  private deleteSync(target: string): void {
+    const record = this.records.get(target);
+    if (!record) return;
+
+    if (record.type === FileType.Directory) {
+      for (const child of this.childPaths(target)) {
+        this.records.delete(child);
+      }
+    }
+    if (target !== '/') {
+      this.records.delete(target);
+    }
+  }
+}
+
+export class FakeWorkspaceProvider implements WorkspaceProvider {
+  constructor(private readonly workspacePath = '/workspace') {}
+
+  getWorkspacePath(): string | undefined {
+    return this.workspacePath;
+  }
+
+  asRelativePath(filePath: string): string {
+    const workspacePath = normalizePath(this.workspacePath);
+    const normalized = normalizePath(filePath);
+    const relative = path.relative(workspacePath, normalized);
+    if (
+      relative === '' ||
+      relative.startsWith('..') ||
+      path.isAbsolute(relative)
+    ) {
+      return filePath;
+    }
+    return relative;
+  }
+}
+
+export class FakeStorageProvider implements StorageProvider {
+  constructor(
+    private readonly storagePath = '/workspace/.texra/storage',
+    private readonly globalStoragePath = '/global/.texra/storage',
+  ) {}
+
+  getStoragePath(): string {
+    return this.storagePath;
+  }
+
+  getGlobalStoragePath(): string {
+    return this.globalStoragePath;
+  }
+}
+
+export class FakeSecrets implements PlatformSecrets {
+  private readonly values = new Map<string, string>();
+
+  constructor(values: Record<string, string> = {}) {
+    for (const [key, value] of Object.entries(values)) {
+      this.values.set(key, value);
+    }
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
+  }
+}
+
+export interface FakePlatformOptions {
+  config?: Record<string, unknown>;
+  globalState?: Record<string, unknown>;
+  workspaceState?: Record<string, unknown>;
+  files?: Record<string, string | Uint8Array>;
+  secrets?: Record<string, string>;
+  workspacePath?: string;
+  storagePath?: string;
+  globalStoragePath?: string;
+}
+
+export function createFakePlatform(
+  options: FakePlatformOptions = {},
+  overrides: Partial<Platform> = {},
+): Platform {
+  return {
+    config: new FakeConfigProvider(options.config),
+    globalState: new FakeStateStore(options.globalState),
+    workspaceState: new FakeStateStore(options.workspaceState),
+    log: new RecordingLogBackend(),
+    fs: new FakeFileSystemProvider(options.files),
+    workspace: new FakeWorkspaceProvider(options.workspacePath),
+    storage: new FakeStorageProvider(
+      options.storagePath,
+      options.globalStoragePath,
+    ),
+    secrets: new FakeSecrets(options.secrets),
+    ...overrides,
+  };
+}
+
+function stringToBytes(content: string | Uint8Array): Uint8Array {
+  if (typeof content === 'string') {
+    return Buffer.from(content, 'utf8');
+  }
+  return content;
+}

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -217,6 +217,9 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     options?: { recursive?: boolean },
   ): Promise<void> {
     const normalized = normalizePath(target);
+    if (normalized === '/') {
+      throw fakeFsError('EPERM', 'Cannot delete filesystem root');
+    }
     const record = this.records.get(normalized);
     if (!record) {
       return;

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -290,8 +290,10 @@ export class FakeFileSystemProvider implements FileSystemProvider {
 
     this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
     this.assertParentDirectoryExists(normalizedDest);
+    const children = this.childPaths(normalizedSource);
+    this.assertDirectoryCopyTargets(normalizedSource, normalizedDest, children);
     this.createDirectorySync(normalizedDest);
-    for (const child of this.childPaths(normalizedSource)) {
+    for (const child of children) {
       const relative = path.posix.relative(normalizedSource, child);
       const childDest = path.posix.join(normalizedDest, relative);
       this.records.set(childDest, cloneRecord(this.requireRecord(child)));
@@ -471,6 +473,26 @@ export class FakeFileSystemProvider implements FileSystemProvider {
       this.childPaths(dest).length > 0
     ) {
       throw fakeFsError('ENOTEMPTY', `Directory is not empty: ${dest}`);
+    }
+  }
+
+  private assertDirectoryCopyTargets(
+    source: string,
+    dest: string,
+    children: string[],
+  ): void {
+    for (const child of children) {
+      const relative = path.posix.relative(source, child);
+      const childDest = path.posix.join(dest, relative);
+      const sourceRecord = this.requireRecord(child);
+      const destRecord = this.records.get(childDest);
+      if (!destRecord || destRecord.type === sourceRecord.type) {
+        continue;
+      }
+      if (destRecord.type === FileType.Directory) {
+        throw fakeFsError('EISDIR', `Path is a directory: ${childDest}`);
+      }
+      throw fakeFsError('ENOTDIR', `Path is a file: ${childDest}`);
     }
   }
 

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -282,9 +282,9 @@ export class FakeFileSystemProvider implements FileSystemProvider {
           : `Cannot copy a file onto itself: ${source} -> ${dest}`,
       );
     }
-    this.assertWritableTarget(normalizedDest, options?.overwrite);
 
     if (sourceRecord.type === FileType.File) {
+      this.assertWritableTarget(normalizedDest, options?.overwrite);
       this.writeFileSync(normalizedDest, sourceRecord.content, {
         overwrite: options?.overwrite,
       });
@@ -292,9 +292,15 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     }
 
     this.assertNotSelfDescendant(normalizedSource, normalizedDest, 'copy');
+    this.assertDirectoryCopyRootTarget(normalizedDest);
     this.assertParentDirectoryExists(normalizedDest);
     const children = this.childPaths(normalizedSource);
-    this.assertDirectoryCopyTargets(normalizedSource, normalizedDest, children);
+    this.assertDirectoryCopyTargets(
+      normalizedSource,
+      normalizedDest,
+      children,
+      options?.overwrite,
+    );
     this.createDirectorySync(normalizedDest);
     for (const child of children) {
       const relative = path.posix.relative(normalizedSource, child);
@@ -479,17 +485,31 @@ export class FakeFileSystemProvider implements FileSystemProvider {
     }
   }
 
+  private assertDirectoryCopyRootTarget(dest: string): void {
+    const destRecord = this.records.get(dest);
+    if (destRecord?.type === FileType.File) {
+      throw fakeFsError('ENOTDIR', `Path is a file: ${dest}`);
+    }
+  }
+
   private assertDirectoryCopyTargets(
     source: string,
     dest: string,
     children: string[],
+    overwrite?: boolean,
   ): void {
     for (const child of children) {
       const relative = path.posix.relative(source, child);
       const childDest = path.posix.join(dest, relative);
       const sourceRecord = this.requireRecord(child);
       const destRecord = this.records.get(childDest);
-      if (!destRecord || destRecord.type === sourceRecord.type) {
+      if (!destRecord) {
+        continue;
+      }
+      if (destRecord.type === sourceRecord.type) {
+        if (sourceRecord.type === FileType.File && !overwrite) {
+          throw fakeFsError('EEXIST', `Target already exists: ${childDest}`);
+        }
         continue;
       }
       if (destRecord.type === FileType.Directory) {

--- a/src/test/support/FakePlatform.ts
+++ b/src/test/support/FakePlatform.ts
@@ -7,7 +7,12 @@ import {
   type FileStat,
   type FileSystemProvider,
 } from '@platform/interfaces/filesystem';
-import type { ConfigProvider } from '@platform/interfaces/config';
+import type {
+  ConfigInspection,
+  ConfigProvider,
+  ConfigTarget,
+} from '@platform/interfaces/config';
+import type { Disposable } from '@platform/interfaces/disposable';
 import type { LogBackend, LogUtilsOptions } from '@platform/interfaces/log';
 import type { StateStore } from '@platform/interfaces/state';
 import type { StorageProvider } from '@platform/interfaces/storage';
@@ -107,9 +112,17 @@ function cloneRecord(record: FakeFileRecord): FakeFileRecord {
 export class FakeConfigProvider implements ConfigProvider {
   private readonly values = new Map<string, unknown>();
 
+  private readonly targets = new Map<string, ConfigTarget>();
+
+  private readonly watchers = new Set<{
+    key: string | readonly string[] | RegExp;
+    listener: () => void;
+  }>();
+
   constructor(values: Record<string, unknown> = {}) {
     for (const [key, value] of Object.entries(values)) {
       this.values.set(key, value);
+      this.targets.set(key, 'workspace');
     }
   }
 
@@ -122,6 +135,74 @@ export class FakeConfigProvider implements ConfigProvider {
 
   set(key: string, value: unknown): void {
     this.values.set(key, value);
+    this.targets.set(key, 'workspace');
+    this.notifyWatchers(key);
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    target: ConfigTarget = 'workspace',
+  ): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+      this.targets.delete(key);
+    } else {
+      this.values.set(key, value);
+      this.targets.set(key, target);
+    }
+    this.notifyWatchers(key);
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    if (!this.values.has(key)) {
+      return undefined;
+    }
+    const value = this.values.get(key) as T;
+    const target = this.targets.get(key) ?? 'workspace';
+    return {
+      globalValue: target === 'global' ? value : undefined,
+      workspaceValue: target === 'workspace' ? value : undefined,
+      effectiveValue: value,
+    };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return this.values.has(key);
+  }
+
+  watch(
+    key: string | readonly string[] | RegExp,
+    listener: () => void,
+  ): Disposable {
+    const watcher = { key, listener };
+    this.watchers.add(watcher);
+    return {
+      dispose: () => {
+        this.watchers.delete(watcher);
+      },
+    };
+  }
+
+  private notifyWatchers(changedKey: string): void {
+    for (const watcher of this.watchers) {
+      if (this.matchesWatchedKey(watcher.key, changedKey)) {
+        watcher.listener();
+      }
+    }
+  }
+
+  private matchesWatchedKey(
+    watchedKey: string | readonly string[] | RegExp,
+    changedKey: string,
+  ): boolean {
+    if (watchedKey instanceof RegExp) {
+      return watchedKey.test(changedKey);
+    }
+    if (typeof watchedKey === 'string') {
+      return watchedKey === changedKey;
+    }
+    return watchedKey.includes(changedKey);
   }
 }
 
@@ -525,6 +606,11 @@ export class FakeFileSystemProvider implements FileSystemProvider {
 }
 
 export class FakeWorkspaceProvider implements WorkspaceProvider {
+  private readonly watchers = new Set<{
+    globPattern: string;
+    listener: () => void;
+  }>();
+
   constructor(private readonly workspacePath: string | undefined) {}
 
   getWorkspacePath(): string | undefined {
@@ -542,6 +628,16 @@ export class FakeWorkspaceProvider implements WorkspaceProvider {
       return filePath;
     }
     return relative.replaceAll('\\', '/');
+  }
+
+  watch(globPattern: string, listener: () => void): Disposable {
+    const watcher = { globPattern, listener };
+    this.watchers.add(watcher);
+    return {
+      dispose: () => {
+        this.watchers.delete(watcher);
+      },
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable FakePlatform test harness for Electron/platform migration work
- provide fake config/state/log/fs/workspace/storage/secrets implementations
- cover platform construction, overrides, log recording, and in-memory filesystem behavior

Part of prds/prd-electron-app.md section 9, item 16.

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new test-only fakes for core platform services (config/state/fs/etc.) plus a broad filesystem semantics test suite; low risk to production but could affect test stability if behavior diverges from real providers.
> 
> **Overview**
> Introduces a reusable `createFakePlatform` test harness that assembles fake implementations of `Platform` services (config/state/log/fs/workspace/storage/secrets), with support for per-test overrides.
> 
> Adds a comprehensive `FakePlatform.test.ts` suite that validates config aliasing and watcher behavior, log recording, and an in-memory `FileSystemProvider` with realistic error/overwrite/recursive semantics for `writeFile`, `copy`, `rename`, `readDirectory`, and `delete`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b5b6cc8fda4fc99f1542bd285ce1e8bb3fb0f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->