### PR TITLE
[codex] Extract main view startup controller

### DIFF
--- a/src/controllers/mainView/MainViewStartupController.ts
+++ b/src/controllers/mainView/MainViewStartupController.ts
@@ -1,0 +1,78 @@
+// Local imports - common
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import type {
+  AgentOptionData,
+  MainViewMessage,
+  ModelOptionData,
+} from '@shared/schemas';
+
+export interface MainViewStartupOptions {
+  modelOptions: ModelOptionData[];
+  agentOptions: {
+    workflow?: AgentOptionData[];
+    toolUse?: AgentOptionData[];
+  };
+}
+
+export interface MainViewAuthStatus {
+  authenticated: boolean;
+}
+
+export interface MainViewStartupControllerDeps {
+  getConfig<T>(key: string, defaultValue: T): T;
+  loadOptions(): Promise<MainViewStartupOptions>;
+  getAuthStatus(): Promise<MainViewAuthStatus>;
+}
+
+type MainViewStartupMessage = Extract<
+  MainViewMessage,
+  | { command: typeof MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS }
+  | { command: typeof MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS }
+  | { command: typeof MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER }
+>;
+
+export class MainViewStartupController {
+  constructor(private readonly deps: MainViewStartupControllerDeps) {}
+
+  getOrchestratorBannerMessage(): MainViewStartupMessage {
+    const showOrchestratorBanner = this.deps.getConfig<boolean>(
+      'ui.showOrchestratorBanner',
+      true,
+    );
+    return {
+      command: showOrchestratorBanner
+        ? MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER
+        : MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER,
+    };
+  }
+
+  async getOptionsAndLoginMessages(): Promise<MainViewStartupMessage[]> {
+    const [{ modelOptions, agentOptions }, authStatus] = await Promise.all([
+      this.deps.loadOptions(),
+      this.deps.getAuthStatus(),
+    ]);
+
+    const showLoginBanner =
+      !authStatus.authenticated &&
+      this.deps.getConfig<boolean>('ui.showLoginBanner', true);
+
+    return [
+      {
+        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        optionsData: modelOptions,
+      },
+      {
+        command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        optionsData: agentOptions,
+      },
+      {
+        command: showLoginBanner
+          ? MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER
+          : MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+      },
+    ];
+  }
+}

--- a/src/test/controllers/MainViewStartupController.test.ts
+++ b/src/test/controllers/MainViewStartupController.test.ts
@@ -1,0 +1,78 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - common
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+// Local imports - controllers
+import { MainViewStartupController } from '../../controllers/mainView/MainViewStartupController';
+
+describe('MainViewStartupController', () => {
+  it('uses config to choose the orchestrator banner message', () => {
+    const controller = new MainViewStartupController({
+      getConfig: (_key, defaultValue) => defaultValue,
+      loadOptions: async () => ({ modelOptions: [], agentOptions: {} }),
+      getAuthStatus: async () => ({ authenticated: false }),
+    });
+
+    assert.deepEqual(controller.getOrchestratorBannerMessage(), {
+      command: MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER,
+    });
+  });
+
+  it('hides the orchestrator banner when disabled', () => {
+    const controller = new MainViewStartupController({
+      getConfig: <T>() => false as T,
+      loadOptions: async () => ({ modelOptions: [], agentOptions: {} }),
+      getAuthStatus: async () => ({ authenticated: false }),
+    });
+
+    assert.deepEqual(controller.getOrchestratorBannerMessage(), {
+      command: MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER,
+    });
+  });
+
+  it('loads options and shows the login banner for signed-out users', async () => {
+    const controller = new MainViewStartupController({
+      getConfig: (_key, defaultValue) => defaultValue,
+      loadOptions: async () => ({
+        modelOptions: [{ value: 'gemini', label: 'Gemini' }],
+        agentOptions: {
+          workflow: [{ value: 'correct', label: 'Correct' }],
+          toolUse: [{ value: 'orchestrator', label: 'Orchestrator' }],
+        },
+      }),
+      getAuthStatus: async () => ({ authenticated: false }),
+    });
+
+    assert.deepEqual(await controller.getOptionsAndLoginMessages(), [
+      {
+        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+        optionsData: [{ value: 'gemini', label: 'Gemini' }],
+      },
+      {
+        command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        optionsData: {
+          workflow: [{ value: 'correct', label: 'Correct' }],
+          toolUse: [{ value: 'orchestrator', label: 'Orchestrator' }],
+        },
+      },
+      { command: MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER },
+    ]);
+  });
+
+  it('hides the login banner for signed-in users', async () => {
+    const controller = new MainViewStartupController({
+      getConfig: (_key, defaultValue) => defaultValue,
+      loadOptions: async () => ({ modelOptions: [], agentOptions: {} }),
+      getAuthStatus: async () => ({ authenticated: true }),
+    });
+
+    const messages = await controller.getOptionsAndLoginMessages();
+
+    assert.equal(
+      messages.at(-1)?.command,
+      MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+    );
+  });
+});

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -24,6 +24,7 @@ import { DiffManager } from './managers/DiffManager';
 import { ExecutionManager } from './managers/ExecutionManager';
 import { FileManager } from './managers/FileManager';
 import { InstructionManager } from './managers/InstructionManager';
