### PR TITLE
Bootstrap Electron renderer host bridge

### DIFF
--- a/packages/desktop/src/hostBridgeChannels.ts
+++ b/packages/desktop/src/hostBridgeChannels.ts
@@ -1,0 +1,2 @@
+export const ELECTRON_WEBVIEW_MESSAGE_CHANNEL = 'texra:webview-message';
+export const ELECTRON_WEBVIEW_PUSH_CHANNEL = 'texra:webview-push';

--- a/packages/desktop/src/main/hostBridge.ts
+++ b/packages/desktop/src/main/hostBridge.ts
@@ -1,0 +1,36 @@
+import { ipcMain, type BrowserWindow, type IpcMainEvent } from 'electron';
+
+import {
+  ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+  ELECTRON_WEBVIEW_PUSH_CHANNEL,
+} from '../hostBridgeChannels.js';
+
+export interface DesktopHostBridgeOptions {
+  onRendererMessage?: (message: unknown, window: BrowserWindow) => void;
+}
+
+export interface DesktopHostBridge {
+  postToRenderer(message: unknown): void;
+  dispose(): void;
+}
+
+export function installDesktopHostBridge(
+  window: BrowserWindow,
+  options: DesktopHostBridgeOptions = {},
+): DesktopHostBridge {
+  const listener = (event: IpcMainEvent, message: unknown) => {
+    if (event.sender !== window.webContents) return;
+    options.onRendererMessage?.(message, window);
+  };
+  ipcMain.on(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+
+  const dispose = () => ipcMain.off(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+  window.once('closed', dispose);
+  return {
+    postToRenderer: (message) => {
+      if (window.isDestroyed() || window.webContents.isDestroyed()) return;
+      window.webContents.send(ELECTRON_WEBVIEW_PUSH_CHANNEL, message);
+    },
+    dispose,
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, session } from 'electron';
 
+import { installDesktopHostBridge } from './hostBridge.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -42,6 +43,7 @@ function createWindow(): void {
       sandbox: true,
     },
   });
+  installDesktopHostBridge(window);
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);

