### PR TITLE
[codex] Extract agent directory service

### DIFF
--- a/src/agent/index/AgentDirectoryService.ts
+++ b/src/agent/index/AgentDirectoryService.ts
@@ -1,0 +1,170 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports
+import type { AgentSource } from '@agent/core/AgentDataclass';
+
+export const DEFAULT_CUSTOM_AGENTS_DIR_NAME = 'custom_agents';
+
+export interface AgentDirectoryPathStorage {
+  ensureDir(relativePath: string): Promise<void>;
+  fullPath(relativePath: string): string;
+}
+
+export interface CustomAgentDirectoryStore {
+  get(): string | undefined;
+}
+
+export interface AbsoluteDirectoryAccess {
+  exists(absolutePath: string): Promise<boolean>;
+  ensureDir(absolutePath: string): Promise<void>;
+}
+
+export type AgentDirectoryDocsId = 'custom-agents';
+
+export interface AgentDirectoryIssueReporter {
+  report(message: string, docsId: AgentDirectoryDocsId): Promise<void>;
+}
+
+export interface AgentDirectoryServiceLogger {
+  debug(message: string): void;
+  error(message: string): void;
+}
+
+export interface AgentDirectoryServiceOptions {
+  storage: AgentDirectoryPathStorage;
+  customDirectoryStore: CustomAgentDirectoryStore;
+  absoluteDirectories: AbsoluteDirectoryAccess;
+  issueReporter: AgentDirectoryIssueReporter;
+  logger: AgentDirectoryServiceLogger;
+  defaultCustomDirectoryName?: string;
+}
+
+export class AgentDirectoryService {
+  private readonly defaultCustomDirectoryName: string;
+
+  constructor(private readonly options: AgentDirectoryServiceOptions) {
+    this.defaultCustomDirectoryName =
+      options.defaultCustomDirectoryName ?? DEFAULT_CUSTOM_AGENTS_DIR_NAME;
+  }
+
+  async builtIn(): Promise<string> {
+    return this.ensureBuiltInDir('agents');
+  }
+
+  async builtInToolUse(): Promise<string> {
+    return this.ensureBuiltInDir('tool_use_agents');
+  }
+
+  async custom(): Promise<string> {
+    const configuredPath = (
+      this.options.customDirectoryStore.get() ?? ''
+    ).trim();
+
+    const resolvedPath = await this.resolveConfiguredCustomDir(configuredPath);
+    if (resolvedPath) {
+      return resolvedPath;
+    }
+
+    return this.ensureDefaultCustomDir();
+  }
+
+  async getDirectory(source: AgentSource): Promise<string | undefined> {
+    switch (source) {
+      case 'custom':
+        return this.custom();
+      case 'builtInWorkflow':
+        return this.builtIn();
+      case 'builtInToolUse':
+        return this.builtInToolUse();
+      case 'remote':
+        return undefined;
+    }
+  }
+
+  async getAllLocal(): Promise<
+    Array<{ directory: string; source: AgentSource }>
+  > {
+    const [customDir, builtInDir, builtInToolUseDir] = await Promise.all([
+      this.custom(),
+      this.builtIn(),
+      this.builtInToolUse(),
+    ]);
+
+    return [
+      { directory: customDir, source: 'custom' },
+      { directory: builtInDir, source: 'builtInWorkflow' },
+      { directory: builtInToolUseDir, source: 'builtInToolUse' },
+    ];
+  }
+
+  private async ensureBuiltInDir(dirName: string): Promise<string> {
+    await this.options.storage.ensureDir(dirName);
+    const basePath = this.options.storage.fullPath(dirName);
+    this.options.logger.debug(
+      `Using built-in ${dirName} directory: ${basePath}`,
+    );
+    return basePath;
+  }
+
+  private async ensureDefaultCustomDir(): Promise<string> {
+    try {
+      await this.options.storage.ensureDir(this.defaultCustomDirectoryName);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.options.logger.error(
+        `Failed to create default custom agents directory: ${message}`,
+      );
+      throw new Error(
+        'Unable to create custom agents directory. Please check permissions.',
+      );
+    }
+
+    const defaultPath = this.options.storage.fullPath(
+      this.defaultCustomDirectoryName,
+    );
+    this.options.logger.debug(
+      `Using default custom agents directory: ${defaultPath}`,
+    );
+    return defaultPath;
+  }
+
+  private async resolveConfiguredCustomDir(
+    configuredPath: string,
+  ): Promise<string | undefined> {
+    if (!configuredPath) {
+      return undefined;
+    }
+
+    if (!path.isAbsolute(configuredPath)) {
+      this.options.logger.error(
+        `Custom agents directory must be an absolute path: ${configuredPath}`,
+      );
+      await this.options.issueReporter.report(
+        'Custom agents directory must be an absolute path',
+        'custom-agents',
+      );
+      return undefined;
+    }
+
+    const parentDir = path.dirname(configuredPath);
+    const parentExists =
+      await this.options.absoluteDirectories.exists(parentDir);
+    if (!parentExists) {
+      this.options.logger.error(
+        `Parent directory does not exist for custom agents directory: ${parentDir}`,
+      );
+      await this.options.issueReporter.report(
+        'Parent directory for custom agents directory does not exist',
+        'custom-agents',
+      );
+      return undefined;
+    }
+
+    await this.options.absoluteDirectories.ensureDir(configuredPath);
+    this.options.logger.debug(
+      `Using custom agents directory from setting: ${configuredPath}`,
+    );
+    return configuredPath;
+  }
+}

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -6,6 +6,31 @@
 export { AgentSource } from '@agent/core/AgentDataclass';
 
 export {
+  DEFAULT_CUSTOM_AGENTS_DIR_NAME,
+  AgentDirectoryService,
+  type AbsoluteDirectoryAccess,
+  type AgentDirectoryDocsId,
+  type AgentDirectoryIssueReporter,
+  type AgentDirectoryPathStorage,
+  type AgentDirectoryServiceLogger,
+  type AgentDirectoryServiceOptions,
+  type CustomAgentDirectoryStore,
+} from './AgentDirectoryService';
+
+export {
+  BUNDLED_AGENT_DIRECTORY_NAMES,
+  BundledAgentDirectorySync,
+  GlobalStorageAgentDirectoryStorage,
+  PathAgentDirectoryBundleSource,
+  type AgentDirectoryBundleSource,
+  type AgentDirectoryStorage,
+  type AgentDirectorySyncLogger,
+  type AgentDirectoryVersionStore,
+  type BundledAgentDirectoryName,
+  type BundledAgentDirectorySyncOptions,
+} from './AgentDirectorySync';
+
+export {
   // Types
   type AgentEntry,
   type ResolvedAgent,

--- a/src/frontend/agents/AgentDirectoryManager.ts
+++ b/src/frontend/agents/AgentDirectoryManager.ts
@@ -6,15 +6,18 @@ import * as vscode from 'vscode';
 import { minimatch } from 'minimatch';
 
 // Local imports
+import {
+  AgentDirectoryService,
+  GlobalStorageAgentDirectoryStorage,
+} from '@agent/index';
 import type { AgentSource } from '@agent/index';
-import { showLoggedMessageWithDocs, toErrorMessage } from '@common/errors';
+import { showLoggedMessageWithDocs } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import * as logger from '@logger/logUtils';
-import { GlobalStorageFS, AbsoluteFS } from '@utils/files';
+import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'AgentLoad';
 logger.initialize(CHANNEL);
-const DEFAULT_CUSTOM_AGENTS_DIR_NAME = 'custom_agents';
 
 type AgentDirectoryEventType = 'create' | 'change' | 'delete';
 
@@ -38,6 +41,7 @@ interface AgentDirectoryWatcherSubscription {
 
 export class AgentDirectoryManager {
   private context: vscode.ExtensionContext | undefined;
+  private directoryService: AgentDirectoryService | undefined;
   private watcherDisposables: vscode.FileSystemWatcher[] = [];
   private watcherSubscriptions = new Set<AgentDirectoryWatcherSubscription>();
   private watcherDirectories: Array<{
@@ -48,30 +52,41 @@ export class AgentDirectoryManager {
 
   initialize(context: vscode.ExtensionContext): void {
     this.context = context;
+    this.directoryService = new AgentDirectoryService({
+      storage: new GlobalStorageAgentDirectoryStorage(),
+      customDirectoryStore: {
+        get: () => globalSM?.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR, ''),
+      },
+      absoluteDirectories: {
+        exists: (target) => AbsoluteFS.exists(target),
+        ensureDir: (target) => AbsoluteFS.ensureDir(target),
+      },
+      issueReporter: {
+        report: (message, docsId) =>
+          showLoggedMessageWithDocs(CHANNEL, message, docsId),
+      },
+      logger: {
+        debug: (message) => logger.debug(CHANNEL, message),
+        error: (message) => logger.error(CHANNEL, message),
+      },
+    });
   }
 
-  private ensureInitialized(): void {
-    if (!this.context) {
+  private getDirectoryService(): AgentDirectoryService {
+    if (!this.context || !this.directoryService) {
       throw new Error(
         'Agent directories not initialized. Call agentDirectories.initialize(context) first.',
       );
     }
-  }
-
-  private async ensureBuiltInDir(dirName: string): Promise<string> {
-    this.ensureInitialized();
-    await GlobalStorageFS.ensureDir(dirName);
-    const basePath = GlobalStorageFS.fullPath(dirName);
-    logger.debug(CHANNEL, `Using built-in ${dirName} directory: ${basePath}`);
-    return basePath;
+    return this.directoryService;
   }
 
   async builtIn(): Promise<string> {
-    return this.ensureBuiltInDir('agents');
+    return this.getDirectoryService().builtIn();
   }
 
   async builtInToolUse(): Promise<string> {
-    return this.ensureBuiltInDir('tool_use_agents');
+    return this.getDirectoryService().builtInToolUse();
   }
 
   /**
@@ -79,16 +94,7 @@ export class AgentDirectoryManager {
    * Returns undefined for Remote sources (which have no local directory).
    */
   async getDirectory(source: AgentSource): Promise<string | undefined> {
-    switch (source) {
-      case 'custom':
-        return this.custom();
-      case 'builtInWorkflow':
-        return this.builtIn();
-      case 'builtInToolUse':
-        return this.builtInToolUse();
-      case 'remote':
-        return undefined;
-    }
+    return this.getDirectoryService().getDirectory(source);
   }
 
   /**
@@ -98,100 +104,11 @@ export class AgentDirectoryManager {
   async getAllLocal(): Promise<
     Array<{ directory: string; source: AgentSource }>
   > {
-    const [customDir, builtInDir, builtInToolUseDir] = await Promise.all([
-      this.custom(),
-      this.builtIn(),
-      this.builtInToolUse(),
-    ]);
-
-    return [
-      { directory: customDir, source: 'custom' },
-      { directory: builtInDir, source: 'builtInWorkflow' },
-      { directory: builtInToolUseDir, source: 'builtInToolUse' },
-    ];
-  }
-
-  private async ensureDefaultCustomDir(): Promise<string> {
-    this.ensureInitialized();
-
-    try {
-      await GlobalStorageFS.ensureDir(DEFAULT_CUSTOM_AGENTS_DIR_NAME);
-    } catch (error) {
-      const message = toErrorMessage(error);
-      logger.error(
-        CHANNEL,
-        `Failed to create default custom agents directory: ${message}`,
-      );
-      throw new Error(
-        'Unable to create custom agents directory. Please check permissions.',
-      );
-    }
-
-    const defaultPath = GlobalStorageFS.fullPath(
-      DEFAULT_CUSTOM_AGENTS_DIR_NAME,
-    );
-    logger.debug(
-      CHANNEL,
-      `Using default custom agents directory: ${defaultPath}`,
-    );
-    return defaultPath;
-  }
-
-  private async resolveConfiguredCustomDir(
-    configuredPath: string,
-  ): Promise<string | undefined> {
-    if (!configuredPath) {
-      return undefined;
-    }
-
-    if (!path.isAbsolute(configuredPath)) {
-      logger.error(
-        CHANNEL,
-        `Custom agents directory must be an absolute path: ${configuredPath}`,
-      );
-      await showLoggedMessageWithDocs(
-        CHANNEL,
-        'Custom agents directory must be an absolute path',
-        'custom-agents',
-      );
-      return undefined;
-    }
-
-    const parentDir = path.dirname(configuredPath);
-    const parentExists = await AbsoluteFS.exists(parentDir);
-    if (!parentExists) {
-      logger.error(
-        CHANNEL,
-        `Parent directory does not exist for custom agents directory: ${parentDir}`,
-      );
-      await showLoggedMessageWithDocs(
-        CHANNEL,
-        'Parent directory for custom agents directory does not exist',
-        'custom-agents',
-      );
-      return undefined;
-    }
-
-    await AbsoluteFS.ensureDir(configuredPath);
-    logger.debug(
-      CHANNEL,
-      `Using custom agents directory from setting: ${configuredPath}`,
-    );
-    return configuredPath;
+    return this.getDirectoryService().getAllLocal();
   }
 
   async custom(): Promise<string> {
-    this.ensureInitialized();
-    const configuredPath = (
-      globalSM?.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR, '') ?? ''
-    ).trim();
-
-    const resolvedPath = await this.resolveConfiguredCustomDir(configuredPath);
-    if (resolvedPath) {
-      return resolvedPath;
-    }
-
-    return this.ensureDefaultCustomDir();
+    return this.getDirectoryService().custom();
   }
 
   async promptCustom(): Promise<string | undefined> {
@@ -217,7 +134,7 @@ export class AgentDirectoryManager {
   watchAgentDirectories(
     options: AgentDirectoryWatcherOptions,
   ): vscode.Disposable {
-    this.ensureInitialized();
+    this.getDirectoryService();
     const pattern = options.pattern ?? '**/*';
     const subscription: AgentDirectoryWatcherSubscription = {
       pattern,

--- a/src/test/agent/AgentDirectoryService.test.ts
+++ b/src/test/agent/AgentDirectoryService.test.ts
@@ -1,0 +1,181 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports
+import { AgentDirectoryService } from '@agent/index';
+import type {
+  AbsoluteDirectoryAccess,
+  AgentDirectoryIssueReporter,
+  AgentDirectoryPathStorage,
+  AgentDirectoryServiceLogger,
+} from '@agent/index';
+
+const STORAGE_BASE_PATH = path.resolve('/global-storage');
+const VALID_PARENT_PATH = path.resolve('/valid-parent');
+const VALID_CUSTOM_PATH = path.join(VALID_PARENT_PATH, 'custom');
+const MISSING_CUSTOM_PATH = path.join(path.resolve('/missing'), 'custom');
+
+class RecordingStorage implements AgentDirectoryPathStorage {
+  readonly ensured: string[] = [];
+
+  constructor(private readonly basePath: string) {}
+
+  async ensureDir(relativePath: string): Promise<void> {
+    this.ensured.push(relativePath);
+  }
+
+  fullPath(relativePath: string): string {
+    return path.join(this.basePath, relativePath);
+  }
+}
+
+class RecordingAbsoluteDirectories implements AbsoluteDirectoryAccess {
+  readonly ensured: string[] = [];
+
+  constructor(private readonly existingPaths: ReadonlySet<string>) {}
+
+  async exists(absolutePath: string): Promise<boolean> {
+    return this.existingPaths.has(absolutePath);
+  }
+
+  async ensureDir(absolutePath: string): Promise<void> {
+    this.ensured.push(absolutePath);
+  }
+}
+
+class RecordingIssueReporter implements AgentDirectoryIssueReporter {
+  readonly reports: Array<{ message: string; docsId: string }> = [];
+
+  async report(message: string, docsId: string): Promise<void> {
+    this.reports.push({ message, docsId });
+  }
+}
+
+class RecordingLogger implements AgentDirectoryServiceLogger {
+  readonly debugMessages: string[] = [];
+  readonly errorMessages: string[] = [];
+
+  debug(message: string): void {
+    this.debugMessages.push(message);
+  }
+
+  error(message: string): void {
+    this.errorMessages.push(message);
+  }
+}
+
+function createService(customDirectory = ''): {
+  service: AgentDirectoryService;
+  storage: RecordingStorage;
+  absoluteDirectories: RecordingAbsoluteDirectories;
+  reporter: RecordingIssueReporter;
+} {
+  const storage = new RecordingStorage(STORAGE_BASE_PATH);
+  const reporter = new RecordingIssueReporter();
+  const absoluteDirectories = new RecordingAbsoluteDirectories(
+    new Set([VALID_PARENT_PATH]),
+  );
+  const logger = new RecordingLogger();
+  const service = new AgentDirectoryService({
+    storage,
+    customDirectoryStore: {
+      get: () => customDirectory,
+    },
+    absoluteDirectories,
+    issueReporter: reporter,
+    logger,
+  });
+
+  return { service, storage, absoluteDirectories, reporter };
+}
+
+describe('AgentDirectoryService', () => {
+  it('resolves built-in directories from writable storage', async () => {
+    const { service, storage } = createService();
+
+    assert.equal(
+      await service.builtIn(),
+      path.join(STORAGE_BASE_PATH, 'agents'),
+    );
+    assert.equal(
+      await service.builtInToolUse(),
+      path.join(STORAGE_BASE_PATH, 'tool_use_agents'),
+    );
+    assert.deepEqual(storage.ensured, ['agents', 'tool_use_agents']);
+  });
+
+  it('uses the default custom directory when no custom path is configured', async () => {
+    const { service, storage } = createService('   ');
+
+    assert.equal(
+      await service.custom(),
+      path.join(STORAGE_BASE_PATH, 'custom_agents'),
+    );
+    assert.deepEqual(storage.ensured, ['custom_agents']);
+  });
+
+  it('uses a configured absolute custom directory with an existing parent', async () => {
+    const { service, storage, absoluteDirectories, reporter } =
+      createService(VALID_CUSTOM_PATH);
+
+    assert.equal(await service.custom(), VALID_CUSTOM_PATH);
+    assert.deepEqual(storage.ensured, []);
+    assert.deepEqual(absoluteDirectories.ensured, [VALID_CUSTOM_PATH]);
+    assert.deepEqual(reporter.reports, []);
+  });
+
+  it('falls back to the default custom directory for relative configured paths', async () => {
+    const { service, storage, reporter } = createService('relative/custom');
+
+    assert.equal(
+      await service.custom(),
+      path.join(STORAGE_BASE_PATH, 'custom_agents'),
+    );
+    assert.deepEqual(storage.ensured, ['custom_agents']);
+    assert.deepEqual(reporter.reports, [
+      {
+        message: 'Custom agents directory must be an absolute path',
+        docsId: 'custom-agents',
+      },
+    ]);
+  });
+
+  it('falls back to the default custom directory when the configured parent is missing', async () => {
+    const { service, storage, reporter } = createService(MISSING_CUSTOM_PATH);
+
+    assert.equal(
+      await service.custom(),
+      path.join(STORAGE_BASE_PATH, 'custom_agents'),
+    );
+    assert.deepEqual(storage.ensured, ['custom_agents']);
+    assert.deepEqual(reporter.reports, [
+      {
+        message: 'Parent directory for custom agents directory does not exist',
+        docsId: 'custom-agents',
+      },
+    ]);
+  });
+
+  it('returns local directories in source-priority order', async () => {
+    const { service } = createService(VALID_CUSTOM_PATH);
+
+    assert.deepEqual(await service.getAllLocal(), [
+      { directory: VALID_CUSTOM_PATH, source: 'custom' },
+      {
+        directory: path.join(STORAGE_BASE_PATH, 'agents'),
+        source: 'builtInWorkflow',
+      },
+      {
+        directory: path.join(STORAGE_BASE_PATH, 'tool_use_agents'),
+        source: 'builtInToolUse',
+      },
+    ]);
+  });
+
+  it('does not resolve a local directory for remote agents', async () => {
+    const { service } = createService();
+
+    assert.equal(await service.getDirectory('remote'), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Add host-neutral `AgentDirectoryService` for built-in/custom agent directory resolution.
- Refactor the VS Code `AgentDirectoryManager` to delegate directory resolution to the service while keeping prompt/watch behavior in the VS Code shell.
- Add focused unit coverage for built-in, custom, fallback, ordering, and remote-source behavior.

Closes #3306.

## Verification

- `npm run format`
- `npm run compile:safe`
- `npm run lint`
- `npm run compile-tests`
- `npx mocha --require out/test/setup.js out/test/agent/AgentDirectoryService.test.js`
- `npm run compile`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves directory-resolution logic behind a new service; behavior should be preserved but mis-wiring dependencies could affect where agents are loaded from.
> 
> **Overview**
> Extracts agent directory resolution into a new host-neutral `AgentDirectoryService` (built-in, tool-use, and custom directories), including validation/fallback behavior for misconfigured custom paths.
> 
> Refactors the VS Code `AgentDirectoryManager` to delegate all directory lookups to the service while keeping UI prompting and file-watcher behavior in the extension layer, and adds focused unit tests covering built-in/custom resolution, fallback cases, ordering, and remote-source handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5af21134dbd49f0d697f671b3bf823eeae2367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->