### PR TITLE
refactor: route coordinators through runtime host

### DIFF
--- a/src/agent/runtime/AgentProposalCoordinator.ts
+++ b/src/agent/runtime/AgentProposalCoordinator.ts
@@ -16,7 +16,7 @@ import {
   BasePromiseCoordinator,
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
-import type { ProgressSink } from './ProgressSink';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 // ============================================================================
 // Types
@@ -69,10 +69,10 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
     const { proposalId, proposal, timeoutMs } = options;
 
     // Request host to show progress view so user sees the proposal
-    this.progressSink.emit('requestEnsureProgressView', {});
+    this.runtimeHost.emit('requestEnsureProgressView', {});
 
     // Activate the stream that needs approval so user sees the prompt immediately
-    this.progressSink.emit('setActiveStream', { streamId });
+    this.runtimeHost.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
       proposalId,
@@ -87,9 +87,9 @@ export class AgentProposalCoordinator extends BasePromiseCoordinator<
 // ============================================================================
 
 export function createAgentProposalCoordinator(
-  progressSink: ProgressSink,
+  runtimeHost: AgentRuntimeHost,
 ): AgentProposalCoordinator {
-  return new AgentProposalCoordinator(progressSink);
+  return new AgentProposalCoordinator(runtimeHost);
 }
 
 /** Singleton coordinator instance. */

--- a/src/agent/runtime/BasePromiseCoordinator.ts
+++ b/src/agent/runtime/BasePromiseCoordinator.ts
@@ -17,11 +17,10 @@
  * 3. On resolution → emits resolve event to dismiss UI, defers cleanup
  */
 
-// Local imports
 import {
-  getDefaultProgressSink,
-  type ProgressSink,
-} from '@agent/runtime/ProgressSink';
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 
 // ============================================================================
@@ -39,6 +38,7 @@ type RequestState<TResult> =
   | {
       status: 'pending';
       resolve: (result: TResult) => void;
+      runtimeHost: AgentRuntimeHost;
       timeoutId?: NodeJS.Timeout;
     }
   | { status: 'resolved' };
@@ -65,10 +65,10 @@ export abstract class BasePromiseCoordinator<
   TResult extends BaseResult,
   TShowPayload extends Record<string, unknown>,
 > {
-  constructor(private readonly configuredProgressSink?: ProgressSink) {}
+  constructor(private readonly configuredRuntimeHost?: AgentRuntimeHost) {}
 
-  protected get progressSink(): ProgressSink {
-    return this.configuredProgressSink ?? getDefaultProgressSink();
+  protected get runtimeHost(): AgentRuntimeHost {
+    return this.configuredRuntimeHost ?? getAgentRuntimeHost();
   }
 
   /** Single source of truth for all pending requests */
@@ -96,11 +96,14 @@ export abstract class BasePromiseCoordinator<
     payload: TShowPayload,
     options?: { timeoutMs?: number; onTimeout?: () => TResult },
   ): Promise<TResult> {
+    const runtimeHost = this.runtimeHost;
+
     // Cancel any existing pending request for this ID
     const existing = this.requests.get(id);
     if (existing?.status === 'pending') {
       clearTimeout(existing.timeoutId);
       existing.resolve(this.getDefaultCancelResult());
+      this.cleanup(id, existing.runtimeHost);
     }
 
     return new Promise<TResult>((resolve) => {
@@ -118,11 +121,12 @@ export abstract class BasePromiseCoordinator<
       this.requests.set(id, {
         status: 'pending',
         resolve,
+        runtimeHost,
         timeoutId,
       });
 
       // Emit show event (cast needed for generic base class)
-      this.progressSink.emit(this.config.showEventName, payload as any);
+      runtimeHost.emit(this.config.showEventName, payload as any);
     });
   }
 
@@ -150,7 +154,7 @@ export abstract class BasePromiseCoordinator<
 
     clearTimeout(req.timeoutId);
     req.resolve(this.getDefaultCancelResult());
-    this.cleanup(id);
+    this.cleanup(id, req.runtimeHost);
   }
 
   // ==========================================================================
@@ -176,18 +180,18 @@ export abstract class BasePromiseCoordinator<
 
     clearTimeout(req.timeoutId);
     req.resolve(result);
-    this.cleanup(id);
+    this.cleanup(id, req.runtimeHost);
     return true;
   }
 
   /**
    * Clean up state and emit resolution event.
    */
