### PR TITLE
Package extension license notice

### DIFF
--- a/packages/extension/LICENSE.txt
+++ b/packages/extension/LICENSE.txt
@@ -1,0 +1,6 @@
+TeXRA Proprietary License
+
+TeXRA is proprietary software. All rights reserved.
+
+Use of the TeXRA extension is governed by the TeXRA terms of service:
+https://texra.ai/terms

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1505,7 +1505,7 @@
     "type": "git",
     "url": "https://github.com/texra-ai/texra-issues.git"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "SEE LICENSE IN LICENSE.txt",
   "author": "TeXRA.ai",
   "icon": "resources/logo-128x128.png",
   "keywords": [

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1476,6 +1476,7 @@
     "resources/walkthroughs/media/vscode-compare.png"
   ],
   "requiredPackagedPaths": [
+    "LICENSE.txt",
     "resources/agents",
     "resources/docs/agent-creation",
     "resources/examples",

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -36,6 +36,7 @@ const MANIFEST_KEYS = [
 ];
 
 const REQUIRED_PACKAGED_PATHS = [
+  'LICENSE.txt',
   'resources/agents',
   'resources/docs/agent-creation',
   'resources/examples',


### PR DESCRIPTION
## Summary

Add the package-local proprietary license notice that the VSIX publisher expects and make the extension package invariant checks require it. The extension package metadata now points at `LICENSE.txt`, matching the filename that `vsce` includes in the packaged extension.

This resolves the packaging warning where `vsce package` could not find a license file for the extension package.

Closes #3441
Closes #3411

## Validation

- `npm run check:extension-package-invariants`
- `corepack pnpm exec prettier --check packages/extension/package.json scripts/verify-extension-package-invariants.mjs scripts/extension-package-invariants.snapshot.json`
- `npm run build:initial`
- `npm run typecheck`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds/points to a license text file and tightens packaging invariant checks; main impact is build/packaging failure if the file is missing.
> 
> **Overview**
> Adds a package-local `packages/extension/LICENSE.txt` proprietary license notice so `vsce package` can find and include a license file.
> 
> Updates the extension manifest to reference `LICENSE.txt` and extends the extension packaging invariant snapshot/checks (`verify-extension-package-invariants.mjs` and `extension-package-invariants.snapshot.json`) to require the license file be present in the VSIX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500bfaa26e060cb98ba89d6820bdd5a0de78ca68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->