### PR TITLE
Share ProgressFollowUpController test harness helpers

### DIFF
--- a/src/test/controllers/ProgressFollowUpController.test.ts
+++ b/src/test/controllers/ProgressFollowUpController.test.ts
@@ -4,62 +4,50 @@ import { strict as assert } from 'assert';
 // Local imports - agent
 import { ProgressFollowUpController } from '@controllers/progressView/ProgressFollowUpController';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
-
-// Local imports - logger
-import type { WorkflowTaskState } from '@logger/TaskState';
+import type { AgentConfig } from '@agent/core/AgentConfig';
 
 // Local imports - shared
 import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 
+// Local imports - test support
+import {
+  createOutputFile,
+  createWorkflowTaskState,
+} from '../support/ProgressControllerHarnesses';
+
 // Local imports - controllers
 
-function createAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
-  return AgentConfigSchema.parse({
-    agent: 'correct',
-    model: 'gemini31p',
-    inputFile: 'main.tex',
-    inputFiles: [],
-    outputFiles: ['answer.tex'],
-    agentCategory: AgentCategory.Workflow,
+const followUpWorkflowDefaults: Partial<AgentConfig> = {
+  inputFile: 'main.tex',
+  inputFiles: [],
+  outputFiles: ['answer.tex'],
+};
+
+const runStorageOutputDefaults: Partial<OutputFileInfo> = {
+  source: 'main.tex',
+  location: {
+    kind: 'runStorage',
+    absolutePath: '/tmp/exec/answer.tex',
+    relativePath: 'answer.tex',
+    executionId: 'exec-old',
+  },
+  round: 2,
+};
+
+function createFollowUpWorkflowTaskState(overrides: Partial<AgentConfig> = {}) {
+  return createWorkflowTaskState({
+    ...followUpWorkflowDefaults,
     ...overrides,
   });
 }
 
-function createWorkflowTaskState(
-  overrides: Partial<AgentConfig> = {},
-): WorkflowTaskState {
-  return {
-    agentConfig: createAgentConfig({
-      agentCategory: AgentCategory.Workflow,
-      ...overrides,
-    }) as AgentConfig & { agentCategory: AgentCategory.Workflow },
-    activeFiles: {
-      input: true,
-      reference: false,
-      auxiliary: false,
-      media: false,
-      output: true,
-    },
-  };
-}
-
-function createOutputFile(
+function createRunStorageOutputFile(
   overrides: Partial<OutputFileInfo> = {},
 ): OutputFileInfo {
-  return {
-    source: 'main.tex',
-    location: {
-      kind: 'runStorage',
-      absolutePath: '/tmp/exec/answer.tex',
-      relativePath: 'answer.tex',
-      executionId: 'exec-old',
-    },
-    round: 2,
-    lineage: null,
-    diff: null,
+  return createOutputFile({
+    ...runStorageOutputDefaults,
     ...overrides,
-  };
+  });
 }
 
 function createCompileFailure(
@@ -106,8 +94,8 @@ describe('ProgressFollowUpController', () => {
     const controller = createController();
     const plan = controller.planToolUseFollowUp({
       streamId: 'stream-a',
-      taskState: createWorkflowTaskState(),
-      outputFiles: [createOutputFile()],
+      taskState: createFollowUpWorkflowTaskState(),
+      outputFiles: [createRunStorageOutputFile()],
       agent: 'tool-agent',
       model: 'gemini31p',
       initialQuestion: ' Please inspect the proof. ',
@@ -139,8 +127,8 @@ describe('ProgressFollowUpController', () => {
   it('rejects follow-up setup when the selected model is disabled', () => {
     const plan = createController().planToolUseFollowUp({
       streamId: 'stream-a',
-      taskState: createWorkflowTaskState(),
-      outputFiles: [createOutputFile()],
+      taskState: createFollowUpWorkflowTaskState(),
+      outputFiles: [createRunStorageOutputFile()],
       agent: 'tool-agent',
       model: 'gemini31p',
       executeImmediately: false,
@@ -155,10 +143,10 @@ describe('ProgressFollowUpController', () => {
 
   it('plans latexFixer with source files from compile failures before fallbacks', async () => {
     const controller = createController(new Set(['source.tex', 'main.tex']));
-    const output = createOutputFile({ source: 'source.tex' });
+    const output = createRunStorageOutputFile({ source: 'source.tex' });
     const plan = await controller.planCompileFixer({
       streamId: 'stream-a',
-      taskState: createWorkflowTaskState({
+      taskState: createFollowUpWorkflowTaskState({
         inputFile: 'main.tex',
         inputFiles: ['source.tex'],
       }),
@@ -188,10 +176,12 @@ describe('ProgressFollowUpController', () => {
   it('warns when compile failures have no editable workspace source', async () => {
     const plan = await createController(new Set()).planCompileFixer({
       streamId: 'stream-a',
-      taskState: createWorkflowTaskState({ inputFile: '/external/main.tex' }),
+      taskState: createFollowUpWorkflowTaskState({
+        inputFile: '/external/main.tex',
+      }),
       compileFailures: [createCompileFailure()],
       runOutputs: new Map([
-        [2, [createOutputFile({ source: '/external/main.tex' })]],
+        [2, [createRunStorageOutputFile({ source: '/external/main.tex' })]],
       ]),
       modelOptions: [{ value: 'gemini31p' }],
       executionId: 'exec-123',

--- a/src/test/controllers/ProgressFollowUpController.test.ts
+++ b/src/test/controllers/ProgressFollowUpController.test.ts
@@ -30,10 +30,7 @@ const runStorageOutputDefaults = {
   round: 2,
 } satisfies OutputFileHarnessOptions;
 
-type RunStorageOutputOverrides = Omit<
-  OutputFileHarnessOptions,
-  'location'
-> & {
+type RunStorageOutputOverrides = Omit<OutputFileHarnessOptions, 'location'> & {
   location?: Omit<
     Extract<OutputFileInfo['location'], { kind: 'runStorage' }>,
     'kind'

--- a/src/test/controllers/ProgressFollowUpController.test.ts
+++ b/src/test/controllers/ProgressFollowUpController.test.ts
@@ -12,6 +12,7 @@ import type { CompileFailure, OutputFileInfo } from '@shared/schemas';
 // Local imports - test support
 import {
   createOutputFile,
+  type OutputFileHarnessOptions,
   createWorkflowTaskState,
 } from '../support/ProgressControllerHarnesses';
 
@@ -23,18 +24,25 @@ const followUpWorkflowDefaults: Partial<AgentConfig> = {
   outputFiles: ['answer.tex'],
 };
 
-const runStorageOutputDefaults: Partial<OutputFileInfo> = {
+const runStorageOutputDefaults = {
   source: 'main.tex',
-  location: {
-    kind: 'runStorage',
-    absolutePath: '/tmp/exec/answer.tex',
-    relativePath: 'answer.tex',
-    executionId: 'exec-old',
-  },
+  location: { kind: 'runStorage' },
   round: 2,
+} satisfies OutputFileHarnessOptions;
+
+type RunStorageOutputOverrides = Omit<
+  OutputFileHarnessOptions,
+  'location'
+> & {
+  location?: Omit<
+    Extract<OutputFileInfo['location'], { kind: 'runStorage' }>,
+    'kind'
+  >;
 };
 
-function createFollowUpWorkflowTaskState(overrides: Partial<AgentConfig> = {}) {
+function createFollowUpWorkflowTaskState(
+  overrides: Omit<Partial<AgentConfig>, 'agentCategory'> = {},
+) {
   return createWorkflowTaskState({
     ...followUpWorkflowDefaults,
     ...overrides,
@@ -42,11 +50,15 @@ function createFollowUpWorkflowTaskState(overrides: Partial<AgentConfig> = {}) {
 }
 
 function createRunStorageOutputFile(
-  overrides: Partial<OutputFileInfo> = {},
+  overrides: RunStorageOutputOverrides = {},
 ): OutputFileInfo {
   return createOutputFile({
     ...runStorageOutputDefaults,
     ...overrides,
+    location: {
+      ...runStorageOutputDefaults.location,
+      ...overrides.location,
+    },
   });
 }
 

--- a/src/test/controllers/ProgressWorkflowActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowActionsController.test.ts
@@ -63,13 +63,7 @@ describe('ProgressWorkflowActionsController', () => {
   });
 
   it('builds diff requests from workflow task and output state', async () => {
-    const output = createOutputFile({
-      location: {
-        kind: 'workspace',
-        absolutePath: '/workspace/generated.tex',
-        relativePath: 'generated.tex',
-      },
-    });
+    const output = createOutputFile();
     const taskState = createWorkflowTaskState(
       { outputFiles: ['declared.tex'] },
       { output: false },

--- a/src/test/controllers/ProgressWorkflowActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowActionsController.test.ts
@@ -63,10 +63,13 @@ describe('ProgressWorkflowActionsController', () => {
   });
 
   it('builds diff requests from workflow task and output state', async () => {
-    const output = createOutputFile(
-      '/workspace/generated.tex',
-      'generated.tex',
-    );
+    const output = createOutputFile({
+      location: {
+        kind: 'workspace',
+        absolutePath: '/workspace/generated.tex',
+        relativePath: 'generated.tex',
+      },
+    });
     const taskState = createWorkflowTaskState(
       { outputFiles: ['declared.tex'] },
       { output: false },

--- a/src/test/support/ProgressControllerHarnesses.ts
+++ b/src/test/support/ProgressControllerHarnesses.ts
@@ -151,20 +151,72 @@ export function createWorkflowTaskState(
   };
 }
 
+type WorkspaceLocationOverrides = {
+  kind?: 'workspace';
+  absolutePath?: string;
+  relativePath?: string;
+};
+
+type RunStorageLocationOverrides = {
+  kind: 'runStorage';
+  absolutePath?: string;
+  relativePath?: string;
+  executionId?: string;
+};
+
+type ExternalLocationOverrides = {
+  kind: 'external';
+  absolutePath?: string;
+};
+
+type OutputFileLocationOverrides =
+  | WorkspaceLocationOverrides
+  | RunStorageLocationOverrides
+  | ExternalLocationOverrides;
+
+export type OutputFileHarnessOptions = Partial<
+  Omit<OutputFileInfo, 'location'>
+> & {
+  location?: OutputFileLocationOverrides;
+};
+
+function createOutputFileLocation(
+  overrides: OutputFileLocationOverrides = {},
+): OutputFileInfo['location'] {
+  if (overrides.kind === 'external') {
+    return {
+      kind: 'external',
+      absolutePath: overrides.absolutePath ?? '/external/generated.tex',
+    };
+  }
+
+  if (overrides.kind === 'runStorage') {
+    return {
+      kind: 'runStorage',
+      absolutePath: overrides.absolutePath ?? '/tmp/exec/answer.tex',
+      relativePath: overrides.relativePath ?? 'answer.tex',
+      executionId: overrides.executionId ?? 'exec-old',
+    };
+  }
+
+  return {
+    kind: 'workspace',
+    absolutePath: overrides.absolutePath ?? '/workspace/generated.tex',
+    relativePath: overrides.relativePath ?? 'generated.tex',
+  };
+}
+
 export function createOutputFile(
-  overrides: Partial<OutputFileInfo> = {},
+  overrides: OutputFileHarnessOptions = {},
 ): OutputFileInfo {
+  const { location, ...outputOverrides } = overrides;
   return {
     source: 'input.tex',
-    location: {
-      kind: 'workspace',
-      absolutePath: '/workspace/generated.tex',
-      relativePath: 'generated.tex',
-    },
+    location: createOutputFileLocation(location),
     round: 1,
     lineage: null,
     diff: null,
-    ...overrides,
+    ...outputOverrides,
   };
 }
 

--- a/src/test/support/ProgressControllerHarnesses.ts
+++ b/src/test/support/ProgressControllerHarnesses.ts
@@ -152,19 +152,19 @@ export function createWorkflowTaskState(
 }
 
 export function createOutputFile(
-  absolutePath: string,
-  relativePath = absolutePath,
+  overrides: Partial<OutputFileInfo> = {},
 ): OutputFileInfo {
   return {
     source: 'input.tex',
     location: {
       kind: 'workspace',
-      absolutePath,
-      relativePath,
+      absolutePath: '/workspace/generated.tex',
+      relativePath: 'generated.tex',
     },
     round: 1,
     lineage: null,
     diff: null,
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary

- migrate ProgressFollowUpController tests onto the shared progress controller harness builders
- change the shared `createOutputFile` helper to an override-object API so tests can express only the fields that matter
- update the existing workflow-actions harness consumer to the same output helper shape

Closes #3382.

## Validation

- `npm run compile-tests`
- `npm run test:kernel`
- `npm run lint`
- `npm run typecheck`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to test harness utilities and test refactors, with no production controller logic modified.
> 
> **Overview**
> Refactors `ProgressFollowUpController` tests to reuse shared builders from `ProgressControllerHarnesses`, replacing locally-defined task/output factories with harness helpers and adding a small wrapper for run-storage outputs.
> 
> Updates the shared `createOutputFile` test helper to accept an override object (including `workspace`/`runStorage`/`external` locations) instead of positional path args, and adjusts `ProgressWorkflowActionsController` tests to use the new helper shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e065fee9d3a052ef6111be049ce8a0e0bf198fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->