### PR TITLE
refactor: extract main view interaction controller

### DIFF
--- a/src/controllers/mainView/MainViewInteractionController.ts
+++ b/src/controllers/mainView/MainViewInteractionController.ts
@@ -1,0 +1,169 @@
+// Local imports - common
+import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - schemas
+import type { MainViewInboundMessage, MainViewMessage } from '@shared/schemas';
+
+export interface MainViewCommandPlan {
+  command: string;
+  args: unknown[];
+}
+
+export interface MainViewConfigUpdate {
+  key: string;
+  value: boolean;
+}
+
+export type MainViewAgentDirectoryAction =
+  | { kind: 'openAgentSettings' }
+  | { kind: 'revealCustomDirectory' };
+
+export interface MainViewInteractionControllerDeps {
+  getProviderUrl(provider: string): string | undefined;
+  getToolDocsCommand(tool: string): string | undefined;
+}
+
+type SwitchViewMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof COMMON_COMMANDS.SWITCH_VIEW }
+>;
+
+type OpenAgentSettingsMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS }
+>;
+
+type OpenAgentDirectoryMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY }
+>;
+
+type OpenSetProviderApiKeyMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY }
+>;
+
+type OpenProviderApiKeyUrlMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL }
+>;
+
+type OpenInstallGuideMessage = Extract<
+  MainViewInboundMessage,
+  { command: typeof MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE }
+>;
+
+type DismissBannerMessage = Extract<
+  MainViewInboundMessage,
+  | { command: typeof MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER }
+>;
+
+type DependencyBannerMessage = Extract<
+  MainViewMessage,
+  | { command: typeof MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER }
+  | { command: typeof MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER }
+>;
+
+const API_KEY_GUIDE_URL =
+  'https://texra.ai/guide/installation#setting-up-api-keys';
+
+const DISMISS_CONFIG_KEYS: Record<DismissBannerMessage['command'], string> = {
+  [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: 'ui.showLoginBanner',
+  [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]:
+    'ui.showGettingStartedBanner',
+  [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: 'ui.showOrchestratorBanner',
+};
+
+export class MainViewInteractionController {
+  constructor(private readonly deps: MainViewInteractionControllerDeps) {}
+
+  getSwitchViewCommand(message: SwitchViewMessage): MainViewCommandPlan {
+    if (message.view === 'dashboard') {
+      return { command: 'texra.showDashboard', args: [] };
+    }
+    if (message.view === 'main') {
+      return { command: 'texra.showMainView', args: [] };
+    }
+    if (message.openInEditor) {
+      return { command: 'texra.openProgressViewInTab', args: [] };
+    }
+    return {
+      command: 'texra.showProgressView',
+      args: [{ inPlace: true }],
+    };
+  }
+
+  getOpenSettingsCommand(settingsQuery: string): MainViewCommandPlan {
+    return {
+      command: 'workbench.action.openSettings',
+      args: [settingsQuery],
+    };
+  }
+
+  getOpenAgentSettingsCommand(
+    message: OpenAgentSettingsMessage,
+  ): MainViewCommandPlan {
+    return {
+      command: 'texra.showAgents',
+      args: [message.sessionType === 'toolUse' ? 'toolUse' : undefined],
+    };
+  }
+
+  getAgentDirectoryAction(
+    message: OpenAgentDirectoryMessage,
+  ): MainViewAgentDirectoryAction {
+    return message.customDirSet
+      ? { kind: 'revealCustomDirectory' }
+      : { kind: 'openAgentSettings' };
+  }
+
+  getSetProviderApiKeyCommand(
+    message: OpenSetProviderApiKeyMessage,
+  ): MainViewCommandPlan | null {
+    if (!message.provider) return null;
+    return { command: 'texra.setApiKey', args: [message.provider] };
+  }
+
+  getProviderApiKeyUrl(
+    message: OpenProviderApiKeyUrlMessage,
+  ): string | undefined {
+    return message.provider
+      ? this.deps.getProviderUrl(message.provider)
+      : undefined;
+  }
+
+  getApiKeyGuideUrl(): string {
+    return API_KEY_GUIDE_URL;
+  }
+
+  getInstallGuideCommand(
+    message: OpenInstallGuideMessage,
+  ): MainViewCommandPlan | null {
+    const docsCommand = this.deps.getToolDocsCommand(message.tool);
+    if (!docsCommand) return null;
+
+    const [command, ...args] = docsCommand.split(',');
+    return { command, args };
+  }
+
+  getDependencyBannerMessage(
+    missingTools: readonly string[],
+  ): DependencyBannerMessage {
+    if (missingTools.length === 0) {
+      return { command: MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER };
+    }
+    return {
+      command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
+      missingTools: [...missingTools],
+    };
+  }
+
+  getDismissConfigUpdate(message: DismissBannerMessage): MainViewConfigUpdate {
+    return {
+      key: DISMISS_CONFIG_KEYS[message.command],
+      value: false,
+    };
+  }
+}

--- a/src/controllers/mainView/MainViewInteractionController.ts
+++ b/src/controllers/mainView/MainViewInteractionController.ts
@@ -1,5 +1,6 @@
 // Local imports - common
-import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 
 // Local imports - schemas
 import type { MainViewInboundMessage, MainViewMessage } from '@shared/schemas';

--- a/src/test/controllers/MainViewInteractionController.test.ts
+++ b/src/test/controllers/MainViewInteractionController.test.ts
@@ -2,7 +2,8 @@
 import { strict as assert } from 'assert';
 
 // Local imports - common
-import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 
 // Local imports - controllers
 import { MainViewInteractionController } from '../../controllers/mainView/MainViewInteractionController';
@@ -31,6 +32,13 @@ describe('MainViewInteractionController', () => {
     assert.deepEqual(
       controller.getSwitchViewCommand({
         command: COMMON_COMMANDS.SWITCH_VIEW,
+        view: 'main',
+      }),
+      { command: 'texra.showMainView', args: [] },
+    );
+    assert.deepEqual(
+      controller.getSwitchViewCommand({
+        command: COMMON_COMMANDS.SWITCH_VIEW,
         view: 'progress',
         openInEditor: true,
       }),
@@ -42,6 +50,32 @@ describe('MainViewInteractionController', () => {
         view: 'progress',
       }),
       { command: 'texra.showProgressView', args: [{ inPlace: true }] },
+    );
+  });
+
+  it('plans settings entry points', () => {
+    const controller = createController();
+
+    assert.deepEqual(
+      controller.getOpenSettingsCommand('@ext:texra.extension'),
+      {
+        command: 'workbench.action.openSettings',
+        args: ['@ext:texra.extension'],
+      },
+    );
+    assert.deepEqual(
+      controller.getOpenAgentSettingsCommand({
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        sessionType: 'toolUse',
+      }),
+      { command: 'texra.showAgents', args: ['toolUse'] },
+    );
+    assert.deepEqual(
+      controller.getOpenAgentSettingsCommand({
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        sessionType: 'workflow',
+      }),
+      { command: 'texra.showAgents', args: [undefined] },
     );
   });
 
@@ -89,6 +123,10 @@ describe('MainViewInteractionController', () => {
         provider: 'missing',
       }),
       undefined,
+    );
+    assert.equal(
+      controller.getApiKeyGuideUrl(),
+      'https://texra.ai/guide/installation#setting-up-api-keys',
     );
   });
 

