### PR TITLE
Mount reused desktop shell views

### DIFF
--- a/packages/desktop/src/desktopShellMessages.ts
+++ b/packages/desktop/src/desktopShellMessages.ts
@@ -1,10 +1,17 @@
+import { z } from 'zod';
+
 export const DESKTOP_SHELL_COMMANDS = {
   SET_ROUTE: 'desktop:setRoute',
 } as const;
 
-export type DesktopRoute = 'main' | 'progress' | 'settings';
+export const DesktopRouteSchema = z.enum(['main', 'progress', 'settings']);
+export type DesktopRoute = z.infer<typeof DesktopRouteSchema>;
 
-export interface DesktopSetRouteMessage {
-  command: typeof DESKTOP_SHELL_COMMANDS.SET_ROUTE;
-  route: DesktopRoute;
-}
+export const DesktopSetRouteMessageSchema = z.object({
+  command: z.literal(DESKTOP_SHELL_COMMANDS.SET_ROUTE),
+  route: DesktopRouteSchema,
+});
+
+export type DesktopSetRouteMessage = z.infer<
+  typeof DesktopSetRouteMessageSchema
+>;

--- a/packages/desktop/src/desktopShellMessages.ts
+++ b/packages/desktop/src/desktopShellMessages.ts
@@ -1,0 +1,10 @@
+export const DESKTOP_SHELL_COMMANDS = {
+  SET_ROUTE: 'desktop:setRoute',
+} as const;
+
+export type DesktopRoute = 'main' | 'progress' | 'settings';
+
+export interface DesktopSetRouteMessage {
+  command: typeof DESKTOP_SHELL_COMMANDS.SET_ROUTE;
+  route: DesktopRoute;
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,7 +1,8 @@
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, session } from 'electron';
+import { app, BrowserWindow, session, shell } from 'electron';
 
+import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
@@ -43,7 +44,13 @@ function createWindow(): void {
       sandbox: true,
     },
   });
-  installDesktopMainViewIpc(window);
+  installDesktopMainViewIpc(window, {
+    getCustomAgentDirectory: () => getAgentDirectories().custom(),
+    openPath: async (filePath) => {
+      const errorMessage = await shell.openPath(filePath);
+      if (errorMessage) throw new Error(errorMessage);
+    },
+  });
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -4,6 +4,10 @@ import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 
 import {
+  DESKTOP_SHELL_COMMANDS,
+  type DesktopRoute,
+} from '../desktopShellMessages.js';
+import {
   installDesktopHostBridge,
   type DesktopHostBridge,
 } from './hostBridge.js';
@@ -57,6 +61,21 @@ export function installDesktopMainViewIpc(
       debugMode,
     });
   }
