### PR TITLE
[codex] Add fake UI host harness

### DIFF
--- a/src/test/hosts/FakeHosts.test.ts
+++ b/src/test/hosts/FakeHosts.test.ts
@@ -1,0 +1,126 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - test support
+import { FakeTerminalHandle, createFakeUIHosts } from '../support/FakeHosts';
+
+describe('FakeHosts', () => {
+  it('records prompt effects and returns queued responses', async () => {
+    const hosts = createFakeUIHosts({
+      promptResponses: ['Open'],
+      confirmResponses: [false],
+      inputResponses: ['paper'],
+    });
+
+    const selected = await hosts.prompt.info('Ready', {
+      items: ['Open', 'Dismiss'],
+    });
+    const confirmed = await hosts.prompt.confirm('Delete file?');
+    const input = await hosts.prompt.input({ prompt: 'Name' });
+
+    assert.equal(selected, 'Open');
+    assert.equal(confirmed, false);
+    assert.equal(input, 'paper');
+    assert.deepEqual(hosts.prompt.messages, [
+      {
+        kind: 'info',
+        message: 'Ready',
+        options: { items: ['Open', 'Dismiss'] },
+      },
+    ]);
+    assert.deepEqual(hosts.prompt.confirms, [
+      { message: 'Delete file?', options: undefined },
+    ]);
+    assert.deepEqual(hosts.prompt.inputs, [{ options: { prompt: 'Name' } }]);
+  });
+
+  it('defaults unqueued confirmations to cancel', async () => {
+    const hosts = createFakeUIHosts();
+
+    assert.equal(await hosts.prompt.confirm('Continue?'), false);
+    assert.deepEqual(hosts.prompt.confirms, [
+      { message: 'Continue?', options: undefined },
+    ]);
+  });
+
+  it('does not return queued input rejected by validation', async () => {
+    const hosts = createFakeUIHosts({ inputResponses: ['bad-name'] });
+
+    const input = await hosts.prompt.input({
+      prompt: 'Name',
+      validateInput: (value) =>
+        value.includes(' ') ? undefined : 'Enter at least two words',
+    });
+
+    assert.equal(input, undefined);
+    assert.deepEqual(hosts.prompt.inputs, [
+      {
+        options: {
+          prompt: 'Name',
+          validateInput: hosts.prompt.inputs[0]?.options.validateInput,
+        },
+      },
+    ]);
+  });
+
+  it('records opener, clipboard, terminal, and diff effects', async () => {
+    const hosts = createFakeUIHosts({
+      clipboardText: 'initial',
+      proposedDiffContent: { '/tmp/proposed.tex': 'edited' },
+    });
+
+    await hosts.externalOpener.openExternal('https://texra.ai');
+    await hosts.externalOpener.openPath('/workspace/main.pdf');
+    assert.deepEqual(hosts.externalOpener.externalUrls, ['https://texra.ai']);
+    assert.deepEqual(hosts.externalOpener.paths, ['/workspace/main.pdf']);
+
+    assert.equal(await hosts.clipboard.readText(), 'initial');
+    await hosts.clipboard.writeText('copied');
+    assert.equal(await hosts.clipboard.readText(), 'copied');
+    assert.deepEqual(hosts.clipboard.writes, ['copied']);
+
+    const terminal = hosts.terminal.createTerminal({ name: 'Setup' });
+    terminal.show(true);
+    terminal.sendText('npm install', true);
+    const foundTerminal = hosts.terminal.findTerminal('Setup');
+    const listedTerminals = hosts.terminal.getTerminals();
+    assert.ok(foundTerminal);
+    assert.notEqual(foundTerminal, terminal);
+    assert.equal(foundTerminal.name, 'Setup');
+    assert.equal(listedTerminals.length, 1);
+    assert.notEqual(listedTerminals[0], terminal);
+    assert.equal(listedTerminals[0]?.name, 'Setup');
+    assert.ok(terminal instanceof FakeTerminalHandle);
+    assert.deepEqual(terminal.showCalls, [{ preserveFocus: true }]);
+    assert.deepEqual(terminal.sentText, [
+      { text: 'npm install', shouldExecute: true },
+    ]);
+    terminal.dispose();
+    assert.equal(hosts.terminal.findTerminal('Setup'), undefined);
+    assert.deepEqual(hosts.terminal.getTerminals(), []);
+
+    const session = await hosts.diff.openDiff(
+      { filePath: '/tmp/original.tex' },
+      { filePath: '/tmp/proposed.tex' },
+      'Changes',
+      { preserveFocus: false },
+    );
+    await hosts.diff.revealFirstChange(session, 12);
+    await hosts.diff.closeDiff(session);
+
+    assert.equal(
+      await hosts.diff.readProposedContent(session, 'fallback'),
+      'edited',
+    );
+    assert.deepEqual(hosts.diff.opened, [
+      {
+        original: { filePath: '/tmp/original.tex' },
+        proposed: { filePath: '/tmp/proposed.tex' },
+        title: 'Changes',
+        options: { preserveFocus: false },
+      },
+    ]);
+    assert.deepEqual(hosts.diff.revealed, [{ session, line: 12 }]);
+    assert.deepEqual(hosts.diff.closed, [session]);
+  });
+});

