### PR TITLE
Add desktop settings IPC round trip

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,0 +1,119 @@
+import { platform } from '@platform/platform';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { SettingsViewInboundMessageSchema } from '@shared/schemas/settingsViewMessages';
+import {
+  applyGitAuthorSettings,
+  readGitAuthorSettingsFromState,
+} from '@utils/system/gitAuthorSettings';
+import type { StateStore } from '@platform/interfaces/state';
+
+export interface DesktopSettingsIpcOptions {
+  postToRenderer(message: unknown): void;
+  workspaceState?: StateStore;
+  onError?: (error: unknown) => void;
+}
+
+export interface DesktopSettingsIpc {
+  handleMessage(
+    message: { command: string } & Record<string, unknown>,
+  ): boolean;
+}
+
+export function createDesktopSettingsIpc(
+  options: DesktopSettingsIpcOptions,
+): DesktopSettingsIpc {
+  const workspaceState = options.workspaceState ?? platform().workspaceState;
+  const onError =
+    options.onError ??
+    ((error) => {
+      console.error(error);
+    });
+
+  function readCurrentGitAuthorSettings() {
+    return readGitAuthorSettingsFromState(workspaceState);
+  }
+
+  function applyCurrentGitAuthorSettings() {
+    return applyGitAuthorSettings(readCurrentGitAuthorSettings());
+  }
+
+  function postGitAuthorSettings(
+    settings = readCurrentGitAuthorSettings(),
+  ): void {
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      ...settings,
+    });
+  }
+
+  function applyAndPostGitAuthorSettings(): void {
+    postGitAuthorSettings(applyCurrentGitAuthorSettings());
+  }
+
+  async function updateGitAuthorSetting(
+    key: WorkspaceStateKey,
+    value: unknown,
+  ): Promise<void> {
+    await workspaceState.update(key, value);
+    applyAndPostGitAuthorSettings();
+  }
+
+  function runAsync(work: Promise<void>): void {
+    void work.catch(onError);
+  }
+
+  applyCurrentGitAuthorSettings();
+
+  return {
+    handleMessage(message) {
+      const result = SettingsViewInboundMessageSchema.safeParse(message);
+      if (!result.success) return false;
+
+      switch (result.data.command) {
+        case SETTINGS_VIEW_COMMANDS.WEBVIEW_READY:
+          if (result.data.view === 'settings') {
+            postGitAuthorSettings();
+          }
+          return false;
+        case SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS:
+          postGitAuthorSettings();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS:
+          runAsync(
+            updateGitAuthorSetting(
+              WorkspaceStateKey.GIT_MARK_COMMITS,
+              result.data.enabled,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME:
+          runAsync(
+            updateGitAuthorSetting(
+              WorkspaceStateKey.GIT_AUTHOR_NAME,
+              result.data.name,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_EMAIL:
+          runAsync(
+            updateGitAuthorSetting(
+              WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+              result.data.email,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_GIT_WORKTREE_SUPPORT:
+          runAsync(
+            updateGitAuthorSetting(
+              WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+              result.data.enabled,
+            ),
+          );
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { ELECTRON_WEBVIEW_PUSH_CHANNEL } from '../hostBridgeChannels.js';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
+import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
@@ -78,11 +79,16 @@ function createWindow(): void {
     },
     onError: reportAsyncError,
   });
+  const settingsIpc = createDesktopSettingsIpc({
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    onError: reportAsyncError,
+  });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),
     openPath,
     executeAgent: (message) => agentExecution.handleExecute(message),
     fileSelection,
+    settings: settingsIpc,
     onAsyncError: reportAsyncError,
   });
   ipcRef.current = mainViewIpc;

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -23,6 +23,7 @@ import {
 } from './hostBridge.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
+import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 
 type DesktopTheme = 'dark' | 'light' | 'high-contrast';
 
@@ -32,6 +33,7 @@ export interface DesktopMainViewIpcOptions {
   getCustomAgentDirectory?: () => Promise<string>;
   openPath?: (filePath: string) => Promise<void>;
   fileSelection?: DesktopFileSelection;
+  settings?: DesktopSettingsIpc;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
@@ -159,6 +161,7 @@ export function installDesktopMainViewIpc(
   function handleRendererMessage(message: unknown) {
     if (!isMessageWithCommand(message)) return;
     if (options.fileSelection?.handleMessage(message)) return;
+    if (options.settings?.handleMessage(message)) return;
 
     switch (message.command) {
       case MAIN_VIEW_COMMANDS.WEBVIEW_READY:

--- a/packages/extension/src/frontend/git/gitAuthorSetup.ts
+++ b/packages/extension/src/frontend/git/gitAuthorSetup.ts
@@ -5,38 +5,16 @@
  *
  * Called at extension activation and after any git-author setting change.
  */
-import { WorkspaceStateKey, workspaceSM } from '@common/state';
+import { workspaceSM } from '@common/state';
 import {
-  DEFAULT_GIT_AUTHOR_NAME,
-  DEFAULT_GIT_AUTHOR_EMAIL,
-  DEFAULT_GIT_MARK_COMMITS,
-} from '@shared/constants/git';
-import { setWorktreeSupportEnabled } from '@tools/worktreeConfig';
-import { setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+  applyGitAuthorSettings,
+  type GitAuthorSettings,
+  readGitAuthorSettingsFromState,
+} from '@utils/system/gitAuthorSettings';
 
 /** Read the current git author settings from workspace state with defaults. */
-export function readGitAuthorSettings(): {
-  markCommits: boolean;
-  authorName: string;
-  authorEmail: string;
-  worktreeSupport: boolean;
-} {
-  return {
-    markCommits: workspaceSM.get<boolean>(
-      WorkspaceStateKey.GIT_MARK_COMMITS,
-      DEFAULT_GIT_MARK_COMMITS,
-    ),
-    authorName:
-      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) ||
-      DEFAULT_GIT_AUTHOR_NAME,
-    authorEmail:
-      workspaceSM.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
-      DEFAULT_GIT_AUTHOR_EMAIL,
-    worktreeSupport: workspaceSM.get<boolean>(
-      WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
-      false,
-    ),
-  };
+export function readGitAuthorSettings(): GitAuthorSettings {
+  return readGitAuthorSettingsFromState(workspaceSM);
 }
 
 /** Apply settings and return them so callers can forward without re-reading. */
@@ -44,17 +22,5 @@ export function applyGitAuthorConfig(): ReturnType<
   typeof readGitAuthorSettings
 > {
   const settings = readGitAuthorSettings();
-  if (!settings.markCommits) {
-    setGitAuthorEnv({});
-  } else {
-    const { authorName, authorEmail } = settings;
-    setGitAuthorEnv({
-      GIT_AUTHOR_NAME: authorName,
-      GIT_AUTHOR_EMAIL: authorEmail,
-      GIT_COMMITTER_NAME: authorName,
-      GIT_COMMITTER_EMAIL: authorEmail,
-    });
-  }
-  setWorktreeSupportEnabled(settings.worktreeSupport);
-  return settings;
+  return applyGitAuthorSettings(settings);
 }

--- a/src/shared/BaseWebviewApp.ts
+++ b/src/shared/BaseWebviewApp.ts
@@ -91,7 +91,8 @@ export abstract class BaseWebviewApp<TMessage = any> extends LitElement {
     window.addEventListener('message', this.messageListener);
     const command = this.readyCommand;
     if (command) {
-      postMessage(command);
+      const view = this.getAttribute('data-desktop-view');
+      postMessage(command, view == null ? {} : { view });
     }
   }
 

--- a/src/shared/schemas/commonViewMessages.ts
+++ b/src/shared/schemas/commonViewMessages.ts
@@ -26,6 +26,7 @@ export const StateRestoreMessageSchema = z.object({
 
 export const WebviewReadyMessageSchema = z.object({
   command: z.literal(COMMON_COMMANDS.WEBVIEW_READY),
+  view: z.enum(['main', 'progress', 'settings']).nullish(),
 });
 
 export const SwitchViewTargetSchema = z.enum(['main', 'progress', 'dashboard']);

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { DEFAULT_GIT_MARK_COMMITS } from '@shared/constants/git';
+import {
+  isWorktreeSupportEnabled,
+  setWorktreeSupportEnabled,
+} from '@tools/worktreeConfig';
+import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface StateStore {
+  get<T>(key: string, defaultValue?: T): T;
+  update(key: string, value: unknown): PromiseLike<void>;
+}
+
+interface DesktopSettingsIpcModule {
+  createDesktopSettingsIpc(options: {
+    postToRenderer(message: unknown): void;
+    workspaceState?: StateStore;
+    onError?: (error: unknown) => void;
+  }): {
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean;
+  };
+}
+
+class MemoryStateStore implements StateStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    this.values.set(key, value);
+  }
+}
+
+async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopSettingsIpc.ts'))
+  ) as Promise<DesktopSettingsIpcModule>;
+}
+
+describe('desktop settings IPC', () => {
+  afterEach(() => {
+    setGitAuthorEnv({});
+    setWorktreeSupportEnabled(false);
+  });
+
+  it('applies Git author settings on creation and posts only for settings readiness', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.GIT_AUTHOR_NAME, 'TeXRA Bot');
+    workspaceState.values.set(
+      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+      'bot@example.com',
+    );
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(posted).toEqual([]);
+    expect(getGitAuthorEnv()).toEqual({
+      GIT_AUTHOR_NAME: 'TeXRA Bot',
+      GIT_AUTHOR_EMAIL: 'bot@example.com',
+      GIT_COMMITTER_NAME: 'TeXRA Bot',
+      GIT_COMMITTER_EMAIL: 'bot@example.com',
+    });
+    expect(
+      settings.handleMessage({ command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY }),
+    ).toBe(false);
+    expect(posted).toEqual([]);
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'settings',
+      }),
+    ).toBe(false);
+    expect(posted).toEqual([
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+        markCommits: DEFAULT_GIT_MARK_COMMITS,
+        authorName: 'TeXRA Bot',
+        authorEmail: 'bot@example.com',
+        worktreeSupport: false,
+      },
+    ]);
+  });
+
+  it('round-trips Git author writes through workspace state and refreshes the renderer', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
+        name: 'Desktop TeXRA',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(workspaceState.values.get(WorkspaceStateKey.GIT_AUTHOR_NAME)).toBe(
+      'Desktop TeXRA',
+    );
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      authorName: 'Desktop TeXRA',
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS,
+        enabled: false,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(workspaceState.values.get(WorkspaceStateKey.GIT_MARK_COMMITS)).toBe(
+      false,
+    );
+    expect(getGitAuthorEnv()).toEqual({});
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_GIT_WORKTREE_SUPPORT,
+        enabled: true,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.GIT_WORKTREE_SUPPORT),
+    ).toBe(true);
+    expect(isWorktreeSupportEnabled()).toBe(true);
+  });
+
+  it('serves Git author read requests without reapplying process env', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.GIT_AUTHOR_NAME, 'Applied');
+    workspaceState.values.set(
+      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+      'applied@example.com',
+    );
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    workspaceState.values.set(WorkspaceStateKey.GIT_AUTHOR_NAME, 'Read Only');
+    workspaceState.values.set(
+      WorkspaceStateKey.GIT_AUTHOR_EMAIL,
+      'read@example.com',
+    );
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
+      }),
+    ).toBe(true);
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_GIT_AUTHOR_SETTINGS,
+      authorName: 'Read Only',
+      authorEmail: 'read@example.com',
+    });
+    expect(getGitAuthorEnv()).toEqual({
+      GIT_AUTHOR_NAME: 'Applied',
+      GIT_AUTHOR_EMAIL: 'applied@example.com',
+      GIT_COMMITTER_NAME: 'Applied',
+      GIT_COMMITTER_EMAIL: 'applied@example.com',
+    });
+  });
+
+  it('ignores unsupported or malformed settings messages', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(settings.handleMessage({ command: 'unknown' })).toBe(false);
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_GIT_AUTHOR_NAME,
+      }),
+    ).toBe(false);
+    expect(posted).toEqual([]);
+  });
+});

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -27,6 +27,7 @@ interface MainViewIpcModule {
       getCustomAgentDirectory?: () => Promise<string>;
       openPath?: (filePath: string) => Promise<void>;
       fileSelection?: { handleMessage(message: { command: string }): boolean };
+      settings?: { handleMessage(message: { command: string }): boolean };
       executeAgent?: (message: unknown) => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
@@ -109,6 +110,12 @@ describe('desktop main-view IPC', () => {
           message.command === MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
       ),
     };
+    const settings = {
+      handleMessage: vi.fn(
+        (message: { command: string }) =>
+          message.command === SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
+      ),
+    };
     const executeAgent = vi.fn(async (_message: unknown) => {});
     const webContents = {
       isDestroyed: () => false,
@@ -128,6 +135,7 @@ describe('desktop main-view IPC', () => {
       getCustomAgentDirectory: async () => '/agents/custom',
       openPath,
       fileSelection,
+      settings,
       executeAgent,
     });
 
@@ -162,6 +170,14 @@ describe('desktop main-view IPC', () => {
     );
     expect(fileSelection.handleMessage).toHaveBeenCalledWith({
       command: MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE,
+    });
+
+    rendererListener?.(
+      { sender: webContents },
+      { command: SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS },
+    );
+    expect(settings.handleMessage).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
     });
 
     sends.length = 0;

--- a/src/utils/system/gitAuthorSettings.ts
+++ b/src/utils/system/gitAuthorSettings.ts
@@ -1,0 +1,55 @@
+import { WorkspaceStateKey } from '@common/state/stateKeys';
+import {
+  DEFAULT_GIT_AUTHOR_EMAIL,
+  DEFAULT_GIT_AUTHOR_NAME,
+  DEFAULT_GIT_MARK_COMMITS,
+} from '@shared/constants/git';
+import { setWorktreeSupportEnabled } from '@tools/worktreeConfig';
+import { setGitAuthorEnv } from './gitAuthorEnv';
+import type { StateStore } from '@platform/interfaces/state';
+
+export type GitAuthorSettings = {
+  markCommits: boolean;
+  authorName: string;
+  authorEmail: string;
+  worktreeSupport: boolean;
+};
+
+export function readGitAuthorSettingsFromState(
+  workspaceState: StateStore,
+): GitAuthorSettings {
+  return {
+    markCommits: workspaceState.get<boolean>(
+      WorkspaceStateKey.GIT_MARK_COMMITS,
+      DEFAULT_GIT_MARK_COMMITS,
+    ),
+    authorName:
+      workspaceState.get<string>(WorkspaceStateKey.GIT_AUTHOR_NAME) ||
+      DEFAULT_GIT_AUTHOR_NAME,
+    authorEmail:
+      workspaceState.get<string>(WorkspaceStateKey.GIT_AUTHOR_EMAIL) ||
+      DEFAULT_GIT_AUTHOR_EMAIL,
+    worktreeSupport: workspaceState.get<boolean>(
+      WorkspaceStateKey.GIT_WORKTREE_SUPPORT,
+      false,
+    ),
+  };
+}
+
+export function applyGitAuthorSettings(
+  settings: GitAuthorSettings,
+): GitAuthorSettings {
+  if (!settings.markCommits) {
+    setGitAuthorEnv({});
+  } else {
+    const { authorName, authorEmail } = settings;
+    setGitAuthorEnv({
+      GIT_AUTHOR_NAME: authorName,
+      GIT_AUTHOR_EMAIL: authorEmail,
+      GIT_COMMITTER_NAME: authorName,
+      GIT_COMMITTER_EMAIL: authorEmail,
+    });
+  }
+  setWorktreeSupportEnabled(settings.worktreeSupport);
+  return settings;
+}


### PR DESCRIPTION
## Summary

Closes #3460.

Adds the first Electron settings-view IPC round-trip by wiring the Git settings subset through a dedicated desktop settings adapter. The adapter uses the platform workspace state provider, posts the existing `updateGitAuthorSettings` message back to the mounted settings UI, and keeps the current extension settings behavior unchanged.

## Design Notes

- Keeps settings handling in `desktopSettingsIpc` instead of adding settings-specific logic to the launcher switch.
- Uses the existing settings-view Zod inbound schema and existing Git settings state keys.
- Applies Git author/worktree side effects through the same host-neutral helpers used by spawned commands.

## Validation

- `npm run test:kernel -- src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run lint`
- `npm run typecheck`
- `npm run build:initial`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Electron IPC path that can update workspace state and mutate git-author/worktree process side effects, so mistakes could affect spawned git commands and settings persistence. Scope is limited to the desktop settings adapter and a small shared helper extraction with tests covering the message flow.
> 
> **Overview**
> Adds a dedicated `desktopSettingsIpc` adapter to handle Settings view messages in Electron, round-tripping Git author/worktree settings by writing to `workspaceState`, applying side effects (git author env + worktree support), and pushing `UPDATE_GIT_AUTHOR_SETTINGS` back to the renderer.
> 
> Wires this handler into the desktop main IPC dispatch (`mainViewIpc`/`index.ts`) and updates the webview ready handshake to include an optional `view` identifier so Git settings are posted only when the *settings* view reports readiness.
> 
> Extracts shared Git author settings read/apply logic into `@utils/system/gitAuthorSettings` and updates the extension’s `gitAuthorSetup` to use it; adds kernel tests covering settings IPC behavior and main IPC delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e126c9fe2443495376c7a3600b8d7633d81d1ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->