### PR TITLE
refactor: extract settings profile key actions

### DIFF
--- a/src/controllers/settingsView/SettingsProfileKeyController.ts
+++ b/src/controllers/settingsView/SettingsProfileKeyController.ts
@@ -1,0 +1,51 @@
+// Local imports - hosts
+import type { ExternalOpener } from '@hosts/externalOpener';
+import type { PromptHost } from '@hosts/promptHost';
+
+export interface SettingsProfileKeyControllerDeps {
+  prompt: Pick<PromptHost, 'input' | 'info'>;
+  externalOpener: Pick<ExternalOpener, 'openExternal'>;
+  getProviderDisplayName(provider: string): string;
+  getProviderKeyUrl(provider: string): string | undefined;
+  getApiKeySecretName(provider: string): string;
+  setSecret(key: string, value: string): Promise<void>;
+  deleteSecret(key: string): Promise<void>;
+  refreshAfterKeyChange(): Promise<void>;
+}
+
+export class SettingsProfileKeyController {
+  constructor(private readonly deps: SettingsProfileKeyControllerDeps) {}
+
+  getProviderDisplayName(provider: string): string {
+    return this.deps.getProviderDisplayName(provider);
+  }
+
+  async setProviderKey(provider: string): Promise<void> {
+    const displayName = this.getProviderDisplayName(provider);
+    const apiKey = await this.deps.prompt.input({
+      prompt: `Enter ${displayName} API key`,
+      password: true,
+      placeHolder: '************************************',
+    });
+
+    if (!apiKey) return;
+
+    await this.deps.setSecret(this.deps.getApiKeySecretName(provider), apiKey);
+    void this.deps.prompt.info(`${displayName} API key has been set`);
+    await this.deps.refreshAfterKeyChange();
+  }
+
+  async removeProviderKey(provider: string): Promise<void> {
+    const displayName = this.getProviderDisplayName(provider);
+    await this.deps.deleteSecret(this.deps.getApiKeySecretName(provider));
+    void this.deps.prompt.info(`${displayName} API key has been removed`);
+    await this.deps.refreshAfterKeyChange();
+  }
+
+  async openProviderKeyUrl(provider: string): Promise<void> {
+    const url = this.deps.getProviderKeyUrl(provider);
+    if (url) {
+      await this.deps.externalOpener.openExternal(url);
+    }
+  }
+}

--- a/src/settingsView/SettingsViewMessageHandler.ts
+++ b/src/settingsView/SettingsViewMessageHandler.ts
@@ -59,6 +59,7 @@ import {
   applyGitAuthorConfig,
   readGitAuthorSettings,
 } from '@frontend/git/gitAuthorSetup';
