### PR TITLE
Update pnpm setup action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.2
           run_install: false

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.2
           run_install: false


### PR DESCRIPTION
## Summary

- Move `pnpm/action-setup` from `v4` to `v6` in CI and format workflows.
- Keep the pinned pnpm version and install behavior unchanged.
- Remove the Node.js 20 action-runtime deprecation warning reported by the main build run.

Closes #3438.

## Validation

- `git diff --check`
- Checked current official `pnpm/action-setup` README and releases for the Node.js 24-compatible major version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is CI/format jobs could behave differently if `pnpm/action-setup@v6` has breaking behavior compared to `v4`.
> 
> **Overview**
> Updates GitHub Actions workflows (`ci.yml` and `format-pr.yml`) to use `pnpm/action-setup@v6` instead of `v4`, while keeping the pinned pnpm version (`10.33.2`) and `run_install: false` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfffb587db242105e96c2c9edd488c093d923cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->