### PR TITLE
Restore LaTeX housekeeping toasts

### DIFF
--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -8,7 +8,7 @@ import {
   showLoggedMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { withLaTeXGuard } from '@frontend/editor/activeFileGuards';
-import { runIndentTeX } from '@housekeeping';
+import { indentLatexFilesInDirectory } from '@housekeeping';
 import { runLatexFormatter } from '@latex/texFormatter';
 import { getTeXCount, type TexcountMode } from '@latex/texcount';
 import * as logger from '@logger/logUtils';
@@ -52,7 +52,9 @@ export function registerLatexCommands(context: vscode.ExtensionContext): void {
 
 async function handleIndentTeX(): Promise<void> {
   try {
-    const notification = getIndentTeXNotification(await runIndentTeX());
+    const notification = getIndentTeXNotification(
+      await indentLatexFilesInDirectory(),
+    );
     if (!notification) return;
 
     if (notification.severity === 'error') {

--- a/packages/extension/src/commands/latex/latexCommands.ts
+++ b/packages/extension/src/commands/latex/latexCommands.ts
@@ -15,6 +15,8 @@ import * as logger from '@logger/logUtils';
 import replacementEngine from '@replacement/engine';
 import { delay } from '@utils/core';
 
+import { getIndentTeXNotification } from './latexHousekeepingNotifications';
+
 const CHANNEL = 'LaTeXCommands';
 logger.initialize(CHANNEL);
 
@@ -36,7 +38,7 @@ export function registerLatexCommands(context: vscode.ExtensionContext): void {
       latexCommands.getTeXCount,
       handleGetTeXCount,
     ),
-    vscode.commands.registerCommand(latexCommands.indentTeX, runIndentTeX),
+    vscode.commands.registerCommand(latexCommands.indentTeX, handleIndentTeX),
     vscode.commands.registerCommand(
       latexCommands.applyReplacements,
       handleApplyReplacements,
@@ -46,6 +48,25 @@ export function registerLatexCommands(context: vscode.ExtensionContext): void {
       handleFixCompilation,
     ),
   );
+}
+
+async function handleIndentTeX(): Promise<void> {
+  try {
+    const notification = getIndentTeXNotification(await runIndentTeX());
+    if (!notification) return;
+
+    if (notification.severity === 'error') {
+      await showLoggedErrorMessage(
+        CHANNEL,
+        notification.message,
+        notification.error,
+      );
+    } else {
+      await showLoggedMessage(CHANNEL, notification.message);
+    }
+  } catch (err) {
+    await showLoggedErrorMessage(CHANNEL, 'Error in indentTeX command', err);
+  }
 }
 
 async function handleFixCompilation(): Promise<void> {

--- a/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
+++ b/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
@@ -2,6 +2,7 @@
 import type { IndentLatexResult, LatexdiffPackResult } from '@housekeeping';
 
 export interface LatexHousekeepingNotification {
+  // "message" maps to showLoggedMessage, which uses VS Code's error toast.
   severity: 'info' | 'message' | 'error';
   message: string;
   error?: unknown;
@@ -51,6 +52,12 @@ export function getLatexdiffPackNotifications(
         return {
           severity: 'message',
           message: 'No input files provided for multiple LaTeX diff packing',
+        };
+      case 'error':
+        return {
+          severity: 'error',
+          message: `Error during packing ${result.inputFile}`,
+          error: result.error,
         };
       case 'processed':
         return [];

--- a/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
+++ b/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
@@ -1,0 +1,59 @@
+// Local imports
+import type { IndentLatexResult, LatexdiffPackResult } from '@housekeeping';
+
+export interface LatexHousekeepingNotification {
+  severity: 'info' | 'message' | 'error';
+  message: string;
+  error?: unknown;
+}
+
+export function getIndentTeXNotification(
+  result: IndentLatexResult,
+): LatexHousekeepingNotification | undefined {
+  switch (result.status) {
+    case 'missing-config':
+      return {
+        severity: 'message',
+        message: `Formatter config file not found at ${result.configPath}`,
+      };
+    case 'error':
+      return {
+        severity: 'error',
+        message: 'Error during indentation process',
+        error: result.error,
+      };
+    default:
+      return undefined;
+  }
+}
+
+export function getLatexdiffPackNotifications(
+  results: LatexdiffPackResult | LatexdiffPackResult[],
+): LatexHousekeepingNotification[] {
+  return (Array.isArray(results) ? results : [results]).flatMap((result) => {
+    switch (result.status) {
+      case 'no-files':
+        return {
+          severity: 'info',
+          message: 'No LaTeX diff files found to process',
+        };
+      case 'cleaned':
+        return {
+          severity: 'info',
+          message: 'LaTeXdiff files cleaned',
+        };
+      case 'packed':
+        return {
+          severity: 'info',
+          message: `Files packed into ${result.outputFolder}`,
+        };
+      case 'missing-inputs':
+        return {
+          severity: 'message',
+          message: 'No input files provided for multiple LaTeX diff packing',
+        };
+      case 'processed':
+        return [];
+    }
+  });
+}

--- a/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
+++ b/packages/extension/src/commands/latex/latexHousekeepingNotifications.ts
@@ -23,7 +23,8 @@ export function getIndentTeXNotification(
         message: 'Error during indentation process',
         error: result.error,
       };
-    default:
+    case 'disabled':
+    case 'formatted':
       return undefined;
   }
 }

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -16,6 +16,7 @@ import {
 import { workspaceSM, WorkspaceStateKey } from '@common/state';
 import {
   showLoggedErrorMessage,
+  showLoggedInfoMessage,
   showLoggedMessage,
   showLoggedMessageWithDocs,
 } from '@frontend/ui/errorHandlingUtils';
@@ -53,6 +54,11 @@ import {
 } from '@utils/files';
 import { checkToolInstalled } from '@utils/system';
 import { hasExtension } from '@utils/core/pathCore';
+
+import {
+  getLatexdiffPackNotifications,
+  type LatexHousekeepingNotification,
+} from './latexHousekeepingNotifications';
 
 const CHANNEL = 'LaTeXCommands';
 
@@ -137,6 +143,24 @@ async function openLatexdiffResult(
 
   await openBuildDisplayIfTex(diffLocation, { preserveFocus: true });
   return diffFilePath;
+}
+
+async function showLatexdiffPackNotifications(
+  notifications: LatexHousekeepingNotification[],
+): Promise<void> {
+  for (const notification of notifications) {
+    if (notification.severity === 'info') {
+      await showLoggedInfoMessage(CHANNEL, notification.message);
+    } else if (notification.severity === 'error') {
+      await showLoggedErrorMessage(
+        CHANNEL,
+        notification.message,
+        notification.error,
+      );
+    } else {
+      await showLoggedMessage(CHANNEL, notification.message);
+    }
+  }
 }
 
 export function registerLatexdiffCommands(
@@ -273,7 +297,11 @@ async function handlePackLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      await runPackLatexdiffvc(fileToUse, commitHash, clean);
+      await showLatexdiffPackNotifications(
+        getLatexdiffPackNotifications(
+          await runPackLatexdiffvc(fileToUse, commitHash, clean),
+        ),
+      );
     },
   );
 }
@@ -292,7 +320,11 @@ async function handlePackLatexdiffvcMultiple(
         `Command called with: commitHash=${commitHash}, clean=${clean}`,
       );
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean);
+      await showLatexdiffPackNotifications(
+        getLatexdiffPackNotifications(
+          await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean),
+        ),
+      );
     },
   );
 }
