### PR TITLE
Wire desktop Direct-agent execution

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --config vite.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.preload.json && tsc --noEmit -p tsconfig.renderer.json",
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:vscode",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:vscode --external:fsevents",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload/index.cjs --external:electron",
     "build:renderer": "vite build --config vite.config.ts",
     "build": "corepack pnpm run typecheck && corepack pnpm run build:main && corepack pnpm run build:preload && corepack pnpm run build:renderer"

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -33,7 +33,7 @@ import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): void;
   openPath?: (filePath: string) => Promise<void>;
-  showInformationMessage?: (message: string) => Promise<void> | void;
+  showErrorMessage?: (message: string) => Promise<void> | void;
 }
 
 export interface DesktopAgentExecution {
@@ -442,7 +442,7 @@ export function createDesktopAgentExecution(
     async handleExecute(message) {
       const preparation = prepareMainViewExecutionRequest(message);
       if (!preparation.valid) {
-        await options.showInformationMessage?.(preparation.message);
+        await options.showErrorMessage?.(preparation.message);
         return;
       }
 

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -12,13 +12,15 @@ import type { ProgressSink } from '@agent/runtime/ProgressSink';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
-import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { StreamLogStore } from '@logger/StreamLogStore';
 import {
   STREAM_STATUS,
+  type ActiveChildInfo,
   type AgentCategory,
+  type ConversationProgress,
   type ProgressViewOutboundMessage,
   type StreamMetadata,
   type StreamStatus,
@@ -42,7 +44,14 @@ export interface DesktopAgentExecution {
 
 type TaskState = ProgressEventPayloads['setTaskState']['taskState'];
 
-class DesktopProgressBridge {
+type StreamBadgeSnapshot = {
+  activeSubagents: ActiveChildInfo[];
+  finishedSubagentCount: number;
+  activeProcesses: ActiveChildInfo[];
+  finishedProcessCount: number;
+};
+
+export class DesktopProgressBridge {
   private readonly streamLogs = new StreamLogStore();
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly taskStates = new Map<StreamTabId, TaskState>();
@@ -51,6 +60,12 @@ class DesktopProgressBridge {
   private readonly executionIds = new Map<StreamTabId, string>();
   private readonly descriptions = new Map<StreamTabId, string>();
   private readonly parentStreams = new Map<StreamTabId, StreamTabId>();
+  private readonly creationTimestamps = new Map<StreamTabId, number>();
+  private readonly conversationProgress = new Map<
+    StreamTabId,
+    ConversationProgress
+  >();
+  private readonly streamBadges = new Map<StreamTabId, StreamBadgeSnapshot>();
   private activeStream: StreamTabId | '' = '';
   private readonly unsubscribe: () => void;
 
@@ -71,6 +86,15 @@ class DesktopProgressBridge {
   dispose(): void {
     this.unsubscribe();
     this.cursors.clear();
+    this.taskStates.clear();
+    this.statuses.clear();
+    this.categories.clear();
+    this.executionIds.clear();
+    this.descriptions.clear();
+    this.parentStreams.clear();
+    this.creationTimestamps.clear();
+    this.conversationProgress.clear();
+    this.streamBadges.clear();
   }
 
   private send(message: ProgressViewOutboundMessage): void {
@@ -88,10 +112,19 @@ class DesktopProgressBridge {
     streamId: StreamTabId,
     category: AgentCategory = AGENT_CATEGORY.WORKFLOW,
   ): void {
+    this.getCreationTimestamp(streamId);
     this.streamLogs.ensureStream(streamId);
     if (!this.categories.has(streamId)) {
       this.categories.set(streamId, category);
     }
+  }
+
+  private getCreationTimestamp(streamId: StreamTabId): number {
+    const existing = this.creationTimestamps.get(streamId);
+    if (existing != null) return existing;
+    const createdAt = this.streamLogs.getFirstTimestamp(streamId) ?? Date.now();
+    this.creationTimestamps.set(streamId, createdAt);
+    return createdAt;
   }
 
   private buildStreamInfo(streamId: StreamTabId): StreamTabInfo {
@@ -115,8 +148,7 @@ class DesktopProgressBridge {
       agentCategory: category,
       hasMultipleOutputs: config?.useMultipleOutputs ?? false,
       inputFile,
-      creationTimestamp:
-        this.streamLogs.getFirstTimestamp(streamId) ?? Date.now(),
+      creationTimestamp: this.getCreationTimestamp(streamId),
       executionId: this.executionIds.get(streamId),
       parentStreamId: this.parentStreams.get(streamId),
       description: this.descriptions.get(streamId),
@@ -132,12 +164,48 @@ class DesktopProgressBridge {
       kind: category,
       status: this.statuses.get(streamId) ?? STREAM_STATUS.READY,
       lastTimestamp: this.streamLogs.getLastTimestamp(streamId),
-      conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
+      conversationProgress: this.conversationProgress.get(streamId) ?? {
+        conversationTurns: 0,
+        toolCallCount: 0,
+      },
+      activeSubagents: this.streamBadges.get(streamId)?.activeSubagents ?? [],
+      finishedSubagentCount:
+        this.streamBadges.get(streamId)?.finishedSubagentCount ?? 0,
+      activeProcesses: this.streamBadges.get(streamId)?.activeProcesses ?? [],
+      finishedProcessCount:
+        this.streamBadges.get(streamId)?.finishedProcessCount ?? 0,
+    };
+  }
+
+  private updateActiveChildren(
+    parentStreamId: StreamTabId,
+    opts: {
+      activeField: 'activeSubagents' | 'activeProcesses';
+      countField: 'finishedSubagentCount' | 'finishedProcessCount';
+      next: ActiveChildInfo[];
+    },
+  ): StreamBadgeSnapshot {
+    this.ensureStream(parentStreamId);
+    const previous = this.streamBadges.get(parentStreamId) ?? {
       activeSubagents: [],
       finishedSubagentCount: 0,
       activeProcesses: [],
       finishedProcessCount: 0,
     };
+    const previousIds = new Set(
+      previous[opts.activeField].map((child) => child.executionId),
+    );
+    const nextIds = new Set(opts.next.map((child) => child.executionId));
+    const newlyFinished = [...previousIds].filter(
+      (id) => !nextIds.has(id),
+    ).length;
+    const nextBadges = {
+      ...previous,
+      [opts.activeField]: opts.next,
+      [opts.countField]: previous[opts.countField] + newlyFinished,
+    };
+    this.streamBadges.set(parentStreamId, nextBadges);
+    return nextBadges;
   }
 
   private syncStreams(): void {
@@ -222,23 +290,24 @@ class DesktopProgressBridge {
       }
       case 'updateStreamStatus': {
         const data = payload as ProgressEventPayloads['updateStreamStatus'];
+        const wasKnownStream = this.streamLogs.has(data.streamId);
         this.ensureStream(data.streamId);
         this.statuses.set(data.streamId, data.status);
-        if (!this.streamLogs.has(data.streamId)) {
+        if (!wasKnownStream) {
           this.syncStreams();
-        } else {
-          this.send({
-            command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
-            stream: data.streamId,
-            status: data.status,
-            lastTimestamp: this.streamLogs.getLastTimestamp(data.streamId),
-          });
         }
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+          stream: data.streamId,
+          status: data.status,
+          lastTimestamp: this.streamLogs.getLastTimestamp(data.streamId),
+        });
         break;
       }
       case 'updateConversationProgress': {
         const data =
           payload as ProgressEventPayloads['updateConversationProgress'];
+        this.conversationProgress.set(data.streamId, data.progress);
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS,
           stream: data.streamId,
@@ -328,22 +397,25 @@ class DesktopProgressBridge {
         const data = payload as
           | ProgressEventPayloads['updateActiveSubagents']
           | ProgressEventPayloads['updateActiveProcesses'];
+        const badges =
+          event === 'updateActiveSubagents'
+            ? this.updateActiveChildren(data.parentStreamId, {
+                activeField: 'activeSubagents',
+                countField: 'finishedSubagentCount',
+                next: (data as ProgressEventPayloads['updateActiveSubagents'])
+                  .children,
+              })
+            : this.updateActiveChildren(data.parentStreamId, {
+                activeField: 'activeProcesses',
+                countField: 'finishedProcessCount',
+                next: (data as ProgressEventPayloads['updateActiveProcesses'])
+                  .processes,
+              });
         this.syncStreams();
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
           stream: data.parentStreamId,
-          activeSubagents:
-            event === 'updateActiveSubagents'
-              ? (data as ProgressEventPayloads['updateActiveSubagents'])
-                  .children
-              : [],
-          finishedSubagentCount: 0,
-          activeProcesses:
-            event === 'updateActiveProcesses'
-              ? (data as ProgressEventPayloads['updateActiveProcesses'])
-                  .processes
-              : [],
-          finishedProcessCount: 0,
+          ...badges,
         });
         break;
       }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -56,9 +56,7 @@ class DesktopProgressBridge {
 
   readonly runtimeHost: AgentRuntimeHost;
 
-  constructor(
-    private readonly postToRenderer: (message: unknown) => void,
-  ) {
+  constructor(private readonly postToRenderer: (message: unknown) => void) {
     AgentLogger.setStreamLogStore(this.streamLogs);
     setRunStorageService({ isViewVisible: () => true });
     this.unsubscribe = this.streamLogs.onChange((streamId) =>
@@ -143,9 +141,14 @@ class DesktopProgressBridge {
   }
 
   private syncStreams(): void {
-    const streams = this.streamLogs.keys().map((id) => this.buildStreamInfo(id));
+    const streams = this.streamLogs
+      .keys()
+      .map((id) => this.buildStreamInfo(id));
     const streamStates = Object.fromEntries(
-      streams.map((stream) => [stream.name, this.buildStreamMetadata(stream.name)]),
+      streams.map((stream) => [
+        stream.name,
+        this.buildStreamMetadata(stream.name),
+      ]),
     );
     this.send({
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
@@ -207,9 +210,13 @@ class DesktopProgressBridge {
       }
       case 'setTaskState': {
         const data = payload as ProgressEventPayloads['setTaskState'];
-        this.ensureStream(data.streamId, data.taskState.agentConfig.agentCategory);
+        this.ensureStream(
+          data.streamId,
+          data.taskState.agentConfig.agentCategory,
+        );
         this.taskStates.set(data.streamId, data.taskState);
-        if (data.executionId) this.executionIds.set(data.streamId, data.executionId);
+        if (data.executionId)
+          this.executionIds.set(data.streamId, data.executionId);
         this.syncStreams();
         break;
       }
@@ -327,12 +334,14 @@ class DesktopProgressBridge {
           stream: data.parentStreamId,
           activeSubagents:
             event === 'updateActiveSubagents'
-              ? (data as ProgressEventPayloads['updateActiveSubagents']).children
+              ? (data as ProgressEventPayloads['updateActiveSubagents'])
+                  .children
               : [],
           finishedSubagentCount: 0,
           activeProcesses:
             event === 'updateActiveProcesses'
-              ? (data as ProgressEventPayloads['updateActiveProcesses']).processes
+              ? (data as ProgressEventPayloads['updateActiveProcesses'])
+                  .processes
               : [],
           finishedProcessCount: 0,
         });

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -34,7 +34,6 @@ export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): void;
   openPath?: (filePath: string) => Promise<void>;
   showInformationMessage?: (message: string) => Promise<void> | void;
-  onError?: (error: unknown) => void;
 }
 
 export interface DesktopAgentExecution {
@@ -447,20 +446,15 @@ export function createDesktopAgentExecution(
         return;
       }
 
-      try {
-        await runValidatedExecutionRequest(preparation.request, {
-          runtimeHost: progress.runtimeHost,
-          openWorkflowOutput: async (result) => {
-            const output = result.outputs.at(-1);
-            if (output && options.openPath) {
-              await options.openPath(output.absolutePath);
-            }
-          },
-        });
-      } catch (error) {
-        options.onError?.(error);
-        throw error;
-      }
+      await runValidatedExecutionRequest(preparation.request, {
+        runtimeHost: progress.runtimeHost,
+        openWorkflowOutput: async (result) => {
+          const output = result.outputs.at(-1);
+          if (output && options.openPath) {
+            await options.openPath(output.absolutePath);
+          }
+        },
+      });
     },
     dispose() {
       progress.dispose();

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1,0 +1,391 @@
+import { basename } from 'node:path';
+
+import {
+  prepareMainViewExecutionRequest,
+  type MainViewExecuteMessage,
+} from '@controllers/mainView/MainViewExecutionController';
+import {
+  createAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressSink } from '@agent/runtime/ProgressSink';
+import { setRunStorageService } from '@agent/runtime/RunStorageService';
+import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import { AgentLogger } from '@logger/AgentLogger';
+import { StreamLogStore } from '@logger/StreamLogStore';
+import {
+  STREAM_STATUS,
+  type AgentCategory,
+  type ProgressViewOutboundMessage,
+  type StreamMetadata,
+  type StreamStatus,
+  type StreamTabId,
+  type StreamTabInfo,
+} from '@shared/schemas';
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
+
+import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
+
+export interface DesktopAgentExecutionOptions {
+  postToRenderer(message: unknown): void;
+  openPath?: (filePath: string) => Promise<void>;
+  onError?: (error: unknown) => void;
+}
+
+export interface DesktopAgentExecution {
+  handleExecute(message: MainViewExecuteMessage): Promise<void>;
+  dispose(): void;
+}
+
+type TaskState = ProgressEventPayloads['setTaskState']['taskState'];
+
+class DesktopProgressBridge {
+  private readonly streamLogs = new StreamLogStore();
+  private readonly cursors = new Map<StreamTabId, number>();
+  private readonly taskStates = new Map<StreamTabId, TaskState>();
+  private readonly statuses = new Map<StreamTabId, StreamStatus>();
+  private readonly categories = new Map<StreamTabId, AgentCategory>();
+  private readonly executionIds = new Map<StreamTabId, string>();
+  private readonly descriptions = new Map<StreamTabId, string>();
+  private readonly parentStreams = new Map<StreamTabId, StreamTabId>();
+  private activeStream: StreamTabId | '' = '';
+  private readonly unsubscribe: () => void;
+
+  readonly runtimeHost: AgentRuntimeHost;
+
+  constructor(
+    private readonly postToRenderer: (message: unknown) => void,
+  ) {
+    AgentLogger.setStreamLogStore(this.streamLogs);
+    setRunStorageService({ isViewVisible: () => true });
+    this.unsubscribe = this.streamLogs.onChange((streamId) =>
+      this.flushLogs(streamId),
+    );
+    const progressSink: ProgressSink = {
+      emit: (event, payload) => this.handleProgressEvent(event, payload),
+    };
+    this.runtimeHost = createAgentRuntimeHost(progressSink);
+  }
+
+  dispose(): void {
+    this.unsubscribe();
+    this.cursors.clear();
+  }
+
+  private send(message: ProgressViewOutboundMessage): void {
+    this.postToRenderer(message);
+  }
+
+  private routeToProgress(): void {
+    this.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+      route: 'progress',
+    });
+  }
+
+  private ensureStream(
+    streamId: StreamTabId,
+    category: AgentCategory = AGENT_CATEGORY.WORKFLOW,
+  ): void {
+    this.streamLogs.ensureStream(streamId);
+    if (!this.categories.has(streamId)) {
+      this.categories.set(streamId, category);
+    }
+  }
+
+  private buildStreamInfo(streamId: StreamTabId): StreamTabInfo {
+    const taskState = this.taskStates.get(streamId);
+    const config = taskState?.agentConfig;
+    const category =
+      config?.agentCategory ??
+      this.categories.get(streamId) ??
+      AGENT_CATEGORY.WORKFLOW;
+    const inputFile = config?.inputFile ?? '';
+    const agentName = config?.agent ?? streamId.split('@')[0] ?? streamId;
+    return {
+      name: streamId,
+      label:
+        category !== AGENT_CATEGORY.TOOL_USE && inputFile
+          ? `${agentName}: ${basename(inputFile)}`
+          : agentName,
+      model: config?.model,
+      modelLabel: config?.model,
+      agent: config?.agent,
+      agentCategory: category,
+      hasMultipleOutputs: config?.useMultipleOutputs ?? false,
+      inputFile,
+      creationTimestamp:
+        this.streamLogs.getFirstTimestamp(streamId) ?? Date.now(),
+      executionId: this.executionIds.get(streamId),
+      parentStreamId: this.parentStreams.get(streamId),
+      description: this.descriptions.get(streamId),
+    };
+  }
+
+  private buildStreamMetadata(streamId: StreamTabId): StreamMetadata {
+    const category =
+      this.taskStates.get(streamId)?.agentConfig.agentCategory ??
+      this.categories.get(streamId) ??
+      AGENT_CATEGORY.WORKFLOW;
+    return {
+      kind: category,
+      status: this.statuses.get(streamId) ?? STREAM_STATUS.READY,
+      lastTimestamp: this.streamLogs.getLastTimestamp(streamId),
+      conversationProgress: { conversationTurns: 0, toolCallCount: 0 },
+      activeSubagents: [],
+      finishedSubagentCount: 0,
+      activeProcesses: [],
+      finishedProcessCount: 0,
+    };
+  }
+
+  private syncStreams(): void {
+    const streams = this.streamLogs.keys().map((id) => this.buildStreamInfo(id));
+    const streamStates = Object.fromEntries(
+      streams.map((stream) => [stream.name, this.buildStreamMetadata(stream.name)]),
+    );
+    this.send({
+      command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      streams,
+      activeStream: this.activeStream,
+      agentFilter: 'all',
+      streamStates,
+    });
+  }
+
+  private flushLogs(streamId: StreamTabId): void {
+    if (streamId !== this.activeStream) return;
+    const log = this.streamLogs.get(streamId);
+    if (!log) return;
+    const cursor = this.cursors.get(streamId) ?? 0;
+    const entries = log.getRange(cursor, log.head);
+    const updates = log.drainDirtyUpdates(cursor);
+    if (entries.length === 0 && updates.length === 0) return;
+    this.send({
+      command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      streamId,
+      entries,
+      updates,
+    });
+    this.cursors.set(streamId, log.head);
+  }
+
+  private handleProgressEvent<K extends keyof ProgressEventPayloads>(
+    event: K,
+    payload: ProgressEventPayloads[K],
+  ): void {
+    switch (event) {
+      case 'requestEnsureProgressView':
+        this.routeToProgress();
+        break;
+      case 'setActiveStream': {
+        const data = payload as ProgressEventPayloads['setActiveStream'];
+        if (!data.streamId) {
+          this.activeStream = '';
+          this.send({
+            command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+            activeStream: '',
+          });
+          break;
+        }
+        this.ensureStream(
+          data.streamId,
+          data.agentCategory ?? AGENT_CATEGORY.WORKFLOW,
+        );
+        this.activeStream = data.streamId;
+        this.routeToProgress();
+        this.syncStreams();
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+          activeStream: data.streamId,
+        });
+        this.flushLogs(data.streamId);
+        break;
+      }
+      case 'setTaskState': {
+        const data = payload as ProgressEventPayloads['setTaskState'];
+        this.ensureStream(data.streamId, data.taskState.agentConfig.agentCategory);
+        this.taskStates.set(data.streamId, data.taskState);
+        if (data.executionId) this.executionIds.set(data.streamId, data.executionId);
+        this.syncStreams();
+        break;
+      }
+      case 'updateStreamStatus': {
+        const data = payload as ProgressEventPayloads['updateStreamStatus'];
+        this.ensureStream(data.streamId);
+        this.statuses.set(data.streamId, data.status);
+        if (!this.streamLogs.has(data.streamId)) {
+          this.syncStreams();
+        } else {
+          this.send({
+            command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+            stream: data.streamId,
+            status: data.status,
+            lastTimestamp: this.streamLogs.getLastTimestamp(data.streamId),
+          });
+        }
+        break;
+      }
+      case 'updateConversationProgress': {
+        const data =
+          payload as ProgressEventPayloads['updateConversationProgress'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_CONVERSATION_PROGRESS,
+          stream: data.streamId,
+          progress: data.progress,
+        });
+        break;
+      }
+      case 'updateTodos': {
+        const data = payload as ProgressEventPayloads['updateTodos'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_TODOS,
+          stream: data.streamId,
+          todos: data.todos,
+        });
+        break;
+      }
+      case 'updatePlan': {
+        const data = payload as ProgressEventPayloads['updatePlan'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PLAN,
+          stream: data.streamId,
+          plan: data.plan,
+        });
+        break;
+      }
+      case 'updateStreamUsage': {
+        const data = payload as ProgressEventPayloads['updateStreamUsage'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_RUN_USAGE,
+          stream: data.streamId,
+          runId: data.executionId ?? data.storageKey,
+          usage: data.usage,
+        });
+        break;
+      }
+      case 'addOutputFiles': {
+        const data = payload as ProgressEventPayloads['addOutputFiles'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
+          stream: data.streamId,
+          rounds: data.filesByRound,
+        });
+        break;
+      }
+      case 'updateMissingOutputs': {
+        const data = payload as ProgressEventPayloads['updateMissingOutputs'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_MISSING_OUTPUTS,
+          stream: data.streamId,
+          rounds: data.filesByRound,
+        });
+        break;
+      }
+      case 'updateCompileFailures': {
+        const data = payload as ProgressEventPayloads['updateCompileFailures'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_COMPILE_FAILURES,
+          stream: data.streamId,
+          rounds: data.filesByRound,
+          reset: true,
+        });
+        break;
+      }
+      case 'updateStreamDescription': {
+        const data =
+          payload as ProgressEventPayloads['updateStreamDescription'];
+        this.descriptions.set(data.streamId, data.description);
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_DESCRIPTION,
+          stream: data.streamId,
+          description: data.description,
+        });
+        break;
+      }
+      case 'setParentStream': {
+        const data = payload as ProgressEventPayloads['setParentStream'];
+        this.parentStreams.set(data.childStreamId, data.parentStreamId);
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PARENT_STREAM,
+          stream: data.childStreamId,
+          parentStreamId: data.parentStreamId,
+        });
+        break;
+      }
+      case 'updateActiveSubagents':
+      case 'updateActiveProcesses': {
+        const data = payload as
+          | ProgressEventPayloads['updateActiveSubagents']
+          | ProgressEventPayloads['updateActiveProcesses'];
+        this.syncStreams();
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+          stream: data.parentStreamId,
+          activeSubagents:
+            event === 'updateActiveSubagents'
+              ? (data as ProgressEventPayloads['updateActiveSubagents']).children
+              : [],
+          finishedSubagentCount: 0,
+          activeProcesses:
+            event === 'updateActiveProcesses'
+              ? (data as ProgressEventPayloads['updateActiveProcesses']).processes
+              : [],
+          finishedProcessCount: 0,
+        });
+        break;
+      }
+      case 'updateProcessOutput': {
+        const data = payload as ProgressEventPayloads['updateProcessOutput'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PROCESS_OUTPUT,
+          stream: data.parentStreamId,
+          executionId: data.executionId,
+          stdout: data.stdout,
+          stderr: data.stderr,
+        });
+        break;
+      }
+    }
+  }
+}
+
+export function createDesktopAgentExecution(
+  options: DesktopAgentExecutionOptions,
+): DesktopAgentExecution {
+  const progress = new DesktopProgressBridge(options.postToRenderer);
+
+  return {
+    async handleExecute(message) {
+      const preparation = prepareMainViewExecutionRequest(message);
+      if (!preparation.valid) {
+        options.postToRenderer({
+          command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
+          text: preparation.message,
+        });
+        return;
+      }
+
+      try {
+        await runValidatedExecutionRequest(preparation.request, {
+          runtimeHost: progress.runtimeHost,
+          openWorkflowOutput: async (result) => {
+            const output = result.outputs.at(-1);
+            if (output && options.openPath) {
+              await options.openPath(output.absolutePath);
+            }
+          },
+        });
+      } catch (error) {
+        options.onError?.(error);
+        throw error;
+      }
+    },
+    dispose() {
+      progress.dispose();
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -11,7 +11,6 @@ import {
 import type { ProgressSink } from '@agent/runtime/ProgressSink';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -34,6 +33,7 @@ import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): void;
   openPath?: (filePath: string) => Promise<void>;
+  showInformationMessage?: (message: string) => Promise<void> | void;
   onError?: (error: unknown) => void;
 }
 
@@ -443,10 +443,7 @@ export function createDesktopAgentExecution(
     async handleExecute(message) {
       const preparation = prepareMainViewExecutionRequest(message);
       if (!preparation.valid) {
-        options.postToRenderer({
-          command: MAIN_VIEW_COMMANDS.SHOW_INFORMATION_MESSAGE,
-          text: preparation.message,
-        });
+        await options.showInformationMessage?.(preparation.message);
         return;
       }
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -55,8 +55,8 @@ function createWindow(): void {
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     openPath,
-    showInformationMessage: async (message) => {
-      await dialog.showMessageBox(window, { message, type: 'info' });
+    showErrorMessage: async (message) => {
+      await dialog.showMessageBox(window, { message, type: 'error' });
     },
   });
   const mainViewIpc = installDesktopMainViewIpc(window, {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, session, shell } from 'electron';
 
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
@@ -44,13 +45,27 @@ function createWindow(): void {
       sandbox: true,
     },
   });
-  installDesktopMainViewIpc(window, {
+  const ipcRef: {
+    current?: ReturnType<typeof installDesktopMainViewIpc>;
+  } = {};
+  const agentExecution = createDesktopAgentExecution({
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    openPath: async (filePath) => {
+      const errorMessage = await shell.openPath(filePath);
+      if (errorMessage) throw new Error(errorMessage);
+    },
+    onError: (error) => console.error(error),
+  });
+  const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),
     openPath: async (filePath) => {
       const errorMessage = await shell.openPath(filePath);
       if (errorMessage) throw new Error(errorMessage);
     },
+    executeAgent: (message) => agentExecution.handleExecute(message),
   });
+  ipcRef.current = mainViewIpc;
+  window.once('closed', () => agentExecution.dispose());
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -58,7 +58,6 @@ function createWindow(): void {
     showInformationMessage: async (message) => {
       await dialog.showMessageBox(window, { message, type: 'info' });
     },
-    onError: (error) => console.error(error),
   });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, session, shell } from 'electron';
