### PR TITLE
Tighten desktop package startup smoke

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -420,9 +420,10 @@ npm run build:initial
 That command builds the Electron desktop app and the VS Code extension package, then checks that the
 desktop build artifacts and `.vsix` are present.
 
-`npm run desktop:package:smoke` launches the packaged app briefly from the command line and fails on
-early exits, desktop startup failures, or runtime VS Code import errors. Set
-`TEXRA_DESKTOP_LAUNCH_SMOKE_MS` to change the default 8 second launch window.
+`npm run desktop:package:smoke` launches the packaged app briefly from the command line using an
+isolated temporary user profile. It fails on early exits, desktop startup failures, unsupported
+dynamic `require()` calls, or runtime VS Code import errors. Set `TEXRA_DESKTOP_LAUNCH_SMOKE_MS` to
+change the default 8 second launch window.
 
 ---
 

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -1,4 +1,5 @@
-import { access } from 'node:fs/promises';
+import { access, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
 import { spawn } from 'node:child_process';
@@ -32,6 +33,10 @@ const fatalLogPatterns = [
   {
     label: 'unhandled runtime exception',
     pattern: /Uncaught Exception|UnhandledPromiseRejection/i,
+  },
+  {
+    label: 'esbuild dynamic require failure',
+    pattern: /Dynamic require of ["'][^"']+["'] is not supported/i,
   },
   {
     label: 'constructor startup failure',
@@ -121,42 +126,51 @@ const timeoutMs = readPositiveNumber(
 
 await assertExecutableExists(executablePath);
 
-const child = spawn(executablePath, [], {
-  cwd: repoRoot,
-  env: {
-    ...process.env,
-    ELECTRON_ENABLE_LOGGING: process.env.ELECTRON_ENABLE_LOGGING ?? '1',
-  },
-  stdio: ['ignore', 'pipe', 'pipe'],
-});
-
+const smokeHome = await mkdtemp(join(tmpdir(), 'texra-desktop-smoke-home-'));
 let output = '';
-child.stdout.on('data', (chunk) => {
-  output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
-});
-child.stderr.on('data', (chunk) => {
-  output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
-});
+let result;
 
-const exitPromise = waitForExit(child);
-const closePromise = waitForClose(child);
-const result = await waitForExitOrTimeout(exitPromise, timeoutMs);
+try {
+  const child = spawn(executablePath, [], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ELECTRON_ENABLE_LOGGING: process.env.ELECTRON_ENABLE_LOGGING ?? '1',
+      HOME: smokeHome,
+      XDG_CONFIG_HOME: join(smokeHome, '.config'),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 
-if (result.timeout) {
-  if (hasExited(child)) {
-    result.exit = await exitPromise;
-  } else {
-    result.exit = await readPendingExit(exitPromise);
-    if (!result.exit) {
-      await stopChild(child, exitPromise, {
-        graceMs: SHUTDOWN_GRACE_MS,
-        label: 'Packaged app',
-      });
+  child.stdout.on('data', (chunk) => {
+    output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
+  });
+  child.stderr.on('data', (chunk) => {
+    output = appendBoundedLog(output, chunk, MAX_LOG_CHARS);
+  });
+
+  const exitPromise = waitForExit(child);
+  const closePromise = waitForClose(child);
+  result = await waitForExitOrTimeout(exitPromise, timeoutMs);
+
+  if (result.timeout) {
+    if (hasExited(child)) {
+      result.exit = await exitPromise;
+    } else {
+      result.exit = await readPendingExit(exitPromise);
+      if (!result.exit) {
+        await stopChild(child, exitPromise, {
+          graceMs: SHUTDOWN_GRACE_MS,
+          label: 'Packaged app',
+        });
+      }
     }
   }
-}
 
-await closePromise;
+  await closePromise;
+} finally {
+  await rm(smokeHome, { force: true, recursive: true });
+}
 
 if (result.exit) {
   failEarlyExit(result.exit, timeoutMs, output);

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -18,6 +18,7 @@ const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const desktopRoot = join(repoRoot, 'packages', 'desktop');
 const packageRoot = join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
+const desktopIconPath = join(desktopRoot, 'build', 'icon.icns');
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(repoRoot);
 const desktopVscodeFreeSourceDirs = getDesktopVscodeFreeSourceDirs(repoRoot);
 const desktopSharedSourceDirSet = new Set(desktopSharedSourceDirs);
@@ -110,6 +111,12 @@ function createAsarAppReader(asarPath) {
     async readText(path) {
       return extractFile(asarPath, path).toString('utf8');
     },
+    async readBuffer(path) {
+      if (entries.has(normalizeAsarPath(path))) {
+        return extractFile(asarPath, path);
+      }
+      return readFile(join(resourceRoot, path));
+    },
     async listDir(path) {
       const prefix = `${normalizeAsarPath(path)}/`;
       const asarEntries = [...entries]
@@ -139,6 +146,9 @@ function createDirectoryAppReader(appRoot) {
     },
     readText(path) {
       return readFile(join(appRoot, path), 'utf8');
+    },
+    readBuffer(path) {
+      return readFile(join(appRoot, path));
     },
     async listDir(path) {
       try {
@@ -272,8 +282,30 @@ async function checkBundledResources(app, failures) {
   }
 }
 
+async function checkMacIcon(app, failures) {
+  if (!app.label.includes('.app/Contents/Resources/app.asar')) return false;
+
+  const appIconPath = 'icon.icns';
+  if (!(await app.exists(appIconPath))) {
+    failures.push(`Packaged macOS app is missing TeXRA icon: ${appIconPath}`);
+    return true;
+  }
+
+  const [expectedIcon, actualIcon] = await Promise.all([
+    readFile(desktopIconPath),
+    app.readBuffer(appIconPath),
+  ]);
+  if (!expectedIcon.equals(actualIcon)) {
+    failures.push(
+      `Packaged macOS app icon does not match source icon: ${appIconPath}`,
+    );
+  }
+  return true;
+}
+
 const app = await findPackagedApp();
 const failures = [];
+let checkedMacIcon = false;
 
 if (!app) {
   failures.push(`No packaged Electron app found under ${packageRoot}`);
@@ -291,6 +323,7 @@ if (!app) {
   await checkExists(app, 'dist/preload/index.cjs', 'preload bundle', failures);
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
   await checkBundledResources(app, failures);
+  checkedMacIcon = await checkMacIcon(app, failures);
   await checkNoVscodeRuntimeImport(app, failures);
   await checkDesktopMainDynamicRequireShim(app, failures);
 
@@ -311,20 +344,22 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(
-  [
-    `Desktop package check passed for ${app.label}`,
-    '- dist/main/index.js',
-    '- dist/preload/index.cjs',
-    '- dist/renderer/index.html',
-    '- dist/renderer/assets/*.js',
-    '- dist/renderer/assets/*.css',
-    '- resources/agents and resources/tool_use_agents',
-    '- package.json runtime dependencies',
-    '- node_modules runtime dependency packages',
-    '- no VS Code extension host runtime import',
-    '- desktop main dynamic require shim',
-    '- desktop-shared source uses vscode-free state keys',
-    '- desktop-shared source avoids VS Code runtime imports',
-  ].join('\n'),
-);
+const summary = [
+  `Desktop package check passed for ${app.label}`,
+  '- dist/main/index.js',
+  '- dist/preload/index.cjs',
+  '- dist/renderer/index.html',
+  '- dist/renderer/assets/*.js',
+  '- dist/renderer/assets/*.css',
+  '- resources/agents and resources/tool_use_agents',
+  '- package.json runtime dependencies',
+  '- node_modules runtime dependency packages',
+  '- no VS Code extension host runtime import',
+  '- desktop main dynamic require shim',
+  '- desktop-shared source uses vscode-free state keys',
+  '- desktop-shared source avoids VS Code runtime imports',
+];
+
+if (checkedMacIcon) summary.splice(7, 0, '- macOS app icon');
+
+console.log(summary.join('\n'));


### PR DESCRIPTION
## Summary

- Run the packaged desktop launch smoke with an isolated temporary user profile so it behaves more like a clean first install.
- Treat the original esbuild `Dynamic require of ... is not supported` startup failure as an explicit fatal smoke signature.
- Verify the packaged macOS app includes the TeXRA icon and document the stronger smoke behavior.

## Root Cause

#3511 fixed the current packaged startup crashes on `main`, but #3508 was reopened because the verification still had gaps: the launch smoke reused the developer profile and did not explicitly match the original dynamic-require failure text. The packaged app can now only pass this path if a clean profile launch avoids that failure mode.

Fixes #3508.

## Validation

- `npm run desktop:package:local`
- `npm run check:desktop-package`
- `npm run desktop:package:smoke`
- `HOME=$(mktemp -d /tmp/texra-desktop-home.XXXXXX) TEXRA_DESKTOP_LAUNCH_SMOKE_MS=12000 npm run desktop:package:smoke`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the packaged Electron app is launched in smoke tests (isolated HOME/XDG config) and adds stricter failure signatures, which may surface new CI failures or environment-specific issues without impacting production runtime.
> 
> **Overview**
> Tightens the packaged desktop launch smoke by running the app with an isolated temporary user profile (`HOME`/`XDG_CONFIG_HOME`) and cleaning it up afterward, making the check closer to a first-install launch.
> 
> Extends smoke/verification to explicitly fail on the esbuild “Dynamic require … is not supported” runtime error and enhances `check:desktop-package` to validate that the packaged macOS app includes the expected `icon.icns` (and matches the source icon), updating the documentation to reflect these stricter checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e7307f84166a6ce8aa06af8a0ea1a27fa87498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->