### PR TITLE
Build initial desktop artifact on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,15 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    name: validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
 
     steps:
       - name: Checkout repository
@@ -57,6 +64,7 @@ jobs:
         run: pnpm run build:initial
 
       - name: Upload extension VSIX artifact
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: texra-extension-vsix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,17 @@ jobs:
           path: packages/desktop/dist/
           if-no-files-found: error
           retention-days: 14
+
+  validate-status:
+    name: validate
+    runs-on: ubuntu-latest
+    needs: validate
+    if: always()
+
+    steps:
+      - name: Require validation matrix success
+        run: |
+          if [ '${{ needs.validate.result }}' != 'success' ]; then
+            echo 'Validation matrix result: ${{ needs.validate.result }}'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds `macos-latest` to the CI validation matrix so the initial Electron desktop bundle is built on macOS as well as Linux.

The VSIX upload remains Linux-only to avoid duplicate extension artifacts, while the desktop artifact upload keeps using the runner OS in the artifact name. This should produce both `texra-desktop-dist-Linux` and `texra-desktop-dist-macOS` from CI.

Closes #3443.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `npm run typecheck`
- `npm run lint`
- `npm run test:kernel`
- `npm run compile`
- `npm run build:initial`
- `git diff --check`

`build:initial` passed locally on macOS and produced the extension VSIX plus the desktop main, preload, and renderer artifacts. The existing `LICENSE not found` VSIX warning remains tracked in #3441.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main impact is longer CI and potential new macOS-specific build failures for `build:initial`.
> 
> **Overview**
> Extends the `validate` job into an OS matrix (`ubuntu-latest`, `macos-latest`) so `build:initial` produces desktop artifacts on macOS as well as Linux.
> 
> Keeps the extension VSIX upload **Linux-only** to avoid duplicate artifacts, uploads desktop dist artifacts per runner OS, and adds a `validate-status` gate job to fail the workflow if any matrix run fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 478b6e60cee020781f1221af06ff4bceda27cebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->