### PR TITLE
refactor: extract latex config persistence controller

### DIFF
--- a/src/controllers/settingsView/LatexConfigPersistenceController.ts
+++ b/src/controllers/settingsView/LatexConfigPersistenceController.ts
@@ -1,0 +1,78 @@
+// Local imports - state keys
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+
+// Local imports - shared constants
+import {
+  LATEX_FIELD_TO_KEY,
+  type LatexConfigField,
+} from '@shared/constants/latex';
+
+// Local imports - shared schemas
+import {
+  LatexConfigValuesSchema,
+  type LatexConfigValues,
+} from '@shared/schemas/settingsViewMessages';
+
+export type LatexConfigPersistenceEntry = {
+  field: LatexConfigField;
+  key: WorkspaceStateKey;
+};
+
+export type LatexConfigPersistenceUpdatePlan =
+  | {
+      ok: true;
+      update: {
+        key: WorkspaceStateKey;
+        value: unknown;
+      };
+    }
+  | {
+      ok: false;
+      error: unknown;
+    };
+
+/** Plans storage-backed LaTeX config reads and writes without host side effects. */
+export class LatexConfigPersistenceController {
+  getEntries(): LatexConfigPersistenceEntry[] {
+    return Object.entries(LATEX_FIELD_TO_KEY).map(([field, key]) => ({
+      field: field as LatexConfigField,
+      key,
+    }));
+  }
+
+  buildConfigValues(
+    readStoredValue: (key: WorkspaceStateKey) => unknown,
+  ): LatexConfigValues {
+    const values: Partial<Record<LatexConfigField, unknown>> = {};
+
+    for (const { field, key } of this.getEntries()) {
+      const stored = readStoredValue(key);
+      if (stored !== undefined) values[field] = stored;
+    }
+
+    return values as LatexConfigValues;
+  }
+
+  planUpdate(input: {
+    field: LatexConfigField;
+    value: unknown;
+  }): LatexConfigPersistenceUpdatePlan {
+    const fieldSchema = LatexConfigValuesSchema.shape[input.field];
+    const parsed = fieldSchema.safeParse(input.value ?? undefined);
+
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: parsed.error,
+      };
+    }
+
+    return {
+      ok: true,
+      update: {
+        key: LATEX_FIELD_TO_KEY[input.field],
+        value: parsed.data,
+      },
+    };
+  }
+}

