### PR TITLE
refactor: extract settings memory controller

### DIFF
--- a/src/controllers/settingsView/SettingsMemoryController.ts
+++ b/src/controllers/settingsView/SettingsMemoryController.ts
@@ -1,0 +1,137 @@
+// Local imports - common
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+
+// Local imports - hosts
+import type { PromptHost } from '@hosts/promptHost';
+
+// Local imports - shared
+import type { MemoryViewItem } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - memory
+import type { MemoryFileMeta } from '@tools/memory/memoryMeta';
+
+export interface SettingsMemoryStorage {
+  delete(path: string, options?: { recursive?: boolean }): Promise<void>;
+  read(path: string): Promise<string>;
+  write(path: string, content: string): Promise<void>;
+}
+
+export type SettingsMemoryMeta = MemoryFileMeta;
+
+export interface SettingsMemoryControllerDeps {
+  prompt: Pick<PromptHost, 'confirm' | 'warning'>;
+  loadMemoryItems(): Promise<MemoryViewItem[]>;
+  isMemoryEnabled(): boolean;
+  setMemoryEnabled(enabled: boolean): Promise<void>;
+  resolveStoragePath(storagePath: string): string;
+  storage: SettingsMemoryStorage;
+  maxPinnedMemories: number;
+  parseMemoryFile(raw: string): {
+    meta: SettingsMemoryMeta | null;
+    content: string;
+  };
+  buildMemoryFile(content: string, meta: SettingsMemoryMeta | null): string;
+  setPinnedMeta(
+    meta: SettingsMemoryMeta | null,
+    pinned: boolean,
+  ): SettingsMemoryMeta;
+  countPinnedMemories(maxCount: number): Promise<number>;
+}
+
+export type SettingsMemoryMessage =
+  | {
+      command: typeof SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY;
+      items: MemoryViewItem[];
+    }
+  | {
+      command: typeof SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED;
+      enabled: boolean;
+    };
+
+export class SettingsMemoryController {
+  constructor(private readonly deps: SettingsMemoryControllerDeps) {}
+
+  async getMemoryDataMessage(): Promise<SettingsMemoryMessage> {
+    return {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY,
+      items: await this.deps.loadMemoryItems(),
+    };
+  }
+
+  getMemoryEnabledMessage(): SettingsMemoryMessage {
+    return {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled: this.deps.isMemoryEnabled(),
+    };
+  }
+
+  async deleteMemory(input: {
+    storagePath: string;
+    displayPath: string;
+  }): Promise<SettingsMemoryMessage | null> {
+    const confirmed = await this.deps.prompt.confirm(
+      `Delete "${input.displayPath}"?`,
+      {
+        modal: true,
+        confirmLabel: 'Delete',
+      },
+    );
+    if (!confirmed) return null;
+
+    await this.deps.storage.delete(
+      this.deps.resolveStoragePath(input.storagePath),
+      {
+        recursive: true,
+      },
+    );
+    return this.getMemoryDataMessage();
+  }
+
+  async setMemoryEnabled(enabled: boolean): Promise<SettingsMemoryMessage> {
+    await this.deps.setMemoryEnabled(enabled);
+    return this.getMemoryEnabledMessage();
+  }
+
+  async pinMemory(storagePath: string): Promise<SettingsMemoryMessage | null> {
+    return this.setMemoryPinned(storagePath, true);
+  }
+
+  async unpinMemory(
+    storagePath: string,
+  ): Promise<SettingsMemoryMessage | null> {
+    return this.setMemoryPinned(storagePath, false);
+  }
+
+  private async setMemoryPinned(
+    storagePath: string,
+    pinned: boolean,
+  ): Promise<SettingsMemoryMessage | null> {
+    const resolvedPath = this.deps.resolveStoragePath(storagePath);
+    const raw = await this.deps.storage.read(resolvedPath);
+    const { meta, content } = this.deps.parseMemoryFile(raw);
+
+    const alreadyInState = pinned ? !!meta?.pinned : !meta?.pinned;
+    if (alreadyInState) {
+      return this.getMemoryDataMessage();
+    }
+
+    if (pinned) {
+      const pinnedCount = await this.deps.countPinnedMemories(
+        this.deps.maxPinnedMemories,
+      );
+      if (pinnedCount >= this.deps.maxPinnedMemories) {
+        await this.deps.prompt.warning(
+          `Cannot pin: maximum of ${this.deps.maxPinnedMemories} pinned memories reached. Unpin an existing memory first.`,
+        );
+        return null;
+      }
+    }
+
+    const updatedMeta = this.deps.setPinnedMeta(meta, pinned);
+    await this.deps.storage.write(
+      resolvedPath,
+      this.deps.buildMemoryFile(content, updatedMeta),
+    );
+    return this.getMemoryDataMessage();
+  }
+}

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -59,6 +59,7 @@ import {
   applyGitAuthorConfig,
   readGitAuthorSettings,
 } from '@frontend/git/gitAuthorSetup';
