### PR TITLE
Wire desktop main-view IPC

### DIFF
--- a/packages/desktop/src/main/hostBridge.ts
+++ b/packages/desktop/src/main/hostBridge.ts
@@ -18,13 +18,18 @@ export function installDesktopHostBridge(
   window: BrowserWindow,
   options: DesktopHostBridgeOptions = {},
 ): DesktopHostBridge {
+  let disposed = false;
   const listener = (event: IpcMainEvent, message: unknown) => {
     if (event.sender !== window.webContents) return;
     options.onRendererMessage?.(message, window);
   };
   ipcMain.on(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
 
-  const dispose = () => ipcMain.off(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    ipcMain.off(ELECTRON_WEBVIEW_MESSAGE_CHANNEL, listener);
+  };
   window.once('closed', dispose);
   return {
     postToRenderer: (message) => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, session } from 'electron';
 
-import { installDesktopHostBridge } from './hostBridge.js';
+import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
@@ -43,7 +43,7 @@ function createWindow(): void {
       sandbox: true,
     },
   });
-  installDesktopHostBridge(window);
+  installDesktopMainViewIpc(window);
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,0 +1,100 @@
+import { nativeTheme, type BrowserWindow } from 'electron';
+
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+import {
+  installDesktopHostBridge,
+  type DesktopHostBridge,
+} from './hostBridge.js';
+
+type DesktopTheme = 'dark' | 'light' | 'high-contrast';
+
+export interface DesktopMainViewIpcOptions {
+  debugMode?: boolean;
+  getTheme?: () => DesktopTheme;
+}
+
+export interface DesktopMainViewIpc {
+  postToRenderer(message: unknown): void;
+  dispose(): void;
+}
+
+function isMessageWithCommand(
+  message: unknown,
+): message is { command: string } {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'command' in message &&
+    typeof message.command === 'string'
+  );
+}
+
+function getNativeTheme(): DesktopTheme {
+  if (nativeTheme.shouldUseHighContrastColors) return 'high-contrast';
+  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+}
+
+export function installDesktopMainViewIpc(
+  window: BrowserWindow,
+  options: DesktopMainViewIpcOptions = {},
+): DesktopMainViewIpc {
+  const getTheme = options.getTheme ?? getNativeTheme;
+  const debugMode = options.debugMode ?? false;
+
+  let disposed = false;
+
+  function postTheme() {
+    bridge.postToRenderer({
+      command: COMMON_COMMANDS.THEME_SET,
+      theme: getTheme(),
+    });
+  }
+  function postDebugMode() {
+    bridge.postToRenderer({
+      command: COMMON_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
+    });
+  }
+  function postInitialState() {
+    postTheme();
+    postDebugMode();
+  }
+  function handleRendererMessage(message: unknown) {
+    if (!isMessageWithCommand(message)) return;
+
+    switch (message.command) {
+      case MAIN_VIEW_COMMANDS.WEBVIEW_READY:
+        postInitialState();
+        break;
+      case MAIN_VIEW_COMMANDS.GET_THEME:
+        postTheme();
+        break;
+      case MAIN_VIEW_COMMANDS.GET_DEBUG_MODE:
+        postDebugMode();
+        break;
+    }
+  }
+
+  const handleNativeThemeUpdate = () => postTheme();
+
+  const bridge = installDesktopHostBridge(window, {
+    onRendererMessage: handleRendererMessage,
+  });
+
+  nativeTheme.on('updated', handleNativeThemeUpdate);
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    nativeTheme.off('updated', handleNativeThemeUpdate);
+    bridge.dispose();
+  };
+  window.once('closed', dispose);
+
+  return {
+    postToRenderer: (message) => bridge.postToRenderer(message),
+    dispose,
+  };
+}

