### PR TITLE
refactor: extract Supabase session coordinator

### DIFF
--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -23,7 +23,6 @@ import {
   SupabaseSessionCoordinator,
   type SupabaseSession,
 } from './SupabaseSession';
-import type { SessionTokens } from './TokenProvider';
 import type { SupabaseUriHandler } from './UriHandler';
 
 /** Timeout for Edge Function requests (30 seconds) */
@@ -104,10 +103,6 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
     return this.instance;
   }
 
-  async whenReady(): Promise<void> {
-    await this.sessionCoordinator.whenReady();
-  }
-
   /**
    * Store session with optional notification.
    * @param notify - If true, fires session change event and clears caches (for new logins)
@@ -125,25 +120,6 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
         changed: [],
       });
     }
-  }
-
-  /**
-   * Ensure the access token is fresh, refreshing proactively if near expiry.
-   * Called by SupabaseClient.getAccessToken() to avoid token expiration during
-   * long-running operations (e.g., GPT-5 background mode).
-   *
-   * @returns Fresh access token, or null if no session or refresh failed
-   */
-  async ensureFreshToken(forceRefresh?: boolean): Promise<string | null> {
-    return this.sessionCoordinator.ensureFreshToken(forceRefresh);
-  }
-
-  /**
-   * Get access and refresh tokens from secure storage.
-   * Ensures tokens are fresh before returning.
-   */
-  async getSessionTokens(): Promise<SessionTokens | null> {
-    return this.sessionCoordinator.getSessionTokens();
   }
 
   /**

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
-import { z } from 'zod';
 import { toErrorMessage } from '@common/errors/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { SupabaseClient } from './SupabaseClient';
-import { parseAuthCallbackTokens } from './core/authCallback';
 import {
   SUPABASE_CONFIG,
   DEFAULT_OAUTH_PROVIDER,
@@ -20,32 +18,13 @@ import {
 } from './config';
 import { getServerSideKeyService } from './serverKeys';
 import {
-  parseStoredSupabaseSession,
-  toStorableSupabaseSession,
+  fetchWithTimeout,
+  parseTokenExchangeResponse,
+  SupabaseSessionCoordinator,
   type SupabaseSession,
 } from './SupabaseSession';
-import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
+import type { SessionTokens } from './TokenProvider';
 import type { SupabaseUriHandler } from './UriHandler';
-
-/** Response schema for GitHub token exchange Edge Function. */
-const GitHubTokenExchangeSchema = z.object({
-  access_token: z.string(),
-  refresh_token: z.string(),
-  expires_at: z.number().optional(),
-  expires_in: z.number().optional(),
-  token_type: z.string(),
-  user: z.object({
-    id: z.string(),
-    email: z.string().nullish(),
-    user_metadata: z
-      .object({
-        avatar_url: z.string().optional(),
-        user_name: z.string().optional(),
-      })
-      .optional(),
-  }),
-});
-type GitHubTokenExchangeResponse = z.infer<typeof GitHubTokenExchangeSchema>;
 
 /** Timeout for Edge Function requests (30 seconds) */
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
@@ -60,29 +39,6 @@ const GITHUB_TOKEN_TYPE_MAP: Record<string, string> = {
   ghs_: 'server-to-server token',
 };
 
-function parseStoredProviderSession(
-  sessionData: string | undefined,
-): SupabaseSession | null {
-  return parseStoredSupabaseSession(sessionData, {
-    logSource: 'SupabaseAuthProvider',
-    warn: logger.warn,
-  });
-}
-
-/** Result of parsing auth callback URI */
-interface CallbackParseResult {
-  success: true;
-  session: SupabaseSession;
-}
-
-interface CallbackParseError {
-  success: false;
-  error: string;
-  isAuthError?: boolean;
-}
-
-type CallbackResult = CallbackParseResult | CallbackParseError;
-
 /**
  * Type guard to check if a string is a valid OAuth provider.
  */
@@ -96,9 +52,7 @@ function isOAuthProvider(value: string | undefined): value is OAuthProvider {
  * Authentication provider for Supabase integration.
  * Manages user sessions for remote agent access.
  */
-export class SupabaseAuthProvider
-  implements vscode.AuthenticationProvider, AuthTokenProvider
-{
+export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
   private static instance: SupabaseAuthProvider | null = null;
 
   private _onDidChangeSessions =
@@ -107,7 +61,7 @@ export class SupabaseAuthProvider
 
   private uriHandler: SupabaseUriHandler | null = null;
   private uriHandlerSubscription: vscode.Disposable | null = null;
-  private refreshPromise: Promise<SupabaseSession | null> | null = null;
+  private readonly sessionCoordinator: SupabaseSessionCoordinator;
   /** Flag to prevent race conditions between OAuth and magic link handlers */
   private isProcessingCallback = false;
 
@@ -117,8 +71,32 @@ export class SupabaseAuthProvider
       SUPABASE_CONFIG.publicKey,
       context,
     );
+    this.sessionCoordinator = new SupabaseSessionCoordinator({
+      storage: {
+        get: () => Promise.resolve(context.secrets.get(SUPABASE_SESSION_KEY)),
+        store: (sessionData) =>
+          Promise.resolve(
+            context.secrets.store(SUPABASE_SESSION_KEY, sessionData),
+          ),
+        delete: () =>
+          Promise.resolve(context.secrets.delete(SUPABASE_SESSION_KEY)),
+      },
+      getClient: () => SupabaseClient.getClient(),
+      whenReady: async () => {
+        if (!this.uriHandler) {
+          throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
+        }
+      },
+      tokenRefreshThresholdMs: TOKEN_REFRESH_THRESHOLD_MS,
+      defaultSessionExpiryMs: DEFAULT_SESSION_EXPIRY_MS,
+      githubTokenRefreshUrl: GITHUB_TOKEN_REFRESH_URL,
+      edgeFunctionTimeoutMs: EDGE_FUNCTION_TIMEOUT_MS,
+      log: logger,
+      onTokenExpiryChanged: (expiresAt) =>
+        SupabaseClient.setTokenExpiry(expiresAt),
+    });
     SupabaseAuthProvider.instance = this;
-    SupabaseClient.setAuthProvider(this);
+    SupabaseClient.setAuthProvider(this.sessionCoordinator);
   }
 
   /** Get singleton instance for sign out operations. */