+import { MainViewStartupController } from '../controllers/mainView/MainViewStartupController';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -31,6 +32,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly executionManager: ExecutionManager;
   private readonly diffManager: DiffManager;
   private readonly instructionManager: InstructionManager;
+  private readonly startupController: MainViewStartupController;
 
   constructor(context: vscode.ExtensionContext) {
     super('MainView', { trackActiveView: true });
@@ -45,6 +47,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager(context);
+    this.startupController = new MainViewStartupController({
+      getConfig,
+      loadOptions,
+      getAuthStatus,
+    });
   }
 
   public override async handleMessage(
@@ -397,39 +404,16 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       return;
     }
     await super.handleWebviewReady(undefined, webviewView);
-    const showOrchestratorBanner = getConfig<boolean>(
-      'ui.showOrchestratorBanner',
-      true,
+    webviewView.webview.postMessage(
+      this.startupController.getOrchestratorBannerMessage(),
     );
-    webviewView.webview.postMessage({
-      command: showOrchestratorBanner
-        ? MAIN_VIEW_COMMANDS.SHOW_ORCHESTRATOR_BANNER
-        : MAIN_VIEW_COMMANDS.HIDE_ORCHESTRATOR_BANNER,
-    });
 
     try {
-      const [{ modelOptions, agentOptions }, authStatus] = await Promise.all([
-        loadOptions(),
-        getAuthStatus(),
-      ]);
-
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
-        optionsData: modelOptions,
-      });
-      webviewView.webview.postMessage({
-        command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
-        optionsData: agentOptions,
-      });
-
-      const showLoginBanner =
-        !authStatus.authenticated &&
-        getConfig<boolean>('ui.showLoginBanner', true);
-      webviewView.webview.postMessage({
-        command: showLoginBanner
-          ? MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER
-          : MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
-      });
+      const messages =
+        await this.startupController.getOptionsAndLoginMessages();
+      for (const message of messages) {
+        webviewView.webview.postMessage(message);
+      }
     } catch (error) {
       this.logger.error(
         this.channel,


### PR DESCRIPTION
## Summary
- extract main-view startup message computation into a host-neutral controller with injected dependencies
- keep the VS Code message handler responsible only for posting startup messages and logging load failures
- add focused controller tests for orchestrator/login banner and option messages

## Verification
- npm run format
- npm run compile:safe
- npm run lint
- npm run compile-tests
- npx mocha --require out/test/setup.js out/test/controllers/MainViewStartupController.test.js
- npm run compile
- git diff --check

Base strategy: this PR targets codex/electron-prd-integration so the next Electron PRD slices do not keep extending the per-PR stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves main-view startup message computation into a dedicated controller; behavior should be unchanged but it affects initial webview messaging (banners/options).
> 
> **Overview**
> Extracts main-view startup message computation into a new `MainViewStartupController`, with injected `getConfig`/`loadOptions`/`getAuthStatus` dependencies.
> 
> Updates `MainViewMessageHandler.handleWebviewReady()` to delegate orchestrator-banner, model/agent option, and login-banner message generation to the controller and simply post the returned messages (keeping error logging in the handler).
> 
> Adds focused unit tests covering orchestrator banner toggling, option loading messages, and login banner show/hide behavior based on auth status and config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66cbb9dc54182b9c025f83db5dbeaa06b00bbbee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->