### PR TITLE
fix: avoid external recursive agent watchers

### DIFF
--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -1,4 +1,5 @@
 // Standard library imports
+import * as fs from 'fs/promises';
 import * as path from 'path';
 
 // Third-party imports
@@ -44,11 +45,13 @@ export class AgentDirectoryManager {
   private directoryService: AgentDirectoryService | undefined;
   private watcherDisposables: vscode.Disposable[] = [];
   private watcherSubscriptions = new Set<AgentDirectoryWatcherSubscription>();
+  private externalWatcherDirectoryPaths = new Set<string>();
   private watcherDirectories: Array<{
     directory: string;
     source: AgentSource;
   }> | null = null;
   private watcherSetupPromise: Promise<void> | null = null;
+  private watcherRebuildRequested = false;
 
   initialize(context: vscode.ExtensionContext): void {
     this.context = context;
@@ -184,17 +187,19 @@ export class AgentDirectoryManager {
   }
 
   private async ensureAgentWatchers(): Promise<void> {
-    // Wait for any in-progress setup to complete
     if (this.watcherSetupPromise) {
       await this.watcherSetupPromise;
-      return; // After waiting, watchers are set up - no need to rebuild
+      if (this.watcherRebuildRequested) {
+        await this.ensureAgentWatchers();
+      }
+      return;
     }
 
-    // Set promise immediately to prevent concurrent callers from proceeding
     let resolveSetup: () => void;
     this.watcherSetupPromise = new Promise((resolve) => {
       resolveSetup = resolve;
     });
+    this.watcherRebuildRequested = false;
 
     try {
       const directories = await this.getAllLocal();
@@ -210,6 +215,10 @@ export class AgentDirectoryManager {
       resolveSetup!();
       this.watcherSetupPromise = null;
     }
+
+    if (this.watcherRebuildRequested) {
+      await this.ensureAgentWatchers();
+    }
   }
 
   private async buildAgentWatchers(
@@ -218,6 +227,7 @@ export class AgentDirectoryManager {
     // Dispose old watchers
     this.watcherDisposables.forEach((watcher) => watcher.dispose());
     this.watcherDisposables = [];
+    this.externalWatcherDirectoryPaths.clear();
     this.watcherDirectories = directories;
 
     const watchedDirectories: string[] = [];
@@ -259,7 +269,10 @@ export class AgentDirectoryManager {
     entry: { directory: string; source: AgentSource },
     directoryUri: vscode.Uri,
     pattern: string,
-    onCreateOrDelete?: () => void,
+    onCreateOrDelete?: (
+      type: 'create' | 'delete',
+      uri: vscode.Uri,
+    ) => void | Promise<void>,
   ): void {
     const watcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(directoryUri, pattern),
@@ -271,12 +284,12 @@ export class AgentDirectoryManager {
 
     watcher.onDidCreate((uri) => {
       this.dispatchAgentEvent(entry, 'create', uri);
-      onCreateOrDelete?.();
+      void onCreateOrDelete?.('create', uri);
     });
     watcher.onDidChange((uri) => this.dispatchAgentEvent(entry, 'change', uri));
     watcher.onDidDelete((uri) => {
       this.dispatchAgentEvent(entry, 'delete', uri);
-      onCreateOrDelete?.();
+      void onCreateOrDelete?.('delete', uri);
     });
   }
 
@@ -287,36 +300,94 @@ export class AgentDirectoryManager {
     const directories = await this.collectDirectoryUris(directoryUri);
 
     for (const dirUri of directories) {
-      this.watchDirectoryTree(entry, dirUri, '*', () => {
-        this.watcherDirectories = null;
-        void this.ensureAgentWatchers();
-      });
+      this.externalWatcherDirectoryPaths.add(
+        this.normalizeFsPath(dirUri.fsPath),
+      );
+      this.watchDirectoryTree(entry, dirUri, '*', (type, uri) =>
+        this.handleExternalDirectoryTreeChange(type, uri),
+      );
     }
   }
 
   private async collectDirectoryUris(root: vscode.Uri): Promise<vscode.Uri[]> {
-    const directories: vscode.Uri[] = [root];
+    const directories: vscode.Uri[] = [];
+    const pending: vscode.Uri[] = [root];
+    const visitedRealPaths = new Set<string>();
 
-    for (let i = 0; i < directories.length; i++) {
+    for (let i = 0; i < pending.length; i++) {
+      const uri = pending[i];
+      const realPath = await this.realDirectoryPath(uri);
+      if (visitedRealPaths.has(realPath)) {
+        continue;
+      }
+
+      visitedRealPaths.add(realPath);
+      directories.push(uri);
+
       let entries: [string, vscode.FileType][];
       try {
-        entries = await vscode.workspace.fs.readDirectory(directories[i]);
+        entries = await vscode.workspace.fs.readDirectory(uri);
       } catch (error) {
         logger.debug(
           CHANNEL,
-          `Unable to scan agent directory ${directories[i].fsPath}: ${error instanceof Error ? error.message : String(error)}`,
+          `Unable to scan agent directory ${uri.fsPath}: ${error instanceof Error ? error.message : String(error)}`,
         );
         continue;
       }
 
       for (const [name, type] of entries) {
-        if (type === vscode.FileType.Directory) {
-          directories.push(vscode.Uri.joinPath(directories[i], name));
+        if ((type & vscode.FileType.Directory) !== 0) {
+          pending.push(vscode.Uri.joinPath(uri, name));
         }
       }
     }
 
     return directories;
+  }
+
+  private async handleExternalDirectoryTreeChange(
+    type: 'create' | 'delete',
+    uri: vscode.Uri,
+  ): Promise<void> {
+    if (type === 'create') {
+      if (await this.isDirectoryUri(uri)) {
+        this.requestAgentWatcherRebuild();
+      }
+      return;
+    }
+
+    if (
+      this.externalWatcherDirectoryPaths.has(this.normalizeFsPath(uri.fsPath))
+    ) {
+      this.requestAgentWatcherRebuild();
+    }
+  }
+
+  private requestAgentWatcherRebuild(): void {
+    this.watcherDirectories = null;
+    this.watcherRebuildRequested = true;
+    void this.ensureAgentWatchers();
+  }
+
+  private async isDirectoryUri(uri: vscode.Uri): Promise<boolean> {
+    try {
+      const stat = await vscode.workspace.fs.stat(uri);
+      return (stat.type & vscode.FileType.Directory) !== 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private async realDirectoryPath(uri: vscode.Uri): Promise<string> {
+    try {
+      return this.normalizeFsPath(await fs.realpath(uri.fsPath));
+    } catch {
+      return this.normalizeFsPath(uri.fsPath);
+    }
+  }
+
+  private normalizeFsPath(fsPath: string): string {
+    return path.resolve(fsPath);
   }
 
   private dispatchAgentEvent(
@@ -350,8 +421,10 @@ export class AgentDirectoryManager {
   private disposeAgentWatchers(): void {
     this.watcherDisposables.forEach((watcher) => watcher.dispose());
     this.watcherDisposables = [];
+    this.externalWatcherDirectoryPaths.clear();
     this.watcherDirectories = null;
     this.watcherSetupPromise = null;
+    this.watcherRebuildRequested = false;
   }
 }
 

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -15,6 +15,7 @@ import type { AgentSource } from '@agent/index';
 import { showLoggedMessageWithDocs } from '@common/errors';
 import { GlobalStateKey, globalSM } from '@common/state';
 import * as logger from '@logger/logUtils';
+import { AGENT_SOURCE } from '@shared/schemas/agent';
 import { AbsoluteFS } from '@utils/files';
 
 const CHANNEL = 'AgentLoad';
@@ -150,7 +151,7 @@ export class AgentDirectoryManager {
     };
 
     this.watcherSubscriptions.add(subscription);
-    void this.ensureAgentWatchers();
+    this.scheduleAgentWatcherSetup();
 
     return {
       dispose: () => {
@@ -243,7 +244,7 @@ export class AgentDirectoryManager {
         continue;
       }
 
-      if (entry.source !== 'custom') {
+      if (entry.source !== AGENT_SOURCE.CUSTOM) {
         skippedDirectories.push(entry.directory);
         continue;
       }
@@ -366,7 +367,16 @@ export class AgentDirectoryManager {
   private requestAgentWatcherRebuild(): void {
     this.watcherDirectories = null;
     this.watcherRebuildRequested = true;
-    void this.ensureAgentWatchers();
+    this.scheduleAgentWatcherSetup();
+  }
+
+  private scheduleAgentWatcherSetup(): void {
+    void this.ensureAgentWatchers().catch((error) => {
+      logger.error(
+        CHANNEL,
+        `Failed to refresh agent directory watchers: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
   }
 
   private async isDirectoryUri(uri: vscode.Uri): Promise<boolean> {
@@ -380,7 +390,7 @@ export class AgentDirectoryManager {
 
   private async realDirectoryPath(uri: vscode.Uri): Promise<string> {
     try {
-      return this.normalizeFsPath(await fs.realpath(uri.fsPath));
+      return await fs.realpath(uri.fsPath);
     } catch {
       return this.normalizeFsPath(uri.fsPath);
     }

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -42,7 +42,7 @@ interface AgentDirectoryWatcherSubscription {
 export class AgentDirectoryManager {
   private context: vscode.ExtensionContext | undefined;
   private directoryService: AgentDirectoryService | undefined;
-  private watcherDisposables: vscode.FileSystemWatcher[] = [];
+  private watcherDisposables: vscode.Disposable[] = [];
   private watcherSubscriptions = new Set<AgentDirectoryWatcherSubscription>();
   private watcherDirectories: Array<{
     directory: string;
@@ -205,45 +205,118 @@ export class AgentDirectoryManager {
         return;
       }
 
-      this.buildAgentWatchers(directories);
+      await this.buildAgentWatchers(directories);
     } finally {
       resolveSetup!();
       this.watcherSetupPromise = null;
     }
   }
 
-  private buildAgentWatchers(
+  private async buildAgentWatchers(
     directories: Array<{ directory: string; source: AgentSource }>,
-  ): void {
+  ): Promise<void> {
     // Dispose old watchers
     this.watcherDisposables.forEach((watcher) => watcher.dispose());
     this.watcherDisposables = [];
     this.watcherDirectories = directories;
 
+    const watchedDirectories: string[] = [];
+    const skippedDirectories: string[] = [];
+
     for (const entry of directories) {
-      const pattern = new vscode.RelativePattern(entry.directory, '**/*');
-      const watcher = vscode.workspace.createFileSystemWatcher(
-        pattern,
-        false,
-        false,
-        false,
-      );
-      this.watcherDisposables.push(watcher);
+      const directoryUri = vscode.Uri.file(entry.directory);
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(directoryUri);
 
-      const dispatch = (type: AgentDirectoryEventType) => (uri: vscode.Uri) =>
-        this.dispatchAgentEvent(entry, type, uri);
+      if (workspaceFolder) {
+        this.watchDirectoryTree(entry, directoryUri, '**/*');
+        watchedDirectories.push(entry.directory);
+        continue;
+      }
 
-      watcher.onDidCreate(dispatch('create'));
-      watcher.onDidChange(dispatch('change'));
-      watcher.onDidDelete(dispatch('delete'));
+      if (entry.source !== 'custom') {
+        skippedDirectories.push(entry.directory);
+        continue;
+      }
+
+      await this.watchExternalCustomDirectory(entry, directoryUri);
+      watchedDirectories.push(entry.directory);
     }
 
     logger.info(
       CHANNEL,
-      `Agent directory watchers enabled: ${directories
-        .map((dir) => dir.directory)
-        .join(', ')}`,
+      `Agent directory watchers enabled: ${watchedDirectories.join(', ')}`,
     );
+
+    if (skippedDirectories.length > 0) {
+      logger.debug(
+        CHANNEL,
+        `Skipped external built-in agent directory watchers: ${skippedDirectories.join(', ')}`,
+      );
+    }
+  }
+
+  private watchDirectoryTree(
+    entry: { directory: string; source: AgentSource },
+    directoryUri: vscode.Uri,
+    pattern: string,
+    onCreateOrDelete?: () => void,
+  ): void {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(directoryUri, pattern),
+      false,
+      false,
+      false,
+    );
+    this.watcherDisposables.push(watcher);
+
+    watcher.onDidCreate((uri) => {
+      this.dispatchAgentEvent(entry, 'create', uri);
+      onCreateOrDelete?.();
+    });
+    watcher.onDidChange((uri) => this.dispatchAgentEvent(entry, 'change', uri));
+    watcher.onDidDelete((uri) => {
+      this.dispatchAgentEvent(entry, 'delete', uri);
+      onCreateOrDelete?.();
+    });
+  }
+
+  private async watchExternalCustomDirectory(
+    entry: { directory: string; source: AgentSource },
+    directoryUri: vscode.Uri,
+  ): Promise<void> {
+    const directories = await this.collectDirectoryUris(directoryUri);
+
+    for (const dirUri of directories) {
+      this.watchDirectoryTree(entry, dirUri, '*', () => {
+        this.watcherDirectories = null;
+        void this.ensureAgentWatchers();
+      });
+    }
+  }
+
+  private async collectDirectoryUris(root: vscode.Uri): Promise<vscode.Uri[]> {
+    const directories: vscode.Uri[] = [root];
+
+    for (let i = 0; i < directories.length; i++) {
+      let entries: [string, vscode.FileType][];
+      try {
+        entries = await vscode.workspace.fs.readDirectory(directories[i]);
+      } catch (error) {
+        logger.debug(
+          CHANNEL,
+          `Unable to scan agent directory ${directories[i].fsPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        continue;
+      }
+
+      for (const [name, type] of entries) {
+        if (type === vscode.FileType.Directory) {
+          directories.push(vscode.Uri.joinPath(directories[i], name));
+        }
+      }
+    }
+
+    return directories;
   }
 
   private dispatchAgentEvent(


### PR DESCRIPTION
## Summary

- avoid recursive VS Code file-system watchers for agent directories outside the opened workspace
- skip runtime watchers for external built-in agent directories, which are synced during activation and are not edited live
- preserve live custom-agent refreshes outside the workspace with shallow per-directory watchers that rebuild when directory shape changes

## Validation

- `corepack pnpm exec prettier --check packages/extension/src/frontend/agents/AgentDirectoryManager.ts`
- `npm run lint`
- `npm run compile:safe`
- isolated VS Code Extension Development Host smoke with `--extensionDevelopmentPath packages/extension`; log grep found no `files.watcherExclude` matches

Closes #3402.
Refs #3389.

Note: the same smoke on this branch still shows the older navigator/config activation warnings because #3403 has not merged into `main` yet; this PR removes the remaining watcher-specific warning path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes VS Code filesystem-watcher strategy for agent directories, which can affect live refresh behavior for custom/built-in agents especially when directories are outside the workspace. Risk is moderate due to new async scanning/rebuild logic and path handling (realpath/normalization) that could miss or over-trigger refreshes on some platforms.
> 
> **Overview**
> Updates agent directory watching to **avoid recursive watchers for folders outside the open workspace**.
> 
> Workspace-contained agent dirs still use a recursive `**/*` watcher, but external dirs now **skip built-in sources** and only support external *custom* agents by creating shallow per-directory watchers (scanning subdirectories up front, tracking real paths, and rebuilding watchers when directory structure changes). Adds a scheduled/re-entrant watcher setup flow with explicit rebuild requests and improved logging for watched vs skipped directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98d47ee7c76d868bb25a35a30b6b8cdabfbca1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->