### PR TITLE
Invalidate API key caches on mutation

### DIFF
--- a/packages/extension/src/commands/api/apiKeyCommands.ts
+++ b/packages/extension/src/commands/api/apiKeyCommands.ts
@@ -8,6 +8,7 @@ import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { invalidateApiKeyCache } from '@model/apiProviders';
 import { PROVIDER_URLS } from '@shared/constants/providers';
 
 const CHANNEL = 'ApiKeyCommands';
@@ -20,6 +21,7 @@ export const apiKeyCommands = {
 
 async function refreshApiKeyUI(): Promise<void> {
   invalidateModelOptionsCache();
+  invalidateApiKeyCache();
   await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
   await vscode.commands.executeCommand('texra.refreshAllOptions');
 }

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -74,7 +74,10 @@ import {
   formatCost,
   invalidateModelOptionsCache,
 } from '@model/computeModelOptions';
-import { invalidateApiKeyCache, lookupApiKeyOrigin } from '@model/apiProviders';
+import {
+  invalidateApiKeyCache,
+  loadApiKeyStatusMap,
+} from '@model/apiProviders';
 import { ProgressViewProvider } from '@progressView/ProgressViewProvider';
 import { buildStreamInfo } from '@progressView/streamInfoUtils';
 import type { ExecutionId } from '@shared/schemas';
@@ -224,45 +227,11 @@ function getReliabilitySettings(): NumberVscodeSetting[] {
   }));
 }
 
-type SecretStatusMap = Record<string, ProviderKeyStatus['status']>;
-
-let _secretStatusCache: SecretStatusMap | null = null;
-let _secretStatusPending: Promise<SecretStatusMap> | null = null;
-
-function invalidateProviderSecretStatusCache(): void {
-  _secretStatusCache = null;
-  _secretStatusPending = null;
-}
-
-async function loadProviderSecretStatuses(): Promise<SecretStatusMap> {
-  if (_secretStatusCache) return _secretStatusCache;
-  if (_secretStatusPending) return _secretStatusPending;
-
-  const request = (async () => {
-    const secrets = platform().secrets;
-    const entries = await Promise.all(
-      SecretManager.API_PROVIDERS.map(async (provider) => {
-        const origin = await lookupApiKeyOrigin(secrets, provider);
-        const status: ProviderKeyStatus['status'] =
-          origin === 'secret' ? 'set' : origin === 'env' ? 'env' : 'not-set';
-        return [provider, status] as const;
-      }),
-    );
-    return Object.fromEntries(entries) as SecretStatusMap;
-  })();
-
-  _secretStatusPending = request;
-  try {
-    const result = await request;
-    if (_secretStatusPending === request) _secretStatusCache = result;
-    return result;
-  } finally {
-    if (_secretStatusPending === request) _secretStatusPending = null;
-  }
-}
-
 async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