+import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { compileLatex2Pdf } from '@latex/texTools';
 import {
   DEFAULT_MODELS,
@@ -126,10 +127,10 @@ import {
   MAX_PINNED_MEMORIES,
 } from '@tools/memory/constants';
 import {
-  parseFrontmatter,
   buildFile,
-  setPinnedMeta,
   countPinnedMemories,
+  parseFrontmatter,
+  setPinnedMeta,
 } from '@tools/memory/memoryMeta';
 import { resolveMemoryStoragePath } from '@tools/memory/memoryUtils';
 import { StorageFS } from '@utils/files';
@@ -147,6 +148,10 @@ import {
 } from '@utils/config/providerConfig';
 import { getConfig, updateConfig } from '@utils/config/configUtils';
 import { setToolEnabled } from '@utils/config/constants';
+import {
+  SettingsMemoryController,
+  type SettingsMemoryMessage,
+} from '../controllers/settingsView/SettingsMemoryController';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import { AgentHandlers } from './handlers/agentHandlers';
@@ -350,6 +355,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   // Domain-specific handler delegates
   private readonly agentHandlers: AgentHandlers;
   private readonly latexHandlers: LatexSettingsHandlers;
+  private readonly memoryController: SettingsMemoryController;
 
   constructor(context: vscode.ExtensionContext) {
     super('SettingsView', { trackActiveView: true });
@@ -361,6 +367,20 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       withActiveWebview: (fn) => this.withActiveWebview(fn),
     };
 
+    this.memoryController = new SettingsMemoryController({
+      prompt: new VscodePromptHost(),
+      loadMemoryItems,
+      isMemoryEnabled: () =>
+        globalSM?.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true) ?? true,
+      setMemoryEnabled: setToolUseMemoryEnabled,
+      resolveStoragePath: resolveMemoryStoragePath,
+      storage: StorageFS,
+      maxPinnedMemories: MAX_PINNED_MEMORIES,
+      parseMemoryFile: parseFrontmatter,
+      buildMemoryFile: buildFile,
+      setPinnedMeta,
+      countPinnedMemories,
+    });
     this.agentHandlers = new AgentHandlers(ctx, () =>
       this.refreshAfterAgentMutation(),
     );
