### PR TITLE
refactor: simplify agent launch context resolution

### DIFF
--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -91,7 +91,7 @@ import type {
 const CHANNEL = 'executeAgent';
 const logger = new AgentLogger(CHANNEL);
 
-interface ResolvedAgentBase extends AgentCore {
+interface AgentLaunchContext extends AgentCore {
   runtimeHost: AgentRuntimeHost;
   usageMonitor: UsageMonitor;
   storageKey: StorageKey;
@@ -155,28 +155,62 @@ async function beginRunStage(
   return agentLogger.stage(label);
 }
 
-interface ResolveAgentOptions {
+interface AgentLaunchInput {
+  configPayload: AgentConfigPayload;
+  executionId?: ExecutionId;
   runtimeHost?: AgentRuntimeHost;
   streamTabIdOverride?: StreamTabId;
+  taskType?: string;
   /** Fires after streamId is assigned but before setActiveStream is emitted. */
   onBeforeActivation?: (streamId: StreamTabId) => void;
-  /**
-   * Fires immediately after setActiveStream is emitted. Marks the activation
-   * boundary: any subsequent failure should surface on this stream (the UI
-   * tab is now visible) rather than be dropped silently.
-   */
-  onActivated?: (streamId: StreamTabId) => void;
   /** When true, reject if configPayload.agentCategory doesn't match the YAML-defined category. */
   enforceCategory?: boolean;
+  /** Skip the `requestShowError` toast -- for callers that show their own UI. */
+  suppressErrorNotification?: boolean;
 }
-async function resolveAgentBase(
-  configPayload: AgentConfigPayload,
-  providedExecutionId?: ExecutionId,
-  options?: ResolveAgentOptions,
-): Promise<ResolvedAgentBase> {
-  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
-  const executionId: ExecutionId = providedExecutionId ?? generateExecutionId();
 
+interface AgentLaunchPlan extends Omit<
+  AgentLaunchInput,
+  'executionId' | 'runtimeHost'
+> {
+  executionId: ExecutionId;
+  runtimeHost: AgentRuntimeHost;
+  preliminaryStreamId?: StreamTabId;
+}
+
+function createAgentLaunchPlan(input: AgentLaunchInput): AgentLaunchPlan {
+  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
+  const executionId = input.executionId ?? generateExecutionId();
+  const preliminaryStreamId = input.streamTabIdOverride
+    ? undefined
+    : getPreliminaryStreamId(input.configPayload, executionId);
+
+  return {
+    ...input,
+    executionId,
+    runtimeHost,
+    preliminaryStreamId,
+  };
+}
+
+function getPreliminaryStreamId(
+  configPayload: AgentConfigPayload,
+  executionId: ExecutionId,
+): StreamTabId {
+  if (!configPayload.agent || !configPayload.model) {
+    throw new Error('Missing required fields: model and/or agent');
+  }
+
+  return getStreamTabId(configPayload.agent, configPayload.model, {
+    executionId,
+  });
+}
+
+async function createAgentLaunchContext(
+  launch: AgentLaunchPlan,
+  onActivated: (streamId: StreamTabId) => void,
+): Promise<AgentLaunchContext> {
+  const { configPayload, executionId, runtimeHost } = launch;
   const fullConfig = AgentConfigSchema.parse(configPayload);
   const resolution = await getAgentPath(fullConfig.agent, {
     preferMultiple: fullConfig.useMultipleOutputs,
@@ -198,7 +232,7 @@ async function resolveAgentBase(
   // because many code paths pass pre-parsed configs where agentCategory was
   // prefaulted to Workflow by the schema (not explicitly chosen by the caller).
   if (
-    options?.enforceCategory &&
+    launch.enforceCategory &&
     configPayload.agentCategory &&
     configPayload.agentCategory !== setting.agentCategory
   ) {
@@ -226,7 +260,7 @@ async function resolveAgentBase(
   const modelHandler = createModelHandler(MODEL_CONFIGS[fullConfig.model]);
 
   const streamId =
-    options?.streamTabIdOverride ??
+    launch.streamTabIdOverride ??
     getStreamTabId(config.agent, fullConfig.model, { executionId });
 
   const agentLogger = new AgentLogger(streamId, true);
@@ -239,7 +273,7 @@ async function resolveAgentBase(
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
 
-  options?.onBeforeActivation?.(streamId);
+  launch.onBeforeActivation?.(streamId);
 
   runtimeHost.emit('setActiveStream', {
     streamId,
@@ -247,12 +281,12 @@ async function resolveAgentBase(
     isRemote: isRemoteAgent(fullConfig.agent),
     hasMultipleOutputs: useMultipleOutputs,
   });
-  options?.onActivated?.(streamId);
+  onActivated(streamId);
 
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
   const initialInstruction =
-    config.instruction?.trim() && !options?.streamTabIdOverride
+    config.instruction?.trim() && !launch.streamTabIdOverride
       ? config.instruction.trim()
       : undefined;
 
@@ -409,7 +443,7 @@ function createRoundProgressCallback(
 }
 
 async function runFlowWithLifecycle(
-  ctx: ResolvedAgentBase,
+  ctx: AgentLaunchContext,
   streamId: StreamTabId,
   agentName: string,
   runner: () => Promise<AgentFlowResult>,
@@ -543,19 +577,12 @@ function buildFallbackNotification(config: AgentConfig) {
  *    `useMultipleOutputs` flips during resolution).
  */
 function compensateFailedActivation(args: {
-  preliminaryStreamId?: StreamTabId;
+  launch: AgentLaunchPlan;
   activatedStreamId?: StreamTabId;
-  configPayload: AgentConfigPayload;
-  runtimeHost: AgentRuntimeHost;
   err: unknown;
 }): void {
-  const {
-    preliminaryStreamId,
-    activatedStreamId,
-    configPayload,
-    runtimeHost,
-    err,
-  } = args;
+  const { launch, activatedStreamId, err } = args;
+  const { configPayload, preliminaryStreamId, runtimeHost } = launch;
 
   if (activatedStreamId) {
     new AgentLogger(activatedStreamId, true).logError(
@@ -583,57 +610,32 @@ function compensateFailedActivation(args: {
  * resolution failures before that point release the lock silently; failures
  * after surface on the visible tab via {@link compensateFailedActivation}.
  */
-async function resolveAndAcquireStream(
-  configPayload: AgentConfigPayload,
-  executionId?: ExecutionId,
-  options?: {
-    runtimeHost?: AgentRuntimeHost;
-    streamTabIdOverride?: StreamTabId;
-    taskType?: string;
-    onBeforeActivation?: (streamId: StreamTabId) => void;
-    enforceCategory?: boolean;
-    /** Skip the `requestShowError` toast — for callers that show their own UI. */
-    suppressErrorNotification?: boolean;
-  },
-): Promise<ResolvedAgentBase> {
-  const runtimeHost = options?.runtimeHost ?? getAgentRuntimeHost();
-  let preliminaryStreamId: StreamTabId | undefined;
-  let resolvedExecutionId = executionId;
+async function buildAgentLaunchContext(
+  input: AgentLaunchInput,
+): Promise<AgentLaunchContext> {
+  const launch = createAgentLaunchPlan(input);
 
-  if (!options?.streamTabIdOverride) {
-    if (!configPayload.agent || !configPayload.model) {
-      throw new Error('Missing required fields: model and/or agent');
-    }
-    resolvedExecutionId = executionId ?? generateExecutionId();
-    preliminaryStreamId = getStreamTabId(
-      configPayload.agent,
-      configPayload.model,
-      { executionId: resolvedExecutionId },
+  if (launch.preliminaryStreamId) {
+    acquireStreamOrThrow(
+      launch.preliminaryStreamId,
+      launch.runtimeHost,
+      launch.taskType,
     );
-    acquireStreamOrThrow(preliminaryStreamId, runtimeHost, options?.taskType);
   }
 
   let activatedStreamId: StreamTabId | undefined;
   try {
-    return await resolveAgentBase(configPayload, resolvedExecutionId, {
-      runtimeHost,
-      streamTabIdOverride: options?.streamTabIdOverride,
-      onBeforeActivation: options?.onBeforeActivation,
-      onActivated: (streamId) => {
-        activatedStreamId = streamId;
-      },
-      enforceCategory: options?.enforceCategory,
+    return await createAgentLaunchContext(launch, (streamId) => {
+      activatedStreamId = streamId;
     });
   } catch (err) {
     compensateFailedActivation({
-      preliminaryStreamId,
+      launch,
       activatedStreamId,
-      configPayload,
-      runtimeHost,
       err,
     });
-    if (!options?.suppressErrorNotification && !(err instanceof ZodError)) {
-      runtimeHost.emit('requestShowError', {
+    if (!launch.suppressErrorNotification && !(err instanceof ZodError)) {
+      launch.runtimeHost.emit('requestShowError', {
         message: toErrorMessage(err),
       });
     }
@@ -687,7 +689,9 @@ export async function executeAgent(
   options?: ExecuteAgentOptions,
 ): Promise<AgentFlowResult> {
   return runWithAgentRuntimeHost(options?.runtimeHost, async () => {
-    const ctx = await resolveAndAcquireStream(configPayload, executionId, {
+    const ctx = await buildAgentLaunchContext({
+      configPayload,
+      executionId,
       onBeforeActivation: options?.onStreamResolved,
       enforceCategory: options?.enforceCategory,
       suppressErrorNotification: options?.isSubagent,
@@ -842,7 +846,8 @@ export async function executeMergeAgent(
       inputFile,
       editedFile,
     };
-    const ctx = await resolveAndAcquireStream(configPayload, undefined, {
+    const ctx = await buildAgentLaunchContext({
+      configPayload,
       taskType: 'Merge task',
     });
     const { streamId, executionId } = ctx;
@@ -895,16 +900,14 @@ export async function resumeToolUseFromSnapshot(
 ): Promise<void> {
   const host = runtimeHost ?? getAgentRuntimeHost();
   return runWithAgentRuntimeHost(host, async () => {
-    const ctx = await resolveAndAcquireStream(
-      snapshot.agentConfig,
-      snapshot.executionId,
-      {
-        streamTabIdOverride: snapshot.streamId,
-        // resumeCommand surfaces its own warning toast on failure; skip the
-        // bus-level error to avoid double-notifying.
-        suppressErrorNotification: true,
-      },
-    );
+    const ctx = await buildAgentLaunchContext({
+      configPayload: snapshot.agentConfig,
+      executionId: snapshot.executionId,
+      streamTabIdOverride: snapshot.streamId,
+      // resumeCommand surfaces its own warning toast on failure; skip the
+      // bus-level error to avoid double-notifying.
+      suppressErrorNotification: true,
+    });
     // Recover delegation depth from the persisted parent-execution chain
     // so resumed subagents remain gated by the nested-delegation policy
     // instead of silently promoting to root.

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -169,48 +169,14 @@ interface AgentLaunchInput {
   suppressErrorNotification?: boolean;
 }
 
-interface AgentLaunchPlan extends Omit<
-  AgentLaunchInput,
-  'executionId' | 'runtimeHost'
-> {
-  executionId: ExecutionId;
-  runtimeHost: AgentRuntimeHost;
-  preliminaryStreamId?: StreamTabId;
-}
-
-function createAgentLaunchPlan(input: AgentLaunchInput): AgentLaunchPlan {
-  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
-  const executionId = input.executionId ?? generateExecutionId();
-  const preliminaryStreamId = input.streamTabIdOverride
-    ? undefined
-    : getPreliminaryStreamId(input.configPayload, executionId);
-
-  return {
-    ...input,
-    executionId,
-    runtimeHost,
-    preliminaryStreamId,
-  };
-}
-
-function getPreliminaryStreamId(
-  configPayload: AgentConfigPayload,
+async function assembleAgentLaunchContext(
+  input: AgentLaunchInput,
   executionId: ExecutionId,
-): StreamTabId {
-  if (!configPayload.agent || !configPayload.model) {
-    throw new Error('Missing required fields: model and/or agent');
-  }
-
-  return getStreamTabId(configPayload.agent, configPayload.model, {
-    executionId,
-  });
-}
-
-async function createAgentLaunchContext(
-  launch: AgentLaunchPlan,
+  runtimeHost: AgentRuntimeHost,
+  preliminaryStreamId: StreamTabId | undefined,
   onActivated: (streamId: StreamTabId) => void,
 ): Promise<AgentLaunchContext> {
-  const { configPayload, executionId, runtimeHost } = launch;
+  const { configPayload } = input;
   const fullConfig = AgentConfigSchema.parse(configPayload);
   const resolution = await getAgentPath(fullConfig.agent, {
     preferMultiple: fullConfig.useMultipleOutputs,
@@ -232,7 +198,7 @@ async function createAgentLaunchContext(
   // because many code paths pass pre-parsed configs where agentCategory was
   // prefaulted to Workflow by the schema (not explicitly chosen by the caller).
   if (
-    launch.enforceCategory &&
+    input.enforceCategory &&
     configPayload.agentCategory &&
     configPayload.agentCategory !== setting.agentCategory
   ) {
@@ -260,7 +226,8 @@ async function createAgentLaunchContext(
   const modelHandler = createModelHandler(MODEL_CONFIGS[fullConfig.model]);
 
   const streamId =
-    launch.streamTabIdOverride ??
+    input.streamTabIdOverride ??
+    preliminaryStreamId ??
     getStreamTabId(config.agent, fullConfig.model, { executionId });
 
   const agentLogger = new AgentLogger(streamId, true);
@@ -273,7 +240,7 @@ async function createAgentLaunchContext(
   modelHandler.setAgentCategory(setting.agentCategory);
   modelHandler.setLogger(agentLogger);
 
-  launch.onBeforeActivation?.(streamId);
+  input.onBeforeActivation?.(streamId);
 
   runtimeHost.emit('setActiveStream', {
     streamId,
@@ -286,7 +253,7 @@ async function createAgentLaunchContext(
   // Log the initial instruction as a user message so both workflow and
   // tool-use tabs display it inline with the stream log (no separate panel).
   const initialInstruction =
-    config.instruction?.trim() && !launch.streamTabIdOverride
+    config.instruction?.trim() && !input.streamTabIdOverride
       ? config.instruction.trim()
       : undefined;
 
@@ -572,18 +539,22 @@ function buildFallbackNotification(config: AgentConfig) {
  *
  *  - Post-activation failure (`activatedStreamId` set): the UI tab is
  *    visible. Surface the failure on it and transition to ERROR so the
- *    tab doesn't hang in INITIALIZING. Release the preliminary lock only
- *    when the activation id differs from the reserved id. They should match
- *    for normal launches; the mismatch guard keeps future stream-id changes
- *    from leaking an initializing lock.
+ *    tab doesn't hang in INITIALIZING.
  */
 function compensateFailedActivation(args: {
-  launch: AgentLaunchPlan;
+  configPayload: AgentConfigPayload;
+  preliminaryStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
+  runtimeHost: AgentRuntimeHost;
   err: unknown;
 }): void {
-  const { launch, activatedStreamId, err } = args;
-  const { configPayload, preliminaryStreamId, runtimeHost } = launch;
+  const {
+    configPayload,
+    preliminaryStreamId,
+    activatedStreamId,
+    runtimeHost,
+    err,
+  } = args;
 
   if (activatedStreamId) {
     new AgentLogger(activatedStreamId, true).logError(
@@ -594,9 +565,10 @@ function compensateFailedActivation(args: {
     StreamStatusService.set(activatedStreamId, STREAM_STATUS.ERROR, {
       runtimeHost,
     });
+    return;
   }
 
-  if (preliminaryStreamId && preliminaryStreamId !== activatedStreamId) {
+  if (preliminaryStreamId) {
     StreamStatusService.releaseIfInitializing(preliminaryStreamId, {
       runtimeHost,
     });
@@ -614,29 +586,44 @@ function compensateFailedActivation(args: {
 async function buildAgentLaunchContext(
   input: AgentLaunchInput,
 ): Promise<AgentLaunchContext> {
-  const launch = createAgentLaunchPlan(input);
+  const { configPayload } = input;
+  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
+  const executionId = input.executionId ?? generateExecutionId();
 
-  if (launch.preliminaryStreamId) {
-    acquireStreamOrThrow(
-      launch.preliminaryStreamId,
-      launch.runtimeHost,
-      launch.taskType,
+  let preliminaryStreamId: StreamTabId | undefined;
+  if (!input.streamTabIdOverride) {
+    if (!configPayload.agent || !configPayload.model) {
+      throw new Error('Missing required fields: model and/or agent');
+    }
+    preliminaryStreamId = getStreamTabId(
+      configPayload.agent,
+      configPayload.model,
+      { executionId },
     );
+    acquireStreamOrThrow(preliminaryStreamId, runtimeHost, input.taskType);
   }
 
   let activatedStreamId: StreamTabId | undefined;
   try {
-    return await createAgentLaunchContext(launch, (streamId) => {
-      activatedStreamId = streamId;
-    });
+    return await assembleAgentLaunchContext(
+      input,
+      executionId,
+      runtimeHost,
+      preliminaryStreamId,
+      (streamId) => {
+        activatedStreamId = streamId;
+      },
+    );
   } catch (err) {
     compensateFailedActivation({
-      launch,
+      configPayload,
+      preliminaryStreamId,
       activatedStreamId,
+      runtimeHost,
       err,
     });
-    if (!launch.suppressErrorNotification && !(err instanceof ZodError)) {
-      launch.runtimeHost.emit('requestShowError', {
+    if (!input.suppressErrorNotification && !(err instanceof ZodError)) {
+      runtimeHost.emit('requestShowError', {
         message: toErrorMessage(err),
       });
     }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -173,7 +173,7 @@ async function assembleAgentLaunchContext(
   input: AgentLaunchInput,
   executionId: ExecutionId,
   runtimeHost: AgentRuntimeHost,
-  preliminaryStreamId: StreamTabId | undefined,
+  onReserved: (streamId: StreamTabId) => void,
   onActivated: (streamId: StreamTabId) => void,
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
@@ -227,8 +227,12 @@ async function assembleAgentLaunchContext(
 
   const streamId =
     input.streamTabIdOverride ??
-    preliminaryStreamId ??
     getStreamTabId(config.agent, fullConfig.model, { executionId });
+
+  if (!input.streamTabIdOverride) {
+    acquireStreamOrThrow(streamId, runtimeHost, input.taskType);
+    onReserved(streamId);
+  }
 
   const agentLogger = new AgentLogger(streamId, true);
   const usageReporter = new AgentUsageReporter(
@@ -534,8 +538,8 @@ function buildFallbackNotification(config: AgentConfig) {
  * Saga-style compensation for a failed stream activation.
  *
  *  - Pre-activation failure (no `activatedStreamId`): the UI tab was never
- *    registered. Release the preliminary lock if we held it; the caller
- *    won't ever see a stream.
+ *    registered. Release the reserved lock if we held it; the caller won't
+ *    ever see a stream.
  *
  *  - Post-activation failure (`activatedStreamId` set): the UI tab is
  *    visible. Surface the failure on it and transition to ERROR so the
@@ -543,14 +547,14 @@ function buildFallbackNotification(config: AgentConfig) {
  */
 function compensateFailedActivation(args: {
   configPayload: AgentConfigPayload;
-  preliminaryStreamId?: StreamTabId;
+  reservedStreamId?: StreamTabId;
   activatedStreamId?: StreamTabId;
   runtimeHost: AgentRuntimeHost;
   err: unknown;
 }): void {
   const {
     configPayload,
-    preliminaryStreamId,
+    reservedStreamId,
     activatedStreamId,
     runtimeHost,
     err,
@@ -568,16 +572,16 @@ function compensateFailedActivation(args: {
     return;
   }
 
-  if (preliminaryStreamId) {
-    StreamStatusService.releaseIfInitializing(preliminaryStreamId, {
+  if (reservedStreamId) {
+    StreamStatusService.releaseIfInitializing(reservedStreamId, {
       runtimeHost,
     });
   }
 }
 
 /**
- * Resolves agent context and acquires the preliminary stream lock before the
- * UI is activated.
+ * Resolves agent context and reserves the final stream id before the UI is
+ * activated.
  *
  * Treats the `setActiveStream` emission as a transactional commit point:
  * resolution failures before that point release the lock silently; failures
@@ -589,27 +593,23 @@ async function buildAgentLaunchContext(
   const { configPayload } = input;
   const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
   const executionId = input.executionId ?? generateExecutionId();
-
-  let preliminaryStreamId: StreamTabId | undefined;
-  if (!input.streamTabIdOverride) {
-    if (!configPayload.agent || !configPayload.model) {
-      throw new Error('Missing required fields: model and/or agent');
-    }
-    preliminaryStreamId = getStreamTabId(
-      configPayload.agent,
-      configPayload.model,
-      { executionId },
-    );
-    acquireStreamOrThrow(preliminaryStreamId, runtimeHost, input.taskType);
+  if (
+    !input.streamTabIdOverride &&
+    (!configPayload.agent || !configPayload.model)
+  ) {
+    throw new Error('Missing required fields: model and/or agent');
   }
 
+  let reservedStreamId: StreamTabId | undefined;
   let activatedStreamId: StreamTabId | undefined;
   try {
     return await assembleAgentLaunchContext(
       input,
       executionId,
       runtimeHost,
-      preliminaryStreamId,
+      (streamId) => {
+        reservedStreamId = streamId;
+      },
       (streamId) => {
         activatedStreamId = streamId;
       },
@@ -617,7 +617,7 @@ async function buildAgentLaunchContext(
   } catch (err) {
     compensateFailedActivation({
       configPayload,
-      preliminaryStreamId,
+      reservedStreamId,
       activatedStreamId,
       runtimeHost,
       err,

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -573,8 +573,9 @@ function buildFallbackNotification(config: AgentConfig) {
  *  - Post-activation failure (`activatedStreamId` set): the UI tab is
  *    visible. Surface the failure on it and transition to ERROR so the
  *    tab doesn't hang in INITIALIZING. Release the preliminary lock only
- *    when the activation switched to a different id (rare: when
- *    `useMultipleOutputs` flips during resolution).
+ *    when the activation id differs from the reserved id. They should match
+ *    for normal launches; the mismatch guard keeps future stream-id changes
+ *    from leaking an initializing lock.
  */
 function compensateFailedActivation(args: {
   launch: AgentLaunchPlan;
@@ -603,8 +604,8 @@ function compensateFailedActivation(args: {
 }
 
 /**
- * Resolves agent context and acquires stream lock, handling the preliminary→final
- * stream ID correction that occurs when useMultipleOutputs changes during resolution.
+ * Resolves agent context and acquires the preliminary stream lock before the
+ * UI is activated.
  *
  * Treats the `setActiveStream` emission as a transactional commit point:
  * resolution failures before that point release the lock silently; failures

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -173,7 +173,7 @@ async function assembleAgentLaunchContext(
   input: AgentLaunchInput,
   executionId: ExecutionId,
   runtimeHost: AgentRuntimeHost,
-  onReserved: (streamId: StreamTabId) => void,
+  reservedStreamId: StreamTabId | undefined,
   onActivated: (streamId: StreamTabId) => void,
 ): Promise<AgentLaunchContext> {
   const { configPayload } = input;
@@ -227,12 +227,8 @@ async function assembleAgentLaunchContext(
 
   const streamId =
     input.streamTabIdOverride ??
+    reservedStreamId ??
     getStreamTabId(config.agent, fullConfig.model, { executionId });
-
-  if (!input.streamTabIdOverride) {
-    acquireStreamOrThrow(streamId, runtimeHost, input.taskType);
-    onReserved(streamId);
-  }
 
   const agentLogger = new AgentLogger(streamId, true);
   const usageReporter = new AgentUsageReporter(
@@ -600,16 +596,20 @@ async function buildAgentLaunchContext(
     throw new Error('Missing required fields: model and/or agent');
   }
 
-  let reservedStreamId: StreamTabId | undefined;
+  const reservedStreamId = input.streamTabIdOverride
+    ? undefined
+    : getStreamTabId(configPayload.agent, configPayload.model, { executionId });
+  if (reservedStreamId) {
+    acquireStreamOrThrow(reservedStreamId, runtimeHost, input.taskType);
+  }
+
   let activatedStreamId: StreamTabId | undefined;
   try {
     return await assembleAgentLaunchContext(
       input,
       executionId,
       runtimeHost,
-      (streamId) => {
-        reservedStreamId = streamId;
-      },
+      reservedStreamId,
       (streamId) => {
         activatedStreamId = streamId;
       },


### PR DESCRIPTION
## Summary

- replace the overlapping agent launch resolve option shapes with a single typed launch input and launch plan
- make execution id, runtime host, preliminary stream id, stream activation, and activation-failure compensation flow through that launch plan
- keep normal launch, merge launch, and tool-use resume on the same launch-context builder without changing runtime behavior

Closes #3324

## Validation

- npm run format
- npm run typecheck
- npm run compile-tests
- npm run test:kernel
- npm run lint
- npm run compile:safe
- npm run compile
- git diff --check

## Review Gate

This PR should not be merged until the latest-head checks and reviews from Claude Code, Cursor Bugbot, Copilot, and Codex have finished, unless a maintainer explicitly approves bypassing a stuck external reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors stream-id reservation/activation and failure-compensation logic during agent startup; mistakes could cause stuck/duplicate streams or missing error surfacing in the UI.
> 
> **Overview**
> Simplifies agent startup by replacing multiple overlapping “resolve” option shapes with a single `AgentLaunchInput` and a new `buildAgentLaunchContext`/`assembleAgentLaunchContext` flow.
> 
> Stream handling is reworked to **reserve the final stream ID before UI activation**, track the activated stream explicitly, and centralize saga-style compensation (release reserved locks on pre-activation failures; log+set `ERROR` on post-activation failures).
> 
> All entry points (`executeAgent`, `executeMergeAgent`, `resumeToolUseFromSnapshot`) are updated to use the shared launch-context builder, including consistent suppression of `requestShowError` notifications for subagents/resume paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eea97a8a990d56b7fabfe6dc98c90ef2f823885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->