### PR TITLE
Keep common error utilities host-neutral

### DIFF
--- a/packages/extension/src/commands/agent/agentCreatorCommands.ts
+++ b/packages/extension/src/commands/agent/agentCreatorCommands.ts
@@ -17,14 +17,14 @@ import { createHelperModelKit } from '@agent/runtime/helperModel';
 import { validateAgentYamlContent } from '@agent/runtime/agentLoad';
 import { renderAgentTemplateString } from '@commands/agent/agentTemplateRenderer';
 import {
-  showLoggedErrorMessage,
-  toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
-import {
   agentDirectories,
   promptToAddAgentToConfig,
   type AgentVariantMetadata,
 } from '@frontend/agents';
+import {
+  showLoggedErrorMessage,
+  toErrorMessage,
+} from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { AbsoluteFS } from '@utils/files';
 import { isNonEmptyString } from '@utils/core/stringCore';

--- a/packages/extension/src/commands/agent/mergeCommands.ts
+++ b/packages/extension/src/commands/agent/mergeCommands.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 // Local imports
 import { executeMergeAgent } from '@agent/runtime/executeAgent';
 import { getHelperModelName } from '@agent/runtime/helperModel';
-import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
+import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 
 const CHANNEL = 'MergeCommands';
 

--- a/packages/extension/src/commands/agent/resumeCommand.ts
+++ b/packages/extension/src/commands/agent/resumeCommand.ts
@@ -8,7 +8,7 @@ import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { ToolUseSessionSnapshot } from '@agent/implementations/flows/tooluse';
-import { logErrorMessage } from '@common/errors/errorHandlingUtils';
+import { logErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { STREAM_STATUS } from '@shared/schemas';
 import { getToolUsePersistenceEnabled } from '@utils/config';
 

--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -3,8 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 import { SecretManager, ApiProvider } from '@frontend/secretManager';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';

--- a/packages/extension/src/commands/files/fileSelectionCommands.ts
+++ b/packages/extension/src/commands/files/fileSelectionCommands.ts
@@ -3,8 +3,8 @@ import * as vscode from 'vscode';
 
 // Local imports - log
 import { FILE_SELECTION_COMMAND_IDS, getFilterExtensions } from '@common/files';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 import { getFileLister } from '@frontend/files';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { selectFile, selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -3,9 +3,9 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { setPendingState } from '@common/state';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { buildMainViewState } from '@frontend/mainViewStateUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { TaskStateSchema, type TaskState } from '@logger/TaskState';

--- a/packages/extension/src/commands/housekeeping/cleanCommands.ts
+++ b/packages/extension/src/commands/housekeeping/cleanCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types';
-import { parseWithErrorDisplay } from '@common/errors/errorHandlingUtils';
+import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
 import {
   runCleanSingle,
   runCleanMultiple,

--- a/packages/extension/src/commands/housekeeping/packCommands.ts
+++ b/packages/extension/src/commands/housekeeping/packCommands.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Local imports
 import type { FileOpResult } from '@agent/types';
-import { parseWithErrorDisplay } from '@common/errors/errorHandlingUtils';
+import { parseWithErrorDisplay } from '@frontend/ui/errorHandlingUtils';
 import {
   runPack,
   runPackSingle,

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -6,11 +6,11 @@ import * as vscode from 'vscode';
 
 // Local imports
 import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
+import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
   toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
-import { bus } from '@eventBus/ProgressEventBus';
+} from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
 import * as logger from '@logger/logUtils';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latex';

--- a/packages/extension/src/commands/latex/figCommands.ts
+++ b/packages/extension/src/commands/latex/figCommands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import {
   showLoggedErrorMessage,
   showLoggedInfoMessage,
-} from '@common/errors/errorHandlingUtils';
+} from '@frontend/ui/errorHandlingUtils';
 import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
 import { extractFigurePathsFromLatex } from '@latex/extractFigure';
 import { tikzPictureManager } from '@latex/TikzPictureManager';

--- a/packages/extension/src/commands/latex/imageCommands.ts
+++ b/packages/extension/src/commands/latex/imageCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - errors
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as dialogUtils from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import {

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -6,7 +6,7 @@ import {
   showLoggedErrorMessage,
   showLoggedInfoMessage,
   showLoggedMessage,
-} from '@common/errors/errorHandlingUtils';
+} from '@frontend/ui/errorHandlingUtils';
 import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
 import { runIndentTeX } from '@housekeeping';
 import { runLatexFormatter } from '@latex/texFormatter';

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -18,7 +18,7 @@ import {
   showLoggedErrorMessage,
   showLoggedMessage,
   showLoggedMessageWithDocs,
-} from '@common/errors/errorHandlingUtils';
+} from '@frontend/ui/errorHandlingUtils';
 import { openBuildDisplayIfTex } from '@frontend/latex/openBuild';
 import {
   runPackLatexdiffvc,

--- a/packages/extension/src/commands/latex/linterCommands.ts
+++ b/packages/extension/src/commands/latex/linterCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getLinterMessages } from '@frontend/latex/linter';
 import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
 import * as logger from '@logger/logUtils';

--- a/packages/extension/src/commands/system/sampleProjectCommands.ts
+++ b/packages/extension/src/commands/system/sampleProjectCommands.ts
@@ -6,7 +6,7 @@ import fsExtra from 'fs-extra';
 import * as vscode from 'vscode';
 
 // Local imports - fs
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 

--- a/packages/extension/src/commands/system/textEditorCommands.ts
+++ b/packages/extension/src/commands/system/textEditorCommands.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports - Tool implementations
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import {
   TextEditorTool,

--- a/packages/extension/src/commands/system/xmlCommands.ts
+++ b/packages/extension/src/commands/system/xmlCommands.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { XMLParser } from 'fast-xml-parser';
 
 // Local imports - core
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   getActiveEditorWithGuards,
   logGuardFailure,

--- a/packages/extension/src/commands/system/yamlCommands.ts
+++ b/packages/extension/src/commands/system/yamlCommands.ts
@@ -9,7 +9,7 @@ import * as yaml from 'yaml';
 import { resolveAgent, getWorkflowAgents } from '@agent/index';
 import { loadYaml, loadAgentSettingAndPrompts } from '@agent/runtime/agentLoad';
 import { getAgentPath } from '@agent/runtime/executeAgent';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { showInstructionWithSuppress } from '@frontend/ui/instruction';
 import {
   getActiveEditorWithGuards,

--- a/packages/extension/src/commands/tests/connectionTests.ts
+++ b/packages/extension/src/commands/tests/connectionTests.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   bestConnectionMethod,
   bestConnectionMethodAnthropic,

--- a/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
+++ b/packages/extension/src/frontend/agents/AgentDirectoryManager.ts
@@ -13,7 +13,7 @@ import {
 } from '@agent/index';
 import type { AgentSource } from '@agent/index';
 import { GlobalStateKey, globalSM } from '@common/state';
-import { showLoggedMessageWithDocs } from '@common/errors/errorHandlingUtils';
+import { showLoggedMessageWithDocs } from '@frontend/ui/errorHandlingUtils';
 import * as logger from '@logger/logUtils';
 import { AGENT_SOURCE } from '@shared/schemas/agent';
 import { AbsoluteFS } from '@utils/files';

--- a/packages/extension/src/frontend/system/commandUtils.ts
+++ b/packages/extension/src/frontend/system/commandUtils.ts
@@ -2,7 +2,7 @@
 import * as vscode from 'vscode';
 
 // Local imports
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 
 const DEFAULT_CHANNEL = 'commandUtils';
 

--- a/packages/extension/src/frontend/ui/errorHandlingUtils.ts
+++ b/packages/extension/src/frontend/ui/errorHandlingUtils.ts
@@ -1,12 +1,15 @@
 import * as vscode from 'vscode';
 
+import { formatError, formatZodError } from '@common/errors';
 import * as logger from '@logger/logUtils';
-import { formatError, formatZodError } from './errorFormatUtils';
 import type { z } from 'zod';
 
 export { formatError, formatZodError };
-export { toErrorMessage } from './errorMessage';
-export { isDiskFullError, isFileNotFoundError } from './errorPredicates';
+export {
+  isDiskFullError,
+  isFileNotFoundError,
+  toErrorMessage,
+} from '@common/errors';
 
 /** Valid documentation identifiers for error messages. */
 export type DocId = 'intelligent-merge' | 'custom-agents' | 'latex-diff';

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -57,9 +57,9 @@ import {
   globalSM,
   workspaceSM,
 } from '@common/state';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import { SecretManager, type ApiProvider } from '@frontend/secretManager';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { selectAgentInMainView } from '@frontend/agents/remoteAgentUtils';
 import {
   applyGitAuthorConfig,

--- a/packages/extension/src/settingsView/handlers/agentHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/agentHandlers.ts
@@ -37,7 +37,7 @@ import {
 import {
   isFileNotFoundError,
   showLoggedErrorMessage,
-} from '@common/errors/errorHandlingUtils';
+} from '@frontend/ui/errorHandlingUtils';
 import { agentDirectories } from '@frontend/agents/AgentDirectoryManager';
 import {
   SETTINGS_VIEW_CMD,

--- a/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
+++ b/packages/extension/src/settingsView/handlers/latexSettingsHandlers.ts
@@ -12,7 +12,7 @@ import { LatexRecommendedSettingsController } from '@controllers/settingsView/La
 import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview';
 import { workspaceSM } from '@common/state';
-import { showLoggedErrorMessage } from '@common/errors/errorHandlingUtils';
+import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import {
   SETTINGS_VIEW_CMD,
   type SettingsMessageFor,

--- a/packages/extension/src/webview/managers/FileManager.ts
+++ b/packages/extension/src/webview/managers/FileManager.ts
@@ -15,11 +15,11 @@ import {
   type MultiFileCategory,
 } from '@common/files';
 import { MAIN_VIEW_COMMANDS } from '@common/webview';
+import { getFileLister } from '@frontend/files';
 import {
   showLoggedErrorMessage,
   toErrorMessage,
-} from '@common/errors/errorHandlingUtils';
-import { getFileLister } from '@frontend/files';
+} from '@frontend/ui/errorHandlingUtils';
 import { selectFiles } from '@frontend/ui/dialogs';
 import * as logger from '@logger/logUtils';
 import type { MainViewInboundMessage } from '@shared/schemas';

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -21,8 +21,19 @@ const desktopSharedSourceDirSegments = [
   ['src', 'utils'],
 ];
 
+const desktopVscodeFreeSourceDirSegments = [
+  ...desktopSharedSourceDirSegments,
+  ['src', 'common', 'errors'],
+];
+
 export function getDesktopSharedSourceDirs(rootDir) {
   return desktopSharedSourceDirSegments.map((segments) =>
+    path.join(rootDir, ...segments),
+  );
+}
+
+export function getDesktopVscodeFreeSourceDirs(rootDir) {
+  return desktopVscodeFreeSourceDirSegments.map((segments) =>
     path.join(rootDir, ...segments),
   );
 }

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   getDesktopSharedSourceDirs,
+  getDesktopVscodeFreeSourceDirs,
   readJson,
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
@@ -51,6 +52,7 @@ const requiredFiles = [
 ];
 const failures = [];
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(rootDir);
+const desktopVscodeFreeSourceDirs = getDesktopVscodeFreeSourceDirs(rootDir);
 
 for (const filePath of requiredFiles) {
   if (!fileExists(filePath)) {
@@ -91,6 +93,20 @@ for (const dir of desktopSharedSourceDirs) {
   }
 }
 
+for (const dir of desktopVscodeFreeSourceDirs) {
+  if (!fs.existsSync(dir)) continue;
+  for (const filePath of collectFiles(dir)) {
+    if (!/\.[cm]?tsx?$/.test(filePath)) continue;
+    if (!vscodeRuntimeImportPattern.test(fs.readFileSync(filePath, 'utf8')))
+      continue;
+    failures.push(
+      `Desktop-shared source imports the VS Code runtime module: ${relative(
+        filePath,
+      )}`,
+    );
+  }
+}
+
 if (failures.length > 0) {
   console.error('Desktop build artifact check failed:');
   for (const failure of failures) console.error(`- ${failure}`);
@@ -106,3 +122,4 @@ const artifactList = [
 
 console.log('Desktop build artifact check passed:');
 for (const artifact of artifactList) console.log(`- ${artifact}`);
+console.log('- desktop-shared source avoids VS Code runtime imports');

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -53,6 +53,11 @@ const requiredFiles = [
 const failures = [];
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(rootDir);
 const desktopVscodeFreeSourceDirs = getDesktopVscodeFreeSourceDirs(rootDir);
+const desktopSharedSourceDirSet = new Set(desktopSharedSourceDirs);
+const desktopVscodeFreeSourceDirSet = new Set(desktopVscodeFreeSourceDirs);
+const desktopSourceBoundaryDirs = [
+  ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
+];
 
 for (const filePath of requiredFiles) {
   if (!fileExists(filePath)) {
@@ -79,31 +84,31 @@ if (
   );
 }
 
-for (const dir of desktopSharedSourceDirs) {
+for (const dir of desktopSourceBoundaryDirs) {
   if (!fs.existsSync(dir)) continue;
   for (const filePath of collectFiles(dir)) {
     if (!/\.[cm]?tsx?$/.test(filePath)) continue;
-    if (!vscodeBackedStateImportPattern.test(fs.readFileSync(filePath, 'utf8')))
-      continue;
-    failures.push(
-      `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
-        filePath,
-      )}`,
-    );
-  }
-}
-
-for (const dir of desktopVscodeFreeSourceDirs) {
-  if (!fs.existsSync(dir)) continue;
-  for (const filePath of collectFiles(dir)) {
-    if (!/\.[cm]?tsx?$/.test(filePath)) continue;
-    if (!vscodeRuntimeImportPattern.test(fs.readFileSync(filePath, 'utf8')))
-      continue;
-    failures.push(
-      `Desktop-shared source imports the VS Code runtime module: ${relative(
-        filePath,
-      )}`,
-    );
+    const source = fs.readFileSync(filePath, 'utf8');
+    if (
+      desktopSharedSourceDirSet.has(dir) &&
+      vscodeBackedStateImportPattern.test(source)
+    ) {
+      failures.push(
+        `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
+          filePath,
+        )}`,
+      );
+    }
+    if (
+      desktopVscodeFreeSourceDirSet.has(dir) &&
+      vscodeRuntimeImportPattern.test(source)
+    ) {
+      failures.push(
+        `Desktop-shared source imports the VS Code runtime module: ${relative(
+          filePath,
+        )}`,
+      );
+    }
   }
 }
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   getDesktopSharedSourceDirs,
+  getDesktopVscodeFreeSourceDirs,
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
@@ -18,6 +19,7 @@ const desktopRoot = join(repoRoot, 'packages', 'desktop');
 const packageRoot = join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(repoRoot);
+const desktopVscodeFreeSourceDirs = getDesktopVscodeFreeSourceDirs(repoRoot);
 
 async function exists(path) {
   try {
@@ -167,6 +169,21 @@ async function checkDesktopSourceBoundaries(failures) {
       );
     }
   }
+
+  for (const dir of desktopVscodeFreeSourceDirs) {
+    if (!(await exists(dir))) continue;
+    for (const filePath of await collectFiles(dir)) {
+      if (!/\.[cm]?tsx?$/.test(filePath)) continue;
+      if (!vscodeRuntimeImportPattern.test(await readFile(filePath, 'utf8')))
+        continue;
+      failures.push(
+        `Desktop-shared source imports the VS Code runtime module: ${relative(
+          repoRoot,
+          filePath,
+        )}`,
+      );
+    }
+  }
 }
 
 function dependencyPackageJsonPath(name) {
@@ -268,5 +285,6 @@ console.log(
     '- node_modules runtime dependency packages',
     '- no VS Code extension host runtime import',
     '- desktop-shared source uses vscode-free state keys',
+    '- desktop-shared source avoids VS Code runtime imports',
   ].join('\n'),
 );

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -20,6 +20,11 @@ const packageRoot = join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(repoRoot);
 const desktopVscodeFreeSourceDirs = getDesktopVscodeFreeSourceDirs(repoRoot);
+const desktopSharedSourceDirSet = new Set(desktopSharedSourceDirs);
+const desktopVscodeFreeSourceDirSet = new Set(desktopVscodeFreeSourceDirs);
+const desktopSourceBoundaryDirs = [
+  ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
+];
 
 async function exists(path) {
   try {
@@ -152,36 +157,33 @@ async function checkNoVscodeRuntimeImport(app, failures) {
 }
 
 async function checkDesktopSourceBoundaries(failures) {
-  for (const dir of desktopSharedSourceDirs) {
+  for (const dir of desktopSourceBoundaryDirs) {
     if (!(await exists(dir))) continue;
     for (const filePath of await collectFiles(dir)) {
       if (!/\.[cm]?tsx?$/.test(filePath)) continue;
+      const source = await readFile(filePath, 'utf8');
       if (
-        !vscodeBackedStateImportPattern.test(await readFile(filePath, 'utf8'))
+        desktopSharedSourceDirSet.has(dir) &&
+        vscodeBackedStateImportPattern.test(source)
       ) {
-        continue;
+        failures.push(
+          `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
+            repoRoot,
+            filePath,
+          )}`,
+        );
       }
-      failures.push(
-        `Desktop-shared source imports the VS Code-backed state barrel instead of @common/state/stateKeys: ${relative(
-          repoRoot,
-          filePath,
-        )}`,
-      );
-    }
-  }
-
-  for (const dir of desktopVscodeFreeSourceDirs) {
-    if (!(await exists(dir))) continue;
-    for (const filePath of await collectFiles(dir)) {
-      if (!/\.[cm]?tsx?$/.test(filePath)) continue;
-      if (!vscodeRuntimeImportPattern.test(await readFile(filePath, 'utf8')))
-        continue;
-      failures.push(
-        `Desktop-shared source imports the VS Code runtime module: ${relative(
-          repoRoot,
-          filePath,
-        )}`,
-      );
+      if (
+        desktopVscodeFreeSourceDirSet.has(dir) &&
+        vscodeRuntimeImportPattern.test(source)
+      ) {
+        failures.push(
+          `Desktop-shared source imports the VS Code runtime module: ${relative(
+            repoRoot,
+            filePath,
+          )}`,
+        );
+      }
     }
   }
 }

--- a/src/common/errors/index.ts
+++ b/src/common/errors/index.ts
@@ -1,7 +1,7 @@
 /**
  * Common host-neutral error utilities.
  *
- * VS Code notification helpers live in @common/errors/errorHandlingUtils.
+ * VS Code notification helpers live in @frontend/ui/errorHandlingUtils.
  * SDK-specific utilities (isContextWindowError, attachStreamDiagnostics,
  * buildErrorLogData, etc.) should be imported directly from
  * @common/errors/sdkErrorUtils - they are not part of the public barrel.


### PR DESCRIPTION
## Summary
- move VS Code notification helpers out of `src/common/errors` into the extension host UI layer
- update extension-host imports to use `@frontend/ui/errorHandlingUtils`
- extend desktop build/package guards to reject VS Code runtime imports in desktop-shared source and `src/common/errors`

Fixes #3483.

## Verification
- `npm run compile:safe`
- `npm run lint`
- `npm run desktop:build`
- `npm run desktop:package:local && npm run check:desktop-package`
- `npm run build:fast && npm run check:initial-build-artifacts`
- Vite desktop shell smoke via Playwright/Chrome: `http://127.0.0.1:5173/` loaded without the `vscode` import overlay
- packaged macOS app launch smoke: `TeXRA.app/Contents/MacOS/TeXRA` stayed running for 5 seconds with no stderr output

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that moves VS Code-specific notification helpers out of `src/common/errors` and updates imports; main risk is build/runtime breakage from missed import updates, now partially guarded by stricter desktop checks.
> 
> **Overview**
> Decouples host-neutral error formatting/utilities from VS Code UI notifications by shifting extension-host code to import notification helpers from `@frontend/ui/errorHandlingUtils` and updating `src/common/errors` docs accordingly.
> 
> Strengthens desktop build/package verification scripts to treat `src/common/errors` as VS Code-runtime-free and fail if desktop-shared (and now vscode-free) source imports the VS Code runtime module, preventing accidental `vscode` dependencies from leaking into desktop bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e68de16284d7ef264aeeab59a2a3dbbe2476f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->