### PR TITLE
fix: clean activation warning sources

### DIFF
--- a/packages/extension/esbuild.config.mjs
+++ b/packages/extension/esbuild.config.mjs
@@ -122,8 +122,14 @@ const extensionConfig = {
   // Polyfill import.meta.url for ESM-only dependencies (e.g. @openai/codex-sdk)
   // bundled into CJS. Without this, esbuild replaces import.meta with {} and
   // calls like createRequire(import.meta.url) throw at runtime.
+  // The extension host bundle targets Node. Keep unqualified browser
+  // `navigator` probes inside bundled dependencies on the Node path instead of
+  // touching VS Code's deprecated extension-host navigator shim. Webview
+  // bundles are built separately and keep the real browser navigator.
   banner: {
-    js: `"use strict"; var importMetaUrl = require("url").pathToFileURL(__filename).href;`,
+    js:
+      `"use strict"; var navigator = undefined; ` +
+      `var importMetaUrl = require("url").pathToFileURL(__filename).href;`,
   },
   define: {
     'process.env.NODE_ENV': production ? '"production"' : '"development"',

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -334,7 +334,7 @@ export async function activate(context: vscode.ExtensionContext) {
             `Setup config adapter is scoped to texra.* keys; refused: ${key}`,
           );
         }
-        return vscode.workspace.getConfiguration().get(key);
+        return vscode.workspace.getConfiguration(undefined, null).get(key);
       },
       update: async (key, value, target) => {
         if (!key.startsWith('texra.')) {
@@ -346,7 +346,9 @@ export async function activate(context: vscode.ExtensionContext) {
           target === 'workspace'
             ? vscode.ConfigurationTarget.Workspace
             : vscode.ConfigurationTarget.Global;
-        await vscode.workspace.getConfiguration().update(key, value, scope);
+        await vscode.workspace
+          .getConfiguration(undefined, null)
+          .update(key, value, scope);
       },
     },
     terminal: {

--- a/packages/extension/src/frontend/vscode/vscodeConfig.ts
+++ b/packages/extension/src/frontend/vscode/vscodeConfig.ts
@@ -20,8 +20,14 @@ function configKeys(key: string): string[] {
   return [key, `texra.${key}`];
 }
 
+function workspaceConfiguration(
+  section?: string,
+): vscode.WorkspaceConfiguration {
+  return vscode.workspace.getConfiguration(section, null);
+}
+
 function inspectKey<T>(key: string): VscodeConfigInspection<T> | undefined {
-  return vscode.workspace.getConfiguration().inspect<T>(key);
+  return workspaceConfiguration().inspect<T>(key);
 }
 
 function toConfigurationTarget(
@@ -55,15 +61,15 @@ export class VscodeConfigProvider implements ConfigProvider {
 
     // Try multiple namespaces in order of priority (using === undefined to
     // preserve null values).
-    let result: unknown = vscode.workspace
-      .getConfiguration(parts[0])
-      .get(parts.slice(1).join('.'));
+    let result: unknown = workspaceConfiguration(parts[0]).get(
+      parts.slice(1).join('.'),
+    );
 
     if (result === undefined) {
-      result = vscode.workspace.getConfiguration('texra').get(key);
+      result = workspaceConfiguration('texra').get(key);
     }
     if (result === undefined) {
-      result = vscode.workspace.getConfiguration().get(`texra.${key}`);
+      result = workspaceConfiguration().get(`texra.${key}`);
     }
 
     return result !== undefined ? (result as T) : (defaultValue as T);
@@ -76,9 +82,11 @@ export class VscodeConfigProvider implements ConfigProvider {
   ): Promise<void> {
     // `configUtils.updateConfig` owns prefix policy, including explicit
     // `prefix: false` writes. Preserve the exact key passed to this adapter.
-    await vscode.workspace
-      .getConfiguration()
-      .update(key, value, toConfigurationTarget(target));
+    await workspaceConfiguration().update(
+      key,
+      value,
+      toConfigurationTarget(target),
+    );
   }
 
   inspect<T = unknown>(key: string): ConfigInspection<T> | undefined {

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -257,7 +257,7 @@ const modelProvidersSet = new Set<string>(MODEL_PROVIDERS_ORDER);
 
 /**
  * Reverse of LEVEL_TO_EFFORT: maps ReasoningEffort enum values → UI level strings.
- * Derived from the canonical map in ModelFactory so there's one source of truth.
+ * Derived from the canonical map in reasoningEffort.ts so there's one source of truth.
  * Efforts not in LEVEL_TO_EFFORT (e.g. XHIGH) intentionally have no entry —
  * the UI will show a plain "Default" label instead of lying about the level.
  */

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -33,7 +33,7 @@ import {
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
 import { getHelperModelName } from '@agent/runtime/helperModel';
-import { LEVEL_TO_EFFORT } from '@agent/runtime/ModelFactory';
+import { LEVEL_TO_EFFORT } from '@agent/runtime/reasoningEffort';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { FREE_TIER, ULTRA_TIER, MAX_TIER } from '@auth/config';

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -1,4 +1,4 @@
-import { ModelProvider, ReasoningEffort, type ModelConfig } from 'llm-zoo';
+import { ModelProvider, type ModelConfig } from 'llm-zoo';
 import { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { ModelHandlerAnthropic } from '@agent/modelHandlers/modelHandlerAnthropic';
 import { ModelHandlerGoogleGenAI } from '@agent/modelHandlers/modelHandlerGoogleGenAI';
@@ -18,6 +18,7 @@ import { getGlobalState } from '@agent/core/stateStore';
 import { getConfig } from '@agent/core/config';
 import { GlobalStateKey } from '@common/state';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
+import { LEVEL_TO_EFFORT } from './reasoningEffort';
 
 const CHANNEL = 'ModelFactory';
 logger.initialize(CHANNEL);
@@ -40,17 +41,6 @@ const PROVIDER_HANDLERS: Record<
   [ModelProvider.GLM]: ModelHandlerGLM,
   [ModelProvider.OTHERS]: ModelHandlerOpenRouterNative,
   [ModelProvider.COPILOT]: null,
-};
-
-/**
- * Single source of truth: user-facing reasoning level strings → ReasoningEffort enum.
- * The reverse mapping (for the settings UI) is derived from this in SettingsViewMessageHandler.
- */
-export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
-  none: ReasoningEffort.NONE,
-  low: ReasoningEffort.LOW,
-  medium: ReasoningEffort.MEDIUM,
-  high: ReasoningEffort.HIGH,
 };
 
 /**

--- a/src/agent/runtime/reasoningEffort.ts
+++ b/src/agent/runtime/reasoningEffort.ts
@@ -1,0 +1,12 @@
+import { ReasoningEffort } from 'llm-zoo';
+
+/**
+ * Single source of truth: user-facing reasoning level strings -> ReasoningEffort enum.
+ * The reverse mapping for settings UI controls is derived from this record.
+ */
+export const LEVEL_TO_EFFORT: Readonly<Record<string, ReasoningEffort>> = {
+  none: ReasoningEffort.NONE,
+  low: ReasoningEffort.LOW,
+  medium: ReasoningEffort.MEDIUM,
+  high: ReasoningEffort.HIGH,
+};

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -95,13 +95,16 @@ export interface ExternalToolDef {
 async function fetchLocalhost(
   url: string,
   timeoutMs = ZOTERO_PROBE_TIMEOUT_MS,
-): Promise<Response> {
+): Promise<Pick<Response, 'ok' | 'status'>> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response | undefined;
   try {
-    return await fetch(url, { signal: controller.signal });
+    response = await fetch(url, { signal: controller.signal });
+    return { ok: response.ok, status: response.status };
   } finally {
     clearTimeout(timeout);
+    await response?.body?.cancel().catch(() => undefined);
   }
 }
 

--- a/src/tools/externalToolDefs.ts
+++ b/src/tools/externalToolDefs.ts
@@ -11,9 +11,6 @@
  *   - {@link @settingsView/utils/toolDashboardData} — reads everything for the UI
  */
 
-// Third-party imports
-import axios from 'axios';
-
 // Local imports
 import type { ToolCategory } from '@shared/schemas/settingsViewMessages';
 import type { RegisteredToolName } from '@tools/registry';
@@ -29,6 +26,7 @@ import { checkToolInstalled } from '@utils/system/toolUtils';
 import { isWSL } from '@utils/system/wslDetect';
 
 const LEAN4_EXT_ID = 'leanprover.lean4';
+const ZOTERO_PROBE_TIMEOUT_MS = 2000;
 
 /**
  * Pluggable check for VS Code extension availability.
@@ -94,16 +92,25 @@ export interface ExternalToolDef {
 // Zotero probe helpers
 // ============================================================
 
+async function fetchLocalhost(
+  url: string,
+  timeoutMs = ZOTERO_PROBE_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /** Probe the Zotero connector endpoint (responds if Zotero is running). */
 async function probeZoteroConnector(port: number): Promise<boolean> {
   try {
-    await axios.get(`http://127.0.0.1:${port}/connector/ping`, {
-      timeout: 2000,
-    });
+    await fetchLocalhost(`http://127.0.0.1:${port}/connector/ping`);
     return true;
-  } catch (error: unknown) {
-    // Any HTTP response means Zotero is running
-    if (axios.isAxiosError(error) && error.response) return true;
+  } catch {
     return false;
   }
 }
@@ -111,15 +118,11 @@ async function probeZoteroConnector(port: number): Promise<boolean> {
 /** Probe the Better BibTeX JSON-RPC endpoint. */
 async function probeZoteroBbt(port: number): Promise<boolean> {
   try {
-    await axios.get(`http://127.0.0.1:${port}/better-bibtex/json-rpc`, {
-      timeout: 2000,
-    });
-    return true;
-  } catch (error: unknown) {
-    // 405 = server running but expects POST — BBT is available
-    if (axios.isAxiosError(error) && error.response?.status === 405) {
-      return true;
-    }
+    const response = await fetchLocalhost(
+      `http://127.0.0.1:${port}/better-bibtex/json-rpc`,
+    );
+    return response.ok || response.status === 405;
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- read VS Code configuration with an explicit `null` scope in the VS Code config adapters
- keep Node extension-host dependency probes off VS Code's deprecated `navigator` shim without touching webview bundles
- remove activation-time Axios loading from external tool metadata and decouple settings reasoning constants from `ModelFactory`

Closes #3399. Closes #3400. Refs #3389. Follow-up remains #3402 for `files.watcherExclude`.

## Validation

- `corepack pnpm exec prettier --check packages/extension/esbuild.config.mjs src/tools/externalToolDefs.ts src/agent/runtime/ModelFactory.ts src/agent/runtime/reasoningEffort.ts packages/extension/src/settingsView/SettingsViewMessageHandler.ts packages/extension/src/frontend/vscode/vscodeConfig.ts packages/extension/src/extension.ts`
- `npm run lint`
- `npm run compile:safe`
- isolated VS Code 1.117.0 Extension Development Host activation from `packages/extension`; log includes `TeXRA extension activated` and no `PendingMigrationError`, no `navigator is now a global`, and no `texra.*` resource-scoped configuration warnings

## Remaining Warning

The same smoke still reports `files.watcherExclude` resource-scope warnings. That is tracked separately in #3402 so this PR stays focused on the activation warnings identified by #3399 and #3400.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes extension-host bundling globals, VS Code configuration scoping, and Zotero probe networking code, which could affect activation/runtime behavior and tool availability detection.
> 
> **Overview**
> Reduces VS Code activation-time warnings by reading/updating configuration via `getConfiguration(..., null)` (avoiding resource-scoped lookups) and by ensuring the extension-host bundle keeps browser `navigator` probes on the Node path (esbuild banner sets `navigator = undefined`).
> 
> Decouples reasoning-level constants from `ModelFactory` into a new `reasoningEffort.ts`, updates Settings UI to import from it, and removes activation-time Axios usage by switching Zotero availability probes to a lightweight `fetch` + timeout helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510b6bb475132c3c18131fc41a9ed745fb540427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->