@@ -756,20 +776,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   }
 
   public async sendMemoryData(webview: vscode.Webview): Promise<void> {
-    const items = await loadMemoryItems();
-    await webview.postMessage({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY,
-      items,
-    });
+    await webview.postMessage(
+      await this.memoryController.getMemoryDataMessage(),
+    );
   }
 
   public async sendMemoryEnabled(webview: vscode.Webview): Promise<void> {
-    const enabled =
-      globalSM?.get<boolean>(GlobalStateKey.MEMORY_ENABLED, true) ?? true;
-    await webview.postMessage({
-      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
-      enabled,
-    });
+    await webview.postMessage(this.memoryController.getMemoryEnabledMessage());
   }
 
   public async sendHistoryData(webview: vscode.Webview): Promise<void> {
@@ -1197,26 +1210,16 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleDeleteMemory(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.DELETE_MEMORY>,
   ): Promise<void> {
-    const confirm = await vscode.window.showWarningMessage(
-      `Delete "${data.displayPath}"?`,
-      { modal: true },
-      'Delete',
-    );
-
-    if (confirm !== 'Delete') {
-      return;
-    }
-
     try {
-      const resolvedPath = resolveMemoryStoragePath(data.storagePath);
-      await StorageFS.delete(resolvedPath, { recursive: true });
+      await this.postSettingsMemoryMessage(
+        await this.memoryController.deleteMemory(data),
+      );
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
         'Failed to delete memory',
         error,
       );
-    } finally {
       await this.withActiveWebview((w) => this.sendMemoryData(w));
     }
   }
@@ -1224,8 +1227,9 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetMemoryEnabled(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_MEMORY_ENABLED>,
   ): Promise<void> {
-    await setToolUseMemoryEnabled(data.enabled);
-    await this.withActiveWebview((w) => this.sendMemoryEnabled(w));
+    await this.postSettingsMemoryMessage(
+      await this.memoryController.setMemoryEnabled(data.enabled),
+    );
   }
 
   private async handlePinMemory(
@@ -1240,36 +1244,25 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     await this.setMemoryPinned(data.storagePath, false);
   }
 
