### PR TITLE
Fix desktop progress stream delete race

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -458,7 +458,6 @@ export class DesktopProgressBridge {
       this.streamLogs.has(streamId) || this.taskStates.has(streamId);
     if (!hadStream) return;
 
-    const wasActive = this.activeStream === streamId;
     await this.streamLogs.delete(streamId);
     this.taskStates.delete(streamId);
     this.statuses.delete(streamId);
@@ -471,7 +470,7 @@ export class DesktopProgressBridge {
     this.streamBadges.delete(streamId);
     this.cursors.delete(streamId);
 
-    const shouldSelectFallback = wasActive && this.activeStream === streamId;
+    const shouldSelectFallback = this.activeStream === streamId;
     if (shouldSelectFallback) {
       this.activeStream = this.streamLogs.keys()[0] ?? '';
     }

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -471,7 +471,8 @@ export class DesktopProgressBridge {
     this.streamBadges.delete(streamId);
     this.cursors.delete(streamId);
 
-    if (wasActive) {
+    const shouldSelectFallback = wasActive && this.activeStream === streamId;
+    if (shouldSelectFallback) {
       this.activeStream = this.streamLogs.keys()[0] ?? '';
     }
     this.send({
@@ -479,7 +480,7 @@ export class DesktopProgressBridge {
       stream: streamId,
     });
     this.syncStreams();
-    if (wasActive && this.activeStream) {
+    if (shouldSelectFallback && this.activeStream) {
       this.send({
         command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
         activeStream: this.activeStream,

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -56,16 +56,15 @@ export class ProgressStreamLifecycleController {
 
     let shouldActivateStream = false;
     const activeAfterClear = this.deps.state.getActiveStream();
-    const shouldSelectFallback = activeAfterClear === stream;
+    const shouldSelectFallback = wasActive || activeAfterClear === stream;
     if (shouldSelectFallback) {
-      this.deps.state.setActiveStream(
-        this.deps.state.pickValidActiveStream(
-          this.deps.host.getVisibleStreamIds(),
-        ),
-      );
-      shouldActivateStream = true;
-    } else if (wasActive && activeAfterClear) {
-      shouldActivateStream = true;
+      const visibleStreams = this.deps.host.getVisibleStreamIds();
+      const nextActive =
+        visibleStreams.length === 0
+          ? ''
+          : this.deps.state.pickValidActiveStream(visibleStreams);
+      this.deps.state.setActiveStream(nextActive);
+      shouldActivateStream = nextActive !== '';
     }
 
     this.deps.host.deleteRenderedStream(stream);

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -54,20 +54,24 @@ export class ProgressStreamLifecycleController {
     const wasActive = this.deps.state.getActiveStream() === stream;
     await this.deps.state.clearStream(stream);
 
-    const shouldSelectFallback =
-      wasActive && this.deps.state.getActiveStream() === stream;
+    let shouldActivateStream = false;
+    const activeAfterClear = this.deps.state.getActiveStream();
+    const shouldSelectFallback = activeAfterClear === stream;
     if (shouldSelectFallback) {
       this.deps.state.setActiveStream(
         this.deps.state.pickValidActiveStream(
           this.deps.host.getVisibleStreamIds(),
         ),
       );
+      shouldActivateStream = true;
+    } else if (wasActive && activeAfterClear) {
+      shouldActivateStream = true;
     }
 
     this.deps.host.deleteRenderedStream(stream);
 
     const nextActive = this.deps.state.getActiveStream();
-    if (shouldSelectFallback && nextActive) {
+    if (shouldActivateStream && nextActive) {
       await this.deps.host.activateStream(nextActive);
     }
   }

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -56,15 +56,18 @@ export class ProgressStreamLifecycleController {
 
     let shouldActivateStream = false;
     const activeAfterClear = this.deps.state.getActiveStream();
-    const shouldSelectFallback = wasActive || activeAfterClear === stream;
-    if (shouldSelectFallback) {
-      const visibleStreams = this.deps.host.getVisibleStreamIds();
+    const visibleStreams = this.deps.host.getVisibleStreamIds();
+    const hasVisibleActive =
+      activeAfterClear !== '' && visibleStreams.includes(activeAfterClear);
+    if (activeAfterClear === stream || (wasActive && !hasVisibleActive)) {
       const nextActive =
         visibleStreams.length === 0
           ? ''
           : this.deps.state.pickValidActiveStream(visibleStreams);
       this.deps.state.setActiveStream(nextActive);
       shouldActivateStream = nextActive !== '';
+    } else if (wasActive && hasVisibleActive) {
+      shouldActivateStream = true;
     }
 
     this.deps.host.deleteRenderedStream(stream);

--- a/src/controllers/progressView/ProgressStreamLifecycleController.ts
+++ b/src/controllers/progressView/ProgressStreamLifecycleController.ts
@@ -54,7 +54,9 @@ export class ProgressStreamLifecycleController {
     const wasActive = this.deps.state.getActiveStream() === stream;
     await this.deps.state.clearStream(stream);
 
-    if (wasActive) {
+    const shouldSelectFallback =
+      wasActive && this.deps.state.getActiveStream() === stream;
+    if (shouldSelectFallback) {
       this.deps.state.setActiveStream(
         this.deps.state.pickValidActiveStream(
           this.deps.host.getVisibleStreamIds(),
@@ -65,7 +67,7 @@ export class ProgressStreamLifecycleController {
     this.deps.host.deleteRenderedStream(stream);
 
     const nextActive = this.deps.state.getActiveStream();
-    if (wasActive && nextActive) {
+    if (shouldSelectFallback && nextActive) {
       await this.deps.host.activateStream(nextActive);
     }
   }

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -474,6 +474,53 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('falls back if a deleted stream is reactivated during deletion', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'first',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'second',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.setActiveStream('first');
+      messages.length = 0;
+
+      const deletePromise = bridge.deleteStream('second');
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'second',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      await deletePromise;
+
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
+      ).toEqual([
+        {
+          activeStream: 'second',
+          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        },
+        {
+          activeStream: 'first',
+          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        },
+      ]);
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+          -1,
+        ),
+      ).toMatchObject({
+        activeStream: 'first',
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('emits delete-all cleanup before syncing an empty stream list', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000);
     const messages: unknown[] = [];

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -430,6 +430,50 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('preserves renderer stream switches that land during active stream deletion', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'first',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'second',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.handleProgressEvent('setActiveStream', {
+        streamId: 'third',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+      });
+      bridge.setActiveStream('second');
+      messages.length = 0;
+
+      const deletePromise = bridge.deleteStream('second');
+      bridge.setActiveStream('third');
+      await deletePromise;
+
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM),
+      ).toEqual([
+        {
+          activeStream: 'third',
+          command: PROGRESS_VIEW_COMMANDS.SET_ACTIVE_STREAM,
+        },
+      ]);
+      expect(
+        progressMessages(messages, PROGRESS_VIEW_COMMANDS.UPDATE_STREAMS).at(
+          -1,
+        ),
+      ).toMatchObject({
+        activeStream: 'third',
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
   it('emits delete-all cleanup before syncing an empty stream list', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1_000);
     const messages: unknown[] = [];

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -51,6 +51,24 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
   });
 
+  it('preserves stream switches that land during active stream deletion', async () => {
+    const { controller, recorder, state, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        streams: ['stream-a', 'stream-b', 'stream-c'],
+        activeStream: 'stream-a',
+        visibleStreams: ['stream-b', 'stream-c'],
+      });
+
+    const deletePromise = controller.deleteStream('stream-a');
+    state.setActiveStream('stream-c');
+    await deletePromise;
+
+    assert.deepEqual(streams(), ['stream-b', 'stream-c']);
+    assert.equal(activeStream(), 'stream-c');
+    assert.deepEqual(recorder.calls.get('setActiveStream'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
+  });
+
   it('stops running streams and activates the next visible stream', async () => {
     const { controller, recorder, streams, activeStream } =
       createProgressStreamLifecycleHarness({

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -51,6 +51,38 @@ describe('ProgressStreamLifecycleController', () => {
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
   });
 
+  it('skips hidden fallback streams after deleting the active stream', async () => {
+    const { controller, recorder, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        streams: ['stream-a', 'hidden', 'stream-c'],
+        activeStream: 'stream-a',
+        visibleStreams: ['stream-c'],
+      });
+
+    await controller.deleteStream('stream-a');
+
+    assert.deepEqual(streams(), ['hidden', 'stream-c']);
+    assert.equal(activeStream(), 'stream-c');
+    assert.deepEqual(recorder.calls.get('setActiveStream'), ['stream-c']);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
+  });
+
+  it('clears active stream when no visible fallback remains', async () => {
+    const { controller, recorder, streams, activeStream } =
+      createProgressStreamLifecycleHarness({
+        streams: ['stream-a', 'hidden'],
+        activeStream: 'stream-a',
+        visibleStreams: [],
+      });
+
+    await controller.deleteStream('stream-a');
+
+    assert.deepEqual(streams(), ['hidden']);
+    assert.equal(activeStream(), '');
+    assert.deepEqual(recorder.calls.get('setActiveStream'), undefined);
+    assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
+  });
+
   it('preserves stream switches that land during active stream deletion', async () => {
     const { controller, recorder, state, streams, activeStream } =
       createProgressStreamLifecycleHarness({

--- a/src/test/controllers/ProgressStreamLifecycleController.test.ts
+++ b/src/test/controllers/ProgressStreamLifecycleController.test.ts
@@ -65,7 +65,7 @@ describe('ProgressStreamLifecycleController', () => {
 
     assert.deepEqual(streams(), ['stream-b', 'stream-c']);
     assert.equal(activeStream(), 'stream-c');
-    assert.deepEqual(recorder.calls.get('setActiveStream'), undefined);
+    assert.deepEqual(recorder.calls.get('setActiveStream'), ['stream-c']);
     assert.deepEqual(recorder.calls.get('deleteWebview'), ['stream-a']);
   });
 

--- a/src/test/support/ProgressControllerHarnesses.ts
+++ b/src/test/support/ProgressControllerHarnesses.ts
@@ -67,6 +67,9 @@ export function createProgressStreamLifecycleHarness(
     pickValidActiveStream: (availableStreams) => availableStreams[0] ?? '',
     clearStream: async (stream) => {
       streams = streams.filter((candidate) => candidate !== stream);
+      if (activeStream === stream) {
+        activeStream = streams[0] ?? '';
+      }
     },
     clearAll: async () => {
       streams = [];


### PR DESCRIPTION
## Summary

- Keep a concurrent renderer stream switch from being overwritten after deleting the previously active stream.
- Apply the same post-await active-stream re-check in both the desktop progress bridge and the shared extension progress lifecycle controller.
- Add regressions for desktop bridge deletion and the extension/controller delete path.

## Root cause

Both delete paths captured whether the deleted stream was active before awaiting deletion work. During that await, renderer/frontend IPC can switch to another stream. The old post-await fallback still used the stale pre-await `wasActive` value and could reset the active stream to the first remaining stream.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run compile-tests`
- `npm run desktop:build`
- `npm run format`

Note: `src/test/controllers/ProgressStreamLifecycleController.test.ts` is part of the repo's Mocha/VS Code test suite rather than the Vitest include set, so I validated it through `npm run compile-tests` and the shared logic through typecheck/lint.

Closes #3497

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts active-stream selection during stream deletion to account for concurrent renderer/state updates; mistakes could still cause incorrect active stream or activation behavior in edge cases.
> 
> **Overview**
> Fixes a race where deleting a stream could overwrite a concurrent active-stream switch by re-checking the active stream *after* async deletion work and only applying fallback selection when the deleted stream is still active.
> 
> Mirrors this logic in the shared `ProgressStreamLifecycleController` by activating a next stream only when needed and ensuring fallbacks come from *visible* streams (or clearing active when none remain). Adds regression tests for both the desktop bridge and controller deletion paths, plus a harness tweak to better simulate active-stream changes during `clearStream`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5dcb5109a3a7036bc24f7d23556728a318a4d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->