### PR TITLE
[codex] Skip Copilot issue tracker reviews

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -18,10 +18,15 @@ concurrency:
 jobs:
   track:
     # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
+    # Skip Copilot review summaries: the Claude action cannot exchange their
+    # OIDC token for a repo-writing app token, and Playbook C has no useful
+    # tracking action for those comment-only automated reviews.
     if: |
       (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
       (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
-      github.event_name == 'pull_request_review'
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.user.login != 'copilot-pull-request-reviewer[bot]' &&
+       github.actor != 'Copilot')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- skip Issue Tracker runs for Copilot PR review summaries
- keep existing issue, PR, and non-Copilot review tracking behavior

## Why
Copilot review submissions trigger the Claude action, but Anthropic rejects the OIDC app-token exchange with `User does not have write access on this repository`. Those comment-only automated reviews do not need Playbook C tracking work.

## Validation
- `npx prettier --check .github/workflows/issue-tracker.yml`
- `git diff --check`
- YAML parse via Ruby
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions change that only narrows when the `issue-tracker` workflow runs. Potential impact is missed tracking comments for Copilot-generated review submissions, while human reviews and other events remain unchanged.
> 
> **Overview**
> Prevents the `issue-tracker` GitHub Action from running on `pull_request_review` events generated by Copilot (both `copilot-pull-request-reviewer[bot]` and the `Copilot` actor), avoiding OIDC/app-token exchange failures and unnecessary tracking work.
> 
> Issue and PR event handling is unchanged; the workflow still runs for completed issue closures, relevant PR events, and non-Copilot review submissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4fd2909fbe7b17dbcf3d370fc33fb1621b19cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->