### PR TITLE
refactor: collapse progress stream lifecycle host

### DIFF
--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -14,28 +14,28 @@ export interface ProgressStreamLifecycleState {
 
 export interface ProgressStreamLifecycleControllerDeps {
   state: ProgressStreamLifecycleState;
-  isStreamInFlight(stream: StreamTabId): boolean;
+  host: ProgressStreamLifecycleHost;
+}
+
+export interface ProgressStreamLifecycleHost {
   getVisibleStreamIds(): StreamTabId[];
-  stopStream(stream: StreamTabId): Promise<void>;
-  clearRetryRequest(stream: StreamTabId): void;
-  releaseFollowUpQueue(stream: StreamTabId): void;
-  cleanupApprovalsForStream(stream: StreamTabId): void;
-  cleanupAllApprovals(): void;
-  clearModelOutputBackups(stream?: StreamTabId): void;
-  clearWebviewStream(stream: StreamTabId): void;
-  clearAllWebviewStreams(): void;
-  deleteWebviewStream(stream: StreamTabId): void;
-  syncFullView(options: { forceRebuild: boolean }): void;
-  setActiveStream(stream: StreamTabId): Promise<void>;
+  isStreamInFlight(stream: StreamTabId): boolean;
+  stopStream(
+    stream: StreamTabId,
+    options?: { clearRetryRequest?: boolean },
+  ): Promise<void>;
+  cleanupDeletedStream(stream: StreamTabId): void;
+  cleanupDeletedStreams(streams: StreamTabId[]): void;
+  deleteRenderedStream(stream: StreamTabId): void;
+  rebuildRenderedStreams(options: { forceRebuild: boolean }): void;
+  activateStream(stream: StreamTabId): Promise<void>;
 }
 
 export class ProgressStreamLifecycleController {
   constructor(private readonly deps: ProgressStreamLifecycleControllerDeps) {}
 
   async stopStream(stream: StreamTabId): Promise<void> {
-    // Clear pending retry requests so the UI panel is dismissed with the stop.
-    this.deps.clearRetryRequest(stream);
-    await this.deps.stopStream(stream);
+    await this.deps.host.stopStream(stream, { clearRetryRequest: true });
   }
 
   async deleteStream(stream: StreamTabId): Promise<void> {
@@ -43,32 +43,30 @@ export class ProgressStreamLifecycleController {
       this.deps.state.hasStream(stream) || this.deps.state.hasTaskState(stream);
     if (!hasStream) return;
 
-    if (this.deps.isStreamInFlight(stream)) {
+    if (this.deps.host.isStreamInFlight(stream)) {
       // Finished streams should not get synthetic STOPPED transitions or child
       // interrupts after they completed naturally.
-      await this.deps.stopStream(stream);
+      await this.deps.host.stopStream(stream);
     }
 
-    this.deps.cleanupApprovalsForStream(stream);
-    this.deps.clearRetryRequest(stream);
-    this.deps.releaseFollowUpQueue(stream);
-    this.deps.clearModelOutputBackups(stream);
-    this.deps.clearWebviewStream(stream);
+    this.deps.host.cleanupDeletedStream(stream);
 
     const wasActive = this.deps.state.getActiveStream() === stream;
     await this.deps.state.clearStream(stream);
 
     if (wasActive) {
       this.deps.state.setActiveStream(
-        this.deps.state.pickValidActiveStream(this.deps.getVisibleStreamIds()),
+        this.deps.state.pickValidActiveStream(
+          this.deps.host.getVisibleStreamIds(),
+        ),
       );
     }
 
-    this.deps.deleteWebviewStream(stream);
+    this.deps.host.deleteRenderedStream(stream);
 
     const nextActive = this.deps.state.getActiveStream();
     if (wasActive && nextActive) {
-      await this.deps.setActiveStream(nextActive);
+      await this.deps.host.activateStream(nextActive);
     }
   }
 
@@ -76,17 +74,11 @@ export class ProgressStreamLifecycleController {
     const streamIds = this.deps.state.getStreamIds();
 
     await Promise.allSettled(
-      streamIds.map((stream) => this.deps.stopStream(stream)),
+      streamIds.map((stream) => this.deps.host.stopStream(stream)),
     );
 
-    this.deps.cleanupAllApprovals();
-    for (const stream of streamIds) {
-      this.deps.clearRetryRequest(stream);
-      this.deps.releaseFollowUpQueue(stream);
-    }
-    this.deps.clearModelOutputBackups();
-    this.deps.clearAllWebviewStreams();
+    this.deps.host.cleanupDeletedStreams(streamIds);
     await this.deps.state.clearAll();
-    this.deps.syncFullView({ forceRebuild: true });
+    this.deps.host.rebuildRenderedStreams({ forceRebuild: true });
   }
 }

--- a/src/progressView/ProgressViewMessageHandler.ts
+++ b/src/progressView/ProgressViewMessageHandler.ts
@@ -7,8 +7,6 @@ import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
-import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import {
   validateExecutionRequest,
   type ExecutionRequest,
@@ -21,7 +19,6 @@ import {
   COMMON_COMMANDS,
   PROGRESS_VIEW_COMMANDS,
 } from '@common/webview';
-import { isInFlightStatus } from '@common/constants/streamStatus';
 import { RecordingManager } from '@common/managers/RecordingManager';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
@@ -30,7 +27,6 @@ import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nat
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import type { TaskState } from '@logger/TaskState';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import { buildStreamInfos } from '@progressView/streamInfoUtils';
 import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 import type { AgentProposal } from '@shared/schemas/prompts';
 import {
@@ -40,8 +36,6 @@ import {
 } from '@shared/schemas/progressView';
 import { handleExternalInquiryAction } from '@tools/inquiry';
 import {
-  cleanupAllApprovals,
-  cleanupApprovalsForStream,
   handleProgressViewBashApprovalAction,
   toggleToolEditApprovalSessionBypass,
   setToolEditApprovalSessionBypass,
@@ -70,6 +64,7 @@ import {
   type ProgressFollowUpPlan,
 } from '../controllers/progressView/ProgressFollowUpController';
 import { ProgressWorkflowActionsController } from '../controllers/progressView/ProgressWorkflowActionsController';
+import { ProgressStreamLifecycleHost } from './managers/ProgressStreamLifecycleHost';
 import type { ProgressViewProvider } from './ProgressViewProvider';
 
 // Type helper for extracting specific message types
@@ -365,34 +360,10 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         clearStream: (stream) => this.provider.state.clearStream(stream),
         clearAll: () => this.provider.state.clearAll(),
       },
-      isStreamInFlight: (stream) =>
-        isInFlightStatus(StreamStatusService.get(stream)),
-      getVisibleStreamIds: () =>
-        buildStreamInfos(
-          this.provider.state,
-          this.provider.state.agentCategoryFilter,
-        ).map((stream) => stream.name),
-      stopStream: async (stream) => {
-        await vscode.commands.executeCommand('texra.stopAgent', stream);
-      },
-      clearRetryRequest: (stream) => retryCoordinator.clearRequest(stream),
-      releaseFollowUpQueue: (stream) => ToolUseFollowUpQueue.release(stream),
-      cleanupApprovalsForStream: (stream) => cleanupApprovalsForStream(stream),
-      cleanupAllApprovals: () => cleanupAllApprovals(),
-      clearModelOutputBackups: (stream) => {
-        if (stream) {
-          this.modelOutputBackups.delete(stream);
-        } else {
-          this.modelOutputBackups.clear();
-        }
-      },
-      clearWebviewStream: (stream) =>
-        this.provider.webviewBridge.clearStream(stream),
-      clearAllWebviewStreams: () => this.provider.webviewBridge.clearAll(),
-      deleteWebviewStream: (stream) =>
-        this.provider.webviewUpdater.deleteStream(stream),
-      syncFullView: (options) => this.provider.syncFullView(options),
-      setActiveStream: (stream) => this.provider.setActiveStream(stream),
+      host: new ProgressStreamLifecycleHost(
+        this.provider,
+        this.modelOutputBackups,
+      ),
     });
   }
 

--- a/src/progressView/managers/ProgressStreamLifecycleHost.ts
+++ b/src/progressView/managers/ProgressStreamLifecycleHost.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode';
+
+import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { isInFlightStatus } from '@common/constants/streamStatus';
+import {
+  cleanupAllApprovals,
+  cleanupApprovalsForStream,
+} from '@tools/approval';
+
+import { buildStreamInfos } from '../streamInfoUtils';
+import type { ProgressStreamLifecycleHost as ProgressStreamLifecycleHostPort } from '../../controllers/progressView/ProgressStreamLifecycleController';
+import type { ProgressViewProvider } from '../ProgressViewProvider';
+
+type StreamTabId = import('@shared/schemas').StreamTabId;
+type ModelOutputBackups = Map<
+  StreamTabId,
+  Map<string, { content: string; streamId: StreamTabId }>
+>;
+
+export class ProgressStreamLifecycleHost implements ProgressStreamLifecycleHostPort {
+  constructor(
+    private readonly provider: ProgressViewProvider,
+    private readonly modelOutputBackups: ModelOutputBackups,
+  ) {}
+
+  getVisibleStreamIds(): StreamTabId[] {
+    return buildStreamInfos(
+      this.provider.state,
+      this.provider.state.agentCategoryFilter,
+    ).map((stream) => stream.name);
+  }
+
+  isStreamInFlight(stream: StreamTabId): boolean {
+    return isInFlightStatus(StreamStatusService.get(stream));
+  }
+
+  async stopStream(
+    stream: StreamTabId,
+    options: { clearRetryRequest?: boolean } = {},
+  ): Promise<void> {
+    if (options.clearRetryRequest === true) {
+      retryCoordinator.clearRequest(stream);
+    }
+    await vscode.commands.executeCommand('texra.stopAgent', stream);
+  }
+
+  cleanupDeletedStream(stream: StreamTabId): void {
+    cleanupApprovalsForStream(stream);
+    retryCoordinator.clearRequest(stream);
+    ToolUseFollowUpQueue.release(stream);
+    this.modelOutputBackups.delete(stream);
+    this.provider.webviewBridge.clearStream(stream);
+  }
+
+  cleanupDeletedStreams(streams: StreamTabId[]): void {
+    cleanupAllApprovals();
+    for (const stream of streams) {
+      retryCoordinator.clearRequest(stream);
+      ToolUseFollowUpQueue.release(stream);
+    }
+    this.modelOutputBackups.clear();
+    this.provider.webviewBridge.clearAll();
+  }
+
+  deleteRenderedStream(stream: StreamTabId): void {
+    this.provider.webviewUpdater.deleteStream(stream);
+  }
+
+  rebuildRenderedStreams(options: { forceRebuild: boolean }): void {
+    this.provider.syncFullView(options);
+  }
+
+  async activateStream(stream: StreamTabId): Promise<void> {
+    await this.provider.setActiveStream(stream);
+  }
+}

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -34,6 +34,23 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-b']);
   });
 
