### PR TITLE
fix: lazy-load desktop execution startup

### DIFF
--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,15 +1,21 @@
 import * as esbuild from 'esbuild';
+import { rm } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const outdir = resolve(__dirname, 'dist/main');
+
+await rm(outdir, { force: true, recursive: true });
 
 await esbuild.build({
-  entryPoints: [resolve(__dirname, 'src/main/bootstrap.ts')],
+  entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
-  outfile: resolve(__dirname, 'dist/main/index.js'),
+  splitting: true,
+  outdir,
+  chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
   tsconfig: resolve(__dirname, 'tsconfig.main.json'),
   target: 'node22',

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -6,7 +6,6 @@ import {
 } from '@controllers/mainView/MainViewExecutionController';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
-import { runValidatedExecutionRequest } from '@agent/runtime/runExecutionRequest';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -520,6 +519,8 @@ export function createDesktopAgentExecution(
         return;
       }
 
+      const { runValidatedExecutionRequest } =
+        await import('@agent/runtime/runExecutionRequest');
       await runValidatedExecutionRequest(preparation.request, {
         runtimeHost: progress.runtimeHost,
         openWorkflowOutput: async (result) => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,5 @@
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
@@ -12,7 +13,25 @@ import { createDesktopShellActions } from './desktopShellIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = findDesktopMainDir(moduleDirname);
+
+function findDesktopMainDir(startDir: string): string {
+  let currentDir = startDir;
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (
+      existsSync(join(currentDir, '../preload/index.cjs')) &&
+      existsSync(join(currentDir, '../renderer/index.html'))
+    ) {
+      return currentDir;
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+  return startDir;
+}
 
 // The packaged renderer uses Lit style attributes and bundled font data URLs
 // (codicons/KaTeX). Keep script execution locked to app files while allowing

--- a/scripts/smoke-desktop-package-launch.mjs
+++ b/scripts/smoke-desktop-package-launch.mjs
@@ -42,6 +42,11 @@ const fatalLogPatterns = [
     label: 'constructor startup failure',
     pattern: /TypeError: .* is not a constructor/i,
   },
+  {
+    label: 'packaged asset load failure',
+    pattern:
+      /Failed to load URL:.*ERR_FILE_NOT_FOUND|Unable to load preload script|preload\/index\.cjs not found/i,
+  },
 ];
 
 function readPositiveNumber(value, fallback) {

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -1,6 +1,6 @@
-import { access, readdir, readFile } from 'node:fs/promises';
+import { access, readdir, readFile, stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { basename, dirname, join, relative } from 'node:path';
+import { basename, dirname, join, posix, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
@@ -27,6 +27,24 @@ const desktopSourceBoundaryDirs = [
   ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
 ];
 const bundledAgentResourceDirs = ['agents', 'tool_use_agents'];
+const desktopStartupForbiddenBundleMarkers = [
+  {
+    label: '@google/genai',
+    patterns: [
+      '@google/genai',
+      'node_modules/.pnpm/@google+genai',
+      'google-auth-library',
+    ],
+  },
+  {
+    label: 'OpenAI SDK',
+    patterns: ['node_modules/.pnpm/openai@'],
+  },
+  {
+    label: 'Anthropic SDK',
+    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+  },
+];
 
 async function exists(path) {
   try {
@@ -105,6 +123,18 @@ function createAsarAppReader(asarPath) {
       if (entries.has(normalizeAsarPath(path))) return true;
       return exists(join(resourceRoot, path));
     },
+    async isDirectory(path) {
+      const normalizedPath = normalizeAsarPath(path);
+      for (const entry of entries) {
+        if (entry.startsWith(`${normalizedPath}/`)) return true;
+      }
+      try {
+        return (await stat(join(resourceRoot, path))).isDirectory();
+      } catch (error) {
+        if (error?.code === 'ENOENT') return false;
+        throw error;
+      }
+    },
     async readJson(path) {
       return JSON.parse(extractFile(asarPath, path).toString('utf8'));
     },
@@ -141,6 +171,14 @@ function createDirectoryAppReader(appRoot) {
     exists(path) {
       return exists(join(appRoot, path));
     },
+    async isDirectory(path) {
+      try {
+        return (await stat(join(appRoot, path))).isDirectory();
+      } catch (error) {
+        if (error?.code === 'ENOENT') return false;
+        throw error;
+      }
+    },
     readJson(path) {
       return readJson(join(appRoot, path));
     },
@@ -167,26 +205,102 @@ async function checkExists(app, path, label, failures) {
 }
 
 async function checkNoVscodeRuntimeImport(app, failures) {
-  const mainBundlePath = 'dist/main/index.js';
-  if (!(await app.exists(mainBundlePath))) return;
-  const mainBundle = await app.readText(mainBundlePath);
-  if (!vscodeRuntimeImportPattern.test(mainBundle)) return;
-  failures.push(
-    'Packaged desktop main bundle contains a runtime import of the VS Code extension host module.',
-  );
+  for (const bundlePath of await collectMainJavaScriptBundles(app)) {
+    const mainBundle = await app.readText(bundlePath);
+    if (!vscodeRuntimeImportPattern.test(mainBundle)) continue;
+    failures.push(
+      `Packaged desktop main bundle contains a runtime import of the VS Code extension host module: ${bundlePath}`,
+    );
+  }
 }
 
 async function checkDesktopMainDynamicRequireShim(app, failures) {
-  const mainBundlePath = 'dist/main/index.js';
-  if (!(await app.exists(mainBundlePath))) return;
+  for (const bundlePath of await collectMainJavaScriptBundles(app)) {
+    const mainBundle = await app.readText(bundlePath);
+    if (!mainBundle.includes('Dynamic require of')) continue;
+    if (mainBundle.includes('__texraCreateRequire(import.meta.url)')) continue;
 
-  const mainBundle = await app.readText(mainBundlePath);
-  if (!mainBundle.includes('Dynamic require of')) return;
-  if (mainBundle.includes('__texraCreateRequire(import.meta.url)')) return;
+    failures.push(
+      `Packaged desktop main bundle contains esbuild dynamic require calls without the Node createRequire shim: ${bundlePath}`,
+    );
+  }
+}
 
-  failures.push(
-    'Packaged desktop main bundle contains esbuild dynamic require calls without the Node createRequire shim.',
-  );
+async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
+  const entries = await app.listDir(dir);
+  const bundles = [];
+  for (const entry of entries) {
+    const entryPath = posix.join(dir, entry);
+    if (entry.endsWith('.js')) {
+      bundles.push(entryPath);
+    } else if (await app.isDirectory(entryPath)) {
+      bundles.push(...(await collectMainJavaScriptBundles(app, entryPath)));
+    }
+  }
+  return bundles.sort();
+}
+
+function parseStaticRelativeImports(source) {
+  const imports = [];
+  const staticImportPattern =
+    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
+  for (const match of source.matchAll(staticImportPattern)) {
+    imports.push(match[1]);
+  }
+  return imports;
+}
+
+function parseDynamicRelativeImports(source) {
+  const imports = [];
+  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
+  for (const match of source.matchAll(dynamicImportPattern)) {
+    imports.push(match[1]);
+  }
+  return imports;
+}
+
+async function checkDesktopStartupBundles(app, failures) {
+  const entryPath = 'dist/main/index.js';
+  if (!(await app.exists(entryPath))) return;
+
+  const pending = [entryPath];
+  const visited = new Set();
+  while (pending.length > 0) {
+    const bundlePath = pending.shift();
+    if (!bundlePath || visited.has(bundlePath)) continue;
+    visited.add(bundlePath);
+
+    const source = await app.readText(bundlePath);
+    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
+      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+    );
+    if (forbidden.length > 0) {
+      failures.push(
+        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
+          .map(({ label }) => label)
+          .join(', ')}): ${bundlePath}`,
+      );
+    }
+
+    const imports = parseStaticRelativeImports(source);
+    if (bundlePath === entryPath) {
+      const dynamicImports = parseDynamicRelativeImports(source);
+      if (dynamicImports.length !== 1) {
+        failures.push(
+          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
+        );
+      }
+      imports.push(...dynamicImports);
+    }
+    for (const specifier of imports) {
+      const importedPath = posix.normalize(
+        posix.join(posix.dirname(bundlePath), specifier),
+      );
+      if (await app.exists(importedPath)) {
+        pending.push(importedPath);
+      }
+    }
+  }
 }
 
 async function checkDesktopSourceBoundaries(failures) {
@@ -326,6 +440,7 @@ if (!app) {
   checkedMacIcon = await checkMacIcon(app, failures);
   await checkNoVscodeRuntimeImport(app, failures);
   await checkDesktopMainDynamicRequireShim(app, failures);
+  await checkDesktopStartupBundles(app, failures);
 
   const assets = await app.listDir('dist/renderer/assets');
   if (!assets.some((asset) => asset.endsWith('.js'))) {
@@ -356,6 +471,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
+  '- desktop startup bundles exclude provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,35 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIConnectionError as AnthropicConnectionError,
-  APIConnectionTimeoutError as AnthropicConnectionTimeoutError,
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicUserAbortError,
-  AuthenticationError as AnthropicAuthenticationError,
-  BadRequestError as AnthropicBadRequestError,
-  ConflictError as AnthropicConflictError,
-  InternalServerError as AnthropicInternalServerError,
-  NotFoundError as AnthropicNotFoundError,
-  PermissionDeniedError as AnthropicPermissionDeniedError,
-  RateLimitError as AnthropicRateLimitError,
-  UnprocessableEntityError as AnthropicUnprocessableEntityError,
-} from '@anthropic-ai/sdk';
-import { ApiError as GoogleGenAIApiError } from '@google/genai';
-import {
-  APIConnectionError as OpenAIConnectionError,
-  APIConnectionTimeoutError as OpenAIConnectionTimeoutError,
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIUserAbortError,
-  AuthenticationError as OpenAIAuthenticationError,
-  BadRequestError as OpenAIBadRequestError,
-  ConflictError as OpenAIConflictError,
-  InternalServerError as OpenAIInternalServerError,
-  NotFoundError as OpenAINotFoundError,
-  PermissionDeniedError as OpenAIPermissionDeniedError,
-  RateLimitError as OpenAIRateLimitError,
-  UnprocessableEntityError as OpenAIUnprocessableEntityError,
-} from 'openai';
-
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -49,78 +19,67 @@ function safeGetReasonPhrase(statusCode: number): string | undefined {
   }
 }
 
-type ErrorConstructor<T extends Error = Error> = abstract new (
-  ...args: never[]
-) => T;
-
 /** SDK error mapping entry. Provider detected from class name. */
 interface SdkErrorEntry {
-  ctor: ErrorConstructor;
+  classNames: readonly string[];
   message?: string;
   fallbackStatusCode?: number;
   retryable?: boolean;
 }
 
-function createErrorPair(
-  openAiCtor: ErrorConstructor,
-  anthropicCtor: ErrorConstructor,
-  config: Omit<SdkErrorEntry, 'ctor'>,
-): SdkErrorEntry[] {
-  return [
-    { ctor: openAiCtor, ...config },
-    { ctor: anthropicCtor, ...config },
-  ];
-}
-
 const SDK_ERRORS: SdkErrorEntry[] = [
   // Connection errors (retryable)
-  ...createErrorPair(
-    OpenAIConnectionTimeoutError,
-    AnthropicConnectionTimeoutError,
-    { message: 'Connection timed out', retryable: true },
-  ),
-  ...createErrorPair(OpenAIConnectionError, AnthropicConnectionError, {
+  {
+    classNames: ['APIConnectionTimeoutError'],
+    message: 'Connection timed out',
+    retryable: true,
+  },
+  {
+    classNames: ['APIConnectionError'],
     message: 'Connection error',
     retryable: true,
-  }),
+  },
   // Abort errors (not retryable)
-  ...createErrorPair(OpenAIUserAbortError, AnthropicUserAbortError, {
+  {
+    classNames: ['APIUserAbortError'],
     message: 'Request aborted',
     retryable: false,
-  }),
+  },
   // HTTP errors (retryable derived from status code)
-  ...createErrorPair(OpenAIBadRequestError, AnthropicBadRequestError, {
+  {
+    classNames: ['BadRequestError'],
     fallbackStatusCode: StatusCodes.BAD_REQUEST,
-  }),
-  ...createErrorPair(OpenAIAuthenticationError, AnthropicAuthenticationError, {
+  },
+  {
+    classNames: ['AuthenticationError'],
     fallbackStatusCode: StatusCodes.UNAUTHORIZED,
-  }),
-  ...createErrorPair(
-    OpenAIPermissionDeniedError,
-    AnthropicPermissionDeniedError,
-    { fallbackStatusCode: StatusCodes.FORBIDDEN },
-  ),
-  ...createErrorPair(OpenAINotFoundError, AnthropicNotFoundError, {
+  },
+  {
+    classNames: ['PermissionDeniedError'],
+    fallbackStatusCode: StatusCodes.FORBIDDEN,
+  },
+  {
+    classNames: ['NotFoundError'],
     fallbackStatusCode: StatusCodes.NOT_FOUND,
-  }),
-  ...createErrorPair(OpenAIConflictError, AnthropicConflictError, {
+  },
+  {
+    classNames: ['ConflictError'],
     fallbackStatusCode: StatusCodes.CONFLICT,
-  }),
-  ...createErrorPair(
-    OpenAIUnprocessableEntityError,
-    AnthropicUnprocessableEntityError,
-    { fallbackStatusCode: StatusCodes.UNPROCESSABLE_ENTITY },
-  ),
-  ...createErrorPair(OpenAIRateLimitError, AnthropicRateLimitError, {
+  },
+  {
+    classNames: ['UnprocessableEntityError'],
+    fallbackStatusCode: StatusCodes.UNPROCESSABLE_ENTITY,
+  },
+  {
+    classNames: ['RateLimitError'],
     fallbackStatusCode: StatusCodes.TOO_MANY_REQUESTS,
-  }),
-  ...createErrorPair(OpenAIInternalServerError, AnthropicInternalServerError, {
+  },
+  {
+    classNames: ['InternalServerError'],
     fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-  }),
+  },
   // Generic API errors (no fallback)
-  { ctor: OpenAIAPIError },
-  { ctor: AnthropicAPIError },
-  { ctor: GoogleGenAIApiError },
+  { classNames: ['APIError', 'ApiError'] },
 ];
 
 /** Server errors (5xx), rate limits (429), and request timeouts (408) are retryable
@@ -142,7 +101,10 @@ function matchSdkError(
   err: unknown,
   rawErrorBody: unknown,
 ): SdkMatchResult | undefined {
-  const entry = SDK_ERRORS.find(({ ctor }) => err instanceof ctor);
+  const errorClassNames = getErrorClassNames(err);
+  const entry = SDK_ERRORS.find(({ classNames }) =>
+    classNames.some((className) => errorClassNames.includes(className)),
+  );
   if (!entry) {
     return undefined;
   }
@@ -200,6 +162,21 @@ function matchSdkError(
     retryable: isRetryableStatusCode(statusCode),
     requestId,
   };
+}
+
+function getErrorClassNames(err: unknown): string[] {
+  if (!isObject(err)) return [];
+
+  const classNames = new Set<string>();
+  let prototype = Object.getPrototypeOf(err);
+  while (prototype && prototype !== Object.prototype) {
+    const className = prototype.constructor?.name;
+    if (isString(className) && className.length > 0) {
+      classNames.add(className);
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return [...classNames];
 }
 
 type StatusCarrier = {
@@ -349,10 +326,7 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  return (
-    err instanceof OpenAIUserAbortError ||
-    err instanceof AnthropicUserAbortError
-  );
+  return getErrorClassNames(err).includes('APIUserAbortError');
 }
 
 /** Factory for symbol-keyed error metadata. Creates matched attach/detect

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,0 +1,20 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - common errors
+import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+
+class APIError extends Error {}
+
+class UnknownSdkApiError extends APIError {}
+
+describe('formatProviderHttpError', () => {
+  it('matches generic SDK API errors through the prototype chain', () => {
+    const formatted = formatProviderHttpError(
+      new UnknownSdkApiError('new provider error shape'),
+    );
+
+    expect(formatted.message).toBe('new provider error shape');
+    expect(formatted.retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the remaining startup risk in #3508 by keeping provider SDKs out of the packaged desktop startup path.

- build the Electron main process as split ESM chunks so agent execution can be loaded on demand
- lazy-load `runValidatedExecutionRequest` only when the desktop renderer sends an execute request
- keep packaged path resolution stable when main code runs from a generated `dist/main/chunks/*` file
- remove eager OpenAI/Anthropic/Google SDK imports from shared SDK error classification
- harden package verification and smoke coverage for provider-SDK startup imports, dynamic require shims, constructor failures, and packaged asset load failures

## Root Cause

The previous fixes addressed the concrete `KVStore` constructor and dynamic-require crashes, but the desktop main startup path still imported shared execution/logger/error modules that could initialize provider SDK dependency graphs before the app window was usable. In a packaged ESM bundle, that makes unrelated SDK packaging or init-shape problems show up as application startup failures.

## Validation

- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run compile:fast`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts src/test-kernel/desktop/ElectronCompositionRoot.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run desktop:package:local`
- `npm run check:desktop-package`
- `npm run desktop:package:smoke`

Closes #3508.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Electron main-process bundling/output layout and adds runtime path discovery plus lazy imports; mistakes could break packaged startup or execution. Also refactors shared SDK error classification to avoid direct SDK imports, which could subtly alter error matching behavior.
> 
> **Overview**
> Reduces packaged desktop startup surface by **splitting the Electron main-process build into ESM chunks** (`esbuild.main.mjs` now cleans `dist/main`, enables `splitting`, and writes to `outdir` with chunk naming).
> 
> Moves agent execution onto an on-demand path by **lazy-importing** `runValidatedExecutionRequest` only when an execute IPC arrives (`desktopAgentExecution.ts`), and hardens packaged path resolution when code runs from chunk files by **searching upward for `dist/preload`/`dist/renderer` assets** (`main/index.ts`).
> 
> Strengthens packaging checks: smoke test now flags packaged asset load failures, and `verify-desktop-package.mjs` now scans **all main JS bundles (including chunks)** for VS Code runtime imports / missing `createRequire` shim and enforces that the startup bundle chain **does not eagerly include provider SDK code**.
> 
> Removes eager OpenAI/Anthropic/Google SDK imports from `sdkErrorUtils.ts` by matching errors via **prototype-chain class names** instead of `instanceof`, and adds a vitest regression test covering the new matching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5585bc93e2f6ae2abc50b7533bb65d6e1ad0586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->