### PR TITLE
refactor: extract progress workflow actions

### DIFF
--- a/src/controllers/progressView/ProgressWorkflowActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowActionsController.ts
@@ -1,0 +1,148 @@
+// Local imports - agent
+import type { ExecutionRequest } from '@agent/core/executionRequests';
+
+// Local imports - logger
+import {
+  isWorkflowTaskState,
+  type TaskState,
+  type WorkflowTaskState,
+} from '@logger/TaskState';
+
+// Local imports - shared
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+
+export interface WorkflowDiffRequest {
+  agent: string;
+  model: string;
+  inputFile: string;
+  outputFiles: string[];
+  outputFilesActive: boolean;
+  streamId: StreamTabId;
+  runId?: string;
+  outputsByRound?: Record<string, OutputFileInfo[]>;
+}
+
+export type WorkflowFileOperation = 'pack' | 'clean';
+
+export interface WorkflowFileOperationRequest {
+  streamId: StreamTabId;
+  agent: string;
+  model: string;
+  inputFile: string;
+  outputFiles: string[];
+  useMultipleOutputs: boolean;
+  executionId?: string;
+  skipProgressViewClear: boolean;
+}
+
+export interface ProgressWorkflowActionsState {
+  getTaskState(stream: StreamTabId): TaskState | undefined;
+  getExecutionId(stream: StreamTabId): string | undefined;
+  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
+  getKnownWorkspaceOutputPaths(stream: StreamTabId): Set<string>;
+}
+
+export interface ProgressWorkflowActionsControllerDeps {
+  state: ProgressWorkflowActionsState;
+  executeAgent(request: ExecutionRequest): Promise<void>;
+  runDiff(request: WorkflowDiffRequest): Promise<void>;
+  runFileOperation(
+    operation: WorkflowFileOperation,
+    request: WorkflowFileOperationRequest,
+  ): Promise<void>;
+}
+
+export class ProgressWorkflowActionsController {
+  constructor(private readonly deps: ProgressWorkflowActionsControllerDeps) {}
+
+  async resume(stream: StreamTabId): Promise<void> {
+    const taskState = this.deps.state.getTaskState(stream);
+    if (!taskState) return;
+
+    const executionId = isWorkflowTaskState(taskState)
+      ? this.deps.state.getExecutionId(stream)
+      : undefined;
+
+    await this.deps.executeAgent({
+      config: taskState.agentConfig,
+      ...(executionId && { executionId }),
+    });
+  }
+
+  async runNew(stream: StreamTabId): Promise<void> {
+    const taskState = this.deps.state.getTaskState(stream);
+    if (!taskState) return;
+
+    await this.deps.executeAgent({ config: taskState.agentConfig });
+  }
+
+  async diffStream(stream: StreamTabId): Promise<void> {
+    await this.withWorkflowTaskState(stream, async (taskState) => {
+      const runOutputs = this.deps.state.getOutputFiles(stream);
+      const outputsByRound = runOutputs.size
+        ? Object.fromEntries(runOutputs.entries())
+        : undefined;
+
+      await this.deps.runDiff({
+        agent: taskState.agentConfig.agent,
+        model: taskState.agentConfig.model,
+        inputFile: taskState.agentConfig.inputFile,
+        outputFiles: taskState.agentConfig.outputFiles,
+        outputFilesActive: taskState.activeFiles.output,
+        streamId: stream,
+        runId: this.deps.state.getExecutionId(stream),
+        outputsByRound,
+      });
+    });
+  }
+
+  async runFileOperation(
+    stream: StreamTabId,
+    operation: WorkflowFileOperation,
+  ): Promise<void> {
+    await this.withWorkflowTaskState(stream, async (taskState) => {
+      const outputFiles = this.resolveOutputFiles(stream, taskState);
+      const useMultipleOutputs =
+        taskState.agentConfig.useMultipleOutputs ??
+        taskState.activeFiles.output ??
+        outputFiles.length > 1;
+      const executionId = this.deps.state.getExecutionId(stream);
+
+      await this.deps.runFileOperation(operation, {
+        streamId: stream,
+        agent: taskState.agentConfig.agent,
+        model: taskState.agentConfig.model,
+        inputFile: taskState.agentConfig.inputFile,
+        outputFiles: useMultipleOutputs ? outputFiles : [],
+        useMultipleOutputs,
+        ...(executionId && { executionId }),
+        skipProgressViewClear: true,
+      });
+    });
+  }
+
+  private async withWorkflowTaskState(
+    stream: StreamTabId,
+    action: (taskState: WorkflowTaskState) => Promise<void>,
+  ): Promise<void> {
+    const taskState = this.deps.state.getTaskState(stream);
+    if (!taskState || !isWorkflowTaskState(taskState)) return;
+
+    await action(taskState);
+  }
+
+  private resolveOutputFiles(
+    stream: StreamTabId,
+    taskState: WorkflowTaskState,
+  ): string[] {
+    const generatedPaths = this.deps.state.getKnownWorkspaceOutputPaths(stream);
+    const outputFiles = [
+      ...new Set(
+        [...taskState.agentConfig.outputFiles, ...generatedPaths].filter(
+          Boolean,
+        ),
+      ),
+    ];
+    return outputFiles;
+  }
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -74,6 +74,7 @@ import {
 } from '@utils/text/textEnhancementUtils';
 
 import { ProgressStreamLifecycleController } from '../controllers/progressView/ProgressStreamLifecycleController';
+import { ProgressWorkflowActionsController } from '../controllers/progressView/ProgressWorkflowActionsController';
 import type { ProgressViewProvider } from './ProgressViewProvider';
 
 // Type helper for extracting specific message types
@@ -93,6 +94,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 > {
   private readonly recordingManager: RecordingManager;
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
+  private readonly workflowActionsController: ProgressWorkflowActionsController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
     Map<string, { content: string; streamId: StreamTabId }>
@@ -125,6 +127,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
 
     this.handlerRegistry = this.createHandlerRegistry();
     this.streamLifecycleController = this.createStreamLifecycleController();
+    this.workflowActionsController = this.createWorkflowActionsController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
       void this.handleDeleteStream({
@@ -177,18 +180,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         vscode.commands.executeCommand('texra.compactResponse', data.stream),
 
       // Actions
-      [PROGRESS_VIEW_COMMANDS.RESUME]: (data) => this.handleResume(data),
-      [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (data) => this.handleRunNew(data),
+      [PROGRESS_VIEW_COMMANDS.RESUME]: (data) =>
+        this.workflowActionsController.resume(data.stream),
+      [PROGRESS_VIEW_COMMANDS.RUN_NEW]: (data) =>
+        this.workflowActionsController.runNew(data.stream),
       [PROGRESS_VIEW_COMMANDS.DIFF_STREAM]: (data) =>
-        this.handleDiffStream(data),
+        this.workflowActionsController.diffStream(data.stream),
       [PROGRESS_VIEW_COMMANDS.PACK_STREAM]: (data) =>
-        this.withToolbarTaskState(data.stream, (ts) =>
-          this.handleFileOperation(data.stream, ts, 'texra.pack'),
-        ),
+        this.workflowActionsController.runFileOperation(data.stream, 'pack'),
       [PROGRESS_VIEW_COMMANDS.CLEAN_STREAM]: (data) =>
-        this.withToolbarTaskState(data.stream, (ts) =>
-          this.handleFileOperation(data.stream, ts, 'texra.clean'),
-        ),
+        this.workflowActionsController.runFileOperation(data.stream, 'clean'),
       [PROGRESS_VIEW_COMMANDS.FILTER_STREAMS]: (data) => {
         this.provider.state.agentCategoryFilter = data.filter;
         this.provider.syncFullView();
@@ -398,6 +399,31 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
+  private createWorkflowActionsController(): ProgressWorkflowActionsController {
+    return new ProgressWorkflowActionsController({
+      state: {
+        getTaskState: (stream) => this.provider.state.meta.getTaskState(stream),
+        getExecutionId: (stream) =>
+          this.provider.state.meta.getExecutionId(stream),
+        getOutputFiles: (stream) =>
+          this.provider.state.outputFiles.getFiles(stream),
+        getKnownWorkspaceOutputPaths: (stream) =>
+          this.provider.state.outputFiles.getKnownFilePaths(stream, {
+            workspaceOnly: true,
+          }),
+      },
+      executeAgent: async (request) => {
+        await this.executeValidated(request);
+      },
+      runDiff: async (request) => {
+        await vscode.commands.executeCommand('texra.runLatexdiff', request);
+      },
+      runFileOperation: async (operation, request) => {
+        await vscode.commands.executeCommand(`texra.${operation}`, request);
+      },
+    });
+  }
+
   // ============================================================
   // Stream management handlers
   // ============================================================
@@ -423,32 +449,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   // ============================================================
   // Action handlers
   // ============================================================
-
-  private async handleResume(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RESUME>,
-  ): Promise<void> {
-    const taskState = this.provider.state.meta.getTaskState(data.stream);
-    if (!taskState) return;
-
-    const executionId = isWorkflowTaskState(taskState)
-      ? this.provider.state.meta.getExecutionId(data.stream)
-      : undefined;
-
-    await this.executeValidated({
-      config: taskState.agentConfig,
-      ...(executionId && { executionId }),
-    });
-  }
-
-  private async handleRunNew(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RUN_NEW>,
-  ): Promise<void> {
-    const taskState = this.provider.state.meta.getTaskState(data.stream);
-    if (!taskState) {
-      return;
-    }
-    await this.executeValidated({ config: taskState.agentConfig });
-  }
 
   private async handleRetryStreamRequest(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RETRY_STREAM_REQUEST>,
@@ -537,30 +537,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         'Switched to your own API key. No pending retry to resume — run the agent again when ready.',
       );
     }
-  }
-
-  private async handleDiffStream(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.DIFF_STREAM>,
-  ): Promise<void> {
-    const streamId = data.stream;
-    await this.withToolbarTaskState(streamId, async (taskState) => {
-      const executionId = this.provider.state.meta.getExecutionId(streamId);
-      const runOutputs = this.provider.state.outputFiles.getFiles(streamId);
-      const outputsByRound = runOutputs.size
-        ? Object.fromEntries(runOutputs.entries())
-        : undefined;
-
-      await vscode.commands.executeCommand('texra.runLatexdiff', {
-        agent: taskState.agentConfig.agent,
-        model: taskState.agentConfig.model,
-        inputFile: taskState.agentConfig.inputFile,
-        outputFiles: taskState.agentConfig.outputFiles,
-        outputFilesActive: taskState.activeFiles.output,
-        streamId,
-        runId: executionId,
-        outputsByRound,
-      });
-    });
   }
 
   private async handlePolishFollowUp(
@@ -989,53 +965,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
     await safeExecuteCommand('texra.execute', [validation.request]);
     return true;
-  }
-
-  private async handleFileOperation(
-    streamId: StreamTabId,
-    taskState: WorkflowTaskState,
-    command: 'texra.pack' | 'texra.clean',
-  ): Promise<void> {
-    const generatedPaths = this.provider.state.outputFiles.getKnownFilePaths(
-      streamId,
-      { workspaceOnly: true },
-    );
-
-    // Collect all output files from declared config and generated paths
-    const declaredOutputs = taskState.agentConfig.outputFiles;
-    const allFiles = [...declaredOutputs, ...generatedPaths].filter(Boolean);
-    const outputFiles = [...new Set(allFiles)];
-
-    // Priority: explicit config > activeFiles flag > infer from file count
-    const useMultipleOutputs =
-      taskState.agentConfig.useMultipleOutputs ??
-      taskState.activeFiles.output ??
-      outputFiles.length > 1;
-
-    const executionId = this.provider.state.meta.getExecutionId(streamId);
-
-    await vscode.commands.executeCommand(command, {
-      streamId,
-      agent: taskState.agentConfig.agent,
-      model: taskState.agentConfig.model,
-      inputFile: taskState.agentConfig.inputFile,
-      outputFiles: useMultipleOutputs ? outputFiles : [],
-      useMultipleOutputs,
-      ...(executionId && { executionId }),
-      skipProgressViewClear: true,
-    });
-  }
-
-  private async withToolbarTaskState(
-    streamId: StreamTabId,
-    action: (taskState: WorkflowTaskState) => Promise<void>,
-  ): Promise<void> {
-    const taskState = this.provider.state.meta.getTaskState(streamId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      return;
-    }
-
-    await action(taskState);
   }
 
   private async executeWithBaseFile(

--- a/src/test/controllers/ProgressWorkflowActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowActionsController.test.ts
@@ -1,0 +1,263 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import type { ExecutionRequest } from '@agent/core/executionRequests';
+
+// Local imports - logger
+import type { TaskState, WorkflowTaskState } from '@logger/TaskState';
+
+// Local imports - shared
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+
+// Local imports - controllers
+import {
+  ProgressWorkflowActionsController,
+  type WorkflowDiffRequest,
+  type WorkflowFileOperation,
+  type WorkflowFileOperationRequest,
+} from '../../controllers/progressView/ProgressWorkflowActionsController';
+
+function createAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: 'correct',
+    model: 'gemini31p',
+    inputFile: 'input.tex',
+    outputFiles: ['declared.tex'],
+    agentCategory: AgentCategory.Workflow,
+    ...overrides,
+  });
+}
+
+function createWorkflowTaskState(
+  overrides: Partial<AgentConfig> = {},
+  activeFiles: Partial<WorkflowTaskState['activeFiles']> = {},
+): WorkflowTaskState {
+  return {
+    agentConfig: createAgentConfig({
+      agentCategory: AgentCategory.Workflow,
+      ...overrides,
+    }) as AgentConfig & { agentCategory: AgentCategory.Workflow },
+    activeFiles: {
+      input: true,
+      reference: false,
+      auxiliary: false,
+      media: false,
+      output: true,
+      ...activeFiles,
+    },
+  };
+}
+
+function createOutputFile(
+  absolutePath: string,
+  relativePath = absolutePath,
+): OutputFileInfo {
+  return {
+    source: 'input.tex',
+    location: {
+      kind: 'workspace',
+      absolutePath,
+      relativePath,
+    },
+    round: 1,
+    lineage: null,
+    diff: null,
+  };
+}
+
+function createController(options?: {
+  taskStates?: Map<StreamTabId, TaskState>;
+  executionIds?: Map<StreamTabId, string>;
+  outputs?: Map<StreamTabId, Map<number, OutputFileInfo[]>>;
+  knownWorkspaceOutputs?: Map<StreamTabId, Set<string>>;
+}): {
+  controller: ProgressWorkflowActionsController;
+  executed: ExecutionRequest[];
+  diffs: WorkflowDiffRequest[];
+  fileOperations: Array<{
+    operation: WorkflowFileOperation;
+    request: WorkflowFileOperationRequest;
+  }>;
+} {
+  const executed: ExecutionRequest[] = [];
+  const diffs: WorkflowDiffRequest[] = [];
+  const fileOperations: Array<{
+    operation: WorkflowFileOperation;
+    request: WorkflowFileOperationRequest;
+  }> = [];
+
+  return {
+    controller: new ProgressWorkflowActionsController({
+      state: {
+        getTaskState: (stream) => options?.taskStates?.get(stream),
+        getExecutionId: (stream) => options?.executionIds?.get(stream),
+        getOutputFiles: (stream) =>
+          new Map(options?.outputs?.get(stream) ?? []),
+        getKnownWorkspaceOutputPaths: (stream) =>
+          new Set(options?.knownWorkspaceOutputs?.get(stream) ?? []),
+      },
+      executeAgent: async (request) => {
+        executed.push(request);
+      },
+      runDiff: async (request) => {
+        diffs.push(request);
+      },
+      runFileOperation: async (operation, request) => {
+        fileOperations.push({ operation, request });
+      },
+    }),
+    executed,
+    diffs,
+    fileOperations,
+  };
+}
+
+describe('ProgressWorkflowActionsController', () => {
+  it('resumes workflow streams with their execution id', async () => {
+    const taskState = createWorkflowTaskState();
+    const { controller, executed } = createController({
+      taskStates: new Map([['stream-a', taskState]]),
+      executionIds: new Map([['stream-a', 'exec-123']]),
+    });
+
+    await controller.resume('stream-a');
+
+    assert.deepEqual(executed, [
+      { config: taskState.agentConfig, executionId: 'exec-123' },
+    ]);
+  });
+
+  it('runs a fresh request without the existing execution id', async () => {
+    const taskState = createWorkflowTaskState();
+    const { controller, executed } = createController({
+      taskStates: new Map([['stream-a', taskState]]),
+      executionIds: new Map([['stream-a', 'exec-123']]),
+    });
+
+    await controller.runNew('stream-a');
+
+    assert.deepEqual(executed, [{ config: taskState.agentConfig }]);
+  });
+
+  it('ignores toolbar actions for non-workflow streams', async () => {
+    const toolUseState: TaskState = {
+      agentConfig: createAgentConfig({
+        agentCategory: AgentCategory.ToolUse,
+        outputFiles: [],
+      }) as AgentConfig & { agentCategory: AgentCategory.ToolUse },
+    };
+    const { controller, diffs, fileOperations } = createController({
+      taskStates: new Map([['stream-a', toolUseState]]),
+    });
+
+    await controller.diffStream('stream-a');
+    await controller.runFileOperation('stream-a', 'pack');
+
+    assert.equal(diffs.length, 0);
+    assert.equal(fileOperations.length, 0);
+  });
+
+  it('builds diff requests from workflow task and output state', async () => {
+    const output = createOutputFile(
+      '/workspace/generated.tex',
+      'generated.tex',
+    );
+    const taskState = createWorkflowTaskState(
+      { outputFiles: ['declared.tex'] },
+      { output: false },
+    );
+    const { controller, diffs } = createController({
+      taskStates: new Map([['stream-a', taskState]]),
+      executionIds: new Map([['stream-a', 'exec-123']]),
+      outputs: new Map([['stream-a', new Map([[1, [output]]])]]),
+    });
+
+    await controller.diffStream('stream-a');
+
+    assert.deepEqual(diffs, [
+      {
+        agent: 'correct',
+        model: 'gemini31p',
+        inputFile: 'input.tex',
+        outputFiles: ['declared.tex'],
+        outputFilesActive: false,
+        streamId: 'stream-a',
+        runId: 'exec-123',
+        outputsByRound: { 1: [output] },
+      },
+    ]);
+  });
+
+  it('deduplicates generated outputs for pack and includes execution context', async () => {
+    const taskState = createWorkflowTaskState({
+      inputFiles: ['extra-input.tex'],
+      outputFiles: ['declared.tex', '/workspace/generated.tex'],
+      useMultipleOutputs: true,
+    });
+    const { controller, fileOperations } = createController({
+      taskStates: new Map([['stream-a', taskState]]),
+      executionIds: new Map([['stream-a', 'exec-123']]),
+      knownWorkspaceOutputs: new Map([
+        ['stream-a', new Set(['/workspace/generated.tex', 'extra.tex'])],
+      ]),
+    });
+
+    await controller.runFileOperation('stream-a', 'pack');
+
+    assert.deepEqual(fileOperations, [
+      {
+        operation: 'pack',
+        request: {
+          streamId: 'stream-a',
+          agent: 'correct',
+          model: 'gemini31p',
+          inputFile: 'input.tex',
+          outputFiles: [
+            'declared.tex',
+            '/workspace/generated.tex',
+            'extra.tex',
+          ],
+          useMultipleOutputs: true,
+          executionId: 'exec-123',
+          skipProgressViewClear: true,
+        },
+      },
+    ]);
+  });
+
+  it('hides output files for single-output clean requests', async () => {
+    const taskState = createWorkflowTaskState(
+      {
+        outputFiles: ['declared.tex'],
+        useMultipleOutputs: false,
+      },
+      { output: true },
+    );
+    const { controller, fileOperations } = createController({
+      taskStates: new Map([['stream-a', taskState]]),
+      knownWorkspaceOutputs: new Map([
+        ['stream-a', new Set(['generated.tex'])],
+      ]),
+    });
+
+    await controller.runFileOperation('stream-a', 'clean');
+
+    assert.deepEqual(fileOperations, [
+      {
+        operation: 'clean',
+        request: {
+          streamId: 'stream-a',
+          agent: 'correct',
+          model: 'gemini31p',
+          inputFile: 'input.tex',
+          outputFiles: [],
+          useMultipleOutputs: false,
+          skipProgressViewClear: true,
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract progress workflow toolbar actions into `ProgressWorkflowActionsController`.
- Keep `ProgressViewMessageHandler` as the VS Code adapter for resume, run-new, diff, pack, and clean actions.
- Add focused controller tests for execution requests, diff payloads, and pack/clean output selection.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/progressView/ProgressWorkflowActionsController.ts src/progressView/ProgressViewMessageHandler.ts src/test/controllers/ProgressWorkflowActionsController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/ProgressWorkflowActionsController.test.js out/test/controllers/ProgressStreamLifecycleController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves progress-view workflow action wiring into a dedicated controller; behavior should be unchanged but touches command dispatch for resume/diff/pack/clean.
> 
> **Overview**
> Extracts Progress View workflow toolbar logic (resume, run new, diff, pack, clean) into a new `ProgressWorkflowActionsController`, leaving `ProgressViewMessageHandler` as a thin VS Code command adapter.
> 
> Adds unit tests covering execution-id handling, diff payload construction (including `outputsByRound`), and pack/clean output selection/deduplication for workflow streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95675007a62200833a17db9589e76dfec26a2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->