### PR TITLE
refactor: extract settings agent visibility

### DIFF
--- a/src/controllers/settingsView/SettingsAgentVisibilityController.ts
+++ b/src/controllers/settingsView/SettingsAgentVisibilityController.ts
@@ -1,0 +1,93 @@
+// Local imports - shared
+import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
+import { agentKey } from '@shared/schemas/agent';
+
+export interface SettingsAgentVisibilityEntry {
+  source: AgentSource;
+  name: string;
+}
+
+export interface SettingsAgentVisibilityState {
+  getEnabledAgentKeys(category: AgentCategory): string[] | undefined;
+  setEnabledAgentKeys(
+    category: AgentCategory,
+    enabledKeys: string[],
+  ): Promise<void>;
+  getAgents(category: AgentCategory): SettingsAgentVisibilityEntry[];
+}
+
+export interface SettingsAgentVisibilityControllerDeps {
+  state: SettingsAgentVisibilityState;
+}
+
+export class SettingsAgentVisibilityController {
+  constructor(private readonly deps: SettingsAgentVisibilityControllerDeps) {}
+
+  async setAgentEnabled(input: {
+    category: AgentCategory;
+    source: AgentSource;
+    name: string;
+    enabled: boolean;
+  }): Promise<void> {
+    const raw = this.deps.state.getEnabledAgentKeys(input.category);
+    const current = raw ?? [];
+    const key = agentKey(input.source, input.name);
+
+    let updated: string[];
+    if (input.enabled) {
+      updated =
+        current.includes(key) || current.includes(input.name)
+          ? current
+          : [...current, key];
+    } else if (raw === undefined) {
+      updated = this.deps.state
+        .getAgents(input.category)
+        .map((entry) => agentKey(entry.source, entry.name))
+        .filter((candidate) => candidate !== key);
+    } else {
+      updated = current.filter(
+        (entry) => entry !== key && entry !== input.name,
+      );
+    }
+
+    await this.deps.state.setEnabledAgentKeys(input.category, updated);
+  }
+
+  async setAllAgentsEnabled(input: {
+    category: AgentCategory;
+    source: AgentSource;
+    enabled: boolean;
+  }): Promise<void> {
+    const allAgents = this.deps.state.getAgents(input.category);
+    const sourceAgents = allAgents.filter(
+      (entry) => entry.source === input.source,
+    );
+    const targetKeys = new Set(
+      sourceAgents.map((entry) => agentKey(entry.source, entry.name)),
+    );
+    const targetLegacyNames = new Set(sourceAgents.map((entry) => entry.name));
+
+    const raw = this.deps.state.getEnabledAgentKeys(input.category);
+    const current =
+      raw ?? allAgents.map((entry) => agentKey(entry.source, entry.name));
+
+    const updated = input.enabled
+      ? this.enableAllForSource(current, targetKeys)
+      : current.filter(
+          (key) => !targetKeys.has(key) && !targetLegacyNames.has(key),
+        );
+
+    await this.deps.state.setEnabledAgentKeys(input.category, updated);
+  }
+
+  private enableAllForSource(
+    current: string[],
+    targetKeys: Set<string>,
+  ): string[] {
+    const currentSet = new Set(current);
+    return [
+      ...current,
+      ...[...targetKeys].filter((key) => !currentSet.has(key)),
+    ];
+  }
+}

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -42,6 +42,7 @@ import {
   type AgentSelectionItem,
 } from '@shared/schemas/settingsViewMessages';
 import { AbsoluteFS } from '@utils/files';