+import { VscodeExternalOpener } from '@frontend/hosts/VscodeExternalOpener';
 import { VscodePromptHost } from '@frontend/hosts/VscodePromptHost';
 import { compileLatex2Pdf } from '@latex/texTools';
 import {
@@ -152,6 +153,7 @@ import {
   SettingsMemoryController,
   type SettingsMemoryMessage,
 } from '../controllers/settingsView/SettingsMemoryController';
+import { SettingsProfileKeyController } from '../controllers/settingsView/SettingsProfileKeyController';
 import { loadMemoryItems } from './utils/memoryFileSystem';
 import { buildToolDashboardItems } from './utils/toolDashboardData';
 import { AgentHandlers } from './handlers/agentHandlers';
@@ -356,6 +358,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private readonly agentHandlers: AgentHandlers;
   private readonly latexHandlers: LatexSettingsHandlers;
   private readonly memoryController: SettingsMemoryController;
+  private readonly profileKeyController: SettingsProfileKeyController;
 
   constructor(context: vscode.ExtensionContext) {
     super('SettingsView', { trackActiveView: true });
@@ -380,6 +383,19 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
       buildMemoryFile: buildFile,
       setPinnedMeta,
       countPinnedMemories,
+    });
+    this.profileKeyController = new SettingsProfileKeyController({
+      prompt: new VscodePromptHost(),
+      externalOpener: new VscodeExternalOpener(),
+      getProviderDisplayName: (provider) =>
+        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+      getProviderKeyUrl: (provider) =>
+        getProviderKeyUrl(provider, PROVIDER_URLS[provider]),
+      getApiKeySecretName: (provider) =>
+        SecretManager.getApiKeySecretName(provider as ApiProvider),
+      setSecret: (key, value) => SecretManager.set(key, value),
+      deleteSecret: (key) => SecretManager.delete(key),
+      refreshAfterKeyChange: () => this.refreshAfterKeyChange(),
     });
     this.agentHandlers = new AgentHandlers(ctx, () =>
       this.refreshAfterAgentMutation(),
@@ -1517,33 +1533,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleSetProviderKey(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.SET_PROVIDER_KEY>,
   ): Promise<void> {
-    const provider = data.provider as ApiProvider;
-    const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
-
-    const apiKey = await vscode.window.showInputBox({
-      prompt: `Enter ${displayName} API key`,
-      password: true,
-      placeHolder: '************************************',
-    });
-
-    if (!apiKey) {
-      return;
-    }
-
+    const provider = data.provider;
     try {
-      await SecretManager.set(
-        SecretManager.getApiKeySecretName(provider),
-        apiKey,
-      );
-      void vscode.window.showInformationMessage(
-        `${displayName} API key has been set`,
-      );
-      // refreshAfterKeyChange now includes sendProfileData, no separate finally needed.
-      await this.refreshAfterKeyChange();
+      await this.profileKeyController.setProviderKey(provider);
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to set ${displayName} API key`,
+        `Failed to set ${this.profileKeyController.getProviderDisplayName(provider)} API key`,
         error,
       );
       // On error, still refresh settings view to reflect current key state.
@@ -1554,20 +1550,13 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleRemoveProviderKey(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.REMOVE_PROVIDER_KEY>,
   ): Promise<void> {
-    const provider = data.provider as ApiProvider;
-    const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
-
+    const provider = data.provider;
     try {
-      await SecretManager.delete(SecretManager.getApiKeySecretName(provider));
-      void vscode.window.showInformationMessage(
-        `${displayName} API key has been removed`,
-      );
-      // refreshAfterKeyChange now includes sendProfileData, no separate finally needed.
-      await this.refreshAfterKeyChange();
+      await this.profileKeyController.removeProviderKey(provider);
     } catch (error) {
       await showLoggedErrorMessage(
         this.channel,
-        `Failed to remove ${displayName} API key`,
+        `Failed to remove ${this.profileKeyController.getProviderDisplayName(provider)} API key`,
         error,
       );
       // On error, still refresh settings view to reflect current key state.
@@ -1603,11 +1592,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
   private async handleOpenProviderKeyUrl(
     data: MessageFor<typeof SETTINGS_VIEW_CMD.OPEN_PROVIDER_KEY_URL>,
   ): Promise<void> {
-    const provider = data.provider as ApiProvider;
-    const url = getProviderKeyUrl(provider, PROVIDER_URLS[provider]);
-    if (url) {
-      await vscode.env.openExternal(vscode.Uri.parse(url));
-    }
+    await this.profileKeyController.openProviderKeyUrl(data.provider);
   }
 
   private async handleSetProviderStreaming(

--- a/src/test/controllers/SettingsProfileKeyController.test.ts
+++ b/src/test/controllers/SettingsProfileKeyController.test.ts
@@ -1,0 +1,145 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - test support
+import { createFakeUIHosts } from '../support/FakeHosts';
+
+// Local imports - controllers
+import { SettingsProfileKeyController } from '../../controllers/settingsView/SettingsProfileKeyController';
+
+function createController(options?: {
+  inputResponses?: readonly (string | undefined)[];
+  urls?: Record<string, string | undefined>;
+  setError?: Error;
+  deleteError?: Error;
+}): {
+  controller: SettingsProfileKeyController;
+  hosts: ReturnType<typeof createFakeUIHosts>;
+  secrets: Map<string, string>;
+  deleted: string[];
+  refreshCount: () => number;
+} {
+  const hosts = createFakeUIHosts({
+    inputResponses: options?.inputResponses,
+  });
+  const secrets = new Map<string, string>();
+  const deleted: string[] = [];
+  let refreshCount = 0;
+
+  return {
+    controller: new SettingsProfileKeyController({
+      prompt: hosts.prompt,
+      externalOpener: hosts.externalOpener,
+      getProviderDisplayName: (provider) =>
+        provider === 'openai' ? 'OpenAI' : provider,
+      getProviderKeyUrl: (provider) => options?.urls?.[provider],
+      getApiKeySecretName: (provider) => `${provider}-secret`,
+      setSecret: async (key, value) => {
+        if (options?.setError) throw options.setError;
+        secrets.set(key, value);
+      },
+      deleteSecret: async (key) => {
+        if (options?.deleteError) throw options.deleteError;
+        deleted.push(key);
+        secrets.delete(key);
+      },
+      refreshAfterKeyChange: async () => {
+        refreshCount += 1;
+      },
+    }),
+    hosts,
+    secrets,
+    deleted,
+    refreshCount: () => refreshCount,
+  };
+}
+
+describe('SettingsProfileKeyController', () => {
+  it('stores provider keys and refreshes dependent state', async () => {
+    const { controller, hosts, secrets, refreshCount } = createController({
+      inputResponses: ['sk-test'],
+    });
+
+    await controller.setProviderKey('openai');
+
+    assert.equal(secrets.get('openai-secret'), 'sk-test');
+    assert.equal(refreshCount(), 1);
+    assert.equal(
+      hosts.prompt.inputs[0]?.options.prompt,
+      'Enter OpenAI API key',
+    );
+    assert.equal(hosts.prompt.inputs[0]?.options.password, true);
+    assert.equal(
+      hosts.prompt.messages.at(-1)?.message,
+      'OpenAI API key has been set',
+    );
+  });
+
+  it('does nothing when provider key input is cancelled', async () => {
+    const { controller, secrets, refreshCount, hosts } = createController({
+      inputResponses: [undefined],
+    });
+
+    await controller.setProviderKey('openai');
+
+    assert.equal(secrets.size, 0);
+    assert.equal(refreshCount(), 0);
+    assert.equal(hosts.prompt.messages.length, 0);
+  });
+
+  it('removes provider keys and refreshes dependent state', async () => {
+    const { controller, deleted, refreshCount, hosts } = createController();
+
+    await controller.removeProviderKey('openai');
+
+    assert.deepEqual(deleted, ['openai-secret']);
+    assert.equal(refreshCount(), 1);
+    assert.equal(
+      hosts.prompt.messages.at(-1)?.message,
+      'OpenAI API key has been removed',
+    );
+  });
+
+  it('opens provider key URLs when configured', async () => {
+    const { controller, hosts } = createController({
+      urls: { openai: 'https://platform.openai.com/api-keys' },
+    });
+
+    await controller.openProviderKeyUrl('openai');
+
+    assert.deepEqual(hosts.externalOpener.externalUrls, [
+      'https://platform.openai.com/api-keys',
+    ]);
+  });
+
+  it('skips opening missing provider key URLs', async () => {
+    const { controller, hosts } = createController();
+
+    await controller.openProviderKeyUrl('unknown');
+
+    assert.deepEqual(hosts.externalOpener.externalUrls, []);
+  });
+
+  it('does not refresh when secret storage fails', async () => {
+    const error = new Error('write failed');
+    const { controller, refreshCount } = createController({
+      inputResponses: ['sk-test'],
+      setError: error,
+    });
+
+    await assert.rejects(() => controller.setProviderKey('openai'), error);
+    assert.equal(refreshCount(), 0);
+  });
+
+  it('does not refresh when secret deletion fails', async () => {
+    const error = new Error('delete failed');
+    const { controller, refreshCount, deleted } = createController({
+      deleteError: error,
+    });
+
+    await assert.rejects(() => controller.removeProviderKey('openai'), error);
+
+    assert.deepEqual(deleted, []);
+    assert.equal(refreshCount(), 0);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract provider API-key set/remove/open-url behavior into `SettingsProfileKeyController`.
- Keep `SettingsViewMessageHandler` as the VS Code adapter for prompt, secret, opener, and refresh ports.
- Add focused controller tests for key save, cancellation, removal, provider URL opening, and storage failure behavior.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/SettingsProfileKeyController.ts src/settingsView/SettingsViewMessageHandler.ts src/test/controllers/SettingsProfileKeyController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsProfileKeyController.test.js out/test/controllers/SettingsMemoryController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors API key set/remove/open-url flows that touch secret storage and UI prompts; behavior should be unchanged but any wiring/regression could break key management or refresh behavior.
> 
> **Overview**
> Extracts provider API-key interactions (prompting for key, storing/deleting secrets, opening provider key URLs, and triggering refresh) into a new `SettingsProfileKeyController` with injected prompt/opener/secret/refresh dependencies.
> 
> Updates `SettingsViewMessageHandler` to delegate `SET_PROVIDER_KEY`, `REMOVE_PROVIDER_KEY`, and `OPEN_PROVIDER_KEY_URL` handling to the controller (using `VscodePromptHost`/`VscodeExternalOpener`) and adjusts error messages accordingly.
> 
> Adds unit tests covering successful save/remove flows, cancel behavior, URL opening, and ensuring refresh is not triggered when secret operations fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63fe1b3a5e909bbffaaef2fb91a59626f589ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->