### PR TITLE
refactor: extract progress follow-up controller

### DIFF
--- a/src/controllers/progressView/ProgressFollowUpController.ts
+++ b/src/controllers/progressView/ProgressFollowUpController.ts
@@ -1,0 +1,332 @@
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import type { ExecutionRequest } from '@agent/core/executionRequests';
+
+// Local imports - logger
+import {
+  isWorkflowTaskState,
+  type TaskState,
+  type WorkflowTaskState,
+} from '@logger/TaskState';
+
+// Local imports - shared
+import type {
+  CompileFailure,
+  OutputFileInfo,
+  StreamTabId,
+} from '@shared/schemas';
+
+export interface ProgressFollowUpModelOption {
+  value: string;
+  disabled?: boolean;
+}
+
+export interface ProgressFollowUpWorkspace {
+  locatePath(path: string):
+    | { kind: 'workspace'; relativePath: string }
+    | {
+        kind: 'external';
+      };
+  exists(relativePath: string): Promise<boolean>;
+}
+
+export interface ProgressFollowUpControllerDeps {
+  getAgentCategory(agent: string): AgentCategory | undefined;
+  workspace: ProgressFollowUpWorkspace;
+}
+
+export type ProgressFollowUpPlan =
+  | { kind: 'warning'; message: string }
+  | { kind: 'info'; message: string }
+  | {
+      kind: 'restoreState';
+      taskState: TaskState;
+      executeImmediately: boolean;
+    }
+  | { kind: 'execute'; request: ExecutionRequest };
+
+export interface ToolUseFollowUpInput {
+  streamId: StreamTabId;
+  taskState: TaskState | undefined;
+  outputFiles: OutputFileInfo[];
+  agent: string;
+  model: string;
+  initialQuestion?: string;
+  executeImmediately: boolean;
+  modelOptions: readonly ProgressFollowUpModelOption[];
+  executionId?: string;
+}
+
+export interface CompileFixerInput {
+  streamId: StreamTabId;
+  taskState: TaskState | undefined;
+  compileFailures: CompileFailure[];
+  runOutputs: Map<number, OutputFileInfo[]>;
+  modelOptions: readonly ProgressFollowUpModelOption[];
+  executionId?: string;
+}
+
+export class ProgressFollowUpController {
+  constructor(private readonly deps: ProgressFollowUpControllerDeps) {}
+
+  planToolUseFollowUp(input: ToolUseFollowUpInput): ProgressFollowUpPlan {
+    if (!input.taskState || !isWorkflowTaskState(input.taskState)) {
+      return {
+        kind: 'warning',
+        message:
+          'No workflow state found for this stream. Cannot set up a follow-up.',
+      };
+    }
+
+    if (input.outputFiles.length === 0) {
+      return {
+        kind: 'info',
+        message: 'No workflow output files are available for a follow-up yet.',
+      };
+    }
+
+    if (this.deps.getAgentCategory(input.agent) !== AgentCategory.ToolUse) {
+      return {
+        kind: 'warning',
+        message: 'Select a tool-use agent before starting a follow-up.',
+      };
+    }
+
+    if (!this.hasEnabledModel(input.modelOptions, input.model)) {
+      return {
+        kind: 'warning',
+        message: 'Select an available model before starting a follow-up.',
+      };
+    }
+
+    const agentConfig = AgentConfigSchema.parse({
+      ...input.taskState.agentConfig,
+      agent: input.agent,
+      model: input.model,
+      agentCategory: AgentCategory.ToolUse,
+      instruction: this.buildWorkflowToolUseFollowupInstruction(
+        input.outputFiles,
+        input.initialQuestion,
+        input.executionId,
+      ),
+      outputFiles: [],
+      useMultipleOutputs: false,
+      editedFile: null,
+      editedFiles: [],
+    }) as AgentConfig & { agentCategory: AgentCategory.ToolUse };
+
+    return {
+      kind: 'restoreState',
+      taskState: { agentConfig },
+      executeImmediately: input.executeImmediately,
+    };
+  }
+
+  async planCompileFixer(
+    input: CompileFixerInput,
+  ): Promise<ProgressFollowUpPlan> {
+    if (!input.taskState || !isWorkflowTaskState(input.taskState)) {
+      return {
+        kind: 'warning',
+        message:
+          'No workflow state found for this stream. Cannot run latexFixer.',
+      };
+    }
+
+    if (input.compileFailures.length === 0) {
+      return {
+        kind: 'info',
+        message: 'No compile failures are recorded for this stream.',
+      };
+    }
+
+    const model = this.resolveWorkflowModel(
+      input.taskState,
+      input.modelOptions,
+    );
+    if (!model) {
+      return {
+        kind: 'warning',
+        message: 'No model is available to launch latexFixer.',
+      };
+    }
+
+    const editableFiles = await this.resolveCompileFixerInputFiles(
+      input.taskState.agentConfig,
+      input.compileFailures,
+      input.runOutputs,
+    );
+    if (editableFiles.length === 0) {
+      return {
+        kind: 'warning',
+        message:
+          'No editable workspace source file matched the compile failure. Accept the output into the workspace first, then run latexFixer.',
+      };
+    }
+
+    return {
+      kind: 'execute',
+      request: {
+        config: this.buildCompileFixerConfig(
+          input.taskState.agentConfig,
+          model,
+          editableFiles,
+          this.buildCompileFixerQuestion(
+            input.compileFailures,
+            editableFiles,
+            input.executionId,
+          ),
+        ),
+      },
+    };
+  }
+
+  private hasEnabledModel(
+    modelOptions: readonly ProgressFollowUpModelOption[],
+    model: string,
+  ): boolean {
+    return modelOptions.some((option) => {
+      return option.value === model && !option.disabled;
+    });
+  }
+
+  private resolveWorkflowModel(
+    taskState: WorkflowTaskState,
+    modelOptions: readonly ProgressFollowUpModelOption[],
+  ): string | null {
+    const workflowModel = taskState.agentConfig.model;
+    if (this.hasEnabledModel(modelOptions, workflowModel)) {
+      return workflowModel;
+    }
+    return modelOptions.find((option) => !option.disabled)?.value ?? null;
+  }
+
+  private buildWorkflowToolUseFollowupInstruction(
+    outputFiles: OutputFileInfo[],
+    initialQuestion: string | undefined,
+    executionId: string | undefined,
+  ): string {
+    const executionHint = executionId ? `Execution: ${executionId}` : undefined;
+    const userQuestion = initialQuestion?.trim();
+    const outputLines = outputFiles.map((output) => {
+      const outputPath = this.formatOutputReferencePath(output, executionId);
+      const source = output.source ? ` (source: ${output.source})` : '';
+      return `- r${output.round}: ${outputPath}${source}`;
+    });
+
+    return [
+      'Continue from the completed workflow run. The workflow wrote generated files to task-run storage, so use the output paths below as read-only context unless a path is explicitly in the workspace.',
+      executionHint,
+      'Workflow outputs:',
+      ...outputLines,
+      userQuestion ? `User follow-up request: ${userQuestion}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private buildCompileFixerQuestion(
+    compileFailures: CompileFailure[],
+    editableFiles: string[],
+    executionId: string | undefined,
+  ): string {
+    const executionHint = executionId ? `Execution: ${executionId}` : undefined;
+    const editableHint =
+      editableFiles.length > 0
+        ? `Editable workspace target${editableFiles.length === 1 ? '' : 's'}: ${editableFiles.join(', ')}`
+        : undefined;
+    const failureLines = compileFailures.map((failure) => {
+      const outputPath =
+        executionId && failure.output.kind === 'runStorage'
+          ? `/executions/${executionId}/files/${failure.output.relativePath}`
+          : failure.output.kind === 'external'
+            ? failure.output.absolutePath
+            : failure.output.relativePath;
+      const logPath = executionId
+        ? `/executions/${executionId}/files/${failure.logRelativePath}`
+        : failure.log.absolutePath;
+      return `- r${failure.round} ${failure.displayName}: output ${outputPath}; compile log ${logPath}`;
+    });
+
+    return [
+      'The workflow compile check failed. Diagnose and fix the generated LaTeX output using the compile log context below.',
+      executionHint,
+      editableHint,
+      ...failureLines,
+      'Use read_file/edit_file on the editable workspace target files. Use /executions paths only to inspect the generated output and logs.',
+      'If the failure is caused by a missing external dependency rather than editable LaTeX, report that clearly instead of inventing the missing file.',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private buildCompileFixerConfig(
+    originalConfig: AgentConfig,
+    model: string,
+    editableFiles: string[],
+    instruction: string,
+  ): AgentConfig {
+    const [inputFile = '', ...inputFiles] = editableFiles;
+    return {
+      ...originalConfig,
+      agent: 'latexFixer',
+      model,
+      instruction,
+      agentCategory: AgentCategory.ToolUse,
+      inputFile,
+      inputFiles,
+      outputFiles: [],
+      useMultipleOutputs: false,
+      editedFile: null,
+      editedFiles: [],
+    };
+  }
+
+  private async resolveCompileFixerInputFiles(
+    originalConfig: AgentConfig,
+    compileFailures: CompileFailure[],
+    runOutputs: Map<number, OutputFileInfo[]>,
+  ): Promise<string[]> {
+    const outputByPath = new Map<string, OutputFileInfo>();
+    for (const output of [...runOutputs.values()].flat()) {
+      outputByPath.set(output.location.absolutePath, output);
+    }
+
+    const sourceCandidates = compileFailures
+      .map((failure) => outputByPath.get(failure.output.absolutePath)?.source)
+      .filter((source): source is string => !!source);
+    const fallbackCandidates = [
+      originalConfig.inputFile,
+      ...originalConfig.inputFiles,
+    ].filter(Boolean);
+
+    const preferred = [...sourceCandidates, ...fallbackCandidates];
+    const targets: string[] = [];
+    const seen = new Set<string>();
+    for (const candidate of preferred) {
+      const location = this.deps.workspace.locatePath(candidate);
+      if (location.kind === 'external') continue;
+      if (seen.has(location.relativePath)) continue;
+      if (!(await this.deps.workspace.exists(location.relativePath))) continue;
+      seen.add(location.relativePath);
+      targets.push(location.relativePath);
+    }
+    return targets;
+  }
+
+  private formatOutputReferencePath(
+    output: OutputFileInfo,
+    executionId: string | undefined,
+  ): string {
+    const location = output.location;
+    switch (location.kind) {
+      case 'runStorage':
+        return `/executions/${executionId ?? location.executionId}/files/${location.relativePath}`;
+      case 'workspace':
+        return location.relativePath;
+      case 'external':
+        return location.absolutePath;
+    }
+  }
+}

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -28,19 +28,10 @@ import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import {
-  isWorkflowTaskState,
-  type TaskState,
-  type WorkflowTaskState,
-} from '@logger/TaskState';
+import type { TaskState } from '@logger/TaskState';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { buildStreamInfos } from '@progressView/streamInfoUtils';
-import type {
-  CompileFailure,
-  OutputFileInfo,
-  StorageKey,
-  StreamTabId,
-} from '@shared/schemas';
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 import type { AgentProposal } from '@shared/schemas/prompts';
 import {
   dispatchProgressViewInbound,
@@ -74,6 +65,10 @@ import {
 } from '@utils/text/textEnhancementUtils';
 
 import { ProgressStreamLifecycleController } from '../controllers/progressView/ProgressStreamLifecycleController';
+import {
+  ProgressFollowUpController,
+  type ProgressFollowUpPlan,
+} from '../controllers/progressView/ProgressFollowUpController';
 import { ProgressWorkflowActionsController } from '../controllers/progressView/ProgressWorkflowActionsController';
 import type { ProgressViewProvider } from './ProgressViewProvider';
 
@@ -95,6 +90,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly recordingManager: RecordingManager;
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
   private readonly workflowActionsController: ProgressWorkflowActionsController;
+  private readonly followUpController: ProgressFollowUpController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
     Map<string, { content: string; streamId: StreamTabId }>
@@ -128,6 +124,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.handlerRegistry = this.createHandlerRegistry();
     this.streamLifecycleController = this.createStreamLifecycleController();
     this.workflowActionsController = this.createWorkflowActionsController();
+    this.followUpController = this.createFollowUpController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
       void this.handleDeleteStream({
@@ -420,6 +417,16 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       },
       runFileOperation: async (operation, request) => {
         await vscode.commands.executeCommand(`texra.${operation}`, request);
+      },
+    });
+  }
+
+  private createFollowUpController(): ProgressFollowUpController {
+    return new ProgressFollowUpController({
+      getAgentCategory: (agent) => getAgent(agent, true)?.category,
+      workspace: {
+        locatePath: (candidate) => WorkspaceFS.locatePath(candidate),
+        exists: (relativePath) => WorkspaceFS.exists(relativePath),
       },
     });
   }
@@ -1017,260 +1024,62 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     executeImmediately: boolean,
   ): Promise<void> {
     const taskState = this.provider.state.meta.getTaskState(data.stream);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      await vscode.window.showWarningMessage(
-        'No workflow state found for this stream. Cannot set up a follow-up.',
-      );
-      return;
-    }
-
     const outputFiles = [
       ...this.provider.state.outputFiles.getFiles(data.stream).values(),
     ].flat();
-    if (outputFiles.length === 0) {
-      await vscode.window.showInformationMessage(
-        'No workflow output files are available for a follow-up yet.',
-      );
-      return;
-    }
-
-    const agentEntry = getAgent(data.agent, true);
-    if (!agentEntry || agentEntry.category !== AgentCategory.ToolUse) {
-      await vscode.window.showWarningMessage(
-        'Select a tool-use agent before starting a follow-up.',
-      );
-      return;
-    }
-
     const { modelOptions } = await loadOptions();
-    const selectedModel = modelOptions.find(
-      (option) => option.value === data.model,
-    );
-    if (!selectedModel || selectedModel.disabled) {
-      await vscode.window.showWarningMessage(
-        'Select an available model before starting a follow-up.',
-      );
-      return;
-    }
 
-    const agentConfig = AgentConfigSchema.parse({
-      ...taskState.agentConfig,
-      agent: data.agent,
-      model: data.model,
-      agentCategory: AgentCategory.ToolUse,
-      instruction: this.buildWorkflowToolUseFollowupInstruction(
-        data.stream,
+    await this.applyFollowUpPlan(
+      this.followUpController.planToolUseFollowUp({
+        streamId: data.stream,
+        taskState,
         outputFiles,
-        data.initialQuestion,
-      ),
-      outputFiles: [],
-      useMultipleOutputs: false,
-      editedFile: null,
-      editedFiles: [],
-    }) as AgentConfig & { agentCategory: AgentCategory.ToolUse };
-
-    const followupTaskState: TaskState = { agentConfig };
-    await vscode.commands.executeCommand(
-      'texra.restoreState',
-      followupTaskState,
-      executeImmediately,
+        agent: data.agent,
+        model: data.model,
+        initialQuestion: data.initialQuestion,
+        executeImmediately,
+        modelOptions,
+        executionId: this.provider.state.meta.getExecutionId(data.stream),
+      }),
     );
-  }
-
-  private buildWorkflowToolUseFollowupInstruction(
-    streamId: StreamTabId,
-    outputFiles: OutputFileInfo[],
-    initialQuestion: string | undefined,
-  ): string {
-    const executionId = this.provider.state.meta.getExecutionId(streamId);
-    const executionHint = executionId ? `Execution: ${executionId}` : undefined;
-    const userQuestion = initialQuestion?.trim();
-    const outputLines = outputFiles.map((output) => {
-      const outputPath = this.formatOutputReferencePath(output, executionId);
-      const source = output.source ? ` (source: ${output.source})` : '';
-      return `- r${output.round}: ${outputPath}${source}`;
-    });
-
-    return [
-      'Continue from the completed workflow run. The workflow wrote generated files to task-run storage, so use the output paths below as read-only context unless a path is explicitly in the workspace.',
-      executionHint,
-      'Workflow outputs:',
-      ...outputLines,
-      userQuestion ? `User follow-up request: ${userQuestion}` : undefined,
-    ]
-      .filter(Boolean)
-      .join('\n');
-  }
-
-  private formatOutputReferencePath(
-    output: OutputFileInfo,
-    executionId: string | undefined,
-  ): string {
-    const location = output.location;
-    switch (location.kind) {
-      case 'runStorage':
-        return `/executions/${executionId ?? location.executionId}/files/${location.relativePath}`;
-      case 'workspace':
-        return location.relativePath;
-      case 'external':
-        return location.absolutePath;
-    }
   }
 
   private async handleRunCompileFixer(streamId: StreamTabId): Promise<void> {
     const taskState = this.provider.state.meta.getTaskState(streamId);
-    if (!taskState || !isWorkflowTaskState(taskState)) {
-      await vscode.window.showWarningMessage(
-        'No workflow state found for this stream. Cannot run latexFixer.',
-      );
-      return;
-    }
-
     const compileFailures = [
       ...this.provider.state.outputFiles.getCompileFailures(streamId).values(),
     ].flat();
-    if (compileFailures.length === 0) {
-      await vscode.window.showInformationMessage(
-        'No compile failures are recorded for this stream.',
-      );
-      return;
-    }
-
-    const model = await this.resolveWorkflowModel(taskState);
-    if (!model) {
-      await vscode.window.showWarningMessage(
-        'No model is available to launch latexFixer.',
-      );
-      return;
-    }
-
-    const editableFiles = await this.resolveCompileFixerInputFiles(
-      taskState.agentConfig,
-      compileFailures,
-      this.provider.state.outputFiles.getFiles(streamId),
-    );
-    if (editableFiles.length === 0) {
-      await vscode.window.showWarningMessage(
-        'No editable workspace source file matched the compile failure. Accept the output into the workspace first, then run latexFixer.',
-      );
-      return;
-    }
-
-    await this.executeValidated({
-      config: this.buildCompileFixerConfig(
-        taskState.agentConfig,
-        model,
-        editableFiles,
-        this.buildCompileFixerQuestion(
-          streamId,
-          compileFailures,
-          editableFiles,
-        ),
-      ),
-    });
-  }
-
-  private async resolveWorkflowModel(
-    taskState: WorkflowTaskState,
-  ): Promise<string | null> {
     const { modelOptions } = await loadOptions();
-    const workflowModel = taskState.agentConfig.model;
-    const workflowOption = modelOptions.find(
-      (option) => option.value === workflowModel,
+
+    await this.applyFollowUpPlan(
+      await this.followUpController.planCompileFixer({
+        streamId,
+        taskState,
+        compileFailures,
+        runOutputs: this.provider.state.outputFiles.getFiles(streamId),
+        modelOptions,
+        executionId: this.provider.state.meta.getExecutionId(streamId),
+      }),
     );
-    if (workflowOption && !workflowOption.disabled) {
-      return workflowModel;
-    }
-    return modelOptions.find((option) => !option.disabled)?.value ?? null;
   }
 
-  private buildCompileFixerQuestion(
-    streamId: StreamTabId,
-    compileFailures: CompileFailure[],
-    editableFiles: string[],
-  ): string {
-    const executionId = this.provider.state.meta.getExecutionId(streamId);
-    const executionHint = executionId ? `Execution: ${executionId}` : undefined;
-    const editableHint =
-      editableFiles.length > 0
-        ? `Editable workspace target${editableFiles.length === 1 ? '' : 's'}: ${editableFiles.join(', ')}`
-        : undefined;
-    const failureLines = compileFailures.map((failure) => {
-      const outputPath =
-        executionId && failure.output.kind === 'runStorage'
-          ? `/executions/${executionId}/files/${failure.output.relativePath}`
-          : failure.output.kind === 'external'
-            ? failure.output.absolutePath
-            : failure.output.relativePath;
-      const logPath = executionId
-        ? `/executions/${executionId}/files/${failure.logRelativePath}`
-        : failure.log.absolutePath;
-      return `- r${failure.round} ${failure.displayName}: output ${outputPath}; compile log ${logPath}`;
-    });
-
-    return [
-      'The workflow compile check failed. Diagnose and fix the generated LaTeX output using the compile log context below.',
-      executionHint,
-      editableHint,
-      ...failureLines,
-      'Use read_file/edit_file on the editable workspace target files. Use /executions paths only to inspect the generated output and logs.',
-      'If the failure is caused by a missing external dependency rather than editable LaTeX, report that clearly instead of inventing the missing file.',
-    ]
-      .filter(Boolean)
-      .join('\n');
-  }
-
-  private buildCompileFixerConfig(
-    originalConfig: AgentConfig,
-    model: string,
-    editableFiles: string[],
-    instruction: string,
-  ): AgentConfig {
-    const [inputFile = '', ...inputFiles] = editableFiles;
-    return {
-      ...originalConfig,
-      agent: 'latexFixer',
-      model,
-      instruction,
-      agentCategory: AgentCategory.ToolUse,
-      inputFile,
-      inputFiles,
-      outputFiles: [],
-      useMultipleOutputs: false,
-      editedFile: null,
-      editedFiles: [],
-    };
-  }
-
-  private async resolveCompileFixerInputFiles(
-    originalConfig: AgentConfig,
-    compileFailures: CompileFailure[],
-    runOutputs: Map<number, OutputFileInfo[]>,
-  ): Promise<string[]> {
-    const outputByPath = new Map<string, OutputFileInfo>();
-    for (const output of [...runOutputs.values()].flat()) {
-      outputByPath.set(output.location.absolutePath, output);
+  private async applyFollowUpPlan(plan: ProgressFollowUpPlan): Promise<void> {
+    switch (plan.kind) {
+      case 'warning':
+        await vscode.window.showWarningMessage(plan.message);
+        return;
+      case 'info':
+        await vscode.window.showInformationMessage(plan.message);
+        return;
+      case 'restoreState':
+        await vscode.commands.executeCommand(
+          'texra.restoreState',
+          plan.taskState,
+          plan.executeImmediately,
+        );
+        return;
+      case 'execute':
+        await this.executeValidated(plan.request);
     }
-
-    const sourceCandidates = compileFailures
-      .map((failure) => outputByPath.get(failure.output.absolutePath)?.source)
-      .filter((source): source is string => !!source);
-    const fallbackCandidates = [
-      originalConfig.inputFile,
-      ...originalConfig.inputFiles,
-    ].filter(Boolean);
-
-    const preferred = [...sourceCandidates, ...fallbackCandidates];
-    const targets: string[] = [];
-    const seen = new Set<string>();
-    for (const candidate of preferred) {
-      const location = WorkspaceFS.locatePath(candidate);
-      if (location.kind === 'external') continue;
-      if (seen.has(location.relativePath)) continue;
-      if (!(await WorkspaceFS.exists(location.relativePath))) continue;
-      seen.add(location.relativePath);
-      targets.push(location.relativePath);
-    }
-    return targets;
   }
 }

--- a/src/test/controllers/ProgressFollowUpController.test.ts
+++ b/src/test/controllers/ProgressFollowUpController.test.ts
@@ -1,0 +1,206 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+
+// Local imports - logger
+import type { WorkflowTaskState } from '@logger/TaskState';
+
+// Local imports - shared
+import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
+
+// Local imports - controllers
+import { ProgressFollowUpController } from '../../controllers/progressView/ProgressFollowUpController';
+
+function createAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: 'correct',
+    model: 'gemini31p',
+    inputFile: 'main.tex',
+    inputFiles: [],
+    outputFiles: ['answer.tex'],
+    agentCategory: AgentCategory.Workflow,
+    ...overrides,
+  });
+}
+
+function createWorkflowTaskState(
+  overrides: Partial<AgentConfig> = {},
+): WorkflowTaskState {
+  return {
+    agentConfig: createAgentConfig({
+      agentCategory: AgentCategory.Workflow,
+      ...overrides,
+    }) as AgentConfig & { agentCategory: AgentCategory.Workflow },
+    activeFiles: {
+      input: true,
+      reference: false,
+      auxiliary: false,
+      media: false,
+      output: true,
+    },
+  };
+}
+
+function createOutputFile(
+  overrides: Partial<OutputFileInfo> = {},
+): OutputFileInfo {
+  return {
+    source: 'main.tex',
+    location: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.tex',
+      relativePath: 'answer.tex',
+      executionId: 'exec-old',
+    },
+    round: 2,
+    lineage: null,
+    diff: null,
+    ...overrides,
+  };
+}
+
+function createCompileFailure(
+  overrides: Partial<CompileFailure> = {},
+): CompileFailure {
+  return {
+    round: 2,
+    displayName: 'answer.tex',
+    output: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.tex',
+      relativePath: 'answer.tex',
+      executionId: 'exec-old',
+    },
+    log: {
+      kind: 'runStorage',
+      absolutePath: '/tmp/exec/answer.log',
+      relativePath: 'answer.log',
+      executionId: 'exec-old',
+    },
+    logRelativePath: 'answer.log',
+    ...overrides,
+  };
+}
+
+function createController(
+  existingFiles = new Set(['main.tex']),
+): ProgressFollowUpController {
+  return new ProgressFollowUpController({
+    getAgentCategory: (agent) =>
+      agent === 'tool-agent' ? AgentCategory.ToolUse : AgentCategory.Workflow,
+    workspace: {
+      locatePath: (candidate) =>
+        candidate.startsWith('/external/')
+          ? { kind: 'external' }
+          : { kind: 'workspace', relativePath: candidate },
+      exists: async (relativePath) => existingFiles.has(relativePath),
+    },
+  });
+}
+
+describe('ProgressFollowUpController', () => {
+  it('builds a tool-use follow-up restore plan from workflow outputs', () => {
+    const controller = createController();
+    const plan = controller.planToolUseFollowUp({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState(),
+      outputFiles: [createOutputFile()],
+      agent: 'tool-agent',
+      model: 'gemini31p',
+      initialQuestion: ' Please inspect the proof. ',
+      executeImmediately: true,
+      modelOptions: [{ value: 'gemini31p' }],
+      executionId: 'exec-123',
+    });
+
+    assert.equal(plan.kind, 'restoreState');
+    if (plan.kind !== 'restoreState') return;
+    assert.equal(plan.executeImmediately, true);
+    assert.equal(plan.taskState.agentConfig.agent, 'tool-agent');
+    assert.equal(
+      plan.taskState.agentConfig.agentCategory,
+      AgentCategory.ToolUse,
+    );
+    assert.equal(plan.taskState.agentConfig.inputFile, 'main.tex');
+    assert.equal(plan.taskState.agentConfig.outputFiles.length, 0);
+    assert.match(
+      plan.taskState.agentConfig.instruction,
+      /\/executions\/exec-123\/files\/answer\.tex/,
+    );
+    assert.match(
+      plan.taskState.agentConfig.instruction,
+      /User follow-up request: Please inspect the proof\./,
+    );
+  });
+
+  it('rejects follow-up setup when the selected model is disabled', () => {
+    const plan = createController().planToolUseFollowUp({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState(),
+      outputFiles: [createOutputFile()],
+      agent: 'tool-agent',
+      model: 'gemini31p',
+      executeImmediately: false,
+      modelOptions: [{ value: 'gemini31p', disabled: true }],
+    });
+
+    assert.deepEqual(plan, {
+      kind: 'warning',
+      message: 'Select an available model before starting a follow-up.',
+    });
+  });
+
+  it('plans latexFixer with source files from compile failures before fallbacks', async () => {
+    const controller = createController(new Set(['source.tex', 'main.tex']));
+    const output = createOutputFile({ source: 'source.tex' });
+    const plan = await controller.planCompileFixer({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState({
+        inputFile: 'main.tex',
+        inputFiles: ['source.tex'],
+      }),
+      compileFailures: [createCompileFailure()],
+      runOutputs: new Map([[2, [output]]]),
+      modelOptions: [{ value: 'other-model' }],
+      executionId: 'exec-123',
+    });
+
+    assert.equal(plan.kind, 'execute');
+    if (plan.kind !== 'execute') return;
+    const config = plan.request.config;
+    assert.equal(config.agent, 'latexFixer');
+    assert.equal(config.model, 'other-model');
+    assert.equal(config.inputFile, 'source.tex');
+    assert.deepEqual(config.inputFiles, ['main.tex']);
+    assert.match(
+      config.instruction ?? '',
+      /Editable workspace targets: source\.tex, main\.tex/,
+    );
+    assert.match(
+      config.instruction ?? '',
+      /output \/executions\/exec-123\/files\/answer\.tex; compile log \/executions\/exec-123\/files\/answer\.log/,
+    );
+  });
+
+  it('warns when compile failures have no editable workspace source', async () => {
+    const plan = await createController(new Set()).planCompileFixer({
+      streamId: 'stream-a',
+      taskState: createWorkflowTaskState({ inputFile: '/external/main.tex' }),
+      compileFailures: [createCompileFailure()],
+      runOutputs: new Map([
+        [2, [createOutputFile({ source: '/external/main.tex' })]],
+      ]),
+      modelOptions: [{ value: 'gemini31p' }],
+      executionId: 'exec-123',
+    });
+
+    assert.deepEqual(plan, {
+      kind: 'warning',
+      message:
+        'No editable workspace source file matched the compile failure. Accept the output into the workspace first, then run latexFixer.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract workflow follow-up and latexFixer planning from ProgressViewMessageHandler into ProgressFollowUpController.
- Keep VS Code effects in the handler while moving workflow-state validation, model/agent checks, instruction construction, and editable-source resolution into host-neutral code.
- Add focused controller coverage for follow-up restore plans, disabled model rejection, latexFixer source selection, and no-editable-source warnings.

Part of #3305.

## Validation

- npm install
- npx prettier --check src/controllers/progressView/ProgressFollowUpController.ts src/progressView/ProgressViewMessageHandler.ts src/test/controllers/ProgressFollowUpController.test.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/controllers/ProgressFollowUpController.test.js out/test/controllers/ProgressWorkflowActionsController.test.js
- npm run lint
- npm run compile:safe

Did not run npm test; repository guidance says it downloads the VS Code test environment and should be avoided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor, but it rewires follow-up setup and `latexFixer` launch logic into a new planner and could subtly change validation/model-selection or file-target resolution paths.
> 
> **Overview**
> Extracts progress follow-up planning into a new host-neutral `ProgressFollowUpController`, which returns a `ProgressFollowUpPlan` (`warning`/`info`/`restoreState`/`execute`) for tool-use follow-ups and `latexFixer` runs.
> 
> Updates `ProgressViewMessageHandler` to delegate all workflow-state validation, agent/model checks, instruction/question construction, model fallback selection, and editable workspace source-file resolution to the controller, keeping only VS Code side effects (messages, `texra.restoreState`, `texra.execute`). Adds focused unit tests covering follow-up restore planning, disabled-model rejection, `latexFixer` input-file selection precedence, and no-editable-source warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870cc8158742a8663174df927aa15f0196bbefd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->