### PR TITLE
[codex] Extract host-agnostic command catalog

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -107,14 +107,6 @@ export function registerCommands(context: vscode.ExtensionContext): void {
 export { linterCommands, arXivCommands } from '@commands/latex';
 export { runExecuteCommand, agentCreatorCommands } from '@commands/agent';
 export {
-  commandCatalog,
-  commandCatalogById,
-  commandKeybindings,
-  type CommandCatalogEntry,
-  type CommandId,
-  type CommandKeybinding,
-} from '@commands/catalog';
-export {
   xmlCommands,
   yamlCommands,
   helpCommands,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -107,6 +107,14 @@ export function registerCommands(context: vscode.ExtensionContext): void {
 export { linterCommands, arXivCommands } from '@commands/latex';
 export { runExecuteCommand, agentCreatorCommands } from '@commands/agent';
 export {
+  commandCatalog,
+  commandCatalogById,
+  commandKeybindings,
+  type CommandCatalogEntry,
+  type CommandId,
+  type CommandKeybinding,
+} from '@commands/catalog';
+export {
   xmlCommands,
   yamlCommands,
   helpCommands,

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -1,0 +1,376 @@
+export interface CommandKeybinding {
+  key: string;
+  mac?: string;
+  when?: string;
+}
+
+export interface CommandCatalogEntry {
+  id: string;
+  title: string;
+  shortTitle?: string;
+  category: string;
+  icon?: string;
+  enablement?: string;
+  keybinding?: CommandKeybinding;
+}
+
+export const commandCatalog = [
+  {
+    id: 'texra.createSampleProject',
+    title: 'Create Sample Project',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.runSetupAssistant',
+    title: 'Run Setup Assistant Agent (Setup Wizard)',
+    category: 'TeXRA',
+    icon: '$(rocket)',
+  },
+  {
+    id: 'texra.openGettingStarted',
+    title: 'Open Getting Started Walkthrough',
+    category: 'TeXRA',
+    icon: '$(mortar-board)',
+  },
+  {
+    id: 'texra.cleanOutput',
+    title: 'Clean All LLM Output Files (Workspace-wide)',
+    shortTitle: 'Clean LLM Outputs',
+    category: 'TeXRA',
+    icon: '$(clear-all)',
+    keybinding: {
+      key: 'ctrl+alt+shift+c',
+      mac: 'cmd+option+shift+c',
+      when: 'texra.activated',
+    },
+  },
+  {
+    id: 'texra.cleanBuild',
+    title: 'Clean All Build Files (Workspace-wide)',
+    shortTitle: 'Clean Build Files',
+    category: 'TeXRA',
+    icon: '$(close-all)',
+    keybinding: {
+      key: 'ctrl+alt+shift+b',
+      mac: 'cmd+option+shift+b',
+      when: 'texra.activated',
+    },
+  },
+  {
+    id: 'texra.indentTeX',
+    title: 'Indent All LaTeX Files',
+    category: 'TeXRA',
+    icon: '$(indent)',
+  },
+  {
+    id: 'texra.getRecentCommits',
+    title: 'Get Recent Commits',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.cloneOverleafProject',
+    title: 'Clone Overleaf/ShareLaTeX Project',
+    category: 'TeXRA',
+    icon: '$(repo-clone)',
+  },
+  {
+    id: 'texra.refreshCommits',
+    title: 'Refresh Commits',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.indentCurrentTeX',
+    title: 'Indent Current TeX',
+    category: 'TeXRA',
+    icon: '$(indent)',
+    enablement: '!virtualWorkspace',
+  },
+  {
+    id: 'texra.resumeAgent',
+    title: 'Resume Tool-Use Agent',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.applyReplacements',
+    title: 'Apply LaTeX Replacements to Current File',
+    category: 'TeXRA',
+    icon: '$(symbol-text)',
+    enablement: '!virtualWorkspace',
+  },
+  {
+    id: 'texra.fixCompilation',
+    title: 'Fix LaTeX Compilation Errors',
+    category: 'TeXRA',
+    icon: '$(wrench)',
+    enablement: '!virtualWorkspace',
+  },
+  {
+    id: 'texra.getTeXCount',
+    title: 'Count Words in Current TeX File',
+    category: 'TeXRA',
+    icon: '$(symbol-number)',
+    enablement: '!virtualWorkspace',
+  },
+  {
+    id: 'texra.countPdfPages',
+    title: 'Count PDF Pages',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.encodeImageToBase64',
+    title: 'Encode Image to Base64',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.convertPdfToImages',
+    title: 'Convert PDF to Images',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.extractFigurePaths',
+    title: 'Extract Figure Paths from LaTeX',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.extractTikzFigures',
+    title: 'Extract TikZ Figures from Current File',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.compileTikzFigures',
+    title: 'Compile TikZ Figures from Current File',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.testConnection',
+    title: 'Test API Connection',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.testAgentLoading',
+    title: 'Test Agent Loading',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.loadSpecificAgent',
+    title: 'Load Specific Agent',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.downloadArXivSource',
+    title: 'Download arXiv Source',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.showImportOptions',
+    title: 'Import or Create LaTeX Project',
+    category: 'TeXRA',
+    icon: '$(cloud-download)',
+  },
+  {
+    id: 'texra.parseXml',
+    title: 'Parse XML Structure',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.parseYaml',
+    title: 'Parse YAML Structure',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.stopAgent',
+    title: 'Stop Agent',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.execute',
+    title: 'Execute Agent',
+    category: 'TeXRA',
+    keybinding: {
+      key: 'ctrl+alt+e',
+      mac: 'cmd+option+e',
+      when: 'texra.activated',
+    },
+  },
+  {
+    id: 'texra.pack',
+    title: 'Pack Output into History Folder',
+    shortTitle: 'Pack Output',
+    category: 'TeXRA',
+    icon: '$(archive)',
+  },
+  {
+    id: 'texra.clean',
+    title: 'Clean Agent Output Files',
+    shortTitle: 'Clean Output',
+    category: 'TeXRA',
+    icon: '$(trash)',
+  },
+  {
+    id: 'texra.createAgentWithAI',
+    title: 'Create AI Agent',
+    category: 'TeXRA',
+    icon: '$(sparkle)',
+  },
+  {
+    id: 'texra.setApiKey',
+    title: 'Set API Key',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.removeApiKey',
+    title: 'Remove API Key',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.auth.signIn',
+    title: 'Sign In',
+    category: 'TeXRA',
+    icon: '$(sign-in)',
+  },
+  {
+    id: 'texra.auth.signOut',
+    title: 'Sign Out',
+    category: 'TeXRA',
+    icon: '$(sign-out)',
+  },
+  {
+    id: 'texra.auth.viewProfile',
+    title: 'View Profile',
+    category: 'TeXRA',
+    icon: '$(account)',
+  },
+  {
+    id: 'texra.testTextEditor',
+    title: 'Test Text Editor Tool',
+    category: 'TeXRA',
+    icon: '$(edit)',
+  },
+  {
+    id: 'texra.showLinterMessages',
+    title: 'Show Linter Messages',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.countLinterMessages',
+    title: 'Count Linter Messages',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.openDoc',
+    title: 'Open TeXRA Documentation',
+    category: 'TeXRA',
+  },
+  {
+    id: 'texra.mainView.reset',
+    title: 'New Session',
+    shortTitle: 'New',
+    category: 'TeXRA',
+    icon: '$(new-file)',
+  },
+  {
+    id: 'texra.showAgentHistory',
+    title: 'Show Agent Execution History',
+    category: 'TeXRA',
+    icon: '$(history)',
+  },
+  {
+    id: 'texra.showMemory',
+    title: 'Show Memory',
+    category: 'TeXRA',
+    icon: '$(database)',
+  },
+  {
+    id: 'texra.showModels',
+    title: 'Show Models',
+    category: 'TeXRA',
+    icon: '$(hubot)',
+  },
+  {
+    id: 'texra.showAgents',
+    title: 'Show Agents',
+    category: 'TeXRA',
+    icon: '$(symbol-method)',
+  },
+  {
+    id: 'texra.showTools',
+    title: 'Show Tool Dashboard',
+    category: 'TeXRA',
+    icon: '$(tools)',
+  },
+  {
+    id: 'texra.showMultiAgent',
+    title: 'Show Multi-Agent Settings',
+    category: 'TeXRA',
+    icon: '$(organization)',
+  },
+  {
+    id: 'texra.openSettings',
+    title: 'Open TeXRA Settings',
+    category: 'TeXRA',
+    icon: '$(settings-gear)',
+  },
+  {
+    id: 'texra.showMainView',
+    title: 'Show Launcher',
+    category: 'TeXRA',
+    icon: '$(edit)',
+    keybinding: {
+      key: 'ctrl+alt+m',
+      mac: 'cmd+option+m',
+      when: 'texra.activated',
+    },
+  },
+  {
+    id: 'texra.showProgressView',
+    title: 'Show Progress',
+    category: 'TeXRA',
+    icon: '$(eye)',
+    keybinding: {
+      key: 'ctrl+alt+p',
+      mac: 'cmd+option+p',
+      when: 'texra.activated',
+    },
+  },
+  {
+    id: 'texra.toggleView',
+    title: 'Toggle Launcher/Progress View',
+    category: 'TeXRA',
+    icon: '$(split-horizontal)',
+    keybinding: {
+      key: 'ctrl+alt+t',
+      mac: 'cmd+option+t',
+      when: 'texra.activated && focusedView == texra.mainView',
+    },
+  },
+  {
+    id: 'texra.openProgressViewInTab',
+    title: 'Open Progress in Editor Tab',
+    shortTitle: 'Open in Tab',
+    category: 'TeXRA',
+    icon: '$(multiple-windows)',
+  },
+  {
+    id: 'texra.showDashboard',
+    title: 'Show Settings Dashboard',
+    shortTitle: 'Settings',
+    category: 'TeXRA',
+    icon: '$(gear)',
+  },
+  {
+    id: 'texra.showSettingsView',
+    title: 'Show Settings',
+    category: 'TeXRA',
+    icon: '$(gear)',
+  },
+] as const satisfies readonly CommandCatalogEntry[];
+
+export type CommandId = (typeof commandCatalog)[number]['id'];
+
+export const commandCatalogById = new Map<CommandId, CommandCatalogEntry>(
+  commandCatalog.map((entry) => [entry.id, entry]),
+);
+
+export const commandKeybindings = commandCatalog.flatMap((entry) =>
+  'keybinding' in entry ? [{ command: entry.id, ...entry.keybinding }] : [],
+);

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -371,6 +371,28 @@ export const commandCatalogById = new Map<CommandId, CommandCatalogEntry>(
   commandCatalog.map((entry) => [entry.id, entry]),
 );
 
-export const commandKeybindings = commandCatalog.flatMap((entry) =>
-  'keybinding' in entry ? [{ command: entry.id, ...entry.keybinding }] : [],
-);
+const commandKeybindingOrder = [
+  'texra.showMainView',
+  'texra.showProgressView',
+  'texra.cleanOutput',
+  'texra.cleanBuild',
+  'texra.toggleView',
+  'texra.execute',
+] as const satisfies readonly CommandId[];
+
+function keybindingForCommand(id: CommandId): CommandKeybinding {
+  const entry = commandCatalogById.get(id);
+  if (!entry || !('keybinding' in entry)) {
+    throw new Error(`Command has no keybinding: ${id}`);
+  }
+  const keybinding = entry.keybinding;
+  if (keybinding == null) {
+    throw new Error(`Command has no keybinding: ${id}`);
+  }
+  return keybinding;
+}
+
+export const commandKeybindings = commandKeybindingOrder.map((id) => ({
+  command: id,
+  ...keybindingForCommand(id),
+}));

--- a/src/test/commands/CommandCatalog.test.ts
+++ b/src/test/commands/CommandCatalog.test.ts
@@ -28,28 +28,38 @@ interface PackageJson {
   };
 }
 
-const require = createRequire(__filename);
-const packageJson = require('../../../package.json') as PackageJson;
+const packageRequire = createRequire(__filename);
+const packageJson = packageRequire('../../../package.json') as PackageJson;
+
+function normalizeCommand(command: PackageCommand): PackageCommand {
+  return {
+    command: command.command,
+    title: command.title,
+    ...(command.shortTitle == null ? {} : { shortTitle: command.shortTitle }),
+    category: command.category,
+    ...(command.icon == null ? {} : { icon: command.icon }),
+    ...(command.enablement == null ? {} : { enablement: command.enablement }),
+  };
+}
 
 function normalizeCatalogCommands(): PackageCommand[] {
-  return commandCatalog.map((entry) => {
-    const command: PackageCommand = {
+  return commandCatalog.map((entry) =>
+    normalizeCommand({
       command: entry.id,
       title: entry.title,
+      ...('shortTitle' in entry ? { shortTitle: entry.shortTitle } : {}),
       category: entry.category,
-    };
-    if ('shortTitle' in entry) command.shortTitle = entry.shortTitle;
-    if ('icon' in entry) command.icon = entry.icon;
-    if ('enablement' in entry) command.enablement = entry.enablement;
-    return command;
-  });
+      ...('icon' in entry ? { icon: entry.icon } : {}),
+      ...('enablement' in entry ? { enablement: entry.enablement } : {}),
+    }),
+  );
 }
 
 describe('commandCatalog', () => {
   it('matches package command contributions', () => {
     assert.deepEqual(
       normalizeCatalogCommands(),
-      packageJson.contributes.commands,
+      packageJson.contributes.commands.map(normalizeCommand),
     );
   });
 

--- a/src/test/commands/CommandCatalog.test.ts
+++ b/src/test/commands/CommandCatalog.test.ts
@@ -1,0 +1,62 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import { createRequire } from 'module';
+
+// Local imports - commands
+import { commandCatalog, commandKeybindings } from '@commands/catalog';
+
+interface PackageCommand {
+  command: string;
+  title: string;
+  shortTitle?: string;
+  category: string;
+  icon?: string;
+  enablement?: string;
+}
+
+interface PackageKeybinding {
+  command: string;
+  key: string;
+  mac?: string;
+  when?: string;
+}
+
+interface PackageJson {
+  contributes: {
+    commands: PackageCommand[];
+    keybindings?: PackageKeybinding[];
+  };
+}
+
+const require = createRequire(__filename);
+const packageJson = require('../../../package.json') as PackageJson;
+
+function normalizeCatalogCommands(): PackageCommand[] {
+  return commandCatalog.map((entry) => {
+    const command: PackageCommand = {
+      command: entry.id,
+      title: entry.title,
+      category: entry.category,
+    };
+    if ('shortTitle' in entry) command.shortTitle = entry.shortTitle;
+    if ('icon' in entry) command.icon = entry.icon;
+    if ('enablement' in entry) command.enablement = entry.enablement;
+    return command;
+  });
+}
+
+describe('commandCatalog', () => {
+  it('matches package command contributions', () => {
+    assert.deepEqual(
+      normalizeCatalogCommands(),
+      packageJson.contributes.commands,
+    );
+  });
+
+  it('matches package keybinding contributions', () => {
+    assert.deepEqual(
+      commandKeybindings,
+      packageJson.contributes.keybindings ?? [],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a pure command catalog with VS Code command metadata and keybindings for desktop/menu consumers
- re-export the catalog from the current command registration entrypoint
- add a consistency test that compares catalog metadata against package.json contributions

Part of prds/prd-electron-app.md section 9, item 17.

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a typed command metadata catalog and a test asserting it matches `package.json` contributions, without changing runtime command behavior.
> 
> **Overview**
> Introduces a new `src/commands/catalog.ts` that centralizes TeXRA command metadata (ids, titles, categories, icons, enablement) and defines an ordered `commandKeybindings` export derived from the catalog.
> 
> Adds `CommandCatalog.test.ts` to ensure the catalog and derived keybindings stay **exactly in sync** with `package.json` `contributes.commands` and `contributes.keybindings`, failing tests if they drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebeab4769272a8a296eb42c8bf4637c31336002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->