### PR TITLE
Consolidate desktop settings-tab message construction

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -3,6 +3,7 @@ import {
   type CommandId,
   type CommandKeybinding,
 } from '@commands/catalog';
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { type AgentCategory } from '@shared/schemas/agent';
 import {
   SETTINGS_TAB,
@@ -35,6 +36,12 @@ export interface DesktopCommandMenuEntry {
 export interface DesktopCommandActions {
   showRoute(route: DesktopRoute): void;
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
+}
+
+export interface DesktopSettingsTabMessage {
+  command: typeof SETTINGS_VIEW_COMMANDS.SET_TAB;
+  tabIndex: SettingsTab;
+  agentSubTab?: AgentCategory;
 }
 
 const DESKTOP_MENU_GROUPS = [
@@ -114,6 +121,17 @@ export function dispatchDesktopCommand(
     default:
       return false;
   }
+}
+
+export function buildDesktopSettingsTabMessage(
+  tabIndex: SettingsTab,
+  agentSubTab?: AgentCategory,
+): DesktopSettingsTabMessage {
+  return {
+    command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+    tabIndex,
+    ...(agentSubTab && { agentSubTab }),
+  };
 }
 
 export function buildDesktopMenuTemplate(

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -1,6 +1,5 @@
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
-import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { AGENT_CATEGORY, type AgentCategory } from '@shared/schemas/agent';
 import {
   SwitchViewMessageSchema,
@@ -20,7 +19,10 @@ import {
   type DesktopMessageHandler,
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
-import type { DesktopCommandActions } from '../desktopCommandSurface.js';
+import {
+  buildDesktopSettingsTabMessage,
+  type DesktopCommandActions,
+} from '../desktopCommandSurface.js';
 
 export interface DesktopShellIpcOptions {
   actions?: DesktopShellActions;
@@ -65,11 +67,9 @@ export function createDesktopShellActions(
   ) {
     postRoute('settings');
     if (tabIndex == null) return;
-    renderer.postToRenderer({
-      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-      tabIndex,
-      ...(agentSubTab && { agentSubTab }),
-    });
+    renderer.postToRenderer(
+      buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
+    );
   }
 
   async function openCustomAgentDirectory() {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -5,13 +5,12 @@ import '@progressView/frontend';
 import '@settingsView/frontend';
 import '@webview/frontend';
 
-import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
-
 import {
   DesktopSetRouteMessageSchema,
   type DesktopRoute,
   type DesktopSetRouteMessage,
 } from '../desktopShellMessages';
+import { buildDesktopSettingsTabMessage } from '../desktopCommandSurface';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
 
 const root = document.querySelector<HTMLElement>('#app');
@@ -103,11 +102,7 @@ const commandPalette = createDesktopCommandPalette({
       setRoute('settings');
       if (tabIndex == null) return;
       window.postMessage(
-        {
-          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
-          tabIndex,
-          ...(agentSubTab && { agentSubTab }),
-        },
+        buildDesktopSettingsTabMessage(tabIndex, agentSubTab),
         getWindowTargetOrigin(),
       );
     },

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 // Local imports - command catalog
 import { commandCatalogById, type CommandId } from '@commands/catalog';
 
+// Local imports - webview commands
+import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
+
 // Local imports - shared schemas
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
@@ -141,7 +144,7 @@ describe('desktop command surface', () => {
       await loadDesktopCommandSurface();
 
     expect(buildDesktopSettingsTabMessage(SETTINGS_TAB.MODELS)).toEqual({
-      command: 'setTab',
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.MODELS,
     });
     expect(
@@ -151,7 +154,7 @@ describe('desktop command surface', () => {
       ),
     ).toEqual({
       agentSubTab: AGENT_CATEGORY.TOOL_USE,
-      command: 'setTab',
+      command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.AGENTS,
     });
   });

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { commandCatalogById, type CommandId } from '@commands/catalog';
 
 // Local imports - shared schemas
+import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 
 // Local imports - desktop test paths
@@ -38,6 +39,14 @@ interface DesktopCommandSurfaceModule {
     keybinding: { key: string; mac?: string },
     platform?: NodeJS.Platform,
   ): string;
+  buildDesktopSettingsTabMessage(
+    tabIndex: number,
+    agentSubTab?: string,
+  ): {
+    command: string;
+    tabIndex: number;
+    agentSubTab?: string;
+  };
 }
 
 interface DesktopMenuItem {
@@ -125,6 +134,26 @@ describe('desktop command surface', () => {
       3,
       SETTINGS_TAB.AGENTS,
     );
+  });
+
+  it('builds settings-tab messages from one shared helper', async () => {
+    const { buildDesktopSettingsTabMessage } =
+      await loadDesktopCommandSurface();
+
+    expect(buildDesktopSettingsTabMessage(SETTINGS_TAB.MODELS)).toEqual({
+      command: 'setTab',
+      tabIndex: SETTINGS_TAB.MODELS,
+    });
+    expect(
+      buildDesktopSettingsTabMessage(
+        SETTINGS_TAB.AGENTS,
+        AGENT_CATEGORY.TOOL_USE,
+      ),
+    ).toEqual({
+      agentSubTab: AGENT_CATEGORY.TOOL_USE,
+      command: 'setTab',
+      tabIndex: SETTINGS_TAB.AGENTS,
+    });
   });
 
   it('wires menu clicks to the catalog-backed dispatcher', async () => {

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -49,7 +49,7 @@ describe('desktop renderer shell', () => {
 
     expect(rendererMain).toContain('createDesktopCommandPalette');
     expect(rendererMain).toContain('data-command-palette-button');
-    expect(rendererMain).toContain('SETTINGS_VIEW_COMMANDS.SET_TAB');
+    expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
     expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
   });
 });


### PR DESCRIPTION
## Summary

- Add a shared `buildDesktopSettingsTabMessage` helper next to the desktop command surface.
- Route both the Electron main-process shell IPC and renderer command palette through the helper.
- Add command-surface coverage for the payload with and without the agent sub-tab.

## Why

The desktop renderer and main-process IPC were constructing the same settings-tab message object independently. Keeping the shape in one helper reduces drift as the settings-tab payload grows.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run format`

Closes #3505

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that consolidates construction of the settings-tab postMessage payload; behavior should be unchanged but mistakes could break settings tab navigation.
> 
> **Overview**
> Introduces a shared `buildDesktopSettingsTabMessage` helper (and typed `DesktopSettingsTabMessage`) on the desktop command surface to construct the `SETTINGS_VIEW_COMMANDS.SET_TAB` payload.
> 
> Updates both main-process shell IPC (`desktopShellIpc`) and the renderer command palette (`renderer/main.ts`) to use this helper instead of duplicating the message object, and adds/adjusts tests to cover the helper and assert the renderer uses it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a879def3414d93d91a431545ea3487a55abbe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->