+  function postRoute(route: DesktopRoute) {
+    bridge.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+      route,
+    });
+  }
+  function postRouteForSwitchView(message: unknown) {
+    const view =
+      typeof message === 'object' && message !== null && 'view' in message
+        ? message.view
+        : undefined;
+    const route =
+      view === 'progress' ? 'progress' : view === 'main' ? 'main' : 'settings';
+    postRoute(route);
+  }
   function postInitialState() {
     postTheme();
     postDebugMode();
@@ -73,6 +92,15 @@ export function installDesktopMainViewIpc(
         break;
       case MAIN_VIEW_COMMANDS.GET_DEBUG_MODE:
         postDebugMode();
+        break;
+      case COMMON_COMMANDS.SWITCH_VIEW:
+        postRouteForSwitchView(message);
+        break;
+      case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
+      case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
+      case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
+      case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
+        postRoute('settings');
         break;
     }
   }

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -2,6 +2,12 @@ import { nativeTheme, type BrowserWindow } from 'electron';
 
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
+import {
+  SETTINGS_TAB,
+  type SettingsTab,
+} from '@shared/schemas/settingsViewMessages';
 
 import {
   DESKTOP_SHELL_COMMANDS,
@@ -40,6 +46,18 @@ function getNativeTheme(): DesktopTheme {
   return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
 }
 
+function getAgentSettingsSubTab(message: unknown): AgentCategory | undefined {
+  if (
+    typeof message === 'object' &&
+    message !== null &&
+    'sessionType' in message &&
+    message.sessionType === AGENT_CATEGORY.TOOL_USE
+  ) {
+    return AGENT_CATEGORY.TOOL_USE;
+  }
+  return undefined;
+}
+
 export function installDesktopMainViewIpc(
   window: BrowserWindow,
   options: DesktopMainViewIpcOptions = {},
@@ -65,6 +83,18 @@ export function installDesktopMainViewIpc(
     bridge.postToRenderer({
       command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
       route,
+    });
+  }
+  function postSettingsRoute(
+    tabIndex?: SettingsTab,
+    agentSubTab?: AgentCategory,
+  ) {
+    postRoute('settings');
+    if (tabIndex == null) return;
+    bridge.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+      tabIndex,
+      ...(agentSubTab && { agentSubTab }),
     });
   }
   function postRouteForSwitchView(message: unknown) {
@@ -97,10 +127,19 @@ export function installDesktopMainViewIpc(
         postRouteForSwitchView(message);
         break;
       case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
+        postSettingsRoute();
+        break;
       case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
+        postSettingsRoute(SETTINGS_TAB.AGENTS, getAgentSettingsSubTab(message));
+        break;
       case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
+        postSettingsRoute(SETTINGS_TAB.MODELS);
+        break;
       case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
-        postRoute('settings');
+        postSettingsRoute(SETTINGS_TAB.MULTI_AGENT);
+        break;
+      case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
+        postSettingsRoute(SETTINGS_TAB.AGENTS);
         break;
     }
   }

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -5,6 +5,10 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
 import {
+  SwitchViewMessageSchema,
+  type SwitchViewTarget,
+} from '@shared/schemas/commonViewMessages';
+import {
   SETTINGS_TAB,
   type SettingsTab,
 } from '@shared/schemas/settingsViewMessages';
@@ -23,6 +27,9 @@ type DesktopTheme = 'dark' | 'light' | 'high-contrast';
 export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
   getTheme?: () => DesktopTheme;
+  getCustomAgentDirectory?: () => Promise<string>;
+  openPath?: (filePath: string) => Promise<void>;
+  onAsyncError?: (error: unknown) => void;
 }
 
 export interface DesktopMainViewIpc {
@@ -57,6 +64,12 @@ function getAgentSettingsSubTab(message: unknown): AgentCategory | undefined {
   }
   return undefined;
 }
+
+const SWITCH_VIEW_ROUTES = {
+  main: 'main',
+  progress: 'progress',
+  dashboard: 'settings',
+} satisfies Record<SwitchViewTarget, DesktopRoute>;
 
 export function installDesktopMainViewIpc(
   window: BrowserWindow,
@@ -98,13 +111,36 @@ export function installDesktopMainViewIpc(
     });
   }
   function postRouteForSwitchView(message: unknown) {
-    const view =
-      typeof message === 'object' && message !== null && 'view' in message
-        ? message.view
-        : undefined;
-    const route =
-      view === 'progress' ? 'progress' : view === 'main' ? 'main' : 'settings';
-    postRoute(route);
+    const result = SwitchViewMessageSchema.safeParse(message);
+    if (!result.success) return;
+    postRoute(SWITCH_VIEW_ROUTES[result.data.view]);
+  }
+  function reportAsyncError(error: unknown) {
+    if (options.onAsyncError) {
+      options.onAsyncError(error);
+      return;
+    }
+    console.error(error);
+  }
+  async function openCustomAgentDirectory() {
+    if (!options.getCustomAgentDirectory || !options.openPath) {
+      postSettingsRoute(SETTINGS_TAB.AGENTS);
+      return;
+    }
+    const customDir = await options.getCustomAgentDirectory();
+    await options.openPath(customDir);
+  }
+  function handleOpenAgentDirectory(message: unknown) {
+    const customDirSet =
+      typeof message === 'object' &&
+      message !== null &&
+      'customDirSet' in message &&
+      message.customDirSet === true;
+    if (!customDirSet) {
+      postSettingsRoute(SETTINGS_TAB.AGENTS);
+      return;
+    }
+    void openCustomAgentDirectory().catch(reportAsyncError);
   }
   function postInitialState() {
     postTheme();
@@ -139,7 +175,7 @@ export function installDesktopMainViewIpc(
         postSettingsRoute(SETTINGS_TAB.MULTI_AGENT);
         break;
       case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
-        postSettingsRoute(SETTINGS_TAB.AGENTS);
+        handleOpenAgentDirectory(message);
         break;
     }
   }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -1,7 +1,15 @@
 import './styles.css';
 import './themeTokens.css';
 
