### PR TITLE
refactor: extract latex tooling status

### DIFF
--- a/src/controllers/settingsView/LatexToolingController.ts
+++ b/src/controllers/settingsView/LatexToolingController.ts
@@ -1,0 +1,101 @@
+// Local imports - shared constants
+import {
+  DEPENDENCY_INSTALL_COMMANDS,
+  HOMEBREW_INSTALL_COMMAND,
+  SCOOP_INSTALL_COMMAND,
+  type Platform,
+} from '@shared/constants/latex';
+import {
+  DEFAULT_LATEX_SETTINGS_STATUS,
+  type LatexSettingsStatus,
+} from '@shared/schemas/settingsViewMessages';
+
+const LATEX_PROBE_TOOLS = [
+  'pdflatex',
+  'latexmk',
+  'latexdiff',
+  'latexindent',
+  'perl',
+  'texcount',
+  'gs',
+  'gm',
+  'magick',
+] as const;
+
+export type LatexProbeTool = (typeof LATEX_PROBE_TOOLS)[number];
+
+export type LatexPathTool = Exclude<LatexProbeTool, 'perl'>;
+
+export type LatexRecommendedStatus = Pick<
+  LatexSettingsStatus,
+  'outDir' | 'autoRevealExclude'
+>;
+
+export interface LatexToolingControllerDeps {
+  checkToolInstalled(tool: LatexProbeTool): Promise<boolean>;
+  resolvePath(tool: LatexPathTool): string | null;
+  detectPackageManager(): LatexSettingsStatus['packageManager'];
+  getPlatform(): Platform;
+  isLatexWorkshopInstalled(): boolean;
+  getRecommendedStatus(): LatexRecommendedStatus;
+  onDetectionError?: (error: unknown) => void;
+}
+
+const ALLOWED_INSTALL_COMMANDS: ReadonlySet<string> = new Set([
+  HOMEBREW_INSTALL_COMMAND,
+  SCOOP_INSTALL_COMMAND,
+  ...Object.values(DEPENDENCY_INSTALL_COMMANDS).flatMap((platforms) =>
+    Object.values(platforms).flatMap((cmds) => cmds.map((cmd) => cmd.command)),
+  ),
+]);
+
+/** Builds the LaTeX settings status from tool probes and host-provided facts. */
+export class LatexToolingController {
+  constructor(private readonly deps: LatexToolingControllerDeps) {}
+
+  isAllowedInstallCommand(command: string): boolean {
+    return ALLOWED_INSTALL_COMMANDS.has(command);
+  }
+
+  async detectStatus(): Promise<LatexSettingsStatus> {
+    try {
+      const installed = await this.checkTools();
+      return {
+        ...this.deps.getRecommendedStatus(),
+        texDistributionInstalled: installed.pdflatex || installed.latexmk,
+        latexWorkshopInstalled: this.deps.isLatexWorkshopInstalled(),
+        latexdiffInstalled: installed.latexdiff,
+        latexindentInstalled: installed.latexindent && installed.perl,
+        texcountInstalled: installed.texcount,
+        imageProcessingInstalled:
+          installed.gs && (installed.gm || installed.magick),
+        platform: this.deps.getPlatform(),
+        pdflatexPath: this.deps.resolvePath('pdflatex'),
+        latexmkPath: this.deps.resolvePath('latexmk'),
+        latexdiffPath: this.deps.resolvePath('latexdiff'),
+        latexindentPath: this.deps.resolvePath('latexindent'),
+        texcountPath: this.deps.resolvePath('texcount'),
+        ghostscriptPath: this.deps.resolvePath('gs'),
+        graphicsmagickPath:
+          this.deps.resolvePath('gm') ?? this.deps.resolvePath('magick'),
+        packageManager: this.deps.detectPackageManager(),
+      };
+    } catch (error) {
+      this.deps.onDetectionError?.(error);
+      return {
+        ...DEFAULT_LATEX_SETTINGS_STATUS,
+        platform: this.deps.getPlatform(),
+      };
+    }
+  }
+
+  private async checkTools(): Promise<Record<LatexProbeTool, boolean>> {
+    const entries = await Promise.all(
+      LATEX_PROBE_TOOLS.map(
+        async (tool) =>
+          [tool, await this.deps.checkToolInstalled(tool)] as const,
+      ),
+    );
+    return Object.fromEntries(entries) as Record<LatexProbeTool, boolean>;
+  }
+}

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -20,14 +20,10 @@ import {
   type SettingsMessageFor,
   type LatexConfigValues,
   type LatexSettingsStatus,
-  DEFAULT_LATEX_SETTINGS_STATUS,
 } from '@shared/schemas/settingsViewMessages';
 import {
   LATEX_WORKSHOP_EXT_ID,
   normalizePlatform,
-  DEPENDENCY_INSTALL_COMMANDS,
-  HOMEBREW_INSTALL_COMMAND,
-  SCOOP_INSTALL_COMMAND,
 } from '@shared/constants/latex';
 import {
   getConfig,
@@ -41,20 +37,12 @@ import {
 } from '@utils/system/toolUtils';
 import { BinaryResolver } from '@utils/system/binaryResolver';
 import { LatexRecommendedSettingsController } from '../../controllers/settingsView/LatexRecommendedSettingsController';
+import { LatexToolingController } from '../../controllers/settingsView/LatexToolingController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
 /** How long cached LaTeX settings remain valid (ms). */
 const LATEX_SETTINGS_CACHE_TTL = 60_000;
-
-/** Allowlist of commands that may be executed via the Run in Terminal button. */
-const ALLOWED_INSTALL_COMMANDS: ReadonlySet<string> = new Set([
-  HOMEBREW_INSTALL_COMMAND,
-  SCOOP_INSTALL_COMMAND,
-  ...Object.values(DEPENDENCY_INSTALL_COMMANDS).flatMap((platforms) =>
-    Object.values(platforms).flatMap((cmds) => cmds.map((cmd) => cmd.command)),
-  ),
-]);
 
 /**
  * LaTeX settings handler delegate.
@@ -71,6 +59,31 @@ export class LatexSettingsHandlers {
       },
     });
 
+  private readonly toolingController = new LatexToolingController({
+    checkToolInstalled: (tool) => checkToolInstalled(tool, false),
+    resolvePath: (tool) => BinaryResolver.resolvePath(tool),
+    detectPackageManager,
+    getPlatform: () => normalizePlatform(process.platform),
+    isLatexWorkshopInstalled: () =>
+      Boolean(vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID)),
+    getRecommendedStatus: () => ({
+      outDir:
+        this.recommendedSettingsController.isRecommendedValueSet('outDir'),
+      autoRevealExclude:
+        this.recommendedSettingsController.isRecommendedValueSet(
+          'autoRevealExclude',
+        ),
+    }),
+    onDetectionError: (error) => {
+      this.ctx.logger.error(
+        this.ctx.channel,
+        `LaTeX settings detection failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    },
+  });
+
   /** Cached LaTeX settings to avoid redundant tool detection on repeat opens. */
   private latexSettingsCache: {
     settings: LatexSettingsStatus;
@@ -86,7 +99,7 @@ export class LatexSettingsHandlers {
       now - this.latexSettingsCache.timestamp >= LATEX_SETTINGS_CACHE_TTL
     ) {
       this.latexSettingsCache = {
-        settings: await this.detectLatexSettings(),
+        settings: await this.toolingController.detectStatus(),
         timestamp: now,
       };
     }
@@ -201,7 +214,7 @@ export class LatexSettingsHandlers {
   async handleRunInstallCommand(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.RUN_INSTALL_COMMAND>,
   ): Promise<void> {
-    if (!ALLOWED_INSTALL_COMMANDS.has(data.installCommand)) {
+    if (!this.toolingController.isAllowedInstallCommand(data.installCommand)) {
       this.ctx.logger.warn(
         this.ctx.channel,
         `Rejected unknown install command: ${data.installCommand}`,
@@ -215,75 +228,6 @@ export class LatexSettingsHandlers {
     });
     terminal.show();
     terminal.sendText(data.installCommand);
-  }
-
-  // ── Private helpers ──
-
-  /** Run all tool checks and build the LaTeX settings status object.
-   *  Returns defaults on failure so the webview spinner always dismisses. */
-  private async detectLatexSettings(): Promise<LatexSettingsStatus> {
-    try {
-      const [
-        pdflatexOk,
-        latexmkOk,
-        latexdiffOk,
-        latexindentOk,
-        perlOk,
-        texcountOk,
-        gsOk,
-        gmOk,
-        magickOk,
-      ] = await Promise.all([
-        checkToolInstalled('pdflatex', false),
-        checkToolInstalled('latexmk', false),
-        checkToolInstalled('latexdiff', false),
-        checkToolInstalled('latexindent', false),
-        checkToolInstalled('perl', false),
-        checkToolInstalled('texcount', false),
-        checkToolInstalled('gs', false),
-        checkToolInstalled('gm', false),
-        checkToolInstalled('magick', false),
-      ]);
-
-      const platform = normalizePlatform(process.platform);
-
-      return {
-        outDir:
-          this.recommendedSettingsController.isRecommendedValueSet('outDir'),
-        autoRevealExclude:
-          this.recommendedSettingsController.isRecommendedValueSet(
-            'autoRevealExclude',
-          ),
-        texDistributionInstalled: pdflatexOk || latexmkOk,
-        latexWorkshopInstalled: Boolean(
-          vscode.extensions.getExtension(LATEX_WORKSHOP_EXT_ID),
-        ),
-        latexdiffInstalled: latexdiffOk,
-        latexindentInstalled: latexindentOk && perlOk,
-        texcountInstalled: texcountOk,
-        imageProcessingInstalled: gsOk && (gmOk || magickOk),
-        platform,
-        pdflatexPath: BinaryResolver.resolvePath('pdflatex'),
-        latexmkPath: BinaryResolver.resolvePath('latexmk'),
-        latexdiffPath: BinaryResolver.resolvePath('latexdiff'),
-        latexindentPath: BinaryResolver.resolvePath('latexindent'),
-        texcountPath: BinaryResolver.resolvePath('texcount'),
-        ghostscriptPath: BinaryResolver.resolvePath('gs'),
-        graphicsmagickPath:
-          BinaryResolver.resolvePath('gm') ??
-          BinaryResolver.resolvePath('magick'),
-        packageManager: detectPackageManager(),
-      };
-    } catch (err) {
-      this.ctx.logger.error(
-        this.ctx.channel,
-        `LaTeX settings detection failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return {
-        ...DEFAULT_LATEX_SETTINGS_STATUS,
-        platform: normalizePlatform(process.platform),
-      };
-    }
   }
 
   /** Install a VS Code extension and optionally refresh the given view data. */

--- a/src/test/controllers/LatexToolingController.test.ts
+++ b/src/test/controllers/LatexToolingController.test.ts
@@ -1,0 +1,156 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - shared constants
+import {
+  HOMEBREW_INSTALL_COMMAND,
+  type Platform,
+} from '../../shared/constants/latex';
+
+// Local imports - shared schemas
+import { DEFAULT_LATEX_SETTINGS_STATUS } from '../../shared/schemas/settingsViewMessages';
+
+// Local imports - controllers
+import {
+  LatexToolingController,
+  type LatexPathTool,
+  type LatexToolingControllerDeps,
+} from '../../controllers/settingsView/LatexToolingController';
+
+const INSTALLED_TOOLS = {
+  pdflatex: false,
+  latexmk: false,
+  latexdiff: false,
+  latexindent: false,
+  perl: false,
+  texcount: false,
+  gs: false,
+  gm: false,
+  magick: false,
+};
+
+function createController(
+  options?: Partial<{
+    installedTools: Partial<Record<keyof typeof INSTALLED_TOOLS, boolean>>;
+    paths: Partial<Record<LatexPathTool, string | null>>;
+    platform: Platform;
+    packageManager: 'brew' | 'apt' | 'scoop' | null;
+    extensionInstalled: boolean;
+    outDir: boolean;
+    autoRevealExclude: boolean;
+    onDetectionError: (error: unknown) => void;
+  }>,
+): LatexToolingController {
+  const installedTools = {
+    ...INSTALLED_TOOLS,
+    ...options?.installedTools,
+  };
+  const paths = options?.paths ?? {};
+  const deps: LatexToolingControllerDeps = {
+    checkToolInstalled: async (tool) => installedTools[tool],
+    resolvePath: (tool) => paths[tool] ?? null,
+    detectPackageManager: () => options?.packageManager ?? null,
+    getPlatform: () => options?.platform ?? 'linux',
+    isLatexWorkshopInstalled: () => options?.extensionInstalled ?? false,
+    getRecommendedStatus: () => ({
+      outDir: options?.outDir ?? false,
+      autoRevealExclude: options?.autoRevealExclude ?? false,
+    }),
+    onDetectionError: options?.onDetectionError,
+  };
+  return new LatexToolingController(deps);
+}
+
+describe('LatexToolingController', () => {
+  it('builds status from probes, paths, and host facts', async () => {
+    const status = await createController({
+      installedTools: {
+        latexmk: true,
+        latexdiff: true,
+        latexindent: true,
+        perl: true,
+        texcount: true,
+        gs: true,
+        magick: true,
+      },
+      paths: {
+        latexmk: '/usr/bin/latexmk',
+        latexdiff: '/usr/bin/latexdiff',
+        latexindent: '/usr/bin/latexindent',
+        texcount: '/usr/bin/texcount',
+        gs: '/usr/bin/gs',
+        magick: '/usr/bin/magick',
+      },
+      platform: 'darwin',
+      packageManager: 'brew',
+      extensionInstalled: true,
+      outDir: true,
+      autoRevealExclude: true,
+    }).detectStatus();
+
+    assert.deepEqual(status, {
+      outDir: true,
+      autoRevealExclude: true,
+      texDistributionInstalled: true,
+      latexWorkshopInstalled: true,
+      latexdiffInstalled: true,
+      latexindentInstalled: true,
+      texcountInstalled: true,
+      imageProcessingInstalled: true,
+      platform: 'darwin',
+      pdflatexPath: null,
+      latexmkPath: '/usr/bin/latexmk',
+      latexdiffPath: '/usr/bin/latexdiff',
+      latexindentPath: '/usr/bin/latexindent',
+      texcountPath: '/usr/bin/texcount',
+      ghostscriptPath: '/usr/bin/gs',
+      graphicsmagickPath: '/usr/bin/magick',
+      packageManager: 'brew',
+    });
+  });
+
+  it('keeps compound dependency flags false until every required tool is present', async () => {
+    const status = await createController({
+      installedTools: {
+        pdflatex: true,
+        latexindent: true,
+        gs: true,
+      },
+    }).detectStatus();
+
+    assert.equal(status.texDistributionInstalled, true);
+    assert.equal(status.latexindentInstalled, false);
+    assert.equal(status.imageProcessingInstalled, false);
+  });
+
+  it('falls back to defaults when detection fails', async () => {
+    const errors: unknown[] = [];
+    const controller = new LatexToolingController({
+      checkToolInstalled: async () => {
+        throw new Error('probe failed');
+      },
+      resolvePath: () => null,
+      detectPackageManager: () => 'apt',
+      getPlatform: () => 'win32',
+      isLatexWorkshopInstalled: () => true,
+      getRecommendedStatus: () => ({ outDir: true, autoRevealExclude: true }),
+      onDetectionError: (error) => errors.push(error),
+    });
+
+    assert.deepEqual(await controller.detectStatus(), {
+      ...DEFAULT_LATEX_SETTINGS_STATUS,
+      platform: 'win32',
+    });
+    assert.equal(errors.length, 1);
+  });
+
+  it('allowlists structured install commands only', () => {
+    const controller = createController();
+
+    assert.equal(
+      controller.isAllowedInstallCommand(HOMEBREW_INSTALL_COMMAND),
+      true,
+    );
+    assert.equal(controller.isAllowedInstallCommand('rm -rf ~/.texra'), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Move LaTeX tool probing, derived status flags, and install-command allowlisting into a host-neutral settings controller.
- Keep VS Code side effects in the LaTeX settings handler while narrowing its role to webview messages, terminals, extension installation, and cache refresh.
- Add focused controller coverage for derived status, compound dependency flags, fallback behavior, and install-command validation.

Closes part of #3305.

## Validation
- npx prettier --check src/controllers/settingsView/LatexToolingController.ts src/settingsView/handlers/latexSettingsHandlers.ts src/test/controllers/LatexToolingController.test.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/controllers/LatexToolingController.test.js out/test/controllers/LatexRecommendedSettingsController.test.js
- npm run lint
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the LaTeX settings detection and install-command allowlisting that gate terminal command execution; behavior should be equivalent but mistakes could impact dependency status reporting or inadvertently reject/allow install commands.
> 
> **Overview**
> Introduces a new host-neutral `LatexToolingController` that owns LaTeX tool probing, derived status flags (e.g. TeX distribution, `latexindent+perl`, image-processing dependencies), path resolution, and install-command allowlisting.
> 
> Updates `LatexSettingsHandlers` to delegate status detection and command allowlisting to the controller, removing the inline probe/allowlist logic while keeping VS Code side effects (logging, terminals, extension install) in the handler.
> 
> Adds unit tests covering status composition, compound dependency flags, error fallback to `DEFAULT_LATEX_SETTINGS_STATUS`, and install-command validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd3cdd680931bf4157afabb483a0fc9b00dfc65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->