### PR TITLE
Add Windows desktop artifact coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,61 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  desktop-windows-artifact:
+    name: desktop artifact (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.2
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build desktop artifacts
+        run: pnpm run desktop:build
+
+      - name: Check desktop build artifacts
+        run: pnpm run check:desktop-build-artifacts
+
+      - name: Upload desktop build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-desktop-dist-Windows
+          path: packages/desktop/dist/
+          if-no-files-found: error
+          retention-days: 14
+
   validate-status:
     name: validate
     runs-on: ubuntu-latest
-    needs: validate
+    needs:
+      - validate
+      - desktop-windows-artifact
     if: always()
 
     steps:
-      - name: Require validation matrix success
+      - name: Require validation jobs success
         run: |
           if [ '${{ needs.validate.result }}' != 'success' ]; then
             echo 'Validation matrix result: ${{ needs.validate.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.desktop-windows-artifact.result }}' != 'success' ]; then
+            echo 'Windows desktop artifact result: ${{ needs.desktop-windows-artifact.result }}'
             exit 1
           fi

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "sync:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs --update",
     "check:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs",
     "check:vsix-contents": "node scripts/verify-vsix-contents.mjs",
-    "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && node scripts/verify-desktop-build-artifacts.mjs",
+    "check:desktop-build-artifacts": "node scripts/verify-desktop-build-artifacts.mjs",
+    "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && corepack pnpm run check:desktop-build-artifacts",
     "check:desktop-package": "node scripts/verify-desktop-package.mjs",
     "sync:remote-agents": "node scripts/sync-remote-agents.mjs -o docs/supabase/SYNC_REFERENCE_AGENTS.sql",
     "check:remote-agents": "node scripts/sync-remote-agents.mjs --check"


### PR DESCRIPTION
## Summary

Closes #3466.

Adds a focused Windows CI job for the Electron desktop build output. The existing Linux/macOS validation still runs the full combined initial build gate; this job keeps Windows scoped to the desktop `dist/` artifact path so the VSIX verifier does not become a Windows portability blocker.

## Design Notes

- Adds `check:desktop-build-artifacts` as the shared root script for the existing desktop artifact verifier.
- Leaves `build:initial` semantics unchanged, but routes its desktop check through the named script.
- Uploads `packages/desktop/dist/` from `windows-latest` as `texra-desktop-dist-Windows`.
- Does not introduce installer packaging, signing, notarization, or release publishing.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write package.json .github/workflows/ci.yml`
- `npm run desktop:build`
- `npm run check:desktop-build-artifacts`
- `npm run lint`
- `npm run typecheck`
- `npm run build:initial`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds Windows coverage for the desktop build and slightly refactors npm scripts; the main risk is increased CI time or Windows-specific build flakes.
> 
> **Overview**
> **Adds Windows coverage for desktop artifacts in CI.** Introduces a new `windows-latest` job that installs dependencies, runs `desktop:build`, verifies the desktop `dist/` output, and uploads `packages/desktop/dist/` as `texra-desktop-dist-Windows`.
> 
> **Refactors artifact verification scripts.** Splits desktop verification into `check:desktop-build-artifacts` and updates `check:initial-build-artifacts` to call it (keeping the initial build gate behavior the same).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9ac7f305a14afca8ba9ad3407c056364e2726f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->