--- a/src/test/controllers/MainViewInteractionController.test.ts
+++ b/src/test/controllers/MainViewInteractionController.test.ts
@@ -1,0 +1,153 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - common
+import { COMMON_COMMANDS, MAIN_VIEW_COMMANDS } from '@common/webview/commands';
+
+// Local imports - controllers
+import { MainViewInteractionController } from '../../controllers/mainView/MainViewInteractionController';
+
+function createController(options?: {
+  providerUrls?: Record<string, string | undefined>;
+  docsCommands?: Record<string, string | undefined>;
+}): MainViewInteractionController {
+  return new MainViewInteractionController({
+    getProviderUrl: (provider) => options?.providerUrls?.[provider],
+    getToolDocsCommand: (tool) => options?.docsCommands?.[tool],
+  });
+}
+
+describe('MainViewInteractionController', () => {
+  it('routes switch-view messages to concrete VS Code commands', () => {
+    const controller = createController();
+
+    assert.deepEqual(
+      controller.getSwitchViewCommand({
+        command: COMMON_COMMANDS.SWITCH_VIEW,
+        view: 'dashboard',
+      }),
+      { command: 'texra.showDashboard', args: [] },
+    );
+    assert.deepEqual(
+      controller.getSwitchViewCommand({
+        command: COMMON_COMMANDS.SWITCH_VIEW,
+        view: 'progress',
+        openInEditor: true,
+      }),
+      { command: 'texra.openProgressViewInTab', args: [] },
+    );
+    assert.deepEqual(
+      controller.getSwitchViewCommand({
+        command: COMMON_COMMANDS.SWITCH_VIEW,
+        view: 'progress',
+      }),
+      { command: 'texra.showProgressView', args: [{ inPlace: true }] },
+    );
+  });
+
+  it('keeps agent-directory resolution separate from the side effect', () => {
+    const controller = createController();
+
+    assert.deepEqual(
+      controller.getAgentDirectoryAction({
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
+        customDirSet: false,
+      }),
+      { kind: 'openAgentSettings' },
+    );
+    assert.deepEqual(
+      controller.getAgentDirectoryAction({
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
+        customDirSet: true,
+      }),
+      { kind: 'revealCustomDirectory' },
+    );
+  });
+
+  it('resolves provider key commands and URLs', () => {
+    const controller = createController({
+      providerUrls: { openai: 'https://platform.openai.com/api-keys' },
+    });
+
+    assert.deepEqual(
+      controller.getSetProviderApiKeyCommand({
+        command: MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY,
+        provider: 'openai',
+      }),
+      { command: 'texra.setApiKey', args: ['openai'] },
+    );
+    assert.equal(
+      controller.getProviderApiKeyUrl({
+        command: MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL,
+        provider: 'openai',
+      }),
+      'https://platform.openai.com/api-keys',
+    );
+    assert.equal(
+      controller.getProviderApiKeyUrl({
+        command: MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL,
+        provider: 'missing',
+      }),
+      undefined,
+    );
+  });
+
+  it('plans install guide commands from tool metadata', () => {
+    const controller = createController({
+      docsCommands: { latexindent: 'texra.openDoc,installation' },
+    });
+
+    assert.deepEqual(
+      controller.getInstallGuideCommand({
+        command: MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE,
+        tool: 'latexindent',
+      }),
+      { command: 'texra.openDoc', args: ['installation'] },
+    );
+    assert.equal(
+      controller.getInstallGuideCommand({
+        command: MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE,
+        tool: 'unknown',
+      }),
+      null,
+    );
+  });
+
+  it('builds dependency banner messages from dependency results', () => {
+    const controller = createController();
+
+    assert.deepEqual(controller.getDependencyBannerMessage([]), {
+      command: MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER,
+    });
+    assert.deepEqual(
+      controller.getDependencyBannerMessage(['latexindent', 'gs']),
+      {
+        command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
+        missingTools: ['latexindent', 'gs'],
+      },
+    );
+  });
+
+  it('maps dismissed banners to their config updates', () => {
+    const controller = createController();
+
+    assert.deepEqual(
+      controller.getDismissConfigUpdate({
+        command: MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER,
+      }),
+      { key: 'ui.showLoginBanner', value: false },
+    );
+    assert.deepEqual(
+      controller.getDismissConfigUpdate({
+        command: MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER,
+      }),
+      { key: 'ui.showGettingStartedBanner', value: false },
+    );
+    assert.deepEqual(
+      controller.getDismissConfigUpdate({
+        command: MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER,
+      }),
+      { key: 'ui.showOrchestratorBanner', value: false },
+    );
+  });
+});

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -318,11 +318,17 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         }
       },
       [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: (m) =>
-        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
+        this.applyConfigUpdate(
+          this.interactionController.getDismissConfigUpdate(m),
+        ),
       [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: (m) =>
-        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
+        this.applyConfigUpdate(
+          this.interactionController.getDismissConfigUpdate(m),
+        ),
       [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: (m) =>
-        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
+        this.applyConfigUpdate(
+          this.interactionController.getDismissConfigUpdate(m),
+        ),
 
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: (m) =>
         this.diffManager.handleRequestRecentCommits(m),
@@ -381,7 +387,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     await safeExecuteCommand(plan.command, plan.args, this.viewName);
   }
 
-  private async updateConfig(configUpdate: {
+  private async applyConfigUpdate(configUpdate: {
     key: string;
     value: boolean;
   }): Promise<void> {

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -24,6 +24,10 @@ import { DiffManager } from './managers/DiffManager';
 import { ExecutionManager } from './managers/ExecutionManager';
 import { FileManager } from './managers/FileManager';
 import { InstructionManager } from './managers/InstructionManager';
+import {
+  MainViewInteractionController,
+  type MainViewCommandPlan,
+} from '../controllers/mainView/MainViewInteractionController';
 import { MainViewStartupController } from '../controllers/mainView/MainViewStartupController';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
@@ -32,6 +36,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly executionManager: ExecutionManager;
   private readonly diffManager: DiffManager;
   private readonly instructionManager: InstructionManager;
+  private readonly interactionController: MainViewInteractionController;
   private readonly startupController: MainViewStartupController;
 
   constructor(context: vscode.ExtensionContext) {
@@ -47,6 +52,11 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
     this.executionManager = new ExecutionManager();
     this.diffManager = new DiffManager();
     this.instructionManager = new InstructionManager(context);
+    this.interactionController = new MainViewInteractionController({
+      getProviderUrl: (provider) =>
+        PROVIDER_URLS[provider as keyof typeof PROVIDER_URLS],
+      getToolDocsCommand,
+    });
     this.startupController = new MainViewStartupController({
       getConfig,
       loadOptions,
@@ -98,23 +108,8 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.GET_THEME]: () => this.handleThemeRequest(),
       [MAIN_VIEW_COMMANDS.GET_DEBUG_MODE]: () => this.handleDebugModeRequest(),
       [COMMON_COMMANDS.SWITCH_VIEW]: (m) => {
-        if (m.view === 'dashboard') {
-          return safeExecuteCommand('texra.showDashboard', [], this.viewName);
-        }
-        if (m.view === 'main') {
-          return safeExecuteCommand('texra.showMainView', [], this.viewName);
-        }
-        if (m.openInEditor) {
-          return safeExecuteCommand(
-            'texra.openProgressViewInTab',
-            [],
-            this.viewName,
-          );
-        }
-        return safeExecuteCommand(
-          'texra.showProgressView',
-          [{ inPlace: true }],
-          this.viewName,
+        return this.runCommandPlan(
+          this.interactionController.getSwitchViewCommand(m),
         );
       },
 
@@ -124,23 +119,22 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           model: m.model,
         }),
       [MAIN_VIEW_COMMANDS.SETTINGS_OPEN]: () =>
-        safeExecuteCommand(
-          'workbench.action.openSettings',
-          [SETTINGS_QUERY.EXTENSION],
-          this.viewName,
+        this.runCommandPlan(
+          this.interactionController.getOpenSettingsCommand(
+            SETTINGS_QUERY.EXTENSION,
+          ),
         ),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS]: (m) =>
-        safeExecuteCommand(
-          'texra.showAgents',
-          [m.sessionType === 'toolUse' ? 'toolUse' : undefined],
-          this.viewName,
+        this.runCommandPlan(
+          this.interactionController.getOpenAgentSettingsCommand(m),
         ),
       [MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS]: () =>
         safeExecuteCommand('texra.showModels', [], this.viewName),
       [MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS]: () =>
         safeExecuteCommand('texra.showMultiAgent', [], this.viewName),
       [MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY]: async (m) => {
-        if (!m.customDirSet) {
+        const action = this.interactionController.getAgentDirectoryAction(m);
+        if (action.kind === 'openAgentSettings') {
           await safeExecuteCommand('texra.showAgents', [], this.viewName);
           return;
         }
@@ -261,23 +255,19 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY]: () =>
         safeExecuteCommand('texra.setApiKey'),
       [MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY]: (m) => {
-        if (m.provider) {
-          return safeExecuteCommand('texra.setApiKey', [m.provider]);
-        }
+        return this.runCommandPlan(
+          this.interactionController.getSetProviderApiKeyCommand(m),
+        );
       },
       [MAIN_VIEW_COMMANDS.OPEN_PROVIDER_API_KEY_URL]: async (m) => {
-        if (m.provider) {
-          const url = PROVIDER_URLS[m.provider as keyof typeof PROVIDER_URLS];
-          if (url) {
-            await vscode.env.openExternal(vscode.Uri.parse(url));
-          }
+        const url = this.interactionController.getProviderApiKeyUrl(m);
+        if (url) {
+          await vscode.env.openExternal(vscode.Uri.parse(url));
         }
       },
       [MAIN_VIEW_COMMANDS.OPEN_API_KEY_GUIDE]: async () => {
         await vscode.env.openExternal(
-          vscode.Uri.parse(
-            'https://texra.ai/guide/installation#setting-up-api-keys',
-          ),
+          vscode.Uri.parse(this.interactionController.getApiKeyGuideUrl()),
         );
       },
 
@@ -292,11 +282,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       [MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER]: (m) =>
         this.postToActiveView(m),
       [MAIN_VIEW_COMMANDS.OPEN_INSTALL_GUIDE]: (m) => {
-        const cmd = getToolDocsCommand(m.tool);
-        if (cmd) {
-          const [command, ...args] = cmd.split(',');
-          return safeExecuteCommand(command, args);
-        }
+        return this.runCommandPlan(
+          this.interactionController.getInstallGuideCommand(m),
+        );
       },
       [MAIN_VIEW_COMMANDS.RECHECK_DEPENDENCIES]: async () => {
         const view = this.getActiveView();
@@ -304,16 +292,9 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           return;
         }
         const missingTools = await checkCoreDependencies(true);
-        if (missingTools.length > 0) {
-          view.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.SHOW_DEPENDENCY_BANNER,
-            missingTools,
-          });
-        } else {
-          view.webview.postMessage({
-            command: MAIN_VIEW_COMMANDS.HIDE_DEPENDENCY_BANNER,
-          });
-        }
+        view.webview.postMessage(
+          this.interactionController.getDependencyBannerMessage(missingTools),
+        );
       },
       [MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER]: (m) => this.postToActiveView(m),
       [MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER]: () =>
@@ -336,12 +317,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
           );
         }
       },
-      [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: () =>
-        updateConfig('ui.showLoginBanner', false),
-      [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: () =>
-        updateConfig('ui.showGettingStartedBanner', false),
-      [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: () =>
-        updateConfig('ui.showOrchestratorBanner', false),
+      [MAIN_VIEW_COMMANDS.DISMISS_LOGIN_BANNER]: (m) =>
+        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
+      [MAIN_VIEW_COMMANDS.DISMISS_GETTING_STARTED_BANNER]: (m) =>
+        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
+      [MAIN_VIEW_COMMANDS.DISMISS_ORCHESTRATOR_BANNER]: (m) =>
+        this.updateConfig(this.interactionController.getDismissConfigUpdate(m)),
 
       [MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS]: (m) =>
         this.diffManager.handleRequestRecentCommits(m),
@@ -391,6 +372,20 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
       command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
       debugMode,
     });
+  }
+
+  private async runCommandPlan(
+    plan: MainViewCommandPlan | null,
+  ): Promise<void> {
+    if (!plan) return;
+    await safeExecuteCommand(plan.command, plan.args, this.viewName);
+  }
+
+  private async updateConfig(configUpdate: {
+    key: string;
+    value: boolean;
+  }): Promise<void> {
+    await updateConfig(configUpdate.key, configUpdate.value);
   }
 
   /** Post message to active view if available */


### PR DESCRIPTION
## Summary

Extracts the main view interaction decision logic into `MainViewInteractionController` so `MainViewMessageHandler` keeps the VS Code command execution, webview posting, and configuration writes while the pure routing decisions are covered by focused tests.

This continues the controller extraction work for #3305 without changing the command payloads or user-facing behavior.

## Validation

- `npm install`
- `npx prettier --check src/controllers/mainView/MainViewInteractionController.ts src/webview/MainViewMessageHandler.ts src/test/controllers/MainViewInteractionController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/MainViewInteractionController.test.js out/test/controllers/MainViewStartupController.test.js`
- `npm run lint`
- `npm run compile:safe`

Closes part of #3305.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mostly moves main-view message routing/decision logic into a pure controller and adds unit tests; behavior should remain the same but regressions could occur if any command mapping differs.
> 
> **Overview**
> Extracts main view “interaction planning” into a new `MainViewInteractionController`, which turns inbound webview messages into **command plans**, URLs, banner messages, and config updates (e.g., switch-view routing, agent directory action choice, provider API key actions, install guide lookup, dependency banner show/hide, and banner dismiss config keys).
> 
> `MainViewMessageHandler` is refactored to delegate these decisions to the controller while keeping side effects local (executing VS Code commands via a new `runCommandPlan`, posting dependency banner messages, and applying config writes via `applyConfigUpdate`). Adds focused unit tests covering the new controller’s mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d90ec7cc9ecb60d6559b5f4158a32f8519d40d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->