--- a/src/test/support/FakeHosts.ts
+++ b/src/test/support/FakeHosts.ts
@@ -1,0 +1,309 @@
+// Local imports - hosts
+import type { ClipboardHost } from '@hosts/clipboardHost';
+import type {
+  DiffOptions,
+  DiffSession,
+  DiffSource,
+  DiffViewHost,
+} from '@hosts/diffViewHost';
+import type { ExternalOpener } from '@hosts/externalOpener';
+import type {
+  PromptConfirmOptions,
+  PromptHost,
+  PromptInputOptions,
+  PromptMessageOptions,
+} from '@hosts/promptHost';
+import type {
+  TerminalHandle,
+  TerminalHost,
+  TerminalOptions,
+} from '@hosts/terminalHost';
+import type { UIHosts } from '@hosts/uiHosts';
+
+export type PromptEventKind = 'info' | 'warning' | 'error';
+
+export interface PromptMessageEvent {
+  kind: PromptEventKind;
+  message: string;
+  options?: PromptMessageOptions;
+}
+
+export interface PromptConfirmEvent {
+  message: string;
+  options?: PromptConfirmOptions;
+}
+
+export interface PromptInputEvent {
+  options: PromptInputOptions;
+}
+
+export interface DiffOpenEvent {
+  original: DiffSource;
+  proposed: DiffSource;
+  title: string;
+  options?: DiffOptions;
+}
+
+export interface DiffRevealEvent {
+  session: DiffSession;
+  line: number;
+}
+
+export interface TerminalSendEvent {
+  text: string;
+  shouldExecute?: boolean;
+}
+
+export interface TerminalShowEvent {
+  preserveFocus?: boolean;
+}
+
+export interface FakeUIHostsOptions {
+  promptResponses?: readonly string[];
+  confirmResponses?: readonly boolean[];
+  inputResponses?: readonly (string | undefined)[];
+  clipboardText?: string;
+  proposedDiffContent?: Record<string, string>;
+}
+
+export class FakePromptHost implements PromptHost {
+  readonly messages: PromptMessageEvent[] = [];
+
+  readonly confirms: PromptConfirmEvent[] = [];
+
+  readonly inputs: PromptInputEvent[] = [];
+
+  private readonly promptResponses: string[];
+
+  private readonly confirmResponses: boolean[];
+
+  private readonly inputResponses: (string | undefined)[];
+
+  constructor(
+    options: Pick<
+      FakeUIHostsOptions,
+      'promptResponses' | 'confirmResponses' | 'inputResponses'
+    > = {},
+  ) {
+    this.promptResponses = [...(options.promptResponses ?? [])];
+    this.confirmResponses = [...(options.confirmResponses ?? [])];
+    this.inputResponses = [...(options.inputResponses ?? [])];
+  }
+
+  async info<T extends string = string>(
+    message: string,
+    options?: PromptMessageOptions<T>,
+  ): Promise<T | undefined> {
+    return this.recordMessage('info', message, options);
+  }
+
+  async warning<T extends string = string>(
+    message: string,
+    options?: PromptMessageOptions<T>,
+  ): Promise<T | undefined> {
+    return this.recordMessage('warning', message, options);
+  }
+
+  async error<T extends string = string>(
+    message: string,
+    options?: PromptMessageOptions<T>,
+  ): Promise<T | undefined> {
+    return this.recordMessage('error', message, options);
+  }
+
+  async confirm(
+    message: string,
+    options?: PromptConfirmOptions,
+  ): Promise<boolean> {
+    this.confirms.push({ message, options });
+    return this.confirmResponses.shift() ?? false;
+  }
+
+  async input(options: PromptInputOptions): Promise<string | undefined> {
+    this.inputs.push({ options });
+    const response = this.inputResponses.shift();
+    if (response == null) {
+      return response;
+    }
+
+    const validationMessage = await options.validateInput?.(response);
+    return validationMessage == null ? response : undefined;
+  }
+
+  private recordMessage<T extends string>(
+    kind: PromptEventKind,
+    message: string,
+    options?: PromptMessageOptions<T>,
+  ): T | undefined {
+    this.messages.push({ kind, message, options });
+    return this.promptResponses.shift() as T | undefined;
+  }
+}
+
+export class FakeExternalOpener implements ExternalOpener {
+  readonly externalUrls: string[] = [];
+
+  readonly paths: string[] = [];
+
+  async openExternal(url: string): Promise<void> {
+    this.externalUrls.push(url);
+  }
+
+  async openPath(filePath: string): Promise<void> {
+    this.paths.push(filePath);
+  }
+}
+
+export class FakeClipboardHost implements ClipboardHost {
+  readonly writes: string[] = [];
+
+  constructor(private text = '') {}
+
+  async readText(): Promise<string> {
+    return this.text;
+  }
+
+  async writeText(text: string): Promise<void> {
+    this.text = text;
+    this.writes.push(text);
+  }
+}
+
+export class FakeDiffViewHost implements DiffViewHost {
+  readonly opened: DiffOpenEvent[] = [];
+
+  readonly closed: DiffSession[] = [];
+
+  readonly revealed: DiffRevealEvent[] = [];
+
+  private readonly proposedContent = new Map<string, string>();
+
+  constructor(proposedContent: Record<string, string> = {}) {
+    for (const [filePath, content] of Object.entries(proposedContent)) {
+      this.proposedContent.set(filePath, content);
+    }
+  }
+
+  async openDiff(
+    original: DiffSource,
+    proposed: DiffSource,
+    title: string,
+    options?: DiffOptions,
+  ): Promise<DiffSession> {
+    this.opened.push({ original, proposed, title, options });
+    return { original, proposed, title };
+  }
+
+  async closeDiff(session: DiffSession): Promise<void> {
+    this.closed.push(session);
+  }
+
+  async revealFirstChange(session: DiffSession, line: number): Promise<void> {
+    this.revealed.push({ session, line });
+  }
+
+  async readProposedContent(
+    session: DiffSession,
+    fallbackContent: string,
+  ): Promise<string> {
+    return (
+      this.proposedContent.get(session.proposed.filePath) ?? fallbackContent
+    );
+  }
+
+  setProposedContent(filePath: string, content: string): void {
+    this.proposedContent.set(filePath, content);
+  }
+}
+
+export class FakeTerminalHost implements TerminalHost {
+  readonly created: FakeTerminalHandle[] = [];
+
+  createTerminal(options: TerminalOptions): FakeTerminalHandle {
+    const terminal = new FakeTerminalHandle(options);
+    this.created.push(terminal);
+    return terminal;
+  }
+
+  findTerminal(name: string): TerminalHandle | undefined {
+    const terminal = this.created.find(
+      (terminal) => terminal.name === name && !terminal.isDisposed,
+    );
+    return terminal?.createLookupHandle();
+  }
+
+  getTerminals(): readonly TerminalHandle[] {
+    return this.created
+      .filter((terminal) => !terminal.isDisposed)
+      .map((terminal) => terminal.createLookupHandle());
+  }
+}
+
+interface FakeTerminalState {
+  sentText: TerminalSendEvent[];
+  showCalls: TerminalShowEvent[];
+  isDisposed: boolean;
+}
+
+export class FakeTerminalHandle implements TerminalHandle {
+  constructor(
+    readonly options: TerminalOptions,
+    private readonly state: FakeTerminalState = {
+      sentText: [],
+      showCalls: [],
+      isDisposed: false,
+    },
+  ) {}
+
+  get sentText(): readonly TerminalSendEvent[] {
+    return this.state.sentText;
+  }
+
+  get showCalls(): readonly TerminalShowEvent[] {
+    return this.state.showCalls;
+  }
+
+  get isDisposed(): boolean {
+    return this.state.isDisposed;
+  }
+
+  get name(): string {
+    return this.options.name;
+  }
+
+  sendText(text: string, shouldExecute?: boolean): void {
+    this.state.sentText.push({ text, shouldExecute });
+  }
+
+  show(preserveFocus?: boolean): void {
+    this.state.showCalls.push({ preserveFocus });
+  }
+
+  dispose(): void {
+    this.state.isDisposed = true;
+  }
+
+  createLookupHandle(): FakeTerminalHandle {
+    return new FakeTerminalHandle(this.options, this.state);
+  }
+}
+
+export interface FakeUIHosts extends UIHosts {
+  readonly prompt: FakePromptHost;
+  readonly externalOpener: FakeExternalOpener;
+  readonly diff: FakeDiffViewHost;
+  readonly terminal: FakeTerminalHost;
+  readonly clipboard: FakeClipboardHost;
+}
+
+export function createFakeUIHosts(
+  options: FakeUIHostsOptions = {},
+): FakeUIHosts {
+  return {
+    prompt: new FakePromptHost(options),
+    externalOpener: new FakeExternalOpener(),
+    diff: new FakeDiffViewHost(options.proposedDiffContent),
+    terminal: new FakeTerminalHost(),
+    clipboard: new FakeClipboardHost(options.clipboardText),
+  };
+}


