### PR TITLE
Wire desktop Progress route IPC basics

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -436,7 +436,9 @@ export class DesktopProgressBridge {
   }
 
   setActiveStream(streamId: StreamTabId): void {
-    this.ensureStream(streamId);
+    if (!this.streamLogs.has(streamId) && !this.taskStates.has(streamId)) {
+      return;
+    }
     this.activeStream = streamId;
     this.syncStreams();
     this.send({

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -452,6 +452,11 @@ export class DesktopProgressBridge {
   }
 
   async deleteStream(streamId: StreamTabId): Promise<void> {
+    const hadStream =
+      this.streamLogs.has(streamId) || this.taskStates.has(streamId);
+    if (!hadStream) return;
+
+    const wasActive = this.activeStream === streamId;
     await this.streamLogs.delete(streamId);
     this.taskStates.delete(streamId);
     this.statuses.delete(streamId);
@@ -464,10 +469,21 @@ export class DesktopProgressBridge {
     this.streamBadges.delete(streamId);
     this.cursors.delete(streamId);
 
-    if (this.activeStream === streamId) {
+    if (wasActive) {
       this.activeStream = this.streamLogs.keys()[0] ?? '';
     }
+    this.send({
+      command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+      stream: streamId,
+    });
     this.syncStreams();
+    if (wasActive && this.activeStream) {
+      this.send({
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        activeStream: this.activeStream,
+      });
+      this.flushLogs(this.activeStream);
+    }
   }
 
   async deleteAllStreams(): Promise<void> {
@@ -483,6 +499,7 @@ export class DesktopProgressBridge {
     this.conversationProgress.clear();
     this.streamBadges.clear();
     this.activeStream = '';
+    this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
     this.syncStreams();
   }
 }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -15,6 +15,7 @@ import {
   STREAM_STATUS,
   type ActiveChildInfo,
   type AgentCategory,
+  type AgentCategoryFilter,
   type ConversationProgress,
   type ProgressViewOutboundMessage,
   type StreamMetadata,
@@ -34,6 +35,7 @@ export interface DesktopAgentExecutionOptions {
 
 export interface DesktopAgentExecution {
   handleExecute(message: MainViewExecuteMessage): Promise<void>;
+  progress: DesktopProgressBridge;
   dispose(): void;
 }
 
@@ -62,6 +64,7 @@ export class DesktopProgressBridge {
   >();
   private readonly streamBadges = new Map<StreamTabId, StreamBadgeSnapshot>();
   private activeStream: StreamTabId | '' = '';
+  private agentFilter: AgentCategoryFilter = 'all';
   private readonly unsubscribe: () => void;
 
   readonly runtimeHost: AgentRuntimeHost;
@@ -216,7 +219,7 @@ export class DesktopProgressBridge {
       command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
       streams,
       activeStream: this.activeStream,
-      agentFilter: 'all',
+      agentFilter: this.agentFilter,
       streamStates,
     });
   }
@@ -426,6 +429,62 @@ export class DesktopProgressBridge {
       }
     }
   }
+
+  syncFullView(): void {
+    this.syncStreams();
+    if (this.activeStream) this.flushLogs(this.activeStream);
+  }
+
+  setActiveStream(streamId: StreamTabId): void {
+    this.ensureStream(streamId);
+    this.activeStream = streamId;
+    this.syncStreams();
+    this.send({
+      command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+      activeStream: streamId,
+    });
+    this.flushLogs(streamId);
+  }
+
+  setAgentFilter(filter: AgentCategoryFilter): void {
+    this.agentFilter = filter;
+    this.syncStreams();
+  }
+
+  async deleteStream(streamId: StreamTabId): Promise<void> {
+    await this.streamLogs.delete(streamId);
+    this.taskStates.delete(streamId);
+    this.statuses.delete(streamId);
+    this.categories.delete(streamId);
+    this.executionIds.delete(streamId);
+    this.descriptions.delete(streamId);
+    this.parentStreams.delete(streamId);
+    this.creationTimestamps.delete(streamId);
+    this.conversationProgress.delete(streamId);
+    this.streamBadges.delete(streamId);
+    this.cursors.delete(streamId);
+
+    if (this.activeStream === streamId) {
+      this.activeStream = this.streamLogs.keys()[0] ?? '';
+    }
+    this.syncStreams();
+  }
+
+  async deleteAllStreams(): Promise<void> {
+    await this.streamLogs.clear();
+    this.cursors.clear();
+    this.taskStates.clear();
+    this.statuses.clear();
+    this.categories.clear();
+    this.executionIds.clear();
+    this.descriptions.clear();
+    this.parentStreams.clear();
+    this.creationTimestamps.clear();
+    this.conversationProgress.clear();
+    this.streamBadges.clear();
+    this.activeStream = '';
+    this.syncStreams();
+  }
 }
 
 export function createDesktopAgentExecution(
@@ -434,6 +493,7 @@ export function createDesktopAgentExecution(
   const progress = new DesktopProgressBridge(options.postToRenderer);
 
   return {
+    progress,
     async handleExecute(message) {
       const preparation = prepareMainViewExecutionRequest(message);
       if (!preparation.valid) {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -20,7 +20,6 @@ export interface DesktopProgressIpcOptions {
 export type DesktopProgressIpc = DesktopMessageHandler;
 
 const passThroughCommands = new Set<string>([
-  PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
   PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
   PROGRESS_VIEW_COMMANDS.THEME_SET,
   PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -4,11 +4,12 @@ import {
   type ProgressViewInboundMessage,
 } from '@shared/schemas/progressView';
 
-import type { DesktopProgressBridge } from './desktopAgentExecution.js';
-import type {
-  DesktopCommandMessage,
-  DesktopMessageHandler,
+import {
+  createDesktopErrorReporter,
+  type DesktopCommandMessage,
+  type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
+import type { DesktopProgressBridge } from './desktopAgentExecution.js';
 
 export interface DesktopProgressIpcOptions {
   progress: DesktopProgressBridge;
@@ -28,11 +29,7 @@ const passThroughCommands = new Set<string>([
 export function createDesktopProgressIpc(
   options: DesktopProgressIpcOptions,
 ): DesktopProgressIpc {
-  const onAsyncError =
-    options.onAsyncError ??
-    ((error) => {
-      console.error(error);
-    });
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
   const onUnsupportedCommand =
     options.onUnsupportedCommand ??
     ((message) => {
@@ -40,7 +37,7 @@ export function createDesktopProgressIpc(
     });
 
   function runAsync(work: Promise<void>): void {
-    void work.catch(onAsyncError);
+    void work.catch(reportAsyncError);
   }
 
   return {

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -1,0 +1,74 @@
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
+import {
+  ProgressViewInboundMessageSchema,
+  type ProgressViewInboundMessage,
+} from '@shared/schemas/progressView';
+
+import type { DesktopProgressBridge } from './desktopAgentExecution.js';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+} from './desktopIpcTypes.js';
+
+export interface DesktopProgressIpcOptions {
+  progress: DesktopProgressBridge;
+  onUnsupportedCommand?: (message: ProgressViewInboundMessage) => void;
+  onAsyncError?: (error: unknown) => void;
+}
+
+export type DesktopProgressIpc = DesktopMessageHandler;
+
+const passThroughCommands = new Set<string>([
+  PROGRESS_VIEW_COMMANDS.WEBVIEW_READY,
+  PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
+  PROGRESS_VIEW_COMMANDS.THEME_SET,
+  PROGRESS_VIEW_COMMANDS.DEBUG_MODE_SET,
+]);
+
+export function createDesktopProgressIpc(
+  options: DesktopProgressIpcOptions,
+): DesktopProgressIpc {
+  const onAsyncError =
+    options.onAsyncError ??
+    ((error) => {
+      console.error(error);
+    });
+  const onUnsupportedCommand =
+    options.onUnsupportedCommand ??
+    ((message) => {
+      console.warn(`Unsupported desktop Progress command: ${message.command}`);
+    });
+
+  function runAsync(work: Promise<void>): void {
+    void work.catch(onAsyncError);
+  }
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      const result = ProgressViewInboundMessageSchema.safeParse(message);
+      if (!result.success) return false;
+
+      switch (result.data.command) {
+        case PROGRESS_VIEW_COMMANDS.WEBVIEW_READY:
+          options.progress.syncFullView();
+          return false;
+        case PROGRESS_VIEW_COMMANDS.SWITCH_STREAM:
+          options.progress.setActiveStream(result.data.stream);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.FILTER_STREAMS:
+          options.progress.setAgentFilter(result.data.filter);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.DELETE_STREAM:
+          runAsync(options.progress.deleteStream(result.data.stream));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.DELETE_ALL:
+          runAsync(options.progress.deleteAllStreams());
+          return true;
+        default:
+          if (passThroughCommands.has(result.data.command)) return false;
+          onUnsupportedCommand(result.data);
+          return true;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
+import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
@@ -79,12 +80,17 @@ function createWindow(): void {
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     onError: reportAsyncError,
   });
+  const progressIpc = createDesktopProgressIpc({
+    progress: agentExecution.progress,
+    onAsyncError: reportAsyncError,
+  });
   const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),
     openPath,
     executeAgent: (message) => agentExecution.handleExecute(message),
     fileSelection,
     settings: settingsIpc,
+    progress: progressIpc,
     onAsyncError: reportAsyncError,
   });
   ipcRef.current = mainViewIpc;

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -9,6 +9,7 @@ import {
   createDesktopViewStateIpc,
   type DesktopTheme,
 } from './desktopViewStateIpc.js';
+import type { DesktopProgressIpc } from './desktopProgressIpc.js';
 import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
@@ -21,6 +22,7 @@ export interface DesktopMainViewIpcOptions {
   openPath?: (filePath: string) => Promise<void>;
   fileSelection?: DesktopFileSelection;
   settings?: DesktopSettingsIpc;
+  progress?: DesktopProgressIpc;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
@@ -63,6 +65,7 @@ export function installDesktopMainViewIpc(
   messageHandlers = [
     options.fileSelection,
     options.settings,
+    options.progress,
     viewState,
     shell,
     execution,

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - progress schemas
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
-import { AGENT_CATEGORY, STREAM_STATUS } from '@shared/schemas';
+import {
+  AGENT_CATEGORY,
+  LOG_LEVELS,
+  STREAM_LOG_ENTRY_TYPES,
+  STREAM_STATUS,
+  type StreamTabId,
+} from '@shared/schemas';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
@@ -14,6 +20,20 @@ type Bridge = {
 
 type TestableBridge = Bridge & {
   handleProgressEvent(event: string, payload: unknown): void;
+  deleteStream(streamId: StreamTabId): Promise<void>;
+  deleteAllStreams(): Promise<void>;
+  streamLogs: {
+    append(
+      streamId: StreamTabId,
+      entry: {
+        id: string;
+        type: string;
+        level: string;
+        timestamp: number;
+        text: string;
+      },
+    ): unknown;
+  };
 };
 
 type DesktopExecution = {
@@ -34,6 +54,10 @@ interface DesktopAgentExecutionModule {
 
 type ProgressMessage = {
   command?: string;
+  activeStream?: string;
+  stream?: string;
+  streamId?: string;
+  entries?: Array<{ text?: string }>;
   streams?: Array<{ name: string; creationTimestamp: number }>;
   streamStates?: Record<string, unknown>;
 };
@@ -332,6 +356,92 @@ describe('DesktopProgressBridge', () => {
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)[0]
           ?.streamStates?.['new-stream'],
       ).toMatchObject({ status: STREAM_STATUS.RUNNING });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('emits delete-stream cleanup and flushes fallback active stream logs', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'first',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'second',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.streamLogs.append('first', {
+        id: 'first-log',
+        type: STREAM_LOG_ENTRY_TYPES.LOG,
+        level: LOG_LEVELS.INFO,
+        timestamp: 1_500,
+        text: 'first stream log',
+      });
+      messages.length = 0;
+
+      await bridge.deleteStream('second');
+
+      expect(
+        messages.map((message) => (message as ProgressMessage).command),
+      ).toEqual([
+        PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+      ]);
+      expect(messages[0]).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        stream: 'second',
+      });
+      expect(messages[1]).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        activeStream: 'first',
+      });
+      expect(messages[2]).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        activeStream: 'first',
+      });
+      expect(messages[3]).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.LOG_DELTA,
+        streamId: 'first',
+        entries: [expect.objectContaining({ text: 'first stream log' })],
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('emits delete-all cleanup before syncing an empty stream list', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'active',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      messages.length = 0;
+
+      await bridge.deleteAllStreams();
+
+      expect(
+        messages.map((message) => (message as ProgressMessage).command),
+      ).toEqual([
+        PROGRESS_VIEW_COMMANDS.DELETE_ALL,
+        PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+      ]);
+      expect(messages[1]).toMatchObject({
+        command: PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS,
+        activeStream: '',
+        streams: [],
+        streamStates: {},
+      });
     } finally {
       bridge.dispose();
     }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -20,6 +20,7 @@ type Bridge = {
 
 type TestableBridge = Bridge & {
   handleProgressEvent(event: string, payload: unknown): void;
+  setActiveStream(streamId: StreamTabId): void;
   deleteStream(streamId: StreamTabId): Promise<void>;
   deleteAllStreams(): Promise<void>;
   streamLogs: {
@@ -356,6 +357,19 @@ describe('DesktopProgressBridge', () => {
         progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS)[0]
           ?.streamStates?.['new-stream'],
       ).toMatchObject({ status: STREAM_STATUS.RUNNING });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  it('ignores renderer switches to unknown streams', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.setActiveStream('ghost-stream');
+
+      expect(messages).toEqual([]);
     } finally {
       bridge.dispose();
     }

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -1,0 +1,122 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - webview command constants
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopProgressIpcModule {
+  createDesktopProgressIpc(options: {
+    progress: {
+      syncFullView(): void;
+      setActiveStream(stream: string): void;
+      setAgentFilter(filter: string): void;
+      deleteStream(stream: string): Promise<void>;
+      deleteAllStreams(): Promise<void>;
+    };
+    onUnsupportedCommand?: (message: { command: string }) => void;
+    onAsyncError?: (error: unknown) => void;
+  }): {
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean | Promise<boolean>;
+  };
+}
+
+async function loadDesktopProgressIpc(): Promise<DesktopProgressIpcModule> {
+  vi.resetModules();
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopProgressIpc.ts'))
+  ) as Promise<DesktopProgressIpcModule>;
+}
+
+function createProgress() {
+  return {
+    syncFullView: vi.fn(),
+    setActiveStream: vi.fn(),
+    setAgentFilter: vi.fn(),
+    deleteStream: vi.fn(async (_stream: string) => {}),
+    deleteAllStreams: vi.fn(async () => {}),
+  };
+}
+
+describe('desktop Progress IPC', () => {
+  it('syncs Progress state on readiness while allowing shared view-state handling', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.WEBVIEW_READY }),
+    ).toBe(false);
+    expect(progress.syncFullView).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles basic Progress stream commands through the shared bridge', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    expect(progress.setActiveStream).toHaveBeenCalledWith('run-1');
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.FILTER_STREAMS,
+        filter: 'workflow',
+      }),
+    ).toBe(true);
+    expect(progress.setAgentFilter).toHaveBeenCalledWith('workflow');
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.DELETE_STREAM,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(progress.deleteStream).toHaveBeenCalledWith('run-1');
+
+    expect(
+      ipc.handleMessage({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(progress.deleteAllStreams).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes unsupported Progress commands through an explicit handler', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress,
+      onUnsupportedCommand,
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.STOP_STREAM,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    expect(onUnsupportedCommand).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.STOP_STREAM,
+      stream: 'run-1',
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.SWITCH_VIEW,
+        view: 'progress',
+      }),
+    ).toBe(false);
+    expect(onUnsupportedCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - webview command constants
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
@@ -28,6 +29,7 @@ interface MainViewIpcModule {
       openPath?: (filePath: string) => Promise<void>;
       fileSelection?: { handleMessage(message: { command: string }): boolean };
       settings?: { handleMessage(message: { command: string }): boolean };
+      progress?: { handleMessage(message: { command: string }): boolean };
       executeAgent?: (message: unknown) => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
@@ -116,6 +118,12 @@ describe('desktop main-view IPC', () => {
           message.command === SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
       ),
     };
+    const progress = {
+      handleMessage: vi.fn(
+        (message: { command: string }) =>
+          message.command === PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+      ),
+    };
     const executeAgent = vi.fn(async (_message: unknown) => {});
     const webContents = {
       isDestroyed: () => false,
@@ -136,6 +144,7 @@ describe('desktop main-view IPC', () => {
       openPath,
       fileSelection,
       settings,
+      progress,
       executeAgent,
     });
 
@@ -178,6 +187,15 @@ describe('desktop main-view IPC', () => {
     );
     expect(settings.handleMessage).toHaveBeenCalledWith({
       command: SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS,
+    });
+
+    rendererListener?.(
+      { sender: webContents },
+      { command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM, stream: 'run-1' },
+    );
+    expect(progress.handleMessage).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.SWITCH_STREAM,
+      stream: 'run-1',
     });
 
     sends.length = 0;


### PR DESCRIPTION
## Summary

- Add a dedicated desktop Progress IPC adapter for the first inbound Progress route commands.
- Reuse `DesktopProgressBridge` as the single owner of Progress stream state for readiness sync, active stream switching, filtering, and stream deletion.
- Wire the adapter into desktop main-view IPC and cover the handler chain with kernel tests.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run desktop:build`
- `npm run smoke:webviews`
- `npm run compile:safe`

Closes #3495

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new IPC command handling and mutates in-memory Progress stream state (active stream, filtering, deletion), which could affect UI consistency and log syncing if edge cases are missed.
> 
> **Overview**
> Adds a dedicated desktop Progress IPC handler that validates inbound Progress-view messages and routes core commands (`WEBVIEW_READY`, stream switching/filtering, and stream deletion) to the shared `DesktopProgressBridge`, while letting common view-state commands pass through.
> 
> Extends `DesktopProgressBridge` to persist the current agent filter, support renderer-driven stream switching, and implement `deleteStream`/`deleteAllStreams` cleanup with appropriate re-syncing and log flushing when the active stream changes.
> 
> Wires this Progress IPC handler into the desktop main-view IPC chain (`index.ts`/`mainViewIpc.ts`) and adds kernel tests covering routing, readiness sync behavior, and stream deletion edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54e2d97cafca4f11d4949f82e4f352e171779ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->