@@ -311,7 +343,11 @@ async function handleCleanLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      await runCleanLatexdiffvc(fileToUse, commitHash);
+      await showLatexdiffPackNotifications(
+        getLatexdiffPackNotifications(
+          await runCleanLatexdiffvc(fileToUse, commitHash),
+        ),
+      );
     },
   );
 }
@@ -326,7 +362,11 @@ async function handleCleanLatexdiffvcMultiple(
     async () => {
       logger.debug(CHANNEL, `Command called with: commitHash=${commitHash}`);
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      await runCleanLatexdiffvcMultiple(inputFiles, commitHash);
+      await showLatexdiffPackNotifications(
+        getLatexdiffPackNotifications(
+          await runCleanLatexdiffvcMultiple(inputFiles, commitHash),
+        ),
+      );
     },
   );
 }

--- a/packages/extension/src/commands/latex/latexdiffCommands.ts
+++ b/packages/extension/src/commands/latex/latexdiffCommands.ts
@@ -145,20 +145,20 @@ async function openLatexdiffResult(
   return diffFilePath;
 }
 
-async function showLatexdiffPackNotifications(
+function showLatexdiffPackNotifications(
   notifications: LatexHousekeepingNotification[],
-): Promise<void> {
+): void {
   for (const notification of notifications) {
     if (notification.severity === 'info') {
-      await showLoggedInfoMessage(CHANNEL, notification.message);
+      void showLoggedInfoMessage(CHANNEL, notification.message);
     } else if (notification.severity === 'error') {
-      await showLoggedErrorMessage(
+      void showLoggedErrorMessage(
         CHANNEL,
         notification.message,
         notification.error,
       );
     } else {
-      await showLoggedMessage(CHANNEL, notification.message);
+      void showLoggedMessage(CHANNEL, notification.message);
     }
   }
 }
@@ -297,7 +297,7 @@ async function handlePackLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}, clean=${clean}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      await showLatexdiffPackNotifications(
+      showLatexdiffPackNotifications(
         getLatexdiffPackNotifications(
           await runPackLatexdiffvc(fileToUse, commitHash, clean),
         ),
@@ -320,7 +320,7 @@ async function handlePackLatexdiffvcMultiple(
         `Command called with: commitHash=${commitHash}, clean=${clean}`,
       );
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      await showLatexdiffPackNotifications(
+      showLatexdiffPackNotifications(
         getLatexdiffPackNotifications(
           await runPackLatexdiffvcMultiple(inputFiles, commitHash, clean),
         ),
@@ -343,7 +343,7 @@ async function handleCleanLatexdiffvc(
         `Command called with: inputFile=${inputFile}, baseFile=${baseFile}, commitHash=${commitHash}`,
       );
       const fileToUse = baseFile ?? inputFile;
-      await showLatexdiffPackNotifications(
+      showLatexdiffPackNotifications(
         getLatexdiffPackNotifications(
           await runCleanLatexdiffvc(fileToUse, commitHash),
         ),
@@ -362,7 +362,7 @@ async function handleCleanLatexdiffvcMultiple(
     async () => {
       logger.debug(CHANNEL, `Command called with: commitHash=${commitHash}`);
       logger.debug(CHANNEL, `Input files: ${inputFiles.join(', ')}`);
-      await showLatexdiffPackNotifications(
+      showLatexdiffPackNotifications(
         getLatexdiffPackNotifications(
           await runCleanLatexdiffvcMultiple(inputFiles, commitHash),
         ),

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -44,7 +44,7 @@ export type IndentLatexResult =
  * @param progressCallback Optional callback for progress updates
  * @returns Promise<IndentLatexResult> The formatting outcome
  */
-export async function inspectAndIndentLatexFilesInDirectory(
+export async function indentLatexFilesInDirectory(
   directory: string = '.',
   progressCallback?: (message: string, increment?: number) => void,
 ): Promise<IndentLatexResult> {
@@ -139,23 +139,8 @@ export async function inspectAndIndentLatexFilesInDirectory(
 }
 
 /**
- * Formats LaTeX files in a specific directory and its subdirectories.
- * @returns Promise<number> The number of files formatted.
- */
-export async function indentLatexFilesInDirectory(
-  directory: string = '.',
-  progressCallback?: (message: string, increment?: number) => void,
-): Promise<number> {
-  const result = await inspectAndIndentLatexFilesInDirectory(
-    directory,
-    progressCallback,
-  );
-  return result.count;
-}
-
-/**
  * Indents all LaTeX files in the workspace
  */
 export async function runIndentTeX(): Promise<IndentLatexResult> {
-  return inspectAndIndentLatexFilesInDirectory('.');
+  return indentLatexFilesInDirectory('.');
 }

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -14,16 +14,40 @@ import { EXCLUDED_DIRS } from './constants';
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
 
+export type IndentLatexResult =
+  | {
+      status: 'formatted';
+      directory: string;
+      count: number;
+    }
+  | {
+      status: 'disabled';
+      directory: string;
+      count: 0;
+    }
+  | {
+      status: 'missing-config';
+      directory: string;
+      count: 0;
+      configPath: string;
+    }
+  | {
+      status: 'error';
+      directory: string;
+      count: 0;
+      error: unknown;
+    };
+
 /**
  * Formats LaTeX files in a specific directory and its subdirectories
  * @param directory The directory to process (relative to workspace). If not provided, uses the root.
  * @param progressCallback Optional callback for progress updates
- * @returns Promise<number> The number of files formatted
+ * @returns Promise<IndentLatexResult> The formatting outcome
  */
-export async function indentLatexFilesInDirectory(
+export async function inspectAndIndentLatexFilesInDirectory(
   directory: string = '.',
   progressCallback?: (message: string, increment?: number) => void,
-): Promise<number> {
+): Promise<IndentLatexResult> {
   logger.debug(
     CHANNEL,
     `Starting LaTeX indentation process for directory: ${directory}`,
@@ -35,7 +59,7 @@ export async function indentLatexFilesInDirectory(
   );
   if (formatter === 'none') {
     logger.debug(CHANNEL, 'LaTeX formatter disabled; skipping indentation');
-    return 0;
+    return { status: 'disabled', directory, count: 0 };
   }
   const configKey =
     formatter === 'tex-fmt'
@@ -46,7 +70,12 @@ export async function indentLatexFilesInDirectory(
 
   if (config && !(await AbsoluteFS.exists(config))) {
     logger.error(CHANNEL, `Formatter config file not found at ${config}`);
-    return 0;
+    return {
+      status: 'missing-config',
+      directory,
+      count: 0,
+      configPath: config,
+    };
   }
 
   let indentedCount = 0;
@@ -99,19 +128,34 @@ export async function indentLatexFilesInDirectory(
       CHANNEL,
       `${indentedCount} .tex files have been formatted in ${directory}`,
     );
-    return indentedCount;
+    return { status: 'formatted', directory, count: indentedCount };
   } catch (err) {
     logger.error(
       CHANNEL,
       `Error during indentation process: ${toErrorMessage(err)}`,
     );
-    return 0;
+    return { status: 'error', directory, count: 0, error: err };
   }
+}
+
+/**
+ * Formats LaTeX files in a specific directory and its subdirectories.
+ * @returns Promise<number> The number of files formatted.
+ */
+export async function indentLatexFilesInDirectory(
+  directory: string = '.',
+  progressCallback?: (message: string, increment?: number) => void,
+): Promise<number> {
+  const result = await inspectAndIndentLatexFilesInDirectory(
+    directory,
+    progressCallback,
+  );
+  return result.count;
 }
 
 /**
  * Indents all LaTeX files in the workspace
  */
-export async function runIndentTeX(): Promise<void> {
-  await indentLatexFilesInDirectory('.');
+export async function runIndentTeX(): Promise<IndentLatexResult> {
+  return inspectAndIndentLatexFilesInDirectory('.');
 }

--- a/src/housekeeping/indent.ts
+++ b/src/housekeeping/indent.ts
@@ -137,10 +137,3 @@ export async function indentLatexFilesInDirectory(
     return { status: 'error', directory, count: 0, error: err };
   }
 }
-
-/**
- * Indents all LaTeX files in the workspace
- */
-export async function runIndentTeX(): Promise<IndentLatexResult> {
-  return indentLatexFilesInDirectory('.');
-}

--- a/src/housekeeping/index.ts
+++ b/src/housekeeping/index.ts
@@ -13,8 +13,4 @@ export {
   runCleanLatexdiffvcMultiple,
   type LatexdiffPackResult,
 } from './latexdiff';
-export {
-  indentLatexFilesInDirectory,
-  runIndentTeX,
-  type IndentLatexResult,
-} from './indent';
+export { indentLatexFilesInDirectory, type IndentLatexResult } from './indent';

--- a/src/housekeeping/index.ts
+++ b/src/housekeeping/index.ts
@@ -15,7 +15,6 @@ export {
 } from './latexdiff';
 export {
   indentLatexFilesInDirectory,
-  inspectAndIndentLatexFilesInDirectory,
   runIndentTeX,
   type IndentLatexResult,
 } from './indent';

--- a/src/housekeeping/index.ts
+++ b/src/housekeeping/index.ts
@@ -11,5 +11,11 @@ export {
   runPackLatexdiffvcMultiple,
   runCleanLatexdiffvc,
   runCleanLatexdiffvcMultiple,
+  type LatexdiffPackResult,
 } from './latexdiff';
-export { runIndentTeX } from './indent';
+export {
+  indentLatexFilesInDirectory,
+  inspectAndIndentLatexFilesInDirectory,
+  runIndentTeX,
+  type IndentLatexResult,
+} from './indent';

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
@@ -29,6 +30,11 @@ export type LatexdiffPackResult =
     }
   | {
       status: 'missing-inputs';
+    }
+  | {
+      status: 'error';
+      inputFile: string;
+      error: unknown;
     };
 
 export async function runPackLatexdiffvc(
@@ -109,7 +115,15 @@ export async function runPackLatexdiffvcMultiple(
 
   const results: LatexdiffPackResult[] = [];
   for (const inputFile of inputFiles) {
-    results.push(await runPackLatexdiffvc(inputFile, commitHash, clean));
+    try {
+      results.push(await runPackLatexdiffvc(inputFile, commitHash, clean));
+    } catch (err) {
+      logger.error(
+        CHANNEL,
+        `Error during packing ${inputFile}: ${toErrorMessage(err)}`,
+      );
+      results.push({ status: 'error', inputFile, error: err });
+    }
   }
   return results;
 }

--- a/src/housekeeping/latexdiff.ts
+++ b/src/housekeeping/latexdiff.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 
-import { toErrorMessage } from '@common/errors';
 import * as logger from '@logger/logUtils';
 import { WorkspaceFS } from '@utils/files';
 
@@ -10,11 +9,33 @@ import { TEMP_EXTENSIONS } from './constants';
 const CHANNEL = 'Housekeeping';
 logger.initialize(CHANNEL);
 
+export type LatexdiffPackResult =
+  | {
+      status: 'no-files';
+      inputFile: string;
+    }
+  | {
+      status: 'cleaned';
+      inputFile: string;
+    }
+  | {
+      status: 'packed';
+      inputFile: string;
+      outputFolder: string;
+    }
+  | {
+      status: 'processed';
+      inputFile: string;
+    }
+  | {
+      status: 'missing-inputs';
+    };
+
 export async function runPackLatexdiffvc(
   inputFile: string,
   commitHash: string,
   clean: boolean = false,
-): Promise<void> {
+): Promise<LatexdiffPackResult> {
   const baseName = path.parse(inputFile).name;
   const inputDir = path.dirname(inputFile);
   const filePatterns = [`${baseName}-diff${commitHash}`];
@@ -31,7 +52,7 @@ export async function runPackLatexdiffvc(
 
   if (mainFiles.length === 0 && tempFiles.length === 0) {
     logger.warn(CHANNEL, 'No LaTeX diff files found to process');
-    return;
+    return { status: 'no-files', inputFile };
   }
 
   if (clean) {
@@ -39,7 +60,7 @@ export async function runPackLatexdiffvc(
       await WorkspaceFS.delete(file);
     }
     logger.info(CHANNEL, 'Cleanup complete.');
-    return;
+    return { status: 'cleaned', inputFile };
   }
 
   const now = new Date().toISOString().replaceAll(/[-:]/g, '').split('.')[0];
@@ -49,59 +70,60 @@ export async function runPackLatexdiffvc(
     `${now}_${baseName}_${commitHash}`,
   );
 
-  try {
-    let dirCreated = false;
-    for (const file of mainFiles) {
-      if (!dirCreated) {
-        await WorkspaceFS.createDir(outputFolder);
-        dirCreated = true;
-      }
-      await WorkspaceFS.rename(
-        file,
-        path.join(outputFolder, path.basename(file)),
-      );
+  let dirCreated = false;
+  for (const file of mainFiles) {
+    if (!dirCreated) {
+      await WorkspaceFS.createDir(outputFolder);
+      dirCreated = true;
     }
-
-    for (const file of tempFiles) {
-      await WorkspaceFS.delete(file);
-    }
-
-    if (dirCreated) {
-      logger.info(CHANNEL, `Files packed into ${outputFolder}`);
-    }
-  } catch (err) {
-    logger.error(CHANNEL, `Error during packing: ${toErrorMessage(err)}`);
+    await WorkspaceFS.rename(
+      file,
+      path.join(outputFolder, path.basename(file)),
+    );
   }
+
+  for (const file of tempFiles) {
+    await WorkspaceFS.delete(file);
+  }
+
+  if (dirCreated) {
+    logger.info(CHANNEL, `Files packed into ${outputFolder}`);
+    return { status: 'packed', inputFile, outputFolder };
+  }
+
+  return { status: 'processed', inputFile };
 }
 
 export async function runPackLatexdiffvcMultiple(
   inputFiles: string[],
   commitHash: string,
   clean: boolean = false,
-): Promise<void> {
+): Promise<LatexdiffPackResult[]> {
   if (!inputFiles || inputFiles.length === 0) {
     logger.error(
       CHANNEL,
       'No input files provided for multiple LaTeX diff packing',
     );
-    return;
+    return [{ status: 'missing-inputs' }];
   }
 
+  const results: LatexdiffPackResult[] = [];
   for (const inputFile of inputFiles) {
-    await runPackLatexdiffvc(inputFile, commitHash, clean);
+    results.push(await runPackLatexdiffvc(inputFile, commitHash, clean));
   }
+  return results;
 }
 
 export async function runCleanLatexdiffvc(
   inputFile: string,
   commitHash: string,
-): Promise<void> {
-  await runPackLatexdiffvc(inputFile, commitHash, true);
+): Promise<LatexdiffPackResult> {
+  return runPackLatexdiffvc(inputFile, commitHash, true);
 }
 
 export async function runCleanLatexdiffvcMultiple(
   inputFiles: string[],
   commitHash: string,
-): Promise<void> {
-  await runPackLatexdiffvcMultiple(inputFiles, commitHash, true);
+): Promise<LatexdiffPackResult[]> {
+  return runPackLatexdiffvcMultiple(inputFiles, commitHash, true);
 }

--- a/src/latex/arxivProcessor.ts
+++ b/src/latex/arxivProcessor.ts
@@ -321,12 +321,12 @@ export class ArxivSourceProcessor {
     if (autoIndent && !isRoot) {
       progressCallback?.('Formatting LaTeX files...', 85);
 
-      const indentedCount = await indentLatexFilesInDirectory(
+      const indentResult = await indentLatexFilesInDirectory(
         paperDirRelative,
         progressCallback,
       );
 
-      progressCallback?.(`Formatted ${indentedCount} LaTeX files`, 95);
+      progressCallback?.(`Formatted ${indentResult.count} LaTeX files`, 95);
     }
 
     progressCallback?.('arXiv source downloaded successfully!', 100);

--- a/src/test-kernel/commands/LatexHousekeepingNotifications.vitest.ts
+++ b/src/test-kernel/commands/LatexHousekeepingNotifications.vitest.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getIndentTeXNotification,
+  getLatexdiffPackNotifications,
+} from '@commands/latex/latexHousekeepingNotifications';
+import type { IndentLatexResult, LatexdiffPackResult } from '@housekeeping';
+
+describe('latex housekeeping command notifications', () => {
+  it('restores indent config and error notifications', () => {
+    const missingConfig: IndentLatexResult = {
+      status: 'missing-config',
+      directory: '.',
+      count: 0,
+      configPath: '/tmp/missing.yaml',
+    };
+    const error = new Error('walk failed');
+    const failed: IndentLatexResult = {
+      status: 'error',
+      directory: '.',
+      count: 0,
+      error,
+    };
+
+    expect(getIndentTeXNotification(missingConfig)).toEqual({
+      severity: 'message',
+      message: 'Formatter config file not found at /tmp/missing.yaml',
+    });
+    expect(getIndentTeXNotification(failed)).toEqual({
+      severity: 'error',
+      message: 'Error during indentation process',
+      error,
+    });
+    expect(
+      getIndentTeXNotification({
+        status: 'formatted',
+        directory: '.',
+        count: 2,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('restores latexdiff pack and clean notifications', () => {
+    const results: LatexdiffPackResult[] = [
+      { status: 'no-files', inputFile: 'paper.tex' },
+      { status: 'cleaned', inputFile: 'paper.tex' },
+      {
+        status: 'packed',
+        inputFile: 'paper.tex',
+        outputFolder: 'Diffs/20260505_paper_HEAD',
+      },
+      { status: 'missing-inputs' },
+      { status: 'processed', inputFile: 'paper.tex' },
+    ];
+
+    expect(getLatexdiffPackNotifications(results)).toEqual([
+      {
+        severity: 'info',
+        message: 'No LaTeX diff files found to process',
+      },
+      {
+        severity: 'info',
+        message: 'LaTeXdiff files cleaned',
+      },
+      {
+        severity: 'info',
+        message: 'Files packed into Diffs/20260505_paper_HEAD',
+      },
+      {
+        severity: 'message',
+        message: 'No input files provided for multiple LaTeX diff packing',
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/commands/LatexHousekeepingNotifications.vitest.ts
+++ b/src/test-kernel/commands/LatexHousekeepingNotifications.vitest.ts
@@ -51,9 +51,15 @@ describe('latex housekeeping command notifications', () => {
       },
       { status: 'missing-inputs' },
       { status: 'processed', inputFile: 'paper.tex' },
+      {
+        status: 'error',
+        inputFile: 'broken.tex',
+        error: new Error('rename failed'),
+      },
     ];
 
-    expect(getLatexdiffPackNotifications(results)).toEqual([
+    const notifications = getLatexdiffPackNotifications(results);
+    expect(notifications).toMatchObject([
       {
         severity: 'info',
         message: 'No LaTeX diff files found to process',
@@ -70,6 +76,11 @@ describe('latex housekeeping command notifications', () => {
         severity: 'message',
         message: 'No input files provided for multiple LaTeX diff packing',
       },
+      {
+        severity: 'error',
+        message: 'Error during packing broken.tex',
+      },
     ]);
+    expect(notifications.at(-1)?.error).toBeInstanceOf(Error);
   });
 });


### PR DESCRIPTION
## Summary
- return structured outcomes from LaTeX indent and latexdiff housekeeping helpers instead of swallowing user-visible states
- map those outcomes back to VS Code notifications in the command layer while keeping `src/housekeeping` host-neutral
- add focused test-kernel coverage for the restored notification decisions

Closes #3472.

## Validation
- npm run test:kernel -- src/test-kernel/commands/LatexHousekeepingNotifications.vitest.ts
- npm run compile:safe
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes return types and control flow across housekeeping helpers and VS Code commands; incorrect status mapping could suppress toasts or misreport outcomes, but no auth/data-sensitive logic is touched.
> 
> **Overview**
> **Restores user-visible VS Code toasts for LaTeX housekeeping actions.** The `indentTeX` command now runs a new `handleIndentTeX` wrapper that interprets a structured `IndentLatexResult` and shows appropriate error/message notifications (e.g., missing formatter config, indentation failure).
> 
> **Makes housekeeping helpers return structured outcomes instead of `void`/counts.** `indentLatexFilesInDirectory` and `latexdiff` pack/clean helpers now return typed status objects (`IndentLatexResult`, `LatexdiffPackResult`), which are mapped to notifications via a new `latexHousekeepingNotifications` module and used by `latexdiff` pack/clean commands.
> 
> Adds focused kernel tests covering the notification mapping decisions, and updates arXiv auto-indent progress reporting to use the new `count` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22ee45ff000a842ffd07b62ee688b51dfb771b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->