+import '@progressView/frontend';
+import '@settingsView/frontend';
 import '@webview/frontend';
+
+import {
+  DESKTOP_SHELL_COMMANDS,
+  type DesktopRoute,
+  type DesktopSetRouteMessage,
+} from '../desktopShellMessages';
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -13,7 +21,11 @@ const appRoot = root;
 
 appRoot.innerHTML = `
   <section class="desktop-shell">
-    <main class="desktop-view" id="desktop-view"></main>
+    <main class="desktop-view" id="desktop-view">
+      <section class="desktop-route" data-route="main"></section>
+      <section class="desktop-route" data-route="progress" hidden></section>
+      <section class="desktop-route" data-route="settings" hidden></section>
+    </main>
   </section>
 `;
 
@@ -23,6 +35,54 @@ if (desktopViewContainer == null) {
   throw new Error('TeXRA desktop view container was not found.');
 }
 
+const routeContainers = new Map<DesktopRoute, HTMLElement>();
+for (const route of ['main', 'progress', 'settings'] as const) {
+  const container = desktopViewContainer.querySelector<HTMLElement>(
+    `[data-route="${route}"]`,
+  );
+  if (container == null) {
+    throw new Error(`TeXRA desktop route container was not found: ${route}`);
+  }
+  routeContainers.set(route, container);
+}
+
 const mainApp = document.createElement('main-app');
 mainApp.setAttribute('data-desktop-view', 'main');
-desktopViewContainer.replaceChildren(mainApp);
+
+const progressApp = document.createElement('progress-app');
+progressApp.setAttribute('data-desktop-view', 'progress');
+
+const settingsApp = document.createElement('settings-app');
+settingsApp.setAttribute('data-desktop-view', 'settings');
+
+routeContainers.get('main')?.replaceChildren(mainApp);
+routeContainers.get('progress')?.replaceChildren(progressApp);
+routeContainers.get('settings')?.replaceChildren(settingsApp);
+
+function isDesktopSetRouteMessage(
+  message: unknown,
+): message is DesktopSetRouteMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'command' in message &&
+    message.command === DESKTOP_SHELL_COMMANDS.SET_ROUTE &&
+    'route' in message &&
+    (message.route === 'main' ||
+      message.route === 'progress' ||
+      message.route === 'settings')
+  );
+}
+
+function setRoute(route: DesktopRoute): void {
+  for (const [candidate, container] of routeContainers) {
+    container.hidden = candidate !== route;
+  }
+  document.body.dataset.desktopRoute = route;
+}
+
+window.addEventListener('message', (event) => {
+  if (isDesktopSetRouteMessage(event.data)) {
+    setRoute(event.data.route);
+  }
+});

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,7 +6,7 @@ import '@settingsView/frontend';
 import '@webview/frontend';
 
 import {
-  DESKTOP_SHELL_COMMANDS,
+  DesktopSetRouteMessageSchema,
   type DesktopRoute,
   type DesktopSetRouteMessage,
 } from '../desktopShellMessages';
