### PR TITLE
refactor: add runtime host event helpers

### DIFF
--- a/src/agent/runtime/AgentRuntimeHost.ts
+++ b/src/agent/runtime/AgentRuntimeHost.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from 'async_hooks';
 
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
 import {
   getDefaultProgressSink,
   setDefaultProgressSink,
@@ -9,14 +11,39 @@ import {
 export interface AgentRuntimeHost {
   progressSink: ProgressSink;
   emit: ProgressSink['emit'];
+  updateStreamStatus: (
+    payload: ProgressEventPayloads['updateStreamStatus'],
+  ) => void;
+  updateQueuedFollowUps: (
+    payload: ProgressEventPayloads['updateQueuedFollowUps'],
+  ) => void;
+  updateActiveSubagents: (
+    payload: ProgressEventPayloads['updateActiveSubagents'],
+  ) => void;
+  updateActiveProcesses: (
+    payload: ProgressEventPayloads['updateActiveProcesses'],
+  ) => void;
+  updateProcessOutput: (
+    payload: ProgressEventPayloads['updateProcessOutput'],
+  ) => void;
+  setParentStream: (payload: ProgressEventPayloads['setParentStream']) => void;
 }
 
 export function createAgentRuntimeHost(
   progressSink: ProgressSink,
 ): AgentRuntimeHost {
+  const emit: ProgressSink['emit'] = (event, payload) =>
+    progressSink.emit(event, payload);
+
   return {
     progressSink,
-    emit: (event, payload) => progressSink.emit(event, payload),
+    emit,
+    updateStreamStatus: (payload) => emit('updateStreamStatus', payload),
+    updateQueuedFollowUps: (payload) => emit('updateQueuedFollowUps', payload),
+    updateActiveSubagents: (payload) => emit('updateActiveSubagents', payload),
+    updateActiveProcesses: (payload) => emit('updateActiveProcesses', payload),
+    updateProcessOutput: (payload) => emit('updateProcessOutput', payload),
+    setParentStream: (payload) => emit('setParentStream', payload),
   };
 }
 

--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -263,7 +263,7 @@ export function emitActiveSubagentsUpdate(
     handles,
     AgentExecutionHandle,
   );
-  runtimeHost.emit('updateActiveSubagents', {
+  runtimeHost.updateActiveSubagents({
     parentStreamId,
     children,
   });
@@ -280,7 +280,7 @@ export function emitActiveProcessesUpdate(
     handles,
     ProcessExecutionHandle,
   );
-  runtimeHost.emit('updateActiveProcesses', {
+  runtimeHost.updateActiveProcesses({
     parentStreamId,
     processes,
   });

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -100,7 +100,7 @@ function send(
 ): void {
   void sendFollowUp(streamId, wrapAndSanitizeTag(TAG, text)).then((result) => {
     if (result.status === 'sent' || result.status === 'queued') {
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.updateQueuedFollowUps({ streamId });
     }
   });
 }

--- a/src/agent/runtime/StreamStatusService.ts
+++ b/src/agent/runtime/StreamStatusService.ts
@@ -66,10 +66,7 @@ export const StreamStatusService = {
         status,
         previousStatus,
       };
-      (options.runtimeHost ?? getAgentRuntimeHost()).emit(
-        'updateStreamStatus',
-        change,
-      );
+      (options.runtimeHost ?? getAgentRuntimeHost()).updateStreamStatus(change);
       for (const listener of statusListeners) {
         listener(change);
       }

--- a/src/agent/runtime/executeAgent.ts
+++ b/src/agent/runtime/executeAgent.ts
@@ -766,7 +766,7 @@ export async function executeAgent(
                 options?.onProgress?.(update);
               },
               onFollowUpConsumed: () => {
-                ctx.runtimeHost.emit('updateQueuedFollowUps', {
+                ctx.runtimeHost.updateQueuedFollowUps({
                   streamId: ctx.streamId,
                 });
                 options?.onFollowUpConsumed?.();
@@ -933,7 +933,7 @@ export async function resumeToolUseFromSnapshot(
             // /memories protocol) that the fresh run had included.
             isSubagent: (ctx.delegationDepth ?? 0) > 0,
             onFollowUpConsumed: () =>
-              ctx.runtimeHost.emit('updateQueuedFollowUps', {
+              ctx.runtimeHost.updateQueuedFollowUps({
                 streamId: ctx.streamId,
               }),
           },

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -83,7 +83,7 @@ export function trackExecution(handle: ExecutionHandle): void {
         registry.values(),
         runtimeHost,
       );
-      runtimeHost.emit('setParentStream', {
+      runtimeHost.setParentStream({
         childStreamId: handle.childStreamId,
         parentStreamId: handle.parentStreamId,
       });
@@ -481,7 +481,7 @@ async function readIncremental(
         stderr: err.newOffset,
       });
 
-      runtimeHost.emit('updateProcessOutput', {
+      runtimeHost.updateProcessOutput({
         parentStreamId,
         executionId,
         stdout: out.text,

--- a/src/commands/agent/followUpCommand.ts
+++ b/src/commands/agent/followUpCommand.ts
@@ -117,10 +117,10 @@ async function handleFollowUpResult(
 
   switch (result.status) {
     case 'sent':
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.updateQueuedFollowUps({ streamId });
       break;
     case 'queued':
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      runtimeHost.updateQueuedFollowUps({ streamId });
       if (result.reason === 'waiting' || result.reason === 'children_running') {
         const resumed = await tryAutoResume(streamId);
         // tryAutoResume also returns false when the stream is already
@@ -133,7 +133,7 @@ async function handleFollowUpResult(
             // too, but that's the lesser evil — leaving the queue open would
             // leak late child deliveries into the next run on this stream.
             ToolUseFollowUpQueue.release(streamId);
-            runtimeHost.emit('updateQueuedFollowUps', { streamId });
+            runtimeHost.updateQueuedFollowUps({ streamId });
             await vscode.window.showWarningMessage(
               'Message dropped — no session available to receive it. Start a new agent task to continue.',
             );

--- a/src/commands/agent/resumeCommand.ts
+++ b/src/commands/agent/resumeCommand.ts
@@ -49,7 +49,7 @@ async function resumeFromSnapshot(
   let queuedFollowUps: string[] = [];
   try {
     queuedFollowUps = ToolUseFollowUpQueue.drain(streamId);
-    runtimeHost.emit('updateQueuedFollowUps', {
+    runtimeHost.updateQueuedFollowUps({
       streamId,
     });
 

--- a/src/test/agent/runtime/RuntimeHostEvents.test.ts
+++ b/src/test/agent/runtime/RuntimeHostEvents.test.ts
@@ -1,0 +1,109 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports
+import {
+  createAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { STREAM_STATUS } from '@shared/schemas';
+
+type RecordedEvent = {
+  event: keyof ProgressEventPayloads;
+  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+};
+
+function createRecordingHost(): {
+  events: RecordedEvent[];
+  host: AgentRuntimeHost;
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    host: createAgentRuntimeHost({
+      emit: (event, payload) => events.push({ event, payload }),
+    }),
+  };
+}
+
+describe('agent runtime host events', () => {
+  it('routes runtime event helpers through the progress sink', () => {
+    const { events, host } = createRecordingHost();
+
+    host.updateQueuedFollowUps({ streamId: 'stream:queued' });
+    host.setParentStream({
+      childStreamId: 'stream:child',
+      parentStreamId: 'stream:parent',
+    });
+    host.updateActiveSubagents({
+      parentStreamId: 'stream:parent',
+      children: [],
+    });
+    host.updateActiveProcesses({
+      parentStreamId: 'stream:parent',
+      processes: [],
+    });
+    host.updateProcessOutput({
+      parentStreamId: 'stream:parent',
+      executionId: 'execution:process',
+      stdout: 'out',
+      stderr: 'err',
+    });
+
+    assert.deepEqual(events, [
+      {
+        event: 'updateQueuedFollowUps',
+        payload: { streamId: 'stream:queued' },
+      },
+      {
+        event: 'setParentStream',
+        payload: {
+          childStreamId: 'stream:child',
+          parentStreamId: 'stream:parent',
+        },
+      },
+      {
+        event: 'updateActiveSubagents',
+        payload: { parentStreamId: 'stream:parent', children: [] },
+      },
+      {
+        event: 'updateActiveProcesses',
+        payload: { parentStreamId: 'stream:parent', processes: [] },
+      },
+      {
+        event: 'updateProcessOutput',
+        payload: {
+          parentStreamId: 'stream:parent',
+          executionId: 'execution:process',
+          stdout: 'out',
+          stderr: 'err',
+        },
+      },
+    ]);
+  });
+
+  it('lets StreamStatusService emit through a scoped runtime host', () => {
+    const { events, host } = createRecordingHost();
+
+    StreamStatusService.set('stream:status', STREAM_STATUS.RUNNING, {
+      runtimeHost: host,
+    });
+    StreamStatusService.clear('stream:status', {
+      emit: false,
+      runtimeHost: host,
+    });
+
+    assert.deepEqual(events, [
+      {
+        event: 'updateStreamStatus',
+        payload: {
+          streamId: 'stream:status',
+          status: STREAM_STATUS.RUNNING,
+          previousStatus: STREAM_STATUS.READY,
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add typed runtime-host helper methods for recurring progress events used by runtime coordination code.
- Route stream status, queued follow-up, active child/process, parent linkage, and process-output emissions through those helpers.
- Keep underlying progress event names and payloads unchanged while reducing stringly runtime plumbing.
- Add focused fake-host coverage for helper routing and StreamStatusService scoped host emission.

Closes part of #3327.

## Validation
- npm install
- npx prettier --check src/agent/runtime/AgentRuntimeHost.ts src/agent/runtime/StreamStatusService.ts src/agent/runtime/ExecutionHandle.ts src/agent/runtime/executionRegistry.ts src/agent/runtime/ExecutionSubscriptionBinder.ts src/test/agent/runtime/RuntimeHostEvents.test.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/agent/runtime/RuntimeHostEvents.test.js out/test/agent/runtime/PromiseCoordinators.test.js
- npm run lint
- npm run compile:safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes several progress-event emissions behind typed helpers; behavior should remain the same but regressions would show up as missing/incorrect progress UI updates.
> 
> **Overview**
> Adds typed helper methods to `AgentRuntimeHost` for frequently used progress events (stream status, queued follow-ups, active subagents/processes, process output, and parent linkage), reducing stringly-typed `emit` usage.
> 
> Updates runtime/command code paths (e.g. `StreamStatusService`, execution registry/subscription, follow-up/resume flows) to call these helpers instead of `runtimeHost.emit('eventName', payload)` while keeping event names/payloads unchanged.
> 
> Introduces `RuntimeHostEvents.test.ts` to verify helper routing through the progress sink and that `StreamStatusService` can emit via an injected/scoped runtime host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e6940f85d8f6895f1f5cae89932a207d726d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->