### PR DESCRIPTION
## Summary
- add a test-only FakeHosts harness for the host-neutral UI ports introduced in the prior PR
- record prompt, opener, clipboard, terminal, and diff effects for deterministic controller tests
- cover queued prompt responses, terminal lifecycle behavior, clipboard state, opener calls, and diff sessions

## Validation
- npm run format
- npm run compile:safe
- npm run lint
- npm run compile-tests
- npm run compile
- git diff --check

Note: did not run npm test per repository guidance; it invokes vscode-test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only and add new fakes without modifying production UI host implementations; main risk is minor test brittleness if host interfaces evolve.
> 
> **Overview**
> Adds a test-only `createFakeUIHosts` harness that implements the `UIHosts` ports with in-memory fakes for prompts, external opening, clipboard, terminals, and diff views.
> 
> The fakes **record side effects** (prompt messages/inputs/confirms, opened URLs/paths, clipboard writes, terminal lifecycle and sent text, diff open/reveal/close events) and support **queued responses** plus prompt input validation behavior.
> 
> Introduces a new `FakeHosts.test.ts` suite covering queued prompt responses, default confirm behavior, validation rejecting input, terminal lookup/disposal semantics, clipboard state, opener calls, and diff session tracking/content lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e057d977b3bfea86565b71dd9141846d1407602b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->