### PR TITLE
refactor: extract latex recommendation settings

### DIFF
--- a/src/controllers/settingsView/LatexRecommendedSettingsController.ts
+++ b/src/controllers/settingsView/LatexRecommendedSettingsController.ts
@@ -1,0 +1,113 @@
+export type LatexRecommendedSettingField = 'outDir' | 'autoRevealExclude';
+
+export interface LatexRecommendedSettingUpdate {
+  key: string;
+  value: unknown;
+}
+
+export interface LatexRecommendedSettingsConfig {
+  getConfig(key: string): unknown;
+  getGlobalValue(key: string): unknown;
+  isExplicitlySet(key: string): boolean;
+}
+
+export interface LatexRecommendedSettingsControllerDeps {
+  config: LatexRecommendedSettingsConfig;
+}
+
+/** Recommended LaTeX-related VS Code settings and their target values. */
+const LATEX_RECOMMENDED_SETTINGS: {
+  key: string;
+  value: unknown;
+  field: LatexRecommendedSettingField;
+  /** Object keys from older TeXRA versions to migrate when writing. */
+  legacyKeys?: string[];
+}[] = [
+  {
+    key: 'latex-workshop.latex.outDir',
+    value: '%DIR%/build/',
+    field: 'outDir',
+  },
+  {
+    key: 'explorer.autoRevealExclude',
+    value: { '**/build/': true },
+    field: 'autoRevealExclude',
+    legacyKeys: ['build/'],
+  },
+];
+
+export class LatexRecommendedSettingsController {
+  constructor(private readonly deps: LatexRecommendedSettingsControllerDeps) {}
+
+  buildUpdates(input: {
+    field?: LatexRecommendedSettingField;
+    reset: boolean;
+  }): LatexRecommendedSettingUpdate[] {
+    return this.getTargets(input.field).map(({ key, value, legacyKeys }) => ({
+      key,
+      value: this.resolveUpdateValue(key, value, legacyKeys, input.reset),
+    }));
+  }
+
+  isRecommendedValueSet(field: LatexRecommendedSettingField): boolean {
+    const setting = LATEX_RECOMMENDED_SETTINGS.find(
+      (setting) => setting.field === field,
+    );
+    if (!setting) return false;
+    if (!this.deps.config.isExplicitlySet(setting.key)) return false;
+
+    const current = this.deps.config.getConfig(setting.key);
+    if (typeof setting.value === 'object' && setting.value !== null) {
+      if (typeof current !== 'object' || current === null) return false;
+      const currentObject = current as Record<string, unknown>;
+      const recommended = setting.value as Record<string, unknown>;
+      return (
+        Object.entries(recommended).every(
+          ([key, value]) => currentObject[key] === value,
+        ) ||
+        (setting.legacyKeys?.some((key) => currentObject[key] !== undefined) ??
+          false)
+      );
+    }
+    return current === setting.value;
+  }
+
+  private getTargets(
+    field?: LatexRecommendedSettingField,
+  ): typeof LATEX_RECOMMENDED_SETTINGS {
+    return field
+      ? LATEX_RECOMMENDED_SETTINGS.filter((setting) => setting.field === field)
+      : LATEX_RECOMMENDED_SETTINGS;
+  }
+
+  private resolveUpdateValue(
+    key: string,
+    recommendedValue: unknown,
+    legacyKeys: string[] | undefined,
+    reset: boolean,
+  ): unknown {
+    if (typeof recommendedValue !== 'object' || recommendedValue === null) {
+      return reset ? undefined : recommendedValue;
+    }
+
+    const recommended = recommendedValue as Record<string, unknown>;
+    const globalValue = this.deps.config.getGlobalValue(key);
+    const remaining =
+      typeof globalValue === 'object' && globalValue !== null
+        ? { ...(globalValue as Record<string, unknown>) }
+        : {};
+
+    for (const legacyKey of legacyKeys ?? []) {
+      delete remaining[legacyKey];
+    }
+
+    if (reset) {
+      for (const recommendedKey of Object.keys(recommended)) {
+        delete remaining[recommendedKey];
+      }
+      return Object.keys(remaining).length > 0 ? remaining : undefined;
+    }
+
+    return { ...remaining, ...recommended };
+  }
+}

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -40,33 +40,12 @@ import {
   detectPackageManager,
 } from '@utils/system/toolUtils';
 import { BinaryResolver } from '@utils/system/binaryResolver';
