### PR TITLE
Split desktop IPC composition into focused adapters

### DIFF
--- a/packages/desktop/src/main/desktopExecutionIpc.ts
+++ b/packages/desktop/src/main/desktopExecutionIpc.ts
@@ -1,0 +1,29 @@
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import {
+  createDesktopErrorReporter,
+  type DesktopCommandMessage,
+  type DesktopMessageHandler,
+} from './desktopIpcTypes.js';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+
+export interface DesktopExecutionIpcOptions {
+  executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
+  onAsyncError?: (error: unknown) => void;
+}
+
+export function createDesktopExecutionIpc(
+  options: DesktopExecutionIpcOptions = {},
+): DesktopMessageHandler {
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      if (message.command !== MAIN_VIEW_COMMANDS.EXECUTE) return false;
+      if (!options.executeAgent) return true;
+      void options
+        .executeAgent(message as MainViewExecuteMessage)
+        .catch(reportAsyncError);
+      return true;
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -18,6 +18,11 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { normalizeFilePath } from '@shared/utils/path';
 import { getConfig } from '@utils/config/configUtils';
 
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+} from './desktopIpcTypes.js';
+
 export interface DesktopFileSelectionDialogOptions {
   title: string;
   defaultPath?: string;
@@ -33,11 +38,7 @@ export interface DesktopFileSelectionOptions {
   onError?: (error: unknown) => void;
 }
 
-export interface DesktopFileSelection {
-  handleMessage(
-    message: { command: string } & Record<string, unknown>,
-  ): boolean;
-}
+export type DesktopFileSelection = DesktopMessageHandler;
 
 const RESPONSE_BY_SELECT_COMMAND = {
   [MAIN_VIEW_COMMANDS.SELECT_INPUT_FILE]:
@@ -217,9 +218,7 @@ export function createDesktopFileSelection(
     postFileList('edited', files);
   }
 
-  function handleMessage(
-    message: { command: string } & Record<string, unknown>,
-  ): boolean {
+  function handleMessage(message: DesktopCommandMessage): boolean {
     switch (message.command) {
       case MAIN_VIEW_COMMANDS.REQUEST_INPUT_FILE:
         runAsync(requestSingleFileList('input'));

--- a/packages/desktop/src/main/desktopIpcTypes.ts
+++ b/packages/desktop/src/main/desktopIpcTypes.ts
@@ -1,0 +1,34 @@
+export type DesktopCommandMessage = { command: string } & Record<
+  string,
+  unknown
+>;
+
+export interface DesktopMessageHandler {
+  handleMessage(message: DesktopCommandMessage): boolean;
+}
+
+export interface DesktopRenderer {
+  postToRenderer(message: unknown): void;
+}
+
+export function isDesktopCommandMessage(
+  message: unknown,
+): message is DesktopCommandMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'command' in message &&
+    typeof message.command === 'string'
+  );
+}
+
+export function createDesktopErrorReporter(
+  onError?: (error: unknown) => void,
+): (error: unknown) => void {
+  return (
+    onError ??
+    ((error) => {
+      console.error(error);
+    })
+  );
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -7,6 +7,10 @@ import {
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
 import type { StateStore } from '@platform/interfaces/state';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+} from './desktopIpcTypes.js';
 
 export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
@@ -14,11 +18,7 @@ export interface DesktopSettingsIpcOptions {
   onError?: (error: unknown) => void;
 }
 
-export interface DesktopSettingsIpc {
-  handleMessage(
-    message: { command: string } & Record<string, unknown>,
-  ): boolean;
-}
+export type DesktopSettingsIpc = DesktopMessageHandler;
 
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
@@ -66,7 +66,7 @@ export function createDesktopSettingsIpc(
   applyCurrentGitAuthorSettings();
 
   return {
-    handleMessage(message) {
+    handleMessage(message: DesktopCommandMessage) {
       const result = SettingsViewInboundMessageSchema.safeParse(message);
       if (!result.success) return false;
 

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,0 +1,127 @@
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
+import {
+  SwitchViewMessageSchema,
+  type SwitchViewTarget,
+} from '@shared/schemas/commonViewMessages';
+import {
+  SETTINGS_TAB,
+  type SettingsTab,
+} from '@shared/schemas/settingsViewMessages';
+import {
+  DESKTOP_SHELL_COMMANDS,
+  type DesktopRoute,
+} from '../desktopShellMessages.js';
+import {
+  createDesktopErrorReporter,
+  type DesktopCommandMessage,
+  type DesktopMessageHandler,
+  type DesktopRenderer,
+} from './desktopIpcTypes.js';
+
+export interface DesktopShellIpcOptions {
+  getCustomAgentDirectory?: () => Promise<string>;
+  openPath?: (filePath: string) => Promise<void>;
+  onAsyncError?: (error: unknown) => void;
+}
+
+const SWITCH_VIEW_ROUTES = {
+  main: 'main',
+  progress: 'progress',
+  dashboard: 'settings',
+} satisfies Record<SwitchViewTarget, DesktopRoute>;
+
+function getAgentSettingsSubTab(message: DesktopCommandMessage) {
+  return message.sessionType === AGENT_CATEGORY.TOOL_USE
+    ? AGENT_CATEGORY.TOOL_USE
+    : undefined;
+}
+
+export function createDesktopShellIpc(
+  renderer: DesktopRenderer,
+  options: DesktopShellIpcOptions = {},
+): DesktopMessageHandler {
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
+  function postRoute(route: DesktopRoute) {
+    renderer.postToRenderer({
+      command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+      route,
+    });
+  }
+
+  function postSettingsRoute(
+    tabIndex?: SettingsTab,
+    agentSubTab?: AgentCategory,
+  ) {
+    postRoute('settings');
+    if (tabIndex == null) return;
+    renderer.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+      tabIndex,
+      ...(agentSubTab && { agentSubTab }),
+    });
+  }
+
+  function postRouteForSwitchView(message: DesktopCommandMessage) {
+    const result = SwitchViewMessageSchema.safeParse(message);
+    if (!result.success) return;
+    postRoute(SWITCH_VIEW_ROUTES[result.data.view]);
+  }
+
+  async function openCustomAgentDirectory() {
+    if (!options.getCustomAgentDirectory || !options.openPath) {
+      postSettingsRoute(SETTINGS_TAB.AGENTS);
+      return;
+    }
+    const customDir = await options.getCustomAgentDirectory();
+    await options.openPath(customDir);
+  }
+
+  function handleOpenAgentDirectory(message: DesktopCommandMessage) {
+    if (message.customDirSet !== true) {
+      postSettingsRoute(SETTINGS_TAB.AGENTS);
+      return;
+    }
+    void openCustomAgentDirectory().catch(reportAsyncError);
+  }
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      switch (message.command) {
+        case COMMON_COMMANDS.SWITCH_VIEW:
+          postRouteForSwitchView(message);
+          return true;
+        case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
+          postSettingsRoute();
+          return true;
+        case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
+          postSettingsRoute(
+            SETTINGS_TAB.AGENTS,
+            getAgentSettingsSubTab(message),
+          );
+          return true;
+        case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
+          postSettingsRoute(SETTINGS_TAB.MODELS);
+          return true;
+        case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
+          postSettingsRoute(SETTINGS_TAB.MULTI_AGENT);
+          return true;
+        case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
+          handleOpenAgentDirectory(message);
+          return true;
+        case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
+          renderer.postToRenderer({
+            command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+            commits: [],
+            isGitRepo: false,
+          });
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopViewStateIpc.ts
+++ b/packages/desktop/src/main/desktopViewStateIpc.ts
@@ -1,0 +1,77 @@
+import { nativeTheme } from 'electron';
+
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+  DesktopRenderer,
+} from './desktopIpcTypes.js';
+
+export type DesktopTheme = 'dark' | 'light' | 'high-contrast';
+
+export interface DesktopViewStateIpcOptions {
+  debugMode?: boolean;
+  getTheme?: () => DesktopTheme;
+}
+
+export interface DesktopViewStateIpc extends DesktopMessageHandler {
+  dispose(): void;
+}
+
+function getNativeTheme(): DesktopTheme {
+  if (nativeTheme.shouldUseHighContrastColors) return 'high-contrast';
+  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+}
+
+export function createDesktopViewStateIpc(
+  renderer: DesktopRenderer,
+  options: DesktopViewStateIpcOptions = {},
+): DesktopViewStateIpc {
+  const getTheme = options.getTheme ?? getNativeTheme;
+  const debugMode = options.debugMode ?? false;
+
+  function postTheme() {
+    renderer.postToRenderer({
+      command: COMMON_COMMANDS.THEME_SET,
+      theme: getTheme(),
+    });
+  }
+
+  function postDebugMode() {
+    renderer.postToRenderer({
+      command: COMMON_COMMANDS.DEBUG_MODE_SET,
+      debugMode,
+    });
+  }
+
+  function postInitialState() {
+    postTheme();
+    postDebugMode();
+  }
+
+  const handleNativeThemeUpdate = () => postTheme();
+  nativeTheme.on('updated', handleNativeThemeUpdate);
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      switch (message.command) {
+        case MAIN_VIEW_COMMANDS.WEBVIEW_READY:
+          postInitialState();
+          return true;
+        case MAIN_VIEW_COMMANDS.GET_THEME:
+          postTheme();
+          return true;
+        case MAIN_VIEW_COMMANDS.GET_DEBUG_MODE:
+          postDebugMode();
+          return true;
+        default:
+          return false;
+      }
+    },
+    dispose() {
+      nativeTheme.off('updated', handleNativeThemeUpdate);
+    },
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { ELECTRON_WEBVIEW_PUSH_CHANNEL } from '../hostBridgeChannels.js';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
@@ -64,10 +63,7 @@ function createWindow(): void {
     },
   });
   const fileSelection = createDesktopFileSelection({
-    postToRenderer: (message) => {
-      if (window.isDestroyed() || window.webContents.isDestroyed()) return;
-      window.webContents.send(ELECTRON_WEBVIEW_PUSH_CHANNEL, message);
-    },
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     showOpenFileDialog: async (options) => {
       const result = await dialog.showOpenDialog(window, {
         title: options.title,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,31 +1,21 @@
-import { nativeTheme, type BrowserWindow } from 'electron';
-
-import { COMMON_COMMANDS } from '@common/webview/commonCommands';
-import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
-import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
-import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
-import {
-  SwitchViewMessageSchema,
-  type SwitchViewTarget,
-} from '@shared/schemas/commonViewMessages';
-import {
-  SETTINGS_TAB,
-  type SettingsTab,
-} from '@shared/schemas/settingsViewMessages';
-
-import {
-  DESKTOP_SHELL_COMMANDS,
-  type DesktopRoute,
-} from '../desktopShellMessages.js';
 import {
   installDesktopHostBridge,
   type DesktopHostBridge,
 } from './hostBridge.js';
-import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
-import type { DesktopFileSelection } from './desktopFileSelection.js';
+import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
+import {
+  isDesktopCommandMessage,
+  type DesktopMessageHandler,
+} from './desktopIpcTypes.js';
+import { createDesktopShellIpc } from './desktopShellIpc.js';
+import {
+  createDesktopViewStateIpc,
+  type DesktopTheme,
+} from './desktopViewStateIpc.js';
 import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
-
-type DesktopTheme = 'dark' | 'light' | 'high-contrast';
+import type { DesktopFileSelection } from './desktopFileSelection.js';
+import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+import type { BrowserWindow } from 'electron';
 
 export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
@@ -43,179 +33,48 @@ export interface DesktopMainViewIpc {
   dispose(): void;
 }
 
-function isMessageWithCommand(
-  message: unknown,
-): message is { command: string } {
-  return (
-    typeof message === 'object' &&
-    message !== null &&
-    'command' in message &&
-    typeof message.command === 'string'
-  );
-}
-
-function getNativeTheme(): DesktopTheme {
-  if (nativeTheme.shouldUseHighContrastColors) return 'high-contrast';
-  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
-}
-
-function getAgentSettingsSubTab(message: unknown): AgentCategory | undefined {
-  if (
-    typeof message === 'object' &&
-    message !== null &&
-    'sessionType' in message &&
-    message.sessionType === AGENT_CATEGORY.TOOL_USE
-  ) {
-    return AGENT_CATEGORY.TOOL_USE;
-  }
-  return undefined;
-}
-
-const SWITCH_VIEW_ROUTES = {
-  main: 'main',
-  progress: 'progress',
-  dashboard: 'settings',
-} satisfies Record<SwitchViewTarget, DesktopRoute>;
-
 export function installDesktopMainViewIpc(
   window: BrowserWindow,
   options: DesktopMainViewIpcOptions = {},
 ): DesktopMainViewIpc {
-  const getTheme = options.getTheme ?? getNativeTheme;
-  const debugMode = options.debugMode ?? false;
-
   let disposed = false;
+  let messageHandlers: DesktopMessageHandler[] = [];
 
-  function postTheme() {
-    bridge.postToRenderer({
-      command: COMMON_COMMANDS.THEME_SET,
-      theme: getTheme(),
-    });
-  }
-  function postDebugMode() {
-    bridge.postToRenderer({
-      command: COMMON_COMMANDS.DEBUG_MODE_SET,
-      debugMode,
-    });
-  }
-  function postRoute(route: DesktopRoute) {
-    bridge.postToRenderer({
-      command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
-      route,
-    });
-  }
-  function postSettingsRoute(
-    tabIndex?: SettingsTab,
-    agentSubTab?: AgentCategory,
-  ) {
-    postRoute('settings');
-    if (tabIndex == null) return;
-    bridge.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex,
-      ...(agentSubTab && { agentSubTab }),
-    });
-  }
-  function postRouteForSwitchView(message: unknown) {
-    const result = SwitchViewMessageSchema.safeParse(message);
-    if (!result.success) return;
-    postRoute(SWITCH_VIEW_ROUTES[result.data.view]);
-  }
-  function reportAsyncError(error: unknown) {
-    if (options.onAsyncError) {
-      options.onAsyncError(error);
-      return;
-    }
-    console.error(error);
-  }
-  async function openCustomAgentDirectory() {
-    if (!options.getCustomAgentDirectory || !options.openPath) {
-      postSettingsRoute(SETTINGS_TAB.AGENTS);
-      return;
-    }
-    const customDir = await options.getCustomAgentDirectory();
-    await options.openPath(customDir);
-  }
-  function handleOpenAgentDirectory(message: unknown) {
-    const customDirSet =
-      typeof message === 'object' &&
-      message !== null &&
-      'customDirSet' in message &&
-      message.customDirSet === true;
-    if (!customDirSet) {
-      postSettingsRoute(SETTINGS_TAB.AGENTS);
-      return;
-    }
-    void openCustomAgentDirectory().catch(reportAsyncError);
-  }
-  function handleExecute(message: unknown) {
-    if (!options.executeAgent) return;
-    void options
-      .executeAgent(message as MainViewExecuteMessage)
-      .catch(reportAsyncError);
-  }
-  function postInitialState() {
-    postTheme();
-    postDebugMode();
-  }
   function handleRendererMessage(message: unknown) {
-    if (!isMessageWithCommand(message)) return;
-    if (options.fileSelection?.handleMessage(message)) return;
-    if (options.settings?.handleMessage(message)) return;
-
-    switch (message.command) {
-      case MAIN_VIEW_COMMANDS.WEBVIEW_READY:
-        postInitialState();
-        break;
-      case MAIN_VIEW_COMMANDS.GET_THEME:
-        postTheme();
-        break;
-      case MAIN_VIEW_COMMANDS.GET_DEBUG_MODE:
-        postDebugMode();
-        break;
-      case COMMON_COMMANDS.SWITCH_VIEW:
-        postRouteForSwitchView(message);
-        break;
-      case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
-        postSettingsRoute();
-        break;
-      case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
-        postSettingsRoute(SETTINGS_TAB.AGENTS, getAgentSettingsSubTab(message));
-        break;
-      case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
-        postSettingsRoute(SETTINGS_TAB.MODELS);
-        break;
-      case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
-        postSettingsRoute(SETTINGS_TAB.MULTI_AGENT);
-        break;
-      case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
-        handleOpenAgentDirectory(message);
-        break;
-      case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
-        bridge.postToRenderer({
-          command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-          commits: [],
-          isGitRepo: false,
-        });
-        break;
-      case MAIN_VIEW_COMMANDS.EXECUTE:
-        handleExecute(message);
-        break;
+    if (!isDesktopCommandMessage(message)) return;
+    for (const handler of messageHandlers) {
+      if (handler.handleMessage(message)) return;
     }
   }
-
-  const handleNativeThemeUpdate = () => postTheme();
 
   const bridge = installDesktopHostBridge(window, {
     onRendererMessage: handleRendererMessage,
   });
-
-  nativeTheme.on('updated', handleNativeThemeUpdate);
+  const viewState = createDesktopViewStateIpc(bridge, {
+    debugMode: options.debugMode,
+    getTheme: options.getTheme,
+  });
+  const shell = createDesktopShellIpc(bridge, {
+    getCustomAgentDirectory: options.getCustomAgentDirectory,
+    openPath: options.openPath,
+    onAsyncError: options.onAsyncError,
+  });
+  const execution = createDesktopExecutionIpc({
+    executeAgent: options.executeAgent,
+    onAsyncError: options.onAsyncError,
+  });
+  messageHandlers = [
+    options.fileSelection,
+    options.settings,
+    viewState,
+    shell,
+    execution,
+  ].filter((handler): handler is DesktopMessageHandler => handler != null);
 
   const dispose = () => {
     if (disposed) return;
     disposed = true;
-    nativeTheme.off('updated', handleNativeThemeUpdate);
+    viewState.dispose();
     bridge.dispose();
   };
   window.once('closed', dispose);

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,7 +1,4 @@
-import {
-  installDesktopHostBridge,
-  type DesktopHostBridge,
-} from './hostBridge.js';
+import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
 import {
   isDesktopCommandMessage,

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -1,0 +1,229 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - webview command constants
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopRenderer {
+  postToRenderer(message: unknown): void;
+}
+
+interface DesktopShellIpcModule {
+  createDesktopShellIpc(
+    renderer: DesktopRenderer,
+    options?: {
+      getCustomAgentDirectory?: () => Promise<string>;
+      openPath?: (filePath: string) => Promise<void>;
+      onAsyncError?: (error: unknown) => void;
+    },
+  ): {
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean;
+  };
+}
+
+interface DesktopExecutionIpcModule {
+  createDesktopExecutionIpc(options?: {
+    executeAgent?: (message: unknown) => Promise<void>;
+    onAsyncError?: (error: unknown) => void;
+  }): {
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean;
+  };
+}
+
+interface DesktopViewStateIpcModule {
+  createDesktopViewStateIpc(
+    renderer: DesktopRenderer,
+    options?: {
+      debugMode?: boolean;
+      getTheme?: () => 'dark' | 'light' | 'high-contrast';
+    },
+  ): {
+    handleMessage(message: { command: string }): boolean;
+    dispose(): void;
+  };
+}
+
+async function loadDesktopShellIpc(): Promise<DesktopShellIpcModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopShellIpc.ts'))
+  ) as Promise<DesktopShellIpcModule>;
+}
+
+async function loadDesktopExecutionIpc(): Promise<DesktopExecutionIpcModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopExecutionIpc.ts'))
+  ) as Promise<DesktopExecutionIpcModule>;
+}
+
+async function loadDesktopViewStateIpc(nativeTheme: {
+  shouldUseDarkColors: boolean;
+  shouldUseHighContrastColors: boolean;
+  on(event: 'updated', listener: () => void): void;
+  off(event: 'updated', listener: () => void): void;
+}): Promise<DesktopViewStateIpcModule> {
+  vi.resetModules();
+  vi.doMock('electron', () => ({ nativeTheme }));
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopViewStateIpc.ts'))
+  ) as Promise<DesktopViewStateIpcModule>;
+}
+
+describe('desktop IPC adapters', () => {
+  afterEach(() => {
+    vi.doUnmock('electron');
+  });
+
+  it('keeps theme and debug state in the view-state adapter', async () => {
+    let themeListener: (() => void) | undefined;
+    const nativeTheme = {
+      shouldUseDarkColors: true,
+      shouldUseHighContrastColors: false,
+      on: vi.fn((_event: 'updated', listener: () => void) => {
+        themeListener = listener;
+      }),
+      off: vi.fn(),
+    };
+    const { createDesktopViewStateIpc } =
+      await loadDesktopViewStateIpc(nativeTheme);
+    const postToRenderer = vi.fn();
+    const stateIpc = createDesktopViewStateIpc(
+      { postToRenderer },
+      { debugMode: true },
+    );
+
+    expect(
+      stateIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.WEBVIEW_READY }),
+    ).toBe(true);
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: COMMON_COMMANDS.THEME_SET,
+      theme: 'dark',
+    });
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: COMMON_COMMANDS.DEBUG_MODE_SET,
+      debugMode: true,
+    });
+
+    nativeTheme.shouldUseHighContrastColors = true;
+    themeListener?.();
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: COMMON_COMMANDS.THEME_SET,
+      theme: 'high-contrast',
+    });
+
+    stateIpc.dispose();
+    expect(nativeTheme.off).toHaveBeenCalledWith('updated', themeListener);
+  });
+
+  it('keeps shell routing and launcher fallbacks in the shell adapter', async () => {
+    const { createDesktopShellIpc } = await loadDesktopShellIpc();
+    const postToRenderer = vi.fn();
+    const openPath = vi.fn(async (_filePath: string) => {});
+    const shellIpc = createDesktopShellIpc(
+      { postToRenderer },
+      {
+        getCustomAgentDirectory: async () => '/agents/custom',
+        openPath,
+      },
+    );
+
+    shellIpc.handleMessage({
+      command: COMMON_COMMANDS.SWITCH_VIEW,
+      view: 'progress',
+    });
+    shellIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS });
+    shellIpc.handleMessage({
+      command: MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS,
+      sessionType: AGENT_CATEGORY.TOOL_USE,
+    });
+    shellIpc.handleMessage({
+      command: MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS,
+    });
+
+    expect(postToRenderer).toHaveBeenNthCalledWith(1, {
+      command: 'desktop:setRoute',
+      route: 'progress',
+    });
+    expect(postToRenderer).toHaveBeenNthCalledWith(2, {
+      command: 'desktop:setRoute',
+      route: 'settings',
+    });
+    expect(postToRenderer).toHaveBeenNthCalledWith(3, {
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+      tabIndex: SETTINGS_TAB.MODELS,
+    });
+    expect(postToRenderer).toHaveBeenNthCalledWith(4, {
+      command: 'desktop:setRoute',
+      route: 'settings',
+    });
+    expect(postToRenderer).toHaveBeenNthCalledWith(5, {
+      agentSubTab: AGENT_CATEGORY.TOOL_USE,
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+      tabIndex: SETTINGS_TAB.AGENTS,
+    });
+    expect(postToRenderer).toHaveBeenNthCalledWith(6, {
+      command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+      commits: [],
+      isGitRepo: false,
+    });
+
+    shellIpc.handleMessage({
+      command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
+      customDirSet: true,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(openPath).toHaveBeenCalledWith('/agents/custom');
+
+    postToRenderer.mockClear();
+    createDesktopShellIpc({ postToRenderer }).handleMessage({
+      command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY,
+      customDirSet: true,
+    });
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: 'desktop:setRoute',
+      route: 'settings',
+    });
+    expect(postToRenderer).toHaveBeenCalledWith({
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+      tabIndex: SETTINGS_TAB.AGENTS,
+    });
+  });
+
+  it('keeps execution forwarding in the execution adapter', async () => {
+    const { createDesktopExecutionIpc } = await loadDesktopExecutionIpc();
+    const executeMessage = {
+      command: MAIN_VIEW_COMMANDS.EXECUTE,
+      agent: 'direct-agent',
+      model: 'gpt-5.4',
+    };
+    const executeAgent = vi.fn(async (_message: unknown) => {});
+    const executionIpc = createDesktopExecutionIpc({ executeAgent });
+
+    expect(executionIpc.handleMessage(executeMessage)).toBe(true);
+    await Promise.resolve();
+    expect(executeAgent).toHaveBeenCalledWith(executeMessage);
+
+    const error = new Error('execution failed');
+    const onAsyncError = vi.fn();
+    createDesktopExecutionIpc({
+      executeAgent: vi.fn(async () => {
+        throw error;
+      }),
+      onAsyncError,
+    }).handleMessage(executeMessage);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onAsyncError).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
## Summary

Refactors the Electron desktop IPC composition so `mainViewIpc.ts` only installs the host bridge and dispatches to focused handlers.

- Adds dedicated desktop IPC adapters for view state, shell and launcher routing, and execution forwarding.
- Reuses one shared desktop IPC message-handler type across file selection and settings handlers.
- Routes file-selection renderer pushes through the same main IPC poster, keeping destroyed-window guards in the host bridge path.
- Adds focused adapter regression tests for theme/debug state, route and settings-tab routing, custom agent-directory fallback, recent-commit fallback, and execution error reporting.

Closes #3459.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --write packages/desktop/src/main/desktopIpcTypes.ts packages/desktop/src/main/desktopViewStateIpc.ts packages/desktop/src/main/desktopShellIpc.ts packages/desktop/src/main/desktopExecutionIpc.ts packages/desktop/src/main/desktopFileSelection.ts packages/desktop/src/main/desktopSettingsIpc.ts packages/desktop/src/main/mainViewIpc.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts`
- `npm run test:kernel -- src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/desktop/ElectronFileSelection.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run lint`
- `npm run typecheck`
- `npm run build:initial`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors Electron main-process IPC dispatch and routing into multiple handlers, which could subtly change which messages are handled or the order they’re processed. Adds regression tests, but issues would impact core desktop navigation/state and execution triggering.
> 
> **Overview**
> Splits the desktop main-process IPC logic previously embedded in `mainViewIpc.ts` into focused adapters: `desktopViewStateIpc` (theme/debug + nativeTheme updates), `desktopShellIpc` (route/settings-tab navigation, agent-directory open fallback, recent-commit fallback), and `desktopExecutionIpc` (forward `EXECUTE` to `executeAgent` with async error reporting).
> 
> Introduces shared IPC types/utilities in `desktopIpcTypes.ts` (`DesktopCommandMessage`, `DesktopMessageHandler`, `isDesktopCommandMessage`, `createDesktopErrorReporter`) and updates existing handlers (`desktopFileSelection`, `desktopSettingsIpc`) to use the shared handler type. `index.ts` now routes file-selection/settings renderer posts through `mainViewIpc.postToRenderer` (reusing host-bridge destroyed-window guards) instead of sending directly.
> 
> Adds `DesktopIpcAdapters.vitest.mts` kernel tests covering view-state posting/disposal, shell routing/settings behavior and fallbacks, and execution forwarding + async error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2f4ed2bc3048783833a2c4553ad79d9f272930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->