### PR TITLE
refactor: extract settings agent directory controller

### DIFF
--- a/src/controllers/settingsView/SettingsAgentDirectoryController.ts
+++ b/src/controllers/settingsView/SettingsAgentDirectoryController.ts
@@ -1,0 +1,90 @@
+// Local imports - shared
+import type { AgentSource } from '@shared/schemas/agent';
+
+export interface SettingsAgentDirectoryEntry {
+  path?: string;
+  multiplePath?: string;
+}
+
+export interface SettingsAgentDirectoryState {
+  getConfiguredCustomDir(): string | undefined;
+  setConfiguredCustomDir(path: string): Promise<void>;
+  getCustomDir(): Promise<string>;
+  getSourceDir(source: AgentSource): Promise<string | undefined>;
+  getAgent(
+    source: AgentSource,
+    name: string,
+  ): SettingsAgentDirectoryEntry | null;
+}
+
+export interface SettingsAgentDirectoryControllerDeps {
+  state: SettingsAgentDirectoryState;
+}
+
+export interface SettingsCustomAgentDirStatus {
+  path: string;
+  isDefault: boolean;
+}
+
+export type SettingsOpenAgentYamlResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: 'missingAgent' | 'missingPath' };
+
+export type SettingsRevealAgentFileResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: 'missingFile' };
+
+export type SettingsOpenAgentFolderResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: 'missingLocalDirectory' };
+
+export class SettingsAgentDirectoryController {
+  constructor(private readonly deps: SettingsAgentDirectoryControllerDeps) {}
+
+  async getCustomDirStatus(): Promise<SettingsCustomAgentDirStatus> {
+    const configuredPath =
+      this.deps.state.getConfiguredCustomDir()?.trim() ?? '';
+    return {
+      path: await this.deps.state.getCustomDir(),
+      isDefault: configuredPath === '',
+    };
+  }
+
+  async resetCustomDir(): Promise<void> {
+    await this.deps.state.setConfiguredCustomDir('');
+  }
+
+  planOpenAgentYaml(input: {
+    source: AgentSource;
+    name: string;
+    variant: 'base' | 'multiple';
+  }): SettingsOpenAgentYamlResult {
+    const entry = this.deps.state.getAgent(input.source, input.name);
+    if (!entry) return { ok: false, reason: 'missingAgent' };
+
+    const selectedPath =
+      input.variant === 'multiple' ? entry.multiplePath : entry.path;
+    if (!selectedPath) return { ok: false, reason: 'missingPath' };
+
+    return { ok: true, path: selectedPath };
+  }
+
+  planRevealAgentFile(input: {
+    source: AgentSource;
+    name: string;
+  }): SettingsRevealAgentFileResult {
+    const entry = this.deps.state.getAgent(input.source, input.name);
+    if (!entry?.path) return { ok: false, reason: 'missingFile' };
+
+    return { ok: true, path: entry.path };
+  }
+
+  async planOpenAgentFolder(
+    source: AgentSource,
+  ): Promise<SettingsOpenAgentFolderResult> {
+    const sourceDir = await this.deps.state.getSourceDir(source);
+    if (!sourceDir) return { ok: false, reason: 'missingLocalDirectory' };
+
+    return { ok: true, path: sourceDir };
+  }
+}

--- a/src/settingsView/handlers/agentHandlers.ts
+++ b/src/settingsView/handlers/agentHandlers.ts
@@ -38,6 +38,7 @@ import {
   SettingsAgentCatalogController,
   type SettingsAgentCatalogState,
 } from '../../controllers/settingsView/SettingsAgentCatalogController';
+import { SettingsAgentDirectoryController } from '../../controllers/settingsView/SettingsAgentDirectoryController';
 import { SettingsAgentFileController } from '../../controllers/settingsView/SettingsAgentFileController';
 import { SettingsAgentVisibilityController } from '../../controllers/settingsView/SettingsAgentVisibilityController';
 