--- a/src/controllers/settingsView/LatexConfigPersistenceController.ts
+++ b/src/controllers/settingsView/LatexConfigPersistenceController.ts
@@ -34,8 +34,13 @@ export type LatexConfigPersistenceUpdatePlan =
 /** Plans storage-backed LaTeX config reads and writes without host side effects. */
 export class LatexConfigPersistenceController {
   getEntries(): LatexConfigPersistenceEntry[] {
-    return Object.entries(LATEX_FIELD_TO_KEY).map(([field, key]) => ({
-      field: field as LatexConfigField,
+    return (
+      Object.entries(LATEX_FIELD_TO_KEY) as [
+        LatexConfigField,
+        WorkspaceStateKey,
+      ][]
+    ).map(([field, key]) => ({
+      field,
       key,
     }));
   }
@@ -47,7 +52,10 @@ export class LatexConfigPersistenceController {
 
     for (const { field, key } of this.getEntries()) {
       const stored = readStoredValue(key);
-      if (stored !== undefined) values[field] = stored;
+      if (stored === undefined) continue;
+
+      const parsed = LatexConfigValuesSchema.shape[field].safeParse(stored);
+      if (parsed.success) values[field] = parsed.data;
     }
 
     return values as LatexConfigValues;

--- a/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -11,14 +11,8 @@ import { SETTINGS_VIEW_COMMANDS } from '@common/webview';
 import { showLoggedErrorMessage } from '@common/errors';
 import { workspaceSM } from '@common/state';
 import {
-  LATEX_FIELD_TO_KEY,
-  type LatexConfigField,
-} from '@shared/constants/latex';
-import {
-  LatexConfigValuesSchema,
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,
-  type LatexConfigValues,
   type LatexSettingsStatus,
 } from '@shared/schemas/settingsViewMessages';
 import {
@@ -36,6 +30,7 @@ import {
   detectPackageManager,
 } from '@utils/system/toolUtils';
 import { BinaryResolver } from '@utils/system/binaryResolver';
+import { LatexConfigPersistenceController } from '../../controllers/settingsView/LatexConfigPersistenceController';
 import { LatexRecommendedSettingsController } from '../../controllers/settingsView/LatexRecommendedSettingsController';
 import { LatexToolingController } from '../../controllers/settingsView/LatexToolingController';
 
@@ -83,6 +78,9 @@ export class LatexSettingsHandlers {
       );
     },
   });
+
+  private readonly configPersistenceController =
+    new LatexConfigPersistenceController();
 
   /** Cached LaTeX settings to avoid redundant tool detection on repeat opens. */
   private latexSettingsCache: {
@@ -159,17 +157,12 @@ export class LatexSettingsHandlers {
    * and the migration helper.
    */
   async sendLatexConfigValues(webview: vscode.Webview): Promise<void> {
-    const values: Partial<Record<LatexConfigField, unknown>> = {};
-    for (const [field, key] of Object.entries(LATEX_FIELD_TO_KEY) as [
-      LatexConfigField,
-      Parameters<typeof workspaceSM.get>[0],
-    ][]) {
-      const stored = workspaceSM.get(key);
-      if (stored !== undefined) values[field] = stored;
-    }
+    const values = this.configPersistenceController.buildConfigValues((key) =>
+      workspaceSM.get(key),
+    );
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
-      values: values as LatexConfigValues,
+      values,
     });
   }
 
@@ -185,22 +178,20 @@ export class LatexSettingsHandlers {
   async handleSetLatexConfigValue(
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.SET_LATEX_CONFIG_VALUE>,
   ): Promise<void> {
-    const key = LATEX_FIELD_TO_KEY[data.field];
-    // Validate value against the per-field schema in LatexConfigValuesSchema.
-    // Both schemas mark the property optional, so undefined/null both parse to
-    // undefined and clear the key.
-    const fieldSchema = LatexConfigValuesSchema.shape[data.field];
-    const parsed = fieldSchema.safeParse(data.value ?? undefined);
-    if (!parsed.success) {
+    const plan = this.configPersistenceController.planUpdate({
+      field: data.field,
+      value: data.value,
+    });
+    if (!plan.ok) {
       await showLoggedErrorMessage(
         this.ctx.channel,
         `Invalid value for ${data.field}`,
-        parsed.error,
+        plan.error,
       );
       return;
     }
     try {
-      await workspaceSM.update(key, parsed.data);
+      await workspaceSM.update(plan.update.key, plan.update.value);
       await this.ctx.withActiveWebview((w) => this.sendLatexConfigValues(w));
     } catch (error) {
       await showLoggedErrorMessage(

--- a/src/test/controllers/LatexConfigPersistenceController.test.ts
+++ b/src/test/controllers/LatexConfigPersistenceController.test.ts
@@ -27,6 +27,24 @@ describe('LatexConfigPersistenceController', () => {
     );
   });
 
+  it('drops invalid stored values from the webview config projection', () => {
+    const controller = new LatexConfigPersistenceController();
+    const storedValues: Partial<Record<WorkspaceStateKey, unknown>> = {
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: false,
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: 1000,
+      [WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS]: 25000,
+      [WorkspaceStateKey.LATEXDIFF_MATH_MARKUP]: 'invalid',
+    };
+
+    assert.deepEqual(
+      controller.buildConfigValues((key) => storedValues[key]),
+      {
+        workflowAutoCompile: false,
+        latexdiffTimeoutMs: 25000,
+      },
+    );
+  });
+
   it('plans validated field updates using workspace storage keys', () => {
     const controller = new LatexConfigPersistenceController();
 

--- a/src/test/controllers/LatexConfigPersistenceController.test.ts
+++ b/src/test/controllers/LatexConfigPersistenceController.test.ts
@@ -1,0 +1,75 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - state keys
+import { WorkspaceStateKey } from '../../common/state/stateKeys';
+
+// Local imports - controllers
+import { LatexConfigPersistenceController } from '../../controllers/settingsView/LatexConfigPersistenceController';
+
+describe('LatexConfigPersistenceController', () => {
+  it('builds webview config values from defined workspace entries', () => {
+    const controller = new LatexConfigPersistenceController();
+    const storedValues: Partial<Record<WorkspaceStateKey, unknown>> = {
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE]: false,
+      [WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS]: undefined,
+      [WorkspaceStateKey.LATEXDIFF_MATH_MARKUP]: 'fine',
+      [WorkspaceStateKey.LATEX_FORMATTER]: 'tex-fmt',
+    };
+
+    assert.deepEqual(
+      controller.buildConfigValues((key) => storedValues[key]),
+      {
+        workflowAutoCompile: false,
+        latexdiffMathMarkup: 'fine',
+        latexFormatter: 'tex-fmt',
+      },
+    );
+  });
+
+  it('plans validated field updates using workspace storage keys', () => {
+    const controller = new LatexConfigPersistenceController();
+
+    assert.deepEqual(
+      controller.planUpdate({
+        field: 'latexdiffTimeoutMs',
+        value: 25000,
+      }),
+      {
+        ok: true,
+        update: {
+          key: WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS,
+          value: 25000,
+        },
+      },
+    );
+  });
+
+  it('normalizes null writes to undefined so callers clear the key', () => {
+    const controller = new LatexConfigPersistenceController();
+
+    assert.deepEqual(
+      controller.planUpdate({
+        field: 'latexFormatter',
+        value: null,
+      }),
+      {
+        ok: true,
+        update: {
+          key: WorkspaceStateKey.LATEX_FORMATTER,
+          value: undefined,
+        },
+      },
+    );
+  });
+
+  it('rejects values that do not match the selected field schema', () => {
+    const controller = new LatexConfigPersistenceController();
+    const plan = controller.planUpdate({
+      field: 'workflowAutoCompileTimeoutMs',
+      value: 1000,
+    });
+
+    assert.equal(plan.ok, false);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the remaining LaTeX config persistence planning from `LatexSettingsHandlers` into a host-neutral `LatexConfigPersistenceController`.

The controller now owns the storage-key mapping, webview value projection, per-field schema validation, and null-to-clear normalization for `SET_LATEX_CONFIG_VALUE`. The settings handler remains responsible for VS Code-facing side effects: workspace storage reads/writes, webview refreshes, and error reporting.

This addresses the LaTeX config persistence slice of #3305 while keeping the change isolated from the agent, runtime, and main-view controller work in neighboring PRs.

## Validation

- `npm install`
- `npx prettier --check src/controllers/settingsView/LatexConfigPersistenceController.ts src/settingsView/handlers/latexSettingsHandlers.ts src/test/controllers/LatexConfigPersistenceController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/LatexConfigPersistenceController.test.js out/test/controllers/LatexRecommendedSettingsController.test.js out/test/controllers/LatexToolingController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes LaTeX workspace-storage read/write validation; main behavior change is now filtering out invalid stored values before sending them to the webview.
> 
> **Overview**
> Extracts LaTeX config persistence logic from `latexSettingsHandlers.ts` into a host-neutral `LatexConfigPersistenceController`, which owns the field→storage-key mapping iteration, per-field Zod validation, and null/undefined normalization for clears.
> 
> `LatexSettingsHandlers` now delegates config value projection and update planning to this controller, and adds tests covering value projection, invalid-value dropping, and update planning/validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd558f7f2b23b524cd8014ffe2b49814ff37dcfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->