### PR TITLE
fix: guard Supabase session clear races

### DIFF
--- a/src/auth/SupabaseSession.ts
+++ b/src/auth/SupabaseSession.ts
@@ -95,6 +95,11 @@ export type SupabaseCallbackResult =
   | SupabaseCallbackParseResult
   | SupabaseCallbackParseError;
 
+interface StableSessionSnapshot {
+  session: SupabaseSession | null;
+  version: number;
+}
+
 /**
  * Parse and validate stored session data.
  * Returns null if session data is missing or invalid.
@@ -252,6 +257,11 @@ export function toStorableGitHubTokenExchangeSession(
  */
 export class SupabaseSessionCoordinator implements AuthTokenProvider {
   private refreshPromise: Promise<SupabaseSession | null> | null = null;
+  private sessionMutationVersion = 0;
+  private lastStoredSession: SupabaseSession | null = null;
+  private lastStoredSessionVersion = 0;
+  private pendingSessionMutations = 0;
+  private sessionMutationTail: Promise<void> = Promise.resolve();
 
   constructor(private readonly options: SupabaseSessionCoordinatorOptions) {}
 
@@ -267,12 +277,14 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
   }
 
   async storeSession(session: SupabaseSession): Promise<void> {
-    await this.options.storage.store(JSON.stringify(session));
+    await this.runSessionMutation(session, () =>
+      this.options.storage.store(JSON.stringify(session)),
+    );
     this.options.onTokenExpiryChanged?.(session.expiresAt);
   }
 
   async clearSession(): Promise<void> {
-    await this.options.storage.delete();
+    await this.runSessionMutation(null, () => this.options.storage.delete());
     this.options.onTokenExpiryChanged?.(null);
   }
 
@@ -344,6 +356,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
    */
   async refreshSession(
     session: SupabaseSession,
+    expectedVersion = this.sessionMutationVersion,
   ): Promise<SupabaseSession | null> {
     if (this.refreshPromise) {
       return this.refreshPromise;
@@ -354,6 +367,11 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
         ? this.refreshViaCustomEndpoint(session)
         : this.refreshViaSupabase(session)
     )
+      .then((refreshed) =>
+        refreshed
+          ? this.storeRefreshIfCurrent(refreshed, expectedVersion)
+          : null,
+      )
       .catch((error) => {
         this.options.log?.error?.(
           'SupabaseSession',
@@ -380,7 +398,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     }
 
     const refreshed = toStorableSupabaseSession(data.session);
-    await this.storeSession(refreshed);
     return refreshed;
   }
 
@@ -388,7 +405,7 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
     forceRefresh?: boolean,
   ): Promise<SupabaseSession | null> {
     try {
-      const session = await this.loadSession();
+      const { session, version } = await this.loadStableSessionSnapshot();
       if (!session) {
         return null;
       }
@@ -403,10 +420,8 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
           'SupabaseSession',
           `Token expires in ${Math.round(timeUntilExpiry / 1000)}s, refreshing proactively`,
         );
-        const refreshed = await this.refreshSession(session);
-        if (refreshed) {
-          return refreshed;
-        }
+        const refreshed = await this.refreshSession(session, version);
+        if (refreshed) return refreshed;
         if (forceRefresh || timeUntilExpiry <= 0) {
           this.options.log?.warn?.(
             'SupabaseSession',
@@ -426,6 +441,80 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       );
       return null;
     }
+  }
+
+  private async loadStableSession(): Promise<SupabaseSession | null> {
+    return (await this.loadStableSessionSnapshot()).session;
+  }
+
+  private async loadStableSessionSnapshot(): Promise<StableSessionSnapshot> {
+    let versionBeforeLoad = this.sessionMutationVersion;
+    for (;;) {
+      const pendingBeforeLoad = this.pendingSessionMutations;
+      const session = await this.loadSession();
+      if (
+        versionBeforeLoad === this.sessionMutationVersion &&
+        pendingBeforeLoad === 0 &&
+        this.pendingSessionMutations === 0
+      ) {
+        return { session, version: versionBeforeLoad };
+      }
+      await this.sessionMutationTail;
+      versionBeforeLoad = this.sessionMutationVersion;
+    }
+  }
+
+  private async runSessionMutation(
+    session: SupabaseSession | null,
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    this.sessionMutationVersion += 1;
+    this.pendingSessionMutations += 1;
+    const mutationVersion = this.sessionMutationVersion;
+    const previousMutation = this.sessionMutationTail;
+    const run = previousMutation
+      .then(operation)
+      .then(() => {
+        this.lastStoredSession = session;
+        this.lastStoredSessionVersion = mutationVersion;
+      })
+      .finally(() => {
+        this.pendingSessionMutations -= 1;
+      });
+    this.sessionMutationTail = run.catch(() => {});
+    await run;
+  }
+
+  private async storeRefreshIfCurrent(
+    refreshed: SupabaseSession,
+    expectedVersion: number,
+  ): Promise<SupabaseSession | null> {
+    if (
+      this.sessionMutationVersion !== expectedVersion ||
+      this.pendingSessionMutations > 0
+    ) {
+      return this.loadStableSession();
+    }
+
+    await this.storeSession(refreshed);
+    if (refreshed.useCustomRefresh) {
+      this.options.log?.info?.(
+        'SupabaseSession',
+        'Token refreshed via custom endpoint',
+      );
+    }
+    return this.isCurrentStoredSession(refreshed)
+      ? refreshed
+      : this.loadStableSession();
+  }
+
+  private isCurrentStoredSession(session: SupabaseSession): boolean {
+    return (
+      this.lastStoredSessionVersion === this.sessionMutationVersion &&
+      this.lastStoredSession?.accessToken === session.accessToken &&
+      this.lastStoredSession.refreshToken === session.refreshToken &&
+      this.lastStoredSession.id === session.id
+    );
   }
 
   private getCallbackExpiry(expiresIn: string | null): number {
@@ -475,11 +564,6 @@ export class SupabaseSessionCoordinator implements AuthTokenProvider {
       this.options.defaultSessionExpiryMs,
     );
 
-    await this.storeSession(refreshed);
-    this.options.log?.info?.(
-      'SupabaseSession',
-      'Token refreshed via custom endpoint',
-    );
     return refreshed;
   }
 }

