### PR TITLE
[codex] Inject agent runtime progress sink

### DIFF
--- a/src/agent/core/flows/ToolUseCycleFlow.ts
+++ b/src/agent/core/flows/ToolUseCycleFlow.ts
@@ -766,6 +766,7 @@ class ToolUseDispatchNode<C> extends Node<
           model: options.modelName ?? options.config.model,
           agentName: options.agentName,
           workingDirectory: options.workingDirectory,
+          runtimeHost: options.runtimeHost,
           delegationDepth: options.delegationDepth,
           delegationConfig: options.delegationConfig,
           onExecutionReady,

--- a/src/agent/implementations/flows/common/BaseFlowServices.ts
+++ b/src/agent/implementations/flows/common/BaseFlowServices.ts
@@ -3,6 +3,7 @@ import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentPrompt, AgentSetting } from '@agent/core/AgentDataclass';
 import type { UserVariableChannels } from '@agent/core/AgentCycleOptions';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
@@ -13,6 +14,7 @@ export interface AgentCore<C = unknown> {
   setting: AgentSetting;
   prompt: AgentPrompt;
   logger: AgentLogger;
+  runtimeHost?: AgentRuntimeHost;
   streamId: StreamTabId;
   executionId: ExecutionId;
   userVarChannels: UserVariableChannels;

--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,0 +1,46 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+import {
+  getDefaultProgressSink,
+  setDefaultProgressSink,
+  type ProgressSink,
+} from './ProgressSink';
+
+export interface AgentRuntimeHost {
+  progressSink: ProgressSink;
+  emit: ProgressSink['emit'];
+}
+
+export function createAgentRuntimeHost(
+  progressSink: ProgressSink,
+): AgentRuntimeHost {
+  return {
+    progressSink,
+    emit: (event, payload) => progressSink.emit(event, payload),
+  };
+}
+
+let defaultAgentRuntimeHost: AgentRuntimeHost | undefined;
+const runtimeHostScope = new AsyncLocalStorage<AgentRuntimeHost>();
+
+export function setDefaultAgentRuntimeHost(host: AgentRuntimeHost): void {
+  defaultAgentRuntimeHost = host;
+  setDefaultProgressSink(host.progressSink);
+}
+
+export function getDefaultAgentRuntimeHost(): AgentRuntimeHost {
+  return (
+    defaultAgentRuntimeHost ?? createAgentRuntimeHost(getDefaultProgressSink())
+  );
+}
+
+export function getAgentRuntimeHost(): AgentRuntimeHost {
+  return runtimeHostScope.getStore() ?? getDefaultAgentRuntimeHost();
+}
+
+export function runWithAgentRuntimeHost<T>(
+  host: AgentRuntimeHost | undefined,
+  fn: () => T,
+): T {
+  return host ? runtimeHostScope.run(host, fn) : fn();
+}

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -19,7 +19,7 @@
 
 // Local imports
 import {
-  defaultProgressSink,
+  getDefaultProgressSink,
   type ProgressSink,
 } from '@agent/runtime/ProgressSink';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
@@ -65,9 +65,11 @@ export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
-  constructor(
-    protected readonly progressSink: ProgressSink = defaultProgressSink,
-  ) {}
+  constructor(private readonly configuredProgressSink?: ProgressSink) {}
+
+  protected get progressSink(): ProgressSink {
+    return this.configuredProgressSink ?? getDefaultProgressSink();
+  }
 
   /** Single source of truth for all pending requests */
   protected readonly requests = new Map<string, RequestState<TResult>>();

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -7,8 +7,11 @@
  */
 
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
@@ -51,6 +54,7 @@ export interface ExecutionHandle {
   readonly category: 'workflow' | 'toolUse' | 'process';
   readonly agentName: string;
   readonly startedAt: number;
+  readonly runtimeHost?: AgentRuntimeHost;
 
   /** Get current status without probing multiple registries. */
   getStatus(): ExecutionStatusInfo;
@@ -90,6 +94,7 @@ export class AgentExecutionHandle implements ExecutionHandle {
     readonly childStreamId: StreamTabId,
     readonly agentName: string,
     readonly category: 'workflow' | 'toolUse',
+    readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
   ) {
     this._parentStreamId = parentStreamId;
   }
@@ -119,7 +124,9 @@ export class AgentExecutionHandle implements ExecutionHandle {
     const interruptible = getInterruptible(this.childStreamId);
     if (!interruptible) return false;
     interruptible.interrupt();
-    StreamStatusService.set(this.childStreamId, STREAM_STATUS.STOPPED);
+    StreamStatusService.set(this.childStreamId, STREAM_STATUS.STOPPED, {
+      runtimeHost: this.runtimeHost,
+    });
     return true;
   }
 
@@ -158,6 +165,7 @@ export class ProcessExecutionHandle implements ExecutionHandle {
     readonly parentStreamId: StreamTabId,
     readonly agentName: string,
     private readonly killFn: () => boolean,
+    readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
   ) {}
 
   getStatus(): ExecutionStatusInfo {
@@ -248,24 +256,32 @@ export function collectChildSummary(
 export function emitActiveSubagentsUpdate(
   parentStreamId: StreamTabId,
   handles: Iterable<ExecutionHandle>,
+  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
 ): void {
   const children = collectChildSummary(
     parentStreamId,
     handles,
     AgentExecutionHandle,
   );
-  bus.emit('updateActiveSubagents', { parentStreamId, children });
+  runtimeHost.emit('updateActiveSubagents', {
+    parentStreamId,
+    children,
+  });
 }
 
 /** Emit the current active processes list for a parent to the progress UI. */
 export function emitActiveProcessesUpdate(
   parentStreamId: StreamTabId,
   handles: Iterable<ExecutionHandle>,
+  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
 ): void {
   const processes = collectChildSummary(
     parentStreamId,
     handles,
     ProcessExecutionHandle,
   );
-  bus.emit('updateActiveProcesses', { parentStreamId, processes });
+  runtimeHost.emit('updateActiveProcesses', {
+    parentStreamId,
+    processes,
+  });
 }

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -16,9 +16,12 @@ import {
   getHandle,
   type ExecutionHandle,
 } from '@agent/runtime/executionRegistry';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
-import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId } from '@shared/schemas';
 import { wrapAndSanitizeTag } from '@utils/text/sanitizeTag';
@@ -90,10 +93,14 @@ function snapshot(handle: ExecutionHandle): SnapshotState {
   };
 }
 
-function send(streamId: StreamTabId, text: string): void {
+function send(
+  streamId: StreamTabId,
+  text: string,
+  runtimeHost: AgentRuntimeHost,
+): void {
   void sendFollowUp(streamId, wrapAndSanitizeTag(TAG, text)).then((result) => {
     if (result.status === 'sent' || result.status === 'queued') {
-      bus.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.emit('updateQueuedFollowUps', { streamId });
     }
   });
 }
@@ -126,6 +133,7 @@ export function bindExecutionSubscription(
 
   const agentName = handle.agentName;
   const category = handle.category;
+  const subscriberRuntimeHost = getAgentRuntimeHost();
   let last: SnapshotState | null = snapshot(handle);
 
   let removeListener: (() => void) | null = null;
@@ -144,6 +152,7 @@ export function bindExecutionSubscription(
       send(
         streamId,
         `${executionId} (${agentName}, ${category}) finished. Last known status: ${previous}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
+        subscriberRuntimeHost,
       );
       dispose();
       return;
@@ -166,7 +175,7 @@ export function bindExecutionSubscription(
       `${executionId} (${agentName}, ${category}) ${transition}${elapsed}`,
     ];
     if (current.round) lines.push(current.round);
-    send(streamId, lines.join('\n'));
+    send(streamId, lines.join('\n'), subscriberRuntimeHost);
     last = current;
   });
 
@@ -177,6 +186,7 @@ export function bindExecutionSubscription(
     send(
       streamId,
       `${executionId} (${agentName}, ${category}) finished. Last known status: ${last?.status ?? 'unknown'}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
+      subscriberRuntimeHost,
     );
     dispose();
     return;

--- a/src/agent/runtime/ProgressSink.ts
+++ b/src/agent/runtime/ProgressSink.ts
@@ -1,4 +1,4 @@
-import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 export interface ProgressSink {
   emit<K extends keyof ProgressEventPayloads>(
@@ -7,4 +7,16 @@ export interface ProgressSink {
   ): void;
 }
 
-export const defaultProgressSink: ProgressSink = bus;
+export const noopProgressSink: ProgressSink = {
+  emit: () => {},
+};
+
+let defaultProgressSink: ProgressSink = noopProgressSink;
+
+export function setDefaultProgressSink(progressSink: ProgressSink): void {
+  defaultProgressSink = progressSink;
+}
+
+export function getDefaultProgressSink(): ProgressSink {
+  return defaultProgressSink;
+}

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -1,8 +1,11 @@
 import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import {
   isActiveStatus,
   isInFlightStatus,
 } from '@common/constants/streamStatus';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   STREAM_STATUS,
   type StreamTabId,
@@ -10,9 +13,17 @@ import {
 } from '@shared/schemas';
 
 const statusMemory = new Map<StreamTabId, StreamStatus>();
+const statusListeners = new Set<(change: StreamStatusChange) => void>();
+
+export interface StreamStatusChange {
+  streamId: StreamTabId;
+  status: StreamStatus;
+  previousStatus: StreamStatus;
+}
 
 interface SetOptions {
   emit?: boolean;
+  runtimeHost?: AgentRuntimeHost;
 }
 
 export const StreamStatusService = {
@@ -20,17 +31,17 @@ export const StreamStatusService = {
     return statusMemory.get(stream);
   },
 
-  tryAcquire(stream: StreamTabId): boolean {
+  tryAcquire(stream: StreamTabId, options: SetOptions = {}): boolean {
     if (isInFlightStatus(statusMemory.get(stream))) {
       return false;
     }
-    this.set(stream, STREAM_STATUS.INITIALIZING);
+    this.set(stream, STREAM_STATUS.INITIALIZING, options);
     return true;
   },
 
-  releaseIfInitializing(stream: StreamTabId): void {
+  releaseIfInitializing(stream: StreamTabId, options: SetOptions = {}): void {
     if (statusMemory.get(stream) === STREAM_STATUS.INITIALIZING) {
-      this.clear(stream);
+      this.clear(stream, options);
     }
   },
 
@@ -50,16 +61,23 @@ export const StreamStatusService = {
     }
 
     if (emit) {
-      bus.emit('updateStreamStatus', {
+      const change: StreamStatusChange = {
         streamId: stream,
         status,
         previousStatus,
-      });
+      };
+      (options.runtimeHost ?? getAgentRuntimeHost()).emit(
+        'updateStreamStatus',
+        change,
+      );
+      for (const listener of statusListeners) {
+        listener(change);
+      }
     }
   },
 
-  clear(stream: StreamTabId): void {
-    this.set(stream, STREAM_STATUS.READY);
+  clear(stream: StreamTabId, options: SetOptions = {}): void {
+    this.set(stream, STREAM_STATUS.READY, options);
   },
 
   /** Reset every stream to READY. Used by ProgressViewState.clearAll(). */
@@ -88,5 +106,12 @@ export const StreamStatusService = {
   shouldPreserveOnCompletion(stream: StreamTabId): boolean {
     const status = statusMemory.get(stream);
     return status === STREAM_STATUS.WAITING || status === STREAM_STATUS.STOPPED;
+  },
+
+  onDidChange(listener: (change: StreamStatusChange) => void): () => void {
+    statusListeners.add(listener);
+    return () => {
+      statusListeners.delete(listener);
+    };
   },
 };

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -47,7 +47,6 @@ import {
   toErrorMessage,
 } from '@common/errors/errorHandlingUtils';
 import { getSdkErrorMessage } from '@common/errors/sdkErrorUtils';
-import { bus } from '@eventBus/ProgressEventBus';
 import {
   AgentLogger,
   AgentUsageReporter,
@@ -69,6 +68,11 @@ import { generateExecutionId } from '@utils/core/executionId';
 import { ensureRunDir } from '@utils/files/taskRunStorage';
 
 import { StreamStatusService } from './StreamStatusService';
+import {
+  getAgentRuntimeHost,
+  runWithAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from './AgentRuntimeHost';
 import { createInterruptCallbacks } from './InterruptManager';
 import {
   trackExecution,
@@ -88,6 +92,7 @@ const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
 
 interface ResolvedAgentBase extends AgentCore {
+  runtimeHost: AgentRuntimeHost;
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
   parentStage: AgentLogStage;
@@ -95,19 +100,25 @@ interface ResolvedAgentBase extends AgentCore {
 
 export async function getAgentPath(
   agentIdentifier: string,
-  options?: AgentLoadOptions,
+  options?: AgentLoadOptions & { runtimeHost?: AgentRuntimeHost },
 ): Promise<ResolvedAgent> {
   const result = resolveAgent(agentIdentifier, options?.preferMultiple);
   if (result) return result;
 
-  bus.emit('showAgentConfigBanner', { agentName: agentIdentifier });
+  (options?.runtimeHost ?? getAgentRuntimeHost()).emit(
+    'showAgentConfigBanner',
+    { agentName: agentIdentifier },
+  );
   throw new Error(`Could not find agent: ${agentIdentifier}`);
 }
 
-async function validateModelExists(modelName: string): Promise<void> {
+async function validateModelExists(
+  modelName: string,
+  runtimeHost: AgentRuntimeHost,
+): Promise<void> {
   if (modelName in MODEL_CONFIGS) return;
 
-  bus.emit('requestShowInstruction', {
+  runtimeHost.emit('requestShowInstruction', {
     key: 'modelNotRecognized',
     message: `Model "${modelName}" is not recognized. Review the documentation for supported models.`,
     actions: [
@@ -145,6 +156,7 @@ async function beginRunStage(
 }
 
 interface ResolveAgentOptions {
+  runtimeHost?: AgentRuntimeHost;
   streamTabIdOverride?: StreamTabId;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
@@ -157,17 +169,18 @@ interface ResolveAgentOptions {
   /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
   enforceCategory?: boolean;
 }
-
 async function resolveAgentBase(
   configPayload: AgentConfigPayload,
   providedExecutionId?: ExecutionId,
   options?: ResolveAgentOptions,
 ): Promise<ResolvedAgentBase> {
+  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
   const executionId: ExecutionId = providedExecutionId ?? generateExecutionId();
 
   const fullConfig = AgentConfigSchema.parse(configPayload);
   const resolution = await getAgentPath(fullConfig.agent, {
     preferMultiple: fullConfig.useMultipleOutputs,
+    runtimeHost,
   });
   const [loadedSettings, prompt] = await loadAgentSettingAndPrompts(
     resolution,
@@ -198,7 +211,7 @@ async function resolveAgentBase(
     );
   }
 
-  await validateModelExists(fullConfig.model);
+  await validateModelExists(fullConfig.model, runtimeHost);
 
   const useMultipleOutputs =
     fullConfig.useMultipleOutputs &&
@@ -221,13 +234,14 @@ async function resolveAgentBase(
     agentLogger,
     streamId,
     setting.agentCategory,
+    runtimeHost,
   );
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
 
   options?.onBeforeActivation?.(streamId);
 
-  bus.emit('setActiveStream', {
+  runtimeHost.emit('setActiveStream', {
     streamId,
     agentCategory: setting.agentCategory,
     isRemote: isRemoteAgent(fullConfig.agent),
@@ -300,6 +314,7 @@ async function resolveAgentBase(
     storageKey,
     userVarChannels,
     usageMonitor,
+    runtimeHost,
     workingDirectory: configPayload.workingDirectory?.trim() || undefined,
   };
 }
@@ -313,9 +328,16 @@ const STATUS_MESSAGES: Record<string, string> = {
 
 function acquireStreamOrThrow(
   streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
   taskType: string = 'Task',
 ): void {
-  if (StreamStatusService.tryAcquire(streamId)) return;
+  if (
+    StreamStatusService.tryAcquire(streamId, {
+      runtimeHost,
+    })
+  ) {
+    return;
+  }
 
   const status = StreamStatusService.get(streamId) ?? '';
   const statusMsg = STATUS_MESSAGES[status] || 'already running';
@@ -363,6 +385,7 @@ function toCompileFailureSummaries(
 function createRoundProgressCallback(
   executionId: ExecutionId,
   streamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost,
   onProgress?: (update: SubagentProgressUpdate) => void,
 ): (roundIndex: number, totalRounds: number) => void {
   return (roundIndex, totalRounds) => {
@@ -375,7 +398,7 @@ function createRoundProgressCallback(
       currentRound: roundIndex,
       totalRounds,
     });
-    bus.emit('updateConversationProgress', {
+    runtimeHost.emit('updateConversationProgress', {
       streamId,
       progress: {
         conversationTurns: roundIndex + 1,
@@ -405,6 +428,7 @@ async function runFlowWithLifecycle(
     streamId,
     agentName,
     category,
+    ctx.runtimeHost,
   );
   trackExecution(handle);
   try {
@@ -418,7 +442,9 @@ async function runFlowWithLifecycle(
     if (!StreamStatusService.shouldPreserveOnCompletion(streamId)) {
       const status =
         result.status === 'error' ? STREAM_STATUS.ERROR : STREAM_STATUS.STOPPED;
-      StreamStatusService.set(streamId, status);
+      StreamStatusService.set(streamId, status, {
+        runtimeHost: ctx.runtimeHost,
+      });
     }
     logger.debug(`Task completed with status: ${result.status}`);
     return result;
@@ -433,20 +459,24 @@ async function runFlowWithLifecycle(
     });
 
     ctx.parentStage.end(END_GROUP_STATUS.ERROR);
-    StreamStatusService.set(streamId, STREAM_STATUS.ERROR);
+    StreamStatusService.set(streamId, STREAM_STATUS.ERROR, {
+      runtimeHost: ctx.runtimeHost,
+    });
 
     // Subagents propagate errors to the orchestrator via FollowUpQueue —
     // don't show VS Code popups that would confuse the user.
     if (!options?.isSubagent) {
       if (isDiskFullError(err)) {
-        bus.emit('requestShowError', { message: getSdkErrorMessage(err) });
+        ctx.runtimeHost.emit('requestShowError', {
+          message: getSdkErrorMessage(err),
+        });
       } else {
         const msg = toErrorMessage(err);
         if (
           msg.includes('Missing API key') ||
           msg.includes('API key not found')
         ) {
-          bus.emit('requestShowInstruction', {
+          ctx.runtimeHost.emit('requestShowInstruction', {
             key: 'missingApiKey',
             message:
               'API key not found. Set your API key in the extension settings and run again.',
@@ -461,7 +491,9 @@ async function runFlowWithLifecycle(
             showSuppress: false,
           });
         } else {
-          bus.emit('requestShowError', { message: errorMsg });
+          ctx.runtimeHost.emit('requestShowError', {
+            message: errorMsg,
+          });
         }
       }
     }
@@ -514,9 +546,16 @@ function compensateFailedActivation(args: {
   preliminaryStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
   configPayload: AgentConfigPayload;
+  runtimeHost: AgentRuntimeHost;
   err: unknown;
 }): void {
-  const { preliminaryStreamId, activatedStreamId, configPayload, err } = args;
+  const {
+    preliminaryStreamId,
+    activatedStreamId,
+    configPayload,
+    runtimeHost,
+    err,
+  } = args;
 
   if (activatedStreamId) {
     new AgentLogger(activatedStreamId, true).logError(
@@ -524,11 +563,15 @@ function compensateFailedActivation(args: {
       err,
       { operation: `start ${configPayload.agent}` },
     );
-    StreamStatusService.set(activatedStreamId, STREAM_STATUS.ERROR);
+    StreamStatusService.set(activatedStreamId, STREAM_STATUS.ERROR, {
+      runtimeHost,
+    });
   }
 
   if (preliminaryStreamId && preliminaryStreamId !== activatedStreamId) {
-    StreamStatusService.releaseIfInitializing(preliminaryStreamId);
+    StreamStatusService.releaseIfInitializing(preliminaryStreamId, {
+      runtimeHost,
+    });
   }
 }
 
@@ -544,6 +587,7 @@ async function resolveAndAcquireStream(
   configPayload: AgentConfigPayload,
   executionId?: ExecutionId,
   options?: {
+    runtimeHost?: AgentRuntimeHost;
     streamTabIdOverride?: StreamTabId;
     taskType?: string;
     onBeforeActivation?: (streamId: StreamTabId) => void;
@@ -552,6 +596,7 @@ async function resolveAndAcquireStream(
     suppressErrorNotification?: boolean;
   },
 ): Promise<ResolvedAgentBase> {
+  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
   let preliminaryStreamId: StreamTabId | undefined;
   let resolvedExecutionId = executionId;
 
@@ -565,12 +610,13 @@ async function resolveAndAcquireStream(
       configPayload.model,
       { executionId: resolvedExecutionId },
     );
-    acquireStreamOrThrow(preliminaryStreamId, options?.taskType);
+    acquireStreamOrThrow(preliminaryStreamId, runtimeHost, options?.taskType);
   }
 
   let activatedStreamId: StreamTabId | undefined;
   try {
     return await resolveAgentBase(configPayload, resolvedExecutionId, {
+      runtimeHost,
       streamTabIdOverride: options?.streamTabIdOverride,
       onBeforeActivation: options?.onBeforeActivation,
       onActivated: (streamId) => {
@@ -583,10 +629,13 @@ async function resolveAndAcquireStream(
       preliminaryStreamId,
       activatedStreamId,
       configPayload,
+      runtimeHost,
       err,
     });
     if (!options?.suppressErrorNotification && !(err instanceof ZodError)) {
-      bus.emit('requestShowError', { message: toErrorMessage(err) });
+      runtimeHost.emit('requestShowError', {
+        message: toErrorMessage(err),
+      });
     }
     throw err;
   }
@@ -598,6 +647,8 @@ async function resolveAndAcquireStream(
 
 /** Options for executeAgent. */
 export interface ExecuteAgentOptions {
+  /** Host services used by the runtime to report progress/UI events. */
+  runtimeHost?: AgentRuntimeHost;
   /** When true, proposal tools are filtered out to prevent nesting. */
   isSubagent?: boolean;
   /**
@@ -635,113 +686,194 @@ export async function executeAgent(
   executionId?: ExecutionId,
   options?: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
-  const ctx = await resolveAndAcquireStream(configPayload, executionId, {
-    onBeforeActivation: options?.onStreamResolved,
-    enforceCategory: options?.enforceCategory,
-    suppressErrorNotification: options?.isSubagent,
-  });
-  ctx.delegationDepth = options?.delegationDepth ?? 0;
-  const { setting, streamId, config } = ctx;
-  const { agent: agentName } = config;
-  const { isSubagent } = options ?? {};
+  return runWithAgentRuntimeHost(options?.runtimeHost, async () => {
+    const ctx = await resolveAndAcquireStream(configPayload, executionId, {
+      onBeforeActivation: options?.onStreamResolved,
+      enforceCategory: options?.enforceCategory,
+      suppressErrorNotification: options?.isSubagent,
+    });
+    ctx.delegationDepth = options?.delegationDepth ?? 0;
+    const { setting, streamId, config } = ctx;
+    const { agent: agentName } = config;
+    const { isSubagent } = options ?? {};
 
-  // Fire-and-forget: generate AI session description from the user's instruction.
-  // Triggered at the start so cancelled/errored sessions still get descriptions.
-  // Applies to all agents including subagents so their progress tabs show
-  // meaningful descriptions in multi-agent pipelines.
-  generateSessionDescription(ctx.executionId, streamId, config).catch(() => {});
-  return runFlowWithLifecycle(
-    ctx,
-    streamId,
-    agentName,
-    async () => {
-      // Pre-execution UI setup
-      if (executionId) await ensureRunDir(executionId);
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
-      logger.info(`Starting task execution (streamId: ${streamId})`);
-      logger.info(`Input file: ${config.inputFile}`);
-      logger.debug(
-        `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,
-      );
-      logger.debug(
-        `Output files: ${config.outputFiles?.length ?? 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
-      );
-      // Subagents don't need to force-open the progress board or show notifications —
-      // the orchestrator's stream is already visible.
-      if (!isSubagent && !getRunStorageService().isViewVisible()) {
-        bus.emit('requestEnsureProgressView', {
-          fallbackNotification: buildFallbackNotification(config),
+    // Fire-and-forget: generate AI session description from the user's instruction.
+    // Triggered at the start so cancelled/errored sessions still get descriptions.
+    // Applies to all agents including subagents so their progress tabs show
+    // meaningful descriptions in multi-agent pipelines.
+    generateSessionDescription(
+      ctx.executionId,
+      streamId,
+      config,
+      ctx.runtimeHost,
+    ).catch(() => {});
+    return runFlowWithLifecycle(
+      ctx,
+      streamId,
+      agentName,
+      async () => {
+        // Pre-execution UI setup
+        if (executionId) await ensureRunDir(executionId);
+        StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+          runtimeHost: ctx.runtimeHost,
         });
-      }
-      bus.emit('setTaskState', {
-        streamId,
-        executionId,
-        taskState: agentConfigToTaskState(config),
-      });
-      if (config.outputFiles.length > 1 && !config.useMultipleOutputs) {
-        logger.warn(
-          `Multiple output files provided (${config.outputFiles.length}) but useMultipleOutputs flag is disabled.`,
+        logger.info(`Starting task execution (streamId: ${streamId})`);
+        logger.info(`Input file: ${config.inputFile}`);
+        logger.debug(
+          `Stream ID: ${streamId}, Agent: ${config.agent}, Model: ${config.model}`,
         );
-      }
+        logger.debug(
+          `Output files: ${config.outputFiles?.length ?? 0}, useMultipleOutputs: ${config.useMultipleOutputs}`,
+        );
+        // Subagents don't need to force-open the progress board or show notifications —
+        // the orchestrator's stream is already visible.
+        if (!isSubagent && !getRunStorageService().isViewVisible()) {
+          ctx.runtimeHost.emit('requestEnsureProgressView', {
+            fallbackNotification: buildFallbackNotification(config),
+          });
+        }
+        ctx.runtimeHost.emit('setTaskState', {
+          streamId,
+          executionId,
+          taskState: agentConfigToTaskState(config),
+        });
+        if (config.outputFiles.length > 1 && !config.useMultipleOutputs) {
+          logger.warn(
+            `Multiple output files provided (${config.outputFiles.length}) but useMultipleOutputs flag is disabled.`,
+          );
+        }
 
-      const taskStage = await logger.stage(
-        `Task: ${agentName}@${config.model}`,
-      );
-      return taskStage.run(async () => {
-        logger.info(`Executing ${agentName} with model ${config.model}`);
-        const interrupts = createInterruptCallbacks();
+        const taskStage = await logger.stage(
+          `Task: ${agentName}@${config.model}`,
+        );
+        return taskStage.run(async () => {
+          logger.info(`Executing ${agentName} with model ${config.model}`);
+          const interrupts = createInterruptCallbacks();
 
-        if (setting.agentCategory === AgentCategory.ToolUse) {
-          let toolUseTurns = 0;
-          const result = await runToolUseFlow({
+          if (setting.agentCategory === AgentCategory.ToolUse) {
+            let toolUseTurns = 0;
+            const result = await runToolUseFlow({
+              ...ctx,
+              ...interrupts,
+              onRoundFinalized: (run) =>
+                ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+              setting: ctx.setting as AgentToolUseSetting,
+              isSubagent,
+              onBeforeWaiting: options?.onBeforeWaiting,
+              onProgress: (update) => {
+                if (update.kind === 'overview') {
+                  toolUseTurns++;
+                  ctx.runtimeHost.emit('updateConversationProgress', {
+                    streamId,
+                    progress: {
+                      conversationTurns: toolUseTurns,
+                      toolCallCount: update.toolCallCount,
+                    },
+                  });
+                }
+                options?.onProgress?.(update);
+              },
+              onFollowUpConsumed: () => {
+                ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                  streamId: ctx.streamId,
+                });
+                options?.onFollowUpConsumed?.();
+              },
+            });
+            return {
+              category: 'toolUse' as const,
+              status: result.status,
+              lastResponse: result.lastResponse,
+              touchedFiles: result.touchedFiles,
+              executionId: ctx.executionId,
+              streamId,
+            };
+          }
+
+          const onRoundCompleted = createRoundProgressCallback(
+            ctx.executionId,
+            streamId,
+            ctx.runtimeHost,
+            options?.onProgress,
+          );
+          const result = await runReflectionFlow({
             ...ctx,
             ...interrupts,
             onRoundFinalized: (run) =>
-              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-            setting: ctx.setting as AgentToolUseSetting,
-            isSubagent,
-            onBeforeWaiting: options?.onBeforeWaiting,
-            onProgress: (update) => {
-              if (update.kind === 'overview') {
-                toolUseTurns++;
-                bus.emit('updateConversationProgress', {
-                  streamId,
-                  progress: {
-                    conversationTurns: toolUseTurns,
-                    toolCallCount: update.toolCallCount,
-                  },
-                });
-              }
-              options?.onProgress?.(update);
-            },
-            onFollowUpConsumed: () => {
-              bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId });
-              options?.onFollowUpConsumed?.();
-            },
+              ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
+            setting: ctx.setting as AgentWorkflowSetting,
+            parentStage: ctx.parentStage,
+            onRoundCompleted,
           });
           return {
-            category: 'toolUse' as const,
+            category: 'workflow' as const,
             status: result.status,
-            lastResponse: result.lastResponse,
-            touchedFiles: result.touchedFiles,
+            outputs: toOutputSummaries(result.roundOutputs),
+            compileFailures: toCompileFailureSummaries(result.roundOutputs),
             executionId: ctx.executionId,
             streamId,
           };
-        }
+        });
+      },
+      {
+        isSubagent,
+        category:
+          setting.agentCategory === AgentCategory.ToolUse
+            ? 'toolUse'
+            : 'workflow',
+        parentStreamId: options?.parentStreamId,
+        onCompleted: options?.onCompleted,
+      },
+    );
+  });
+}
 
-        const onRoundCompleted = createRoundProgressCallback(
-          ctx.executionId,
-          streamId,
-          options?.onProgress,
-        );
+export async function executeMergeAgent(
+  model: string,
+  inputFile: string,
+  editedFile: string,
+  runtimeHost?: AgentRuntimeHost,
+): Promise<void> {
+  const host = runtimeHost ?? getAgentRuntimeHost();
+  return runWithAgentRuntimeHost(host, async () => {
+    const configPayload: AgentConfigPayload = {
+      agent: 'merge',
+      model,
+      inputFile,
+      editedFile,
+    };
+    const ctx = await resolveAndAcquireStream(configPayload, undefined, {
+      taskType: 'Merge task',
+    });
+    const { streamId, executionId } = ctx;
+
+    await runFlowWithLifecycle(ctx, streamId, 'merge', async () => {
+      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+        runtimeHost: ctx.runtimeHost,
+      });
+
+      const taskStage = await logger.stage(`Task: merge@${model}`);
+      return taskStage.run(async () => {
+        logger.info(`Executing merge with model ${model}`);
+
+        const fileService = new TaskRunFileService(executionId);
+        const mergeSetting = ctx.setting as AgentWorkflowSetting;
         const result = await runReflectionFlow({
           ...ctx,
-          ...interrupts,
+          ...createInterruptCallbacks(),
           onRoundFinalized: (run) =>
             ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-          setting: ctx.setting as AgentWorkflowSetting,
+          setting: mergeSetting,
+          getOutputFileLocation: createMergeOutputFileLocationGetter(
+            fileService,
+            mergeSetting.outputExt,
+          ),
           parentStage: ctx.parentStage,
-          onRoundCompleted,
+          onRoundCompleted: createRoundProgressCallback(
+            ctx.executionId,
+            streamId,
+            ctx.runtimeHost,
+          ),
         });
         return {
           category: 'workflow' as const,
@@ -752,68 +884,6 @@ export async function executeAgent(
           streamId,
         };
       });
-    },
-    {
-      isSubagent,
-      category:
-        setting.agentCategory === AgentCategory.ToolUse
-          ? 'toolUse'
-          : 'workflow',
-      parentStreamId: options?.parentStreamId,
-      onCompleted: options?.onCompleted,
-    },
-  );
-}
-
-export async function executeMergeAgent(
-  model: string,
-  inputFile: string,
-  editedFile: string,
-): Promise<void> {
-  const configPayload: AgentConfigPayload = {
-    agent: 'merge',
-    model,
-    inputFile,
-    editedFile,
-  };
-  const ctx = await resolveAndAcquireStream(configPayload, undefined, {
-    taskType: 'Merge task',
-  });
-  const { streamId, executionId } = ctx;
-
-  await runFlowWithLifecycle(ctx, streamId, 'merge', async () => {
-    StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
-
-    const taskStage = await logger.stage(`Task: merge@${model}`);
-    return taskStage.run(async () => {
-      logger.info(`Executing merge with model ${model}`);
-
-      const fileService = new TaskRunFileService(executionId);
-      const mergeSetting = ctx.setting as AgentWorkflowSetting;
-      const result = await runReflectionFlow({
-        ...ctx,
-        ...createInterruptCallbacks(),
-        onRoundFinalized: (run) =>
-          ctx.usageMonitor.recordUsage(run, { runKind: 'workflow' }),
-        setting: mergeSetting,
-        getOutputFileLocation: createMergeOutputFileLocationGetter(
-          fileService,
-          mergeSetting.outputExt,
-        ),
-        parentStage: ctx.parentStage,
-        onRoundCompleted: createRoundProgressCallback(
-          ctx.executionId,
-          streamId,
-        ),
-      });
-      return {
-        category: 'workflow' as const,
-        status: result.status,
-        outputs: toOutputSummaries(result.roundOutputs),
-        compileFailures: toCompileFailureSummaries(result.roundOutputs),
-        executionId: ctx.executionId,
-        streamId,
-      };
     });
   });
 }
@@ -821,66 +891,74 @@ export async function executeMergeAgent(
 export async function resumeToolUseFromSnapshot(
   snapshot: ToolUseSessionSnapshot,
   setupSession?: (session: IToolUseSession) => void,
+  runtimeHost?: AgentRuntimeHost,
 ): Promise<void> {
-  const ctx = await resolveAndAcquireStream(
-    snapshot.agentConfig,
-    snapshot.executionId,
-    {
-      streamTabIdOverride: snapshot.streamId,
-      // resumeCommand surfaces its own warning toast on failure; skip the
-      // bus-level error to avoid double-notifying.
-      suppressErrorNotification: true,
-    },
-  );
-  // Recover delegation depth from the persisted parent-execution chain
-  // so resumed subagents remain gated by the nested-delegation policy
-  // instead of silently promoting to root.
-  ctx.delegationDepth = await computeDelegationDepthFromStorage(
-    snapshot.executionId,
-  );
-  const { setting, streamId } = ctx;
-
-  if (setting.agentCategory !== AgentCategory.ToolUse) {
-    throw new Error(
-      'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
+  const host = runtimeHost ?? getAgentRuntimeHost();
+  return runWithAgentRuntimeHost(host, async () => {
+    const ctx = await resolveAndAcquireStream(
+      snapshot.agentConfig,
+      snapshot.executionId,
+      {
+        streamTabIdOverride: snapshot.streamId,
+        // resumeCommand surfaces its own warning toast on failure; skip the
+        // bus-level error to avoid double-notifying.
+        suppressErrorNotification: true,
+      },
     );
-  }
+    // Recover delegation depth from the persisted parent-execution chain
+    // so resumed subagents remain gated by the nested-delegation policy
+    // instead of silently promoting to root.
+    ctx.delegationDepth = await computeDelegationDepthFromStorage(
+      snapshot.executionId,
+    );
+    const { setting, streamId } = ctx;
 
-  await runFlowWithLifecycle(
-    ctx,
-    streamId,
-    snapshot.agentConfig.agent,
-    async () => {
-      StreamStatusService.set(streamId, STREAM_STATUS.RUNNING);
-
-      const result = await runToolUseFlow(
-        {
-          ...ctx,
-          ...createInterruptCallbacks(),
-          onRoundFinalized: (run) =>
-            ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
-          setting: setting as AgentToolUseSetting,
-          resumeSnapshot: snapshot,
-          // Derive from the recovered parent chain: any execution with a
-          // parent is a subagent. Without this, the rebuilt system prompt
-          // would drop subagent-specific instructions (e.g. the shared
-          // /memories protocol) that the fresh run had included.
-          isSubagent: (ctx.delegationDepth ?? 0) > 0,
-          onFollowUpConsumed: () =>
-            bus.emit('updateQueuedFollowUps', { streamId: ctx.streamId }),
-        },
-        undefined,
-        setupSession ? (context) => setupSession(context.session) : undefined,
+    if (setting.agentCategory !== AgentCategory.ToolUse) {
+      throw new Error(
+        'Attempted to resume a non tool-use agent with resumeToolUseFromSnapshot.',
       );
-      return {
-        category: 'toolUse' as const,
-        status: result.status,
-        lastResponse: result.lastResponse,
-        touchedFiles: result.touchedFiles,
-        executionId: ctx.executionId,
-        streamId,
-      };
-    },
-    { category: 'toolUse' },
-  );
+    }
+
+    await runFlowWithLifecycle(
+      ctx,
+      streamId,
+      snapshot.agentConfig.agent,
+      async () => {
+        StreamStatusService.set(streamId, STREAM_STATUS.RUNNING, {
+          runtimeHost: ctx.runtimeHost,
+        });
+
+        const result = await runToolUseFlow(
+          {
+            ...ctx,
+            ...createInterruptCallbacks(),
+            onRoundFinalized: (run) =>
+              ctx.usageMonitor.recordUsage(run, { runKind: 'tool-use' }),
+            setting: setting as AgentToolUseSetting,
+            resumeSnapshot: snapshot,
+            // Derive from the recovered parent chain: any execution with a
+            // parent is a subagent. Without this, the rebuilt system prompt
+            // would drop subagent-specific instructions (e.g. the shared
+            // /memories protocol) that the fresh run had included.
+            isSubagent: (ctx.delegationDepth ?? 0) > 0,
+            onFollowUpConsumed: () =>
+              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                streamId: ctx.streamId,
+              }),
+          },
+          undefined,
+          setupSession ? (context) => setupSession(context.session) : undefined,
+        );
+        return {
+          category: 'toolUse' as const,
+          status: result.status,
+          lastResponse: result.lastResponse,
+          touchedFiles: result.touchedFiles,
+          executionId: ctx.executionId,
+          streamId,
+        };
+      },
+      { category: 'toolUse' },
+    );
+  });
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -7,7 +7,11 @@
 
 import * as fs from 'fs';
 
-import { bus } from '@eventBus/ProgressEventBus';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import type { ActiveChildInfo, StreamTabId } from '@shared/schemas';
 import {
   type ExecutionHandle,
@@ -39,17 +43,22 @@ const persistentListeners = new Map<
 // Notify waiters and refresh UI badges when stream status changes (e.g. RUNNING → WAITING).
 // Without this, waitForExecutionChange only resolves on progress/kill/untrack,
 // and the background tasks panel would show stale running/waiting badges.
-bus.on('updateStreamStatus', ({ streamId }) => {
+StreamStatusService.onDidChange(({ streamId }) => {
   for (const [executionId, handle] of registry) {
     if (
       handle instanceof AgentExecutionHandle &&
       handle.childStreamId === streamId
     ) {
+      const runtimeHost = runtimeHostFor(handle);
       notifyWaiters(executionId);
       // Re-emit badge update so the parent's background tasks panel
       // reflects the new status (e.g. running → waiting).
       if (handle.parentStreamId !== handle.childStreamId) {
-        emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
+        emitActiveSubagentsUpdate(
+          handle.parentStreamId,
+          registry.values(),
+          runtimeHost,
+        );
       }
       break;
     }
@@ -63,13 +72,18 @@ bus.on('updateStreamStatus', ({ streamId }) => {
 /** Register an execution handle. */
 export function trackExecution(handle: ExecutionHandle): void {
   registry.set(handle.executionId, handle);
+  const runtimeHost = runtimeHostFor(handle);
 
   // Emit subagent UI update and parent linkage only for actual subagents
   // (where parentStreamId differs from childStreamId)
   if (handle instanceof AgentExecutionHandle) {
     if (handle.parentStreamId !== handle.childStreamId) {
-      emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
-      bus.emit('setParentStream', {
+      emitActiveSubagentsUpdate(
+        handle.parentStreamId,
+        registry.values(),
+        runtimeHost,
+      );
+      runtimeHost.emit('setParentStream', {
         childStreamId: handle.childStreamId,
         parentStreamId: handle.parentStreamId,
       });
@@ -78,7 +92,11 @@ export function trackExecution(handle: ExecutionHandle): void {
 
   // Emit process badge update for background bash processes
   if (handle instanceof ProcessExecutionHandle) {
-    emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
+    emitActiveProcessesUpdate(
+      handle.parentStreamId,
+      registry.values(),
+      runtimeHost,
+    );
     reconcileOutputPoller();
   }
 }
@@ -88,13 +106,18 @@ export function untrackExecution(executionId: string): void {
   const handle = registry.get(executionId);
   registry.delete(executionId);
   notifyWaiters(executionId);
+  const runtimeHost = runtimeHostFor(handle);
 
   // Emit subagent UI update on removal (only for actual subagents)
   if (
     handle instanceof AgentExecutionHandle &&
     handle.parentStreamId !== handle.childStreamId
   ) {
-    emitActiveSubagentsUpdate(handle.parentStreamId, registry.values());
+    emitActiveSubagentsUpdate(
+      handle.parentStreamId,
+      registry.values(),
+      runtimeHost,
+    );
   }
 
   // Emit process badge update on removal and flush final output.
@@ -103,7 +126,11 @@ export function untrackExecution(executionId: string): void {
   if (handle instanceof ProcessExecutionHandle) {
     const finalize = (): void => {
       outputOffsets.delete(executionId);
-      emitActiveProcessesUpdate(handle.parentStreamId, registry.values());
+      emitActiveProcessesUpdate(
+        handle.parentStreamId,
+        registry.values(),
+        runtimeHost,
+      );
       reconcileOutputPoller();
     };
     if (handle.outputPaths) {
@@ -112,6 +139,7 @@ export function untrackExecution(executionId: string): void {
         handle.parentStreamId,
         handle.outputPaths.stdout,
         handle.outputPaths.stderr,
+        runtimeHost,
       ).finally(finalize);
     } else {
       finalize();
@@ -262,7 +290,11 @@ export function detachActiveChildren(parentStreamId: StreamTabId): void {
       handle.terminate();
     }
   }
-  emitActiveSubagentsUpdate(parentStreamId, registry.values());
+  emitActiveSubagentsUpdate(
+    parentStreamId,
+    registry.values(),
+    runtimeHostForParent(parentStreamId),
+  );
 }
 
 /** Get active subagent and process children for a parent stream. */
@@ -348,6 +380,7 @@ async function pollProcessOutputs(): Promise<void> {
         handle.parentStreamId,
         handle.outputPaths.stdout,
         handle.outputPaths.stderr,
+        runtimeHostFor(handle),
       ),
     );
   }
@@ -419,6 +452,7 @@ async function readIncremental(
   parentStreamId: StreamTabId,
   stdoutPath: string,
   stderrPath: string,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<void> {
   // If another read is in flight, wait for it then read again —
   // the final flush must not be skipped or it loses tail output.
@@ -447,7 +481,7 @@ async function readIncremental(
         stderr: err.newOffset,
       });
 
-      bus.emit('updateProcessOutput', {
+      runtimeHost.emit('updateProcessOutput', {
         parentStreamId,
         executionId,
         stdout: out.text,
@@ -472,6 +506,25 @@ async function readIncremental(
 // ============================================================================
 // Internal helpers
 // ============================================================================
+
+function runtimeHostFor(handle: ExecutionHandle | undefined): AgentRuntimeHost {
+  return handle?.runtimeHost ?? getAgentRuntimeHost();
+}
+
+function runtimeHostForParent(parentStreamId: StreamTabId): AgentRuntimeHost {
+  for (const handle of registry.values()) {
+    if (handle.parentStreamId === parentStreamId) {
+      return runtimeHostFor(handle);
+    }
+    if (
+      handle instanceof AgentExecutionHandle &&
+      handle.childStreamId === parentStreamId
+    ) {
+      return runtimeHostFor(handle);
+    }
+  }
+  return getAgentRuntimeHost();
+}
 
 function addChangeCallback(executionId: string, cb: () => void): void {
   let callbacks = changeCallbacks.get(executionId);

--- a/src/agent/runtime/sessionDescription.ts
+++ b/src/agent/runtime/sessionDescription.ts
@@ -10,9 +10,9 @@
 import { getAgent } from '@agent/index';
 import { writeSessionDescription } from '@agent/storage';
 import type { AgentConfig } from '@agent/core/AgentConfig';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { createHelperModelKit } from '@agent/runtime/helperModel';
 import * as logger from '@agent/core/logger';
-import { bus } from '@eventBus/ProgressEventBus';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import { isNonEmptyString } from '@utils/core';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -67,6 +67,7 @@ export async function generateSessionDescription(
   executionId: ExecutionId,
   streamId: StreamTabId,
   config: AgentConfig,
+  runtimeHost: AgentRuntimeHost,
 ): Promise<void> {
   try {
     const instruction = config.instruction?.trim();
@@ -105,7 +106,10 @@ export async function generateSessionDescription(
       const description = cleanSessionDescription(text);
       if (!description) return;
       await writeSessionDescription(executionId, description);
-      bus.emit('updateStreamDescription', { streamId, description });
+      runtimeHost.emit('updateStreamDescription', {
+        streamId,
+        description,
+      });
       logger.info(CHANNEL, `Generated session description for ${executionId}`);
     }
   } catch (err) {

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -4,6 +4,7 @@ import type {
   PlanState,
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
@@ -17,6 +18,8 @@ export interface ToolFileInteractionContext {
   agentName?: string;
   /** Working directory override for tool calls (e.g. a git worktree path). */
   workingDirectory?: string;
+  /** Runtime host inherited from the executing agent. */
+  runtimeHost?: AgentRuntimeHost;
   /**
    * Delegation depth of the agent executing this tool call. 0 for root (user-initiated),
    * N for an agent N levels deep. Read by delegation tools to compute the child's depth.

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -4,11 +4,11 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { resumeToolUseFromSnapshot } from '@agent/runtime/executeAgent';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
 import { logErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 import { STREAM_STATUS } from '@shared/schemas';
 import { getToolUsePersistenceEnabled } from '@utils/config';
 
@@ -41,23 +41,32 @@ async function resumeFromSnapshot(
   }
 
   ToolUseFollowUpQueue.acquire(streamId);
-  StreamStatusService.set(streamId, STREAM_STATUS.RESUMING);
+  const runtimeHost = getAgentRuntimeHost();
+  StreamStatusService.set(streamId, STREAM_STATUS.RESUMING, {
+    runtimeHost,
+  });
 
   let queuedFollowUps: string[] = [];
   try {
     queuedFollowUps = ToolUseFollowUpQueue.drain(streamId);
-    bus.emit('updateQueuedFollowUps', { streamId });
-
-    await resumeToolUseFromSnapshot(snapshot, (session) => {
-      const allFollowUps =
-        followUp !== undefined
-          ? [followUp, ...queuedFollowUps]
-          : queuedFollowUps;
-
-      for (const text of allFollowUps) {
-        session.appendFollowUp(text);
-      }
+    runtimeHost.emit('updateQueuedFollowUps', {
+      streamId,
     });
+
+    await resumeToolUseFromSnapshot(
+      snapshot,
+      (session) => {
+        const allFollowUps =
+          followUp !== undefined
+            ? [followUp, ...queuedFollowUps]
+            : queuedFollowUps;
+
+        for (const text of allFollowUps) {
+          session.appendFollowUp(text);
+        }
+      },
+      runtimeHost,
+    );
 
     return { success: true };
   } catch (error) {
@@ -83,7 +92,9 @@ async function resumeFromSnapshot(
   } finally {
     const status = StreamStatusService.get(streamId);
     if (status === STREAM_STATUS.RESUMING) {
-      StreamStatusService.set(streamId, STREAM_STATUS.WAITING);
+      StreamStatusService.set(streamId, STREAM_STATUS.WAITING, {
+        runtimeHost,
+      });
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import dotenv from 'dotenv';
 import { initPlatform } from '@platform/platform';
 import { loadAgents, setAgentDirectories } from '@agent/index';
 import { clearStoreCache } from '@agent/storage';
+import { setDefaultAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { killBackgroundProcesses } from '@agent/runtime/executionRegistry';
 import { initializePolishModel } from '@agent/runtime/polishModel';
 import {
@@ -51,6 +52,7 @@ import { registerFileDecorations } from '@frontend/ui/fileDecorations';
 import { registerWelcomeView } from '@frontend/ui/welcomeView';
 import { initializeNativeToolEditApproval } from '@frontend/approval/nativeToolEditApproval';
 import { registerAgentEventListeners } from '@frontend/events/agentEventListeners';
+import { extensionAgentRuntimeHost } from '@frontend/agentRuntime/extensionAgentRuntimeHost';
 import * as leanVscodeIntegration from '@frontend/lean/VscodeIntegration';
 import { applyGitAuthorConfig } from '@frontend/git/gitAuthorSetup';
 import { getLinterMessages } from '@frontend/latex/linter';
@@ -152,6 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
     storage: new VscodeStorage(context),
     secrets: new VscodeSecrets(context),
   });
+  setDefaultAgentRuntimeHost(extensionAgentRuntimeHost);
   await StorageFS.ensureDir(TASK_RUNS_DIR);
   FileLister.initialize(context);
   initializeServerSideKeyAccess(

--- a/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
+++ b/src/frontend/agentRuntime/extensionAgentRuntimeHost.ts
@@ -1,0 +1,11 @@
+import { createAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressSink } from '@agent/runtime/ProgressSink';
+import { bus } from '@eventBus/ProgressEventBus';
+
+const extensionProgressSink: ProgressSink = {
+  emit: (event, payload) => bus.emit(event, payload),
+};
+
+export const extensionAgentRuntimeHost = createAgentRuntimeHost(
+  extensionProgressSink,
+);

--- a/src/logger/AgentUsageReporter.ts
+++ b/src/logger/AgentUsageReporter.ts
@@ -1,5 +1,8 @@
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { bus } from '@eventBus/ProgressEventBus';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 
 import type {
   ExtendedTokenUsageStats,
@@ -13,6 +16,7 @@ export class AgentUsageReporter {
     private readonly logger: AgentLogger,
     private readonly streamId: StreamTabId,
     private readonly agentCategory: AgentCategory = AgentCategory.Workflow,
+    private readonly runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
   ) {}
 
   report(
@@ -20,7 +24,7 @@ export class AgentUsageReporter {
     storageKey: StorageKey,
     groupId?: string,
   ): void {
-    bus.emit('updateStreamUsage', {
+    this.runtimeHost.emit('updateStreamUsage', {
       streamId: this.streamId,
       storageKey,
       usage: stats,

--- a/src/test/logger/AgentUsageReporter.test.ts
+++ b/src/test/logger/AgentUsageReporter.test.ts
@@ -3,10 +3,28 @@ import { strict as assert } from 'assert';
 
 // Local imports
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { bus } from '@eventBus/ProgressEventBus';
+import {
+  createAgentRuntimeHost,
+  runWithAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type { ExtendedTokenUsageStats, StorageKey } from '@shared/schemas';
 import { AgentUsageReporter } from '@/logger/AgentUsageReporter';
+
+function createUsageHost(): { events: unknown[]; host: AgentRuntimeHost } {
+  const events: unknown[] = [];
+  return {
+    events,
+    host: createAgentRuntimeHost({
+      emit: (event, payload) => {
+        if (event === 'updateStreamUsage') {
+          events.push(payload);
+        }
+      },
+    }),
+  };
+}
 
 describe('AgentUsageReporter', () => {
   /**
@@ -16,10 +34,7 @@ describe('AgentUsageReporter', () => {
   it('trusts storageKey as single source of truth (no round-trip to logger)', () => {
     const streamId = 'stream:test';
     const storageKey = 'task-group-123' as StorageKey;
-    const streamEvents: unknown[] = [];
-    const disposeStream = bus.on('updateStreamUsage', (payload) => {
-      streamEvents.push(payload);
-    });
+    const { events, host } = createUsageHost();
 
     let recordedStats: ExtendedTokenUsageStats | undefined;
     let recordedStorageKey: string | undefined;
@@ -40,6 +55,7 @@ describe('AgentUsageReporter', () => {
       loggerStub,
       streamId,
       AgentCategory.Workflow,
+      host,
     );
     const stats: ExtendedTokenUsageStats = {
       inputTokens: 10,
@@ -48,37 +64,30 @@ describe('AgentUsageReporter', () => {
       cacheCreationInputTokens: 4,
     };
 
-    try {
-      reporter.report(stats, storageKey);
+    reporter.report(stats, storageKey);
 
-      assert.equal(streamEvents.length, 1);
-      // storageKey is THE single source of truth - no runId needed
-      // Cache tokens are passed through for display
-      assert.deepEqual(streamEvents[0], {
-        stream: streamId,
-        storageKey,
-        usage: {
-          inputTokens: 10,
-          outputTokens: 5,
-          cost: 0.25,
-          cacheCreationInputTokens: 4,
-        },
-      });
-      // Verify statistics were logged with storageKey
-      assert.strictEqual(recordedStats, stats);
-      assert.strictEqual(recordedStorageKey, storageKey);
-    } finally {
-      disposeStream();
-    }
+    assert.equal(events.length, 1);
+    // storageKey is THE single source of truth - no runId needed
+    // Cache tokens are passed through for display
+    assert.deepEqual(events[0], {
+      streamId,
+      storageKey,
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cost: 0.25,
+        cacheCreationInputTokens: 4,
+      },
+    });
+    // Verify statistics were logged with storageKey
+    assert.strictEqual(recordedStats, stats);
+    assert.strictEqual(recordedStorageKey, storageKey);
   });
 
   it('skips statistics logging for tool-use sessions', () => {
     const streamId = 'stream:test';
     const storageKey = 'execution-id-456' as StorageKey;
-    const streamEvents: unknown[] = [];
-    const disposeStream = bus.on('updateStreamUsage', (payload) => {
-      streamEvents.push(payload);
-    });
+    const { events, host } = createUsageHost();
 
     const loggerStub = {
       withCurrentGroup: <T>(_: (groupId: string) => T): T | undefined => {
@@ -93,6 +102,7 @@ describe('AgentUsageReporter', () => {
       loggerStub,
       streamId,
       AgentCategory.ToolUse,
+      host,
     );
 
     const stats: ExtendedTokenUsageStats = {
@@ -102,33 +112,26 @@ describe('AgentUsageReporter', () => {
       cacheCreationInputTokens: 1,
     };
 
-    try {
-      reporter.report(stats, storageKey);
+    reporter.report(stats, storageKey);
 
-      assert.equal(streamEvents.length, 1);
-      // Cache tokens are passed through for display
-      assert.deepEqual(streamEvents[0], {
-        stream: streamId,
-        storageKey,
-        usage: {
-          inputTokens: 6,
-          outputTokens: 2,
-          cost: 0.1,
-          cacheCreationInputTokens: 1,
-        },
-      });
-    } finally {
-      disposeStream();
-    }
+    assert.equal(events.length, 1);
+    // Cache tokens are passed through for display
+    assert.deepEqual(events[0], {
+      streamId,
+      storageKey,
+      usage: {
+        inputTokens: 6,
+        outputTokens: 2,
+        cost: 0.1,
+        cacheCreationInputTokens: 1,
+      },
+    });
   });
 
   it('passes through both cacheRead and cacheCreation tokens', () => {
     const streamId = 'stream:test';
     const storageKey = 'task-group-789' as StorageKey;
-    const streamEvents: unknown[] = [];
-    const disposeStream = bus.on('updateStreamUsage', (payload) => {
-      streamEvents.push(payload);
-    });
+    const { events, host } = createUsageHost();
 
     const loggerStub = {
       statistics: () => {
@@ -140,6 +143,7 @@ describe('AgentUsageReporter', () => {
       loggerStub,
       streamId,
       AgentCategory.Workflow,
+      host,
     );
 
     const stats: ExtendedTokenUsageStats = {
@@ -151,35 +155,28 @@ describe('AgentUsageReporter', () => {
       cacheCreationInputTokens: 20, // Cache writes (1.25x for Anthropic)
     };
 
-    try {
-      reporter.report(stats, storageKey);
+    reporter.report(stats, storageKey);
 
-      assert.equal(streamEvents.length, 1);
-      // Both cache token types should be passed through
-      assert.deepEqual(streamEvents[0], {
-        stream: streamId,
-        storageKey,
-        usage: {
-          inputTokens: 100,
-          outputTokens: 50,
-          cost: 1.5,
-          cacheReadInputTokens: 80,
-          cacheMissInputTokens: 20,
-          cacheCreationInputTokens: 20,
-        },
-      });
-    } finally {
-      disposeStream();
-    }
+    assert.equal(events.length, 1);
+    // Both cache token types should be passed through
+    assert.deepEqual(events[0], {
+      streamId,
+      storageKey,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cost: 1.5,
+        cacheReadInputTokens: 80,
+        cacheMissInputTokens: 20,
+        cacheCreationInputTokens: 20,
+      },
+    });
   });
 
   it('omits cache tokens when zero or undefined', () => {
     const streamId = 'stream:test';
     const storageKey = 'task-group-000' as StorageKey;
-    const streamEvents: unknown[] = [];
-    const disposeStream = bus.on('updateStreamUsage', (payload) => {
-      streamEvents.push(payload);
-    });
+    const { events, host } = createUsageHost();
 
     const loggerStub = {
       statistics: () => {
@@ -191,6 +188,7 @@ describe('AgentUsageReporter', () => {
       loggerStub,
       streamId,
       AgentCategory.Workflow,
+      host,
     );
 
     // No cache tokens in stats
@@ -200,22 +198,58 @@ describe('AgentUsageReporter', () => {
       cost: 0.1,
     };
 
-    try {
-      reporter.report(stats, storageKey);
+    reporter.report(stats, storageKey);
 
-      assert.equal(streamEvents.length, 1);
-      // Cache tokens should be omitted when not present
-      assert.deepEqual(streamEvents[0], {
-        stream: streamId,
+    assert.equal(events.length, 1);
+    // Cache tokens should be omitted when not present
+    assert.deepEqual(events[0], {
+      streamId,
+      storageKey,
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cost: 0.1,
+      },
+    });
+  });
+
+  it('uses the scoped runtime host when no host is passed', () => {
+    const streamId = 'stream:test';
+    const storageKey = 'task-group-scoped' as StorageKey;
+    const { events, host } = createUsageHost();
+
+    const loggerStub = {
+      statistics: () => {
+        /* no-op */
+      },
+    } as unknown as AgentLogger;
+
+    runWithAgentRuntimeHost(host, () => {
+      const reporter = new AgentUsageReporter(
+        loggerStub,
+        streamId,
+        AgentCategory.Workflow,
+      );
+      reporter.report(
+        {
+          inputTokens: 1,
+          outputTokens: 2,
+          cost: 0.03,
+        },
+        storageKey,
+      );
+    });
+
+    assert.deepEqual(events, [
+      {
+        streamId,
         storageKey,
         usage: {
-          inputTokens: 10,
-          outputTokens: 5,
-          cost: 0.1,
+          inputTokens: 1,
+          outputTokens: 2,
+          cost: 0.03,
         },
-      });
-    } finally {
-      disposeStream();
-    }
+      },
+    ]);
   });
 });

--- a/src/tools/DelegationTools.ts
+++ b/src/tools/DelegationTools.ts
@@ -283,6 +283,7 @@ async function executeSubagent(
   const parentContext = getCurrentToolFileInteractionContext();
   const parentExecutionId = parentContext?.executionId;
   const parentDelegationDepth = parentContext?.delegationDepth ?? 0;
+  const runtimeHost = parentContext?.runtimeHost;
 
   const gated = depthGateError(
     parentDelegationDepth,
@@ -319,6 +320,7 @@ async function executeSubagent(
   }
 
   const promise = executeAgent(configPayload, executionId, {
+    runtimeHost,
     isSubagent: true,
     enforceCategory: true,
     parentStreamId: orchestratorStreamId,


### PR DESCRIPTION
## Summary

- add an AgentRuntimeHost boundary around runtime progress emission and install the VS Code host from extension activation
- use a scoped runtime host for execution paths so downstream helpers can emit through the current execution context without command-level adapter plumbing
- route stream status, execution registry, session description, resume, delegation, and usage-reporting events through the runtime host
- update usage reporter tests to use a small recording host, including coverage for scoped host lookup

Closes #3303.

Tracked follow-ups: #3324, #3327.

## Validation

- npm run format
- npm run typecheck
- npm run compile-tests
- npx mocha --require out/test/setup.js out/test/logger/AgentUsageReporter.test.js
- npm run test:kernel
- npm run lint
- npm run compile:safe
- npm run compile
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core execution lifecycle and progress/status emission paths; incorrect scoping or missing host propagation could lead to lost/misrouted UI updates during agent runs and subagent/process tracking.
> 
> **Overview**
> Introduces a new `AgentRuntimeHost` abstraction (backed by `AsyncLocalStorage`) to scope progress/UI event emission per execution and to decouple runtime code from the global `ProgressEventBus`.
> 
> Routes stream status updates, execution registry notifications (active subagents/processes and process output), session description updates, resume flow updates, and usage reporting through the active runtime host; `executeAgent`/`executeMergeAgent`/`resumeToolUseFromSnapshot` now establish the host scope and pass it through tool-use contexts and delegation so child executions inherit the same emitter.
> 
> Updates `ProgressSink` to support a configurable default sink and adds VS Code’s default host wiring during extension activation; adjusts `StreamStatusService` to accept a host and adds a local `onDidChange` listener API; updates `AgentUsageReporter` tests to use a recording runtime host and verify scoped-host lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083f28930ba8e7ba9bbf1259355f1fea90c43fff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->