@@ -48,6 +49,7 @@ import type { SettingsHandlerContext } from './SettingsHandlerContext';
  */
 export class AgentHandlers {
   private readonly catalogController: SettingsAgentCatalogController;
+  private readonly directoryController: SettingsAgentDirectoryController;
   private readonly fileController = new SettingsAgentFileController();
   private readonly visibilityController: SettingsAgentVisibilityController;
 
@@ -90,6 +92,18 @@ export class AgentHandlers {
     this.catalogController = new SettingsAgentCatalogController({
       state: agentCatalogState,
     });
+    this.directoryController = new SettingsAgentDirectoryController({
+      state: {
+        getConfiguredCustomDir: () =>
+          globalSM.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR, ''),
+        setConfiguredCustomDir: async (customDir) => {
+          await globalSM.update(GlobalStateKey.CUSTOM_AGENT_DIR, customDir);
+        },
+        getCustomDir: () => agentDirectories.custom(),
+        getSourceDir: (source) => agentDirectories.getDirectory(source),
+        getAgent: (source, name) => getAgent(createKey(source, name)) ?? null,
+      },
+    });
     this.visibilityController = new SettingsAgentVisibilityController({
       state: {
         getEnabledAgentKeys: agentCatalogState.getEnabledAgentKeys,
@@ -121,25 +135,26 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.OPEN_AGENT_YAML>,
   ): Promise<void> {
     try {
-      const key = createKey(data.agentSource, data.agentName);
-      const entry = getAgent(key);
-      if (!entry) {
+      const result = this.directoryController.planOpenAgentYaml({
+        source: data.agentSource,
+        name: data.agentName,
+        variant: data.variant,
+      });
+      if (!result.ok && result.reason === 'missingAgent') {
         await vscode.window.showErrorMessage(
           `Agent "${data.agentName}" could not be found. It may have been removed or renamed. Check the Agents tab in Settings to see available agents.`,
         );
         return;
       }
 
-      const agentPath =
-        data.variant === 'multiple' ? entry.multiplePath : entry.path;
-      if (!agentPath) {
+      if (!result.ok) {
         await vscode.window.showErrorMessage(
           `No configuration file found for agent "${data.agentName}". The agent definition may be incomplete — try re-creating it from the Agents tab.`,
         );
         return;
       }
 
-      const doc = await vscode.workspace.openTextDocument(agentPath);
+      const doc = await vscode.workspace.openTextDocument(result.path);
       await vscode.window.showTextDocument(doc, { preview: false });
     } catch (error) {
       await showLoggedErrorMessage(
@@ -193,8 +208,10 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.OPEN_AGENT_FOLDER>,
   ): Promise<void> {
     try {
-      const folderPath = await agentDirectories.getDirectory(data.folderType);
-      if (!folderPath) {
+      const result = await this.directoryController.planOpenAgentFolder(
+        data.folderType,
+      );
+      if (!result.ok) {
         await vscode.window.showErrorMessage(
           `No local directory for agent source: ${data.folderType}`,
         );
@@ -202,7 +219,7 @@ export class AgentHandlers {
       }
       await vscode.commands.executeCommand(
         'revealFileInOS',
-        vscode.Uri.file(folderPath),
+        vscode.Uri.file(result.path),
       );
     } catch (error) {
       await showLoggedErrorMessage(
@@ -217,9 +234,11 @@ export class AgentHandlers {
     data: SettingsMessageFor<typeof SETTINGS_VIEW_CMD.REVEAL_AGENT_FILE>,
   ): Promise<void> {
     try {
-      const key = createKey(data.agentSource, data.agentName);
-      const entry = getAgent(key);
-      if (!entry?.path) {
+      const result = this.directoryController.planRevealAgentFile({
+        source: data.agentSource,
+        name: data.agentName,
+      });
+      if (!result.ok) {
         await vscode.window.showErrorMessage(
           `Agent not found or has no file: ${data.agentName}`,
         );
@@ -227,7 +246,7 @@ export class AgentHandlers {
       }
       await vscode.commands.executeCommand(
         'revealFileInOS',
-        vscode.Uri.file(entry.path),
+        vscode.Uri.file(result.path),
       );
     } catch (error) {
       await showLoggedErrorMessage(
@@ -444,15 +463,11 @@ export class AgentHandlers {
   // ── Custom agent directory handlers ──
 
   async sendCustomAgentDir(webview: vscode.Webview): Promise<void> {
-    const configuredPath = globalSM
-      .get<string>(GlobalStateKey.CUSTOM_AGENT_DIR, '')
-      .trim();
-    const isDefault = configuredPath === '';
-    const resolvedPath = await agentDirectories.custom();
+    const status = await this.directoryController.getCustomDirStatus();
     await webview.postMessage({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_CUSTOM_AGENT_DIR,
-      path: resolvedPath,
-      isDefault,
+      path: status.path,
+      isDefault: status.isDefault,
     });
   }
 
@@ -472,7 +487,7 @@ export class AgentHandlers {
 
   async handleResetCustomAgentDir(): Promise<void> {
     try {
-      await globalSM.update(GlobalStateKey.CUSTOM_AGENT_DIR, '');
+      await this.directoryController.resetCustomDir();
       await this.refreshAgentDirUI();
     } catch (error) {
       await showLoggedErrorMessage(

--- a/src/test/controllers/SettingsAgentDirectoryController.test.ts
+++ b/src/test/controllers/SettingsAgentDirectoryController.test.ts
@@ -1,0 +1,161 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - controllers
+import {
+  SettingsAgentDirectoryController,
+  type SettingsAgentDirectoryEntry,
+} from '../../controllers/settingsView/SettingsAgentDirectoryController';
+
+const AGENTS = new Map<string, SettingsAgentDirectoryEntry>([
+  [
+    'builtInWorkflow:writer',
+    {
+      path: '/repo/resources/agents/writer.yaml',
+      multiplePath: '/repo/resources/agents/writer_multiple.yaml',
+    },
+  ],
+  ['custom:pathless', {}],
+]);
+
+function createController(options?: {
+  configuredCustomDir?: string;
+  customDir?: string;
+  sourceDirs?: Record<string, string | undefined>;
+  agents?: Map<string, SettingsAgentDirectoryEntry>;
+}): {
+  controller: SettingsAgentDirectoryController;
+  getConfiguredCustomDir: () => string | undefined;
+} {
+  let configuredCustomDir = options?.configuredCustomDir;
+  const agents = options?.agents ?? AGENTS;
+  return {
+    controller: new SettingsAgentDirectoryController({
+      state: {
+        getConfiguredCustomDir: () => configuredCustomDir,
+        setConfiguredCustomDir: async (path) => {
+          configuredCustomDir = path;
+        },
+        getCustomDir: async () => options?.customDir ?? '/repo/custom-agents',
+        getSourceDir: async (source) => options?.sourceDirs?.[source],
+        getAgent: (source, name) => agents.get(`${source}:${name}`) ?? null,
+      },
+    }),
+    getConfiguredCustomDir: () => configuredCustomDir,
+  };
+}
+
+describe('SettingsAgentDirectoryController', () => {
+  it('reports default custom directory status from blank persisted state', async () => {
+    const { controller } = createController({
+      configuredCustomDir: '  ',
+      customDir: '/repo/.texra/agents',
+    });
+
+    assert.deepEqual(await controller.getCustomDirStatus(), {
+      path: '/repo/.texra/agents',
+      isDefault: true,
+    });
+  });
+
+  it('reports configured custom directory status from trimmed persisted state', async () => {
+    const { controller } = createController({
+      configuredCustomDir: ' /repo/custom ',
+      customDir: '/repo/custom',
+    });
+
+    assert.deepEqual(await controller.getCustomDirStatus(), {
+      path: '/repo/custom',
+      isDefault: false,
+    });
+  });
+
+  it('resets configured custom directory state', async () => {
+    const { controller, getConfiguredCustomDir } = createController({
+      configuredCustomDir: '/repo/custom',
+    });
+
+    await controller.resetCustomDir();
+
+    assert.equal(getConfiguredCustomDir(), '');
+  });
+
+  it('plans base and multiple YAML opens', () => {
+    const { controller } = createController();
+
+    assert.deepEqual(
+      controller.planOpenAgentYaml({
+        source: 'builtInWorkflow',
+        name: 'writer',
+        variant: 'base',
+      }),
+      { ok: true, path: '/repo/resources/agents/writer.yaml' },
+    );
+    assert.deepEqual(
+      controller.planOpenAgentYaml({
+        source: 'builtInWorkflow',
+        name: 'writer',
+        variant: 'multiple',
+      }),
+      { ok: true, path: '/repo/resources/agents/writer_multiple.yaml' },
+    );
+  });
+
+  it('distinguishes missing agents from missing YAML paths', () => {
+    const { controller } = createController();
+
+    assert.deepEqual(
+      controller.planOpenAgentYaml({
+        source: 'custom',
+        name: 'unknown',
+        variant: 'base',
+      }),
+      { ok: false, reason: 'missingAgent' },
+    );
+    assert.deepEqual(
+      controller.planOpenAgentYaml({
+        source: 'custom',
+        name: 'pathless',
+        variant: 'base',
+      }),
+      { ok: false, reason: 'missingPath' },
+    );
+  });
+
+  it('plans reveal file only for agents with a primary path', () => {
+    const { controller } = createController();
+
+    assert.deepEqual(
+      controller.planRevealAgentFile({
+        source: 'builtInWorkflow',
+        name: 'writer',
+      }),
+      { ok: true, path: '/repo/resources/agents/writer.yaml' },
+    );
+    assert.deepEqual(
+      controller.planRevealAgentFile({
+        source: 'custom',
+        name: 'pathless',
+      }),
+      { ok: false, reason: 'missingFile' },
+    );
+  });
+
+  it('plans source directory opens only for local directories', async () => {
+    const { controller } = createController({
+      sourceDirs: {
+        builtInWorkflow: '/repo/resources/agents',
+        remote: undefined,
+      },
+    });
+
+    assert.deepEqual(await controller.planOpenAgentFolder('builtInWorkflow'), {
+      ok: true,
+      path: '/repo/resources/agents',
+    });
+    assert.deepEqual(await controller.planOpenAgentFolder('remote'), {
+      ok: false,
+      reason: 'missingLocalDirectory',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracts host-neutral planning for the remaining settings agent directory/open/reveal handlers into `SettingsAgentDirectoryController`. The VS Code handler still owns dialogs, document opening, OS reveal commands, webview posts, refreshes, and error reporting.

This covers the next settings-agent slice of #3305 without stacking on the open LaTeX branch. It closes part of #3305.

## Validation

- `npm install`
- `npx prettier --check src/settingsView/handlers/agentHandlers.ts src/controllers/settingsView/SettingsAgentDirectoryController.ts src/test/controllers/SettingsAgentDirectoryController.test.ts`
- `git diff --check`
- `npm run compile-tests`
- `npx mocha --require ./out/test/setup.js out/test/controllers/SettingsAgentDirectoryController.test.js out/test/controllers/SettingsAgentFileController.test.js out/test/controllers/SettingsAgentCatalogController.test.js out/test/controllers/SettingsAgentVisibilityController.test.js`
- `npm run lint`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes agent directory/YAML open/reveal planning logic; behavior should be unchanged aside from more explicit error-case handling now covered by unit tests.
> 
> **Overview**
> Extracts agent directory/YAML open/reveal/custom-dir *planning* into a new host-neutral `SettingsAgentDirectoryController`, returning typed results for missing-agent/missing-path/missing-directory cases.
> 
> Updates `AgentHandlers` to delegate `OPEN_AGENT_YAML`, `OPEN_AGENT_FOLDER`, `REVEAL_AGENT_FILE`, and custom agent dir status/reset to the new controller while keeping VS Code UI concerns (dialogs, commands, webview posts, error messages) in the handler.
> 
> Adds a dedicated unit test suite for the new controller, covering custom dir default/configured detection, reset behavior, and the various planning outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721a36934c070f06fcf5538e06e808fc7f62be3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->