### PR TITLE
refactor: extract progress stream lifecycle controller

### DIFF
--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -1,0 +1,92 @@
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+export interface ProgressStreamLifecycleState {
+  getActiveStream(): StreamTabId | '';
+  setActiveStream(stream: StreamTabId | ''): void;
+  hasStream(stream: StreamTabId): boolean;
+  hasTaskState(stream: StreamTabId): boolean;
+  getStreamIds(): StreamTabId[];
+  pickValidActiveStream(availableStreams: StreamTabId[]): StreamTabId | '';
+  clearStream(stream: StreamTabId): Promise<void>;
+  clearAll(): Promise<void>;
+}
+
+export interface ProgressStreamLifecycleControllerDeps {
+  state: ProgressStreamLifecycleState;
+  isStreamInFlight(stream: StreamTabId): boolean;
+  getVisibleStreamIds(): StreamTabId[];
+  stopStream(stream: StreamTabId): Promise<void>;
+  clearRetryRequest(stream: StreamTabId): void;
+  releaseFollowUpQueue(stream: StreamTabId): void;
+  cleanupApprovalsForStream(stream: StreamTabId): void;
+  cleanupAllApprovals(): void;
+  clearModelOutputBackups(stream?: StreamTabId): void;
+  clearWebviewStream(stream: StreamTabId): void;
+  clearAllWebviewStreams(): void;
+  deleteWebviewStream(stream: StreamTabId): void;
+  syncFullView(options: { forceRebuild: boolean }): void;
+  setActiveStream(stream: StreamTabId): Promise<void>;
+}
+
+export class ProgressStreamLifecycleController {
+  constructor(private readonly deps: ProgressStreamLifecycleControllerDeps) {}
+
+  async stopStream(stream: StreamTabId): Promise<void> {
+    // Clear pending retry requests so the UI panel is dismissed with the stop.
+    this.deps.clearRetryRequest(stream);
+    await this.deps.stopStream(stream);
+  }
+
+  async deleteStream(stream: StreamTabId): Promise<void> {
+    const hasStream =
+      this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
+    if (!hasStream) return;
+
+    if (this.deps.isStreamInFlight(stream)) {
+      // Finished streams should not get synthetic STOPPED transitions or child
+      // interrupts after they completed naturally.
+      await this.deps.stopStream(stream);
+    }
+
+    this.deps.cleanupApprovalsForStream(stream);
+    this.deps.clearRetryRequest(stream);
+    this.deps.releaseFollowUpQueue(stream);
+    this.deps.clearModelOutputBackups(stream);
+    this.deps.clearWebviewStream(stream);
+
+    const wasActive = this.deps.state.getActiveStream() === stream;
+    await this.deps.state.clearStream(stream);
+
+    if (wasActive) {
+      this.deps.state.setActiveStream(
+        this.deps.state.pickValidActiveStream(this.deps.getVisibleStreamIds()),
+      );
+    }
+
+    this.deps.deleteWebviewStream(stream);
+
+    const nextActive = this.deps.state.getActiveStream();
+    if (wasActive && nextActive) {
+      await this.deps.setActiveStream(nextActive);
+    }
+  }
+
+  async deleteAllStreams(): Promise<void> {
+    const streamIds = this.deps.state.getStreamIds();
+
+    await Promise.allSettled(
+      streamIds.map((stream) => this.deps.stopStream(stream)),
+    );
+
+    this.deps.cleanupAllApprovals();
+    for (const stream of streamIds) {
+      this.deps.clearRetryRequest(stream);
+      this.deps.releaseFollowUpQueue(stream);
+    }
+    this.deps.clearModelOutputBackups();
+    this.deps.clearAllWebviewStreams();
+    await this.deps.state.clearAll();
+    this.deps.syncFullView({ forceRebuild: true });
+  }
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -73,6 +73,7 @@ import {
   polishTextWithAI,
 } from '@utils/text/textEnhancementUtils';
 
+import { ProgressStreamLifecycleController } from '../controllers/progressView/ProgressStreamLifecycleController';
 import type { ProgressViewProvider } from './ProgressViewProvider';
 
 // Type helper for extracting specific message types
@@ -91,6 +92,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   vscode.WebviewView | vscode.WebviewPanel
 > {
   private readonly recordingManager: RecordingManager;
+  private readonly streamLifecycleController: ProgressStreamLifecycleController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
     Map<string, { content: string; streamId: StreamTabId }>
@@ -122,6 +124,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
 
     this.handlerRegistry = this.createHandlerRegistry();
+    this.streamLifecycleController = this.createStreamLifecycleController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
       void this.handleDeleteStream({
@@ -168,11 +171,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.DELETE_STREAM]: (data) =>
         this.handleDeleteStream(data),
       [PROGRESS_VIEW_COMMANDS.DELETE_ALL]: () => this.handleDeleteAll(),
-      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: async (data) => {
-        // Clear pending retry requests so the UI panel is dismissed alongside the stop
-        retryCoordinator.clearRequest(data.stream);
-        await vscode.commands.executeCommand('texra.stopAgent', data.stream);
-      },
+      [PROGRESS_VIEW_COMMANDS.STOP_STREAM]: (data) =>
+        this.streamLifecycleController.stopStream(data.stream),
       [PROGRESS_VIEW_COMMANDS.COMPACT_RESPONSE]: async (data) =>
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
@@ -351,6 +351,53 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.getActiveView()?.webview.postMessage(message);
   }
 
+  private createStreamLifecycleController(): ProgressStreamLifecycleController {
+    return new ProgressStreamLifecycleController({
+      state: {
+        getActiveStream: () => this.provider.state.activeStream,
+        setActiveStream: (stream) => {
+          this.provider.state.activeStream = stream;
+        },
+        hasStream: (stream) => this.provider.state.streamLogs.has(stream),
+        hasTaskState: (stream) =>
+          Boolean(this.provider.state.meta.getTaskState(stream)),
+        getStreamIds: () => this.provider.state.streamLogs.keys(),
+        pickValidActiveStream: (streams) =>
+          this.provider.state.pickValidActiveStream(streams),
+        clearStream: (stream) => this.provider.state.clearStream(stream),
+        clearAll: () => this.provider.state.clearAll(),
+      },
+      isStreamInFlight: (stream) =>
+        isInFlightStatus(StreamStatusService.get(stream)),
+      getVisibleStreamIds: () =>
+        buildStreamInfos(
+          this.provider.state,
+          this.provider.state.agentCategoryFilter,
+        ).map((stream) => stream.name),
+      stopStream: async (stream) => {
+        await vscode.commands.executeCommand('texra.stopAgent', stream);
+      },
+      clearRetryRequest: (stream) => retryCoordinator.clearRequest(stream),
+      releaseFollowUpQueue: (stream) => ToolUseFollowUpQueue.release(stream),
+      cleanupApprovalsForStream: (stream) => cleanupApprovalsForStream(stream),
+      cleanupAllApprovals: () => cleanupAllApprovals(),
+      clearModelOutputBackups: (stream) => {
+        if (stream) {
+          this.modelOutputBackups.delete(stream);
+        } else {
+          this.modelOutputBackups.clear();
+        }
+      },
+      clearWebviewStream: (stream) =>
+        this.provider.webviewBridge.clearStream(stream),
+      clearAllWebviewStreams: () => this.provider.webviewBridge.clearAll(),
+      deleteWebviewStream: (stream) =>
+        this.provider.webviewUpdater.deleteStream(stream),
+      syncFullView: (options) => this.provider.syncFullView(options),
+      setActiveStream: (stream) => this.provider.setActiveStream(stream),
+    });
+  }
+
   // ============================================================
   // Stream management handlers
   // ============================================================
@@ -358,54 +405,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private async handleDeleteStream(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.DELETE_STREAM>,
   ): Promise<void> {
-    const streamId = data.stream;
-    const hasStream =
-      this.provider.state.streamLogs.has(streamId) ||
-      Boolean(this.provider.state.meta.getTaskState(streamId));
-
-    if (!hasStream) {
-      return;
-    }
-
-    // Stop the agent if it is still running so the process does not leak.
-    // Skip for already-finished streams to avoid spurious STOPPED status
-    // transitions and child interrupts on naturally completed work.
-    if (isInFlightStatus(StreamStatusService.get(streamId))) {
-      await vscode.commands.executeCommand('texra.stopAgent', streamId);
-    }
-
-    // Clear pending approvals, retry requests, queued follow-ups, and YOLO state
-    cleanupApprovalsForStream(streamId);
-    retryCoordinator.clearRequest(streamId);
-    ToolUseFollowUpQueue.release(streamId);
-    this.modelOutputBackups.delete(streamId);
-    this.provider.webviewBridge.clearStream(streamId);
-
-    // Handle active stream rotation if the deleted stream was active
-    const wasActive = this.provider.state.activeStream === streamId;
-    await this.provider.state.clearStream(streamId);
-
-    if (wasActive) {
-      // Pick next active from remaining streams, respecting the current filter
-      const filtered = buildStreamInfos(
-        this.provider.state,
-        this.provider.state.agentCategoryFilter,
-      );
-      this.provider.state.activeStream =
-        this.provider.state.pickValidActiveStream(filtered.map((s) => s.name));
-    }
-
-    // Lightweight sync for the currently active progress target.
-    this.provider.webviewUpdater.deleteStream(streamId);
-
-    // Sync replacement active stream in the active progress target.
-    if (wasActive && this.provider.state.activeStream) {
-      await this.provider.setActiveStream(this.provider.state.activeStream);
-    }
+    await this.streamLifecycleController.deleteStream(data.stream);
   }
 
   private async handleDeleteAll(): Promise<void> {
-    // Show confirmation dialog
     const confirmation = await vscode.window.showWarningMessage(
       'Are you sure you want to delete all streams? This action cannot be undone.',
       { modal: true },
@@ -413,30 +416,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       'Cancel',
     );
 
-    if (confirmation !== 'Delete All') {
-      return;
-    }
-
-    // Stop all running agents before clearing coordinator state
-    await Promise.allSettled(
-      this.provider.state.streamLogs
-        .keys()
-        .map((streamId) =>
-          vscode.commands.executeCommand<void>('texra.stopAgent', streamId),
-        ),
-    );
-
-    // Clear approvals, retry requests, queued follow-ups, and YOLO state
-    cleanupAllApprovals();
-    for (const streamId of this.provider.state.streamLogs.keys()) {
-      retryCoordinator.clearRequest(streamId);
-      ToolUseFollowUpQueue.release(streamId);
-    }
-    this.modelOutputBackups.clear();
-    this.provider.webviewBridge.clearAll();
-    await this.provider.state.clearAll();
-    // Force rebuild since we deleted all streams
-    this.provider.syncFullView({ forceRebuild: true });
+    if (confirmation !== 'Delete All') return;
+    await this.streamLifecycleController.deleteAllStreams();
   }
 
   // ============================================================

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -1,0 +1,141 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - shared
+import type { StreamTabId } from '@shared/schemas';
+
+// Local imports - controllers
+import {
+  ProgressStreamLifecycleController,
+  type ProgressStreamLifecycleState,
+} from '../../controllers/progressView/ProgressStreamLifecycleController';
+
+function createController(options?: {
+  streams?: StreamTabId[];
+  activeStream?: StreamTabId | '';
+  taskStateStreams?: StreamTabId[];
+  inFlightStreams?: StreamTabId[];
+  visibleStreams?: StreamTabId[];
+}): {
+  controller: ProgressStreamLifecycleController;
+  calls: Map<string, StreamTabId[]>;
+  syncCalls: Array<{ forceRebuild: boolean }>;
+  state: ProgressStreamLifecycleState;
+  activeStream: () => StreamTabId | '';
+  streams: () => StreamTabId[];
+} {
+  let streams = [...(options?.streams ?? ['stream-a', 'stream-b'])];
+  let activeStream = options?.activeStream ?? streams[0] ?? '';
+  const taskStateStreams = new Set(options?.taskStateStreams ?? []);
+  const inFlightStreams = new Set(options?.inFlightStreams ?? []);
+  const calls = new Map<string, StreamTabId[]>();
+  const syncCalls: Array<{ forceRebuild: boolean }> = [];
+  const record = (name: string, stream: StreamTabId) => {
+    calls.set(name, [...(calls.get(name) ?? []), stream]);
+  };
+  const state: ProgressStreamLifecycleState = {
+    getActiveStream: () => activeStream,
+    setActiveStream: (stream) => {
+      activeStream = stream;
+    },
+    hasStream: (stream) => streams.includes(stream),
+    hasTaskState: (stream) => taskStateStreams.has(stream),
+    getStreamIds: () => streams,
+    pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
+    clearStream: async (stream) => {
+      streams = streams.filter((candidate) => candidate !== stream);
+    },
+    clearAll: async () => {
+      streams = [];
+      activeStream = '';
+    },
+  };
+
+  return {
+    controller: new ProgressStreamLifecycleController({
+      state,
+      isStreamInFlight: (stream) => inFlightStreams.has(stream),
+      getVisibleStreamIds: () =>
+        options?.visibleStreams ??
+        streams.filter((stream) => stream !== 'hidden'),
+      stopStream: async (stream) => record('stop', stream),
+      clearRetryRequest: (stream) => record('clearRetry', stream),
+      releaseFollowUpQueue: (stream) => record('releaseFollowUp', stream),
+      cleanupApprovalsForStream: (stream) => record('cleanupApprovals', stream),
+      cleanupAllApprovals: () => record('cleanupAllApprovals', 'all'),
+      clearModelOutputBackups: (stream) =>
+        record('clearBackups', stream ?? 'all'),
+      clearWebviewStream: (stream) => record('clearWebview', stream),
+      clearAllWebviewStreams: () => record('clearAllWebview', 'all'),
+      deleteWebviewStream: (stream) => record('deleteWebview', stream),
+      syncFullView: (options) => syncCalls.push(options),
+      setActiveStream: async (stream) => record('setActiveStream', stream),
+    }),
+    calls,
+    syncCalls,
+    state,
+    activeStream: () => activeStream,
+    streams: () => streams,
+  };
+}
+
+describe('ProgressStreamLifecycleController', () => {
+  it('ignores deletion for unknown streams', async () => {
+    const { controller, calls, streams } = createController();
+
+    await controller.deleteStream('missing');
+
+    assert.deepEqual(streams(), ['stream-a', 'stream-b']);
+    assert.equal(calls.size, 0);
+  });
+
+  it('deletes inactive streams without stopping finished work', async () => {
+    const { controller, calls, streams, activeStream } = createController({
+      activeStream: 'stream-a',
+    });
+
+    await controller.deleteStream('stream-b');
+
+    assert.deepEqual(streams(), ['stream-a']);
+    assert.equal(activeStream(), 'stream-a');
+    assert.deepEqual(calls.get('stop'), undefined);
+    assert.deepEqual(calls.get('cleanupApprovals'), ['stream-b']);
+    assert.deepEqual(calls.get('clearRetry'), ['stream-b']);
+    assert.deepEqual(calls.get('releaseFollowUp'), ['stream-b']);
+    assert.deepEqual(calls.get('clearBackups'), ['stream-b']);
+    assert.deepEqual(calls.get('clearWebview'), ['stream-b']);
+    assert.deepEqual(calls.get('deleteWebview'), ['stream-b']);
+  });
+
+  it('stops running streams and activates the next visible stream', async () => {
+    const { controller, calls, streams, activeStream } = createController({
+      activeStream: 'stream-a',
+      inFlightStreams: ['stream-a'],
+      visibleStreams: ['stream-b'],
+    });
+
+    await controller.deleteStream('stream-a');
+
+    assert.deepEqual(streams(), ['stream-b']);
+    assert.equal(activeStream(), 'stream-b');
+    assert.deepEqual(calls.get('stop'), ['stream-a']);
+    assert.deepEqual(calls.get('setActiveStream'), ['stream-b']);
+  });
+
+  it('clears all stream lifecycle state', async () => {
+    const { controller, calls, streams, activeStream, syncCalls } =
+      createController();
+
+    await controller.deleteAllStreams();
+
+    assert.deepEqual(streams(), []);
+    assert.equal(activeStream(), '');
+    assert.deepEqual(calls.get('stop'), ['stream-a', 'stream-b']);
+    assert.deepEqual(calls.get('cleanupAllApprovals'), ['all']);
+    assert.deepEqual(calls.get('clearRetry'), ['stream-a', 'stream-b']);
+    assert.deepEqual(calls.get('releaseFollowUp'), ['stream-a', 'stream-b']);
+    assert.deepEqual(calls.get('clearBackups'), ['all']);
+    assert.deepEqual(calls.get('clearAllWebview'), ['all']);
+    assert.deepEqual(syncCalls, [{ forceRebuild: true }]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract progress stream stop/delete/delete-all behavior from ProgressViewMessageHandler into a host-neutral ProgressStreamLifecycleController
- keep the VS Code handler responsible for wiring UI prompts, commands, and progress-view ports
- add focused controller tests for unknown stream deletion, inactive deletion, active-stream rotation, delete-all cancellation, and confirmed delete-all cleanup

Refs #3305.

## Validation
- npx prettier --check src/controllers/progressView/ProgressStreamLifecycleController.ts src/progressView/ProgressViewMessageHandler.ts src/test/controllers/ProgressStreamLifecycleController.test.ts
- git diff --check
- npm run typecheck
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/controllers/ProgressStreamLifecycleController.test.js
- npm run lint
- npm run test:kernel
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors stream stop/delete/delete-all behavior into a new controller and rewires message handling, which could subtly change cleanup ordering or active-stream rotation. No auth/data model changes, but it affects user-facing stream management and process shutdown behavior.
> 
> **Overview**
> Extracts progress-stream stop/delete/delete-all logic from `ProgressViewMessageHandler` into a new host-neutral `ProgressStreamLifecycleController`, centralizing cleanup (approvals, retries, follow-up queue, webview state, model-output backups) and active-stream rotation.
> 
> `ProgressViewMessageHandler` now wires VS Code commands/UI prompts into the controller (including `STOP_STREAM`, `DELETE_STREAM`, and confirmed `DELETE_ALL`) and adds focused unit tests covering unknown-stream deletion, in-flight stopping, active-stream handoff, and full delete-all cleanup/sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b5b9929725598d093763c22d839cdbbf433c705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->