### PR TITLE
chore: guard deep relative imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -156,7 +156,7 @@ function aliasedImportFor(filename, importPath) {
     if (!isSameOrUnderPath(targetPath, aliasEntry.absolutePath)) return false;
 
     const relativePath = path.relative(aliasEntry.absolutePath, targetPath);
-    return Boolean(relativePath) || !aliasEntry.requiresSubpath;
+    return aliasEntry.requiresSubpath === Boolean(relativePath);
   });
 
   if (!matchingAlias) return undefined;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,8 @@ import globals from 'globals';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { loadAliasEntries } from './scripts/aliasUtils.mjs';
+
 const INTERNAL_ALIAS_NAMES = [
   'agent',
   'auth',
@@ -58,6 +60,13 @@ const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
 ]);
 
+const extensionPackageDir = path.join(__dirname, 'packages', 'extension');
+
+const ALIAS_CONFIGS = [
+  aliasConfigForRoot(extensionPackageDir),
+  aliasConfigForRoot(__dirname),
+];
+
 const VSCODE_FREE_ZONE_DIRS = [
   'src/agent',
   'src/model',
@@ -80,6 +89,83 @@ function isUnderDir(filename, dir) {
     !relativePath.startsWith('..') &&
     !path.isAbsolute(relativePath)
   );
+}
+
+function aliasConfigForRoot(rootDir) {
+  return {
+    rootDir,
+    entries: aliasEntriesFromTsconfigPaths(rootDir),
+  };
+}
+
+function aliasEntriesFromTsconfigPaths(rootDir) {
+  const byAliasAndPath = new Map();
+
+  for (const { alias, absolutePath, requiresSubpath } of loadAliasEntries(
+    rootDir,
+  )) {
+    const key = `${alias}\0${absolutePath}\0${requiresSubpath}`;
+    byAliasAndPath.set(key, {
+      alias,
+      requiresSubpath,
+      absolutePath: path.normalize(absolutePath),
+    });
+  }
+
+  return [...byAliasAndPath.values()].sort(
+    (left, right) => right.absolutePath.length - left.absolutePath.length,
+  );
+}
+
+function toPosixPath(importPath) {
+  return importPath.split(path.sep).join('/');
+}
+
+function parentTraversalCount(importPath) {
+  return importPath.split('/').filter((part) => part === '..').length;
+}
+
+function isSameOrUnderPath(childPath, parentPath) {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
+function aliasEntriesForFile(filename) {
+  return (
+    ALIAS_CONFIGS.find(({ rootDir }) => isSameOrUnderPath(filename, rootDir))
+      ?.entries ?? []
+  );
+}
+
+function aliasedImportFor(filename, importPath) {
+  if (
+    typeof importPath !== 'string' ||
+    parentTraversalCount(importPath) < 2 ||
+    !path.isAbsolute(filename)
+  ) {
+    return undefined;
+  }
+
+  const targetPath = path.normalize(
+    path.resolve(path.dirname(filename), importPath),
+  );
+  const matchingAlias = aliasEntriesForFile(filename).find((aliasEntry) => {
+    if (!isSameOrUnderPath(targetPath, aliasEntry.absolutePath)) return false;
+
+    const relativePath = path.relative(aliasEntry.absolutePath, targetPath);
+    return Boolean(relativePath) || !aliasEntry.requiresSubpath;
+  });
+
+  if (!matchingAlias) return undefined;
+  const relativePath = path.relative(matchingAlias.absolutePath, targetPath);
+  const aliasedPath = relativePath
+    ? `${matchingAlias.alias}/${toPosixPath(relativePath)}`
+    : matchingAlias.alias;
+
+  return aliasedPath === importPath ? undefined : aliasedPath;
 }
 
 const localRules = {
@@ -193,6 +279,69 @@ const localRules = {
         };
       },
     },