--- a/src/test/auth/SupabaseSession.test.ts
+++ b/src/test/auth/SupabaseSession.test.ts
@@ -67,6 +67,17 @@ function createClient(overrides?: Partial<Client['auth']>): Client {
   } as unknown as Client;
 }
 
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 function createCoordinator(options?: {
   initialSession?: SupabaseSession;
   client?: Client;
@@ -273,6 +284,25 @@ describe('SupabaseSession', () => {
       assert.deepEqual(expiries, [session.expiresAt]);
     });
 
+    it('reads storage once when ensuring a cached fresh token', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() + 120_000,
+      };
+      const { coordinator, getReadCount } = createCoordinator({
+        initialSession,
+      });
+
+      assert.equal(await coordinator.ensureFreshToken(), 'access-token');
+      assert.equal(getReadCount(), 1);
+    });
+
     it('creates a session from host-neutral callback URI parts', async () => {
       const { coordinator } = createCoordinator();
 
@@ -331,7 +361,7 @@ describe('SupabaseSession', () => {
         expiresAt: Date.now() - 1_000,
         useCustomRefresh: true,
       };
-      const { coordinator, read } = createCoordinator({
+      const { coordinator, read, getReadCount } = createCoordinator({
         initialSession,
         fetch: async () =>
           new Response(
@@ -350,6 +380,7 @@ describe('SupabaseSession', () => {
       });
 
       assert.equal(await coordinator.ensureFreshToken(), 'new-access');
+      assert.equal(getReadCount(), 1);
 
       assert.deepEqual(read(), {
         id: 'user-id',
@@ -362,6 +393,28 @@ describe('SupabaseSession', () => {
         expiresAt: 789_000,
         useCustomRefresh: true,
       });
+    });
+
+    it('force-refreshes native sessions without reloading storage', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() + 120_000,
+      };
+      const { coordinator, getReadCount } = createCoordinator({
+        initialSession,
+      });
+
+      assert.equal(
+        await coordinator.ensureFreshToken(true),
+        'refreshed-access',
+      );
+      assert.equal(getReadCount(), 1);
     });
 
     it('returns refreshed session tokens without reloading storage', async () => {
@@ -399,6 +452,175 @@ describe('SupabaseSession', () => {
         refreshToken: 'new-refresh',
       });
       assert.equal(getReadCount(), 1);
+    });
+
+    it('returns native refreshed session tokens without reloading storage', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() - 1_000,
+      };
+      const { coordinator, getReadCount } = createCoordinator({
+        initialSession,
+      });
+
+      assert.deepEqual(await coordinator.getSessionTokens(), {
+        accessToken: 'refreshed-access',
+        refreshToken: 'refreshed-refresh',
+      });
+      assert.equal(getReadCount(), 1);
+    });
+
+    it('does not return tokens cleared while loading the session', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() + 120_000,
+      };
+      let value: string | undefined = JSON.stringify(initialSession);
+      let readCount = 0;
+      let clearDuringFirstRead = true;
+      const coordinatorRef: { current?: SupabaseSessionCoordinator } = {};
+      const storage: SupabaseSessionStorage = {
+        get: async () => {
+          readCount += 1;
+          const snapshot = value;
+          if (clearDuringFirstRead) {
+            clearDuringFirstRead = false;
+            await coordinatorRef.current?.clearSession();
+          }
+          return snapshot;
+        },
+        store: async (sessionData) => {
+          value = sessionData;
+        },
+        delete: async () => {
+          value = undefined;
+        },
+      };
+      const coordinator = new SupabaseSessionCoordinator({
+        storage,
+        getClient: () => createClient(),
+        whenReady: async () => {},
+        tokenRefreshThresholdMs: 60_000,
+        defaultSessionExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+        githubTokenRefreshUrl:
+          'https://example.supabase.co/functions/v1/refresh',
+        edgeFunctionTimeoutMs: 30_000,
+      });
+      coordinatorRef.current = coordinator;
+
+      assert.equal(await coordinator.getSessionTokens(), null);
+      assert.equal(readCount, 2);
+    });
+
+    it('does not return tokens when a clear is still pending after load', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() + 120_000,
+      };
+      let value: string | undefined = JSON.stringify(initialSession);
+      let readCount = 0;
+      let clearDuringFirstRead = true;
+      const deleteStarted = createDeferred();
+      const allowDelete = createDeferred();
+      const coordinatorRef: { current?: SupabaseSessionCoordinator } = {};
+      const storage: SupabaseSessionStorage = {
+        get: async () => {
+          readCount += 1;
+          const snapshot = value;
+          if (clearDuringFirstRead) {
+            clearDuringFirstRead = false;
+            void coordinatorRef.current?.clearSession();
+          }
+          return snapshot;
+        },
+        store: async (sessionData) => {
+          value = sessionData;
+        },
+        delete: async () => {
+          deleteStarted.resolve();
+          await allowDelete.promise;
+          value = undefined;
+        },
+      };
+      const coordinator = new SupabaseSessionCoordinator({
+        storage,
+        getClient: () => createClient(),
+        whenReady: async () => {},
+        tokenRefreshThresholdMs: 60_000,
+        defaultSessionExpiryMs: DEFAULT_SUPABASE_SESSION_EXPIRY_MS,
+        githubTokenRefreshUrl:
+          'https://example.supabase.co/functions/v1/refresh',
+        edgeFunctionTimeoutMs: 30_000,
+      });
+      coordinatorRef.current = coordinator;
+
+      const tokensPromise = coordinator.getSessionTokens();
+      await deleteStarted.promise;
+      allowDelete.resolve();
+
+      assert.equal(await tokensPromise, null);
+      assert.equal(readCount, 2);
+    });
+
+    it('does not resurrect a cleared session when refresh finishes later', async () => {
+      const initialSession: SupabaseSession = {
+        id: 'user-id',
+        accessToken: 'old-access',
+        refreshToken: 'old-refresh',
+        account: {
+          id: 'user-id',
+          label: 'user@example.com',
+        },
+        expiresAt: Date.now() - 1_000,
+        useCustomRefresh: true,
+      };
+      const refreshStarted = createDeferred();
+      const allowRefresh = createDeferred();
+      const { coordinator, read } = createCoordinator({
+        initialSession,
+        fetch: async () => {
+          refreshStarted.resolve();
+          await allowRefresh.promise;
+          return new Response(
+            JSON.stringify({
+              access_token: 'new-access',
+              refresh_token: 'new-refresh',
+              expires_at: 123,
+              token_type: 'bearer',
+              user: {
+                id: 'user-id',
+                email: 'user@example.com',
+              },
+            }),
+          );
+        },
+      });
+
+      const tokenPromise = coordinator.ensureFreshToken();
+      await refreshStarted.promise;
+      await coordinator.clearSession();
+      allowRefresh.resolve();
+
+      assert.equal(await tokenPromise, null);
+      assert.equal(read(), null);
     });
 
     it('does not return expired session tokens when refresh fails', async () => {


### PR DESCRIPTION
## Summary
- guard SupabaseSessionCoordinator reads with a mutation version so a clear/store during async storage load forces a stable reload
- verify refreshed sessions are still the current stored session before returning tokens
- add regression coverage for read-count behavior and a clear-during-load race

Closes #3344.
Closes #3345.

## Validation
- npx prettier --check src/auth/SupabaseSession.ts src/test/auth/SupabaseSession.test.ts
- git diff --check
- npm run compile:safe
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/auth/SupabaseSession.test.js out/test/auth/SupabaseClient.test.js
- npm run test:kernel
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session persistence and refresh behavior; incorrect versioning/concurrency handling could cause stale tokens to be returned or sessions to be unintentionally resurrected.
> 
> **Overview**
> Hardens `SupabaseSessionCoordinator` against async storage races by serializing `storeSession`/`clearSession` mutations, tracking a mutation `version`, and requiring a *stable* session snapshot before returning tokens.
> 
> Refresh now only persists/returns a refreshed session if it still matches the expected version; otherwise it reloads the latest stable session, preventing a late refresh from resurrecting a cleared session. Tests add regression coverage for single-read behavior and clear-during-load/clear-during-refresh race scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71427d9fd342adbbe06328953ef9bab218e19be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->