### PR TITLE
Smoke packaged desktop launch

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -389,6 +389,7 @@ From the repository root:
 corepack pnpm install --frozen-lockfile
 npm run desktop:package:local
 npm run check:desktop-package
+npm run desktop:package:smoke
 ```
 
 On Apple Silicon macOS, the local app bundle is written to:
@@ -418,6 +419,10 @@ npm run build:initial
 
 That command builds the Electron desktop app and the VS Code extension package, then checks that the
 desktop build artifacts and `.vsix` are present.
+
+`npm run desktop:package:smoke` launches the packaged app briefly from the command line and fails on
+early exits, desktop startup failures, or runtime VS Code import errors. Set
+`TEXRA_DESKTOP_LAUNCH_SMOKE_MS` to change the default 8 second launch window.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "workspace:build": "corepack pnpm --recursive --if-present build",
     "desktop:build": "corepack pnpm --filter @texra/desktop build",
     "desktop:package:local": "corepack pnpm run desktop:build && corepack pnpm --filter @texra/desktop package:dir",
+    "desktop:package:smoke": "node scripts/smoke-desktop-package-launch.mjs",
     "build:initial": "corepack pnpm run desktop:build && corepack pnpm run build:fast && corepack pnpm run check:initial-build-artifacts",
     "build": "corepack pnpm --filter texra build:fast",
     "format": "prettier --write .",

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -12,7 +12,7 @@ const fatalLogPatterns = [
   {
     label: 'VS Code runtime import',
     pattern:
-      /Cannot find (?:module|package) ['"]vscode['"]|ERR_MODULE_NOT_FOUND.*['"]vscode['"]|from ['"]vscode['"]/is,
+      /Cannot find (?:module|package) ['"]vscode['"]|ERR_MODULE_NOT_FOUND.*['"]vscode['"]|from ['"]vscode['"]/i,
   },
   {
     label: 'desktop startup failure',

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -1,0 +1,160 @@
+import { access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const DEFAULT_TIMEOUT_MS = 8_000;
+const MAX_LOG_CHARS = 256_000;
+const fatalLogPatterns = [
+  {
+    label: 'VS Code runtime import',
+    pattern:
+      /Cannot find (?:module|package) ['"]vscode['"]|ERR_MODULE_NOT_FOUND.*['"]vscode['"]|from ['"]vscode['"]/is,
+  },
+  {
+    label: 'desktop startup failure',
+    pattern: /Failed to start TeXRA desktop/i,
+  },
+  {
+    label: 'unhandled runtime exception',
+    pattern: /Uncaught Exception|UnhandledPromiseRejection/i,
+  },
+];
+
+function readPositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function defaultPackagedExecutable() {
+  if (process.platform !== 'darwin') return undefined;
+  const archDir = process.arch === 'arm64' ? 'mac-arm64' : 'mac';
+  return join(
+    repoRoot,
+    'packages',
+    'desktop',
+    'dist-packaged',
+    archDir,
+    'TeXRA.app',
+    'Contents',
+    'MacOS',
+    'TeXRA',
+  );
+}
+
+function parseAppPath(argv) {
+  const appFlagIndex = argv.indexOf('--app');
+  if (appFlagIndex === -1) return defaultPackagedExecutable();
+  const value = argv[appFlagIndex + 1];
+  if (!value) {
+    throw new Error('Missing value after --app.');
+  }
+  return resolve(value);
+}
+
+function appendBoundedLog(current, chunk) {
+  const next = current + chunk.toString('utf8');
+  return next.length > MAX_LOG_CHARS ? next.slice(-MAX_LOG_CHARS) : next;
+}
+
+async function assertExecutableExists(executablePath) {
+  if (!executablePath) {
+    throw new Error(
+      'No default packaged app path is available on this platform. Pass --app <executable>.',
+    );
+  }
+  try {
+    await access(executablePath);
+  } catch (error) {
+    throw new Error(
+      [
+        `Packaged desktop executable was not found: ${executablePath}`,
+        'Run `npm run desktop:package:local` first.',
+        error instanceof Error ? error.message : String(error),
+      ].join('\n'),
+    );
+  }
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function findFatalLog(output) {
+  return fatalLogPatterns.find(({ pattern }) => pattern.test(output));
+}
+
+function formatOutput(output) {
+  return output.trim().length > 0 ? output.trim() : '(no output)';
+}
+
+const executablePath = parseAppPath(process.argv.slice(2));
+const timeoutMs = readPositiveNumber(
+  process.env.TEXRA_DESKTOP_LAUNCH_SMOKE_MS,
+  DEFAULT_TIMEOUT_MS,
+);
+
+await assertExecutableExists(executablePath);
+
+const child = spawn(executablePath, [], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    ELECTRON_ENABLE_LOGGING: process.env.ELECTRON_ENABLE_LOGGING ?? '1',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let output = '';
+child.stdout.on('data', (chunk) => {
+  output = appendBoundedLog(output, chunk);
+});
+child.stderr.on('data', (chunk) => {
+  output = appendBoundedLog(output, chunk);
+});
+
+const exitPromise = waitForExit(child);
+const result = await Promise.race([
+  exitPromise.then((exit) => ({ exit })),
+  new Promise((resolve) => {
+    setTimeout(() => resolve({ timeout: true }), timeoutMs);
+  }),
+]);
+
+if (result.timeout) {
+  child.kill('SIGTERM');
+  await exitPromise.catch(() => undefined);
+  const fatalLog = findFatalLog(output);
+  if (fatalLog) {
+    console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
+    console.error(formatOutput(output));
+    process.exit(1);
+  }
+  console.log(
+    `Desktop launch smoke passed for ${executablePath} after ${timeoutMs}ms.`,
+  );
+  if (output.trim().length > 0) {
+    console.log(formatOutput(output));
+  }
+  process.exit(0);
+}
+
+const fatalLog = findFatalLog(output);
+if (fatalLog) {
+  console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
+  console.error(formatOutput(output));
+  process.exit(1);
+}
+
+console.error(
+  `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${
+    result.exit.signal ?? `code ${result.exit.code}`
+  }.`,
+);
+console.error(formatOutput(output));
+process.exit(1);

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -94,7 +94,8 @@ function waitForClose(child) {
 
 function delay(ms) {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+    const timeout = setTimeout(resolve, ms);
+    timeout.unref();
   });
 }
 

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const DEFAULT_TIMEOUT_MS = 8_000;
+const SHUTDOWN_GRACE_MS = 3_000;
 const MAX_LOG_CHARS = 256_000;
 const fatalLogPatterns = [
   {
@@ -85,12 +86,51 @@ function waitForExit(child) {
   });
 }
 
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 function findFatalLog(output) {
   return fatalLogPatterns.find(({ pattern }) => pattern.test(output));
 }
 
 function formatOutput(output) {
   return output.trim().length > 0 ? output.trim() : '(no output)';
+}
+
+function formatExit(exit) {
+  return exit.signal ?? `code ${exit.code}`;
+}
+
+function hasExited(child) {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForExitOrTimeout(exitPromise, timeoutMs) {
+  return Promise.race([
+    exitPromise.then((exit) => ({ exit })),
+    delay(timeoutMs).then(() => ({ timeout: true })),
+  ]);
+}
+
+async function stopChild(child, exitPromise) {
+  if (hasExited(child)) return exitPromise;
+  child.kill('SIGTERM');
+  const gracefulExit = await waitForExitOrTimeout(
+    exitPromise,
+    SHUTDOWN_GRACE_MS,
+  );
+  if (!gracefulExit.timeout) return gracefulExit.exit;
+
+  child.kill('SIGKILL');
+  const forcedExit = await waitForExitOrTimeout(exitPromise, SHUTDOWN_GRACE_MS);
+  if (!forcedExit.timeout) return forcedExit.exit;
+
+  throw new Error(
+    `Packaged app did not exit within ${SHUTDOWN_GRACE_MS}ms after SIGKILL.`,
+  );
 }
 
 const executablePath = parseAppPath(process.argv.slice(2));
@@ -119,29 +159,47 @@ child.stderr.on('data', (chunk) => {
 });
 
 const exitPromise = waitForExit(child);
-const result = await Promise.race([
-  exitPromise.then((exit) => ({ exit })),
-  new Promise((resolve) => {
-    setTimeout(() => resolve({ timeout: true }), timeoutMs);
-  }),
-]);
+const result = await waitForExitOrTimeout(exitPromise, timeoutMs);
 
 if (result.timeout) {
-  child.kill('SIGTERM');
-  await exitPromise.catch(() => undefined);
+  if (hasExited(child)) {
+    result.exit = await exitPromise;
+  } else {
+    await stopChild(child, exitPromise);
+  }
+}
+
+if (!result.timeout) {
   const fatalLog = findFatalLog(output);
   if (fatalLog) {
     console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
     console.error(formatOutput(output));
     process.exit(1);
   }
-  console.log(
-    `Desktop launch smoke passed for ${executablePath} after ${timeoutMs}ms.`,
+
+  console.error(
+    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
+      result.exit,
+    )}.`,
   );