+    'prefer-alias-for-deep-relative-imports': {
+      meta: {
+        type: 'suggestion',
+        fixable: 'code',
+        docs: {
+          description:
+            'Prefer configured path aliases over deep relative imports.',
+        },
+        messages: {
+          preferAlias:
+            'Use "{{aliasPath}}" instead of deep relative import "{{importPath}}".',
+        },
+        schema: [],
+      },
+      create(context) {
+        function reportIfAliasExists(source) {
+          const importPath = source?.value;
+          const aliasPath = aliasedImportFor(context.filename, importPath);
+
+          if (!aliasPath) return;
+
+          context.report({
+            node: source,
+            messageId: 'preferAlias',
+            data: {
+              aliasPath,
+              importPath,
+            },
+            fix(fixer) {
+              const quote = source.raw?.startsWith("'") ? "'" : '"';
+              return fixer.replaceText(source, `${quote}${aliasPath}${quote}`);
+            },
+          });
+        }
+
+        return {
+          ImportDeclaration(node) {
+            reportIfAliasExists(node.source);
+          },
+          ExportAllDeclaration(node) {
+            reportIfAliasExists(node.source);
+          },
+          ExportNamedDeclaration(node) {
+            reportIfAliasExists(node.source);
+          },
+          TSImportEqualsDeclaration(node) {
+            reportIfAliasExists(node.moduleReference?.expression);
+          },
+          CallExpression(node) {
+            if (
+              node.callee.type === 'Identifier' &&
+              node.callee.name === 'require' &&
+              node.arguments.length === 1
+            ) {
+              reportIfAliasExists(node.arguments[0]);
+            }
+          },
+          ImportExpression(node) {
+            reportIfAliasExists(node.source);
+          },
+        };
+      },
+    },
   },
 };
 
@@ -248,6 +397,7 @@ export default tseslint.config(
       curly: 'off',
       eqeqeq: ['warn', 'always', { null: 'ignore' }],
       'no-throw-literal': 'warn',
+      'local/prefer-alias-for-deep-relative-imports': 'error',
       'import/order': [
         'warn',
         {

--- a/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
+++ b/packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
@@ -71,8 +71,8 @@ import {
 import { codexToolRenderers } from './codexToolTemplates';
 
 // Side-effect import to register <tool-timer> custom element
-import '../../components/ToolTimer';
-import '../../components/TerminalOutput';
+import '@progressView/frontend/components/ToolTimer';
+import '@progressView/frontend/components/TerminalOutput';
 
 /** Known per-tool default timeouts (ms) for display in the running timer. */
 const TOOL_DEFAULT_TIMEOUTS: Record<string, number> = {

--- a/scripts/aliasUtils.mjs
+++ b/scripts/aliasUtils.mjs
@@ -20,6 +20,25 @@ export function loadAliases(rootDir) {
   );
 }
 
+export function loadAliasEntries(rootDir) {
+  const tsconfig = readTsconfig(resolve(rootDir, 'tsconfig.json'));
+
+  return Object.entries(tsconfig.compilerOptions.paths).flatMap(
+    ([key, values]) => {
+      const alias = key.replace('/*', '');
+      const requiresSubpath = key.endsWith('/*');
+
+      return values
+        .filter((pathValue) => !pathValue.endsWith('.d.ts'))
+        .map((pathValue) => ({
+          alias,
+          requiresSubpath,
+          absolutePath: resolve(rootDir, pathValue.replace('/*', '')),
+        }));
+    },
+  );
+}
+
 function readTsconfig(tsconfigPath) {
   const tsconfigText = readFileSync(tsconfigPath, 'utf8');
   return JSON.parse(stripJsonComments(tsconfigText));


### PR DESCRIPTION
Closes #3396.

## Summary
- Add a local ESLint rule that rejects deep relative imports when the same target is covered by a configured tsconfig path alias.
- Source the rule from the existing alias loader instead of duplicating an import map.
- Replace the remaining progress-view component side-effect imports with the existing @progressView alias.

## Validation
- corepack pnpm exec prettier --check eslint.config.mjs packages/extension/src/progressView/frontend/formatters/logFormatters/toolFormatters.ts
- Temporary fixture confirmed the rule reports and can autofix a deep import.
- npm run lint
- npm run compile:safe
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new autofixable ESLint error that can break CI if existing deep relative imports are present or if alias resolution mismatches project roots/tsconfig paths.
> 
> **Overview**
> Adds a new local ESLint rule (`local/prefer-alias-for-deep-relative-imports`) that detects *deep* relative imports (2+ `..` segments) and auto-fixes them to the appropriate `tsconfig` path alias, sourcing alias mappings via a new `loadAliasEntries()` helper.
> 
> Updates alias utility code to expose per-alias entry metadata (including whether an alias requires a subpath) and switches the remaining progress-view side-effect component imports to use the existing `@progressView/...` alias instead of relative paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d5d2cc533b9e5162bc7e0e4a0a4a109fcb8b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->