### PR TITLE
ci: validate workspace package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Type check
         run: pnpm run typecheck
 
+      - name: Type check workspace packages
+        run: pnpm run workspace:typecheck
+
       - name: Lint
         run: pnpm run lint
 
@@ -46,3 +49,6 @@ jobs:
 
       - name: Compile
         run: pnpm run compile
+
+      - name: Build workspace packages
+        run: pnpm run workspace:build

--- a/package.json
+++ b/package.json
@@ -1517,6 +1517,7 @@
     "test": "vscode-test",
     "test:kernel": "vitest run --config vitest.config.mjs",
     "test:kernel:watch": "vitest --config vitest.config.mjs",
+    "workspace:typecheck": "corepack pnpm --recursive --if-present typecheck",
     "workspace:build": "corepack pnpm --recursive --if-present build",
     "desktop:build": "corepack pnpm --filter @texra/desktop build",
     "build": "npm run compile && vsce package --out releases/texra-$npm_package_version.vsix",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -10,7 +10,7 @@
     "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:vscode",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload/index.cjs --external:electron",
     "build:renderer": "vite build --config vite.config.ts",
-    "build": "npm run typecheck && npm run build:main && npm run build:preload && npm run build:renderer"
+    "build": "corepack pnpm run typecheck && corepack pnpm run build:main && corepack pnpm run build:preload && corepack pnpm run build:renderer"
   },
   "devDependencies": {
     "@texra/core": "workspace:*",


### PR DESCRIPTION
## Summary

- add an explicit workspace package typecheck gate to CI
- add a workspace package build gate so the new core and desktop packages cannot drift outside CI coverage
- run the desktop package build through `corepack pnpm` instead of `npm run` to keep recursive pnpm builds clean

Closes #3377.
Part of #3376 and #3307.

## Verification

- `npm run format`
- `corepack pnpm run workspace:typecheck`
- `corepack pnpm run workspace:build`
- `npm run lint`
- `npm run compile-tests`
- `npm run test:kernel`
- `npm run compile:safe`

Did not run `npm test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI gating and workspace build execution, which may introduce new CI failures due to previously-unchecked package scripts or pnpm/corepack differences.
> 
> **Overview**
> Adds explicit CI gates to run `workspace:typecheck` and `workspace:build`, ensuring all workspace packages are typechecked and built during PR validation.
> 
> Introduces a new root `workspace:typecheck` script (recursive pnpm `typecheck` where present) and updates `@texra/desktop`’s `build` script to run sub-steps via `corepack pnpm` instead of `npm run` for cleaner recursive workspace builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad510c3ef184293e5cd077cf995f5d90717ed2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->