@@ -127,9 +105,7 @@ export class SupabaseAuthProvider
   }
 
   async whenReady(): Promise<void> {
-    if (!this.uriHandler) {
-      throw new Error(AUTH_URI_HANDLER_NOT_INITIALIZED);
-    }
+    await this.sessionCoordinator.whenReady();
   }
 
   /**
@@ -140,12 +116,7 @@ export class SupabaseAuthProvider
     session: SupabaseSession,
     notify = false,
   ): Promise<void> {
-    await this.context.secrets.store(
-      SUPABASE_SESSION_KEY,
-      JSON.stringify(session),
-    );
-    // Keep in-memory expiry cache in sync for fast pre-invocation checks.
-    SupabaseClient.setTokenExpiry(session.expiresAt);
+    await this.sessionCoordinator.storeSession(session);
     if (notify) {
       getServerSideKeyService().clearAllCaches();
       this._onDidChangeSessions.fire({
@@ -164,49 +135,7 @@ export class SupabaseAuthProvider
    * @returns Fresh access token, or null if no session or refresh failed
    */
   async ensureFreshToken(forceRefresh?: boolean): Promise<string | null> {
-    try {
-      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
-      const session = parseStoredProviderSession(sessionData);
-      if (!session) {
-        return null;
-      }
-
-      const timeUntilExpiry = session.expiresAt - Date.now();
-
-      // Refresh proactively if token expires within threshold,
-      // or immediately if the caller knows the current token is invalid (relay 401).
-      if (forceRefresh || timeUntilExpiry < TOKEN_REFRESH_THRESHOLD_MS) {
-        logger.info(
-          'SupabaseAuthProvider',
-          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
-        );
-        const refreshed = await this.refreshSession(session);
-        if (refreshed) {
-          return refreshed.accessToken;
-        }
-        // If token is already expired or caller explicitly requested refresh
-        // (e.g., relay rejected the current token), return null so the caller
-        // doesn't get back the same token the server already rejected.
-        if (forceRefresh || timeUntilExpiry <= 0) {
-          logger.warn(
-            'SupabaseAuthProvider',
-            forceRefresh
-              ? 'Force refresh requested but refresh failed, returning null'
-              : 'Token expired and refresh failed, returning null',
-          );
-          return null;
-        }
-        // Token still valid but refresh failed - return existing token
-      }
-
-      return session.accessToken;
-    } catch (error) {
-      logger.error(
-        'SupabaseAuthProvider',
-        `Error ensuring fresh token: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
+    return this.sessionCoordinator.ensureFreshToken(forceRefresh);
   }
 
   /**
@@ -214,25 +143,7 @@ export class SupabaseAuthProvider
    * Ensures tokens are fresh before returning.
    */
   async getSessionTokens(): Promise<SessionTokens | null> {
-    await this.ensureFreshToken();
-
-    try {
-      const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
-      const session = parseStoredProviderSession(sessionData);
-      if (!session) {
-        return null;
-      }
-      return {
-        accessToken: session.accessToken,
-        refreshToken: session.refreshToken,
-      };
-    } catch (error) {
-      logger.error(
-        'SupabaseAuthProvider',
-        `Error getting session tokens: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
+    return this.sessionCoordinator.getSessionTokens();
   }
 
   /**
@@ -274,14 +185,16 @@ export class SupabaseAuthProvider
 
     try {
       // Check if we already have a session (after claiming the lock)
-      const existingSession = parseStoredProviderSession(
-        await this.context.secrets.get(SUPABASE_SESSION_KEY),
-      );
+      const existingSession = await this.sessionCoordinator.loadSession();
       if (existingSession) {
         return;
       }
 
-      const result = await this.parseCallbackAndCreateSession(uri);
+      const result = await this.sessionCoordinator.createSessionFromCallback({
+        path: uri.path,
+        query: uri.query,
+        fragment: uri.fragment,
+      });
 
       if (!result.success) {
         if (result.isAuthError) {
@@ -319,63 +232,12 @@ export class SupabaseAuthProvider
     }
   }
 
-  /**
-   * Parse auth callback URI and create a session.
-   * Shared logic for both OAuth and magic link flows.
-   *
-   * Tokens are typically in the fragment (implicit flow), but we also
-   * check query params as fallback for PKCE flow or web environments.
-   */
-  private async parseCallbackAndCreateSession(
-    uri: vscode.Uri,
-  ): Promise<CallbackResult> {
-    const parsedCallback = parseAuthCallbackTokens({
-      path: uri.path,
-      query: uri.query,
-      fragment: uri.fragment,
-    });
-
-    if (!parsedCallback.success) return parsedCallback;
-
-    const { accessToken, refreshToken, expiresIn } = parsedCallback.tokens;
-
-    // Verify user with Supabase
-    const supabase = SupabaseClient.getClient();
-    const { data, error: userError } = await supabase.auth.getUser(accessToken);
-
-    if (userError || !data.user) {
-      return {
-        success: false,
-        error: userError?.message || 'User verification failed',
-        isAuthError: true,
-      };
-    }
-
-    const expiresAt = expiresIn
-      ? Date.now() + parseInt(expiresIn) * 1000
-      : Date.now() + DEFAULT_SESSION_EXPIRY_MS;
-
-    const session: SupabaseSession = {
-      id: data.user.id,
-      accessToken,
-      refreshToken,
-      account: {
-        id: data.user.id,
-        label: data.user.email || data.user.id,
-      },
-      expiresAt,
-    };
-
-    return { success: true, session };
-  }
-
   /** Get sessions from secure storage. */
   async getSessions(
     _scopes?: readonly string[],
     _options?: vscode.AuthenticationProviderSessionOptions,
   ): Promise<vscode.AuthenticationSession[]> {
-    const sessionData = await this.context.secrets.get(SUPABASE_SESSION_KEY);
-    const session = parseStoredProviderSession(sessionData);
+    const session = await this.sessionCoordinator.loadSession();
     if (!session) {
       return [];
     }
@@ -386,7 +248,7 @@ export class SupabaseAuthProvider
 
     try {
       if (Date.now() >= session.expiresAt) {
-        const refreshed = await this.refreshSession(session);
+        const refreshed = await this.sessionCoordinator.refreshSession(session);
         if (!refreshed) {
           await this.handleInvalidSession(session.id, 'expired');
           return [];
@@ -544,7 +406,7 @@ export class SupabaseAuthProvider
       );
 
       // Exchange GitHub token for Supabase session via Edge Function
-      const response = await this.fetchWithTimeout(
+      const response = await fetchWithTimeout(
         GITHUB_TOKEN_EXCHANGE_URL,
         {
           method: 'POST',
@@ -572,7 +434,7 @@ export class SupabaseAuthProvider
         throw new Error(errorMsg);
       }
 
-      const data = await this.parseTokenExchangeResponse(response);
+      const data = await parseTokenExchangeResponse(response, logger);
 
       // Create session in same format as Supabase OAuth
       // Note: expires_at from Edge Function is in seconds, convert to milliseconds
@@ -607,41 +469,6 @@ export class SupabaseAuthProvider
       void vscode.window.showErrorMessage(`Authentication failed: ${message}`);
       throw error;
     }
-  }
-
-  private async fetchWithTimeout(
-    url: string,
-    options: RequestInit,
-    timeoutMs: number,
-    timeoutMessage: string,
-  ): Promise<Response> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      return await fetch(url, { ...options, signal: controller.signal });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(timeoutMessage);
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }
-
-  private async parseTokenExchangeResponse(
-    response: Response,
-  ): Promise<GitHubTokenExchangeResponse> {
-    const rawData = await response.json();
-    const parsed = GitHubTokenExchangeSchema.safeParse(rawData);
-    if (!parsed.success) {
-      logger.error(
-        'SupabaseAuthProvider',
-        `Token exchange response validation failed: ${parsed.error.message}`,
-      );
-      throw new Error('Invalid response format from authentication server');
-    }
-    return parsed.data;
   }
 
   /**
@@ -712,8 +539,7 @@ export class SupabaseAuthProvider
   async removeSession(sessionId: string): Promise<void> {
     try {
       await SupabaseClient.getClient().auth.signOut();
-      await this.context.secrets.delete(SUPABASE_SESSION_KEY);
-      SupabaseClient.setTokenExpiry(null);
+      await this.sessionCoordinator.clearSession();
       // Clear server-side key cache when session is removed (handles automatic invalidation)
       getServerSideKeyService().clearAllCaches();
       this._onDidChangeSessions.fire({
@@ -766,7 +592,12 @@ export class SupabaseAuthProvider
           cleanupListeners();
 
           try {
-            const result = await this.parseCallbackAndCreateSession(uri);
+            const result =
+              await this.sessionCoordinator.createSessionFromCallback({
+                path: uri.path,
+                query: uri.query,
+                fragment: uri.fragment,
+              });
 
             if (!result.success) {
               if (result.error === 'Missing tokens in callback') {
@@ -806,95 +637,6 @@ export class SupabaseAuthProvider
         resolve(null);
       });
     });
-  }
-
-  /**
-   * Refresh session with concurrency protection.
-   * Routes to custom endpoint for GitHub auth sessions, otherwise uses Supabase native refresh.
-   */
-  private async refreshSession(
-    session: SupabaseSession,
-  ): Promise<SupabaseSession | null> {
-    if (this.refreshPromise) {
-      return this.refreshPromise;
-    }
-
-    this.refreshPromise = (
-      session.useCustomRefresh
-        ? this.refreshViaCustomEndpoint(session)
-        : this.refreshViaSupabase(session)
-    )
-      .catch((error) => {
-        logger.error(
-          'SupabaseAuthProvider',
-          `Error refreshing session: ${toErrorMessage(error)}`,
-        );
-        return null;
-      })
-      .finally(() => {
-        this.refreshPromise = null;
-      });
-
-    return this.refreshPromise;
-  }
-
-  private async refreshViaSupabase(
-    session: SupabaseSession,
-  ): Promise<SupabaseSession | null> {
-    const { data, error } =
-      await SupabaseClient.getClient().auth.refreshSession({
-        refresh_token: session.refreshToken,
-      });
-
-    if (error || !data.session) {
-      return null;
-    }
-
-    const refreshed = toStorableSupabaseSession(data.session);
-    await this.storeSession(refreshed);
-    return refreshed;
-  }
-
-  private async refreshViaCustomEndpoint(
-    session: SupabaseSession,
-  ): Promise<SupabaseSession | null> {
-    const response = await this.fetchWithTimeout(
-      GITHUB_TOKEN_REFRESH_URL,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: session.refreshToken }),
-      },
-      EDGE_FUNCTION_TIMEOUT_MS,
-      'Token refresh timeout',
-    );
-
-    if (!response.ok) {
-      logger.warn(
-        'SupabaseAuthProvider',
-        `Token refresh failed: ${response.status}`,
-      );
-      return null;
-    }
-
-    const data = await this.parseTokenExchangeResponse(response);
-    const refreshed: SupabaseSession = {
-      id: data.user.id,
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      account: {
-        id: data.user.id,
-        label: data.user.email || session.account.label,
-      },
-      expiresAt: data.expires_at
-        ? data.expires_at * 1000
-        : Date.now() + DEFAULT_SESSION_EXPIRY_MS,
-      useCustomRefresh: true,
-    };
-
-    await this.storeSession(refreshed);
-    logger.info('SupabaseAuthProvider', 'Token refreshed via custom endpoint');
-    return refreshed;
   }
 
   private toVSCodeSession(

--- a/src/auth/SupabaseAuthProvider.ts
+++ b/src/auth/SupabaseAuthProvider.ts
@@ -21,6 +21,7 @@ import {
   fetchWithTimeout,
   parseTokenExchangeResponse,
   SupabaseSessionCoordinator,
+  toStorableGitHubTokenExchangeSession,
   type SupabaseSession,
 } from './SupabaseSession';
 import type { SupabaseUriHandler } from './UriHandler';
@@ -411,24 +412,11 @@ export class SupabaseAuthProvider implements vscode.AuthenticationProvider {
       }
 
       const data = await parseTokenExchangeResponse(response, logger);
-
-      // Create session in same format as Supabase OAuth
-      // Note: expires_at from Edge Function is in seconds, convert to milliseconds
-      const session: SupabaseSession = {
-        id: data.user.id,
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token,
-        account: {
-          id: data.user.id,
-          label: data.user.email || githubSession.account.label,
-        },
-        expiresAt: data.expires_at
-          ? data.expires_at * 1000
-          : Date.now() + DEFAULT_SESSION_EXPIRY_MS,
-        // Use custom refresh since our tokens are stored in sessions table,
-        // not Supabase's internal auth tables
-        useCustomRefresh: true,
-      };
+      const session = toStorableGitHubTokenExchangeSession(
+        data,
+        githubSession.account.label,
+        DEFAULT_SESSION_EXPIRY_MS,
+      );
 
       await this.storeSession(session, true);
       void vscode.window.showInformationMessage(

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -142,6 +142,9 @@ export async function fetchWithTimeout(
     return await fetchImpl(url, { ...options, signal });
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
+      if (options.signal?.aborted && !controller.signal.aborted) {
+        throw error;
+      }
       throw new Error(timeoutMessage);
     }
     throw error;

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -225,6 +225,27 @@ export function toStorableSupabaseSession(
   };
 }
 
+/** Convert Edge Function token responses into the stored custom-refresh shape. */
+export function toStorableGitHubTokenExchangeSession(
+  data: GitHubTokenExchangeResponse,
+  fallbackLabel: string,
+  defaultSessionExpiryMs: number,
+): SupabaseSession {
+  return {
+    id: data.user.id,
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    account: {
+      id: data.user.id,
+      label: data.user.email || fallbackLabel,
+    },
+    expiresAt: data.expires_at
+      ? data.expires_at * 1000
+      : Date.now() + defaultSessionExpiryMs,
+    useCustomRefresh: true,
+  };
+}
+
 /**
  * Host-neutral coordinator for Supabase session storage, token freshness,
  * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
@@ -455,19 +476,11 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     const data = await parseTokenExchangeResponse(response, this.options.log);
-    const refreshed: SupabaseSession = {
-      id: data.user.id,
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      account: {
-        id: data.user.id,
-        label: data.user.email || session.account.label,
-      },
-      expiresAt: data.expires_at
-        ? data.expires_at * 1000
-        : Date.now() + this.options.defaultSessionExpiryMs,
-      useCustomRefresh: true,
-    };
+    const refreshed = toStorableGitHubTokenExchangeSession(
+      data,
+      session.account.label,
+      this.options.defaultSessionExpiryMs,
+    );
 
     await this.storeSession(refreshed);
     this.options.log?.info?.(

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { toErrorMessage } from '@common/errors/errorMessage';
-import type { Session as SupabaseNativeSession } from '@supabase/supabase-js';
+import {
+  parseAuthCallbackTokens,
+  type AuthCallbackUriParts,
+} from './core/authCallback';
+import type { AuthTokenProvider, SessionTokens } from './TokenProvider';
+import type {
+  Session as SupabaseNativeSession,
+  SupabaseClient as Client,
+} from '@supabase/supabase-js';
 
 export const DEFAULT_SUPABASE_SESSION_EXPIRY_MS = 60 * 60 * 1000;
 
@@ -17,10 +25,75 @@ export const SupabaseSessionSchema = z.object({
 });
 export type SupabaseSession = z.infer<typeof SupabaseSessionSchema>;
 
+/** Response schema for GitHub token exchange and refresh Edge Functions. */
+export const GitHubTokenExchangeSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  expires_at: z.number().optional(),
+  expires_in: z.number().optional(),
+  token_type: z.string(),
+  user: z.object({
+    id: z.string(),
+    email: z.string().nullish(),
+    user_metadata: z
+      .object({
+        avatar_url: z.string().optional(),
+        user_name: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+export type GitHubTokenExchangeResponse = z.infer<
+  typeof GitHubTokenExchangeSchema
+>;
+
 export interface SupabaseSessionParseOptions {
   logSource?: string;
   warn?: (source: string, message: string) => void;
 }
+
+/** Storage boundary for persisted Supabase session data. */
+export interface SupabaseSessionStorage {
+  get(): Promise<string | undefined>;
+  store(sessionData: string): Promise<void>;
+  delete(): Promise<void>;
+}
+
+export interface SupabaseSessionLog {
+  debug?(source: string, message: string): void;
+  info?(source: string, message: string): void;
+  warn?(source: string, message: string): void;
+  error?(source: string, message: string): void;
+}
+
+export interface SupabaseSessionCoordinatorOptions {
+  storage: SupabaseSessionStorage;
+  getClient: () => Client;
+  whenReady: () => Promise<void>;
+  tokenRefreshThresholdMs: number;
+  defaultSessionExpiryMs: number;
+  githubTokenRefreshUrl: string;
+  edgeFunctionTimeoutMs: number;
+  fetch?: typeof fetch;
+  log?: SupabaseSessionLog;
+  onTokenExpiryChanged?: (expiresAt: number | null) => void;
+}
+
+/** Result of converting an auth callback into a stored session. */
+export interface SupabaseCallbackParseResult {
+  success: true;
+  session: SupabaseSession;
+}
+
+export interface SupabaseCallbackParseError {
+  success: false;
+  error: string;
+  isAuthError?: boolean;
+}
+
+export type SupabaseCallbackResult =
+  | SupabaseCallbackParseResult
+  | SupabaseCallbackParseError;
 
 /**
  * Parse and validate stored session data.
@@ -52,6 +125,43 @@ export function parseStoredSupabaseSession(
   }
 }
 
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit,
+  timeoutMs: number,
+  timeoutMessage: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(timeoutMessage);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function parseTokenExchangeResponse(
+  response: Response,
+  log?: SupabaseSessionLog,
+): Promise<GitHubTokenExchangeResponse> {
+  const rawData = await response.json();
+  const parsed = GitHubTokenExchangeSchema.safeParse(rawData);
+  if (!parsed.success) {
+    log?.error?.(
+      'SupabaseSession',
+      `Token exchange response validation failed: ${parsed.error.message}`,
+    );
+    throw new Error('Invalid response format from authentication server');
+  }
+  return parsed.data;
+}
+
 /**
  * Convert Supabase's native Session to our storage format.
  * Handles the snake_case to camelCase and seconds to milliseconds conversions.
@@ -73,4 +183,240 @@ export function toStorableSupabaseSession(
       : Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
     useCustomRefresh: options?.useCustomRefresh,
   };
+}
+
+/**
+ * Host-neutral coordinator for Supabase session storage, token freshness,
+ * OAuth callback conversion, and refresh. Host wrappers own UI and registration.
+ */
+export class SupabaseSessionCoordinator implements AuthTokenProvider {
+  private refreshPromise: Promise<SupabaseSession | null> | null = null;
+
+  constructor(private readonly options: SupabaseSessionCoordinatorOptions) {}
+
+  async whenReady(): Promise<void> {
+    await this.options.whenReady();
+  }
+
+  async loadSession(): Promise<SupabaseSession | null> {
+    return parseStoredSupabaseSession(await this.options.storage.get(), {
+      logSource: 'SupabaseSession',
+      warn: this.options.log?.warn,
+    });
+  }
+
+  async storeSession(session: SupabaseSession): Promise<void> {
+    await this.options.storage.store(JSON.stringify(session));
+    this.options.onTokenExpiryChanged?.(session.expiresAt);
+  }
+
+  async clearSession(): Promise<void> {
+    await this.options.storage.delete();
+    this.options.onTokenExpiryChanged?.(null);
+  }
+
+  /**
+   * Ensure the access token is fresh, refreshing proactively if near expiry.
+   *
+   * @returns Fresh access token, or null if no session or refresh failed.
+   */
+  async ensureFreshToken(forceRefresh?: boolean): Promise<string | null> {
+    try {
+      const session = await this.loadSession();
+      if (!session) {
+        return null;
+      }
+
+      const timeUntilExpiry = session.expiresAt - Date.now();
+
+      if (
+        forceRefresh ||
+        timeUntilExpiry < this.options.tokenRefreshThresholdMs
+      ) {
+        this.options.log?.info?.(
+          'SupabaseSession',
+          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
+        );
+        const refreshed = await this.refreshSession(session);
+        if (refreshed) {
+          return refreshed.accessToken;
+        }
+        if (forceRefresh || timeUntilExpiry <= 0) {
+          this.options.log?.warn?.(
+            'SupabaseSession',
+            forceRefresh
+              ? 'Force refresh requested but refresh failed, returning null'
+              : 'Token expired and refresh failed, returning null',
+          );
+          return null;
+        }
+      }
+
+      return session.accessToken;
+    } catch (error) {
+      this.options.log?.error?.(
+        'SupabaseSession',
+        `Error ensuring fresh token: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /** Get access and refresh tokens from secure storage. */
+  async getSessionTokens(): Promise<SessionTokens | null> {
+    await this.ensureFreshToken();
+
+    try {
+      const session = await this.loadSession();
+      if (!session) {
+        return null;
+      }
+      return {
+        accessToken: session.accessToken,
+        refreshToken: session.refreshToken,
+      };
+    } catch (error) {
+      this.options.log?.error?.(
+        'SupabaseSession',
+        `Error getting session tokens: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Parse auth callback URI parts, verify the user with Supabase, and build a
+   * host-neutral session record.
+   */
+  async createSessionFromCallback(
+    uri: AuthCallbackUriParts,
+  ): Promise<SupabaseCallbackResult> {
+    const parsedCallback = parseAuthCallbackTokens(uri);
+
+    if (!parsedCallback.success) return parsedCallback;
+
+    const { accessToken, refreshToken, expiresIn } = parsedCallback.tokens;
+    const { data, error: userError } = await this.options
+      .getClient()
+      .auth.getUser(accessToken);
+
+    if (userError || !data.user) {
+      return {
+        success: false,
+        error: userError?.message || 'User verification failed',
+        isAuthError: true,
+      };
+    }
+
+    const expiresAt = expiresIn
+      ? Date.now() + Number.parseInt(expiresIn, 10) * 1000
+      : Date.now() + this.options.defaultSessionExpiryMs;
+
+    return {
+      success: true,
+      session: {
+        id: data.user.id,
+        accessToken,
+        refreshToken,
+        account: {
+          id: data.user.id,
+          label: data.user.email || data.user.id,
+        },
+        expiresAt,
+      },
+    };
+  }
+
+  /**
+   * Refresh session with concurrency protection.
+   * Routes to custom endpoint for GitHub auth sessions, otherwise uses Supabase
+   * native refresh.
+   */
+  async refreshSession(
+    session: SupabaseSession,
+  ): Promise<SupabaseSession | null> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = (
+      session.useCustomRefresh
+        ? this.refreshViaCustomEndpoint(session)
+        : this.refreshViaSupabase(session)
+    )
+      .catch((error) => {
+        this.options.log?.error?.(
+          'SupabaseSession',
+          `Error refreshing session: ${toErrorMessage(error)}`,
+        );
+        return null;
+      })
+      .finally(() => {
+        this.refreshPromise = null;
+      });
+
+    return this.refreshPromise;
+  }
+
+  private async refreshViaSupabase(
+    session: SupabaseSession,
+  ): Promise<SupabaseSession | null> {
+    const { data, error } = await this.options.getClient().auth.refreshSession({
+      refresh_token: session.refreshToken,
+    });
+
+    if (error || !data.session) {
+      return null;
+    }
+
+    const refreshed = toStorableSupabaseSession(data.session);
+    await this.storeSession(refreshed);
+    return refreshed;
+  }
+
+  private async refreshViaCustomEndpoint(
+    session: SupabaseSession,
+  ): Promise<SupabaseSession | null> {
+    const response = await fetchWithTimeout(
+      this.options.githubTokenRefreshUrl,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: session.refreshToken }),
+      },
+      this.options.edgeFunctionTimeoutMs,
+      'Token refresh timeout',
+      this.options.fetch,
+    );
+
+    if (!response.ok) {
+      this.options.log?.warn?.(
+        'SupabaseSession',
+        `Token refresh failed: ${response.status}`,
+      );
+      return null;
+    }
+
+    const data = await parseTokenExchangeResponse(response, this.options.log);
+    const refreshed: SupabaseSession = {
+      id: data.user.id,
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      account: {
+        id: data.user.id,
+        label: data.user.email || session.account.label,
+      },
+      expiresAt: data.expires_at
+        ? data.expires_at * 1000
+        : Date.now() + this.options.defaultSessionExpiryMs,
+      useCustomRefresh: true,
+    };
+
+    await this.storeSession(refreshed);
+    this.options.log?.info?.(
+      'SupabaseSession',
+      'Token refreshed via custom endpoint',
+    );
+    return refreshed;
+  }
 }

--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -134,16 +134,53 @@ export async function fetchWithTimeout(
 ): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const { signal, cleanup } = combineAbortSignals(
+    options.signal ?? undefined,
+    controller.signal,
+  );
   try {
-    return await fetchImpl(url, { ...options, signal: controller.signal });
+    return await fetchImpl(url, { ...options, signal });
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
       throw new Error(timeoutMessage);
     }
     throw error;
   } finally {
+    cleanup();
     clearTimeout(timeoutId);
   }
+}
+
+function combineAbortSignals(
+  upstreamSignal: AbortSignal | undefined,
+  timeoutSignal: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } {
+  if (!upstreamSignal) {
+    return { signal: timeoutSignal, cleanup: () => {} };
+  }
+
+  if (typeof AbortSignal.any === 'function') {
+    return {
+      signal: AbortSignal.any([upstreamSignal, timeoutSignal]),
+      cleanup: () => {},
+    };
+  }
+
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  upstreamSignal.addEventListener('abort', abort, { once: true });
+  timeoutSignal.addEventListener('abort', abort, { once: true });
+  if (upstreamSignal.aborted || timeoutSignal.aborted) {
+    controller.abort();
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      upstreamSignal.removeEventListener('abort', abort);
+      timeoutSignal.removeEventListener('abort', abort);
+    },
+  };
 }
 
 export async function parseTokenExchangeResponse(
@@ -264,7 +301,9 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
 
   /** Get access and refresh tokens from secure storage. */
   async getSessionTokens(): Promise<SessionTokens | null> {
-    await this.ensureFreshToken();
+    if (!(await this.ensureFreshToken())) {
+      return null;
+    }
 
     try {
       const session = await this.loadSession();
@@ -308,9 +347,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       };
     }
 
-    const expiresAt = expiresIn
-      ? Date.now() + Number.parseInt(expiresIn, 10) * 1000
-      : Date.now() + this.options.defaultSessionExpiryMs;
+    const expiresAt = this.getCallbackExpiry(expiresIn);
 
     return {
       success: true,
@@ -372,6 +409,23 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     const refreshed = toStorableSupabaseSession(data.session);
     await this.storeSession(refreshed);
     return refreshed;
+  }
+
+  private getCallbackExpiry(expiresIn: string | null): number {
+    if (!expiresIn) {
+      return Date.now() + this.options.defaultSessionExpiryMs;
+    }
+
+    const expiresInSeconds = Number(expiresIn);
+    if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+      this.options.log?.warn?.(
+        'SupabaseSession',
+        `Invalid expires_in callback value: ${expiresIn}`,
+      );
+      return Date.now() + this.options.defaultSessionExpiryMs;
+    }
+
+    return Date.now() + expiresInSeconds * 1000;
   }
 
   private async refreshViaCustomEndpoint(

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -5,12 +5,85 @@ import { strict as assert } from 'assert';
 import {
   DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
   parseStoredSupabaseSession,
+  SupabaseSessionCoordinator,
   toStorableSupabaseSession,
   type SupabaseSession,
+  type SupabaseSessionStorage,
 } from '@auth/SupabaseSession';
 
 // Third-party imports
-import type { Session as SupabaseNativeSession } from '@supabase/supabase-js';
+import type {
+  Session as SupabaseNativeSession,
+  SupabaseClient as Client,
+} from '@supabase/supabase-js';
+
+function createMemoryStorage(initial?: SupabaseSession): {
+  storage: SupabaseSessionStorage;
+  read: () => SupabaseSession | null;
+} {
+  let value = initial ? JSON.stringify(initial) : undefined;
+  return {
+    storage: {
+      get: async () => value,
+      store: async (sessionData) => {
+        value = sessionData;
+      },
+      delete: async () => {
+        value = undefined;
+      },
+    },
+    read: () => parseStoredSupabaseSession(value),
+  };
+}
+
+function createClient(overrides?: Partial<Client['auth']>): Client {
+  return {
+    auth: {
+      getUser: async () => ({
+        data: { user: { id: 'user-id', email: 'user@example.com' } },
+        error: null,
+      }),
+      refreshSession: async () => ({
+        data: {
+          session: {
+            access_token: 'refreshed-access',
+            refresh_token: 'refreshed-refresh',
+            expires_at: 456,
+            user: { id: 'user-id', email: 'user@example.com' },
+          },
+        },
+        error: null,
+      }),
+      ...overrides,
+    },
+  } as unknown as Client;
+}
+
+function createCoordinator(options?: {
+  initialSession?: SupabaseSession;
+  client?: Client;
+  fetch?: typeof fetch;
+  onTokenExpiryChanged?: (expiresAt: number | null) => void;
+}): {
+  coordinator: SupabaseSessionCoordinator;
+  read: () => SupabaseSession | null;
+} {
+  const { storage, read } = createMemoryStorage(options?.initialSession);
+  return {
+    coordinator: new SupabaseSessionCoordinator({
+      storage,
+      getClient: () => options?.client ?? createClient(),
+      whenReady: async () => {},
+      tokenRefreshThresholdMs: 60_000,
+      defaultSessionExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+      githubTokenRefreshUrl: 'https://example.supabase.co/functions/v1/refresh',
+      edgeFunctionTimeoutMs: 30_000,
+      fetch: options?.fetch,
+      onTokenExpiryChanged: options?.onTokenExpiryChanged,
+    }),
+    read,
+  };
+}
 
 describe('SupabaseSession', () => {
   describe('parseStoredSupabaseSession', () => {
@@ -27,7 +100,7 @@ describe('SupabaseSession', () => {
           id: 'user-id',
           label: 'user@example.com',
         },
-        expiresAt: 123_000,
+        expiresAt: Date.now() + 120_000,
       };
 
       assert.deepEqual(
@@ -103,6 +176,103 @@ describe('SupabaseSession', () => {
       assert.ok(
         session.expiresAt <= Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
       );
+    });
+  });
+
+  describe('SupabaseSessionCoordinator', () => {
+    it('stores session data and exposes session tokens', async () => {
+      const expiries: Array<number | null> = [];
+      const { coordinator, read } = createCoordinator({
+        onTokenExpiryChanged: (expiresAt) => expiries.push(expiresAt),
+      });
+      const session: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() + 120_000,
+      };
+
+      await coordinator.storeSession(session);
+
+      assert.deepEqual(read(), session);
+      assert.deepEqual(await coordinator.getSessionTokens(), {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+      });
+      assert.deepEqual(expiries, [session.expiresAt]);
+    });
+
+    it('creates a session from host-neutral callback URI parts', async () => {
+      const { coordinator } = createCoordinator();
+
+      const result = await coordinator.createSessionFromCallback({
+        path: '/auth-callback',
+        fragment: new URLSearchParams({
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_in: '3600',
+        }).toString(),
+      });
+
+      assert.equal(result.success, true);
+      if (!result.success) return;
+      assert.equal(result.session.id, 'user-id');
+      assert.equal(result.session.accessToken, 'access-token');
+      assert.equal(result.session.refreshToken, 'refresh-token');
+      assert.deepEqual(result.session.account, {
+        id: 'user-id',
+        label: 'user@example.com',
+      });
+      assert.ok(result.session.expiresAt > Date.now());
+    });
+
+    it('refreshes custom sessions through the injected fetch boundary', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() - 1_000,
+        useCustomRefresh: true,
+      };
+      const { coordinator, read } = createCoordinator({
+        initialSession,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              refresh_token: 'new-refresh',
+              expires_at: 789,
+              token_type: 'bearer',
+              user: {
+                id: 'user-id',
+                email: 'new@example.com',
+              },
+            }),
+            { status: 200 },
+          ),
+      });
+
+      assert.equal(await coordinator.ensureFreshToken(), 'new-access');
+
+      assert.deepEqual(read(), {
+        id: 'user-id',
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        account: {
+          id: 'user-id',
+          label: 'new@example.com',
+        },
+        expiresAt: 789_000,
+        useCustomRefresh: true,
+      });
     });
   });
 });

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -7,6 +7,7 @@ import {
   fetchWithTimeout,
   parseStoredSupabaseSession,
   SupabaseSessionCoordinator,
+  toStorableGitHubTokenExchangeSession,
   toStorableSupabaseSession,
   type SupabaseSession,
   type SupabaseSessionStorage,
@@ -173,6 +174,60 @@ describe('SupabaseSession', () => {
 
       const session = toStorableSupabaseSession(nativeSession);
 
+      assert.ok(session.expiresAt >= earliestExpiry);
+      assert.ok(
+        session.expiresAt <= Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+      );
+    });
+  });
+
+  describe('toStorableGitHubTokenExchangeSession', () => {
+    it('converts GitHub token exchange responses into the stored shape', () => {
+      const session = toStorableGitHubTokenExchangeSession(
+        {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_at: 123,
+          token_type: 'bearer',
+          user: {
+            id: 'user-id',
+            email: 'user@example.com',
+          },
+        },
+        'fallback@example.com',
+        DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+      );
+
+      assert.deepEqual(session, {
+        id: 'user-id',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: 123_000,
+        useCustomRefresh: true,
+      });
+    });
+
+    it('falls back to the supplied label and default expiry', () => {
+      const earliestExpiry = Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS;
+      const session = toStorableGitHubTokenExchangeSession(
+        {
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          token_type: 'bearer',
+          user: {
+            id: 'user-id',
+            email: null,
+          },
+        },
+        'fallback@example.com',
+        DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+      );
+
+      assert.equal(session.account.label, 'fallback@example.com');
       assert.ok(session.expiresAt >= earliestExpiry);
       assert.ok(
         session.expiresAt <= Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -4,6 +4,7 @@ import { strict as assert } from 'assert';
 // Local imports - auth
 import {
   DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+  fetchWithTimeout,
   parseStoredSupabaseSession,
   SupabaseSessionCoordinator,
   toStorableSupabaseSession,
@@ -230,6 +231,28 @@ describe('SupabaseSession', () => {
       assert.ok(result.session.expiresAt > Date.now());
     });
 
+    it('falls back to default callback expiry when expires_in is invalid', async () => {
+      const { coordinator } = createCoordinator();
+      const earliestExpiry = Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS;
+
+      const result = await coordinator.createSessionFromCallback({
+        path: '/auth-callback',
+        fragment: new URLSearchParams({
+          access_token: 'access-token',
+          refresh_token: 'refresh-token',
+          expires_in: 'not-a-number',
+        }).toString(),
+      });
+
+      assert.equal(result.success, true);
+      if (!result.success) return;
+      assert.ok(result.session.expiresAt >= earliestExpiry);
+      assert.ok(
+        result.session.expiresAt <=
+          Date.now() + DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+      );
+    });
+
     it('refreshes custom sessions through the injected fetch boundary', async () => {
       const initialSession: SupabaseSession = {
         id: 'user-id',
@@ -273,6 +296,49 @@ describe('SupabaseSession', () => {
         expiresAt: 789_000,
         useCustomRefresh: true,
       });
+    });
+
+    it('does not return expired session tokens when refresh fails', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() - 1_000,
+        useCustomRefresh: true,
+      };
+      const { coordinator } = createCoordinator({
+        initialSession,
+        fetch: async () =>
+          new Response(JSON.stringify({ error: 'invalid refresh token' }), {
+            status: 401,
+          }),
+      });
+
+      assert.equal(await coordinator.getSessionTokens(), null);
+    });
+
+    it('preserves upstream abort signals when adding a timeout', async () => {
+      const upstream = new AbortController();
+      let fetchSignal: AbortSignal | undefined;
+
+      await fetchWithTimeout(
+        'https://example.com',
+        { signal: upstream.signal },
+        30_000,
+        'timeout',
+        async (_url, init) => {
+          fetchSignal = init?.signal ?? undefined;
+          upstream.abort();
+          assert.equal(fetchSignal?.aborted, true);
+          return new Response(null, { status: 204 });
+        },
+      );
+
+      assert.ok(fetchSignal);
     });
   });
 });

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -340,5 +340,29 @@ describe('SupabaseSession', () => {
 
       assert.ok(fetchSignal);
     });
+
+    it('preserves upstream abort errors instead of reporting timeout', async () => {
+      const upstream = new AbortController();
+
+      await assert.rejects(
+        fetchWithTimeout(
+          'https://example.com',
+          { signal: upstream.signal },
+          30_000,
+          'timeout',
+          async (_url, init) => {
+            upstream.abort();
+            throw new DOMException(
+              init?.signal?.reason ?? 'Aborted',
+              'AbortError',
+            );
+          },
+        ),
+        (error) =>
+          error instanceof DOMException &&
+          error.name === 'AbortError' &&
+          error.message !== 'timeout',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extract the Supabase session lifecycle into a host-neutral coordinator while keeping the VS Code authentication provider focused on VS Code registration, UI notifications, and built-in GitHub login glue.

## Changes

- Add `SupabaseSessionCoordinator` as the `AuthTokenProvider` implementation for stored session parsing, token freshness, callback-token conversion, and Supabase/custom refresh.
- Keep `SupabaseAuthProvider` as a thinner VS Code wrapper that wires SecretStorage, URI callbacks, auth events, and notifications into the coordinator.
- Move the GitHub token exchange response parser and timeout helper into the host-neutral session module so both login and refresh paths use the same validation.
- Add focused coordinator tests for storage, callback conversion, and custom-refresh behavior.

Closes #3304.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/auth/SupabaseSession.test.js out/test/auth/SupabaseClient.test.js`
- `npm run test:kernel`
- `npm run compile:safe`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core session parsing/refresh/callback handling for Supabase auth into a new coordinator used by `SupabaseClient`, which could affect login and token refresh behavior across environments. Adds tests and shared helpers to reduce risk, but regressions would impact authentication flows.
> 
> **Overview**
> **Refactors Supabase auth session lifecycle** by moving stored-session parsing, OAuth callback token conversion/user verification, token freshness (`ensureFreshToken`/`getSessionTokens`), and refresh (native vs custom GitHub endpoint) into a new `SupabaseSessionCoordinator` in `SupabaseSession.ts`.
> 
> `SupabaseAuthProvider` is slimmed down to a VS Code-specific wrapper: it wires SecretStorage into the coordinator, delegates magic-link/OAuth callback handling and refresh via `sessionCoordinator`, and registers the coordinator as the `SupabaseClient` `AuthTokenProvider`.
> 
> Shared utilities were centralized: GitHub token exchange schema validation and a more robust `fetchWithTimeout` (preserving upstream abort semantics) now live in `SupabaseSession.ts`, and new unit tests cover coordinator storage/callback/refresh behavior plus timeout+abort edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74bab244746c3e22d10272b290ed335ea1b4625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->