### PR TITLE
ci: gate initial monorepo build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,5 @@ jobs:
       - name: Compile
         run: pnpm run compile
 
-      - name: Build workspace packages
-        run: pnpm run workspace:build
-
-      - name: Build extension VSIX
-        run: pnpm run build:fast
-
-      - name: Check VSIX contents
-        run: pnpm run check:vsix-contents
+      - name: Build initial extension and desktop artifacts
+        run: pnpm run build:initial

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "workspace:typecheck": "corepack pnpm --recursive --if-present typecheck",
     "workspace:build": "corepack pnpm --recursive --if-present build",
     "desktop:build": "corepack pnpm --filter @texra/desktop build",
+    "build:initial": "corepack pnpm run workspace:build && corepack pnpm run build:fast && corepack pnpm run check:initial-build-artifacts",
     "build": "corepack pnpm --filter texra build:fast",
     "format": "prettier --write .",
     "esbuild:ext": "corepack pnpm --filter texra esbuild:ext",
@@ -42,6 +43,7 @@
     "sync:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs --update",
     "check:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs",
     "check:vsix-contents": "node scripts/verify-vsix-contents.mjs",
+    "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && node scripts/verify-desktop-build-artifacts.mjs",
     "sync:remote-agents": "node scripts/sync-remote-agents.mjs -o docs/supabase/SYNC_REFERENCE_AGENTS.sql",
     "check:remote-agents": "node scripts/sync-remote-agents.mjs --check"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "workspace:typecheck": "corepack pnpm --recursive --if-present typecheck",
     "workspace:build": "corepack pnpm --recursive --if-present build",
     "desktop:build": "corepack pnpm --filter @texra/desktop build",
-    "build:initial": "corepack pnpm run workspace:build && corepack pnpm run build:fast && corepack pnpm run check:initial-build-artifacts",
+    "build:initial": "corepack pnpm run desktop:build && corepack pnpm run build:fast && corepack pnpm run check:initial-build-artifacts",
     "build": "corepack pnpm --filter texra build:fast",
     "format": "prettier --write .",
     "esbuild:ext": "corepack pnpm --filter texra esbuild:ext",

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -3,15 +3,13 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { readJson } from './extension-package-utils.mjs';
+
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '..',
 );
 const desktopDir = path.join(rootDir, 'packages', 'desktop');
-
-function readJson(filePath) {
-  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-}
 
 function relative(filePath) {
   return path.relative(rootDir, filePath);
@@ -36,7 +34,7 @@ function collectFiles(dir) {
       files.push(entryPath);
     }
   }
-  return files;
+  return files.sort();
 }
 
 const packageJson = readJson(path.join(desktopDir, 'package.json'));

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const desktopDir = path.join(rootDir, 'packages', 'desktop');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function relative(filePath) {
+  return path.relative(rootDir, filePath);
+}
+
+function fileExists(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function collectFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(entryPath));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+const packageJson = readJson(path.join(desktopDir, 'package.json'));
+const manifestMain = path.join(desktopDir, packageJson.main);
+const requiredFiles = [
+  manifestMain,
+  path.join(desktopDir, 'dist', 'preload', 'index.cjs'),
+  path.join(desktopDir, 'dist', 'renderer', 'index.html'),
+];
+const failures = [];
+
+for (const filePath of requiredFiles) {
+  if (!fileExists(filePath)) {
+    failures.push(`Missing desktop build artifact: ${relative(filePath)}`);
+  }
+}
+
+const rendererAssetsDir = path.join(desktopDir, 'dist', 'renderer', 'assets');
+const rendererAssets = fs.existsSync(rendererAssetsDir)
+  ? collectFiles(rendererAssetsDir)
+  : [];
+if (!rendererAssets.some((filePath) => filePath.endsWith('.js'))) {
+  failures.push('Desktop renderer build did not emit a JavaScript asset.');
+}
+if (!rendererAssets.some((filePath) => filePath.endsWith('.css'))) {
+  failures.push('Desktop renderer build did not emit a CSS asset.');
+}
+
+if (failures.length > 0) {
+  console.error('Desktop build artifact check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+const artifactList = [
+  ...requiredFiles,
+  ...rendererAssets.filter(
+    (filePath) => filePath.endsWith('.js') || filePath.endsWith('.css'),
+  ),
+].map(relative);
+
+console.log('Desktop build artifact check passed:');
+for (const artifact of artifactList) console.log(`- ${artifact}`);


### PR DESCRIPTION
## Summary

Add a root `build:initial` command that produces the first monorepo build outputs for both deliverables:

- VS Code extension VSIX via the existing `build:fast` path.
- Electron desktop `dist` output via `desktop:build`.
- A desktop artifact verifier that checks the main, preload, renderer HTML, and renderer asset outputs.

CI now runs the combined build gate after the dedicated typecheck and lint steps, so pull requests prove the initial extension and desktop artifacts together without repeating the full workspace build.

Closes #3419.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write package.json .github/workflows/ci.yml scripts/verify-desktop-build-artifacts.mjs`
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run build:initial`