-  if (output.trim().length > 0) {
-    console.log(formatOutput(output));
+  console.error(formatOutput(output));
+  process.exit(1);
+}
+
+if (result.exit) {
+  const fatalLog = findFatalLog(output);
+  if (fatalLog) {
+    console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
+    console.error(formatOutput(output));
+    process.exit(1);
   }
-  process.exit(0);
+  console.error(
+    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
+      result.exit,
+    )}.`,
+  );
+  console.error(formatOutput(output));
+  process.exit(1);
 }
 
 const fatalLog = findFatalLog(output);
@@ -151,10 +209,9 @@ if (fatalLog) {
   process.exit(1);
 }
 
-console.error(
-  `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${
-    result.exit.signal ?? `code ${result.exit.code}`
-  }.`,
+console.log(
+  `Desktop launch smoke passed for ${executablePath} after ${timeoutMs}ms.`,
 );
-console.error(formatOutput(output));
-process.exit(1);
+if (output.trim().length > 0) {
+  console.log(formatOutput(output));
+}

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -86,6 +86,12 @@ function waitForExit(child) {
   });
 }
 
+function waitForClose(child) {
+  return new Promise((resolve) => {
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+}
+
 function delay(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -102,6 +108,26 @@ function formatOutput(output) {
 
 function formatExit(exit) {
   return exit.signal ?? `code ${exit.code}`;
+}
+
+function failIfFatalLog(output) {
+  const fatalLog = findFatalLog(output);
+  if (!fatalLog) return false;
+
+  console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
+  console.error(formatOutput(output));
+  process.exit(1);
+}
+
+function failEarlyExit(exit, timeoutMs, output) {
+  failIfFatalLog(output);
+  console.error(
+    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
+      exit,
+    )}.`,
+  );
+  console.error(formatOutput(output));
+  process.exit(1);
 }
 
 function hasExited(child) {
@@ -159,6 +185,7 @@ child.stderr.on('data', (chunk) => {
 });
 
 const exitPromise = waitForExit(child);
+const closePromise = waitForClose(child);
 const result = await waitForExitOrTimeout(exitPromise, timeoutMs);
 
 if (result.timeout) {
@@ -169,45 +196,13 @@ if (result.timeout) {
   }
 }
 
-if (!result.timeout) {
-  const fatalLog = findFatalLog(output);
-  if (fatalLog) {
-    console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
-    console.error(formatOutput(output));
-    process.exit(1);
-  }
-
-  console.error(
-    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
-      result.exit,
-    )}.`,
-  );
-  console.error(formatOutput(output));
-  process.exit(1);
-}
+await closePromise;
 
 if (result.exit) {
-  const fatalLog = findFatalLog(output);
-  if (fatalLog) {
-    console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
-    console.error(formatOutput(output));
-    process.exit(1);
-  }
-  console.error(
-    `Desktop launch smoke failed: app exited before ${timeoutMs}ms with ${formatExit(
-      result.exit,
-    )}.`,
-  );
-  console.error(formatOutput(output));
-  process.exit(1);
+  failEarlyExit(result.exit, timeoutMs, output);
 }
 
-const fatalLog = findFatalLog(output);
-if (fatalLog) {
-  console.error(`Desktop launch smoke failed: ${fatalLog.label}.`);
-  console.error(formatOutput(output));
-  process.exit(1);
-}
+failIfFatalLog(output);
 
 console.log(
   `Desktop launch smoke passed for ${executablePath} after ${timeoutMs}ms.`,

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -142,6 +142,16 @@ async function waitForExitOrTimeout(exitPromise, timeoutMs) {
   ]);
 }
 
+async function readPendingExit(exitPromise) {
+  const result = await Promise.race([
+    exitPromise.then((exit) => ({ exit })),
+    new Promise((resolve) => {
+      setImmediate(() => resolve({}));
+    }),
+  ]);
+  return result.exit;
+}
+
 async function stopChild(child, exitPromise) {
   if (hasExited(child)) return exitPromise;
   child.kill('SIGTERM');
@@ -193,7 +203,10 @@ if (result.timeout) {
   if (hasExited(child)) {
     result.exit = await exitPromise;
   } else {
-    await stopChild(child, exitPromise);
+    result.exit = await readPendingExit(exitPromise);
+    if (!result.exit) {
+      await stopChild(child, exitPromise);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- add `npm run desktop:package:smoke` for launching the packaged desktop app briefly from the command line
- fail the smoke on early app exit, desktop startup failures, or runtime VS Code import errors
- document the launch smoke next to the local macOS desktop package workflow

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run desktop:package:local`
- `npm run check:desktop-package`
- `npm run desktop:package:smoke`
- `TEXRA_DESKTOP_LAUNCH_SMOKE_MS= npm run desktop:package:smoke`
- `npm run compile-tests`
- `npm run build:initial`
- `npx prettier --check package.json docs/electron-migration-plan.md scripts/smoke-desktop-package-launch.mjs`

Closes #3491

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new opt-in smoke script and documentation without changing app/runtime behavior. Main risk is potential flakiness on macOS environments due to timing/launch differences and log-pattern false positives.
> 
> **Overview**
> Adds a new `desktop:package:smoke` workflow step that launches the locally packaged desktop app for a short window and treats early exits as failures.
> 
> Introduces `scripts/smoke-desktop-package-launch.mjs`, which locates the default macOS `.app` binary (or accepts `--app`), captures bounded stdout/stderr, fails on specific fatal log patterns (e.g., missing `vscode` import, startup failure, unhandled exceptions), and supports a configurable timeout via `TEXRA_DESKTOP_LAUNCH_SMOKE_MS`.
> 
> Updates the Electron migration docs to include and explain the new smoke command alongside the local packaging/check steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f0c7f95d8611b13344a2dc21c333c6f2267a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->