-  const secretStatuses = await loadProviderSecretStatuses();
+  const secretStatuses = await loadApiKeyStatusMap(
+    platform().secrets,
+    SecretManager.API_PROVIDERS,
+  );
   return SecretManager.API_PROVIDERS.map((provider) => ({
     provider,
     displayName: getProviderDisplayName(
@@ -1598,7 +1567,6 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
     // Invalidate caches so downstream refreshes see fresh key state.
     invalidateModelOptionsCache();
     invalidateApiKeyCache();
-    invalidateProviderSecretStatusCache();
     await vscode.commands.executeCommand('texra.refreshApiKeyStatus');
     await Promise.all([
       vscode.commands.executeCommand('texra.refreshAllOptions'),

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -34,6 +34,9 @@ export function apiKeyEnvName(provider: ApiProvider): string {
 /** Where a resolved API key came from. */
 export type ApiKeyOrigin = 'secret' | 'env' | 'none';
 
+/** UI-safe provider key status derived from a resolved API key origin. */
+export type ApiKeyStatus = 'set' | 'env' | 'not-set';
+
 interface ResolvedApiKey {
   value: string | undefined;
   origin: ApiKeyOrigin;
@@ -48,8 +51,10 @@ const lookupCache = new Map<
   { value: ResolvedApiKey; expiry: number }
 >();
 const lookupPending = new Map<ApiProvider, Promise<ResolvedApiKey>>();
+let lookupCacheGeneration = 0;
 
 export function invalidateApiKeyCache(): void {
+  lookupCacheGeneration += 1;
   lookupCache.clear();
   lookupPending.clear();
 }
@@ -64,6 +69,7 @@ async function resolveApiKey(
   const inFlight = lookupPending.get(provider);
   if (inFlight) return inFlight;
 
+  const requestGeneration = lookupCacheGeneration;
   const request = (async (): Promise<ResolvedApiKey> => {
     const stored = await secrets.get(apiKeySecretName(provider));
     if (stored) return { value: stored, origin: 'secret' };
@@ -74,10 +80,12 @@ async function resolveApiKey(
   lookupPending.set(provider, request);
   try {
     const value = await request;
-    lookupCache.set(provider, {
-      value,
-      expiry: Date.now() + LOOKUP_CACHE_TTL_MS,
-    });
+    if (lookupCacheGeneration === requestGeneration) {
+      lookupCache.set(provider, {
+        value,
+        expiry: Date.now() + LOOKUP_CACHE_TTL_MS,
+      });
+    }
     return value;
   } finally {
     if (lookupPending.get(provider) === request) lookupPending.delete(provider);
@@ -105,6 +113,28 @@ export async function lookupApiKeyOrigin(
   provider: ApiProvider,
 ): Promise<ApiKeyOrigin> {
   return (await resolveApiKey(secrets, provider)).origin;
+}
+
+function apiKeyStatusFromOrigin(origin: ApiKeyOrigin): ApiKeyStatus {
+  if (origin === 'secret') return 'set';
+  if (origin === 'env') return 'env';
+  return 'not-set';
+}
+
+/**
+ * Resolve key statuses for providers from the canonical API-key origin cache.
+ */
+export async function loadApiKeyStatusMap<const Provider extends ApiProvider>(
+  secrets: PlatformSecrets,
+  providers: readonly Provider[],
+): Promise<Record<Provider, ApiKeyStatus>> {
+  const entries = await Promise.all(
+    providers.map(async (provider) => [
+      provider,
+      apiKeyStatusFromOrigin(await lookupApiKeyOrigin(secrets, provider)),
+    ]),
+  );
+  return Object.fromEntries(entries) as Record<Provider, ApiKeyStatus>;
 }
 
 /**

--- a/src/test-kernel/model/ApiProviders.vitest.ts
+++ b/src/test-kernel/model/ApiProviders.vitest.ts
@@ -1,0 +1,197 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports
+import {
+  apiKeySecretName,
+  invalidateApiKeyCache,
+  loadApiKeyStatusMap,
+  lookupApiKeyOrigin,
+} from '@model/apiProviders';
+import { SetApiKeyTool } from '@tools/setup/SetApiKeyTool';
+import { UnsetApiKeyTool } from '@tools/setup/UnsetApiKeyTool';
+import { setSetupPlatform, type SetupPlatform } from '@tools/setup/platform';
+import type { PlatformSecrets } from '@platform/secrets';
+
+function createSecrets(initial: Record<string, string> = {}): {
+  secrets: PlatformSecrets;
+  store: Map<string, string>;
+} {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    secrets: {
+      async get(key) {
+        return store.get(key);
+      },
+      async set(key, value) {
+        store.set(key, value);
+      },
+      async delete(key) {
+        store.delete(key);
+      },
+    },
+  };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function setupApiKeyToolPlatform(store: Map<string, string>): void {
+  function keyName(provider: string): string {
+    if (provider !== 'openai')
+      throw new Error(`Unexpected provider ${provider}`);
+    return apiKeySecretName(provider);
+  }
+
+  const platform: SetupPlatform = {
+    secrets: {
+      providers: ['openai'],
+      async setApiKey(provider, key) {
+        store.set(keyName(provider), key);
+      },
+      async deleteApiKey(provider) {
+        store.delete(keyName(provider));
+      },
+      async apiKeyExists(provider) {
+        return store.has(keyName(provider));
+      },
+      async hasUsableApiKey(provider) {
+        return (store.get(keyName(provider))?.trim().length ?? 0) > 0;
+      },
+      async storedApiKeyExists(provider) {
+        return store.has(keyName(provider));
+      },
+      async anyApiKeyExists() {
+        return store.size > 0;
+      },
+      async gitHubTokenExists() {
+        return 'none';
+      },
+    },
+    commands: {
+      async invoke() {},
+    },
+    extensions: {
+      isInstalled() {
+        return false;
+      },
+      async install() {},
+    },
+    auth: {
+      async getStatus() {
+        return { authenticated: false };
+      },
+    },
+    config: {
+      get() {
+        return undefined;
+      },
+      async update() {},
+    },
+    terminal: {
+      async runCommand() {
+        return { exitCode: 0, output: '', timedOut: false };
+      },
+    },
+  };
+  setSetupPlatform(platform);
+}
+
+describe('API provider key caches', () => {
+  let hadOpenAiApiKey = false;
+  let originalOpenAiApiKey: string | undefined;
+
+  beforeEach(() => {
+    hadOpenAiApiKey = Object.hasOwn(process.env, 'OPENAI_API_KEY');
+    originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+    invalidateApiKeyCache();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    invalidateApiKeyCache();
+    if (hadOpenAiApiKey && originalOpenAiApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+  });
+
+  it('derives provider status from the canonical API-key origin cache', async () => {
+    const { secrets } = createSecrets({
+      [apiKeySecretName('openai')]: 'sk-test',
+    });
+
+    await expect(loadApiKeyStatusMap(secrets, ['openai'])).resolves.toEqual({
+      openai: 'set',
+    });
+
+    invalidateApiKeyCache();
+    const empty = createSecrets();
+    process.env.OPENAI_API_KEY = 'from-env';
+
+    await expect(
+      loadApiKeyStatusMap(empty.secrets, ['openai']),
+    ).resolves.toEqual({
+      openai: 'env',
+    });
+  });
+
+  it('set_api_key invalidates stale missing-key lookups', async () => {
+    const { secrets, store } = createSecrets();
+    setupApiKeyToolPlatform(store);
+
+    await expect(lookupApiKeyOrigin(secrets, 'openai')).resolves.toBe('none');
+    await new SetApiKeyTool().call({ provider: 'openai', key: 'sk-real-key' });
+
+    await expect(lookupApiKeyOrigin(secrets, 'openai')).resolves.toBe('secret');
+  });
+
+  it('does not let in-flight stale lookups repopulate the cache after invalidation', async () => {
+    const firstLookup = createDeferred<string | undefined>();
+    const store = new Map<string, string>();
+    let reads = 0;
+    const secrets: PlatformSecrets = {
+      async get(key) {
+        reads += 1;
+        if (reads === 1) return firstLookup.promise;
+        return store.get(key);
+      },
+      async set(key, value) {
+        store.set(key, value);
+      },
+      async delete(key) {
+        store.delete(key);
+      },
+    };
+
+    const staleLookup = lookupApiKeyOrigin(secrets, 'openai');
+    await secrets.set(apiKeySecretName('openai'), 'sk-after-invalidate');
+    invalidateApiKeyCache();
+    firstLookup.resolve(undefined);
+
+    await expect(staleLookup).resolves.toBe('none');
+    await expect(lookupApiKeyOrigin(secrets, 'openai')).resolves.toBe('secret');
+  });
+
+  it('unset_api_key invalidates stale stored-key lookups', async () => {
+    const { secrets, store } = createSecrets({
+      [apiKeySecretName('openai')]: 'sk-test',
+    });
+    setupApiKeyToolPlatform(store);
+
+    await expect(lookupApiKeyOrigin(secrets, 'openai')).resolves.toBe('secret');
+    await new UnsetApiKeyTool().call({ provider: 'openai' });
+
+    await expect(lookupApiKeyOrigin(secrets, 'openai')).resolves.toBe('none');
+  });
+});

--- a/src/tools/setup/SetApiKeyTool.ts
+++ b/src/tools/setup/SetApiKeyTool.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { invalidateApiKeyCache } from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -82,12 +83,11 @@ export class SetApiKeyTool extends defineTool({
 
     await platform.secrets.setApiKey(provider, input.key.trim());
 
-    // Drop the TTL-cached model-options computation before the refresh
-    // so the re-rendered picker actually reflects the just-added key —
-    // otherwise the UI can replay a recent pre-key result and still
-    // show the provider's models as unavailable. Matches the manual
-    // `texra.setApiKey` command's ordering in `apiKeyCommands`.
+    // Drop cached model availability and key-origin lookups before the refresh
+    // so every downstream status surface sees the just-added key. Matches the
+    // manual `texra.setApiKey` command's ordering in `apiKeyCommands`.
     invalidateModelOptionsCache();
+    invalidateApiKeyCache();
     await Promise.all([
       platform.commands
         .invoke('texra.refreshApiKeyStatus')

--- a/src/tools/setup/UnsetApiKeyTool.ts
+++ b/src/tools/setup/UnsetApiKeyTool.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 // Local imports
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import { invalidateApiKeyCache } from '@model/apiProviders';
 import { ToolError, type ToolResult } from '@tools/result';
 
 // Local file imports
@@ -56,11 +57,11 @@ export class UnsetApiKeyTool extends defineTool({
     }
 
     await platform.secrets.deleteApiKey(provider);
-    // Mirror the manual removal flow: drop the cached model-options
-    // computation and refresh the options UI so models that just lost
-    // their credential stop appearing selectable. Without this, the
-    // user could pick a now-unauthenticated model and fail at runtime.
+    // Mirror the manual removal flow: drop cached model availability and
+    // key-origin lookups so models that just lost their credential stop
+    // appearing selectable.
     invalidateModelOptionsCache();
+    invalidateApiKeyCache();
     await Promise.all([
       platform.commands
         .invoke('texra.refreshApiKeyStatus')


### PR DESCRIPTION
## Summary

Consolidate provider key status around the canonical API-key origin cache and invalidate that cache from all key mutation flows.

The settings view no longer keeps a second module-local provider status cache. Instead, `src/model/apiProviders.ts` exposes key status helpers derived from `lookupApiKeyOrigin`, so settings profile state, command-palette changes, and setup-tool mutations all share one source of truth.

Closes #3477

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/model/ApiProviders.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npm run compile:safe`
- `npm run build:initial`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API-key resolution and cache invalidation across the extension and setup tools; mistakes could cause stale/incorrect key status or model availability until TTL expiry.
> 
> **Overview**
> Ensures all API-key mutation paths (command palette, settings profile, and setup tools) **invalidate the canonical API-key lookup cache** so UI/model availability refreshes reflect key changes immediately.
> 
> Removes the settings-view’s separate provider-status cache and replaces it with a shared `loadApiKeyStatusMap` helper in `apiProviders`, alongside a generation guard that prevents in-flight stale lookups from repopulating the cache after invalidation. Adds focused vitest coverage for cache invalidation and race conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f3c87243e553aa35a46118d1efb9c948fb2664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->