### PR TITLE
Fix packaged desktop startup verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Build initial extension and desktop artifacts
         run: pnpm run build:initial
 
+      - name: Package desktop app
+        if: runner.os == 'macOS'
+        run: pnpm run desktop:package:local
+
+      - name: Check desktop package
+        if: runner.os == 'macOS'
+        run: pnpm run check:desktop-package
+
+      - name: Smoke packaged desktop launch
+        if: runner.os == 'macOS'
+        run: pnpm run desktop:package:smoke
+
       - name: Smoke extension webviews in Electron
         if: runner.os == 'macOS'
         run: pnpm run smoke:webviews:run

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -12,6 +12,11 @@ files:
     filter:
       - '**/*'
   - package.json
+extraResources:
+  - from: ../extension/resources
+    to: resources
+    filter:
+      - '**/*'
 mac:
   icon: build/icon.icns
   target:

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 await esbuild.build({
-  entryPoints: [resolve(__dirname, 'src/main/index.ts')],
+  entryPoints: [resolve(__dirname, 'src/main/bootstrap.ts')],
   bundle: true,
   platform: 'node',
   format: 'esm',

--- a/packages/desktop/src/main/bootstrap.ts
+++ b/packages/desktop/src/main/bootstrap.ts
@@ -1,0 +1,60 @@
+import { app, dialog } from 'electron';
+
+let fatalStartupErrorReported = false;
+
+function formatFatalStartupError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function reportFatalStartupError(error: unknown): void {
+  if (fatalStartupErrorReported) return;
+  fatalStartupErrorReported = true;
+
+  const detail = formatFatalStartupError(error);
+  console.error(`Fatal TeXRA desktop error:\n${detail}`);
+
+  const showFailureDialog = () => {
+    dialog.showErrorBox(
+      'TeXRA failed to start',
+      [
+        'TeXRA hit a startup error before the desktop window was ready.',
+        '',
+        detail,
+      ].join('\n'),
+    );
+    app.quit();
+  };
+
+  if (app.isReady()) {
+    showFailureDialog();
+    return;
+  }
+
+  app.once('ready', showFailureDialog);
+}
+
+function installFatalStartupHandlers(): () => void {
+  const onUncaughtException = (error: unknown) =>
+    reportFatalStartupError(error);
+  const onUnhandledRejection = (error: unknown) =>
+    reportFatalStartupError(error);
+
+  process.on('uncaughtException', onUncaughtException);
+  process.on('unhandledRejection', onUnhandledRejection);
+
+  return () => {
+    process.off('uncaughtException', onUncaughtException);
+    process.off('unhandledRejection', onUnhandledRejection);
+  };
+}
+
+const removeFatalStartupHandlers = installFatalStartupHandlers();
+try {
+  await import('./index.js');
+  removeFatalStartupHandlers();
+} catch (error) {
+  reportFatalStartupError(error);
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -14,8 +14,15 @@ import { initializeElectronPlatform } from './platform/index.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
-const PRODUCTION_CSP =
-  "default-src 'self'; script-src 'self'; style-src 'self';";
+// The packaged renderer uses Lit style attributes and bundled font data URLs
+// (codicons/KaTeX). Keep script execution locked to app files while allowing
+// those renderer primitives.
+const PRODUCTION_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+].join('; ');
 const DEVELOPMENT_CSP = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-eval'",

--- a/packages/extension/src/progressView/persistence/StreamTabStore.ts
+++ b/packages/extension/src/progressView/persistence/StreamTabStore.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'path';
 
-import { KVStore } from '@common/storage';
+import { KVStore } from '@common/storage/KVStore';
 import * as logger from '@logger/logUtils';
 
 import type {

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -27,11 +27,15 @@ const fatalLogPatterns = [
   },
   {
     label: 'desktop startup failure',
-    pattern: /Failed to start TeXRA desktop/i,
+    pattern: /Failed to start TeXRA desktop|Fatal TeXRA desktop error/i,
   },
   {
     label: 'unhandled runtime exception',
     pattern: /Uncaught Exception|UnhandledPromiseRejection/i,
+  },
+  {
+    label: 'constructor startup failure',
+    pattern: /TypeError: .* is not a constructor/i,
   },
 ];
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -1,6 +1,6 @@
 import { access, readdir, readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { basename, join, relative } from 'node:path';
+import { basename, dirname, join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
@@ -25,6 +25,7 @@ const desktopVscodeFreeSourceDirSet = new Set(desktopVscodeFreeSourceDirs);
 const desktopSourceBoundaryDirs = [
   ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
 ];
+const bundledAgentResourceDirs = ['agents', 'tool_use_agents'];
 
 async function exists(path) {
   try {
@@ -96,10 +97,12 @@ function normalizeAsarPath(path) {
 
 function createAsarAppReader(asarPath) {
   const entries = new Set(listPackage(asarPath));
+  const resourceRoot = dirname(asarPath);
   return {
     label: relative(repoRoot, asarPath),
     async exists(path) {
-      return entries.has(normalizeAsarPath(path));
+      if (entries.has(normalizeAsarPath(path))) return true;
+      return exists(join(resourceRoot, path));
     },
     async readJson(path) {
       return JSON.parse(extractFile(asarPath, path).toString('utf8'));
@@ -109,11 +112,18 @@ function createAsarAppReader(asarPath) {
     },
     async listDir(path) {
       const prefix = `${normalizeAsarPath(path)}/`;
-      return [...entries]
+      const asarEntries = [...entries]
         .filter((entry) => entry.startsWith(prefix))
         .map((entry) => entry.slice(prefix.length))
         .filter((entry) => entry && !entry.includes('/'))
         .map((entry) => basename(entry));
+      if (asarEntries.length > 0) return asarEntries;
+      try {
+        return await readdir(join(resourceRoot, path));
+      } catch (error) {
+        if (error?.code === 'ENOENT') return [];
+        throw error;
+      }
     },
   };
 }
@@ -251,6 +261,17 @@ async function checkRuntimeDependencies(app, appPackageJson, failures) {
   }
 }
 
+async function checkBundledResources(app, failures) {
+  for (const directoryName of bundledAgentResourceDirs) {
+    const entries = await app.listDir(`resources/${directoryName}`);
+    if (entries.length === 0) {
+      failures.push(
+        `Packaged app is missing bundled resource directory: resources/${directoryName}`,
+      );
+    }
+  }
+}
+
 const app = await findPackagedApp();
 const failures = [];
 
@@ -269,6 +290,7 @@ if (!app) {
   await checkExists(app, 'dist/main/index.js', 'main bundle', failures);
   await checkExists(app, 'dist/preload/index.cjs', 'preload bundle', failures);
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
+  await checkBundledResources(app, failures);
   await checkNoVscodeRuntimeImport(app, failures);
   await checkDesktopMainDynamicRequireShim(app, failures);
 
@@ -297,6 +319,7 @@ console.log(
     '- dist/renderer/index.html',
     '- dist/renderer/assets/*.js',
     '- dist/renderer/assets/*.css',
+    '- resources/agents and resources/tool_use_agents',
     '- package.json runtime dependencies',
     '- node_modules runtime dependency packages',
     '- no VS Code extension host runtime import',

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -34,16 +34,17 @@ import {
 
 // Type imports
 import type { ToolFileAttachment } from '@tools/result';
-import type { FileLocation } from '@utils/files';
 
 // Local imports - utils
 import { delay } from '@utils/core';
-import { flexibleFS, OFFICE_MIME_TYPES } from '@utils/files';
 import { isNonEmptyString } from '@utils/core';
 import {
   getWebSocketEnabled,
   getUseOpenRouter,
 } from '@utils/config/providerConfig';
+import { flexibleFS } from '@utils/files/flexibleFS';
+import type { FileLocation } from '@utils/files/taskRunStorage';
+import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
 

--- a/src/agent/storage/ExecutionKVStore.ts
+++ b/src/agent/storage/ExecutionKVStore.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import { z } from 'zod';
 
 import { type AgentConfig, AgentConfigSchema } from '@agent/core/AgentConfig';
-import { KVStore } from '@common/storage';
+import { KVStore } from '@common/storage/KVStore';
 import { ExecutionIdSchema, type ExecutionId } from '@shared/schemas';
 
 // ============================================================================

--- a/src/common/storage/KVStore.ts
+++ b/src/common/storage/KVStore.ts
@@ -9,10 +9,10 @@
 
 import * as path from 'path';
 
-import { isFileNotFoundError } from '@common/errors';
+import { isFileNotFoundError } from '@common/errors/errorPredicates';
 import { isFile } from '@common/files/fsEntryType';
-import { StorageFS } from '@utils/files';
 import { hasExtension } from '@utils/core/pathCore';
+import { StorageFS } from '@utils/files/storageFS';
 
 async function withNotFoundFallback<T>(
   operation: () => Promise<T>,

--- a/src/logger/AgentLogger.ts
+++ b/src/logger/AgentLogger.ts
@@ -117,7 +117,7 @@ export interface AgentLogStream {
 }
 
 export class AgentLogger {
-  private static streamLogStore: StreamLogStore = getDefaultStreamLogStore();
+  private static streamLogStore: StreamLogStore | undefined;
 
   static setStreamLogStore(store: StreamLogStore): void {
     setDefaultStreamLogStore(store);
@@ -125,11 +125,12 @@ export class AgentLogger {
   }
 
   static getStreamLogStore(): StreamLogStore {
+    AgentLogger.streamLogStore ??= getDefaultStreamLogStore();
     return AgentLogger.streamLogStore;
   }
 
   private get store(): StreamLogStore {
-    return AgentLogger.streamLogStore;
+    return AgentLogger.getStreamLogStore();
   }
 
   constructor(

--- a/src/logger/StreamLogStore.ts
+++ b/src/logger/StreamLogStore.ts
@@ -1,4 +1,4 @@
-import { KVStore } from '@common/storage';
+import { KVStore } from '@common/storage/KVStore';
 import { WorkspaceStateKey } from '@common/state/stateKeys';
 import type { MementoStorage } from '@progressView/persistence/PersistentMapManager';
 import {

--- a/src/tools/ReadTool.ts
+++ b/src/tools/ReadTool.ts
@@ -17,12 +17,12 @@ import {
 } from '@tools/pathResolution';
 import { recordToolFileRead } from '@tools/fileInteractions';
 import { parseEml } from '@tools/emlParser';
+import { WorkspaceFS } from '@utils/files/workspaceFS';
 import {
-  WorkspaceFS,
   getMimeType,
   OFFICE_EXTENSIONS,
   OFFICE_MIME_TYPES,
-} from '@utils/files';
+} from '@utils/files/mimeUtils';
 import { splitContentLines } from '@utils/text/stringUtils';
 
 // Local file imports


### PR DESCRIPTION
## Summary

Fixes #3508.

This follows up the first packaged desktop startup fix with the remaining install-time failures that only show up when the macOS app is actually packaged and launched.

## Changes

- Install a small desktop bootstrap entry before importing the main app graph, so fatal startup errors are reported consistently.
- Make `AgentLogger` create the default `StreamLogStore` lazily instead of during module evaluation.
- Replace broad storage/files barrel imports on startup-sensitive paths with direct module imports to avoid bundled initialization cycles.
- Package bundled agent resources through Electron `extraResources` so the app can read them as real directories outside `app.asar`.
- Let production desktop CSP allow the app's own inline style updates and data fonts used by the renderer.
- Extend desktop package verification and CI to package, verify, and smoke-launch the macOS app.

## Verification

- `npm run desktop:package:local`
- `npm run check:desktop-package`
- `npm run desktop:package:smoke`
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Electron packaged startup flow (new bootstrap entrypoint, CSP relaxation) and packaging layout (`extraResources`), which can affect runtime behavior and security posture in production builds.
> 
> **Overview**
> Improves packaged desktop startup robustness by introducing a `bootstrap.ts` entrypoint that traps uncaught startup failures and shows a fatal error dialog before importing the main app.
> 
> Updates packaging and verification to better reflect real packaged behavior: bundles extension `resources/` into the Electron app via `extraResources`, extends `verify-desktop-package` to validate those resources (including outside `app.asar`), and broadens the packaged-launch smoke test’s fatal log detection.
> 
> Adjusts packaged renderer security settings by expanding the production CSP to allow inline styles and `data:` fonts needed by the bundled renderer, and updates CI (macOS) to package, verify, and smoke-launch the desktop app as part of validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf3f42e18e8c3249e2c7bf965649dbe2c6d502a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->