### PR TITLE
test: audit Electron composition root

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,7 @@ const __dirname = path.dirname(__filename);
 
 const COMPOSITION_ROOT_FILES = new Set([
   path.join(__dirname, 'packages/extension/src/extension.ts'),
+  path.join(__dirname, 'packages/desktop/src/main/platform/index.ts'),
 ]);
 
 const extensionPackageDir = path.join(__dirname, 'packages', 'extension');
@@ -356,11 +357,20 @@ export default tseslint.config(
 
   // Configuration for TypeScript files
   {
-    files: ['src/**/*.ts', 'packages/extension/src/**/*.ts'],
+    files: [
+      'src/**/*.ts',
+      'packages/extension/src/**/*.ts',
+      'packages/desktop/src/**/*.ts',
+    ],
     extends: [...tseslint.configs.recommended],
     languageOptions: {
       parserOptions: {
-        project: true,
+        project: [
+          './tsconfig.json',
+          './packages/desktop/tsconfig.main.json',
+          './packages/desktop/tsconfig.preload.json',
+          './packages/desktop/tsconfig.renderer.json',
+        ],
         tsconfigRootDir: __dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compile-tests": "tsc -p tsconfig.json --outDir out",
     "watch-tests": "tsc -p tsconfig.json -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
-    "lint": "eslint src packages/extension/src",
+    "lint": "eslint src packages/extension/src packages/desktop/src",
     "test": "vscode-test",
     "test:kernel": "vitest run --config vitest.config.mjs",
     "test:kernel:watch": "vitest --config vitest.config.mjs",

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
-import { app, BrowserWindow, session } from 'electron';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { app, BrowserWindow, session } from 'electron';
 
 import { initializeElectronPlatform } from './platform/index.js';
 

--- a/packages/desktop/src/main/platform/agentDirectories.ts
+++ b/packages/desktop/src/main/platform/agentDirectories.ts
@@ -1,3 +1,4 @@
+import { platform } from '@platform/platform';
 import { AgentDirectoryService } from '@agent/index/AgentDirectoryService';
 import {
   BundledAgentDirectorySync,
@@ -7,7 +8,6 @@ import {
 import { setAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { GlobalStateKey } from '@common/state/stateKeys';
-import { platform } from '@platform/platform';
 
 export function createElectronAgentDirectories(): AgentDirectoryService {
   return new AgentDirectoryService({

--- a/packages/desktop/src/main/platform/electronConfig.ts
+++ b/packages/desktop/src/main/platform/electronConfig.ts
@@ -6,7 +6,6 @@ import type {
 } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
 
-
 type ConfigWatcher = {
   key: string | readonly string[] | RegExp;
   listener: () => void;

--- a/packages/desktop/src/main/platform/electronConfig.ts
+++ b/packages/desktop/src/main/platform/electronConfig.ts
@@ -1,3 +1,4 @@
+import { JsonStore } from './jsonStore.js';
 import type {
   ConfigInspection,
   ConfigProvider,
@@ -5,7 +6,6 @@ import type {
 } from '@platform/interfaces/config';
 import type { Disposable } from '@platform/interfaces/disposable';
 
-import { JsonStore } from './jsonStore.js';
 
 type ConfigWatcher = {
   key: string | readonly string[] | RegExp;

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -1,8 +1,8 @@
 import { safeStorage } from 'electron';
 
+import { JsonStore } from './jsonStore.js';
 import type { PlatformSecrets } from '@platform/secrets';
 
-import { JsonStore } from './jsonStore.js';
 
 type StoredSecret = { encrypted: true; value: string };
 

--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -3,7 +3,6 @@ import { safeStorage } from 'electron';
 import { JsonStore } from './jsonStore.js';
 import type { PlatformSecrets } from '@platform/secrets';
 
-
 type StoredSecret = { encrypted: true; value: string };
 
 function isStoredSecret(value: unknown): value is StoredSecret {

--- a/packages/desktop/src/main/platform/electronState.ts
+++ b/packages/desktop/src/main/platform/electronState.ts
@@ -1,7 +1,6 @@
 import { JsonStore } from './jsonStore.js';
 import type { StateStore } from '@platform/interfaces/state';
 
-
 export class ElectronStateStore implements StateStore {
   constructor(private readonly store: JsonStore) {}
 

--- a/packages/desktop/src/main/platform/electronState.ts
+++ b/packages/desktop/src/main/platform/electronState.ts
@@ -1,6 +1,6 @@
+import { JsonStore } from './jsonStore.js';
 import type { StateStore } from '@platform/interfaces/state';
 
-import { JsonStore } from './jsonStore.js';
 
 export class ElectronStateStore implements StateStore {
   constructor(private readonly store: JsonStore) {}

--- a/packages/desktop/src/main/platform/pathFix.ts
+++ b/packages/desktop/src/main/platform/pathFix.ts
@@ -38,7 +38,11 @@ export function repairLaunchPathWithOptions(
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
   if (platform === 'darwin') {
-    (options.fixPath ?? fixPath)();
+    if (options.fixPath != null) {
+      options.fixPath();
+    } else if (env === process.env) {
+      fixPath();
+    }
     env.PATH = prependMissingPathEntries(env.PATH, MACOS_PATH_ENTRIES);
   }
   return env.PATH ?? '';

--- a/packages/desktop/src/main/platform/pathFix.ts
+++ b/packages/desktop/src/main/platform/pathFix.ts
@@ -1,5 +1,5 @@
-import fixPath from 'fix-path';
 import { delimiter } from 'node:path';
+import fixPath from 'fix-path';
 
 const MACOS_PATH_ENTRIES = [
   '/Library/TeX/texbin',
@@ -11,7 +11,13 @@ const MACOS_PATH_ENTRIES = [
   '/sbin',
 ] as const;
 
-function prependMissingPathEntries(
+interface LaunchPathRepairOptions {
+  env?: Pick<NodeJS.ProcessEnv, 'PATH'>;
+  fixPath?: () => void;
+  platform?: NodeJS.Platform;
+}
+
+export function prependMissingPathEntries(
   pathValue: string | undefined,
   entries: readonly string[],
 ): string {
@@ -23,12 +29,17 @@ function prependMissingPathEntries(
 }
 
 export function repairLaunchPath(): string {
-  if (process.platform === 'darwin') {
-    fixPath();
-    process.env.PATH = prependMissingPathEntries(
-      process.env.PATH,
-      MACOS_PATH_ENTRIES,
-    );
+  return repairLaunchPathWithOptions();
+}
+
+export function repairLaunchPathWithOptions(
+  options: LaunchPathRepairOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  if (platform === 'darwin') {
+    (options.fixPath ?? fixPath)();
+    env.PATH = prependMissingPathEntries(env.PATH, MACOS_PATH_ENTRIES);
   }
-  return process.env.PATH ?? '';
+  return env.PATH ?? '';
 }

--- a/packages/desktop/src/main/platform/pathFix.ts
+++ b/packages/desktop/src/main/platform/pathFix.ts
@@ -17,7 +17,7 @@ interface LaunchPathRepairOptions {
   platform?: NodeJS.Platform;
 }
 
-export function prependMissingPathEntries(
+function prependMissingPathEntries(
   pathValue: string | undefined,
   entries: readonly string[],
 ): string {
@@ -28,11 +28,7 @@ export function prependMissingPathEntries(
   return parts.join(delimiter);
 }
 
-export function repairLaunchPath(): string {
-  return repairLaunchPathWithOptions();
-}
-
-export function repairLaunchPathWithOptions(
+export function repairLaunchPath(
   options: LaunchPathRepairOptions = {},
 ): string {
   const env = options.env ?? process.env;

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -1,9 +1,9 @@
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import { app } from 'electron';
 
-import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/AgentDirectorySync';
+import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/BundledAgentDirectories';
 
 interface WorkspacePathOptions {
   env?: Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>;
@@ -12,7 +12,7 @@ interface WorkspacePathOptions {
 interface ResourcesPathOptions {
   appPath?: string;
   env?: Pick<NodeJS.ProcessEnv, 'TEXRA_RESOURCES_PATH'>;
-  exists?: (path: string) => boolean;
+  isDirectory?: (path: string) => boolean;
   resourcesPath?: string;
 }
 
@@ -40,9 +40,9 @@ export function resolveResourcesPath(
     join(mainDirname, '../../../../resources'),
   ].filter((candidate): candidate is string => Boolean(candidate));
 
-  const exists = options.exists ?? existsSync;
+  const isDirectory = options.isDirectory ?? isExistingDirectory;
   const found = candidates.find((candidate) =>
-    hasRequiredResourceDirectories(candidate, exists),
+    hasRequiredResourceDirectories(candidate, isDirectory),
   );
   if (!found) {
     throw new Error(
@@ -54,12 +54,20 @@ export function resolveResourcesPath(
 
 function hasRequiredResourceDirectories(
   candidate: string,
-  exists: (path: string) => boolean,
+  isDirectory: (path: string) => boolean,
 ): boolean {
   return (
-    exists(candidate) &&
+    isDirectory(candidate) &&
     BUNDLED_AGENT_DIRECTORY_NAMES.every((directoryName) =>
-      exists(join(candidate, directoryName)),
+      isDirectory(join(candidate, directoryName)),
     )
   );
+}
+
+function isExistingDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -3,25 +3,63 @@ import { join, resolve } from 'node:path';
 
 import { app } from 'electron';
 
-export function resolveWorkspacePath(): string | undefined {
-  const configured = process.env.TEXRA_WORKSPACE_PATH?.trim();
+import { BUNDLED_AGENT_DIRECTORY_NAMES } from '@agent/index/AgentDirectorySync';
+
+interface WorkspacePathOptions {
+  env?: Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>;
+}
+
+interface ResourcesPathOptions {
+  appPath?: string;
+  env?: Pick<NodeJS.ProcessEnv, 'TEXRA_RESOURCES_PATH'>;
+  exists?: (path: string) => boolean;
+  resourcesPath?: string;
+}
+
+export function resolveWorkspacePath(
+  options: WorkspacePathOptions = {},
+): string | undefined {
+  const env = options.env ?? process.env;
+  const configured = env.TEXRA_WORKSPACE_PATH?.trim();
   return configured ? resolve(configured) : undefined;
 }
 
-export function resolveResourcesPath(mainDirname: string): string {
-  const configured = process.env.TEXRA_RESOURCES_PATH?.trim();
+export function resolveResourcesPath(
+  mainDirname: string,
+  options: ResourcesPathOptions = {},
+): string {
+  const env = options.env ?? process.env;
+  const configured = env.TEXRA_RESOURCES_PATH?.trim();
+  const appPath = options.appPath ?? app.getAppPath();
+  const resourcesPath = options.resourcesPath ?? process.resourcesPath;
   const candidates = [
     configured,
-    join(app.getAppPath(), 'resources'),
-    join(process.resourcesPath, 'resources'),
+    join(appPath, 'resources'),
+    resourcesPath ? join(resourcesPath, 'resources') : undefined,
+    join(mainDirname, '../../../extension/resources'),
     join(mainDirname, '../../../../resources'),
   ].filter((candidate): candidate is string => Boolean(candidate));
 
-  const found = candidates.find((candidate) => existsSync(candidate));
+  const exists = options.exists ?? existsSync;
+  const found = candidates.find((candidate) =>
+    hasRequiredResourceDirectories(candidate, exists),
+  );
   if (!found) {
     throw new Error(
       `Unable to locate TeXRA resources. Checked: ${candidates.join(', ')}`,
     );
   }
   return found;
+}
+
+function hasRequiredResourceDirectories(
+  candidate: string,
+  exists: (path: string) => boolean,
+): boolean {
+  return (
+    exists(candidate) &&
+    BUNDLED_AGENT_DIRECTORY_NAMES.every((directoryName) =>
+      exists(join(candidate, directoryName)),
+    )
+  );
 }

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -14,11 +14,6 @@ import {
   type BundledAgentDirectoryName,
 } from './BundledAgentDirectories';
 
-export {
-  BUNDLED_AGENT_DIRECTORY_NAMES,
-  type BundledAgentDirectoryName,
-} from './BundledAgentDirectories';
-
 const LEGACY_AGENT_FILES = [
   'agents/generic.yaml',
   'agents/generic_multiple.yaml',

--- a/src/agent/index/AgentDirectorySync.ts
+++ b/src/agent/index/AgentDirectorySync.ts
@@ -8,13 +8,16 @@ import { glob } from 'glob';
 // Local imports
 import { GlobalStorageFS } from '@utils/files/storageFS';
 
-export const BUNDLED_AGENT_DIRECTORY_NAMES = [
-  'agents',
-  'tool_use_agents',
-] as const;
+// Local imports - agent index
+import {
+  BUNDLED_AGENT_DIRECTORY_NAMES,
+  type BundledAgentDirectoryName,
+} from './BundledAgentDirectories';
 
-export type BundledAgentDirectoryName =
-  (typeof BUNDLED_AGENT_DIRECTORY_NAMES)[number];
+export {
+  BUNDLED_AGENT_DIRECTORY_NAMES,
+  type BundledAgentDirectoryName,
+} from './BundledAgentDirectories';
 
 const LEGACY_AGENT_FILES = [
   'agents/generic.yaml',

--- a/src/agent/index/BundledAgentDirectories.ts
+++ b/src/agent/index/BundledAgentDirectories.ts
@@ -1,0 +1,7 @@
+export const BUNDLED_AGENT_DIRECTORY_NAMES = [
+  'agents',
+  'tool_use_agents',
+] as const;
+
+export type BundledAgentDirectoryName =
+  (typeof BUNDLED_AGENT_DIRECTORY_NAMES)[number];

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -19,6 +19,10 @@ export {
 
 export {
   BUNDLED_AGENT_DIRECTORY_NAMES,
+  type BundledAgentDirectoryName,
+} from './BundledAgentDirectories';
+
+export {
   BundledAgentDirectorySync,
   GlobalStorageAgentDirectoryStorage,
   PathAgentDirectoryBundleSource,
@@ -26,7 +30,6 @@ export {
   type AgentDirectoryStorage,
   type AgentDirectorySyncLogger,
   type AgentDirectoryVersionStore,
-  type BundledAgentDirectoryName,
   type BundledAgentDirectorySyncOptions,
 } from './AgentDirectorySync';
 

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -17,7 +17,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
 
 interface PathFixModule {
-  repairLaunchPathWithOptions(options?: {
+  repairLaunchPath(options?: {
     env?: { PATH?: string };
     fixPath?: () => void;
     platform?: NodeJS.Platform;
@@ -232,7 +232,7 @@ describe('desktop composition root and launch environment', () => {
   });
 
   it('repairs macOS launch PATH idempotently without changing non-macOS PATH', async () => {
-    const { repairLaunchPathWithOptions } =
+    const { repairLaunchPath } =
       await loadDesktopPlatformModule<PathFixModule>('pathFix.ts');
     const env = { PATH: '/custom/bin:/usr/bin' };
     let fixPathCalls = 0;
@@ -240,12 +240,12 @@ describe('desktop composition root and launch environment', () => {
       fixPathCalls += 1;
     };
 
-    const first = repairLaunchPathWithOptions({
+    const first = repairLaunchPath({
       env,
       fixPath,
       platform: 'darwin',
     });
-    const second = repairLaunchPathWithOptions({
+    const second = repairLaunchPath({
       env,
       fixPath,
       platform: 'darwin',
@@ -266,7 +266,7 @@ describe('desktop composition root and launch environment', () => {
 
     const linuxEnv = { PATH: '/custom/bin' };
     expect(
-      repairLaunchPathWithOptions({
+      repairLaunchPath({
         env: linuxEnv,
         fixPath,
         platform: 'linux',
@@ -275,13 +275,13 @@ describe('desktop composition root and launch environment', () => {
   });
 
   it('does not call the process-level PATH fixer for injected environments', async () => {
-    const { repairLaunchPathWithOptions } =
+    const { repairLaunchPath } =
       await loadDesktopPlatformModule<PathFixModule>('pathFix.ts');
     const processPath = process.env.PATH;
     const env = { PATH: '/custom/bin' };
 
     expect(
-      repairLaunchPathWithOptions({
+      repairLaunchPath({
         env,
         platform: 'darwin',
       }),

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -1,0 +1,257 @@
+// Node imports
+import { mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - test support
+import { loadDesktopPlatformModule } from './loadDesktopPlatformModule';
+
+interface PathFixModule {
+  repairLaunchPathWithOptions(options?: {
+    env?: { PATH?: string };
+    fixPath?: () => void;
+    platform?: NodeJS.Platform;
+  }): string;
+}
+
+interface PathsModule {
+  resolveResourcesPath(
+    mainDirname: string,
+    options?: {
+      appPath?: string;
+      env?: { TEXRA_RESOURCES_PATH?: string };
+      resourcesPath?: string;
+    },
+  ): string;
+  resolveWorkspacePath(options?: {
+    env?: { TEXRA_WORKSPACE_PATH?: string };
+  }): string | undefined;
+}
+
+async function walkTypeScriptFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkTypeScriptFiles(entryPath)));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
+}
+
+describe('desktop composition root and launch environment', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir == null) return;
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  async function makeTempDir(): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), 'texra-electron-root-'));
+    return tempDir;
+  }
+
+  async function createResourceTree(resourcesPath: string): Promise<void> {
+    await Promise.all([
+      mkdir(join(resourcesPath, 'agents'), { recursive: true }),
+      mkdir(join(resourcesPath, 'tool_use_agents'), { recursive: true }),
+    ]);
+  }
+
+  it('keeps platform initialization in the Electron composition root', async () => {
+    const desktopMainDir = join(process.cwd(), 'packages', 'desktop', 'src');
+    const files = await walkTypeScriptFiles(desktopMainDir);
+    const initPlatformFiles: string[] = [];
+
+    for (const filePath of files) {
+      const source = await readFile(filePath, 'utf8');
+      if (source.includes('initPlatform(')) {
+        initPlatformFiles.push(relative(process.cwd(), filePath));
+      }
+    }
+
+    expect(initPlatformFiles).toEqual([
+      'packages/desktop/src/main/platform/index.ts',
+    ]);
+  });
+
+  it('repairs PATH before platform services and bundled agents are initialized', async () => {
+    const source = await readFile(
+      join(
+        process.cwd(),
+        'packages',
+        'desktop',
+        'src',
+        'main',
+        'platform',
+        'index.ts',
+      ),
+      'utf8',
+    );
+
+    expect(source.indexOf('repairLaunchPath();')).toBeGreaterThanOrEqual(0);
+    expect(source.indexOf('repairLaunchPath();')).toBeLessThan(
+      source.indexOf('initPlatform({'),
+    );
+    expect(source.indexOf('initPlatform({')).toBeLessThan(
+      source.indexOf('bootstrapElectronAgentDirectories('),
+    );
+  });
+
+  it('resolves workspace paths only from an explicit launch environment', async () => {
+    const { resolveWorkspacePath } =
+      await loadDesktopPlatformModule<PathsModule>('paths.ts');
+
+    expect(
+      resolveWorkspacePath({
+        env: { TEXRA_WORKSPACE_PATH: ' ./project ' },
+      }),
+    ).toBe(resolve('./project'));
+    expect(
+      resolveWorkspacePath({ env: { TEXRA_WORKSPACE_PATH: '   ' } }),
+    ).toBeUndefined();
+  });
+
+  it('finds resources in configured, packaged, and monorepo development layouts', async () => {
+    const { resolveResourcesPath } =
+      await loadDesktopPlatformModule<PathsModule>('paths.ts');
+    const root = await makeTempDir();
+    const configuredResources = join(root, 'configured-resources');
+    const appResources = join(root, 'app', 'resources');
+    const packagedResources = join(root, 'electron-resources', 'resources');
+    const monorepoResources = join(root, 'packages', 'extension', 'resources');
+    const mainDirname = join(root, 'packages', 'desktop', 'dist', 'main');
+
+    await Promise.all(
+      [
+        configuredResources,
+        appResources,
+        packagedResources,
+        monorepoResources,
+      ].map(createResourceTree),
+    );
+
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'missing-app'),
+        env: { TEXRA_RESOURCES_PATH: configuredResources },
+        resourcesPath: join(root, 'missing-electron-resources'),
+      }),
+    ).toBe(configuredResources);
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'app'),
+        env: {},
+        resourcesPath: join(root, 'missing-electron-resources'),
+      }),
+    ).toBe(appResources);
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'missing-app'),
+        env: {},
+        resourcesPath: join(root, 'electron-resources'),
+      }),
+    ).toBe(packagedResources);
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'missing-app'),
+        env: {},
+        resourcesPath: join(root, 'missing-electron-resources'),
+      }),
+    ).toBe(monorepoResources);
+  });
+
+  it('does not accept resource directories missing bundled agent sources', async () => {
+    const { resolveResourcesPath } =
+      await loadDesktopPlatformModule<PathsModule>('paths.ts');
+    const root = await makeTempDir();
+    const incompleteResources = join(root, 'configured-resources');
+    const monorepoResources = join(root, 'packages', 'extension', 'resources');
+    const mainDirname = join(root, 'packages', 'desktop', 'dist', 'main');
+
+    await Promise.all([
+      mkdir(join(incompleteResources, 'agents'), { recursive: true }),
+      createResourceTree(monorepoResources),
+    ]);
+
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'missing-app'),
+        env: { TEXRA_RESOURCES_PATH: incompleteResources },
+        resourcesPath: join(root, 'missing-electron-resources'),
+      }),
+    ).toBe(monorepoResources);
+  });
+
+  it('throws with every checked resource candidate when resources are missing', async () => {
+    const { resolveResourcesPath } =
+      await loadDesktopPlatformModule<PathsModule>('paths.ts');
+    const root = await makeTempDir();
+    const mainDirname = join(root, 'packages', 'desktop', 'dist', 'main');
+
+    expect(() =>
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'app'),
+        env: { TEXRA_RESOURCES_PATH: join(root, 'configured') },
+        resourcesPath: join(root, 'electron-resources'),
+      }),
+    ).toThrow(
+      [
+        join(root, 'configured'),
+        join(root, 'app', 'resources'),
+        join(root, 'electron-resources', 'resources'),
+        join(root, 'packages', 'extension', 'resources'),
+      ].join(', '),
+    );
+  });
+
+  it('repairs macOS launch PATH idempotently without changing non-macOS PATH', async () => {
+    const { repairLaunchPathWithOptions } =
+      await loadDesktopPlatformModule<PathFixModule>('pathFix.ts');
+    const env = { PATH: '/custom/bin:/usr/bin' };
+    let fixPathCalls = 0;
+    const fixPath = () => {
+      fixPathCalls += 1;
+    };
+
+    const first = repairLaunchPathWithOptions({
+      env,
+      fixPath,
+      platform: 'darwin',
+    });
+    const second = repairLaunchPathWithOptions({
+      env,
+      fixPath,
+      platform: 'darwin',
+    });
+
+    expect(first).toBe(second);
+    expect(fixPathCalls).toBe(2);
+    expect(second.split(':')).toEqual([
+      '/Library/TeX/texbin',
+      '/opt/homebrew/bin',
+      '/usr/local/bin',
+      '/bin',
+      '/usr/sbin',
+      '/sbin',
+      '/custom/bin',
+      '/usr/bin',
+    ]);
+
+    const linuxEnv = { PATH: '/custom/bin' };
+    expect(
+      repairLaunchPathWithOptions({
+        env: linuxEnv,
+        fixPath,
+        platform: 'linux',
+      }),
+    ).toBe('/custom/bin');
+  });
+});

--- a/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
+++ b/src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts
@@ -1,5 +1,12 @@
 // Node imports
-import { mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 
@@ -23,6 +30,7 @@ interface PathsModule {
     options?: {
       appPath?: string;
       env?: { TEXRA_RESOURCES_PATH?: string };
+      isDirectory?: (path: string) => boolean;
       resourcesPath?: string;
     },
   ): string;
@@ -168,19 +176,29 @@ describe('desktop composition root and launch environment', () => {
     ).toBe(monorepoResources);
   });
 
-  it('does not accept resource directories missing bundled agent sources', async () => {
+  it('requires bundled agent sources to be directories', async () => {
     const { resolveResourcesPath } =
       await loadDesktopPlatformModule<PathsModule>('paths.ts');
     const root = await makeTempDir();
     const incompleteResources = join(root, 'configured-resources');
+    const fileBackedResources = join(root, 'file-backed-resources');
     const monorepoResources = join(root, 'packages', 'extension', 'resources');
     const mainDirname = join(root, 'packages', 'desktop', 'dist', 'main');
 
     await Promise.all([
       mkdir(join(incompleteResources, 'agents'), { recursive: true }),
+      mkdir(join(fileBackedResources, 'agents'), { recursive: true }),
       createResourceTree(monorepoResources),
     ]);
+    await writeFile(join(fileBackedResources, 'tool_use_agents'), '');
 
+    expect(
+      resolveResourcesPath(mainDirname, {
+        appPath: join(root, 'missing-app'),
+        env: { TEXRA_RESOURCES_PATH: fileBackedResources },
+        resourcesPath: join(root, 'missing-electron-resources'),
+      }),
+    ).toBe(monorepoResources);
     expect(
       resolveResourcesPath(mainDirname, {
         appPath: join(root, 'missing-app'),
@@ -208,6 +226,7 @@ describe('desktop composition root and launch environment', () => {
         join(root, 'app', 'resources'),
         join(root, 'electron-resources', 'resources'),
         join(root, 'packages', 'extension', 'resources'),
+        join(root, 'resources'),
       ].join(', '),
     );
   });
@@ -253,5 +272,20 @@ describe('desktop composition root and launch environment', () => {
         platform: 'linux',
       }),
     ).toBe('/custom/bin');
+  });
+
+  it('does not call the process-level PATH fixer for injected environments', async () => {
+    const { repairLaunchPathWithOptions } =
+      await loadDesktopPlatformModule<PathFixModule>('pathFix.ts');
+    const processPath = process.env.PATH;
+    const env = { PATH: '/custom/bin' };
+
+    expect(
+      repairLaunchPathWithOptions({
+        env,
+        platform: 'darwin',
+      }),
+    ).toContain('/custom/bin');
+    expect(process.env.PATH).toBe(processPath);
   });
 });


### PR DESCRIPTION
## Summary

Complete the Phase 1 Electron composition-root audit with executable coverage and one startup-path fix:

- Add kernel coverage for Electron platform initialization ownership, startup ordering, workspace env resolution, resource path resolution, missing-resource behavior, and macOS PATH repair idempotence.
- Fix the monorepo development resource fallback to resolve `packages/extension/resources` from the desktop `dist/main` directory.
- Require resolved resource roots to contain the bundled `agents` and `tool_use_agents` directories before accepting them.
- Include `packages/desktop/src` in the root lint command and composition-root rule so desktop `initPlatform` ownership is enforced by lint, not just convention.

Closes #3416.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write package.json eslint.config.mjs packages/desktop/src/main/platform/pathFix.ts packages/desktop/src/main/platform/paths.ts src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts`
- `corepack pnpm exec eslint packages/desktop/src src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts --fix`
- `git diff --check`
- `npm run test:kernel -- src/test-kernel/desktop/ElectronCompositionRoot.vitest.ts`
- `npm run test:kernel -- src/test-kernel/desktop`
- `npm run test:kernel`
- `npm run lint`
- `npm run typecheck`
- `npm run desktop:build`
- `npm run workspace:build`
- `npm run build:initial`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron startup path/resource resolution and PATH repair behavior, which can affect desktop app bootstrapping and bundled agent loading across environments. Changes are well-covered by new kernel tests but still carry some cross-platform packaging risk.
> 
> **Overview**
> Adds a new vitest kernel suite (`ElectronCompositionRoot.vitest.ts`) that enforces desktop composition-root invariants (only `platform/index.ts` calls `initPlatform`), validates startup ordering (`repairLaunchPath` before platform init and agent bootstrap), and tests workspace/resource path resolution plus failure messaging.
> 
> Hardens desktop startup helpers: `resolveResourcesPath` now validates candidates by requiring the bundled agent directories to exist and fixes the monorepo-dev fallback to find `packages/extension/resources` relative to the desktop `dist/main` output; `repairLaunchPath` is refactored to accept injected env/platform/fixers for safer, testable macOS PATH repair.
> 
> Expands tooling enforcement by including `packages/desktop/src` in linting/type-aware ESLint projects and adding the desktop platform composition root file to the `no-platform-init-outside-composition-root` allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2569522511dfcd208cf43ff4bdc1a86a919ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->