-  private cleanup(id: string): void {
+  private cleanup(id: string, runtimeHost: AgentRuntimeHost): void {
     this.requests.set(id, { status: 'resolved' });
 
     // Emit resolve event (cast needed for generic base class)
-    this.progressSink.emit(this.config.resolveEventName, {
+    runtimeHost.emit(this.config.resolveEventName, {
       [this.config.idFieldName]: id,
     } as any);
 

--- a/src/agent/runtime/PlanApprovalCoordinator.ts
+++ b/src/agent/runtime/PlanApprovalCoordinator.ts
@@ -12,7 +12,7 @@ import {
   BasePromiseCoordinator,
   type CoordinatorConfig,
 } from './BasePromiseCoordinator';
-import type { ProgressSink } from './ProgressSink';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
 
 // ============================================================================
 // Types
@@ -73,10 +73,10 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
     this.approvalStreamMap.set(approvalId, streamId);
 
     // Request host to show progress view so user sees the approval prompt
-    this.progressSink.emit('requestEnsureProgressView', {});
+    this.runtimeHost.emit('requestEnsureProgressView', {});
 
     // Activate the stream that needs approval so user sees the prompt immediately
-    this.progressSink.emit('setActiveStream', { streamId });
+    this.runtimeHost.emit('setActiveStream', { streamId });
 
     return this.waitForUserAction(
       approvalId,
@@ -126,9 +126,9 @@ export class PlanApprovalCoordinator extends BasePromiseCoordinator<
 // ============================================================================
 
 export function createPlanApprovalCoordinator(
-  progressSink: ProgressSink,
+  runtimeHost: AgentRuntimeHost,
 ): PlanApprovalCoordinator {
-  return new PlanApprovalCoordinator(progressSink);
+  return new PlanApprovalCoordinator(runtimeHost);
 }
 
 /** Singleton coordinator instance. */

--- a/src/test/agent/runtime/PromiseCoordinators.test.ts
+++ b/src/test/agent/runtime/PromiseCoordinators.test.ts
@@ -1,0 +1,110 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import {
+  createAgentRuntimeHost,
+  runWithAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { PlanApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { Plan } from '@shared/schemas';
+
+type RecordedEvent = {
+  event: keyof ProgressEventPayloads;
+  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+};
+
+function createRecordingHost(): {
+  events: RecordedEvent[];
+  host: AgentRuntimeHost;
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    host: createAgentRuntimeHost({
+      emit: (event, payload) => events.push({ event, payload }),
+    }),
+  };
+}
+
+describe('promise coordinators', () => {
+  it('captures the scoped runtime host for approval show and resolve events', async () => {
+    const coordinator = new PlanApprovalCoordinator();
+    const { events, host } = createRecordingHost();
+    const plan: Plan = {
+      summary: 'Refactor runtime event plumbing',
+      steps: [
+        {
+          title: 'Capture host',
+          description: 'Use the current runtime host for approval events',
+          status: 'pending',
+          files: [],
+        },
+      ],
+    };
+
+    const resultPromise = runWithAgentRuntimeHost(host, () =>
+      coordinator.waitForApproval('stream:runtime', {
+        approvalId: 'approval:runtime',
+        plan,
+      }),
+    );
+
+    coordinator.resolveRequest('approval:runtime', { action: 'approve' });
+
+    assert.deepEqual(await resultPromise, { action: 'approve' });
+    assert.deepEqual(events, [
+      { event: 'requestEnsureProgressView', payload: {} },
+      { event: 'setActiveStream', payload: { streamId: 'stream:runtime' } },
+      {
+        event: 'showPlanApproval',
+        payload: {
+          approvalId: 'approval:runtime',
+          streamId: 'stream:runtime',
+          plan,
+        },
+      },
+      {
+        event: 'resolvePlanApproval',
+        payload: { approvalId: 'approval:runtime' },
+      },
+    ]);
+  });
+
+  it('dismisses the previous host when a scoped request is replaced', async () => {
+    const coordinator = new PlanApprovalCoordinator();
+    const first = createRecordingHost();
+    const second = createRecordingHost();
+    const plan: Plan = {
+      summary: 'Replace pending approval',
+      steps: [],
+    };
+
+    const firstResult = runWithAgentRuntimeHost(first.host, () =>
+      coordinator.waitForApproval('stream:first', {
+        approvalId: 'approval:replace',
+        plan,
+      }),
+    );
+    const secondResult = runWithAgentRuntimeHost(second.host, () =>
+      coordinator.waitForApproval('stream:second', {
+        approvalId: 'approval:replace',
+        plan,
+      }),
+    );
+
+    assert.deepEqual(await firstResult, { action: 'reject' });
+    assert.equal(
+      first.events.at(-1)?.event,
+      'resolvePlanApproval',
+      'the first host should receive the dismissal event',
+    );
+
+    coordinator.resolveRequest('approval:replace', { action: 'approve' });
+
+    assert.deepEqual(await secondResult, { action: 'approve' });
+    assert.equal(second.events.at(-1)?.event, 'resolvePlanApproval');
+  });
+});


### PR DESCRIPTION
## Summary
- Route promise coordinator emissions through AgentRuntimeHost instead of keeping a lower-level progress sink dependency in the coordinator base class.
- Capture the runtime host when a request is created so later resolve and clear paths emit through the same host context.
- Update plan approval and agent proposal coordinator factories to accept the runtime host boundary directly.
- Add focused runtime coverage for scoped host capture across show and resolve events.

Closes part of #3327.

## Validation
- npx prettier --check src/agent/runtime/BasePromiseCoordinator.ts src/agent/runtime/PlanApprovalCoordinator.ts src/agent/runtime/AgentProposalCoordinator.ts src/test/agent/runtime/PromiseCoordinators.test.ts
- git diff --check origin/main..HEAD
- npm run compile-tests
- npx mocha --require ./out/test/setup.js ./out/test/agent/runtime/PromiseCoordinators.test.js
- npm run lint
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how promise coordinators choose where to emit UI show/resolve events by capturing and reusing a scoped `AgentRuntimeHost`, which could affect dismissal/show behavior across concurrent streams if incorrect. Scope is limited to coordinator plumbing and is covered by new runtime-focused tests.
> 
> **Overview**
> Promise-based coordinators now emit `show*`/`resolve*` progress events through `AgentRuntimeHost` rather than a direct `ProgressSink`, and each pending request captures the host at creation time so later `resolve`/`clear`/replacement cleanup emits back to the same host.
> 
> `PlanApprovalCoordinator` and `AgentProposalCoordinator` factories are updated to accept an `AgentRuntimeHost`, and a new test suite (`PromiseCoordinators.test.ts`) verifies host scoping for both normal resolution and request replacement cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d678e997424faff27a71ca17e789cc24dfa7902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->