### PR TITLE
[codex] Inject Supabase token provider

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -18,6 +18,7 @@ import {
   type OAuthProvider,
 } from './config';
 import { getServerSideKeyService } from './serverKeys';
+import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
 import type { Session as SupabaseNativeSession } from '@supabase/supabase-js';
 import type { SupabaseUriHandler } from './UriHandler';
 
@@ -144,7 +145,9 @@ function isOAuthProvider(value: string | undefined): value is OAuthProvider {
  * Authentication provider for Supabase integration.
  * Manages user sessions for remote agent access.
  */
-export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
+export class SupabaseAuthProvider
+  implements vscode.AuthenticationProvider, AuthTokenProvider
+{
   private static instance: SupabaseAuthProvider | null = null;
 
   private _onDidChangeSessions =
@@ -244,6 +247,32 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       logger.error(
         'SupabaseAuthProvider',
         `Error ensuring fresh token: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Get access and refresh tokens from secure storage.
+   * Ensures tokens are fresh before returning.
+   */
+  async getSessionTokens(): Promise<SessionTokens | null> {
+    await this.ensureFreshToken();
+
+    try {
+      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
+      const session = parseStoredSession(sessionData);
+      if (!session) {
+        return null;
+      }
+      return {
+        accessToken: session.accessToken,
+        refreshToken: session.refreshToken,
+      };
+    } catch (error) {
+      logger.error(
+        'SupabaseAuthProvider',
+        `Error getting session tokens: ${toErrorMessage(error)}`,
       );
       return null;
     }

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -3,21 +3,15 @@ import {
   SupabaseClient as Client,
   User,
 } from '@supabase/supabase-js';
-import * as vscode from 'vscode';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   type UserAuthContext,
   type UserTier,
   UserAuthContextSchema,
-  SUPABASE_SESSION_KEY,
   TOKEN_REFRESH_THRESHOLD_MS,
 } from './config';
-
-/** Interface for auth provider to avoid circular imports. */
-interface AuthTokenProvider {
-  ensureFreshToken(forceRefresh?: boolean): Promise<string | null>;
-}
+import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
 
 /**
  * Singleton Supabase client with authentication helpers.
@@ -26,14 +20,13 @@ interface AuthTokenProvider {
 export class SupabaseClient {
   private static instance: Client | null = null;
   private static config: { url: string; publicKey: string } | null = null;
-  private static context: vscode.ExtensionContext | null = null;
   private static authProvider: AuthTokenProvider | null = null;
 
   /**
-   * Whether VS Code's auth provider registration succeeded.
+   * Whether the host auth provider registration succeeded.
    * This is separate from authProvider being set (which happens in constructor).
    */
-  private static vscodeProviderRegistered = false;
+  private static authProviderRegistered = false;
 
   /**
    * Error that occurred during initialization, if any.
@@ -58,10 +51,10 @@ export class SupabaseClient {
 
   /**
    * Mark VS Code auth provider as successfully registered.
-   * Called after vscode.authentication.registerAuthenticationProvider() succeeds.
+   * Called after the host registers its authentication provider.
    */
   static setVSCodeProviderRegistered(): void {
-    this.vscodeProviderRegistered = true;
+    this.authProviderRegistered = true;
   }
 
   /**
@@ -106,7 +99,7 @@ export class SupabaseClient {
     return (
       this.instance !== null &&
       this.authProvider !== null &&
-      this.vscodeProviderRegistered &&
+      this.authProviderRegistered &&
       this.initError === null
     );
   }
@@ -114,20 +107,13 @@ export class SupabaseClient {
   /**
    * Initialize the Supabase client with project credentials.
    */
-  static initialize(
-    url: string,
-    publicKey: string,
-    context?: vscode.ExtensionContext,
-  ): void {
+  static initialize(url: string, publicKey: string, _context?: unknown): void {
     if (!url || !publicKey) {
       throw new Error(
         'Supabase credentials missing. Check extension configuration.',
       );
     }
     this.config = { url, publicKey };
-    if (context) {
-      this.context = context;
-    }
     this.instance = createClient(url, publicKey, {
       auth: {
         persistSession: false, // VS Code manages session storage
@@ -174,42 +160,12 @@ export class SupabaseClient {
    * Get access and refresh tokens from secure storage.
    * Ensures tokens are fresh before returning.
    */
-  static async getSessionTokens(): Promise<{
-    accessToken: string;
-    refreshToken: string;
-  } | null> {
-    // Ensure token is fresh before reading from storage
-    if (this.authProvider) {
-      await this.authProvider.ensureFreshToken();
-    }
-
-    if (!this.context) {
-      logger.warn('SupabaseClient', 'Extension context not set');
-      const accessToken = await this.getAccessToken();
-      if (!accessToken) {
-        return null;
-      }
-      return { accessToken, refreshToken: '' };
-    }
-
-    try {
-      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
-      if (!sessionData) {
-        return null;
-      }
-
-      const { accessToken, refreshToken } = JSON.parse(sessionData) as {
-        accessToken: string;
-        refreshToken: string;
-      };
-      return { accessToken, refreshToken };
-    } catch (error) {
-      logger.error(
-        'SupabaseClient',
-        `Error getting session tokens: ${toErrorMessage(error)}`,
-      );
+  static async getSessionTokens(): Promise<SessionTokens | null> {
+    if (!this.authProvider) {
       return null;
     }
+
+    return this.authProvider.getSessionTokens();
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -50,11 +50,21 @@ export class SupabaseClient {
   }
 
   /**
-   * Mark VS Code auth provider as successfully registered.
+   * Mark the host auth provider as successfully registered.
    * Called after the host registers its authentication provider.
    */
-  static setVSCodeProviderRegistered(): void {
+  static setHostAuthProviderRegistered(): void {
     this.authProviderRegistered = true;
+  }
+
+  /** Reset singleton state between unit tests. */
+  static resetForTests(): void {
+    this.instance = null;
+    this.config = null;
+    this.authProvider = null;
+    this.authProviderRegistered = false;
+    this.initError = null;
+    this.tokenExpiresAt = null;
   }
 
   /**
@@ -165,7 +175,15 @@ export class SupabaseClient {
       return null;
     }
 
-    return this.authProvider.getSessionTokens();
+    try {
+      return await this.authProvider.getSessionTokens();
+    } catch (error) {
+      logger.error(
+        'SupabaseClient',
+        `Error getting session tokens: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -1,0 +1,10 @@
+export interface SessionTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/** Host-neutral source for authenticated Supabase session tokens. */
+export interface AuthTokenProvider {
+  ensureFreshToken(forceRefresh?: boolean): Promise<string | null>;
+  getSessionTokens(): Promise<SessionTokens | null>;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,7 +207,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const uriHandler = new SupabaseUriHandler();
       context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
       authProvider.setUriHandler(uriHandler);
-      SupabaseClient.setVSCodeProviderRegistered();
+      SupabaseClient.setHostAuthProviderRegistered();
 
       logger.info('extension', 'Supabase authentication provider registered');
 

--- a/src/test/auth/SupabaseClient.test.ts
+++ b/src/test/auth/SupabaseClient.test.ts
@@ -1,0 +1,26 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - auth
+import { SupabaseClient } from '@auth/SupabaseClient';
+import type { AuthTokenProvider } from '@auth/TokenProvider';
+
+describe('SupabaseClient', () => {
+  it('reads session tokens through the registered token provider', async () => {
+    const provider: AuthTokenProvider = {
+      ensureFreshToken: async () => 'access-token',
+      getSessionTokens: async () => ({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      }),
+    };
+
+    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+    SupabaseClient.setAuthProvider(provider);
+
+    assert.deepEqual(await SupabaseClient.getSessionTokens(), {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+  });
+});

--- a/src/test/auth/SupabaseClient.test.ts
+++ b/src/test/auth/SupabaseClient.test.ts
@@ -6,6 +6,10 @@ import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
 
 describe('SupabaseClient', () => {
+  afterEach(() => {
+    SupabaseClient.resetForTests();
+  });
+
   it('reads session tokens through the registered token provider', async () => {
     const provider: AuthTokenProvider = {
       ensureFreshToken: async () => 'access-token',
@@ -15,12 +19,24 @@ describe('SupabaseClient', () => {
       }),
     };
 
-    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
     SupabaseClient.setAuthProvider(provider);
 
     assert.deepEqual(await SupabaseClient.getSessionTokens(), {
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
     });
+  });
+
+  it('returns null when the token provider throws while reading session tokens', async () => {
+    const provider: AuthTokenProvider = {
+      ensureFreshToken: async () => 'access-token',
+      getSessionTokens: async () => {
+        throw new Error('storage unavailable');
+      },
+    };
+
+    SupabaseClient.setAuthProvider(provider);
+
+    assert.equal(await SupabaseClient.getSessionTokens(), null);
   });
 });


### PR DESCRIPTION
## Summary
- add a host-neutral `AuthTokenProvider` interface for Supabase session tokens
- move secure-session token reads out of `SupabaseClient` and into `SupabaseAuthProvider`
- remove the direct `vscode` / `ExtensionContext` dependency from `SupabaseClient`
- add a focused test that verifies `SupabaseClient` reads tokens through the registered provider

## Validation
- npm run format
- npm run compile:safe
- npm run compile
- npm run lint
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/auth/SupabaseClient.test.js
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session token retrieval and auth readiness checks, which can affect sign-in state and any features relying on Supabase tokens if the provider registration flow is miswired. Scope is contained to auth plumbing with added unit coverage.
> 
> **Overview**
> Refactors Supabase token access to flow through a new host-neutral `AuthTokenProvider`/`SessionTokens` contract, removing `SupabaseClient`'s direct dependency on VS Code `ExtensionContext`/SecretStorage.
> 
> `SupabaseAuthProvider` now implements the provider and becomes the single place that reads secure session storage and returns both access+refresh tokens (after ensuring freshness); `SupabaseClient.getSessionTokens()` delegates to it. Provider-registration bookkeeping is renamed to host-neutral (`setHostAuthProviderRegistered`), and `SupabaseClient` gains `resetForTests()` plus unit tests validating delegation and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad365b5bf9c5fed9baaeab221152c74a474302f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->