### PR TITLE
test: extract progress controller harnesses

### DIFF
--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -1,141 +1,75 @@
 // Standard library imports
 import { strict as assert } from 'assert';
 
-// Local imports - shared
-import type { StreamTabId } from '@shared/schemas';
-
-// Local imports - controllers
-import {
-  ProgressStreamLifecycleController,
-  type ProgressStreamLifecycleState,
-} from '../../controllers/progressView/ProgressStreamLifecycleController';
-
-function createController(options?: {
-  streams?: StreamTabId[];
-  activeStream?: StreamTabId | '';
-  taskStateStreams?: StreamTabId[];
-  inFlightStreams?: StreamTabId[];
-  visibleStreams?: StreamTabId[];
-}): {
-  controller: ProgressStreamLifecycleController;
-  calls: Map<string, StreamTabId[]>;
-  syncCalls: Array<{ forceRebuild: boolean }>;
-  state: ProgressStreamLifecycleState;
-  activeStream: () => StreamTabId | '';
-  streams: () => StreamTabId[];
-} {
-  let streams = [...(options?.streams ?? ['stream-a', 'stream-b'])];
-  let activeStream = options?.activeStream ?? streams[0] ?? '';
-  const taskStateStreams = new Set(options?.taskStateStreams ?? []);
-  const inFlightStreams = new Set(options?.inFlightStreams ?? []);
-  const calls = new Map<string, StreamTabId[]>();
-  const syncCalls: Array<{ forceRebuild: boolean }> = [];
-  const record = (name: string, stream: StreamTabId) => {
-    calls.set(name, [...(calls.get(name) ?? []), stream]);
-  };
-  const state: ProgressStreamLifecycleState = {
-    getActiveStream: () => activeStream,
-    setActiveStream: (stream) => {
-      activeStream = stream;
-    },
-    hasStream: (stream) => streams.includes(stream),
-    hasTaskState: (stream) => taskStateStreams.has(stream),
-    getStreamIds: () => streams,
-    pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
-    clearStream: async (stream) => {
-      streams = streams.filter((candidate) => candidate !== stream);
-    },
-    clearAll: async () => {
-      streams = [];
-      activeStream = '';
-    },
-  };
-
-  return {
-    controller: new ProgressStreamLifecycleController({
-      state,
-      isStreamInFlight: (stream) => inFlightStreams.has(stream),
-      getVisibleStreamIds: () =>
-        options?.visibleStreams ??
-        streams.filter((stream) => stream !== 'hidden'),
-      stopStream: async (stream) => record('stop', stream),
-      clearRetryRequest: (stream) => record('clearRetry', stream),
-      releaseFollowUpQueue: (stream) => record('releaseFollowUp', stream),
-      cleanupApprovalsForStream: (stream) => record('cleanupApprovals', stream),
-      cleanupAllApprovals: () => record('cleanupAllApprovals', 'all'),
-      clearModelOutputBackups: (stream) =>
-        record('clearBackups', stream ?? 'all'),
-      clearWebviewStream: (stream) => record('clearWebview', stream),
-      clearAllWebviewStreams: () => record('clearAllWebview', 'all'),
-      deleteWebviewStream: (stream) => record('deleteWebview', stream),
-      syncFullView: (options) => syncCalls.push(options),
-      setActiveStream: async (stream) => record('setActiveStream', stream),
-    }),
-    calls,
-    syncCalls,
-    state,
-    activeStream: () => activeStream,
-    streams: () => streams,
-  };
-}
+// Local imports - test support
+import { createProgressStreamLifecycleHarness } from '../support/ProgressControllerHarnesses';
 
 describe('ProgressStreamLifecycleController', () => {
   it('ignores deletion for unknown streams', async () => {
-    const { controller, calls, streams } = createController();
+    const { controller, recorder, streams } =
+      createProgressStreamLifecycleHarness();
 
     await controller.deleteStream('missing');
 
     assert.deepEqual(streams(), ['stream-a', 'stream-b']);
-    assert.equal(calls.size, 0);
+    assert.equal(recorder.calls.size, 0);
   });
 
   it('deletes inactive streams without stopping finished work', async () => {
-    const { controller, calls, streams, activeStream } = createController({
-      activeStream: 'stream-a',
-    });
+    const { controller, recorder, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        activeStream: 'stream-a',
+      });
 
     await controller.deleteStream('stream-b');
 
     assert.deepEqual(streams(), ['stream-a']);
     assert.equal(activeStream(), 'stream-a');
-    assert.deepEqual(calls.get('stop'), undefined);
-    assert.deepEqual(calls.get('cleanupApprovals'), ['stream-b']);
-    assert.deepEqual(calls.get('clearRetry'), ['stream-b']);
-    assert.deepEqual(calls.get('releaseFollowUp'), ['stream-b']);
-    assert.deepEqual(calls.get('clearBackups'), ['stream-b']);
-    assert.deepEqual(calls.get('clearWebview'), ['stream-b']);
-    assert.deepEqual(calls.get('deleteWebview'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('stop'), undefined);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('clearRetry'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('releaseFollowUp'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('clearBackups'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('clearWebview'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-b']);
   });
 
   it('stops running streams and activates the next visible stream', async () => {
-    const { controller, calls, streams, activeStream } = createController({
-      activeStream: 'stream-a',
-      inFlightStreams: ['stream-a'],
-      visibleStreams: ['stream-b'],
-    });
+    const { controller, recorder, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        activeStream: 'stream-a',
+        inFlightStreams: ['stream-a'],
+        visibleStreams: ['stream-b'],
+      });
 
     await controller.deleteStream('stream-a');
 
     assert.deepEqual(streams(), ['stream-b']);
     assert.equal(activeStream(), 'stream-b');
-    assert.deepEqual(calls.get('stop'), ['stream-a']);
-    assert.deepEqual(calls.get('setActiveStream'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('stop'), ['stream-a']);
+    assert.deepEqual(recorder.calls.get('setActiveStream'), ['stream-b']);
   });
 
   it('clears all stream lifecycle state', async () => {
-    const { controller, calls, streams, activeStream, syncCalls } =
-      createController();
+    const { controller, recorder, streams, activeStream, syncCalls } =
+      createProgressStreamLifecycleHarness();
 
     await controller.deleteAllStreams();
 
     assert.deepEqual(streams(), []);
     assert.equal(activeStream(), '');
-    assert.deepEqual(calls.get('stop'), ['stream-a', 'stream-b']);
-    assert.deepEqual(calls.get('cleanupAllApprovals'), ['all']);
-    assert.deepEqual(calls.get('clearRetry'), ['stream-a', 'stream-b']);
-    assert.deepEqual(calls.get('releaseFollowUp'), ['stream-a', 'stream-b']);
-    assert.deepEqual(calls.get('clearBackups'), ['all']);
-    assert.deepEqual(calls.get('clearAllWebview'), ['all']);
+    assert.deepEqual(recorder.calls.get('stop'), ['stream-a', 'stream-b']);
+    assert.deepEqual(recorder.calls.get('cleanupAllApprovals'), ['all']);
+    assert.deepEqual(recorder.calls.get('clearRetry'), [
+      'stream-a',
+      'stream-b',
+    ]);
+    assert.deepEqual(recorder.calls.get('releaseFollowUp'), [
+      'stream-a',
+      'stream-b',
+    ]);
+    assert.deepEqual(recorder.calls.get('clearBackups'), ['all']);
+    assert.deepEqual(recorder.calls.get('clearAllWebview'), ['all']);
     assert.deepEqual(syncCalls, [{ forceRebuild: true }]);
   });
 });

--- a/src/test/controllers/ProgressWorkflowActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowActionsController.test.ts
@@ -3,122 +3,23 @@ import { strict as assert } from 'assert';
 
 // Local imports - agent
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
-import type { ExecutionRequest } from '@agent/core/executionRequests';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports - logger
-import type { TaskState, WorkflowTaskState } from '@logger/TaskState';
+import type { TaskState } from '@logger/TaskState';
 
-// Local imports - shared
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
-
-// Local imports - controllers
+// Local imports - test support
 import {
-  ProgressWorkflowActionsController,
-  type WorkflowDiffRequest,
-  type WorkflowFileOperation,
-  type WorkflowFileOperationRequest,
-} from '../../controllers/progressView/ProgressWorkflowActionsController';
-
-function createAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
-  return AgentConfigSchema.parse({
-    agent: 'correct',
-    model: 'gemini31p',
-    inputFile: 'input.tex',
-    outputFiles: ['declared.tex'],
-    agentCategory: AgentCategory.Workflow,
-    ...overrides,
-  });
-}
-
-function createWorkflowTaskState(
-  overrides: Partial<AgentConfig> = {},
-  activeFiles: Partial<WorkflowTaskState['activeFiles']> = {},
-): WorkflowTaskState {
-  return {
-    agentConfig: createAgentConfig({
-      agentCategory: AgentCategory.Workflow,
-      ...overrides,
-    }) as AgentConfig & { agentCategory: AgentCategory.Workflow },
-    activeFiles: {
-      input: true,
-      reference: false,
-      auxiliary: false,
-      media: false,
-      output: true,
-      ...activeFiles,
-    },
-  };
-}
-
-function createOutputFile(
-  absolutePath: string,
-  relativePath = absolutePath,
-): OutputFileInfo {
-  return {
-    source: 'input.tex',
-    location: {
-      kind: 'workspace',
-      absolutePath,
-      relativePath,
-    },
-    round: 1,
-    lineage: null,
-    diff: null,
-  };
-}
-
-function createController(options?: {
-  taskStates?: Map<StreamTabId, TaskState>;
-  executionIds?: Map<StreamTabId, string>;
-  outputs?: Map<StreamTabId, Map<number, OutputFileInfo[]>>;
-  knownWorkspaceOutputs?: Map<StreamTabId, Set<string>>;
-}): {
-  controller: ProgressWorkflowActionsController;
-  executed: ExecutionRequest[];
-  diffs: WorkflowDiffRequest[];
-  fileOperations: Array<{
-    operation: WorkflowFileOperation;
-    request: WorkflowFileOperationRequest;
-  }>;
-} {
-  const executed: ExecutionRequest[] = [];
-  const diffs: WorkflowDiffRequest[] = [];
-  const fileOperations: Array<{
-    operation: WorkflowFileOperation;
-    request: WorkflowFileOperationRequest;
-  }> = [];
-
-  return {
-    controller: new ProgressWorkflowActionsController({
-      state: {
-        getTaskState: (stream) => options?.taskStates?.get(stream),
-        getExecutionId: (stream) => options?.executionIds?.get(stream),
-        getOutputFiles: (stream) =>
-          new Map(options?.outputs?.get(stream) ?? []),
-        getKnownWorkspaceOutputPaths: (stream) =>
-          new Set(options?.knownWorkspaceOutputs?.get(stream) ?? []),
-      },
-      executeAgent: async (request) => {
-        executed.push(request);
-      },
-      runDiff: async (request) => {
-        diffs.push(request);
-      },
-      runFileOperation: async (operation, request) => {
-        fileOperations.push({ operation, request });
-      },
-    }),
-    executed,
-    diffs,
-    fileOperations,
-  };
-}
+  createAgentConfig,
+  createOutputFile,
+  createProgressWorkflowActionsHarness,
+  createWorkflowTaskState,
+} from '../support/ProgressControllerHarnesses';
 
 describe('ProgressWorkflowActionsController', () => {
   it('resumes workflow streams with their execution id', async () => {
     const taskState = createWorkflowTaskState();
-    const { controller, executed } = createController({
+    const { controller, executed } = createProgressWorkflowActionsHarness({
       taskStates: new Map([['stream-a', taskState]]),
       executionIds: new Map([['stream-a', 'exec-123']]),
     });
@@ -132,7 +33,7 @@ describe('ProgressWorkflowActionsController', () => {
 
   it('runs a fresh request without the existing execution id', async () => {
     const taskState = createWorkflowTaskState();
-    const { controller, executed } = createController({
+    const { controller, executed } = createProgressWorkflowActionsHarness({
       taskStates: new Map([['stream-a', taskState]]),
       executionIds: new Map([['stream-a', 'exec-123']]),
     });
@@ -149,9 +50,10 @@ describe('ProgressWorkflowActionsController', () => {
         outputFiles: [],
       }) as AgentConfig & { agentCategory: AgentCategory.ToolUse },
     };
-    const { controller, diffs, fileOperations } = createController({
-      taskStates: new Map([['stream-a', toolUseState]]),
-    });
+    const { controller, diffs, fileOperations } =
+      createProgressWorkflowActionsHarness({
+        taskStates: new Map([['stream-a', toolUseState]]),
+      });
 
     await controller.diffStream('stream-a');
     await controller.runFileOperation('stream-a', 'pack');
@@ -169,7 +71,7 @@ describe('ProgressWorkflowActionsController', () => {
       { outputFiles: ['declared.tex'] },
       { output: false },
     );
-    const { controller, diffs } = createController({
+    const { controller, diffs } = createProgressWorkflowActionsHarness({
       taskStates: new Map([['stream-a', taskState]]),
       executionIds: new Map([['stream-a', 'exec-123']]),
       outputs: new Map([['stream-a', new Map([[1, [output]]])]]),
@@ -197,13 +99,15 @@ describe('ProgressWorkflowActionsController', () => {
       outputFiles: ['declared.tex', '/workspace/generated.tex'],
       useMultipleOutputs: true,
     });
-    const { controller, fileOperations } = createController({
-      taskStates: new Map([['stream-a', taskState]]),
-      executionIds: new Map([['stream-a', 'exec-123']]),
-      knownWorkspaceOutputs: new Map([
-        ['stream-a', new Set(['/workspace/generated.tex', 'extra.tex'])],
-      ]),
-    });
+    const { controller, fileOperations } = createProgressWorkflowActionsHarness(
+      {
+        taskStates: new Map([['stream-a', taskState]]),
+        executionIds: new Map([['stream-a', 'exec-123']]),
+        knownWorkspaceOutputs: new Map([
+          ['stream-a', new Set(['/workspace/generated.tex', 'extra.tex'])],
+        ]),
+      },
+    );
 
     await controller.runFileOperation('stream-a', 'pack');
 
@@ -236,12 +140,14 @@ describe('ProgressWorkflowActionsController', () => {
       },
       { output: true },
     );
-    const { controller, fileOperations } = createController({
-      taskStates: new Map([['stream-a', taskState]]),
-      knownWorkspaceOutputs: new Map([
-        ['stream-a', new Set(['generated.tex'])],
-      ]),
-    });
+    const { controller, fileOperations } = createProgressWorkflowActionsHarness(
+      {
+        taskStates: new Map([['stream-a', taskState]]),
+        knownWorkspaceOutputs: new Map([
+          ['stream-a', new Set(['generated.tex'])],
+        ]),
+      },
+    );
 
     await controller.runFileOperation('stream-a', 'clean');
 

--- a/src/test/support/ProgressControllerHarnesses.ts
+++ b/src/test/support/ProgressControllerHarnesses.ts
@@ -1,0 +1,207 @@
+// Local imports - agent
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import type { ExecutionRequest } from '@agent/core/executionRequests';
+
+// Local imports - logger
+import type { TaskState, WorkflowTaskState } from '@logger/TaskState';
+
+// Local imports - shared
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+
+// Local imports - controllers
+import {
+  ProgressStreamLifecycleController,
+  type ProgressStreamLifecycleState,
+} from '../../controllers/progressView/ProgressStreamLifecycleController';
+import {
+  ProgressWorkflowActionsController,
+  type WorkflowDiffRequest,
+  type WorkflowFileOperation,
+  type WorkflowFileOperationRequest,
+} from '../../controllers/progressView/ProgressWorkflowActionsController';
+
+export class ControllerCallRecorder<T = unknown> {
+  readonly calls = new Map<string, T[]>();
+
+  record(name: string, payload: T): void {
+    this.calls.set(name, [...(this.calls.get(name) ?? []), payload]);
+  }
+}
+
+export interface ProgressStreamLifecycleHarnessOptions {
+  streams?: StreamTabId[];
+  activeStream?: StreamTabId | '';
+  taskStateStreams?: StreamTabId[];
+  inFlightStreams?: StreamTabId[];
+  visibleStreams?: StreamTabId[];
+}
+
+export interface ProgressStreamLifecycleHarness {
+  controller: ProgressStreamLifecycleController;
+  recorder: ControllerCallRecorder<StreamTabId>;
+  syncCalls: Array<{ forceRebuild: boolean }>;
+  state: ProgressStreamLifecycleState;
+  activeStream(): StreamTabId | '';
+  streams(): StreamTabId[];
+}
+
+export function createProgressStreamLifecycleHarness(
+  options: ProgressStreamLifecycleHarnessOptions = {},
+): ProgressStreamLifecycleHarness {
+  let streams = [...(options.streams ?? ['stream-a', 'stream-b'])];
+  let activeStream = options.activeStream ?? streams[0] ?? '';
+  const taskStateStreams = new Set(options.taskStateStreams ?? []);
+  const inFlightStreams = new Set(options.inFlightStreams ?? []);
+  const recorder = new ControllerCallRecorder<StreamTabId>();
+  const syncCalls: Array<{ forceRebuild: boolean }> = [];
+  const state: ProgressStreamLifecycleState = {
+    getActiveStream: () => activeStream,
+    setActiveStream: (stream) => {
+      activeStream = stream;
+    },
+    hasStream: (stream) => streams.includes(stream),
+    hasTaskState: (stream) => taskStateStreams.has(stream),
+    getStreamIds: () => streams,
+    pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
+    clearStream: async (stream) => {
+      streams = streams.filter((candidate) => candidate !== stream);
+    },
+    clearAll: async () => {
+      streams = [];
+      activeStream = '';
+    },
+  };
+
+  return {
+    controller: new ProgressStreamLifecycleController({
+      state,
+      isStreamInFlight: (stream) => inFlightStreams.has(stream),
+      getVisibleStreamIds: () =>
+        options.visibleStreams ??
+        streams.filter((stream) => stream !== 'hidden'),
+      stopStream: async (stream) => recorder.record('stop', stream),
+      clearRetryRequest: (stream) => recorder.record('clearRetry', stream),
+      releaseFollowUpQueue: (stream) =>
+        recorder.record('releaseFollowUp', stream),
+      cleanupApprovalsForStream: (stream) =>
+        recorder.record('cleanupApprovals', stream),
+      cleanupAllApprovals: () => recorder.record('cleanupAllApprovals', 'all'),
+      clearModelOutputBackups: (stream) =>
+        recorder.record('clearBackups', stream ?? 'all'),
+      clearWebviewStream: (stream) => recorder.record('clearWebview', stream),
+      clearAllWebviewStreams: () => recorder.record('clearAllWebview', 'all'),
+      deleteWebviewStream: (stream) => recorder.record('deleteWebview', stream),
+      syncFullView: (options) => syncCalls.push(options),
+      setActiveStream: async (stream) =>
+        recorder.record('setActiveStream', stream),
+    }),
+    recorder,
+    syncCalls,
+    state,
+    activeStream: () => activeStream,
+    streams: () => streams,
+  };
+}
+
+export function createAgentConfig(
+  overrides: Partial<AgentConfig> = {},
+): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: 'correct',
+    model: 'gemini31p',
+    inputFile: 'input.tex',
+    outputFiles: ['declared.tex'],
+    agentCategory: AgentCategory.Workflow,
+    ...overrides,
+  });
+}
+
+export function createWorkflowTaskState(
+  overrides: Omit<Partial<AgentConfig>, 'agentCategory'> = {},
+  activeFiles: Partial<WorkflowTaskState['activeFiles']> = {},
+): WorkflowTaskState {
+  return {
+    agentConfig: createAgentConfig({
+      ...overrides,
+      agentCategory: AgentCategory.Workflow,
+    }) as AgentConfig & { agentCategory: AgentCategory.Workflow },
+    activeFiles: {
+      input: true,
+      reference: false,
+      auxiliary: false,
+      media: false,
+      output: true,
+      ...activeFiles,
+    },
+  };
+}
+
+export function createOutputFile(
+  absolutePath: string,
+  relativePath = absolutePath,
+): OutputFileInfo {
+  return {
+    source: 'input.tex',
+    location: {
+      kind: 'workspace',
+      absolutePath,
+      relativePath,
+    },
+    round: 1,
+    lineage: null,
+    diff: null,
+  };
+}
+
+export interface ProgressWorkflowActionsHarnessOptions {
+  taskStates?: Map<StreamTabId, TaskState>;
+  executionIds?: Map<StreamTabId, string>;
+  outputs?: Map<StreamTabId, Map<number, OutputFileInfo[]>>;
+  knownWorkspaceOutputs?: Map<StreamTabId, Set<string>>;
+}
+
+export interface ProgressWorkflowActionsHarness {
+  controller: ProgressWorkflowActionsController;
+  executed: ExecutionRequest[];
+  diffs: WorkflowDiffRequest[];
+  fileOperations: Array<{
+    operation: WorkflowFileOperation;
+    request: WorkflowFileOperationRequest;
+  }>;
+}
+
+export function createProgressWorkflowActionsHarness(
+  options: ProgressWorkflowActionsHarnessOptions = {},
+): ProgressWorkflowActionsHarness {
+  const executed: ExecutionRequest[] = [];
+  const diffs: WorkflowDiffRequest[] = [];
+  const fileOperations: Array<{
+    operation: WorkflowFileOperation;
+    request: WorkflowFileOperationRequest;
+  }> = [];
+
+  return {
+    controller: new ProgressWorkflowActionsController({
+      state: {
+        getTaskState: (stream) => options.taskStates?.get(stream),
+        getExecutionId: (stream) => options.executionIds?.get(stream),
+        getOutputFiles: (stream) => new Map(options.outputs?.get(stream) ?? []),
+        getKnownWorkspaceOutputPaths: (stream) =>
+          new Set(options.knownWorkspaceOutputs?.get(stream) ?? []),
+      },
+      executeAgent: async (request) => {
+        executed.push(request);
+      },
+      runDiff: async (request) => {
+        diffs.push(request);
+      },
+      runFileOperation: async (operation, request) => {
+        fileOperations.push({ operation, request });
+      },
+    }),
+    executed,
+    diffs,
+    fileOperations,
+  };
+}


### PR DESCRIPTION
## Summary

Extract shared progress controller test harnesses so controller tests can reuse realistic setup without repeating wiring.

This cleanup reduces duplicated fake controller scaffolding in the progress stream lifecycle and workflow action tests while keeping the tested behavior unchanged.

Fixes #3374.

## Validation

- npm run compile-tests
- npm run test:kernel
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors test scaffolding only by centralizing harness setup; production controller logic is unchanged, with main risk limited to subtle test behavior differences due to the new shared harness.
> 
> **Overview**
> Refactors progress controller tests to use a shared harness instead of duplicating local fake controller wiring.
> 
> Adds `src/test/support/ProgressControllerHarnesses.ts`, which centralizes setup for `ProgressStreamLifecycleController` and `ProgressWorkflowActionsController` tests (including a `ControllerCallRecorder`, agent/task/output helpers, and harness factory functions), and updates the two test suites to consume these helpers while keeping the assertions and tested behaviors the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff791baa0c9e31b73929c3444104f6ed5e9d8d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->