### PR TITLE
[codex] Decouple server key initialization

### DIFF
--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -8,23 +8,26 @@
  */
 import * as vscode from 'vscode';
 import { z } from 'zod';
-
-/**
- * Supabase configuration interface
- */
-export interface SupabaseConfig {
-  /** Supabase project URL */
-  url: string;
-  /**
-   * Supabase public key - safe to include in client code.
-   * Can be either:
-   * - Publishable key (recommended): starts with `sb_publishable_...`
-   * - Anon key (legacy): JWT starting with `eyJ...`
-   */
-  publicKey: string;
-  /** Edge function URL for fetching remote agent configurations */
-  edgeFunctionUrl: string;
-}
+import {
+  SUPABASE_CONFIG,
+  UserTierSchema,
+  type OAuthProvider,
+} from './sharedConfig';
+export {
+  FREE_TIER,
+  GITHUB_TOKEN_EXCHANGE_URL,
+  GITHUB_TOKEN_REFRESH_URL,
+  MAX_TIER,
+  OAUTH_PROVIDERS,
+  SERVER_SIDE_CACHE_TTL_MS,
+  SUPABASE_CONFIG,
+  SUPABASE_CUSTOM_DOMAIN,
+  ULTRA_TIER,
+  UserTierSchema,
+  type OAuthProvider,
+  type SupabaseConfig,
+  type UserTier,
+} from './sharedConfig';
 
 /**
  * Official TeXRA Supabase configuration.
@@ -33,32 +36,6 @@ export interface SupabaseConfig {
  * The public key (anon or publishable) is safe to include in client code.
  * Row Level Security (RLS) policies protect data access, not the key.
  */
-
-/** Custom domain for Supabase (remote agent access) */
-export const SUPABASE_CUSTOM_DOMAIN = 'remote.texra.ai';
-
-export const SUPABASE_CONFIG: SupabaseConfig = {
-  // Production Supabase URL via custom domain
-  url: `https://${SUPABASE_CUSTOM_DOMAIN}`,
-
-  // Production public key - safe to include in client code
-  publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw',
-
-  // Edge function URL via custom domain
-  edgeFunctionUrl: `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/get-agent-config`,
-};
-
-/**
- * Edge function URL for GitHub token exchange.
- * Used in VS Code web/Codespaces where standard OAuth callbacks don't work.
- */
-export const GITHUB_TOKEN_EXCHANGE_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/auth-github/exchange`;
-
-/**
- * Edge function URL for custom token refresh.
- * Used for sessions created via VS Code GitHub auth (not standard Supabase OAuth).
- */
-export const GITHUB_TOKEN_REFRESH_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/auth-github/refresh`;
 
 /**
  * Check if Supabase is configured.
@@ -72,13 +49,6 @@ export function isSupabaseConfigured(): boolean {
   );
 }
 
-/**
- * Supported OAuth providers for TeXRA authentication.
- * Users can choose between GitHub and Google during sign-in.
- */
-export const OAUTH_PROVIDERS = ['github', 'google'] as const;
-export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
-
 // ============================================================================
 // User Groups & Permissions
 // ============================================================================
@@ -90,25 +60,6 @@ export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
  *
  * Note: 'tier' column is reserved for future server-side API key access.
  */
-
-/**
- * Single source of truth for tier values used in server-side API key access.
- *
- * CROSS-REFERENCE: These exact string values are duplicated in:
- *   supabase/functions/relay/models.ts (lines 143-145)
- * Deno Edge Functions cannot import TypeScript source, so the values must
- * be kept in sync manually. If you change any value here, you MUST also
- * update the corresponding constants in that file.
- *
- * The schema enum order is: 'free', 'Max', 'Ultra' (ascending privilege).
- */
-export const UserTierSchema = z.enum(['free', 'Max', 'Ultra']);
-export type UserTier = z.infer<typeof UserTierSchema>;
-
-/** Tier constants derived from the schema — use these instead of string literals. */
-export const FREE_TIER: UserTier = 'free';
-export const MAX_TIER: UserTier = 'Max';
-export const ULTRA_TIER: UserTier = 'Ultra';
 
 /**
  * User's authorization context.
@@ -260,9 +211,6 @@ export async function getExternalAuthCallbackUri(): Promise<string> {
 
 /** Timeout for waiting for OAuth callback (2 minutes in ms) */
 export const AUTH_CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
