### PR TITLE
ci: verify extension package invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Check extension package invariants
+        run: pnpm run check:extension-package-invariants
+
       - name: Kernel tests
         run: pnpm run test:kernel
 

--- a/package.json
+++ b/package.json
@@ -1538,6 +1538,8 @@
     "build:safe": "npm run typecheck && npm run build:fast",
     "sync:settings-configuration": "npm run compile-tests && node scripts/sync-settings-configuration.mjs",
     "check:settings-configuration": "npm run compile-tests && node scripts/sync-settings-configuration.mjs --check",
+    "sync:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs --update",
+    "check:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs",
     "sync:remote-agents": "node scripts/sync-remote-agents.mjs -o docs/supabase/SYNC_REFERENCE_AGENTS.sql",
     "check:remote-agents": "node scripts/sync-remote-agents.mjs --check"
   },

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1,0 +1,1501 @@
+{
+  "manifest": {
+    "name": "texra",
+    "displayName": "TeXRA",
+    "description": "TeXRA: Your LLM-powered 24/7 LaTeX Research Assistant.",
+    "publisher": "texra-ai",
+    "engines": {
+      "vscode": "^1.105.0"
+    },
+    "categories": [
+      "Programming Languages",
+      "Chat",
+      "Machine Learning",
+      "Linters",
+      "Formatters",
+      "AI",
+      "Education",
+      "Data Science"
+    ],
+    "activationEvents": ["onStartupFinished", "onColorTheme"],
+    "main": "./dist/extension.js",
+    "capabilities": {
+      "untrustedWorkspaces": {
+        "description": "TeXRA runs AI agents that read workspace files and execute shell commands (LaTeX compilation, bash tools, external MCP tools). Open trusted workspaces only.",
+        "supported": false
+      }
+    },
+    "contributes": {
+      "authentication": [
+        {
+          "id": "texra-supabase",
+          "label": "TeXRA"
+        }
+      ],
+      "commands": [
+        {
+          "category": "TeXRA",
+          "command": "texra.createSampleProject",
+          "title": "Create Sample Project"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.runSetupAssistant",
+          "icon": "$(rocket)",
+          "title": "Run Setup Assistant Agent (Setup Wizard)"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.openGettingStarted",
+          "icon": "$(mortar-board)",
+          "title": "Open Getting Started Walkthrough"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.cleanOutput",
+          "icon": "$(clear-all)",
+          "shortTitle": "Clean LLM Outputs",
+          "title": "Clean All LLM Output Files (Workspace-wide)"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.cleanBuild",
+          "icon": "$(close-all)",
+          "shortTitle": "Clean Build Files",
+          "title": "Clean All Build Files (Workspace-wide)"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.indentTeX",
+          "icon": "$(indent)",
+          "title": "Indent All LaTeX Files"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.getRecentCommits",
+          "title": "Get Recent Commits"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.cloneOverleafProject",
+          "icon": "$(repo-clone)",
+          "title": "Clone Overleaf/ShareLaTeX Project"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.refreshCommits",
+          "title": "Refresh Commits"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.indentCurrentTeX",
+          "enablement": "!virtualWorkspace",
+          "icon": "$(indent)",
+          "title": "Indent Current TeX"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.resumeAgent",
+          "title": "Resume Tool-Use Agent"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.applyReplacements",
+          "enablement": "!virtualWorkspace",
+          "icon": "$(symbol-text)",
+          "title": "Apply LaTeX Replacements to Current File"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.fixCompilation",
+          "enablement": "!virtualWorkspace",
+          "icon": "$(wrench)",
+          "title": "Fix LaTeX Compilation Errors"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.getTeXCount",
+          "enablement": "!virtualWorkspace",
+          "icon": "$(symbol-number)",
+          "title": "Count Words in Current TeX File"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.countPdfPages",
+          "title": "Count PDF Pages"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.encodeImageToBase64",
+          "title": "Encode Image to Base64"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.convertPdfToImages",
+          "title": "Convert PDF to Images"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.extractFigurePaths",
+          "title": "Extract Figure Paths from LaTeX"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.extractTikzFigures",
+          "title": "Extract TikZ Figures from Current File"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.compileTikzFigures",
+          "title": "Compile TikZ Figures from Current File"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.testConnection",
+          "title": "Test API Connection"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.testAgentLoading",
+          "title": "Test Agent Loading"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.loadSpecificAgent",
+          "title": "Load Specific Agent"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.downloadArXivSource",
+          "title": "Download arXiv Source"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showImportOptions",
+          "icon": "$(cloud-download)",
+          "title": "Import or Create LaTeX Project"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.parseXml",
+          "title": "Parse XML Structure"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.parseYaml",
+          "title": "Parse YAML Structure"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.stopAgent",
+          "title": "Stop Agent"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.execute",
+          "title": "Execute Agent"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.pack",
+          "icon": "$(archive)",
+          "shortTitle": "Pack Output",
+          "title": "Pack Output into History Folder"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.clean",
+          "icon": "$(trash)",
+          "shortTitle": "Clean Output",
+          "title": "Clean Agent Output Files"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.createAgentWithAI",
+          "icon": "$(sparkle)",
+          "title": "Create AI Agent"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.setApiKey",
+          "title": "Set API Key"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.removeApiKey",
+          "title": "Remove API Key"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.auth.signIn",
+          "icon": "$(sign-in)",
+          "title": "Sign In"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.auth.signOut",
+          "icon": "$(sign-out)",
+          "title": "Sign Out"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.auth.viewProfile",
+          "icon": "$(account)",
+          "title": "View Profile"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.testTextEditor",
+          "icon": "$(edit)",
+          "title": "Test Text Editor Tool"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showLinterMessages",
+          "title": "Show Linter Messages"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.countLinterMessages",
+          "title": "Count Linter Messages"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.openDoc",
+          "title": "Open TeXRA Documentation"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.mainView.reset",
+          "icon": "$(new-file)",
+          "shortTitle": "New",
+          "title": "New Session"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showAgentHistory",
+          "icon": "$(history)",
+          "title": "Show Agent Execution History"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showMemory",
+          "icon": "$(database)",
+          "title": "Show Memory"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showModels",
+          "icon": "$(hubot)",
+          "title": "Show Models"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showAgents",
+          "icon": "$(symbol-method)",
+          "title": "Show Agents"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showTools",
+          "icon": "$(tools)",
+          "title": "Show Tool Dashboard"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showMultiAgent",
+          "icon": "$(organization)",
+          "title": "Show Multi-Agent Settings"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.openSettings",
+          "icon": "$(settings-gear)",
+          "title": "Open TeXRA Settings"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showMainView",
+          "icon": "$(edit)",
+          "title": "Show Launcher"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showProgressView",
+          "icon": "$(eye)",
+          "title": "Show Progress"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.toggleView",
+          "icon": "$(split-horizontal)",
+          "title": "Toggle Launcher/Progress View"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.openProgressViewInTab",
+          "icon": "$(multiple-windows)",
+          "shortTitle": "Open in Tab",
+          "title": "Open Progress in Editor Tab"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showDashboard",
+          "icon": "$(gear)",
+          "shortTitle": "Settings",
+          "title": "Show Settings Dashboard"
+        },
+        {
+          "category": "TeXRA",
+          "command": "texra.showSettingsView",
+          "icon": "$(gear)",
+          "title": "Show Settings"
+        }
+      ],
+      "configuration": [
+        {
+          "properties": {
+            "texra.agentOutputs.autoOpenFinal": {
+              "default": true,
+              "description": "When a workflow run completes, automatically preview the final revised file in a new editor tab. Disable for batch runs when you don't want a tab to steal focus.",
+              "order": 51,
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "TeXRA"
+        },
+        {
+          "properties": {
+            "texra.auth.enableVSCodeGitHub": {
+              "default": false,
+              "description": "Enable VS Code native GitHub authentication (experimental)",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.ui.showApiKeyReminders": {
+              "default": true,
+              "description": "Show API key reminders in the status bar and main view when no API keys are configured",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.ui.showGettingStartedBanner": {
+              "default": true,
+              "description": "Show getting started banner with import options when no LaTeX files are found",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.ui.showLoginBanner": {
+              "default": true,
+              "description": "Show login banner prompting users to sign in for access to remote agents",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.ui.showOrchestratorBanner": {
+              "default": true,
+              "description": "Show orchestrator and session reminder text in the main view",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "User Interface"
+        },
+        {
+          "properties": {
+            "texra.model.compactionThresholdPercent": {
+              "default": 75,
+              "description": "When the conversation reaches this percentage of the model's context limit, TeXRA automatically summarizes earlier messages to free up space. Lower values trigger summarization sooner. Set to 0 to disable.",
+              "maximum": 100,
+              "minimum": 0,
+              "scope": "resource",
+              "type": "number"
+            },
+            "texra.model.gpt5ReasoningSummary": {
+              "default": false,
+              "description": "Show the model's reasoning steps alongside its output when using GPT-5 models. Requires an OpenAI account with access to reasoning features.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.model.improvedConnectionDomain": {
+              "default": "proxy.texra.ai",
+              "description": "Domain to use when using improved connection",
+              "scope": "resource",
+              "type": "string"
+            },
+            "texra.model.openaiParallelToolCalls": {
+              "default": false,
+              "description": "Let OpenAI models use multiple tools at the same time for faster results. Disabled by default for more predictable behavior.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.model.useBackgroundResponses": {
+              "default": true,
+              "description": "Keep long-running OpenAI requests alive in the background (polling) instead of timing out after 10 minutes. Applies automatically to GPT models running workflow agents; ignored otherwise. Disable to fall back to synchronous streaming requests.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.model.useImprovedConnection": {
+              "default": false,
+              "description": "Use improved connection for API requests",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.model.useOpenAIResponsesAPI": {
+              "default": true,
+              "description": "Use OpenAI's newer Responses API for additional features like built-in tool use. Disable to fall back to the classic Chat Completions API.",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "Model Settings"
+        },
+        {
+          "properties": {
+            "texra.files.ignored.auxiliaryKeywords": {
+              "default": [
+                "o1",
+                "o3",
+                "o4",
+                "gpt",
+                "sonnet",
+                "haiku",
+                "opus",
+                "gemini",
+                "grok",
+                "deepseek",
+                "qwen",
+                "kimi",
+                "llama",
+                "egg-info",
+                "yaml"
+              ],
+              "description": "Additional keywords to ignore when listing auxiliary files, including model names",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 12,
+              "type": "array"
+            },
+            "texra.files.ignored.directories": {
+              "default": [
+                "build",
+                "node_modules",
+                "__pycache__",
+                "figures",
+                "media",
+                "figs",
+                "versions",
+                "history",
+                "stuff",
+                "draft",
+                "miscellaneous",
+                "diffs",
+                "venv"
+              ],
+              "description": "Directories to ignore when listing files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 14,
+              "type": "array"
+            },
+            "texra.files.ignored.fileExtensions": {
+              "default": [
+                ".pdf",
+                ".bst",
+                ".json",
+                ".py",
+                ".ipynb",
+                ".png",
+                ".vsix",
+                ".ts",
+                ".js",
+                ".yaml"
+              ],
+              "description": "File extensions to ignore when listing text files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 9,
+              "type": "array"
+            },
+            "texra.files.ignored.inputDirectories": {
+              "default": [],
+              "description": "Additional directories to ignore when listing input and edited files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 11,
+              "type": "array"
+            },
+            "texra.files.ignored.inputFiles": {
+              "default": [
+                "command.tex",
+                "commands.tex",
+                "preamble.tex",
+                "yaml"
+              ],
+              "description": "Files to ignore when listing input, sample, and edited files, but not auxiliary files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 10,
+              "type": "array"
+            },
+            "texra.files.ignored.keywords": {
+              "default": [
+                "Makefile",
+                "template",
+                "_thinking",
+                "_diff",
+                "draw",
+                "versions",
+                "history",
+                ".egg-info",
+                "venv",
+                "yaml"
+              ],
+              "description": "Keywords to ignore when selecting files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 15,
+              "type": "array"
+            },
+            "texra.files.ignored.mediaDirectories": {
+              "default": [
+                "build",
+                "node_modules",
+                "__pycache__",
+                "versions",
+                "history",
+                "venv",
+                "Diffs"
+              ],
+              "description": "Directories to ignore in the figure path",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 13,
+              "type": "array"
+            },
+            "texra.files.included.auxiliaryExtensions": {
+              "default": [".txt", ".tex", ".cls", ".md", ".sty"],
+              "description": "File extensions to include when searching for auxiliary files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 7,
+              "type": "array"
+            },
+            "texra.files.included.editedExtensions": {
+              "default": [".txt", ".tex"],
+              "description": "File extensions to include when searching for edited files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 8,
+              "type": "array"
+            },
+            "texra.files.included.inputExtensions": {
+              "default": [".txt", ".tex", ".md"],
+              "description": "File extensions to include when searching for input files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 5,
+              "type": "array"
+            },
+            "texra.files.included.mediaExtensions": {
+              "default": [
+                ".png",
+                ".pdf",
+                ".jpeg",
+                ".jpg",
+                ".gif",
+                ".heic",
+                ".heif",
+                ".webp",
+                ".wav",
+                ".m4a",
+                ".mp3",
+                ".aiff",
+                ".aac",
+                ".opus",
+                ".l16",
+                ".alaw",
+                ".mulaw",
+                ".ogg",
+                ".flac"
+              ],
+              "description": "File extensions to include when searching for media files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 4,
+              "type": "array"
+            },
+            "texra.files.included.referenceExtensions": {
+              "default": [".txt", ".tex", ".md", ".bib", ".bbl"],
+              "description": "File extensions to include when searching for reference files",
+              "editPresentation": "multilineText",
+              "items": {
+                "type": "string"
+              },
+              "order": 6,
+              "type": "array"
+            },
+            "texra.maxImageDimension": {
+              "default": 2000,
+              "description": "Maximum dimension (width or height) in pixels for images before resizing. Images larger than this will be resized to fit within this dimension while maintaining aspect ratio.",
+              "maximum": 10000,
+              "minimum": 100,
+              "order": 16,
+              "type": "number"
+            }
+          },
+          "title": "File Handling"
+        },
+        {
+          "properties": {},
+          "title": "LaTeX"
+        },
+        {
+          "properties": {
+            "texra.bib.defaultPath": {
+              "default": "",
+              "description": "Default path to bibliography file (.bib). This is used by bibliography tools when no explicit path is provided. Supports Zotero auto-exported .bib files.",
+              "editPresentation": "singlelineText",
+              "order": 1,
+              "scope": "resource",
+              "type": "string"
+            },
+            "texra.bib.zoteroPort": {
+              "default": 23119,
+              "description": "Port number for Zotero integration (default: 23119). Used by both the Connector API and Better BibTeX JSON-RPC.",
+              "maximum": 65535,
+              "minimum": 1,
+              "order": 2,
+              "scope": "resource",
+              "type": "number"
+            }
+          },
+          "title": "Bibliography"
+        },
+        {
+          "properties": {
+            "texra.latex.latexindentConfig": {
+              "default": "",
+              "description": "Path to latexindent configuration file",
+              "editPresentation": "singlelineText",
+              "order": 3,
+              "type": "string"
+            },
+            "texra.latex.showLatexindentWarning": {
+              "default": false,
+              "description": "Show warning when latexindent is not installed",
+              "order": 2,
+              "type": "boolean"
+            },
+            "texra.latex.texfmtConfig": {
+              "default": "",
+              "description": "Path to tex-fmt configuration file",
+              "editPresentation": "singlelineText",
+              "order": 4,
+              "type": "string"
+            }
+          },
+          "title": "LaTeX Formatter"
+        },
+        {
+          "properties": {
+            "texra.latex.includeWorkspaceInTexinputs": {
+              "default": true,
+              "description": "Include the workspace root directory in TEXINPUTS when compiling TikZ figures",
+              "order": 6,
+              "type": "boolean"
+            },
+            "texra.latex.tikzInputDirectory": {
+              "default": "",
+              "description": "Directory where to look for extra input files when compiling extracted TikZ figures. Absolute path is required. Sets TEXINPUTS environment variable for TikZ compilation.",
+              "editPresentation": "singlelineText",
+              "order": 4,
+              "type": "string"
+            },
+            "texra.latex.tikzTemplate": {
+              "default": "\\documentclass[tikz,border=10pt]{standalone}\n\\usepackage{tikz}\n\\usepackage{pgfplots}\n\\usetikzlibrary{positioning}\n\\usetikzlibrary{patterns}\n\\usetikzlibrary{arrows.meta, shapes.geometric, matrix, calc, decorations.pathreplacing}\n\\usetikzlibrary{shapes, arrows}\n\n\\begin{document}\n{{ tikzpicture }}\n\\end{document}",
+              "description": "Template used for generating standalone documents when extracting and compiling TikZ figures",
+              "editPresentation": "multilineText",
+              "order": 5,
+              "type": "string"
+            }
+          },
+          "title": "TikZ Figures"
+        },
+        {
+          "properties": {
+            "texra.latex.customReplacements": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {},
+              "description": "Custom LaTeX replacements in the format: { 'from': 'to' }. Example: { '\\alpha': '\\al' }",
+              "order": 11,
+              "type": "object"
+            },
+            "texra.latex.customReplacementsRegex": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {},
+              "description": "Custom regex replacements in the format: { 'pattern': 'replacement' }. Use capture groups with $1, $2, etc. Example: { '\\\\section\\{([^}]+)\\}': '\\section{$1}' }",
+              "order": 10,
+              "type": "object"
+            },
+            "texra.latex.enabledReplacements": {
+              "default": [
+                "latex_spacing",
+                "equations",
+                "sections",
+                "latex_forbidden_commands",
+                "characters",
+                "latex_xml",
+                "latex_document",
+                "unicode",
+                "html_entities",
+                "scratchpad_xml",
+                "latexdiff",
+                "gptness"
+              ],
+              "description": "List of enabled non-regex LaTeX replacement categories",
+              "items": {
+                "enum": [
+                  "latex_spacing",
+                  "equations",
+                  "sections",
+                  "latex_forbidden_commands",
+                  "characters",
+                  "latex_xml",
+                  "latex_document",
+                  "unicode",
+                  "html_entities",
+                  "scratchpad_xml",
+                  "latexdiff",
+                  "gptness",
+                  "personal_style",
+                  "max_style"
+                ],
+                "type": "string"
+              },
+              "order": 8,
+              "type": "array"
+            },
+            "texra.latex.enabledReplacementsRegex": {
+              "default": [
+                "inline_math",
+                "parentheses",
+                "latexdiff_markup",
+                "equation_style"
+              ],
+              "description": "List of enabled regex LaTeX replacement categories",
+              "items": {
+                "enum": [
+                  "inline_math",
+                  "parentheses",
+                  "latexdiff_markup",
+                  "equation_style",
+                  "equation_macros",
+                  "max_style_regex"
+                ],
+                "type": "string"
+              },
+              "order": 9,
+              "type": "array"
+            },
+            "texra.latex.wrapCritiqueInAlign": {
+              "default": true,
+              "description": "When enabled, bare \\critique and \\comment commands inside align blocks are wrapped with \\intertext.",
+              "order": 7,
+              "type": "boolean"
+            }
+          },
+          "title": "LaTeX Replacements"
+        },
+        {
+          "properties": {
+            "texra.latexdiff.pictureEnvironments": {
+              "default": "(?:picture|tikzpicture|scope|DIFnomarkup)[\\w\\d*@]*",
+              "description": "Regular expression pattern for environments to be treated as pictures. These environments will be processed as a unit without internal differencing.",
+              "order": 3,
+              "type": "string"
+            },
+            "texra.latexdiff.tempFileLocation": {
+              "default": "sameDirectory",
+              "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
+              "enum": ["sameDirectory", "workspaceTemp"],
+              "enumDescriptions": [
+                "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
+                "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
+              ],
+              "order": 5,
+              "type": "string"
+            }
+          },
+          "title": "LaTeXdiff"
+        },
+        {
+          "properties": {
+            "texra.git.numberOfCommitsToShow": {
+              "default": 20,
+              "description": "Number of recent commits to show in the commit selection dropdown",
+              "maximum": 100,
+              "minimum": 1,
+              "order": 1,
+              "type": "number"
+            }
+          },
+          "title": "Git"
+        },
+        {
+          "properties": {
+            "texra.audio.soxPath": {
+              "default": "",
+              "description": "Path to the SoX executable. Overrides automatic detection.",
+              "scope": "resource",
+              "type": "string"
+            }
+          },
+          "title": "Audio"
+        },
+        {
+          "properties": {
+            "texra.apiKeys.remove": {
+              "markdownDescription": "API keys are now stored securely. [Click here to remove the stored key](command:texra.removeApiKey)",
+              "readOnly": true,
+              "scope": "application",
+              "type": "null"
+            },
+            "texra.apiKeys.set": {
+              "markdownDescription": "API keys are now stored securely. [Click here to set an API key](command:texra.setApiKey)",
+              "readOnly": true,
+              "scope": "application",
+              "type": "null"
+            }
+          },
+          "title": "API Keys"
+        },
+        {
+          "properties": {
+            "texra.debug.saveDebugObjects": {
+              "default": false,
+              "description": "Save message and response objects to JSON files for debugging purposes",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.debug.saveInputPrompt": {
+              "default": false,
+              "description": "Save the final input prompt sent to the model as an XML file for debugging purposes",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.logger.debugMode": {
+              "default": false,
+              "description": "Whether to show verbose debug messages in the logger view",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "Logger"
+        },
+        {
+          "properties": {
+            "texra.toolUse.persistence.enabled": {
+              "default": true,
+              "description": "Persist tool-use conversations across VS Code restarts",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.toolUse.persistence.ttlHours": {
+              "default": 336,
+              "description": "Maximum age (in hours) to keep saved tool-use sessions before automatic cleanup",
+              "minimum": 1,
+              "scope": "resource",
+              "type": "number"
+            },
+            "texra.toolUse.requireBashApproval": {
+              "default": true,
+              "description": "Require user approval before tool-use agents execute bash commands",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "texra.toolUse.requireEditApproval": {
+              "default": true,
+              "description": "Require user approval in a diff view before tool-driven edits modify workspace files",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "Tool Use Agents"
+        },
+        {
+          "properties": {
+            "texra.model.retry.backoffMs": {
+              "default": 1000,
+              "description": "Base backoff delay in milliseconds between retry attempts for model calls",
+              "minimum": 0,
+              "scope": "resource",
+              "type": "number"
+            },
+            "texra.model.retry.maxAttempts": {
+              "default": 0,
+              "description": "Number of automatic retry attempts before surfacing a manual retry option for model calls. Set to 0 for no automatic retries (manual retry button only).",
+              "minimum": 0,
+              "scope": "resource",
+              "type": "number"
+            }
+          },
+          "title": "Model Retries"
+        }
+      ],
+      "keybindings": [
+        {
+          "command": "texra.showMainView",
+          "key": "ctrl+alt+m",
+          "mac": "cmd+option+m",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.showProgressView",
+          "key": "ctrl+alt+p",
+          "mac": "cmd+option+p",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.cleanOutput",
+          "key": "ctrl+alt+shift+c",
+          "mac": "cmd+option+shift+c",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.cleanBuild",
+          "key": "ctrl+alt+shift+b",
+          "mac": "cmd+option+shift+b",
+          "when": "texra.activated"
+        },
+        {
+          "command": "texra.toggleView",
+          "key": "ctrl+alt+t",
+          "mac": "cmd+option+t",
+          "when": "texra.activated && focusedView == texra.mainView"
+        },
+        {
+          "command": "texra.execute",
+          "key": "ctrl+alt+e",
+          "mac": "cmd+option+e",
+          "when": "texra.activated"
+        }
+      ],
+      "menus": {
+        "commandPalette": [
+          {
+            "command": "texra.createSampleProject",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.openGettingStarted",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.runSetupAssistant",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.cleanOutput",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.cleanBuild",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.indentTeX",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.getRecentCommits",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.cloneOverleafProject",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.refreshCommits",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.indentCurrentTeX",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.resumeAgent",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.applyReplacements",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.fixCompilation",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.getTeXCount",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.countPdfPages",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.encodeImageToBase64",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.convertPdfToImages",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.extractFigurePaths",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.extractTikzFigures",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.compileTikzFigures",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.testConnection",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.testAgentLoading",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.loadSpecificAgent",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.downloadArXivSource",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showImportOptions",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.parseXml",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.parseYaml",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.stopAgent",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.execute",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.pack",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.clean",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.createAgentWithAI",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.setApiKey",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.removeApiKey",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.auth.signIn",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.auth.signOut",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.auth.viewProfile",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.testTextEditor",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.showLinterMessages",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.countLinterMessages",
+            "when": "texra.activated && config.texra.logger.debugMode"
+          },
+          {
+            "command": "texra.openDoc",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.mainView.reset",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showAgentHistory",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showMemory",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showModels",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showAgents",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showTools",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showMultiAgent",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.openSettings",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showMainView",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showProgressView",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.toggleView",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.openProgressViewInTab",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showDashboard",
+            "when": "texra.activated"
+          },
+          {
+            "command": "texra.showSettingsView",
+            "when": "texra.activated"
+          }
+        ],
+        "editor/context": [
+          {
+            "command": "texra.cleanOutput",
+            "group": "z_texra@1",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.cleanBuild",
+            "group": "z_texra@2",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          }
+        ],
+        "editor/title": [
+          {
+            "command": "texra.indentCurrentTeX",
+            "group": "navigation",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.applyReplacements",
+            "group": "navigation",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.fixCompilation",
+            "group": "navigation",
+            "when": "texra.activated && editorLangId == latex"
+          },
+          {
+            "command": "texra.getTeXCount",
+            "group": "navigation",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.cleanOutput",
+            "group": "2_texra_housekeeping@1",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.cleanBuild",
+            "group": "2_texra_housekeeping@2",
+            "when": "texra.activated && editorLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          }
+        ],
+        "explorer/context": [
+          {
+            "command": "texra.cleanOutput",
+            "group": "z_texra@1",
+            "when": "texra.activated && resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          },
+          {
+            "command": "texra.cleanBuild",
+            "group": "z_texra@2",
+            "when": "texra.activated && resourceLangId =~ /^latex$|^latex-expl3$|^doctex$/"
+          }
+        ],
+        "view/title": [
+          {
+            "command": "texra.indentTeX",
+            "group": "navigation@1",
+            "when": "texra.activated && view == texra.mainView && texra.activeView == 'progress'"
+          },
+          {
+            "command": "texra.cleanOutput",
+            "group": "navigation@2",
+            "when": "texra.activated && view == texra.mainView && texra.activeView == 'progress'"
+          },
+          {
+            "command": "texra.cleanBuild",
+            "group": "navigation@3",
+            "when": "texra.activated && view == texra.mainView && texra.activeView == 'progress'"
+          },
+          {
+            "command": "texra.showDashboard",
+            "group": "navigation@4",
+            "when": "texra.activated && view == texra.mainView && texra.activeView == 'progress'"
+          },
+          {
+            "command": "texra.mainView.reset",
+            "group": "navigation@0",
+            "when": "texra.activated && view == texra.mainView && texra.activeView != 'progress'"
+          },
+          {
+            "command": "texra.showDashboard",
+            "group": "navigation@1",
+            "when": "texra.activated && view == texra.mainView && texra.activeView != 'progress'"
+          }
+        ]
+      },
+      "views": {
+        "texra": [
+          {
+            "contextualTitle": "TeXRA",
+            "id": "texra.mainView",
+            "name": "TeXRA",
+            "type": "webview"
+          }
+        ]
+      },
+      "viewsContainers": {
+        "activitybar": [
+          {
+            "icon": "resources/logo-128x128.svg",
+            "id": "texra",
+            "title": "TeXRA"
+          }
+        ]
+      },
+      "walkthroughs": [
+        {
+          "description": "Get TeXRA up and running in a few minutes. Connect your account, pick your field, and run your first paper through the orchestrator.",
+          "id": "texra.gettingStarted",
+          "steps": [
+            {
+              "completionEvents": ["onCommand:texra.runSetupAssistant"],
+              "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
+              "id": "texra.gettingStarted.setupAssistant",
+              "media": {
+                "markdown": "resources/walkthroughs/getting-started.md"
+              },
+              "title": "Run the setup assistant agent"
+            },
+            {
+              "completionEvents": ["onCommand:texra.createSampleProject"],
+              "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
+              "id": "texra.gettingStarted.sampleWorkspace",
+              "media": {
+                "markdown": "resources/walkthroughs/getting-started.md"
+              },
+              "title": "Try the sample project"
+            },
+            {
+              "completionEvents": ["onCommand:texra.setApiKey"],
+              "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
+              "id": "texra.gettingStarted.apiKeys",
+              "media": {
+                "altText": "Screenshot of the API key configuration view",
+                "image": "resources/walkthroughs/media/api-key-setup.png"
+              },
+              "title": "Add your API key"
+            },
+            {
+              "completionEvents": ["onCommand:texra.auth.signIn"],
+              "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
+              "id": "texra.gettingStarted.signIn",
+              "media": {
+                "altText": "Screenshot of the sign-in flow",
+                "image": "resources/walkthroughs/media/api-key-setup.png"
+              },
+              "title": "Or just sign in"
+            },
+            {
+              "completionEvents": ["onCommand:texra.showMainView"],
+              "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Reference** -- papers or notes for context (optional)\n- **Auxiliary** -- bib files, style files, preambles (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
+              "id": "texra.gettingStarted.stageFiles",
+              "media": {
+                "altText": "Screenshot of the file selection interface",
+                "image": "resources/walkthroughs/media/file-selection.png"
+              },
+              "title": "Pick your files"
+            },
+            {
+              "description": "We recommend starting with the **orchestrator**. It reads your paper, figures out what needs work, and hands each task to the right agent automatically.\n\nJust pick **orchestrator** from the agent dropdown. You'll also want to choose a model -- bigger models give better results, smaller ones are faster and cheaper.\n\nIf you'd rather do one specific thing (just fix grammar, just draw a diagram), you can pick a single agent instead.",
+              "id": "texra.gettingStarted.agentModel",
+              "media": {
+                "altText": "Screenshot of the agent and model selection UI",
+                "image": "resources/walkthroughs/media/agent-model-selection.png"
+              },
+              "title": "Use the orchestrator"
+            },
+            {
+              "completionEvents": ["onCommand:texra.showDashboard"],
+              "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
+              "id": "texra.gettingStarted.multiAgent",
+              "media": {
+                "altText": "Screenshot of multi-agent team selection",
+                "image": "resources/walkthroughs/media/agent-model-selection.png"
+              },
+              "title": "Pick your field"
+            },
+            {
+              "completionEvents": [
+                "onCommand:texra.extractFigurePaths",
+                "onCommand:texra.extractTikzFigures"
+              ],
+              "description": "Got figures or TikZ diagrams in your paper? Turn on auto-extraction and TeXRA will pull them out before running.\n\nFlip the **Auto-extract figures** and **Auto-extract TikZ** toggles in the main view. Or run them manually:\n\n[Extract figure paths](command:texra.extractFigurePaths) | [Extract TikZ figures](command:texra.extractTikzFigures)",
+              "id": "texra.gettingStarted.autoExtract",
+              "media": {
+                "altText": "Screenshot showing auto-extraction options",
+                "image": "resources/walkthroughs/media/auto-extract-options.png"
+              },
+              "title": "Auto-extract figures (optional)"
+            },
+            {
+              "completionEvents": ["onCommand:texra.execute"],
+              "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
+              "id": "texra.gettingStarted.progress",
+              "media": {
+                "altText": "Screenshot of the Progress view",
+                "image": "resources/walkthroughs/media/texra-progressboard.png"
+              },
+              "title": "Hit Execute!"
+            },
+            {
+              "description": "Your originals are safe -- TeXRA writes edits to new files. Open them up and use VS Code's diff view to see exactly what changed. Accept what you like, ignore what you don't.",
+              "id": "texra.gettingStarted.review",
+              "media": {
+                "altText": "Screenshot of the VS Code diff view",
+                "image": "resources/walkthroughs/media/vscode-compare.png"
+              },
+              "title": "Check what it did"
+            },
+            {
+              "completionEvents": [
+                "onCommand:texra.cleanOutput",
+                "onCommand:texra.cleanBuild",
+                "onCommand:texra.pack",
+                "onCommand:texra.clean"
+              ],
+              "description": "Happy with the results? Use **Pack** $(archive) to save everything to a `History/` folder. Want to start over? Use **Clean** $(trash) to wipe the generated files.\n\nYou'll find both in the Progress toolbar, or right-click any `.tex` file.\n\n[Clean all outputs](command:texra.cleanOutput) | [Clean build files](command:texra.cleanBuild)",
+              "id": "texra.gettingStarted.housekeeping",
+              "media": {
+                "altText": "Screenshot showing pack and clean buttons in the Progress toolbar",
+                "image": "resources/walkthroughs/media/texra-progressboard.png"
+              },
+              "title": "Clean up when you're done"
+            }
+          ],
+          "title": "Get started with TeXRA",
+          "when": "texra.activated"
+        }
+      ]
+    },
+    "icon": "resources/logo-128x128.png"
+  },
+  "manifestAssetReferences": [
+    "resources/logo-128x128.png",
+    "resources/logo-128x128.svg",
+    "resources/walkthroughs/getting-started.md",
+    "resources/walkthroughs/media/agent-model-selection.png",
+    "resources/walkthroughs/media/api-key-setup.png",
+    "resources/walkthroughs/media/auto-extract-options.png",
+    "resources/walkthroughs/media/file-selection.png",
+    "resources/walkthroughs/media/texra-progressboard.png",
+    "resources/walkthroughs/media/vscode-compare.png"
+  ],
+  "requiredPackagedPaths": [
+    "resources/agents",
+    "resources/docs/agent-creation",
+    "resources/examples",
+    "resources/logo-128x128.png",
+    "resources/logo-128x128.svg",
+    "resources/shared/latex_style_rules.txt",
+    "resources/templates",
+    "resources/tool_use_agents",
+    "resources/walkthroughs",
+    "src/common/styles/common.css",
+    "src/progressView/index.html",
+    "src/settingsView/index.html",
+    "src/webview/index.html"
+  ],
+  "requiredVscodeIgnoreLines": [
+    "src/**",
+    "!resources/**",
+    "!src/common/styles/*.css",
+    "!src/progressView/*.html",
+    "!src/settingsView/*.html",
+    "!src/webview/*.html"
+  ]
+}

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -1,0 +1,243 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const snapshotPath = path.join(
+  rootDir,
+  'scripts',
+  'extension-package-invariants.snapshot.json',
+);
+const packagePath = findExtensionPackagePath();
+const packageDir = path.dirname(packagePath);
+const vscodeIgnorePath = path.join(packageDir, '.vscodeignore');
+
+const MANIFEST_KEYS = [
+  'name',
+  'displayName',
+  'description',
+  'publisher',
+  'engines',
+  'categories',
+  'activationEvents',
+  'main',
+  'capabilities',
+  'contributes',
+  'icon',
+];
+
+const REQUIRED_PACKAGED_PATHS = [
+  'resources/agents',
+  'resources/docs/agent-creation',
+  'resources/examples',
+  'resources/logo-128x128.png',
+  'resources/logo-128x128.svg',
+  'resources/shared/latex_style_rules.txt',
+  'resources/templates',
+  'resources/tool_use_agents',
+  'resources/walkthroughs',
+  'src/common/styles/common.css',
+  'src/progressView/index.html',
+  'src/settingsView/index.html',
+  'src/webview/index.html',
+];
+
+const REQUIRED_VSCODEIGNORE_LINES = [
+  'src/**',
+  '!resources/**',
+  '!src/common/styles/*.css',
+  '!src/progressView/*.html',
+  '!src/settingsView/*.html',
+  '!src/webview/*.html',
+];
+
+function findExtensionPackagePath() {
+  const splitPackagePath = path.join(
+    rootDir,
+    'packages',
+    'extension',
+    'package.json',
+  );
+  return fs.existsSync(splitPackagePath)
+    ? splitPackagePath
+    : path.join(rootDir, 'package.json');
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, stable(child)]),
+  );
+}
+
+function extensionManifestSnapshot(packageJson) {
+  return Object.fromEntries(
+    MANIFEST_KEYS.map((key) => [key, stable(packageJson[key])]),
+  );
+}
+
+function collectStringValues(value, results = []) {
+  if (typeof value === 'string') {
+    results.push(value);
+    return results;
+  }
+
+  if (Array.isArray(value)) {
+    for (const child of value) collectStringValues(child, results);
+    return results;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value))
+      collectStringValues(child, results);
+  }
+
+  return results;
+}
+
+function manifestAssetReferences(packageJson) {
+  const manifest = extensionManifestSnapshot(packageJson);
+  return [
+    ...new Set(
+      collectStringValues(manifest).filter(
+        (value) =>
+          value.startsWith('resources/') || value.startsWith('./resources/'),
+      ),
+    ),
+  ].sort();
+}
+
+function assert(condition, message, failures) {
+  if (!condition) failures.push(message);
+}
+
+function relativeExists(relativePath) {
+  return fs.existsSync(path.join(packageDir, relativePath));
+}
+
+function hasFiles(relativeDir) {
+  const absoluteDir = path.join(packageDir, relativeDir);
+  if (!fs.existsSync(absoluteDir)) return false;
+  const entries = fs.readdirSync(absoluteDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const child = path.join(relativeDir, entry.name);
+    if (entry.isFile()) return true;
+    if (entry.isDirectory() && hasFiles(child)) return true;
+  }
+  return false;
+}
+
+function buildSnapshot() {
+  const packageJson = readJson(packagePath);
+  return {
+    manifest: extensionManifestSnapshot(packageJson),
+    manifestAssetReferences: manifestAssetReferences(packageJson),
+    requiredPackagedPaths: REQUIRED_PACKAGED_PATHS,
+    requiredVscodeIgnoreLines: REQUIRED_VSCODEIGNORE_LINES,
+  };
+}
+
+function verifySnapshot(actualSnapshot, failures) {
+  if (!fs.existsSync(snapshotPath)) {
+    failures.push(
+      'Missing scripts/extension-package-invariants.snapshot.json. Run npm run sync:extension-package-invariants.',
+    );
+    return;
+  }
+
+  const expectedSnapshot = readJson(snapshotPath);
+  const actualText = `${JSON.stringify(actualSnapshot, null, 2)}\n`;
+  const expectedText = `${JSON.stringify(expectedSnapshot, null, 2)}\n`;
+
+  assert(
+    actualText === expectedText,
+    [
+      'Extension package invariants are out of sync.',
+      'Run npm run sync:extension-package-invariants and review the manifest/resource changes.',
+    ].join(' '),
+    failures,
+  );
+}
+
+function verifyAssets(snapshot, failures) {
+  for (const assetPath of snapshot.manifestAssetReferences) {
+    assert(
+      relativeExists(assetPath),
+      `Manifest asset is missing: ${assetPath}`,
+      failures,
+    );
+  }
+
+  for (const packagedPath of snapshot.requiredPackagedPaths) {
+    const absolutePath = path.join(packageDir, packagedPath);
+    const exists = fs.existsSync(absolutePath);
+    assert(
+      exists,
+      `Required extension package path is missing: ${packagedPath}`,
+      failures,
+    );
+    if (exists && fs.statSync(absolutePath).isDirectory()) {
+      assert(
+        hasFiles(packagedPath),
+        `Required extension package directory is empty: ${packagedPath}`,
+        failures,
+      );
+    }
+  }
+}
+
+function verifyVscodeIgnore(snapshot, failures) {
+  if (!fs.existsSync(vscodeIgnorePath)) {
+    failures.push(
+      `Missing ${path.relative(rootDir, vscodeIgnorePath)}. Add package ignore rules before moving the extension package.`,
+    );
+    return;
+  }
+
+  const lines = fs
+    .readFileSync(vscodeIgnorePath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim());
+
+  for (const line of snapshot.requiredVscodeIgnoreLines) {
+    assert(
+      lines.includes(line),
+      `.vscodeignore must include ${line} so extension resources stay packaged after the workspace split.`,
+      failures,
+    );
+  }
+}
+
+const update = process.argv.includes('--update');
+const snapshot = buildSnapshot();
+
+if (update) {
+  fs.writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+  console.log('Updated extension package invariant snapshot');
+  process.exit(0);
+}
+
+const failures = [];
+verifySnapshot(snapshot, failures);
+verifyAssets(snapshot, failures);
+verifyVscodeIgnore(snapshot, failures);
+
+if (failures.length > 0) {
+  console.error('Extension package invariant check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Extension package invariants are in sync');


### PR DESCRIPTION
## Summary

- add an extension package invariant verifier for the VS Code manifest and packaged resources
- snapshot the current extension manifest surface so the package-split PR can prove JSON-equivalent contributions
- wire the verifier into CI before the Phase 0 source move

Closes #3388.
Part of #3307.

## Verification

- `npm run format`
- `npm run check:extension-package-invariants`
- `npm run lint`
- `corepack pnpm run workspace:typecheck`
- `corepack pnpm run workspace:build`
- `npm run compile-tests`
- `npm run test:kernel`
- `npm run compile:safe`

Did not run `npm test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate that can fail builds if the VS Code extension manifest, packaged resources, or `.vscodeignore` rules drift, which may block merges until snapshots/rules are updated. Logic is straightforward but touches release/packaging invariants that are easy to inadvertently break during future refactors.
> 
> **Overview**
> **Introduces an extension packaging invariant check** by adding `scripts/verify-extension-package-invariants.mjs` plus a committed `scripts/extension-package-invariants.snapshot.json` that snapshots the extension `package.json` manifest surface and referenced `resources/` assets.
> 
> Adds `sync:extension-package-invariants` / `check:extension-package-invariants` npm scripts and wires `pnpm run check:extension-package-invariants` into the GitHub Actions CI workflow to fail if the snapshot changes, required packaged paths are missing/empty, or required `.vscodeignore` lines are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786a9e628e8832fa5111190a20909e0f470b6c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->