@@ -85,16 +85,7 @@ routeContainers.get('settings')?.replaceChildren(settingsApp);
 function isDesktopSetRouteMessage(
   message: unknown,
 ): message is DesktopSetRouteMessage {
-  return (
-    typeof message === 'object' &&
-    message !== null &&
-    'command' in message &&
-    message.command === DESKTOP_SHELL_COMMANDS.SET_ROUTE &&
-    'route' in message &&
-    (message.route === 'main' ||
-      message.route === 'progress' ||
-      message.route === 'settings')
-  );
+  return DesktopSetRouteMessageSchema.safeParse(message).success;
 }
 
 function setRoute(route: DesktopRoute): void {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -21,6 +21,17 @@ const appRoot = root;
 
 appRoot.innerHTML = `
   <section class="desktop-shell">
+    <nav class="desktop-nav" aria-label="Desktop views">
+      <button class="desktop-nav-button" type="button" data-route-button="main" aria-pressed="true">
+        Launcher
+      </button>
+      <button class="desktop-nav-button" type="button" data-route-button="progress" aria-pressed="false">
+        Progress
+      </button>
+      <button class="desktop-nav-button" type="button" data-route-button="settings" aria-pressed="false">
+        Settings
+      </button>
+    </nav>
     <main class="desktop-view" id="desktop-view">
       <section class="desktop-route" data-route="main"></section>
       <section class="desktop-route" data-route="progress" hidden></section>
@@ -44,6 +55,18 @@ for (const route of ['main', 'progress', 'settings'] as const) {
     throw new Error(`TeXRA desktop route container was not found: ${route}`);
   }
   routeContainers.set(route, container);
+}
+
+const routeButtons = new Map<DesktopRoute, HTMLButtonElement>();
+for (const route of ['main', 'progress', 'settings'] as const) {
+  const button = appRoot.querySelector<HTMLButtonElement>(
+    `[data-route-button="${route}"]`,
+  );
+  if (button == null) {
+    throw new Error(`TeXRA desktop route button was not found: ${route}`);
+  }
+  button.addEventListener('click', () => setRoute(route));
+  routeButtons.set(route, button);
 }
 
 const mainApp = document.createElement('main-app');
@@ -77,6 +100,9 @@ function isDesktopSetRouteMessage(
 function setRoute(route: DesktopRoute): void {
   for (const [candidate, container] of routeContainers) {
     container.hidden = candidate !== route;
+  }
+  for (const [candidate, button] of routeButtons) {
+    button.setAttribute('aria-pressed', candidate === route ? 'true' : 'false');
   }
   document.body.dataset.desktopRoute = route;
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -22,7 +22,16 @@ body {
   box-sizing: border-box;
 }
 
-.desktop-view > * {
+.desktop-route {
+  display: block;
+  min-height: 100vh;
+}
+
+.desktop-route[hidden] {
+  display: none;
+}
+
+.desktop-route > * {
   display: block;
   min-height: 100vh;
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -1,4 +1,5 @@
 :root {
+  --desktop-nav-height: 40px;
   font-family: var(--texra-font-family);
   background: var(--texra-editor-background);
   color: var(--texra-editor-foreground);
@@ -11,20 +12,53 @@ body {
 
 .desktop-shell {
   min-height: 100vh;
+  display: grid;
+  grid-template-rows: var(--desktop-nav-height) minmax(0, 1fr);
   background: var(--texra-editor-background);
   color: var(--texra-editor-foreground);
+}
+
+.desktop-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: var(--desktop-nav-height);
+  padding: 0 8px;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--texra-panel-border);
+  background: var(--texra-sideBar-background);
+}
+
+.desktop-nav-button {
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--texra-foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.desktop-nav-button:hover {
+  background: var(--texra-toolbar-hoverBackground);
+}
+
+.desktop-nav-button[aria-pressed='true'] {
+  border-color: var(--texra-focusBorder);
+  background: var(--texra-button-secondaryBackground);
 }
 
 .desktop-view {
   display: block;
   min-width: 0;
-  min-height: 100vh;
+  min-height: 0;
   box-sizing: border-box;
 }
 
 .desktop-route {
   display: block;
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 .desktop-route[hidden] {
@@ -33,5 +67,5 @@ body {
 
 .desktop-route > * {
   display: block;
-  min-height: 100vh;
+  min-height: 100%;
 }

--- a/packages/desktop/tsconfig.main.json
+++ b/packages/desktop/tsconfig.main.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node", "electron"]
   },
-  "include": ["src/main/**/*.ts"]
+  "include": ["src/main/**/*.ts", "../../src/types/**/*.d.ts"]
 }

--- a/packages/desktop/tsconfig.preload.json
+++ b/packages/desktop/tsconfig.preload.json
@@ -5,5 +5,5 @@
     "moduleResolution": "nodenext",
     "types": ["node", "electron"]
   },
-  "include": ["src/preload/**/*.ts"]
+  "include": ["src/preload/**/*.ts", "../../src/types/**/*.d.ts"]
 }

--- a/packages/desktop/tsconfig.renderer.json
+++ b/packages/desktop/tsconfig.renderer.json
@@ -4,5 +4,9 @@
     "lib": ["ES2023", "DOM"],
     "types": ["vite/client"]
   },
-  "include": ["src/renderer/**/*.ts", "src/renderer/**/*.d.ts"]
+  "include": [
+    "src/renderer/**/*.ts",
+    "src/renderer/**/*.d.ts",
+    "../../src/types/**/*.d.ts"
+  ]
 }

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -24,6 +24,9 @@ interface MainViewIpcModule {
     options?: {
       debugMode?: boolean;
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
+      getCustomAgentDirectory?: () => Promise<string>;
+      openPath?: (filePath: string) => Promise<void>;
+      onAsyncError?: (error: unknown) => void;
     },
   ): {
     postToRenderer(message: unknown): void;
@@ -97,6 +100,7 @@ describe('desktop main-view IPC', () => {
       installDesktopMainViewIpc,
     } = await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
+    const openPath = vi.fn(async (_filePath: string) => {});
     const webContents = {
       isDestroyed: () => false,
       send: vi.fn((channel, message) => sends.push({ channel, message })),
@@ -110,7 +114,11 @@ describe('desktop main-view IPC', () => {
       webContents,
     };
 
-    const ipc = installDesktopMainViewIpc(window, { debugMode: true });
+    const ipc = installDesktopMainViewIpc(window, {
+      debugMode: true,
+      getCustomAgentDirectory: async () => '/agents/custom',
+      openPath,
+    });
 
     expect(ipcMain.on).toHaveBeenCalledWith(
       ELECTRON_WEBVIEW_MESSAGE_CHANNEL,
@@ -249,6 +257,16 @@ describe('desktop main-view IPC', () => {
         },
       },
     ]);
+
+    sends.length = 0;
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY, customDirSet: true },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(openPath).toHaveBeenCalledWith('/agents/custom');
+    expect(sends).toEqual([]);
 
     nativeTheme.shouldUseHighContrastColors = true;
     themeListener?.();

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -159,6 +159,38 @@ describe('desktop main-view IPC', () => {
       },
     ]);
 
+    sends.length = 0;
+    rendererListener?.(
+      { sender: webContents },
+      { command: COMMON_COMMANDS.SWITCH_VIEW, view: 'progress' },
+    );
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'progress' },
+      },
+    ]);
+
+    sends.length = 0;
+    rendererListener?.(
+      { sender: webContents },
+      { command: COMMON_COMMANDS.SWITCH_VIEW, view: 'dashboard' },
+    );
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS },
+    );
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+    ]);
+
     nativeTheme.shouldUseHighContrastColors = true;
     themeListener?.();
     expect(sends.at(-1)).toEqual({

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -4,6 +4,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - webview command constants
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -180,6 +183,21 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       { command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS },
     );
+    rendererListener?.(
+      { sender: webContents },
+      {
+        command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+        sessionType: AGENT_CATEGORY.TOOL_USE,
+      },
+    );
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS },
+    );
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY },
+    );
     expect(sends).toEqual([
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
@@ -188,6 +206,47 @@ describe('desktop main-view IPC', () => {
       {
         channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
         message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: {
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex: SETTINGS_TAB.MODELS,
+        },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: {
+          agentSubTab: AGENT_CATEGORY.TOOL_USE,
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex: SETTINGS_TAB.AGENTS,
+        },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: {
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex: SETTINGS_TAB.MULTI_AGENT,
+        },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: {
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex: SETTINGS_TAB.AGENTS,
+        },
       },
     ]);
 

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -34,4 +34,14 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('window.addEventListener');
     expect(rendererMain).toContain('document.body.dataset.desktopRoute');
   });
+
+  it('provides persistent shell controls for returning between routes', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('data-route-button="main"');
+    expect(rendererMain).toContain('data-route-button="progress"');
+    expect(rendererMain).toContain('data-route-button="settings"');
+    expect(rendererMain).toContain("button.addEventListener('click'");
+    expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
+  });
 });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -29,8 +29,7 @@ describe('desktop renderer shell', () => {
   it('listens for desktop route pushes from the Electron host', () => {
     const rendererMain = readRendererMain();
 
-    expect(rendererMain).toContain('DESKTOP_SHELL_COMMANDS.SET_ROUTE');
-    expect(rendererMain).toContain('message.command ===');
+    expect(rendererMain).toContain('DesktopSetRouteMessageSchema.safeParse');
     expect(rendererMain).toContain('window.addEventListener');
     expect(rendererMain).toContain('document.body.dataset.desktopRoute');
   });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -1,0 +1,37 @@
+// Node imports
+import { readFileSync } from 'node:fs';
+
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { repoPath } from './desktopTestPaths.mjs';
+
+function readRendererMain(): string {
+  return readFileSync(
+    repoPath('packages/desktop/src/renderer/main.ts'),
+    'utf8',
+  );
+}
+
+describe('desktop renderer shell', () => {
+  it('mounts the reused launcher, progress, and settings Lit apps', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain("import '@webview/frontend'");
+    expect(rendererMain).toContain("import '@progressView/frontend'");
+    expect(rendererMain).toContain("import '@settingsView/frontend'");
+    expect(rendererMain).toContain("document.createElement('main-app')");
+    expect(rendererMain).toContain("document.createElement('progress-app')");
+    expect(rendererMain).toContain("document.createElement('settings-app')");
+  });
+
+  it('listens for desktop route pushes from the Electron host', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('DESKTOP_SHELL_COMMANDS.SET_ROUTE');
+    expect(rendererMain).toContain('message.command ===');
+    expect(rendererMain).toContain('window.addEventListener');
+    expect(rendererMain).toContain('document.body.dataset.desktopRoute');
+  });
+});


### PR DESCRIPTION
## Summary

Mounts the reused launcher, progress, and settings Lit apps inside the Electron renderer shell and routes shared view-switch messages without VS Code commands.

The desktop main-process bridge now translates `switchView` into a small desktop route message. Dashboard/settings-oriented launcher actions route to the settings view, while progress tab actions route to the progress view. The renderer keeps stable containers for all three views and hides inactive routes.

The desktop tsconfigs now include the repo ambient type declarations so the reused progress/settings frontend modules typecheck under the desktop renderer boundary.

Closes #3445.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write ...`
- `npm run typecheck`
- `npm run lint`
- `npm run test:kernel -- src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- `npm run test:kernel`
- `npm run build:initial`
- `git diff --check`

`build:initial` passed and verified both the VSIX and desktop build artifacts. The existing `LICENSE not found` VSIX warning remains tracked in #3441.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes desktop IPC/view-switching behavior and introduces host-triggered `shell.openPath` for opening agent directories, which could affect navigation flow and error handling.
> 
> **Overview**
> Adds a simple desktop shell routing layer (`desktop:setRoute`) and updates the Electron main-process IPC to translate shared `switchView`/settings-related launcher commands into route + settings-tab pushes.
> 
> Updates the renderer shell to *persistently mount* the launcher, progress, and settings Lit apps in separate containers with a new top navigation bar, toggling visibility based on route messages from the host or user clicks. Desktop tsconfigs now include repo ambient `.d.ts` types, and kernel tests are extended/added to cover the new routing and view mounting behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9554115750ec102800d481eb65ffd54c0130928c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->