### PR TITLE
Add support for emitting check run annotations as separate events

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -60,7 +60,8 @@ function createInitialState(pr: PRKey): SubscriptionState {
     seenReviewCommentIds: new Set(),
     seenReviewIds: new Set(),
     lastFailedCheckKeys: new Set(),
-    seenAnnotatedCheckKeys: new Set(),
+    lastAnnotationKeys: new Set(),
+    pendingAnnotationRuns: [],
     ciCompleteSha: undefined,
     ciPassedSha: undefined,
     headSha: undefined,
@@ -91,9 +92,11 @@ const MAX_CHECK_RUNS_PAGES = 50;
 // we'd only truncate; remaining count is sourced from `annotations_count`.
 const ANNOTATIONS_PAGE_SIZE = 20;
 // Bound the per-tick fan-out across runs (e.g. a matrix build lighting up a
-// fleet of checks). Runs we skip this tick stay eligible next tick — keys
-// are added to the seen-set only on successful fetch + emit.
-const MAX_ANNOTATION_FETCHES_PER_TICK = 5;
+// fleet of checks). Excess candidates land in `pendingAnnotationRuns` and are
+// drained on subsequent ticks (including 304 ticks where check-runs haven't
+// changed). The cap is per-PR; the PollingSourceBase rate-limit handler is
+// the process-wide safety net via GitHubRateLimitError + skipPollUntilMs.
+const MAX_ANNOTATION_FETCHES_PER_TICK = 3;
 
 export interface PRKey {
   owner: string;
@@ -120,8 +123,20 @@ interface SubscriptionState extends BasePollSubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
-  /** `${id}:${completed_at}` — re-runs change `completed_at`, re-emitting. */
-  seenAnnotatedCheckKeys: Set<string>;
+  /**
+   * `${id}:${completed_at}` for runs observed (with annotations) on the most
+   * recent 200 tick. Replaced wholesale every 200 tick (mirrors
+   * `lastFailedCheckKeys`) so it can't grow unboundedly and FIFO eviction
+   * can't mistake a still-present run for a new one.
+   */
+  lastAnnotationKeys: Set<string>;
+  /**
+   * Annotated runs awaiting an annotations-endpoint fetch. Populated by the
+   * 200 branch (newly-seen keys), drained on every tick (200 OR 304) so a
+   * burst that overflows `MAX_ANNOTATION_FETCHES_PER_TICK` isn't stranded
+   * once the check-runs cache stabilizes.
+   */
+  pendingAnnotationRuns: GhCheckRun[];
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
   ciCompleteSha: string | undefined;
   /** Head SHA for which the one-shot "CI passed" event has been emitted. */
@@ -231,6 +246,9 @@ export class PRPollingSource extends PollingSourceBase<
         state.ciCompleteSha = undefined;
         state.ciPassedSha = undefined;
         state.checkRunsCache = undefined;
+        // Old SHA's deferred annotations are no longer the user's focus; the
+        // new SHA's runs will re-enqueue from the next 200 tick.
+        state.pendingAnnotationRuns = [];
       }
       state.headSha = newHead;
 
@@ -349,13 +367,13 @@ export class PRPollingSource extends PollingSourceBase<
           if (this.isCheckFailure(r)) {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
-          // Seed the annotated-check dedupe so pre-subscription annotations
-          // don't replay; the timestamp in the key lets re-runs re-emit.
+          // Seed annotation keys so pre-subscription annotations don't
+          // replay; the timestamp in the key lets re-runs re-emit.
           if (
             r.status === 'completed' &&
             (r.output?.annotations_count ?? 0) > 0
           ) {
-            state.seenAnnotatedCheckKeys.add(this.checkKey(r));
+            state.lastAnnotationKeys.add(this.checkKey(r));
           }
         }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
@@ -504,8 +522,15 @@ export class PRPollingSource extends PollingSourceBase<
 
       // Annotations are emitted independently of failures: they also surface
       // on passing checks (lint suggestions, custom workflow advisories).
-      await this.fetchAndEmitAnnotations(state, runs);
+      // Enqueue here, drain below — the drain runs on every tick (including
+      // 304) so excess candidates aren't stranded once check-runs settle.
+      this.enqueueAnnotationCandidates(state, runs);
     }
+
+    // Always drain pending annotation fetches, even on a 304 check-runs tick.
+    // The 200 branch enqueues; this is what unblocks the queue when the
+    // check-runs response stops changing but candidates remain unfetched.
+    await this.drainAnnotationQueue(state);
 
     // Commit the deferred check-runs cache only after successfully consuming
     // the response (including the diff branch above). See `fetchAllCheckRuns`
@@ -780,44 +805,68 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   /**
-   * Fetch and forward inline annotations for newly-completed runs. Gating on
-   * `completed` keeps the dedupe key (`${id}:${completed_at}`) stable — only
-   * completion has a settled `annotations_count`. Errors propagate to the
-   * tick wrapper for retry; keys advance only on successful emit.
+   * Replace `lastAnnotationKeys` with this tick's set and enqueue any newly-
+   * appeared annotated runs. Replace-each-tick semantics (mirroring
+   * `lastFailedCheckKeys`) keep the set bounded by the head SHA's check-run
+   * count — no FIFO eviction, no risk of an evicted-then-rediscovered run
+   * re-emitting duplicates against an unchanged check-runs response.
    */