+import { SettingsAgentVisibilityController } from '../../controllers/settingsView/SettingsAgentVisibilityController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
@@ -94,10 +95,39 @@ export function buildAgentSelectionItems(): {
  * Agent selection, directory, and team handler delegate.
  */
 export class AgentHandlers {
+  private readonly visibilityController: SettingsAgentVisibilityController;
+
   constructor(
     private readonly ctx: SettingsHandlerContext,
     private readonly refreshAfterAgentMutation: () => Promise<void>,
-  ) {}
+  ) {
+    this.visibilityController = new SettingsAgentVisibilityController({
+      state: {
+        getEnabledAgentKeys: (category) =>
+          workspaceSM.get<string[]>(
+            category === 'workflow'
+              ? WorkspaceStateKey.ENABLED_AGENTS
+              : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+          ),
+        setEnabledAgentKeys: async (category, enabledKeys) => {
+          await workspaceSM.update(
+            category === 'workflow'
+              ? WorkspaceStateKey.ENABLED_AGENTS
+              : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+            enabledKeys,
+          );
+        },
+        getAgents: (category) =>
+          (category === 'workflow'
+            ? getWorkflowAgents()
+            : getToolUseAgents()
+          ).map((entry) => ({
+            source: entry.source,
+            name: entry.name,
+          })),
+      },
+    });
+  }
 
   // ── Agent selection data ──
 
@@ -150,43 +180,12 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.SET_AGENT_ENABLED>,
   ): Promise<void> {
     try {
-      const stateKey =
-        data.category === 'workflow'
-          ? WorkspaceStateKey.ENABLED_AGENTS
-          : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS;
-      // No default → undefined means "never configured" (all enabled)
-      const raw = workspaceSM.get<string[]>(stateKey);
-      const current = raw ?? [];
-      const key = createKey(data.agentSource, data.agentName);
-
-      let updated: string[];
-      if (data.enabled) {
-        // Add by source:name key if not already present (check both formats)
-        if (current.includes(key) || current.includes(data.agentName)) {
-          updated = current;
-        } else {
-          updated = [...current, key];
-        }
-      } else if (raw === undefined) {
-        // Never configured (undefined) = "all enabled". To disable one agent,
-        // seed the config with all OTHER agents: undefined → [all except this one].
-        const allAgents =
-          data.category === 'workflow'
-            ? getWorkflowAgents()
-            : getToolUseAgents();
-        updated = allAgents
-          .map((e) => createKey(e.source, e.name))
-          .filter((k) => k !== key);
-      } else {
-        // Remove both name and source:name formats.
-        // An empty result means "nothing enabled" (not "all enabled").
-        updated = current.filter(
-          (entry) => entry !== key && entry !== data.agentName,
-        );
-      }
-
-      await workspaceSM.update(stateKey, updated);
-
+      await this.visibilityController.setAgentEnabled({
+        category: data.category,
+        source: data.agentSource,
+        name: data.agentName,
+        enabled: data.enabled,
+      });
       await this.refreshAfterAgentMutation();
     } catch (error) {
       await showLoggedErrorMessage(
@@ -201,44 +200,11 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.SET_ALL_AGENTS_ENABLED>,
   ): Promise<void> {
     try {
-      const stateKey =
-        data.category === 'workflow'
-          ? WorkspaceStateKey.ENABLED_AGENTS
-          : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS;
-
-      const allAgents =
-        data.category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
-
-      const sourceAgents = allAgents.filter((e) => e.source === data.source);
-      const targetKeys = new Set<string>();
-      // Legacy entries may use plain agent names without source prefix
-      const targetLegacyNames = new Set<string>();
-      for (const e of sourceAgents) {
-        targetKeys.add(createKey(e.source, e.name));
-        targetLegacyNames.add(e.name);
-      }
-
-      // Resolve current state: undefined means "all enabled" (never configured)
-      const raw = workspaceSM.get<string[]>(stateKey);
-      const current = raw ?? allAgents.map((e) => createKey(e.source, e.name));
-
-      let updated: string[];
-      if (data.enabled) {
-        // Add all keys from the target source (deduplicated)
-        const currentSet = new Set(current);
-        updated = [
-          ...current,
-          ...[...targetKeys].filter((k) => !currentSet.has(k)),
-        ];
-      } else {
-        // Remove both source:name and legacy plain-name entries for this source
-        updated = current.filter(
-          (k) => !targetKeys.has(k) && !targetLegacyNames.has(k),
-        );
-      }
-
-      await workspaceSM.update(stateKey, updated);
-
+      await this.visibilityController.setAllAgentsEnabled({
+        category: data.category,
+        source: data.source,
+        enabled: data.enabled,
+      });
       await this.refreshAfterAgentMutation();
     } catch (error) {
       await showLoggedErrorMessage(

--- a/src/test/controllers/SettingsAgentVisibilityController.test.ts
+++ b/src/test/controllers/SettingsAgentVisibilityController.test.ts
@@ -1,0 +1,141 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - shared
+import type { AgentCategory } from '@shared/schemas/agent';
+
+// Local imports - controllers
+import {
+  SettingsAgentVisibilityController,
+  type SettingsAgentVisibilityEntry,
+} from '../../controllers/settingsView/SettingsAgentVisibilityController';
+
+const AGENTS: Record<AgentCategory, SettingsAgentVisibilityEntry[]> = {
+  workflow: [
+    { source: 'builtInWorkflow', name: 'correct' },
+    { source: 'custom', name: 'customWriter' },
+    { source: 'remote', name: 'remoteWriter' },
+  ],
+  toolUse: [
+    { source: 'builtInToolUse', name: 'claudeCode' },
+    { source: 'custom', name: 'customTool' },
+  ],
+};
+
+function createController(options?: {
+  enabled?: Partial<Record<AgentCategory, string[] | undefined>>;
+}): {
+  controller: SettingsAgentVisibilityController;
+  enabled: Partial<Record<AgentCategory, string[] | undefined>>;
+} {
+  const enabled = { ...(options?.enabled ?? {}) };
+  return {
+    controller: new SettingsAgentVisibilityController({
+      state: {
+        getEnabledAgentKeys: (category) => enabled[category],
+        setEnabledAgentKeys: async (category, enabledKeys) => {
+          enabled[category] = enabledKeys;
+        },
+        getAgents: (category) => AGENTS[category],
+      },
+    }),
+    enabled,
+  };
+}
+
+describe('SettingsAgentVisibilityController', () => {
+  it('seeds all other agents when disabling from never-configured state', async () => {
+    const { controller, enabled } = createController();
+
+    await controller.setAgentEnabled({
+      category: 'workflow',
+      source: 'custom',
+      name: 'customWriter',
+      enabled: false,
+    });
+
+    assert.deepEqual(enabled.workflow, [
+      'builtInWorkflow:correct',
+      'remote:remoteWriter',
+    ]);
+  });
+
+  it('removes canonical and legacy names from configured state', async () => {
+    const { controller, enabled } = createController({
+      enabled: {
+        workflow: [
+          'builtInWorkflow:correct',
+          'customWriter',
+          'remote:remoteWriter',
+        ],
+      },
+    });
+
+    await controller.setAgentEnabled({
+      category: 'workflow',
+      source: 'custom',
+      name: 'customWriter',
+      enabled: false,
+    });
+
+    assert.deepEqual(enabled.workflow, [
+      'builtInWorkflow:correct',
+      'remote:remoteWriter',
+    ]);
+  });
+
+  it('adds canonical keys without duplicating legacy enabled entries', async () => {
+    const { controller, enabled } = createController({
+      enabled: { workflow: ['customWriter'] },
+    });
+
+    await controller.setAgentEnabled({
+      category: 'workflow',
+      source: 'custom',
+      name: 'customWriter',
+      enabled: true,
+    });
+
+    assert.deepEqual(enabled.workflow, ['customWriter']);
+  });
+
+  it('disables every agent from a source while preserving other sources', async () => {
+    const { controller, enabled } = createController({
+      enabled: {
+        workflow: [
+          'builtInWorkflow:correct',
+          'custom:customWriter',
+          'remoteWriter',
+        ],
+      },
+    });
+
+    await controller.setAllAgentsEnabled({
+      category: 'workflow',
+      source: 'remote',
+      enabled: false,
+    });
+
+    assert.deepEqual(enabled.workflow, [
+      'builtInWorkflow:correct',
+      'custom:customWriter',
+    ]);
+  });
+
+  it('enables missing source agents without duplicating existing keys', async () => {
+    const { controller, enabled } = createController({
+      enabled: { workflow: ['builtInWorkflow:correct'] },
+    });
+
+    await controller.setAllAgentsEnabled({
+      category: 'workflow',
+      source: 'custom',
+      enabled: true,
+    });
+
+    assert.deepEqual(enabled.workflow, [
+      'builtInWorkflow:correct',
+      'custom:customWriter',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract settings agent visibility state transitions into `SettingsAgentVisibilityController`.
- Keep `AgentHandlers` as the VS Code-facing adapter for persistence, refresh, and error reporting.
- Add focused tests for single-agent enable/disable, source-wide enable/disable, never-configured defaults, and legacy plain-name entries.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/SettingsAgentVisibilityController.ts src/settingsView/handlers/agentHandlers.ts src/test/controllers/SettingsAgentVisibilityController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsAgentVisibilityController.test.js out/test/controllers/SettingsProfileKeyController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves existing enable/disable logic into a dedicated controller and adds unit tests; behavior should be equivalent but could affect edge cases around legacy key formats and never-configured defaults.
> 
> **Overview**
> Extracts settings agent visibility mutations into a new `SettingsAgentVisibilityController`, centralizing the rules for single-agent and source-wide enable/disable (including *never-configured = all enabled* semantics and legacy plain-name entries).
> 
> Updates `AgentHandlers` to delegate visibility updates to the controller while keeping VS Code persistence, refresh, and error handling in place, and adds focused unit tests covering the key state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a803187fd7d57e50b6307a6eb7444b9bc611a4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->