### PR TITLE
Build desktop command palette from command catalog

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -4,8 +4,10 @@ import {
   type CommandKeybinding,
 } from '@commands/catalog';
 import { type AgentCategory } from '@shared/schemas/agent';
-import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
-import type { SettingsTab } from '@shared/schemas/settingsViewMessages';
+import {
+  SETTINGS_TAB,
+  type SettingsTab,
+} from '@shared/schemas/settingsViewMessages';
 import type { MenuItemConstructorOptions } from 'electron';
 import type { DesktopRoute } from './desktopShellMessages.js';
 

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -3,9 +3,11 @@ import {
   type CommandId,
   type CommandKeybinding,
 } from '@commands/catalog';
+import { type AgentCategory } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import type { SettingsTab } from '@shared/schemas/settingsViewMessages';
 import type { MenuItemConstructorOptions } from 'electron';
-import type { DesktopShellActions } from './desktopShellIpc.js';
+import type { DesktopRoute } from './desktopShellMessages.js';
 
 export const DESKTOP_COMMAND_IDS = [
   'texra.showMainView',
@@ -26,6 +28,11 @@ export interface DesktopCommandMenuEntry {
   label: string;
   category: string;
   accelerator?: string;
+}
+
+export interface DesktopCommandActions {
+  showRoute(route: DesktopRoute): void;
+  showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
 }
 
 const DESKTOP_MENU_GROUPS = [
@@ -72,7 +79,7 @@ export function toElectronAccelerator(
 
 export function dispatchDesktopCommand(
   id: CommandId,
-  actions: DesktopShellActions,
+  actions: DesktopCommandActions,
 ): boolean {
   switch (id) {
     case 'texra.showMainView':
@@ -108,7 +115,7 @@ export function dispatchDesktopCommand(
 }
 
 export function buildDesktopMenuTemplate(
-  actions: DesktopShellActions,
+  actions: DesktopCommandActions,
   platform: NodeJS.Platform = process.platform,
 ): MenuItemConstructorOptions[] {
   const entriesById = new Map(

--- a/packages/desktop/src/main/desktopMenu.ts
+++ b/packages/desktop/src/main/desktopMenu.ts
@@ -1,6 +1,6 @@
 import { Menu } from 'electron';
 
-import { buildDesktopMenuTemplate } from './desktopCommandSurface.js';
+import { buildDesktopMenuTemplate } from '../desktopCommandSurface.js';
 import type { DesktopShellActions } from './desktopShellIpc.js';
 
 export function installDesktopMenu(actions: DesktopShellActions): void {

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -20,6 +20,7 @@ import {
   type DesktopMessageHandler,
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
+import type { DesktopCommandActions } from '../desktopCommandSurface.js';
 
 export interface DesktopShellIpcOptions {
   actions?: DesktopShellActions;
@@ -28,11 +29,9 @@ export interface DesktopShellIpcOptions {
   onAsyncError?: (error: unknown) => void;
 }
 
-export interface DesktopShellActions {
+export interface DesktopShellActions extends DesktopCommandActions {
   openAgentDirectory(customDirSet?: boolean): void;
   setRecentCommitsUnavailable(): void;
-  showRoute(route: DesktopRoute): void;
-  showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
 }
 
 const SWITCH_VIEW_ROUTES = {

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -138,9 +138,11 @@ export function createDesktopCommandPalette({
   };
 
   const open = (): void => {
-    previouslyFocusedElement = isHTMLElement(view, document.activeElement)
-      ? document.activeElement
-      : null;
+    if (element.hidden) {
+      previouslyFocusedElement = isHTMLElement(view, document.activeElement)
+        ? document.activeElement
+        : null;
+    }
     element.hidden = false;
     input.value = '';
     refreshFilter();
@@ -204,6 +206,7 @@ export function createDesktopCommandPalette({
 
   document.defaultView?.addEventListener('keydown', (event) => {
     if (!isCommandPaletteShortcut(event)) return;
+    if (isTextEntryTarget(view, event.target)) return;
     event.preventDefault();
     open();
   });
@@ -272,5 +275,28 @@ function isHTMLElement(
       : (view as Window & { HTMLElement?: typeof HTMLElement }).HTMLElement;
   return (
     htmlElementConstructor != null && element instanceof htmlElementConstructor
+  );
+}
+
+function isElement(
+  view: Window | null,
+  target: EventTarget | null,
+): target is Element {
+  const elementConstructor =
+    view == null
+      ? undefined
+      : (view as Window & { Element?: typeof Element }).Element;
+  return elementConstructor != null && target instanceof elementConstructor;
+}
+
+function isTextEntryTarget(
+  view: Window | null,
+  target: EventTarget | null,
+): boolean {
+  if (!isElement(view, target)) return false;
+  return (
+    target.closest(
+      'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
+    ) != null
   );
 }

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -206,7 +206,7 @@ export function createDesktopCommandPalette({
 
   document.defaultView?.addEventListener('keydown', (event) => {
     if (!isCommandPaletteShortcut(event)) return;
-    if (isTextEntryTarget(view, event.target)) return;
+    if (isTextEntryShortcutTarget(view, document, event)) return;
     event.preventDefault();
     open();
   });
@@ -289,7 +289,18 @@ function isElement(
   return elementConstructor != null && target instanceof elementConstructor;
 }
 
-function isTextEntryTarget(
+function isTextEntryShortcutTarget(
+  view: Window | null,
+  document: Document,
+  event: KeyboardEvent,
+): boolean {
+  if (event.composedPath().some((target) => isTextEntryElement(view, target))) {
+    return true;
+  }
+  return isTextEntryElement(view, getDeepActiveElement(document));
+}
+
+function isTextEntryElement(
   view: Window | null,
   target: EventTarget | null,
 ): boolean {
@@ -299,4 +310,12 @@ function isTextEntryTarget(
       'input, textarea, select, [contenteditable]:not([contenteditable="false"])',
     ) != null
   );
+}
+
+function getDeepActiveElement(document: Document): Element | null {
+  let activeElement = document.activeElement;
+  while (activeElement?.shadowRoot?.activeElement) {
+    activeElement = activeElement.shadowRoot.activeElement;
+  }
+  return activeElement;
 }

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -49,9 +49,11 @@ export function createDesktopCommandPalette({
   actions,
   platform = getRendererPlatform(document.defaultView),
 }: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
+  const view = document.defaultView;
   const entries = getDesktopCommandMenuEntries(undefined, platform);
   let visibleEntries = entries;
   let activeIndex = entries.length > 0 ? 0 : -1;
+  let previouslyFocusedElement: HTMLElement | null = null;
 
   const element = document.createElement('div');
   element.className = 'desktop-command-palette';
@@ -78,7 +80,7 @@ export function createDesktopCommandPalette({
   element.append(panel);
 
   const executeActiveCommand = (): void => {
-    const entry = visibleEntries.at(activeIndex);
+    const entry = visibleEntries[activeIndex];
     if (!entry) return;
     if (dispatchDesktopCommand(entry.id, actions)) close();
   };
@@ -136,6 +138,9 @@ export function createDesktopCommandPalette({
   };
 
   const open = (): void => {
+    previouslyFocusedElement = isHTMLElement(view, document.activeElement)
+      ? document.activeElement
+      : null;
     element.hidden = false;
     input.value = '';
     refreshFilter();
@@ -144,12 +149,26 @@ export function createDesktopCommandPalette({
 
   const close = (): void => {
     element.hidden = true;
+    if (previouslyFocusedElement?.isConnected) {
+      previouslyFocusedElement.focus();
+    }
+    previouslyFocusedElement = null;
   };
 
   element.addEventListener('click', (event) => {
     if (event.target === element) close();
   });
   input.addEventListener('input', refreshFilter);
+  element.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key === 'Tab') {
+      trapPaletteFocus(event, panel);
+    }
+  });
   input.addEventListener('keydown', (event) => {
     switch (event.key) {
       case 'ArrowDown':
@@ -207,4 +226,51 @@ function getRendererPlatform(view: Window | null): NodeJS.Platform {
   if (platform.includes('mac')) return 'darwin';
   if (platform.includes('win')) return 'win32';
   return 'linux';
+}
+
+function trapPaletteFocus(event: KeyboardEvent, panel: HTMLElement): void {
+  const focusableElements = getFocusableElements(panel);
+  if (focusableElements.length === 0) return;
+
+  const activeElement = panel.ownerDocument.activeElement;
+  const firstElement = focusableElements[0];
+  const lastElement = focusableElements.at(-1);
+  if (!firstElement || !lastElement) return;
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+    return;
+  }
+  if (!event.shiftKey && activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return [
+    ...container.querySelectorAll<HTMLElement>(
+      [
+        'button:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(','),
+    ),
+  ].filter((element) => !element.hidden);
+}
+
+function isHTMLElement(
+  view: Window | null,
+  element: Element | null,
+): element is HTMLElement {
+  const htmlElementConstructor =
+    view == null
+      ? undefined
+      : (view as Window & { HTMLElement?: typeof HTMLElement }).HTMLElement;
+  return (
+    htmlElementConstructor != null && element instanceof htmlElementConstructor
+  );
 }

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -60,6 +60,7 @@ export function createDesktopCommandPalette({
   element.hidden = true;
   element.setAttribute('role', 'dialog');
   element.setAttribute('aria-modal', 'true');
+  element.setAttribute('aria-label', 'Command palette');
 
   const panel = document.createElement('div');
   panel.className = 'desktop-command-palette-panel';

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -1,0 +1,210 @@
+import {
+  dispatchDesktopCommand,
+  getDesktopCommandMenuEntries,
+  type DesktopCommandActions,
+  type DesktopCommandMenuEntry,
+} from '../desktopCommandSurface';
+
+export interface DesktopCommandPaletteOptions {
+  document: Document;
+  actions: DesktopCommandActions;
+  platform?: NodeJS.Platform;
+}
+
+export interface DesktopCommandPaletteController {
+  element: HTMLElement;
+  open(): void;
+  close(): void;
+}
+
+const COMMAND_PALETTE_SHORTCUT_KEY = 'k';
+
+export function filterDesktopCommandPaletteEntries(
+  entries: readonly DesktopCommandMenuEntry[],
+  query: string,
+): DesktopCommandMenuEntry[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...entries];
+
+  const queryParts = normalizedQuery.split(/\s+/);
+  return entries.filter((entry) => {
+    const searchable = `${entry.label} ${entry.category} ${entry.id}`
+      .replaceAll('.', ' ')
+      .toLowerCase();
+    return queryParts.every((part) => searchable.includes(part));
+  });
+}
+
+export function getNextDesktopCommandPaletteIndex(
+  currentIndex: number,
+  itemCount: number,
+  delta: number,
+): number {
+  if (itemCount <= 0) return -1;
+  return (currentIndex + delta + itemCount) % itemCount;
+}
+
+export function createDesktopCommandPalette({
+  document,
+  actions,
+  platform = getRendererPlatform(document.defaultView),
+}: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
+  const entries = getDesktopCommandMenuEntries(undefined, platform);
+  let visibleEntries = entries;
+  let activeIndex = entries.length > 0 ? 0 : -1;
+
+  const element = document.createElement('div');
+  element.className = 'desktop-command-palette';
+  element.hidden = true;
+  element.setAttribute('role', 'dialog');
+  element.setAttribute('aria-modal', 'true');
+
+  const panel = document.createElement('div');
+  panel.className = 'desktop-command-palette-panel';
+
+  const input = document.createElement('input');
+  input.className = 'desktop-command-palette-input';
+  input.type = 'search';
+  input.autocomplete = 'off';
+  input.spellcheck = false;
+  input.placeholder = 'Run command';
+  input.setAttribute('aria-label', 'Run command');
+
+  const list = document.createElement('div');
+  list.className = 'desktop-command-palette-list';
+  list.setAttribute('role', 'listbox');
+
+  panel.append(input, list);
+  element.append(panel);
+
+  const executeActiveCommand = (): void => {
+    const entry = visibleEntries.at(activeIndex);
+    if (!entry) return;
+    if (dispatchDesktopCommand(entry.id, actions)) close();
+  };
+
+  const renderEntries = (): void => {
+    list.replaceChildren();
+    visibleEntries.forEach((entry, index) => {
+      const item = document.createElement('button');
+      item.className = 'desktop-command-palette-item';
+      item.type = 'button';
+      item.dataset.commandId = entry.id;
+      item.setAttribute('role', 'option');
+      item.setAttribute(
+        'aria-selected',
+        index === activeIndex ? 'true' : 'false',
+      );
+
+      const label = document.createElement('span');
+      label.className = 'desktop-command-palette-label';
+      label.textContent = entry.label;
+
+      const meta = document.createElement('span');
+      meta.className = 'desktop-command-palette-meta';
+      meta.textContent = entry.accelerator ?? entry.category;
+
+      item.append(label, meta);
+      item.addEventListener('mouseenter', () => {
+        activeIndex = index;
+        syncActiveItem();
+      });
+      item.addEventListener('click', () => {
+        if (dispatchDesktopCommand(entry.id, actions)) close();
+      });
+      list.append(item);
+    });
+  };
+
+  const syncActiveItem = (): void => {
+    const items = list.querySelectorAll<HTMLButtonElement>(
+      '.desktop-command-palette-item',
+    );
+    items.forEach((item, index) => {
+      item.setAttribute(
+        'aria-selected',
+        index === activeIndex ? 'true' : 'false',
+      );
+      if (index === activeIndex) item.scrollIntoView({ block: 'nearest' });
+    });
+  };
+
+  const refreshFilter = (): void => {
+    visibleEntries = filterDesktopCommandPaletteEntries(entries, input.value);
+    activeIndex = visibleEntries.length > 0 ? 0 : -1;
+    renderEntries();
+  };
+
+  const open = (): void => {
+    element.hidden = false;
+    input.value = '';
+    refreshFilter();
+    input.focus();
+  };
+
+  const close = (): void => {
+    element.hidden = true;
+  };
+
+  element.addEventListener('click', (event) => {
+    if (event.target === element) close();
+  });
+  input.addEventListener('input', refreshFilter);
+  input.addEventListener('keydown', (event) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        activeIndex = getNextDesktopCommandPaletteIndex(
+          activeIndex,
+          visibleEntries.length,
+          1,
+        );
+        syncActiveItem();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        activeIndex = getNextDesktopCommandPaletteIndex(
+          activeIndex,
+          visibleEntries.length,
+          -1,
+        );
+        syncActiveItem();
+        break;
+      case 'Enter':
+        event.preventDefault();
+        executeActiveCommand();
+        break;
+      case 'Escape':
+        event.preventDefault();
+        close();
+        break;
+      default:
+        break;
+    }
+  });
+
+  document.defaultView?.addEventListener('keydown', (event) => {
+    if (!isCommandPaletteShortcut(event)) return;
+    event.preventDefault();
+    open();
+  });
+
+  renderEntries();
+  return { element, open, close };
+}
+
+export function isCommandPaletteShortcut(event: KeyboardEvent): boolean {
+  return (
+    event.key.toLowerCase() === COMMAND_PALETTE_SHORTCUT_KEY &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
+function getRendererPlatform(view: Window | null): NodeJS.Platform {
+  const platform = view?.navigator.platform.toLowerCase() ?? '';
+  if (platform.includes('mac')) return 'darwin';
+  if (platform.includes('win')) return 'win32';
+  return 'linux';
+}

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -5,11 +5,14 @@ import '@progressView/frontend';
 import '@settingsView/frontend';
 import '@webview/frontend';
 
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+
 import {
   DesktopSetRouteMessageSchema,
   type DesktopRoute,
   type DesktopSetRouteMessage,
 } from '../desktopShellMessages';
+import { createDesktopCommandPalette } from './desktopCommandPalette';
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -30,6 +33,9 @@ appRoot.innerHTML = `
       </button>
       <button class="desktop-nav-button" type="button" data-route-button="settings" aria-pressed="false">
         Settings
+      </button>
+      <button class="desktop-command-button" type="button" data-command-palette-button aria-haspopup="dialog">
+        Commands
       </button>
     </nav>
     <main class="desktop-view" id="desktop-view">
@@ -82,6 +88,34 @@ routeContainers.get('main')?.replaceChildren(mainApp);
 routeContainers.get('progress')?.replaceChildren(progressApp);
 routeContainers.get('settings')?.replaceChildren(settingsApp);
 
+const commandPaletteButton = appRoot.querySelector<HTMLButtonElement>(
+  '[data-command-palette-button]',
+);
+if (commandPaletteButton == null) {
+  throw new Error('TeXRA desktop command palette button was not found.');
+}
+
+const commandPalette = createDesktopCommandPalette({
+  document,
+  actions: {
+    showRoute: setRoute,
+    showSettings: (tabIndex, agentSubTab) => {
+      setRoute('settings');
+      if (tabIndex == null) return;
+      window.postMessage(
+        {
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex,
+          ...(agentSubTab && { agentSubTab }),
+        },
+        getWindowTargetOrigin(),
+      );
+    },
+  },
+});
+appRoot.append(commandPalette.element);
+commandPaletteButton.addEventListener('click', commandPalette.open);
+
 function isDesktopSetRouteMessage(
   message: unknown,
 ): message is DesktopSetRouteMessage {
@@ -103,3 +137,9 @@ window.addEventListener('message', (event) => {
     setRoute(event.data.route);
   }
 });
+
+function getWindowTargetOrigin(): string {
+  return window.location.origin && window.location.origin !== 'null'
+    ? window.location.origin
+    : '*';
+}

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -139,6 +139,7 @@ window.addEventListener('message', (event) => {
 });
 
 function getWindowTargetOrigin(): string {
+  // Electron loads this renderer over file://, where origin is "null".
   return window.location.origin && window.location.origin !== 'null'
     ? window.location.origin
     : '*';

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -49,6 +49,22 @@ body {
   background: var(--texra-button-secondaryBackground);
 }
 
+.desktop-command-button {
+  height: 28px;
+  margin-left: auto;
+  padding: 0 10px;
+  border: 1px solid var(--texra-panel-border);
+  border-radius: 4px;
+  background: var(--texra-button-secondaryBackground);
+  color: var(--texra-foreground);
+  font: inherit;
+  cursor: pointer;
+}
+
+.desktop-command-button:hover {
+  background: var(--texra-toolbar-hoverBackground);
+}
+
 .desktop-view {
   display: block;
   min-width: 0;
@@ -68,4 +84,82 @@ body {
 .desktop-route > * {
   display: block;
   min-height: 100%;
+}
+
+.desktop-command-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: start center;
+  padding: 12vh 16px 16px;
+  box-sizing: border-box;
+  background: rgb(0 0 0 / 35%);
+}
+
+.desktop-command-palette[hidden] {
+  display: none;
+}
+
+.desktop-command-palette-panel {
+  width: min(560px, 100%);
+  border: 1px solid var(--texra-panel-border);
+  border-radius: 6px;
+  background: var(--texra-editor-background);
+  box-shadow: 0 16px 40px rgb(0 0 0 / 32%);
+  overflow: hidden;
+}
+
+.desktop-command-palette-input {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  border: 0;
+  border-bottom: 1px solid var(--texra-panel-border);
+  outline: 0;
+  background: var(--texra-input-background);
+  color: var(--texra-input-foreground);
+  font: inherit;
+}
+
+.desktop-command-palette-list {
+  max-height: min(420px, 58vh);
+  overflow: auto;
+  padding: 4px;
+}
+
+.desktop-command-palette-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  min-height: 34px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--texra-foreground);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.desktop-command-palette-item[aria-selected='true'] {
+  background: var(--texra-list-activeSelectionBackground);
+  color: var(--texra-list-activeSelectionForeground);
+}
+
+.desktop-command-palette-label,
+.desktop-command-palette-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.desktop-command-palette-meta {
+  color: var(--texra-descriptionForeground);
+  font-size: 12px;
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -123,6 +123,11 @@ body {
   font: inherit;
 }
 
+.desktop-command-palette-input:focus {
+  outline: 2px solid var(--texra-focusBorder);
+  outline-offset: -2px;
+}
+
 .desktop-command-palette-list {
   max-height: min(420px, 58vh);
   overflow: auto;

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -281,4 +281,34 @@ describe('desktop command palette', () => {
     );
     expect(controller.element.hidden).toBe(false);
   });
+
+  it('does not steal shortcuts from shadow-dom text entry targets', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const dom = new JSDOM('<main-app id="host"></main-app>');
+    const host = dom.window.document.querySelector<HTMLElement>('#host');
+    const shadowRoot = host?.attachShadow({ mode: 'open' });
+    const shadowInput = dom.window.document.createElement('input');
+    shadowRoot?.append(shadowInput);
+    const controller = createDesktopCommandPalette({
+      document: dom.window.document,
+      actions: {
+        showRoute: vi.fn(),
+        showSettings: vi.fn(),
+      },
+      platform: 'darwin',
+    });
+
+    dom.window.document.body.append(controller.element);
+    shadowInput.focus();
+    shadowInput.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    expect(controller.element.hidden).toBe(true);
+  });
 });

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -1,0 +1,100 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopCommandPaletteModule {
+  filterDesktopCommandPaletteEntries(
+    entries: DesktopPaletteEntry[],
+    query: string,
+  ): DesktopPaletteEntry[];
+  getNextDesktopCommandPaletteIndex(
+    currentIndex: number,
+    itemCount: number,
+    delta: number,
+  ): number;
+  isCommandPaletteShortcut(event: KeyboardEvent): boolean;
+}
+
+interface DesktopPaletteEntry {
+  id: string;
+  label: string;
+  category: string;
+  accelerator?: string;
+}
+
+async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('renderer', 'desktopCommandPalette.ts'))
+  ) as Promise<DesktopCommandPaletteModule>;
+}
+
+describe('desktop command palette', () => {
+  const entries = [
+    {
+      id: 'texra.showMainView',
+      label: 'Show Launcher',
+      category: 'TeXRA',
+      accelerator: 'Command+Option+M',
+    },
+    {
+      id: 'texra.showProgressView',
+      label: 'Show Progress',
+      category: 'TeXRA',
+      accelerator: 'Command+Option+P',
+    },
+    {
+      id: 'texra.showModels',
+      label: 'Show Models',
+      category: 'TeXRA',
+    },
+  ];
+
+  it('filters command entries by label, category, and id tokens', async () => {
+    const { filterDesktopCommandPaletteEntries } =
+      await loadDesktopCommandPalette();
+
+    expect(
+      filterDesktopCommandPaletteEntries(entries, 'progress').map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(['texra.showProgressView']);
+    expect(
+      filterDesktopCommandPaletteEntries(entries, 'texra models').map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(['texra.showModels']);
+    expect(
+      filterDesktopCommandPaletteEntries(entries, '').map((entry) => entry.id),
+    ).toEqual(entries.map((entry) => entry.id));
+  });
+
+  it('wraps active command selection through filtered entries', async () => {
+    const { getNextDesktopCommandPaletteIndex } =
+      await loadDesktopCommandPalette();
+
+    expect(getNextDesktopCommandPaletteIndex(0, 3, 1)).toBe(1);
+    expect(getNextDesktopCommandPaletteIndex(2, 3, 1)).toBe(0);
+    expect(getNextDesktopCommandPaletteIndex(0, 3, -1)).toBe(2);
+    expect(getNextDesktopCommandPaletteIndex(0, 0, 1)).toBe(-1);
+  });
+
+  it('uses the native command palette shortcut shape', async () => {
+    const { isCommandPaletteShortcut } = await loadDesktopCommandPalette();
+
+    expect(
+      isCommandPaletteShortcut({ key: 'k', metaKey: true } as KeyboardEvent),
+    ).toBe(true);
+    expect(
+      isCommandPaletteShortcut({ key: 'k', ctrlKey: true } as KeyboardEvent),
+    ).toBe(true);
+    expect(
+      isCommandPaletteShortcut({
+        key: 'k',
+        metaKey: true,
+        shiftKey: true,
+      } as KeyboardEvent),
+    ).toBe(false);
+  });
+});

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -212,4 +212,73 @@ describe('desktop command palette', () => {
     expect(controller.element.hidden).toBe(true);
     expect(dom.window.document.activeElement).toBe(trigger);
   });
+
+  it('keeps the original focus restoration target across repeated opens', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const dom = new JSDOM('<button id="trigger">Commands</button>');
+    const trigger =
+      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
+    const controller = createDesktopCommandPalette({
+      document: dom.window.document,
+      actions: {
+        showRoute: vi.fn(),
+        showSettings: vi.fn(),
+      },
+      platform: 'darwin',
+    });
+
+    dom.window.document.body.append(controller.element);
+    trigger?.focus();
+    controller.open();
+    expect(
+      controller.element.querySelector<HTMLInputElement>(
+        '.desktop-command-palette-input',
+      ),
+    ).toBe(dom.window.document.activeElement);
+
+    controller.open();
+    controller.close();
+
+    expect(dom.window.document.activeElement).toBe(trigger);
+  });
+
+  it('does not steal command palette shortcuts from text entry targets', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const dom = new JSDOM(
+      '<button id="trigger">Commands</button><input id="search" />',
+    );
+    const trigger =
+      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
+    const search =
+      dom.window.document.querySelector<HTMLInputElement>('#search');
+    const controller = createDesktopCommandPalette({
+      document: dom.window.document,
+      actions: {
+        showRoute: vi.fn(),
+        showSettings: vi.fn(),
+      },
+      platform: 'darwin',
+    });
+
+    dom.window.document.body.append(controller.element);
+    search?.focus();
+    search?.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+      }),
+    );
+    expect(controller.element.hidden).toBe(true);
+
+    trigger?.focus();
+    trigger?.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'k',
+        metaKey: true,
+        bubbles: true,
+      }),
+    );
+    expect(controller.element.hidden).toBe(false);
+  });
 });

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -1,10 +1,26 @@
 // Third-party imports
-import { describe, expect, it } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - shared schemas
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 interface DesktopCommandPaletteModule {
+  createDesktopCommandPalette(options: {
+    document: Document;
+    actions: {
+      showRoute(route: string): void;
+      showSettings(tabIndex?: number): void;
+    };
+    platform?: NodeJS.Platform;
+  }): {
+    element: HTMLElement;
+    open(): void;
+    close(): void;
+  };
   filterDesktopCommandPaletteEntries(
     entries: DesktopPaletteEntry[],
     query: string,
@@ -96,5 +112,104 @@ describe('desktop command palette', () => {
         shiftKey: true,
       } as KeyboardEvent),
     ).toBe(false);
+  });
+
+  it('renders catalog entries and dispatches the active command', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const dom = new JSDOM('<button id="trigger">Commands</button>');
+    const actions = {
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
+    const controller = createDesktopCommandPalette({
+      document: dom.window.document,
+      actions,
+      platform: 'darwin',
+    });
+
+    dom.window.document.body.append(controller.element);
+    controller.open();
+
+    const input = controller.element.querySelector<HTMLInputElement>(
+      '.desktop-command-palette-input',
+    );
+    const initialItems = controller.element.querySelectorAll<HTMLButtonElement>(
+      '.desktop-command-palette-item',
+    );
+    expect(input).not.toBeNull();
+    expect(initialItems.length).toBeGreaterThan(1);
+
+    input!.value = 'models';
+    input!.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    const filteredItems =
+      controller.element.querySelectorAll<HTMLButtonElement>(
+        '.desktop-command-palette-item',
+      );
+    expect([...filteredItems].map((item) => item.dataset.commandId)).toEqual([
+      'texra.showModels',
+    ]);
+
+    input!.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+      }),
+    );
+    expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+    expect(controller.element.hidden).toBe(true);
+  });
+
+  it('traps focus while open and restores focus when closed', async () => {
+    const { createDesktopCommandPalette } = await loadDesktopCommandPalette();
+    const dom = new JSDOM('<button id="trigger">Commands</button>');
+    const trigger =
+      dom.window.document.querySelector<HTMLButtonElement>('#trigger');
+    const controller = createDesktopCommandPalette({
+      document: dom.window.document,
+      actions: {
+        showRoute: vi.fn(),
+        showSettings: vi.fn(),
+      },
+      platform: 'darwin',
+    });
+
+    dom.window.document.body.append(controller.element);
+    trigger?.focus();
+    controller.open();
+
+    const input = controller.element.querySelector<HTMLInputElement>(
+      '.desktop-command-palette-input',
+    );
+    expect(dom.window.document.activeElement).toBe(input);
+
+    input!.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    expect(
+      dom.window.document.activeElement?.classList.contains(
+        'desktop-command-palette-item',
+      ),
+    ).toBe(true);
+
+    dom.window.document.activeElement?.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+      }),
+    );
+    expect(dom.window.document.activeElement).toBe(input);
+
+    input!.dispatchEvent(
+      new dom.window.KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+      }),
+    );
+    expect(controller.element.hidden).toBe(true);
+    expect(dom.window.document.activeElement).toBe(trigger);
   });
 });

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -130,6 +130,9 @@ describe('desktop command palette', () => {
     dom.window.document.body.append(controller.element);
     controller.open();
 
+    expect(controller.element.getAttribute('aria-label')).toBe(
+      'Command palette',
+    );
     const input = controller.element.querySelector<HTMLInputElement>(
       '.desktop-command-palette-input',
     );

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -9,19 +9,22 @@ import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
-import type { DesktopShellActions } from '../../../packages/desktop/src/main/desktopShellIpc';
+import type { DesktopCommandActions } from '../../../packages/desktop/src/desktopCommandSurface';
 
 interface DesktopCommandSurfaceModule {
   DESKTOP_COMMAND_IDS: readonly CommandId[];
   buildDesktopMenuTemplate(
-    actions: DesktopShellActions,
+    actions: DesktopCommandActions,
     platform?: NodeJS.Platform,
   ): Array<{
     label?: string;
     role?: string;
     submenu?: DesktopMenuItem[];
   }>;
-  dispatchDesktopCommand(id: CommandId, actions: DesktopShellActions): boolean;
+  dispatchDesktopCommand(
+    id: CommandId,
+    actions: DesktopCommandActions,
+  ): boolean;
   getDesktopCommandMenuEntries(
     ids?: readonly CommandId[],
     platform?: NodeJS.Platform,
@@ -47,7 +50,7 @@ interface DesktopMenuItem {
 
 async function loadDesktopCommandSurface(): Promise<DesktopCommandSurfaceModule> {
   return import(
-    moduleFileUrl(desktopSourcePath('main', 'desktopCommandSurface.ts'))
+    moduleFileUrl(desktopSourcePath('desktopCommandSurface.ts'))
   ) as Promise<DesktopCommandSurfaceModule>;
 }
 
@@ -98,8 +101,6 @@ describe('desktop command surface', () => {
   it('dispatches supported commands through typed shell actions', async () => {
     const { dispatchDesktopCommand } = await loadDesktopCommandSurface();
     const actions = {
-      openAgentDirectory: vi.fn(),
-      setRecentCommitsUnavailable: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };
@@ -129,8 +130,6 @@ describe('desktop command surface', () => {
   it('wires menu clicks to the catalog-backed dispatcher', async () => {
     const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
     const actions = {
-      openAgentDirectory: vi.fn(),
-      setRecentCommitsUnavailable: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -43,4 +43,13 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain("button.addEventListener('click'");
     expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
   });
+
+  it('mounts the catalog-backed command palette', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('createDesktopCommandPalette');
+    expect(rendererMain).toContain('data-command-palette-button');
+    expect(rendererMain).toContain('SETTINGS_VIEW_COMMANDS.SET_TAB');
+    expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
+  });
 });


### PR DESCRIPTION
## Summary

- Add an Electron renderer command palette opened from the desktop shell or Cmd/Ctrl+K.
- Generate palette entries from the shared command catalog and dispatch through the same typed desktop command actions used by the native menu.
- Move the desktop command surface out of `main/` so both the Electron main process and renderer can share it.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopCommandPalette.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run desktop:build`
- `npm run smoke:webviews`
- `npm run compile:safe`
- `npm run desktop:package:local`
- `npm run desktop:package:smoke`

Closes #3500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new renderer UI + global Cmd/Ctrl+K shortcut and refactors shared command dispatch/types used by both main and renderer, which could affect desktop navigation and settings routing if miswired.
> 
> **Overview**
> Adds a **renderer-side command palette** (open via *Cmd/Ctrl+K* or a new “Commands” button) that filters and executes desktop commands sourced from the shared command catalog.
> 
> Refactors `desktopCommandSurface` into a shared module with a new `DesktopCommandActions` interface so both the Electron main-process menu (`buildDesktopMenuTemplate`) and the renderer palette dispatch through the same `dispatchDesktopCommand` wiring, including posting `SETTINGS_VIEW_COMMANDS.SET_TAB` when switching settings tabs. Includes new palette UI styles and focused Vitest coverage for filtering, selection wraparound, shortcut handling, and focus trapping/restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac7dc5e10a2ff1ea55e844c0cfa464cfc6bd5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->