### PR TITLE
Harden Electron adapter test stub

### DIFF
--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -4,9 +4,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Third-party imports
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - test support
+import {
+  app as electronApp,
+  configureElectronTestStub,
+  resetElectronTestStub,
+} from './electronTestStub.mjs';
 import { loadDesktopPlatformModule } from './loadDesktopPlatformModule.mjs';
 
 interface JsonStore {
@@ -69,20 +74,35 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 describe('desktop platform adapters', () => {
-  let tempDir: string | undefined;
+  const tempDirs: string[] = [];
   const originalEnv = { ...process.env };
+  const testSecretKey = 'TEXRA_TEST_TOKEN';
 
   afterEach(async () => {
     process.env = { ...originalEnv };
-    if (tempDir == null) return;
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
+    resetElectronTestStub();
+    vi.restoreAllMocks();
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((path) => rm(path, { recursive: true, force: true })),
+    );
   });
 
   async function makeTempDir(prefix: string): Promise<string> {
-    tempDir = await mkdtemp(join(tmpdir(), prefix));
+    const tempDir = await mkdtemp(join(tmpdir(), prefix));
+    tempDirs.push(tempDir);
     return tempDir;
   }
+
+  it('keeps Electron app paths isolated from the checkout', async () => {
+    const root = await makeTempDir('texra-electron-user-data-');
+
+    configureElectronTestStub({ userDataPath: root });
+
+    expect(electronApp.getPath('userData')).toBe(root);
+    expect(electronApp.getPath('logs')).toBe(join(root, 'logs'));
+  });
 
   it('persists state values and deletes undefined updates through JsonStore', async () => {
     const [{ JsonStore }, { ElectronStateStore }] = await Promise.all([
@@ -132,21 +152,56 @@ describe('desktop platform adapters', () => {
     const store = await JsonStore.open(join(root, 'secrets.json'));
     const secrets = new ElectronSecrets(store);
 
-    await secrets.set('TEXRA_TOKEN', 'persisted');
+    await secrets.set(testSecretKey, 'persisted');
 
-    expect(await secrets.get('TEXRA_TOKEN')).toBe('persisted');
-    expect(store.snapshot().TEXRA_TOKEN).toEqual({
+    expect(await secrets.get(testSecretKey)).toBe('persisted');
+    expect(store.snapshot()[testSecretKey]).toMatchObject({
       encrypted: true,
-      value: Buffer.from('encrypted:persisted').toString('base64'),
+      value: expect.any(String),
     });
 
-    process.env.TEXRA_TOKEN = 'from-env';
-    expect(await secrets.get('TEXRA_TOKEN')).toBe('from-env');
+    process.env[testSecretKey] = 'from-env';
+    expect(await secrets.get(testSecretKey)).toBe('from-env');
 
-    delete process.env.TEXRA_TOKEN;
-    await secrets.delete('TEXRA_TOKEN');
+    delete process.env[testSecretKey];
+    await secrets.delete(testSecretKey);
 
-    expect(await secrets.get('TEXRA_TOKEN')).toBeUndefined();
+    expect(await secrets.get(testSecretKey)).toBeUndefined();
+    expect(store.snapshot()).toEqual({});
+  });
+
+  it('rejects secret writes when Electron safe storage is unavailable', async () => {
+    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
+      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+      loadJsonStore(),
+    ]);
+    const root = await makeTempDir('texra-electron-secrets-');
+    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const secrets = new ElectronSecrets(store);
+
+    configureElectronTestStub({ safeStorageEncryptionAvailable: false });
+
+    await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
+      'Electron safeStorage is unavailable for secret writes.',
+    );
+    expect(store.snapshot()).toEqual({});
+  });
+
+  it('rejects secret writes on the Linux basic_text safe storage backend', async () => {
+    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
+      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+      loadJsonStore(),
+    ]);
+    const root = await makeTempDir('texra-electron-secrets-');
+    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const secrets = new ElectronSecrets(store);
+
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    configureElectronTestStub({ safeStorageBackend: 'basic_text' });
+
+    await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
+      'Electron safeStorage is unavailable for secret writes.',
+    );
     expect(store.snapshot()).toEqual({});
   });
 
@@ -159,8 +214,8 @@ describe('desktop platform adapters', () => {
     const store = await JsonStore.open(join(root, 'secrets.json'));
     const secrets = new ElectronSecrets(store);
 
-    await store.set('TEXRA_TOKEN', { encrypted: false, value: 'plain' });
+    await store.set(testSecretKey, { encrypted: false, value: 'plain' });
 
-    expect(await secrets.get('TEXRA_TOKEN')).toBeUndefined();
+    expect(await secrets.get(testSecretKey)).toBeUndefined();
   });
 });

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -10,8 +10,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   app as electronApp,
   configureElectronTestStub,