+import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
@@ -48,20 +48,21 @@ function createWindow(): void {
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
   } = {};
+  const openPath = async (filePath: string) => {
+    const errorMessage = await shell.openPath(filePath);
+    if (errorMessage) throw new Error(errorMessage);
+  };
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
-    openPath: async (filePath) => {
-      const errorMessage = await shell.openPath(filePath);
-      if (errorMessage) throw new Error(errorMessage);
+    openPath,
+    showInformationMessage: async (message) => {
+      await dialog.showMessageBox(window, { message, type: 'info' });
     },
     onError: (error) => console.error(error),
   });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),
-    openPath: async (filePath) => {
-      const errorMessage = await shell.openPath(filePath);
-      if (errorMessage) throw new Error(errorMessage);
-    },
+    openPath,
     executeAgent: (message) => agentExecution.handleExecute(message),
   });
   ipcRef.current = mainViewIpc;

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -21,6 +21,7 @@ import {
   installDesktopHostBridge,
   type DesktopHostBridge,
 } from './hostBridge.js';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
 
 type DesktopTheme = 'dark' | 'light' | 'high-contrast';
 
@@ -29,6 +30,7 @@ export interface DesktopMainViewIpcOptions {
   getTheme?: () => DesktopTheme;
   getCustomAgentDirectory?: () => Promise<string>;
   openPath?: (filePath: string) => Promise<void>;
+  executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -142,6 +144,12 @@ export function installDesktopMainViewIpc(
     }
     void openCustomAgentDirectory().catch(reportAsyncError);
   }
