### PR TITLE
feat(github): emit "CI triggered" event when GitHub Actions register …

### DIFF
--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -19,6 +19,7 @@ import {
   formatCheckFailureSummary,
   formatCIComplete,
   formatCIPassed,
+  formatCIStarted,
   formatIssueComment,
   formatMergeConflictDetected,
   formatMergeConflictResolved,
@@ -58,6 +59,7 @@ function createInitialState(pr: PRKey): SubscriptionState {
     seenReviewCommentIds: new Set(),
     seenReviewIds: new Set(),
     lastFailedCheckKeys: new Set(),
+    ciStartedSha: undefined,
     ciCompleteSha: undefined,
     ciPassedSha: undefined,
     headSha: undefined,
@@ -110,6 +112,14 @@ interface SubscriptionState extends BasePollSubscriptionState {
   seenReviewCommentIds: Set<number>;
   seenReviewIds: Set<number>;
   lastFailedCheckKeys: Set<string>;
+  /**
+   * Head SHA for which the one-shot "CI started" event has been emitted —
+   * fires the first tick we observe non-empty check-runs at this SHA, so
+   * agents see what GitHub Actions / other CI providers picked up the push.
+   * On seeding (subscribe-time existing runs) this is set to suppress
+   * a spurious replay event.
+   */
+  ciStartedSha: string | undefined;
   /** Head SHA for which the one-shot "CI complete" event has been emitted. */
   ciCompleteSha: string | undefined;
   /** Head SHA for which the one-shot "CI passed" event has been emitted. */
@@ -216,6 +226,7 @@ export class PRPollingSource extends PollingSourceBase<
       // Letting it linger would cost one wasted If-None-Match per page on
       // the first post-push tick before the cache naturally refreshes.
       if (state.headSha !== newHead) {
+        state.ciStartedSha = undefined;
         state.ciCompleteSha = undefined;
         state.ciPassedSha = undefined;
         state.checkRunsCache = undefined;
@@ -338,6 +349,12 @@ export class PRPollingSource extends PollingSourceBase<
             state.lastFailedCheckKeys.add(this.checkKey(r));
           }
         }
+        // Seed "started" so pre-existing runs at subscribe time don't replay
+        // as a "CI triggered" event on the next tick. Only surface starts
+        // that happen after we begin watching.
+        if (state.headSha && runs.length > 0) {
+          state.ciStartedSha = state.headSha;
+        }
         // Seed so pre-existing terminal CI doesn't fire on the next tick —
         // we only surface transitions that happen after subscribe. Gate on
         // runs.length > 0: an empty array is ambiguous (no CI configured vs.
@@ -421,6 +438,24 @@ export class PRPollingSource extends PollingSourceBase<
       // ETag/page caching is owned by `fetchAllCheckRuns` via
       // `state.checkRunsCache`; nothing to record on `state.etags` here.
       const runs = checksRes.data.check_runs;
+
+      // Fire "CI triggered" the first tick we observe non-empty runs at this
+      // head SHA (deduped per SHA). This complements the terminal "complete"
+      // / "passed" events: the agent now sees what GitHub Actions / other CI
+      // workflows picked up the push as soon as they register, without
+      // needing to wait for them to finish.
+      if (
+        state.headSha &&
+        runs.length > 0 &&
+        state.ciStartedSha !== state.headSha
+      ) {
+        state.ciStartedSha = state.headSha;
+        this.emit(
+          state,
+          formatCIStarted(state.slug, pr.pullNumber, state.headSha, runs),
+        );
+      }
+
       const newFailures: GhCheckRun[] = [];
       const currentFailureKeys = new Set<string>();
       for (const r of runs) {

--- a/src/tools/github/formatPREvent.ts
+++ b/src/tools/github/formatPREvent.ts
@@ -144,6 +144,32 @@ export function formatCIPassed(
   );
 }
 
+/**
+ * Emitted once per head SHA the first time we observe non-empty check-runs
+ * after that SHA appeared (i.e., GitHub Actions / other CI providers picked
+ * up the new commit and registered work). Lists the unique check / workflow
+ * names so the agent can see what was triggered without tailing logs.
+ *
+ * Deduped via a per-SHA `ciStartedSha` marker so a push always produces at
+ * most one "started" event for that SHA, regardless of how many ticks elapse
+ * before all jobs register.
+ */
+export function formatCIStarted(
+  slug: string,
+  prNumber: number,
+  sha: string,
+  runs: GhCheckRun[],
+): string {
+  const uniqueNames = [...new Set(runs.map((r) => r.name))].sort();
+  const list = uniqueNames.map((n) => `- ${n}`).join('\n');
+  return wrap(
+    sections(
+      `CI triggered on ${prRef(slug, prNumber)} (head ${sha.slice(0, 7)}): ${runs.length} check${runs.length === 1 ? '' : 's'} registered across ${uniqueNames.length} workflow${uniqueNames.length === 1 ? '' : 's'}.`,
+      list,
+    ),
+  );
+}
+
 export function formatCIComplete(
   slug: string,
   prNumber: number,


### PR DESCRIPTION
…on a PR

PR subscriptions previously only surfaced terminal CI states (complete, passed, individual failures), so agents had no signal between push and the first failure / completion. Add a one-shot "CI triggered" event fired the first tick non-empty check-runs appear at a head SHA, listing the unique workflow names so the agent sees what was kicked off.

Deduped per-SHA via a new ciStartedSha marker, reset on push alongside the existing ciCompleteSha / ciPassedSha resets, and seeded at subscribe time so pre-existing runs don't replay.

https://claude.ai/code/session_01XM4jCFpGa49NCrNm6avhRh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new deduped, informational PR-subscription event without changing existing CI completion/failure detection logic, though it may increase event volume by one per pushed SHA.
> 
> **Overview**
> Adds a new one-shot **"CI triggered"** PR-subscription event that fires the first time non-empty GitHub check-runs are observed for a head SHA, so agents get a signal immediately after a push (before failures/completion).
> 
> Introduces a per-SHA `ciStartedSha` marker in `PRPollingSource` to **dedupe and seed** this event (avoiding replay on subscribe), resets it on new pushes alongside existing CI terminal-state markers, and formats the event via new `formatCIStarted` output listing unique workflow/check names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb46b2aedbdad6329b0243398eaa4c5828e404b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->