### PR TITLE
test: verify desktop agent bootstrap

### DIFF
--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - agent
 
@@ -20,7 +20,6 @@ import {
   FakeSecrets,
   RecordingLogBackend,
 } from '@test/support/FakePlatform';
-import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { GlobalStateKey } from '@common/state/stateKeys';
 
 import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
@@ -62,6 +61,13 @@ interface ElectronAgentDirectoriesModule {
   ): Promise<void>;
 }
 
+interface AgentDirectoriesRegistryModule {
+  getAgentDirectories(): {
+    builtIn(): Promise<string>;
+    builtInToolUse(): Promise<string>;
+  };
+}
+
 async function writeText(filePath: string, content: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
   await writeFile(filePath, content);
@@ -71,6 +77,7 @@ describe('desktop agent directory bootstrap', () => {
   let tempDir: string | undefined;
 
   afterEach(async () => {
+    vi.resetModules();
     if (tempDir == null) return;
     await rm(tempDir, { recursive: true, force: true });
     tempDir = undefined;
@@ -78,10 +85,12 @@ describe('desktop agent directory bootstrap', () => {
 
   async function createHarness(): Promise<{
     bootstrapElectronAgentDirectories: ElectronAgentDirectoriesModule['bootstrapElectronAgentDirectories'];
+    getAgentDirectories: AgentDirectoriesRegistryModule['getAgentDirectories'];
     globalStateStore: JsonStore;
     resourcesPath: string;
     storage: ElectronStorageProvider;
   }> {
+    vi.resetModules();
     tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-agents-'));
     const resourcesPath = join(tempDir, 'resources');
     const userDataPath = join(tempDir, 'userData');
@@ -101,6 +110,7 @@ describe('desktop agent directory bootstrap', () => {
       { ElectronStorageProvider },
       { bootstrapElectronAgentDirectories },
       { initPlatform },
+      { getAgentDirectories },
     ] = await Promise.all([
       loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts'),
       loadDesktopPlatformModule<ElectronStateStoreModule>('electronState.ts'),
@@ -109,14 +119,15 @@ describe('desktop agent directory bootstrap', () => {
         'agentDirectories.ts',
       ),
       import('@platform/platform'),
+      import('@agent/index/agentDirectoriesRegistry'),
     ]);
+    const storage = new ElectronStorageProvider(userDataPath, workspacePath);
     const globalStateStore = await JsonStore.open(
       join(userDataPath, 'state', 'global.json'),
     );
     const workspaceStateStore = await JsonStore.open(
-      join(userDataPath, 'state', 'workspace.json'),
+      join(storage.getStoragePath(), 'state.json'),
     );
-    const storage = new ElectronStorageProvider(userDataPath, workspacePath);
 
     initPlatform({
       config: new FakeConfigProvider(),
@@ -131,6 +142,7 @@ describe('desktop agent directory bootstrap', () => {
 
     return {
       bootstrapElectronAgentDirectories,
+      getAgentDirectories,
       globalStateStore,
       resourcesPath,
       storage,
@@ -140,6 +152,7 @@ describe('desktop agent directory bootstrap', () => {
   it('copies bundled agents into fresh userData storage and registers directory access', async () => {
     const {
       bootstrapElectronAgentDirectories,
+      getAgentDirectories,
       globalStateStore,
       resourcesPath,
       storage,

--- a/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
+++ b/src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts
@@ -1,0 +1,190 @@
+// Node imports
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - agent
+
+// Local imports - common
+
+// Local imports - platform
+import { createNodeWorkspace } from '@platform/defaults/nodeWorkspace';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+
+// Local imports - test support
+import {
+  FakeConfigProvider,
+  FakeSecrets,
+  RecordingLogBackend,
+} from '@test/support/FakePlatform';
+import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { GlobalStateKey } from '@common/state/stateKeys';
+
+import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
+
+interface JsonStore {
+  get<T>(key: string, defaultValue?: T): T;
+  snapshot(): Record<string, unknown>;
+}
+
+interface JsonStoreModule {
+  JsonStore: {
+    open(filePath: string): Promise<JsonStore>;
+  };
+}
+
+interface ElectronStateStoreModule {
+  ElectronStateStore: new (store: JsonStore) => {
+    get<T>(key: string, defaultValue?: T): T;
+    update(key: string, value: unknown): PromiseLike<void>;
+  };
+}
+
+interface ElectronStorageProvider {
+  getGlobalStoragePath(): string;
+  getStoragePath(): string;
+}
+
+interface ElectronStorageModule {
+  ElectronStorageProvider: new (
+    userDataPath: string,
+    workspacePath: string | undefined,
+  ) => ElectronStorageProvider;
+}
+
+interface ElectronAgentDirectoriesModule {
+  bootstrapElectronAgentDirectories(
+    resourcesPath: string,
+    appVersion: string | undefined,
+  ): Promise<void>;
+}
+
+async function writeText(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, content);
+}
+
+describe('desktop agent directory bootstrap', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function createHarness(): Promise<{
+    bootstrapElectronAgentDirectories: ElectronAgentDirectoriesModule['bootstrapElectronAgentDirectories'];
+    globalStateStore: JsonStore;
+    resourcesPath: string;
+    storage: ElectronStorageProvider;
+  }> {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-agents-'));
+    const resourcesPath = join(tempDir, 'resources');
+    const userDataPath = join(tempDir, 'userData');
+    const workspacePath = join(tempDir, 'workspace');
+    await Promise.all([
+      writeText(join(resourcesPath, 'agents', 'writer.yaml'), 'name: writer\n'),
+      writeText(
+        join(resourcesPath, 'tool_use_agents', 'researcher.yaml'),
+        'name: researcher\n',
+      ),
+      mkdir(workspacePath, { recursive: true }),
+    ]);
+
+    const [
+      { JsonStore },
+      { ElectronStateStore },
+      { ElectronStorageProvider },
+      { bootstrapElectronAgentDirectories },
+      { initPlatform },
+    ] = await Promise.all([
+      loadDesktopPlatformModule<JsonStoreModule>('jsonStore.ts'),
+      loadDesktopPlatformModule<ElectronStateStoreModule>('electronState.ts'),
+      loadDesktopPlatformModule<ElectronStorageModule>('electronStorage.ts'),
+      loadDesktopPlatformModule<ElectronAgentDirectoriesModule>(
+        'agentDirectories.ts',
+      ),
+      import('@platform/platform'),
+    ]);
+    const globalStateStore = await JsonStore.open(
+      join(userDataPath, 'state', 'global.json'),
+    );
+    const workspaceStateStore = await JsonStore.open(
+      join(userDataPath, 'state', 'workspace.json'),
+    );
+    const storage = new ElectronStorageProvider(userDataPath, workspacePath);
+
+    initPlatform({
+      config: new FakeConfigProvider(),
+      globalState: new ElectronStateStore(globalStateStore),
+      workspaceState: new ElectronStateStore(workspaceStateStore),
+      log: new RecordingLogBackend(),
+      fs: nodeFilesystem,
+      workspace: createNodeWorkspace(() => workspacePath),
+      storage,
+      secrets: new FakeSecrets(),
+    });
+
+    return {
+      bootstrapElectronAgentDirectories,
+      globalStateStore,
+      resourcesPath,
+      storage,
+    };
+  }
+
+  it('copies bundled agents into fresh userData storage and registers directory access', async () => {
+    const {
+      bootstrapElectronAgentDirectories,
+      globalStateStore,
+      resourcesPath,
+      storage,
+    } = await createHarness();
+
+    await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
+
+    const builtInDir = await getAgentDirectories().builtIn();
+    const toolUseDir = await getAgentDirectories().builtInToolUse();
+
+    expect(builtInDir).toBe(join(storage.getGlobalStoragePath(), 'agents'));
+    expect(toolUseDir).toBe(
+      join(storage.getGlobalStoragePath(), 'tool_use_agents'),
+    );
+    await expect(
+      readFile(join(builtInDir, 'writer.yaml'), 'utf8'),
+    ).resolves.toBe('name: writer\n');
+    await expect(
+      readFile(join(toolUseDir, 'researcher.yaml'), 'utf8'),
+    ).resolves.toBe('name: researcher\n');
+    expect(globalStateStore.get(GlobalStateKey.LAST_KNOWN_VERSION)).toBe(
+      '1.2.3',
+    );
+  });
+
+  it('preserves current copied agents on same-version runs and restores missing bundled files', async () => {
+    const { bootstrapElectronAgentDirectories, resourcesPath, storage } =
+      await createHarness();
+
+    await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
+    const copiedAgent = join(
+      storage.getGlobalStoragePath(),
+      'agents',
+      'writer.yaml',
+    );
+    await writeFile(copiedAgent, 'name: locally-edited\n');
+
+    await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
+    await expect(readFile(copiedAgent, 'utf8')).resolves.toBe(
+      'name: locally-edited\n',
+    );
+
+    await rm(copiedAgent);
+    await bootstrapElectronAgentDirectories(resourcesPath, '1.2.3');
+
+    await expect(readFile(copiedAgent, 'utf8')).resolves.toBe('name: writer\n');
+  });
+});


### PR DESCRIPTION
## Summary

- add a desktop kernel test for `bootstrapElectronAgentDirectories` against temporary userData-style storage
- verify bundled workflow and tool-use agents copy into writable global storage on first run
- verify same-version bootstrap preserves existing copied files and restores missing bundled files
- assert the desktop agent directory registry points at the copied global-storage directories after bootstrap

Refs #3415.

## Validation

- `corepack pnpm exec prettier --write src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts`
- `corepack pnpm exec eslint src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts --fix`
- `git diff --check`
- `npm run test:kernel -- src/test-kernel/desktop`
- `npm run test:kernel`
- `npm run lint`
- `npm run desktop:build`
- `npm run workspace:build`

## Notes

The test still runs in plain Node. It initializes the platform with real temp storage and the node filesystem, then calls the Electron desktop bootstrap wrapper directly without launching an Electron GUI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a Node-based Vitest kernel test only; no production runtime logic changes.
> 
> **Overview**
> Adds `ElectronAgentDirectories.vitest.ts`, a kernel test harness that boots the desktop platform against temporary `userData`-style storage and calls `bootstrapElectronAgentDirectories`.
> 
> Verifies first-run behavior (bundled `agents` and `tool_use_agents` are copied into global storage, `GlobalStateKey.LAST_KNOWN_VERSION` is updated, and `getAgentDirectories()` resolves to the copied paths) and same-version behavior (local edits are preserved while missing bundled files are restored).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55ad935a77d847daf3655a7a714510902a7860a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Additional validation after review fix `d55ad935a`:
- `npm run test:kernel -- src/test-kernel/desktop/ElectronAgentDirectories.vitest.ts`
- `npm run test:kernel -- src/test-kernel/desktop`
- `npm run test:kernel`
- `npm run lint`
- `npm run desktop:build`
- `npm run workspace:build`

