### PR TITLE
refactor: simplify Supabase token lookup

### DIFF
--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -282,69 +282,18 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    * @returns Fresh access token, or null if no session or refresh failed.
    */
   async ensureFreshToken(forceRefresh?: boolean): Promise<string | null> {
-    try {
-      const session = await this.loadSession();
-      if (!session) {
-        return null;
-      }
-
-      const timeUntilExpiry = session.expiresAt - Date.now();
-
-      if (
-        forceRefresh ||
-        timeUntilExpiry < this.options.tokenRefreshThresholdMs
-      ) {
-        this.options.log?.info?.(
-          'SupabaseSession',
-          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
-        );
-        const refreshed = await this.refreshSession(session);
-        if (refreshed) {
-          return refreshed.accessToken;
-        }
-        if (forceRefresh || timeUntilExpiry <= 0) {
-          this.options.log?.warn?.(
-            'SupabaseSession',
-            forceRefresh
-              ? 'Force refresh requested but refresh failed, returning null'
-              : 'Token expired and refresh failed, returning null',
-          );
-          return null;
-        }
-      }
-
-      return session.accessToken;
-    } catch (error) {
-      this.options.log?.error?.(
-        'SupabaseSession',
-        `Error ensuring fresh token: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
+    const session = await this.getFreshSession(forceRefresh);
+    return session?.accessToken ?? null;
   }
 
   /** Get access and refresh tokens from secure storage. */
   async getSessionTokens(): Promise<SessionTokens | null> {
-    if (!(await this.ensureFreshToken())) {
-      return null;
-    }
-
-    try {
-      const session = await this.loadSession();
-      if (!session) {
-        return null;
-      }
-      return {
-        accessToken: session.accessToken,
-        refreshToken: session.refreshToken,
-      };
-    } catch (error) {
-      this.options.log?.error?.(
-        'SupabaseSession',
-        `Error getting session tokens: ${toErrorMessage(error)}`,
-      );
-      return null;
-    }
+    const session = await this.getFreshSession();
+    if (!session) return null;
+    return {
+      accessToken: session.accessToken,
+      refreshToken: session.refreshToken,
+    };
   }
 
   /**
@@ -433,6 +382,50 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     const refreshed = toStorableSupabaseSession(data.session);
     await this.storeSession(refreshed);
     return refreshed;
+  }
+
+  private async getFreshSession(
+    forceRefresh?: boolean,
+  ): Promise<SupabaseSession | null> {
+    try {
+      const session = await this.loadSession();
+      if (!session) {
+        return null;
+      }
+
+      const timeUntilExpiry = session.expiresAt - Date.now();
+
+      if (
+        forceRefresh ||
+        timeUntilExpiry < this.options.tokenRefreshThresholdMs
+      ) {
+        this.options.log?.info?.(
+          'SupabaseSession',
+          `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
+        );
+        const refreshed = await this.refreshSession(session);
+        if (refreshed) {
+          return refreshed;
+        }
+        if (forceRefresh || timeUntilExpiry <= 0) {
+          this.options.log?.warn?.(
+            'SupabaseSession',
+            forceRefresh
+              ? 'Force refresh requested but refresh failed, returning null'
+              : 'Token expired and refresh failed, returning null',
+          );
+          return null;
+        }
+      }
+
+      return session;
+    } catch (error) {
+      this.options.log?.error?.(
+        'SupabaseSession',
+        `Error loading fresh session: ${toErrorMessage(error)}`,
+      );
+      return null;
+    }
   }
 
   private getCallbackExpiry(expiresIn: string | null): number {

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -22,11 +22,16 @@ import type {
 function createMemoryStorage(initial?: SupabaseSession): {
   storage: SupabaseSessionStorage;
   read: () => SupabaseSession | null;
+  getReadCount: () => number;
 } {
   let value = initial ? JSON.stringify(initial) : undefined;
+  let readCount = 0;
   return {
     storage: {
-      get: async () => value,
+      get: async () => {
+        readCount += 1;
+        return value;
+      },
       store: async (sessionData) => {
         value = sessionData;
       },
@@ -35,6 +40,7 @@ function createMemoryStorage(initial?: SupabaseSession): {
       },
     },
     read: () => parseStoredSupabaseSession(value),
+    getReadCount: () => readCount,
   };
 }
 
@@ -69,8 +75,11 @@ function createCoordinator(options?: {
 }): {
   coordinator: SupabaseSessionCoordinator;
   read: () => SupabaseSession | null;
+  getReadCount: () => number;
 } {
-  const { storage, read } = createMemoryStorage(options?.initialSession);
+  const { storage, read, getReadCount } = createMemoryStorage(
+    options?.initialSession,
+  );
   return {
     coordinator: new SupabaseSessionCoordinator({
       storage,
@@ -84,6 +93,7 @@ function createCoordinator(options?: {
       onTokenExpiryChanged: options?.onTokenExpiryChanged,
     }),
     read,
+    getReadCount,
   };
 }
 
@@ -238,7 +248,7 @@ describe('SupabaseSession', () => {
   describe('SupabaseSessionCoordinator', () => {
     it('stores session data and exposes session tokens', async () => {
       const expiries: Array<number | null> = [];
-      const { coordinator, read } = createCoordinator({
+      const { coordinator, read, getReadCount } = createCoordinator({
         onTokenExpiryChanged: (expiresAt) => expiries.push(expiresAt),
       });
       const session: SupabaseSession = {
@@ -259,6 +269,7 @@ describe('SupabaseSession', () => {
         accessToken: 'access-token',
         refreshToken: 'refresh-token',
       });
+      assert.equal(getReadCount(), 1);
       assert.deepEqual(expiries, [session.expiresAt]);
     });
 
@@ -351,6 +362,43 @@ describe('SupabaseSession', () => {
         expiresAt: 789_000,
         useCustomRefresh: true,
       });
+    });
+
+    it('returns refreshed session tokens without reloading storage', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() - 1_000,
+        useCustomRefresh: true,
+      };
+      const { coordinator, getReadCount } = createCoordinator({
+        initialSession,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              refresh_token: 'new-refresh',
+              expires_at: 789,
+              token_type: 'bearer',
+              user: {
+                id: 'user-id',
+                email: 'new@example.com',
+              },
+            }),
+            { status: 200 },
+          ),
+      });
+
+      assert.deepEqual(await coordinator.getSessionTokens(), {
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+      });
+      assert.equal(getReadCount(), 1);
     });
 
     it('does not return expired session tokens when refresh fails', async () => {


### PR DESCRIPTION
## Summary

- share the loaded/refreshed session path between `ensureFreshToken()` and `getSessionTokens()`
- return session tokens from the same fresh session object instead of re-reading storage
- add focused tests that assert fresh and refreshed token lookup only read storage once

Closes #3338.

## Validation

- `npx prettier --check src/auth/SupabaseSession.ts src/test/auth/SupabaseSession.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile:safe`
- `npx mocha --require ./out/test/setup.js out/test/auth/SupabaseSession.test.js out/test/auth/SupabaseClient.test.js`
- `npm run test:kernel`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors session/token refresh flow in authentication code; while intended to be behavior-preserving, mistakes could impact token refresh/expiry handling and user sessions.
> 
> **Overview**
> Refactors `SupabaseSessionCoordinator` token lookup to use a single `getFreshSession()` helper for both `ensureFreshToken()` and `getSessionTokens()`, avoiding an extra storage reload after a refresh.
> 
> Updates tests to count storage reads and adds coverage asserting that both normal token retrieval and refreshed token retrieval only read secure storage once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adae470971fedd729a53fce47498a5b0ab7b4bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->