+  function handleExecute(message: unknown) {
+    if (!options.executeAgent) return;
+    void options
+      .executeAgent(message as MainViewExecuteMessage)
+      .catch(reportAsyncError);
+  }
   function postInitialState() {
     postTheme();
     postDebugMode();
@@ -176,6 +184,9 @@ export function installDesktopMainViewIpc(
         break;
       case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
         handleOpenAgentDirectory(message);
+        break;
+      case MAIN_VIEW_COMMANDS.EXECUTE:
+        handleExecute(message);
         break;
     }
   }

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -36,8 +36,7 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
       : null;
     const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
 
-    const executionId =
-      (wrapped?.executionId as ExecutionId | undefined) ?? undefined;
+    const executionId = wrapped?.executionId as ExecutionId | undefined;
     await runValidatedExecutionRequest(
       { config, executionId },
       { openWorkflowOutput: openFinalOutputIfAvailable },

--- a/packages/extension/src/commands/agent/executeCommand.ts
+++ b/packages/extension/src/commands/agent/executeCommand.ts
@@ -4,13 +4,11 @@ import { ZodError } from 'zod';
 
 // Local imports
 import { AgentConfigSchema } from '@agent/core';
-import { registerExecution } from '@agent/storage';
-import { executeAgent } from '@agent/runtime/executeAgent';
+import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
 import { formatZodError } from '@common/errors';
 import { openFinalOutputIfAvailable } from '@frontend/agents/finalOutputOpener';
 import * as logger from '@logger/logUtils';
 import type { ExecutionId } from '@shared/schemas';
-import { generateExecutionId } from '@utils/core/executionId';
 
 const CHANNEL = 'ExecuteCommand';
 
@@ -39,17 +37,11 @@ export async function runExecuteCommand(input: unknown): Promise<void> {
     const config = AgentConfigSchema.parse(wrapped ? wrapped.config : input);
 
     const executionId =
-      (wrapped?.executionId as ExecutionId | undefined) ??
-      generateExecutionId();
-    const isResume = wrapped?.executionId !== undefined;
-
-    if (!isResume) {
-      await registerExecution(executionId, config, config.agent);
-    }
-    const result = await executeAgent(config, executionId);
-    if (result.category === 'workflow') {
-      await openFinalOutputIfAvailable(result);
-    }
+      (wrapped?.executionId as ExecutionId | undefined) ?? undefined;
+    await runValidatedExecutionRequest(
+      { config, executionId },
+      { openWorkflowOutput: openFinalOutputIfAvailable },
+    );
   } catch (error) {
     if (error instanceof ZodError) {
       const message = `Invalid agent configuration. ${formatZodError(error)}`;

--- a/packages/extension/src/webview/managers/ExecutionManager.ts
+++ b/packages/extension/src/webview/managers/ExecutionManager.ts
@@ -39,7 +39,10 @@ export class ExecutionManager {
       } else {
         vscode.window.showErrorMessage(preparation.message);
       }
-      logger.error(CHANNEL, `AgentConfig validation failed: ${preparation.message}`);
+      logger.error(
+        CHANNEL,
+        `AgentConfig validation failed: ${preparation.message}`,
+      );
       return;
     }
 

--- a/packages/extension/src/webview/managers/ExecutionManager.ts
+++ b/packages/extension/src/webview/managers/ExecutionManager.ts
@@ -1,35 +1,13 @@
 import * as vscode from 'vscode';
 
-import type { AgentConfigInput } from '@agent/core/AgentConfig';
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import { validateExecutionRequest } from '@agent/core/executionRequests';
+import {
+  prepareMainViewExecutionRequest,
+  type MainViewExecuteMessage,
+} from '@controllers/mainView/MainViewExecutionController';
 import * as logger from '@logger/logUtils';
-import {
-  DEFAULT_TOOL_CONFIG,
-  ToolConfigSchema,
-} from '@shared/schemas/toolConfig';
-import {
-  getPastedImageFullPath,
-  isPastedImage,
-} from '@utils/files/pastedImageUtils';
-import type { z } from 'zod';
 
 const CHANNEL = 'ExecutionManager';
 logger.initialize(CHANNEL);
-
-/**
- * Message shape from webview for agent execution.
- * Extends AgentConfigInput with UI-specific fields.
- * ToolConfig fields are sent flat from the UI form.
- */
-type ExecuteMessage = AgentConfigInput & {
-  /** UI toggle indicating tool-use vs workflow agent */
-  isToolUseAgent?: boolean;
-  /** UI toggle for multiple outputs mode */
-  outputFilesActive?: boolean;
-  /** Media files may contain nulls from UI (filtered during processing) */
-  mediaFiles?: (string | null)[];
-} & z.input<typeof ToolConfigSchema>;
 
 /** Message shape for command-based operations. */
 interface CommandMessage {
@@ -43,70 +21,29 @@ interface CommandMessage {
 }
 
 export class ExecutionManager {
-  async handleExecute(message: ExecuteMessage): Promise<void> {
-    // IMPORTANT: Validate required fields before schema parsing.
-    // AgentConfigSchema uses .prefault() for agent/model (see AgentConfig.ts:96-97),
-    // which would silently provide defaults instead of failing on missing values.
-    if (!message.agent || !message.model) {
-      vscode.window.showErrorMessage(
-        'Agent and model selection required. Please select both before running.',
-      );
-      return;
-    }
-
-    const isToolUse = Boolean(message.isToolUseAgent);
-
-    // Tool-use agents don't need input file validation
-    if (!isToolUse && !message.inputFile) {
-      const openDocs = 'File Management Guide';
-      const choice = await vscode.window.showErrorMessage(
-        'Please select an input file.',
-        openDocs,
-      );
-      if (choice === openDocs) {
-        void vscode.commands.executeCommand('texra.openDoc', 'file-management');
+  async handleExecute(message: MainViewExecuteMessage): Promise<void> {
+    const preparation = prepareMainViewExecutionRequest(message);
+    if (!preparation.valid) {
+      if (preparation.docsCommand) {
+        const openDocs = 'File Management Guide';
+        const choice = await vscode.window.showErrorMessage(
+          preparation.message,
+          openDocs,
+        );
+        if (choice === openDocs) {
+          void vscode.commands.executeCommand(
+            'texra.openDoc',
+            preparation.docsCommand,
+          );
+        }
+      } else {
+        vscode.window.showErrorMessage(preparation.message);
       }
+      logger.error(CHANNEL, `AgentConfig validation failed: ${preparation.message}`);
       return;
     }
 
-    const mapMedia = (f: string | null): string | null =>
-      f && isPastedImage(f) ? getPastedImageFullPath(f) : f;
-
-    const outputFiles: string[] = isToolUse ? [] : (message.outputFiles ?? []);
-    const toolConfig = isToolUse
-      ? DEFAULT_TOOL_CONFIG
-      : ToolConfigSchema.parse(message);
-
-    const request = {
-      config: {
-        ...message,
-        agentCategory: isToolUse
-          ? AgentCategory.ToolUse
-          : AgentCategory.Workflow,
-        outputFiles,
-        useMultipleOutputs:
-          !isToolUse &&
-          (Boolean(message.outputFilesActive) || outputFiles.length > 1),
-        toolConfig,
-        mediaFile: mapMedia(message.mediaFile ?? null),
-        mediaFiles: (message.mediaFiles ?? [])
-          .map(mapMedia)
-          .filter((f: string | null): f is string => f !== null),
-        editedFile: null,
-      },
-    };
-
-    const validation = validateExecutionRequest(request);
-    if (!validation.valid) {
-      vscode.window.showErrorMessage(validation.message);
-      logger.error(
-        CHANNEL,
-        `AgentConfig validation failed: ${validation.message}`,
-      );
-      return;
-    }
-
-    await vscode.commands.executeCommand('texra.execute', validation.request);
+    await vscode.commands.executeCommand('texra.execute', preparation.request);
   }
 
   handleFileOperation(message: CommandMessage): void {

--- a/src/agent/runtime/runExecutionRequest.ts
+++ b/src/agent/runtime/runExecutionRequest.ts
@@ -1,0 +1,42 @@
+// Local imports - agent
+import { registerExecution } from '@agent/storage';
+
+import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
+import type { ExecutionId } from '@shared/schemas';
+import { generateExecutionId } from '@utils/core/executionId';
+import { executeAgent } from './executeAgent';
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+import type {
+  AgentFlowResult,
+  WorkflowFlowResult,
+} from './AgentFlowResult';
+
+// Local imports - shared schemas
+
+// Local imports - utilities
+
+export interface RunExecutionRequestOptions {
+  runtimeHost?: AgentRuntimeHost;
+  openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;
+}
+
+export async function runValidatedExecutionRequest(
+  request: ValidatedExecutionRequest,
+  options: RunExecutionRequestOptions = {},
+): Promise<AgentFlowResult> {
+  const executionId =
+    request.executionId ?? (generateExecutionId() as ExecutionId);
+  const isResume = request.executionId !== undefined;
+
+  if (!isResume) {
+    await registerExecution(executionId, request.config, request.config.agent);
+  }
+
+  const result = await executeAgent(request.config, executionId, {
+    runtimeHost: options.runtimeHost,
+  });
+  if (result.category === 'workflow') {
+    await options.openWorkflowOutput?.(result);
+  }
+  return result;
+}

--- a/src/agent/runtime/runExecutionRequest.ts
+++ b/src/agent/runtime/runExecutionRequest.ts
@@ -6,10 +6,7 @@ import type { ExecutionId } from '@shared/schemas';
 import { generateExecutionId } from '@utils/core/executionId';
 import { executeAgent } from './executeAgent';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
-import type {
-  AgentFlowResult,
-  WorkflowFlowResult,
-} from './AgentFlowResult';
+import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 
 // Local imports - shared schemas
 

--- a/src/agent/runtime/runExecutionRequest.ts
+++ b/src/agent/runtime/runExecutionRequest.ts
@@ -8,10 +8,6 @@ import { executeAgent } from './executeAgent';
 import type { AgentRuntimeHost } from './AgentRuntimeHost';
 import type { AgentFlowResult, WorkflowFlowResult } from './AgentFlowResult';
 
-// Local imports - shared schemas
-
-// Local imports - utilities
-
 export interface RunExecutionRequestOptions {
   runtimeHost?: AgentRuntimeHost;
   openWorkflowOutput?: (result: WorkflowFlowResult) => Promise<void>;

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -25,10 +25,7 @@ import type { z } from 'zod';
  * Message shape from the main view for agent execution.
  * ToolConfig fields are sent flat from the UI form.
  */
-export type MainViewExecuteMessage = Omit<
-  AgentConfigInput,
-  'mediaFiles'
-> & {
+export type MainViewExecuteMessage = Omit<AgentConfigInput, 'mediaFiles'> & {
   /** UI toggle indicating tool-use vs workflow agent. */
   isToolUseAgent?: boolean;
   /** UI toggle for multiple outputs mode. */
@@ -53,7 +50,8 @@ export function prepareMainViewExecutionRequest(
   if (!message.agent || !message.model) {
     return {
       valid: false,
-      message: 'Agent and model selection required. Please select both before running.',
+      message:
+        'Agent and model selection required. Please select both before running.',
     };
   }
 
@@ -82,9 +80,7 @@ export function prepareMainViewExecutionRequest(
   const validation = validateExecutionRequest({
     config: {
       ...message,
-      agentCategory: isToolUse
-        ? AgentCategory.ToolUse
-        : AgentCategory.Workflow,
+      agentCategory: isToolUse ? AgentCategory.ToolUse : AgentCategory.Workflow,
       outputFiles,
       useMultipleOutputs:
         !isToolUse &&

--- a/src/controllers/mainView/MainViewExecutionController.ts
+++ b/src/controllers/mainView/MainViewExecutionController.ts
@@ -1,0 +1,106 @@
+// Third-party imports
+
+// Local imports - agent
+import type { AgentConfigInput } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import {
+  validateExecutionRequest,
+  type ValidatedExecutionRequest,
+} from '@agent/core/executionRequests';
+
+// Local imports - shared schemas
+import {
+  DEFAULT_TOOL_CONFIG,
+  ToolConfigSchema,
+} from '@shared/schemas/toolConfig';
+
+// Local imports - utilities
+import {
+  getPastedImageFullPath,
+  isPastedImage,
+} from '@utils/files/pastedImageUtils';
+import type { z } from 'zod';
+
+/**
+ * Message shape from the main view for agent execution.
+ * ToolConfig fields are sent flat from the UI form.
+ */
+export type MainViewExecuteMessage = Omit<
+  AgentConfigInput,
+  'mediaFiles'
+> & {
+  /** UI toggle indicating tool-use vs workflow agent. */
+  isToolUseAgent?: boolean;
+  /** UI toggle for multiple outputs mode. */
+  outputFilesActive?: boolean;
+  /** Media files may contain nulls from UI and are filtered during processing. */
+  mediaFiles?: (string | null)[];
+} & z.input<typeof ToolConfigSchema>;
+
+export type MainViewExecutionPreparationResult =
+  | { valid: true; request: ValidatedExecutionRequest }
+  | { valid: false; message: string; docsCommand?: string };
+
+function mapMediaFile(file: string | null): string | null {
+  return file && isPastedImage(file) ? getPastedImageFullPath(file) : file;
+}
+
+export function prepareMainViewExecutionRequest(
+  message: MainViewExecuteMessage,
+): MainViewExecutionPreparationResult {
+  // AgentConfigSchema prefaults agent/model; reject missing UI selections before
+  // schema parsing so the user sees the real form problem.
+  if (!message.agent || !message.model) {
+    return {
+      valid: false,
+      message: 'Agent and model selection required. Please select both before running.',
+    };
+  }
+
+  const isToolUse = Boolean(message.isToolUseAgent);
+  if (!isToolUse && !message.inputFile) {
+    return {
+      valid: false,
+      message: 'Please select an input file.',
+      docsCommand: 'file-management',
+    };
+  }
+
+  const outputFiles: string[] = isToolUse ? [] : (message.outputFiles ?? []);
+  const toolConfigResult = isToolUse
+    ? { success: true as const, data: DEFAULT_TOOL_CONFIG }
+    : ToolConfigSchema.safeParse(message);
+  if (!toolConfigResult.success) {
+    const issue = toolConfigResult.error.issues[0];
+    const path = issue?.path.join('.') || 'toolConfig';
+    return {
+      valid: false,
+      message: `Invalid tool configuration (${path}): ${issue?.message ?? 'validation failed'}`,
+    };
+  }
+
+  const validation = validateExecutionRequest({
+    config: {
+      ...message,
+      agentCategory: isToolUse
+        ? AgentCategory.ToolUse
+        : AgentCategory.Workflow,
+      outputFiles,
+      useMultipleOutputs:
+        !isToolUse &&
+        (Boolean(message.outputFilesActive) || outputFiles.length > 1),
+      toolConfig: toolConfigResult.data,
+      mediaFile: mapMediaFile(message.mediaFile ?? null),
+      mediaFiles: (message.mediaFiles ?? [])
+        .map(mapMediaFile)
+        .filter((file: string | null): file is string => file !== null),
+      editedFile: null,
+    },
+  });
+
+  if (!validation.valid) {
+    return { valid: false, message: validation.message };
+  }
+
+  return { valid: true, request: validation.request };
+}

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -1,18 +1,23 @@
 import { AsyncLocalStorage } from 'async_hooks';
 
-import * as vscode from 'vscode';
 
 import { type LogLevel } from '@shared/schemas';
 import { getConfig } from '@utils/config';
 import { serializeError } from '@utils/core';
 
 import { getColorForLevel } from './utils';
+import type * as vscode from 'vscode';
 import type { LogUtilsOptions } from './logOptions';
 
 const contextStorage = new AsyncLocalStorage<Map<string, string[]>>();
 
-const channels = new Map<string, vscode.OutputChannel>();
-let mainOutputChannel: vscode.OutputChannel | null = null;
+interface LogSink {
+  appendLine(message: string): void;
+}
+
+const channels = new Map<string, LogSink>();
+let mainOutputChannel: LogSink | null = null;
+let vscodeApi: typeof vscode | null | undefined;
 
 function getKey(channel: string, isAgent: boolean): string {
   return `${channel}::${isAgent ? 'agent' : 'shared'}`;
@@ -25,17 +30,44 @@ function getTimestamp(): string {
   return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}.${pad(now.getMilliseconds(), 3)}`;
 }
 
-function ensureChannel(
-  channel: string,
-  isAgent: boolean,
-): vscode.OutputChannel {
+function loadVscodeApi(): typeof vscode | null {
+  if (vscodeApi !== undefined) return vscodeApi;
+  try {
+    const requireFn = Function(
+      'return typeof require === "function" ? require : undefined',
+    )() as NodeRequire | undefined;
+    vscodeApi = requireFn?.('vscode') as typeof vscode | undefined;
+    vscodeApi ??= null;
+  } catch {
+    vscodeApi = null;
+  }
+  return vscodeApi;
+}
+
+function createConsoleSink(channel: string): LogSink {
+  return {
+    appendLine(message: string) {
+      console.info(`[${channel}] ${message}`);
+    },
+  };
+}
+
+function createOutputChannel(channel: string, isAgent: boolean): LogSink {
+  const api = loadVscodeApi();
+  if (!api) return createConsoleSink(isAgent ? `TeXRA ${channel}` : 'TeXRA');
+  return isAgent
+    ? api.window.createOutputChannel(`TeXRA ${channel}`)
+    : api.window.createOutputChannel('TeXRA');
+}
+
+function ensureChannel(channel: string, isAgent: boolean): LogSink {
   const key = getKey(channel, isAgent);
   const existing = channels.get(key);
   if (existing) return existing;
 
   const output = isAgent
-    ? vscode.window.createOutputChannel(`TeXRA ${channel}`)
-    : (mainOutputChannel ??= vscode.window.createOutputChannel('TeXRA'));
+    ? createOutputChannel(channel, true)
+    : (mainOutputChannel ??= createOutputChannel(channel, false));
   channels.set(key, output);
   return output;
 }
@@ -48,7 +80,7 @@ function getActiveGroupStack(
 }
 
 function writeLine(
-  channel: vscode.OutputChannel,
+  channel: LogSink,
   streamId: string,
   level: LogLevel,
   message: string,

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -1,6 +1,5 @@
 import { AsyncLocalStorage } from 'async_hooks';
 
-
 import { type LogLevel } from '@shared/schemas';
 import { getConfig } from '@utils/config';
 import { serializeError } from '@utils/core';

--- a/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
+++ b/src/test-kernel/controllers/MainViewExecutionController.vitest.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { prepareMainViewExecutionRequest } from '@controllers/mainView/MainViewExecutionController';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+
+describe('MainViewExecutionController', () => {
+  it('keeps missing selections explicit before schema prefaults apply', () => {
+    expect(prepareMainViewExecutionRequest({ model: 'gpt-5.4' }).valid).toBe(
+      false,
+    );
+    expect(prepareMainViewExecutionRequest({ agent: 'direct-agent' })).toEqual({
+      valid: false,
+      message:
+        'Agent and model selection required. Please select both before running.',
+    });
+  });
+
+  it('requires an input file for workflow runs', () => {
+    expect(
+      prepareMainViewExecutionRequest({
+        agent: 'direct-agent',
+        model: 'gpt-5.4',
+      }),
+    ).toEqual({
+      valid: false,
+      message: 'Please select an input file.',
+      docsCommand: 'file-management',
+    });
+  });
+
+  it('normalizes UI execution fields into an agent config request', () => {
+    const result = prepareMainViewExecutionRequest({
+      agent: 'direct-agent',
+      model: 'gpt-5.4',
+      inputFile: 'paper/main.tex',
+      outputFiles: ['paper/revised.tex'],
+      outputFilesActive: true,
+      mediaFiles: ['diagram.png', null],
+    });
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.request.config).toMatchObject({
+      agent: 'direct-agent',
+      model: 'gpt-5.4',
+      inputFile: 'paper/main.tex',
+      outputFiles: ['paper/revised.tex'],
+      useMultipleOutputs: true,
+      agentCategory: AgentCategory.Workflow,
+      mediaFiles: ['diagram.png'],
+      editedFile: null,
+    });
+  });
+});

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -1,0 +1,280 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - progress schemas
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
+import { AGENT_CATEGORY, STREAM_STATUS } from '@shared/schemas';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+type Bridge = {
+  dispose(): void;
+};
+
+type TestableBridge = Bridge & {
+  handleProgressEvent(event: string, payload: unknown): void;
+};
+
+interface DesktopAgentExecutionModule {
+  DesktopProgressBridge: new (
+    postToRenderer: (message: unknown) => void,
+  ) => Bridge;
+}
+
+type ProgressMessage = {
+  command?: string;
+  streams?: Array<{ name: string; creationTimestamp: number }>;
+  streamStates?: Record<string, unknown>;
+};
+
+async function createBridge(messages: unknown[]): Promise<TestableBridge> {
+  vi.doMock('@agent/runtime/AgentRuntimeHost', () => ({
+    createAgentRuntimeHost: vi.fn(() => ({})),
+  }));
+  vi.doMock('@agent/runtime/RunStorageService', () => ({
+    setRunStorageService: vi.fn(),
+  }));
+  vi.doMock('@agent/runtime/runExecutionRequest', () => ({
+    runValidatedExecutionRequest: vi.fn(),
+  }));
+  vi.doMock('@common/storage', () => ({
+    KVStore: class {
+      async read(): Promise<undefined> {
+        return undefined;
+      }
+
+      async write(): Promise<void> {}
+
+      async delete(): Promise<void> {}
+
+      async deleteDir(): Promise<void> {}
+
+      async exists(): Promise<boolean> {
+        return false;
+      }
+
+      async listKeys(): Promise<string[]> {
+        return [];
+      }
+    },
+  }));
+  vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
+    prepareMainViewExecutionRequest: vi.fn(),
+  }));
+  vi.doMock('@logger/AgentLogger', () => ({
+    AgentLogger: class {
+      static setStreamLogStore(): void {}
+    },
+  }));
+  vi.doMock('vscode', () => ({
+    commands: {
+      executeCommand: vi.fn(),
+    },
+    Disposable: class {
+      constructor(private readonly onDispose: () => void = () => undefined) {}
+
+      dispose(): void {
+        this.onDispose();
+      }
+
+      static from(...disposables: Array<{ dispose(): void }>): {
+        dispose(): void;
+      } {
+        return {
+          dispose: () =>
+            disposables.forEach((disposable) => disposable.dispose()),
+        };
+      }
+    },
+    env: {
+      openExternal: vi.fn(),
+    },
+    FileSystemError: {
+      FileNotFound: class extends Error {},
+    },
+    FileType: {
+      File: 1,
+      Directory: 2,
+      SymbolicLink: 64,
+    },
+    Uri: {
+      file: (fsPath: string) => ({
+        fsPath,
+        path: fsPath,
+        toString: () => fsPath,
+      }),
+      parse: (value: string) => ({
+        fsPath: value,
+        path: value,
+        toString: () => value,
+      }),
+    },
+    window: {
+      createOutputChannel: vi.fn(() => ({
+        appendLine: vi.fn(),
+        append: vi.fn(),
+        clear: vi.fn(),
+        dispose: vi.fn(),
+        show: vi.fn(),
+      })),
+      showErrorMessage: vi.fn(),
+      showInformationMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
+    },
+    workspace: {
+      fs: {},
+      getConfiguration: vi.fn(() => ({
+        get: vi.fn(),
+        update: vi.fn(),
+      })),
+      workspaceFolders: [],
+    },
+  }));
+  const { DesktopProgressBridge } = (await import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
+  )) as DesktopAgentExecutionModule;
+  return new DesktopProgressBridge((message) =>
+    messages.push(message),
+  ) as TestableBridge;
+}
+
+function progressMessages(
+  messages: unknown[],
+  command: string,
+): ProgressMessage[] {
+  return messages.filter(
+    (message): message is ProgressMessage =>
+      typeof message === 'object' &&
+      message !== null &&
+      (message as ProgressMessage).command === command,
+  );
+}
+
+describe('DesktopProgressBridge', () => {
+  afterEach(() => {
+    vi.doUnmock('@agent/runtime/AgentRuntimeHost');
+    vi.doUnmock('@agent/runtime/RunStorageService');
+    vi.doUnmock('@agent/runtime/runExecutionRequest');
+    vi.doUnmock('@common/storage');
+    vi.doUnmock('@controllers/mainView/MainViewExecutionController');
+    vi.doUnmock('@logger/AgentLogger');
+    vi.doUnmock('vscode');
+    vi.restoreAllMocks();
+  });
+
+  it('preserves progress and badge metadata across repeated stream syncs', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'parent',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('updateConversationProgress', {
+        streamId: 'parent',
+        progress: { conversationTurns: 3, toolCallCount: 5 },
+      });
+      bridge.handleProgressEvent('updateActiveProcesses', {
+        parentStreamId: 'parent',
+        processes: [{ executionId: 'process-1', agentName: 'bash' }],
+      });
+
+      vi.spyOn(Date, 'now').mockReturnValue(2_000);
+      bridge.handleProgressEvent('updateActiveSubagents', {
+        parentStreamId: 'parent',
+        children: [{ executionId: 'agent-1', agentName: 'reviewer' }],
+      });
+
+      const streamSync = progressMessages(
+        messages,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      ).at(-1);
+      expect(
+        streamSync?.streams?.find((s) => s.name === 'parent'),
+      ).toMatchObject({
+        creationTimestamp: 1_000,
+      });
+      expect(streamSync?.streamStates?.parent).toMatchObject({
+        conversationProgress: { conversationTurns: 3, toolCallCount: 5 },
+        activeSubagents: [{ executionId: 'agent-1', agentName: 'reviewer' }],
+        finishedSubagentCount: 0,
+        activeProcesses: [{ executionId: 'process-1', agentName: 'bash' }],
+        finishedProcessCount: 0,
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('accumulates finished child counts without clobbering the other active dimension', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'parent',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('updateActiveProcesses', {
+        parentStreamId: 'parent',
+        processes: [{ executionId: 'process-1', agentName: 'bash' }],
+      });
+      bridge.handleProgressEvent('updateActiveSubagents', {
+        parentStreamId: 'parent',
+        children: [{ executionId: 'agent-1', agentName: 'reviewer' }],
+      });
+      bridge.handleProgressEvent('updateActiveProcesses', {
+        parentStreamId: 'parent',
+        processes: [],
+      });
+      bridge.handleProgressEvent('updateActiveSubagents', {
+        parentStreamId: 'parent',
+        children: [],
+      });
+
+      const badgeUpdate = progressMessages(
+        messages,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_BADGES,
+      ).at(-1);
+      expect(badgeUpdate).toMatchObject({
+        activeSubagents: [],
+        finishedSubagentCount: 1,
+        activeProcesses: [],
+        finishedProcessCount: 1,
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('announces a new stream before sending its first targeted status update', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('updateStreamStatus', {
+        streamId: 'new-stream',
+        status: STREAM_STATUS.RUNNING,
+        previousStatus: STREAM_STATUS.READY,
+      });
+
+      expect(
+        messages.map((message) => (message as ProgressMessage).command),
+      ).toEqual([
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAM_STATUS,
+      ]);
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)[0]
+          ?.streamStates?.['new-stream'],
+      ).toMatchObject({ status: STREAM_STATUS.RUNNING });
+    } finally {
+      bridge.dispose();
+    }
+  });
+});

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -16,10 +16,21 @@ type TestableBridge = Bridge & {
   handleProgressEvent(event: string, payload: unknown): void;
 };
 
+type DesktopExecution = {
+  handleExecute(message: unknown): Promise<void>;
+  dispose(): void;
+};
+
 interface DesktopAgentExecutionModule {
   DesktopProgressBridge: new (
     postToRenderer: (message: unknown) => void,
   ) => Bridge;
+  createDesktopAgentExecution(options: {
+    postToRenderer(message: unknown): void;
+    openPath?: (filePath: string) => Promise<void>;
+    showInformationMessage?: (message: string) => Promise<void> | void;
+    onError?: (error: unknown) => void;
+  }): DesktopExecution;
 }
 
 type ProgressMessage = {
@@ -29,6 +40,7 @@ type ProgressMessage = {
 };
 
 async function createBridge(messages: unknown[]): Promise<TestableBridge> {
+  vi.resetModules();
   vi.doMock('@agent/runtime/AgentRuntimeHost', () => ({
     createAgentRuntimeHost: vi.fn(() => ({})),
   }));
@@ -137,6 +149,61 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
   return new DesktopProgressBridge((message) =>
     messages.push(message),
   ) as TestableBridge;
+}
+
+async function createExecution(options: {
+  postToRenderer?: (message: unknown) => void;
+  showInformationMessage?: (message: string) => Promise<void> | void;
+  prepareMainViewExecutionRequest: (message: unknown) => unknown;
+  runValidatedExecutionRequest?: () => Promise<void>;
+}): Promise<DesktopExecution> {
+  vi.resetModules();
+  vi.doMock('@agent/runtime/AgentRuntimeHost', () => ({
+    createAgentRuntimeHost: vi.fn(() => ({})),
+  }));
+  vi.doMock('@agent/runtime/RunStorageService', () => ({
+    setRunStorageService: vi.fn(),
+  }));
+  vi.doMock('@agent/runtime/runExecutionRequest', () => ({
+    runValidatedExecutionRequest:
+      options.runValidatedExecutionRequest ?? vi.fn(async () => {}),
+  }));
+  vi.doMock('@common/storage', () => ({
+    KVStore: class {
+      async read(): Promise<undefined> {
+        return undefined;
+      }
+
+      async write(): Promise<void> {}
+
+      async delete(): Promise<void> {}
+
+      async deleteDir(): Promise<void> {}
+
+      async exists(): Promise<boolean> {
+        return false;
+      }
+
+      async listKeys(): Promise<string[]> {
+        return [];
+      }
+    },
+  }));
+  vi.doMock('@controllers/mainView/MainViewExecutionController', () => ({
+    prepareMainViewExecutionRequest: options.prepareMainViewExecutionRequest,
+  }));
+  vi.doMock('@logger/AgentLogger', () => ({
+    AgentLogger: class {
+      static setStreamLogStore(): void {}
+    },
+  }));
+  const { createDesktopAgentExecution } = (await import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopAgentExecution.ts'))
+  )) as DesktopAgentExecutionModule;
+  return createDesktopAgentExecution({
+    postToRenderer: options.postToRenderer ?? vi.fn(),
+    showInformationMessage: options.showInformationMessage,
+  });
 }
 
 function progressMessages(
@@ -275,6 +342,32 @@ describe('DesktopProgressBridge', () => {
       ).toMatchObject({ status: STREAM_STATUS.RUNNING });
     } finally {
       bridge.dispose();
+    }
+  });
+
+  it('surfaces invalid execution requests through the host notification path', async () => {
+    const postToRenderer = vi.fn();
+    const showInformationMessage = vi.fn();
+    const runValidatedExecutionRequest = vi.fn(async () => {});
+    const execution = await createExecution({
+      postToRenderer,
+      showInformationMessage,
+      runValidatedExecutionRequest,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: false,
+        message: 'Select an input file first.',
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(showInformationMessage).toHaveBeenCalledWith(
+        'Select an input file first.',
+      );
+      expect(postToRenderer).not.toHaveBeenCalled();
+      expect(runValidatedExecutionRequest).not.toHaveBeenCalled();
+    } finally {
+      execution.dispose();
     }
   });
 });

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -29,7 +29,6 @@ interface DesktopAgentExecutionModule {
     postToRenderer(message: unknown): void;
     openPath?: (filePath: string) => Promise<void>;
     showInformationMessage?: (message: string) => Promise<void> | void;
-    onError?: (error: unknown) => void;
   }): DesktopExecution;
 }
 
@@ -366,6 +365,31 @@ describe('DesktopProgressBridge', () => {
       );
       expect(postToRenderer).not.toHaveBeenCalled();
       expect(runValidatedExecutionRequest).not.toHaveBeenCalled();
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  it('lets runtime execution errors propagate to the IPC error handler', async () => {
+    const failure = new Error('execution failed');
+    const execution = await createExecution({
+      runValidatedExecutionRequest: vi.fn(async () => {
+        throw failure;
+      }),
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    try {
+      await expect(
+        execution.handleExecute({ command: 'execute' }),
+      ).rejects.toThrow(failure);
     } finally {
       execution.dispose();
     }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -28,7 +28,7 @@ interface DesktopAgentExecutionModule {
   createDesktopAgentExecution(options: {
     postToRenderer(message: unknown): void;
     openPath?: (filePath: string) => Promise<void>;
-    showInformationMessage?: (message: string) => Promise<void> | void;
+    showErrorMessage?: (message: string) => Promise<void> | void;
   }): DesktopExecution;
 }
 
@@ -152,7 +152,7 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
 
 async function createExecution(options: {
   postToRenderer?: (message: unknown) => void;
-  showInformationMessage?: (message: string) => Promise<void> | void;
+  showErrorMessage?: (message: string) => Promise<void> | void;
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
   runValidatedExecutionRequest?: () => Promise<void>;
 }): Promise<DesktopExecution> {
@@ -201,7 +201,7 @@ async function createExecution(options: {
   )) as DesktopAgentExecutionModule;
   return createDesktopAgentExecution({
     postToRenderer: options.postToRenderer ?? vi.fn(),
-    showInformationMessage: options.showInformationMessage,
+    showErrorMessage: options.showErrorMessage,
   });
 }
 
@@ -344,13 +344,13 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
-  it('surfaces invalid execution requests through the host notification path', async () => {
+  it('surfaces invalid execution requests through the host error path', async () => {
     const postToRenderer = vi.fn();
-    const showInformationMessage = vi.fn();
+    const showErrorMessage = vi.fn();
     const runValidatedExecutionRequest = vi.fn(async () => {});
     const execution = await createExecution({
       postToRenderer,
-      showInformationMessage,
+      showErrorMessage,
       runValidatedExecutionRequest,
       prepareMainViewExecutionRequest: vi.fn(() => ({
         valid: false,
@@ -360,7 +360,7 @@ describe('DesktopProgressBridge', () => {
 
     try {
       await execution.handleExecute({ command: 'execute' });
-      expect(showInformationMessage).toHaveBeenCalledWith(
+      expect(showErrorMessage).toHaveBeenCalledWith(
         'Select an input file first.',
       );
       expect(postToRenderer).not.toHaveBeenCalled();

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -26,6 +26,7 @@ interface MainViewIpcModule {
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
       getCustomAgentDirectory?: () => Promise<string>;
       openPath?: (filePath: string) => Promise<void>;
+      executeAgent?: (message: unknown) => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -101,6 +102,7 @@ describe('desktop main-view IPC', () => {
     } = await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
     const openPath = vi.fn(async (_filePath: string) => {});
+    const executeAgent = vi.fn(async (_message: unknown) => {});
     const webContents = {
       isDestroyed: () => false,
       send: vi.fn((channel, message) => sends.push({ channel, message })),
@@ -118,6 +120,7 @@ describe('desktop main-view IPC', () => {
       debugMode: true,
       getCustomAgentDirectory: async () => '/agents/custom',
       openPath,
+      executeAgent,
     });
 
     expect(ipcMain.on).toHaveBeenCalledWith(
@@ -267,6 +270,15 @@ describe('desktop main-view IPC', () => {
     await Promise.resolve();
     expect(openPath).toHaveBeenCalledWith('/agents/custom');
     expect(sends).toEqual([]);
+
+    const executeMessage = {
+      command: MAIN_VIEW_COMMANDS.EXECUTE,
+      agent: 'direct-agent',
+      model: 'gpt-5.4',
+    };
+    rendererListener?.({ sender: webContents }, executeMessage);
+    await Promise.resolve();
+    expect(executeAgent).toHaveBeenCalledWith(executeMessage);
 
     nativeTheme.shouldUseHighContrastColors = true;
     themeListener?.();


### PR DESCRIPTION
## Summary

- Extract the main-view execute message preparation into a host-neutral controller.
- Share the validated execution launcher between VS Code commands and Electron.
- Add an Electron desktop execution adapter that routes Direct-agent runs through the shared runtime and forwards progress/log messages to the reused progress view.
- Keep Electron main bundling compatible with the shared runtime by avoiding a top-level `vscode` logger import and externalizing the optional native `fsevents` module, matching the extension bundle boundary.

## Design Notes

The root issue was that the reusable runtime already had a clean `AgentRuntimeHost` seam, but the caller above it was VS Code-specific. This PR moves the shallow pass-through and validation work into shared code, leaving VS Code and Electron responsible only for host behavior: notifications, output opening, IPC transport, and progress rendering.

The Electron progress path intentionally does not import `ProgressViewProvider`; that provider is still VS Code-bound. The desktop adapter sends the existing progress-view message protocol directly, so the renderer stays shared without pulling VS Code APIs into the Electron main process.

Refs #3451.

## Validation

- `npm run lint`
- `npm run typecheck`
- `corepack pnpm --filter @texra/desktop typecheck`
- `npm run test:kernel -- src/test-kernel/controllers/MainViewExecutionController.vitest.ts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run build:initial`

Known existing warning: `vsce` still reports `LICENSE not found`, tracked separately by #3441.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Electron execution path and refactors extension execution to use shared request-prep and execution runner, which could affect how runs are validated, tracked, and how progress/log updates are delivered. Also changes logger initialization to avoid hard VS Code dependency, so mistakes could reduce logging or break bundling in non-extension hosts.
> 
> **Overview**
> Wires desktop main-view `EXECUTE` to actually run agents in Electron: adds a `DesktopProgressBridge` that forwards runtime progress/log events to the renderer using the existing progress-view message protocol, and a `createDesktopAgentExecution` adapter that validates requests, launches runs, and optionally opens the final workflow output.
> 
> Extracts main-view execute message normalization/validation into host-neutral `prepareMainViewExecutionRequest`, and centralizes execution launch into `runValidatedExecutionRequest`; the VS Code extension’s `ExecutionManager` and `texra.execute` command are updated to use these shared helpers. Updates desktop IPC to handle `MAIN_VIEW_COMMANDS.EXECUTE`, adjusts desktop bundling to externalize optional `fsevents`, and makes `logUtils` lazily load `vscode` (fallback to console) to keep Electron main bundling compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c2307837052a6230c747037d023b4519b759b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->