### PR TITLE
refactor: tighten runtime event context

### DIFF
--- a/src/agent/runtime/ExecutionHandle.ts
+++ b/src/agent/runtime/ExecutionHandle.ts
@@ -251,37 +251,3 @@ export function collectChildSummary(
   }
   return result;
 }
-
-/** Emit the current active subagent list for a parent to the progress UI. */
-export function emitActiveSubagentsUpdate(
-  parentStreamId: StreamTabId,
-  handles: Iterable<ExecutionHandle>,
-  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
-): void {
-  const children = collectChildSummary(
-    parentStreamId,
-    handles,
-    AgentExecutionHandle,
-  );
-  runtimeHost.emit('updateActiveSubagents', {
-    parentStreamId,
-    children,
-  });
-}
-
-/** Emit the current active processes list for a parent to the progress UI. */
-export function emitActiveProcessesUpdate(
-  parentStreamId: StreamTabId,
-  handles: Iterable<ExecutionHandle>,
-  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
-): void {
-  const processes = collectChildSummary(
-    parentStreamId,
-    handles,
-    ProcessExecutionHandle,
-  );
-  runtimeHost.emit('updateActiveProcesses', {
-    parentStreamId,
-    processes,
-  });
-}

--- a/src/agent/runtime/ExecutionSubscriptionBinder.ts
+++ b/src/agent/runtime/ExecutionSubscriptionBinder.ts
@@ -93,16 +93,95 @@ function snapshot(handle: ExecutionHandle): SnapshotState {
   };
 }
 