-  /** Shared implementation for pin/unpin with limit enforcement. */
+  private async postSettingsMemoryMessage(
+    message: SettingsMemoryMessage | null,
+  ): Promise<void> {
+    if (!message) return;
+    await this.withActiveWebview(async (webview) => {
+      await webview.postMessage(message);
+    });
+  }
+
   private async setMemoryPinned(
     storagePath: string,
     pinned: boolean,
   ): Promise<void> {
     try {
-      const resolvedPath = resolveMemoryStoragePath(storagePath);
-      const raw = await StorageFS.read(resolvedPath);
-      const { meta, content } = parseFrontmatter(raw);
-
-      const alreadyInState = pinned ? !!meta?.pinned : !meta?.pinned;
-      if (alreadyInState) {
-        // Already in desired state — still refresh to sync potentially stale UI
-        await this.withActiveWebview((w) => this.sendMemoryData(w));
-        return;
-      }
-
-      if (pinned) {
-        const pinnedCount = await countPinnedMemories(MAX_PINNED_MEMORIES);
-        if (pinnedCount >= MAX_PINNED_MEMORIES) {
-          void vscode.window.showWarningMessage(
-            `Cannot pin: maximum of ${MAX_PINNED_MEMORIES} pinned memories reached. Unpin an existing memory first.`,
-          );
-          return;
-        }
-      }
-
-      const updatedMeta = setPinnedMeta(meta, pinned);
-      await StorageFS.write(resolvedPath, buildFile(content, updatedMeta));
-      await this.withActiveWebview((w) => this.sendMemoryData(w));
+      await this.postSettingsMemoryMessage(
+        pinned
+          ? await this.memoryController.pinMemory(storagePath)
+          : await this.memoryController.unpinMemory(storagePath),
+      );
     } catch (error) {
       const action = pinned ? 'pin' : 'unpin';
       await showLoggedErrorMessage(

--- a/src/test/controllers/SettingsMemoryController.test.ts
+++ b/src/test/controllers/SettingsMemoryController.test.ts
@@ -1,0 +1,223 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - common
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+
+// Local imports - test support
+import { createFakeUIHosts } from '../support/FakeHosts';
+
+// Local imports - controllers
+import {
+  SettingsMemoryController,
+  type SettingsMemoryMeta,
+  type SettingsMemoryStorage,
+} from '../../controllers/settingsView/SettingsMemoryController';
+
+function buildMemoryFile(content: string, meta: SettingsMemoryMeta | null) {
+  if (!meta) return content;
+  return [
+    `modifiedBy=${meta.modifiedBy}`,
+    `modifiedAt=${meta.modifiedAt}`,
+    `pinned=${meta.pinned ? 'true' : 'false'}`,
+    '',
+    content,
+  ].join('\n');
+}
+
+function parseMemoryFile(raw: string): {
+  meta: SettingsMemoryMeta | null;
+  content: string;
+} {
+  if (!raw.includes('\n\n')) return { meta: null, content: raw };
+  const [header, content] = raw.split('\n\n', 2);
+  const fields = Object.fromEntries(
+    header.split('\n').map((line) => line.split('=', 2)),
+  );
+  return {
+    meta: {
+      modifiedBy: fields.modifiedBy ?? 'codex',
+      modifiedAt: fields.modifiedAt ?? '2026-05-03T00:00:00.000Z',
+      pinned: fields.pinned === 'true',
+    },
+    content,
+  };
+}
+
+function createController(options?: {
+  confirmResponses?: boolean[];
+  memoryEnabled?: boolean;
+  pinnedCount?: number;
+  memoryFile?: string;
+}): {
+  controller: SettingsMemoryController;
+  deleted: string[];
+  files: Map<string, string>;
+  hosts: ReturnType<typeof createFakeUIHosts>;
+  memoryEnabledValue: () => boolean;
+} {
+  const hosts = createFakeUIHosts({
+    confirmResponses: options?.confirmResponses,
+  });
+  const files = new Map<string, string>([
+    [
+      'mem/item.md',
+      options?.memoryFile ??
+        buildMemoryFile('remember this', {
+          modifiedBy: 'codex',
+          modifiedAt: '2026-05-03T00:00:00.000Z',
+          pinned: false,
+        }),
+    ],
+  ]);
+  const deleted: string[] = [];
+  let memoryEnabled = options?.memoryEnabled ?? true;
+  const storage: SettingsMemoryStorage = {
+    delete: async (path) => {
+      deleted.push(path);
+      files.delete(path);
+    },
+    read: async (path) => {
+      const value = files.get(path);
+      if (value == null) throw new Error(`Missing file: ${path}`);
+      return value;
+    },
+    write: async (path, content) => {
+      files.set(path, content);
+    },
+  };
+
+  return {
+    controller: new SettingsMemoryController({
+      prompt: hosts.prompt,
+      loadMemoryItems: async () => [
+        {
+          displayPath: 'item.md',
+          storagePath: 'item.md',
+          size: 13,
+          mtime: '2026-05-03T00:00:00.000Z',
+          lineCount: 1,
+          preview: 'remember this',
+        },
+      ],
+      isMemoryEnabled: () => memoryEnabled,
+      setMemoryEnabled: async (enabled) => {
+        memoryEnabled = enabled;
+      },
+      resolveStoragePath: (storagePath) => `mem/${storagePath}`,
+      storage,
+      maxPinnedMemories: 3,
+      parseMemoryFile,
+      buildMemoryFile,
+      setPinnedMeta: (meta, pinned) => ({
+        ...(meta ?? {
+          modifiedBy: 'codex',
+          modifiedAt: '2026-05-03T00:00:00.000Z',
+        }),
+        pinned,
+      }),
+      countPinnedMemories: async () => options?.pinnedCount ?? 0,
+    }),
+    deleted,
+    files,
+    hosts,
+    memoryEnabledValue: () => memoryEnabled,
+  };
+}
+
+describe('SettingsMemoryController', () => {
+  it('builds memory data messages from the injected loader', async () => {
+    const { controller } = createController();
+
+    assert.deepEqual(await controller.getMemoryDataMessage(), {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY,
+      items: [
+        {
+          displayPath: 'item.md',
+          storagePath: 'item.md',
+          size: 13,
+          mtime: '2026-05-03T00:00:00.000Z',
+          lineCount: 1,
+          preview: 'remember this',
+        },
+      ],
+    });
+  });
+
+  it('updates memory enabled state and returns the refreshed setting', async () => {
+    const { controller, memoryEnabledValue } = createController();
+
+    assert.deepEqual(await controller.setMemoryEnabled(false), {
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY_ENABLED,
+      enabled: false,
+    });
+    assert.equal(memoryEnabledValue(), false);
+  });
+
+  it('leaves memory files untouched when deletion is cancelled', async () => {
+    const { controller, deleted } = createController({
+      confirmResponses: [false],
+    });
+
+    assert.equal(
+      await controller.deleteMemory({
+        storagePath: 'item.md',
+        displayPath: 'item.md',
+      }),
+      null,
+    );
+    assert.deepEqual(deleted, []);
+  });
+
+  it('deletes confirmed memory files and returns refreshed data', async () => {
+    const { controller, deleted } = createController({
+      confirmResponses: [true],
+    });
+
+    const message = await controller.deleteMemory({
+      storagePath: 'item.md',
+      displayPath: 'item.md',
+    });
+
+    assert.deepEqual(deleted, ['mem/item.md']);
+    assert.equal(message?.command, SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY);
+  });
+
+  it('pins memory files without VS Code dependencies', async () => {
+    const { controller, files } = createController();
+
+    const message = await controller.pinMemory('item.md');
+    const { meta, content } = parseMemoryFile(files.get('mem/item.md') ?? '');
+
+    assert.equal(message?.command, SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY);
+    assert.equal(meta?.pinned, true);
+    assert.equal(content, 'remember this');
+  });
+
+  it('unpins memory files without VS Code dependencies', async () => {
+    const { controller, files } = createController({
+      memoryFile: buildMemoryFile('remember this', {
+        modifiedBy: 'codex',
+        modifiedAt: '2026-05-03T00:00:00.000Z',
+        pinned: true,
+      }),
+    });
+
+    const message = await controller.unpinMemory('item.md');
+    const { meta } = parseMemoryFile(files.get('mem/item.md') ?? '');
+
+    assert.equal(message?.command, SETTINGS_VIEW_COMMANDS.UPDATE_MEMORY);
+    assert.equal(meta?.pinned, false);
+  });
+
+  it('warns and skips writes when the pinned memory limit is reached', async () => {
+    const { controller, files, hosts } = createController({
+      pinnedCount: 3,
+    });
+    const before = files.get('mem/item.md');
+
+    assert.equal(await controller.pinMemory('item.md'), null);
+    assert.equal(files.get('mem/item.md'), before);
+    assert.equal(hosts.prompt.messages.at(-1)?.kind, 'warning');
+  });
+});


### PR DESCRIPTION
## Summary

- extract settings memory list, enable, delete, pin, and unpin behavior into a host-neutral `SettingsMemoryController`
- keep VS Code-specific file/folder opening and webview posting in `SettingsViewMessageHandler`
- add focused controller tests using fake prompt/storage dependencies

This is the first narrow controller slice for #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/SettingsMemoryController.ts src/settingsView/SettingsViewMessageHandler.ts src/test/controllers/SettingsMemoryController.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile:safe`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsMemoryController.test.js out/test/controllers/MainViewStartupController.test.js`
- `npm run test:kernel`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing settings-memory enable/delete/pin logic into a new controller and adds tests; behavior should remain the same aside from minor message-posting flow changes.
> 
> **Overview**
> Extracts settings “Memory” behaviors (load list, enabled toggle, delete with confirmation, pin/unpin with max limit enforcement) into a new host-neutral `SettingsMemoryController` with injected prompt/storage/meta helpers.
> 
> Updates `SettingsViewMessageHandler` to delegate these actions to the controller, centralizing webview message posting via `postSettingsMemoryMessage` and replacing direct VS Code/UI and filesystem calls for memory operations.
> 
> Adds focused unit tests for the controller covering message construction, enable toggling, delete confirmation flow, pin/unpin writes, and pinned-limit warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eedee8ba4388efa68d6b98c16f0edc7512118e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->