### PR TITLE
[codex] Extract auth callback parsing

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { SupabaseClient } from './SupabaseClient';
+import { parseAuthCallbackTokens } from './core/authCallback';
 import {
   SUPABASE_CONFIG,
   DEFAULT_OAUTH_PROVIDER,
@@ -19,7 +20,6 @@ import {
 } from './config';
 import { getServerSideKeyService } from './serverKeys';
 import {
-  parseAuthCallbackTokens,
   parseStoredSupabaseSession,
   toStorableSupabaseSession,
   type SupabaseSession,
@@ -321,14 +321,15 @@ export class SupabaseAuthProvider
   private async parseCallbackAndCreateSession(
     uri: vscode.Uri,
   ): Promise<CallbackResult> {
-    const parsedTokens = parseAuthCallbackTokens({
-      fragment: uri.fragment,
+    const parsedCallback = parseAuthCallbackTokens({
+      path: uri.path,
       query: uri.query,
+      fragment: uri.fragment,
     });
-    if (!parsedTokens.success) {
-      return parsedTokens;
-    }
-    const { accessToken, refreshToken, expiresIn } = parsedTokens.tokens;
+
+    if (!parsedCallback.success) return parsedCallback;
+
+    const { accessToken, refreshToken, expiresIn } = parsedCallback.tokens;
 
     // Verify user with Supabase
     const supabase = SupabaseClient.getClient();

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -17,28 +17,6 @@ export const SupabaseSessionSchema = z.object({
 });
 export type SupabaseSession = z.infer<typeof SupabaseSessionSchema>;
 
-export interface AuthCallbackParts {
-  fragment: string;
-  query: string;
-}
-
-export interface AuthCallbackTokens {
-  accessToken: string;
-  refreshToken: string;
-  expiresIn: string | null;
-}
-
-export type AuthCallbackTokenResult =
-  | {
-      success: true;
-      tokens: AuthCallbackTokens;
-    }
-  | {
-      success: false;
-      error: string;
-      isAuthError?: boolean;
-    };
-
 export interface SupabaseSessionParseOptions {
   logSource?: string;
   warn?: (source: string, message: string) => void;
@@ -94,49 +72,5 @@ export function toStorableSupabaseSession(
       ? nativeSession.expires_at * 1000
       : Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
     useCustomRefresh: options?.useCustomRefresh,
-  };
-}
-
-/**
- * Parse auth callback tokens from host-provided URI parts.
- * Tokens usually arrive in the fragment, with query params as a fallback for
- * PKCE and web environments.
- */
-export function parseAuthCallbackTokens(
-  parts: AuthCallbackParts,
-): AuthCallbackTokenResult {
-  const fragmentParams = new URLSearchParams(parts.fragment);
-  const queryParams = new URLSearchParams(parts.query);
-  const getParam = (name: string): string | null =>
-    fragmentParams.get(name) ?? queryParams.get(name);
-
-  const accessToken = getParam('access_token');
-  const refreshToken = getParam('refresh_token');
-  const expiresIn = getParam('expires_in');
-  const error = getParam('error');
-  const errorDescription = getParam('error_description');
-
-  if (error) {
-    return {
-      success: false,
-      error: errorDescription || error,
-      isAuthError: true,
-    };
-  }
-
-  if (!accessToken || !refreshToken) {
-    return {
-      success: false,
-      error: 'Missing tokens in callback',
-    };
-  }
-
-  return {
-    success: true,
-    tokens: {
-      accessToken,
-      refreshToken,
-      expiresIn,
-    },
   };
 }

--- a/src/auth/UriHandler.ts
+++ b/src/auth/UriHandler.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isAuthCallbackPath } from './core/authCallback';
 
 /**
  * URI handler for OAuth callbacks.
@@ -19,11 +20,7 @@ export class SupabaseUriHandler implements vscode.UriHandler {
   handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
     // Check if this is an auth callback (both desktop and web/Codespaces paths)
     // In Codespaces, the state param may be URL-encoded into the path (e.g., /extension-auth-callback?state=xxx)
-    const basePath = uri.path.split('?')[0];
-    if (
-      basePath === '/auth-callback' ||
-      basePath === '/extension-auth-callback'
-    ) {
+    if (isAuthCallbackPath(uri.path)) {
       // Fire event so the auth provider can handle it
       this._onDidReceiveCallback.fire(uri);
     }

--- a/src/auth/core/authCallback.ts
+++ b/src/auth/core/authCallback.ts
@@ -1,0 +1,92 @@
+export const AUTH_CALLBACK_PATHS = [
+  '/auth-callback',
+  '/extension-auth-callback',
+] as const;
+
+export interface AuthCallbackUriParts {
+  path: string;
+  query?: string;
+  fragment?: string;
+}
+
+export interface AuthCallbackTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: string | null;
+}
+
+export interface AuthCallbackTokenParseSuccess {
+  success: true;
+  tokens: AuthCallbackTokens;
+}
+
+export interface AuthCallbackTokenParseError {
+  success: false;
+  error: string;
+  isAuthError?: boolean;
+}
+
+export type AuthCallbackTokenParseResult =
+  | AuthCallbackTokenParseSuccess
+  | AuthCallbackTokenParseError;
+
+export function getAuthCallbackBasePath(path: string): string {
+  return path.split('?')[0];
+}
+
+export function isAuthCallbackPath(path: string): boolean {
+  return AUTH_CALLBACK_PATHS.includes(
+    getAuthCallbackBasePath(path) as (typeof AUTH_CALLBACK_PATHS)[number],
+  );
+}
+
+function getQueryFromPath(path: string): string {
+  const queryStart = path.indexOf('?');
+  return queryStart === -1 ? '' : path.slice(queryStart + 1);
+}
+
+/**
+ * Extract Supabase callback tokens or auth errors from host-neutral URI parts.
+ * Fragment params win over query params, matching the implicit-flow callback.
+ */
+export function parseAuthCallbackTokens(
+  uri: AuthCallbackUriParts,
+): AuthCallbackTokenParseResult {
+  const fragmentParams = new URLSearchParams(uri.fragment ?? '');
+  const queryParams = new URLSearchParams(
+    uri.query || getQueryFromPath(uri.path),
+  );
+
+  const getParam = (name: string): string | null =>
+    fragmentParams.get(name) ?? queryParams.get(name);
+
+  const accessToken = getParam('access_token');
+  const refreshToken = getParam('refresh_token');
+  const expiresIn = getParam('expires_in');
+  const error = getParam('error');
+  const errorDescription = getParam('error_description');
+
+  if (error) {
+    return {
+      success: false,
+      error: errorDescription || error,
+      isAuthError: true,
+    };
+  }
+
+  if (!accessToken || !refreshToken) {
+    return {
+      success: false,
+      error: 'Missing tokens in callback',
+    };
+  }
+
+  return {
+    success: true,
+    tokens: {
+      accessToken,
+      refreshToken,
+      expiresIn,
+    },
+  };
+}

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -4,7 +4,6 @@ import { strict as assert } from 'assert';
 // Local imports - auth
 import {
   DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-  parseAuthCallbackTokens,
   parseStoredSupabaseSession,
   toStorableSupabaseSession,
   type SupabaseSession,
@@ -103,72 +102,6 @@ describe('SupabaseSession', () => {
       assert.ok(session.expiresAt >= earliestExpiry);
       assert.ok(
         session.expiresAt <= Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
-      );
-    });
-  });
-
-  describe('parseAuthCallbackTokens', () => {
-    it('prefers fragment tokens over query tokens', () => {
-      assert.deepEqual(
-        parseAuthCallbackTokens({
-          fragment:
-            'access_token=fragment-access&refresh_token=fragment-refresh&expires_in=60',
-          query:
-            'access_token=query-access&refresh_token=query-refresh&expires_in=120',
-        }),
-        {
-          success: true,
-          tokens: {
-            accessToken: 'fragment-access',
-            refreshToken: 'fragment-refresh',
-            expiresIn: '60',
-          },
-        },
-      );
-    });
-
-    it('does not fall back to query tokens when fragment tokens are empty', () => {
-      assert.deepEqual(
-        parseAuthCallbackTokens({
-          fragment: 'access_token=&refresh_token=fragment-refresh',
-          query: 'access_token=query-access&refresh_token=query-refresh',
-        }),
-        {
-          success: false,
-          error: 'Missing tokens in callback',
-        },
-      );
-    });
-
-    it('uses query tokens when the fragment is missing them', () => {
-      assert.deepEqual(
-        parseAuthCallbackTokens({
-          fragment: '',
-          query: 'access_token=query-access&refresh_token=query-refresh',
-        }),
-        {
-          success: true,
-          tokens: {
-            accessToken: 'query-access',
-            refreshToken: 'query-refresh',
-            expiresIn: null,
-          },
-        },
-      );
-    });
-
-    it('returns auth errors from callback parameters', () => {
-      assert.deepEqual(
-        parseAuthCallbackTokens({
-          fragment:
-            'error=access_denied&error_description=User%20cancelled%20login',
-          query: '',
-        }),
-        {
-          success: false,
-          error: 'User cancelled login',
-          isAuthError: true,
-        },
       );
     });
   });

--- a/src/test/auth/authCallback.test.ts
+++ b/src/test/auth/authCallback.test.ts
@@ -41,18 +41,17 @@ describe('authCallback', () => {
     });
   });
 
-  it('does not fall back to query tokens when fragment tokens are empty', () => {
-    assert.deepEqual(
-      parseAuthCallbackTokens({
-        path: '/auth-callback',
-        fragment: 'access_token=&refresh_token=fragment-refresh',
-        query: 'access_token=query-access&refresh_token=query-refresh',
-      }),
-      {
-        success: false,
-        error: 'Missing tokens in callback',
-      },
-    );
+  it('preserves empty fragment params instead of falling back to query', () => {
+    const result = parseAuthCallbackTokens({
+      path: '/auth-callback',
+      query: 'access_token=query-access&refresh_token=query-refresh',
+      fragment: 'access_token=&refresh_token=fragment-refresh',
+    });
+
+    assert.deepEqual(result, {
+      success: false,
+      error: 'Missing tokens in callback',
+    });
   });
 
   it('extracts tokens from query params when no fragment tokens exist', () => {

--- a/src/test/auth/authCallback.test.ts
+++ b/src/test/auth/authCallback.test.ts
@@ -1,0 +1,107 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - auth
+import {
+  getAuthCallbackBasePath,
+  isAuthCallbackPath,
+  parseAuthCallbackTokens,
+} from '@auth/core/authCallback';
+
+describe('authCallback', () => {
+  it('recognizes desktop and web callback paths', () => {
+    assert.equal(isAuthCallbackPath('/auth-callback'), true);
+    assert.equal(isAuthCallbackPath('/extension-auth-callback'), true);
+    assert.equal(
+      isAuthCallbackPath('/extension-auth-callback?state=vscode-state'),
+      true,
+    );
+    assert.equal(isAuthCallbackPath('/not-auth'), false);
+    assert.equal(
+      getAuthCallbackBasePath('/extension-auth-callback?state=abc'),
+      '/extension-auth-callback',
+    );
+  });
+
+  it('extracts tokens from fragment params before query params', () => {
+    const result = parseAuthCallbackTokens({
+      path: '/auth-callback',
+      query: 'access_token=query-access&refresh_token=query-refresh',
+      fragment:
+        'access_token=fragment-access&refresh_token=fragment-refresh&expires_in=3600',
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      tokens: {
+        accessToken: 'fragment-access',
+        refreshToken: 'fragment-refresh',
+        expiresIn: '3600',
+      },
+    });
+  });
+
+  it('does not fall back to query tokens when fragment tokens are empty', () => {
+    assert.deepEqual(
+      parseAuthCallbackTokens({
+        path: '/auth-callback',
+        fragment: 'access_token=&refresh_token=fragment-refresh',
+        query: 'access_token=query-access&refresh_token=query-refresh',
+      }),
+      {
+        success: false,
+        error: 'Missing tokens in callback',
+      },
+    );
+  });
+
+  it('extracts tokens from query params when no fragment tokens exist', () => {
+    const result = parseAuthCallbackTokens({
+      path: '/auth-callback',
+      query: 'access_token=query-access&refresh_token=query-refresh',
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      tokens: {
+        accessToken: 'query-access',
+        refreshToken: 'query-refresh',
+        expiresIn: null,
+      },
+    });
+  });
+
+  it('extracts query params embedded in the path fallback', () => {
+    const result = parseAuthCallbackTokens({
+      path: '/extension-auth-callback?access_token=access&refresh_token=refresh',
+    });
+
+    assert.deepEqual(result, {
+      success: true,
+      tokens: {
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        expiresIn: null,
+      },
+    });
+  });
+
+  it('reports auth errors and missing tokens', () => {
+    assert.deepEqual(
+      parseAuthCallbackTokens({
+        path: '/auth-callback',
+        fragment: 'error=access_denied&error_description=Nope',
+      }),
+      {
+        success: false,
+        error: 'Nope',
+        isAuthError: true,
+      },
+    );
+
+    assert.deepEqual(parseAuthCallbackTokens({ path: '/auth-callback' }), {
+      success: false,
+      error: 'Missing tokens in callback',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract OAuth callback path and token parsing into a VS Code-free auth core helper
- route the existing Supabase URI handler and provider through the shared parser
- add focused parser tests for desktop, web/Codespaces, query, fragment, and error callbacks

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/auth/authCallback.test.js
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/magic-link callback parsing and routing, so mistakes could break sign-in flows across desktop/web/Codespaces; changes are contained and covered by new focused tests.
> 
> **Overview**
> Extracts auth callback path recognition and token/error parsing into a new VS Code-free helper (`auth/core/authCallback.ts`), including a fallback to parse query params embedded in the callback path.
> 
> Routes `SupabaseAuthProvider` and `SupabaseUriHandler` through the shared helper and removes the old callback parsing code from `SupabaseSession`. Test coverage is moved/expanded to a dedicated `authCallback` test suite covering desktop/web paths, fragment vs query precedence, embedded query-in-path, and error/missing-token cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b1c83588769ccce689944da60314459e67c7f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->