--- a/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
+++ b/src/test-kernel/desktop/ElectronHostBridge.vitest.mts
@@ -186,6 +186,6 @@ describe('desktop Electron host bridge', () => {
       rendererListener,
     );
     closedListeners[0]?.();
-    expect(ipcMain.off).toHaveBeenCalledTimes(2);
+    expect(ipcMain.off).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -1,0 +1,191 @@
+// Node imports
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - webview command constants
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+interface MainViewIpcModule {
+  installDesktopMainViewIpc(
+    window: {
+      isDestroyed(): boolean;
+      once(event: 'closed', listener: () => void): void;
+      webContents: {
+        isDestroyed(): boolean;
+        send(channel: string, message: unknown): void;
+      };
+    },
+    options?: {
+      debugMode?: boolean;
+      getTheme?: () => 'dark' | 'light' | 'high-contrast';
+    },
+  ): {
+    postToRenderer(message: unknown): void;
+    dispose(): void;
+  };
+}
+
+interface HostBridgeModule {
+  ELECTRON_WEBVIEW_MESSAGE_CHANNEL: string;
+  ELECTRON_WEBVIEW_PUSH_CHANNEL: string;
+}
+
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+
+async function loadDesktopMainViewIpcModule(electron: {
+  ipcMain: {
+    on(
+      channel: string,
+      listener: (event: { sender: unknown }, message: unknown) => void,
+    ): void;
+    off(
+      channel: string,
+      listener: (event: { sender: unknown }, message: unknown) => void,
+    ): void;
+  };
+  nativeTheme: {
+    shouldUseDarkColors: boolean;
+    shouldUseHighContrastColors: boolean;
+    on(event: 'updated', listener: () => void): void;
+    off(event: 'updated', listener: () => void): void;
+  };
+}): Promise<MainViewIpcModule & HostBridgeModule> {
+  vi.resetModules();
+  vi.doMock('electron', () => electron);
+  const mainViewIpcPath = resolve(
+    TEST_DIR,
+    '../../../packages/desktop/src/main/mainViewIpc.ts',
+  );
+  const hostBridgePath = resolve(
+    TEST_DIR,
+    '../../../packages/desktop/src/preload/hostBridge.ts',
+  );
+  const [mainViewIpc, hostBridge] = await Promise.all([
+    import(pathToFileURL(mainViewIpcPath).href) as Promise<MainViewIpcModule>,
+    import(pathToFileURL(hostBridgePath).href) as Promise<HostBridgeModule>,
+  ]);
+  return { ...mainViewIpc, ...hostBridge };
+}
+
+describe('desktop main-view IPC', () => {
+  afterEach(() => {
+    vi.doUnmock('electron');
+  });
+
+  it('pushes theme and debug state over the fixed host bridge channel', async () => {
+    let rendererListener:
+      | ((event: { sender: unknown }, message: unknown) => void)
+      | undefined;
+    let themeListener: (() => void) | undefined;
+    const ipcMain = {
+      on: vi.fn((channel, listener) => {
+        rendererListener = listener;
+      }),
+      off: vi.fn(),
+    };
+    const nativeTheme = {
+      shouldUseDarkColors: true,
+      shouldUseHighContrastColors: false,
+      on: vi.fn((_event: 'updated', listener: () => void) => {
+        themeListener = listener;
+      }),
+      off: vi.fn(),
+    };
+    const {
+      ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+      ELECTRON_WEBVIEW_PUSH_CHANNEL,
+      installDesktopMainViewIpc,
+    } = await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
+    const sends: Array<{ channel: string; message: unknown }> = [];
+    const webContents = {
+      isDestroyed: () => false,
+      send: vi.fn((channel, message) => sends.push({ channel, message })),
+    };
+    const closedListeners: Array<() => void> = [];
+    const window = {
+      isDestroyed: () => false,
+      once: vi.fn((_event: 'closed', listener: () => void) => {
+        closedListeners.push(listener);
+      }),
+      webContents,
+    };
+
+    const ipc = installDesktopMainViewIpc(window, { debugMode: true });
+
+    expect(ipcMain.on).toHaveBeenCalledWith(
+      ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
+      rendererListener,
+    );
+    rendererListener?.(
+      { sender: {} },
+      { command: MAIN_VIEW_COMMANDS.GET_THEME },
+    );
+    expect(sends).toEqual([]);
+
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY },
+    );
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: COMMON_COMMANDS.THEME_SET, theme: 'dark' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
+      },
+    ]);
+
+    sends.length = 0;
+    nativeTheme.shouldUseDarkColors = false;
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.GET_THEME },
+    );
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: COMMON_COMMANDS.THEME_SET, theme: 'light' },
+      },
+    ]);
+
+    sends.length = 0;
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.GET_DEBUG_MODE },
+    );
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: COMMON_COMMANDS.DEBUG_MODE_SET, debugMode: true },
+      },
+    ]);
+
+    nativeTheme.shouldUseHighContrastColors = true;
+    themeListener?.();
+    expect(sends.at(-1)).toEqual({
+      channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+      message: {
+        command: COMMON_COMMANDS.THEME_SET,
+        theme: 'high-contrast',
+      },
+    });
+
+    ipc.postToRenderer({ command: 'customPush' });
+    expect(sends.at(-1)).toEqual({
+      channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+      message: { command: 'customPush' },
+    });
+
+    ipc.dispose();
+    expect(nativeTheme.off).toHaveBeenCalledWith('updated', themeListener);
+    expect(ipcMain.off).toHaveBeenCalledTimes(1);
+    closedListeners.forEach((listener) => listener());
+    expect(ipcMain.off).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a desktop main-view IPC layer over the fixed Electron host bridge.
- Respond to `webviewReady`, `getTheme`, and `getDebugMode` from the mounted `main-app` by pushing `setTheme` and `setDebugMode` over the host-to-renderer channel.
- Forward native Electron theme changes to the renderer without adding a generic RPC surface.
- Make host bridge disposal idempotent so explicit disposal and window close cannot double-unregister the IPC listener.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:kernel -- src/test-kernel/desktop/ElectronHostBridge.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run desktop:build`
- `npm run test:kernel`
- `npm run build:initial`
- `git diff --check`

Closes #3425.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Electron main-process IPC wiring and lifecycle disposal; mistakes could cause missed renderer updates or leaked listeners, but the surface area is small and covered by new kernel tests.
> 
> **Overview**
> Adds a dedicated desktop main-view IPC layer (`installDesktopMainViewIpc`) on top of the fixed Electron host bridge to respond to renderer commands (`WEBVIEW_READY`, `GET_THEME`, `GET_DEBUG_MODE`) by pushing `THEME_SET` and `DEBUG_MODE_SET` messages.
> 
> The main process now installs this IPC layer at window creation and forwards native theme changes (`nativeTheme.updated`) to the renderer. Host-bridge disposal is made idempotent to avoid double-unregistering the IPC listener, with tests updated/added to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ca34d7f98b1e71c6064537352d910e090e03d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->