-
-/** Cache TTL for server-side key access and tier config (5 minutes). */
-export const SERVER_SIDE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 /** Refresh token proactively if it expires within this threshold (30 minutes). */
 export const TOKEN_REFRESH_THRESHOLD_MS = 30 * 60 * 1000;

--- a/src/auth/serverKeys/ServerSideKeyService.ts
+++ b/src/auth/serverKeys/ServerSideKeyService.ts
@@ -15,13 +15,16 @@
  */
 
 import { EventEmitter } from 'events';
-import * as logger from '@logger/logUtils';
 import {
   SERVER_SIDE_CACHE_TTL_MS,
   ULTRA_TIER,
   FREE_TIER,
   type UserTier,
-} from '../config';
+} from '../sharedConfig';
+import {
+  NOOP_AUTH_SERVICE_LOGGER,
+  type AuthServiceLogger,
+} from '../serviceLogger';
 import type { StateStore } from '@platform/interfaces/state';
 import type { TierService } from '../tier/TierService';
 import type { ServerSideProvider } from './types';
@@ -68,10 +71,13 @@ export type ServerSideKeyState = StateStore;
 export interface ServerSideKeyServiceInit {
   state?: ServerSideKeyState;
   subscriptions?: ServerSideKeyDisposable[];
+  logger?: AuthServiceLogger;
 }
 
 class NodeEventEmitter<T> implements ServerSideKeyDisposable {
   private readonly emitter = new EventEmitter();
+
+  constructor(private readonly logger: AuthServiceLogger) {}
 
   readonly event: ServerSideKeyEvent<T> = (listener, thisArgs, disposables) => {
     const boundListener =
@@ -90,7 +96,7 @@ class NodeEventEmitter<T> implements ServerSideKeyDisposable {
         listener(event);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        logger.error(CHANNEL, `Event listener failed: ${message}`);
+        this.logger.error(CHANNEL, `Event listener failed: ${message}`);
       }
     }
   }