-  private async fetchAndEmitAnnotations(
+  private enqueueAnnotationCandidates(
     state: SubscriptionState,
     runs: ReadonlyArray<GhCheckRun>,
-  ): Promise<void> {
-    const candidates: { run: GhCheckRun; key: string }[] = [];
+  ): void {
+    const currentKeys = new Set<string>();
+    const pendingIds = new Set(state.pendingAnnotationRuns.map((r) => r.id));
     for (const run of runs) {
       if (run.status !== 'completed') continue;
       if ((run.output?.annotations_count ?? 0) <= 0) continue;
       const key = this.checkKey(run);
-      if (state.seenAnnotatedCheckKeys.has(key)) continue;
-      candidates.push({ run, key });
+      currentKeys.add(key);
+      if (state.lastAnnotationKeys.has(key)) continue;
+      // Run id alone catches the rerun-mid-pending case: same check, same
+      // pending entry, but `completed_at` (and therefore the key) changed.
+      // We skip enqueuing a duplicate; the queued entry will be fetched and
+      // re-emit when its annotations land — annotation_level is what users
+      // care about, not the precise completed_at the queue holds.
+      if (pendingIds.has(run.id)) continue;
+      state.pendingAnnotationRuns.push(run);
     }
-    if (candidates.length === 0) return;
+    state.lastAnnotationKeys = currentKeys;
+  }
 
-    const toFetch = candidates.slice(0, MAX_ANNOTATION_FETCHES_PER_TICK);
-    const { pr } = state;
-    await Promise.all(
-      toFetch.map(async ({ run, key }) => {
-        const annotations = await this.fetchAnnotations(
-          pr.owner,
-          pr.repo,
-          run.id,
-        );
-        state.seenAnnotatedCheckKeys.add(key);
-        if (annotations.length > 0) {
-          this.emit(
-            state,
-            formatCheckAnnotations(state.slug, pr.pullNumber, run, annotations),
-          );
-        }
-      }),
+  /**
+   * Drain up to `MAX_ANNOTATION_FETCHES_PER_TICK` queued runs by hitting the
+   * annotations endpoint and emitting one event per non-empty result. Runs
+   * are removed from the queue only after the parallel batch resolves; on
+   * any rejection (network blip, rate limit) the entire batch stays queued
+   * for the next tick. Emits happen after the synchronous queue mutation so
+   * a listener throw can't desync the queue from `lastAnnotationKeys`.
+   */
+  private async drainAnnotationQueue(state: SubscriptionState): Promise<void> {
+    if (state.pendingAnnotationRuns.length === 0) return;
+    const candidates = state.pendingAnnotationRuns.slice(
+      0,
+      MAX_ANNOTATION_FETCHES_PER_TICK,
     );
-    trimSet(state.seenAnnotatedCheckKeys, MAX_SEEN_IDS);
+    const { pr } = state;
+    const results = await Promise.all(
+      candidates.map(async (run) => ({
+        run,
+        annotations: await this.fetchAnnotations(pr.owner, pr.repo, run.id),
+      })),
+    );
+    const fetchedIds = new Set(results.map((r) => r.run.id));
+    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
+      (p) => !fetchedIds.has(p.id),
+    );
+    for (const { run, annotations } of results) {
+      if (annotations.length > 0) {
+        this.emit(
+          state,
+          formatCheckAnnotations(state.slug, pr.pullNumber, run, annotations),
+        );
+      }
+    }
   }
 
   private async fetchAnnotations(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -33,6 +33,7 @@ import { getNewestTimestamp, trimSet } from './formatUtils';
 import {
   type ConditionalResponse,
   ghGet,
+  GitHubAuthError,
   GitHubPermanentError,
 } from './githubClient';
 import {
@@ -841,16 +842,19 @@ export class PRPollingSource extends PollingSourceBase<
   /**
    * Drain up to `MAX_ANNOTATION_FETCHES_PER_TICK` queued runs by hitting the
    * annotations endpoint. Errors are isolated per-fetch — annotations are
-   * best-effort, so a single bad check (e.g. 404 on a deleted run) must not
-   * propagate to `handleFailure` and detach the whole PR subscription.
+   * best-effort, so a single bad check (e.g. 404 on a deleted run, or a
+   * permission-scoped token) must not propagate to `handleFailure` and
+   * detach the whole PR subscription.
    *
    * - Success: emit, remove from queue.
-   * - `GitHubPermanentError` (404/410/422): log + remove from queue. Retrying
-   *   won't help and we don't want a poisoned entry blocking the budget.
-   * - Anything else (network blip, timeout, transient auth/rate-limit):
-   *   leave in queue for the next tick. Real auth/rate-limit failures will
-   *   surface from the main poll path's fetches and trigger the global
-   *   handling there.
+   * - `GitHubPermanentError` (404/410/422): log + drop. Retrying won't help.
+   * - `GitHubAuthError` (401/403): log + drop. Almost always a permission-
+   *   scoped token (the main poll's other ghGet calls succeeded, else we
+   *   wouldn't be here). If the token is genuinely bad, the main poll path
+   *   will detach the subscription via its own ghGet failure.
+   * - Anything else (network, timeout, rate-limit): rotate to the BACK of
+   *   the queue. Without rotation, a persistently-failing head entry would
+   *   starve every other queued run forever.
    */
   private async drainAnnotationQueue(state: SubscriptionState): Promise<void> {
     if (state.pendingAnnotationRuns.length === 0) return;
@@ -863,12 +867,13 @@ export class PRPollingSource extends PollingSourceBase<
       candidates.map((run) => this.fetchAnnotations(pr.owner, pr.repo, run.id)),
     );
 
-    const completedIds = new Set<number>();
+    const dropIds = new Set<number>();
+    const rotateIds = new Set<number>();
     for (let i = 0; i < settled.length; i += 1) {
       const run = candidates[i];
       const result = settled[i];
       if (result.status === 'fulfilled') {
-        completedIds.add(run.id);
+        dropIds.add(run.id);
         if (result.value.length > 0) {
           this.emit(
             state,
@@ -885,18 +890,31 @@ export class PRPollingSource extends PollingSourceBase<
       const err = result.reason;
       if (err instanceof GitHubPermanentError) {
         this.logger.warn(
-          `Annotations for check ${run.id} unavailable (HTTP ${err.status}); skipping.`,
+          `Annotations for check ${run.id} unavailable (HTTP ${err.status}); dropping.`,
         );
-        completedIds.add(run.id);
+        dropIds.add(run.id);
         continue;
       }
+      if (err instanceof GitHubAuthError) {
+        this.logger.warn(
+          `Annotations for check ${run.id} forbidden (${err.message}); dropping.`,
+        );
+        dropIds.add(run.id);
+        continue;
+      }
+      rotateIds.add(run.id);
       this.logger.warn(
-        `Annotation fetch for check ${run.id} failed; will retry next tick: ${String(err)}`,
+        `Annotation fetch for check ${run.id} failed; rotating to back of queue: ${String(err)}`,
       );
     }
-    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
-      (p) => !completedIds.has(p.id),
+
+    const rotated = state.pendingAnnotationRuns.filter((p) =>
+      rotateIds.has(p.id),
     );
+    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
+      (p) => !dropIds.has(p.id) && !rotateIds.has(p.id),
+    );
+    state.pendingAnnotationRuns.push(...rotated);
   }
 
   private async fetchAnnotations(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -821,19 +821,20 @@ export class PRPollingSource extends PollingSourceBase<
     runs: ReadonlyArray<GhCheckRun>,
   ): void {
     const currentKeys = new Set<string>();
-    const pendingIds = new Set(state.pendingAnnotationRuns.map((r) => r.id));
+    // Dedupe against pending by full `checkKey` (id + completed_at), not by
+    // id alone: a fast rerun produces a new completed_at while the prior
+    // entry may still be queued, and both completions carry distinct
+    // annotation sets we want to emit.
+    const pendingKeys = new Set(
+      state.pendingAnnotationRuns.map((r) => this.checkKey(r)),
+    );
     for (const run of runs) {
       if (run.status !== 'completed') continue;
       if ((run.output?.annotations_count ?? 0) <= 0) continue;
       const key = this.checkKey(run);
       currentKeys.add(key);
       if (state.lastAnnotationKeys.has(key)) continue;
-      // Run id alone catches the rerun-mid-pending case: same check, same
-      // pending entry, but `completed_at` (and therefore the key) changed.
-      // We skip enqueuing a duplicate; the queued entry will be fetched and
-      // re-emit when its annotations land — annotation_level is what users
-      // care about, not the precise completed_at the queue holds.
-      if (pendingIds.has(run.id)) continue;
+      if (pendingKeys.has(key)) continue;
       state.pendingAnnotationRuns.push(run);
     }
     state.lastAnnotationKeys = currentKeys;
@@ -867,13 +868,17 @@ export class PRPollingSource extends PollingSourceBase<
       candidates.map((run) => this.fetchAnnotations(pr.owner, pr.repo, run.id)),
     );
 
-    const dropIds = new Set<number>();
-    const rotateIds = new Set<number>();
+    // Categorize by `checkKey` (id + completed_at), not id alone — a fast
+    // rerun can leave the queue holding two distinct completion attempts
+    // with the same id, and they need to be drop/rotated independently.
+    const dropKeys = new Set<string>();
+    const rotateKeys = new Set<string>();
     for (let i = 0; i < settled.length; i += 1) {
       const run = candidates[i];
+      const key = this.checkKey(run);
       const result = settled[i];
       if (result.status === 'fulfilled') {
-        dropIds.add(run.id);
+        dropKeys.add(key);
         if (result.value.length > 0) {
           this.emit(
             state,
@@ -892,28 +897,29 @@ export class PRPollingSource extends PollingSourceBase<
         this.logger.warn(
           `Annotations for check ${run.id} unavailable (HTTP ${err.status}); dropping.`,
         );
-        dropIds.add(run.id);
+        dropKeys.add(key);
         continue;
       }
       if (err instanceof GitHubAuthError) {
         this.logger.warn(
           `Annotations for check ${run.id} forbidden (${err.message}); dropping.`,
         );
-        dropIds.add(run.id);
+        dropKeys.add(key);
         continue;
       }
-      rotateIds.add(run.id);
+      rotateKeys.add(key);
       this.logger.warn(
         `Annotation fetch for check ${run.id} failed; rotating to back of queue: ${String(err)}`,
       );
     }
 
     const rotated = state.pendingAnnotationRuns.filter((p) =>
-      rotateIds.has(p.id),
+      rotateKeys.has(this.checkKey(p)),
     );
-    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
-      (p) => !dropIds.has(p.id) && !rotateIds.has(p.id),
-    );
+    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter((p) => {
+      const k = this.checkKey(p);
+      return !dropKeys.has(k) && !rotateKeys.has(k);
+    });
     state.pendingAnnotationRuns.push(...rotated);
   }
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -30,7 +30,7 @@ import {
   isPassingConclusion,
 } from './formatPREvent';
 import { getNewestTimestamp, trimSet } from './formatUtils';
-import { type ConditionalResponse, ghGet } from './githubClient';
+import { type ConditionalResponse, ghGet, GitHubPermanentError } from './githubClient';
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,
@@ -836,11 +836,17 @@ export class PRPollingSource extends PollingSourceBase<
 
   /**
    * Drain up to `MAX_ANNOTATION_FETCHES_PER_TICK` queued runs by hitting the
-   * annotations endpoint and emitting one event per non-empty result. Runs
-   * are removed from the queue only after the parallel batch resolves; on
-   * any rejection (network blip, rate limit) the entire batch stays queued
-   * for the next tick. Emits happen after the synchronous queue mutation so
-   * a listener throw can't desync the queue from `lastAnnotationKeys`.
+   * annotations endpoint. Errors are isolated per-fetch — annotations are
+   * best-effort, so a single bad check (e.g. 404 on a deleted run) must not
+   * propagate to `handleFailure` and detach the whole PR subscription.
+   *
+   * - Success: emit, remove from queue.
+   * - `GitHubPermanentError` (404/410/422): log + remove from queue. Retrying
+   *   won't help and we don't want a poisoned entry blocking the budget.
+   * - Anything else (network blip, timeout, transient auth/rate-limit):
+   *   leave in queue for the next tick. Real auth/rate-limit failures will
+   *   surface from the main poll path's fetches and trigger the global
+   *   handling there.
    */
   private async drainAnnotationQueue(state: SubscriptionState): Promise<void> {
     if (state.pendingAnnotationRuns.length === 0) return;
@@ -849,24 +855,44 @@ export class PRPollingSource extends PollingSourceBase<
       MAX_ANNOTATION_FETCHES_PER_TICK,
     );
     const { pr } = state;
-    const results = await Promise.all(
-      candidates.map(async (run) => ({
-        run,
-        annotations: await this.fetchAnnotations(pr.owner, pr.repo, run.id),
-      })),
+    const settled = await Promise.allSettled(
+      candidates.map((run) => this.fetchAnnotations(pr.owner, pr.repo, run.id)),
     );
-    const fetchedIds = new Set(results.map((r) => r.run.id));
-    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
-      (p) => !fetchedIds.has(p.id),
-    );
-    for (const { run, annotations } of results) {
-      if (annotations.length > 0) {
-        this.emit(
-          state,
-          formatCheckAnnotations(state.slug, pr.pullNumber, run, annotations),
-        );
+
+    const completedIds = new Set<number>();
+    for (let i = 0; i < settled.length; i += 1) {
+      const run = candidates[i];
+      const result = settled[i];
+      if (result.status === 'fulfilled') {
+        completedIds.add(run.id);
+        if (result.value.length > 0) {
+          this.emit(
+            state,
+            formatCheckAnnotations(
+              state.slug,
+              pr.pullNumber,
+              run,
+              result.value,
+            ),
+          );
+        }
+        continue;
       }
+      const err = result.reason;
+      if (err instanceof GitHubPermanentError) {
+        this.logger.warn(
+          `Annotations for check ${run.id} unavailable (HTTP ${err.status}); skipping.`,
+        );
+        completedIds.add(run.id);
+        continue;
+      }
+      this.logger.warn(
+        `Annotation fetch for check ${run.id} failed; will retry next tick: ${String(err)}`,
+      );
     }
+    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
+      (p) => !completedIds.has(p.id),
+    );
   }
 
   private async fetchAnnotations(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -87,15 +87,12 @@ const CHECK_RUNS_PAGE_SIZE = 100;
 // Without a cap a malformed/runaway `total_count` could fan out into
 // hundreds of GETs per tick.
 const MAX_CHECK_RUNS_PAGES = 50;
-// GitHub caps the per-check-run annotations endpoint at 100 per page; the
-// poller fetches a single page per affected run to bound API cost. Runs
-// with more annotations are reported via the in-message overflow hint
-// pointing at the run's html_url.
-const ANNOTATIONS_PAGE_SIZE = 50;
-// Bound how many annotation fetches we issue in one tick. A push that lights
-// up a fleet of matrix checks could otherwise produce a fan-out of GETs per
-// tick; the rest get picked up on subsequent ticks (we only mark a check key
-// as seen on successful fetch + emit, so deferred runs aren't lost).
+// Matches the formatter's per-run display cap so we don't pay for annotations
+// we'd only truncate; remaining count is sourced from `annotations_count`.
+const ANNOTATIONS_PAGE_SIZE = 20;
+// Bound the per-tick fan-out across runs (e.g. a matrix build lighting up a
+// fleet of checks). Runs we skip this tick stay eligible next tick — keys
+// are added to the seen-set only on successful fetch + emit.
 const MAX_ANNOTATION_FETCHES_PER_TICK = 5;
 
 export interface PRKey {
@@ -123,12 +120,7 @@ interface SubscriptionState extends BasePollSubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
-  /**
-   * `${id}:${completed_at}` for completed check runs whose inline annotations
-   * we've already fetched and forwarded. The completion timestamp is part of
-   * the key so a re-run (which yields a new `completed_at` for the same id)
-   * re-emits its annotations.
-   */
+  /** `${id}:${completed_at}` — re-runs change `completed_at`, re-emitting. */
   seenAnnotatedCheckKeys: Set<string>;
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
   ciCompleteSha: string | undefined;
@@ -357,10 +349,12 @@ export class PRPollingSource extends PollingSourceBase<
           if (this.isCheckFailure(r)) {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
-          // Seed the annotated-check dedupe set so existing annotations on
-          // pre-subscription completed runs don't replay. Mirrors how
-          // comments/reviews are seeded silently on the first tick.
-          if (this.hasAnnotations(r)) {
+          // Seed the annotated-check dedupe so pre-subscription annotations
+          // don't replay; the timestamp in the key lets re-runs re-emit.
+          if (
+            r.status === 'completed' &&
+            (r.output?.annotations_count ?? 0) > 0
+          ) {
             state.seenAnnotatedCheckKeys.add(this.checkKey(r));
           }
         }
@@ -508,10 +502,8 @@ export class PRPollingSource extends PollingSourceBase<
         }
       }
 
-      // Forward inline check annotations (warnings / notices / failures
-      // pinned to specific file lines). Decoupled from the failure path
-      // because annotations also appear on *passing* checks — lint
-      // suggestions, blueprint advisories, custom workflow hints.
+      // Annotations are emitted independently of failures: they also surface
+      // on passing checks (lint suggestions, custom workflow advisories).
       await this.fetchAndEmitAnnotations(state, runs);
     }
 
@@ -788,46 +780,35 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   /**
-   * Only completed runs with a positive `annotations_count` are candidates.
-   * In-progress runs may report partial counts that change on completion;
-   * gating on `completed` keeps the dedupe key (which carries `completed_at`)
-   * stable so we don't double-emit for the same run.
-   */
-  private hasAnnotations(r: GhCheckRun): boolean {
-    if (r.status !== 'completed') return false;
-    const count = r.output?.annotations_count;
-    return typeof count === 'number' && count > 0;
-  }
-
-  /**
-   * For each newly-completed run with annotations, fetch the annotations
-   * endpoint (one page) and forward them as a `<github-webhook-activity>`
-   * event. Errors here propagate to the tick wrapper so transient failures
-   * are retried — the dedupe key is added only on successful emit, so a
-   * failed fetch isn't silently lost.
+   * Fetch and forward inline annotations for newly-completed runs. Gating on
+   * `completed` keeps the dedupe key (`${id}:${completed_at}`) stable — only
+   * completion has a settled `annotations_count`. Errors propagate to the
+   * tick wrapper for retry; keys advance only on successful emit.
    */
   private async fetchAndEmitAnnotations(
     state: SubscriptionState,
     runs: ReadonlyArray<GhCheckRun>,
   ): Promise<void> {
-    const candidates: GhCheckRun[] = [];
-    for (const r of runs) {
-      if (!this.hasAnnotations(r)) continue;
-      if (state.seenAnnotatedCheckKeys.has(this.checkKey(r))) continue;
-      candidates.push(r);
+    const candidates: { run: GhCheckRun; key: string }[] = [];
+    for (const run of runs) {
+      if (run.status !== 'completed') continue;
+      if ((run.output?.annotations_count ?? 0) <= 0) continue;
+      const key = this.checkKey(run);
+      if (state.seenAnnotatedCheckKeys.has(key)) continue;
+      candidates.push({ run, key });
     }
     if (candidates.length === 0) return;
 
     const toFetch = candidates.slice(0, MAX_ANNOTATION_FETCHES_PER_TICK);
     const { pr } = state;
     await Promise.all(
-      toFetch.map(async (run) => {
+      toFetch.map(async ({ run, key }) => {
         const annotations = await this.fetchAnnotations(
           pr.owner,
           pr.repo,
           run.id,
         );
-        state.seenAnnotatedCheckKeys.add(this.checkKey(run));
+        state.seenAnnotatedCheckKeys.add(key);
         if (annotations.length > 0) {
           this.emit(
             state,

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -15,6 +15,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
+  formatCheckAnnotations,
   formatCheckFailure,
   formatCheckFailureSummary,
   formatCIComplete,
@@ -41,6 +42,7 @@ import {
 } from './prSubscriptionConstants';
 import {
   isDefiniteMergeableState,
+  type GhCheckAnnotation,
   type GhCheckRun,
   type GhIssueComment,
   type GhPullRequest,
@@ -58,6 +60,7 @@ function createInitialState(pr: PRKey): SubscriptionState {
     seenReviewCommentIds: new Set(),
     seenReviewIds: new Set(),
     lastFailedCheckKeys: new Set(),
+    seenAnnotatedCheckKeys: new Set(),
     ciCompleteSha: undefined,
     ciPassedSha: undefined,
     headSha: undefined,
@@ -84,6 +87,16 @@ const CHECK_RUNS_PAGE_SIZE = 100;
 // Without a cap a malformed/runaway `total_count` could fan out into
 // hundreds of GETs per tick.
 const MAX_CHECK_RUNS_PAGES = 50;
+// GitHub caps the per-check-run annotations endpoint at 100 per page; the
+// poller fetches a single page per affected run to bound API cost. Runs
+// with more annotations are reported via the in-message overflow hint
+// pointing at the run's html_url.
+const ANNOTATIONS_PAGE_SIZE = 50;
+// Bound how many annotation fetches we issue in one tick. A push that lights
+// up a fleet of matrix checks could otherwise produce a fan-out of GETs per
+// tick; the rest get picked up on subsequent ticks (we only mark a check key
+// as seen on successful fetch + emit, so deferred runs aren't lost).
+const MAX_ANNOTATION_FETCHES_PER_TICK = 5;
 
 export interface PRKey {
   owner: string;
@@ -110,6 +123,13 @@ interface SubscriptionState extends BasePollSubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
+  /**
+   * `${id}:${completed_at}` for completed check runs whose inline annotations
+   * we've already fetched and forwarded. The completion timestamp is part of
+   * the key so a re-run (which yields a new `completed_at` for the same id)
+   * re-emits its annotations.
+   */
+  seenAnnotatedCheckKeys: Set<string>;
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
   ciCompleteSha: string | undefined;
   /** Head SHA for which the one-shot "CI passed" event has been emitted. */
@@ -337,6 +357,12 @@ export class PRPollingSource extends PollingSourceBase<
           if (this.isCheckFailure(r)) {
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
+          // Seed the annotated-check dedupe set so existing annotations on
+          // pre-subscription completed runs don't replay. Mirrors how
+          // comments/reviews are seeded silently on the first tick.
+          if (this.hasAnnotations(r)) {
+            state.seenAnnotatedCheckKeys.add(this.checkKey(r));
+          }
         }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
         // we only surface transitions that happen after subscribe. Gate on
@@ -481,6 +507,12 @@ export class PRPollingSource extends PollingSourceBase<
           );
         }
       }
+
+      // Forward inline check annotations (warnings / notices / failures
+      // pinned to specific file lines). Decoupled from the failure path
+      // because annotations also appear on *passing* checks — lint
+      // suggestions, blueprint advisories, custom workflow hints.
+      await this.fetchAndEmitAnnotations(state, runs);
     }
 
     // Commit the deferred check-runs cache only after successfully consuming
@@ -753,6 +785,73 @@ export class PRPollingSource extends PollingSourceBase<
 
   private checkKey(r: GhCheckRun): string {
     return `${r.id}:${r.completed_at ?? ''}`;
+  }
+
+  /**
+   * Only completed runs with a positive `annotations_count` are candidates.
+   * In-progress runs may report partial counts that change on completion;
+   * gating on `completed` keeps the dedupe key (which carries `completed_at`)
+   * stable so we don't double-emit for the same run.
+   */
+  private hasAnnotations(r: GhCheckRun): boolean {
+    if (r.status !== 'completed') return false;
+    const count = r.output?.annotations_count;
+    return typeof count === 'number' && count > 0;
+  }
+
+  /**
+   * For each newly-completed run with annotations, fetch the annotations
+   * endpoint (one page) and forward them as a `<github-webhook-activity>`
+   * event. Errors here propagate to the tick wrapper so transient failures
+   * are retried — the dedupe key is added only on successful emit, so a
+   * failed fetch isn't silently lost.
+   */
+  private async fetchAndEmitAnnotations(
+    state: SubscriptionState,
+    runs: ReadonlyArray<GhCheckRun>,
+  ): Promise<void> {
+    const candidates: GhCheckRun[] = [];
+    for (const r of runs) {
+      if (!this.hasAnnotations(r)) continue;
+      if (state.seenAnnotatedCheckKeys.has(this.checkKey(r))) continue;
+      candidates.push(r);
+    }
+    if (candidates.length === 0) return;
+
+    const toFetch = candidates.slice(0, MAX_ANNOTATION_FETCHES_PER_TICK);
+    const { pr } = state;
+    await Promise.all(
+      toFetch.map(async (run) => {
+        const annotations = await this.fetchAnnotations(
+          pr.owner,
+          pr.repo,
+          run.id,
+        );
+        state.seenAnnotatedCheckKeys.add(this.checkKey(run));
+        if (annotations.length > 0) {
+          this.emit(
+            state,
+            formatCheckAnnotations(
+              state.slug,
+              pr.pullNumber,
+              run,
+              annotations,
+            ),
+          );
+        }
+      }),
+    );
+    trimSet(state.seenAnnotatedCheckKeys, MAX_SEEN_IDS);
+  }
+
+  private async fetchAnnotations(
+    owner: string,
+    repo: string,
+    checkRunId: number,
+  ): Promise<GhCheckAnnotation[]> {
+    const path = `/repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=${ANNOTATIONS_PAGE_SIZE}`;
+    const res = await ghGet<GhCheckAnnotation[]>(path);
+    return res.status === 200 ? res.data : [];
   }
 }
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -821,20 +821,30 @@ export class PRPollingSource extends PollingSourceBase<
     runs: ReadonlyArray<GhCheckRun>,
   ): void {
     const currentKeys = new Set<string>();
-    // Dedupe against pending by full `checkKey` (id + completed_at), not by
-    // id alone: a fast rerun produces a new completed_at while the prior
-    // entry may still be queued, and both completions carry distinct
-    // annotation sets we want to emit.
-    const pendingKeys = new Set(
-      state.pendingAnnotationRuns.map((r) => this.checkKey(r)),
-    );
+    // Enforce at most one queue entry per check id. The annotations endpoint
+    // always returns the current state for a given id (there's no historical
+    // form), so queueing both A:T1 and A:T2 would produce two identical API
+    // calls and two events with mismatched headline `annotations_count`.
+    // Instead: on a rerun (new `completed_at` for an already-pending id),
+    // REPLACE the queued entry's run reference so the headline metadata
+    // matches what the fetch will actually return. `lastAnnotationKeys`
+    // still keys by full `checkKey`, so a rerun's new key always re-enters
+    // this loop rather than being silently skipped.
+    const pendingIndexById = new Map<number, number>();
+    for (let i = 0; i < state.pendingAnnotationRuns.length; i += 1) {
+      pendingIndexById.set(state.pendingAnnotationRuns[i].id, i);
+    }
     for (const run of runs) {
       if (run.status !== 'completed') continue;
       if ((run.output?.annotations_count ?? 0) <= 0) continue;
       const key = this.checkKey(run);
       currentKeys.add(key);
       if (state.lastAnnotationKeys.has(key)) continue;
-      if (pendingKeys.has(key)) continue;
+      const existingIdx = pendingIndexById.get(run.id);
+      if (existingIdx !== undefined) {
+        state.pendingAnnotationRuns[existingIdx] = run;
+        continue;
+      }
       state.pendingAnnotationRuns.push(run);
     }
     state.lastAnnotationKeys = currentKeys;
@@ -868,17 +878,18 @@ export class PRPollingSource extends PollingSourceBase<
       candidates.map((run) => this.fetchAnnotations(pr.owner, pr.repo, run.id)),
     );
 
-    // Categorize by `checkKey` (id + completed_at), not id alone — a fast
-    // rerun can leave the queue holding two distinct completion attempts
-    // with the same id, and they need to be drop/rotated independently.
-    const dropKeys = new Set<string>();
-    const rotateKeys = new Set<string>();
+    // Dedupe by `id` here: enqueue enforces at most one queue entry per
+    // check id (replacing on rerun), so id is sufficient to identify the
+    // entry to drop or rotate. A rerun arriving DURING this drain wouldn't
+    // observe the queue mid-mutation (ticks don't overlap, see
+    // PollingSourceBase.tickInFlight).
+    const dropIds = new Set<number>();
+    const rotateIds = new Set<number>();
     for (let i = 0; i < settled.length; i += 1) {
       const run = candidates[i];
-      const key = this.checkKey(run);
       const result = settled[i];
       if (result.status === 'fulfilled') {
-        dropKeys.add(key);
+        dropIds.add(run.id);
         if (result.value.length > 0) {
           this.emit(
             state,
@@ -897,29 +908,28 @@ export class PRPollingSource extends PollingSourceBase<
         this.logger.warn(
           `Annotations for check ${run.id} unavailable (HTTP ${err.status}); dropping.`,
         );
-        dropKeys.add(key);
+        dropIds.add(run.id);
         continue;
       }
       if (err instanceof GitHubAuthError) {
         this.logger.warn(
           `Annotations for check ${run.id} forbidden (${err.message}); dropping.`,
         );
-        dropKeys.add(key);
+        dropIds.add(run.id);
         continue;
       }
-      rotateKeys.add(key);
+      rotateIds.add(run.id);
       this.logger.warn(
         `Annotation fetch for check ${run.id} failed; rotating to back of queue: ${String(err)}`,
       );
     }
 
     const rotated = state.pendingAnnotationRuns.filter((p) =>
-      rotateKeys.has(this.checkKey(p)),
+      rotateIds.has(p.id),
     );
-    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter((p) => {
-      const k = this.checkKey(p);
-      return !dropKeys.has(k) && !rotateKeys.has(k);
-    });
+    state.pendingAnnotationRuns = state.pendingAnnotationRuns.filter(
+      (p) => !dropIds.has(p.id) && !rotateIds.has(p.id),
+    );
     state.pendingAnnotationRuns.push(...rotated);
   }
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -30,7 +30,11 @@ import {
   isPassingConclusion,
 } from './formatPREvent';
 import { getNewestTimestamp, trimSet } from './formatUtils';
-import { type ConditionalResponse, ghGet, GitHubPermanentError } from './githubClient';
+import {
+  type ConditionalResponse,
+  ghGet,
+  GitHubPermanentError,
+} from './githubClient';
 import {
   PollingSourceBase,
   type BasePollSubscriptionState,

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -812,12 +812,7 @@ export class PRPollingSource extends PollingSourceBase<
         if (annotations.length > 0) {
           this.emit(
             state,
-            formatCheckAnnotations(
-              state.slug,
-              pr.pullNumber,
-              run,
-              annotations,
-            ),
+            formatCheckAnnotations(state.slug, pr.pullNumber, run, annotations),
           );
         }
       }),

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -26,11 +26,7 @@ import type {
 } from './prTypes';
 
 const MAX_BODY = 500;
-/**
- * A single CI check can emit hundreds of annotations (think: a linter on a
- * large diff). Show the first N inline so the agent gets the gist; for the
- * rest, include a count and a link out to the full list.
- */
+// A single linter run can emit hundreds; show the first N + overflow hint.
 const MAX_ANNOTATIONS_PER_RUN = 20;
 const MAX_ANNOTATION_MESSAGE = 300;
 
@@ -154,11 +150,9 @@ export function formatCheckFailureSummary(
 }
 
 /**
- * Inline check annotations (warnings / notices / failures pinned to specific
- * file lines, like the bubbles GitHub renders on the PR diff view). Emitted
- * separately from `formatCheckFailure` because annotations also appear on
- * *passing* checks — many workflows surface non-blocking lint / suggestion
- * advisories against specific lines without failing the build.
+ * Emitted separately from `formatCheckFailure` because annotations also
+ * appear on *passing* checks — many workflows surface non-blocking lint /
+ * suggestion advisories against specific lines without failing the build.
  */
 export function formatCheckAnnotations(
   slug: string,

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -67,10 +67,22 @@ const reviewCommentPrefix = (c: GhReviewComment): string =>
 const checkRunBlock = (run: GhCheckRun): string =>
   `Check: ${run.name}\nConclusion: ${run.conclusion}\nDetails: ${run.html_url}`;
 
-const annotationLocation = (a: GhCheckAnnotation): string =>
-  a.end_line > a.start_line
-    ? `${a.path}:${a.start_line}-${a.end_line}`
-    : `${a.path}:${a.start_line}`;
+const annotationLocation = (a: GhCheckAnnotation): string => {
+  if (a.end_line > a.start_line) {
+    return `${a.path}:${a.start_line}-${a.end_line}`;
+  }
+  // Per GitHub: start_column / end_column are only meaningful when
+  // start_line === end_line. Include them so multiple annotations on
+  // different columns of the same line stay distinguishable.
+  if (a.start_column != null) {
+    const colRange =
+      a.end_column != null && a.end_column !== a.start_column
+        ? `${a.start_column}-${a.end_column}`
+        : `${a.start_column}`;
+    return `${a.path}:${a.start_line}:${colRange}`;
+  }
+  return `${a.path}:${a.start_line}`;
+};
 
 const annotationBlock = (a: GhCheckAnnotation): string => {
   const level = (a.annotation_level ?? 'notice').toUpperCase();
@@ -169,7 +181,7 @@ export function formatCheckAnnotations(
       : run.html_url;
   return wrap(
     sections(
-      `Check "${run.name}" reported ${total} inline annotation(s) on ${prRef(slug, prNumber)}. Investigate the warnings/notices and determine what action (if any) is needed.`,
+      `Check "${run.name}" reported ${total} inline annotation(s) on ${prRef(slug, prNumber)}. Each annotation is tagged with its level ([NOTICE], [WARNING], or [FAILURE]); investigate and determine what action (if any) is needed.`,
       shown.map(annotationBlock).join('\n\n'),
       overflow,
     ),

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -18,6 +18,7 @@ import {
   wrapWebhookEvent as wrap,
 } from './formatUtils';
 import type {
+  GhCheckAnnotation,
   GhCheckRun,
   GhIssueComment,
   GhReview,
@@ -25,6 +26,13 @@ import type {
 } from './prTypes';
 
 const MAX_BODY = 500;
+/**
+ * A single CI check can emit hundreds of annotations (think: a linter on a
+ * large diff). Show the first N inline so the agent gets the gist; for the
+ * rest, include a count and a link out to the full list.
+ */
+const MAX_ANNOTATIONS_PER_RUN = 20;
+const MAX_ANNOTATION_MESSAGE = 300;
 
 const truncate = (s: string | null | undefined): string =>
   truncateBody(s, MAX_BODY);
@@ -62,6 +70,18 @@ const reviewCommentPrefix = (c: GhReviewComment): string =>
 
 const checkRunBlock = (run: GhCheckRun): string =>
   `Check: ${run.name}\nConclusion: ${run.conclusion}\nDetails: ${run.html_url}`;
+
+const annotationLocation = (a: GhCheckAnnotation): string =>
+  a.end_line > a.start_line
+    ? `${a.path}:${a.start_line}-${a.end_line}`
+    : `${a.path}:${a.start_line}`;
+
+const annotationBlock = (a: GhCheckAnnotation): string => {
+  const level = (a.annotation_level ?? 'notice').toUpperCase();
+  const title = a.title ? `${a.title}: ` : '';
+  const message = truncateBody(a.message, MAX_ANNOTATION_MESSAGE);
+  return `[${level}] ${annotationLocation(a)}\n${title}${message}`;
+};
 
 export function formatIssueComment(
   slug: string,
@@ -129,6 +149,35 @@ export function formatCheckFailureSummary(
       `${runs.length} CI checks failed on the PR. Investigate the failures and determine what action (if any) is needed.`,
       `PR: ${prRef(slug, prNumber)}`,
       runs.map(checkRunBlock).join('\n\n'),
+    ),
+  );
+}
+
+/**
+ * Inline check annotations (warnings / notices / failures pinned to specific
+ * file lines, like the bubbles GitHub renders on the PR diff view). Emitted
+ * separately from `formatCheckFailure` because annotations also appear on
+ * *passing* checks — many workflows surface non-blocking lint / suggestion
+ * advisories against specific lines without failing the build.
+ */
+export function formatCheckAnnotations(
+  slug: string,
+  prNumber: number,
+  run: GhCheckRun,
+  annotations: ReadonlyArray<GhCheckAnnotation>,
+): string {
+  const total = run.output?.annotations_count ?? annotations.length;
+  const shown = annotations.slice(0, MAX_ANNOTATIONS_PER_RUN);
+  const remaining = total - shown.length;
+  const overflow =
+    remaining > 0
+      ? `…and ${remaining} more annotation(s). See ${run.html_url} for the full list.`
+      : run.html_url;
+  return wrap(
+    sections(
+      `Check "${run.name}" reported ${total} inline annotation(s) on ${prRef(slug, prNumber)}. Investigate the warnings/notices and determine what action (if any) is needed.`,
+      shown.map(annotationBlock).join('\n\n'),
+      overflow,
     ),
   );
 }

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -170,7 +170,7 @@ async function execSubscribe(
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
+        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
         : `Already subscribed to ${slug}. Activity continues until command="unsubscribe" or the PR closes.`,
     };
   }
@@ -207,7 +207,7 @@ async function execSubscribe(
           : `Subscribed to ${prSlug}`
         : `Already subscribed to ${prSlug}`,
       output: created
-        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
+        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${prSlug}.`,
     };
   }
@@ -450,7 +450,7 @@ export class GitHubSubscriptionTool extends defineTool({
     'Manage GitHub activity subscriptions for the current agent stream.',
     'Path mirrors GitHub\'s REST URL shape and encodes the hierarchy: "owner/repo" addresses the whole repo (coarse, orchestrator-friendly); "owner/repo/pulls/N" addresses a specific pull request and "owner/repo/issues/N" addresses a specific issue (nuanced, worker-friendly).',
     'Commands:',
-    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
+    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, inline check annotations (notices / warnings / failures pinned to file:line), plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
     '- unsubscribe: stop watching the path.',
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',

--- a/src/tools/github/githubSubscriptionTool.ts
+++ b/src/tools/github/githubSubscriptionTool.ts
@@ -170,7 +170,7 @@ async function execSubscribe(
         ? `Subscribed to ${slug}`
         : `Already subscribed to ${slug}`,
       output: created
-        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
+        ? `Subscribed to ${slug}. New comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on PR close/merge.`
         : `Already subscribed to ${slug}. Activity continues until command="unsubscribe" or the PR closes.`,
     };
   }
@@ -207,7 +207,7 @@ async function execSubscribe(
           : `Subscribed to ${prSlug}`
         : `Already subscribed to ${prSlug}`,
       output: created
-        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
+        ? `${prSlug} is a PR. New comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), and mergeable_state transitions (merge conflict appeared / resolved) arrive as <github-webhook-activity> follow-ups. Auto-unsubscribes on close/merge.`
         : `Already subscribed to ${prSlug}.`,
     };
   }
@@ -450,7 +450,7 @@ export class GitHubSubscriptionTool extends defineTool({
     'Manage GitHub activity subscriptions for the current agent stream.',
     'Path mirrors GitHub\'s REST URL shape and encodes the hierarchy: "owner/repo" addresses the whole repo (coarse, orchestrator-friendly); "owner/repo/pulls/N" addresses a specific pull request and "owner/repo/issues/N" addresses a specific issue (nuanced, worker-friendly).',
     'Commands:',
-    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
+    '- subscribe: start watching the path. For repos: PR opens/closes/merges, conversation comments on PRs and issues, inline review comments, plus a holistic merge-conflict probe that flags open PRs whose mergeable_state newly flipped to "dirty" (one event per PR, or a coalesced summary when many PRs flip at once — typical after a base-branch update). For PRs: comments, reviews, line comments, failed CI checks, inline check annotations (warnings / notices pinned to file:line), plus mergeable_state transitions (dirty / resolved). Auto-unsubscribes on close/merge. For issues: comments, closed (with state_reason), reopened — the subscription stays active across close so reopens are caught; call command="unsubscribe" to release the slot.',
     '- unsubscribe: stop watching the path.',
     '- list: list active subscriptions on this stream.',
     '- find_current: resolve the current git branch to its PR path (returns "owner/repo/pulls/N").',

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -48,6 +48,17 @@ export interface GhReview {
   submitted_at: string | null;
 }
 
+export interface GhCheckRunOutput {
+  title?: string | null;
+  summary?: string | null;
+  /**
+   * GitHub returns this as a number on the check-runs list endpoint, but it
+   * can be 0 (or absent on partial responses). Treat undefined / null as 0.
+   */
+  annotations_count?: number | null;
+  annotations_url?: string | null;
+}
+
 export interface GhCheckRun {
   id: number;
   name: string;
@@ -55,6 +66,33 @@ export interface GhCheckRun {
   conclusion: string | null; // success, failure, cancelled, timed_out, ...
   html_url: string;
   completed_at: string | null;
+  /**
+   * Per-run output block. Surfaced for `annotations_count` so the poller can
+   * decide whether to fetch the (separate, paginated) annotations endpoint
+   * — saves an API call per tick on the common case of zero annotations.
+   */
+  output?: GhCheckRunOutput | null;
+}
+
+/**
+ * Subset of `GET /repos/{o}/{r}/check-runs/{id}/annotations` we consume.
+ * Annotations are GitHub's mechanism for pinning a `notice` / `warning` /
+ * `failure` to a specific file path and line range — the same data that
+ * renders as inline check-warning bubbles on the PR diff view (e.g. lint
+ * suggestions, type errors, custom workflow hints).
+ */
+export interface GhCheckAnnotation {
+  path: string;
+  start_line: number;
+  end_line: number;
+  start_column?: number | null;
+  end_column?: number | null;
+  /** notice | warning | failure (per GitHub); tolerate unexpected values. */
+  annotation_level: string | null;
+  title?: string | null;
+  message: string;
+  raw_details?: string | null;
+  blob_href?: string;
 }
 
 export interface GhPullRequest {

--- a/src/tools/github/prTypes.ts
+++ b/src/tools/github/prTypes.ts
@@ -51,12 +51,8 @@ export interface GhReview {
 export interface GhCheckRunOutput {
   title?: string | null;
   summary?: string | null;
-  /**
-   * GitHub returns this as a number on the check-runs list endpoint, but it
-   * can be 0 (or absent on partial responses). Treat undefined / null as 0.
-   */
+  /** Treat undefined / null / 0 as "no annotations to fetch". */
   annotations_count?: number | null;
-  annotations_url?: string | null;
 }
 
 export interface GhCheckRun {
@@ -66,20 +62,14 @@ export interface GhCheckRun {
   conclusion: string | null; // success, failure, cancelled, timed_out, ...
   html_url: string;
   completed_at: string | null;
-  /**
-   * Per-run output block. Surfaced for `annotations_count` so the poller can
-   * decide whether to fetch the (separate, paginated) annotations endpoint
-   * — saves an API call per tick on the common case of zero annotations.
-   */
+  /** Surfaced for `annotations_count` so the poller can skip the separate
+   * annotations endpoint on the common case of zero annotations. */
   output?: GhCheckRunOutput | null;
 }
 
 /**
  * Subset of `GET /repos/{o}/{r}/check-runs/{id}/annotations` we consume.
- * Annotations are GitHub's mechanism for pinning a `notice` / `warning` /
- * `failure` to a specific file path and line range — the same data that
- * renders as inline check-warning bubbles on the PR diff view (e.g. lint
- * suggestions, type errors, custom workflow hints).
+ * GitHub renders these as inline warning/notice bubbles on the PR diff view.
  */
 export interface GhCheckAnnotation {
   path: string;


### PR DESCRIPTION
## Summary
This change adds support for fetching and emitting GitHub check run annotations (inline warnings, notices, and failures pinned to specific file:line locations) as separate webhook-style events. Annotations are now surfaced independently from check failures, allowing users to see non-blocking lint suggestions and custom workflow advisories even on passing checks.

## Key Changes

- **New annotation fetching pipeline**: Added `fetchAndEmitAnnotations()` method to `PRPollingSource` that:
  - Identifies completed check runs with annotations
  - Fetches annotations from GitHub's check-runs annotations endpoint (paginated, max 20 per run)
  - Deduplicates using `${id}:${completed_at}` keys to handle re-runs
  - Rate-limits to 5 annotation fetches per tick to prevent fan-out on matrix builds

- **Type definitions**: Added `GhCheckAnnotation` and `GhCheckRunOutput` types to `prTypes.ts` to model GitHub's annotation response structure

- **Formatting**: Implemented `formatCheckAnnotations()` in `formatPREvent.ts` that:
  - Displays up to 20 annotations per run with truncated messages (300 chars max)
  - Shows overflow count with link to full details
  - Works independently of check failure formatting

- **State tracking**: Extended `SubscriptionState` with `seenAnnotatedCheckKeys` set to track which check runs have had their annotations emitted, preventing replays on subsequent polls

- **Documentation updates**: Updated subscription help text in `githubSubscriptionTool.ts` to mention inline check annotations as part of the activity feed

## Implementation Details

- Annotations are fetched only for completed runs with `annotations_count > 0` to avoid unnecessary API calls
- The deduplication key includes `completed_at` timestamp so re-runs (which update this field) will re-emit their annotations
- Fetches are batched with `MAX_ANNOTATION_FETCHES_PER_TICK = 5` to bound per-tick API fan-out
- Pagination is capped at `ANNOTATIONS_PAGE_SIZE = 20` to match the formatter's display limit
- The seen-set is trimmed using existing `trimSet()` utility to prevent unbounded growth
- Errors during annotation fetching propagate to the tick wrapper for automatic retry

https://claude.ai/code/session_01GEdFroe9ZHEtbuwtdQ44JG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds additional GitHub API fan-out per PR tick (annotations endpoint) plus new queueing/deduping logic; mistakes could increase rate-limit pressure or cause noisy/duplicate events, but changes are scoped to polling/formatting.
> 
> **Overview**
> PR subscriptions now **fetch and emit check-run inline annotations** (notices/warnings/failures pinned to file/line) as separate `<github-webhook-activity>` events, including for passing checks.
> 
> `PRPollingSource` tracks annotated runs via `lastAnnotationKeys` and a bounded `pendingAnnotationRuns` queue, drains up to `MAX_ANNOTATION_FETCHES_PER_TICK` per tick (including on 304 check-run ticks), and isolates annotation-fetch errors (drop permanent/auth errors; rotate transient failures).
> 
> Adds `GhCheckRun.output.annotations_count` and a `GhCheckAnnotation` type, introduces `formatCheckAnnotations()` with per-run/message truncation + overflow link, and updates `github_subscription` help text to mention annotation events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 755730c80e4591763466c85ec3ca34379410dd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->