### PR TITLE
[codex] Decouple server-key events from VS Code

### DIFF
--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -14,7 +14,7 @@
  * - free tier: Budget models only (under $1/M input)
  */
 
-import * as vscode from 'vscode';
+import { EventEmitter } from 'events';
 import * as logger from '@logger/logUtils';
 import {
   SERVER_SIDE_CACHE_TTL_MS,
@@ -22,6 +22,7 @@ import {
   FREE_TIER,
   type UserTier,
 } from '../config';
+import type { StateStore } from '@platform/interfaces/state';
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
 
@@ -41,6 +42,8 @@ const RELAY_PATH_SUFFIXES: Partial<Record<ServerSideProvider, string>> = {
 /** Global state key for the "use included model access" preference. */
 const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
 
+const SERVICE_EVENT = 'event';
+
 /**
  * Interface for authentication provider that can check auth state and get user tier.
  */
@@ -48,6 +51,53 @@ export interface AuthProvider {
   isAuthenticated(): Promise<boolean>;
   getUserTier(): Promise<UserTier>;
   getAccessToken(): Promise<string | null>;
+}
+
+export interface ServerSideKeyDisposable {
+  dispose(): void;
+}
+
+export type ServerSideKeyEvent<T> = (
+  listener: (event: T) => unknown,
+  thisArgs?: unknown,
+  disposables?: ServerSideKeyDisposable[],
+) => ServerSideKeyDisposable;
+
+export type ServerSideKeyState = StateStore;
+
+export interface ServerSideKeyServiceInit {
+  state?: ServerSideKeyState;
+  subscriptions?: ServerSideKeyDisposable[];
+}
+
+class NodeEventEmitter<T> implements ServerSideKeyDisposable {
+  private readonly emitter = new EventEmitter();
+
+  readonly event: ServerSideKeyEvent<T> = (listener, thisArgs, disposables) => {
+    const boundListener =
+      thisArgs === undefined ? listener : listener.bind(thisArgs);
+    this.emitter.on(SERVICE_EVENT, boundListener);
+    const disposable = {
+      dispose: () => this.emitter.off(SERVICE_EVENT, boundListener),
+    };
+    disposables?.push(disposable);
+    return disposable;
+  };
+
+  fire(event: T): void {
+    for (const listener of this.emitter.listeners(SERVICE_EVENT)) {
+      try {
+        listener(event);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(CHANNEL, `Event listener failed: ${message}`);
+      }
+    }
+  }
+
+  dispose(): void {
+    this.emitter.removeAllListeners();
+  }
 }
 
 /**
@@ -71,10 +121,10 @@ export class ServerSideKeyService {
 
   // Settings
   private useIncludedModelAccess = true;
-  private globalState: vscode.Memento | null = null;
-  private readonly _onDidChangeModelAccess = new vscode.EventEmitter<boolean>();
-  private readonly _onCacheCleared = new vscode.EventEmitter<void>();
-  private readonly _tierServiceClearSubscription: vscode.Disposable;
+  private globalState: ServerSideKeyState | null = null;
+  private readonly _onDidChangeModelAccess = new NodeEventEmitter<boolean>();
+  private readonly _onCacheCleared = new NodeEventEmitter<void>();
+  private readonly _tierServiceClearSubscription: ServerSideKeyDisposable;
 
   readonly onDidChangeModelAccess = this._onDidChangeModelAccess.event;
   readonly onCacheCleared = this._onCacheCleared.event;
@@ -90,18 +140,18 @@ export class ServerSideKeyService {
   }
 
   /**
-   * Initialize the service with VS Code extension context.
-   * This enables settings persistence.
+   * Initialize the service with host-provided state and subscriptions.
+   * This enables settings persistence without coupling the service to VS Code.
    */
-  initialize(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(this._onDidChangeModelAccess);
-    context.subscriptions.push(this._onCacheCleared);
-    context.subscriptions.push(this._tierServiceClearSubscription);
-    this.globalState = context.globalState;
-    this.useIncludedModelAccess = this.globalState.get<boolean>(
-      USE_INCLUDED_ACCESS_KEY,
-      true,
+  initialize(options: ServerSideKeyServiceInit): void {
+    options.subscriptions?.push(
+      this._onDidChangeModelAccess,
+      this._onCacheCleared,
+      this._tierServiceClearSubscription,
     );
+    this.globalState = options.state ?? null;
+    this.useIncludedModelAccess =
+      this.globalState?.get<boolean>(USE_INCLUDED_ACCESS_KEY, true) ?? true;
   }
 
   dispose(): void {
@@ -152,7 +202,7 @@ export class ServerSideKeyService {
     this.accessTimestamp = 0;
     this.accessFetchPromise = null;
     this.userTier = null;
-    this._onCacheCleared.fire();
+    this._onCacheCleared.fire(undefined);
   }
 
   isProviderOnServer(provider: string): boolean {

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -69,5 +69,8 @@ export function initializeServerSideKeyAccess(
     authProvider,
     getTierService(),
   );
-  _instance.initialize(context);
+  _instance.initialize({
+    state: context.globalState,
+    subscriptions: context.subscriptions,
+  });
 }

--- a/src/test/auth/ServerSideKeyService.test.ts
+++ b/src/test/auth/ServerSideKeyService.test.ts
@@ -1,0 +1,170 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - auth
+import { FREE_TIER, type UserTier } from '@auth/config';
+import {
+  ServerSideKeyService,
+  type AuthProvider,
+  type ServerSideKeyState,
+} from '@auth/serverKeys/ServerSideKeyService';
+import type { TierService } from '@auth/tier/TierService';
+
+const USE_INCLUDED_ACCESS_KEY = 'texra.useIncludedModelAccess';
+
+class MemoryState implements ServerSideKeyState {
+  private readonly values = new Map<string, unknown>();
+
+  constructor(initialValues: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(initialValues)) {
+      this.values.set(key, value);
+    }
+  }
+
+  get<T>(key: string, defaultValue?: T): T {
+    return this.values.has(key)
+      ? (this.values.get(key) as T)
+      : (defaultValue as T);
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.values.set(key, value);
+  }
+}
+
+interface FakeTierService {
+  clearCacheCalls: number;
+  getConfigCalls: number;
+  service: TierService;
+}
+
+function createTierService(): FakeTierService {
+  const fake = {
+    clearCacheCalls: 0,
+    getConfigCalls: 0,
+    clearCache() {
+      this.clearCacheCalls += 1;
+    },
+    async getConfig() {
+      this.getConfigCalls += 1;
+      return null;
+    },
+    getConfigSync() {
+      return null;
+    },
+    getProviders() {
+      return [];
+    },
+    isAccessExpired() {
+      return false;
+    },
+    isModelAvailable() {
+      return false;
+    },
+    getAllowedModels() {
+      return [];
+    },
+    getAccessDescription() {
+      return 'No included model access';
+    },
+    getExpirationDate() {
+      return null;
+    },
+  };
+
+  return {
+    get clearCacheCalls() {
+      return fake.clearCacheCalls;
+    },
+    get getConfigCalls() {
+      return fake.getConfigCalls;
+    },
+    service: fake as unknown as TierService,
+  };
+}
+
+function createAuthProvider(): AuthProvider {
+  return {
+    isAuthenticated: async () => false,
+    getUserTier: async (): Promise<UserTier> => FREE_TIER,
+    getAccessToken: async () => null,
+  };
+}
+
+function createService(tierService: TierService): ServerSideKeyService {
+  return new ServerSideKeyService(
+    'https://example.test',
+    createAuthProvider(),
+    tierService,
+  );
+}
+
+describe('ServerSideKeyService', () => {
+  it('reads the included-access setting from host-provided state', () => {
+    const tier = createTierService();
+    const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
+    const service = createService(tier.service);
+
+    service.initialize({ state });
+
+    assert.equal(service.getUseIncludedModelAccess(), false);
+  });
+
+  it('persists setting changes and fires change events', async () => {
+    const tier = createTierService();
+    const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
+    const service = createService(tier.service);
+    const changes: boolean[] = [];
+
+    service.initialize({ state });
+    service.onDidChangeModelAccess((value) => {
+      changes.push(value);
+    });
+
+    await service.setUseIncludedModelAccess(true);
+
+    assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
+    assert.deepEqual(changes, [true]);
+    assert.equal(tier.clearCacheCalls, 1);
+    assert.equal(tier.getConfigCalls, 1);
+  });
+
+  it('supports host subscription disposal without VS Code types', async () => {
+    const tier = createTierService();
+    const service = createService(tier.service);
+    const subscriptions: Array<{ dispose(): void }> = [];
+    const changes: boolean[] = [];
+
+    service.initialize({ subscriptions });
+    const listener = service.onDidChangeModelAccess((value) => {
+      changes.push(value);
+    });
+
+    assert.equal(subscriptions.length, 3);
+
+    listener.dispose();
+    await service.setUseIncludedModelAccess(false);
+
+    assert.deepEqual(changes, []);
+  });
+
+  it('continues dispatching when one listener throws', async () => {
+    const tier = createTierService();
+    const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
+    const service = createService(tier.service);
+    const changes: boolean[] = [];
+
+    service.initialize({ state });
+    service.onDidChangeModelAccess(() => {
+      throw new Error('listener failed');
+    });
+    service.onDidChangeModelAccess((value) => {
+      changes.push(value);
+    });
+
+    await assert.doesNotReject(() => service.setUseIncludedModelAccess(true));
+
+    assert.deepEqual(changes, [true]);
+    assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace ServerSideKeyService's direct VS Code EventEmitter/Memento/Disposable usage with Node-backed host-neutral event and state interfaces
- keep VS Code context wiring in the serverKeys module initializer
- add focused coverage for persisted included-access state, change events, and subscription disposal

## Validation
- npm run format
- npm run compile:safe
- npm run lint
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/auth/ServerSideKeyService.test.js
- npm run compile
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes lifecycle/event wiring and persistence integration for server-side key access; regressions could disable included-model access or stop cache invalidation notifications.
> 
> **Overview**
> Decouples `ServerSideKeyService` from VS Code by replacing direct `vscode.Memento`/`EventEmitter`/`Disposable` usage with host-neutral `StateStore`-backed persistence and a Node `EventEmitter` wrapper (including `ServerSideKeyDisposable`/subscription support).
> 
> Updates the VS Code initializer in `serverKeys/index.ts` to pass `context.globalState` and `context.subscriptions` via the new `initialize({ state, subscriptions })` API, and adds unit tests covering state loading/persistence, event firing/disposal, and resilience when a listener throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a65330733706a810f5f17f5b6217f57bcd98777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->