### PR TITLE
chore: enforce controller vscode boundary

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ const VSCODE_FREE_ZONE_DIRS = [
   'src/model',
   'src/latex',
   'src/tools',
+  'src/controllers',
   'src/shared',
   'src/replacement',
   'src/eventBus',


### PR DESCRIPTION
## Summary
- add `src/controllers` to the ESLint VS Code-free zone directory list
- verify existing controllers do not import `vscode`

Closes #3351.

## Validation
- rg -n "from ['\"]vscode|import .*vscode|require\(['\"]vscode" src/controllers src/test/controllers
- npx eslint src/controllers/__lint_probe.ts (expected failure before deleting the temporary probe)
- npx prettier --check eslint.config.mjs
- git diff --check
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that tightens linting by forbidding `vscode` imports under `src/controllers`, which may surface new lint failures but doesn’t affect runtime behavior.
> 
> **Overview**
> Extends the ESLint `no-vscode-import-in-free-zones` rule to include `src/controllers`, preventing controller code from directly importing `vscode` and forcing host access through existing platform/adapter layers.
> 
> No application logic changes; this primarily adds an additional lint boundary that may cause new CI lint failures if future controller code introduces VS Code dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e010092158e93d61d795acf2ed92bde4a231e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->