--- a/packages/desktop/src/preload/hostBridge.ts
+++ b/packages/desktop/src/preload/hostBridge.ts
@@ -1,0 +1,50 @@
+import {
+  HOST_BRIDGE_API_KEY,
+  type HostBridgeApi,
+} from '@shared/hostBridgeTypes.js';
+
+import {
+  ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+  ELECTRON_WEBVIEW_PUSH_CHANNEL,
+} from '../hostBridgeChannels.js';
+
+export {
+  ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+  ELECTRON_WEBVIEW_PUSH_CHANNEL,
+} from '../hostBridgeChannels.js';
+
+export interface ElectronHostBridgeInstallOptions {
+  exposeInMainWorld(name: string, api: HostBridgeApi): void;
+  onHostMessage(
+    channel: typeof ELECTRON_WEBVIEW_PUSH_CHANNEL,
+    listener: (message: unknown) => void,
+  ): void;
+  postToRenderer(message: unknown): void;
+  sendToMain(
+    channel: typeof ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+    message: unknown,
+  ): void;
+}
+
+export function createElectronHostBridge(
+  sendToMain: ElectronHostBridgeInstallOptions['sendToMain'],
+): HostBridgeApi {
+  let state: unknown;
+  return {
+    postMessage: (message) =>
+      sendToMain(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, message),
+    getState: () => state,
+    setState: (nextState) => {
+      state = nextState;
+    },
+  };
+}
+
+export function installElectronHostBridge(
+  options: ElectronHostBridgeInstallOptions,
+): HostBridgeApi {
+  const bridge = createElectronHostBridge(options.sendToMain);
+  options.exposeInMainWorld(HOST_BRIDGE_API_KEY, bridge);
+  options.onHostMessage(ELECTRON_WEBVIEW_PUSH_CHANNEL, options.postToRenderer);
+  return bridge;
+}

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,4 +1,19 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
+
+import { installElectronHostBridge } from './hostBridge.js';
+
+const rendererWindow = globalThis as typeof globalThis & {
+  postMessage?: (message: unknown, targetOrigin: string) => void;
+};
+
+installElectronHostBridge({
+  exposeInMainWorld: (name, api) => contextBridge.exposeInMainWorld(name, api),
+  onHostMessage: (channel, listener) => {
+    ipcRenderer.on(channel, (_event, message: unknown) => listener(message));
+  },
+  postToRenderer: (message) => rendererWindow.postMessage?.(message, '*'),
+  sendToMain: (channel, message) => ipcRenderer.send(channel, message),
+});
 
 contextBridge.exposeInMainWorld('texraDesktop', {
   electronVersion: process.versions.electron,

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -1,17 +1,36 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 
 import { installElectronHostBridge } from './hostBridge.js';
 
 const rendererWindow = globalThis as typeof globalThis & {
+  addEventListener?: (
+    type: 'beforeunload',
+    listener: () => void,
+    options?: { once?: boolean },
+  ) => void;
+  location?: { origin?: string };
   postMessage?: (message: unknown, targetOrigin: string) => void;
 };
+
+function getRendererTargetOrigin(): string {
+  const origin = rendererWindow.location?.origin;
+  return origin && origin !== 'null' ? origin : '*';
+}
 
 installElectronHostBridge({
   exposeInMainWorld: (name, api) => contextBridge.exposeInMainWorld(name, api),
   onHostMessage: (channel, listener) => {
-    ipcRenderer.on(channel, (_event, message: unknown) => listener(message));
+    const handler = (_event: IpcRendererEvent, message: unknown) =>
+      listener(message);
+    ipcRenderer.on(channel, handler);
+    rendererWindow.addEventListener?.(
+      'beforeunload',
+      () => ipcRenderer.off(channel, handler),
+      { once: true },
+    );
   },
-  postToRenderer: (message) => rendererWindow.postMessage?.(message, '*'),
+  postToRenderer: (message) =>
+    rendererWindow.postMessage?.(message, getRendererTargetOrigin()),
   sendToMain: (channel, message) => ipcRenderer.send(channel, message),
 });
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1,11 +1,28 @@
 import './styles.css';
+import './themeTokens.css';
 
-document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <section class="shell">
-    <div>
-      <p class="eyebrow">TeXRA Desktop</p>
-      <h1>Hello TeXRA</h1>
-      <p class="summary">Ready for the Electron shell.</p>
-    </div>
+import '@webview/frontend';
+
+const root = document.querySelector<HTMLElement>('#app');
+
+if (root == null) {
+  throw new Error('TeXRA desktop renderer root was not found.');
+}
+
+const appRoot = root;
+
+appRoot.innerHTML = `
+  <section class="desktop-shell">
+    <main class="desktop-view" id="desktop-view"></main>
   </section>
 `;
+
+const desktopViewContainer =
+  appRoot.querySelector<HTMLElement>('#desktop-view');
+if (desktopViewContainer == null) {
+  throw new Error('TeXRA desktop view container was not found.');
+}
+
+const mainApp = document.createElement('main-app');
+mainApp.setAttribute('data-desktop-view', 'main');
+desktopViewContainer.replaceChildren(mainApp);

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1,55 +1,28 @@
 :root {
-  color-scheme: light dark;
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    sans-serif;
-  background: #171717;
-  color: #f7f7f2;
+  font-family: var(--texra-font-family);
+  background: var(--texra-editor-background);
+  color: var(--texra-editor-foreground);
 }
 
 body {
   margin: 0;
+  font-size: var(--texra-font-size);
 }
 
-.shell {
-  display: grid;
+.desktop-shell {
   min-height: 100vh;
-  place-items: center;
-  padding: 32px;
+  background: var(--texra-editor-background);
+  color: var(--texra-editor-foreground);
+}
+
+.desktop-view {
+  display: block;
+  min-width: 0;
+  min-height: 100vh;
   box-sizing: border-box;
-  background:
-    linear-gradient(135deg, rgba(29, 78, 216, 0.22), transparent 42%),
-    linear-gradient(315deg, rgba(20, 184, 166, 0.16), transparent 48%), #171717;
 }
 
-.shell > div {
-  width: min(560px, 100%);
-}
-
-.eyebrow {
-  margin: 0 0 10px;
-  color: #8bd3dd;
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-h1 {
-  margin: 0;
-  font-size: 48px;
-  line-height: 1;
-  letter-spacing: 0;
-}
-
-.summary {
-  margin: 18px 0 0;
-  color: #d8d8cf;
-  font-size: 18px;
-  line-height: 1.5;
+.desktop-view > * {
+  display: block;
+  min-height: 100vh;
 }

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -1,0 +1,123 @@
+:root {
+  color-scheme: light;
+  --texra-font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --texra-font-size: 13px;
+  --texra-font-weight: 400;
+  --texra-foreground: #1f2328;
+  --texra-descriptionForeground: #57606a;
+  --texra-editor-background: #ffffff;
+  --texra-editor-foreground: #1f2328;
+  --texra-sideBar-background: #f6f8fa;
+  --texra-sideBar-foreground: #1f2328;
+  --texra-sideBarSectionHeader-background: #eaeef2;
+  --texra-sideBarTitle-foreground: #1f2328;
+  --texra-panel-border: #d0d7de;
+  --texra-panelSection-border: #d0d7de;
+  --texra-focusBorder: #0969da;
+  --texra-button-background: #0969da;
+  --texra-button-foreground: #ffffff;
+  --texra-button-border: transparent;
+  --texra-button-hoverBackground: #0757b7;
+  --texra-button-secondaryBackground: #f6f8fa;
+  --texra-button-secondaryForeground: #24292f;
+  --texra-button-secondaryHoverBackground: #eaeef2;
+  --texra-button-separator: rgb(255 255 255 / 40%);
+  --texra-dropdown-border: #d0d7de;
+  --texra-input-background: #ffffff;
+  --texra-input-border: #d0d7de;
+  --texra-input-foreground: #1f2328;
+  --texra-input-placeholderForeground: #6e7781;
+  --texra-list-activeSelectionBackground: #0969da;
+  --texra-list-activeSelectionForeground: #ffffff;
+  --texra-list-hoverBackground: #eef2f6;
+  --texra-list-warningForeground: #9a6700;
+  --texra-menu-background: #ffffff;
+  --texra-menu-border: #d0d7de;
+  --texra-menu-foreground: #1f2328;
+  --texra-toolbar-activeBackground: #dbeafe;
+  --texra-toolbar-hoverBackground: #eaeef2;
+  --texra-widget-border: #d0d7de;
+  --texra-widget-shadow: rgb(31 35 40 / 15%);
+  --texra-icon-foreground: #57606a;
+  --texra-textLink-foreground: #0969da;
+  --texra-textLink-activeForeground: #0550ae;
+  --texra-errorForeground: #cf222e;
+  --texra-editorError-foreground: #cf222e;
+  --texra-editorWarning-foreground: #9a6700;
+  --texra-editorWarning-background: #fff8c5;
+  --texra-editorInfo-foreground: #0969da;
+  --texra-editorInfo-background: #ddf4ff;
+  --texra-progressBar-background: #0969da;
+  --texra-testing-iconPassed: #1a7f37;
+  --texra-testing-iconFailed: #cf222e;
+  --texra-charts-blue: #0969da;
+  --texra-charts-green: #1a7f37;
+  --texra-charts-orange: #bc4c00;
+  --texra-charts-red: #cf222e;
+  --texra-charts-yellow: #bf8700;
+  --texra-terminal-background: #ffffff;
+  --texra-terminal-foreground: #24292f;
+  --texra-terminal-selectionBackground: #ddf4ff;
+  --texra-terminalCursor-foreground: #24292f;
+}
+
+body.vscode-dark,
+body.texra-dark {
+  color-scheme: dark;
+  --texra-foreground: #d4d4d4;
+  --texra-descriptionForeground: #a6a6a6;
+  --texra-editor-background: #1e1e1e;
+  --texra-editor-foreground: #d4d4d4;
+  --texra-sideBar-background: #181818;
+  --texra-sideBar-foreground: #cccccc;
+  --texra-sideBarSectionHeader-background: #222222;
+  --texra-sideBarTitle-foreground: #cccccc;
+  --texra-panel-border: #2b2b2b;
+  --texra-panelSection-border: #2b2b2b;
+  --texra-focusBorder: #007fd4;
+  --texra-button-background: #0e639c;
+  --texra-button-hoverBackground: #1177bb;
+  --texra-button-secondaryBackground: #313131;
+  --texra-button-secondaryForeground: #cccccc;
+  --texra-button-secondaryHoverBackground: #3c3c3c;
+  --texra-dropdown-border: #3c3c3c;
+  --texra-input-background: #313131;
+  --texra-input-border: #3c3c3c;
+  --texra-input-foreground: #cccccc;
+  --texra-input-placeholderForeground: #a6a6a6;
+  --texra-list-activeSelectionBackground: #04395e;
+  --texra-list-activeSelectionForeground: #ffffff;
+  --texra-list-hoverBackground: #2a2d2e;
+  --texra-menu-background: #252526;
+  --texra-menu-border: #454545;
+  --texra-menu-foreground: #cccccc;
+  --texra-toolbar-activeBackground: #37373d;
+  --texra-toolbar-hoverBackground: #2a2d2e;
+  --texra-widget-border: #454545;
+  --texra-widget-shadow: rgb(0 0 0 / 36%);
+  --texra-icon-foreground: #c5c5c5;
+  --texra-textLink-foreground: #4daafc;
+  --texra-textLink-activeForeground: #8fc8ff;
+  --texra-errorForeground: #f48771;
+  --texra-editorError-foreground: #f48771;
+  --texra-editorWarning-foreground: #cca700;
+  --texra-editorWarning-background: #332a00;
+  --texra-editorInfo-foreground: #75beff;
+  --texra-editorInfo-background: #063b49;
+  --texra-terminal-background: #1e1e1e;
+  --texra-terminal-foreground: #cccccc;
+  --texra-terminal-selectionBackground: #264f78;
+  --texra-terminalCursor-foreground: #cccccc;
+}
+
+body.vscode-high-contrast,
+body.vscode-high-contrast-light,
+body.texra-high-contrast {
+  --texra-contrastBorder: currentColor;
+  --texra-focusBorder: #f38518;
+  --texra-panel-border: currentColor;
+  --texra-panelSection-border: currentColor;
+  --texra-widget-border: currentColor;
+}

--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -90,6 +90,7 @@ body.texra-dark {
   --texra-list-activeSelectionBackground: #04395e;
   --texra-list-activeSelectionForeground: #ffffff;
   --texra-list-hoverBackground: #2a2d2e;
+  --texra-list-warningForeground: #cca700;
   --texra-menu-background: #252526;
   --texra-menu-border: #454545;
   --texra-menu-foreground: #cccccc;
@@ -106,6 +107,14 @@ body.texra-dark {
   --texra-editorWarning-background: #332a00;
   --texra-editorInfo-foreground: #75beff;
   --texra-editorInfo-background: #063b49;
+  --texra-progressBar-background: #0e70c0;
+  --texra-testing-iconPassed: #73c991;
+  --texra-testing-iconFailed: #f48771;
+  --texra-charts-blue: #3794ff;
+  --texra-charts-green: #89d185;
+  --texra-charts-orange: #d18616;
+  --texra-charts-red: #f48771;
+  --texra-charts-yellow: #cca700;
   --texra-terminal-background: #1e1e1e;
   --texra-terminal-foreground: #cccccc;
   --texra-terminal-selectionBackground: #264f78;

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "bundler",
     "target": "ES2022",
     "lib": ["ES2023"],
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,6 +17,9 @@
       "@auth/*": ["src/auth/*"],
       "@common/*": ["src/common/*"],
       "@eventBus/*": ["src/eventBus/*"],
+      "@frontend/*": ["packages/extension/src/frontend/*"],
+      "@housekeeping": ["src/housekeeping"],
+      "@housekeeping/*": ["src/housekeeping/*"],
       "@latex": ["src/latex"],
       "@latex/*": ["src/latex/*"],
       "@logger/*": ["src/logger/*"],
@@ -24,9 +29,12 @@
       "@platform/*": ["src/platform/*"],
       "@replacement/*": ["src/replacement/*"],
       "@shared/*": ["src/shared/*"],
+      "@progressView/*": ["packages/extension/src/progressView/*"],
+      "@settingsView/*": ["packages/extension/src/settingsView/*"],
       "@tools/*": ["src/tools/*"],
       "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@webview/*": ["packages/extension/src/webview/*"]
     }
   },
   "include": ["vite.config.ts"]

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 
+// Shared aliases keep desktop renderer imports aligned with extension webviews.
+// @ts-expect-error - .mjs import works at runtime via Vite's ESM handling
+import { aliases } from '../extension/scripts/aliases.mjs';
+
 export default defineConfig({
   base: './',
   root: resolve(__dirname, 'src/renderer'),
@@ -12,4 +16,5 @@ export default defineConfig({
       input: resolve(__dirname, 'src/renderer/index.html'),
     },
   },
+  resolve: { alias: aliases },
 });

--- a/src/shared/hostBridge.ts
+++ b/src/shared/hostBridge.ts
@@ -1,17 +1,17 @@
-// Local types
-/** Minimal host bridge surface used by frontend code. */
-export interface HostBridgeApi {
-  postMessage(message: unknown): void;
-  getState(): unknown;
-  setState(state: unknown): void;
-}
+import {
+  HOST_BRIDGE_API_KEY,
+  LEGACY_HOST_BRIDGE_API_KEY,
+  type HostBridgeApi,
+} from './hostBridgeTypes';
 
-export type VSCodeApi = HostBridgeApi;
+export {
+  HOST_BRIDGE_API_KEY,
+  LEGACY_HOST_BRIDGE_API_KEY,
+  type HostBridgeApi,
+  type VSCodeApi,
+} from './hostBridgeTypes';
 
 declare const acquireVsCodeApi: (() => HostBridgeApi) | undefined;
-
-const API_KEY = '__texraHostBridgeApi';
-const LEGACY_API_KEY = '__texraVscodeApi';
 
 const fallbackApi: HostBridgeApi = {
   postMessage: () => undefined,
@@ -21,22 +21,22 @@ const fallbackApi: HostBridgeApi = {
 
 function resolveHostBridgeApi(): HostBridgeApi {
   const globalScope = globalThis as typeof globalThis & {
-    [API_KEY]?: HostBridgeApi;
-    [LEGACY_API_KEY]?: HostBridgeApi;
+    [HOST_BRIDGE_API_KEY]?: HostBridgeApi;
+    [LEGACY_HOST_BRIDGE_API_KEY]?: HostBridgeApi;
   };
 
-  if (globalScope[API_KEY]) {
-    return globalScope[API_KEY] as HostBridgeApi;
+  if (globalScope[HOST_BRIDGE_API_KEY]) {
+    return globalScope[HOST_BRIDGE_API_KEY] as HostBridgeApi;
   }
 
-  if (globalScope[LEGACY_API_KEY]) {
-    globalScope[API_KEY] = globalScope[LEGACY_API_KEY];
-    return globalScope[API_KEY] as HostBridgeApi;
+  if (globalScope[LEGACY_HOST_BRIDGE_API_KEY]) {
+    globalScope[HOST_BRIDGE_API_KEY] = globalScope[LEGACY_HOST_BRIDGE_API_KEY];
+    return globalScope[HOST_BRIDGE_API_KEY] as HostBridgeApi;
   }
 
   if (typeof acquireVsCodeApi === 'function') {
     const api = acquireVsCodeApi();
-    globalScope[API_KEY] = api;
+    globalScope[HOST_BRIDGE_API_KEY] = api;
     return api;
   }
 

--- a/src/shared/hostBridgeTypes.ts
+++ b/src/shared/hostBridgeTypes.ts
@@ -1,0 +1,14 @@
+/** Global key where host shells expose the webview bridge API. */
+export const HOST_BRIDGE_API_KEY = '__texraHostBridgeApi';
+
+/** Legacy VS Code bridge key kept for older webview bundles. */
+export const LEGACY_HOST_BRIDGE_API_KEY = '__texraVscodeApi';
+
+/** Minimal host bridge surface used by frontend code. */
+export interface HostBridgeApi {
+  postMessage(message: unknown): void;
+  getState(): unknown;
+  setState(state: unknown): void;
+}
+
+export type VSCodeApi = HostBridgeApi;

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.ts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.ts
@@ -1,0 +1,189 @@
+// Node imports
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared host bridge
+import { HOST_BRIDGE_API_KEY } from '@shared/hostBridgeTypes';
+
+interface HostBridgeModule {
+  ELECTRON_WEBVIEW_MESSAGE_CHANNEL: string;
+  ELECTRON_WEBVIEW_PUSH_CHANNEL: string;
+  createElectronHostBridge(
+    sendToMain: (channel: string, message: unknown) => void,
+  ): {
+    postMessage(message: unknown): void;
+    getState(): unknown;
+    setState(state: unknown): void;
+  };
+  installElectronHostBridge(options: {
+    exposeInMainWorld(name: string, api: unknown): void;
+    onHostMessage(channel: string, listener: (message: unknown) => void): void;
+    postToRenderer(message: unknown): void;
+    sendToMain(channel: string, message: unknown): void;
+  }): unknown;
+}
+
+interface MainHostBridgeModule {
+  installDesktopHostBridge(
+    window: {
+      isDestroyed(): boolean;
+      once(event: 'closed', listener: () => void): void;
+      webContents: {
+        isDestroyed(): boolean;
+        send(channel: string, message: unknown): void;
+      };
+    },
+    options?: {
+      onRendererMessage?(message: unknown, window: unknown): void;
+    },
+  ): {
+    postToRenderer(message: unknown): void;
+    dispose(): void;
+  };
+}
+
+async function loadHostBridgeModule(): Promise<HostBridgeModule> {
+  const modulePath = resolve(
+    process.cwd(),
+    'packages/desktop/src/preload/hostBridge.ts',
+  );
+  return import(pathToFileURL(modulePath).href) as Promise<HostBridgeModule>;
+}
+
+async function loadMainHostBridgeModule(ipcMain: {
+  on(
+    channel: string,
+    listener: (event: { sender: unknown }, message: unknown) => void,
+  ): void;
+  off(
+    channel: string,
+    listener: (event: { sender: unknown }, message: unknown) => void,
+  ): void;
+}): Promise<MainHostBridgeModule> {
+  vi.resetModules();
+  vi.doMock('electron', () => ({ ipcMain }));
+  const modulePath = resolve(
+    process.cwd(),
+    'packages/desktop/src/main/hostBridge.ts',
+  );
+  return import(
+    pathToFileURL(modulePath).href
+  ) as Promise<MainHostBridgeModule>;
+}
+
+describe('desktop Electron host bridge', () => {
+  afterEach(() => {
+    vi.doUnmock('electron');
+  });
+
+  it('exposes only the shared synchronous host bridge surface', async () => {
+    const { ELECTRON_WEBVIEW_MESSAGE_CHANNEL, createElectronHostBridge } =
+      await loadHostBridgeModule();
+    const sends: Array<{ channel: string; message: unknown }> = [];
+    const bridge = createElectronHostBridge((channel, message) => {
+      sends.push({ channel, message });
+    });
+
+    expect(Object.keys(bridge).sort()).toEqual([
+      'getState',
+      'postMessage',
+      'setState',
+    ]);
+    expect(bridge.getState()).toBeUndefined();
+
+    const state = { route: 'main' };
+    bridge.setState(state);
+    expect(bridge.getState()).toBe(state);
+
+    const message = { command: 'webview.ready' };
+    bridge.postMessage(message);
+    expect(sends).toEqual([
+      { channel: ELECTRON_WEBVIEW_MESSAGE_CHANNEL, message },
+    ]);
+  });
+
+  it('installs the bridge on the shared key and forwards host pushes', async () => {
+    const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installElectronHostBridge } =
+      await loadHostBridgeModule();
+    const exposed: Record<string, unknown> = {};
+    const pushes: unknown[] = [];
+    let pushListener: ((message: unknown) => void) | undefined;
+
+    const installed = installElectronHostBridge({
+      exposeInMainWorld: (name, api) => {
+        exposed[name] = api;
+      },
+      onHostMessage: (channel, listener) => {
+        expect(channel).toBe(ELECTRON_WEBVIEW_PUSH_CHANNEL);
+        pushListener = listener;
+      },
+      postToRenderer: (message) => {
+        pushes.push(message);
+      },
+      sendToMain: () => undefined,
+    });
+
+    expect(exposed[HOST_BRIDGE_API_KEY]).toBe(installed);
+    expect(pushListener).toBeDefined();
+
+    const message = { command: 'setTheme', theme: 'vscode-dark' };
+    pushListener?.(message);
+    expect(pushes).toEqual([message]);
+  });
+
+  it('routes main-process bridge messages over fixed Electron channels', async () => {
+    const { ELECTRON_WEBVIEW_MESSAGE_CHANNEL, ELECTRON_WEBVIEW_PUSH_CHANNEL } =
+      await loadHostBridgeModule();
+    let rendererListener:
+      | ((event: { sender: unknown }, message: unknown) => void)
+      | undefined;
+    const ipcMain = {
+      on: vi.fn((channel, listener) => {
+        expect(channel).toBe(ELECTRON_WEBVIEW_MESSAGE_CHANNEL);
+        rendererListener = listener;
+      }),
+      off: vi.fn(),
+    };
+    const { installDesktopHostBridge } =
+      await loadMainHostBridgeModule(ipcMain);
+    const sends: Array<{ channel: string; message: unknown }> = [];
+    const webContents = {
+      isDestroyed: () => false,
+      send: vi.fn((channel, message) => sends.push({ channel, message })),
+    };
+    const closedListeners: Array<() => void> = [];
+    const window = {
+      isDestroyed: () => false,
+      once: vi.fn((_event: 'closed', listener: () => void) => {
+        closedListeners.push(listener);
+      }),
+      webContents,
+    };
+    const rendererMessages: unknown[] = [];
+    const bridge = installDesktopHostBridge(window, {
+      onRendererMessage: (message) => rendererMessages.push(message),
+    });
+
+    expect(rendererListener).toBeDefined();
+    rendererListener?.({ sender: {} }, { ignored: true });
+    rendererListener?.({ sender: webContents }, { command: 'ready' });
+    expect(rendererMessages).toEqual([{ command: 'ready' }]);
+
+    const hostMessage = { command: 'setTheme', theme: 'vscode-dark' };
+    bridge.postToRenderer(hostMessage);
+    expect(sends).toEqual([
+      { channel: ELECTRON_WEBVIEW_PUSH_CHANNEL, message: hostMessage },
+    ]);
+
+    bridge.dispose();
+    expect(ipcMain.off).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+      rendererListener,
+    );
+    closedListeners[0]?.();
+    expect(ipcMain.off).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the first Electron host bridge shared by reused webview frontend code.
- Mounts the existing main Lit webview entry inside the desktop renderer shell.
- Adds fixed Electron IPC channels for renderer-to-main messages and host-to-renderer pushes without exposing a generic RPC surface.
- Shares the host bridge contract from `src/shared` and keeps the existing VS Code bridge fallback intact.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:kernel`
- `npm run desktop:build`
- `npm run build:initial`
- `git diff --check`

Closes #3422.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Electron IPC/preload bridging code and wires it into the desktop window lifecycle; mistakes here could break renderer-main messaging or create security footguns despite using fixed channels and no generic RPC.
> 
> **Overview**
> Bootstraps a shared *Electron host bridge* so desktop can reuse existing webview frontend code via a minimal `HostBridgeApi` surface.
> 
> Adds fixed IPC channels (`texra:webview-message` / `texra:webview-push`) with a main-process bridge (`installDesktopHostBridge`) and a preload-side bridge that exposes the API on a shared global key and forwards host pushes into `window.postMessage`.
> 
> Updates the desktop renderer to mount the extension’s `main-app` web component inside a new shell, aligns styling via new theme token CSS, and adjusts desktop build/TS config (shared Vite aliases, decorators/class-fields settings) to support importing the shared webview packages; includes new Vitest coverage for the bridge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0aa94ef5c1d64ade953eac48b36bddc74a7a4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->