-function send(
-  streamId: StreamTabId,
-  text: string,
-  runtimeHost: AgentRuntimeHost,
-): void {
-  void sendFollowUp(streamId, wrapAndSanitizeTag(TAG, text)).then((result) => {
-    if (result.status === 'sent' || result.status === 'queued') {
-      runtimeHost.emit('updateQueuedFollowUps', { streamId });
+class ExecutionSubscription implements Disposable {
+  private readonly executionId: string;
+  private readonly agentName: string;
+  private readonly category: ExecutionHandle['category'];
+  private last: SnapshotState | null;
+  private removeListener: (() => void) | null = null;
+  private disposed = false;
+
+  constructor(
+    private readonly streamId: StreamTabId,
+    handle: ExecutionHandle,
+    private readonly runtimeHost: AgentRuntimeHost,
+  ) {
+    this.executionId = handle.executionId;
+    this.agentName = handle.agentName;
+    this.category = handle.category;
+    this.last = snapshot(handle);
+  }
+
+  bind(): boolean {
+    this.removeListener = addExecutionListener(this.executionId, (handle) => {
+      this.handleChange(handle);
+    });
+
+    // TOCTOU: handle could untrack between the initial getHandle() check
+    // and listener registration. Re-check; if gone, fire the terminal event
+    // and dispose so the listener never leaks.
+    if (!getHandle(this.executionId)) {
+      this.sendFinished();
+      this.dispose();
+      return false;
     }
-  });
+    return true;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.removeListener?.();
+    const current = perStream.get(this.streamId);
+    if (current) removeBoundKey(this.streamId, current, this.executionId);
+  }
+
+  private handleChange(handle: ExecutionHandle | undefined): void {
+    if (!handle) {
+      this.sendFinished();
+      this.dispose();
+      return;
+    }
+
+    const current = snapshot(handle);
+    const statusChanged = !this.last || this.last.status !== current.status;
+    const roundChanged = this.last?.round !== current.round;
+    if (!statusChanged && !roundChanged) {
+      this.last = current;
+      return;
+    }
+
+    const transition =
+      this.last && statusChanged
+        ? `${this.last.status} → ${current.status}`
+        : current.status;
+    const elapsed = current.elapsed ? ` (${current.elapsed} elapsed)` : '';
+    const lines = [
+      `${this.executionId} (${this.agentName}, ${this.category}) ${transition}${elapsed}`,
+    ];
+    if (current.round) lines.push(current.round);
+    this.send(lines.join('\n'));
+    this.last = current;
+  }
+
+  private sendFinished(): void {
+    const previous = this.last?.status ?? 'unknown';
+    this.send(
+      `${this.executionId} (${this.agentName}, ${this.category}) finished. Last known status: ${previous}. Use executions { path: '/executions/${this.executionId}/report' } for the result.`,
+    );
+  }
+
+  private send(text: string): void {
+    void sendFollowUp(this.streamId, wrapAndSanitizeTag(TAG, text)).then(
+      (result) => {
+        if (result.status === 'sent' || result.status === 'queued') {
+          this.runtimeHost.emit('updateQueuedFollowUps', {
+            streamId: this.streamId,
+          });
+        }
+      },
+    );
+  }
 }
 
 /**
@@ -131,71 +210,17 @@ export function bindExecutionSubscription(
   }
   if (bound.has(executionId)) return;
 
-  const agentName = handle.agentName;
-  const category = handle.category;
-  const subscriberRuntimeHost = getAgentRuntimeHost();
-  let last: SnapshotState | null = snapshot(handle);
-
-  let removeListener: (() => void) | null = null;
-  let disposed = false;
-  const dispose = (): void => {
-    if (disposed) return;
-    disposed = true;
-    if (removeListener) removeListener();
-    const current = perStream.get(streamId);
-    if (current) removeBoundKey(streamId, current, executionId);
-  };
-
-  removeListener = addExecutionListener(executionId, (h) => {
-    if (!h) {
-      const previous = last?.status ?? 'unknown';
-      send(
-        streamId,
-        `${executionId} (${agentName}, ${category}) finished. Last known status: ${previous}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
-        subscriberRuntimeHost,
-      );
-      dispose();
-      return;
-    }
-
-    const current = snapshot(h);
-    const statusChanged = !last || last.status !== current.status;
-    const roundChanged = last?.round !== current.round;
-    if (!statusChanged && !roundChanged) {
-      last = current;
-      return;
-    }
-
-    const transition =
-      last && statusChanged
-        ? `${last.status} → ${current.status}`
-        : current.status;
-    const elapsed = current.elapsed ? ` (${current.elapsed} elapsed)` : '';
-    const lines = [
-      `${executionId} (${agentName}, ${category}) ${transition}${elapsed}`,
-    ];
-    if (current.round) lines.push(current.round);
-    send(streamId, lines.join('\n'), subscriberRuntimeHost);
-    last = current;
-  });
-
-  // TOCTOU: handle could untrack between the initial getHandle() check
-  // and addExecutionListener registration. Re-check; if gone, fire the
-  // terminal event synchronously and dispose so the listener never leaks.
-  if (!getHandle(executionId)) {
-    send(
-      streamId,
-      `${executionId} (${agentName}, ${category}) finished. Last known status: ${last?.status ?? 'unknown'}. Use executions { path: '/executions/${executionId}/report' } for the result.`,
-      subscriberRuntimeHost,
-    );
-    dispose();
-    return;
-  }
-
-  bound.set(executionId, { dispose });
-  logger.info(
-    `Bound execution subscription ${executionId} → stream ${streamId}`,
+  const subscription = new ExecutionSubscription(
+    streamId,
+    handle,
+    getAgentRuntimeHost(),
   );
+  bound.set(executionId, subscription);
+  if (subscription.bind()) {
+    logger.info(
+      `Bound execution subscription ${executionId} → stream ${streamId}`,
+    );
+  }
 }
 
 /**
@@ -214,6 +239,5 @@ export function unbindExecutionSubscription(
   } catch (err) {
     logger.warn(`Disposer threw on explicit unsubscribe: ${String(err)}`);
   }
-  removeBoundKey(streamId, bound, executionId);
   return true;
 }

--- a/src/agent/runtime/executionRegistry.ts
+++ b/src/agent/runtime/executionRegistry.ts
@@ -18,8 +18,6 @@ import {
   AgentExecutionHandle,
   ProcessExecutionHandle,
   collectChildSummary,
-  emitActiveSubagentsUpdate,
-  emitActiveProcessesUpdate,
   interruptActiveChildren as interruptChildren,
 } from './ExecutionHandle';
 
@@ -54,11 +52,7 @@ StreamStatusService.onDidChange(({ streamId }) => {
       // Re-emit badge update so the parent's background tasks panel
       // reflects the new status (e.g. running → waiting).
       if (handle.parentStreamId !== handle.childStreamId) {
-        emitActiveSubagentsUpdate(
-          handle.parentStreamId,
-          registry.values(),
-          runtimeHost,
-        );
+        emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
       }
       break;
     }
@@ -78,11 +72,7 @@ export function trackExecution(handle: ExecutionHandle): void {
   // (where parentStreamId differs from childStreamId)
   if (handle instanceof AgentExecutionHandle) {
     if (handle.parentStreamId !== handle.childStreamId) {
-      emitActiveSubagentsUpdate(
-        handle.parentStreamId,
-        registry.values(),
-        runtimeHost,
-      );
+      emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
       runtimeHost.emit('setParentStream', {
         childStreamId: handle.childStreamId,
         parentStreamId: handle.parentStreamId,
@@ -92,11 +82,7 @@ export function trackExecution(handle: ExecutionHandle): void {
 
   // Emit process badge update for background bash processes
   if (handle instanceof ProcessExecutionHandle) {
-    emitActiveProcessesUpdate(
-      handle.parentStreamId,
-      registry.values(),
-      runtimeHost,
-    );
+    emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
     reconcileOutputPoller();
   }
 }
@@ -113,11 +99,7 @@ export function untrackExecution(executionId: string): void {
     handle instanceof AgentExecutionHandle &&
     handle.parentStreamId !== handle.childStreamId
   ) {
-    emitActiveSubagentsUpdate(
-      handle.parentStreamId,
-      registry.values(),
-      runtimeHost,
-    );
+    emitActiveSubagentsUpdate(handle.parentStreamId, runtimeHost);
   }
 
   // Emit process badge update on removal and flush final output.
@@ -126,11 +108,7 @@ export function untrackExecution(executionId: string): void {
   if (handle instanceof ProcessExecutionHandle) {
     const finalize = (): void => {
       outputOffsets.delete(executionId);
-      emitActiveProcessesUpdate(
-        handle.parentStreamId,
-        registry.values(),
-        runtimeHost,
-      );
+      emitActiveProcessesUpdate(handle.parentStreamId, runtimeHost);
       reconcileOutputPoller();
     };
     if (handle.outputPaths) {
@@ -290,11 +268,7 @@ export function detachActiveChildren(parentStreamId: StreamTabId): void {
       handle.terminate();
     }
   }
-  emitActiveSubagentsUpdate(
-    parentStreamId,
-    registry.values(),
-    runtimeHostForParent(parentStreamId),
-  );
+  emitActiveSubagentsUpdate(parentStreamId);
 }
 
 /** Get active subagent and process children for a parent stream. */
@@ -314,6 +288,38 @@ export function getActiveChildren(parentStreamId: StreamTabId): {
       ProcessExecutionHandle,
     ),
   };
+}
+
+/** Emit the current active subagent list for a parent to the progress UI. */
+function emitActiveSubagentsUpdate(
+  parentStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost = runtimeHostForParent(parentStreamId),
+): void {
+  const children = collectChildSummary(
+    parentStreamId,
+    registry.values(),
+    AgentExecutionHandle,
+  );
+  runtimeHost.emit('updateActiveSubagents', {
+    parentStreamId,
+    children,
+  });
+}
+
+/** Emit the current active processes list for a parent to the progress UI. */
+function emitActiveProcessesUpdate(
+  parentStreamId: StreamTabId,
+  runtimeHost: AgentRuntimeHost = runtimeHostForParent(parentStreamId),
+): void {
+  const processes = collectChildSummary(
+    parentStreamId,
+    registry.values(),
+    ProcessExecutionHandle,
+  );
+  runtimeHost.emit('updateActiveProcesses', {
+    parentStreamId,
+    processes,
+  });
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Keep active-child progress emissions inside the execution registry so registry state and host selection are not pushed through ExecutionHandle event helpers.
- Capture subscription stream/runtime-host state in an ExecutionSubscription object instead of passing the host through a stateless follow-up sender.
- Preserve runtimeHost.emit(...) as the single typed event API; this does not add per-event AgentRuntimeHost wrappers.

Closes #3327.

## Validation
- npm install
- npx prettier --write src/agent/runtime/ExecutionHandle.ts src/agent/runtime/ExecutionSubscriptionBinder.ts src/agent/runtime/executionRegistry.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/agent/runtime/PromiseCoordinators.test.js
- npm run lint
- npm run compile:safe

## Notes
- A broader focused Mocha attempt including out/test/agent/toolUse/ToolUseFollowUp.test.js failed during module import with `TypeError: files_1.OFFICE_MIME_TYPES is not iterable` before assertions ran; the compile/lint gates above passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors runtime event emission and execution subscription lifecycle/disposal logic, where subtle listener/host-selection mistakes could cause stale UI badges or leaked subscriptions.
> 
> **Overview**
> Moves active-child progress UI emissions for subagents/processes out of `ExecutionHandle` and into `executionRegistry`, so the registry owns both *current state* (`registry.values()`) and *runtimeHost selection* when emitting `updateActiveSubagents`/`updateActiveProcesses`.
> 
> Refactors `bindExecutionSubscription` to use an `ExecutionSubscription` object that captures `streamId`, execution metadata, and `runtimeHost`, handles TOCTOU untrack checks, and centralizes change/finished follow-up sending and self-disposal. This also removes the extra helper that passed `runtimeHost` through a stateless send function, keeping `runtimeHost.emit(...)` calls co-located with the subscription instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8f65ff1233403719f6e88356ed6e325b584be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->