### PR TITLE
[codex] Move Supabase client readiness to token provider

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -49,6 +49,8 @@ type GitHubTokenExchangeResponse = z.infer<typeof GitHubTokenExchangeSchema>;
 
 /** Timeout for Edge Function requests (30 seconds) */
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
+const AUTH_URI_HANDLER_NOT_INITIALIZED =
+  'OAuth handler not initialized. Restart the extension.';
 
 /** GitHub token type prefixes for diagnostic logging. */
 const GITHUB_TOKEN_TYPE_MAP: Record<string, string> = {
@@ -126,7 +128,7 @@ export class SupabaseAuthProvider
 
   async whenReady(): Promise<void> {
     if (!this.uriHandler) {
-      throw new Error('Authentication URI handler not initialized');
+      throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
     }
   }
 
@@ -743,7 +745,7 @@ export class SupabaseAuthProvider
     cancellationToken: vscode.CancellationToken,
   ): Promise<SupabaseSession | null> {
     if (!this.uriHandler) {
-      throw new Error('OAuth handler not initialized. Restart the extension.');
+      throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
     }
 
     return new Promise((resolve, reject) => {

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -124,6 +124,12 @@ export class SupabaseAuthProvider
     return this.instance;
   }
 
+  async whenReady(): Promise<void> {
+    if (!this.uriHandler) {
+      throw new Error('Authentication URI handler not initialized');
+    }
+  }
+
   /**
    * Store session with optional notification.
    * @param notify - If true, fires session change event and clears caches (for new logins)

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -23,12 +23,6 @@ export class SupabaseClient {
   private static authProvider: AuthTokenProvider | null = null;
 
   /**
-   * Whether the host auth provider registration succeeded.
-   * This is separate from authProvider being set (which happens in constructor).
-   */
-  private static authProviderRegistered = false;
-
-  /**
    * Error that occurred during initialization, if any.
    * Used to provide meaningful error messages to users.
    */
@@ -49,20 +43,11 @@ export class SupabaseClient {
     this.authProvider = provider;
   }
 
-  /**
-   * Mark the host auth provider as successfully registered.
-   * Called after the host registers its authentication provider.
-   */
-  static setHostAuthProviderRegistered(): void {
-    this.authProviderRegistered = true;
-  }
-
   /** Reset singleton state between unit tests. */
   static resetForTests(): void {
     this.instance = null;
     this.config = null;
     this.authProvider = null;
-    this.authProviderRegistered = false;
     this.initError = null;
     this.tokenExpiresAt = null;
   }
@@ -105,13 +90,24 @@ export class SupabaseClient {
   /**
    * Check if auth system is fully initialized and ready for use.
    */
-  static isReady(): boolean {
-    return (
-      this.instance !== null &&
-      this.authProvider !== null &&
-      this.authProviderRegistered &&
-      this.initError === null
-    );
+  static async isReady(): Promise<boolean> {
+    if (this.instance === null || this.authProvider === null) {
+      return false;
+    }
+    if (this.initError !== null) {
+      return false;
+    }
+
+    try {
+      await this.authProvider.whenReady();
+      return true;
+    } catch (error) {
+      logger.error(
+        'SupabaseClient',
+        `Auth provider not ready: ${toErrorMessage(error)}`,
+      );
+      return false;
+    }
   }
 
   /**

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -27,6 +27,7 @@ export class SupabaseClient {
    * Used to provide meaningful error messages to users.
    */
   private static initError: Error | null = null;
+  private static readinessError: Error | null = null;
 
   /**
    * Cached token expiry time (ms since epoch).
@@ -49,6 +50,7 @@ export class SupabaseClient {
     this.config = null;
     this.authProvider = null;
     this.initError = null;
+    this.readinessError = null;
     this.tokenExpiresAt = null;
   }
 
@@ -64,7 +66,7 @@ export class SupabaseClient {
    * Get initialization error if any occurred.
    */
   static getInitError(): Error | null {
-    return this.initError;
+    return this.initError ?? this.readinessError;
   }
 
   /**
@@ -100,8 +102,11 @@ export class SupabaseClient {
 
     try {
       await this.authProvider.whenReady();
+      this.readinessError = null;
       return true;
     } catch (error) {
+      this.readinessError =
+        error instanceof Error ? error : new Error(toErrorMessage(error));
       logger.error(
         'SupabaseClient',
         `Auth provider not ready: ${toErrorMessage(error)}`,

--- a/src/auth/TokenProvider.ts
+++ b/src/auth/TokenProvider.ts
@@ -5,6 +5,7 @@ export interface SessionTokens {
 
 /** Host-neutral source for authenticated Supabase session tokens. */
 export interface AuthTokenProvider {
+  whenReady(): Promise<void>;
   ensureFreshToken(forceRefresh?: boolean): Promise<string | null>;
   getSessionTokens(): Promise<SessionTokens | null>;
 }

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -22,7 +22,7 @@ async function getExistingSession(): Promise<
   vscode.AuthenticationSession | undefined
 > {
   // Skip VS Code auth API if auth system not ready to avoid timeout
-  if (!SupabaseClient.isReady()) {
+  if (!(await SupabaseClient.isReady())) {
     return undefined;
   }
   return vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
@@ -71,7 +71,7 @@ function getSignInOptions(): SignInOption[] {
 export async function signIn(): Promise<void> {
   try {
     // Check if auth system is ready - if not, provide clear error with reason
-    if (!SupabaseClient.isReady()) {
+    if (!(await SupabaseClient.isReady())) {
       const initError = SupabaseClient.getInitError();
       const reason = initError
         ? initError.message

--- a/src/auth/authCommands.ts
+++ b/src/auth/authCommands.ts
@@ -20,9 +20,15 @@ function isVSCodeGitHubEnabled(): boolean {
 
 async function getExistingSession(): Promise<
   vscode.AuthenticationSession | undefined
-> {
+>;
+async function getExistingSession(
+  authReady: boolean,
+): Promise<vscode.AuthenticationSession | undefined>;
+async function getExistingSession(
+  authReady?: boolean,
+): Promise<vscode.AuthenticationSession | undefined> {
   // Skip VS Code auth API if auth system not ready to avoid timeout
-  if (!(await SupabaseClient.isReady())) {
+  if (!(authReady ?? (await SupabaseClient.isReady()))) {
     return undefined;
   }
   return vscode.authentication.getSession(AUTH_PROVIDER_ID, [], {
@@ -71,7 +77,8 @@ function getSignInOptions(): SignInOption[] {
 export async function signIn(): Promise<void> {
   try {
     // Check if auth system is ready - if not, provide clear error with reason
-    if (!(await SupabaseClient.isReady())) {
+    const authReady = await SupabaseClient.isReady();
+    if (!authReady) {
       const initError = SupabaseClient.getInitError();
       const reason = initError
         ? initError.message
@@ -82,7 +89,7 @@ export async function signIn(): Promise<void> {
       return;
     }
 
-    const existing = await getExistingSession();
+    const existing = await getExistingSession(authReady);
     if (existing) {
       const user = await SupabaseClient.getUser();
       void vscode.window.showInformationMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,7 +208,6 @@ export async function activate(context: vscode.ExtensionContext) {
       const uriHandler = new SupabaseUriHandler();
       context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
       authProvider.setUriHandler(uriHandler);
-      SupabaseClient.setHostAuthProviderRegistered();
 
       logger.info('extension', 'Supabase authentication provider registered');
 

--- a/src/test/auth/SupabaseClient.test.ts
+++ b/src/test/auth/SupabaseClient.test.ts
@@ -12,6 +12,7 @@ describe('SupabaseClient', () => {
 
   it('reads session tokens through the registered token provider', async () => {
     const provider: AuthTokenProvider = {
+      whenReady: async () => {},
       ensureFreshToken: async () => 'access-token',
       getSessionTokens: async () => ({
         accessToken: 'access-token',
@@ -29,6 +30,7 @@ describe('SupabaseClient', () => {
 
   it('returns null when the token provider throws while reading session tokens', async () => {
     const provider: AuthTokenProvider = {
+      whenReady: async () => {},
       ensureFreshToken: async () => 'access-token',
       getSessionTokens: async () => {
         throw new Error('storage unavailable');
@@ -38,5 +40,33 @@ describe('SupabaseClient', () => {
     SupabaseClient.setAuthProvider(provider);
 
     assert.equal(await SupabaseClient.getSessionTokens(), null);
+  });
+
+  it('waits for token provider readiness', async () => {
+    const provider: AuthTokenProvider = {
+      whenReady: async () => {},
+      ensureFreshToken: async () => 'access-token',
+      getSessionTokens: async () => null,
+    };
+
+    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+    SupabaseClient.setAuthProvider(provider);
+
+    assert.equal(await SupabaseClient.isReady(), true);
+  });
+
+  it('reports not ready when token provider readiness fails', async () => {
+    const provider: AuthTokenProvider = {
+      whenReady: async () => {
+        throw new Error('host auth unavailable');
+      },
+      ensureFreshToken: async () => 'access-token',
+      getSessionTokens: async () => null,
+    };
+
+    SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+    SupabaseClient.setAuthProvider(provider);
+
+    assert.equal(await SupabaseClient.isReady(), false);
   });
 });

--- a/src/test/auth/SupabaseClient.test.ts
+++ b/src/test/auth/SupabaseClient.test.ts
@@ -5,6 +5,14 @@ import { strict as assert } from 'assert';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import type { AuthTokenProvider } from '@auth/TokenProvider';
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('SupabaseClient', () => {
   afterEach(() => {
     SupabaseClient.resetForTests();
@@ -43,8 +51,9 @@ describe('SupabaseClient', () => {
   });
 
   it('waits for token provider readiness', async () => {
+    const readiness = createDeferred();
     const provider: AuthTokenProvider = {
-      whenReady: async () => {},
+      whenReady: () => readiness.promise,
       ensureFreshToken: async () => 'access-token',
       getSessionTokens: async () => null,
     };
@@ -52,7 +61,18 @@ describe('SupabaseClient', () => {
     SupabaseClient.initialize('https://example.supabase.co', 'public-key');
     SupabaseClient.setAuthProvider(provider);
 
-    assert.equal(await SupabaseClient.isReady(), true);
+    let settled = false;
+    const readyPromise = SupabaseClient.isReady().then((ready) => {
+      settled = true;
+      return ready;
+    });
+    await Promise.resolve();
+
+    assert.equal(settled, false);
+
+    readiness.resolve();
+
+    assert.equal(await readyPromise, true);
   });
 
   it('reports not ready when token provider readiness fails', async () => {
@@ -68,5 +88,9 @@ describe('SupabaseClient', () => {
     SupabaseClient.setAuthProvider(provider);
 
     assert.equal(await SupabaseClient.isReady(), false);
+    assert.equal(
+      SupabaseClient.getInitError()?.message,
+      'host auth unavailable',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extend the host-neutral Supabase token provider with a readiness hook
- make SupabaseClient readiness await that provider instead of a VS Code registration flag
- update VS Code auth commands and tests for async readiness

## Verification
- npm run format
- npm run compile:safe
- npm run lint
- npm run compile-tests
- npm run compile
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth initialization gating from a VS Code registration flag to an awaited provider readiness hook, which can affect sign-in/session detection timing and error surfacing across the extension.
> 
> **Overview**
> Refactors Supabase auth readiness so `SupabaseClient.isReady()` becomes async and gates on a new `AuthTokenProvider.whenReady()` hook instead of a host registration flag.
> 
> `SupabaseAuthProvider` now implements `whenReady()` (failing fast when the URI handler isn’t set), VS Code auth commands avoid calling the VS Code auth API until readiness resolves, and init/readiness errors are surfaced via `SupabaseClient.getInitError()`.
> 
> Removes the explicit `setHostAuthProviderRegistered()` call from extension activation and updates unit tests to cover readiness waiting and readiness failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4231ca1de063f2fd29eafcab6e7e2478382abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->