### PR TITLE
ci: review PRD changes in Claude workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,8 +51,10 @@ jobs:
             Use `gh pr diff ${{ github.event.pull_request.number }}` and group changed files into
             VS Code-free zones (`src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`,
             `src/replacement/`, `src/eventBus/`, any webview `frontend/`) vs. VS Code-allowed zones
-            (`src/extension.ts`, `src/commands/`, `src/frontend/`, `src/common/webview/`,
-            `src/common/state/`, `src/auth/`, `src/platform/`, `src/utils/config/`).
+            (`packages/extension/src/extension.ts`, `packages/extension/src/commands/`,
+            `packages/extension/src/frontend/`, `src/common/webview/`, `src/common/state/`,
+            `src/auth/`, `src/platform/`, `src/utils/config/`) vs. PRD/design-doc zones
+            (`prds/**`, `docs/prd/**`).
 
             ---
 
@@ -74,7 +76,8 @@ jobs:
                `vscode.FileType.File|Directory` (use `isFile()` / `isDirectory()` from
                `@common/files/fsEntryType`); raw `process.env`, `os.homedir()`, `fs/promises`,
                `child_process.exec` in agnostic zones (use platform interfaces or `executeCommand`
-               from `@utils/system/execUtils`); `initPlatform()` called outside `src/extension.ts`.
+               from `@utils/system/execUtils`); `initPlatform()` called outside
+               `packages/extension/src/extension.ts`.
 
             2. 🔴 **Security & exec hygiene**. String-interpolated shell commands or
                `child_process.exec` calls (use `executeCommand` with arg arrays). Path joins of
@@ -263,6 +266,10 @@ jobs:
                 (Features / Bug Fixes / rarely Breaking Changes). New public APIs without
                 JSDoc. Module-level doc comments missing for new top-level files. Mathematical
                 or domain-specific docstrings that explain TS syntax instead of meaning.
+                Changed PRDs under `prds/**` or `docs/prd/**` must be reviewed against the
+                implementation plan they describe: flag stale acceptance criteria, missing
+                dependency/ordering updates, claims contradicted by current code, and checklist
+                items marked done without matching artifacts in the diff.
 
             ---
 


### PR DESCRIPTION
Closes #3394.

## Summary

- update the Claude Code Review prompt for the post-package-split extension paths under `packages/extension/src`
- classify `prds/**` and `docs/prd/**` as PRD/design-doc review zones
- add PRD-specific review guidance for stale acceptance criteria, ordering drift, contradicted claims, and checklist items marked done without matching artifacts

## Workflow Note

This PR edits `.github/workflows/claude-code-review.yml`. The Claude Code Review action may fail on this PR itself because the action requires the workflow file at the PR head to match the default branch before it exchanges its token. Once merged, future PRs will use the updated prompt normally.

## Validation

- `git diff --check`

The fresh worktree does not have dependencies installed, so I did not run local Prettier here. The PR `format` workflow is the formatter gate for this workflow-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust the text prompt in the Claude Code Review GitHub workflow, affecting review guidance rather than product/runtime behavior.
> 
> **Overview**
> Updates the Claude Code Review workflow prompt to reflect the post-package-split extension layout by switching VS Code-allowed paths to `packages/extension/src/...` and tightening the guidance around where `initPlatform()` may be called.
> 
> Adds explicit PRD/design-doc review zones (`prds/**`, `docs/prd/**`) and extends the documentation-drift checklist with PRD-specific checks for stale acceptance criteria, ordering/dependency drift, and claims/checklist items that don’t match the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73798c3e9ff9525634db4dc868fb67d2d617c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->