### PR TITLE
Wire desktop native menu to command catalog

### DIFF
--- a/packages/desktop/src/main/desktopCommandSurface.ts
+++ b/packages/desktop/src/main/desktopCommandSurface.ts
@@ -4,6 +4,7 @@ import {
   type CommandKeybinding,
 } from '@commands/catalog';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import type { MenuItemConstructorOptions } from 'electron';
 import type { DesktopShellActions } from './desktopShellIpc.js';
 
 export const DESKTOP_COMMAND_IDS = [
@@ -27,14 +28,6 @@ export interface DesktopCommandMenuEntry {
   label: string;
   category: string;
   accelerator?: string;
-}
-
-export interface DesktopMenuItem {
-  label?: string;
-  accelerator?: string;
-  submenu?: DesktopMenuItem[];
-  type?: 'separator';
-  click?: () => void;
 }
 
 const DESKTOP_MENU_GROUPS = [
@@ -121,14 +114,14 @@ export function dispatchDesktopCommand(
 export function buildDesktopMenuTemplate(
   actions: DesktopShellActions,
   platform: NodeJS.Platform = process.platform,
-): DesktopMenuItem[] {
+): MenuItemConstructorOptions[] {
   const entriesById = new Map(
     getDesktopCommandMenuEntries(DESKTOP_COMMAND_IDS, platform).map((entry) => [
       entry.id,
       entry,
     ]),
   );
-  const commandItem = (id: DesktopCommandId): DesktopMenuItem => {
+  const commandItem = (id: DesktopCommandId): MenuItemConstructorOptions => {
     const entry = entriesById.get(id);
     if (!entry) throw new Error(`Missing desktop menu entry: ${id}`);
     return {
@@ -139,16 +132,27 @@ export function buildDesktopMenuTemplate(
       },
     };
   };
+  const customMenu: MenuItemConstructorOptions = {
+    label: 'TeXRA',
+    submenu: [
+      ...DESKTOP_MENU_GROUPS[0].map(commandItem),
+      { type: 'separator' },
+      ...DESKTOP_MENU_GROUPS[1].map(commandItem),
+    ],
+  };
 
   return [
-    {
-      label: 'TeXRA',
-      submenu: [
-        ...DESKTOP_MENU_GROUPS[0].map(commandItem),
-        { type: 'separator' },
-        ...DESKTOP_MENU_GROUPS[1].map(commandItem),
-      ],
-    },
+    ...(platform === 'darwin'
+      ? ([
+          { role: 'appMenu' },
+          { role: 'fileMenu' },
+        ] satisfies MenuItemConstructorOptions[])
+      : ([{ role: 'fileMenu' }] satisfies MenuItemConstructorOptions[])),
+    customMenu,
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+    { role: 'help' },
   ];
 }
 

--- a/packages/desktop/src/main/desktopCommandSurface.ts
+++ b/packages/desktop/src/main/desktopCommandSurface.ts
@@ -11,8 +11,6 @@ export const DESKTOP_COMMAND_IDS = [
   'texra.showMainView',
   'texra.showProgressView',
   'texra.openSettings',
-  'texra.showDashboard',
-  'texra.showSettingsView',
   'texra.showMemory',
   'texra.showAgentHistory',
   'texra.showModels',
@@ -84,8 +82,6 @@ export function dispatchDesktopCommand(
       actions.showRoute('progress');
       return true;
     case 'texra.openSettings':
-    case 'texra.showDashboard':
-    case 'texra.showSettingsView':
       actions.showSettings();
       return true;
     case 'texra.showMemory':
@@ -169,7 +165,16 @@ function toElectronAcceleratorPart(part: string): string {
       return 'Alt';
     case 'shift':
       return 'Shift';
+    case 'enter':
+      return 'Enter';
+    case 'escape':
+      return 'Escape';
+    case 'space':
+      return 'Space';
+    case 'tab':
+      return 'Tab';
     default:
+      if (/^f\d{1,2}$/.test(normalized)) return normalized.toUpperCase();
       return normalized.length === 1 ? normalized.toUpperCase() : normalized;
   }
 }

--- a/packages/desktop/src/main/desktopCommandSurface.ts
+++ b/packages/desktop/src/main/desktopCommandSurface.ts
@@ -1,0 +1,171 @@
+import {
+  commandCatalogById,
+  type CommandId,
+  type CommandKeybinding,
+} from '@commands/catalog';
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import type { DesktopShellActions } from './desktopShellIpc.js';
+
+export const DESKTOP_COMMAND_IDS = [
+  'texra.showMainView',
+  'texra.showProgressView',
+  'texra.openSettings',
+  'texra.showDashboard',
+  'texra.showSettingsView',
+  'texra.showMemory',
+  'texra.showAgentHistory',
+  'texra.showModels',
+  'texra.showAgents',
+  'texra.showTools',
+  'texra.showMultiAgent',
+] as const satisfies readonly CommandId[];
+
+export type DesktopCommandId = (typeof DESKTOP_COMMAND_IDS)[number];
+
+export interface DesktopCommandMenuEntry {
+  id: DesktopCommandId;
+  label: string;
+  category: string;
+  accelerator?: string;
+}
+
+export interface DesktopMenuItem {
+  label?: string;
+  accelerator?: string;
+  submenu?: DesktopMenuItem[];
+  type?: 'separator';
+  click?: () => void;
+}
+
+const DESKTOP_MENU_GROUPS = [
+  ['texra.showMainView', 'texra.showProgressView', 'texra.openSettings'],
+  [
+    'texra.showMemory',
+    'texra.showAgentHistory',
+    'texra.showModels',
+    'texra.showAgents',
+    'texra.showTools',
+    'texra.showMultiAgent',
+  ],
+] as const satisfies readonly (readonly DesktopCommandId[])[];
+
+export function getDesktopCommandMenuEntries(
+  ids: readonly DesktopCommandId[] = DESKTOP_COMMAND_IDS,
+  platform: NodeJS.Platform = process.platform,
+): DesktopCommandMenuEntry[] {
+  return ids.map((id) => {
+    const entry = commandCatalogById.get(id);
+    if (!entry) throw new Error(`Missing command catalog entry: ${id}`);
+
+    const accelerator =
+      entry.keybinding == null
+        ? undefined
+        : toElectronAccelerator(entry.keybinding, platform);
+    return {
+      id,
+      label: entry.shortTitle ?? entry.title,
+      category: entry.category,
+      ...(accelerator && { accelerator }),
+    };
+  });
+}
+
+export function toElectronAccelerator(
+  keybinding: CommandKeybinding,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const key =
+    platform === 'darwin' && keybinding.mac ? keybinding.mac : keybinding.key;
+  return key.split('+').map(toElectronAcceleratorPart).join('+');
+}
+
+export function dispatchDesktopCommand(
+  id: CommandId,
+  actions: DesktopShellActions,
+): boolean {
+  switch (id) {
+    case 'texra.showMainView':
+      actions.showRoute('main');
+      return true;
+    case 'texra.showProgressView':
+      actions.showRoute('progress');
+      return true;
+    case 'texra.openSettings':
+    case 'texra.showDashboard':
+    case 'texra.showSettingsView':
+      actions.showSettings();
+      return true;
+    case 'texra.showMemory':
+      actions.showSettings(SETTINGS_TAB.MEMORY);
+      return true;
+    case 'texra.showAgentHistory':
+      actions.showSettings(SETTINGS_TAB.HISTORY);
+      return true;
+    case 'texra.showModels':
+      actions.showSettings(SETTINGS_TAB.MODELS);
+      return true;
+    case 'texra.showAgents':
+      actions.showSettings(SETTINGS_TAB.AGENTS);
+      return true;
+    case 'texra.showTools':
+      actions.showSettings(SETTINGS_TAB.TOOLS);
+      return true;
+    case 'texra.showMultiAgent':
+      actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function buildDesktopMenuTemplate(
+  actions: DesktopShellActions,
+  platform: NodeJS.Platform = process.platform,
+): DesktopMenuItem[] {
+  const entriesById = new Map(
+    getDesktopCommandMenuEntries(DESKTOP_COMMAND_IDS, platform).map((entry) => [
+      entry.id,
+      entry,
+    ]),
+  );
+  const commandItem = (id: DesktopCommandId): DesktopMenuItem => {
+    const entry = entriesById.get(id);
+    if (!entry) throw new Error(`Missing desktop menu entry: ${id}`);
+    return {
+      label: entry.label,
+      ...(entry.accelerator && { accelerator: entry.accelerator }),
+      click: () => {
+        dispatchDesktopCommand(id, actions);
+      },
+    };
+  };
+
+  return [
+    {
+      label: 'TeXRA',
+      submenu: [
+        ...DESKTOP_MENU_GROUPS[0].map(commandItem),
+        { type: 'separator' },
+        ...DESKTOP_MENU_GROUPS[1].map(commandItem),
+      ],
+    },
+  ];
+}
+
+function toElectronAcceleratorPart(part: string): string {
+  const normalized = part.trim().toLowerCase();
+  switch (normalized) {
+    case 'cmd':
+      return 'Command';
+    case 'ctrl':
+      return 'Control';
+    case 'option':
+      return 'Option';
+    case 'alt':
+      return 'Alt';
+    case 'shift':
+      return 'Shift';
+    default:
+      return normalized.length === 1 ? normalized.toUpperCase() : normalized;
+  }
+}

--- a/packages/desktop/src/main/desktopMenu.ts
+++ b/packages/desktop/src/main/desktopMenu.ts
@@ -1,11 +1,9 @@
-import { Menu, type MenuItemConstructorOptions } from 'electron';
+import { Menu } from 'electron';
 
 import { buildDesktopMenuTemplate } from './desktopCommandSurface.js';
 import type { DesktopShellActions } from './desktopShellIpc.js';
 
 export function installDesktopMenu(actions: DesktopShellActions): void {
-  const template = buildDesktopMenuTemplate(
-    actions,
-  ) as MenuItemConstructorOptions[];
+  const template = buildDesktopMenuTemplate(actions);
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }

--- a/packages/desktop/src/main/desktopMenu.ts
+++ b/packages/desktop/src/main/desktopMenu.ts
@@ -1,0 +1,11 @@
+import { Menu, type MenuItemConstructorOptions } from 'electron';
+
+import { buildDesktopMenuTemplate } from './desktopCommandSurface.js';
+import type { DesktopShellActions } from './desktopShellIpc.js';
+
+export function installDesktopMenu(actions: DesktopShellActions): void {
+  const template = buildDesktopMenuTemplate(
+    actions,
+  ) as MenuItemConstructorOptions[];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -22,9 +22,17 @@ import {
 } from './desktopIpcTypes.js';
 
 export interface DesktopShellIpcOptions {
+  actions?: DesktopShellActions;
   getCustomAgentDirectory?: () => Promise<string>;
   openPath?: (filePath: string) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
+}
+
+export interface DesktopShellActions {
+  openAgentDirectory(customDirSet?: boolean): void;
+  setRecentCommitsUnavailable(): void;
+  showRoute(route: DesktopRoute): void;
+  showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
 }
 
 const SWITCH_VIEW_ROUTES = {
@@ -39,10 +47,10 @@ function getAgentSettingsSubTab(message: DesktopCommandMessage) {
     : undefined;
 }
 
-export function createDesktopShellIpc(
+export function createDesktopShellActions(
   renderer: DesktopRenderer,
   options: DesktopShellIpcOptions = {},
-): DesktopMessageHandler {
+): DesktopShellActions {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
   function postRoute(route: DesktopRoute) {
@@ -65,12 +73,6 @@ export function createDesktopShellIpc(
     });
   }
 
-  function postRouteForSwitchView(message: DesktopCommandMessage) {
-    const result = SwitchViewMessageSchema.safeParse(message);
-    if (!result.success) return;
-    postRoute(SWITCH_VIEW_ROUTES[result.data.view]);
-  }
-
   async function openCustomAgentDirectory() {
     if (!options.getCustomAgentDirectory || !options.openPath) {
       postSettingsRoute(SETTINGS_TAB.AGENTS);
@@ -80,12 +82,39 @@ export function createDesktopShellIpc(
     await options.openPath(customDir);
   }
 
-  function handleOpenAgentDirectory(message: DesktopCommandMessage) {
-    if (message.customDirSet !== true) {
+  function openAgentDirectory(customDirSet?: boolean) {
+    if (customDirSet !== true) {
       postSettingsRoute(SETTINGS_TAB.AGENTS);
       return;
     }
     void openCustomAgentDirectory().catch(reportAsyncError);
+  }
+
+  return {
+    openAgentDirectory,
+    setRecentCommitsUnavailable: () => {
+      renderer.postToRenderer({
+        command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
+        commits: [],
+        isGitRepo: false,
+      });
+    },
+    showRoute: postRoute,
+    showSettings: postSettingsRoute,
+  };
+}
+
+export function createDesktopShellIpc(
+  renderer: DesktopRenderer,
+  options: DesktopShellIpcOptions = {},
+): DesktopMessageHandler {
+  const actions =
+    options.actions ?? createDesktopShellActions(renderer, options);
+
+  function postRouteForSwitchView(message: DesktopCommandMessage) {
+    const result = SwitchViewMessageSchema.safeParse(message);
+    if (!result.success) return;
+    actions.showRoute(SWITCH_VIEW_ROUTES[result.data.view]);
   }
 
   return {
@@ -95,29 +124,25 @@ export function createDesktopShellIpc(
           postRouteForSwitchView(message);
           return true;
         case MAIN_VIEW_COMMANDS.SETTINGS_OPEN:
-          postSettingsRoute();
+          actions.showSettings();
           return true;
         case MAIN_VIEW_COMMANDS.OPEN_AGENT_SETTINGS:
-          postSettingsRoute(
+          actions.showSettings(
             SETTINGS_TAB.AGENTS,
             getAgentSettingsSubTab(message),
           );
           return true;
         case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
-          postSettingsRoute(SETTINGS_TAB.MODELS);
+          actions.showSettings(SETTINGS_TAB.MODELS);
           return true;
         case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
-          postSettingsRoute(SETTINGS_TAB.MULTI_AGENT);
+          actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
           return true;
         case MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY:
-          handleOpenAgentDirectory(message);
+          actions.openAgentDirectory(message.customDirSet === true);
           return true;
         case MAIN_VIEW_COMMANDS.REQUEST_RECENT_COMMITS:
-          renderer.postToRenderer({
-            command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,
-            commits: [],
-            isGitRepo: false,
-          });
+          actions.setRecentCommitsUnavailable();
           return true;
         default:
           return false;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -5,8 +5,10 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
+import { installDesktopMenu } from './desktopMenu.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
+import { createDesktopShellActions } from './desktopShellIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
@@ -84,6 +86,14 @@ function createWindow(): void {
     progress: agentExecution.progress,
     onAsyncError: reportAsyncError,
   });
+  const shellActions = createDesktopShellActions(
+    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
+    {
+      getCustomAgentDirectory: () => getAgentDirectories().custom(),
+      openPath,
+      onAsyncError: reportAsyncError,
+    },
+  );
   const mainViewIpc = installDesktopMainViewIpc(window, {
     getCustomAgentDirectory: () => getAgentDirectories().custom(),
     openPath,
@@ -91,9 +101,11 @@ function createWindow(): void {
     fileSelection,
     settings: settingsIpc,
     progress: progressIpc,
+    shellActions,
     onAsyncError: reportAsyncError,
   });
   ipcRef.current = mainViewIpc;
+  installDesktopMenu(shellActions);
   window.once('closed', () => agentExecution.dispose());
 
   if (process.env.ELECTRON_RENDERER_URL) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -95,8 +95,6 @@ function createWindow(): void {
     },
   );
   const mainViewIpc = installDesktopMainViewIpc(window, {
-    getCustomAgentDirectory: () => getAgentDirectories().custom(),
-    openPath,
     executeAgent: (message) => agentExecution.handleExecute(message),
     fileSelection,
     settings: settingsIpc,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -4,7 +4,10 @@ import {
   isDesktopCommandMessage,
   type DesktopMessageHandler,
 } from './desktopIpcTypes.js';
-import { createDesktopShellIpc } from './desktopShellIpc.js';
+import {
+  createDesktopShellIpc,
+  type DesktopShellActions,
+} from './desktopShellIpc.js';
 import {
   createDesktopViewStateIpc,
   type DesktopTheme,
@@ -23,6 +26,7 @@ export interface DesktopMainViewIpcOptions {
   fileSelection?: DesktopFileSelection;
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
+  shellActions?: DesktopShellActions;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
@@ -54,6 +58,7 @@ export function installDesktopMainViewIpc(
     getTheme: options.getTheme,
   });
   const shell = createDesktopShellIpc(bridge, {
+    actions: options.shellActions,
     getCustomAgentDirectory: options.getCustomAgentDirectory,
     openPath: options.openPath,
     onAsyncError: options.onAsyncError,

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -1,0 +1,162 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - command catalog
+import { commandCatalogById, type CommandId } from '@commands/catalog';
+
+// Local imports - shared schemas
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopCommandSurfaceModule {
+  DESKTOP_COMMAND_IDS: readonly CommandId[];
+  buildDesktopMenuTemplate(
+    actions: DesktopShellActions,
+    platform?: NodeJS.Platform,
+  ): DesktopMenuItem[];
+  dispatchDesktopCommand(id: CommandId, actions: DesktopShellActions): boolean;
+  getDesktopCommandMenuEntries(
+    ids?: readonly CommandId[],
+    platform?: NodeJS.Platform,
+  ): Array<{
+    id: CommandId;
+    label: string;
+    category: string;
+    accelerator?: string;
+  }>;
+  toElectronAccelerator(
+    keybinding: { key: string; mac?: string },
+    platform?: NodeJS.Platform,
+  ): string;
+}
+
+interface DesktopShellActions {
+  openAgentDirectory(customDirSet?: boolean): void;
+  setRecentCommitsUnavailable(): void;
+  showRoute(route: string): void;
+  showSettings(tabIndex?: string): void;
+}
+
+interface DesktopMenuItem {
+  label?: string;
+  accelerator?: string;
+  submenu?: DesktopMenuItem[];
+  type?: 'separator';
+  click?: () => void;
+}
+
+async function loadDesktopCommandSurface(): Promise<DesktopCommandSurfaceModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopCommandSurface.ts'))
+  ) as Promise<DesktopCommandSurfaceModule>;
+}
+
+describe('desktop command surface', () => {
+  it('builds desktop menu entries from the shared command catalog', async () => {
+    const { DESKTOP_COMMAND_IDS, getDesktopCommandMenuEntries } =
+      await loadDesktopCommandSurface();
+    const entries = getDesktopCommandMenuEntries(undefined, 'darwin');
+
+    expect(entries.map((entry) => entry.id)).toEqual(DESKTOP_COMMAND_IDS);
+    for (const entry of entries) {
+      const catalogEntry = commandCatalogById.get(entry.id);
+      expect(catalogEntry).toBeDefined();
+      expect(entry.label).toBe(catalogEntry?.shortTitle ?? catalogEntry?.title);
+      expect(entry.category).toBe(catalogEntry?.category);
+    }
+    expect(entries).toContainEqual({
+      id: 'texra.showMainView',
+      label: 'Show Launcher',
+      category: 'TeXRA',
+      accelerator: 'Command+Option+M',
+    });
+    expect(entries).toContainEqual({
+      id: 'texra.showProgressView',
+      label: 'Show Progress',
+      category: 'TeXRA',
+      accelerator: 'Command+Option+P',
+    });
+  });
+
+  it('normalizes catalog keybindings to Electron accelerators', async () => {
+    const { toElectronAccelerator } = await loadDesktopCommandSurface();
+
+    expect(
+      toElectronAccelerator(
+        { key: 'ctrl+alt+shift+c', mac: 'cmd+option+shift+c' },
+        'darwin',
+      ),
+    ).toBe('Command+Option+Shift+C');
+    expect(
+      toElectronAccelerator(
+        { key: 'ctrl+alt+shift+c', mac: 'cmd+option+shift+c' },
+        'linux',
+      ),
+    ).toBe('Control+Alt+Shift+C');
+  });
+
+  it('dispatches supported commands through typed shell actions', async () => {
+    const { dispatchDesktopCommand } = await loadDesktopCommandSurface();
+    const actions = {
+      openAgentDirectory: vi.fn(),
+      setRecentCommitsUnavailable: vi.fn(),
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
+
+    expect(dispatchDesktopCommand('texra.showMainView', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.showProgressView', actions)).toBe(
+      true,
+    );
+    expect(dispatchDesktopCommand('texra.openSettings', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.showModels', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.showAgents', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.execute', actions)).toBe(false);
+
+    expect(actions.showRoute).toHaveBeenNthCalledWith(1, 'main');
+    expect(actions.showRoute).toHaveBeenNthCalledWith(2, 'progress');
+    expect(actions.showSettings).toHaveBeenNthCalledWith(1);
+    expect(actions.showSettings).toHaveBeenNthCalledWith(
+      2,
+      SETTINGS_TAB.MODELS,
+    );
+    expect(actions.showSettings).toHaveBeenNthCalledWith(
+      3,
+      SETTINGS_TAB.AGENTS,
+    );
+  });
+
+  it('wires menu clicks to the catalog-backed dispatcher', async () => {
+    const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
+    const actions = {
+      openAgentDirectory: vi.fn(),
+      setRecentCommitsUnavailable: vi.fn(),
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
+    const menu = buildDesktopMenuTemplate(actions, 'darwin');
+
+    expect(menu).toHaveLength(1);
+    expect(menu[0].label).toBe('TeXRA');
+    const submenu = menu[0].submenu ?? [];
+    expect(submenu.map((item) => item.label ?? item.type)).toEqual([
+      'Show Launcher',
+      'Show Progress',
+      'Open TeXRA Settings',
+      'separator',
+      'Show Memory',
+      'Show Agent Execution History',
+      'Show Models',
+      'Show Agents',
+      'Show Tool Dashboard',
+      'Show Multi-Agent Settings',
+    ]);
+
+    submenu[0].click?.();
+    submenu[6].click?.();
+    expect(actions.showRoute).toHaveBeenCalledWith('main');
+    expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+  });
+});

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -9,13 +9,18 @@ import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import type { DesktopShellActions } from '../../../packages/desktop/src/main/desktopShellIpc';
 
 interface DesktopCommandSurfaceModule {
   DESKTOP_COMMAND_IDS: readonly CommandId[];
   buildDesktopMenuTemplate(
     actions: DesktopShellActions,
     platform?: NodeJS.Platform,
-  ): DesktopMenuItem[];
+  ): Array<{
+    label?: string;
+    role?: string;
+    submenu?: DesktopMenuItem[];
+  }>;
   dispatchDesktopCommand(id: CommandId, actions: DesktopShellActions): boolean;
   getDesktopCommandMenuEntries(
     ids?: readonly CommandId[],
@@ -30,13 +35,6 @@ interface DesktopCommandSurfaceModule {
     keybinding: { key: string; mac?: string },
     platform?: NodeJS.Platform,
   ): string;
-}
-
-interface DesktopShellActions {
-  openAgentDirectory(customDirSet?: boolean): void;
-  setRecentCommitsUnavailable(): void;
-  showRoute(route: string): void;
-  showSettings(tabIndex?: string): void;
 }
 
 interface DesktopMenuItem {
@@ -138,9 +136,17 @@ describe('desktop command surface', () => {
     };
     const menu = buildDesktopMenuTemplate(actions, 'darwin');
 
-    expect(menu).toHaveLength(1);
-    expect(menu[0].label).toBe('TeXRA');
-    const submenu = menu[0].submenu ?? [];
+    expect(menu.map((item) => item.label ?? item.role)).toEqual([
+      'appMenu',
+      'fileMenu',
+      'TeXRA',
+      'editMenu',
+      'viewMenu',
+      'windowMenu',
+      'help',
+    ]);
+    const texraMenu = menu.find((item) => item.label === 'TeXRA');
+    const submenu = texraMenu?.submenu ?? [];
     expect(submenu.map((item) => item.label ?? item.type)).toEqual([
       'Show Launcher',
       'Show Progress',


### PR DESCRIPTION
## Summary

- Add a catalog-backed desktop command surface for the first native Electron menu entries.
- Route supported desktop menu commands through typed shell actions for main, progress, settings, and settings-tab navigation.
- Reuse the same shell actions from renderer IPC and the native menu so navigation behavior stays in one place.
- Add kernel coverage for catalog metadata, accelerator normalization, dispatch behavior, and menu click wiring.

Closes #3498

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run format`
- `corepack pnpm exec prettier --check packages/desktop/src/main/desktopCommandSurface.ts packages/desktop/src/main/desktopMenu.ts packages/desktop/src/main/desktopShellIpc.ts packages/desktop/src/main/index.ts packages/desktop/src/main/mainViewIpc.ts src/test-kernel/desktop/DesktopCommandSurface.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run desktop:build`
- `npm run smoke:webviews`
- `npm run compile:safe`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new native menu surface and refactors desktop shell IPC to route navigation through injected `DesktopShellActions`, which could impact desktop view switching/settings navigation if wiring is incorrect.
> 
> **Overview**
> Adds a catalog-backed *native Electron application menu* for the desktop app, generating menu items (including platform-specific accelerators) from the shared command catalog and dispatching clicks via `dispatchDesktopCommand`.
> 
> Refactors `desktopShellIpc` to expose reusable `DesktopShellActions` (route changes, settings tab navigation, open agent directory, and recent-commits fallback) and injects them into the renderer IPC handler; `index.ts` now creates these actions once, installs the native menu, and passes them into `mainViewIpc`.
> 
> Adds kernel tests covering menu entry generation, accelerator normalization, command dispatch behavior, and menu click wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dfaf38fb817bfb3753579d77052bc07846820b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->