### PR TITLE
docs: mark controllers host-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ Aim for code that looks like it was designed correctly from the start:
 
 For good separation of concerns and platform independence, core business logic should stay free of host-specific imports. This improves testability and keeps the door open for future reuse outside VS Code.
 
-1. **Never import `vscode` in VS Code-free zones.** See CLAUDE.md "Separation of Concerns: VS Code Coupling" for the full list. The key ones: `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`.
+1. **Never import `vscode` in VS Code-free zones.** See CLAUDE.md "Separation of Concerns: VS Code Coupling" for the full list. The key ones: `src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/controllers/`, `src/shared/`.
 
 2. **Use platform-agnostic helpers instead of VS Code types:**
    - `isFile(type)` / `isDirectory(type)` from `@common/files/fsEntryType` — not `vscode.FileType.File` / `vscode.FileType.Directory`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,7 @@ For good separation of concerns, testability, and platform independence, core bu
 - `src/model/` (model registry, capabilities, pricing)
 - `src/latex/` (LaTeX processing, formatting, diff)
 - `src/tools/` (tool implementations — use `@common/files/fsEntryType` instead of `vscode.FileType`)
+- `src/controllers/` (host-neutral orchestration behind injected ports)
 - `src/shared/` (IPC schemas, message types)
 - `src/replacement/` (text cleanup rules)
 - `src/eventBus/` (progress event system)


### PR DESCRIPTION
## Summary
- document `src/controllers/` as a VS Code-free host-neutral zone in CLAUDE.md
- include `src/controllers/` in the shorter AGENTS.md key-list for platform decoupling

Closes #3349.

## Validation
- npx prettier --check CLAUDE.md AGENTS.md
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify architectural boundaries without changing runtime code or behavior.
> 
> **Overview**
> Updates the platform-decoupling documentation to explicitly classify `src/controllers/` as a VS Code-free, host-neutral zone.
> 
> This aligns `AGENTS.md` and `CLAUDE.md` guidance so reviewers/authors avoid importing `vscode` in controllers alongside other core business-logic directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ead99eeea4f8f498e1dfd56eb4ed88e1f923c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->