### PR TITLE
test: cover desktop platform adapters

### DIFF
--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts
@@ -1,0 +1,166 @@
+// Node imports
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
+
+interface JsonStore {
+  get<T>(key: string, defaultValue?: T): T;
+  set(key: string, value: unknown): Promise<void>;
+  snapshot(): Record<string, unknown>;
+}
+
+interface JsonStoreModule {
+  JsonStore: {
+    open(filePath: string): Promise<JsonStore>;
+  };
+}
+
+interface ElectronStateStore {
+  get<T>(key: string, defaultValue?: T): T;
+  update(key: string, value: unknown): PromiseLike<void>;
+}
+
+interface ElectronStateModule {
+  ElectronStateStore: new (store: JsonStore) => ElectronStateStore;
+}
+
+interface ElectronStorageProvider {
+  getGlobalStoragePath(): string;
+  getStoragePath(): string;
+}
+
+interface ElectronStorageModule {
+  ElectronStorageProvider: new (
+    userDataPath: string,
+    workspacePath: string | undefined,
+  ) => ElectronStorageProvider;
+}
+
+interface ElectronSecrets {
+  delete(key: string): Promise<void>;
+  get(key: string): Promise<string | undefined>;
+  set(key: string, value: string): Promise<void>;
+}
+
+interface ElectronSecretsModule {
+  ElectronSecrets: new (store: JsonStore) => ElectronSecrets;
+}
+
+async function loadJsonStore(): Promise<JsonStoreModule['JsonStore']> {
+  const { JsonStore } =
+    await loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts');
+  return JsonStore;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+describe('desktop platform adapters', () => {
+  let tempDir: string | undefined;
+  const originalEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function makeTempDir(prefix: string): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), prefix));
+    return tempDir;
+  }
+
+  it('persists state values and deletes undefined updates through JsonStore', async () => {
+    const [{ JsonStore }, { ElectronStateStore }] = await Promise.all([
+      loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts'),
+      loadDesktopPlatformModule<ElectronStateModule>('electronState.ts'),
+    ]);
+    const root = await makeTempDir('texra-electron-state-');
+    const store = await JsonStore.open(join(root, 'state.json'));
+    const state = new ElectronStateStore(store);
+
+    await state.update('session', { active: true });
+    await state.update('cleared', 'value');
+    await state.update('cleared', undefined);
+
+    expect(state.get('session')).toEqual({ active: true });
+    expect(state.get('missing', 'fallback')).toBe('fallback');
+    expect(store.snapshot()).toEqual({ session: { active: true } });
+  });
+
+  it('creates stable global and workspace storage roots under userData', async () => {
+    const { ElectronStorageProvider } =
+      await loadDesktopPlatformModule<ElectronStorageModule>(
+        'electronStorage.ts',
+      );
+    const root = await makeTempDir('texra-electron-storage-');
+
+    const first = new ElectronStorageProvider(root, '/workspace/a');
+    const same = new ElectronStorageProvider(root, '/workspace/a');
+    const other = new ElectronStorageProvider(root, '/workspace/b');
+    const noWorkspace = new ElectronStorageProvider(root, undefined);
+
+    expect(first.getGlobalStoragePath()).toBe(join(root, 'global-storage'));
+    expect(first.getStoragePath()).toBe(same.getStoragePath());
+    expect(first.getStoragePath()).not.toBe(other.getStoragePath());
+    expect(noWorkspace.getStoragePath()).toMatch(/workspace-storage/);
+    await expect(pathExists(first.getGlobalStoragePath())).resolves.toBe(true);
+    await expect(pathExists(first.getStoragePath())).resolves.toBe(true);
+    await expect(pathExists(noWorkspace.getStoragePath())).resolves.toBe(true);
+  });
+
+  it('stores encrypted secrets, supports env overrides, and deletes persisted values', async () => {
+    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
+      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+      loadJsonStore(),
+    ]);
+    const root = await makeTempDir('texra-electron-secrets-');
+    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const secrets = new ElectronSecrets(store);
+
+    await secrets.set('TEXRA_TOKEN', 'persisted');
+
+    expect(await secrets.get('TEXRA_TOKEN')).toBe('persisted');
+    expect(store.snapshot().TEXRA_TOKEN).toEqual({
+      encrypted: true,
+      value: Buffer.from('encrypted:persisted').toString('base64'),
+    });
+
+    process.env.TEXRA_TOKEN = 'from-env';
+    expect(await secrets.get('TEXRA_TOKEN')).toBe('from-env');
+
+    delete process.env.TEXRA_TOKEN;
+    await secrets.delete('TEXRA_TOKEN');
+
+    expect(await secrets.get('TEXRA_TOKEN')).toBeUndefined();
+    expect(store.snapshot()).toEqual({});
+  });
+
+  it('ignores malformed persisted secret records', async () => {
+    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
+      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+      loadJsonStore(),
+    ]);
+    const root = await makeTempDir('texra-electron-secrets-');
+    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const secrets = new ElectronSecrets(store);
+
+    await store.set('TEXRA_TOKEN', { encrypted: false, value: 'plain' });
+
+    expect(await secrets.get('TEXRA_TOKEN')).toBeUndefined();
+  });
+});

