### PR TITLE
Upload initial monorepo build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,19 @@ jobs:
 
       - name: Build initial extension and desktop artifacts
         run: pnpm run build:initial
+
+      - name: Upload extension VSIX artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-extension-vsix
+          path: releases/*.vsix
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload desktop build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-desktop-dist-${{ runner.os }}
+          path: packages/desktop/dist/
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary

- Upload the initial VS Code extension VSIX after `pnpm run build:initial` succeeds.
- Upload the initial Electron desktop `dist/` output as a separate workflow artifact.
- Keep this slice limited to CI artifacts; release publishing, signing, and installer packaging remain later work.

Closes #3436.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `npm run build:initial`
- `npm run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes that add artifact uploads after a successful build, with `if-no-files-found: error` potentially causing new workflow failures if build outputs change.
> 
> **Overview**
> After `pnpm run build:initial`, CI now uploads the generated VS Code extension `.vsix` from `releases/*.vsix` and the desktop app build output from `packages/desktop/dist/` as workflow artifacts.
> 
> Artifacts are retained for 14 days and the job fails if expected files are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df21c1144b1100ad5eb88e19141f7704b57cea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->