### PR TITLE
fix: route follow-up queue updates through runtime host

### DIFF
--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - agent
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   sendFollowUp,
@@ -10,7 +11,6 @@ import {
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { retrieveSessionResumeData } from '@agent/runtime/SessionResumeRetrieval';
 import { hasPersistedFlowRecord } from '@agent/storage/detectWaitingStreams';
-import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { STREAM_STATUS } from '@shared/schemas';
@@ -113,12 +113,14 @@ async function handleFollowUpResult(
   result: SendFollowUpResult,
   streamId: StreamTabId,
 ): Promise<void> {
+  const runtimeHost = getAgentRuntimeHost();
+
   switch (result.status) {
     case 'sent':
-      bus.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.emit('updateQueuedFollowUps', { streamId });
       break;
     case 'queued':
-      bus.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.emit('updateQueuedFollowUps', { streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
         // tryAutoResume also returns false when the stream is already
@@ -131,7 +133,7 @@ async function handleFollowUpResult(
             // too, but that's the lesser evil — leaving the queue open would
             // leak late child deliveries into the next run on this stream.
             ToolUseFollowUpQueue.release(streamId);
-            bus.emit('updateQueuedFollowUps', { streamId });
+            runtimeHost.emit('updateQueuedFollowUps', { streamId });
             await vscode.window.showWarningMessage(
               'Message dropped — no session available to receive it. Start a new agent task to continue.',
             );


### PR DESCRIPTION
## Summary

- Route follow-up queue update emissions in `followUpCommand` through `getAgentRuntimeHost()` instead of the global progress event bus.
- Confirm the #3333 runtime sites now avoid direct default-sink/global-bus emissions; the remaining default sink usage is the coordinator fallback tracked separately by #3327.

Closes #3333.

## Validation

- `npx prettier --check src/commands/agent/followUpCommand.ts`
- `git diff --check`
- `npm run compile-tests`
- `npm run test:kernel`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `updateQueuedFollowUps` events are emitted; main risk is missed/duplicated UI updates if the runtime host is not configured as expected.
> 
> **Overview**
> Routes follow-up queue update notifications in `followUpCommand` through `getAgentRuntimeHost().emit(...)` instead of the global progress event bus.
> 
> This centralizes `updateQueuedFollowUps` emissions under the runtime host (including the queue re-release path) so follow-up UI state updates flow through the same runtime-scoped event mechanism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e84d1f058a6dae9afd441ffe2452a7a6816d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->