### PR TITLE
refactor: use OpenAI native response input subtypes

### DIFF
--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -1275,13 +1275,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     if (systemPrompt) {
       const role = this.capabilities.supportsSystemPrompt ? 'system' : 'user';
-      messages.push({
+      const systemMessage: ResponseInputItem.Message = {
         type: 'message',
         role,
-        content: [
-          this.createInputText(systemPrompt),
-        ] as ResponseInputMessageContentList,
-      } as ResponseInputItem);
+        content: [this.createInputText(systemPrompt)],
+      };
+      messages.push(systemMessage);
     }
 
     const supportsMedia =
@@ -1305,11 +1304,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       }
     }
 
-    messages.push({
+    const initialUserMessage: ResponseInputItem.Message = {
       type: 'message',
       role: 'user',
       content: userContent,
-    } as ResponseInputItem);
+    };
+    messages.push(initialUserMessage);
 
     const requestRole = this.capabilities.supportsIntermDevMsgs
       ? 'system'
@@ -1318,13 +1318,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     if (requestRole === 'user' && messages.length > 0) {
       this.appendInputText(messages.at(-1)!, userRequest);
     } else {
-      messages.push({
+      const requestMessage: ResponseInputItem.Message = {
         type: 'message',
         role: requestRole,
-        content: [
-          this.createInputText(userRequest),
-        ] as ResponseInputMessageContentList,
-      } as ResponseInputItem);
+        content: [this.createInputText(userRequest)],
+      };
+      messages.push(requestMessage);
     }
 
     return messages;
@@ -1359,11 +1358,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
 
     roundContent.push(this.createInputText(userMessage));
 
-    messages.push({
+    const roundUserMessage: ResponseInputItem.Message = {
       type: 'message',
       role: 'user',
       content: roundContent,
-    } as ResponseInputItem);
+    };
+    messages.push(roundUserMessage);
 
     return messages;
   }
@@ -2450,13 +2450,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     );
 
     const role = this.capabilities.supportsIntermDevMsgs ? 'system' : 'user';
-    messages.push({
+    const continuationMessage: ResponseInputItem.Message = {
       type: 'message',
       role,
-      content: [
-        this.createInputText(userMessageContinuation),
-      ] as ResponseInputMessageContentList,
-    } as ResponseInputItem);
+      content: [this.createInputText(userMessageContinuation)],
+    };
+    messages.push(continuationMessage);
   }
 
   /** Initializes output file and handles prefill content. */
@@ -2476,13 +2475,12 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
       if (lastMessage) {
         this.appendInputText(lastMessage, pseudoPrefill);
       } else {
-        messages.push({
+        const pseudoPrefillMessage: ResponseInputItem.Message = {
           type: 'message',
           role: 'user',
-          content: [
-            this.createInputText(pseudoPrefill),
-          ] as ResponseInputMessageContentList,
-        } as ResponseInputItem);
+          content: [this.createInputText(pseudoPrefill)],
+        };
+        messages.push(pseudoPrefillMessage);
       }
       this.logger.debug(
         `Added pseudo prefill message to messages:\n${pseudoPrefill}`,
@@ -2764,9 +2762,10 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     // Always clear after processing to prevent accumulation across cycles.
     if (workspaceState?.serverToolContent.contentBlocks.length) {
       if (!isResponseChaining) {
-        const openaiBlocks = workspaceState.serverToolContent.contentBlocks
-          .filter(isOpenAIServerToolContent)
-          .map((block) => block as ResponseInputItem);
+        const openaiBlocks: ResponseInputItem[] =
+          workspaceState.serverToolContent.contentBlocks.filter(
+            isOpenAIServerToolContent,
+          );
         messages.push(...openaiBlocks);
       }
       workspaceState.resetServerToolContent();


### PR DESCRIPTION
## Summary
- replace manual `as ResponseInputItem` casts with native `ResponseInputItem.Message` where appropriate
- rely on existing OpenAI server-tool type guard output directly instead of re-casting
- keep the compaction output cast unchanged because OpenAI SDK still types compact output as `ResponseOutputItem[]`

## Validation
- npm run -s compile:safe
- npm run -s lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor in the OpenAI Responses model handler that reduces casting and relies on SDK subtypes/type guards; runtime behavior should be unchanged, with low risk limited to potential subtle typing/shape mismatches in constructed message objects.
> 
> **Overview**
> Refactors `modelHandlerOpenAIResponse.ts` to construct response `input` messages using the OpenAI SDK’s native `ResponseInputItem.Message` subtype instead of building plain objects and casting them to `ResponseInputItem`.
> 
> Also simplifies server-tool content preservation by using the existing `isOpenAIServerToolContent` type guard output directly (removing extra re-casts) before appending those blocks to follow-up tool messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3895f8849c12310a164b5fe2d4f798cbcf553ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->