### PR TITLE
Prepare Electron install for webview smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check desktop Electron binary
+        run: pnpm run check:desktop-electron-binary
+
       - name: Type check
         run: pnpm run typecheck
 
@@ -104,6 +107,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check desktop Electron binary
+        run: pnpm run check:desktop-electron-binary
 
       - name: Build desktop artifacts
         run: pnpm run desktop:build

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "sync:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs --update",
     "check:extension-package-invariants": "node scripts/verify-extension-package-invariants.mjs",
     "check:vsix-contents": "node scripts/verify-vsix-contents.mjs",
+    "check:desktop-electron-binary": "node scripts/check-desktop-electron-binary.mjs",
     "check:desktop-build-artifacts": "node scripts/verify-desktop-build-artifacts.mjs",
     "check:initial-build-artifacts": "corepack pnpm run check:vsix-contents && corepack pnpm run check:desktop-build-artifacts",
     "check:desktop-package": "node scripts/verify-desktop-package.mjs",
@@ -95,6 +96,11 @@
     "webpack": "^5.106.1",
     "webpack-cli": "^7.0.2",
     "zod-v3-to-v4": "^1.21.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.93.0",

--- a/scripts/check-desktop-electron-binary.mjs
+++ b/scripts/check-desktop-electron-binary.mjs
@@ -1,0 +1,45 @@
+import { access } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const desktopPackageJsonPath = join(
+  repoRoot,
+  'packages',
+  'desktop',
+  'package.json',
+);
+const desktopRequire = createRequire(desktopPackageJsonPath);
+
+let electronBinaryPath;
+try {
+  electronBinaryPath = desktopRequire('electron');
+} catch (error) {
+  console.error('Desktop Electron binary check failed.');
+  console.error(
+    'The electron package did not install its platform binary. Run `corepack pnpm install --frozen-lockfile` with the root pnpm build-script policy applied.',
+  );
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+if (typeof electronBinaryPath !== 'string' || electronBinaryPath.length === 0) {
+  console.error('Desktop Electron binary check failed.');
+  console.error('The electron package did not resolve to a binary path.');
+  process.exit(1);
+}
+
+try {
+  await access(electronBinaryPath);
+} catch (error) {
+  console.error('Desktop Electron binary check failed.');
+  console.error(
+    `Resolved Electron binary does not exist: ${electronBinaryPath}`,
+  );
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+console.log(`Desktop Electron binary check passed: ${electronBinaryPath}`);


### PR DESCRIPTION
## Summary

- allow the `electron` package install script through the root pnpm build-script policy
- add a desktop Electron binary check that resolves from the `@texra/desktop` package context
- run that check in the Linux/macOS validation job and the Windows desktop artifact job

## Context

This prepares #3409 by making the Electron binary path reproducible after `pnpm install --frozen-lockfile`. The render smoke harness itself should land separately after this prerequisite is stable.

## Validation

- `rm -rf node_modules packages/desktop/node_modules packages/extension/node_modules packages/core/node_modules && corepack pnpm install --frozen-lockfile`
- `corepack pnpm run check:desktop-electron-binary`
- `corepack pnpm --filter @texra/desktop exec electron --version`
- `corepack pnpm ignored-builds` (Electron is no longer listed)
- `npm run lint`
- `npm run typecheck`
- `npm run compile-tests`
- `npm run build:initial`
- `npm run desktop:package:local && npm run check:desktop-package`

Part of #3409.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an allowlist for running Electron’s install script and enforces a new Electron-binary resolution check in CI; failures will block builds and the build-script allowlist slightly increases supply-chain exposure.
> 
> **Overview**
> **CI now validates Electron installation for the desktop app.** The workflow runs a new `check:desktop-electron-binary` step after `pnpm install` on Linux/macOS validation and the Windows desktop artifact job.
> 
> **Workspace install policy is updated to support this.** Root `package.json` adds a `pnpm.onlyBuiltDependencies` allowlist for `electron` and introduces `scripts/check-desktop-electron-binary.mjs`, which resolves `electron` from the `packages/desktop` context and fails if the binary path is missing or not present on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c0317d09ecef6dd2c9b9154c3741085a4168a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->