### PR TITLE
Add desktop LaTeX settings IPC round trip

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -82,7 +82,11 @@ export function createDesktopSettingsIpc(
   }): Promise<void> {
     const plan = latexConfigPersistenceController.planUpdate(input);
     if (!plan.ok) {
-      onError(plan.error);
+      onError(
+        new Error(`Invalid LaTeX config value for ${input.field}`, {
+          cause: plan.error,
+        }),
+      );
       return;
     }
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,6 +1,8 @@
 import { platform } from '@platform/platform';
+import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+import type { LatexConfigField } from '@shared/constants/latex';
 import { SettingsViewInboundMessageSchema } from '@shared/schemas/settingsViewMessages';
 import {
   applyGitAuthorSettings,
@@ -29,6 +31,8 @@ export function createDesktopSettingsIpc(
     ((error) => {
       console.error(error);
     });
+  const latexConfigPersistenceController =
+    new LatexConfigPersistenceController();
 
   function readCurrentGitAuthorSettings() {
     return readGitAuthorSettingsFromState(workspaceState);
@@ -51,12 +55,39 @@ export function createDesktopSettingsIpc(
     postGitAuthorSettings(applyCurrentGitAuthorSettings());
   }
 
+  function readLatexConfigValues() {
+    return latexConfigPersistenceController.buildConfigValues((key) =>
+      workspaceState.get(key),
+    );
+  }
+
+  function postLatexConfigValues(): void {
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      values: readLatexConfigValues(),
+    });
+  }
+
   async function updateGitAuthorSetting(
     key: WorkspaceStateKey,
     value: unknown,
   ): Promise<void> {
     await workspaceState.update(key, value);
     applyAndPostGitAuthorSettings();
+  }
+
+  async function updateLatexConfigValue(input: {
+    field: LatexConfigField;
+    value: unknown;
+  }): Promise<void> {
+    const plan = latexConfigPersistenceController.planUpdate(input);
+    if (!plan.ok) {
+      onError(plan.error);
+      return;
+    }
+
+    await workspaceState.update(plan.update.key, plan.update.value);
+    postLatexConfigValues();
   }
 
   function runAsync(work: Promise<void>): void {
@@ -74,10 +105,22 @@ export function createDesktopSettingsIpc(
         case SETTINGS_VIEW_COMMANDS.WEBVIEW_READY:
           if (result.data.view === 'settings') {
             postGitAuthorSettings();
+            postLatexConfigValues();
           }
           return false;
         case SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS:
           postGitAuthorSettings();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_LATEX_CONFIG_VALUES:
+          postLatexConfigValues();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE:
+          runAsync(
+            updateLatexConfigValue({
+              field: result.data.field,
+              value: result.data.value,
+            }),
+          );
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_GIT_MARK_COMMITS:
           runAsync(

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -36,7 +36,11 @@ class MemoryStateStore implements StateStore {
   }
 
   async update(key: string, value: unknown): Promise<void> {
-    this.values.set(key, value);
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
   }
 }
 
@@ -267,6 +271,9 @@ describe('desktop settings IPC', () => {
     expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
       undefined,
     );
+    expect(workspaceState.values.has(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      false,
+    );
     expect(posted.at(-1)).toEqual({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
       values: {},
@@ -295,6 +302,9 @@ describe('desktop settings IPC', () => {
     await Promise.resolve();
 
     expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      message: 'Invalid LaTeX config value for latexdiffTimeoutMs',
+    });
     expect(
       workspaceState.values.has(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
     ).toBe(false);

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -92,6 +92,10 @@ describe('desktop settings IPC', () => {
         authorEmail: 'bot@example.com',
         worktreeSupport: false,
       },
+      {
+        command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+        values: {},
+      },
     ]);
   });
 
@@ -183,6 +187,118 @@ describe('desktop settings IPC', () => {
       GIT_COMMITTER_NAME: 'Applied',
       GIT_COMMITTER_EMAIL: 'applied@example.com',
     });
+  });
+
+  it('serves storage-backed LaTeX config reads through workspace state', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(WorkspaceStateKey.WORKFLOW_AUTO_COMPILE, false);
+    workspaceState.values.set(
+      WorkspaceStateKey.WORKFLOW_AUTO_COMPILE_TIMEOUT_MS,
+      30_000,
+    );
+    workspaceState.values.set(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS, 5_000);
+    workspaceState.values.set(WorkspaceStateKey.LATEXDIFF_MATH_MARKUP, 'fine');
+    workspaceState.values.set(WorkspaceStateKey.LATEX_FORMATTER, 'tex-fmt');
+    workspaceState.values.set('texra.invalidLatexValue', 'ignored');
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_LATEX_CONFIG_VALUES,
+      }),
+    ).toBe(true);
+
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      values: {
+        workflowAutoCompile: false,
+        workflowAutoCompileTimeoutMs: 30_000,
+        latexdiffTimeoutMs: 5_000,
+        latexdiffMathMarkup: 'fine',
+        latexFormatter: 'tex-fmt',
+      },
+    });
+  });
+
+  it('round-trips LaTeX config writes through workspace state and refreshes the renderer', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+        field: 'latexFormatter',
+        value: 'none',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      'none',
+    );
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      values: {
+        latexFormatter: 'none',
+      },
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+        field: 'latexFormatter',
+        value: null,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(workspaceState.values.get(WorkspaceStateKey.LATEX_FORMATTER)).toBe(
+      undefined,
+    );
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_CONFIG_VALUES,
+      values: {},
+    });
+  });
+
+  it('reports invalid LaTeX config writes without mutating workspace state', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+    const errors: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      postToRenderer: (message) => posted.push(message),
+      onError: (error) => errors.push(error),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_LATEX_CONFIG_VALUE,
+        field: 'latexdiffTimeoutMs',
+        value: 100,
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(errors).toHaveLength(1);
+    expect(
+      workspaceState.values.has(WorkspaceStateKey.LATEXDIFF_TIMEOUT_MS),
+    ).toBe(false);
+    expect(posted).toEqual([]);
   });
 
   it('ignores unsupported or malformed settings messages', async () => {


### PR DESCRIPTION
## Summary

- handle storage-backed LaTeX/compile/diff config reads and writes in the Electron desktop settings IPC adapter
- reuse `LatexConfigPersistenceController` so desktop and VS Code settings share the same field/key mapping and validation rules
- extend the desktop kernel test suite to cover reads, writes, reset-to-default, invalid values, and settings-ready hydration

## Validation

- `npm run test:kernel -- src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run lint`
- `npm run typecheck`
- `npm run build:initial`

Closes #3474

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Electron settings IPC commands that read/write persisted LaTeX/compile/diff configuration and update renderer state; incorrect field/key mapping or validation could lead to unexpected settings persistence or UI state.
> 
> **Overview**
> Adds desktop settings IPC support for LaTeX-related configuration, reusing `LatexConfigPersistenceController` to map/validate fields and persist updates into `workspaceState`, and posting `UPDATE_LATEX_CONFIG_VALUES` on settings hydration and after writes.
> 
> Extends the desktop kernel IPC tests to cover LaTeX config reads, writes (including reset-to-default via `undefined` deletion), and invalid-value error handling without mutating state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee6692c6f6f59e49113d11ef70dc23b06c6014b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->