### PR TITLE
Smoke extension webviews in Electron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,19 @@ jobs:
       - name: Build initial extension and desktop artifacts
         run: pnpm run build:initial
 
+      - name: Smoke extension webviews in Electron
+        if: runner.os == 'macOS'
+        run: pnpm run smoke:webviews:run
+
+      - name: Upload webview smoke screenshots
+        if: runner.os == 'macOS' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: texra-webview-smoke-screenshots
+          path: artifacts/webview-smoke/*.png
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Upload extension VSIX artifact
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 .env
 .aider*
 releases/
+artifacts/
 
 .DS_Store
 .cursor

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "vite:webviews": "corepack pnpm --filter texra vite:webviews",
     "vite:webviews:dev": "corepack pnpm --filter texra vite:webviews:dev",
     "vite:webviews:watch": "corepack pnpm --filter texra vite:webviews:watch",
+    "smoke:webviews": "corepack pnpm run vite:webviews && corepack pnpm run smoke:webviews:run",
+    "smoke:webviews:run": "node scripts/smoke-webviews-electron.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test-kernel.json && corepack pnpm --filter texra typecheck",
     "compile:fast": "corepack pnpm --filter texra compile:fast",
     "compile:safe": "npm run typecheck && npm run compile:fast",

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -6,6 +6,10 @@ const path = require('node:path');
 app.commandLine.appendSwitch('disable-gpu');
 app.commandLine.appendSwitch('disable-dev-shm-usage');
 
+const RENDER_TIMEOUT_MS = Number(
+  process.env.TEXRA_WEBVIEW_SMOKE_TIMEOUT_MS ?? 10_000,
+);
+
 function normalizeConsoleMessage(levelOrDetails, message) {
   if (typeof levelOrDetails === 'object' && levelOrDetails !== null) {
     return {
@@ -28,16 +32,34 @@ function isConsoleError(level) {
 }
 
 async function waitForRenderedElement(window, tagName) {
+  const missingElementMessage = `Missing rendered element: ${tagName}`;
+  const timeoutMessage = `Timed out waiting for custom element: ${tagName}`;
   return window.webContents.executeJavaScript(
     `
       (async () => {
-        await customElements.whenDefined(${JSON.stringify(tagName)});
+        await Promise.race([
+          customElements.whenDefined(${JSON.stringify(tagName)}),
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error(${JSON.stringify(timeoutMessage)})),
+              ${JSON.stringify(RENDER_TIMEOUT_MS)},
+            ),
+          ),
+        ]);
         const element = document.querySelector(${JSON.stringify(tagName)});
         if (!element) {
-          throw new Error('Missing rendered element: ${tagName}');
+          throw new Error(${JSON.stringify(missingElementMessage)});
         }
         if (element.updateComplete && typeof element.updateComplete.then === 'function') {
-          await element.updateComplete;
+          await Promise.race([
+            element.updateComplete,
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error(${JSON.stringify(timeoutMessage)})),
+                ${JSON.stringify(RENDER_TIMEOUT_MS)},
+              ),
+            ),
+          ]);
         }
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
         const rect = element.getBoundingClientRect();
@@ -62,9 +84,9 @@ function createSmokeWindow(errors) {
     show: false,
     webPreferences: {
       backgroundThrottling: false,
-      contextIsolation: false,
+      contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false,
+      sandbox: true,
     },
   });
 
@@ -90,7 +112,17 @@ function createSmokeWindow(errors) {
 async function smokeView(window, view, outputDir, errors) {
   errors.length = 0;
   await window.loadFile(view.htmlPath);
-  const result = await waitForRenderedElement(window, view.tagName);
+  let result;
+  try {
+    result = await waitForRenderedElement(window, view.tagName);
+  } catch (error) {
+    if (errors.length === 0) throw error;
+    throw new Error(
+      `${view.name} render failed: ${
+        error instanceof Error ? error.message : String(error)
+      }\n${errors.join('\n')}`,
+    );
+  }
   if (result.width <= 0 || result.height <= 0) {
     throw new Error(
       `${view.name} rendered with invalid bounds: ${result.width}x${result.height}`,
@@ -118,22 +150,18 @@ async function main() {
   }
 
   const config = JSON.parse(await readFile(configPath, 'utf8'));
+  if (!Array.isArray(config.views) || config.views.length === 0) {
+    throw new Error('At least one webview smoke target is required.');
+  }
   mkdirSync(config.outputDir, { recursive: true });
   const errors = [];
   const window = createSmokeWindow(errors);
-  const renderedViews = [];
   try {
     for (const view of config.views) {
       await smokeView(window, view, config.outputDir, errors);
-      renderedViews.push(view.name);
     }
   } finally {
     window.destroy();
-  }
-  if (renderedViews.length !== config.views.length) {
-    throw new Error(
-      `Rendered ${renderedViews.length} of ${config.views.length} webviews.`,
-    );
   }
 }
 

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -6,8 +6,14 @@ const path = require('node:path');
 app.commandLine.appendSwitch('disable-gpu');
 app.commandLine.appendSwitch('disable-dev-shm-usage');
 
-const RENDER_TIMEOUT_MS = Number(
-  process.env.TEXRA_WEBVIEW_SMOKE_TIMEOUT_MS ?? 10_000,
+function readPositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const RENDER_TIMEOUT_MS = readPositiveNumber(
+  process.env.TEXRA_WEBVIEW_SMOKE_TIMEOUT_MS,
+  10_000,
 );
 
 function normalizeConsoleMessage(levelOrDetails, message) {

--- a/scripts/smoke-webviews-electron-runner.cjs
+++ b/scripts/smoke-webviews-electron-runner.cjs
@@ -1,0 +1,147 @@
+const { app, BrowserWindow } = require('electron');
+const { mkdirSync } = require('node:fs');
+const { readFile, writeFile } = require('node:fs/promises');
+const path = require('node:path');
+
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('disable-dev-shm-usage');
+
+function normalizeConsoleMessage(levelOrDetails, message) {
+  if (typeof levelOrDetails === 'object' && levelOrDetails !== null) {
+    return {
+      level: levelOrDetails.level,
+      message: levelOrDetails.message,
+      sourceId: levelOrDetails.sourceId,
+      lineNumber: levelOrDetails.lineNumber,
+    };
+  }
+  return {
+    level: levelOrDetails,
+    message,
+    sourceId: undefined,
+    lineNumber: undefined,
+  };
+}
+
+function isConsoleError(level) {
+  return level === 'error' || level === 3;
+}
+
+async function waitForRenderedElement(window, tagName) {
+  return window.webContents.executeJavaScript(
+    `
+      (async () => {
+        await customElements.whenDefined(${JSON.stringify(tagName)});
+        const element = document.querySelector(${JSON.stringify(tagName)});
+        if (!element) {
+          throw new Error('Missing rendered element: ${tagName}');
+        }
+        if (element.updateComplete && typeof element.updateComplete.then === 'function') {
+          await element.updateComplete;
+        }
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+        const rect = element.getBoundingClientRect();
+        const shadowText = element.shadowRoot?.textContent?.trim() ?? '';
+        const lightText = element.textContent?.trim() ?? '';
+        return {
+          height: rect.height,
+          shadowTextLength: shadowText.length,
+          textLength: lightText.length,
+          width: rect.width,
+        };
+      })();
+    `,
+    true,
+  );
+}
+
+function createSmokeWindow(errors) {
+  const window = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    show: false,
+    webPreferences: {
+      backgroundThrottling: false,
+      contextIsolation: false,
+      nodeIntegration: false,
+      sandbox: false,
+    },
+  });
+
+  window.webContents.on(
+    'console-message',
+    (_event, levelOrDetails, message) => {
+      const entry = normalizeConsoleMessage(levelOrDetails, message);
+      if (!isConsoleError(entry.level)) return;
+      errors.push(
+        `${entry.message ?? ''} (${entry.sourceId ?? 'unknown'}:${entry.lineNumber ?? 0})`,
+      );
+    },
+  );
+  window.webContents.on('render-process-gone', (_event, details) => {
+    errors.push(`Renderer process exited: ${details.reason}`);
+  });
+  window.webContents.on('did-fail-load', (_event, code, description, url) => {
+    errors.push(`Failed to load ${url}: ${code} ${description}`);
+  });
+  return window;
+}
+
+async function smokeView(window, view, outputDir, errors) {
+  errors.length = 0;
+  await window.loadFile(view.htmlPath);
+  const result = await waitForRenderedElement(window, view.tagName);
+  if (result.width <= 0 || result.height <= 0) {
+    throw new Error(
+      `${view.name} rendered with invalid bounds: ${result.width}x${result.height}`,
+    );
+  }
+  if (result.textLength + result.shadowTextLength === 0) {
+    throw new Error(`${view.name} rendered no visible text content.`);
+  }
+  if (errors.length > 0) {
+    throw new Error(`${view.name} console errors:\n${errors.join('\n')}`);
+  }
+
+  const screenshotPath = path.join(outputDir, `${view.name}.png`);
+  const image = await window.webContents.capturePage();
+  await writeFile(screenshotPath, image.toPNG());
+  console.log(
+    `Rendered ${view.name}: ${result.width}x${result.height}, screenshot ${screenshotPath}`,
+  );
+}
+
+async function main() {
+  const configPath = process.env.TEXRA_WEBVIEW_SMOKE_CONFIG;
+  if (!configPath) {
+    throw new Error('TEXRA_WEBVIEW_SMOKE_CONFIG is required.');
+  }
+
+  const config = JSON.parse(await readFile(configPath, 'utf8'));
+  mkdirSync(config.outputDir, { recursive: true });
+  const errors = [];
+  const window = createSmokeWindow(errors);
+  const renderedViews = [];
+  try {
+    for (const view of config.views) {
+      await smokeView(window, view, config.outputDir, errors);
+      renderedViews.push(view.name);
+    }
+  } finally {
+    window.destroy();
+  }
+  if (renderedViews.length !== config.views.length) {
+    throw new Error(
+      `Rendered ${renderedViews.length} of ${config.views.length} webviews.`,
+    );
+  }
+}
+
+app
+  .whenReady()
+  .then(main)
+  .then(() => app.quit())
+  .catch((error) => {
+    console.error(error instanceof Error ? error.stack : String(error));
+    app.exit(1);
+  });

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -120,7 +120,11 @@ function runElectron(configPath) {
     'scripts',
     'smoke-webviews-electron-runner.cjs',
   );
-  const child = spawn(electronBinaryPath, ['--no-sandbox', runnerPath], {
+  const electronArgs =
+    process.env.TEXRA_WEBVIEW_SMOKE_NO_SANDBOX === '1'
+      ? ['--no-sandbox', runnerPath]
+      : [runnerPath];
+  const child = spawn(electronBinaryPath, electronArgs, {
     cwd: repoRoot,
     env: {
       ...process.env,

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -1,0 +1,161 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const extensionRoot = join(repoRoot, 'packages', 'extension');
+const outputDir = join(repoRoot, 'artifacts', 'webview-smoke');
+const generatedHtmlDir = join(outputDir, 'html');
+const desktopRequire = createRequire(
+  join(repoRoot, 'packages', 'desktop', 'package.json'),
+);
+const nonce = 'texra-webview-smoke';
+
+const commonReplacements = {
+  cspSource: 'file:',
+  codiconUri: fileUri('node_modules/@vscode/codicons/dist/codicon.css'),
+  codiconsFontUri: fileUri('node_modules/@vscode/codicons/dist/codicon.ttf'),
+  commonStyleUri: fileUri('packages/extension/src/common/styles/common.css'),
+  commonsBundleUri: fileUri('packages/extension/dist/shared/commons.js'),
+  nonce,
+  vscodeElementsBundleUri: fileUri(
+    'node_modules/@vscode-elements/elements/dist/bundled.js',
+  ),
+};
+
+const views = [
+  {
+    name: 'main',
+    tagName: 'main-app',
+    templatePath: join(extensionRoot, 'src', 'webview', 'index.html'),
+    replacements: {
+      mainViewBundleUri: fileUri('packages/extension/dist/webview/bundle.js'),
+    },
+  },
+  {
+    name: 'progress',
+    tagName: 'progress-app',
+    templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
+    replacements: {
+      progressBundleUri: fileUri(
+        'packages/extension/dist/progressView/bundle.js',
+      ),
+      progressStyleUri: fileUri(
+        'packages/extension/dist/progressView/index.css',
+      ),
+    },
+  },
+  {
+    name: 'settings',
+    tagName: 'settings-app',
+    templatePath: join(extensionRoot, 'src', 'settingsView', 'index.html'),
+    replacements: {
+      settingsBundleUri: fileUri(
+        'packages/extension/dist/settingsView/bundle.js',
+      ),
+    },
+  },
+];
+
+function fileUri(relativePath) {
+  return pathToFileURL(join(repoRoot, relativePath)).toString();
+}
+
+function applyReplacements(template, replacements) {
+  let html = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    html = html.replaceAll(`\${${key}}`, value);
+  }
+  return html;
+}
+
+function hostBridgeShim() {
+  const shim = `
+    const texraSmokeBridge = {
+      _state: undefined,
+      postMessage(message) {
+        window.__texraSmokeMessages = [...(window.__texraSmokeMessages ?? []), message];
+      },
+      getState() {
+        return this._state;
+      },
+      setState(state) {
+        this._state = state;
+      },
+    };
+    window.__texraHostBridgeApi = texraSmokeBridge;
+    window.acquireVsCodeApi = () => texraSmokeBridge;
+  `;
+  return `<script nonce="${nonce}">${shim}</script>`;
+}
+
+function injectHostBridge(html) {
+  return html.replace('<body>', `<body>\n    ${hostBridgeShim()}`);
+}
+
+async function prepareViewHtml(view) {
+  const template = await readFile(view.templatePath, 'utf8');
+  const html = injectHostBridge(
+    applyReplacements(template, {
+      ...commonReplacements,
+      ...view.replacements,
+    }),
+  );
+  const htmlPath = join(generatedHtmlDir, `${view.name}.html`);
+  await writeFile(htmlPath, html);
+  return {
+    htmlPath,
+    name: view.name,
+    tagName: view.tagName,
+  };
+}
+
+function runElectron(configPath) {
+  const electronBinaryPath = desktopRequire('electron');
+  const runnerPath = join(
+    repoRoot,
+    'scripts',
+    'smoke-webviews-electron-runner.cjs',
+  );
+  const child = spawn(electronBinaryPath, ['--no-sandbox', runnerPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      TEXRA_WEBVIEW_SMOKE_CONFIG: configPath,
+    },
+    stdio: 'inherit',
+  });
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new Error(
+          `Electron webview smoke failed with ${signal ?? `exit code ${code}`}.`,
+        ),
+      );
+    });
+  });
+}
+
+await rm(outputDir, { recursive: true, force: true });
+await mkdir(generatedHtmlDir, { recursive: true });
+const smokeViews = [];
+for (const view of views) {
+  smokeViews.push(await prepareViewHtml(view));
+}
+
+const configPath = join(outputDir, 'config.json');
+await writeFile(
+  configPath,
+  `${JSON.stringify({ outputDir, views: smokeViews }, null, 2)}\n`,
+);
+await runElectron(configPath);
+console.log(`Electron webview smoke passed. Screenshots: ${outputDir}`);

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -93,7 +93,14 @@ function hostBridgeShim() {
 }
 
 function injectHostBridge(html) {
-  return html.replace('<body>', `<body>\n    ${hostBridgeShim()}`);
+  const bodyTagPattern = /<body\b[^>]*>/i;
+  if (!bodyTagPattern.test(html)) {
+    throw new Error('Webview template is missing a <body> tag.');
+  }
+  return html.replace(
+    bodyTagPattern,
+    (bodyTag) => `${bodyTag}\n    ${hostBridgeShim()}`,
+  );
 }
 
 async function prepareViewHtml(view) {

--- a/test/manual/vscode-activation-smoke.md
+++ b/test/manual/vscode-activation-smoke.md
@@ -3,6 +3,19 @@
 Use this checklist after changes that affect the extension package layout,
 extension manifest, activation flow, or webview asset packaging.
 
+## Electron Bundle Render Smoke
+
+```bash
+npm run smoke:webviews
+```
+
+This command builds the extension webview bundles, renders the launcher,
+progress view, and settings view in Electron, and writes screenshots to
+`artifacts/webview-smoke/`. It verifies that the bundled webview frontends load
+without renderer errors, but it does not verify VS Code command registration,
+activation events, or view-container integration. Use the VS Code checks below
+for those host-level behaviors.
+
 ## Development Host
 
 ```bash


### PR DESCRIPTION
## Summary

- add `npm run smoke:webviews` to build the extension webview bundles and render launcher, progress, and settings in Electron
- generate Electron-loadable HTML from the existing extension webview templates with a small host-bridge shim
- fail the smoke on renderer errors, missing custom elements, zero-size rendering, or blank rendered text, and save screenshots to `artifacts/webview-smoke/`
- run the smoke in macOS CI after `build:initial` and upload screenshots as artifacts
- document that this is bundle/render evidence, while the VS Code activation checklist still covers command registration and view-container integration

## Validation

- `corepack pnpm install --frozen-lockfile`
- `npm run check:desktop-electron-binary`
- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npm run build:initial`
- `npm run smoke:webviews:run`
- `npm run smoke:webviews`

Local smoke screenshots were generated for `main`, `progress`, and `settings` under `artifacts/webview-smoke/`.

Closes #3409.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Electron-based smoke test to macOS CI that can introduce new sources of CI flakiness and failures (render timing, Electron runtime differences). Changes are mostly isolated to tooling/docs and do not affect shipped runtime behavior.
> 
> **Overview**
> Adds an Electron-driven smoke test (`smoke:webviews`) that builds the extension’s webview bundles, generates Electron-loadable HTML with a lightweight VS Code host-bridge shim, renders the main/progress/settings custom elements, and fails on renderer/console/load errors or blank/zero-size output while saving screenshots under `artifacts/webview-smoke/`.
> 
> Runs this smoke step on macOS CI after `build:initial` and uploads the generated screenshots as a workflow artifact; also ignores the new `artifacts/` output directory in git and documents the new smoke flow in `test/manual/vscode-activation-smoke.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b4b0e6ed1734d08b474653637070c039306976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->