### PR TITLE
refactor: extract agent file planning

### DIFF
--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -1,0 +1,191 @@
+// Standard library imports
+import * as path from 'path';
+
+// Local imports - shared
+import type { AgentCategory } from '@shared/schemas/agent';
+
+export interface SettingsAgentFileEntry {
+  path?: string;
+  multiplePath?: string;
+}
+
+export interface SettingsAgentCustomizePlan {
+  targetPath: string;
+  multipleCopy?: {
+    sourcePath: string;
+    targetPath: string;
+  };
+}
+
+export type SettingsAgentCustomizeResult =
+  | {
+      ok: true;
+      plan: SettingsAgentCustomizePlan;
+    }
+  | {
+      ok: false;
+      reason: 'targetEscapesCustomDir';
+    };
+
+export interface SettingsAgentDeletePlan {
+  path: string;
+  multiplePath?: string;
+}
+
+export type SettingsAgentDeleteResult =
+  | {
+      ok: true;
+      plan: SettingsAgentDeletePlan;
+    }
+  | {
+      ok: false;
+      reason: 'fileOutsideCustomDir';
+    };
+
+export interface SettingsAgentTemplatePlan {
+  fileName: string;
+  filePath: string;
+  baseName: string;
+  description: string;
+  templateKind: 'toolUse' | 'workflowSingle';
+}
+
+export class SettingsAgentFileController {
+  planCustomizeAgent(input: {
+    entry: SettingsAgentFileEntry;
+    customDir: string;
+    sourceDir?: string;
+  }): SettingsAgentCustomizeResult {
+    const sourcePath = input.entry.path;
+    if (!sourcePath) {
+      return { ok: false, reason: 'targetEscapesCustomDir' };
+    }
+
+    const targetPath = this.resolveCustomTargetPath({
+      customDir: input.customDir,
+      sourceDir: input.sourceDir,
+      sourcePath,
+    });
+
+    if (!this.isInside(input.customDir, targetPath)) {
+      return { ok: false, reason: 'targetEscapesCustomDir' };
+    }
+
+    const multipleCopy = this.planMultipleCopy({
+      customDir: input.customDir,
+      sourceDir: input.sourceDir,
+      sourcePath: input.entry.multiplePath,
+    });
+
+    return {
+      ok: true,
+      plan: {
+        targetPath,
+        ...(multipleCopy ? { multipleCopy } : {}),
+      },
+    };
+  }
+
+  planDeleteCustomAgent(input: {
+    entry: SettingsAgentFileEntry;
+    customDir: string;
+  }): SettingsAgentDeleteResult {
+    const sourcePath = input.entry.path;
+    if (!sourcePath || !this.isInside(input.customDir, sourcePath)) {
+      return { ok: false, reason: 'fileOutsideCustomDir' };
+    }
+
+    const multiplePath =
+      input.entry.multiplePath &&
+      this.isInside(input.customDir, input.entry.multiplePath)
+        ? input.entry.multiplePath
+        : undefined;
+
+    return {
+      ok: true,
+      plan: {
+        path: sourcePath,
+        ...(multiplePath ? { multiplePath } : {}),
+      },
+    };
+  }
+
+  validateTemplateName(value: string): string | null {
+    if (!value) return 'Name cannot be empty';
+    if (value.includes('/') || value.includes('\\')) {
+      return 'Name cannot contain path separators';
+    }
+    if (value.includes(' ')) return 'Use underscores instead of spaces';
+    if (/[:#[\]{}|>&*!%@`]/.test(value)) {
+      return 'Name cannot contain YAML-special characters';
+    }
+    return null;
+  }
+
+  planTemplateAgent(input: {
+    category: AgentCategory;
+    name: string;
+    customDir: string;
+  }): SettingsAgentTemplatePlan {
+    const fileName = input.name.endsWith('.yaml')
+      ? input.name
+      : `${input.name}.yaml`;
+    const baseName = input.name.replace(/\.yaml$/, '');
+    const description =
+      input.category === 'toolUse'
+        ? `${baseName} — interactive tool-use agent`
+        : `${baseName} — workflow agent`;
+
+    return {
+      fileName,
+      filePath: path.join(input.customDir, fileName),
+      baseName,
+      description,
+      templateKind: input.category === 'toolUse' ? 'toolUse' : 'workflowSingle',
+    };
+  }
+
+  private planMultipleCopy(input: {
+    customDir: string;
+    sourceDir?: string;
+    sourcePath?: string;
+  }): SettingsAgentCustomizePlan['multipleCopy'] | undefined {
+    if (!input.sourcePath) return undefined;
+
+    const targetPath = this.resolveCustomTargetPath({
+      customDir: input.customDir,
+      sourceDir: input.sourceDir,
+      sourcePath: input.sourcePath,
+    });
+
+    if (!this.isInside(input.customDir, targetPath)) return undefined;
+
+    return {
+      sourcePath: input.sourcePath,
+      targetPath,
+    };
+  }
+
+  private resolveCustomTargetPath(input: {
+    customDir: string;
+    sourceDir?: string;
+    sourcePath: string;
+  }): string {
+    const relativePath = input.sourceDir
+      ? path.relative(input.sourceDir, input.sourcePath)
+      : path.basename(input.sourcePath);
+    return path.join(input.customDir, relativePath);
+  }
+
+  private isInside(parentDir: string, candidatePath: string): boolean {
+    const relativePath = path.relative(
+      path.resolve(parentDir),
+      path.resolve(candidatePath),
+    );
+    return (
+      relativePath !== '' &&
+      !relativePath.startsWith('..') &&
+      !path.isAbsolute(relativePath)
+    );
+  }
+}

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -42,6 +42,7 @@ import {
   type AgentSelectionItem,
 } from '@shared/schemas/settingsViewMessages';
 import { AbsoluteFS } from '@utils/files';
+import { SettingsAgentFileController } from '../../controllers/settingsView/SettingsAgentFileController';
 import { SettingsAgentVisibilityController } from '../../controllers/settingsView/SettingsAgentVisibilityController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
@@ -95,6 +96,7 @@ export function buildAgentSelectionItems(): {
  * Agent selection, directory, and team handler delegate.
  */
 export class AgentHandlers {
+  private readonly fileController = new SettingsAgentFileController();
   private readonly visibilityController: SettingsAgentVisibilityController;
 
   constructor(
@@ -348,22 +350,21 @@ export class AgentHandlers {
       }
 
       const customDir = await agentDirectories.custom();
-      const normalizedCustomDir = path.resolve(customDir);
       const sourceDir = await agentDirectories.getDirectory(data.agentSource);
-      const relativePath = sourceDir
-        ? path.relative(sourceDir, entry.path)
-        : path.basename(entry.path);
-      const targetPath = path.join(customDir, relativePath);
 
-      // Guard: only write files under the custom agent directory
-      if (
-        !path.resolve(targetPath).startsWith(normalizedCustomDir + path.sep)
-      ) {
+      const result = this.fileController.planCustomizeAgent({
+        entry,
+        customDir,
+        sourceDir,
+      });
+      if (!result.ok) {
         await vscode.window.showErrorMessage(
           `Refusing to copy: target path escapes the custom agents directory.`,
         );
         return;
       }
+
+      const { targetPath, multipleCopy } = result.plan;
 
       await AbsoluteFS.ensureDir(path.dirname(targetPath));
 
@@ -380,25 +381,18 @@ export class AgentHandlers {
 
       await AbsoluteFS.copy(entry.path, targetPath, { overwrite: true });
 
-      // Also copy the _multiple variant if it stays inside the custom directory
-      if (entry.multiplePath) {
-        const multipleRelative = sourceDir
-          ? path.relative(sourceDir, entry.multiplePath)
-          : path.basename(entry.multiplePath);
-        const multipleTarget = path.join(customDir, multipleRelative);
-        if (
-          path
-            .resolve(multipleTarget)
-            .startsWith(normalizedCustomDir + path.sep)
-        ) {
-          await AbsoluteFS.ensureDir(path.dirname(multipleTarget));
-          try {
-            await AbsoluteFS.copy(entry.multiplePath, multipleTarget, {
+      if (multipleCopy) {
+        await AbsoluteFS.ensureDir(path.dirname(multipleCopy.targetPath));
+        try {
+          await AbsoluteFS.copy(
+            multipleCopy.sourcePath,
+            multipleCopy.targetPath,
+            {
               overwrite: true,
-            });
-          } catch {
-            // _multiple variant may not exist on disk even if registered
-          }
+            },
+          );
+        } catch {
+          // _multiple variant may not exist on disk even if registered
         }
       }
 
@@ -434,30 +428,29 @@ export class AgentHandlers {
         return;
       }
 
-      // Guard: only delete files under the custom agent directory
       const customDir = await agentDirectories.custom();
-      const normalizedPath = path.resolve(entry.path);
-      const normalizedCustomDir = path.resolve(customDir);
-      if (!normalizedPath.startsWith(normalizedCustomDir + path.sep)) {
+      const result = this.fileController.planDeleteCustomAgent({
+        entry,
+        customDir,
+      });
+      if (!result.ok) {
         await vscode.window.showErrorMessage(
           `Refusing to delete: file is not inside the custom agents directory.`,
         );
         return;
       }
 
-      await AbsoluteFS.delete(entry.path, { recursive: false });
+      await AbsoluteFS.delete(result.plan.path, { recursive: false });
 
-      // Also delete the _multiple variant if it is inside the custom directory
-      if (entry.multiplePath) {
-        const normalizedMultiple = path.resolve(entry.multiplePath);
-        if (normalizedMultiple.startsWith(normalizedCustomDir + path.sep)) {
-          try {
-            await AbsoluteFS.delete(entry.multiplePath, { recursive: false });
-          } catch (err) {
-            // Only ignore FileNotFound; surface other errors
-            if (!isFileNotFoundError(err)) {
-              throw err;
-            }
+      if (result.plan.multiplePath) {
+        try {
+          await AbsoluteFS.delete(result.plan.multiplePath, {
+            recursive: false,
+          });
+        } catch (err) {
+          // Only ignore FileNotFound; surface other errors
+          if (!isFileNotFoundError(err)) {
+            throw err;
           }
         }
       }
@@ -651,49 +644,39 @@ export class AgentHandlers {
       const name = await vscode.window.showInputBox({
         prompt: `Enter a name for the new ${categoryLabel} agent (without .yaml extension)`,
         placeHolder: 'my_agent',
-        validateInput: (value) => {
-          if (!value) return 'Name cannot be empty';
-          if (value.includes('/') || value.includes('\\'))
-            return 'Name cannot contain path separators';
-          if (value.includes(' ')) return 'Use underscores instead of spaces';
-          if (/[:#\[\]{}|>&*!%@`]/.test(value))
-            return 'Name cannot contain YAML-special characters';
-          return null;
-        },
+        validateInput: (value) =>
+          this.fileController.validateTemplateName(value),
       });
       if (!name) return;
 
       const customDir = await agentDirectories.custom();
       await AbsoluteFS.ensureDir(customDir);
 
-      const fileName = name.endsWith('.yaml') ? name : `${name}.yaml`;
-      const filePath = path.join(customDir, fileName);
+      const templatePlan = this.fileController.planTemplateAgent({
+        category,
+        name,
+        customDir,
+      });
 
-      if (await AbsoluteFS.exists(filePath)) {
+      if (await AbsoluteFS.exists(templatePlan.filePath)) {
         await vscode.window.showWarningMessage(
-          `A file named "${fileName}" already exists in the custom agents folder.`,
+          `A file named "${templatePlan.fileName}" already exists in the custom agents folder.`,
         );
         return;
       }
 
-      const baseName = name.replace(/\.yaml$/, '');
-      const defaultDescription =
-        category === 'toolUse'
-          ? `${baseName} — interactive tool-use agent`
-          : `${baseName} — workflow agent`;
-
       const template = await renderAgentTemplateFromBundle(
         this.ctx.extensionContext,
-        category === 'toolUse' ? 'toolUse' : 'workflowSingle',
+        templatePlan.templateKind,
         {
-          agentName: baseName,
-          description: defaultDescription,
+          agentName: templatePlan.baseName,
+          description: templatePlan.description,
         },
       );
 
-      await AbsoluteFS.write(filePath, template);
+      await AbsoluteFS.write(templatePlan.filePath, template);
       const doc = await vscode.workspace.openTextDocument(
-        vscode.Uri.file(filePath),
+        vscode.Uri.file(templatePlan.filePath),
       );
       await vscode.window.showTextDocument(doc);
     } catch (error) {

--- a/src/test/controllers/SettingsAgentFileController.test.ts
+++ b/src/test/controllers/SettingsAgentFileController.test.ts
@@ -1,0 +1,153 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+import * as path from 'path';
+
+// Local imports - controllers
+import { SettingsAgentFileController } from '../../controllers/settingsView/SettingsAgentFileController';
+
+const controller = new SettingsAgentFileController();
+const ROOT = path.join(path.sep, 'repo');
+const BUILT_IN_DIR = path.join(ROOT, 'resources', 'agents');
+const CUSTOM_DIR = path.join(ROOT, 'custom-agents');
+
+describe('SettingsAgentFileController', () => {
+  it('plans custom agent copies while preserving source-relative paths', () => {
+    const result = controller.planCustomizeAgent({
+      customDir: CUSTOM_DIR,
+      sourceDir: BUILT_IN_DIR,
+      entry: {
+        path: path.join(BUILT_IN_DIR, 'writing', 'draft.yaml'),
+        multiplePath: path.join(BUILT_IN_DIR, 'writing', 'draft_multiple.yaml'),
+      },
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(
+      result.plan.targetPath,
+      path.join(CUSTOM_DIR, 'writing', 'draft.yaml'),
+    );
+    assert.deepEqual(result.plan.multipleCopy, {
+      sourcePath: path.join(BUILT_IN_DIR, 'writing', 'draft_multiple.yaml'),
+      targetPath: path.join(CUSTOM_DIR, 'writing', 'draft_multiple.yaml'),
+    });
+  });
+
+  it('rejects customize targets that would escape the custom directory', () => {
+    const result = controller.planCustomizeAgent({
+      customDir: CUSTOM_DIR,
+      sourceDir: BUILT_IN_DIR,
+      entry: {
+        path: path.join(ROOT, 'other', 'outside.yaml'),
+      },
+    });
+
+    assert.deepEqual(result, { ok: false, reason: 'targetEscapesCustomDir' });
+  });
+
+  it('falls back to the basename when the source directory is unknown', () => {
+    const result = controller.planCustomizeAgent({
+      customDir: CUSTOM_DIR,
+      entry: {
+        path: path.join(ROOT, 'elsewhere', 'agent.yaml'),
+      },
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.plan.targetPath, path.join(CUSTOM_DIR, 'agent.yaml'));
+  });
+
+  it('accepts child paths when the custom directory is the filesystem root', () => {
+    const result = controller.planDeleteCustomAgent({
+      customDir: path.parse(ROOT).root,
+      entry: {
+        path: path.join(ROOT, 'custom-agents', 'agent.yaml'),
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      plan: {
+        path: path.join(ROOT, 'custom-agents', 'agent.yaml'),
+      },
+    });
+  });
+
+  it('plans custom agent deletion without deleting outside multiple variants', () => {
+    const result = controller.planDeleteCustomAgent({
+      customDir: CUSTOM_DIR,
+      entry: {
+        path: path.join(CUSTOM_DIR, 'agent.yaml'),
+        multiplePath: path.join(ROOT, 'resources', 'agent_multiple.yaml'),
+      },
+    });
+
+    assert.deepEqual(result, {
+      ok: true,
+      plan: {
+        path: path.join(CUSTOM_DIR, 'agent.yaml'),
+      },
+    });
+  });
+
+  it('rejects deletion outside the custom directory', () => {
+    const result = controller.planDeleteCustomAgent({
+      customDir: CUSTOM_DIR,
+      entry: {
+        path: path.join(ROOT, 'resources', 'agent.yaml'),
+      },
+    });
+
+    assert.deepEqual(result, { ok: false, reason: 'fileOutsideCustomDir' });
+  });
+
+  it('validates template agent names', () => {
+    assert.equal(controller.validateTemplateName(''), 'Name cannot be empty');
+    assert.equal(
+      controller.validateTemplateName('dir/agent'),
+      'Name cannot contain path separators',
+    );
+    assert.equal(
+      controller.validateTemplateName('bad name'),
+      'Use underscores instead of spaces',
+    );
+    assert.equal(
+      controller.validateTemplateName('bad:name'),
+      'Name cannot contain YAML-special characters',
+    );
+    assert.equal(controller.validateTemplateName('good_name'), null);
+  });
+
+  it('plans template agent files and render metadata', () => {
+    assert.deepEqual(
+      controller.planTemplateAgent({
+        category: 'toolUse',
+        name: 'reviewer.yaml',
+        customDir: CUSTOM_DIR,
+      }),
+      {
+        fileName: 'reviewer.yaml',
+        filePath: path.join(CUSTOM_DIR, 'reviewer.yaml'),
+        baseName: 'reviewer',
+        description: 'reviewer — interactive tool-use agent',
+        templateKind: 'toolUse',
+      },
+    );
+
+    assert.deepEqual(
+      controller.planTemplateAgent({
+        category: 'workflow',
+        name: 'writer',
+        customDir: CUSTOM_DIR,
+      }),
+      {
+        fileName: 'writer.yaml',
+        filePath: path.join(CUSTOM_DIR, 'writer.yaml'),
+        baseName: 'writer',
+        description: 'writer — workflow agent',
+        templateKind: 'workflowSingle',
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract custom-agent copy/delete path planning and template-name planning into `SettingsAgentFileController`.
- Keep `AgentHandlers` responsible for VS Code prompts, file operations, editor opening, and refresh side effects.
- Add focused controller tests for source-relative copy targets, path-escape rejection, delete planning, template validation, and template metadata.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/SettingsAgentFileController.ts src/settingsView/handlers/agentHandlers.ts src/test/controllers/SettingsAgentFileController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsAgentFileController.test.js out/test/controllers/LatexRecommendedSettingsController.test.js out/test/controllers/SettingsAgentVisibilityController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the path/filename logic that guards copying and deleting custom agent files; mistakes here could lead to incorrect file operations, but behavior is now centralized and covered by new unit tests.
> 
> **Overview**
> Introduces `SettingsAgentFileController` to centralize planning/validation for **custom agent file operations**: resolving copy targets (including optional `_multiple` variants), ensuring planned targets stay inside the custom agents directory, and validating/template-planning new agent filenames.
> 
> Updates `AgentHandlers` to delegate path-escape checks, delete eligibility, and template metadata/name validation to the new controller while keeping the VS Code prompts, filesystem operations, and UI refresh behavior unchanged.
> 
> Adds unit tests for the new controller covering source-relative copy planning, escape/outside-directory rejection, root-dir edge cases, template name validation, and template render metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c02f4918998c5a9fb87642f4a35bf0a68af3275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->