### PR TITLE
[codex] Add canonical TeXRA settings schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1527,6 +1527,8 @@
     "package:safe": "npm run typecheck && npm run package:fast",
     "build:fast": "npm run package:fast && SKIP_VSCE_PREPUBLISH=1 vsce package --out releases/texra-$npm_package_version.vsix",
     "build:safe": "npm run typecheck && npm run build:fast",
+    "sync:settings-configuration": "npm run compile-tests && node scripts/sync-settings-configuration.mjs",
+    "check:settings-configuration": "npm run compile-tests && node scripts/sync-settings-configuration.mjs --check",
     "sync:remote-agents": "node scripts/sync-remote-agents.mjs -o docs/supabase/SYNC_REFERENCE_AGENTS.sql",
     "check:remote-agents": "node scripts/sync-remote-agents.mjs --check"
   },

--- a/scripts/sync-settings-configuration.mjs
+++ b/scripts/sync-settings-configuration.mjs
@@ -28,6 +28,10 @@ function getConfigurationSections(packageJson) {
   return configuration;
 }
 
+function normalizeLineEndings(text) {
+  return text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+}
+
 const { check } = parseArgs();
 const packageText = await readFile(packagePath, 'utf8');
 const packageJson = JSON.parse(packageText);
@@ -43,7 +47,9 @@ const nextPackageJson = {
 const nextPackageText = `${JSON.stringify(nextPackageJson, null, 2)}\n`;
 
 if (check) {
-  if (nextPackageText !== packageText) {
+  if (
+    normalizeLineEndings(nextPackageText) !== normalizeLineEndings(packageText)
+  ) {
     throw new Error(
       'package.json contributes.configuration is out of sync with TexraSettingsSchema. Run npm run sync:settings-configuration.',
     );

--- a/scripts/sync-settings-configuration.mjs
+++ b/scripts/sync-settings-configuration.mjs
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module';
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import process from 'node:process';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const packagePath = path.join(rootDir, 'package.json');
+const require = createRequire(import.meta.url);
+const {
+  buildTexraPackageConfiguration,
+} = require('../out/shared/schemas/settingsConfiguration.js');
+
+function parseArgs() {
+  return {
+    check: process.argv.includes('--check'),
+  };
+}
+
+function getConfigurationSections(packageJson) {
+  const configuration = packageJson.contributes?.configuration;
+  if (!Array.isArray(configuration)) {
+    throw new Error('package.json contributes.configuration must be an array');
+  }
+  return configuration;
+}
+
+const { check } = parseArgs();
+const packageText = await readFile(packagePath, 'utf8');
+const packageJson = JSON.parse(packageText);
+const nextPackageJson = {
+  ...packageJson,
+  contributes: {
+    ...packageJson.contributes,
+    configuration: buildTexraPackageConfiguration(
+      getConfigurationSections(packageJson),
+    ),
+  },
+};
+const nextPackageText = `${JSON.stringify(nextPackageJson, null, 2)}\n`;
+
+if (check) {
+  if (nextPackageText !== packageText) {
+    throw new Error(
+      'package.json contributes.configuration is out of sync with TexraSettingsSchema. Run npm run sync:settings-configuration.',
+    );
+  }
+  console.log('package.json settings configuration is in sync');
+} else {
+  await writeFile(packagePath, nextPackageText);
+  console.log('Synced package.json settings configuration');
+}

--- a/src/shared/schemas/index.ts
+++ b/src/shared/schemas/index.ts
@@ -7,6 +7,7 @@ export * from './agent';
 export * from './fileFields';
 export * from './proposalFields';
 export * from './toolConfig';
+export * from './settingsConfiguration';
 export * from './errors';
 export * from './usage';
 export * from './contextManagement';

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -557,6 +557,46 @@ export const TEXRA_SETTING_KEYS = TEXRA_SETTING_PATHS.map(
   (path) => `texra.${path}` as TexraSettingKey,
 );
 
+export interface TexraPackageConfigurationProperty {
+  type?: string;
+  items?: unknown;
+  additionalProperties?: unknown;
+  default?: unknown;
+  enum?: unknown[];
+  minimum?: number;
+  maximum?: number;
+  [key: string]: unknown;
+}
+
+export interface TexraPackageConfigurationSection {
+  title?: string;
+  properties?: Record<string, TexraPackageConfigurationProperty>;
+  [key: string]: unknown;
+}
+
+type JsonSchemaObject = {
+  type?: string;
+  properties?: Record<string, JsonSchemaObject>;
+  items?: unknown;
+  additionalProperties?: unknown;
+  enum?: unknown[];
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+};
+
+const GENERATED_PACKAGE_SCHEMA_FIELDS = [
+  'type',
+  'items',
+  'additionalProperties',
+  'default',
+  'enum',
+  'minimum',
+  'maximum',
+] as const;
+
+let texraSettingsJsonSchema: JsonSchemaObject | undefined;
+
 function getNestedValue(source: unknown, path: TexraSettingPath): unknown {
   let value = source;
   for (const segment of path.split('.')) {
@@ -582,4 +622,83 @@ export function flattenTexraSettings(
 
 export function getTexraSettingDefault(path: TexraSettingPath): unknown {
   return getNestedValue(TexraSettingsSchema.parse({}), path);
+}
+
+function getNestedJsonSchema(path: TexraSettingPath): JsonSchemaObject {
+  texraSettingsJsonSchema ??= z.toJSONSchema(
+    TexraSettingsSchema,
+  ) as JsonSchemaObject;
+  let schema = texraSettingsJsonSchema;
+  for (const segment of path.split('.')) {
+    const next = schema.properties?.[segment];
+    if (!next) {
+      throw new Error(`Missing JSON schema node for setting ${path}`);
+    }
+    schema = next;
+  }
+  return schema;
+}
+
+function pickPackageSchemaFields(
+  schema: JsonSchemaObject,
+): TexraPackageConfigurationProperty {
+  const property: Record<string, unknown> = {};
+  for (const field of GENERATED_PACKAGE_SCHEMA_FIELDS) {
+    const value = schema[field];
+    if (value !== undefined) {
+      property[field] = value;
+    }
+  }
+  return property as TexraPackageConfigurationProperty;
+}
+
+function buildTexraPackageConfigurationProperty(
+  key: TexraSettingKey,
+  existing: TexraPackageConfigurationProperty = {},
+): TexraPackageConfigurationProperty {
+  const path = key.replace(/^texra\./, '') as TexraSettingPath;
+  const generated = pickPackageSchemaFields(getNestedJsonSchema(path));
+  if (generated.type !== 'null') {
+    generated.default = getTexraSettingDefault(path);
+  }
+  return { ...existing, ...generated };
+}
+
+export function buildTexraPackageConfiguration(
+  sections: TexraPackageConfigurationSection[],
+): TexraPackageConfigurationSection[] {
+  const seenKeys = new Set<string>();
+  const generatedSections = sections.map((section) => {
+    const properties = section.properties;
+    if (!properties) {
+      return section;
+    }
+
+    const generatedProperties = Object.fromEntries(
+      Object.entries(properties).map(([key, property]) => {
+        if (!TEXRA_SETTING_KEYS.includes(key as TexraSettingKey)) {
+          return [key, property];
+        }
+        seenKeys.add(key);
+        return [
+          key,
+          buildTexraPackageConfigurationProperty(
+            key as TexraSettingKey,
+            property,
+          ),
+        ];
+      }),
+    );
+
+    return { ...section, properties: generatedProperties };
+  });
+
+  const missingKeys = TEXRA_SETTING_KEYS.filter((key) => !seenKeys.has(key));
+  if (missingKeys.length > 0) {
+    throw new Error(
+      `Package configuration is missing setting keys: ${missingKeys.join(', ')}`,
+    );
+  }
+
+  return generatedSections;
 }

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -664,7 +664,16 @@ function buildTexraPackageConfigurationProperty(
   if (generated.type !== 'null') {
     generated.default = getTexraSettingDefault(path);
   }
-  return { ...existing, ...generated };
+  const property: Record<string, unknown> = { ...existing };
+  for (const field of GENERATED_PACKAGE_SCHEMA_FIELDS) {
+    const value = generated[field];
+    if (value === undefined) {
+      delete property[field];
+    } else {
+      property[field] = value;
+    }
+  }
+  return property as TexraPackageConfigurationProperty;
 }
 
 export function buildTexraPackageConfiguration(

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -610,6 +610,10 @@ function getNestedValue(source: unknown, path: TexraSettingPath): unknown {
   return value;
 }
 
+function cloneSettingValue(value: unknown): unknown {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
 export function flattenTexraSettings(settings?: unknown): FlatTexraSettings {
   const parsed =
     settings === undefined
@@ -618,13 +622,13 @@ export function flattenTexraSettings(settings?: unknown): FlatTexraSettings {
   return Object.fromEntries(
     TEXRA_SETTING_PATHS.map((path) => [
       `texra.${path}` satisfies TexraSettingKey,
-      getNestedValue(parsed, path),
+      cloneSettingValue(getNestedValue(parsed, path)),
     ]),
   ) as FlatTexraSettings;
 }
 
 export function getTexraSettingDefault(path: TexraSettingPath): unknown {
-  return getNestedValue(parsedDefaultTexraSettings, path);
+  return cloneSettingValue(getNestedValue(parsedDefaultTexraSettings, path));
 }
 
 function getNestedJsonSchema(path: TexraSettingPath): JsonSchemaObject {

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -689,6 +689,11 @@ export function buildTexraPackageConfiguration(
     const generatedProperties = Object.fromEntries(
       Object.entries(properties).map(([key, property]) => {
         if (!TEXRA_SETTING_KEY_SET.has(key as TexraSettingKey)) {
+          if (key.startsWith('texra.')) {
+            throw new Error(
+              `Package configuration contains unknown setting key: ${key}`,
+            );
+          }
           return [key, property];
         }
         seenKeys.add(key);

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -556,6 +556,7 @@ export type FlatTexraSettings = Record<TexraSettingKey, unknown>;
 export const TEXRA_SETTING_KEYS = TEXRA_SETTING_PATHS.map(
   (path) => `texra.${path}` as TexraSettingKey,
 );
+const TEXRA_SETTING_KEY_SET = new Set<TexraSettingKey>(TEXRA_SETTING_KEYS);
 
 export interface TexraPackageConfigurationProperty {
   type?: string;
@@ -596,6 +597,7 @@ const GENERATED_PACKAGE_SCHEMA_FIELDS = [
 ] as const;
 
 let texraSettingsJsonSchema: JsonSchemaObject | undefined;
+const parsedDefaultTexraSettings = TexraSettingsSchema.parse({});
 
 function getNestedValue(source: unknown, path: TexraSettingPath): unknown {
   let value = source;
@@ -608,10 +610,11 @@ function getNestedValue(source: unknown, path: TexraSettingPath): unknown {
   return value;
 }
 
-export function flattenTexraSettings(
-  settings: TexraSettings = TexraSettingsSchema.parse({}),
-): FlatTexraSettings {
-  const parsed = TexraSettingsSchema.parse(settings);
+export function flattenTexraSettings(settings?: unknown): FlatTexraSettings {
+  const parsed =
+    settings === undefined
+      ? parsedDefaultTexraSettings
+      : TexraSettingsSchema.parse(settings);
   return Object.fromEntries(
     TEXRA_SETTING_PATHS.map((path) => [
       `texra.${path}` satisfies TexraSettingKey,
@@ -621,7 +624,7 @@ export function flattenTexraSettings(
 }
 
 export function getTexraSettingDefault(path: TexraSettingPath): unknown {
-  return getNestedValue(TexraSettingsSchema.parse({}), path);
+  return getNestedValue(parsedDefaultTexraSettings, path);
 }
 
 function getNestedJsonSchema(path: TexraSettingPath): JsonSchemaObject {
@@ -676,7 +679,7 @@ export function buildTexraPackageConfiguration(
 
     const generatedProperties = Object.fromEntries(
       Object.entries(properties).map(([key, property]) => {
-        if (!TEXRA_SETTING_KEYS.includes(key as TexraSettingKey)) {
+        if (!TEXRA_SETTING_KEY_SET.has(key as TexraSettingKey)) {
           return [key, property];
         }
         seenKeys.add(key);

--- a/src/shared/schemas/settingsConfiguration.ts
+++ b/src/shared/schemas/settingsConfiguration.ts
@@ -1,0 +1,585 @@
+// Third-party imports
+import { z } from 'zod';
+
+export const NON_REGEX_REPLACEMENT_CATEGORIES = [
+  'latex_spacing',
+  'equations',
+  'sections',
+  'latex_forbidden_commands',
+  'characters',
+  'latex_xml',
+  'latex_document',
+  'unicode',
+  'html_entities',
+  'scratchpad_xml',
+  'latexdiff',
+  'gptness',
+  'personal_style',
+  'max_style',
+] as const;
+
+export const REGEX_REPLACEMENT_CATEGORIES = [
+  'inline_math',
+  'parentheses',
+  'latexdiff_markup',
+  'equation_style',
+  'equation_macros',
+  'max_style_regex',
+] as const;
+
+export const LATEXDIFF_TEMP_FILE_LOCATIONS = [
+  'sameDirectory',
+  'workspaceTemp',
+] as const;
+
+export type NonRegexReplacementCategory =
+  (typeof NON_REGEX_REPLACEMENT_CATEGORIES)[number];
+export type RegexReplacementCategory =
+  (typeof REGEX_REPLACEMENT_CATEGORIES)[number];
+export type LatexdiffTempFileLocation =
+  (typeof LATEXDIFF_TEMP_FILE_LOCATIONS)[number];
+
+export const DEFAULT_TEXRA_SETTINGS = {
+  agentOutputs: {
+    autoOpenFinal: true,
+  },
+  ui: {
+    showApiKeyReminders: true,
+    showLoginBanner: true,
+    showGettingStartedBanner: true,
+    showOrchestratorBanner: true,
+  },
+  auth: {
+    enableVSCodeGitHub: false,
+  },
+  model: {
+    useImprovedConnection: false,
+    improvedConnectionDomain: 'proxy.texra.ai',
+    useOpenAIResponsesAPI: true,
+    useBackgroundResponses: true,
+    openaiParallelToolCalls: false,
+    compactionThresholdPercent: 75,
+    gpt5ReasoningSummary: false,
+    retry: {
+      maxAttempts: 0,
+      backoffMs: 1000,
+    },
+  },
+  files: {
+    included: {
+      mediaExtensions: [
+        '.png',
+        '.pdf',
+        '.jpeg',
+        '.jpg',
+        '.gif',
+        '.heic',
+        '.heif',
+        '.webp',
+        '.wav',
+        '.m4a',
+        '.mp3',
+        '.aiff',
+        '.aac',
+        '.opus',
+        '.l16',
+        '.alaw',
+        '.mulaw',
+        '.ogg',
+        '.flac',
+      ],
+      inputExtensions: ['.txt', '.tex', '.md'],
+      referenceExtensions: ['.txt', '.tex', '.md', '.bib', '.bbl'],
+      auxiliaryExtensions: ['.txt', '.tex', '.cls', '.md', '.sty'],
+      editedExtensions: ['.txt', '.tex'],
+    },
+    ignored: {
+      fileExtensions: [
+        '.pdf',
+        '.bst',
+        '.json',
+        '.py',
+        '.ipynb',
+        '.png',
+        '.vsix',
+        '.ts',
+        '.js',
+        '.yaml',
+      ],
+      inputFiles: ['command.tex', 'commands.tex', 'preamble.tex', 'yaml'],
+      inputDirectories: [],
+      auxiliaryKeywords: [
+        'o1',
+        'o3',
+        'o4',
+        'gpt',
+        'sonnet',
+        'haiku',
+        'opus',
+        'gemini',
+        'grok',
+        'deepseek',
+        'qwen',
+        'kimi',
+        'llama',
+        'egg-info',
+        'yaml',
+      ],
+      mediaDirectories: [
+        'build',
+        'node_modules',
+        '__pycache__',
+        'versions',
+        'history',
+        'venv',
+        'Diffs',
+      ],
+      directories: [
+        'build',
+        'node_modules',
+        '__pycache__',
+        'figures',
+        'media',
+        'figs',
+        'versions',
+        'history',
+        'stuff',
+        'draft',
+        'miscellaneous',
+        'diffs',
+        'venv',
+      ],
+      keywords: [
+        'Makefile',
+        'template',
+        '_thinking',
+        '_diff',
+        'draw',
+        'versions',
+        'history',
+        '.egg-info',
+        'venv',
+        'yaml',
+      ],
+    },
+  },
+  maxImageDimension: 2000,
+  bib: {
+    defaultPath: '',
+    zoteroPort: 23119,
+  },
+  latex: {
+    showLatexindentWarning: false,
+    latexindentConfig: '',
+    texfmtConfig: '',
+    tikzInputDirectory: '',
+    tikzTemplate:
+      '\\documentclass[tikz,border=10pt]{standalone}\n' +
+      '\\usepackage{tikz}\n' +
+      '\\usepackage{pgfplots}\n' +
+      '\\usetikzlibrary{positioning}\n' +
+      '\\usetikzlibrary{patterns}\n' +
+      '\\usetikzlibrary{arrows.meta, shapes.geometric, matrix, calc, decorations.pathreplacing}\n' +
+      '\\usetikzlibrary{shapes, arrows}\n\n' +
+      '\\begin{document}\n' +
+      '{{ tikzpicture }}\n' +
+      '\\end{document}',
+    includeWorkspaceInTexinputs: true,
+    wrapCritiqueInAlign: true,
+    enabledReplacements: [
+      'latex_spacing',
+      'equations',
+      'sections',
+      'latex_forbidden_commands',
+      'characters',
+      'latex_xml',
+      'latex_document',
+      'unicode',
+      'html_entities',
+      'scratchpad_xml',
+      'latexdiff',
+      'gptness',
+    ] satisfies NonRegexReplacementCategory[],
+    enabledReplacementsRegex: [
+      'inline_math',
+      'parentheses',
+      'latexdiff_markup',
+      'equation_style',
+    ] satisfies RegexReplacementCategory[],
+    customReplacementsRegex: {},
+    customReplacements: {},
+  },
+  latexdiff: {
+    pictureEnvironments: '(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*',
+    tempFileLocation: 'sameDirectory' as LatexdiffTempFileLocation,
+  },
+  git: {
+    numberOfCommitsToShow: 20,
+  },
+  audio: {
+    soxPath: '',
+  },
+  apiKeys: {
+    set: null,
+    remove: null,
+  },
+  logger: {
+    debugMode: false,
+  },
+  debug: {
+    saveDebugObjects: false,
+    saveInputPrompt: false,
+  },
+  toolUse: {
+    requireEditApproval: true,
+    requireBashApproval: true,
+    persistence: {
+      enabled: true,
+      ttlHours: 336,
+    },
+  },
+};
+
+const stringArray = (defaultValue: string[]) =>
+  z.array(z.string()).prefault(defaultValue);
+
+const stringRecord = (defaultValue: Record<string, string>) =>
+  z.record(z.string(), z.string()).prefault(defaultValue);
+
+export const TexraSettingsSchema = z
+  .strictObject({
+    agentOutputs: z
+      .strictObject({
+        autoOpenFinal: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.agentOutputs.autoOpenFinal),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.agentOutputs),
+    ui: z
+      .strictObject({
+        showApiKeyReminders: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.ui.showApiKeyReminders),
+        showLoginBanner: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.ui.showLoginBanner),
+        showGettingStartedBanner: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.ui.showGettingStartedBanner),
+        showOrchestratorBanner: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.ui.showOrchestratorBanner),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.ui),
+    auth: z
+      .strictObject({
+        enableVSCodeGitHub: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.auth.enableVSCodeGitHub),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.auth),
+    model: z
+      .strictObject({
+        useImprovedConnection: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.useImprovedConnection),
+        improvedConnectionDomain: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.improvedConnectionDomain),
+        useOpenAIResponsesAPI: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.useOpenAIResponsesAPI),
+        useBackgroundResponses: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.useBackgroundResponses),
+        openaiParallelToolCalls: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.openaiParallelToolCalls),
+        compactionThresholdPercent: z
+          .number()
+          .min(0)
+          .max(100)
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.compactionThresholdPercent),
+        gpt5ReasoningSummary: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.gpt5ReasoningSummary),
+        retry: z
+          .strictObject({
+            maxAttempts: z
+              .number()
+              .min(0)
+              .prefault(DEFAULT_TEXRA_SETTINGS.model.retry.maxAttempts),
+            backoffMs: z
+              .number()
+              .min(0)
+              .prefault(DEFAULT_TEXRA_SETTINGS.model.retry.backoffMs),
+          })
+          .prefault(DEFAULT_TEXRA_SETTINGS.model.retry),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.model),
+    files: z
+      .strictObject({
+        included: z
+          .strictObject({
+            mediaExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.included.mediaExtensions,
+            ),
+            inputExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.included.inputExtensions,
+            ),
+            referenceExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.included.referenceExtensions,
+            ),
+            auxiliaryExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.included.auxiliaryExtensions,
+            ),
+            editedExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.included.editedExtensions,
+            ),
+          })
+          .prefault(DEFAULT_TEXRA_SETTINGS.files.included),
+        ignored: z
+          .strictObject({
+            fileExtensions: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.fileExtensions,
+            ),
+            inputFiles: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.inputFiles,
+            ),
+            inputDirectories: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.inputDirectories,
+            ),
+            auxiliaryKeywords: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.auxiliaryKeywords,
+            ),
+            mediaDirectories: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.mediaDirectories,
+            ),
+            directories: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.directories,
+            ),
+            keywords: stringArray(
+              DEFAULT_TEXRA_SETTINGS.files.ignored.keywords,
+            ),
+          })
+          .prefault(DEFAULT_TEXRA_SETTINGS.files.ignored),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.files),
+    maxImageDimension: z
+      .number()
+      .min(100)
+      .max(10000)
+      .prefault(DEFAULT_TEXRA_SETTINGS.maxImageDimension),
+    bib: z
+      .strictObject({
+        defaultPath: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.bib.defaultPath),
+        zoteroPort: z
+          .number()
+          .min(1)
+          .max(65535)
+          .prefault(DEFAULT_TEXRA_SETTINGS.bib.zoteroPort),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.bib),
+    latex: z
+      .strictObject({
+        showLatexindentWarning: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.showLatexindentWarning),
+        latexindentConfig: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.latexindentConfig),
+        texfmtConfig: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.texfmtConfig),
+        tikzInputDirectory: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.tikzInputDirectory),
+        tikzTemplate: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.tikzTemplate),
+        includeWorkspaceInTexinputs: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.includeWorkspaceInTexinputs),
+        wrapCritiqueInAlign: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.wrapCritiqueInAlign),
+        enabledReplacements: z
+          .array(z.enum(NON_REGEX_REPLACEMENT_CATEGORIES))
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.enabledReplacements),
+        enabledReplacementsRegex: z
+          .array(z.enum(REGEX_REPLACEMENT_CATEGORIES))
+          .prefault(DEFAULT_TEXRA_SETTINGS.latex.enabledReplacementsRegex),
+        customReplacementsRegex: stringRecord(
+          DEFAULT_TEXRA_SETTINGS.latex.customReplacementsRegex,
+        ),
+        customReplacements: stringRecord(
+          DEFAULT_TEXRA_SETTINGS.latex.customReplacements,
+        ),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.latex),
+    latexdiff: z
+      .strictObject({
+        pictureEnvironments: z
+          .string()
+          .prefault(DEFAULT_TEXRA_SETTINGS.latexdiff.pictureEnvironments),
+        tempFileLocation: z
+          .enum(LATEXDIFF_TEMP_FILE_LOCATIONS)
+          .prefault(DEFAULT_TEXRA_SETTINGS.latexdiff.tempFileLocation),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.latexdiff),
+    git: z
+      .strictObject({
+        numberOfCommitsToShow: z
+          .number()
+          .min(1)
+          .max(100)
+          .prefault(DEFAULT_TEXRA_SETTINGS.git.numberOfCommitsToShow),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.git),
+    audio: z
+      .strictObject({
+        soxPath: z.string().prefault(DEFAULT_TEXRA_SETTINGS.audio.soxPath),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.audio),
+    apiKeys: z
+      .strictObject({
+        set: z.null().prefault(DEFAULT_TEXRA_SETTINGS.apiKeys.set),
+        remove: z.null().prefault(DEFAULT_TEXRA_SETTINGS.apiKeys.remove),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.apiKeys),
+    logger: z
+      .strictObject({
+        debugMode: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.logger.debugMode),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.logger),
+    debug: z
+      .strictObject({
+        saveDebugObjects: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.debug.saveDebugObjects),
+        saveInputPrompt: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.debug.saveInputPrompt),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.debug),
+    toolUse: z
+      .strictObject({
+        requireEditApproval: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.toolUse.requireEditApproval),
+        requireBashApproval: z
+          .boolean()
+          .prefault(DEFAULT_TEXRA_SETTINGS.toolUse.requireBashApproval),
+        persistence: z
+          .strictObject({
+            enabled: z
+              .boolean()
+              .prefault(DEFAULT_TEXRA_SETTINGS.toolUse.persistence.enabled),
+            ttlHours: z
+              .number()
+              .min(1)
+              .prefault(DEFAULT_TEXRA_SETTINGS.toolUse.persistence.ttlHours),
+          })
+          .prefault(DEFAULT_TEXRA_SETTINGS.toolUse.persistence),
+      })
+      .prefault(DEFAULT_TEXRA_SETTINGS.toolUse),
+  })
+  .prefault(DEFAULT_TEXRA_SETTINGS);
+
+export type TexraSettings = z.infer<typeof TexraSettingsSchema>;
+
+export const TEXRA_SETTING_PATHS = [
+  'agentOutputs.autoOpenFinal',
+  'ui.showApiKeyReminders',
+  'ui.showLoginBanner',
+  'ui.showGettingStartedBanner',
+  'ui.showOrchestratorBanner',
+  'auth.enableVSCodeGitHub',
+  'model.useImprovedConnection',
+  'model.improvedConnectionDomain',
+  'model.useOpenAIResponsesAPI',
+  'model.useBackgroundResponses',
+  'model.openaiParallelToolCalls',
+  'model.compactionThresholdPercent',
+  'model.gpt5ReasoningSummary',
+  'files.included.mediaExtensions',
+  'files.included.inputExtensions',
+  'files.included.referenceExtensions',
+  'files.included.auxiliaryExtensions',
+  'files.included.editedExtensions',
+  'files.ignored.fileExtensions',
+  'files.ignored.inputFiles',
+  'files.ignored.inputDirectories',
+  'files.ignored.auxiliaryKeywords',
+  'files.ignored.mediaDirectories',
+  'files.ignored.directories',
+  'files.ignored.keywords',
+  'maxImageDimension',
+  'bib.defaultPath',
+  'bib.zoteroPort',
+  'latex.showLatexindentWarning',
+  'latex.latexindentConfig',
+  'latex.texfmtConfig',
+  'latex.tikzInputDirectory',
+  'latex.tikzTemplate',
+  'latex.includeWorkspaceInTexinputs',
+  'latex.wrapCritiqueInAlign',
+  'latex.enabledReplacements',
+  'latex.enabledReplacementsRegex',
+  'latex.customReplacementsRegex',
+  'latex.customReplacements',
+  'latexdiff.pictureEnvironments',
+  'latexdiff.tempFileLocation',
+  'git.numberOfCommitsToShow',
+  'audio.soxPath',
+  'apiKeys.set',
+  'apiKeys.remove',
+  'logger.debugMode',
+  'debug.saveDebugObjects',
+  'debug.saveInputPrompt',
+  'toolUse.requireEditApproval',
+  'toolUse.requireBashApproval',
+  'toolUse.persistence.enabled',
+  'toolUse.persistence.ttlHours',
+  'model.retry.maxAttempts',
+  'model.retry.backoffMs',
+] as const;
+
+export type TexraSettingPath = (typeof TEXRA_SETTING_PATHS)[number];
+export type TexraSettingKey = `texra.${TexraSettingPath}`;
+export type FlatTexraSettings = Record<TexraSettingKey, unknown>;
+
+export const TEXRA_SETTING_KEYS = TEXRA_SETTING_PATHS.map(
+  (path) => `texra.${path}` as TexraSettingKey,
+);
+
+function getNestedValue(source: unknown, path: TexraSettingPath): unknown {
+  let value = source;
+  for (const segment of path.split('.')) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return undefined;
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+  return value;
+}
+
+export function flattenTexraSettings(
+  settings: TexraSettings = TexraSettingsSchema.parse({}),
+): FlatTexraSettings {
+  const parsed = TexraSettingsSchema.parse(settings);
+  return Object.fromEntries(
+    TEXRA_SETTING_PATHS.map((path) => [
+      `texra.${path}` satisfies TexraSettingKey,
+      getNestedValue(parsed, path),
+    ]),
+  ) as FlatTexraSettings;
+}
+
+export function getTexraSettingDefault(path: TexraSettingPath): unknown {
+  return getNestedValue(TexraSettingsSchema.parse({}), path);
+}

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -30,20 +30,23 @@ interface PackageJson {
 const packageRequire = createRequire(`${process.cwd()}/package.json`);
 const packageJson = packageRequire('./package.json') as PackageJson;
 
+function getPackageConfigurationSections(): PackageConfigurationSection[] {
+  const configuration = packageJson.contributes?.configuration;
+  if (!Array.isArray(configuration)) {
+    assert.fail('package.json contributes.configuration must be an array');
+  }
+  return configuration;
+}
+
 function getPackageConfigurationProperties(): Record<
   string,
   PackageConfigurationProperty
 > {
-  const configuration = packageJson.contributes?.configuration;
-  const sections = Array.isArray(configuration)
-    ? configuration
-    : configuration == null
-      ? []
-      : [configuration];
-
   return Object.assign(
     {},
-    ...sections.map((section) => section.properties ?? {}),
+    ...getPackageConfigurationSections().map(
+      (section) => section.properties ?? {},
+    ),
   );
 }
 
@@ -81,12 +84,7 @@ describe('TexraSettingsSchema', () => {
   });
 
   it('regenerates package.json contributions from schema metadata', () => {
-    const configuration = packageJson.contributes?.configuration;
-    const sections = Array.isArray(configuration)
-      ? configuration
-      : configuration == null
-        ? []
-        : [configuration];
+    const sections = getPackageConfigurationSections();
 
     assert.deepEqual(buildTexraPackageConfiguration(sections), sections);
   });

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -1,0 +1,96 @@
+// Standard library imports
+import { createRequire } from 'module';
+import { strict as assert } from 'assert';
+
+// Local imports - schemas
+import {
+  flattenTexraSettings,
+  TEXRA_SETTING_KEYS,
+  TexraSettingsSchema,
+} from '@shared/schemas/settingsConfiguration';
+
+interface PackageConfigurationProperty {
+  default?: unknown;
+  type?: string;
+}
+
+interface PackageConfigurationSection {
+  properties?: Record<string, PackageConfigurationProperty>;
+}
+
+interface PackageJson {
+  contributes?: {
+    configuration?: PackageConfigurationSection | PackageConfigurationSection[];
+  };
+}
+
+const packageRequire = createRequire(`${process.cwd()}/package.json`);
+const packageJson = packageRequire('./package.json') as PackageJson;
+
+function getPackageConfigurationProperties(): Record<
+  string,
+  PackageConfigurationProperty
+> {
+  const configuration = packageJson.contributes?.configuration;
+  const sections = Array.isArray(configuration)
+    ? configuration
+    : configuration == null
+      ? []
+      : [configuration];
+
+  return Object.assign(
+    {},
+    ...sections.map((section) => section.properties ?? {}),
+  );
+}
+
+describe('TexraSettingsSchema', () => {
+  it('parses default settings', () => {
+    const parsed = TexraSettingsSchema.parse({});
+
+    assert.equal(parsed.model.compactionThresholdPercent, 75);
+    assert.equal(parsed.toolUse.persistence.ttlHours, 336);
+    assert.deepEqual(parsed.latex.customReplacements, {});
+  });
+
+  it('covers every package.json contributed setting key', () => {
+    const packageKeys = Object.keys(getPackageConfigurationProperties()).sort();
+    const schemaKeys = [...TEXRA_SETTING_KEYS].sort();
+
+    assert.deepEqual(schemaKeys, packageKeys);
+  });
+
+  it('keeps schema defaults aligned with package.json contributions', () => {
+    const packageProperties = getPackageConfigurationProperties();
+    const defaults = flattenTexraSettings();
+
+    for (const [key, property] of Object.entries(packageProperties)) {
+      if (Object.hasOwn(property, 'default')) {
+        assert.deepEqual(
+          defaults[key as keyof typeof defaults],
+          property.default,
+          key,
+        );
+      } else if (property.type === 'null') {
+        assert.equal(defaults[key as keyof typeof defaults], null, key);
+      }
+    }
+  });
+
+  it('enforces package numeric ranges and setting enums', () => {
+    assert.throws(() =>
+      TexraSettingsSchema.parse({ model: { compactionThresholdPercent: 101 } }),
+    );
+    assert.throws(() => TexraSettingsSchema.parse({ maxImageDimension: 99 }));
+    assert.throws(() =>
+      TexraSettingsSchema.parse({
+        latexdiff: { tempFileLocation: 'workspace' },
+      }),
+    );
+    assert.throws(() =>
+      TexraSettingsSchema.parse({
+        latex: { enabledReplacements: ['font_commands'] },
+      }),
+    );
+  });
+});

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -114,6 +114,29 @@ describe('TexraSettingsSchema', () => {
     assert.equal(Object.hasOwn(regeneratedProperty ?? {}, 'enum'), false);
   });
 
+  it('rejects unknown texra package configuration keys', () => {
+    const sections = getPackageConfigurationSections();
+    const sectionWithUnknownTexraKey = {
+      ...sections[0],
+      properties: {
+        ...sections[0].properties,
+        'texra.removed.setting': {
+          type: 'boolean',
+          default: false,
+        },
+      },
+    };
+
+    assert.throws(
+      () =>
+        buildTexraPackageConfiguration([
+          sectionWithUnknownTexraKey,
+          ...sections.slice(1),
+        ]),
+      /unknown setting key: texra\.removed\.setting/,
+    );
+  });
+
   it('enforces package numeric ranges and setting enums', () => {
     assert.throws(() =>
       TexraSettingsSchema.parse({ model: { compactionThresholdPercent: 101 } }),

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -89,6 +89,31 @@ describe('TexraSettingsSchema', () => {
     assert.deepEqual(buildTexraPackageConfiguration(sections), sections);
   });
 
+  it('removes stale generated package schema fields during regeneration', () => {
+    const sections = getPackageConfigurationSections();
+    const sectionWithStaleField = {
+      ...sections[0],
+      properties: {
+        ...sections[0].properties,
+        'texra.model.compactionThresholdPercent': {
+          ...sections[0].properties?.['texra.model.compactionThresholdPercent'],
+          description: 'Preserved description',
+          enum: [75],
+        },
+      },
+    };
+
+    const [regenerated] = buildTexraPackageConfiguration([
+      sectionWithStaleField,
+      ...sections.slice(1),
+    ]);
+    const regeneratedProperty =
+      regenerated.properties?.['texra.model.compactionThresholdPercent'];
+
+    assert.equal(regeneratedProperty?.description, 'Preserved description');
+    assert.equal(Object.hasOwn(regeneratedProperty ?? {}, 'enum'), false);
+  });
+
   it('enforces package numeric ranges and setting enums', () => {
     assert.throws(() =>
       TexraSettingsSchema.parse({ model: { compactionThresholdPercent: 101 } }),

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -4,6 +4,7 @@ import { strict as assert } from 'assert';
 
 // Local imports - schemas
 import {
+  buildTexraPackageConfiguration,
   flattenTexraSettings,
   TEXRA_SETTING_KEYS,
   TexraSettingsSchema,
@@ -12,10 +13,12 @@ import {
 interface PackageConfigurationProperty {
   default?: unknown;
   type?: string;
+  [key: string]: unknown;
 }
 
 interface PackageConfigurationSection {
   properties?: Record<string, PackageConfigurationProperty>;
+  [key: string]: unknown;
 }
 
 interface PackageJson {
@@ -75,6 +78,17 @@ describe('TexraSettingsSchema', () => {
         assert.equal(defaults[key as keyof typeof defaults], null, key);
       }
     }
+  });
+
+  it('regenerates package.json contributions from schema metadata', () => {
+    const configuration = packageJson.contributes?.configuration;
+    const sections = Array.isArray(configuration)
+      ? configuration
+      : configuration == null
+        ? []
+        : [configuration];
+
+    assert.deepEqual(buildTexraPackageConfiguration(sections), sections);
   });
 
   it('enforces package numeric ranges and setting enums', () => {

--- a/src/test/shared/settingsConfiguration.test.ts
+++ b/src/test/shared/settingsConfiguration.test.ts
@@ -6,6 +6,7 @@ import { strict as assert } from 'assert';
 import {
   buildTexraPackageConfiguration,
   flattenTexraSettings,
+  getTexraSettingDefault,
   TEXRA_SETTING_KEYS,
   TexraSettingsSchema,
 } from '@shared/schemas/settingsConfiguration';
@@ -81,6 +82,65 @@ describe('TexraSettingsSchema', () => {
         assert.equal(defaults[key as keyof typeof defaults], null, key);
       }
     }
+  });
+
+  it('returns isolated flattened setting defaults', () => {
+    const defaults = flattenTexraSettings();
+    const mediaExtensions = defaults[
+      'texra.files.included.mediaExtensions'
+    ] as string[];
+    mediaExtensions.push('.mutated');
+    const customReplacements = defaults[
+      'texra.latex.customReplacements'
+    ] as Record<string, string>;
+    customReplacements.mutated = 'value';
+
+    const nextDefaults = flattenTexraSettings();
+
+    assert.equal(
+      (
+        nextDefaults['texra.files.included.mediaExtensions'] as string[]
+      ).includes('.mutated'),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(
+        nextDefaults['texra.latex.customReplacements'] as Record<
+          string,
+          string
+        >,
+        'mutated',
+      ),
+      false,
+    );
+  });
+
+  it('returns isolated individual setting defaults', () => {
+    const mediaExtensions = getTexraSettingDefault(
+      'files.included.mediaExtensions',
+    ) as string[];
+    mediaExtensions.push('.mutated');
+    const customReplacements = getTexraSettingDefault(
+      'latex.customReplacements',
+    ) as Record<string, string>;
+    customReplacements.mutated = 'value';
+
+    assert.equal(
+      (
+        getTexraSettingDefault('files.included.mediaExtensions') as string[]
+      ).includes('.mutated'),
+      false,
+    );
+    assert.equal(
+      Object.hasOwn(
+        getTexraSettingDefault('latex.customReplacements') as Record<
+          string,
+          string
+        >,
+        'mutated',
+      ),
+      false,
+    );
   });
 
   it('regenerates package.json contributions from schema metadata', () => {


### PR DESCRIPTION
## Summary
- add a shared Zod schema and defaults object for the existing TeXRA contributed settings
- export typed setting keys/default flattening helpers for future settings-store work
- derive VS Code configuration schema fields from the Zod schema and add sync/check scripts for package.json
- add package.json alignment tests for contributed keys, defaults, numeric ranges, enums, and generated configuration

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- npm run compile-tests
- npm run check:settings-configuration
- npx mocha --require ./out/test/setup.js out/test/shared/settingsConfiguration.test.js
- git diff --check

## Live checks
- format: pass
- validate: pass
- claude-review: external quota failure (`You've hit your limit · resets 12:40am (UTC)`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily schema definitions, dev scripts, and tests; runtime impact is limited to a new exported settings schema module unless other code starts consuming it.
> 
> **Overview**
> Introduces a canonical `TexraSettingsSchema` (with `DEFAULT_TEXRA_SETTINGS`) to define/validate all VS Code `texra.*` contributed settings, plus typed helpers like `TEXRA_SETTING_KEYS`, `flattenTexraSettings`, and `getTexraSettingDefault`.
> 
> Adds a generator (`buildTexraPackageConfiguration`) that derives key JSON-schema fields (`type`, `items`, `default`, `enum`, `minimum/maximum`, etc.) for `package.json` settings from the Zod schema, along with `npm run sync:settings-configuration` / `check:settings-configuration` to keep `contributes.configuration` in sync.
> 
> Adds tests asserting full key coverage, default alignment, mutation-safe returned defaults, regeneration behavior (including stale field removal), unknown-key rejection, and enforcement of numeric ranges/enums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f2c7f37aef1ce2b47e9ede9f0fccc65817fc48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->