### PR TITLE
refactor: extract main view status controller

### DIFF
--- a/src/controllers/mainView/MainViewStartupController.ts
+++ b/src/controllers/mainView/MainViewStartupController.ts
@@ -6,16 +6,15 @@ import type {
   ModelOptionData,
 } from '@shared/schemas';
 
+// Local imports - controllers
+import type { MainViewAuthStatus } from './MainViewTypes';
+
 export interface MainViewStartupOptions {
   modelOptions: ModelOptionData[];
   agentOptions: {
     workflow?: AgentOptionData[];
     toolUse?: AgentOptionData[];
   };
-}
-
-export interface MainViewAuthStatus {
-  authenticated: boolean;
 }
 
 export interface MainViewStartupControllerDeps {

--- a/src/controllers/mainView/MainViewStatusController.ts
+++ b/src/controllers/mainView/MainViewStatusController.ts
@@ -1,0 +1,36 @@
+// Local imports - common
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+export interface MainViewAuthStatus {
+  authenticated: boolean;
+}
+
+type MainViewStatusMessage =
+  | { command: typeof MAIN_VIEW_COMMANDS.THEME_SET; theme: 'dark' | 'light' }
+  | { command: typeof MAIN_VIEW_COMMANDS.DEBUG_MODE_SET; debugMode: boolean }
+  | { command: typeof MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER };
+
+export class MainViewStatusController {
+  getThemeMessage(isDarkTheme: boolean): MainViewStatusMessage {
+    return {
+      command: MAIN_VIEW_COMMANDS.THEME_SET,
+      theme: isDarkTheme ? 'dark' : 'light',
+    };
+  }
+
+  getDebugModeMessage(debugMode: boolean): MainViewStatusMessage {
+    return {
+      command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
+    };
+  }
+
+  getPostSignInMessage(
+    authStatus: MainViewAuthStatus,
+  ): MainViewStatusMessage | null {
+    if (!authStatus.authenticated) return null;
+    return {
+      command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+    };
+  }
+}

--- a/src/controllers/mainView/MainViewStatusController.ts
+++ b/src/controllers/mainView/MainViewStatusController.ts
@@ -1,9 +1,8 @@
 // Local imports - common
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 
-export interface MainViewAuthStatus {
-  authenticated: boolean;
-}
+// Local imports - controllers
+import type { MainViewAuthStatus } from './MainViewTypes';
 
 type MainViewStatusMessage =
   | { command: typeof MAIN_VIEW_COMMANDS.THEME_SET; theme: 'dark' | 'light' }

--- a/src/controllers/mainView/MainViewTypes.ts
+++ b/src/controllers/mainView/MainViewTypes.ts
@@ -1,0 +1,3 @@
+export interface MainViewAuthStatus {
+  authenticated: boolean;
+}

--- a/src/test/controllers/MainViewStatusController.test.ts
+++ b/src/test/controllers/MainViewStatusController.test.ts
@@ -1,0 +1,44 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - common
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+// Local imports - controllers
+import { MainViewStatusController } from '../../controllers/mainView/MainViewStatusController';
+
+describe('MainViewStatusController', () => {
+  it('projects the active theme into webview messages', () => {
+    const controller = new MainViewStatusController();
+
+    assert.deepEqual(controller.getThemeMessage(true), {
+      command: MAIN_VIEW_COMMANDS.THEME_SET,
+      theme: 'dark',
+    });
+    assert.deepEqual(controller.getThemeMessage(false), {
+      command: MAIN_VIEW_COMMANDS.THEME_SET,
+      theme: 'light',
+    });
+  });
+
+  it('projects debug mode into webview messages', () => {
+    const controller = new MainViewStatusController();
+
+    assert.deepEqual(controller.getDebugModeMessage(true), {
+      command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
+      debugMode: true,
+    });
+  });
+
+  it('hides the login banner only after successful sign-in', () => {
+    const controller = new MainViewStatusController();
+
+    assert.deepEqual(controller.getPostSignInMessage({ authenticated: true }), {
+      command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+    });
+    assert.equal(
+      controller.getPostSignInMessage({ authenticated: false }),
+      null,
+    );
+  });
+});

--- a/src/webview/MainViewMessageHandler.ts
+++ b/src/webview/MainViewMessageHandler.ts
@@ -29,6 +29,7 @@ import {
   type MainViewCommandPlan,
 } from '../controllers/mainView/MainViewInteractionController';
 import { MainViewStartupController } from '../controllers/mainView/MainViewStartupController';
+import { MainViewStatusController } from '../controllers/mainView/MainViewStatusController';
 
 export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly recordingManager: RecordingManager;
@@ -38,6 +39,7 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private readonly instructionManager: InstructionManager;
   private readonly interactionController: MainViewInteractionController;
   private readonly startupController: MainViewStartupController;
+  private readonly statusController = new MainViewStatusController();
 
   constructor(context: vscode.ExtensionContext) {
     super('MainView', { trackActiveView: true });
@@ -305,10 +307,10 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
         try {
           await vscode.commands.executeCommand(AUTH_COMMANDS.SIGN_IN);
           const authStatus = await getAuthStatus();
-          if (authStatus.authenticated) {
-            this.postToActiveView({
-              command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
-            });
+          const message =
+            this.statusController.getPostSignInMessage(authStatus);
+          if (message) {
+            this.postToActiveView(message);
           }
         } catch (error) {
           this.logger.debug(
@@ -366,18 +368,12 @@ export class MainViewMessageHandler extends BaseViewMessageHandler {
   private handleThemeRequest(): void {
     const isDarkTheme =
       vscode.window.activeColorTheme.kind === vscode.ColorThemeKind.Dark;
-    this.postToActiveView({
-      command: MAIN_VIEW_COMMANDS.THEME_SET,
-      theme: isDarkTheme ? 'dark' : 'light',
-    });
+    this.postToActiveView(this.statusController.getThemeMessage(isDarkTheme));
   }
 
   private handleDebugModeRequest(): void {
     const debugMode = getConfig<boolean>('texra.logger.debugMode', false);
-    this.postToActiveView({
-      command: MAIN_VIEW_COMMANDS.DEBUG_MODE_SET,
-      debugMode,
-    });
+    this.postToActiveView(this.statusController.getDebugModeMessage(debugMode));
   }
 
   private async runCommandPlan(


### PR DESCRIPTION
## Summary

- Extract main-view theme, debug-mode, and post-sign-in banner projection into MainViewStatusController.
- Keep VS Code theme/config/auth command side effects in MainViewMessageHandler while making the remaining status messages host-neutral and tested.
- Add focused controller tests for theme projection, debug projection, and login-banner hiding after sign-in.

Part of #3305.

## Validation

- npm install
- npx prettier --check src/controllers/mainView/MainViewStatusController.ts src/webview/MainViewMessageHandler.ts src/test/controllers/MainViewStatusController.test.ts
- git diff --check
- npm run compile-tests
- npx mocha --require ./out/test/setup.js out/test/controllers/MainViewStatusController.test.js out/test/controllers/MainViewInteractionController.test.js out/test/controllers/MainViewStartupController.test.js
- npm run lint
- npm run compile:safe

Did not run npm test; repository guidance says it downloads the VS Code test environment and should be avoided.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes construction of theme/debug/login-banner messages without changing underlying VS Code side effects or auth behavior.
> 
> **Overview**
> Refactors main view status projection by introducing `MainViewStatusController` to build webview messages for theme, debug mode, and post-sign-in login banner hiding.
> 
> `MainViewMessageHandler` now delegates message construction to this controller (including sign-in banner flow), and the shared `MainViewAuthStatus` type is moved into a new `MainViewTypes` module. Adds focused unit tests covering theme/debug message generation and login banner hiding behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cdfb9a00d63d496bf3018088c815842521e68c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->