### PR TITLE
Keep desktop alias resolution in sync

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -359,6 +359,7 @@ export default tseslint.config(
   {
     files: [
       'src/**/*.ts',
+      'src/**/*.mts',
       'packages/extension/src/**/*.ts',
       'packages/desktop/src/**/*.ts',
     ],
@@ -367,6 +368,7 @@ export default tseslint.config(
       parserOptions: {
         project: [
           './tsconfig.json',
+          './tsconfig.test-kernel.json',
           './packages/desktop/tsconfig.main.json',
           './packages/desktop/tsconfig.preload.json',
           './packages/desktop/tsconfig.renderer.json',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vite:webviews": "corepack pnpm --filter texra vite:webviews",
     "vite:webviews:dev": "corepack pnpm --filter texra vite:webviews:dev",
     "vite:webviews:watch": "corepack pnpm --filter texra vite:webviews:watch",
-    "typecheck": "tsc --noEmit && corepack pnpm --filter texra typecheck",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck",
     "compile:fast": "corepack pnpm --filter texra compile:fast",
     "compile:safe": "npm run typecheck && npm run compile:fast",
     "watch:fast": "corepack pnpm --filter texra watch:fast",

--- a/packages/desktop/tsconfig.json
+++ b/packages/desktop/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
     "module": "esnext",
@@ -10,32 +11,7 @@
     "strict": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "types": ["node"],
-    "baseUrl": "../..",
-    "paths": {
-      "@agent/*": ["src/agent/*"],
-      "@auth/*": ["src/auth/*"],
-      "@common/*": ["src/common/*"],
-      "@eventBus/*": ["src/eventBus/*"],
-      "@frontend/*": ["packages/extension/src/frontend/*"],
-      "@housekeeping": ["src/housekeeping"],
-      "@housekeeping/*": ["src/housekeeping/*"],
-      "@latex": ["src/latex"],
-      "@latex/*": ["src/latex/*"],
-      "@logger/*": ["src/logger/*"],
-      "@model": ["src/model"],
-      "@model/*": ["src/model/*"],
-      "@platform": ["src/platform"],
-      "@platform/*": ["src/platform/*"],
-      "@replacement/*": ["src/replacement/*"],
-      "@shared/*": ["src/shared/*"],
-      "@progressView/*": ["packages/extension/src/progressView/*"],
-      "@settingsView/*": ["packages/extension/src/settingsView/*"],
-      "@tools/*": ["src/tools/*"],
-      "@types/*": ["src/types/*"],
-      "@utils/*": ["src/utils/*"],
-      "@webview/*": ["packages/extension/src/webview/*"]
-    }
+    "types": ["node"]
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@/*": ["packages/extension/src/*", "src/*"],
+      "~/*": ["packages/extension/src/*", "src/*"],
+      "@shared/*": ["src/shared/*"],
+      "@common/*": ["src/common/*"],
+      "@webview/*": ["packages/extension/src/webview/*"],
+      "@agent/*": ["src/agent/*"],
+      "@frontend/*": ["packages/extension/src/frontend/*"],
+      "@hosts": ["src/hosts"],
+      "@hosts/*": ["src/hosts/*"],
+      "@utils/*": ["src/utils/*"],
+      "@logger/*": ["src/logger/*"],
+      "@latex": ["src/latex"],
+      "@latex/*": ["src/latex/*"],
+      "@commands/*": ["packages/extension/src/commands/*"],
+      "@resources/*": ["packages/extension/resources/*"],
+      "@model": ["src/model"],
+      "@model/*": ["src/model/*"],
+      "@housekeeping": ["src/housekeeping"],
+      "@housekeeping/*": ["src/housekeeping/*"],
+      "@progressView/*": ["packages/extension/src/progressView/*"],
+      "@settingsView/*": ["packages/extension/src/settingsView/*"],
+      "@replacement/*": ["src/replacement/*"],
+      "@tools/*": ["src/tools/*"],
+      "@types/*": ["src/types/*"],
+      "@eventBus/*": ["src/eventBus/*"],
+      "@auth/*": ["src/auth/*"],
+      "@platform": ["src/platform"],
+      "@platform/*": ["src/platform/*"],
+      "@openrouter/sdk": ["node_modules/@openrouter/sdk/esm/index.d.ts"],
+      "@openrouter/sdk/models": [
+        "node_modules/@openrouter/sdk/esm/models/index.d.ts"
+      ],
+      "@controllers/*": ["src/controllers/*"],
+      "@test/*": ["src/test/*"]
+    }
+  }
+}

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 
 // Shared aliases keep desktop renderer imports aligned with extension webviews.
-// @ts-expect-error - .mjs import works at runtime via Vite's ESM handling
-import { aliases } from '../extension/scripts/aliases.mjs';
+import { aliases } from '../../scripts/aliases.mjs';
 
 export default defineConfig({
   base: './',

--- a/scripts/aliases.d.mts
+++ b/scripts/aliases.d.mts
@@ -1,0 +1,2 @@
+export const aliases: Record<string, string>;
+export const rootDir: string;

--- a/src/test-kernel/desktop/DesktopAliasConfig.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAliasConfig.vitest.mts
@@ -1,0 +1,42 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+interface TsconfigJson {
+  extends?: string;
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+const ROOT_DIR = resolve(TEST_DIR, '../../..');
+
+function readTsconfig(relativePath: string): TsconfigJson {
+  return JSON.parse(
+    readFileSync(resolve(ROOT_DIR, relativePath), 'utf8'),
+  ) as TsconfigJson;
+}
+
+function readText(relativePath: string): string {
+  return readFileSync(resolve(ROOT_DIR, relativePath), 'utf8');
+}
+
+describe('desktop alias configuration', () => {
+  it('uses the root alias table for desktop typecheck and bundling', () => {
+    const rootPaths = readTsconfig('tsconfig.json').compilerOptions?.paths;
+    const desktopPaths = readTsconfig('packages/desktop/tsconfig.paths.json')
+      .compilerOptions?.paths;
+    const desktopTsconfig = readTsconfig('packages/desktop/tsconfig.json');
+    const viteConfig = readText('packages/desktop/vite.config.ts');
+
+    expect(desktopTsconfig.extends).toBe('./tsconfig.paths.json');
+    expect(desktopPaths).toEqual(rootPaths);
+    expect(viteConfig).toContain("from '../../scripts/aliases.mjs'");
+    expect(viteConfig).not.toContain('../extension/scripts/aliases.mjs');
+  });
+});

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
@@ -1,6 +1,6 @@
 // Node imports
 import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // Third-party imports
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -45,10 +45,12 @@ interface MainHostBridgeModule {
   };
 }
 
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+
 async function loadHostBridgeModule(): Promise<HostBridgeModule> {
   const modulePath = resolve(
-    process.cwd(),
-    'packages/desktop/src/preload/hostBridge.ts',
+    TEST_DIR,
+    '../../../packages/desktop/src/preload/hostBridge.ts',
   );
   return import(pathToFileURL(modulePath).href) as Promise<HostBridgeModule>;
 }
@@ -66,8 +68,8 @@ async function loadMainHostBridgeModule(ipcMain: {
   vi.resetModules();
   vi.doMock('electron', () => ({ ipcMain }));
   const modulePath = resolve(
-    process.cwd(),
-    'packages/desktop/src/main/hostBridge.ts',
+    TEST_DIR,
+    '../../../packages/desktop/src/main/hostBridge.ts',
   );
   return import(
     pathToFileURL(modulePath).href

--- a/tsconfig.test-kernel.json
+++ b/tsconfig.test-kernel.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"]
+  },
+  "include": ["src/test-kernel/**/*.mts"]
+}

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    include: ['src/test-kernel/**/*.vitest.ts'],
+    include: ['src/test-kernel/**/*.vitest.{ts,mts}'],
     passWithNoTests: false,
   },
 });


### PR DESCRIPTION
## Summary
- Move desktop TypeScript aliases into `packages/desktop/tsconfig.paths.json`, mirroring the root alias table instead of keeping a partial desktop subset.
- Point the desktop Vite build at the root alias loader and add a typed declaration for the shared `.mjs` module.
- Add kernel coverage for desktop alias sync, Vite source selection, and Electron host bridge import anchoring.
- Run the desktop host bridge tests as typed ESM test modules so test-file-relative imports use `import.meta.url` without weakening `typecheck`.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:kernel -- src/test-kernel/desktop/DesktopAliasConfig.vitest.mts src/test-kernel/desktop/ElectronHostBridge.vitest.mts`
- `npm run test:kernel`
- `npm run build:initial`
- `git diff --check`

Closes #3424.
