### PR TITLE
ci: skip bot issue tracker review events

### DIFF
--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -20,7 +20,7 @@ jobs:
     # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
     # Skip automated review summaries: the Claude action cannot exchange their
     # OIDC token for a repo-writing app token, and Playbook C has no useful
-    # tracking action for those comment-only bot reviews.
+    # tracking action for bot-submitted review events.
     if: |
       (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
       (github.event_name == 'pull_request' &&
@@ -47,12 +47,13 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           should_run=true
 
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_ACTION" == "opened" ]]; then
             tracker_workflow_changes="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- .github/workflows/issue-tracker.yml)"
             if [[ -n "$tracker_workflow_changes" ]]; then
               should_run=false

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -18,14 +18,15 @@ concurrency:
 jobs:
   track:
     # Skip: closed-but-not-completed issues, closed-but-not-merged PRs
-    # Skip Copilot review summaries: the Claude action cannot exchange their
+    # Skip automated review summaries: the Claude action cannot exchange their
     # OIDC token for a repo-writing app token, and Playbook C has no useful
-    # tracking action for those comment-only automated reviews.
+    # tracking action for those comment-only bot reviews.
     if: |
       (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
       (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
       (github.event_name == 'pull_request_review' &&
-       github.event.review.user.login != 'copilot-pull-request-reviewer[bot]' &&
+       github.event.review.user.type != 'Bot' &&
+       !endsWith(github.event.review.user.login, '[bot]') &&
        github.actor != 'Copilot')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -4,10 +4,10 @@ on:
   issues:
     types: [closed]
   pull_request:
-    # `labeled` is intentionally omitted — Playbook C does nothing for label
-    # events, and auto-label.yml fires labeled events on every push, which
-    # otherwise cascades into duplicate, costly track runs.
-    types: [closed, opened, review_requested]
+    # `labeled` and `review_requested` are intentionally omitted — Playbook C
+    # does nothing for those events, and automation can otherwise cascade into
+    # duplicate, costly track runs.
+    types: [closed, opened]
   pull_request_review:
     types: [submitted]
 
@@ -23,7 +23,9 @@ jobs:
     # tracking action for those comment-only bot reviews.
     if: |
       (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
-      (github.event_name == 'pull_request' && (github.event.action != 'closed' || github.event.pull_request.merged == true)) ||
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' ||
+        (github.event.action == 'closed' && github.event.pull_request.merged == true))) ||
       (github.event_name == 'pull_request_review' &&
        github.event.review.user.type != 'Bot' &&
        !endsWith(github.event.review.user.login, '[bot]') &&
@@ -40,8 +42,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Gate tracker agent
+        id: tracker-gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          should_run=true
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            tracker_workflow_changes="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- .github/workflows/issue-tracker.yml)"
+            if [[ -n "$tracker_workflow_changes" ]]; then
+              should_run=false
+              echo "Skipping tracker agent because this PR changes issue-tracker.yml."
+              echo "The Claude action requires workflow content to match the default branch before token exchange."
+            fi
+          fi
+
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         id: claude
+        if: steps.tracker-gate.outputs.should_run == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes #3336.

The Issue Tracker workflow already skipped the known Copilot reviewer identity, but other automated pull_request_review submissions could still reach the Claude action before the tracker had useful work to do. Those runs fail during the Claude action OIDC-to-app-token exchange because the automated reviewer does not have repository write access.

This updates the workflow so unsupported events are skipped before invoking the tracker agent:

- automated review summaries are skipped using the reviewer user type, the conventional [bot] login suffix, and the existing Copilot sender guard
- normal human pull request reviews still pass through so approvals and change requests can update tracking issues
- pull_request review_requested events are no longer subscribed because Playbook C does not act on them
- PRs that modify issue-tracker.yml skip the Claude action after checkout because that action requires workflow content to match the default branch before token exchange

## Validation

- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/issue-tracker.yml'); puts 'YAML parse ok'"
- npx prettier --check .github/workflows/issue-tracker.yml
- git diff --check origin/main..HEAD -- .github/workflows/issue-tracker.yml
- Node condition simulation covering human reviews, Bot type reviews, [bot] suffix reviews, Copilot sender reviews, opened PRs, review_requested PR events, merged PRs, and unmerged closed PRs
- Bash gate simulation confirming a PR that changes .github/workflows/issue-tracker.yml sets should_run=false

Did not run npm test; this repository's workflow notes say it downloads the VS Code test environment and should be avoided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that narrows when the Claude tracker job runs; main risk is unintentionally skipping legitimate tracking updates due to event/user filtering or the new workflow-change gate.
> 
> **Overview**
> Reduces unnecessary/failing runs of the `Issue Tracker` workflow by **dropping `pull_request` `review_requested` triggers** and tightening the job `if` guard to **skip bot-submitted `pull_request_review` events** (via `user.type`, `[bot]` suffix, and existing Copilot actor check).
> 
> Adds a pre-step `Gate tracker agent` that, on `pull_request/opened`, detects diffs to `.github/workflows/issue-tracker.yml` and **skips invoking** `anthropics/claude-code-action@v1` when the workflow itself changed, preventing OIDC token exchange failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e08583f1610732a3dba335866cfb012b08faafa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->