+  getElectronTestStubUserDataPath,
   resetElectronTestStub,
+  safeStorage as electronSafeStorage,
 } from './electronTestStub.mjs';
+import { REPO_ROOT } from './desktopTestPaths.mjs';
 import { loadDesktopPlatformModule } from './loadDesktopPlatformModule.mjs';
 
 interface JsonStore {
@@ -80,12 +83,13 @@ describe('desktop platform adapters', () => {
 
   afterEach(async () => {
     process.env = { ...originalEnv };
+    const stubUserDataPath = getElectronTestStubUserDataPath();
+    if (stubUserDataPath != null) tempDirs.push(stubUserDataPath);
     resetElectronTestStub();
     vi.restoreAllMocks();
+    const pathsToRemove = [...new Set(tempDirs.splice(0))];
     await Promise.all(
-      tempDirs
-        .splice(0)
-        .map((path) => rm(path, { recursive: true, force: true })),
+      pathsToRemove.map((path) => rm(path, { recursive: true, force: true })),
     );
   });
 
@@ -95,13 +99,29 @@ describe('desktop platform adapters', () => {
     return tempDir;
   }
 
-  it('keeps Electron app paths isolated from the checkout', async () => {
+  it('keeps default Electron app paths isolated from the checkout', () => {
+    const userDataPath = electronApp.getPath('userData');
+
+    expect(userDataPath).not.toContain(REPO_ROOT);
+    expect(userDataPath).toContain('texra-electron-test-');
+    expect(electronApp.getPath('logs')).toBe(join(userDataPath, 'logs'));
+  });
+
+  it('allows tests to override Electron app paths', async () => {
     const root = await makeTempDir('texra-electron-user-data-');
 
     configureElectronTestStub({ userDataPath: root });
 
     expect(electronApp.getPath('userData')).toBe(root);
     expect(electronApp.getPath('logs')).toBe(join(root, 'logs'));
+  });
+
+  it('merges partial Electron stub safe storage configuration', () => {
+    configureElectronTestStub({ safeStorageEncryptionAvailable: false });
+    configureElectronTestStub({ safeStorageBackend: 'basic_text' });
+
+    expect(electronSafeStorage.isEncryptionAvailable()).toBe(false);
+    expect(electronSafeStorage.getSelectedStorageBackend()).toBe('basic_text');
   });
 
   it('persists state values and deletes undefined updates through JsonStore', async () => {

--- a/src/test-kernel/desktop/electronTestStub.mts
+++ b/src/test-kernel/desktop/electronTestStub.mts
@@ -1,4 +1,5 @@
 // Node imports
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,28 +19,34 @@ interface ElectronTestStubOptions {
 }
 
 const DEFAULT_SAFE_STORAGE_BACKEND = 'os_crypt';
-let resetCounter = 0;
-let userDataPath = makeDefaultUserDataPath();
+let userDataPath: string | undefined;
 let safeStorageBackend: SafeStorageBackend = DEFAULT_SAFE_STORAGE_BACKEND;
 let safeStorageEncryptionAvailable = true;
 
 function makeDefaultUserDataPath(): string {
-  resetCounter += 1;
-  return join(tmpdir(), `texra-electron-test-${process.pid}-${resetCounter}`);
+  return mkdtempSync(join(tmpdir(), 'texra-electron-test-'));
+}
+
+function getUserDataPath(): string {
+  userDataPath ??= makeDefaultUserDataPath();
+  return userDataPath;
 }
 
 export function configureElectronTestStub(
   options: ElectronTestStubOptions,
 ): void {
   userDataPath = options.userDataPath ?? userDataPath;
-  safeStorageBackend =
-    options.safeStorageBackend ?? DEFAULT_SAFE_STORAGE_BACKEND;
+  safeStorageBackend = options.safeStorageBackend ?? safeStorageBackend;
   safeStorageEncryptionAvailable =
-    options.safeStorageEncryptionAvailable ?? true;
+    options.safeStorageEncryptionAvailable ?? safeStorageEncryptionAvailable;
+}
+
+export function getElectronTestStubUserDataPath(): string | undefined {
+  return userDataPath;
 }
 
 export function resetElectronTestStub(): void {
-  userDataPath = makeDefaultUserDataPath();
+  userDataPath = undefined;
   safeStorageBackend = DEFAULT_SAFE_STORAGE_BACKEND;
   safeStorageEncryptionAvailable = true;
 }
@@ -47,7 +54,7 @@ export function resetElectronTestStub(): void {
 export const app = {
   getAppPath: () => repoPath(),
   getPath: (name: string) =>
-    name === 'userData' ? userDataPath : join(userDataPath, name),
+    name === 'userData' ? getUserDataPath() : join(getUserDataPath(), name),
   getVersion: () => '0.0.0-test',
 };
 

--- a/src/test-kernel/desktop/electronTestStub.mts
+++ b/src/test-kernel/desktop/electronTestStub.mts
@@ -1,14 +1,53 @@
 // Node imports
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 // Local imports - desktop test paths
 import { repoPath } from './desktopTestPaths.mjs';
 
-const TEST_ELECTRON_STORAGE_ROOT = repoPath('.test-electron');
+type SafeStorageBackend =
+  | 'basic_text'
+  | 'gnome_libsecret'
+  | 'kwallet'
+  | 'os_crypt';
+
+interface ElectronTestStubOptions {
+  safeStorageBackend?: SafeStorageBackend;
+  safeStorageEncryptionAvailable?: boolean;
+  userDataPath?: string;
+}
+
+const DEFAULT_SAFE_STORAGE_BACKEND = 'os_crypt';
+let resetCounter = 0;
+let userDataPath = makeDefaultUserDataPath();
+let safeStorageBackend: SafeStorageBackend = DEFAULT_SAFE_STORAGE_BACKEND;
+let safeStorageEncryptionAvailable = true;
+
+function makeDefaultUserDataPath(): string {
+  resetCounter += 1;
+  return join(tmpdir(), `texra-electron-test-${process.pid}-${resetCounter}`);
+}
+
+export function configureElectronTestStub(
+  options: ElectronTestStubOptions,
+): void {
+  userDataPath = options.userDataPath ?? userDataPath;
+  safeStorageBackend =
+    options.safeStorageBackend ?? DEFAULT_SAFE_STORAGE_BACKEND;
+  safeStorageEncryptionAvailable =
+    options.safeStorageEncryptionAvailable ?? true;
+}
+
+export function resetElectronTestStub(): void {
+  userDataPath = makeDefaultUserDataPath();
+  safeStorageBackend = DEFAULT_SAFE_STORAGE_BACKEND;
+  safeStorageEncryptionAvailable = true;
+}
 
 export const app = {
   getAppPath: () => repoPath(),
-  getPath: (name: string) => join(TEST_ELECTRON_STORAGE_ROOT, name),
+  getPath: (name: string) =>
+    name === 'userData' ? userDataPath : join(userDataPath, name),
   getVersion: () => '0.0.0-test',
 };
 
@@ -16,6 +55,6 @@ export const safeStorage = {
   decryptString: (value: Buffer) =>
     value.toString('utf8').replace(/^encrypted:/, ''),
   encryptString: (value: string) => Buffer.from(`encrypted:${value}`),
-  getSelectedStorageBackend: () => 'os_crypt',
-  isEncryptionAvailable: () => true,
+  getSelectedStorageBackend: () => safeStorageBackend,
+  isEncryptionAvailable: () => safeStorageEncryptionAvailable,
 };


### PR DESCRIPTION
## Summary
- make the Electron test stub configurable for user-data paths and safeStorage behavior
- move secret adapter assertions to the ElectronSecrets contract instead of the fake encryption bytes
- cover unavailable safeStorage and Linux basic_text rejection branches

Fixes #3417.

## Verification
- `npm run test:kernel -- src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts`
- `npm run test:kernel -- src/test-kernel/desktop`
- `npm run typecheck`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test infrastructure, but they alter Electron stub path and safeStorage behavior which could impact desktop test isolation/cleanup if assumptions differ.
> 
> **Overview**
> **Hardens the Electron desktop test harness** by making `electronTestStub` configurable for `userData` paths and `safeStorage` behavior, with reset/inspection helpers to improve isolation between tests.
> 
> **Expands `ElectronPlatformAdapters` tests** to assert default Electron paths stay out of the repo checkout, allow overriding app paths, avoid asserting exact encrypted bytes, and add coverage for secret write rejection when `safeStorage` is unavailable or on Linux `basic_text` backend, while improving temp directory cleanup and mock resets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4379da7c867e8ad5f85db0e204e4521a7f51a018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->