### PR TITLE
ci: sharpen PRD review guidance

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,7 +54,9 @@ jobs:
             (`packages/extension/src/extension.ts`, `packages/extension/src/commands/`,
             `packages/extension/src/frontend/`, `src/common/webview/`, `src/common/state/`,
             `src/auth/`, `src/platform/`, `src/utils/config/`) vs. PRD/design-doc zones
-            (`prds/**`, `docs/prd/**`).
+            (`prds/**`, `docs/prd/**`, `docs/**`, `*.md`). For PRD/design-doc-only diffs, make the
+            PRD itself the reviewed product: fact-check claims against the current tree and avoid
+            filling the review with code categories that do not apply.
 
             ---
 
@@ -286,6 +288,9 @@ jobs:
             - Prefer 3 grounded findings over 10 generic ones. A "no issues found" review on
               this repo is almost always wrong; if the diff genuinely is clean, say what you
               checked and why each category was a no-op.
+            - For PRD/design-doc diffs, factual drift, impossible sequencing, stale file paths,
+              or acceptance criteria contradicted by current repository state are
+              `Requires changes`, not advisory documentation nits.
 
             **Rendering style for the posted comment (this is what the author sees):**
             Default to calm, declarative prose. The GitHub review status


### PR DESCRIPTION
## Summary
- make PRD/design-doc-only diffs an explicit review mode in Claude Code Review
- classify factual PRD drift, stale paths, and impossible sequencing as review-blocking
- link the workflow cleanup to #3405

Closes #3405.

## Verification
- `/Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/prettier --check .github/workflows/claude-code-review.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the GitHub Actions review prompt text and do not affect build, runtime, or production code paths.
> 
> **Overview**
> Clarifies the `claude-code-review.yml` prompt to explicitly classify PRD/design-doc-only diffs (now including `docs/**` and `*.md`) as their own review mode, directing the reviewer to fact-check claims against the current repo and avoid irrelevant code-category checks.
> 
> Tightens verdict guidance by requiring `Requires changes` for PRD/design-doc factual drift, stale file paths, impossible sequencing, or acceptance criteria contradicted by the current tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133095663c841ef19a3ca1d3add688dd574a79a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->