+  it('deletes active finished streams and activates the next visible stream', async () => {
+    const { controller, recorder, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        activeStream: 'stream-a',
+        visibleStreams: ['stream-b'],
+      });
+
+    await controller.deleteStream('stream-a');
+
+    assert.deepEqual(streams(), ['stream-b']);
+    assert.equal(activeStream(), 'stream-b');
+    assert.deepEqual(recorder.calls.get('stop'), undefined);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), ['stream-a']);
+    assert.deepEqual(recorder.calls.get('setActiveStream'), ['stream-b']);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
+  });
+
   it('stops running streams and activates the next visible stream', async () => {
     const { controller, recorder, streams, activeStream } =
       createProgressStreamLifecycleHarness({
@@ -48,6 +65,16 @@ describe('ProgressStreamLifecycleController', () => {
     assert.equal(activeStream(), 'stream-b');
     assert.deepEqual(recorder.calls.get('stop'), ['stream-a']);
     assert.deepEqual(recorder.calls.get('setActiveStream'), ['stream-b']);
+  });
+
+  it('clears retry UI when stopping a stream without deleting it', async () => {
+    const { controller, recorder } = createProgressStreamLifecycleHarness();
+
+    await controller.stopStream('stream-a');
+
+    assert.deepEqual(recorder.calls.get('clearRetry'), ['stream-a']);
+    assert.deepEqual(recorder.calls.get('stop'), ['stream-a']);
+    assert.deepEqual(recorder.calls.get('cleanupApprovals'), undefined);
   });
 
   it('clears all stream lifecycle state', async () => {

--- a/src/test/support/ProgressControllerHarnesses.ts
+++ b/src/test/support/ProgressControllerHarnesses.ts
@@ -12,6 +12,7 @@ import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 // Local imports - controllers
 import {
   ProgressStreamLifecycleController,
+  type ProgressStreamLifecycleHost,
   type ProgressStreamLifecycleState,
 } from '../../controllers/progressView/ProgressStreamLifecycleController';
 import {
@@ -72,29 +73,42 @@ export function createProgressStreamLifecycleHarness(
       activeStream = '';
     },
   };
+  const host: ProgressStreamLifecycleHost = {
+    getVisibleStreamIds: () =>
+      options.visibleStreams ?? streams.filter((stream) => stream !== 'hidden'),
+    isStreamInFlight: (stream) => inFlightStreams.has(stream),
+    stopStream: async (stream, stopOptions = {}) => {
+      if (stopOptions.clearRetryRequest === true) {
+        recorder.record('clearRetry', stream);
+      }
+      recorder.record('stop', stream);
+    },
+    cleanupDeletedStream: (stream) => {
+      recorder.record('cleanupApprovals', stream);
+      recorder.record('clearRetry', stream);
+      recorder.record('releaseFollowUp', stream);
+      recorder.record('clearBackups', stream);
+      recorder.record('clearWebview', stream);
+    },
+    cleanupDeletedStreams: (streams) => {
+      recorder.record('cleanupAllApprovals', 'all');
+      for (const stream of streams) {
+        recorder.record('clearRetry', stream);
+        recorder.record('releaseFollowUp', stream);
+      }
+      recorder.record('clearBackups', 'all');
+      recorder.record('clearAllWebview', 'all');
+    },
+    deleteRenderedStream: (stream) => recorder.record('deleteWebview', stream),
+    rebuildRenderedStreams: (options) => syncCalls.push(options),
+    activateStream: async (stream) =>
+      recorder.record('setActiveStream', stream),
+  };
 
   return {
     controller: new ProgressStreamLifecycleController({
       state,
-      isStreamInFlight: (stream) => inFlightStreams.has(stream),
-      getVisibleStreamIds: () =>
-        options.visibleStreams ??
-        streams.filter((stream) => stream !== 'hidden'),
-      stopStream: async (stream) => recorder.record('stop', stream),
-      clearRetryRequest: (stream) => recorder.record('clearRetry', stream),
-      releaseFollowUpQueue: (stream) =>
-        recorder.record('releaseFollowUp', stream),
-      cleanupApprovalsForStream: (stream) =>
-        recorder.record('cleanupApprovals', stream),
-      cleanupAllApprovals: () => recorder.record('cleanupAllApprovals', 'all'),
-      clearModelOutputBackups: (stream) =>
-        recorder.record('clearBackups', stream ?? 'all'),
-      clearWebviewStream: (stream) => recorder.record('clearWebview', stream),
-      clearAllWebviewStreams: () => recorder.record('clearAllWebview', 'all'),
-      deleteWebviewStream: (stream) => recorder.record('deleteWebview', stream),
-      syncFullView: (options) => syncCalls.push(options),
-      setActiveStream: async (stream) =>
-        recorder.record('setActiveStream', stream),
+      host,
     }),
     recorder,
     syncCalls,


### PR DESCRIPTION
## Summary

- Introduce a progress stream lifecycle host interface so the controller depends on lifecycle operations instead of individual cleanup callbacks.
- Move VS Code-specific stream cleanup, stop, rendering, and activation effects into src/progressView/managers/ProgressStreamLifecycleHost.ts.
- Expand lifecycle controller coverage for active finished deletion and stop-only retry cleanup.

Closes #3373.

## Validation

- npm run compile-tests
- corepack pnpm run typecheck
- corepack pnpm run lint
- corepack pnpm run compile:safe
- corepack pnpm run test:kernel

Note: the focused Mocha controller test compiles through compile-tests; this worktree does not have a standalone mocha binary, and npm test is intentionally not run because it downloads the VS Code test environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors stream stop/delete side effects into a new host layer and slightly changes stop/delete behavior (retry UI clearing and active-stream activation), which could affect progress view state consistency.
> 
> **Overview**
> Refactors progress-stream lifecycle handling so `ProgressStreamLifecycleController` depends on a single `host` interface instead of many VS Code/UI-specific callbacks.
> 
> Adds `ProgressStreamLifecycleHost` (new manager) to own stop/cleanup/rendering side effects (retry requests, approvals, follow-up queue, model output backups, webview clearing, and full view rebuild), and updates `ProgressViewMessageHandler` to wire it in.
> 
> Tightens lifecycle behavior: `stopStream()` now clears retry UI via `host.stopStream(..., { clearRetryRequest: true })`, and controller tests/harnesses are updated with new coverage for deleting an active finished stream and stop-only retry cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d973b0a3874c706581f0db9ea374034765295fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->