--- a/src/test-kernel/desktop/electronTestStub.ts
+++ b/src/test-kernel/desktop/electronTestStub.ts
@@ -1,0 +1,16 @@
+// Node imports
+import { join } from 'node:path';
+
+export const app = {
+  getAppPath: () => process.cwd(),
+  getPath: (name: string) => join(process.cwd(), '.test-electron', name),
+  getVersion: () => '0.0.0-test',
+};
+
+export const safeStorage = {
+  decryptString: (value: Buffer) =>
+    value.toString('utf8').replace(/^encrypted:/, ''),
+  encryptString: (value: string) => Buffer.from(`encrypted:${value}`),
+  getSelectedStorageBackend: () => 'os_crypt',
+  isEncryptionAvailable: () => true,
+};

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,11 +2,16 @@ import { readFileSync } from 'node:fs';
 
 import { defineConfig } from 'vitest/config';
 
-import { aliases } from './scripts/aliases.mjs';
+import { aliases, rootDir } from './scripts/aliases.mjs';
 
 export default defineConfig({
   plugins: [texTemplatePlugin()],
-  resolve: { alias: aliases },
+  resolve: {
+    alias: {
+      ...aliases,
+      electron: `${rootDir}/src/test-kernel/desktop/electronTestStub.ts`,
+    },
+  },
   test: {
     environment: 'node',
     include: ['src/test-kernel/**/*.vitest.ts'],


### PR DESCRIPTION
## Summary

- add desktop kernel tests for `ElectronStateStore`, `ElectronStorageProvider`, and `ElectronSecrets`
- add a Vitest-only Electron stub so desktop adapter tests can exercise `safeStorage` behavior without requiring the Electron binary install script
- keep the new coverage under the existing `npm run test:kernel` path for Phase 1 platform invariant work

Refs #3413.

## Validation

- `corepack pnpm exec prettier --write vitest.config.mjs src/test-kernel/desktop/ElectronPlatformAdapters.vitest.ts src/test-kernel/desktop/electronTestStub.ts`
- `git diff --check`
- `npm run test:kernel -- src/test-kernel/desktop`
- `npm run test:kernel`
- `npm run lint`
- `npm run desktop:build`
- `npm run workspace:build`

## Notes

The Electron stub is scoped to Vitest resolution only. Production desktop builds still externalize and use the real `electron` package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds test coverage and a Vitest-only `electron` module stub, with no production runtime code changes beyond test config aliasing.
> 
> **Overview**
> Adds a new Vitest suite (`ElectronPlatformAdapters.vitest.ts`) that exercises the desktop platform adapters end-to-end: `ElectronStateStore` persistence/deletion semantics, `ElectronStorageProvider` path stability and directory creation, and `ElectronSecrets` encryption/env override/delete behavior (including ignoring malformed stored records).
> 
> Updates `vitest.config.mjs` to alias `electron` to a new test-only stub (`electronTestStub.ts`), allowing secrets tests to run in Node without requiring the Electron binary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e1653ddde33798e8ef0891b7043169e68fb5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->