### PR TITLE
feat: wire Electron platform bootstrap

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -7,16 +7,19 @@
   "scripts": {
     "dev": "vite --config vite.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.preload.json && tsc --noEmit -p tsconfig.renderer.json",
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:vscode",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload/index.cjs --external:electron",
     "build:renderer": "vite build --config vite.config.ts",
     "build": "npm run typecheck && npm run build:main && npm run build:preload && npm run build:renderer"
   },
   "devDependencies": {
     "@texra/core": "workspace:*",
-    "esbuild": "^0.28.0",
     "electron": "^41.5.0",
+    "esbuild": "^0.28.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.10"
+  },
+  "dependencies": {
+    "fix-path": "^5.0.0"
   }
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow, session } from 'electron';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { initializeElectronPlatform } from './platform/index.js';
+
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const PRODUCTION_CSP =
@@ -49,14 +51,22 @@ function createWindow(): void {
   void window.loadFile(join(__dirname, '../renderer/index.html'));
 }
 
-app.whenReady().then(() => {
-  installContentSecurityPolicy();
-  createWindow();
+app
+  .whenReady()
+  .then(async () => {
+    await initializeElectronPlatform(__dirname);
+    installContentSecurityPolicy();
+    createWindow();
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to start TeXRA desktop: ${message}`);
+    app.quit();
   });
-});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();

--- a/packages/desktop/src/main/platform/agentDirectories.ts
+++ b/packages/desktop/src/main/platform/agentDirectories.ts
@@ -1,0 +1,69 @@
+import { AgentDirectoryService } from '@agent/index/AgentDirectoryService';
+import {
+  BundledAgentDirectorySync,
+  GlobalStorageAgentDirectoryStorage,
+  PathAgentDirectoryBundleSource,
+} from '@agent/index/AgentDirectorySync';
+import { setAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { isFileNotFoundError } from '@common/errors/errorPredicates';
+import { GlobalStateKey } from '@common/state/stateKeys';
+import { platform } from '@platform/platform';
+
+export function createElectronAgentDirectories(): AgentDirectoryService {
+  return new AgentDirectoryService({
+    storage: new GlobalStorageAgentDirectoryStorage(),
+    customDirectoryStore: {
+      get: () =>
+        platform().globalState.get<string>(GlobalStateKey.CUSTOM_AGENT_DIR),
+    },
+    absoluteDirectories: {
+      exists: async (target) => {
+        try {
+          await platform().fs.stat(target);
+          return true;
+        } catch (error) {
+          if (isFileNotFoundError(error)) return false;
+          throw error;
+        }
+      },
+      ensureDir: (target) => platform().fs.createDirectory(target),
+    },
+    issueReporter: {
+      report: async (message, docsId) =>
+        platform().log.warn(
+          'desktop',
+          `${message}. See documentation: ${docsId}`,
+        ),
+    },
+    logger: {
+      debug: (message) => platform().log.debug('desktop', message),
+      error: (message) => platform().log.error('desktop', message),
+    },
+  });
+}
+
+export async function bootstrapElectronAgentDirectories(
+  resourcesPath: string,
+  appVersion: string | undefined,
+): Promise<void> {
+  const sync = new BundledAgentDirectorySync({
+    bundleSource: new PathAgentDirectoryBundleSource(resourcesPath),
+    storage: new GlobalStorageAgentDirectoryStorage(),
+    versionStore: {
+      get: () =>
+        platform().globalState.get<string>(GlobalStateKey.LAST_KNOWN_VERSION),
+      update: (version) =>
+        platform().globalState.update(
+          GlobalStateKey.LAST_KNOWN_VERSION,
+          version,
+        ),
+    },
+    logger: {
+      info: (message) => platform().log.info('desktop', message),
+      warn: (message) => platform().log.warn('desktop', message),
+    },
+  });
+
+  await sync.reconcile(appVersion);
+  setAgentDirectories(createElectronAgentDirectories());
+}

--- a/packages/desktop/src/main/platform/electronConfig.ts
+++ b/packages/desktop/src/main/platform/electronConfig.ts
@@ -1,0 +1,130 @@
+import type {
+  ConfigInspection,
+  ConfigProvider,
+  ConfigTarget,
+} from '@platform/interfaces/config';
+import type { Disposable } from '@platform/interfaces/disposable';
+
+import { JsonStore } from './jsonStore.js';
+
+type ConfigWatcher = {
+  key: string | readonly string[] | RegExp;
+  listener: () => void;
+};
+
+function configKeys(key: string): string[] {
+  const unprefixed = key.startsWith('texra.')
+    ? key.slice('texra.'.length)
+    : key;
+  return [unprefixed, `texra.${unprefixed}`];
+}
+
+function canonicalConfigKey(key: string): string {
+  const unprefixed = key.startsWith('texra.')
+    ? key.slice('texra.'.length)
+    : key;
+  return `texra.${unprefixed}`;
+}
+
+function matchesConfigKey(candidate: string, changedKey: string): boolean {
+  return changedKey === candidate || changedKey.startsWith(`${candidate}.`);
+}
+
+function watcherMatches(
+  watcherKey: ConfigWatcher['key'],
+  changedKey: string,
+): boolean {
+  if (typeof watcherKey === 'string') {
+    return configKeys(watcherKey).some((candidate) =>
+      matchesConfigKey(candidate, changedKey),
+    );
+  }
+  if (watcherKey instanceof RegExp) {
+    return watcherKey.test(changedKey);
+  }
+  if (Array.isArray(watcherKey)) {
+    return watcherKey.some((item) =>
+      configKeys(item).some((candidate) =>
+        matchesConfigKey(candidate, changedKey),
+      ),
+    );
+  }
+  return false;
+}
+
+function firstStoredValue<T>(
+  store: JsonStore,
+  keys: readonly string[],
+): T | undefined {
+  const found = keys.find((candidate) => store.has(candidate));
+  return found === undefined ? undefined : store.get<T>(found);
+}
+
+export class ElectronConfigProvider implements ConfigProvider {
+  private readonly watchers = new Set<ConfigWatcher>();
+
+  constructor(
+    private readonly globalStore: JsonStore,
+    private readonly workspaceStore: JsonStore,
+  ) {}
+
+  get<T>(key: string, defaultValue?: T): T {
+    const keys = configKeys(key);
+    const workspaceValue = firstStoredValue<T>(this.workspaceStore, keys);
+    if (workspaceValue !== undefined) return workspaceValue;
+    const globalValue = firstStoredValue<T>(this.globalStore, keys);
+    if (globalValue !== undefined) return globalValue;
+    return defaultValue as T;
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    target: ConfigTarget = 'workspace',
+  ): Promise<void> {
+    const store = target === 'global' ? this.globalStore : this.workspaceStore;
+    const keys = configKeys(key);
+    if (value === undefined) {
+      await Promise.all(
+        keys
+          .filter((candidate) => store.has(candidate))
+          .map((candidate) => store.set(candidate, undefined)),
+      );
+    } else {
+      const storedKey =
+        keys.find((candidate) => store.has(candidate)) ??
+        canonicalConfigKey(key);
+      await store.set(storedKey, value);
+    }
+    for (const watcher of this.watchers) {
+      if (keys.some((changedKey) => watcherMatches(watcher.key, changedKey))) {
+        watcher.listener();
+      }
+    }
+  }
+
+  inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {
+    const keys = configKeys(key);
+    return {
+      globalValue: firstStoredValue<T>(this.globalStore, keys),
+      workspaceValue: firstStoredValue<T>(this.workspaceStore, keys),
+      effectiveValue: this.get<T>(key),
+    };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return configKeys(key).some(
+      (candidate) =>
+        this.globalStore.has(candidate) || this.workspaceStore.has(candidate),
+    );
+  }
+
+  watch(
+    key: string | readonly string[] | RegExp,
+    listener: () => void,
+  ): Disposable {
+    const watcher = { key, listener };
+    this.watchers.add(watcher);
+    return { dispose: () => this.watchers.delete(watcher) };
+  }
+}

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -1,0 +1,53 @@
+import { safeStorage } from 'electron';
+
+import type { PlatformSecrets } from '@platform/secrets';
+
+import { JsonStore } from './jsonStore.js';
+
+type StoredSecret = { encrypted: true; value: string };
+
+function isStoredSecret(value: unknown): value is StoredSecret {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as StoredSecret).value === 'string' &&
+    (value as StoredSecret).encrypted === true
+  );
+}
+
+export class ElectronSecrets implements PlatformSecrets {
+  constructor(private readonly store: JsonStore) {}
+
+  /** Environment variables override persisted Electron secrets. */
+  async get(key: string): Promise<string | undefined> {
+    const envValue = process.env[key];
+    if (envValue !== undefined) return envValue;
+
+    const stored = this.store.get<unknown>(key);
+    if (!isStoredSecret(stored)) return undefined;
+    return safeStorage.decryptString(Buffer.from(stored.value, 'base64'));
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    if (!isSafeStorageUsable()) {
+      throw new Error('Electron safeStorage is unavailable for secret writes.');
+    }
+    const stored: StoredSecret = {
+      encrypted: true,
+      value: safeStorage.encryptString(value).toString('base64'),
+    };
+    await this.store.set(key, stored);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.store.set(key, undefined);
+  }
+}
+
+function isSafeStorageUsable(): boolean {
+  if (!safeStorage.isEncryptionAvailable()) return false;
+  return (
+    process.platform !== 'linux' ||
+    safeStorage.getSelectedStorageBackend() !== 'basic_text'
+  );
+}

--- a/packages/desktop/src/main/platform/electronState.ts
+++ b/packages/desktop/src/main/platform/electronState.ts
@@ -1,0 +1,15 @@
+import type { StateStore } from '@platform/interfaces/state';
+
+import { JsonStore } from './jsonStore.js';
+
+export class ElectronStateStore implements StateStore {
+  constructor(private readonly store: JsonStore) {}
+
+  get<T>(key: string, defaultValue?: T): T {
+    return this.store.get(key, defaultValue);
+  }
+
+  update(key: string, value: unknown): PromiseLike<void> {
+    return this.store.set(key, value);
+  }
+}

--- a/packages/desktop/src/main/platform/electronStorage.ts
+++ b/packages/desktop/src/main/platform/electronStorage.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { StorageProvider } from '@platform/interfaces/storage';
+
+function workspaceStorageId(workspacePath: string | undefined): string {
+  const source = workspacePath?.trim() || 'no-workspace';
+  return createHash('sha256').update(source).digest('hex').slice(0, 16);
+}
+
+export class ElectronStorageProvider implements StorageProvider {
+  private readonly globalStoragePath: string;
+  private readonly workspaceStoragePath: string;
+
+  constructor(userDataPath: string, workspacePath: string | undefined) {
+    this.globalStoragePath = join(userDataPath, 'global-storage');
+    this.workspaceStoragePath = join(
+      userDataPath,
+      'workspace-storage',
+      workspaceStorageId(workspacePath),
+    );
+    mkdirSync(this.globalStoragePath, { recursive: true });
+    mkdirSync(this.workspaceStoragePath, { recursive: true });
+  }
+
+  getStoragePath(): string {
+    return this.workspaceStoragePath;
+  }
+
+  getGlobalStoragePath(): string {
+    return this.globalStoragePath;
+  }
+}

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -1,0 +1,55 @@
+import { join } from 'node:path';
+
+import { app } from 'electron';
+
+import { consoleLog } from '@platform/defaults/consoleLog';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { initPlatform } from '@platform/platform';
+
+import { bootstrapElectronAgentDirectories } from './agentDirectories.js';
+import { ElectronConfigProvider } from './electronConfig.js';
+import { ElectronSecrets } from './electronSecrets.js';
+import { ElectronStateStore } from './electronState.js';
+import { ElectronStorageProvider } from './electronStorage.js';
+import { JsonStore } from './jsonStore.js';
+import { repairLaunchPath } from './pathFix.js';
+import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
+
+export async function initializeElectronPlatform(
+  mainDirname: string,
+): Promise<void> {
+  const userDataPath = app.getPath('userData');
+  const workspacePath = resolveWorkspacePath();
+  const storage = new ElectronStorageProvider(userDataPath, workspacePath);
+  const globalStateStore = await JsonStore.open(
+    join(userDataPath, 'state', 'global.json'),
+  );
+  const workspaceStateStore = await JsonStore.open(
+    join(storage.getStoragePath(), 'state.json'),
+  );
+  const globalConfigStore = await JsonStore.open(
+    join(userDataPath, 'config', 'global.json'),
+  );
+  const workspaceConfigStore = await JsonStore.open(
+    join(storage.getStoragePath(), 'config.json'),
+  );
+  const secretsStore = await JsonStore.open(join(userDataPath, 'secrets.json'));
+
+  repairLaunchPath();
+  initPlatform({
+    config: new ElectronConfigProvider(globalConfigStore, workspaceConfigStore),
+    globalState: new ElectronStateStore(globalStateStore),
+    workspaceState: new ElectronStateStore(workspaceStateStore),
+    log: consoleLog,
+    fs: nodeFilesystem,
+    workspace: createNodeWorkspace(() => workspacePath),
+    storage,
+    secrets: new ElectronSecrets(secretsStore),
+  });
+
+  await bootstrapElectronAgentDirectories(
+    resolveResourcesPath(mainDirname),
+    app.getVersion(),
+  );
+}

--- a/packages/desktop/src/main/platform/jsonStore.ts
+++ b/packages/desktop/src/main/platform/jsonStore.ts
@@ -1,0 +1,65 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+
+async function readJsonRecord(filePath: string): Promise<JsonRecord> {
+  try {
+    const content = await readFile(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as JsonRecord)
+      : {};
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    if (error instanceof SyntaxError) return {};
+    throw error;
+  }
+}
+
+export class JsonStore {
+  private writeChain = Promise.resolve();
+
+  private constructor(
+    private readonly filePath: string,
+    private data: JsonRecord,
+  ) {}
+
+  static async open(filePath: string): Promise<JsonStore> {
+    await mkdir(dirname(filePath), { recursive: true });
+    return new JsonStore(filePath, await readJsonRecord(filePath));
+  }
+
+  get<T>(key: string, defaultValue?: T): T {
+    const value = this.data[key];
+    return value === undefined ? (defaultValue as T) : (value as T);
+  }
+
+  has(key: string): boolean {
+    return Object.hasOwn(this.data, key);
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      delete this.data[key];
+    } else {
+      this.data[key] = value;
+    }
+    await this.enqueueFlush(this.snapshot());
+  }
+
+  snapshot(): JsonRecord {
+    return { ...this.data };
+  }
+
+  private async enqueueFlush(snapshot: JsonRecord): Promise<void> {
+    const flush = () => this.flush(snapshot);
+    this.writeChain = this.writeChain.then(flush, flush);
+    await this.writeChain;
+  }
+
+  private async flush(snapshot: JsonRecord): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  }
+}

--- a/packages/desktop/src/main/platform/pathFix.ts
+++ b/packages/desktop/src/main/platform/pathFix.ts
@@ -1,0 +1,34 @@
+import fixPath from 'fix-path';
+import { delimiter } from 'node:path';
+
+const MACOS_PATH_ENTRIES = [
+  '/Library/TeX/texbin',
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+  '/usr/sbin',
+  '/sbin',
+] as const;
+
+function prependMissingPathEntries(
+  pathValue: string | undefined,
+  entries: readonly string[],
+): string {
+  const parts = (pathValue ?? '').split(delimiter).filter(Boolean);
+  for (const entry of entries.toReversed()) {
+    if (!parts.includes(entry)) parts.unshift(entry);
+  }
+  return parts.join(delimiter);
+}
+
+export function repairLaunchPath(): string {
+  if (process.platform === 'darwin') {
+    fixPath();
+    process.env.PATH = prependMissingPathEntries(
+      process.env.PATH,
+      MACOS_PATH_ENTRIES,
+    );
+  }
+  return process.env.PATH ?? '';
+}

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -1,0 +1,27 @@
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { app } from 'electron';
+
+export function resolveWorkspacePath(): string | undefined {
+  const configured = process.env.TEXRA_WORKSPACE_PATH?.trim();
+  return configured ? resolve(configured) : undefined;
+}
+
+export function resolveResourcesPath(mainDirname: string): string {
+  const configured = process.env.TEXRA_RESOURCES_PATH?.trim();
+  const candidates = [
+    configured,
+    join(app.getAppPath(), 'resources'),
+    join(process.resourcesPath, 'resources'),
+    join(mainDirname, '../../../../resources'),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Unable to locate TeXRA resources. Checked: ${candidates.join(', ')}`,
+    );
+  }
+  return found;
+}

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "module": "esnext",
     "moduleResolution": "bundler",
     "target": "ES2022",
@@ -7,7 +8,26 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": "../..",
+    "paths": {
+      "@agent/*": ["src/agent/*"],
+      "@auth/*": ["src/auth/*"],
+      "@common/*": ["src/common/*"],
+      "@eventBus/*": ["src/eventBus/*"],
+      "@latex": ["src/latex"],
+      "@latex/*": ["src/latex/*"],
+      "@logger/*": ["src/logger/*"],
+      "@model": ["src/model"],
+      "@model/*": ["src/model/*"],
+      "@platform": ["src/platform"],
+      "@platform/*": ["src/platform/*"],
+      "@replacement/*": ["src/replacement/*"],
+      "@shared/*": ["src/shared/*"],
+      "@tools/*": ["src/tools/*"],
+      "@types/*": ["src/types/*"],
+      "@utils/*": ["src/utils/*"]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/desktop/tsconfig.main.json
+++ b/packages/desktop/tsconfig.main.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "types": ["node", "electron"]
   },
   "include": ["src/main/**/*.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,10 @@ importers:
         version: 6.0.3
 
   packages/desktop:
+    dependencies:
+      fix-path:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@texra/core':
         specifier: workspace:*
@@ -6902,6 +6906,96 @@ packages:
         integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==,
       }
 
+  default-shell@2.2.0:
+    resolution:
+      {
+        integrity: sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  execa@5.1.1:
+    resolution:
+      {
+        integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==,
+      }
+    engines: { node: '>=10' }
+
+  fix-path@5.0.0:
+    resolution:
+      {
+        integrity: sha512-erEWGGCN7RIu1bXTCfNVpVBdm0f5mwcbeja+4QXiEZzIQukP401sbpu8gd3Ny1vS34YNeswyMO0TdT2tP5OlHA==,
+      }
+    engines: { node: '>=20' }
+
+  get-stream@6.0.1:
+    resolution:
+      {
+        integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
+      }
+    engines: { node: '>=10' }
+
+  human-signals@2.1.0:
+    resolution:
+      {
+        integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==,
+      }
+    engines: { node: '>=10.17.0' }
+
+  is-stream@2.0.1:
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: '>=8' }
+
+  mimic-fn@2.1.0:
+    resolution:
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: '>=6' }
+
+  npm-run-path@4.0.1:
+    resolution:
+      {
+        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+      }
+    engines: { node: '>=8' }
+
+  onetime@5.1.2:
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: '>=6' }
+
+  shell-env@4.0.3:
+    resolution:
+      {
+        integrity: sha512-Ioe5h+hCDZ7pKL5+JGzbtPvZ5ESMHePZ8nLxohlDL+twmlcmutttMhRkrQOed8DeLT8mkYBgbwZfohe8pqaA3g==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  shell-path@3.1.0:
+    resolution:
+      {
+        integrity: sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  signal-exit@3.0.7:
+    resolution:
+      {
+        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+      }
+
+  strip-final-newline@2.0.0:
+    resolution:
+      {
+        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+      }
+    engines: { node: '>=6' }
+
 snapshots:
   '@anthropic-ai/sdk@0.92.0(zod@4.4.2)':
     dependencies:
@@ -10909,3 +11003,52 @@ snapshots:
   zod@3.25.12: {}
 
   zod@4.4.2: {}
+
+  default-shell@2.2.0: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  fix-path@5.0.0:
+    dependencies:
+      shell-path: 3.1.0
+      strip-ansi: 7.2.0
+
+  get-stream@6.0.1: {}
+
+  human-signals@2.1.0: {}
+
+  is-stream@2.0.1: {}
+
+  mimic-fn@2.1.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  shell-env@4.0.3:
+    dependencies:
+      default-shell: 2.2.0
+      execa: 5.1.1
+      strip-ansi: 7.2.0
+
+  shell-path@3.1.0:
+    dependencies:
+      shell-env: 4.0.3
+
+  signal-exit@3.0.7: {}
+
+  strip-final-newline@2.0.0: {}

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -6,7 +6,7 @@ import fsExtra from 'fs-extra';
 import { glob } from 'glob';
 
 // Local imports
-import { GlobalStorageFS } from '@utils/files';
+import { GlobalStorageFS } from '@utils/files/storageFS';
 
 export const BUNDLED_AGENT_DIRECTORY_NAMES = [
   'agents',

--- a/src/agent/index/agentDirectoriesRegistry.ts
+++ b/src/agent/index/agentDirectoriesRegistry.ts
@@ -1,0 +1,22 @@
+/** Injectable provider for agent directory paths. */
+export interface AgentDirectories {
+  custom(): Promise<string>;
+  builtIn(): Promise<string>;
+  builtInToolUse(): Promise<string>;
+}
+
+let agentDirectories: AgentDirectories | null = null;
+
+/** Inject the agent directory provider. Called by host composition roots. */
+export function setAgentDirectories(dirs: AgentDirectories): void {
+  agentDirectories = dirs;
+}
+
+export function getAgentDirectories(): AgentDirectories {
+  if (!agentDirectories) {
+    throw new Error(
+      'Agent directories not initialized — call setAgentDirectories() first.',
+    );
+  }
+  return agentDirectories;
+}

--- a/src/agent/index/agentRegistry.ts
+++ b/src/agent/index/agentRegistry.ts
@@ -12,34 +12,15 @@ import {
 import { RemoteAgentLoader } from '@agent/remote/RemoteAgentLoader';
 import * as logger from '@agent/core/logger';
 import { getGlobalState, getWorkspaceState } from '@agent/core/stateStore';
-import { GlobalStateKey, WorkspaceStateKey } from '@common/state';
+import { GlobalStateKey, WorkspaceStateKey } from '@common/state/stateKeys';
 import type { AgentOptionData } from '@shared/schemas';
 import { agentKey as createKey, agentName } from '@shared/schemas/agent';
 import { DELEGATION_TOOLS } from '@shared/constants/delegationTools';
 import { AbsoluteFS } from '@utils/files';
-
-/** Injectable provider for agent directory paths. */
-export interface AgentDirectories {
-  custom(): Promise<string>;
-  builtIn(): Promise<string>;
-  builtInToolUse(): Promise<string>;
-}
-
-let agentDirectories: AgentDirectories | null = null;
-
-/** Inject the agent directory provider. Called from extension.ts at activation. */
-export function setAgentDirectories(dirs: AgentDirectories): void {
-  agentDirectories = dirs;
-}
-
-function getAgentDirectories(): AgentDirectories {
-  if (!agentDirectories) {
-    throw new Error(
-      'Agent directories not initialized — call setAgentDirectories() first.',
-    );
-  }
-  return agentDirectories;
-}
+import {
+  getAgentDirectories,
+  type AgentDirectories,
+} from './agentDirectoriesRegistry';
 
 const CHANNEL = 'agentRegistry';
 logger.initialize(CHANNEL);

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -31,13 +31,16 @@ export {
 } from './AgentDirectorySync';
 
 export {
+  type AgentDirectories,
+  setAgentDirectories,
+} from './agentDirectoriesRegistry';
+
+export {
   // Types
   type AgentEntry,
   type ResolvedAgent,
-  type AgentDirectories,
   // Core functions
   loadAgents,
-  setAgentDirectories,
   getAgent,
   resolveAgent,
   getWorkflowAgents,

--- a/src/agent/remote/RemoteAgentLoader.ts
+++ b/src/agent/remote/RemoteAgentLoader.ts
@@ -20,7 +20,7 @@ import type { AgentLoadOptions } from '@agent/runtime/agentLoad';
 import * as logger from '@agent/core/logger';
 import { SUPABASE_CONFIG } from '@auth/config';
 import { SupabaseClient } from '@auth/SupabaseClient';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
+import { toErrorMessage } from '@common/errors/errorMessage';
 import { resolveToolDefinitions } from '@tools/registry';
 
 import {

--- a/src/auth/SupabaseClient.ts
+++ b/src/auth/SupabaseClient.ts
@@ -3,8 +3,8 @@ import {
   SupabaseClient as Client,
   User,
 } from '@supabase/supabase-js';
-import { toErrorMessage } from '@common/errors/errorHandlingUtils';
-import * as logger from '@logger/logUtils';
+import * as logger from '@agent/core/logger';
+import { toErrorMessage } from '@common/errors/errorMessage';
 import {
   type UserAuthContext,
   type UserTier,

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -6,7 +6,6 @@
  *
  * Similar to how GitHub Copilot works - users sign in to the official service.
  */
-import * as vscode from 'vscode';
 import { z } from 'zod';
 import {
   SUPABASE_CONFIG,
@@ -190,6 +189,8 @@ export interface ExternalAuthCallbackInfo {
  * and passed through the OAuth flow for the callback routing to work.
  */
 export async function getExternalAuthCallbackInfo(): Promise<ExternalAuthCallbackInfo> {
+  // Keep this lazy so Electron bundles can import auth config without resolving VS Code APIs.
+  const vscode = await import('vscode');
   const baseCallbackUri = vscode.Uri.parse(
     getAuthCallbackUri(vscode.env.uriScheme),
   );

--- a/src/common/errors/errorHandlingUtils.ts
+++ b/src/common/errors/errorHandlingUtils.ts
@@ -5,6 +5,7 @@ import { toErrorMessage } from './errorMessage';
 import type { z } from 'zod';
 
 export { toErrorMessage } from './errorMessage';
+export { isDiskFullError, isFileNotFoundError } from './errorPredicates';
 
 /** Valid documentation identifiers for error messages. */
 export type DocId = 'intelligent-merge' | 'custom-agents' | 'latex-diff';
@@ -46,26 +47,6 @@ export async function parseWithErrorDisplay<T>(
     return null;
   }
   return result.data;
-}
-
-/** Check if an error represents a file-not-found condition (ENOENT or VS Code FileNotFound). */
-export function isFileNotFoundError(err: unknown): boolean {
-  const code = (err as { code?: string })?.code;
-  return code === 'ENOENT' || code === 'FileNotFound';
-}
-
-/** Check if an error represents a "no space left on device" condition (ENOSPC). */
-export function isDiskFullError(err: unknown): boolean {
-  // Walk the cause chain — filesystem errors are sometimes wrapped by
-  // higher-level abstractions that lose the original .code property.
-  for (
-    let current: unknown = err;
-    current != null && typeof current === 'object';
-    current = (current as { cause?: unknown }).cause
-  ) {
-    if ((current as { code?: string }).code === 'ENOSPC') return true;
-  }
-  return false;
 }
 
 /** Log a formatted error message and return it. */

--- a/src/common/errors/errorPredicates.ts
+++ b/src/common/errors/errorPredicates.ts
@@ -1,0 +1,17 @@
+/** Check if an error represents a file-not-found condition. */
+export function isFileNotFoundError(err: unknown): boolean {
+  const code = (err as { code?: string })?.code;
+  return code === 'ENOENT' || code === 'FileNotFound';
+}
+
+/** Check if an error represents a "no space left on device" condition. */
+export function isDiskFullError(err: unknown): boolean {
+  for (
+    let current: unknown = err;
+    current != null && typeof current === 'object';
+    current = (current as { cause?: unknown }).cause
+  ) {
+    if ((current as { code?: string }).code === 'ENOSPC') return true;
+  }
+  return false;
+}

--- a/src/platform/defaults/nodeWorkspace.ts
+++ b/src/platform/defaults/nodeWorkspace.ts
@@ -152,53 +152,59 @@ function createRecursiveFallbackWatcher(
   };
 }
 
-export const nodeWorkspace: WorkspaceProvider = {
-  getWorkspacePath(): string | undefined {
-    return process.cwd();
-  },
+export function createNodeWorkspace(
+  getRoot: () => string | undefined = () => process.cwd(),
+): WorkspaceProvider {
+  return {
+    getWorkspacePath(): string | undefined {
+      return getRoot();
+    },
 
-  asRelativePath(filePath: string): string {
-    const root = this.getWorkspacePath();
-    if (!root) return filePath;
-    const relative = path.relative(root, filePath);
-    if (relative.startsWith('..') || path.isAbsolute(relative)) {
-      return filePath;
-    }
-    return normalizeRelativePath(relative);
-  },
+    asRelativePath(filePath: string): string {
+      const root = this.getWorkspacePath();
+      if (!root) return filePath;
+      const relative = path.relative(root, filePath);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        return filePath;
+      }
+      return normalizeRelativePath(relative);
+    },
 
-  watch(globPattern: string, listener: () => void): { dispose(): void } {
-    const root = this.getWorkspacePath();
-    if (!root) {
-      return { dispose: () => {} };
-    }
+    watch(globPattern: string, listener: () => void): { dispose(): void } {
+      const root = this.getWorkspacePath();
+      if (!root) {
+        return { dispose: () => {} };
+      }
 
-    try {
-      let disposed = false;
-      const watcher = fs.watch(
-        root,
-        { recursive: true },
-        (_event, filename) => {
-          if (disposed) return;
+      try {
+        let disposed = false;
+        const watcher = fs.watch(
+          root,
+          { recursive: true },
+          (_event, filename) => {
+            if (disposed) return;
 
-          const absolutePath =
-            filename == null ? null : path.join(root, filename.toString());
-          const relativePath =
-            absolutePath == null ? null : path.relative(root, absolutePath);
-          if (shouldNotify(globPattern, relativePath)) {
-            listener();
-          }
-        },
-      );
-      watcher.on('error', () => closeWatcher(watcher));
-      return {
-        dispose: () => {
-          disposed = true;
-          closeWatcher(watcher);
-        },
-      };
-    } catch {
-      return createRecursiveFallbackWatcher(root, globPattern, listener);
-    }
-  },
-};
+            const absolutePath =
+              filename == null ? null : path.join(root, filename.toString());
+            const relativePath =
+              absolutePath == null ? null : path.relative(root, absolutePath);
+            if (shouldNotify(globPattern, relativePath)) {
+              listener();
+            }
+          },
+        );
+        watcher.on('error', () => closeWatcher(watcher));
+        return {
+          dispose: () => {
+            disposed = true;
+            closeWatcher(watcher);
+          },
+        };
+      } catch {
+        return createRecursiveFallbackWatcher(root, globPattern, listener);
+      }
+    },
+  };
+}
+
+export const nodeWorkspace: WorkspaceProvider = createNodeWorkspace();

--- a/src/test-kernel/desktop/ElectronConfig.vitest.ts
+++ b/src/test-kernel/desktop/ElectronConfig.vitest.ts
@@ -1,0 +1,166 @@
+// Node imports
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
+
+interface JsonStore {
+  set(key: string, value: unknown): Promise<void>;
+  snapshot(): Record<string, unknown>;
+}
+
+interface ElectronConfigProvider {
+  get<T>(key: string, defaultValue?: T): T;
+  inspect<T = unknown>(
+    key: string,
+  ):
+    | {
+        globalValue?: T;
+        workspaceValue?: T;
+        effectiveValue?: T;
+      }
+    | undefined;
+  update<T>(
+    key: string,
+    value: T,
+    target?: 'global' | 'workspace',
+  ): Promise<void>;
+  isExplicitlySet(key: string): boolean;
+  watch(key: string, listener: () => void): { dispose(): void };
+}
+
+interface JsonStoreModule {
+  JsonStore: {
+    open(filePath: string): Promise<JsonStore>;
+  };
+}
+
+interface ElectronConfigModule {
+  ElectronConfigProvider: new (
+    globalStore: JsonStore,
+    workspaceStore: JsonStore,
+  ) => ElectronConfigProvider;
+}
+
+async function loadDesktopConfigConstructors(): Promise<{
+  JsonStore: JsonStoreModule['JsonStore'];
+  ElectronConfigProvider: ElectronConfigModule['ElectronConfigProvider'];
+}> {
+  const [{ JsonStore }, { ElectronConfigProvider }] = await Promise.all([
+    loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts'),
+    loadDesktopPlatformModule<ElectronConfigModule>('electronConfig.ts'),
+  ]);
+  return { JsonStore, ElectronConfigProvider };
+}
+
+describe('desktop ElectronConfigProvider', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function createProvider(): Promise<{
+    provider: ElectronConfigProvider;
+    globalStore: JsonStore;
+    workspaceStore: JsonStore;
+  }> {
+    const { JsonStore, ElectronConfigProvider } =
+      await loadDesktopConfigConstructors();
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-config-'));
+    const globalStore = await JsonStore.open(join(tempDir, 'global.json'));
+    const workspaceStore = await JsonStore.open(
+      join(tempDir, 'workspace.json'),
+    );
+    return {
+      provider: new ElectronConfigProvider(globalStore, workspaceStore),
+      globalStore,
+      workspaceStore,
+    };
+  }
+
+  it('lets workspace values override global values across config aliases', async () => {
+    const { provider, globalStore, workspaceStore } = await createProvider();
+    await globalStore.set('files.exclude', ['dist']);
+    await workspaceStore.set('texra.files.exclude', ['node_modules']);
+
+    expect(provider.get('files.exclude', [])).toEqual(['node_modules']);
+    expect(provider.inspect('files.exclude')).toEqual({
+      globalValue: ['dist'],
+      workspaceValue: ['node_modules'],
+      effectiveValue: ['node_modules'],
+    });
+  });
+
+  it('updates existing alias keys instead of leaving stale shadow entries', async () => {
+    const { provider, workspaceStore } = await createProvider();
+    await workspaceStore.set('texra.files.exclude', ['dist']);
+
+    await provider.update('files.exclude', ['node_modules']);
+
+    expect(workspaceStore.snapshot()).toEqual({
+      'texra.files.exclude': ['node_modules'],
+    });
+  });
+
+  it('stores new config values under the canonical prefixed key', async () => {
+    const { provider, workspaceStore } = await createProvider();
+
+    await provider.update('files.exclude', ['node_modules']);
+
+    expect(provider.get('files.exclude', [])).toEqual(['node_modules']);
+    expect(provider.get('texra.files.exclude', [])).toEqual(['node_modules']);
+    expect(workspaceStore.snapshot()).toEqual({
+      'texra.files.exclude': ['node_modules'],
+    });
+  });
+
+  it('updates an existing shorthand key from a prefixed alias', async () => {
+    const { provider, workspaceStore } = await createProvider();
+    await workspaceStore.set('files.exclude', ['dist']);
+
+    await provider.update('texra.files.exclude', ['node_modules']);
+
+    expect(provider.get('files.exclude', [])).toEqual(['node_modules']);
+    expect(workspaceStore.snapshot()).toEqual({
+      'files.exclude': ['node_modules'],
+    });
+  });
+
+  it('clears every stored alias when a config value is unset', async () => {
+    const { provider, workspaceStore } = await createProvider();
+    await workspaceStore.set('files.exclude', ['dist']);
+    await workspaceStore.set('texra.files.exclude', ['node_modules']);
+
+    await provider.update('files.exclude', undefined);
+
+    expect(provider.isExplicitlySet('files.exclude')).toBe(false);
+    expect(workspaceStore.snapshot()).toEqual({});
+  });
+
+  it('notifies watchers registered under either config alias', async () => {
+    const { provider } = await createProvider();
+    let prefixedChanges = 0;
+    let unprefixedChanges = 0;
+
+    provider.watch('texra.files.exclude', () => {
+      prefixedChanges += 1;
+    });
+    provider.watch('files.exclude', () => {
+      unprefixedChanges += 1;
+    });
+
+    await provider.update('files.exclude', ['node_modules']);
+    await provider.update('texra.files.exclude', ['dist']);
+
+    expect(prefixedChanges).toBe(2);
+    expect(unprefixedChanges).toBe(2);
+  });
+});

--- a/src/test-kernel/desktop/JsonStore.vitest.ts
+++ b/src/test-kernel/desktop/JsonStore.vitest.ts
@@ -1,0 +1,62 @@
+// Node imports
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
+
+interface JsonStore {
+  set(key: string, value: unknown): Promise<void>;
+  snapshot(): Record<string, unknown>;
+}
+
+interface JsonStoreModule {
+  JsonStore: {
+    open(filePath: string): Promise<JsonStore>;
+  };
+}
+
+async function loadJsonStore(): Promise<JsonStoreModule['JsonStore']> {
+  const { JsonStore } =
+    await loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts');
+  return JsonStore;
+}
+
+describe('desktop JsonStore', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function createTempFile(
+    name: string,
+    contents: string,
+  ): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-json-store-'));
+    const filePath = join(tempDir, name);
+    await writeFile(filePath, contents);
+    return filePath;
+  }
+
+  it('recovers from malformed JSON stores and overwrites on the next write', async () => {
+    const JsonStore = await loadJsonStore();
+    const filePath = await createTempFile('state.json', '{"truncated"');
+
+    const store = await JsonStore.open(filePath);
+
+    expect(store.snapshot()).toEqual({});
+
+    await store.set('ready', true);
+
+    expect(JSON.parse(await readFile(filePath, 'utf8'))).toEqual({
+      ready: true,
+    });
+  });
+});

--- a/src/test-kernel/desktop/loadDesktopPlatformModule.ts
+++ b/src/test-kernel/desktop/loadDesktopPlatformModule.ts
@@ -1,0 +1,14 @@
+// Node imports
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export async function loadDesktopPlatformModule<T>(
+  moduleName: string,
+): Promise<T> {
+  const modulePath = resolve(
+    process.cwd(),
+    'packages/desktop/src/main/platform',
+    moduleName,
+  );
+  return import(pathToFileURL(modulePath).href) as Promise<T>;
+}


### PR DESCRIPTION
## Summary

Adds the first real Electron main-process platform bootstrap on top of the desktop package scaffold.

This PR wires initPlatform() for the desktop host, adds Electron-backed config, state, storage, workspace, secrets, PATH repair, and bundled-agent directory bootstrap into Electron userData. It also splits the agent-directory setter into a small registry module so desktop can register directories without importing the full agent loader graph.

Part of #3294.

## Validation

- corepack pnpm install --frozen-lockfile --filter @texra/desktop
- corepack pnpm run typecheck
- corepack pnpm run lint
- corepack pnpm run test:kernel
- corepack pnpm --filter @texra/desktop build
- corepack pnpm run compile:safe
- rg -n vscode packages/desktop/dist/main/index.js (expected no static vscode import matches)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Electron main-process platform bootstrap that initializes persistent config/state/storage/secrets and syncs bundled agent directories, which can affect app startup and on-disk data. Also introduces PATH modification on macOS and changes module bundling/lazy imports to avoid `vscode` in Electron builds.
> 
> **Overview**
> Wires the Electron main process to call `initializeElectronPlatform()` at startup, failing fast with a logged error and `app.quit()` if initialization fails.
> 
> Adds an Electron-backed platform layer under `packages/desktop/src/main/platform` for persistent JSON config/state stores, workspace/global storage paths, encrypted secrets via `safeStorage`, macOS launch `PATH` repair (via `fix-path`), and resource/workspace path resolution.
> 
> Bootstraps bundled agent directories into global storage on app start and factors agent directory injection into a new `agentDirectoriesRegistry` so non-VSCode hosts (Electron) can register directories without pulling in the full agent loader graph; also tweaks shared imports (error helpers, `GlobalStorageFS`, lazy `vscode` import in auth config) and updates desktop build/tsconfig to support these changes and externalize `vscode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aca22a70cb62210c74027815be6afc95b309ed19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->