@@ -122,18 +128,23 @@ export class ServerSideKeyService {
   // Settings
   private useIncludedModelAccess = true;
   private globalState: ServerSideKeyState | null = null;
-  private readonly _onDidChangeModelAccess = new NodeEventEmitter<boolean>();
-  private readonly _onCacheCleared = new NodeEventEmitter<void>();
+  private readonly _onDidChangeModelAccess: NodeEventEmitter<boolean>;
+  private readonly _onCacheCleared: NodeEventEmitter<void>;
   private readonly _tierServiceClearSubscription: ServerSideKeyDisposable;
 
-  readonly onDidChangeModelAccess = this._onDidChangeModelAccess.event;
-  readonly onCacheCleared = this._onCacheCleared.event;
+  readonly onDidChangeModelAccess: ServerSideKeyEvent<boolean>;
+  readonly onCacheCleared: ServerSideKeyEvent<void>;
 
   constructor(
     private readonly baseUrl: string,
     private readonly authProvider: AuthProvider,
     private readonly tierService: TierService,
+    private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
   ) {
+    this._onDidChangeModelAccess = new NodeEventEmitter<boolean>(this.logger);
+    this._onCacheCleared = new NodeEventEmitter<void>(this.logger);
+    this.onDidChangeModelAccess = this._onDidChangeModelAccess.event;
+    this.onCacheCleared = this._onCacheCleared.event;
     this._tierServiceClearSubscription = this._onCacheCleared.event(() => {
       this.tierService.clearCache();
     });
@@ -262,13 +273,13 @@ export class ServerSideKeyService {
       ]);
 
       if (this.tierService.isAccessExpired()) {
-        logger.info(CHANNEL, 'User access has expired');
+        this.logger.info(CHANNEL, 'User access has expired');
         this.accessResult = false;
         return false;
       }
 
       if (!this.hasFullAccess() && tierConfig === null) {
-        logger.info(
+        this.logger.info(
           CHANNEL,
           'Tier config unavailable for non-Ultra user, denying access',
         );

--- a/src/auth/serverKeys/index.ts
+++ b/src/auth/serverKeys/index.ts
@@ -13,12 +13,12 @@
  * - free tier: Budget models only (under $1/M input)
  */
 
-import * as vscode from 'vscode';
-import { SUPABASE_CUSTOM_DOMAIN } from '../config';
+import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';
 import { getTierService } from '../tier';
 import {
   ServerSideKeyService,
   type AuthProvider,
+  type ServerSideKeyServiceInit,
 } from './ServerSideKeyService';
 
 // Types
@@ -57,20 +57,18 @@ export function setServerSideKeyService(service: ServerSideKeyService): void {
  * Initialize the server-side key access module.
  * Call this during extension activation.
  *
- * @param context - VS Code extension context
+ * @param options - Host-provided state and subscriptions
  * @param authProvider - Provider for authentication state checks
  */
 export function initializeServerSideKeyAccess(
-  context: vscode.ExtensionContext,
+  options: ServerSideKeyServiceInit,
   authProvider: AuthProvider,
 ): void {
   _instance = new ServerSideKeyService(
     `https://${SUPABASE_CUSTOM_DOMAIN}`,
     authProvider,
-    getTierService(),
+    getTierService(options.logger),
+    options.logger,
   );
-  _instance.initialize({
-    state: context.globalState,
-    subscriptions: context.subscriptions,
-  });
+  _instance.initialize(options);
 }

--- a/src/auth/serviceLogger.ts
+++ b/src/auth/serviceLogger.ts
@@ -1,0 +1,15 @@
+export interface AuthServiceLogger {
+  info(channel: string, message: string): void;
+  error(channel: string, message: string): void;
+}
+
+export const NOOP_AUTH_SERVICE_LOGGER: AuthServiceLogger = {
+  info(channel, message) {
+    void channel;
+    void message;
+  },
+  error(channel, message) {
+    void channel;
+    void message;
+  },
+};

--- a/src/auth/sharedConfig.ts
+++ b/src/auth/sharedConfig.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+/**
+ * Supabase configuration interface.
+ */
+export interface SupabaseConfig {
+  /** Supabase project URL. */
+  url: string;
+  /**
+   * Supabase public key - safe to include in client code.
+   * Can be either:
+   * - Publishable key (recommended): starts with `sb_publishable_...`
+   * - Anon key (legacy): JWT starting with `eyJ...`
+   */
+  publicKey: string;
+  /** Edge function URL for fetching remote agent configurations. */
+  edgeFunctionUrl: string;
+}
+
+/** Custom domain for Supabase-backed remote services. */
+export const SUPABASE_CUSTOM_DOMAIN = 'remote.texra.ai';
+
+export const SUPABASE_CONFIG: SupabaseConfig = {
+  // Production Supabase URL via custom domain
+  url: `https://${SUPABASE_CUSTOM_DOMAIN}`,
+
+  // Production public key - safe to include in client code
+  publicKey: 'sb_publishable_DUIDjtxk12ZYYncrVUfwOw_xWQYsSvw',
+
+  // Edge function URL via custom domain
+  edgeFunctionUrl: `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/get-agent-config`,
+};
+
+/**
+ * Edge function URL for GitHub token exchange.
+ * Used in VS Code web/Codespaces where standard OAuth callbacks don't work.
+ */
+export const GITHUB_TOKEN_EXCHANGE_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/auth-github/exchange`;
+
+/**
+ * Edge function URL for custom token refresh.
+ * Used for sessions created via VS Code GitHub auth (not standard Supabase OAuth).
+ */
+export const GITHUB_TOKEN_REFRESH_URL = `https://${SUPABASE_CUSTOM_DOMAIN}/functions/v1/auth-github/refresh`;
+
+/**
+ * Supported OAuth providers for TeXRA authentication.
+ * Users can choose between GitHub and Google during sign-in.
+ */
+export const OAUTH_PROVIDERS = ['github', 'google'] as const;
+export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
+
+/**
+ * Single source of truth for tier values used in server-side API key access.
+ *
+ * CROSS-REFERENCE: These exact string values are duplicated in:
+ *   supabase/functions/relay/models.ts (lines 143-145)
+ * Deno Edge Functions cannot import TypeScript source, so the values must
+ * be kept in sync manually. If you change any value here, you MUST also
+ * update the corresponding constants in that file.
+ *
+ * The schema enum order is: 'free', 'Max', 'Ultra' (ascending privilege).
+ */
+export const UserTierSchema = z.enum(['free', 'Max', 'Ultra']);
+export type UserTier = z.infer<typeof UserTierSchema>;
+
+/** Tier constants derived from the schema - use these instead of string literals. */
+export const FREE_TIER: UserTier = 'free';
+export const MAX_TIER: UserTier = 'Max';
+export const ULTRA_TIER: UserTier = 'Ultra';
+
+/** Cache TTL for server-side key access and tier config (5 minutes). */
+export const SERVER_SIDE_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/src/auth/tier/TierService.ts
+++ b/src/auth/tier/TierService.ts
@@ -13,9 +13,12 @@
  * - Ultra: All models including premium ($3+/M input)
  */
 
-import { toErrorMessage } from '@common/errors';
-import * as logger from '@logger/logUtils';
-import { SERVER_SIDE_CACHE_TTL_MS, type UserTier } from '../config';
+import { toErrorMessage } from '@common/errors/errorMessage';
+import { SERVER_SIDE_CACHE_TTL_MS, type UserTier } from '../sharedConfig';
+import {
+  NOOP_AUTH_SERVICE_LOGGER,
+  type AuthServiceLogger,
+} from '../serviceLogger';
 import {
   TierModelConfigSchema,
   UserAccessStatusSchema,
@@ -41,7 +44,10 @@ export class TierService {
    * Create a new TierService.
    * @param baseUrl - The base URL for the relay server (e.g., "https://remote.texra.ai")
    */
-  constructor(private readonly baseUrl: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    private readonly logger: AuthServiceLogger = NOOP_AUTH_SERVICE_LOGGER,
+  ) {}
 
   /**
    * Clear the tier config cache.
@@ -88,13 +94,13 @@ export class TierService {
 
       if (!response.ok) {
         if (response.status === 404) {
-          logger.info(
+          this.logger.info(
             CHANNEL,
             'Tier-config endpoint not available, using defaults',
           );
           return null;
         }
-        logger.error(
+        this.logger.error(
           CHANNEL,
           `Failed to fetch tier config: ${response.status}`,
         );
@@ -114,7 +120,7 @@ export class TierService {
       const parsed = TierModelConfigSchema.safeParse(data);
 
       if (!parsed.success) {
-        logger.error(
+        this.logger.error(
           CHANNEL,
           `Invalid tier config response: ${parsed.error.message}`,
         );
@@ -123,7 +129,7 @@ export class TierService {
 
       return parsed.data;
     } catch (error) {
-      logger.error(
+      this.logger.error(
         CHANNEL,
         `Error fetching tier config: ${toErrorMessage(error)}`,
       );

--- a/src/auth/tier/index.ts
+++ b/src/auth/tier/index.ts
@@ -17,8 +17,9 @@
  * - Ultra: All models including premium ($3+/M input)
  */
 
-import { SUPABASE_CUSTOM_DOMAIN } from '../config';
+import { SUPABASE_CUSTOM_DOMAIN } from '../sharedConfig';
 import { TierService } from './TierService';
+import type { AuthServiceLogger } from '../serviceLogger';
 
 // Service class (internal use only)
 export { TierService };
@@ -32,9 +33,9 @@ let _instance: TierService | null = null;
 /**
  * Get the singleton TierService instance.
  */
-export function getTierService(): TierService {
+export function getTierService(logger?: AuthServiceLogger): TierService {
   if (!_instance) {
-    _instance = new TierService(`https://${SUPABASE_CUSTOM_DOMAIN}`);
+    _instance = new TierService(`https://${SUPABASE_CUSTOM_DOMAIN}`, logger);
   }
   return _instance;
 }

--- a/src/auth/tier/types.ts
+++ b/src/auth/tier/types.ts
@@ -18,7 +18,7 @@
  */
 
 import { z } from 'zod';
-import { UserTierSchema, type UserTier } from '../config';
+import { UserTierSchema, type UserTier } from '../sharedConfig';
 
 // Re-export for convenience
 export { UserTierSchema, type UserTier };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,11 +154,18 @@ export async function activate(context: vscode.ExtensionContext) {
   });
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   FileLister.initialize(context);
-  initializeServerSideKeyAccess(context, {
-    isAuthenticated: () => SupabaseClient.isAuthenticated(),
-    getUserTier: () => SupabaseClient.getUserTier(),
-    getAccessToken: () => SupabaseClient.getAccessToken(),
-  });
+  initializeServerSideKeyAccess(
+    {
+      state: context.globalState,
+      subscriptions: context.subscriptions,
+      logger,
+    },
+    {
+      isAuthenticated: () => SupabaseClient.isAuthenticated(),
+      getUserTier: () => SupabaseClient.getUserTier(),
+      getAccessToken: () => SupabaseClient.getAccessToken(),
+    },
+  );
 
   // Seed first-install defaults (e.g. disabled tools) before anything writes
   // LAST_KNOWN_VERSION, so upgrading users are not affected.

--- a/src/test/auth/ServerSideKeyService.test.ts
+++ b/src/test/auth/ServerSideKeyService.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'assert';
 
 // Local imports - auth
 import { FREE_TIER, type UserTier } from '@auth/config';
+import type { AuthServiceLogger } from '@auth/serviceLogger';
 import {
   ServerSideKeyService,
   type AuthProvider,
@@ -91,11 +92,15 @@ function createAuthProvider(): AuthProvider {
   };
 }
 
-function createService(tierService: TierService): ServerSideKeyService {
+function createService(
+  tierService: TierService,
+  logger?: AuthServiceLogger,
+): ServerSideKeyService {
   return new ServerSideKeyService(
     'https://example.test',
     createAuthProvider(),
     tierService,
+    logger,
   );
 }
 
@@ -151,7 +156,17 @@ describe('ServerSideKeyService', () => {
   it('continues dispatching when one listener throws', async () => {
     const tier = createTierService();
     const state = new MemoryState({ [USE_INCLUDED_ACCESS_KEY]: false });
-    const service = createService(tier.service);
+    const errors: Array<{ channel: string; message: string }> = [];
+    const logger: AuthServiceLogger = {
+      info(channel, message) {
+        void channel;
+        void message;
+      },
+      error(channel, message) {
+        errors.push({ channel, message });
+      },
+    };
+    const service = createService(tier.service, logger);
     const changes: boolean[] = [];
 
     service.initialize({ state });
@@ -166,5 +181,11 @@ describe('ServerSideKeyService', () => {
 
     assert.deepEqual(changes, [true]);
     assert.equal(state.get(USE_INCLUDED_ACCESS_KEY, false), true);
+    assert.deepEqual(errors, [
+      {
+        channel: 'ServerSideKeyService',
+        message: 'Event listener failed: listener failed',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Decouples the server-side key module entry point from VS Code by accepting the existing host-neutral init shape directly. The VS Code activation code now constructs the init object at the composition root, so `src/auth/serverKeys` stays free of VS Code imports while preserving the existing auth provider wiring.

This completes the EventEmitter and host-coupling residue for PRD §9 item 1 in the auth tier/server-key path.

Closes #3301.

Validation:
- `npm run compile:safe`
- `npm run compile-tests`
- `npm run lint`
- `npx mocha --require out/test/setup.js out/test/auth/ServerSideKeyService.test.js`
- `npm run compile`
- `git diff --check`
- `rg -n "vscode\.EventEmitter|import \* as vscode from ['\"]vscode['\"]" src/auth/tier src/auth/serverKeys -S` (no matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors initialization and logging for tier/server-key access; while mostly structural, it touches auth-gated model access decisions and could affect included-access behavior if wiring is incorrect.
> 
> **Overview**
> Decouples the server-side key/tier modules from VS Code-specific types by shifting `initializeServerSideKeyAccess` to accept host-provided `state`/`subscriptions` (wired in `extension.ts`) and by using a Node `EventEmitter` internally.
> 
> Centralizes Supabase/tier constants into a new `sharedConfig.ts` (re-exported via `config.ts`) and introduces an injectable `AuthServiceLogger` (with a NOOP default) for `TierService` and `ServerSideKeyService`, including test coverage that verifies listener failures are logged without breaking event dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7172ef5e644a1f56910078ce1ea4fe0e7c716d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->