+import { LatexRecommendedSettingsController } from '../../controllers/settingsView/LatexRecommendedSettingsController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
 /** How long cached LaTeX settings remain valid (ms). */
 const LATEX_SETTINGS_CACHE_TTL = 60_000;
-
-/** Recommended LaTeX-related VS Code settings and their target values. */
-const LATEX_RECOMMENDED_SETTINGS: {
-  key: string;
-  value: unknown;
-  field: 'outDir' | 'autoRevealExclude';
-  /** Object keys from older TeXRA versions to migrate (remove on apply, clean on reset). */
-  legacyKeys?: string[];
-}[] = [
-  {
-    key: 'latex-workshop.latex.outDir',
-    value: '%DIR%/build/',
-    field: 'outDir',
-  },
-  {
-    key: 'explorer.autoRevealExclude',
-    value: { '**/build/': true },
-    field: 'autoRevealExclude',
-    // Old setup.ts wrote { 'build/': true } — migrate to **/build/
-    legacyKeys: ['build/'],
-  },
-];
 
 /** Allowlist of commands that may be executed via the Run in Terminal button. */
 const ALLOWED_INSTALL_COMMANDS: ReadonlySet<string> = new Set([
@@ -82,6 +61,16 @@ const ALLOWED_INSTALL_COMMANDS: ReadonlySet<string> = new Set([
  * Manages LaTeX tool detection, recommended settings, and installation.
  */
 export class LatexSettingsHandlers {
+  private readonly recommendedSettingsController =
+    new LatexRecommendedSettingsController({
+      config: {
+        getConfig: (key) => getConfig<unknown>(key),
+        getGlobalValue: (key) =>
+          inspectConfig<Record<string, unknown>>(key)?.globalValue,
+        isExplicitlySet: (key) => isConfigExplicitlySet(key),
+      },
+    });
+
   /** Cached LaTeX settings to avoid redundant tool detection on repeat opens. */
   private latexSettingsCache: {
     settings: LatexSettingsStatus;
@@ -112,40 +101,14 @@ export class LatexSettingsHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.APPLY_LATEX_SETTINGS>,
   ): Promise<void> {
     try {
-      const targets = data.field
-        ? LATEX_RECOMMENDED_SETTINGS.filter((s) => s.field === data.field)
-        : LATEX_RECOMMENDED_SETTINGS;
-
-      for (const { key, value, legacyKeys } of targets) {
-        let resolvedValue: unknown = data.reset ? undefined : value;
-
-        if (typeof value === 'object' && value !== null) {
-          const recommended = value as Record<string, unknown>;
-          // Read only the user's explicit global entries — not VS Code defaults —
-          // so we don't leak built-in defaults into settings.json.
-          const inspection = inspectConfig<Record<string, unknown>>(key);
-          const globalObj = inspection?.globalValue ?? {};
-          const remaining = { ...globalObj };
-
-          // Always clean up legacy keys from older TeXRA versions.
-          for (const k of legacyKeys ?? []) {
-            delete remaining[k];
-          }
-
-          if (data.reset) {
-            // Remove the recommended keys, keep the user's other entries.
-            for (const k of Object.keys(recommended)) {
-              delete remaining[k];
-            }
-            resolvedValue =
-              Object.keys(remaining).length > 0 ? remaining : undefined;
-          } else {
-            // Merge recommended keys into existing config.
-            resolvedValue = { ...remaining, ...recommended };
-          }
-        }
-
-        await updateConfig(key, resolvedValue, {
+      for (const {
+        key,
+        value,
+      } of this.recommendedSettingsController.buildUpdates({
+        field: data.field,
+        reset: data.reset ?? false,
+      })) {
+        await updateConfig(key, value, {
           target: 'global',
           prefix: false,
         });
@@ -256,34 +219,6 @@ export class LatexSettingsHandlers {
 
   // ── Private helpers ──
 
-  /**
-   * Check whether a recommended LaTeX setting's value is active.
-   * For string values: exact match.
-   * For object values: recommended keys are a subset of the current config.
-   */
-  private isRecommendedValueSet(
-    field: 'outDir' | 'autoRevealExclude',
-  ): boolean {
-    const setting = LATEX_RECOMMENDED_SETTINGS.find((s) => s.field === field);
-    if (!setting) return false;
-    if (!isConfigExplicitlySet(setting.key)) return false;
-
-    const current = getConfig<unknown>(setting.key);
-    if (typeof setting.value === 'object' && setting.value !== null) {
-      // For object values, check that every recommended key is present
-      if (typeof current !== 'object' || current === null) return false;
-      const cur = current as Record<string, unknown>;
-      const rec = setting.value as Record<string, unknown>;
-      // Also treat legacy keys as "set" so existing users see the check mark
-      // (they'll get migrated to the new key on next Apply).
-      return (
-        Object.entries(rec).every(([k, v]) => cur[k] === v) ||
-        (setting.legacyKeys?.some((k) => cur[k] !== undefined) ?? false)
-      );
-    }
-    return current === setting.value;
-  }
-
   /** Run all tool checks and build the LaTeX settings status object.
    *  Returns defaults on failure so the webview spinner always dismisses. */
   private async detectLatexSettings(): Promise<LatexSettingsStatus> {
@@ -313,8 +248,12 @@ export class LatexSettingsHandlers {
       const platform = normalizePlatform(process.platform);
 
       return {
-        outDir: this.isRecommendedValueSet('outDir'),
-        autoRevealExclude: this.isRecommendedValueSet('autoRevealExclude'),
+        outDir:
+          this.recommendedSettingsController.isRecommendedValueSet('outDir'),
+        autoRevealExclude:
+          this.recommendedSettingsController.isRecommendedValueSet(
+            'autoRevealExclude',
+          ),
         texDistributionInstalled: pdflatexOk || latexmkOk,
         latexWorkshopInstalled: Boolean(
           vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID),

--- a/src/test/controllers/LatexRecommendedSettingsController.test.ts
+++ b/src/test/controllers/LatexRecommendedSettingsController.test.ts
@@ -1,0 +1,147 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - controllers
+import { LatexRecommendedSettingsController } from '../../controllers/settingsView/LatexRecommendedSettingsController';
+
+function createController(options?: {
+  config?: Record<string, unknown>;
+  globalValues?: Record<string, unknown>;
+  explicitlySet?: string[];
+}): LatexRecommendedSettingsController {
+  const explicitlySet = new Set(options?.explicitlySet ?? []);
+  return new LatexRecommendedSettingsController({
+    config: {
+      getConfig: (key) => options?.config?.[key],
+      getGlobalValue: (key) => options?.globalValues?.[key],
+      isExplicitlySet: (key) => explicitlySet.has(key),
+    },
+  });
+}
+
+describe('LatexRecommendedSettingsController', () => {
+  it('builds all recommended apply updates', () => {
+    const controller = createController({
+      globalValues: {
+        'explorer.autoRevealExclude': {
+          '**/node_modules/': true,
+          'build/': true,
+        },
+      },
+    });
+
+    assert.deepEqual(controller.buildUpdates({ reset: false }), [
+      {
+        key: 'latex-workshop.latex.outDir',
+        value: '%DIR%/build/',
+      },
+      {
+        key: 'explorer.autoRevealExclude',
+        value: {
+          '**/node_modules/': true,
+          '**/build/': true,
+        },
+      },
+    ]);
+  });
+
+  it('builds field-specific reset updates without deleting unrelated values', () => {
+    const controller = createController({
+      globalValues: {
+        'explorer.autoRevealExclude': {
+          '**/build/': true,
+          '**/node_modules/': true,
+          'build/': true,
+        },
+      },
+    });
+
+    assert.deepEqual(
+      controller.buildUpdates({
+        field: 'autoRevealExclude',
+        reset: true,
+      }),
+      [
+        {
+          key: 'explorer.autoRevealExclude',
+          value: { '**/node_modules/': true },
+        },
+      ],
+    );
+  });
+
+  it('builds field-specific string reset updates', () => {
+    const controller = createController();
+
+    assert.deepEqual(
+      controller.buildUpdates({
+        field: 'outDir',
+        reset: true,
+      }),
+      [{ key: 'latex-workshop.latex.outDir', value: undefined }],
+    );
+  });
+
+  it('clears object settings when reset leaves no remaining keys', () => {
+    const controller = createController({
+      globalValues: {
+        'explorer.autoRevealExclude': {
+          '**/build/': true,
+          'build/': true,
+        },
+      },
+    });
+
+    assert.deepEqual(
+      controller.buildUpdates({
+        field: 'autoRevealExclude',
+        reset: true,
+      }),
+      [{ key: 'explorer.autoRevealExclude', value: undefined }],
+    );
+  });
+
+  it('reports recommended string and object settings as set', () => {
+    const controller = createController({
+      explicitlySet: [
+        'latex-workshop.latex.outDir',
+        'explorer.autoRevealExclude',
+      ],
+      config: {
+        'latex-workshop.latex.outDir': '%DIR%/build/',
+        'explorer.autoRevealExclude': {
+          '**/build/': true,
+          '**/node_modules/': true,
+        },
+      },
+    });
+
+    assert.equal(controller.isRecommendedValueSet('outDir'), true);
+    assert.equal(controller.isRecommendedValueSet('autoRevealExclude'), true);
+  });
+
+  it('treats legacy autoRevealExclude keys as set for migration display', () => {
+    const controller = createController({
+      explicitlySet: ['explorer.autoRevealExclude'],
+      config: {
+        'explorer.autoRevealExclude': {
+          'build/': true,
+        },
+      },
+    });
+
+    assert.equal(controller.isRecommendedValueSet('autoRevealExclude'), true);
+  });
+
+  it('does not report unset or mismatched recommended settings as set', () => {
+    const controller = createController({
+      explicitlySet: ['latex-workshop.latex.outDir'],
+      config: {
+        'latex-workshop.latex.outDir': 'build',
+      },
+    });
+
+    assert.equal(controller.isRecommendedValueSet('outDir'), false);
+    assert.equal(controller.isRecommendedValueSet('autoRevealExclude'), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract LaTeX recommended-settings apply/reset planning into `LatexRecommendedSettingsController`.
- Keep `LatexSettingsHandlers` as the VS Code-facing adapter for config writes, status refresh, tool detection, terminal commands, and extension install.
- Add focused controller tests for apply/reset planning, legacy `build/` migration, and recommended-status checks.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/LatexRecommendedSettingsController.ts src/settingsView/handlers/latexSettingsHandlers.ts src/test/controllers/LatexRecommendedSettingsController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/LatexRecommendedSettingsController.test.js out/test/controllers/SettingsAgentVisibilityController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the logic that computes VS Code global setting updates for LaTeX recommendations (including merge/reset behavior for object settings), which could affect users' `settings.json` writes; added unit tests reduce the risk.
> 
> **Overview**
> Extracts LaTeX recommended-settings logic out of `LatexSettingsHandlers` into a new `LatexRecommendedSettingsController`, centralizing how apply/reset updates are computed (including merging object settings and cleaning legacy `build/` keys).
> 
> `LatexSettingsHandlers` now delegates both update planning (`buildUpdates`) and “is recommended value set” checks to the controller, and a new focused test suite validates apply/reset behavior, legacy-key migration, and status detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb8b07a7e5f7a43a2c63c8b3604e174f268bac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->