### PR TITLE
Prevent VS Code imports from leaking into desktop main

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite --config vite.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.preload.json && tsc --noEmit -p tsconfig.renderer.json",
-    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:vscode --external:fsevents",
+    "build:main": "esbuild src/main/index.ts --bundle --platform=node --format=esm --outfile=dist/main/index.js --external:electron --external:fsevents",
     "build:preload": "esbuild src/preload/index.ts --bundle --platform=node --format=cjs --outfile=dist/preload/index.cjs --external:electron",
     "build:renderer": "vite build --config vite.config.ts",
     "build": "corepack pnpm run typecheck && corepack pnpm run build:main && corepack pnpm run build:preload && corepack pnpm run build:renderer",

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -19,7 +19,12 @@ import {
 import { SupabaseClient } from '@auth/SupabaseClient';
 import { SupabaseAuthProvider } from '@auth/SupabaseAuthProvider';
 import { SupabaseUriHandler } from '@auth/UriHandler';
-import { isSupabaseConfigured, setRuntimeExtensionId } from '@auth/config';
+import {
+  getAuthCallbackUri,
+  isSupabaseConfigured,
+  setExternalAuthCallbackResolver,
+  setRuntimeExtensionId,
+} from '@auth/config';
 import { getAuthStatus } from '@auth/authCommands';
 import { toErrorMessage } from '@common/errors';
 import {
@@ -142,6 +147,9 @@ export async function activate(context: vscode.ExtensionContext) {
   SecretManager.initialize(context);
   agentDirectories.initialize(context);
   setAgentDirectories(agentDirectories);
+  logger.setOutputChannelFactory((name) =>
+    vscode.window.createOutputChannel(name),
+  );
   initializePolishModel(context.extensionPath);
   initializeStateManagers(context);
   initPlatform({
@@ -198,6 +206,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
   try {
     setRuntimeExtensionId(context.extension.id);
+    setExternalAuthCallbackResolver(async () => {
+      const baseCallbackUri = vscode.Uri.parse(
+        getAuthCallbackUri(vscode.env.uriScheme),
+      );
+      const externalUri = await vscode.env.asExternalUri(baseCallbackUri);
+      const vscodeState = new URLSearchParams(externalUri.query).get('state');
+      const baseUrl = `${externalUri.scheme}://${externalUri.authority}${externalUri.path}`;
+
+      return { baseUrl, vscodeState, fullUrl: externalUri.toString() };
+    });
 
     if (!isSupabaseConfigured()) {
       logger.warn(

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -1,4 +1,31 @@
 import fs from 'node:fs';
+import path from 'node:path';
+
+export const vscodeRuntimeImportPattern =
+  /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
+
+export const vscodeBackedStateImportPattern =
+  /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
+
+const desktopSharedSourceDirSegments = [
+  ['packages', 'desktop', 'src'],
+  ['src', 'agent'],
+  ['src', 'controllers'],
+  ['src', 'eventBus'],
+  ['src', 'latex'],
+  ['src', 'logger'],
+  ['src', 'model'],
+  ['src', 'replacement'],
+  ['src', 'shared'],
+  ['src', 'tools'],
+  ['src', 'utils'],
+];
+
+export function getDesktopSharedSourceDirs(rootDir) {
+  return desktopSharedSourceDirSegments.map((segments) =>
+    path.join(rootDir, ...segments),
+  );
+}
 
 export function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -3,7 +3,12 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { readJson } from './extension-package-utils.mjs';
+import {
+  getDesktopSharedSourceDirs,
+  readJson,
+  vscodeBackedStateImportPattern,
+  vscodeRuntimeImportPattern,
+} from './extension-package-utils.mjs';
 
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -45,23 +50,7 @@ const requiredFiles = [
   path.join(desktopDir, 'dist', 'renderer', 'index.html'),
 ];
 const failures = [];
-const vscodeRuntimeImportPattern =
-  /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
-const vscodeBackedStateImportPattern =
-  /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
-const desktopSharedSourceDirs = [
-  path.join(rootDir, 'packages', 'desktop', 'src'),
-  path.join(rootDir, 'src', 'agent'),
-  path.join(rootDir, 'src', 'controllers'),
-  path.join(rootDir, 'src', 'eventBus'),
-  path.join(rootDir, 'src', 'latex'),
-  path.join(rootDir, 'src', 'logger'),
-  path.join(rootDir, 'src', 'model'),
-  path.join(rootDir, 'src', 'replacement'),
-  path.join(rootDir, 'src', 'shared'),
-  path.join(rootDir, 'src', 'tools'),
-  path.join(rootDir, 'src', 'utils'),
-];
+const desktopSharedSourceDirs = getDesktopSharedSourceDirs(rootDir);
 
 for (const filePath of requiredFiles) {
   if (!fileExists(filePath)) {

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -46,7 +46,18 @@ const requiredFiles = [
 ];
 const failures = [];
 const vscodeRuntimeImportPattern =
-  /\b(?:import\s+[^;]*\s+from\s+['"]vscode['"]|require\(['"]vscode['"]\))/;
+  /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
+const vscodeBackedStateImportPattern =
+  /^\s*import\s+[^;]*\bfrom\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+const desktopSharedSourceDirs = [
+  path.join(rootDir, 'packages', 'desktop', 'src'),
+  path.join(rootDir, 'src', 'agent', 'implementations', 'flows', 'tooluse'),
+  path.join(rootDir, 'src', 'agent', 'runtime'),
+  path.join(rootDir, 'src', 'logger'),
+  path.join(rootDir, 'src', 'model'),
+  path.join(rootDir, 'src', 'shared'),
+  path.join(rootDir, 'src', 'utils'),
+];
 
 for (const filePath of requiredFiles) {
   if (!fileExists(filePath)) {
@@ -71,6 +82,20 @@ if (
   failures.push(
     'Desktop main bundle contains a runtime import of the VS Code extension host module.',
   );
+}
+
+for (const dir of desktopSharedSourceDirs) {
+  if (!fs.existsSync(dir)) continue;
+  for (const filePath of collectFiles(dir)) {
+    if (!/\.[cm]?tsx?$/.test(filePath)) continue;
+    if (!vscodeBackedStateImportPattern.test(fs.readFileSync(filePath, 'utf8')))
+      continue;
+    failures.push(
+      `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
+        filePath,
+      )}`,
+    );
+  }
 }
 
 if (failures.length > 0) {

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -48,14 +48,18 @@ const failures = [];
 const vscodeRuntimeImportPattern =
   /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
 const vscodeBackedStateImportPattern =
-  /^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+  /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
 const desktopSharedSourceDirs = [
   path.join(rootDir, 'packages', 'desktop', 'src'),
-  path.join(rootDir, 'src', 'agent', 'implementations', 'flows', 'tooluse'),
-  path.join(rootDir, 'src', 'agent', 'runtime'),
+  path.join(rootDir, 'src', 'agent'),
+  path.join(rootDir, 'src', 'controllers'),
+  path.join(rootDir, 'src', 'eventBus'),
+  path.join(rootDir, 'src', 'latex'),
   path.join(rootDir, 'src', 'logger'),
   path.join(rootDir, 'src', 'model'),
+  path.join(rootDir, 'src', 'replacement'),
   path.join(rootDir, 'src', 'shared'),
+  path.join(rootDir, 'src', 'tools'),
   path.join(rootDir, 'src', 'utils'),
 ];
 

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -48,7 +48,7 @@ const failures = [];
 const vscodeRuntimeImportPattern =
   /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
 const vscodeBackedStateImportPattern =
-  /^\s*import\s+[^;]*\bfrom\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+  /^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"]/m;
 const desktopSharedSourceDirs = [
   path.join(rootDir, 'packages', 'desktop', 'src'),
   path.join(rootDir, 'src', 'agent', 'implementations', 'flows', 'tooluse'),

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -14,14 +14,18 @@ const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const vscodeRuntimeImportPattern =
   /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
 const vscodeBackedStateImportPattern =
-  /^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+  /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
 const desktopSharedSourceDirs = [
   join(repoRoot, 'packages', 'desktop', 'src'),
-  join(repoRoot, 'src', 'agent', 'implementations', 'flows', 'tooluse'),
-  join(repoRoot, 'src', 'agent', 'runtime'),
+  join(repoRoot, 'src', 'agent'),
+  join(repoRoot, 'src', 'controllers'),
+  join(repoRoot, 'src', 'eventBus'),
+  join(repoRoot, 'src', 'latex'),
   join(repoRoot, 'src', 'logger'),
   join(repoRoot, 'src', 'model'),
+  join(repoRoot, 'src', 'replacement'),
   join(repoRoot, 'src', 'shared'),
+  join(repoRoot, 'src', 'tools'),
   join(repoRoot, 'src', 'utils'),
 ];
 
@@ -244,7 +248,6 @@ if (!app) {
   await checkExists(app, 'dist/preload/index.cjs', 'preload bundle', failures);
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
   await checkNoVscodeRuntimeImport(app, failures);
-  await checkDesktopSourceBoundaries(failures);
 
   const assets = await app.listDir('dist/renderer/assets');
   if (!assets.some((asset) => asset.endsWith('.js'))) {
@@ -254,6 +257,8 @@ if (!app) {
     failures.push('No renderer CSS asset found');
   }
 }
+
+await checkDesktopSourceBoundaries(failures);
 
 if (failures.length > 0) {
   console.error('Desktop package check failed:');

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -14,7 +14,7 @@ const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const vscodeRuntimeImportPattern =
   /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
 const vscodeBackedStateImportPattern =
-  /^\s*import\s+[^;]*\bfrom\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+  /^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"]/m;
 const desktopSharedSourceDirs = [
   join(repoRoot, 'packages', 'desktop', 'src'),
   join(repoRoot, 'src', 'agent', 'implementations', 'flows', 'tooluse'),

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -4,6 +4,12 @@ import { basename, join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import {
+  getDesktopSharedSourceDirs,
+  vscodeBackedStateImportPattern,
+  vscodeRuntimeImportPattern,
+} from './extension-package-utils.mjs';
+
 const require = createRequire(import.meta.url);
 const { extractFile, listPackage } = require('@electron/asar');
 
@@ -11,23 +17,7 @@ const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const desktopRoot = join(repoRoot, 'packages', 'desktop');
 const packageRoot = join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
-const vscodeRuntimeImportPattern =
-  /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
-const vscodeBackedStateImportPattern =
-  /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
-const desktopSharedSourceDirs = [
-  join(repoRoot, 'packages', 'desktop', 'src'),
-  join(repoRoot, 'src', 'agent'),
-  join(repoRoot, 'src', 'controllers'),
-  join(repoRoot, 'src', 'eventBus'),
-  join(repoRoot, 'src', 'latex'),
-  join(repoRoot, 'src', 'logger'),
-  join(repoRoot, 'src', 'model'),
-  join(repoRoot, 'src', 'replacement'),
-  join(repoRoot, 'src', 'shared'),
-  join(repoRoot, 'src', 'tools'),
-  join(repoRoot, 'src', 'utils'),
-];
+const desktopSharedSourceDirs = getDesktopSharedSourceDirs(repoRoot);
 
 async function exists(path) {
   try {

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -12,7 +12,18 @@ const desktopRoot = join(repoRoot, 'packages', 'desktop');
 const packageRoot = join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const vscodeRuntimeImportPattern =
-  /\b(?:import\s+[^;]*\s+from\s+['"]vscode['"]|require\(['"]vscode['"]\))/;
+  /\b(?:import\s*\(\s*['"]vscode['"]\s*\)|import\s+[^;]*\s+from\s+['"]vscode['"]|(?:__require|require|requireFn)(?:\?\.)?\(\s*['"]vscode['"]\s*\))/;
+const vscodeBackedStateImportPattern =
+  /^\s*import\s+[^;]*\bfrom\s+['"]@common\/state(?:\/stateManager)?['"]/m;
+const desktopSharedSourceDirs = [
+  join(repoRoot, 'packages', 'desktop', 'src'),
+  join(repoRoot, 'src', 'agent', 'implementations', 'flows', 'tooluse'),
+  join(repoRoot, 'src', 'agent', 'runtime'),
+  join(repoRoot, 'src', 'logger'),
+  join(repoRoot, 'src', 'model'),
+  join(repoRoot, 'src', 'shared'),
+  join(repoRoot, 'src', 'utils'),
+];
 
 async function exists(path) {
   try {
@@ -25,6 +36,20 @@ async function exists(path) {
 
 async function readJson(path) {
   return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function collectFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(entryPath)));
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files.sort();
 }
 
 async function findPackagedApp() {
@@ -130,6 +155,26 @@ async function checkNoVscodeRuntimeImport(app, failures) {
   );
 }
 
+async function checkDesktopSourceBoundaries(failures) {
+  for (const dir of desktopSharedSourceDirs) {
+    if (!(await exists(dir))) continue;
+    for (const filePath of await collectFiles(dir)) {
+      if (!/\.[cm]?tsx?$/.test(filePath)) continue;
+      if (
+        !vscodeBackedStateImportPattern.test(await readFile(filePath, 'utf8'))
+      ) {
+        continue;
+      }
+      failures.push(
+        `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
+          repoRoot,
+          filePath,
+        )}`,
+      );
+    }
+  }
+}
+
 function dependencyPackageJsonPath(name) {
   return join('node_modules', name, 'package.json');
 }
@@ -199,6 +244,7 @@ if (!app) {
   await checkExists(app, 'dist/preload/index.cjs', 'preload bundle', failures);
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
   await checkNoVscodeRuntimeImport(app, failures);
+  await checkDesktopSourceBoundaries(failures);
 
   const assets = await app.listDir('dist/renderer/assets');
   if (!assets.some((asset) => asset.endsWith('.js'))) {
@@ -226,5 +272,6 @@ console.log(
     '- package.json runtime dependencies',
     '- node_modules runtime dependency packages',
     '- no VS Code extension host runtime import',
+    '- desktop-shared source uses vscode-free state keys',
   ].join('\n'),
 );

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -16,7 +16,7 @@ import type { BaseFlowContextInit } from '@agent/implementations/flows/common/Ba
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getGlobalState } from '@agent/core/stateStore';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
-import { GlobalStateKey } from '@common/state';
+import { GlobalStateKey } from '@common/state/stateKeys';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import type { ToolDefinition } from '@model';
 import {

--- a/src/agent/runtime/ModelFactory.ts
+++ b/src/agent/runtime/ModelFactory.ts
@@ -16,7 +16,7 @@ import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage
 import * as logger from '@agent/core/logger';
 import { getGlobalState } from '@agent/core/stateStore';
 import { getConfig } from '@agent/core/config';
-import { GlobalStateKey } from '@common/state';
+import { GlobalStateKey } from '@common/state/stateKeys';
 import { getUseOpenRouter } from '@utils/config/providerConfig';
 import { LEVEL_TO_EFFORT } from './reasoningEffort';
 

--- a/src/agent/runtime/delegationPolicy.ts
+++ b/src/agent/runtime/delegationPolicy.ts
@@ -9,7 +9,7 @@
 import { getExecutionStore } from '@agent/storage';
 import type { ExecutionMeta } from '@agent/storage/ExecutionKVStore';
 import { getWorkspaceState } from '@agent/core/stateStore';
-import { WorkspaceStateKey } from '@common/state';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type { ExecutionId } from '@shared/schemas';
 import {
   clampNestedDelegationDepth,

--- a/src/agent/runtime/helperModel.ts
+++ b/src/agent/runtime/helperModel.ts
@@ -11,7 +11,7 @@ import { MODEL_CONFIGS } from 'llm-zoo';
 import type { ModelHandler } from '@agent/modelHandlers/ModelHandler';
 import { createModelHandler } from '@agent/runtime/ModelFactory';
 import { getGlobalState } from '@agent/core/stateStore';
-import { GlobalStateKey } from '@common/state';
+import { GlobalStateKey } from '@common/state/stateKeys';
 import { getModelUnavailableReason } from '@model/computeModelOptions';
 import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
 import { isNonEmptyString } from '@utils/core';

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -177,9 +177,27 @@ export interface ExternalAuthCallbackInfo {
   fullUrl: string;
 }
 
+export type ExternalAuthCallbackResolver =
+  () => Promise<ExternalAuthCallbackInfo>;
+
+let externalAuthCallbackResolver: ExternalAuthCallbackResolver | null = null;
+
+/**
+ * Register the host-specific OAuth callback adapter.
+ *
+ * VS Code must route web auth redirects through env.asExternalUri(), but shared
+ * auth config also loads in Electron. Keeping the adapter host-owned prevents
+ * Electron bundles from carrying a runtime dependency on the VS Code module.
+ */
+export function setExternalAuthCallbackResolver(
+  resolver: ExternalAuthCallbackResolver | null,
+): void {
+  externalAuthCallbackResolver = resolver;
+}
+
 /**
  * Get the external auth callback URI with parsed components.
- * Uses vscode.env.asExternalUri() to handle different environments:
+ * Uses the host-provided adapter to handle different environments:
  * - Desktop VS Code: returns vscode://texra-ai.texra/auth-callback
  * - Cursor: returns cursor://texra-ai.texra/auth-callback
  * - Codespaces: returns https://*.github.dev/extension-auth-callback
@@ -189,16 +207,11 @@ export interface ExternalAuthCallbackInfo {
  * and passed through the OAuth flow for the callback routing to work.
  */
 export async function getExternalAuthCallbackInfo(): Promise<ExternalAuthCallbackInfo> {
-  // Keep this lazy so Electron bundles can import auth config without resolving VS Code APIs.
-  const vscode = await import('vscode');
-  const baseCallbackUri = vscode.Uri.parse(
-    getAuthCallbackUri(vscode.env.uriScheme),
-  );
-  const externalUri = await vscode.env.asExternalUri(baseCallbackUri);
-  const vscodeState = new URLSearchParams(externalUri.query).get('state');
-  const baseUrl = `${externalUri.scheme}://${externalUri.authority}${externalUri.path}`;
-
-  return { baseUrl, vscodeState, fullUrl: externalUri.toString() };
+  if (!externalAuthCallbackResolver) {
+    const baseUrl = getAuthCallbackUri('vscode');
+    return { baseUrl, vscodeState: null, fullUrl: baseUrl };
+  }
+  return externalAuthCallbackResolver();
 }
 
 /**

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -1,5 +1,5 @@
 import { KVStore } from '@common/storage';
-import { WorkspaceStateKey } from '@common/state';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type { MementoStorage } from '@progressView/persistence/PersistentMapManager';
 import {
   PersistedStreamLogEntrySchema,

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -11,6 +11,7 @@ const contextStorage = new AsyncLocalStorage<Map<string, string[]>>();
 
 interface LogSink {
   appendLine(message: string): void;
+  dispose?(): void;
 }
 
 type OutputChannelFactory = (name: string) => LogSink;
@@ -107,6 +108,13 @@ export function initialize(channel: string, isAgent = false): void {
 export function setOutputChannelFactory(
   factory: OutputChannelFactory | null,
 ): void {
+  const sinks = new Set<LogSink>(channels.values());
+  if (mainOutputChannel) {
+    sinks.add(mainOutputChannel);
+  }
+  for (const sink of sinks) {
+    sink.dispose?.();
+  }
   outputChannelFactory = factory;
   channels.clear();
   mainOutputChannel = null;

--- a/src/logger/logUtils.ts
+++ b/src/logger/logUtils.ts
@@ -5,7 +5,6 @@ import { getConfig } from '@utils/config';
 import { serializeError } from '@utils/core';
 
 import { getColorForLevel } from './utils';
-import type * as vscode from 'vscode';
 import type { LogUtilsOptions } from './logOptions';
 
 const contextStorage = new AsyncLocalStorage<Map<string, string[]>>();
@@ -14,9 +13,11 @@ interface LogSink {
   appendLine(message: string): void;
 }
 
+type OutputChannelFactory = (name: string) => LogSink;
+
 const channels = new Map<string, LogSink>();
 let mainOutputChannel: LogSink | null = null;
-let vscodeApi: typeof vscode | null | undefined;
+let outputChannelFactory: OutputChannelFactory | null = null;
 
 function getKey(channel: string, isAgent: boolean): string {
   return `${channel}::${isAgent ? 'agent' : 'shared'}`;
@@ -29,20 +30,6 @@ function getTimestamp(): string {
   return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}.${pad(now.getMilliseconds(), 3)}`;
 }
 
-function loadVscodeApi(): typeof vscode | null {
-  if (vscodeApi !== undefined) return vscodeApi;
-  try {
-    const requireFn = Function(
-      'return typeof require === "function" ? require : undefined',
-    )() as NodeRequire | undefined;
-    vscodeApi = requireFn?.('vscode') as typeof vscode | undefined;
-    vscodeApi ??= null;
-  } catch {
-    vscodeApi = null;
-  }
-  return vscodeApi;
-}
-
 function createConsoleSink(channel: string): LogSink {
   return {
     appendLine(message: string) {
@@ -52,11 +39,8 @@ function createConsoleSink(channel: string): LogSink {
 }
 
 function createOutputChannel(channel: string, isAgent: boolean): LogSink {
-  const api = loadVscodeApi();
-  if (!api) return createConsoleSink(isAgent ? `TeXRA ${channel}` : 'TeXRA');
-  return isAgent
-    ? api.window.createOutputChannel(`TeXRA ${channel}`)
-    : api.window.createOutputChannel('TeXRA');
+  const name = isAgent ? `TeXRA ${channel}` : 'TeXRA';
+  return outputChannelFactory?.(name) ?? createConsoleSink(name);
 }
 
 function ensureChannel(channel: string, isAgent: boolean): LogSink {
@@ -118,6 +102,14 @@ function logWithGroup(
 
 export function initialize(channel: string, isAgent = false): void {
   ensureChannel(channel, isAgent);
+}
+
+export function setOutputChannelFactory(
+  factory: OutputChannelFactory | null,
+): void {
+  outputChannelFactory = factory;
+  channels.clear();
+  mainOutputChannel = null;
 }
 
 export function getActiveGroupId(

--- a/src/model/computeModelOptions.ts
+++ b/src/model/computeModelOptions.ts
@@ -8,7 +8,7 @@ import { platform } from '@platform/platform';
 import { getServerSideKeyService } from '@auth/serverKeys';
 
 // Local imports - state
-import { GlobalStateKey, globalSM } from '@common/state';
+import { GlobalStateKey } from '@common/state/stateKeys';
 
 // Local imports - shared schemas
 import type { ModelOptionData } from '@shared/schemas';
@@ -62,7 +62,10 @@ export const MODEL_LIST_VERSION = 15;
  * This should be used to validate model selections in proposals.
  */
 export function getVisibleModels(): string[] {
-  return globalSM.get<string[]>(GlobalStateKey.ENABLED_MODELS, DEFAULT_MODELS);
+  return platform().globalState.get<string[]>(
+    GlobalStateKey.ENABLED_MODELS,
+    DEFAULT_MODELS,
+  );
 }
 
 /**

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -64,3 +64,8 @@ export function platform(): Readonly<Platform> {
 export function tryPlatform(): Readonly<Platform> | null {
   return _platform;
 }
+
+/** Get global state if the platform has been initialized. */
+export function tryGlobalState(): StateStore | null {
+  return _platform?.globalState ?? null;
+}

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { ModelProvider } from 'llm-zoo';
 
-import { GlobalStateKey } from '@common/state/stateManager';
+import { GlobalStateKey } from '@common/state/stateKeys';
 
 // ============================================================================
 // Provider Registry — single source of truth for all provider metadata

--- a/src/test/auth/config.test.ts
+++ b/src/test/auth/config.test.ts
@@ -1,0 +1,34 @@
+import { strict as assert } from 'assert';
+
+import {
+  getExternalAuthCallbackInfo,
+  setExternalAuthCallbackResolver,
+} from '@auth/config';
+
+describe('auth config', () => {
+  afterEach(() => {
+    setExternalAuthCallbackResolver(null);
+  });
+
+  it('uses a host-provided external callback resolver', async () => {
+    setExternalAuthCallbackResolver(async () => ({
+      baseUrl: 'https://example.test/extension-auth-callback',
+      vscodeState: 'state-value',
+      fullUrl: 'https://example.test/extension-auth-callback?state=state-value',
+    }));
+
+    assert.deepEqual(await getExternalAuthCallbackInfo(), {
+      baseUrl: 'https://example.test/extension-auth-callback',
+      vscodeState: 'state-value',
+      fullUrl: 'https://example.test/extension-auth-callback?state=state-value',
+    });
+  });
+
+  it('falls back without importing host APIs', async () => {
+    assert.deepEqual(await getExternalAuthCallbackInfo(), {
+      baseUrl: 'vscode://texra-ai.texra/auth-callback',
+      vscodeState: null,
+      fullUrl: 'vscode://texra-ai.texra/auth-callback',
+    });
+  });
+});

--- a/src/tools/ExecutionsTool.ts
+++ b/src/tools/ExecutionsTool.ts
@@ -34,9 +34,10 @@ import {
   bindExecutionSubscription,
   unbindExecutionSubscription,
 } from '@agent/runtime/ExecutionSubscriptionBinder';
+import { getWorkspaceState } from '@agent/core/stateStore';
 
 // Local imports - utils
-import { WorkspaceStateKey, workspaceSM } from '@common/state';
+import { WorkspaceStateKey } from '@common/state/stateKeys';
 import { isDirectory } from '@common/files/fsEntryType';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
@@ -607,7 +608,10 @@ Use action: "subscribe" on /executions/{id} to receive future status, progress, 
     // Only block subagent kills when the toggle is disabled; process kills are always allowed.
     if (
       target instanceof AgentExecutionHandle &&
-      !workspaceSM.get<boolean>(WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL, true)
+      !getWorkspaceState().get<boolean>(
+        WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+        true,
+      )
     ) {
       return {
         output:

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,5 +1,5 @@
 // Local imports - platform
-import { tryPlatform } from '@platform/platform';
+import { tryGlobalState } from '@platform/platform';
 
 // Local imports - common
 import { GlobalStateKey } from '@common/state/stateKeys';
@@ -9,10 +9,6 @@ import * as logger from '@logger/logUtils';
 import { getConfig } from './configUtils';
 
 const CHANNEL = 'config';
-
-function globalState() {
-  return tryPlatform()?.globalState;
-}
 
 // Settings query constants for VS Code settings UI
 export const SETTINGS_QUERY = {
@@ -74,13 +70,13 @@ export function getToolUsePersistenceTtlHours(): number {
 
 /** Set whether the memory tool is enabled for tool-use sessions. */
 export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
-  await globalState()?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
+  await tryGlobalState()?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
 }
 
 /** Get the set of tool group IDs disabled by the user. */
 export function getDisabledToolIds(): ReadonlySet<string> {
   const raw =
-    globalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+    tryGlobalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
   return new Set(raw);
 }
 
@@ -90,12 +86,12 @@ export async function setToolEnabled(
   enabled: boolean,
 ): Promise<void> {
   const current =
-    globalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+    tryGlobalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
   const set = new Set(current);
   if (enabled) {
     set.delete(toolId);
   } else {
     set.add(toolId);
   }
-  await globalState()?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
+  await tryGlobalState()?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
 }

--- a/src/utils/config/constants.ts
+++ b/src/utils/config/constants.ts
@@ -1,11 +1,18 @@
-// Local imports - common (direct import to avoid circular dependency via barrel)
-import { globalSM, GlobalStateKey } from '@common/state/stateManager';
+// Local imports - platform
+import { tryPlatform } from '@platform/platform';
+
+// Local imports - common
+import { GlobalStateKey } from '@common/state/stateKeys';
 
 // Local imports - config utils
 import * as logger from '@logger/logUtils';
 import { getConfig } from './configUtils';
 
 const CHANNEL = 'config';
+
+function globalState() {
+  return tryPlatform()?.globalState;
+}
 
 // Settings query constants for VS Code settings UI
 export const SETTINGS_QUERY = {
@@ -67,12 +74,13 @@ export function getToolUsePersistenceTtlHours(): number {
 
 /** Set whether the memory tool is enabled for tool-use sessions. */
 export async function setToolUseMemoryEnabled(enabled: boolean): Promise<void> {
-  await globalSM?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
+  await globalState()?.update(GlobalStateKey.MEMORY_ENABLED, enabled);
 }
 
 /** Get the set of tool group IDs disabled by the user. */
 export function getDisabledToolIds(): ReadonlySet<string> {
-  const raw = globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+  const raw =
+    globalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
   return new Set(raw);
 }
 
@@ -82,12 +90,12 @@ export async function setToolEnabled(
   enabled: boolean,
 ): Promise<void> {
   const current =
-    globalSM?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
+    globalState()?.get<string[]>(GlobalStateKey.DISABLED_TOOLS, []) ?? [];
   const set = new Set(current);
   if (enabled) {
     set.delete(toolId);
   } else {
     set.add(toolId);
   }
-  await globalSM?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
+  await globalState()?.update(GlobalStateKey.DISABLED_TOOLS, [...set]);
 }

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -7,7 +7,8 @@
  * @shared/constants/providers.
  */
 
-import { globalSM, GlobalStateKey } from '@common/state/stateManager';
+import { tryPlatform } from '@platform/platform';
+import { GlobalStateKey } from '@common/state/stateKeys';
 import { getConfig } from '@utils/config';
 
 /**
@@ -89,12 +90,16 @@ const PROVIDERS: Record<string, ProviderEntry> = {
   },
 };
 
+function globalState() {
+  return tryPlatform()?.globalState;
+}
+
 function entry(provider: string): ProviderEntry | undefined {
   return PROVIDERS[provider.toLowerCase()];
 }
 
 function read<T>(key: GlobalStateKey, defaultValue: T): T {
-  return globalSM?.get(key, defaultValue) ?? defaultValue;
+  return globalState()?.get(key, defaultValue) ?? defaultValue;
 }
 
 function regionSet(provider: string): boolean | undefined {
@@ -111,7 +116,7 @@ export function getGlobalStreaming(): boolean {
 }
 
 export async function setGlobalStreaming(enabled: boolean): Promise<void> {
-  await globalSM?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
+  await globalState()?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
 }
 
 export function getProviderStreaming(provider: string): boolean {
@@ -125,7 +130,7 @@ export async function setProviderStreaming(
   enabled: boolean,
 ): Promise<void> {
   const key = entry(provider)?.streaming;
-  if (key) await globalSM?.update(key, enabled);
+  if (key) await globalState()?.update(key, enabled);
 }
 
 // ---------------------------------------------------------------------------
@@ -142,7 +147,7 @@ export async function setProviderEndpoint(
   endpoint: string,
 ): Promise<void> {
   const key = entry(provider)?.endpoint;
-  if (key) await globalSM?.update(key, endpoint);
+  if (key) await globalState()?.update(key, endpoint);
 }
 
 export function supportsCustomEndpoint(provider: string): boolean {
@@ -210,7 +215,7 @@ export function getWebSocketEnabled(): boolean {
  */
 export function getUseOpenRouter(): boolean {
   return (
-    globalSM?.get(GlobalStateKey.USE_OPENROUTER, false) ??
+    globalState()?.get(GlobalStateKey.USE_OPENROUTER, false) ??
     getConfig<boolean>('texra.model.useOpenRouter', false)
   );
 }

--- a/src/utils/config/providerConfig.ts
+++ b/src/utils/config/providerConfig.ts
@@ -7,7 +7,7 @@
  * @shared/constants/providers.
  */
 
-import { tryPlatform } from '@platform/platform';
+import { tryGlobalState } from '@platform/platform';
 import { GlobalStateKey } from '@common/state/stateKeys';
 import { getConfig } from '@utils/config';
 
@@ -90,16 +90,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
   },
 };
 
-function globalState() {
-  return tryPlatform()?.globalState;
-}
-
 function entry(provider: string): ProviderEntry | undefined {
   return PROVIDERS[provider.toLowerCase()];
 }
 
 function read<T>(key: GlobalStateKey, defaultValue: T): T {
-  return globalState()?.get(key, defaultValue) ?? defaultValue;
+  return tryGlobalState()?.get(key, defaultValue) ?? defaultValue;
 }
 
 function regionSet(provider: string): boolean | undefined {
@@ -116,7 +112,7 @@ export function getGlobalStreaming(): boolean {
 }
 
 export async function setGlobalStreaming(enabled: boolean): Promise<void> {
-  await globalState()?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
+  await tryGlobalState()?.update(GlobalStateKey.STREAMING_GLOBAL, enabled);
 }
 
 export function getProviderStreaming(provider: string): boolean {
@@ -130,7 +126,7 @@ export async function setProviderStreaming(
   enabled: boolean,
 ): Promise<void> {
   const key = entry(provider)?.streaming;
-  if (key) await globalState()?.update(key, enabled);
+  if (key) await tryGlobalState()?.update(key, enabled);
 }
 
 // ---------------------------------------------------------------------------
@@ -147,7 +143,7 @@ export async function setProviderEndpoint(
   endpoint: string,
 ): Promise<void> {
   const key = entry(provider)?.endpoint;
-  if (key) await globalState()?.update(key, endpoint);
+  if (key) await tryGlobalState()?.update(key, endpoint);
 }
 
 export function supportsCustomEndpoint(provider: string): boolean {
@@ -215,7 +211,7 @@ export function getWebSocketEnabled(): boolean {
  */
 export function getUseOpenRouter(): boolean {
   return (
-    globalState()?.get(GlobalStateKey.USE_OPENROUTER, false) ??
+    tryGlobalState()?.get(GlobalStateKey.USE_OPENROUTER, false) ??
     getConfig<boolean>('texra.model.useOpenRouter', false)
   );
 }


### PR DESCRIPTION
Closes #3480.\n\n## Summary\n- move VS Code OAuth callback adaptation and output-channel creation behind extension-host registration points\n- remove the desktop main build's `--external:vscode` escape hatch so reachable VS Code imports fail at build time\n- switch desktop-shared state-key imports to `@common/state/stateKeys` and read shared config state through the platform global state backend\n- strengthen desktop artifact/package checks for VS Code runtime imports and desktop-shared state boundary regressions\n\n## Validation\n- `corepack pnpm install --frozen-lockfile`\n- `npm run compile-tests`\n- `npm run test:kernel -- src/test/auth/config.test.ts src/test-kernel/desktop`\n- `npm run lint && npm run typecheck`\n- `npm run build:initial`\n- `npm run desktop:package:local`\n- `npm run check:desktop-package`\n- launched `packages/desktop/dist-packaged/mac-arm64/TeXRA.app/Contents/MacOS/TeXRA --no-sandbox` for startup smoke; no VS Code import failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes authentication callback resolution and logging initialization wiring, and tightens desktop build/packaging constraints that could fail builds if any remaining VS Code-coupled imports exist.
> 
> **Overview**
> Prevents the Electron desktop main bundle from accidentally depending on the VS Code extension host by removing `--external:vscode` from the desktop `esbuild` step and moving VS Code-specific integrations behind explicit host registration.
> 
> Auth and logging are refactored to be host-provided: `@auth/config` now uses a registered `setExternalAuthCallbackResolver()` (with a safe fallback) instead of dynamically importing `vscode`, and `@logger/logUtils` now relies on an injected `setOutputChannelFactory()` rather than runtime `vscode` loading. Desktop/package verification scripts are strengthened to fail if built artifacts contain VS Code runtime imports or if desktop-shared source imports VS Code-backed state barrels (enforcing `@common/state/stateKeys` + platform state access), with a small set of shared-state callsites updated accordingly and a new test covering the auth resolver behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41056b0cc677a09cdb51a8a405e96ca80319758. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->