### PR TITLE
refactor: extract agent catalog controller

### DIFF
--- a/src/controllers/settingsView/SettingsAgentCatalogController.ts
+++ b/src/controllers/settingsView/SettingsAgentCatalogController.ts
@@ -1,0 +1,171 @@
+// Local imports - shared
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+import {
+  AGENT_MODE_PRESETS,
+  AgentModePresetSchema,
+} from '@shared/schemas/agentPresets';
+import {
+  agentKey,
+  type AgentCategory,
+  type AgentSource,
+} from '@shared/schemas/agent';
+import type { AgentSelectionItem } from '@shared/schemas/settingsViewMessages';
+
+export interface SettingsAgentCatalogEntry {
+  name: string;
+  source: AgentSource;
+  category: AgentCategory;
+  description?: string;
+  path?: string;
+  multiplePath?: string;
+  isMultiple?: boolean;
+  tools?: string[];
+}
+
+export interface SettingsAgentCatalogState {
+  getEnabledAgentKeys(category: AgentCategory): string[] | undefined;
+  setEnabledAgentKeys(
+    category: AgentCategory,
+    enabledKeys: string[],
+  ): Promise<void>;
+  getAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
+  getVisibleAgents(category: AgentCategory): SettingsAgentCatalogEntry[];
+  getCustomPresetsRaw(): unknown;
+  setCustomPresets(presets: AgentModePreset[]): Promise<void>;
+}
+
+export interface SettingsAgentCatalogControllerDeps {
+  state: SettingsAgentCatalogState;
+  now?: () => number;
+}
+
+export type SettingsAgentPresetApplyResult =
+  | { ok: true; preset: AgentModePreset }
+  | { ok: false; reason: 'unknownPreset' };
+
+export class SettingsAgentCatalogController {
+  constructor(private readonly deps: SettingsAgentCatalogControllerDeps) {}
+
+  buildSelectionItems(): {
+    workflow: AgentSelectionItem[];
+    toolUse: AgentSelectionItem[];
+  } {
+    return {
+      workflow: this.buildCategorySelectionItems('workflow'),
+      toolUse: this.buildCategorySelectionItems('toolUse'),
+    };
+  }
+
+  getCustomPresets(): AgentModePreset[] {
+    return AgentModePresetSchema.array()
+      .catch([])
+      .parse(this.deps.state.getCustomPresetsRaw());
+  }
+
+  getCustomPreset(presetId: string): AgentModePreset | null {
+    return (
+      this.getCustomPresets().find((preset) => preset.id === presetId) ?? null
+    );
+  }
+
+  async applyPreset(presetId: string): Promise<SettingsAgentPresetApplyResult> {
+    const preset = this.getPreset(presetId);
+    if (!preset) return { ok: false, reason: 'unknownPreset' };
+
+    await this.deps.state.setEnabledAgentKeys(
+      'workflow',
+      this.resolveAgentKeys('workflow', new Set(preset.workflowAgents)),
+    );
+    await this.deps.state.setEnabledAgentKeys(
+      'toolUse',
+      this.resolveAgentKeys('toolUse', new Set(preset.toolUseAgents)),
+    );
+
+    return { ok: true, preset };
+  }
+
+  async saveCurrentPreset(name: string): Promise<AgentModePreset> {
+    const trimmedName = name.trim();
+    const workflowAgents = this.deps.state
+      .getVisibleAgents('workflow')
+      .map((entry) => entry.name);
+    const toolUseAgents = this.deps.state
+      .getVisibleAgents('toolUse')
+      .map((entry) => entry.name);
+    const preset: AgentModePreset = {
+      id: `custom-${this.deps.now?.() ?? Date.now()}`,
+      name: trimmedName,
+      description: `Custom team: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
+      icon: 'codicon-bookmark',
+      workflowAgents,
+      toolUseAgents,
+    };
+
+    await this.deps.state.setCustomPresets([
+      ...this.getCustomPresets(),
+      preset,
+    ]);
+    return preset;
+  }
+
+  async deleteCustomPreset(presetId: string): Promise<AgentModePreset | null> {
+    const presets = this.getCustomPresets();
+    const target = presets.find((preset) => preset.id === presetId);
+    if (!target) return null;
+
+    await this.deps.state.setCustomPresets(
+      presets.filter((preset) => preset.id !== presetId),
+    );
+    return target;
+  }
+
+  private buildCategorySelectionItems(
+    category: AgentCategory,
+  ): AgentSelectionItem[] {
+    const enabledKeys = this.deps.state.getEnabledAgentKeys(category);
+    return this.deps.state
+      .getAgents(category)
+      .map((entry) => this.toSelectionItem(entry, enabledKeys))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private toSelectionItem(
+    entry: SettingsAgentCatalogEntry,
+    enabledKeys: string[] | undefined,
+  ): AgentSelectionItem {
+    const key = agentKey(entry.source, entry.name);
+    return {
+      name: entry.name,
+      source: entry.source,
+      category: entry.category,
+      description: entry.description,
+      hasPath: Boolean(entry.path),
+      filePath: entry.path || undefined,
+      tools: entry.tools,
+      hasMultiple: entry.isMultiple ?? Boolean(entry.multiplePath),
+      hasMultiplePath: Boolean(entry.multiplePath),
+      // undefined = never configured -> all enabled; [] = explicitly none enabled.
+      enabled:
+        enabledKeys === undefined ||
+        enabledKeys.includes(key) ||
+        enabledKeys.includes(entry.name),
+    };
+  }
+
+  private getPreset(presetId: string): AgentModePreset | null {
+    return (
+      AGENT_MODE_PRESETS.find((preset) => preset.id === presetId) ??
+      this.getCustomPreset(presetId)
+    );
+  }
+
+  private resolveAgentKeys(
+    category: AgentCategory,
+    names: Set<string>,
+  ): string[] {
+    return this.deps.state
+      .getAgents(category)
+      .filter((entry) => names.has(entry.name))
+      .map((entry) => agentKey(entry.source, entry.name));
+  }
+}

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -7,10 +7,8 @@
  */
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { z } from 'zod';
 
 import {
-  type AgentEntry,
   createKey,
   getAgent,
   getVisibleAgents,
@@ -32,70 +30,24 @@ import {
 } from '@common/state';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import {
-  AGENT_MODE_PRESETS,
-  AgentModePresetSchema,
-  type AgentModePreset,
-} from '@shared/schemas/agentPresets';
-import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
-  type AgentSelectionItem,
 } from '@shared/schemas/settingsViewMessages';
 import { AbsoluteFS } from '@utils/files';
+import {
+  SettingsAgentCatalogController,
+  type SettingsAgentCatalogState,
+} from '../../controllers/settingsView/SettingsAgentCatalogController';
 import { SettingsAgentFileController } from '../../controllers/settingsView/SettingsAgentFileController';
 import { SettingsAgentVisibilityController } from '../../controllers/settingsView/SettingsAgentVisibilityController';
 
 import type { SettingsHandlerContext } from './SettingsHandlerContext';
 
-function entryToSelectionItem(
-  entry: AgentEntry,
-  enabledKeys: string[] | undefined,
-): AgentSelectionItem {
-  const key = createKey(entry.source, entry.name);
-  // undefined = never configured → all enabled; [] = explicitly empty → none enabled
-  const enabled =
-    enabledKeys === undefined ||
-    enabledKeys.includes(key) ||
-    enabledKeys.includes(entry.name);
-  return {
-    name: entry.name,
-    source: entry.source,
-    category: entry.category,
-    description: entry.description,
-    hasPath: Boolean(entry.path),
-    filePath: entry.path || undefined,
-    tools: entry.tools,
-    hasMultiple: entry.isMultiple ?? Boolean(entry.multiplePath),
-    hasMultiplePath: Boolean(entry.multiplePath),
-    enabled,
-  };
-}
-
-export function buildAgentSelectionItems(): {
-  workflow: AgentSelectionItem[];
-  toolUse: AgentSelectionItem[];
-} {
-  // No default → undefined means "never configured" (all enabled)
-  const workflowEnabled = workspaceSM.get<string[]>(
-    WorkspaceStateKey.ENABLED_AGENTS,
-  );
-  const toolUseEnabled = workspaceSM.get<string[]>(
-    WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-  );
-
-  const workflow = getWorkflowAgents()
-    .map((e) => entryToSelectionItem(e, workflowEnabled))
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const toolUse = getToolUseAgents()
-    .map((e) => entryToSelectionItem(e, toolUseEnabled))
-    .sort((a, b) => a.name.localeCompare(b.name));
-  return { workflow, toolUse };
-}
-
 /**
  * Agent selection, directory, and team handler delegate.
  */
 export class AgentHandlers {
+  private readonly catalogController: SettingsAgentCatalogController;
   private readonly fileController = new SettingsAgentFileController();
   private readonly visibilityController: SettingsAgentVisibilityController;
 
@@ -103,27 +55,47 @@ export class AgentHandlers {
     private readonly ctx: SettingsHandlerContext,
     private readonly refreshAfterAgentMutation: () => Promise<void>,
   ) {
+    const agentCatalogState: SettingsAgentCatalogState = {
+      getEnabledAgentKeys: (category: 'workflow' | 'toolUse') =>
+        workspaceSM.get<string[]>(
+          category === 'workflow'
+            ? WorkspaceStateKey.ENABLED_AGENTS
+            : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+        ),
+      setEnabledAgentKeys: async (
+        category: 'workflow' | 'toolUse',
+        enabledKeys: string[],
+      ) => {
+        await workspaceSM.update(
+          category === 'workflow'
+            ? WorkspaceStateKey.ENABLED_AGENTS
+            : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
+          enabledKeys,
+        );
+      },
+      getAgents: (category: 'workflow' | 'toolUse') =>
+        category === 'workflow' ? getWorkflowAgents() : getToolUseAgents(),
+      getVisibleAgents: (category: 'workflow' | 'toolUse') =>
+        getVisibleAgents(category),
+      getCustomPresetsRaw: () =>
+        workspaceSM.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
+      setCustomPresets: async (presets) => {
+        await workspaceSM.update(
+          WorkspaceStateKey.CUSTOM_AGENT_PRESETS,
+          presets,
+        );
+      },
+    };
+
+    this.catalogController = new SettingsAgentCatalogController({
+      state: agentCatalogState,
+    });
     this.visibilityController = new SettingsAgentVisibilityController({
       state: {
-        getEnabledAgentKeys: (category) =>
-          workspaceSM.get<string[]>(
-            category === 'workflow'
-              ? WorkspaceStateKey.ENABLED_AGENTS
-              : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-          ),
-        setEnabledAgentKeys: async (category, enabledKeys) => {
-          await workspaceSM.update(
-            category === 'workflow'
-              ? WorkspaceStateKey.ENABLED_AGENTS
-              : WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-            enabledKeys,
-          );
-        },
+        getEnabledAgentKeys: agentCatalogState.getEnabledAgentKeys,
+        setEnabledAgentKeys: agentCatalogState.setEnabledAgentKeys,
         getAgents: (category) =>
-          (category === 'workflow'
-            ? getWorkflowAgents()
-            : getToolUseAgents()
-          ).map((entry) => ({
+          agentCatalogState.getAgents(category).map((entry) => ({
             source: entry.source,
             name: entry.name,
           })),
@@ -135,7 +107,7 @@ export class AgentHandlers {
 
   async sendAgentSelectionData(webview: vscode.Webview): Promise<void> {
     await loadAgents();
-    const { workflow, toolUse } = buildAgentSelectionItems();
+    const { workflow, toolUse } = this.catalogController.buildSelectionItems();
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
       workflow,
@@ -516,7 +488,7 @@ export class AgentHandlers {
   async sendAgentModePresets(webview: vscode.Webview): Promise<void> {
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
-      customPresets: this.getCustomPresets(),
+      customPresets: this.catalogController.getCustomPresets(),
     });
   }
 
@@ -524,35 +496,16 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const preset =
-        AGENT_MODE_PRESETS.find((p) => p.id === data.presetId) ??
-        this.getCustomPresets().find((p) => p.id === data.presetId);
-      if (!preset) {
+      const result = await this.catalogController.applyPreset(data.presetId);
+      if (!result.ok) {
         await vscode.window.showErrorMessage(`Unknown team: ${data.presetId}`);
         return;
       }
 
-      await loadAgents();
-
-      const workflowKeys = this.resolveAgentKeys(
-        'workflow',
-        new Set(preset.workflowAgents),
-      );
-      const toolUseKeys = this.resolveAgentKeys(
-        'toolUse',
-        new Set(preset.toolUseAgents),
-      );
-
-      await workspaceSM.update(WorkspaceStateKey.ENABLED_AGENTS, workflowKeys);
-      await workspaceSM.update(
-        WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS,
-        toolUseKeys,
-      );
-
       await this.refreshAfterAgentMutation();
 
       void vscode.window.showInformationMessage(
-        `Applied "${preset.name}" team`,
+        `Applied "${result.preset.name}" team`,
       );
     } catch (error) {
       await showLoggedErrorMessage(
@@ -576,23 +529,7 @@ export class AgentHandlers {
 
       await loadAgents();
 
-      const workflowAgents = getVisibleAgents('workflow').map((e) => e.name);
-      const toolUseAgents = getVisibleAgents('toolUse').map((e) => e.name);
-
-      const preset: AgentModePreset = {
-        id: `custom-${Date.now()}`,
-        name: name.trim(),
-        description: `Custom team: ${[...toolUseAgents, ...workflowAgents].join(', ')}`,
-        icon: 'codicon-bookmark',
-        workflowAgents,
-        toolUseAgents,
-      };
-
-      const existing = this.getCustomPresets();
-      await workspaceSM.update(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
-        ...existing,
-        preset,
-      ]);
+      await this.catalogController.saveCurrentPreset(name);
 
       await this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w));
 
@@ -610,8 +547,7 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.DELETE_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
-      const presets = this.getCustomPresets();
-      const target = presets.find((p) => p.id === data.presetId);
+      const target = this.catalogController.getCustomPreset(data.presetId);
       if (!target) return;
 
       const confirm = await vscode.window.showWarningMessage(
@@ -621,8 +557,7 @@ export class AgentHandlers {
       );
       if (confirm !== 'Delete') return;
 
-      const updated = presets.filter((p) => p.id !== data.presetId);
-      await workspaceSM.update(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, updated);
+      await this.catalogController.deleteCustomPreset(data.presetId);
 
       await this.ctx.withActiveWebview((w) => this.sendAgentModePresets(w));
     } catch (error) {
@@ -702,24 +637,5 @@ export class AgentHandlers {
       }),
       vscode.commands.executeCommand('texra.refreshAllOptions'),
     ]);
-  }
-
-  /** Read and validate custom teams from workspace state. */
-  private getCustomPresets(): AgentModePreset[] {
-    const raw = workspaceSM.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []);
-    const parsed = z.array(AgentModePresetSchema).safeParse(raw);
-    return parsed.success ? parsed.data : [];
-  }
-
-  /** Resolve agent names to source:name keys for the given category. */
-  private resolveAgentKeys(
-    category: 'workflow' | 'toolUse',
-    names: Set<string>,
-  ): string[] {
-    const entries =
-      category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
-    return entries
-      .filter((e) => names.has(e.name))
-      .map((e) => createKey(e.source, e.name));
   }
 }

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -496,6 +496,7 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.APPLY_AGENT_MODE_PRESET>,
   ): Promise<void> {
     try {
+      await loadAgents();
       const result = await this.catalogController.applyPreset(data.presetId);
       if (!result.ok) {
         await vscode.window.showErrorMessage(`Unknown team: ${data.presetId}`);

--- a/src/test/controllers/SettingsAgentCatalogController.test.ts
+++ b/src/test/controllers/SettingsAgentCatalogController.test.ts
@@ -56,9 +56,7 @@ function createController(options?: {
   customPresets: AgentModePreset[];
 } {
   const enabled = { ...(options?.enabled ?? {}) };
-  let customPresets: AgentModePreset[] = Array.isArray(options?.customPresets)
-    ? (options.customPresets as AgentModePreset[])
-    : [];
+  let customPresetsRaw: unknown = options?.customPresets ?? [];
   return {
     controller: new SettingsAgentCatalogController({
       now: () => options?.now ?? 123,
@@ -70,15 +68,17 @@ function createController(options?: {
         getAgents: (category) => AGENTS[category],
         getVisibleAgents: (category) =>
           options?.visible?.[category] ?? AGENTS[category],
-        getCustomPresetsRaw: () => options?.customPresets ?? customPresets,
+        getCustomPresetsRaw: () => customPresetsRaw,
         setCustomPresets: async (presets) => {
-          customPresets = presets;
+          customPresetsRaw = presets;
         },
       },
     }),
     enabled,
     get customPresets() {
-      return customPresets;
+      return Array.isArray(customPresetsRaw)
+        ? (customPresetsRaw as AgentModePreset[])
+        : [];
     },
   };
 }

--- a/src/test/controllers/SettingsAgentCatalogController.test.ts
+++ b/src/test/controllers/SettingsAgentCatalogController.test.ts
@@ -1,0 +1,227 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - shared
+import type { AgentCategory } from '@shared/schemas/agent';
+import type { AgentModePreset } from '@shared/schemas/agentPresets';
+
+// Local imports - controllers
+import {
+  SettingsAgentCatalogController,
+  type SettingsAgentCatalogEntry,
+} from '../../controllers/settingsView/SettingsAgentCatalogController';
+
+const AGENTS: Record<AgentCategory, SettingsAgentCatalogEntry[]> = {
+  workflow: [
+    {
+      source: 'remote',
+      name: 'writer',
+      category: 'workflow',
+      description: 'Remote writer',
+      isMultiple: true,
+    },
+    {
+      source: 'builtInWorkflow',
+      name: 'correct',
+      category: 'workflow',
+      path: '/agents/correct.yaml',
+      multiplePath: '/agents/correct_multiple.yaml',
+    },
+  ],
+  toolUse: [
+    {
+      source: 'builtInToolUse',
+      name: 'review',
+      category: 'toolUse',
+      path: '/tools/review.yaml',
+      tools: ['grep'],
+    },
+    {
+      source: 'custom',
+      name: 'customTool',
+      category: 'toolUse',
+      path: '/custom/customTool.yaml',
+    },
+  ],
+};
+
+function createController(options?: {
+  enabled?: Partial<Record<AgentCategory, string[] | undefined>>;
+  visible?: Partial<Record<AgentCategory, SettingsAgentCatalogEntry[]>>;
+  customPresets?: unknown;
+  now?: number;
+}): {
+  controller: SettingsAgentCatalogController;
+  enabled: Partial<Record<AgentCategory, string[] | undefined>>;
+  customPresets: AgentModePreset[];
+} {
+  const enabled = { ...(options?.enabled ?? {}) };
+  let customPresets: AgentModePreset[] = Array.isArray(options?.customPresets)
+    ? (options.customPresets as AgentModePreset[])
+    : [];
+  return {
+    controller: new SettingsAgentCatalogController({
+      now: () => options?.now ?? 123,
+      state: {
+        getEnabledAgentKeys: (category) => enabled[category],
+        setEnabledAgentKeys: async (category, enabledKeys) => {
+          enabled[category] = enabledKeys;
+        },
+        getAgents: (category) => AGENTS[category],
+        getVisibleAgents: (category) =>
+          options?.visible?.[category] ?? AGENTS[category],
+        getCustomPresetsRaw: () => options?.customPresets ?? customPresets,
+        setCustomPresets: async (presets) => {
+          customPresets = presets;
+        },
+      },
+    }),
+    enabled,
+    get customPresets() {
+      return customPresets;
+    },
+  };
+}
+
+describe('SettingsAgentCatalogController', () => {
+  it('builds sorted selection items with never-configured and legacy enabled state', () => {
+    const { controller } = createController({
+      enabled: {
+        toolUse: ['customTool'],
+      },
+    });
+
+    assert.deepEqual(controller.buildSelectionItems(), {
+      workflow: [
+        {
+          name: 'correct',
+          source: 'builtInWorkflow',
+          category: 'workflow',
+          description: undefined,
+          hasPath: true,
+          filePath: '/agents/correct.yaml',
+          tools: undefined,
+          hasMultiple: true,
+          hasMultiplePath: true,
+          enabled: true,
+        },
+        {
+          name: 'writer',
+          source: 'remote',
+          category: 'workflow',
+          description: 'Remote writer',
+          hasPath: false,
+          filePath: undefined,
+          tools: undefined,
+          hasMultiple: true,
+          hasMultiplePath: false,
+          enabled: true,
+        },
+      ],
+      toolUse: [
+        {
+          name: 'customTool',
+          source: 'custom',
+          category: 'toolUse',
+          description: undefined,
+          hasPath: true,
+          filePath: '/custom/customTool.yaml',
+          tools: undefined,
+          hasMultiple: false,
+          hasMultiplePath: false,
+          enabled: true,
+        },
+        {
+          name: 'review',
+          source: 'builtInToolUse',
+          category: 'toolUse',
+          description: undefined,
+          hasPath: true,
+          filePath: '/tools/review.yaml',
+          tools: ['grep'],
+          hasMultiple: false,
+          hasMultiplePath: false,
+          enabled: false,
+        },
+      ],
+    });
+  });
+
+  it('applies custom presets by resolving names to canonical source keys', async () => {
+    const preset: AgentModePreset = {
+      id: 'custom-team',
+      name: 'Custom Team',
+      description: 'test',
+      icon: 'codicon-bookmark',
+      workflowAgents: ['writer'],
+      toolUseAgents: ['review', 'missing'],
+    };
+    const { controller, enabled } = createController({
+      customPresets: [preset],
+    });
+
+    assert.deepEqual(await controller.applyPreset('custom-team'), {
+      ok: true,
+      preset,
+    });
+    assert.deepEqual(enabled.workflow, ['remote:writer']);
+    assert.deepEqual(enabled.toolUse, ['builtInToolUse:review']);
+  });
+
+  it('reports unknown presets without writing enabled agent state', async () => {
+    const { controller, enabled } = createController();
+
+    assert.deepEqual(await controller.applyPreset('missing'), {
+      ok: false,
+      reason: 'unknownPreset',
+    });
+    assert.deepEqual(enabled, {});
+  });
+
+  it('loads invalid custom presets as an empty list', () => {
+    const { controller } = createController({
+      customPresets: [{ id: 'broken' }],
+    });
+
+    assert.deepEqual(controller.getCustomPresets(), []);
+  });
+
+  it('saves the currently visible agents as a custom preset', async () => {
+    const state = createController({
+      now: 456,
+      visible: {
+        workflow: [AGENTS.workflow[1]],
+        toolUse: [AGENTS.toolUse[0]],
+      },
+    });
+
+    assert.deepEqual(await state.controller.saveCurrentPreset('  My Team  '), {
+      id: 'custom-456',
+      name: 'My Team',
+      description: 'Custom team: review, correct',
+      icon: 'codicon-bookmark',
+      workflowAgents: ['correct'],
+      toolUseAgents: ['review'],
+    });
+    assert.equal(state.customPresets.length, 1);
+  });
+
+  it('deletes existing custom presets and ignores missing ones', async () => {
+    const preset: AgentModePreset = {
+      id: 'custom-team',
+      name: 'Custom Team',
+      description: 'test',
+      icon: 'codicon-bookmark',
+      workflowAgents: [],
+      toolUseAgents: [],
+    };
+    const state = createController({ customPresets: [preset] });
+
+    assert.deepEqual(
+      await state.controller.deleteCustomPreset('custom-team'),
+      preset,
+    );
+    assert.deepEqual(state.customPresets, []);
+    assert.equal(await state.controller.deleteCustomPreset('missing'), null);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract agent selection item construction and custom team policy into a host-neutral settings controller.
- Keep VS Code prompts, editors, file operations, and webview refreshes in `AgentHandlers` while moving catalog/team state transitions behind one controller API.
- Reuse the same catalog state adapter for selection and visibility controllers to reduce duplicated enabled-agent storage wiring.
- Add focused controller coverage for selection projection, custom preset parsing, preset application, saving, and deletion.

Closes part of #3305.

## Validation
- npm install
- npx prettier --check src/controllers/settingsView/SettingsAgentCatalogController.ts src/settingsView/handlers/agentHandlers.ts src/test/controllers/SettingsAgentCatalogController.test.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/controllers/SettingsAgentCatalogController.test.js out/test/controllers/SettingsAgentFileController.test.js out/test/controllers/SettingsAgentVisibilityController.test.js
- npm run lint
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors agent selection/team preset logic behind a new controller while still writing to workspace state; mistakes could change which agents are enabled/disabled when applying or saving teams.
> 
> **Overview**
> Extracts agent catalog responsibilities into a new `SettingsAgentCatalogController`, centralizing selection-item projection, custom team (preset) parsing, preset apply, save, and delete behavior.
> 
> Updates `AgentHandlers` to use this controller via a `SettingsAgentCatalogState` adapter (and reuses the same enabled-agent wiring for `SettingsAgentVisibilityController`), removing duplicated selection/preset helper code and adding unit tests covering the controller’s key behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808fe81d5fd0c274ede0bc20fa034dfd27c5a75a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->