### PR TITLE
refactor: tighten agent file planning inputs

### DIFF
--- a/src/controllers/settingsView/SettingsAgentFileController.ts
+++ b/src/controllers/settingsView/SettingsAgentFileController.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import type { AgentCategory } from '@shared/schemas/agent';
 
 export interface SettingsAgentFileEntry {
-  path?: string;
+  path: string;
   multiplePath?: string;
 }
 
@@ -56,15 +56,10 @@ export class SettingsAgentFileController {
     customDir: string;
     sourceDir?: string;
   }): SettingsAgentCustomizeResult {
-    const sourcePath = input.entry.path;
-    if (!sourcePath) {
-      return { ok: false, reason: 'targetEscapesCustomDir' };
-    }
-
     const targetPath = this.resolveCustomTargetPath({
       customDir: input.customDir,
       sourceDir: input.sourceDir,
-      sourcePath,
+      sourcePath: input.entry.path,
     });
 
     if (!this.isInside(input.customDir, targetPath)) {
@@ -90,8 +85,7 @@ export class SettingsAgentFileController {
     entry: SettingsAgentFileEntry;
     customDir: string;
   }): SettingsAgentDeleteResult {
-    const sourcePath = input.entry.path;
-    if (!sourcePath || !this.isInside(input.customDir, sourcePath)) {
+    if (!this.isInside(input.customDir, input.entry.path)) {
       return { ok: false, reason: 'fileOutsideCustomDir' };
     }
 
@@ -104,7 +98,7 @@ export class SettingsAgentFileController {
     return {
       ok: true,
       plan: {
-        path: sourcePath,
+        path: input.entry.path,
         ...(multiplePath ? { multiplePath } : {}),
       },
     };


### PR DESCRIPTION
## Summary

- Tighten `SettingsAgentFileController` input typing so planned custom-agent copy/delete operations require a path.
- Remove the unreachable pathless-entry branch and its misleading escape reason; the VS Code handler already checks missing paths before delegating.

Closes part of #3305.

## Validation

- `npx prettier --check src/controllers/settingsView/SettingsAgentFileController.ts src/test/controllers/SettingsAgentFileController.test.ts src/settingsView/handlers/agentHandlers.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsAgentFileController.test.js out/test/controllers/LatexRecommendedSettingsController.test.js out/test/controllers/SettingsAgentVisibilityController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that tightens TypeScript types and removes an unreachable guard branch; behavior changes only for previously-allowed pathless entries, which now must be validated by callers.
> 
> **Overview**
> Tightens `SettingsAgentFileController` inputs so `SettingsAgentFileEntry.path` is required (no longer optional), aligning the controller’s contract with upstream validation.
> 
> Removes the redundant/unused “missing source path” early-return in `planCustomizeAgent` and simplifies `planDeleteCustomAgent` to always use `entry.path`, while retaining the existing directory-escape checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e45105b54b03a8393f25ae44145a450a98a8c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->