### PR TITLE
prd(cli): round 2 — RunContext, Logger v2, MCP serve, hooks, sessions

### DIFF
--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1120,3 +1120,877 @@ commander (or citty) + Ink (lazy) + picocolors + log-update + ora + @clack/promp
 ```
 
 That's the whole story. The agent core is already CLI-shaped — this PRD is just describing how to wrap it in `process.argv` + a TTY.
+
+---
+
+## 21. Iteration log — round 2 (2026-05-05)
+
+Round 1 above defined the CLI as a thin Node shell over an already host-neutral kernel. Two follow-on investigations sharpened that picture:
+
+1. **Runtime audit** of every `AsyncLocalStorage` scope and module-level `let foo: X | undefined` setter pair across `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/eventBus/`, and `src/logger/`. The audit names ~20 ambient bindings and ~3 singleton coordinators that v1 of the SDK has to live with but a v1.1 MCP-server / re-entrant SDK cannot.
+2. **Ecosystem survey** of Codex CLI (Rust + TOML + `codex mcp` + `codex exec --json --output-last-message`), Claude Code (`claude mcp serve`, JSONL transcripts under `~/.claude/projects/<hash>/`, hook contract with `permissionDecision` namespacing, `--output-format stream-json`), OpenCode (Bun HTTP server + Go TUI generated from OpenAPI 3.1.1, `permission` map with glob+last-match semantics), and the `claude-code-base-action` composite-action / Bun-runner pattern.
+
+**User-feedback intake (2026-05-05):**
+
+- Sandbox-mode dimension on approval policy is too complicated; round-1's 1D `never|ask|auto-edits|auto|yolo` stays. We do not adopt Codex's 2D `approval × sandbox` matrix. (See §26 for the rejection rationale.)
+- Unifying agent-SDK / message-SDK with conversation compaction is a desirable cross-host goal but **not v1 scope** — parked in §32 alongside other v2+ work.
+
+Round 2 lands six concrete deltas plus one cross-cutting kernel refactor that all three hosts (extension, desktop, CLI) benefit from. None of these change the round-1 LOC band by more than ~600 lines combined; most are about replacing ad-hoc patterns with the kernel-shaped abstractions the audit revealed are already partially in place.
+
+| Delta | Round 1 status | Round 2 position | New §  |
+| ----- | -------------- | ---------------- | ------ |
+| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work | **v1 prereq for `texra mcp serve` and re-entrant SDK; v1.0 ships with the migration shim path** | §22 |
+| Structured logger with explicit context, no module globals | Hand-waved as "consoleLog plus filter wrapper" | **v1 deliverable; `LogBackend` interface widened to take a context object** | §23 |
+| `texra mcp serve` (callable from Claude Code, Codex, opencode) | Listed as v1.1 future | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)** | §24 |
+| Hook system (SessionStart, PreToolUse, PostToolUse, …) | Not mentioned | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner** | §25 |
+| Approval policy revisited (no 2D sandbox axis) | 1D `never|ask|auto-edits|auto|yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
+| Session transcripts as JSONL under project-hash sharding | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics** | §27 |
+| GitHub Action: composite + Bun (not JS Action) | §12 picked JS Action | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in** | §28 |
+| Cross-platform shared structure refactor (kernel side) | Implicit | **Explicit — what the three hosts share, what they don't, where the seams go** | §29 |
+| Container / GitHub-runner target matrix (slim, alpine, texlive) | Sketched in §12.3 | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30 |
+| Phase plan delta + LOC delta | — | **Aggregated** | §31 |
+| Parking lot — unified agent-SDK / message-SDK / context compaction | — | **Out of v1; sized in §32 for visibility** | §32 |
+
+The rest of round 2 is the spec for these deltas, in dependency order: §22 → §23 unblock §24 (an MCP server can't safely host concurrent sessions until the kernel's ambient state is gone); §24 + §25 + §26 are independent hosts on the new context; §27 + §28 + §29 + §30 are deployment / packaging concerns that don't gate kernel work.
+
+## 22. RunContext — replace ambient ALS + singletons
+
+### 22.1 What's ambient today
+
+The May 2026 runtime audit (in commit-time order, not severity) found:
+
+**AsyncLocalStorage scopes (2):**
+
+- `src/agent/runtime/AgentRuntimeHost.ts:12` — `runtimeHostScope` carries the current `AgentRuntimeHost` (≡ `ProgressSink`). Entered via `runWithAgentRuntimeHost(host, fn)` at line 27; read via `getAgentRuntimeHost()` at line 23 with fallback to a process-global `defaultAgentRuntimeHost` (line 11) and then to `getDefaultProgressSink()` (`ProgressSink.ts:20`).
+- `src/logger/logUtils.ts:10` — `contextStorage` carries a `Map<channel-key, group-id stack>` so `runWithGroupContext()` can attach a `[groupId]` tag to each line. Read at lines 63 and 136.
+
+**Module-level `let X | undefined` + setter pairs (~20):**
+
+| Concern | Setter | File:line |
+| ------- | ------ | --------- |
+| Default progress sink | `setDefaultProgressSink` | `src/agent/runtime/ProgressSink.ts:14` |
+| Default runtime host | `setDefaultAgentRuntimeHost` | `src/agent/runtime/AgentRuntimeHost.ts:11` |
+| Run storage service | `setRunStorageService` | `src/agent/runtime/RunStorageService.ts:10` |
+| Tool-edit approval handler | `setToolEditApprovalHandler` | `src/tools/approval/toolEditApproval.ts:74,113` |
+| Latex-preview handler | `setLatexBuildDisplay` | `src/tools/approval/latexPreview.ts:21` |
+| GitHub token provider | `setGitHubTokenProvider` | `src/tools/github/githubAuth.ts:13` |
+| Extension checker | `setExtensionChecker` | `src/tools/externalToolDefs.ts:35` |
+| Server-side key service | `setServerSideKeyService` | `src/auth/serverKeys/index.ts:34` |
+| Tier service | `setTierService` | `src/auth/tier/index.ts:31` |
+| Auth callback resolver | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183` |
+| Runtime extension id | `setRuntimeExtensionId` | `src/auth/config.ts:137` |
+| Output-channel factory (logger) | `setOutputChannelFactory` | `src/logger/logUtils.ts:108` |
+
+**Exported singleton coordinators (3):**
+
+- `planApprovalCoordinator` — `src/agent/runtime/PlanApprovalCoordinator.ts:128`
+- `retryCoordinator` — `src/agent/runtime/RetryRequestCoordinator.ts:145`
+- `proposalCoordinator` — `src/agent/runtime/AgentProposalCoordinator.ts:89`
+
+**Caches that survive across runs (4):**
+
+- Agent-registry cache + init promise — `src/agent/index/agentRegistry.ts:143,146-147`
+- Execution listing cache + workspace-path cache — `src/agent/storage/executionListing.ts:52-54`
+- Output-poll timer + in-flight flag — `src/agent/runtime/executionRegistry.ts:335-336`
+- Polish-model template cache — `src/agent/runtime/polishModel.ts:11-12`
+
+### 22.2 Why this hurts the CLI
+
+Round-1 §7.6's caveat — "two SDK callers in the same process can step on each other's defaults" — covers only the tip. The full failure surface for the CLI is:
+
+1. **`texra mcp serve` (§24)** must host N concurrent sessions in one process, each with its own progress sink, its own approval policy, its own logger context, and its own abort signal. Today's ambient-default + ALS-fallback model conflates "this run's sink" with "this process's sink"; an MCP server that serves two clients simultaneously will leak progress events between them whenever a `getDefaultProgressSink()` path is hit (which the audit shows is the default fallback in `getAgentRuntimeHost` at `AgentRuntimeHost.ts:24`).
+2. **Re-entrant `runAgent()` from the SDK (§7.6)** — same problem. A user piping two polish runs in parallel through `Promise.all([runAgent(...), runAgent(...)])` will see interleaved progress on whichever process-global sink the second call happened to install last.
+3. **Hooks (§25)** that fire from a sub-flow (e.g., `PreToolUse` raised inside a delegate-agent subagent) need the hook handler to know which session it belongs to. The ALS scope already passes the runtime host correctly, but the singleton coordinators (`planApprovalCoordinator`) don't — they fan out events to whoever the current global handler is.
+4. **Tests** routinely have to `setDefaultProgressSink(noop)` and `setRunStorageService(fake)` in `beforeEach` and unwind them in `afterEach`. A `RunContext` argument removes ~150 LOC of this kind of setup.
+
+### 22.3 The shape
+
+A single `RunContext` value, threaded explicitly through the call graph, with one ALS scope at the outermost entry to support legacy call sites during migration. No module globals, no per-domain singletons.
+
+```ts
+// packages/core/src/runtime/runContext.ts
+export interface RunContext {
+  /** Stable identifier for this run; root for child contexts. */
+  readonly runId: RunId;
+  /** Stream tab id within the run (one per agent activation). */
+  readonly streamId: StreamTabId;
+  /** Lineage from the user-initiated root, useful for log prefixes. */
+  readonly streamLineage: StreamTabId[];
+
+  /** Where progress events go. Replaces `getAgentRuntimeHost()`. */
+  readonly progress: ProgressSink;
+  /** Structured logger scoped to this run. Replaces `logUtils` group-context ALS. */
+  readonly log: Logger;
+
+  /** Cooperative cancel signal for this run. Replaces InterruptManager singleton. */
+  readonly signal: AbortSignal;
+
+  /** Approval policy for this run (resolved from flag > env > config > schema default). */
+  readonly approval: ApprovalPolicy; // 1D — see §26
+
+  /** Workspace root (cwd) for this run. Per-run override of WorkspaceProvider. */
+  readonly workspaceRoot: string;
+
+  /** Runtime-resolved capabilities. Replaces `setExtensionChecker`, `setGitHubTokenProvider`. */
+  readonly capabilities: RunCapabilities;
+
+  /** Coordinators bound to this run's progress sink. Replaces exported singletons. */
+  readonly coordinators: {
+    plan: PlanApprovalCoordinator;
+    proposal: AgentProposalCoordinator;
+    retry: RetryRequestCoordinator;
+    edit: ToolEditApprovalController;
+    bash: BashApprovalController;
+  };
+
+  /** Spawn a child context for a delegate_agent / delegate_workflow subagent. */
+  child(opts: ChildContextOptions): RunContext;
+}
+
+export interface RunCapabilities {
+  github: GitHubTokenProvider | null;
+  extensionPresent: boolean;
+  externalAuthCallback: ExternalAuthCallbackResolver | null;
+  // …other host capabilities, populated by the host adapter
+}
+```
+
+`buildAgentLaunchContext()` in `executeAgent.ts:166` already constructs almost all of this; the round-2 refactor is to (a) lift it to the kernel boundary so it's the only entry point that matters and (b) pass it explicitly into every coordinator method that today reads from a singleton.
+
+### 22.4 Migration shim
+
+Because the audit found ~30 sites that read singletons today, a hard cutover is not realistic for v1. The shim:
+
+- `runContextScope = new AsyncLocalStorage<RunContext>()` lives in `packages/core/src/runtime/runContext.ts`.
+- `withRunContext(ctx, fn)` wraps every `executeAgent()` call. The existing `runWithAgentRuntimeHost()` wrapper is kept and now reads from `runContextScope.getStore()` for forward compatibility.
+- Every singleton getter (`getDefaultProgressSink()`, `getRunStorageService()`, `getServerSideKeyService()`, …) gets a `// LEGACY:` comment and a path forward: it reads `runContextScope.getStore()?.<field>` first and falls back to the module global.
+- Internal kernel call sites are converted in batches (one per phase): coordinators first (Phase 0 of round 2), then approval handlers (Phase 1), then auth services (Phase 2). Each batch deletes a module global once its readers all take an explicit `ctx`.
+- ESLint rule `no-ambient-runtime-state` blocks new module-level `let` + setter pairs in `src/agent/`, `src/tools/`, `src/auth/`. Rationale: same shape as the §13.1 import-restriction rule.
+
+### 22.5 Migration order (gated on, not blocking, CLI v1.0)
+
+| Round | Singletons retired | Files touched | Net LOC |
+| ----- | ------------------ | ------------- | ------- |
+| Pre-v1.0 | `runContextScope` lives at boundary; `runWithAgentRuntimeHost` reads it; new `Logger`/`progress` getters on context (§23) | `executeAgent.ts`, `runContext.ts` (new), `Logger.ts` (new) | +180 / -10 |
+| v1.0 | `planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator` become per-context instances created in `buildAgentLaunchContext()` | `Plan/Retry/AgentProposalCoordinator.ts`, ~5 call sites | +60 / -30 |
+| v1.1 (gates `texra mcp serve`) | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` singletons removed | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 reader sites | +0 / -120 |
+| v1.2 | `setToolEditApprovalHandler`, `setGitHubTokenProvider`, `setExtensionChecker`, `setLatexBuildDisplay` — replaced by `RunCapabilities` injection | `tools/{approval,github,externalToolDefs}/*` | +40 / -90 |
+| v1.3 | Auth singletons (`tierService`, `serverSideKeyService`) become per-`RunContext` resolutions backed by a kernel-side `AuthRegistry` | `auth/*` | +60 / -100 |
+
+Net: at v1.3 the kernel has zero `let X | undefined` + setter pairs in the agnostic zones, and ~250 LOC has been deleted on net. The CLI's `texra mcp serve` becomes safe at the v1.1 boundary; v1.0 ships with the shim.
+
+### 22.6 Why not "just drop ALS entirely"
+
+The shim is necessary because the kernel has 30+ call sites that read the runtime host implicitly (every emit, every approval prompt, every coordinator call). A pure-explicit migration would touch 30+ files in one PR and break every in-flight branch. ALS-with-an-explicit-context is the ergonomic compromise OpenTelemetry, Vercel AI SDK, and Encore all settled on; we copy that. The audit confirms zero call sites of `getStore()` outside the `runtimeHostScope`/`contextStorage` files themselves, so wrapping access in a single `useRunContext()` helper is a one-line change at every reader.
+
+### 22.7 The "stream context lost across `.then()`" risk
+
+The LangSmith #2274 issue is the canonical foot-gun: ALS context can be lost when a stream's `.then()` resolves outside the original async chain. We have one such site today — `RunStorageService`'s background poll timer (`executionRegistry.ts:335`) fires outside any `runWithAgentRuntimeHost()` scope. The mitigation is the same one the survey flagged: bind the context at registration time. Practically: `pollInFlight` becomes a `Map<RunId, RunContext>` and the timer callback uses `withRunContext(stored, fn)` rather than reading whatever scope happens to be active. ~20 LOC.
+
+## 23. Logger v2 — structured events, explicit context, no module globals
+
+### 23.1 What's wrong with today's logger
+
+`src/logger/logUtils.ts` is a serviceable VS Code-shaped logger. It is also wrong for the CLI in three concrete ways:
+
+1. **`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level state.** The audit finds exactly one setter in production code (`packages/extension/src/extension.ts`), but tests and an MCP-server mode that hosts concurrent runs cannot safely share these. The `setOutputChannelFactory(null)` reset disposes channels for *every* concurrent caller.
+2. **Group context lives in its own ALS (`contextStorage`, line 10), separate from the runtime host's ALS (`runtimeHostScope`, `AgentRuntimeHost.ts:12`).** A sub-agent that emits a log line passes through both scopes; the two are kept in sync by convention, not enforcement.
+3. **`writeLine` calls `getConfig('texra.logger.debugMode', false)` on every line (line 79).** That's fine in the extension where `getConfig` is a wrapped `vscode.workspace.getConfiguration`, but in the CLI before `initPlatform()` runs (which the audit shows happens for ~40 module-load-time `initialize()` calls), the config provider may not exist yet. Today's `tryPlatform()` fallback works because `getConfig` returns the default; in the CLI we want stricter guarantees that log lines emitted during boot don't silently lose their context.
+
+Plus a non-bug observation: the JSON / NDJSON renderer specced in round 1 §11.2 is a *separate* code path from the human renderer. Two formats, one schema is fine; two formats, two code paths is duplication waiting to bit-rot.
+
+### 23.2 Shape
+
+A single `Logger` interface that is part of `RunContext` (§22.3), with sinks plugged in by the host:
+
+```ts
+// packages/core/src/runtime/logger.ts
+export interface Logger {
+  debug(msg: string, fields?: LogFields): void;
+  info(msg: string, fields?: LogFields): void;
+  warn(msg: string, fields?: LogFields): void;
+  error(msg: string, fields?: LogFields): void;
+
+  /** Push a group; returned function pops it. Replaces logUtils' ALS. */
+  group(label: string): () => void;
+  /** Wrap an async fn in a group; returns its result. */
+  withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T>;
+
+  /** Per-domain child — adds a static field to every emission. Cheap. */
+  child(fields: LogFields): Logger;
+}
+
+export interface LogFields {
+  /** Stream lineage. Auto-injected by RunContext.log; usable by hosts for prefix. */
+  readonly streamId?: StreamTabId;
+  readonly runId?: RunId;
+  readonly groupId?: string;
+  /** Free-form structured data; the host decides whether to render it. */
+  readonly [k: string]: unknown;
+}
+```
+
+The host registers a single `LogSink` (renamed from `LogBackend` to make explicit that it consumes structured records, not formatted strings):
+
+```ts
+export interface LogRecord {
+  ts: string;             // ISO-8601 with millis
+  level: LogLevel;
+  message: string;
+  fields: LogFields;
+  groups: readonly string[];   // current group stack at emit time
+}
+
+export interface LogSink {
+  write(record: LogRecord): void;
+  flush?(): Promise<void>;
+}
+```
+
+### 23.3 What each host installs
+
+| Host       | Sink                                                                                            |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| Extension  | `VscodeOutputChannelSink` — writes formatted strings to `vscode.OutputChannel` (today's behavior). One channel per agent. |
+| Desktop    | `electronLogSink` over `electron-log` (Electron PRD §6.4); same channel-per-agent shape.        |
+| CLI headless | `StderrTextSink` — picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`. Also writes to `--log-file` if passed. |
+| CLI JSON   | `NdjsonStdoutSink` — one JSON object per line, schema-validated against `LogRecord`. **This is the same data path §11.2 specs as the event stream — log records and progress events share the JSON Lines envelope.** |
+| CLI MCP    | `McpProgressSink` — converts each record to an MCP `notifications/progress` payload bound to the request's progress token. Respects the client's progress-update opt-in. |
+| Tests      | `MemorySink` — pushes records into an array for assertion; auto-installed via `withRunContext()` in `vitest.setup.ts`. |
+
+### 23.4 Rendering rules — round-1 §11 reconciled
+
+Round 1 §11.2 specifies an NDJSON event stream. Round 2 unifies it with the log stream:
+
+- Every `LogRecord` is also a `ProgressEvent` with `event: "log"`. The schema is `LogRecord ∪ ProgressEventPayloads` (a Zod discriminated union on `event`).
+- Consumers that care only about logs filter `event === "log"`. Consumers that care only about progress (e.g. `texra-action`'s log-group renderer) filter `event !== "log"`.
+- Schema lives in `packages/shared/schemas/runStream.ts` (new). Versioned per round-1 §11.2's policy.
+- The headless text renderer (`StderrTextSink`) renders `event === "log"` lines as `[time] [agent] message` and `event !== "log"` lines as the structured progress format. One renderer, two sub-paths, one schema.
+
+### 23.5 Group context migration
+
+The current `runWithGroupContext()` is replaced by `RunContext.log.withGroup()`. The migration is mechanical:
+
+```ts
+// before
+await runWithGroupContext(channel, groupId, isAgent, async () => {
+  logger.info(channel, 'doing thing');
+});
+
+// after
+await ctx.log.child({ channel }).withGroup(groupId, () => {
+  ctx.log.info('doing thing');
+});
+```
+
+Both forms run for one release; the old form is `@deprecated` and routes to the new one. The `contextStorage` ALS in `logUtils.ts:10` is deleted at the end of the migration.
+
+### 23.6 Boot-time logging
+
+The CLI emits ~3–5 log lines before `initPlatform()` returns (config layer load, secret resolution, agent-directory bootstrap). Today these go through `console.info` at module load time. Round 2 routes them through a `BootstrapLogger` — a `Logger` impl that buffers records into an array until `initPlatform()` finishes, then flushes them through whichever sink the host registered. ~30 LOC. No more "config debug toggle silently broken during boot."
+
+### 23.7 LOC accounting
+
+| Item | New | Modified | Deleted |
+| ---- | --- | -------- | ------- |
+| `packages/core/src/runtime/logger.ts` (new — interface + bootstrap logger + group helpers) | ~180 | — | — |
+| `packages/core/src/runtime/runContext.ts` (logger threaded as field) | (counted under §22) | — | — |
+| `src/logger/logUtils.ts` (kept for legacy callers; routes to new logger) | — | ~80 | — |
+| `src/logger/AgentLogger.ts`, `AgentUsageReporter.ts` (route through `ctx.log`) | — | ~40 | — |
+| Per-host sinks: `VscodeOutputChannelSink` (extension), `StderrTextSink` + `NdjsonStdoutSink` (CLI), `McpProgressSink` (CLI v1.1) | ~250 | — | — |
+| `texra config` exposes `logger.debugMode` via `ConfigProvider.watch()`; remove the per-write `getConfig` lookup | — | ~10 | ~5 |
+| **Subtotal** | **~430** | **~130** | **~5** |
+
+This counts against §14's pre-refactor budget (~430 → ~860 with logger v2 added). Within the engineering-week envelope from §15 because §22 + §23 deliverables are the natural prerequisite for §24.
+
+## 24. `texra mcp serve` — callable from Claude Code, Codex, and opencode
+
+### 24.1 Why now
+
+Round 1 §18.1 deferred MCP-server mode to v1.1. Round 2 promotes it to v1 because the survey is unambiguous: every CLI in this category (Claude Code's `claude mcp serve`, OpenAI Codex's `codex mcp`, opencode via its OpenAPI server) ships a stdio MCP server as its delegate-from-another-agent surface. A TeXRA CLI without one is an island.
+
+The user's framing — "to be callable by Claude Code and Codex etc" — is exactly this surface. From a Claude Code session, the user adds:
+
+```jsonc
+// .mcp.json (project) or ~/.claude/mcp.json (user)
+{
+  "mcpServers": {
+    "texra": {
+      "command": "texra",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+… and Claude Code can now call `texra__run_polish`, `texra__run_elevate`, `texra__list_agents`, etc. as tools. The Codex equivalent goes in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.texra]
+command = "texra"
+args = ["mcp", "serve"]
+transport = "stdio"
+```
+
+`texra mcp serve` is the single most leveraged feature in round 2: it makes every TeXRA agent reusable from every other agent that speaks MCP, without a fork.
+
+### 24.2 Surface
+
+A minimum viable v1 surface — three tools, no resources, no prompts. Resources can come in v1.1 once we know what callers actually want.
+
+| MCP tool name | Backed by | Purpose |
+| ------------- | --------- | ------- |
+| `run_workflow` | `executeAgent({ category: "workflow", ... })` | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`. |
+| `run_chat` | `executeAgent({ category: "toolUse", ... })` | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
+| `list_agents` | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate. |
+
+All three accept an optional `runId` so the caller can correlate progress notifications. Approval policy is forced to `never` by default in MCP mode (no TTY for prompts) — callers wanting bash/edit auto-approval pass `approvalPolicy: "yolo"` explicitly, exactly as round 1 §9 specifies for headless mode.
+
+### 24.3 Process model
+
+stdio JSON-RPC 2.0, one process per client connection, exactly the Claude Code / Codex pattern. The server lifecycle:
+
+1. `texra mcp serve` boots, calls `initPlatform()` once with a special `McpHostAdapter` (config from `~/.config/texra/`, secrets from keyring, no stdout writes — all output is JSON-RPC framed on stdout).
+2. `initialize` request from the MCP client establishes session capabilities and the `progressToken` shape.
+3. Each `tools/call` from the client builds a fresh `RunContext` (§22.3) — fresh `progress: McpProgressSink`, fresh `signal: AbortController`, fresh `coordinators`. **This is why §22's singleton retirement gates v1.1 of `texra mcp serve`** — until coordinators are per-context, two concurrent `tools/call`s leak progress between them.
+4. `notifications/progress` from the server streams progress events to the client (one notification per `ProgressEvent`). The client's handler decides whether to render them (Claude Code's hook system can route them to a sub-stream tab).
+5. On `notifications/cancelled`, the matching run's `signal` is aborted; the run cleans up via existing cooperative-cancel paths.
+6. Server exits when stdin closes.
+
+### 24.4 Permission propagation
+
+The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the *call* (e.g., Claude Code asked the user "let texra__run_polish run?"). What TeXRA still owns is what the *agent inside* TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
+
+Three policies for those inner gates, selected by tool argument:
+
+- `approvalPolicy: "never"` (default in MCP mode) — auto-deny inner edits/bash. The orchestrator agent must complete without them or fail. Suitable for trusted reasoning + read-only file inspection.
+- `approvalPolicy: "yolo"` — auto-approve inner edits/bash. Caller takes responsibility (the caller is itself an agent that already negotiated permission with its user).
+- `approvalPolicy: "ask"` — emit a `notifications/elicitation/create` to ask the caller. Requires MCP Spec 2025-03-26+ elicitation support. v1 ships `never|yolo`; `ask` lands when ecosystem support stabilizes.
+
+### 24.5 v1 vs v1.1 deliverables
+
+**v1.0 ships:**
+
+- `texra mcp serve` subcommand using `@modelcontextprotocol/sdk` (the official TS SDK). ~250 LOC of glue.
+- Three tools above.
+- `notifications/progress` streaming.
+- Cancellation via `notifications/cancelled`.
+- Session isolation **only** to the extent the §22.5 v1.0 migration achieves it (per-context coordinators). One concurrent run per process; concurrent calls serialize. Documented limitation.
+
+**v1.1 ships (gated on §22.5 v1.1 migration):**
+
+- True concurrent sessions in one MCP-server process. The audit's singleton-retirement work removes the leak risk.
+- Optional MCP `resources` surface exposing `~/.texra/projects/<hash>/<sessionId>.jsonl` (§27) for transcript replay.
+- Elicitation-based approvals.
+
+### 24.6 LOC
+
+| Item | New | Modified |
+| ---- | --- | -------- |
+| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising) | ~120 | — |
+| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts` | ~250 | — |
+| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80 | — |
+| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch) | — | ~30 |
+| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`) | ~40 | — |
+| **Subtotal** | **~490** | **~30** |
+
+## 25. Hook system (Claude Code-style)
+
+### 25.1 Why now
+
+Hook contracts are easy to bolt on later in theory and a nightmare in practice — every hook event the kernel doesn't fire today is one that consumers can't depend on tomorrow. The survey shows Claude Code's hook event taxonomy is the de facto standard (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SubagentStop`, `Stop`, `Notification`, `PreCompact`, `PostCompact`, `PermissionRequest`). We adopt the same names and the same wire contract; that buys us:
+
+- Users who already have Claude Code hooks can copy them with a one-line `command:` change.
+- A `texra` hook can call out to a `claude` hook handler and vice versa with no translation.
+- The hook contract — JSON on stdin, JSON or empty on stdout, `exit 2` to block — is dead simple to implement in any language.
+
+### 25.2 Wire contract (verbatim from Claude Code)
+
+```jsonc
+// hook input on stdin
+{
+  "hookEventName": "PreToolUse",
+  "session": { "id": "ses_abc123", "cwd": "/path/to/project", "agent": "orchestrator" },
+  "tool": { "name": "bash", "input": { "command": "rm -rf /" } }
+}
+```
+
+```jsonc
+// hook output on stdout (optional)
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "deny",
+    "reason": "rm -rf is not allowed in this project"
+  }
+}
+```
+
+`exit 0` with no stdout = no opinion (continue). `exit 0` with stdout = parsed as a `HookOutput`. `exit 2` = block; stderr is forwarded to the agent as a tool-result error. Other non-zero codes = log a warning, don't block.
+
+### 25.3 Where hooks fire
+
+| Event | Fires from | RunContext field |
+| ----- | ---------- | ---------------- |
+| `SessionStart` | `executeAgent.ts` after `buildAgentLaunchContext` | `runId`, `streamId`, `cwd` |
+| `UserPromptSubmit` | Tool-use REPL on each user submit | `runId`, `instruction` |
+| `PreToolUse` | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch | `runId`, `tool.name`, `tool.input` |
+| `PostToolUse` | Tool dispatch after result | `runId`, `tool.name`, `tool.result.summary` |
+| `Stop` | `executeAgent` finalizer | `runId`, `result.status` |
+| `SubagentStop` | Delegation child completion | `runId`, `parentStreamId`, `childStreamId`, `result` |
+| `Notification` | Any `requestShowError` / `requestShowInstruction` emission | `runId`, `message` |
+| `PreCompact` / `PostCompact` | (Future, §32 — context compaction) | `runId`, `compactionStats` |
+| `PermissionRequest` | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"|"bash"|"plan"|"proposal"|"retry"` |
+
+### 25.4 Configuration
+
+`hooks.yaml` under each scope, layered the same way config is (`flag > project > user`). `~/.config/texra/hooks.yaml` for user, `.texra/hooks.yaml` for project, both validated against a Zod schema:
+
+```yaml
+# .texra/hooks.yaml
+PreToolUse:
+  - matcher: { tool: bash }
+    handler:
+      type: command
+      command: ./scripts/audit-bash.sh
+      timeoutMs: 5000
+  - matcher: { tool: edit, path: 'src/legacy/**' }
+    handler:
+      type: command
+      command: ./scripts/no-legacy-edits.sh
+
+PostToolUse:
+  - matcher: { tool: '*' }
+    handler:
+      type: command
+      command: ./scripts/log-tool.sh
+
+SessionStart:
+  - handler:
+      type: prompt
+      append: 'Always cite ArXiv numbers when referencing papers.'
+```
+
+Handler types (subset of Claude Code's): `command` (shell), `prompt` (append text to the system prompt), `mcp_tool` (call an MCP tool). `http` and `agent` are deferred — they're nice but not on the critical path.
+
+### 25.5 v1 deliverable
+
+v1.0 ships `command` and `prompt` handlers and the eight events listed above except `Pre/PostCompact`. ~400 LOC, mostly schema validation and the dispatch loop. Each hook runs in a 30s default timeout (configurable per hook). Multi-handler matchers: all run in parallel; any non-zero exit blocks; first-match `permissionDecision` wins.
+
+### 25.6 Why this is in the CLI PRD, not a separate one
+
+Hooks fire from kernel code paths (`executeAgent.ts`, approval coordinators) — which means the kernel needs a `HookHost` interface (shape: `dispatch(event, payload): Promise<HookOutput>`). The extension and the desktop host get hooks for free once the kernel side is wired. That's a kernel pre-refactor (call it C9):
+
+**C9. `HookHost` interface in `core/hosts/hooks.ts`.** _(~60 LOC interface + ~80 LOC dispatcher in core; ~60 LOC of hook-loading + matcher logic in core; ~250 LOC of CLI-side adapter to load `hooks.yaml` and execute commands.)_
+
+The CLI adapter is the only handler-runner v1.0 ships. The extension and desktop hosts can install a no-op `HookHost` at v1.0 and pick up `command`-handler support whenever they want — no kernel work needed.
+
+## 26. Approval policy revisited (no 2D sandbox axis)
+
+### 26.1 Why we're not adopting Codex's matrix
+
+Round 2's first draft proposed adopting Codex's `approval_policy × sandbox_mode` 2D matrix. User feedback: that's too complicated. Round 1's 1D model — `never | ask | auto-edits | auto | yolo` — stays.
+
+The reasons it's the right call:
+
+1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap *all* agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
+2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — *not* a CLI-only knob.
+3. **A 2D matrix doubles the test surface and doubles the doc surface.** The mental load — "if I pass `--approval-policy auto --sandbox workspace-write` what happens to bash that touches `/tmp`?" — is exactly the friction users complained about with Codex's first iteration.
+
+### 26.2 What round 2 *does* sharpen
+
+Round 1 §9.2 says "in-project means the candidate file/cwd is inside the resolved workspace path." Round 2 specifies the predicate concretely so the kernel and the CLI agree:
+
+```ts
+// packages/core/src/runtime/approvalPredicates.ts (new — ~40 LOC)
+export function isInProject(
+  candidate: string,
+  workspaceRoot: string,
+): boolean {
+  const candidateAbs = path.resolve(candidate);
+  const rootAbs = path.resolve(workspaceRoot);
+  const rel = path.relative(rootAbs, candidateAbs);
+  return !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+```
+
+Edge cases the predicate handles explicitly:
+
+- Symlink resolution: `path.resolve()` does NOT resolve symlinks; we deliberately do not follow them. A symlink inside the project pointing outside is treated as outside-project for approval purposes, which matches user intuition ("a symlink to /etc isn't 'inside my project'").
+- Case-insensitive filesystems (macOS HFS+, Windows NTFS): `path.relative` returns the actual case from the filesystem; comparison is exact-string. This is correct — case folding belongs in the filesystem layer, not the policy predicate.
+- `cwd === workspaceRoot`: trivially in-project; no separate codepath.
+- Files under the workspace's `.git/` directory: in-project by predicate, but flagged with a separate `isInsideHiddenDir` helper that approval handlers check before auto-approving (we never auto-approve writes to `.git/`, period).
+
+### 26.3 Bash command predicate
+
+Bash is harder than file paths — "auto-approve when in-project" doesn't make sense for `rm -rf $HOME`. Round 1 punted on this. Round 2 spec:
+
+- `auto` policy auto-approves bash *only* when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
+- Any redirect to `/`, any unquoted variable, any `&&` / `||` / `|` chain that contains a non-listed command → falls back to `ask` even under `auto`.
+- `yolo` short-circuits all of this; `never` always denies.
+
+The argv parser is `shell-quote` (~3 KB, MIT, 30M weekly downloads) — well-trodden territory, no need to write a shell parser.
+
+### 26.4 No new flags, no policy renames
+
+Same vocabulary as round 1 §9.2. Same flags. The §26 work is just the predicate library and ~40 LOC of guard code in `cli/src/approval/policyEngine.ts`. Total: ~80 LOC of new code, ~20 LOC modified.
+
+## 27. Session transcripts — JSONL under project-hash sharding
+
+### 27.1 What today's storage layout looks like
+
+`RunStorageService` (and `executionRegistry.ts`) writes per-execution snapshots to `nodeStorage` workspace storage — the shape is "a directory per execution, files inside." This works for the extension's progress webview (which reads the snapshot to repopulate the tab on reload) but is awkward for a CLI:
+
+- No single file to `tail -f`.
+- No `find` query for "all sessions in project X."
+- No way to import a session into a new project (project identity is implicit).
+- `texra resume <id>` has to reconstruct context from disparate files.
+
+### 27.2 The new layout
+
+Match Claude Code's pattern, with TeXRA's run/stream lineage:
+
+```
+~/.texra/projects/
+  <projectHash>/                # sha256(absolute cwd), first 16 hex chars
+    project.json                # { cwd, agentCategoryDefaults, lastSession }
+    sessions/
+      <sessionId>.jsonl         # one event per line; round-1 §11.2 schema
+      <sessionId>.meta.json     # { createdAt, agent, model, status, duration, parentSession? }
+```
+
+`<sessionId>` is `ses_` + 12 hex chars (collision-safe; ULID-like). Project hash is stable across machines because the cwd is normalized (resolved symlinks, lowercased on case-insensitive filesystems, no trailing slash).
+
+### 27.3 What's in the JSONL
+
+Each line is exactly one `LogRecord ∪ ProgressEventPayloads` from §23.4. The first line is a synthetic `event: "session_start"` carrying the `AgentConfigPayload`, the resolved model, the workspace root, and the approval policy. The last line is `event: "session_end"` with `AgentFlowResult`. Everything between is the round-1 §11.2 NDJSON event stream as it happened, with timestamps preserved.
+
+This gives us several wins for free:
+
+- `texra run ... --output-format ndjson > out.ndjson` and the on-disk transcript are byte-for-byte the same data shape (modulo the synthetic start/end markers). Tools that parse one parse the other.
+- Replay: `cat <sessionId>.jsonl | jq -c .` is a debug session.
+- Compaction (§32): a `texra session compact <id>` subcommand can rewrite the JSONL with summarized turns; the schema knows what's safe to drop.
+
+### 27.4 `texra resume` semantics
+
+```
+texra resume                           # interactive picker over recent sessions in cwd's project
+texra resume <id>                      # resume that specific session
+texra run --continue                   # most recent session in cwd's project
+texra run --fork-session <id>          # branch from <id>; creates new sessionId, copies context up to fork point
+```
+
+`--continue` is shorthand for `texra resume <last>`; `--fork-session` matches Claude Code's verb. The runtime side is the existing `resumeToolUseFromSnapshot()` — but it now takes a `sessionId` and reads the JSONL up to the last `session_end` (or the end of file for a still-active session).
+
+### 27.5 Migration
+
+The existing `~/.texra/global-storage/<workspace>/runs/` layout stays for one release; an entry-point shim translates legacy reads. New sessions write to the new layout. ~80 LOC of migration code; ~120 LOC of writer + reader.
+
+### 27.6 LOC
+
+| Item | New | Modified |
+| ---- | --- | -------- |
+| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200 | — |
+| `packages/core/src/storage/sessionMigration.ts` (legacy → new) | ~80 | — |
+| `cli/src/commands/resume.ts` (consumes sessionStore directly) | — | ~30 |
+| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags) | — | ~20 |
+| **Subtotal** | **~280** | **~50** |
+
+## 28. GitHub Action revisited — composite + Bun, not JS
+
+### 28.1 Why round 1's JS Action pick was wrong
+
+Round 1 §6 #9 picked JS Action ("warm-cached and faster than Docker for this use case"). The survey shows `claude-code-base-action` actually ships as a **composite action** that shells out via `bun run ${GITHUB_ACTION_PATH}/src/index.ts`. The reasons that's the right pick — and round 1 missed them:
+
+1. **No `dist/` checked into the action repo.** JS Actions require a bundled `dist/index.js` committed to the repo (because GitHub Actions runners only download the `action.yml` + the repo contents, not run `npm install`). Composite actions can install dependencies at action-run time, which means the action repo holds source, not bundles, and PRs are reviewable.
+2. **Faster iteration.** A composite action can pin a specific CLI version (`npm install -g @texra/cli@x.y.z`) per release without re-bundling. JS Actions need a release-cut process every CLI release.
+3. **Bun caches the install.** The runner's `actions/cache` key on `~/.bun/install/global` makes repeat runs near-instant, matching JS Action's warm-cache claim.
+4. **Composite + `runs.using: composite`** lets us stitch multiple steps (cache restore → install → run → upload artifacts) without a Node entrypoint that has to do all of those itself.
+
+### 28.2 Revised action shape
+
+```yaml
+# texra-ai/texra-base-action/action.yml
+name: TeXRA Base Action
+description: Run a TeXRA agent on inputs in your repository.
+inputs:
+  agent: { description: 'Agent name (polish, elevate, …)', required: true }
+  input: { description: 'Input file path', required: false }
+  output: { description: 'Output file path', required: false }
+  rounds: { description: 'Workflow rounds', required: false, default: '1' }
+  model: { description: 'Model name', required: false }
+  approval-policy: { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
+  texra-version: { description: 'Pinned CLI version', default: 'latest' }
+  output-format: { description: 'text|json|ndjson', default: 'ndjson' }
+outputs:
+  status: { description: 'completed|failed|cancelled' }
+  output-files: { description: 'JSON array of output file paths' }
+  session-id: { description: 'Session id for resume' }
+  execution-file: { description: 'Path to NDJSON transcript on the runner' }
+runs:
+  using: composite
+  steps:
+    - name: Cache TeXRA CLI
+      id: cache-cli
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.bun/install/global
+          ~/.npm
+        key: texra-cli-${{ runner.os }}-${{ inputs.texra-version }}
+
+    - name: Install TeXRA CLI
+      if: steps.cache-cli.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install -g @texra/cli@${{ inputs.texra-version }}
+
+    - name: Run TeXRA
+      id: run
+      shell: bash
+      env:
+        TEXRA_OUTPUT_FORMAT: ${{ inputs.output-format }}
+      run: |
+        texra run "${{ inputs.agent }}" \
+          ${{ inputs.input && format('--input "{0}"', inputs.input) || '' }} \
+          ${{ inputs.output && format('--output "{0}"', inputs.output) || '' }} \
+          --rounds "${{ inputs.rounds }}" \
+          ${{ inputs.model && format('--model "{0}"', inputs.model) || '' }} \
+          --approval-policy "${{ inputs.approval-policy }}" \
+          --output-format "${{ inputs.output-format }}" \
+          | tee texra-transcript.ndjson
+
+        # Parse final summary line for outputs
+        summary=$(tail -1 texra-transcript.ndjson)
+        echo "status=$(echo "$summary" | jq -r .status)" >> "$GITHUB_OUTPUT"
+        echo "output-files=$(echo "$summary" | jq -c .outputs)" >> "$GITHUB_OUTPUT"
+        echo "session-id=$(echo "$summary" | jq -r .meta.sessionId)" >> "$GITHUB_OUTPUT"
+        echo "execution-file=texra-transcript.ndjson" >> "$GITHUB_OUTPUT"
+
+    - name: Upload transcript
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: texra-transcript-${{ inputs.agent }}
+        path: texra-transcript.ndjson
+        retention-days: 7
+```
+
+~80 lines of YAML; no JS to write at all for the base action. The high-level `texra-action` (§12.2) still has logic — trigger detection, PR comment posting, optional commit-back — and stays a TS-source composite action that runs `bun run src/index.ts` for that logic.
+
+### 28.3 Cold-start measurements (target)
+
+- First run on a fresh runner: `npm install -g @texra/cli` ≈ 12s + first `texra run` ≈ 4s = ~16s overhead before the model call.
+- Cached run: `actions/cache` hit ≈ 1s + `texra run` ≈ 4s = ~5s overhead.
+- JS Action equivalent: ~3s (no install) + ~4s = ~7s. The composite is +2s on the warm path and -∞ on the iteration path (no bundle re-cuts needed).
+
+### 28.4 Updated round-1 §6 decision
+
+| #   | Concern                | Round 1 pick      | Round 2 pick |
+| --- | ---------------------- | ----------------- | ------------ |
+| 9   | GitHub Action          | JS Action         | **Composite action + Bun runner; install CLI from npm at run time** |
+
+No other round-1 picks change.
+
+## 29. Cross-platform shared structure (kernel-side refactor)
+
+### 29.1 Today's shape
+
+The pnpm workspace has three packages skeletoned (`packages/{core,extension,desktop}`) with the kernel still living at root `src/`. Round 1 §7.1 assumed Electron Phase 0 finishes the kernel migration and the CLI is the fourth peer. Round 2 sharpens what "the kernel" means and where the per-host seams go — because the audit revealed three categories of shared code that today live mixed together.
+
+### 29.2 Three layers under `packages/core/`
+
+The kernel splits cleanly into three concentric rings; each ring has a different host-coupling rule.
+
+**Ring 1: pure logic** (zero host coupling, zero ALS).
+
+- `core/agent/` minus runtime — every modelHandler, every flow, every node, every reasoning strategy.
+- `core/model/`, `core/latex/`, `core/replacement/`, `core/eventBus/` (schemas only — no emitters).
+- `core/tools/` minus `core/tools/approval/`.
+- `core/shared/` — IPC schemas, `runStream.ts` (§23.4).
+
+These take a `RunContext` argument (post-§22) but never reach for the ambient store. Test harnesses pass a synthesized `RunContext` and never need a fake host.
+
+**Ring 2: runtime orchestration** (consumes `RunContext`; no `vscode`/`electron`/`process` access).
+
+- `core/runtime/` — `RunContext`, `Logger`, `ProgressSink` interface, `executeAgent`, all coordinators.
+- `core/tools/approval/` — gates and controllers.
+- `core/auth/` — `SupabaseSessionCoordinator`, `TierService`, `ServerSideKeyService` (post-§22.5 per-context).
+- `core/hosts/` — every host port (`PromptHost`, `ExternalOpener`, `DiffViewHost`, `TerminalHost`, `ClipboardHost`, plus the new `HookHost` from §25.6).
+- `core/storage/sessionStore.ts` (§27.6).
+
+These import from Ring 1 freely, and they accept host services through their constructor / `RunContext` — but they never `import 'vscode'`, never `import 'electron'`, never `process.exit`.
+
+**Ring 3: platform defaults** (Node-only; no `vscode`/`electron`).
+
+- `core/platform/defaults/` — today's `consoleLog`, `memoryState`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `EnvSecrets`. CLI uses 5 of 6; desktop uses similar set; extension uses none.
+
+These are the shared concrete impls that any Node host gets for free. Adding a new Node-based host (e.g. a `texra serve` daemon, or a future Tauri-based app) should require only Ring 3 + a thin host adapter — no Ring 1 or Ring 2 changes.
+
+### 29.3 What lives in `packages/{extension,desktop,cli}/`
+
+Per-host code is everything that imports a host SDK or interacts with a host's surface. Crisp rule: **the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is**.
+
+| Host | Owns | Doesn't own |
+| ---- | ---- | ----------- |
+| Extension | `vscode.commands`, webview hosts, `frontend/vscode/*`, controllers wired to webview message handlers, `VscodeOutputChannelSink` | The agent runtime (in core); coordinators (in core) |
+| Desktop | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging | Same |
+| CLI | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner | Same |
+
+### 29.4 The host-port catalog (consolidated)
+
+Round 1 §4.1 lists the host ports already landed (`PromptHost`, `ExternalOpener`, etc.). Round 2 adds:
+
+| Port | Added in | Implementations |
+| ---- | -------- | --------------- |
+| `LogSink` | §23.2 | `VscodeOutputChannelSink`, `electronLogSink`, `StderrTextSink`, `NdjsonStdoutSink`, `McpProgressSink`, `MemorySink` |
+| `HookHost` | §25.6 | `CommandHookHost` (CLI), `NoopHookHost` (extension/desktop v1.0) |
+| `SessionStore` | §27.6 | `JsonlSessionStore` (shared across all Node hosts; extension uses storage path under `globalStorageUri`) |
+
+All ports live in `packages/core/src/hosts/`. The `Platform` interface from `src/platform/platform.ts` stays the same — those are the *infrastructure* services (config, fs, secrets); ports are the *interaction* services. They're not the same thing and they should not merge.
+
+### 29.5 What this saves
+
+The refactor isn't free — it's ~150 LOC of `index.ts` re-exports + ESLint rules + a few moves. What it buys:
+
+- **A new host needs only the rings it cares about.** A future Tauri app: import Ring 1 + Ring 2 + a Tauri-specific Ring 3 (`tauriFilesystem`, `tauriSecrets`); zero extension or CLI code touched.
+- **Tests don't fake hosts to test logic.** Ring 1 has no host. The kernel's existing FakePlatform suite stays in Ring 2 and only exercises Ring 2 code paths.
+- **Webview vs CLI vs Electron diff is a wiring diff, not a behavior diff.** When `polish` rewrites a paragraph differently in the CLI than the extension, we have one place to look (Ring 1 + the agent's YAML), not three.
+
+### 29.6 LOC
+
+| Item | New | Modified | Deleted |
+| ---- | --- | -------- | ------- |
+| Reorg of `packages/core/src/` into `agent/` (R1), `runtime/` (R2), `platform/` (R3) — mostly `git mv` | — | ~10 (re-export files) | — |
+| ESLint `no-cross-ring-imports` rule | ~40 | — | — |
+| `core/hosts/index.ts` re-export catalog | ~30 | — | — |
+| `core/runtime/index.ts` re-export | ~20 | — | — |
+| **Subtotal** | **~90** | **~10** | — |
+
+Mostly mechanical; no rewrites of business logic.
+
+## 30. Container & GitHub-runner target matrix
+
+### 30.1 Survey-driven revisions
+
+Round 1 §12.3 listed five containers as "verified to run." The survey turns up two corrections:
+
+1. **`node:20-alpine` is best-effort, not first-class.** Alpine's musl libc breaks `@napi-rs/keyring` prebuilds (we already plan to fall back to file-based secrets there). It also breaks Bun's prebuilt binaries — relevant if a user wants to run `texra mcp serve` from Bun rather than Node. We document Alpine as supported only with the file-secrets fallback and Node-only execution.
+2. **`node:20-bookworm-slim` is the recommended Linux image.** Glibc, smallish (~80 MB before TeXRA), and `apt-get install libsecret-1-0` for keyring is one line.
+
+### 30.2 Updated matrix
+
+| Image / runner | Tier | Notes |
+| -------------- | ---- | ----- |
+| `ubuntu-22.04` (default GitHub runner) | First-class | Node 20 preinstalled. CI matrix runs full E2E here. |
+| `ubuntu-24.04` | First-class | Same. Recommended once GHA's default flips. |
+| `macos-14` (GitHub-hosted M-series) | First-class | E2E runs here for keyring path coverage. |
+| `windows-latest` | First-class | E2E runs here for path-handling coverage. |
+| `node:20-bookworm-slim` | First-class | Recommended self-hosted/container. ~80 MB. |
+| `node:20-bookworm` | First-class | Same plus build tools. ~150 MB. |
+| `texlive/texlive:latest` | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
+| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0. |
+| `node:20-alpine` | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3. |
+| `gitpod/workspace-full` | Best-effort | Smoke-tested but not in CI matrix. |
+
+### 30.3 Local-development "callable from Claude Code / Codex" verification
+
+The survey-driven user goal — "callable by Claude code and codex etc" — is verified in CI by an integration test:
+
+- A GitHub Actions job spawns a fresh runner.
+- Installs `@anthropic-ai/claude-code` + `@texra/cli`.
+- Writes `.mcp.json` pointing at `texra mcp serve`.
+- Runs `claude --print "list the workflow agents available via texra"` in headless mode.
+- Asserts the response mentions at least three TeXRA workflow agent names.
+
+The same test pattern with `@openai/codex` covers the Codex path. ~120 LOC of test, runs once per PR. Cost: ~$0.03 per run (a few thousand tokens). Catches regressions in the MCP wire contract specifically — the surface most likely to silently rot because no human-in-the-loop session exercises it.
+
+### 30.4 Where-does-the-CLI-write-files matrix
+
+To make GitHub-Actions ephemerality explicit (and prevent secrets leaking via uploaded artifacts), every file path the CLI writes is documented with a default and an env override:
+
+| Concern | Default (linux) | Env override | Allowed in CI artifact upload? |
+| ------- | --------------- | ------------ | ------------------------------ |
+| Config | `~/.config/texra/config.yaml` | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs. |
+| Secrets fallback | `~/.texra/secrets.json` (chmod 0600) | `TEXRA_DATA_DIR` | **Never** — explicit gitignore + `.actignore` patterns. |
+| Session JSONL | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR` | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
+| Runtime cache | `~/.cache/texra/` | `TEXRA_CACHE_DIR` | Yes; non-sensitive (downloaded model schemas, agent registry). |
+| Logs (`--log-file`) | User-specified | — | User-controlled — they pick. |
+
+Documented as `texra config path` output for fast diagnosis from `texra doctor`.
+
+## 31. Round 2 — phase plan delta and aggregate LOC
+
+### 31.1 Phase plan delta vs round 1 §15
+
+Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for the MCP-server surface. Phases 0, 2, 3, 4, 5 from round 1 keep their scope; Phase 1 absorbs §22 + §23 + §26 (all kernel-side, all on the critical path for tool-use agents).
+
+| Phase | Round-1 scope | Round-2 additions |
+| ----- | ------------- | ----------------- |
+| 0 | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29) |
+| 1 | Tool-use + approval engine | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
+| 1.5 (new) | — | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3) |
+| 2 | Config + secrets + auth | unchanged |
+| 3 | Interactive REPL | unchanged |
+| 4 | GitHub Action | composite-action revision (§28) |
+| 5 | Polish, docs | + JSONL session migration (§27.5) + hook system v1 (§25.5) |
+
+### 31.2 Aggregate LOC
+
+| Bucket | Round-1 net | Round-2 additions | Round-2 total |
+| ------ | ----------- | ----------------- | ------------- |
+| `packages/cli/` | 2,800–3,800 | +730 (MCP §24.6, hooks adapter §25, sessions §27.6, sandbox-removed §26 ≈ 0) | **3,530–4,530** |
+| `packages/core/` (CLI pre-refactors) | ~730 | +940 (RunContext §22 net ~+170, Logger v2 §23 ~+430, HookHost §25.6 ~+140, sessionStore §27.6 ~+200, ring re-exports §29.6 ~+90, approval predicates §26 ~+80, minus overlap with Logger) | **~1,670** |
+| `texra-ai/texra-action` (separate repo) | ~800 | -300 (no JS shim; YAML composite + small TS for the high-level action only) | **~500** |
+| **Total v1** | **~4,330–5,330** | **+~1,370** | **~5,700–6,700** |
+
+The round-2 work expands the project by ~30%, but ~70% of the addition is in the kernel — work that the extension and the desktop app inherit unchanged. The CLI shell still finishes in the same ballpark (3.5–4.5 KLOC). v1 ships in **~9–11 weeks** for a single engineer, **~6–8** for two engineers (Phases 0 + 1 sequential, 1.5 + 2 parallel, 3 sequential, 4 + 5 parallel).
+
+### 31.3 Updated success criteria (additive to §17)
+
+- `texra mcp serve` is callable from Claude Code with default `.mcp.json` config; the integration test in §30.3 passes on every PR.
+- `RunContext` is the only path through which kernel code accesses progress / log / signal / approval. The ESLint `no-ambient-runtime-state` rule has zero exceptions in `packages/core/src/agent/`, `core/tools/`, `core/auth/` after v1.3.
+- A user can `texra run polish ...` from inside `texlive/texlive:latest` with only `npm install -g @texra/cli` and `ANTHROPIC_API_KEY` set — no extra setup, no other binaries.
+- Session JSONL transcripts are byte-equivalent to `--output-format ndjson` output (modulo the synthetic `session_start`/`session_end` markers).
+
+## 32. Parking lot — out of v1 scope (sized for visibility)
+
+Items the user surfaced or round-2 research uncovered as "would be nice but not urgent." Sized so the team can pick them up without re-discovering scope.
+
+### 32.1 Unified agent-SDK / message-SDK with conversation compaction
+
+User's words: "It would be nice we have a unifying agent SDK or message SDK with compactization etc but that is no rush."
+
+**Sketch:**
+
+A `core/messages/` ring sitting between Ring 1 and Ring 2: typed message envelope (`UserMessage | AssistantMessage | ToolCall | ToolResult | SystemNote`), compaction policies (`KeepAll`, `SlidingWindow(N)`, `SummarizeOldest(N)`, `TokenBudget(N)`), and a `Conversation` abstraction that all model handlers consume instead of building their own array of provider-shaped messages. Today every modelHandler in `src/agent/modelHandlers/` builds its own message array; the differences are mostly cosmetic. Compaction would hook into `PreCompact` / `PostCompact` events from §25.
+
+**Why not v1:**
+
+- Compaction policies are agent-specific (an OCR agent's "drop oldest message" is different from an orchestrator's). Designing the API right requires usage data we don't yet have.
+- Provider message shapes diverge subtly (Anthropic's vs OpenAI's vs Gemini's tool-result envelopes) — a unifying SDK either picks one and translates, or invents a new shape; both are 4–6 engineering weeks of design.
+- Round 1's existing `executeAgent` surface is enough for the CLI to ship.
+
+**Tracking:** v2.0 work; new PRD when there's a concrete proposal.
+
+### 32.2 OS-level sandbox on agent execution
+
+Codex's `seatbelt` / `landlock` model. Round 2 §26.1 declines for v1 because it's orthogonal to the CLI shell. Tracking issue when the desktop app's macOS-App-Sandbox / Windows-AppContainer story wants to converge with a CLI-side equivalent.
+
+### 32.3 `texra serve` long-lived daemon
+
+Round 1 §18.1. Same shape as opencode's HTTP server. Sized at ~800 LOC if it shares §27's session store + §24's RunContext. v1.x or v2.
+
+### 32.4 MCP resources surface (not just tools)
+
+Round 1 §18 lists `texra mcp serve` as v1.1; round 2 promotes the `tools` half but not `resources`. Resources would expose session JSONL transcripts and agent definitions as MCP resources (callers can `resources/read` to import them). ~150 LOC; depends on what calling agents actually want.
+
+### 32.5 Replay / cost guards / pipeline-as-code
+
+Round 1 §18.1 listed all three. Unchanged.
+
+### 32.6 Hooks: HTTP and `agent` handlers
+
+Round 2 ships only `command` and `prompt` handler types in §25.5. `http` (POST to a webhook) and `agent` (call back into a TeXRA agent) handlers are 80–120 LOC each and should land when there's a concrete user request — building them speculatively risks getting the contract wrong.
+
+---
+
+End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and *callable by every other agent that speaks MCP* — which was the user's framing all along.

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1137,271 +1137,87 @@ Round 1 above defined the CLI as a thin Node shell over an already host-neutral 
 
 Round 2 lands six concrete deltas plus one cross-cutting kernel refactor that all three hosts (extension, desktop, CLI) benefit from. None of these change the round-1 LOC band by more than ~600 lines combined; most are about replacing ad-hoc patterns with the kernel-shaped abstractions the audit revealed are already partially in place.
 
-| Delta                                                                         | Round 1 status                                       | Round 2 position                                                                                                | New §      |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------- | ---- | ----- | ---------------------------------------------------------------------------------------------------------------------------- | --- |
-| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work                               | **v1 prereq for `texra mcp serve` and re-entrant SDK; v1.0 ships with the migration shim path**                 | §22        |
-| Structured logger with explicit context, no module globals                    | Hand-waved as "consoleLog plus filter wrapper"       | **v1 deliverable; `LogBackend` interface widened to take a context object**                                     | §23        |
-| `texra mcp serve` (callable from Claude Code, Codex, opencode)                | Listed as v1.1 future                                | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)**                   | §24        |
-| Hook system (SessionStart, PreToolUse, PostToolUse, …)                        | Not mentioned                                        | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner**           | §25        |
-| Approval policy revisited (no 2D sandbox axis)                                | 1D `never                                            | ask                                                                                                             | auto-edits | auto | yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
-| Session transcripts as JSONL under project-hash sharding                      | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics**                                 | §27        |
-| GitHub Action: composite + Bun (not JS Action)                                | §12 picked JS Action                                 | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in**      | §28        |
-| Cross-platform shared structure refactor (kernel side)                        | Implicit                                             | **Explicit — what the three hosts share, what they don't, where the seams go**                                  | §29        |
-| Container / GitHub-runner target matrix (slim, alpine, texlive)               | Sketched in §12.3                                    | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30        |
-| Phase plan delta + LOC delta                                                  | —                                                    | **Aggregated**                                                                                                  | §31        |
-| Parking lot — unified agent-SDK / message-SDK / context compaction            | —                                                    | **Out of v1; sized in §32 for visibility**                                                                      | §32        |
+| Delta | Round 1 status | Round 2 position | New §  |
+| ----- | -------------- | ---------------- | ------ |
+| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work | **Promoted to standalone PRD — see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md). CLI v1.0 consumes Phase 1; v1.1 consumes Phase 2 (gates concurrent MCP sessions).** | §22 (stub) |
+| Structured logger with explicit context, no module globals | Hand-waved as "consoleLog plus filter wrapper" | **Promoted to standalone PRD — see [`prd-logger-v2.md`](./prd-logger-v2.md). CLI installs four sinks (stderr text, NDJSON stdout, Ink, MCP).** | §23 (stub) |
+| `texra mcp serve` (callable from Claude Code, Codex, opencode) | Listed as v1.1 future | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)** | §24 |
+| Hook system (SessionStart, PreToolUse, PostToolUse, …) | Not mentioned | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner** | §25 |
+| Approval policy revisited (no 2D sandbox axis) | 1D `never|ask|auto-edits|auto|yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
+| Session transcripts as JSONL under project-hash sharding | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics** | §27 |
+| GitHub Action: composite + Bun (not JS Action) | §12 picked JS Action | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in** | §28 |
+| Cross-platform shared structure refactor (kernel side) | Implicit | **Promoted into [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8 (three-ring kernel structure). CLI-side consumption details retained here.** | §29 (stub) |
+| Container / GitHub-runner target matrix (slim, alpine, texlive) | Sketched in §12.3 | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30 |
+| Phase plan delta + LOC delta | — | **Aggregated** | §31 |
+| Parking lot — unified agent-SDK / message-SDK / context compaction | — | **Out of v1; sized in §32 for visibility** | §32 |
 
 The rest of round 2 is the spec for these deltas, in dependency order: §22 → §23 unblock §24 (an MCP server can't safely host concurrent sessions until the kernel's ambient state is gone); §24 + §25 + §26 are independent hosts on the new context; §27 + §28 + §29 + §30 are deployment / packaging concerns that don't gate kernel work.
 
-## 22. RunContext — replace ambient ALS + singletons
-
-### 22.1 What's ambient today
-
-The May 2026 runtime audit (in commit-time order, not severity) found:
-
-**AsyncLocalStorage scopes (2):**
+## 22. RunContext — replace ambient ALS + singletons → see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md)
 
-- `src/agent/runtime/AgentRuntimeHost.ts:12` — `runtimeHostScope` carries the current `AgentRuntimeHost` (≡ `ProgressSink`). Entered via `runWithAgentRuntimeHost(host, fn)` at line 27; read via `getAgentRuntimeHost()` at line 23 with fallback to a process-global `defaultAgentRuntimeHost` (line 11) and then to `getDefaultProgressSink()` (`ProgressSink.ts:20`).
-- `src/logger/logUtils.ts:10` — `contextStorage` carries a `Map<channel-key, group-id stack>` so `runWithGroupContext()` can attach a `[groupId]` tag to each line. Read at lines 63 and 136.
+§22 has been promoted to a standalone PRD because the work is kernel-shaped, benefits all three hosts (extension, desktop, CLI), and is not a CLI-specific concern. See [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) for the full design — the inventory of ambient state, the `RunContext` interface, the migration shim, the phased deletion of singletons, and the three-ring `packages/core/` structure (which previously lived in §29 of this PRD and is now §8 of the RunContext PRD).
 
-**Module-level `let X | undefined` + setter pairs (~20):**
+### 22.1 What the CLI consumes
 
-| Concern                         | Setter                            | File:line                                       |
-| ------------------------------- | --------------------------------- | ----------------------------------------------- |
-| Default progress sink           | `setDefaultProgressSink`          | `src/agent/runtime/ProgressSink.ts:14`          |
-| Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`      |
-| Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`     |
-| Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113` |
-| Latex-preview handler           | `setLatexBuildDisplay`            | `src/tools/approval/latexPreview.ts:21`         |
-| GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`             |
-| Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`              |
-| Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`               |
-| Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                     |
-| Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                        |
-| Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                        |
-| Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                    |
+The CLI's relationship to the RunContext PRD is one of *consumer*, not *driver*:
 
-**Exported singleton coordinators (3):**
+- The CLI's `cli/src/runtime/initPlatform.ts` constructs a `RunContext` per `texra run` invocation, populates `RunCapabilities` (no extension; GitHub token from `process.env.GITHUB_TOKEN`; no callback resolver), and threads it via `withRunContext(ctx, () => executeAgent(...))`.
+- The CLI's `texra mcp serve` host (§24) constructs *one `RunContext` per MCP `tools/call`* — that's the workload that gates the RunContext PRD's Phase 2 (singleton retirement) for v1.1 concurrency safety.
+- Until the RunContext PRD's Phase 1 lands, the CLI's `runAgent()` SDK is documented as **single-consumer-per-process** (round-1 §7.6 caveat). The shim path makes this safe-by-default, not safe-by-design.
 
-- `planApprovalCoordinator` — `src/agent/runtime/PlanApprovalCoordinator.ts:128`
-- `retryCoordinator` — `src/agent/runtime/RetryRequestCoordinator.ts:145`
-- `proposalCoordinator` — `src/agent/runtime/AgentProposalCoordinator.ts:89`
+### 22.2 Phase mapping
 
-**Caches that survive across runs (4):**
+| RunContext-PRD phase | Lands in CLI release | What the CLI gains |
+| -------------------- | -------------------- | ------------------ |
+| Phase 0 (foundations) | CLI v1.0 prereq | `withRunContext` wraps every `runAgent()` SDK call; `tryUseRunContext()` available to CLI sinks. |
+| Phase 1 (per-context coordinators) | CLI v1.0 | Plan / proposal / retry approvals route through the CLI's TTY prompt handler without singleton interference. |
+| Phase 2 (sink + runtime-host singleton retirement) | CLI v1.1 | `texra mcp serve` hosts concurrent sessions safely. |
+| Phase 3 (capability injection) | CLI v1.2 | `--use-my-keys`, `--no-tier-check`, GitHub token CI flow stop relying on module setters. |
+| Phase 4 (auth singletons) | CLI v1.2 | Multi-account testing in CI no longer needs process restart between tests. |
+| Phase 5 (sweep) | CLI v1.3 | `texra` cold-start drops by ~5ms (no fallback chains in hot paths). |
 
-- Agent-registry cache + init promise — `src/agent/index/agentRegistry.ts:143,146-147`
-- Execution listing cache + workspace-path cache — `src/agent/storage/executionListing.ts:52-54`
-- Output-poll timer + in-flight flag — `src/agent/runtime/executionRegistry.ts:335-336`
-- Polish-model template cache — `src/agent/runtime/polishModel.ts:11-12`
+### 22.3 LOC accounting (CLI side only)
 
-### 22.2 Why this hurts the CLI
+| Item | New | Modified |
+| ---- | --- | -------- |
+| `cli/src/runtime/initPlatform.ts` constructs `RunContext` per invocation | ~60 | — |
+| Per-`tools/call` `RunContext` factory in `cli/src/mcp/server.ts` | (counted under §24) | — |
+| Test harness updates to `withRunContext`-wrap all CLI tests | — | ~50 |
+| **Subtotal (CLI side)** | **~60** | **~50** |
 
-Round-1 §7.6's caveat — "two SDK callers in the same process can step on each other's defaults" — covers only the tip. The full failure surface for the CLI is:
+The kernel work is sized in `prd-runcontext-refactor.md` §7 (~6.5 engineering weeks across Phases 0–5).
 
-1. **`texra mcp serve` (§24)** must host N concurrent sessions in one process, each with its own progress sink, its own approval policy, its own logger context, and its own abort signal. Today's ambient-default + ALS-fallback model conflates "this run's sink" with "this process's sink"; an MCP server that serves two clients simultaneously will leak progress events between them whenever a `getDefaultProgressSink()` path is hit (which the audit shows is the default fallback in `getAgentRuntimeHost` at `AgentRuntimeHost.ts:24`).
-2. **Re-entrant `runAgent()` from the SDK (§7.6)** — same problem. A user piping two polish runs in parallel through `Promise.all([runAgent(...), runAgent(...)])` will see interleaved progress on whichever process-global sink the second call happened to install last.
-3. **Hooks (§25)** that fire from a sub-flow (e.g., `PreToolUse` raised inside a delegate-agent subagent) need the hook handler to know which session it belongs to. The ALS scope already passes the runtime host correctly, but the singleton coordinators (`planApprovalCoordinator`) don't — they fan out events to whoever the current global handler is.
-4. **Tests** routinely have to `setDefaultProgressSink(noop)` and `setRunStorageService(fake)` in `beforeEach` and unwind them in `afterEach`. A `RunContext` argument removes ~150 LOC of this kind of setup.
+## 23. Logger v2 — structured records, host sinks → see [`prd-logger-v2.md`](./prd-logger-v2.md)
 
-### 22.3 The shape
+§23 has been promoted to a standalone PRD for the same reason as §22 — the work is kernel-shaped infrastructure, not CLI-specific. See [`prd-logger-v2.md`](./prd-logger-v2.md) for the design: the `Logger` / `LogRecord` / `LogSink` interfaces, the `BootstrapLogger`, schema unification with the round-1 §11.2 NDJSON event stream, per-host sink mapping, and the phased migration off `src/logger/logUtils.ts` and the `outputChannelFactory` module global.
 
-A single `RunContext` value, threaded explicitly through the call graph, with one ALS scope at the outermost entry to support legacy call sites during migration. No module globals, no per-domain singletons.
+### 23.1 What the CLI installs
 
-```ts
-// packages/core/src/runtime/runContext.ts
-export interface RunContext {
-  /** Stable identifier for this run; root for child contexts. */
-  readonly runId: RunId;
-  /** Stream tab id within the run (one per agent activation). */
-  readonly streamId: StreamTabId;
-  /** Lineage from the user-initiated root, useful for log prefixes. */
-  readonly streamLineage: StreamTabId[];
+| Mode | Sink | What it does |
+| ---- | ---- | ------------ |
+| Headless text (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
+| JSON / NDJSON (`--output-format json|ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout (the same union the §11.2 progress stream uses). |
+| Interactive (Ink TUI) | `InkLogSink` | Routes records to the `<StreamPane />` component as `event === "log"` rows alongside progress events. |
+| MCP server (`texra mcp serve`) | `McpProgressSink` | Records become `notifications/progress` payloads bound to the request's progress token. |
 
-  /** Where progress events go. Replaces `getAgentRuntimeHost()`. */
-  readonly progress: ProgressSink;
-  /** Structured logger scoped to this run. Replaces `logUtils` group-context ALS. */
-  readonly log: Logger;
+All four CLI-side sinks live in `packages/cli/src/render/sinks/`. `BootstrapLogger` is constructed in `cli/src/bin/texra.ts` immediately and threaded through config-load, secret resolution, agent-directory bootstrap, and mode selection — its buffer flushes through whichever sink the resolved mode picks.
 
-  /** Cooperative cancel signal for this run. Replaces InterruptManager singleton. */
-  readonly signal: AbortSignal;
+### 23.2 What the CLI inherits free
 
-  /** Approval policy for this run (resolved from flag > env > config > schema default). */
-  readonly approval: ApprovalPolicy; // 1D — see §26
+The unification of progress events and log records into one `RunStreamEvent` union (per `prd-logger-v2.md` §6) means the CLI's round-1 §11.2 NDJSON renderer becomes a no-op: it forwards records and events through the same pipe, with the same Zod-validated schema. The session JSONL transcript (§27) uses the same union — a run's transcript is byte-equivalent to its NDJSON output (modulo the synthetic `session_start` / `session_end` markers).
 
-  /** Workspace root (cwd) for this run. Per-run override of WorkspaceProvider. */
-  readonly workspaceRoot: string;
+### 23.3 LOC accounting (CLI side only)
 
-  /** Runtime-resolved capabilities. Replaces `setExtensionChecker`, `setGitHubTokenProvider`. */
-  readonly capabilities: RunCapabilities;
+| Item | New |
+| ---- | --- |
+| `StderrTextSink` (picocolors-aware) | ~120 |
+| `NdjsonStdoutSink` (schema-validated) | ~60 |
+| `InkLogSink` (Ink-component-aware; lazy chunk) | ~80 |
+| `McpProgressSink` (counted under §24) | (— ) |
+| Bootstrap wiring in `cli/src/bin/texra.ts` and `cli/src/runtime/initPlatform.ts` | ~30 |
+| **Subtotal (CLI side)** | **~290** |
 
-  /** Coordinators bound to this run's progress sink. Replaces exported singletons. */
-  readonly coordinators: {
-    plan: PlanApprovalCoordinator;
-    proposal: AgentProposalCoordinator;
-    retry: RetryRequestCoordinator;
-    edit: ToolEditApprovalController;
-    bash: BashApprovalController;
-  };
-
-  /** Spawn a child context for a delegate_agent / delegate_workflow subagent. */
-  child(opts: ChildContextOptions): RunContext;
-}
-
-export interface RunCapabilities {
-  github: GitHubTokenProvider | null;
-  extensionPresent: boolean;
-  externalAuthCallback: ExternalAuthCallbackResolver | null;
-  // …other host capabilities, populated by the host adapter
-}
-```
-
-`buildAgentLaunchContext()` in `executeAgent.ts:166` already constructs almost all of this; the round-2 refactor is to (a) lift it to the kernel boundary so it's the only entry point that matters and (b) pass it explicitly into every coordinator method that today reads from a singleton.
-
-### 22.4 Migration shim
-
-Because the audit found ~30 sites that read singletons today, a hard cutover is not realistic for v1. The shim:
-
-- `runContextScope = new AsyncLocalStorage<RunContext>()` lives in `packages/core/src/runtime/runContext.ts`.
-- `withRunContext(ctx, fn)` wraps every `executeAgent()` call. The existing `runWithAgentRuntimeHost()` wrapper is kept and now reads from `runContextScope.getStore()` for forward compatibility.
-- Every singleton getter (`getDefaultProgressSink()`, `getRunStorageService()`, `getServerSideKeyService()`, …) gets a `// LEGACY:` comment and a path forward: it reads `runContextScope.getStore()?.<field>` first and falls back to the module global.
-- Internal kernel call sites are converted in batches (one per phase): coordinators first (Phase 0 of round 2), then approval handlers (Phase 1), then auth services (Phase 2). Each batch deletes a module global once its readers all take an explicit `ctx`.
-- ESLint rule `no-ambient-runtime-state` blocks new module-level `let` + setter pairs in `src/agent/`, `src/tools/`, `src/auth/`. Rationale: same shape as the §13.1 import-restriction rule.
-
-### 22.5 Migration order (gated on, not blocking, CLI v1.0)
-
-| Round                          | Singletons retired                                                                                                                              | Files touched                                                                       | Net LOC    |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------- |
-| Pre-v1.0                       | `runContextScope` lives at boundary; `runWithAgentRuntimeHost` reads it; new `Logger`/`progress` getters on context (§23)                       | `executeAgent.ts`, `runContext.ts` (new), `Logger.ts` (new)                         | +180 / -10 |
-| v1.0                           | `planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator` become per-context instances created in `buildAgentLaunchContext()`        | `Plan/Retry/AgentProposalCoordinator.ts`, ~5 call sites                             | +60 / -30  |
-| v1.1 (gates `texra mcp serve`) | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` singletons removed                                                        | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 reader sites | +0 / -120  |
-| v1.2                           | `setToolEditApprovalHandler`, `setGitHubTokenProvider`, `setExtensionChecker`, `setLatexBuildDisplay` — replaced by `RunCapabilities` injection | `tools/{approval,github,externalToolDefs}/*`                                        | +40 / -90  |
-| v1.3                           | Auth singletons (`tierService`, `serverSideKeyService`) become per-`RunContext` resolutions backed by a kernel-side `AuthRegistry`              | `auth/*`                                                                            | +60 / -100 |
-
-Net: at v1.3 the kernel has zero `let X | undefined` + setter pairs in the agnostic zones, and ~250 LOC has been deleted on net. The CLI's `texra mcp serve` becomes safe at the v1.1 boundary; v1.0 ships with the shim.
-
-### 22.6 Why not "just drop ALS entirely"
-
-The shim is necessary because the kernel has 30+ call sites that read the runtime host implicitly (every emit, every approval prompt, every coordinator call). A pure-explicit migration would touch 30+ files in one PR and break every in-flight branch. ALS-with-an-explicit-context is the ergonomic compromise OpenTelemetry, Vercel AI SDK, and Encore all settled on; we copy that. The audit confirms zero call sites of `getStore()` outside the `runtimeHostScope`/`contextStorage` files themselves, so wrapping access in a single `useRunContext()` helper is a one-line change at every reader.
-
-### 22.7 The "stream context lost across `.then()`" risk
-
-The LangSmith #2274 issue is the canonical foot-gun: ALS context can be lost when a stream's `.then()` resolves outside the original async chain. We have one such site today — `RunStorageService`'s background poll timer (`executionRegistry.ts:335`) fires outside any `runWithAgentRuntimeHost()` scope. The mitigation is the same one the survey flagged: bind the context at registration time. Practically: `pollInFlight` becomes a `Map<RunId, RunContext>` and the timer callback uses `withRunContext(stored, fn)` rather than reading whatever scope happens to be active. ~20 LOC.
-
-## 23. Logger v2 — structured events, explicit context, no module globals
-
-### 23.1 What's wrong with today's logger
-
-`src/logger/logUtils.ts` is a serviceable VS Code-shaped logger. It is also wrong for the CLI in three concrete ways:
-
-1. **`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level state.** The audit finds exactly one setter in production code (`packages/extension/src/extension.ts`), but tests and an MCP-server mode that hosts concurrent runs cannot safely share these. The `setOutputChannelFactory(null)` reset disposes channels for _every_ concurrent caller.
-2. **Group context lives in its own ALS (`contextStorage`, line 10), separate from the runtime host's ALS (`runtimeHostScope`, `AgentRuntimeHost.ts:12`).** A sub-agent that emits a log line passes through both scopes; the two are kept in sync by convention, not enforcement.
-3. **`writeLine` calls `getConfig('texra.logger.debugMode', false)` on every line (line 79).** That's fine in the extension where `getConfig` is a wrapped `vscode.workspace.getConfiguration`, but in the CLI before `initPlatform()` runs (which the audit shows happens for ~40 module-load-time `initialize()` calls), the config provider may not exist yet. Today's `tryPlatform()` fallback works because `getConfig` returns the default; in the CLI we want stricter guarantees that log lines emitted during boot don't silently lose their context.
-
-Plus a non-bug observation: the JSON / NDJSON renderer specced in round 1 §11.2 is a _separate_ code path from the human renderer. Two formats, one schema is fine; two formats, two code paths is duplication waiting to bit-rot.
-
-### 23.2 Shape
-
-A single `Logger` interface that is part of `RunContext` (§22.3), with sinks plugged in by the host:
-
-```ts
-// packages/core/src/runtime/logger.ts
-export interface Logger {
-  debug(msg: string, fields?: LogFields): void;
-  info(msg: string, fields?: LogFields): void;
-  warn(msg: string, fields?: LogFields): void;
-  error(msg: string, fields?: LogFields): void;
-
-  /** Push a group; returned function pops it. Replaces logUtils' ALS. */
-  group(label: string): () => void;
-  /** Wrap an async fn in a group; returns its result. */
-  withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T>;
-
-  /** Per-domain child — adds a static field to every emission. Cheap. */
-  child(fields: LogFields): Logger;
-}
-
-export interface LogFields {
-  /** Stream lineage. Auto-injected by RunContext.log; usable by hosts for prefix. */
-  readonly streamId?: StreamTabId;
-  readonly runId?: RunId;
-  readonly groupId?: string;
-  /** Free-form structured data; the host decides whether to render it. */
-  readonly [k: string]: unknown;
-}
-```
-
-The host registers a single `LogSink` (renamed from `LogBackend` to make explicit that it consumes structured records, not formatted strings):
-
-```ts
-export interface LogRecord {
-  ts: string; // ISO-8601 with millis
-  level: LogLevel;
-  message: string;
-  fields: LogFields;
-  groups: readonly string[]; // current group stack at emit time
-}
-
-export interface LogSink {
-  write(record: LogRecord): void;
-  flush?(): Promise<void>;
-}
-```
-
-### 23.3 What each host installs
-
-| Host         | Sink                                                                                                                                                                                                                 |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Extension    | `VscodeOutputChannelSink` — writes formatted strings to `vscode.OutputChannel` (today's behavior). One channel per agent.                                                                                            |
-| Desktop      | `electronLogSink` over `electron-log` (Electron PRD §6.4); same channel-per-agent shape.                                                                                                                             |
-| CLI headless | `StderrTextSink` — picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`. Also writes to `--log-file` if passed.                                                                                       |
-| CLI JSON     | `NdjsonStdoutSink` — one JSON object per line, schema-validated against `LogRecord`. **This is the same data path §11.2 specs as the event stream — log records and progress events share the JSON Lines envelope.** |
-| CLI MCP      | `McpProgressSink` — converts each record to an MCP `notifications/progress` payload bound to the request's progress token. Respects the client's progress-update opt-in.                                             |
-| Tests        | `MemorySink` — pushes records into an array for assertion; auto-installed via `withRunContext()` in `vitest.setup.ts`.                                                                                               |
-
-### 23.4 Rendering rules — round-1 §11 reconciled
-
-Round 1 §11.2 specifies an NDJSON event stream. Round 2 unifies it with the log stream:
-
-- Every `LogRecord` is also a `ProgressEvent` with `event: "log"`. The schema is `LogRecord ∪ ProgressEventPayloads` (a Zod discriminated union on `event`).
-- Consumers that care only about logs filter `event === "log"`. Consumers that care only about progress (e.g. `texra-action`'s log-group renderer) filter `event !== "log"`.
-- Schema lives in `packages/shared/schemas/runStream.ts` (new). Versioned per round-1 §11.2's policy.
-- The headless text renderer (`StderrTextSink`) renders `event === "log"` lines as `[time] [agent] message` and `event !== "log"` lines as the structured progress format. One renderer, two sub-paths, one schema.
-
-### 23.5 Group context migration
-
-The current `runWithGroupContext()` is replaced by `RunContext.log.withGroup()`. The migration is mechanical:
-
-```ts
-// before
-await runWithGroupContext(channel, groupId, isAgent, async () => {
-  logger.info(channel, 'doing thing');
-});
-
-// after
-await ctx.log.child({ channel }).withGroup(groupId, () => {
-  ctx.log.info('doing thing');
-});
-```
-
-Both forms run for one release; the old form is `@deprecated` and routes to the new one. The `contextStorage` ALS in `logUtils.ts:10` is deleted at the end of the migration.
-
-### 23.6 Boot-time logging
-
-The CLI emits ~3–5 log lines before `initPlatform()` returns (config layer load, secret resolution, agent-directory bootstrap). Today these go through `console.info` at module load time. Round 2 routes them through a `BootstrapLogger` — a `Logger` impl that buffers records into an array until `initPlatform()` finishes, then flushes them through whichever sink the host registered. ~30 LOC. No more "config debug toggle silently broken during boot."
-
-### 23.7 LOC accounting
-
-| Item                                                                                                                             | New                 | Modified | Deleted |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------- | ------- |
-| `packages/core/src/runtime/logger.ts` (new — interface + bootstrap logger + group helpers)                                       | ~180                | —        | —       |
-| `packages/core/src/runtime/runContext.ts` (logger threaded as field)                                                             | (counted under §22) | —        | —       |
-| `src/logger/logUtils.ts` (kept for legacy callers; routes to new logger)                                                         | —                   | ~80      | —       |
-| `src/logger/AgentLogger.ts`, `AgentUsageReporter.ts` (route through `ctx.log`)                                                   | —                   | ~40      | —       |
-| Per-host sinks: `VscodeOutputChannelSink` (extension), `StderrTextSink` + `NdjsonStdoutSink` (CLI), `McpProgressSink` (CLI v1.1) | ~250                | —        | —       |
-| `texra config` exposes `logger.debugMode` via `ConfigProvider.watch()`; remove the per-write `getConfig` lookup                  | —                   | ~10      | ~5      |
-| **Subtotal**                                                                                                                     | **~430**            | **~130** | **~5**  |
-
-This counts against §14's pre-refactor budget (~430 → ~860 with logger v2 added). Within the engineering-week envelope from §15 because §22 + §23 deliverables are the natural prerequisite for §24.
+The kernel work is sized in `prd-logger-v2.md` §9 (~3.8 engineering weeks across Phases 0–5).
 
 ## 24. `texra mcp serve` — callable from Claude Code, Codex, and opencode
 
@@ -1417,9 +1233,9 @@ The user's framing — "to be callable by Claude Code and Codex etc" — is exac
   "mcpServers": {
     "texra": {
       "command": "texra",
-      "args": ["mcp", "serve"],
-    },
-  },
+      "args": ["mcp", "serve"]
+    }
+  }
 }
 ```
 
@@ -1438,11 +1254,11 @@ transport = "stdio"
 
 A minimum viable v1 surface — three tools, no resources, no prompts. Resources can come in v1.1 once we know what callers actually want.
 
-| MCP tool name  | Backed by                                               | Purpose                                                                                                                                                                                                                           |
-| -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `run_workflow` | `executeAgent({ category: "workflow", ... })`           | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`.                           |
-| `run_chat`     | `executeAgent({ category: "toolUse", ... })`            | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
-| `list_agents`  | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate.                                                                                                             |
+| MCP tool name | Backed by | Purpose |
+| ------------- | --------- | ------- |
+| `run_workflow` | `executeAgent({ category: "workflow", ... })` | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`. |
+| `run_chat` | `executeAgent({ category: "toolUse", ... })` | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
+| `list_agents` | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate. |
 
 All three accept an optional `runId` so the caller can correlate progress notifications. Approval policy is forced to `never` by default in MCP mode (no TTY for prompts) — callers wanting bash/edit auto-approval pass `approvalPolicy: "yolo"` explicitly, exactly as round 1 §9 specifies for headless mode.
 
@@ -1459,7 +1275,7 @@ stdio JSON-RPC 2.0, one process per client connection, exactly the Claude Code /
 
 ### 24.4 Permission propagation
 
-The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the _call_ (e.g., Claude Code asked the user "let texra\_\_run_polish run?"). What TeXRA still owns is what the _agent inside_ TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
+The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the *call* (e.g., Claude Code asked the user "let texra__run_polish run?"). What TeXRA still owns is what the *agent inside* TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
 
 Three policies for those inner gates, selected by tool argument:
 
@@ -1485,14 +1301,14 @@ Three policies for those inner gates, selected by tool argument:
 
 ### 24.6 LOC
 
-| Item                                                                           | New      | Modified |
-| ------------------------------------------------------------------------------ | -------- | -------- |
-| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)    | ~120     | —        |
-| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`               | ~250     | —        |
-| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80      | —        |
-| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)             | —        | ~30      |
-| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                         | ~40      | —        |
-| **Subtotal**                                                                   | **~490** | **~30**  |
+| Item | New | Modified |
+| ---- | --- | -------- |
+| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising) | ~120 | — |
+| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts` | ~250 | — |
+| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80 | — |
+| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch) | — | ~30 |
+| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`) | ~40 | — |
+| **Subtotal** | **~490** | **~30** |
 
 ## 25. Hook system (Claude Code-style)
 
@@ -1510,12 +1326,8 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 // hook input on stdin
 {
   "hookEventName": "PreToolUse",
-  "session": {
-    "id": "ses_abc123",
-    "cwd": "/path/to/project",
-    "agent": "orchestrator",
-  },
-  "tool": { "name": "bash", "input": { "command": "rm -rf /" } },
+  "session": { "id": "ses_abc123", "cwd": "/path/to/project", "agent": "orchestrator" },
+  "tool": { "name": "bash", "input": { "command": "rm -rf /" } }
 }
 ```
 
@@ -1524,8 +1336,8 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 {
   "hookSpecificOutput": {
     "permissionDecision": "deny",
-    "reason": "rm -rf is not allowed in this project",
-  },
+    "reason": "rm -rf is not allowed in this project"
+  }
 }
 ```
 
@@ -1533,17 +1345,17 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 
 ### 25.3 Where hooks fire
 
-| Event                        | Fires from                                                                          | RunContext field                                     |
-| ---------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ------ | ---------- | -------- |
-| `SessionStart`               | `executeAgent.ts` after `buildAgentLaunchContext`                                   | `runId`, `streamId`, `cwd`                           |
-| `UserPromptSubmit`           | Tool-use REPL on each user submit                                                   | `runId`, `instruction`                               |
-| `PreToolUse`                 | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch             | `runId`, `tool.name`, `tool.input`                   |
-| `PostToolUse`                | Tool dispatch after result                                                          | `runId`, `tool.name`, `tool.result.summary`          |
-| `Stop`                       | `executeAgent` finalizer                                                            | `runId`, `result.status`                             |
-| `SubagentStop`               | Delegation child completion                                                         | `runId`, `parentStreamId`, `childStreamId`, `result` |
-| `Notification`               | Any `requestShowError` / `requestShowInstruction` emission                          | `runId`, `message`                                   |
-| `PreCompact` / `PostCompact` | (Future, §32 — context compaction)                                                  | `runId`, `compactionStats`                           |
-| `PermissionRequest`          | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"              | "bash" | "plan" | "proposal" | "retry"` |
+| Event | Fires from | RunContext field |
+| ----- | ---------- | ---------------- |
+| `SessionStart` | `executeAgent.ts` after `buildAgentLaunchContext` | `runId`, `streamId`, `cwd` |
+| `UserPromptSubmit` | Tool-use REPL on each user submit | `runId`, `instruction` |
+| `PreToolUse` | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch | `runId`, `tool.name`, `tool.input` |
+| `PostToolUse` | Tool dispatch after result | `runId`, `tool.name`, `tool.result.summary` |
+| `Stop` | `executeAgent` finalizer | `runId`, `result.status` |
+| `SubagentStop` | Delegation child completion | `runId`, `parentStreamId`, `childStreamId`, `result` |
+| `Notification` | Any `requestShowError` / `requestShowInstruction` emission | `runId`, `message` |
+| `PreCompact` / `PostCompact` | (Future, §32 — context compaction) | `runId`, `compactionStats` |
+| `PermissionRequest` | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"|"bash"|"plan"|"proposal"|"retry"` |
 
 ### 25.4 Configuration
 
@@ -1596,17 +1408,20 @@ Round 2's first draft proposed adopting Codex's `approval_policy × sandbox_mode
 
 The reasons it's the right call:
 
-1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap _all_ agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
-2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — _not_ a CLI-only knob.
+1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap *all* agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
+2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — *not* a CLI-only knob.
 3. **A 2D matrix doubles the test surface and doubles the doc surface.** The mental load — "if I pass `--approval-policy auto --sandbox workspace-write` what happens to bash that touches `/tmp`?" — is exactly the friction users complained about with Codex's first iteration.
 
-### 26.2 What round 2 _does_ sharpen
+### 26.2 What round 2 *does* sharpen
 
 Round 1 §9.2 says "in-project means the candidate file/cwd is inside the resolved workspace path." Round 2 specifies the predicate concretely so the kernel and the CLI agree:
 
 ```ts
 // packages/core/src/runtime/approvalPredicates.ts (new — ~40 LOC)
-export function isInProject(candidate: string, workspaceRoot: string): boolean {
+export function isInProject(
+  candidate: string,
+  workspaceRoot: string,
+): boolean {
   const candidateAbs = path.resolve(candidate);
   const rootAbs = path.resolve(workspaceRoot);
   const rel = path.relative(rootAbs, candidateAbs);
@@ -1625,7 +1440,7 @@ Edge cases the predicate handles explicitly:
 
 Bash is harder than file paths — "auto-approve when in-project" doesn't make sense for `rm -rf $HOME`. Round 1 punted on this. Round 2 spec:
 
-- `auto` policy auto-approves bash _only_ when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
+- `auto` policy auto-approves bash *only* when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
 - Any redirect to `/`, any unquoted variable, any `&&` / `||` / `|` chain that contains a non-listed command → falls back to `ask` even under `auto`.
 - `yolo` short-circuits all of this; `never` always denies.
 
@@ -1688,13 +1503,13 @@ The existing `~/.texra/global-storage/<workspace>/runs/` layout stays for one re
 
 ### 27.6 LOC
 
-| Item                                                                                         | New      | Modified |
-| -------------------------------------------------------------------------------------------- | -------- | -------- |
-| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200     | —        |
-| `packages/core/src/storage/sessionMigration.ts` (legacy → new)                               | ~80      | —        |
-| `cli/src/commands/resume.ts` (consumes sessionStore directly)                                | —        | ~30      |
-| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags)                             | —        | ~20      |
-| **Subtotal**                                                                                 | **~280** | **~50**  |
+| Item | New | Modified |
+| ---- | --- | -------- |
+| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200 | — |
+| `packages/core/src/storage/sessionMigration.ts` (legacy → new) | ~80 | — |
+| `cli/src/commands/resume.ts` (consumes sessionStore directly) | — | ~30 |
+| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags) | — | ~20 |
+| **Subtotal** | **~280** | **~50** |
 
 ## 28. GitHub Action revisited — composite + Bun, not JS
 
@@ -1719,8 +1534,7 @@ inputs:
   output: { description: 'Output file path', required: false }
   rounds: { description: 'Workflow rounds', required: false, default: '1' }
   model: { description: 'Model name', required: false }
-  approval-policy:
-    { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
+  approval-policy: { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
   texra-version: { description: 'Pinned CLI version', default: 'latest' }
   output-format: { description: 'text|json|ndjson', default: 'ndjson' }
 outputs:
@@ -1786,88 +1600,27 @@ runs:
 
 ### 28.4 Updated round-1 §6 decision
 
-| #   | Concern       | Round 1 pick | Round 2 pick                                                        |
-| --- | ------------- | ------------ | ------------------------------------------------------------------- |
-| 9   | GitHub Action | JS Action    | **Composite action + Bun runner; install CLI from npm at run time** |
+| #   | Concern                | Round 1 pick      | Round 2 pick |
+| --- | ---------------------- | ----------------- | ------------ |
+| 9   | GitHub Action          | JS Action         | **Composite action + Bun runner; install CLI from npm at run time** |
 
 No other round-1 picks change.
 
-## 29. Cross-platform shared structure (kernel-side refactor)
+## 29. Cross-platform shared structure → see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8
 
-### 29.1 Today's shape
+§29 has been promoted into [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8 (three-ring kernel structure). The CLI-specific implications stay here:
 
-The pnpm workspace has three packages skeletoned (`packages/{core,extension,desktop}`) with the kernel still living at root `src/`. Round 1 §7.1 assumed Electron Phase 0 finishes the kernel migration and the CLI is the fourth peer. Round 2 sharpens what "the kernel" means and where the per-host seams go — because the audit revealed three categories of shared code that today live mixed together.
+### 29.1 What the CLI is allowed to import
 
-### 29.2 Three layers under `packages/core/`
+Per the rule — "the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is" — the CLI's `packages/cli/src/` can import Rings 1 + 2 + 3 from `packages/core/`, plus `commander`, `ink`, `@modelcontextprotocol/sdk`, `@clack/prompts`, `picocolors`, `log-update`, `ora`. Cross-host imports (CLI → extension, CLI → desktop) are forbidden by the same ESLint rule.
 
-The kernel splits cleanly into three concentric rings; each ring has a different host-coupling rule.
+### 29.2 What the CLI ships in each ring
 
-**Ring 1: pure logic** (zero host coupling, zero ALS).
+- **No Ring 1 contributions** — the CLI is a host shell, not a logic library.
+- **No Ring 2 contributions** — runtime orchestration lives in core.
+- **No Ring 3 contributions** — the CLI uses the existing Node defaults (`consoleLog`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `memoryState`) plus the two CLI-side platform adapters from §7.3 (`ConfConfigProvider`, `KeyringSecrets`). The latter are CLI-package code, not Ring 3 code.
 
-- `core/agent/` minus runtime — every modelHandler, every flow, every node, every reasoning strategy.
-- `core/model/`, `core/latex/`, `core/replacement/`, `core/eventBus/` (schemas only — no emitters).
-- `core/tools/` minus `core/tools/approval/`.
-- `core/shared/` — IPC schemas, `runStream.ts` (§23.4).
-
-These take a `RunContext` argument (post-§22) but never reach for the ambient store. Test harnesses pass a synthesized `RunContext` and never need a fake host.
-
-**Ring 2: runtime orchestration** (consumes `RunContext`; no `vscode`/`electron`/`process` access).
-
-- `core/runtime/` — `RunContext`, `Logger`, `ProgressSink` interface, `executeAgent`, all coordinators.
-- `core/tools/approval/` — gates and controllers.
-- `core/auth/` — `SupabaseSessionCoordinator`, `TierService`, `ServerSideKeyService` (post-§22.5 per-context).
-- `core/hosts/` — every host port (`PromptHost`, `ExternalOpener`, `DiffViewHost`, `TerminalHost`, `ClipboardHost`, plus the new `HookHost` from §25.6).
-- `core/storage/sessionStore.ts` (§27.6).
-
-These import from Ring 1 freely, and they accept host services through their constructor / `RunContext` — but they never `import 'vscode'`, never `import 'electron'`, never `process.exit`.
-
-**Ring 3: platform defaults** (Node-only; no `vscode`/`electron`).
-
-- `core/platform/defaults/` — today's `consoleLog`, `memoryState`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `EnvSecrets`. CLI uses 5 of 6; desktop uses similar set; extension uses none.
-
-These are the shared concrete impls that any Node host gets for free. Adding a new Node-based host (e.g. a `texra serve` daemon, or a future Tauri-based app) should require only Ring 3 + a thin host adapter — no Ring 1 or Ring 2 changes.
-
-### 29.3 What lives in `packages/{extension,desktop,cli}/`
-
-Per-host code is everything that imports a host SDK or interacts with a host's surface. Crisp rule: **the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is**.
-
-| Host      | Owns                                                                                                                            | Doesn't own                                         |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| Extension | `vscode.commands`, webview hosts, `frontend/vscode/*`, controllers wired to webview message handlers, `VscodeOutputChannelSink` | The agent runtime (in core); coordinators (in core) |
-| Desktop   | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging                                         | Same                                                |
-| CLI       | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner                      | Same                                                |
-
-### 29.4 The host-port catalog (consolidated)
-
-Round 1 §4.1 lists the host ports already landed (`PromptHost`, `ExternalOpener`, etc.). Round 2 adds:
-
-| Port           | Added in | Implementations                                                                                                     |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
-| `LogSink`      | §23.2    | `VscodeOutputChannelSink`, `electronLogSink`, `StderrTextSink`, `NdjsonStdoutSink`, `McpProgressSink`, `MemorySink` |
-| `HookHost`     | §25.6    | `CommandHookHost` (CLI), `NoopHookHost` (extension/desktop v1.0)                                                    |
-| `SessionStore` | §27.6    | `JsonlSessionStore` (shared across all Node hosts; extension uses storage path under `globalStorageUri`)            |
-
-All ports live in `packages/core/src/hosts/`. The `Platform` interface from `src/platform/platform.ts` stays the same — those are the _infrastructure_ services (config, fs, secrets); ports are the _interaction_ services. They're not the same thing and they should not merge.
-
-### 29.5 What this saves
-
-The refactor isn't free — it's ~150 LOC of `index.ts` re-exports + ESLint rules + a few moves. What it buys:
-
-- **A new host needs only the rings it cares about.** A future Tauri app: import Ring 1 + Ring 2 + a Tauri-specific Ring 3 (`tauriFilesystem`, `tauriSecrets`); zero extension or CLI code touched.
-- **Tests don't fake hosts to test logic.** Ring 1 has no host. The kernel's existing FakePlatform suite stays in Ring 2 and only exercises Ring 2 code paths.
-- **Webview vs CLI vs Electron diff is a wiring diff, not a behavior diff.** When `polish` rewrites a paragraph differently in the CLI than the extension, we have one place to look (Ring 1 + the agent's YAML), not three.
-
-### 29.6 LOC
-
-| Item                                                                                                  | New     | Modified              | Deleted |
-| ----------------------------------------------------------------------------------------------------- | ------- | --------------------- | ------- |
-| Reorg of `packages/core/src/` into `agent/` (R1), `runtime/` (R2), `platform/` (R3) — mostly `git mv` | —       | ~10 (re-export files) | —       |
-| ESLint `no-cross-ring-imports` rule                                                                   | ~40     | —                     | —       |
-| `core/hosts/index.ts` re-export catalog                                                               | ~30     | —                     | —       |
-| `core/runtime/index.ts` re-export                                                                     | ~20     | —                     | —       |
-| **Subtotal**                                                                                          | **~90** | **~10**               | —       |
-
-Mostly mechanical; no rewrites of business logic.
+The CLI is purely a *consumer* of the three-ring structure. The benefits accrue at the kernel boundary: a future Tauri or daemon host imports the rings and ships only their own host package.
 
 ## 30. Container & GitHub-runner target matrix
 
@@ -1880,18 +1633,18 @@ Round 1 §12.3 listed five containers as "verified to run." The survey turns up 
 
 ### 30.2 Updated matrix
 
-| Image / runner                                       | Tier        | Notes                                                                                 |
-| ---------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
-| `ubuntu-22.04` (default GitHub runner)               | First-class | Node 20 preinstalled. CI matrix runs full E2E here.                                   |
-| `ubuntu-24.04`                                       | First-class | Same. Recommended once GHA's default flips.                                           |
-| `macos-14` (GitHub-hosted M-series)                  | First-class | E2E runs here for keyring path coverage.                                              |
-| `windows-latest`                                     | First-class | E2E runs here for path-handling coverage.                                             |
-| `node:20-bookworm-slim`                              | First-class | Recommended self-hosted/container. ~80 MB.                                            |
-| `node:20-bookworm`                                   | First-class | Same plus build tools. ~150 MB.                                                       |
-| `texlive/texlive:latest`                             | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
-| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0.                                               |
-| `node:20-alpine`                                     | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3.                       |
-| `gitpod/workspace-full`                              | Best-effort | Smoke-tested but not in CI matrix.                                                    |
+| Image / runner | Tier | Notes |
+| -------------- | ---- | ----- |
+| `ubuntu-22.04` (default GitHub runner) | First-class | Node 20 preinstalled. CI matrix runs full E2E here. |
+| `ubuntu-24.04` | First-class | Same. Recommended once GHA's default flips. |
+| `macos-14` (GitHub-hosted M-series) | First-class | E2E runs here for keyring path coverage. |
+| `windows-latest` | First-class | E2E runs here for path-handling coverage. |
+| `node:20-bookworm-slim` | First-class | Recommended self-hosted/container. ~80 MB. |
+| `node:20-bookworm` | First-class | Same plus build tools. ~150 MB. |
+| `texlive/texlive:latest` | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
+| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0. |
+| `node:20-alpine` | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3. |
+| `gitpod/workspace-full` | Best-effort | Smoke-tested but not in CI matrix. |
 
 ### 30.3 Local-development "callable from Claude Code / Codex" verification
 
@@ -1909,13 +1662,13 @@ The same test pattern with `@openai/codex` covers the Codex path. ~120 LOC of te
 
 To make GitHub-Actions ephemerality explicit (and prevent secrets leaking via uploaded artifacts), every file path the CLI writes is documented with a default and an env override:
 
-| Concern             | Default (linux)                                | Env override       | Allowed in CI artifact upload?                                                                   |
-| ------------------- | ---------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------ |
-| Config              | `~/.config/texra/config.yaml`                  | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs.                                                                  |
-| Secrets fallback    | `~/.texra/secrets.json` (chmod 0600)           | `TEXRA_DATA_DIR`   | **Never** — explicit gitignore + `.actignore` patterns.                                          |
-| Session JSONL       | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR`   | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
-| Runtime cache       | `~/.cache/texra/`                              | `TEXRA_CACHE_DIR`  | Yes; non-sensitive (downloaded model schemas, agent registry).                                   |
-| Logs (`--log-file`) | User-specified                                 | —                  | User-controlled — they pick.                                                                     |
+| Concern | Default (linux) | Env override | Allowed in CI artifact upload? |
+| ------- | --------------- | ------------ | ------------------------------ |
+| Config | `~/.config/texra/config.yaml` | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs. |
+| Secrets fallback | `~/.texra/secrets.json` (chmod 0600) | `TEXRA_DATA_DIR` | **Never** — explicit gitignore + `.actignore` patterns. |
+| Session JSONL | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR` | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
+| Runtime cache | `~/.cache/texra/` | `TEXRA_CACHE_DIR` | Yes; non-sensitive (downloaded model schemas, agent registry). |
+| Logs (`--log-file`) | User-specified | — | User-controlled — they pick. |
 
 Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
@@ -1925,26 +1678,35 @@ Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
 Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for the MCP-server surface. Phases 0, 2, 3, 4, 5 from round 1 keep their scope; Phase 1 absorbs §22 + §23 + §26 (all kernel-side, all on the critical path for tool-use agents).
 
-| Phase     | Round-1 scope                        | Round-2 additions                                                                  |
-| --------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
-| 0         | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29)                         |
-| 1         | Tool-use + approval engine           | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
-| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3)                  |
-| 2         | Config + secrets + auth              | unchanged                                                                          |
-| 3         | Interactive REPL                     | unchanged                                                                          |
-| 4         | GitHub Action                        | composite-action revision (§28)                                                    |
-| 5         | Polish, docs                         | + JSONL session migration (§27.5) + hook system v1 (§25.5)                         |
+| Phase | Round-1 scope | Round-2 additions |
+| ----- | ------------- | ----------------- |
+| 0 | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29) |
+| 1 | Tool-use + approval engine | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
+| 1.5 (new) | — | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3) |
+| 2 | Config + secrets + auth | unchanged |
+| 3 | Interactive REPL | unchanged |
+| 4 | GitHub Action | composite-action revision (§28) |
+| 5 | Polish, docs | + JSONL session migration (§27.5) + hook system v1 (§25.5) |
 
 ### 31.2 Aggregate LOC
 
-| Bucket                                  | Round-1 net      | Round-2 additions                                                                                                                                                                         | Round-2 total    |
-| --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `packages/cli/`                         | 2,800–3,800      | +730 (MCP §24.6, hooks adapter §25, sessions §27.6, sandbox-removed §26 ≈ 0)                                                                                                              | **3,530–4,530**  |
-| `packages/core/` (CLI pre-refactors)    | ~730             | +940 (RunContext §22 net ~+170, Logger v2 §23 ~+430, HookHost §25.6 ~+140, sessionStore §27.6 ~+200, ring re-exports §29.6 ~+90, approval predicates §26 ~+80, minus overlap with Logger) | **~1,670**       |
-| `texra-ai/texra-action` (separate repo) | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                                                                                               | **~500**         |
-| **Total v1**                            | **~4,330–5,330** | **+~1,370**                                                                                                                                                                               | **~5,700–6,700** |
+After the §22/§23/§29 split into dedicated kernel PRDs, the CLI PRD's LOC accounting only counts CLI-package work. Kernel-side LOC is tracked in those PRDs.
 
-The round-2 work expands the project by ~30%, but ~70% of the addition is in the kernel — work that the extension and the desktop app inherit unchanged. The CLI shell still finishes in the same ballpark (3.5–4.5 KLOC). v1 ships in **~9–11 weeks** for a single engineer, **~6–8** for two engineers (Phases 0 + 1 sequential, 1.5 + 2 parallel, 3 sequential, 4 + 5 parallel).
+| Bucket | Round-1 net | Round-2 additions (CLI-only after split) | Round-2 total |
+| ------ | ----------- | ---------------------------------------- | ------------- |
+| `packages/cli/` | 2,800–3,800 | +730 + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.3) | **~3,880–4,880** |
+| `packages/core/` (CLI's *own* pre-refactors only — C1–C8 from §14) | ~730 | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs) | **~950** |
+| `texra-ai/texra-action` (separate repo) | ~800 | -300 (no JS shim; YAML composite + small TS for the high-level action only) | **~500** |
+| **Total v1 (this PRD's scope)** | **~4,330–5,330** | **+~1,000** | **~5,330–6,330** |
+
+Kernel work that the CLI consumes but does not own (sized in the linked PRDs):
+
+| PRD | Kernel net new | Engineering weeks |
+| --- | -------------- | ----------------- |
+| [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) | ~-10 (refactor pays for itself) | ~6.5 |
+| [`prd-logger-v2.md`](./prd-logger-v2.md) | ~+310 | ~3.8 |
+
+CLI v1.0 consumes RunContext Phase 1 + Logger Phase 1; CLI v1.1 consumes RunContext Phase 2 + Logger Phase 5. Both kernel PRDs land alongside CLI Phase 0–1 on the engineering plan. v1 of the CLI ships in **~9–11 weeks** for a single engineer, **~6–8** for two engineers running CLI + kernel work in parallel.
 
 ### 31.3 Updated success criteria (additive to §17)
 
@@ -1995,4 +1757,4 @@ Round 2 ships only `command` and `prompt` handler types in §25.5. `http` (POST 
 
 ---
 
-End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and _callable by every other agent that speaks MCP_ — which was the user's framing all along.
+End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and *callable by every other agent that speaks MCP* — which was the user's framing all along.

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1137,19 +1137,19 @@ Round 1 above defined the CLI as a thin Node shell over an already host-neutral 
 
 Round 2 lands six concrete deltas plus one cross-cutting kernel refactor that all three hosts (extension, desktop, CLI) benefit from. None of these change the round-1 LOC band by more than ~600 lines combined; most are about replacing ad-hoc patterns with the kernel-shaped abstractions the audit revealed are already partially in place.
 
-| Delta | Round 1 status | Round 2 position | New §  |
-| ----- | -------------- | ---------------- | ------ |
-| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work | **Promoted to standalone PRD — see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md). CLI v1.0 consumes Phase 1; v1.1 consumes Phase 2 (gates concurrent MCP sessions).** | §22 (stub) |
-| Structured logger with explicit context, no module globals | Hand-waved as "consoleLog plus filter wrapper" | **Promoted to standalone PRD — see [`prd-logger-v2.md`](./prd-logger-v2.md). CLI installs four sinks (stderr text, NDJSON stdout, Ink, MCP).** | §23 (stub) |
-| `texra mcp serve` (callable from Claude Code, Codex, opencode) | Listed as v1.1 future | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)** | §24 |
-| Hook system (SessionStart, PreToolUse, PostToolUse, …) | Not mentioned | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner** | §25 |
-| Approval policy revisited (no 2D sandbox axis) | 1D `never|ask|auto-edits|auto|yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
-| Session transcripts as JSONL under project-hash sharding | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics** | §27 |
-| GitHub Action: composite + Bun (not JS Action) | §12 picked JS Action | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in** | §28 |
-| Cross-platform shared structure refactor (kernel side) | Implicit | **Promoted into [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8 (three-ring kernel structure). CLI-side consumption details retained here.** | §29 (stub) |
-| Container / GitHub-runner target matrix (slim, alpine, texlive) | Sketched in §12.3 | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30 |
-| Phase plan delta + LOC delta | — | **Aggregated** | §31 |
-| Parking lot — unified agent-SDK / message-SDK / context compaction | — | **Out of v1; sized in §32 for visibility** | §32 |
+| Delta                                                                         | Round 1 status                                       | Round 2 position                                                                                                                                                                     | New §      |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ---- | ----- | ---------------------------------------------------------------------------------------------------------------------------- | --- |
+| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work                               | **Promoted to standalone PRD — see [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md). CLI v1.0 consumes Phase 1; v1.1 consumes Phase 2 (gates concurrent MCP sessions).** | §22 (stub) |
+| Structured logger with explicit context, no module globals                    | Hand-waved as "consoleLog plus filter wrapper"       | **Promoted to standalone PRD — see [`prd-logger-v2.md`](./prd-logger-v2.md). CLI installs four sinks (stderr text, NDJSON stdout, Ink, MCP).**                                       | §23 (stub) |
+| `texra mcp serve` (callable from Claude Code, Codex, opencode)                | Listed as v1.1 future                                | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)**                                                                                        | §24        |
+| Hook system (SessionStart, PreToolUse, PostToolUse, …)                        | Not mentioned                                        | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner**                                                                                | §25        |
+| Approval policy revisited (no 2D sandbox axis)                                | 1D `never                                            | ask                                                                                                                                                                                  | auto-edits | auto | yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
+| Session transcripts as JSONL under project-hash sharding                      | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics**                                                                                                      | §27        |
+| GitHub Action: composite + Bun (not JS Action)                                | §12 picked JS Action                                 | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in**                                                                           | §28        |
+| Cross-platform shared structure refactor (kernel side)                        | Implicit                                             | **Promoted into [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) §8 (three-ring kernel structure). CLI-side consumption details retained here.**                         | §29 (stub) |
+| Container / GitHub-runner target matrix (slim, alpine, texlive)               | Sketched in §12.3                                    | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues**                                                                      | §30        |
+| Phase plan delta + LOC delta                                                  | —                                                    | **Aggregated**                                                                                                                                                                       | §31        |
+| Parking lot — unified agent-SDK / message-SDK / context compaction            | —                                                    | **Out of v1; sized in §32 for visibility**                                                                                                                                           | §32        |
 
 The rest of round 2 is the spec for these deltas, in dependency order: §22 → §23 unblock §24 (an MCP server can't safely host concurrent sessions until the kernel's ambient state is gone); §24 + §25 + §26 are independent hosts on the new context; §27 + §28 + §29 + §30 are deployment / packaging concerns that don't gate kernel work.
 
@@ -1159,31 +1159,31 @@ The rest of round 2 is the spec for these deltas, in dependency order: §22 → 
 
 ### 22.1 What the CLI consumes
 
-The CLI's relationship to the RunContext PRD is one of *consumer*, not *driver*:
+The CLI's relationship to the RunContext PRD is one of _consumer_, not _driver_:
 
 - The CLI's `cli/src/runtime/initPlatform.ts` constructs a `RunContext` per `texra run` invocation, populates `RunCapabilities` (no extension; GitHub token from `process.env.GITHUB_TOKEN`; no callback resolver), and threads it via `withRunContext(ctx, () => executeAgent(...))`.
-- The CLI's `texra mcp serve` host (§24) constructs *one `RunContext` per MCP `tools/call`* — that's the workload that gates the RunContext PRD's Phase 2 (singleton retirement) for v1.1 concurrency safety.
+- The CLI's `texra mcp serve` host (§24) constructs _one `RunContext` per MCP `tools/call`_ — that's the workload that gates the RunContext PRD's Phase 2 (singleton retirement) for v1.1 concurrency safety.
 - Until the RunContext PRD's Phase 1 lands, the CLI's `runAgent()` SDK is documented as **single-consumer-per-process** (round-1 §7.6 caveat). The shim path makes this safe-by-default, not safe-by-design.
 
 ### 22.2 Phase mapping
 
-| RunContext-PRD phase | Lands in CLI release | What the CLI gains |
-| -------------------- | -------------------- | ------------------ |
-| Phase 0 (foundations) | CLI v1.0 prereq | `withRunContext` wraps every `runAgent()` SDK call; `tryUseRunContext()` available to CLI sinks. |
-| Phase 1 (per-context coordinators) | CLI v1.0 | Plan / proposal / retry approvals route through the CLI's TTY prompt handler without singleton interference. |
-| Phase 2 (sink + runtime-host singleton retirement) | CLI v1.1 | `texra mcp serve` hosts concurrent sessions safely. |
-| Phase 3 (capability injection) | CLI v1.2 | `--use-my-keys`, `--no-tier-check`, GitHub token CI flow stop relying on module setters. |
-| Phase 4 (auth singletons) | CLI v1.2 | Multi-account testing in CI no longer needs process restart between tests. |
-| Phase 5 (sweep) | CLI v1.3 | `texra` cold-start drops by ~5ms (no fallback chains in hot paths). |
+| RunContext-PRD phase                               | Lands in CLI release | What the CLI gains                                                                                           |
+| -------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Phase 0 (foundations)                              | CLI v1.0 prereq      | `withRunContext` wraps every `runAgent()` SDK call; `tryUseRunContext()` available to CLI sinks.             |
+| Phase 1 (per-context coordinators)                 | CLI v1.0             | Plan / proposal / retry approvals route through the CLI's TTY prompt handler without singleton interference. |
+| Phase 2 (sink + runtime-host singleton retirement) | CLI v1.1             | `texra mcp serve` hosts concurrent sessions safely.                                                          |
+| Phase 3 (capability injection)                     | CLI v1.2             | `--use-my-keys`, `--no-tier-check`, GitHub token CI flow stop relying on module setters.                     |
+| Phase 4 (auth singletons)                          | CLI v1.2             | Multi-account testing in CI no longer needs process restart between tests.                                   |
+| Phase 5 (sweep)                                    | CLI v1.3             | `texra` cold-start drops by ~5ms (no fallback chains in hot paths).                                          |
 
 ### 22.3 LOC accounting (CLI side only)
 
-| Item | New | Modified |
-| ---- | --- | -------- |
-| `cli/src/runtime/initPlatform.ts` constructs `RunContext` per invocation | ~60 | — |
-| Per-`tools/call` `RunContext` factory in `cli/src/mcp/server.ts` | (counted under §24) | — |
-| Test harness updates to `withRunContext`-wrap all CLI tests | — | ~50 |
-| **Subtotal (CLI side)** | **~60** | **~50** |
+| Item                                                                     | New                 | Modified |
+| ------------------------------------------------------------------------ | ------------------- | -------- |
+| `cli/src/runtime/initPlatform.ts` constructs `RunContext` per invocation | ~60                 | —        |
+| Per-`tools/call` `RunContext` factory in `cli/src/mcp/server.ts`         | (counted under §24) | —        |
+| Test harness updates to `withRunContext`-wrap all CLI tests              | —                   | ~50      |
+| **Subtotal (CLI side)**                                                  | **~60**             | **~50**  |
 
 The kernel work is sized in `prd-runcontext-refactor.md` §7 (~6.5 engineering weeks across Phases 0–5).
 
@@ -1193,12 +1193,12 @@ The kernel work is sized in `prd-runcontext-refactor.md` §7 (~6.5 engineering w
 
 ### 23.1 What the CLI installs
 
-| Mode | Sink | What it does |
-| ---- | ---- | ------------ |
-| Headless text (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
-| JSON / NDJSON (`--output-format json|ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout (the same union the §11.2 progress stream uses). |
-| Interactive (Ink TUI) | `InkLogSink` | Routes records to the `<StreamPane />` component as `event === "log"` rows alongside progress events. |
-| MCP server (`texra mcp serve`) | `McpProgressSink` | Records become `notifications/progress` payloads bound to the request's progress token. |
+| Mode                                 | Sink              | What it does                                                                                           |
+| ------------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Headless text (`--print` or non-TTY) | `StderrTextSink`  | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
+| JSON / NDJSON (`--output-format json | ndjson`)          | `NdjsonStdoutSink`                                                                                     | One `RunStreamEvent` per line on stdout (the same union the §11.2 progress stream uses). |
+| Interactive (Ink TUI)                | `InkLogSink`      | Routes records to the `<StreamPane />` component as `event === "log"` rows alongside progress events.  |
+| MCP server (`texra mcp serve`)       | `McpProgressSink` | Records become `notifications/progress` payloads bound to the request's progress token.                |
 
 All four CLI-side sinks live in `packages/cli/src/render/sinks/`. `BootstrapLogger` is constructed in `cli/src/bin/texra.ts` immediately and threaded through config-load, secret resolution, agent-directory bootstrap, and mode selection — its buffer flushes through whichever sink the resolved mode picks.
 
@@ -1208,14 +1208,14 @@ The unification of progress events and log records into one `RunStreamEvent` uni
 
 ### 23.3 LOC accounting (CLI side only)
 
-| Item | New |
-| ---- | --- |
-| `StderrTextSink` (picocolors-aware) | ~120 |
-| `NdjsonStdoutSink` (schema-validated) | ~60 |
-| `InkLogSink` (Ink-component-aware; lazy chunk) | ~80 |
-| `McpProgressSink` (counted under §24) | (— ) |
-| Bootstrap wiring in `cli/src/bin/texra.ts` and `cli/src/runtime/initPlatform.ts` | ~30 |
-| **Subtotal (CLI side)** | **~290** |
+| Item                                                                             | New      |
+| -------------------------------------------------------------------------------- | -------- |
+| `StderrTextSink` (picocolors-aware)                                              | ~120     |
+| `NdjsonStdoutSink` (schema-validated)                                            | ~60      |
+| `InkLogSink` (Ink-component-aware; lazy chunk)                                   | ~80      |
+| `McpProgressSink` (counted under §24)                                            | (— )     |
+| Bootstrap wiring in `cli/src/bin/texra.ts` and `cli/src/runtime/initPlatform.ts` | ~30      |
+| **Subtotal (CLI side)**                                                          | **~290** |
 
 The kernel work is sized in `prd-logger-v2.md` §9 (~3.8 engineering weeks across Phases 0–5).
 
@@ -1233,9 +1233,9 @@ The user's framing — "to be callable by Claude Code and Codex etc" — is exac
   "mcpServers": {
     "texra": {
       "command": "texra",
-      "args": ["mcp", "serve"]
-    }
-  }
+      "args": ["mcp", "serve"],
+    },
+  },
 }
 ```
 
@@ -1254,11 +1254,11 @@ transport = "stdio"
 
 A minimum viable v1 surface — three tools, no resources, no prompts. Resources can come in v1.1 once we know what callers actually want.
 
-| MCP tool name | Backed by | Purpose |
-| ------------- | --------- | ------- |
-| `run_workflow` | `executeAgent({ category: "workflow", ... })` | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`. |
-| `run_chat` | `executeAgent({ category: "toolUse", ... })` | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
-| `list_agents` | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate. |
+| MCP tool name  | Backed by                                               | Purpose                                                                                                                                                                                                                           |
+| -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_workflow` | `executeAgent({ category: "workflow", ... })`           | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`.                           |
+| `run_chat`     | `executeAgent({ category: "toolUse", ... })`            | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
+| `list_agents`  | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate.                                                                                                             |
 
 All three accept an optional `runId` so the caller can correlate progress notifications. Approval policy is forced to `never` by default in MCP mode (no TTY for prompts) — callers wanting bash/edit auto-approval pass `approvalPolicy: "yolo"` explicitly, exactly as round 1 §9 specifies for headless mode.
 
@@ -1275,7 +1275,7 @@ stdio JSON-RPC 2.0, one process per client connection, exactly the Claude Code /
 
 ### 24.4 Permission propagation
 
-The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the *call* (e.g., Claude Code asked the user "let texra__run_polish run?"). What TeXRA still owns is what the *agent inside* TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
+The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the _call_ (e.g., Claude Code asked the user "let texra\_\_run_polish run?"). What TeXRA still owns is what the _agent inside_ TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
 
 Three policies for those inner gates, selected by tool argument:
 
@@ -1301,14 +1301,14 @@ Three policies for those inner gates, selected by tool argument:
 
 ### 24.6 LOC
 
-| Item | New | Modified |
-| ---- | --- | -------- |
-| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising) | ~120 | — |
-| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts` | ~250 | — |
-| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80 | — |
-| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch) | — | ~30 |
-| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`) | ~40 | — |
-| **Subtotal** | **~490** | **~30** |
+| Item                                                                           | New      | Modified |
+| ------------------------------------------------------------------------------ | -------- | -------- |
+| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)    | ~120     | —        |
+| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`               | ~250     | —        |
+| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80      | —        |
+| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)             | —        | ~30      |
+| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                         | ~40      | —        |
+| **Subtotal**                                                                   | **~490** | **~30**  |
 
 ## 25. Hook system (Claude Code-style)
 
@@ -1326,8 +1326,12 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 // hook input on stdin
 {
   "hookEventName": "PreToolUse",
-  "session": { "id": "ses_abc123", "cwd": "/path/to/project", "agent": "orchestrator" },
-  "tool": { "name": "bash", "input": { "command": "rm -rf /" } }
+  "session": {
+    "id": "ses_abc123",
+    "cwd": "/path/to/project",
+    "agent": "orchestrator",
+  },
+  "tool": { "name": "bash", "input": { "command": "rm -rf /" } },
 }
 ```
 
@@ -1336,8 +1340,8 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 {
   "hookSpecificOutput": {
     "permissionDecision": "deny",
-    "reason": "rm -rf is not allowed in this project"
-  }
+    "reason": "rm -rf is not allowed in this project",
+  },
 }
 ```
 
@@ -1345,17 +1349,17 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 
 ### 25.3 Where hooks fire
 
-| Event | Fires from | RunContext field |
-| ----- | ---------- | ---------------- |
-| `SessionStart` | `executeAgent.ts` after `buildAgentLaunchContext` | `runId`, `streamId`, `cwd` |
-| `UserPromptSubmit` | Tool-use REPL on each user submit | `runId`, `instruction` |
-| `PreToolUse` | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch | `runId`, `tool.name`, `tool.input` |
-| `PostToolUse` | Tool dispatch after result | `runId`, `tool.name`, `tool.result.summary` |
-| `Stop` | `executeAgent` finalizer | `runId`, `result.status` |
-| `SubagentStop` | Delegation child completion | `runId`, `parentStreamId`, `childStreamId`, `result` |
-| `Notification` | Any `requestShowError` / `requestShowInstruction` emission | `runId`, `message` |
-| `PreCompact` / `PostCompact` | (Future, §32 — context compaction) | `runId`, `compactionStats` |
-| `PermissionRequest` | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"|"bash"|"plan"|"proposal"|"retry"` |
+| Event                        | Fires from                                                                          | RunContext field                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ------ | ---------- | -------- |
+| `SessionStart`               | `executeAgent.ts` after `buildAgentLaunchContext`                                   | `runId`, `streamId`, `cwd`                           |
+| `UserPromptSubmit`           | Tool-use REPL on each user submit                                                   | `runId`, `instruction`                               |
+| `PreToolUse`                 | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch             | `runId`, `tool.name`, `tool.input`                   |
+| `PostToolUse`                | Tool dispatch after result                                                          | `runId`, `tool.name`, `tool.result.summary`          |
+| `Stop`                       | `executeAgent` finalizer                                                            | `runId`, `result.status`                             |
+| `SubagentStop`               | Delegation child completion                                                         | `runId`, `parentStreamId`, `childStreamId`, `result` |
+| `Notification`               | Any `requestShowError` / `requestShowInstruction` emission                          | `runId`, `message`                                   |
+| `PreCompact` / `PostCompact` | (Future, §32 — context compaction)                                                  | `runId`, `compactionStats`                           |
+| `PermissionRequest`          | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"              | "bash" | "plan" | "proposal" | "retry"` |
 
 ### 25.4 Configuration
 
@@ -1408,20 +1412,17 @@ Round 2's first draft proposed adopting Codex's `approval_policy × sandbox_mode
 
 The reasons it's the right call:
 
-1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap *all* agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
-2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — *not* a CLI-only knob.
+1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap _all_ agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
+2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — _not_ a CLI-only knob.
 3. **A 2D matrix doubles the test surface and doubles the doc surface.** The mental load — "if I pass `--approval-policy auto --sandbox workspace-write` what happens to bash that touches `/tmp`?" — is exactly the friction users complained about with Codex's first iteration.
 
-### 26.2 What round 2 *does* sharpen
+### 26.2 What round 2 _does_ sharpen
 
 Round 1 §9.2 says "in-project means the candidate file/cwd is inside the resolved workspace path." Round 2 specifies the predicate concretely so the kernel and the CLI agree:
 
 ```ts
 // packages/core/src/runtime/approvalPredicates.ts (new — ~40 LOC)
-export function isInProject(
-  candidate: string,
-  workspaceRoot: string,
-): boolean {
+export function isInProject(candidate: string, workspaceRoot: string): boolean {
   const candidateAbs = path.resolve(candidate);
   const rootAbs = path.resolve(workspaceRoot);
   const rel = path.relative(rootAbs, candidateAbs);
@@ -1440,7 +1441,7 @@ Edge cases the predicate handles explicitly:
 
 Bash is harder than file paths — "auto-approve when in-project" doesn't make sense for `rm -rf $HOME`. Round 1 punted on this. Round 2 spec:
 
-- `auto` policy auto-approves bash *only* when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
+- `auto` policy auto-approves bash _only_ when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
 - Any redirect to `/`, any unquoted variable, any `&&` / `||` / `|` chain that contains a non-listed command → falls back to `ask` even under `auto`.
 - `yolo` short-circuits all of this; `never` always denies.
 
@@ -1503,13 +1504,13 @@ The existing `~/.texra/global-storage/<workspace>/runs/` layout stays for one re
 
 ### 27.6 LOC
 
-| Item | New | Modified |
-| ---- | --- | -------- |
-| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200 | — |
-| `packages/core/src/storage/sessionMigration.ts` (legacy → new) | ~80 | — |
-| `cli/src/commands/resume.ts` (consumes sessionStore directly) | — | ~30 |
-| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags) | — | ~20 |
-| **Subtotal** | **~280** | **~50** |
+| Item                                                                                         | New      | Modified |
+| -------------------------------------------------------------------------------------------- | -------- | -------- |
+| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200     | —        |
+| `packages/core/src/storage/sessionMigration.ts` (legacy → new)                               | ~80      | —        |
+| `cli/src/commands/resume.ts` (consumes sessionStore directly)                                | —        | ~30      |
+| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags)                             | —        | ~20      |
+| **Subtotal**                                                                                 | **~280** | **~50**  |
 
 ## 28. GitHub Action revisited — composite + Bun, not JS
 
@@ -1534,7 +1535,8 @@ inputs:
   output: { description: 'Output file path', required: false }
   rounds: { description: 'Workflow rounds', required: false, default: '1' }
   model: { description: 'Model name', required: false }
-  approval-policy: { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
+  approval-policy:
+    { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
   texra-version: { description: 'Pinned CLI version', default: 'latest' }
   output-format: { description: 'text|json|ndjson', default: 'ndjson' }
 outputs:
@@ -1600,9 +1602,9 @@ runs:
 
 ### 28.4 Updated round-1 §6 decision
 
-| #   | Concern                | Round 1 pick      | Round 2 pick |
-| --- | ---------------------- | ----------------- | ------------ |
-| 9   | GitHub Action          | JS Action         | **Composite action + Bun runner; install CLI from npm at run time** |
+| #   | Concern       | Round 1 pick | Round 2 pick                                                        |
+| --- | ------------- | ------------ | ------------------------------------------------------------------- |
+| 9   | GitHub Action | JS Action    | **Composite action + Bun runner; install CLI from npm at run time** |
 
 No other round-1 picks change.
 
@@ -1620,7 +1622,7 @@ Per the rule — "the host package's `src/` is allowed to import `vscode` / `ele
 - **No Ring 2 contributions** — runtime orchestration lives in core.
 - **No Ring 3 contributions** — the CLI uses the existing Node defaults (`consoleLog`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `memoryState`) plus the two CLI-side platform adapters from §7.3 (`ConfConfigProvider`, `KeyringSecrets`). The latter are CLI-package code, not Ring 3 code.
 
-The CLI is purely a *consumer* of the three-ring structure. The benefits accrue at the kernel boundary: a future Tauri or daemon host imports the rings and ships only their own host package.
+The CLI is purely a _consumer_ of the three-ring structure. The benefits accrue at the kernel boundary: a future Tauri or daemon host imports the rings and ships only their own host package.
 
 ## 30. Container & GitHub-runner target matrix
 
@@ -1633,18 +1635,18 @@ Round 1 §12.3 listed five containers as "verified to run." The survey turns up 
 
 ### 30.2 Updated matrix
 
-| Image / runner | Tier | Notes |
-| -------------- | ---- | ----- |
-| `ubuntu-22.04` (default GitHub runner) | First-class | Node 20 preinstalled. CI matrix runs full E2E here. |
-| `ubuntu-24.04` | First-class | Same. Recommended once GHA's default flips. |
-| `macos-14` (GitHub-hosted M-series) | First-class | E2E runs here for keyring path coverage. |
-| `windows-latest` | First-class | E2E runs here for path-handling coverage. |
-| `node:20-bookworm-slim` | First-class | Recommended self-hosted/container. ~80 MB. |
-| `node:20-bookworm` | First-class | Same plus build tools. ~150 MB. |
-| `texlive/texlive:latest` | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
-| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0. |
-| `node:20-alpine` | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3. |
-| `gitpod/workspace-full` | Best-effort | Smoke-tested but not in CI matrix. |
+| Image / runner                                       | Tier        | Notes                                                                                 |
+| ---------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `ubuntu-22.04` (default GitHub runner)               | First-class | Node 20 preinstalled. CI matrix runs full E2E here.                                   |
+| `ubuntu-24.04`                                       | First-class | Same. Recommended once GHA's default flips.                                           |
+| `macos-14` (GitHub-hosted M-series)                  | First-class | E2E runs here for keyring path coverage.                                              |
+| `windows-latest`                                     | First-class | E2E runs here for path-handling coverage.                                             |
+| `node:20-bookworm-slim`                              | First-class | Recommended self-hosted/container. ~80 MB.                                            |
+| `node:20-bookworm`                                   | First-class | Same plus build tools. ~150 MB.                                                       |
+| `texlive/texlive:latest`                             | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
+| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0.                                               |
+| `node:20-alpine`                                     | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3.                       |
+| `gitpod/workspace-full`                              | Best-effort | Smoke-tested but not in CI matrix.                                                    |
 
 ### 30.3 Local-development "callable from Claude Code / Codex" verification
 
@@ -1662,13 +1664,13 @@ The same test pattern with `@openai/codex` covers the Codex path. ~120 LOC of te
 
 To make GitHub-Actions ephemerality explicit (and prevent secrets leaking via uploaded artifacts), every file path the CLI writes is documented with a default and an env override:
 
-| Concern | Default (linux) | Env override | Allowed in CI artifact upload? |
-| ------- | --------------- | ------------ | ------------------------------ |
-| Config | `~/.config/texra/config.yaml` | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs. |
-| Secrets fallback | `~/.texra/secrets.json` (chmod 0600) | `TEXRA_DATA_DIR` | **Never** — explicit gitignore + `.actignore` patterns. |
-| Session JSONL | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR` | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
-| Runtime cache | `~/.cache/texra/` | `TEXRA_CACHE_DIR` | Yes; non-sensitive (downloaded model schemas, agent registry). |
-| Logs (`--log-file`) | User-specified | — | User-controlled — they pick. |
+| Concern             | Default (linux)                                | Env override       | Allowed in CI artifact upload?                                                                   |
+| ------------------- | ---------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------ |
+| Config              | `~/.config/texra/config.yaml`                  | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs.                                                                  |
+| Secrets fallback    | `~/.texra/secrets.json` (chmod 0600)           | `TEXRA_DATA_DIR`   | **Never** — explicit gitignore + `.actignore` patterns.                                          |
+| Session JSONL       | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR`   | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
+| Runtime cache       | `~/.cache/texra/`                              | `TEXRA_CACHE_DIR`  | Yes; non-sensitive (downloaded model schemas, agent registry).                                   |
+| Logs (`--log-file`) | User-specified                                 | —                  | User-controlled — they pick.                                                                     |
 
 Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
@@ -1678,33 +1680,33 @@ Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
 Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for the MCP-server surface. Phases 0, 2, 3, 4, 5 from round 1 keep their scope; Phase 1 absorbs §22 + §23 + §26 (all kernel-side, all on the critical path for tool-use agents).
 
-| Phase | Round-1 scope | Round-2 additions |
-| ----- | ------------- | ----------------- |
-| 0 | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29) |
-| 1 | Tool-use + approval engine | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
-| 1.5 (new) | — | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3) |
-| 2 | Config + secrets + auth | unchanged |
-| 3 | Interactive REPL | unchanged |
-| 4 | GitHub Action | composite-action revision (§28) |
-| 5 | Polish, docs | + JSONL session migration (§27.5) + hook system v1 (§25.5) |
+| Phase     | Round-1 scope                        | Round-2 additions                                                                  |
+| --------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
+| 0         | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29)                         |
+| 1         | Tool-use + approval engine           | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
+| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3)                  |
+| 2         | Config + secrets + auth              | unchanged                                                                          |
+| 3         | Interactive REPL                     | unchanged                                                                          |
+| 4         | GitHub Action                        | composite-action revision (§28)                                                    |
+| 5         | Polish, docs                         | + JSONL session migration (§27.5) + hook system v1 (§25.5)                         |
 
 ### 31.2 Aggregate LOC
 
 After the §22/§23/§29 split into dedicated kernel PRDs, the CLI PRD's LOC accounting only counts CLI-package work. Kernel-side LOC is tracked in those PRDs.
 
-| Bucket | Round-1 net | Round-2 additions (CLI-only after split) | Round-2 total |
-| ------ | ----------- | ---------------------------------------- | ------------- |
-| `packages/cli/` | 2,800–3,800 | +730 + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.3) | **~3,880–4,880** |
-| `packages/core/` (CLI's *own* pre-refactors only — C1–C8 from §14) | ~730 | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs) | **~950** |
-| `texra-ai/texra-action` (separate repo) | ~800 | -300 (no JS shim; YAML composite + small TS for the high-level action only) | **~500** |
-| **Total v1 (this PRD's scope)** | **~4,330–5,330** | **+~1,000** | **~5,330–6,330** |
+| Bucket                                                             | Round-1 net      | Round-2 additions (CLI-only after split)                                                                     | Round-2 total    |
+| ------------------------------------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `packages/cli/`                                                    | 2,800–3,800      | +730 + ~350 (CLI-side RunContext + Logger sinks + bootstrap wiring, per §§22.3, 23.3)                        | **~3,880–4,880** |
+| `packages/core/` (CLI's _own_ pre-refactors only — C1–C8 from §14) | ~730             | +220 (HookHost §25.6, sessionStore §27.6, approval predicates §26 — minus the items moved to dedicated PRDs) | **~950**         |
+| `texra-ai/texra-action` (separate repo)                            | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                  | **~500**         |
+| **Total v1 (this PRD's scope)**                                    | **~4,330–5,330** | **+~1,000**                                                                                                  | **~5,330–6,330** |
 
 Kernel work that the CLI consumes but does not own (sized in the linked PRDs):
 
-| PRD | Kernel net new | Engineering weeks |
-| --- | -------------- | ----------------- |
-| [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) | ~-10 (refactor pays for itself) | ~6.5 |
-| [`prd-logger-v2.md`](./prd-logger-v2.md) | ~+310 | ~3.8 |
+| PRD                                                          | Kernel net new                  | Engineering weeks |
+| ------------------------------------------------------------ | ------------------------------- | ----------------- |
+| [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md) | ~-10 (refactor pays for itself) | ~6.5              |
+| [`prd-logger-v2.md`](./prd-logger-v2.md)                     | ~+310                           | ~3.8              |
 
 CLI v1.0 consumes RunContext Phase 1 + Logger Phase 1; CLI v1.1 consumes RunContext Phase 2 + Logger Phase 5. Both kernel PRDs land alongside CLI Phase 0–1 on the engineering plan. v1 of the CLI ships in **~9–11 weeks** for a single engineer, **~6–8** for two engineers running CLI + kernel work in parallel.
 
@@ -1757,4 +1759,4 @@ Round 2 ships only `command` and `prompt` handler types in §25.5. `http` (POST 
 
 ---
 
-End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and *callable by every other agent that speaks MCP* — which was the user's framing all along.
+End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and _callable by every other agent that speaks MCP_ — which was the user's framing all along.

--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1137,19 +1137,19 @@ Round 1 above defined the CLI as a thin Node shell over an already host-neutral 
 
 Round 2 lands six concrete deltas plus one cross-cutting kernel refactor that all three hosts (extension, desktop, CLI) benefit from. None of these change the round-1 LOC band by more than ~600 lines combined; most are about replacing ad-hoc patterns with the kernel-shaped abstractions the audit revealed are already partially in place.
 
-| Delta | Round 1 status | Round 2 position | New §  |
-| ----- | -------------- | ---------------- | ------ |
-| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work | **v1 prereq for `texra mcp serve` and re-entrant SDK; v1.0 ships with the migration shim path** | §22 |
-| Structured logger with explicit context, no module globals | Hand-waved as "consoleLog plus filter wrapper" | **v1 deliverable; `LogBackend` interface widened to take a context object** | §23 |
-| `texra mcp serve` (callable from Claude Code, Codex, opencode) | Listed as v1.1 future | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)** | §24 |
-| Hook system (SessionStart, PreToolUse, PostToolUse, …) | Not mentioned | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner** | §25 |
-| Approval policy revisited (no 2D sandbox axis) | 1D `never|ask|auto-edits|auto|yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
-| Session transcripts as JSONL under project-hash sharding | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics** | §27 |
-| GitHub Action: composite + Bun (not JS Action) | §12 picked JS Action | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in** | §28 |
-| Cross-platform shared structure refactor (kernel side) | Implicit | **Explicit — what the three hosts share, what they don't, where the seams go** | §29 |
-| Container / GitHub-runner target matrix (slim, alpine, texlive) | Sketched in §12.3 | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30 |
-| Phase plan delta + LOC delta | — | **Aggregated** | §31 |
-| Parking lot — unified agent-SDK / message-SDK / context compaction | — | **Out of v1; sized in §32 for visibility** | §32 |
+| Delta                                                                         | Round 1 status                                       | Round 2 position                                                                                                | New §      |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------- | ---- | ----- | ---------------------------------------------------------------------------------------------------------------------------- | --- |
+| Explicit `RunContext` replaces ambient ALS + singletons (§7.6 caveat / #3397) | Tracked as future work                               | **v1 prereq for `texra mcp serve` and re-entrant SDK; v1.0 ships with the migration shim path**                 | §22        |
+| Structured logger with explicit context, no module globals                    | Hand-waved as "consoleLog plus filter wrapper"       | **v1 deliverable; `LogBackend` interface widened to take a context object**                                     | §23        |
+| `texra mcp serve` (callable from Claude Code, Codex, opencode)                | Listed as v1.1 future                                | **Promoted to v1; minimum surface = three tools (`run_workflow`, `run_chat`, `list_agents`)**                   | §24        |
+| Hook system (SessionStart, PreToolUse, PostToolUse, …)                        | Not mentioned                                        | **v1.1 — copy Claude Code's contract verbatim; spec'd here so v1 doesn't paint itself into a corner**           | §25        |
+| Approval policy revisited (no 2D sandbox axis)                                | 1D `never                                            | ask                                                                                                             | auto-edits | auto | yolo` | **Stays 1D per user feedback. Round 2 sharpens the "in-project / outside-project" semantics with concrete file:line rules.** | §26 |
+| Session transcripts as JSONL under project-hash sharding                      | Implicit reuse of `RunStorageService` snapshot files | **Explicit format; `texra resume` / `--continue` / `--fork-session` semantics**                                 | §27        |
+| GitHub Action: composite + Bun (not JS Action)                                | §12 picked JS Action                                 | **Reverse — match `claude-code-base-action`'s composite pattern; faster iteration, no `dist/` checked in**      | §28        |
+| Cross-platform shared structure refactor (kernel side)                        | Implicit                                             | **Explicit — what the three hosts share, what they don't, where the seams go**                                  | §29        |
+| Container / GitHub-runner target matrix (slim, alpine, texlive)               | Sketched in §12.3                                    | **Refined per survey; `node:20-alpine` is downgraded to "best-effort" because of glibc/Bun/native-deps issues** | §30        |
+| Phase plan delta + LOC delta                                                  | —                                                    | **Aggregated**                                                                                                  | §31        |
+| Parking lot — unified agent-SDK / message-SDK / context compaction            | —                                                    | **Out of v1; sized in §32 for visibility**                                                                      | §32        |
 
 The rest of round 2 is the spec for these deltas, in dependency order: §22 → §23 unblock §24 (an MCP server can't safely host concurrent sessions until the kernel's ambient state is gone); §24 + §25 + §26 are independent hosts on the new context; §27 + §28 + §29 + §30 are deployment / packaging concerns that don't gate kernel work.
 
@@ -1166,20 +1166,20 @@ The May 2026 runtime audit (in commit-time order, not severity) found:
 
 **Module-level `let X | undefined` + setter pairs (~20):**
 
-| Concern | Setter | File:line |
-| ------- | ------ | --------- |
-| Default progress sink | `setDefaultProgressSink` | `src/agent/runtime/ProgressSink.ts:14` |
-| Default runtime host | `setDefaultAgentRuntimeHost` | `src/agent/runtime/AgentRuntimeHost.ts:11` |
-| Run storage service | `setRunStorageService` | `src/agent/runtime/RunStorageService.ts:10` |
-| Tool-edit approval handler | `setToolEditApprovalHandler` | `src/tools/approval/toolEditApproval.ts:74,113` |
-| Latex-preview handler | `setLatexBuildDisplay` | `src/tools/approval/latexPreview.ts:21` |
-| GitHub token provider | `setGitHubTokenProvider` | `src/tools/github/githubAuth.ts:13` |
-| Extension checker | `setExtensionChecker` | `src/tools/externalToolDefs.ts:35` |
-| Server-side key service | `setServerSideKeyService` | `src/auth/serverKeys/index.ts:34` |
-| Tier service | `setTierService` | `src/auth/tier/index.ts:31` |
-| Auth callback resolver | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183` |
-| Runtime extension id | `setRuntimeExtensionId` | `src/auth/config.ts:137` |
-| Output-channel factory (logger) | `setOutputChannelFactory` | `src/logger/logUtils.ts:108` |
+| Concern                         | Setter                            | File:line                                       |
+| ------------------------------- | --------------------------------- | ----------------------------------------------- |
+| Default progress sink           | `setDefaultProgressSink`          | `src/agent/runtime/ProgressSink.ts:14`          |
+| Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`      |
+| Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`     |
+| Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113` |
+| Latex-preview handler           | `setLatexBuildDisplay`            | `src/tools/approval/latexPreview.ts:21`         |
+| GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`             |
+| Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`              |
+| Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`               |
+| Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                     |
+| Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                        |
+| Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                        |
+| Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                    |
 
 **Exported singleton coordinators (3):**
 
@@ -1269,13 +1269,13 @@ Because the audit found ~30 sites that read singletons today, a hard cutover is 
 
 ### 22.5 Migration order (gated on, not blocking, CLI v1.0)
 
-| Round | Singletons retired | Files touched | Net LOC |
-| ----- | ------------------ | ------------- | ------- |
-| Pre-v1.0 | `runContextScope` lives at boundary; `runWithAgentRuntimeHost` reads it; new `Logger`/`progress` getters on context (§23) | `executeAgent.ts`, `runContext.ts` (new), `Logger.ts` (new) | +180 / -10 |
-| v1.0 | `planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator` become per-context instances created in `buildAgentLaunchContext()` | `Plan/Retry/AgentProposalCoordinator.ts`, ~5 call sites | +60 / -30 |
-| v1.1 (gates `texra mcp serve`) | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` singletons removed | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 reader sites | +0 / -120 |
-| v1.2 | `setToolEditApprovalHandler`, `setGitHubTokenProvider`, `setExtensionChecker`, `setLatexBuildDisplay` — replaced by `RunCapabilities` injection | `tools/{approval,github,externalToolDefs}/*` | +40 / -90 |
-| v1.3 | Auth singletons (`tierService`, `serverSideKeyService`) become per-`RunContext` resolutions backed by a kernel-side `AuthRegistry` | `auth/*` | +60 / -100 |
+| Round                          | Singletons retired                                                                                                                              | Files touched                                                                       | Net LOC    |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------- |
+| Pre-v1.0                       | `runContextScope` lives at boundary; `runWithAgentRuntimeHost` reads it; new `Logger`/`progress` getters on context (§23)                       | `executeAgent.ts`, `runContext.ts` (new), `Logger.ts` (new)                         | +180 / -10 |
+| v1.0                           | `planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator` become per-context instances created in `buildAgentLaunchContext()`        | `Plan/Retry/AgentProposalCoordinator.ts`, ~5 call sites                             | +60 / -30  |
+| v1.1 (gates `texra mcp serve`) | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` singletons removed                                                        | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 reader sites | +0 / -120  |
+| v1.2                           | `setToolEditApprovalHandler`, `setGitHubTokenProvider`, `setExtensionChecker`, `setLatexBuildDisplay` — replaced by `RunCapabilities` injection | `tools/{approval,github,externalToolDefs}/*`                                        | +40 / -90  |
+| v1.3                           | Auth singletons (`tierService`, `serverSideKeyService`) become per-`RunContext` resolutions backed by a kernel-side `AuthRegistry`              | `auth/*`                                                                            | +60 / -100 |
 
 Net: at v1.3 the kernel has zero `let X | undefined` + setter pairs in the agnostic zones, and ~250 LOC has been deleted on net. The CLI's `texra mcp serve` becomes safe at the v1.1 boundary; v1.0 ships with the shim.
 
@@ -1293,11 +1293,11 @@ The LangSmith #2274 issue is the canonical foot-gun: ALS context can be lost whe
 
 `src/logger/logUtils.ts` is a serviceable VS Code-shaped logger. It is also wrong for the CLI in three concrete ways:
 
-1. **`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level state.** The audit finds exactly one setter in production code (`packages/extension/src/extension.ts`), but tests and an MCP-server mode that hosts concurrent runs cannot safely share these. The `setOutputChannelFactory(null)` reset disposes channels for *every* concurrent caller.
+1. **`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level state.** The audit finds exactly one setter in production code (`packages/extension/src/extension.ts`), but tests and an MCP-server mode that hosts concurrent runs cannot safely share these. The `setOutputChannelFactory(null)` reset disposes channels for _every_ concurrent caller.
 2. **Group context lives in its own ALS (`contextStorage`, line 10), separate from the runtime host's ALS (`runtimeHostScope`, `AgentRuntimeHost.ts:12`).** A sub-agent that emits a log line passes through both scopes; the two are kept in sync by convention, not enforcement.
 3. **`writeLine` calls `getConfig('texra.logger.debugMode', false)` on every line (line 79).** That's fine in the extension where `getConfig` is a wrapped `vscode.workspace.getConfiguration`, but in the CLI before `initPlatform()` runs (which the audit shows happens for ~40 module-load-time `initialize()` calls), the config provider may not exist yet. Today's `tryPlatform()` fallback works because `getConfig` returns the default; in the CLI we want stricter guarantees that log lines emitted during boot don't silently lose their context.
 
-Plus a non-bug observation: the JSON / NDJSON renderer specced in round 1 §11.2 is a *separate* code path from the human renderer. Two formats, one schema is fine; two formats, two code paths is duplication waiting to bit-rot.
+Plus a non-bug observation: the JSON / NDJSON renderer specced in round 1 §11.2 is a _separate_ code path from the human renderer. Two formats, one schema is fine; two formats, two code paths is duplication waiting to bit-rot.
 
 ### 23.2 Shape
 
@@ -1334,11 +1334,11 @@ The host registers a single `LogSink` (renamed from `LogBackend` to make explici
 
 ```ts
 export interface LogRecord {
-  ts: string;             // ISO-8601 with millis
+  ts: string; // ISO-8601 with millis
   level: LogLevel;
   message: string;
   fields: LogFields;
-  groups: readonly string[];   // current group stack at emit time
+  groups: readonly string[]; // current group stack at emit time
 }
 
 export interface LogSink {
@@ -1349,14 +1349,14 @@ export interface LogSink {
 
 ### 23.3 What each host installs
 
-| Host       | Sink                                                                                            |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| Extension  | `VscodeOutputChannelSink` — writes formatted strings to `vscode.OutputChannel` (today's behavior). One channel per agent. |
-| Desktop    | `electronLogSink` over `electron-log` (Electron PRD §6.4); same channel-per-agent shape.        |
-| CLI headless | `StderrTextSink` — picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`. Also writes to `--log-file` if passed. |
-| CLI JSON   | `NdjsonStdoutSink` — one JSON object per line, schema-validated against `LogRecord`. **This is the same data path §11.2 specs as the event stream — log records and progress events share the JSON Lines envelope.** |
-| CLI MCP    | `McpProgressSink` — converts each record to an MCP `notifications/progress` payload bound to the request's progress token. Respects the client's progress-update opt-in. |
-| Tests      | `MemorySink` — pushes records into an array for assertion; auto-installed via `withRunContext()` in `vitest.setup.ts`. |
+| Host         | Sink                                                                                                                                                                                                                 |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Extension    | `VscodeOutputChannelSink` — writes formatted strings to `vscode.OutputChannel` (today's behavior). One channel per agent.                                                                                            |
+| Desktop      | `electronLogSink` over `electron-log` (Electron PRD §6.4); same channel-per-agent shape.                                                                                                                             |
+| CLI headless | `StderrTextSink` — picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`. Also writes to `--log-file` if passed.                                                                                       |
+| CLI JSON     | `NdjsonStdoutSink` — one JSON object per line, schema-validated against `LogRecord`. **This is the same data path §11.2 specs as the event stream — log records and progress events share the JSON Lines envelope.** |
+| CLI MCP      | `McpProgressSink` — converts each record to an MCP `notifications/progress` payload bound to the request's progress token. Respects the client's progress-update opt-in.                                             |
+| Tests        | `MemorySink` — pushes records into an array for assertion; auto-installed via `withRunContext()` in `vitest.setup.ts`.                                                                                               |
 
 ### 23.4 Rendering rules — round-1 §11 reconciled
 
@@ -1391,15 +1391,15 @@ The CLI emits ~3–5 log lines before `initPlatform()` returns (config layer loa
 
 ### 23.7 LOC accounting
 
-| Item | New | Modified | Deleted |
-| ---- | --- | -------- | ------- |
-| `packages/core/src/runtime/logger.ts` (new — interface + bootstrap logger + group helpers) | ~180 | — | — |
-| `packages/core/src/runtime/runContext.ts` (logger threaded as field) | (counted under §22) | — | — |
-| `src/logger/logUtils.ts` (kept for legacy callers; routes to new logger) | — | ~80 | — |
-| `src/logger/AgentLogger.ts`, `AgentUsageReporter.ts` (route through `ctx.log`) | — | ~40 | — |
-| Per-host sinks: `VscodeOutputChannelSink` (extension), `StderrTextSink` + `NdjsonStdoutSink` (CLI), `McpProgressSink` (CLI v1.1) | ~250 | — | — |
-| `texra config` exposes `logger.debugMode` via `ConfigProvider.watch()`; remove the per-write `getConfig` lookup | — | ~10 | ~5 |
-| **Subtotal** | **~430** | **~130** | **~5** |
+| Item                                                                                                                             | New                 | Modified | Deleted |
+| -------------------------------------------------------------------------------------------------------------------------------- | ------------------- | -------- | ------- |
+| `packages/core/src/runtime/logger.ts` (new — interface + bootstrap logger + group helpers)                                       | ~180                | —        | —       |
+| `packages/core/src/runtime/runContext.ts` (logger threaded as field)                                                             | (counted under §22) | —        | —       |
+| `src/logger/logUtils.ts` (kept for legacy callers; routes to new logger)                                                         | —                   | ~80      | —       |
+| `src/logger/AgentLogger.ts`, `AgentUsageReporter.ts` (route through `ctx.log`)                                                   | —                   | ~40      | —       |
+| Per-host sinks: `VscodeOutputChannelSink` (extension), `StderrTextSink` + `NdjsonStdoutSink` (CLI), `McpProgressSink` (CLI v1.1) | ~250                | —        | —       |
+| `texra config` exposes `logger.debugMode` via `ConfigProvider.watch()`; remove the per-write `getConfig` lookup                  | —                   | ~10      | ~5      |
+| **Subtotal**                                                                                                                     | **~430**            | **~130** | **~5**  |
 
 This counts against §14's pre-refactor budget (~430 → ~860 with logger v2 added). Within the engineering-week envelope from §15 because §22 + §23 deliverables are the natural prerequisite for §24.
 
@@ -1417,9 +1417,9 @@ The user's framing — "to be callable by Claude Code and Codex etc" — is exac
   "mcpServers": {
     "texra": {
       "command": "texra",
-      "args": ["mcp", "serve"]
-    }
-  }
+      "args": ["mcp", "serve"],
+    },
+  },
 }
 ```
 
@@ -1438,11 +1438,11 @@ transport = "stdio"
 
 A minimum viable v1 surface — three tools, no resources, no prompts. Resources can come in v1.1 once we know what callers actually want.
 
-| MCP tool name | Backed by | Purpose |
-| ------------- | --------- | ------- |
-| `run_workflow` | `executeAgent({ category: "workflow", ... })` | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`. |
-| `run_chat` | `executeAgent({ category: "toolUse", ... })` | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
-| `list_agents` | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate. |
+| MCP tool name  | Backed by                                               | Purpose                                                                                                                                                                                                                           |
+| -------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_workflow` | `executeAgent({ category: "workflow", ... })`           | Run a workflow agent (correct, polish, elevate, devise, criticize, merge, OCR, transcribe). Inputs: `agent`, `inputFile`, `outputFile`, `rounds?`, `model?`, `useMultiple?`. Output: `AgentFlowResult`.                           |
+| `run_chat`     | `executeAgent({ category: "toolUse", ... })`            | Run a tool-use agent (orchestrator, devise, search, generic). Inputs: `agent`, `instruction`, `cwd?`, `allowedTools?`, `disallowedTools?`. Output: streaming via `notifications/progress`; final `AgentFlowResult` on completion. |
+| `list_agents`  | `getAgentsBySource()` from `@agent/index/agentRegistry` | Returns the agent catalog (id, category, description, source). Lets the calling agent decide what's safe to delegate.                                                                                                             |
 
 All three accept an optional `runId` so the caller can correlate progress notifications. Approval policy is forced to `never` by default in MCP mode (no TTY for prompts) — callers wanting bash/edit auto-approval pass `approvalPolicy: "yolo"` explicitly, exactly as round 1 §9 specifies for headless mode.
 
@@ -1459,7 +1459,7 @@ stdio JSON-RPC 2.0, one process per client connection, exactly the Claude Code /
 
 ### 24.4 Permission propagation
 
-The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the *call* (e.g., Claude Code asked the user "let texra__run_polish run?"). What TeXRA still owns is what the *agent inside* TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
+The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the _call_ (e.g., Claude Code asked the user "let texra\_\_run_polish run?"). What TeXRA still owns is what the _agent inside_ TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
 
 Three policies for those inner gates, selected by tool argument:
 
@@ -1485,14 +1485,14 @@ Three policies for those inner gates, selected by tool argument:
 
 ### 24.6 LOC
 
-| Item | New | Modified |
-| ---- | --- | -------- |
-| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising) | ~120 | — |
-| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts` | ~250 | — |
-| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80 | — |
-| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch) | — | ~30 |
-| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`) | ~40 | — |
-| **Subtotal** | **~490** | **~30** |
+| Item                                                                           | New      | Modified |
+| ------------------------------------------------------------------------------ | -------- | -------- |
+| `packages/cli/src/mcp/server.ts` (server bootstrap, capability advertising)    | ~120     | —        |
+| `packages/cli/src/mcp/tools/{runWorkflow,runChat,listAgents}.ts`               | ~250     | —        |
+| `packages/cli/src/mcp/sinks/McpProgressSink.ts` (also used by Logger v2 §23.3) | ~80      | —        |
+| `packages/cli/src/runtime/initPlatform.ts` (McpHostAdapter branch)             | —        | ~30      |
+| `packages/cli/src/commands/mcp.ts` (`texra mcp serve`)                         | ~40      | —        |
+| **Subtotal**                                                                   | **~490** | **~30**  |
 
 ## 25. Hook system (Claude Code-style)
 
@@ -1510,8 +1510,12 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 // hook input on stdin
 {
   "hookEventName": "PreToolUse",
-  "session": { "id": "ses_abc123", "cwd": "/path/to/project", "agent": "orchestrator" },
-  "tool": { "name": "bash", "input": { "command": "rm -rf /" } }
+  "session": {
+    "id": "ses_abc123",
+    "cwd": "/path/to/project",
+    "agent": "orchestrator",
+  },
+  "tool": { "name": "bash", "input": { "command": "rm -rf /" } },
 }
 ```
 
@@ -1520,8 +1524,8 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 {
   "hookSpecificOutput": {
     "permissionDecision": "deny",
-    "reason": "rm -rf is not allowed in this project"
-  }
+    "reason": "rm -rf is not allowed in this project",
+  },
 }
 ```
 
@@ -1529,17 +1533,17 @@ Hook contracts are easy to bolt on later in theory and a nightmare in practice �
 
 ### 25.3 Where hooks fire
 
-| Event | Fires from | RunContext field |
-| ----- | ---------- | ---------------- |
-| `SessionStart` | `executeAgent.ts` after `buildAgentLaunchContext` | `runId`, `streamId`, `cwd` |
-| `UserPromptSubmit` | Tool-use REPL on each user submit | `runId`, `instruction` |
-| `PreToolUse` | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch | `runId`, `tool.name`, `tool.input` |
-| `PostToolUse` | Tool dispatch after result | `runId`, `tool.name`, `tool.result.summary` |
-| `Stop` | `executeAgent` finalizer | `runId`, `result.status` |
-| `SubagentStop` | Delegation child completion | `runId`, `parentStreamId`, `childStreamId`, `result` |
-| `Notification` | Any `requestShowError` / `requestShowInstruction` emission | `runId`, `message` |
-| `PreCompact` / `PostCompact` | (Future, §32 — context compaction) | `runId`, `compactionStats` |
-| `PermissionRequest` | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"|"bash"|"plan"|"proposal"|"retry"` |
+| Event                        | Fires from                                                                          | RunContext field                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ------ | ---------- | -------- |
+| `SessionStart`               | `executeAgent.ts` after `buildAgentLaunchContext`                                   | `runId`, `streamId`, `cwd`                           |
+| `UserPromptSubmit`           | Tool-use REPL on each user submit                                                   | `runId`, `instruction`                               |
+| `PreToolUse`                 | `requestToolEditApproval`, `requestBashApproval`, generic tool dispatch             | `runId`, `tool.name`, `tool.input`                   |
+| `PostToolUse`                | Tool dispatch after result                                                          | `runId`, `tool.name`, `tool.result.summary`          |
+| `Stop`                       | `executeAgent` finalizer                                                            | `runId`, `result.status`                             |
+| `SubagentStop`               | Delegation child completion                                                         | `runId`, `parentStreamId`, `childStreamId`, `result` |
+| `Notification`               | Any `requestShowError` / `requestShowInstruction` emission                          | `runId`, `message`                                   |
+| `PreCompact` / `PostCompact` | (Future, §32 — context compaction)                                                  | `runId`, `compactionStats`                           |
+| `PermissionRequest`          | The same gate `PreToolUse` covers, but specifically for the approval gates §9 lists | Same as `PreToolUse` plus `gate: "edit"              | "bash" | "plan" | "proposal" | "retry"` |
 
 ### 25.4 Configuration
 
@@ -1592,20 +1596,17 @@ Round 2's first draft proposed adopting Codex's `approval_policy × sandbox_mode
 
 The reasons it's the right call:
 
-1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap *all* agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
-2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — *not* a CLI-only knob.
+1. **Codex's `sandbox_mode` solves a problem we don't have.** Codex sandbox modes wrap _all_ agent file/network access in an OS-level sandbox (Seatbelt on macOS, Landlock on Linux). TeXRA today doesn't sandbox — its tools call `executeCommand` (`@utils/system/execUtils`) and `nodeFilesystem` directly. Adding a real OS sandbox is a 4–6 engineering-week project of its own and orthogonal to the CLI shell.
+2. **Surface-level "in-project / outside-project" distinction is enough for v1.** Round 1 §9.2 already says "in-project" auto-approves under `auto`/`auto-edits`, "outside-project" prompts. That's where 90% of the value is. The remaining 10% is "I want a true OS sandbox," which the desktop's macOS App Sandbox / Windows AppContainer / Linux unprivileged-namespaces story will eventually solve in a host-uniform way — _not_ a CLI-only knob.
 3. **A 2D matrix doubles the test surface and doubles the doc surface.** The mental load — "if I pass `--approval-policy auto --sandbox workspace-write` what happens to bash that touches `/tmp`?" — is exactly the friction users complained about with Codex's first iteration.
 
-### 26.2 What round 2 *does* sharpen
+### 26.2 What round 2 _does_ sharpen
 
 Round 1 §9.2 says "in-project means the candidate file/cwd is inside the resolved workspace path." Round 2 specifies the predicate concretely so the kernel and the CLI agree:
 
 ```ts
 // packages/core/src/runtime/approvalPredicates.ts (new — ~40 LOC)
-export function isInProject(
-  candidate: string,
-  workspaceRoot: string,
-): boolean {
+export function isInProject(candidate: string, workspaceRoot: string): boolean {
   const candidateAbs = path.resolve(candidate);
   const rootAbs = path.resolve(workspaceRoot);
   const rel = path.relative(rootAbs, candidateAbs);
@@ -1624,7 +1625,7 @@ Edge cases the predicate handles explicitly:
 
 Bash is harder than file paths — "auto-approve when in-project" doesn't make sense for `rm -rf $HOME`. Round 1 punted on this. Round 2 spec:
 
-- `auto` policy auto-approves bash *only* when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
+- `auto` policy auto-approves bash _only_ when the resolved cwd is in-project AND the command's argv[0] is in a built-in safe list. The safe list is small and conservative: `ls`, `cat`, `head`, `tail`, `wc`, `find` (read-only flags only), `grep`, `rg`, `git status`, `git diff`, `git log`, `pdflatex`, `latexmk`, `pandoc`, `texcount`. Editable per-project via `approval.allowedBash` in config (round 1 §9.4).
 - Any redirect to `/`, any unquoted variable, any `&&` / `||` / `|` chain that contains a non-listed command → falls back to `ask` even under `auto`.
 - `yolo` short-circuits all of this; `never` always denies.
 
@@ -1687,13 +1688,13 @@ The existing `~/.texra/global-storage/<workspace>/runs/` layout stays for one re
 
 ### 27.6 LOC
 
-| Item | New | Modified |
-| ---- | --- | -------- |
-| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200 | — |
-| `packages/core/src/storage/sessionMigration.ts` (legacy → new) | ~80 | — |
-| `cli/src/commands/resume.ts` (consumes sessionStore directly) | — | ~30 |
-| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags) | — | ~20 |
-| **Subtotal** | **~280** | **~50** |
+| Item                                                                                         | New      | Modified |
+| -------------------------------------------------------------------------------------------- | -------- | -------- |
+| `packages/core/src/storage/sessionStore.ts` (new — JSONL writer + reader, project-hash util) | ~200     | —        |
+| `packages/core/src/storage/sessionMigration.ts` (legacy → new)                               | ~80      | —        |
+| `cli/src/commands/resume.ts` (consumes sessionStore directly)                                | —        | ~30      |
+| `cli/src/commands/run.ts` (`--continue`, `--fork-session` flags)                             | —        | ~20      |
+| **Subtotal**                                                                                 | **~280** | **~50**  |
 
 ## 28. GitHub Action revisited — composite + Bun, not JS
 
@@ -1718,7 +1719,8 @@ inputs:
   output: { description: 'Output file path', required: false }
   rounds: { description: 'Workflow rounds', required: false, default: '1' }
   model: { description: 'Model name', required: false }
-  approval-policy: { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
+  approval-policy:
+    { description: 'never|ask|auto-edits|auto|yolo', default: 'never' }
   texra-version: { description: 'Pinned CLI version', default: 'latest' }
   output-format: { description: 'text|json|ndjson', default: 'ndjson' }
 outputs:
@@ -1784,9 +1786,9 @@ runs:
 
 ### 28.4 Updated round-1 §6 decision
 
-| #   | Concern                | Round 1 pick      | Round 2 pick |
-| --- | ---------------------- | ----------------- | ------------ |
-| 9   | GitHub Action          | JS Action         | **Composite action + Bun runner; install CLI from npm at run time** |
+| #   | Concern       | Round 1 pick | Round 2 pick                                                        |
+| --- | ------------- | ------------ | ------------------------------------------------------------------- |
+| 9   | GitHub Action | JS Action    | **Composite action + Bun runner; install CLI from npm at run time** |
 
 No other round-1 picks change.
 
@@ -1829,23 +1831,23 @@ These are the shared concrete impls that any Node host gets for free. Adding a n
 
 Per-host code is everything that imports a host SDK or interacts with a host's surface. Crisp rule: **the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is**.
 
-| Host | Owns | Doesn't own |
-| ---- | ---- | ----------- |
+| Host      | Owns                                                                                                                            | Doesn't own                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | Extension | `vscode.commands`, webview hosts, `frontend/vscode/*`, controllers wired to webview message handlers, `VscodeOutputChannelSink` | The agent runtime (in core); coordinators (in core) |
-| Desktop | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging | Same |
-| CLI | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner | Same |
+| Desktop   | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging                                         | Same                                                |
+| CLI       | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner                      | Same                                                |
 
 ### 29.4 The host-port catalog (consolidated)
 
 Round 1 §4.1 lists the host ports already landed (`PromptHost`, `ExternalOpener`, etc.). Round 2 adds:
 
-| Port | Added in | Implementations |
-| ---- | -------- | --------------- |
-| `LogSink` | §23.2 | `VscodeOutputChannelSink`, `electronLogSink`, `StderrTextSink`, `NdjsonStdoutSink`, `McpProgressSink`, `MemorySink` |
-| `HookHost` | §25.6 | `CommandHookHost` (CLI), `NoopHookHost` (extension/desktop v1.0) |
-| `SessionStore` | §27.6 | `JsonlSessionStore` (shared across all Node hosts; extension uses storage path under `globalStorageUri`) |
+| Port           | Added in | Implementations                                                                                                     |
+| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| `LogSink`      | §23.2    | `VscodeOutputChannelSink`, `electronLogSink`, `StderrTextSink`, `NdjsonStdoutSink`, `McpProgressSink`, `MemorySink` |
+| `HookHost`     | §25.6    | `CommandHookHost` (CLI), `NoopHookHost` (extension/desktop v1.0)                                                    |
+| `SessionStore` | §27.6    | `JsonlSessionStore` (shared across all Node hosts; extension uses storage path under `globalStorageUri`)            |
 
-All ports live in `packages/core/src/hosts/`. The `Platform` interface from `src/platform/platform.ts` stays the same — those are the *infrastructure* services (config, fs, secrets); ports are the *interaction* services. They're not the same thing and they should not merge.
+All ports live in `packages/core/src/hosts/`. The `Platform` interface from `src/platform/platform.ts` stays the same — those are the _infrastructure_ services (config, fs, secrets); ports are the _interaction_ services. They're not the same thing and they should not merge.
 
 ### 29.5 What this saves
 
@@ -1857,13 +1859,13 @@ The refactor isn't free — it's ~150 LOC of `index.ts` re-exports + ESLint rule
 
 ### 29.6 LOC
 
-| Item | New | Modified | Deleted |
-| ---- | --- | -------- | ------- |
-| Reorg of `packages/core/src/` into `agent/` (R1), `runtime/` (R2), `platform/` (R3) — mostly `git mv` | — | ~10 (re-export files) | — |
-| ESLint `no-cross-ring-imports` rule | ~40 | — | — |
-| `core/hosts/index.ts` re-export catalog | ~30 | — | — |
-| `core/runtime/index.ts` re-export | ~20 | — | — |
-| **Subtotal** | **~90** | **~10** | — |
+| Item                                                                                                  | New     | Modified              | Deleted |
+| ----------------------------------------------------------------------------------------------------- | ------- | --------------------- | ------- |
+| Reorg of `packages/core/src/` into `agent/` (R1), `runtime/` (R2), `platform/` (R3) — mostly `git mv` | —       | ~10 (re-export files) | —       |
+| ESLint `no-cross-ring-imports` rule                                                                   | ~40     | —                     | —       |
+| `core/hosts/index.ts` re-export catalog                                                               | ~30     | —                     | —       |
+| `core/runtime/index.ts` re-export                                                                     | ~20     | —                     | —       |
+| **Subtotal**                                                                                          | **~90** | **~10**               | —       |
 
 Mostly mechanical; no rewrites of business logic.
 
@@ -1878,18 +1880,18 @@ Round 1 §12.3 listed five containers as "verified to run." The survey turns up 
 
 ### 30.2 Updated matrix
 
-| Image / runner | Tier | Notes |
-| -------------- | ---- | ----- |
-| `ubuntu-22.04` (default GitHub runner) | First-class | Node 20 preinstalled. CI matrix runs full E2E here. |
-| `ubuntu-24.04` | First-class | Same. Recommended once GHA's default flips. |
-| `macos-14` (GitHub-hosted M-series) | First-class | E2E runs here for keyring path coverage. |
-| `windows-latest` | First-class | E2E runs here for path-handling coverage. |
-| `node:20-bookworm-slim` | First-class | Recommended self-hosted/container. ~80 MB. |
-| `node:20-bookworm` | First-class | Same plus build tools. ~150 MB. |
-| `texlive/texlive:latest` | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
-| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0. |
-| `node:20-alpine` | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3. |
-| `gitpod/workspace-full` | Best-effort | Smoke-tested but not in CI matrix. |
+| Image / runner                                       | Tier        | Notes                                                                                 |
+| ---------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `ubuntu-22.04` (default GitHub runner)               | First-class | Node 20 preinstalled. CI matrix runs full E2E here.                                   |
+| `ubuntu-24.04`                                       | First-class | Same. Recommended once GHA's default flips.                                           |
+| `macos-14` (GitHub-hosted M-series)                  | First-class | E2E runs here for keyring path coverage.                                              |
+| `windows-latest`                                     | First-class | E2E runs here for path-handling coverage.                                             |
+| `node:20-bookworm-slim`                              | First-class | Recommended self-hosted/container. ~80 MB.                                            |
+| `node:20-bookworm`                                   | First-class | Same plus build tools. ~150 MB.                                                       |
+| `texlive/texlive:latest`                             | First-class | TeXRA's primary integration container. Adds Node 20 via `apt-get install nodejs npm`. |
+| `mcr.microsoft.com/devcontainers/typescript-node:20` | First-class | Dev container; smoke-tested in Phase 0.                                               |
+| `node:20-alpine`                                     | Best-effort | Keyring fallback to file. Bun unavailable. Documented in §10.3.                       |
+| `gitpod/workspace-full`                              | Best-effort | Smoke-tested but not in CI matrix.                                                    |
 
 ### 30.3 Local-development "callable from Claude Code / Codex" verification
 
@@ -1907,13 +1909,13 @@ The same test pattern with `@openai/codex` covers the Codex path. ~120 LOC of te
 
 To make GitHub-Actions ephemerality explicit (and prevent secrets leaking via uploaded artifacts), every file path the CLI writes is documented with a default and an env override:
 
-| Concern | Default (linux) | Env override | Allowed in CI artifact upload? |
-| ------- | --------------- | ------------ | ------------------------------ |
-| Config | `~/.config/texra/config.yaml` | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs. |
-| Secrets fallback | `~/.texra/secrets.json` (chmod 0600) | `TEXRA_DATA_DIR` | **Never** — explicit gitignore + `.actignore` patterns. |
-| Session JSONL | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR` | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
-| Runtime cache | `~/.cache/texra/` | `TEXRA_CACHE_DIR` | Yes; non-sensitive (downloaded model schemas, agent registry). |
-| Logs (`--log-file`) | User-specified | — | User-controlled — they pick. |
+| Concern             | Default (linux)                                | Env override       | Allowed in CI artifact upload?                                                                   |
+| ------------------- | ---------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------ |
+| Config              | `~/.config/texra/config.yaml`                  | `TEXRA_CONFIG_DIR` | No — may contain endpoint URLs.                                                                  |
+| Secrets fallback    | `~/.texra/secrets.json` (chmod 0600)           | `TEXRA_DATA_DIR`   | **Never** — explicit gitignore + `.actignore` patterns.                                          |
+| Session JSONL       | `~/.texra/projects/<hash>/sessions/<id>.jsonl` | `TEXRA_DATA_DIR`   | Yes if `--allow-session-upload` (false by default). Inputs/outputs are paths, not content; safe. |
+| Runtime cache       | `~/.cache/texra/`                              | `TEXRA_CACHE_DIR`  | Yes; non-sensitive (downloaded model schemas, agent registry).                                   |
+| Logs (`--log-file`) | User-specified                                 | —                  | User-controlled — they pick.                                                                     |
 
 Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
@@ -1923,24 +1925,24 @@ Documented as `texra config path` output for fast diagnosis from `texra doctor`.
 
 Round 2 adds new work into existing phases plus one new phase (Phase 1.5) for the MCP-server surface. Phases 0, 2, 3, 4, 5 from round 1 keep their scope; Phase 1 absorbs §22 + §23 + §26 (all kernel-side, all on the critical path for tool-use agents).
 
-| Phase | Round-1 scope | Round-2 additions |
-| ----- | ------------- | ----------------- |
-| 0 | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29) |
-| 1 | Tool-use + approval engine | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
-| 1.5 (new) | — | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3) |
-| 2 | Config + secrets + auth | unchanged |
-| 3 | Interactive REPL | unchanged |
-| 4 | GitHub Action | composite-action revision (§28) |
-| 5 | Polish, docs | + JSONL session migration (§27.5) + hook system v1 (§25.5) |
+| Phase     | Round-1 scope                        | Round-2 additions                                                                  |
+| --------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
+| 0         | Workspace + headless workflow runner | + `RunContext` shim + Ring 1/2/3 reorg (§22.5 pre-v1, §29)                         |
+| 1         | Tool-use + approval engine           | + per-context coordinators (§22.5 v1.0) + Logger v2 (§23) + bash predicate (§26.3) |
+| 1.5 (new) | —                                    | `texra mcp serve` v1.0 surface (§24.5) + integration test (§30.3)                  |
+| 2         | Config + secrets + auth              | unchanged                                                                          |
+| 3         | Interactive REPL                     | unchanged                                                                          |
+| 4         | GitHub Action                        | composite-action revision (§28)                                                    |
+| 5         | Polish, docs                         | + JSONL session migration (§27.5) + hook system v1 (§25.5)                         |
 
 ### 31.2 Aggregate LOC
 
-| Bucket | Round-1 net | Round-2 additions | Round-2 total |
-| ------ | ----------- | ----------------- | ------------- |
-| `packages/cli/` | 2,800–3,800 | +730 (MCP §24.6, hooks adapter §25, sessions §27.6, sandbox-removed §26 ≈ 0) | **3,530–4,530** |
-| `packages/core/` (CLI pre-refactors) | ~730 | +940 (RunContext §22 net ~+170, Logger v2 §23 ~+430, HookHost §25.6 ~+140, sessionStore §27.6 ~+200, ring re-exports §29.6 ~+90, approval predicates §26 ~+80, minus overlap with Logger) | **~1,670** |
-| `texra-ai/texra-action` (separate repo) | ~800 | -300 (no JS shim; YAML composite + small TS for the high-level action only) | **~500** |
-| **Total v1** | **~4,330–5,330** | **+~1,370** | **~5,700–6,700** |
+| Bucket                                  | Round-1 net      | Round-2 additions                                                                                                                                                                         | Round-2 total    |
+| --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `packages/cli/`                         | 2,800–3,800      | +730 (MCP §24.6, hooks adapter §25, sessions §27.6, sandbox-removed §26 ≈ 0)                                                                                                              | **3,530–4,530**  |
+| `packages/core/` (CLI pre-refactors)    | ~730             | +940 (RunContext §22 net ~+170, Logger v2 §23 ~+430, HookHost §25.6 ~+140, sessionStore §27.6 ~+200, ring re-exports §29.6 ~+90, approval predicates §26 ~+80, minus overlap with Logger) | **~1,670**       |
+| `texra-ai/texra-action` (separate repo) | ~800             | -300 (no JS shim; YAML composite + small TS for the high-level action only)                                                                                                               | **~500**         |
+| **Total v1**                            | **~4,330–5,330** | **+~1,370**                                                                                                                                                                               | **~5,700–6,700** |
 
 The round-2 work expands the project by ~30%, but ~70% of the addition is in the kernel — work that the extension and the desktop app inherit unchanged. The CLI shell still finishes in the same ballpark (3.5–4.5 KLOC). v1 ships in **~9–11 weeks** for a single engineer, **~6–8** for two engineers (Phases 0 + 1 sequential, 1.5 + 2 parallel, 3 sequential, 4 + 5 parallel).
 
@@ -1993,4 +1995,4 @@ Round 2 ships only `command` and `prompt` handler types in §25.5. `http` (POST 
 
 ---
 
-End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and *callable by every other agent that speaks MCP* — which was the user's framing all along.
+End of round 2. The CLI is still a thin Node shell over a host-neutral kernel; round 2 just makes the kernel honestly host-neutral (no ambient singletons), bigger in the right direction (RunContext + Logger v2 + HookHost + SessionStore are kernel-shared infra), and _callable by every other agent that speaks MCP_ — which was the user's framing all along.

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -43,7 +43,7 @@ The total kernel work is ~430 LOC new + ~130 LOC modified + ~5 LOC deleted. None
 
 `outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The audit (per `prd-runcontext-refactor.md` §4) finds exactly one setter in production code (`packages/extension/src/extension.ts`), but:
 
-- Tests have to `setOutputChannelFactory(null)` in `afterEach`, which calls `dispose?.()` on every cached channel. With concurrent vitest runs in the same process this disposes channels for *other* tests' runs.
+- Tests have to `setOutputChannelFactory(null)` in `afterEach`, which calls `dispose?.()` on every cached channel. With concurrent vitest runs in the same process this disposes channels for _other_ tests' runs.
 - An MCP-server mode that hosts concurrent runs cannot share these channels — two `tools/call`s want two distinct sinks.
 - A re-entrant SDK has the same problem.
 
@@ -53,11 +53,11 @@ Group context lives in its own ALS (`contextStorage`, line 10). `runtimeHostScop
 
 ### 4.3 Per-line config lookup
 
-`writeLine` (line 79) calls `getConfig('texra.logger.debugMode', false)` *on every line*. In the extension that's a wrapped `vscode.workspace.getConfiguration` lookup — fast but not free. In the CLI before `initPlatform()` returns it goes through `tryPlatform()` and silently uses the default. Today's behavior is "config debug toggle is silently ignored during boot" — observed when debugging agent-directory bootstrap issues.
+`writeLine` (line 79) calls `getConfig('texra.logger.debugMode', false)` _on every line_. In the extension that's a wrapped `vscode.workspace.getConfiguration` lookup — fast but not free. In the CLI before `initPlatform()` returns it goes through `tryPlatform()` and silently uses the default. Today's behavior is "config debug toggle is silently ignored during boot" — observed when debugging agent-directory bootstrap issues.
 
 ### 4.4 Non-bug observation: two parallel pipelines
 
-The CLI's round-1 §11.2 NDJSON event stream is a *separate* code path from the logger. Two formats, one schema is fine; two formats, two code paths is duplication that will bit-rot. Logger v2 unifies them.
+The CLI's round-1 §11.2 NDJSON event stream is a _separate_ code path from the logger. Two formats, one schema is fine; two formats, two code paths is duplication that will bit-rot. Logger v2 unifies them.
 
 ## 5. Shape
 
@@ -98,11 +98,11 @@ export interface Logger {
 
 ```ts
 export interface LogRecord {
-  ts: string;                  // ISO-8601 with millis
+  ts: string; // ISO-8601 with millis
   level: LogLevel;
   message: string;
   fields: LogFields;
-  groups: readonly string[];   // current group stack at emit time
+  groups: readonly string[]; // current group stack at emit time
 }
 
 export interface LogSink {
@@ -171,14 +171,14 @@ Implications:
 
 Each host installs the sinks it wants. The mapping:
 
-| Host | Sink | Rendering |
-| ---- | ---- | --------- |
-| Extension | `VscodeOutputChannelSink` | Formatted string per line, written to one `vscode.OutputChannel` per agent (today's behavior). |
-| Desktop | `ElectronLogSink` | Wraps `electron-log` (per `prd-electron-app.md` §6.4); same channel-per-agent shape. |
-| CLI headless (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
-| CLI JSON (`--output-format json|ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout; schema-validated. |
-| CLI MCP server (`texra mcp serve`) | `McpProgressSink` | Converts each record to an MCP `notifications/progress` payload; respects the client's progress-update opt-in. |
-| Tests | `MemorySink` | Pushes records into an array; auto-installed via `withRunContext()` in `vitest.setup.ts`. |
+| Host                                | Sink                      | Rendering                                                                                                      |
+| ----------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Extension                           | `VscodeOutputChannelSink` | Formatted string per line, written to one `vscode.OutputChannel` per agent (today's behavior).                 |
+| Desktop                             | `ElectronLogSink`         | Wraps `electron-log` (per `prd-electron-app.md` §6.4); same channel-per-agent shape.                           |
+| CLI headless (`--print` or non-TTY) | `StderrTextSink`          | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed.         |
+| CLI JSON (`--output-format json     | ndjson`)                  | `NdjsonStdoutSink`                                                                                             | One `RunStreamEvent` per line on stdout; schema-validated. |
+| CLI MCP server (`texra mcp serve`)  | `McpProgressSink`         | Converts each record to an MCP `notifications/progress` payload; respects the client's progress-update opt-in. |
+| Tests                               | `MemorySink`              | Pushes records into an array; auto-installed via `withRunContext()` in `vitest.setup.ts`.                      |
 
 Per-host sinks live in their respective host packages (`packages/{extension,desktop,cli}/`); only the interface lives in `core/hosts/logSink.ts`.
 
@@ -192,7 +192,11 @@ The shim keeps the old signatures working:
 
 ```ts
 // src/logger/logUtils.ts (after migration)
-export function info(channel: string, message: string, options: LogUtilsOptions = {}): void {
+export function info(
+  channel: string,
+  message: string,
+  options: LogUtilsOptions = {},
+): void {
   const ctx = tryUseRunContext();
   const logger = ctx
     ? ctx.log.child({ channel, isAgent: options.isAgent ?? false })
@@ -278,15 +282,15 @@ Today these go through `console.info`. After this PRD: the CLI's `bin/texra.ts` 
 
 ### Aggregate timeline
 
-| Phase | Scope | Net LOC | Engineering weeks |
-| ----- | ----- | ------- | ----------------- |
-| 0 | Interface + bootstrap + legacy sink | +200 / -10 | 1 |
-| 1 | Per-host sinks (extension, desktop, CLI text, CLI ndjson, tests) | +250 / -50 | 1 |
-| 2 | Schema unification with progress | +30 / -80 | 0.5 |
-| 3 | Group ALS retirement | +20 / -60 | 0.5 |
-| 4 | `outputChannelFactory` retirement | +20 / -90 | 0.5 |
-| 5 | MCP sink | +80 | 0.3 |
-| **Total** | | **+~600 / -~290** | **~3.8** |
+| Phase     | Scope                                                            | Net LOC           | Engineering weeks |
+| --------- | ---------------------------------------------------------------- | ----------------- | ----------------- |
+| 0         | Interface + bootstrap + legacy sink                              | +200 / -10        | 1                 |
+| 1         | Per-host sinks (extension, desktop, CLI text, CLI ndjson, tests) | +250 / -50        | 1                 |
+| 2         | Schema unification with progress                                 | +30 / -80         | 0.5               |
+| 3         | Group ALS retirement                                             | +20 / -60         | 0.5               |
+| 4         | `outputChannelFactory` retirement                                | +20 / -90         | 0.5               |
+| 5         | MCP sink                                                         | +80               | 0.3               |
+| **Total** |                                                                  | **+~600 / -~290** | **~3.8**          |
 
 Net code: **~+310 LOC** (the new structured pipeline is bigger than the string-based one it replaces, but the 5 host sinks together are smaller than today's extension-only output-channel logic plus the JSON-renderer duplication).
 
@@ -298,14 +302,14 @@ Net code: **~+310 LOC** (the new structured pipeline is bigger than the string-b
 
 ## 11. Risks & mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-| ---- | ---------- | ------ | ---------- |
-| Phase 1 sinks render differently from the old logger and surface a regression | Medium | Low | Snapshot tests in `packages/extension/`, `packages/desktop/`, `packages/cli/` capture the rendered output for representative records. CI gate. |
-| Schema unification breaks downstream NDJSON consumers (e.g., `texra-action`) | Low | High | `RunStreamEventSchema` is a strict superset of today's `ProgressEventSchema`. Breaking changes bump `@texra/shared/schemas` major. Documented in the round-1 §11.2 schema doc. |
-| `BootstrapLogger`'s buffer grows unbounded when boot fails | Low | Low | Cap at 1,000 records; warn on overflow. Boot is normally <10 records. |
-| `LogFields` is open-ended; consumers serialize non-JSON-safe values | Medium | Medium | Sink-level guard: `JSON.stringify(record)` is exception-caught; on failure, the sink writes a degraded `{level: 'error', message: 'log serialization failed', error: ...}` record. |
-| Concurrent runs in one process produce interleaved output on `StderrTextSink` | Medium | Low | Each record carries `streamId`/`runId` in fields; `StderrTextSink` renders a `[stream-N]` prefix when more than one run is active. |
-| Extension's existing OutputChannel API doesn't accept structured fields | Low | Low | `VscodeOutputChannelSink` flattens `fields` to `key=value` suffixes — same shape today's logger emits when `texra.logger.debugMode = true`. |
+| Risk                                                                          | Likelihood | Impact | Mitigation                                                                                                                                                                         |
+| ----------------------------------------------------------------------------- | ---------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase 1 sinks render differently from the old logger and surface a regression | Medium     | Low    | Snapshot tests in `packages/extension/`, `packages/desktop/`, `packages/cli/` capture the rendered output for representative records. CI gate.                                     |
+| Schema unification breaks downstream NDJSON consumers (e.g., `texra-action`)  | Low        | High   | `RunStreamEventSchema` is a strict superset of today's `ProgressEventSchema`. Breaking changes bump `@texra/shared/schemas` major. Documented in the round-1 §11.2 schema doc.     |
+| `BootstrapLogger`'s buffer grows unbounded when boot fails                    | Low        | Low    | Cap at 1,000 records; warn on overflow. Boot is normally <10 records.                                                                                                              |
+| `LogFields` is open-ended; consumers serialize non-JSON-safe values           | Medium     | Medium | Sink-level guard: `JSON.stringify(record)` is exception-caught; on failure, the sink writes a degraded `{level: 'error', message: 'log serialization failed', error: ...}` record. |
+| Concurrent runs in one process produce interleaved output on `StderrTextSink` | Medium     | Low    | Each record carries `streamId`/`runId` in fields; `StderrTextSink` renders a `[stream-N]` prefix when more than one run is active.                                                 |
+| Extension's existing OutputChannel API doesn't accept structured fields       | Low        | Low    | `VscodeOutputChannelSink` flattens `fields` to `key=value` suffixes — same shape today's logger emits when `texra.logger.debugMode = true`.                                        |
 
 ## 12. Success criteria
 
@@ -314,7 +318,7 @@ Net code: **~+310 LOC** (the new structured pipeline is bigger than the string-b
 - A `texra run` and the same `texra-action` workflow against the same `--output-format ndjson` produce byte-equivalent output streams.
 - The kernel's existing `npm run typecheck` and the test suite pass on every phase merge.
 - An MCP client receives `notifications/progress` for every log emitted inside a `tools/call` (Phase 5 integration test).
-- Boot-time log lines from `texra` show up *with* their structured fields in the final rendered output, not before init drops them.
+- Boot-time log lines from `texra` show up _with_ their structured fields in the final rendered output, not before init drops them.
 
 ## 13. Open questions
 

--- a/prds/prd-logger-v2.md
+++ b/prds/prd-logger-v2.md
@@ -1,0 +1,337 @@
+# PRD: Logger v2 — structured records, host sinks, schema unified with progress
+
+**Status:** Draft (v1 — extracted from `prd-cli-app.md` round 2 §23; 2026-05-05)
+**Owner:** TBD
+**Date:** 2026-05-05
+**Branch:** `claude/refactor-texra-cli-tOC5U`
+**Companions:** [`prd-runcontext-refactor.md`](./prd-runcontext-refactor.md), [`prd-cli-app.md`](./prd-cli-app.md), [`prd-electron-app.md`](./prd-electron-app.md)
+
+## 1. Summary
+
+Today's logger (`src/logger/logUtils.ts`) is a serviceable VS Code-shaped string sink. It is also wrong for the CLI in three concrete ways and wrong for the future MCP-server / re-entrant SDK / `texra serve` daemon in five. This PRD specifies a host-neutral structured logger that:
+
+- Emits **`LogRecord`s** (timestamp + level + message + structured fields + group stack), not pre-formatted strings.
+- Routes every record through a per-host **`LogSink`** (extension → `vscode.OutputChannel`, desktop → `electron-log`, CLI text → stderr, CLI JSON → stdout NDJSON, CLI MCP → MCP `notifications/progress`, tests → in-memory).
+- Lives on **`RunContext`** (per `prd-runcontext-refactor.md`) — one logger per run, no module globals, no second ALS scope.
+- Shares a **single Zod schema** with the round-1 CLI progress NDJSON stream — `LogRecord` is a `ProgressEvent` with `event: "log"`. Tools that parse one parse the other.
+- Provides a **`BootstrapLogger`** that buffers records emitted before `initPlatform()` returns, then flushes them through the host's chosen sink.
+
+The total kernel work is ~430 LOC new + ~130 LOC modified + ~5 LOC deleted. None of it gates a v1 CLI deliverable except the structured CLI renderer (which today's logger cannot produce).
+
+## 2. Goals
+
+- Replace `LogBackend` (`src/platform/interfaces/log.ts`) with a `LogSink` that consumes `LogRecord` objects rather than formatted strings.
+- Unify the round-1 CLI §11.2 NDJSON event stream with the log stream — one schema, one renderer pipeline, two surface modes (text vs JSON).
+- Move group context off its own ALS (`src/logger/logUtils.ts:10` `contextStorage`) onto a per-`Logger` stack accessible via `withGroup`/`group`.
+- Eliminate `outputChannelFactory` (line 21) and the `channels` Map (line 19) as module-level state — every host installs one `LogSink` per run via `RunContext.log`.
+- Provide a `BootstrapLogger` so log lines emitted before `initPlatform()` returns are captured and replayed (today's `console.info` boot lines are unstructured and lose group context).
+- Maintain backward compatibility: `src/logger/logUtils.ts`'s public functions (`debug`, `info`, `warn`, `error`, `runWithGroupContext`, `setOutputChannelFactory`) keep working for one release, deprecated, routing to the new logger.
+
+## 3. Non-goals
+
+- **Not** a logging-framework selection — no `pino`, no `winston`. The interface is small; the impl per host is small. We do not adopt a third-party framework's opinions.
+- **Not** a redaction subsystem. The `prd-cli-app.md` round-1 §16 risk row mentions secret-redaction in the `consoleLog` adapter; that's a sink-level concern, sized separately, and not in scope here.
+- **Not** a tracing system. Spans, trace IDs, and OpenTelemetry exporter wiring are future work. `LogRecord.fields` is open, so adding `traceId` later is non-breaking.
+- **Not** a per-line filter language. Filtering by level / channel / agent is a sink concern — implemented in the host's sink, not in the kernel.
+- **Not** a UI surface for browsing logs. The extension's existing OutputChannel pickers and the desktop's `electron-log` UI don't change.
+
+## 4. Background — what's wrong with today's logger
+
+`src/logger/logUtils.ts` is the canonical kernel logger today. Three concrete defects:
+
+### 4.1 Module-level state collides under concurrency
+
+`outputChannelFactory` (line 21) and the `channels` Map (line 19) are module-level. The audit (per `prd-runcontext-refactor.md` §4) finds exactly one setter in production code (`packages/extension/src/extension.ts`), but:
+
+- Tests have to `setOutputChannelFactory(null)` in `afterEach`, which calls `dispose?.()` on every cached channel. With concurrent vitest runs in the same process this disposes channels for *other* tests' runs.
+- An MCP-server mode that hosts concurrent runs cannot share these channels — two `tools/call`s want two distinct sinks.
+- A re-entrant SDK has the same problem.
+
+### 4.2 Two ALS scopes that shadow each other
+
+Group context lives in its own ALS (`contextStorage`, line 10). `runtimeHostScope` (`AgentRuntimeHost.ts:12`) is the runtime context. A sub-agent emits a log line and passes through both scopes; the two are kept in sync by convention. It works today but it's fragile — every new background timer or `then()` boundary risks losing one scope but not the other.
+
+### 4.3 Per-line config lookup
+
+`writeLine` (line 79) calls `getConfig('texra.logger.debugMode', false)` *on every line*. In the extension that's a wrapped `vscode.workspace.getConfiguration` lookup — fast but not free. In the CLI before `initPlatform()` returns it goes through `tryPlatform()` and silently uses the default. Today's behavior is "config debug toggle is silently ignored during boot" — observed when debugging agent-directory bootstrap issues.
+
+### 4.4 Non-bug observation: two parallel pipelines
+
+The CLI's round-1 §11.2 NDJSON event stream is a *separate* code path from the logger. Two formats, one schema is fine; two formats, two code paths is duplication that will bit-rot. Logger v2 unifies them.
+
+## 5. Shape
+
+### 5.1 The `Logger` interface
+
+Lives on `RunContext` (per `prd-runcontext-refactor.md` §5). One `Logger` per run, plus a `BootstrapLogger` for the pre-`initPlatform()` window.
+
+```ts
+// packages/core/src/runtime/logger.ts
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogFields {
+  /** Stream lineage. Auto-injected by RunContext.log; usable by hosts for prefix. */
+  readonly streamId?: StreamTabId;
+  readonly runId?: RunId;
+  readonly groupId?: string;
+  /** Free-form structured data; the host decides whether to render it. */
+  readonly [k: string]: unknown;
+}
+
+export interface Logger {
+  debug(msg: string, fields?: LogFields): void;
+  info(msg: string, fields?: LogFields): void;
+  warn(msg: string, fields?: LogFields): void;
+  error(msg: string, fields?: LogFields): void;
+
+  /** Push a group; returned function pops it. Replaces logUtils' ALS. */
+  group(label: string): () => void;
+  /** Wrap an async fn in a group; returns its result. */
+  withGroup<T>(label: string, fn: () => Promise<T> | T): Promise<T>;
+
+  /** Per-domain child — adds a static field to every emission. Cheap. */
+  child(fields: LogFields): Logger;
+}
+```
+
+### 5.2 The `LogRecord` and `LogSink`
+
+```ts
+export interface LogRecord {
+  ts: string;                  // ISO-8601 with millis
+  level: LogLevel;
+  message: string;
+  fields: LogFields;
+  groups: readonly string[];   // current group stack at emit time
+}
+
+export interface LogSink {
+  write(record: LogRecord): void;
+  flush?(): Promise<void>;
+}
+```
+
+`LogSink` is a host port — installed once per `RunContext` (or once per host, if the host wants a process-shared sink). It accepts structured records; formatting is its job.
+
+### 5.3 The `BootstrapLogger`
+
+A `Logger` impl that buffers records in an array. `flushTo(sink)` drains the buffer through the given sink and switches subsequent emissions to direct passthrough.
+
+```ts
+export class BootstrapLogger implements Logger {
+  private buffer: LogRecord[] = [];
+  private downstream: LogSink | null = null;
+
+  /* … level methods build a LogRecord, push onto buffer if downstream is null,
+     otherwise write directly … */
+
+  flushTo(sink: LogSink): void {
+    this.downstream = sink;
+    for (const r of this.buffer) sink.write(r);
+    this.buffer.length = 0;
+  }
+}
+```
+
+The CLI's `bin/texra.ts` constructs a `BootstrapLogger` immediately, threads it through config-load + secret-resolution + agent-directory bootstrap, then calls `bootstrap.flushTo(stderrSink)` (or whichever sink the resolved mode picks) right after `initPlatform()` returns.
+
+## 6. Schema unification with progress events
+
+The round-1 CLI PRD §11.2 specs an NDJSON event stream (`{ts, event, streamId, …}`). Logger v2's `LogRecord` becomes the `event: "log"` variant of that union:
+
+```ts
+// packages/core/src/shared/schemas/runStream.ts (new)
+import { z } from 'zod';
+
+export const LogRecordSchema = z.object({
+  event: z.literal('log'),
+  ts: z.string(),
+  level: z.enum(['debug', 'info', 'warn', 'error']),
+  message: z.string(),
+  fields: z.record(z.unknown()),
+  groups: z.array(z.string()).readonly(),
+});
+
+// ProgressEventSchema is the existing union from @eventBus/ProgressEventBus
+// (event: "setActiveStream" | "setTaskState" | … )
+
+export const RunStreamEventSchema = z.discriminatedUnion('event', [
+  LogRecordSchema,
+  ...progressEventVariants,
+]);
+```
+
+Implications:
+
+- The CLI's `--output-format ndjson` writes one `RunStreamEvent` per line. Consumers filter `event === 'log'` for logs and `event !== 'log'` for progress.
+- The session JSONL format (per `prd-cli-app.md` §27) uses the same schema. A run's transcript is byte-equivalent to its NDJSON output (modulo synthetic `session_start` / `session_end` markers).
+- A schema bump in either pipeline is a schema bump in the other. `@texra/shared/schemas` versioning gates both.
+
+## 7. Per-host sinks
+
+Each host installs the sinks it wants. The mapping:
+
+| Host | Sink | Rendering |
+| ---- | ---- | --------- |
+| Extension | `VscodeOutputChannelSink` | Formatted string per line, written to one `vscode.OutputChannel` per agent (today's behavior). |
+| Desktop | `ElectronLogSink` | Wraps `electron-log` (per `prd-electron-app.md` §6.4); same channel-per-agent shape. |
+| CLI headless (`--print` or non-TTY) | `StderrTextSink` | picocolors-formatted; respects `--quiet` / `--verbose` / `NO_COLOR`; copies to `--log-file` if passed. |
+| CLI JSON (`--output-format json|ndjson`) | `NdjsonStdoutSink` | One `RunStreamEvent` per line on stdout; schema-validated. |
+| CLI MCP server (`texra mcp serve`) | `McpProgressSink` | Converts each record to an MCP `notifications/progress` payload; respects the client's progress-update opt-in. |
+| Tests | `MemorySink` | Pushes records into an array; auto-installed via `withRunContext()` in `vitest.setup.ts`. |
+
+Per-host sinks live in their respective host packages (`packages/{extension,desktop,cli}/`); only the interface lives in `core/hosts/logSink.ts`.
+
+## 8. Migration path
+
+### 8.1 The shim
+
+Today's `src/logger/logUtils.ts` exports `debug(channel, message, options)` etc. — channel-first signatures used at ~40 import sites. Logger v2's call site is `ctx.log.info(message, fields)` — channel becomes a field on the per-`child()` logger.
+
+The shim keeps the old signatures working:
+
+```ts
+// src/logger/logUtils.ts (after migration)
+export function info(channel: string, message: string, options: LogUtilsOptions = {}): void {
+  const ctx = tryUseRunContext();
+  const logger = ctx
+    ? ctx.log.child({ channel, isAgent: options.isAgent ?? false })
+    : bootstrapLogger.child({ channel, isAgent: options.isAgent ?? false });
+  logger.info(message, options.data ? { data: options.data } : undefined);
+}
+```
+
+Same shape for `debug`, `warn`, `error`. No call site changes for one release; `@deprecated` annotations point to the new path.
+
+### 8.2 `runWithGroupContext` migration
+
+The current `runWithGroupContext()` is mechanically replaced:
+
+```ts
+// before
+await runWithGroupContext(channel, groupId, isAgent, async () => {
+  logger.info(channel, 'doing thing');
+});
+
+// after
+await ctx.log.child({ channel }).withGroup(groupId, () => {
+  ctx.log.info('doing thing');
+});
+```
+
+Both forms run for one release. The `contextStorage` ALS in `logUtils.ts:10` is deleted at the end of the migration.
+
+### 8.3 Boot-time logging
+
+The CLI emits ~3–5 log lines before `initPlatform()` returns:
+
+1. Config-layer load: "loaded config from `~/.config/texra/config.yaml` + `.texra/config.yaml`".
+2. Secret resolution: "using keyring backend `secret-service`".
+3. Agent-directory bootstrap: "synced 47 bundled agents".
+4. Workspace resolution: "resolved cwd to /home/user/proj".
+5. Mode selection: "selected `headless` (CI=true)".
+
+Today these go through `console.info`. After this PRD: the CLI's `bin/texra.ts` constructs `bootstrapLogger = new BootstrapLogger()` immediately and threads it through every pre-`initPlatform()` call. After `initPlatform()` returns and the host's sink is installed, `bootstrapLogger.flushTo(sink)` drains the buffer.
+
+## 9. Phases
+
+### Phase 0 — Interface + bootstrap (~1 week)
+
+- Add `core/runtime/logger.ts` with `Logger`, `LogRecord`, `LogSink`, `BootstrapLogger`.
+- Add `core/shared/schemas/runStream.ts` with `LogRecordSchema` + the `RunStreamEventSchema` union. Move existing progress-event Zod schemas alongside.
+- `Logger` is a field on `RunContext` (per `prd-runcontext-refactor.md`); add it to `buildRunContext()`.
+- The default sink during this phase is `consoleLog`-shaped: `class LegacyConsoleSink implements LogSink { write(r) { console[r.level](formatLikeBefore(r)); } }`. Keeps existing behavior.
+- **Exit criteria:** `ctx.log.info('hi', { foo: 'bar' })` from inside `executeAgent()` produces the same console output the old logger did, plus the structured `{ foo: 'bar' }` payload visible to a `MemorySink` in tests.
+
+### Phase 1 — Per-host sinks, except MCP (~1 week)
+
+- `VscodeOutputChannelSink` in `packages/extension/`.
+- `ElectronLogSink` in `packages/desktop/`.
+- `StderrTextSink` and `NdjsonStdoutSink` in `packages/cli/`.
+- `MemorySink` in `core/runtime/testing.ts`.
+- Each host's bootstrap flow: construct `BootstrapLogger`, run pre-`initPlatform` work, install host-specific sink, `bootstrap.flushTo(sink)`.
+- **Exit criteria:** Three hosts produce their existing log output through Logger v2. `texra run polish --output-format ndjson` writes `event: "log"` records to stdout, validated against the schema.
+
+### Phase 2 — Schema unification with progress (~0.5 weeks)
+
+- Migrate the round-1 §11.2 progress NDJSON renderer to use `RunStreamEventSchema` directly. Delete the duplicated formatting logic in `cli/src/runtime/progressSink/json.ts`.
+- The progress sink and the log sink converge — both write `RunStreamEvent`s to the same NDJSON pipe. Order is preserved.
+- **Exit criteria:** the integration test `texra run polish --output-format ndjson | tail -1 | jq .event === "session_end"` passes; `cat <session>.jsonl | jq -c 'select(.event == "log")' | wc -l` equals the count of log records emitted during the run.
+
+### Phase 3 — `runWithGroupContext` retirement + `contextStorage` ALS deletion (~0.5 weeks)
+
+- Convert ~10 reader sites of `runWithGroupContext` to `ctx.log.withGroup`.
+- Delete `contextStorage` from `src/logger/logUtils.ts:10` and `runWithGroupContext` itself.
+- **Exit criteria:** `git grep "runWithGroupContext\|contextStorage" packages/core/` returns zero hits.
+
+### Phase 4 — `outputChannelFactory` + module-level state retirement (~0.5 weeks)
+
+- Delete `outputChannelFactory`, `channels`, `mainOutputChannel`, `setOutputChannelFactory` from `logUtils.ts`. The extension's old call site (`packages/extension/src/extension.ts`) instead installs `VscodeOutputChannelSink` via `Platform.log`.
+- The `LogBackend` interface in `core/platform/interfaces/log.ts` is renamed to `LogSink` and moved to `core/hosts/logSink.ts` to live alongside the other host ports.
+- **Exit criteria:** `git grep "outputChannelFactory\|setOutputChannelFactory" packages/` returns zero hits. Phase aligns with `prd-runcontext-refactor.md` Phase 2 (singleton retirement); the two should land in the same release.
+
+### Phase 5 — `McpProgressSink` (gates `texra mcp serve` v1.1) (~0.3 weeks)
+
+- `McpProgressSink` in `packages/cli/src/mcp/sinks/`.
+- Wires into the per-`tools/call` `RunContext` in the MCP server (per `prd-cli-app.md` §24.6).
+- **Exit criteria:** an MCP client running `tools/call` with `progressToken` set receives `notifications/progress` for each log + progress event in the run.
+
+### Aggregate timeline
+
+| Phase | Scope | Net LOC | Engineering weeks |
+| ----- | ----- | ------- | ----------------- |
+| 0 | Interface + bootstrap + legacy sink | +200 / -10 | 1 |
+| 1 | Per-host sinks (extension, desktop, CLI text, CLI ndjson, tests) | +250 / -50 | 1 |
+| 2 | Schema unification with progress | +30 / -80 | 0.5 |
+| 3 | Group ALS retirement | +20 / -60 | 0.5 |
+| 4 | `outputChannelFactory` retirement | +20 / -90 | 0.5 |
+| 5 | MCP sink | +80 | 0.3 |
+| **Total** | | **+~600 / -~290** | **~3.8** |
+
+Net code: **~+310 LOC** (the new structured pipeline is bigger than the string-based one it replaces, but the 5 host sinks together are smaller than today's extension-only output-channel logic plus the JSON-renderer duplication).
+
+## 10. Compatibility
+
+- Existing `src/logger/logUtils.ts` exports stay for one release as `@deprecated` shims that route to the new logger. Deletion in v1.x.
+- Existing `LogBackend` interface stays for one release, renamed to `LogSink` with a re-export. Deletion in v1.x.
+- Existing `texra.logger.debugMode` config key stays. The new pipeline reads it at sink construction (via `ConfigProvider.watch()`), not on every line.
+
+## 11. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| Phase 1 sinks render differently from the old logger and surface a regression | Medium | Low | Snapshot tests in `packages/extension/`, `packages/desktop/`, `packages/cli/` capture the rendered output for representative records. CI gate. |
+| Schema unification breaks downstream NDJSON consumers (e.g., `texra-action`) | Low | High | `RunStreamEventSchema` is a strict superset of today's `ProgressEventSchema`. Breaking changes bump `@texra/shared/schemas` major. Documented in the round-1 §11.2 schema doc. |
+| `BootstrapLogger`'s buffer grows unbounded when boot fails | Low | Low | Cap at 1,000 records; warn on overflow. Boot is normally <10 records. |
+| `LogFields` is open-ended; consumers serialize non-JSON-safe values | Medium | Medium | Sink-level guard: `JSON.stringify(record)` is exception-caught; on failure, the sink writes a degraded `{level: 'error', message: 'log serialization failed', error: ...}` record. |
+| Concurrent runs in one process produce interleaved output on `StderrTextSink` | Medium | Low | Each record carries `streamId`/`runId` in fields; `StderrTextSink` renders a `[stream-N]` prefix when more than one run is active. |
+| Extension's existing OutputChannel API doesn't accept structured fields | Low | Low | `VscodeOutputChannelSink` flattens `fields` to `key=value` suffixes — same shape today's logger emits when `texra.logger.debugMode = true`. |
+
+## 12. Success criteria
+
+- After Phase 4, `git grep "AsyncLocalStorage" packages/core/src/logger/` returns zero hits. (The remaining ALS in the kernel is `runContextScope`.)
+- After Phase 4, `packages/core/src/logger/logUtils.ts` is gone or reduced to a re-export shim.
+- A `texra run` and the same `texra-action` workflow against the same `--output-format ndjson` produce byte-equivalent output streams.
+- The kernel's existing `npm run typecheck` and the test suite pass on every phase merge.
+- An MCP client receives `notifications/progress` for every log emitted inside a `tools/call` (Phase 5 integration test).
+- Boot-time log lines from `texra` show up *with* their structured fields in the final rendered output, not before init drops them.
+
+## 13. Open questions
+
+- **Should `LogSink.write` be sync or async?** Today's logger is sync. Async would let sinks batch (e.g., NDJSON write coalescing), but every kernel emit site assumes sync. Lean: keep sync; sinks that need async use a queue + `flush?()`.
+- **Should `BootstrapLogger` be exposed as a public API for SDK consumers?** Some users may want to capture pre-init logs from `runAgent()`. Lean: yes; export from `@texra/cli/sdk` once the SDK lands.
+- **Schema versioning policy: per-record `schemaVersion` field, or repo-version pinning?** Per-record is robust to in-flight upgrades but bloats every line by ~20 bytes. Lean: repo-version pinning; consumers verify `@texra/shared/schemas` major matches.
+- **Should the extension's per-agent output channel pattern survive?** It's a UX choice (filtering to one agent's logs) that doesn't translate to other hosts. Lean: keep it as a `VscodeOutputChannelSink` configuration option, not a kernel concept.
+- **Do we need a `trace` level below `debug`?** Today's vocabulary stops at `debug`. OTel uses `trace`. Lean: not yet — add when a consumer asks.
+
+## 14. Tech stack one-liner
+
+```
+LogRecord (structured) + LogSink (host port) + BootstrapLogger (pre-init buffer)
+- one Logger per RunContext, no module-level state, no second ALS scope
+- per-host sinks: VscodeOutputChannel, electron-log, stderr text, NDJSON stdout, MCP progress, in-memory tests
+- LogRecord is event: "log" in the unified RunStreamEvent schema (shared with progress NDJSON)
+- Phased migration with deprecated shims for one release; net ~+310 LOC across the kernel
+```
+
+The logger gets honest about being structured. The CLI's two output pipelines become one. The kernel loses its second ALS scope and its last module-level state in `src/logger/`. That's the whole story.

--- a/prds/prd-runcontext-refactor.md
+++ b/prds/prd-runcontext-refactor.md
@@ -1,0 +1,343 @@
+# PRD: RunContext + ambient-state retirement
+
+**Status:** Draft (v1 — extracted from `prd-cli-app.md` round 2 §§22, 29; 2026-05-05)
+**Owner:** TBD
+**Date:** 2026-05-05
+**Branch:** `claude/refactor-texra-cli-tOC5U`
+**Companions:** [`prd-cli-app.md`](./prd-cli-app.md), [`prd-electron-app.md`](./prd-electron-app.md), [`prd-logger-v2.md`](./prd-logger-v2.md)
+
+## 1. Summary
+
+The TeXRA agent runtime today reaches host services through two ALS scopes plus ~20 module-level `let X | undefined` setter pairs and three exported singleton coordinators. That ambient-state model is fine for the VS Code extension (one process, one user, one runtime host) but leaks under three workloads the next 12 months will bring:
+
+- The **CLI's `texra mcp serve`** mode, which must host N concurrent sessions per process (one per MCP `tools/call`).
+- A **re-entrant SDK** — multiple `Promise.all([runAgent(...), runAgent(...)])` calls from a single Node process.
+- An eventual **`texra serve` daemon** or **embedded library** that runs many users' workloads in one process.
+
+This PRD specifies the refactor: a single explicit `RunContext` value carrying every per-run service (progress sink, logger, abort signal, approval policy, coordinators, capabilities), threaded through the kernel call graph; one ALS scope at the outermost entry point as a migration ergonomics shim; and a phased deletion of the ~20 singleton bindings the audit names. It also specifies the three-ring layering of `packages/core/` that this work makes legible.
+
+The kernel migration is independently valuable to all three hosts (extension, desktop, CLI) and does not gate any v1 CLI deliverable except `texra mcp serve` v1.1 (true session concurrency).
+
+## 2. Goals
+
+- Replace every implicit lookup of `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService`, the singleton approval coordinators (`planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator`), and per-domain setters (`setToolEditApprovalHandler`, `setGitHubTokenProvider`, `setExtensionChecker`, …) with explicit `RunContext` access.
+- Provide a single ALS scope at the outermost agent-execution boundary so existing call sites can adopt `RunContext` mechanically without a 30-file PR.
+- Delete the singletons in retirement waves; each wave is independently mergeable and shrinks the ambient surface monotonically.
+- Lock in the three-ring structure under `packages/core/` (pure logic / runtime orchestration / platform defaults) so a new host adapter (Tauri, daemon, embedded SDK) needs only Ring 3 + a thin host package — no Ring 1 or Ring 2 changes.
+- Add an ESLint rule blocking new module-level `let X | undefined` + setter pairs in the agnostic zones, so this never grows back.
+
+## 3. Non-goals
+
+- **Not** a pure-explicit refactor — we keep one ALS scope (`runContextScope`) for ergonomic adoption. The OpenTelemetry, Vercel AI SDK, and Encore ecosystems all settled on this hybrid; we copy that.
+- **Not** an OS-level sandbox / capability-based-security project. `RunCapabilities` is a *value-typed* capability bag ("does this run have a github token?"), not a syscall sandbox.
+- **Not** an attempt to delete `getConfig`-style platform service lookups. `platform()` from `@platform` is composition-root state, not per-run state, and stays.
+- **Not** a rewrite of any modelHandler, flow node, or tool. Their interfaces gain a `ctx: RunContext` parameter; their bodies do not change.
+- **Not** a host-specific logger redesign. Logger v2 is its own PRD (`prd-logger-v2.md`); this PRD only states that `Logger` is a field on `RunContext`.
+
+## 4. Background — what's ambient today
+
+A May 2026 audit of `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/eventBus/`, and `src/logger/` enumerated every cross-call-site state binding. The full inventory:
+
+### 4.1 AsyncLocalStorage scopes (2)
+
+| Scope | File:line | Holds | Entered by | Read by |
+| ----- | --------- | ----- | ---------- | ------- |
+| `runtimeHostScope` | `src/agent/runtime/AgentRuntimeHost.ts:12` | Current `AgentRuntimeHost` (≡ `ProgressSink`) | `runWithAgentRuntimeHost(host, fn)` (line 27) | `getAgentRuntimeHost()` (line 23) — falls back to `defaultAgentRuntimeHost` (line 11), then `getDefaultProgressSink()` |
+| `contextStorage` | `src/logger/logUtils.ts:10` | `Map<channel-key, group-id stack>` for log grouping | `runWithGroupContext()` (line 130) | `getActiveGroupStack()` (line 63), `runWithGroupContext` (line 136) |
+
+### 4.2 Module-level setter/getter pairs (~12 in audit, plus the 8 the controllers list)
+
+| Concern | Setter | File:line |
+| ------- | ------ | --------- |
+| Default progress sink | `setDefaultProgressSink` | `src/agent/runtime/ProgressSink.ts:14` |
+| Default runtime host | `setDefaultAgentRuntimeHost` | `src/agent/runtime/AgentRuntimeHost.ts:11` |
+| Run storage service | `setRunStorageService` | `src/agent/runtime/RunStorageService.ts:10` |
+| Tool-edit approval handler | `setToolEditApprovalHandler` | `src/tools/approval/toolEditApproval.ts:74,113` |
+| Latex-preview handler | `setLatexBuildDisplay` | `src/tools/approval/latexPreview.ts:21` |
+| GitHub token provider | `setGitHubTokenProvider` | `src/tools/github/githubAuth.ts:13` |
+| Extension checker | `setExtensionChecker` | `src/tools/externalToolDefs.ts:35` |
+| Server-side key service | `setServerSideKeyService` | `src/auth/serverKeys/index.ts:34` |
+| Tier service | `setTierService` | `src/auth/tier/index.ts:31` |
+| Auth callback resolver | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183` |
+| Runtime extension id | `setRuntimeExtensionId` | `src/auth/config.ts:137` |
+| Output-channel factory (logger) | `setOutputChannelFactory` | `src/logger/logUtils.ts:108` |
+
+### 4.3 Exported singleton coordinators (3)
+
+- `planApprovalCoordinator` — `src/agent/runtime/PlanApprovalCoordinator.ts:128`
+- `retryCoordinator` — `src/agent/runtime/RetryRequestCoordinator.ts:145`
+- `proposalCoordinator` — `src/agent/runtime/AgentProposalCoordinator.ts:89`
+
+These are problematic because they fan out events to whoever the current global handler is — concurrent runs leak approval prompts between sessions.
+
+### 4.4 Caches that survive across runs (4)
+
+- Agent-registry cache + init promise — `src/agent/index/agentRegistry.ts:143,146-147`
+- Execution listing cache + workspace-path cache — `src/agent/storage/executionListing.ts:52-54`
+- Output-poll timer + in-flight flag — `src/agent/runtime/executionRegistry.ts:335-336`
+- Polish-model template cache — `src/agent/runtime/polishModel.ts:11-12`
+
+These are intentional caches of *immutable* data (registry, model templates) and stay. They are not the target of this PRD; they're listed only to bound the audit.
+
+### 4.5 Why this is the right time
+
+Three concurrent forces:
+
+1. **CLI v1 is in flight** (`prd-cli-app.md`). Round 2 of that PRD names `texra mcp serve` as a v1 deliverable. MCP-server safety with concurrent sessions requires per-context coordinators; that's the v1.1 milestone of this refactor.
+2. **The host-neutral split is at the right point.** Per `prd-electron-app.md` §9, almost all VS Code-coupling has been factored out. The remaining hot spot — ambient runtime state — is the natural next refactor before the kernel moves into `packages/core/`.
+3. **Tests already pay the cost.** `setDefaultProgressSink(noop)` and `setRunStorageService(fake)` calls in `beforeEach` / `afterEach` total ~150 LOC across the test suite. Removing them is a strict win for test hermeticity.
+
+## 5. The shape: `RunContext`
+
+A single value, threaded through the kernel call graph, carrying every per-run service.
+
+```ts
+// packages/core/src/runtime/runContext.ts
+export interface RunContext {
+  /** Stable identifier for this run; root for child contexts. */
+  readonly runId: RunId;
+  /** Stream tab id within the run (one per agent activation). */
+  readonly streamId: StreamTabId;
+  /** Lineage from the user-initiated root, useful for log prefixes. */
+  readonly streamLineage: readonly StreamTabId[];
+
+  /** Where progress events go. Replaces `getAgentRuntimeHost()`. */
+  readonly progress: ProgressSink;
+  /** Structured logger scoped to this run. (See prd-logger-v2.md.) */
+  readonly log: Logger;
+
+  /** Cooperative cancel signal. Replaces InterruptManager-as-singleton. */
+  readonly signal: AbortSignal;
+
+  /** Approval policy for this run (resolved from flag > env > config > schema default). */
+  readonly approval: ApprovalPolicy;
+
+  /** Workspace root (cwd) for this run — per-run override of WorkspaceProvider. */
+  readonly workspaceRoot: string;
+
+  /** Runtime-resolved capabilities. Replaces setExtensionChecker, setGitHubTokenProvider, … */
+  readonly capabilities: RunCapabilities;
+
+  /** Coordinators bound to this run's progress sink. Replaces exported singletons. */
+  readonly coordinators: {
+    plan: PlanApprovalCoordinator;
+    proposal: AgentProposalCoordinator;
+    retry: RetryRequestCoordinator;
+    edit: ToolEditApprovalController;
+    bash: BashApprovalController;
+  };
+
+  /** Spawn a child context for a delegate_agent / delegate_workflow subagent. */
+  child(opts: ChildContextOptions): RunContext;
+}
+
+export interface RunCapabilities {
+  github: GitHubTokenProvider | null;
+  extensionPresent: boolean;
+  externalAuthCallback: ExternalAuthCallbackResolver | null;
+  // …other host capabilities the host adapter populates at run start
+}
+
+export interface ChildContextOptions {
+  streamId: StreamTabId;
+  // override fields the child should diverge on (e.g., a child's signal
+  // chains from the parent's via AbortSignal.any)
+  approval?: ApprovalPolicy;
+}
+```
+
+`buildAgentLaunchContext()` in `executeAgent.ts:166` already constructs almost all of this; the refactor is to (a) lift it to the kernel boundary so it's the only entry point that matters, (b) rename it `buildRunContext()`, and (c) pass the result explicitly into every coordinator method that today reads from a singleton.
+
+## 6. Migration shim — one ALS, gradual cutover
+
+Because the audit found ~30 reader sites of singletons today, a hard cutover is unrealistic. The shim:
+
+```ts
+// packages/core/src/runtime/runContext.ts
+export const runContextScope = new AsyncLocalStorage<RunContext>();
+
+export function withRunContext<T>(ctx: RunContext, fn: () => T | Promise<T>): T | Promise<T> {
+  return runContextScope.run(ctx, fn);
+}
+
+export function useRunContext(): RunContext {
+  const ctx = runContextScope.getStore();
+  if (!ctx) {
+    throw new Error('useRunContext() called outside withRunContext()');
+  }
+  return ctx;
+}
+
+export function tryUseRunContext(): RunContext | undefined {
+  return runContextScope.getStore();
+}
+```
+
+- Every `executeAgent()` call becomes `withRunContext(ctx, () => /* existing body */)`.
+- The existing `runWithAgentRuntimeHost()` keeps working — it now reads from `runContextScope.getStore()?.progress` and falls back to its current path.
+- Every singleton getter (`getDefaultProgressSink`, `getRunStorageService`, `getServerSideKeyService`, …) gets a `// LEGACY:` comment plus a path forward: read `runContextScope.getStore()?.<field>` first, fall back to the module global, log a `DEBUG` if the fallback was used.
+- Internal kernel call sites convert in batches (one per phase). Each batch deletes a module global once *all* its readers take an explicit `ctx`.
+
+## 7. Migration phases
+
+Each phase is independently mergeable and ships a concrete kernel improvement.
+
+### Phase 0 — Foundations (~1.5 weeks)
+
+- Add `packages/core/src/runtime/runContext.ts` with the interface, the scope, and `withRunContext` / `useRunContext` / `tryUseRunContext` / `child()`.
+- Wire `withRunContext` at every `executeAgent()`, `executeMergeAgent()`, `resumeToolUseFromSnapshot()` call site.
+- Rename `buildAgentLaunchContext` → `buildRunContext` and have it return a `RunContext` directly (instead of the bag of fields it currently returns).
+- Test harness: `withRunContext(synthesizedContext, fn)` available from `packages/core/src/runtime/testing.ts`.
+- Add ESLint rule `no-ambient-runtime-state` that flags new `let X: T | undefined` + `setX` pairs in `packages/core/src/agent/`, `core/tools/`, `core/auth/`. Existing pairs are grandfathered with `// eslint-disable-line` + `// PRD: prd-runcontext-refactor.md` comments to make them visible at sweep time.
+- **Exit criteria:** every entry from `executeAgent()` runs inside a `withRunContext`. The grandfathered list of `eslint-disable` lines exactly matches §4.2's table.
+
+### Phase 1 — Per-context coordinators (~1 week)
+
+- `planApprovalCoordinator`, `proposalCoordinator`, `retryCoordinator` are no longer module-level exports. They become factories (`createPlanApprovalCoordinator(ctx)`) and instances live on `ctx.coordinators`.
+- The same three coordinators today extend `BasePromiseCoordinator`, which holds a `Map<streamId, Resolver>`. Per-context instances close over the run's stream lineage; cross-stream interference goes away.
+- Update ~5 reader sites (mostly inside `tools/approval/` and `agent/runtime/`).
+- **Exit criteria:** the three singleton exports are deleted from `PlanApprovalCoordinator.ts:128`, `RetryRequestCoordinator.ts:145`, `AgentProposalCoordinator.ts:89`. CI passes; no `let coordinator = new …Coordinator()` remains.
+
+### Phase 2 — Progress sink + runtime host singleton retirement (gates `texra mcp serve` v1.1) (~1.5 weeks)
+
+- Delete `defaultProgressSink` (`ProgressSink.ts:14`), `defaultAgentRuntimeHost` (`AgentRuntimeHost.ts:11`), and the entire fallback chain in `getAgentRuntimeHost()` (`AgentRuntimeHost.ts:24`).
+- Delete `setDefaultProgressSink`, `setDefaultAgentRuntimeHost`, `getDefaultProgressSink`. The only valid path to a sink is `useRunContext().progress`.
+- Delete `runStorageService` singleton (`RunStorageService.ts:10`); per-context storage handle on `ctx.coordinators` (or its own `ctx.storage` field if the API justifies it).
+- Walk the remaining ~40 reader sites; convert each to `useRunContext().progress` / `tryUseRunContext()`. The audit lists 0 reader sites outside `getStore()`-aware code, so this is mechanical.
+- **Exit criteria:** `git grep "defaultProgressSink\|defaultAgentRuntimeHost\|runStorageService = "` returns zero hits in `packages/core/`. `texra mcp serve` integration test (`prd-cli-app.md` §30.3) runs two concurrent `tools/call`s with no progress-event interleaving.
+
+### Phase 3 — Approval handlers + capabilities injection (~1 week)
+
+- `setToolEditApprovalHandler` (`toolEditApproval.ts:74`), `setLatexBuildDisplay` (`latexPreview.ts:21`), `setGitHubTokenProvider` (`githubAuth.ts:13`), `setExtensionChecker` (`externalToolDefs.ts:35`) — replaced by `RunCapabilities` injection.
+- The host adapter populates `RunCapabilities` once when building the `RunContext`. No more "the global was set during boot but the test forgot to clear it."
+- **Exit criteria:** the four setters and their backing `let` declarations are deleted; `RunCapabilities` covers their use cases.
+
+### Phase 4 — Auth singletons (~1 week)
+
+- `tierService` (`auth/tier/index.ts:31`), `serverSideKeyService` (`auth/serverKeys/index.ts:34`), `externalAuthCallbackResolver` (`auth/config.ts:183`), `runtimeExtensionId` (`auth/config.ts:137`) — replaced by per-`RunContext` resolutions backed by a kernel-side `AuthRegistry`.
+- The auth registry itself is composition-root state (initialized once at `initPlatform()`), so it's allowed to be a module global; what's *per-run* is which session/keys/tier resolution applies. That distinction collapses today.
+- **Exit criteria:** auth tests no longer install global services in `beforeEach`.
+
+### Phase 5 — `then()`-boundary fix + sweep (~3 days)
+
+- The LangSmith-style "ALS lost across `.then()`" foot-gun: `RunStorageService`'s background poll timer (`executionRegistry.ts:335`) currently fires outside any context scope. Refactor `pollInFlight` from `bool` to `Map<RunId, RunContext>` and wrap the timer callback in `withRunContext(stored, fn)`.
+- ESLint sweep: remove every `// PRD: prd-runcontext-refactor.md` grandfather comment introduced in Phase 0. The list shrinks to zero by definition once Phases 1–4 land.
+- **Exit criteria:** zero ambient-state lints disabled in agnostic zones. `git grep "let .*: .* | undefined" packages/core/src/agent packages/core/src/tools packages/core/src/auth | grep -v test` returns only legitimate caches (the four §4.4 entries).
+
+### Aggregate timeline
+
+| Phase | Singletons retired | Files touched | Net LOC | Engineering weeks |
+| ----- | ------------------ | ------------- | ------- | ----------------- |
+| 0 | — (foundations) | `runContext.ts` (new), `executeAgent.ts`, `runtime/testing.ts` | +220 / -10 | 1.5 |
+| 1 | 3 coordinators | `Plan/Retry/AgentProposalCoordinator.ts` + 5 readers | +60 / -30 | 1 |
+| 2 | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 readers | +20 / -160 | 1.5 |
+| 3 | 4 capability setters | `tools/{approval,github,externalToolDefs}/*` | +60 / -110 | 1 |
+| 4 | 4 auth singletons + extension-id setter | `auth/*` | +80 / -130 | 1 |
+| 5 | (sweep) | `executionRegistry.ts` + lint rule cleanups | +20 / -30 | 0.5 |
+| **Total** | **~14 ambient bindings + 3 coordinators** | | **+460 / -470** | **~6.5** |
+
+Net code change: **~-10 LOC** (the refactor pays for itself in deleted boilerplate). The CLI consumes Phase 1 deliverables for v1.0 and Phase 2 for v1.1; the extension and desktop benefit from every phase but don't gate on them.
+
+## 8. Three-ring kernel structure (`packages/core/`)
+
+The audit revealed three categories of shared code that today live mixed together. Round 2 of the CLI PRD §29 sketched this; this PRD makes it normative.
+
+### 8.1 The rings
+
+**Ring 1: pure logic** (zero host coupling, zero ALS).
+
+- `core/agent/` minus runtime — every modelHandler, every flow, every node, every reasoning strategy.
+- `core/model/`, `core/latex/`, `core/replacement/`.
+- `core/eventBus/` — schemas only, no emitters.
+- `core/tools/` minus `core/tools/approval/`.
+- `core/shared/` — IPC schemas, including `runStream.ts` (the unified log+progress envelope from `prd-logger-v2.md`).
+
+These take a `ctx: RunContext` argument (post-this-PRD) but never reach for the ambient store. Test harnesses synthesize a `RunContext` and never need a fake host.
+
+**Ring 2: runtime orchestration** (consumes `RunContext`; no `vscode`/`electron`/`process` access).
+
+- `core/runtime/` — `RunContext`, `Logger` interface, `ProgressSink` interface, `executeAgent`, all coordinators.
+- `core/tools/approval/` — gates and controllers.
+- `core/auth/` — `SupabaseSessionCoordinator`, `TierService`, `ServerSideKeyService` (post-Phase-4 per-context).
+- `core/hosts/` — every host port (`PromptHost`, `ExternalOpener`, `DiffViewHost`, `TerminalHost`, `ClipboardHost`, plus `LogSink` from `prd-logger-v2.md`, plus `HookHost` and `SessionStore` from forthcoming PRDs).
+- `core/storage/sessionStore.ts` (interface only; impls in Ring 3).
+
+These import Ring 1 freely and accept host services through their constructor / `RunContext` — but they never `import 'vscode'`, never `import 'electron'`, never `process.exit`.
+
+**Ring 3: platform defaults** (Node-only; no `vscode`/`electron`).
+
+- `core/platform/defaults/` — today's `consoleLog`, `memoryState`, `nodeFilesystem`, `nodeStorage`, `nodeWorkspace`, `EnvSecrets`. CLI uses 5 of 6; desktop uses similar set; extension uses none.
+- `core/storage/jsonlSessionStore.ts` — Node-fs-backed `SessionStore` impl.
+
+Adding a new Node-based host (e.g. a `texra serve` daemon, or a future Tauri-based app) requires only Ring 3 + a thin host adapter. No Ring 1 or Ring 2 changes.
+
+### 8.2 Per-host packages
+
+Crisp rule: **the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is.**
+
+| Host | Owns | Doesn't own |
+| ---- | ---- | ----------- |
+| `packages/extension/` | `vscode.commands`, webview hosts, `frontend/vscode/*`, controllers wired to webview message handlers, `VscodeOutputChannelSink` | The agent runtime (in core); coordinators (in core) |
+| `packages/desktop/` | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging | Same |
+| `packages/cli/` | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner | Same |
+
+### 8.3 ESLint enforcement
+
+A flat-config rule that the host of each package can import only the rings it cares about:
+
+- `packages/core/src/agent/**` may import `core/agent/**`, `core/model/**`, `core/latex/**`, `core/eventBus/**`, `core/tools/**` (excluding `tools/approval/**`), `core/shared/**`.
+- `packages/core/src/runtime/**` may additionally import Ring 1.
+- `packages/core/src/platform/defaults/**` may additionally import `node:*` modules.
+- `packages/{extension,desktop,cli}/src/**` may import `core/**` and the host's own SDK.
+- Cross-package host imports (e.g., extension importing from desktop) are forbidden.
+
+~40 LOC of ESLint config; mechanical to maintain.
+
+### 8.4 What the refactor saves
+
+- **A new host needs only the rings it cares about.** A future Tauri app: import Rings 1+2 and a Tauri-specific Ring 3 (`tauriFilesystem`, `tauriSecrets`); zero extension or CLI code touched.
+- **Tests don't fake hosts to test logic.** Ring 1 has no host. The kernel's existing FakePlatform suite stays in Ring 2 and only exercises Ring 2 code paths.
+- **Webview vs CLI vs Electron diff is a wiring diff, not a behavior diff.** When `polish` rewrites a paragraph differently in CLI than extension, we have one place to look (Ring 1 + the agent's YAML), not three.
+
+## 9. Risks & mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| ---- | ---------- | ------ | ---------- |
+| ALS context lost across `.then()` boundary (the LangSmith-style foot-gun) | Medium | Medium | Phase 5 fixes the one known site (`executionRegistry.ts:335`); ESLint rule + dev review for new timers. |
+| Phase 1 coordinator change breaks an in-flight reader site no one tested | Medium | Medium | Each coordinator's per-context factory keeps the same observable interface; existing tests catch the regression. |
+| `RunContext.child()` semantics get wrong (e.g., child's `signal` doesn't chain) | Low | Medium | Implement child via `AbortSignal.any([parent.signal, childAbort])`; covered by a tabletop test in `runContext.test.ts`. |
+| Singleton retirement merges before consumers update | Low | High | Each phase's exit criteria require zero `git grep` hits for the deleted symbols before merge; CI gate. |
+| `RunCapabilities` shape drifts as new capabilities are added | Medium | Low | Add capabilities incrementally; Zod schema validates at construction; ESLint rule forbids reading capabilities outside `useRunContext()`. |
+| Test setup churn during migration | Medium | Low | `runtime/testing.ts` exposes `synthesizeRunContext({ overrides })` — one call replaces ~5–10 LOC of `beforeEach` setup. |
+| Three-ring ESLint rule produces noisy false positives | Medium | Low | Soft-fail mode in CI for the first two weeks; harden after. |
+| Per-context coordinator instances over-allocate (one set per run) | Low | Low | Coordinators are tiny (Map + a Resolver list); per-run cost is sub-µs. Profiled in tabletop benchmark. |
+
+## 10. Success criteria
+
+- After Phase 5, `git grep "let [a-zA-Z_]*: .* | undefined" packages/core/src/agent packages/core/src/tools packages/core/src/auth packages/core/src/logger | grep -v // | grep -v test` returns only the four §4.4 caches.
+- `git grep "AsyncLocalStorage" packages/core/src/` returns exactly one hit (`runContext.ts`).
+- `texra mcp serve` integration test (per `prd-cli-app.md` §30.3) runs two concurrent `tools/call`s and the resulting NDJSON streams contain zero cross-session events when grouped by `runId`.
+- `npm run typecheck` and the existing kernel test suite both pass on every phase merge.
+- The three-ring ESLint rule has zero exceptions in `packages/core/src/agent/`, `core/tools/`, `core/auth/` after Phase 5.
+- A new "synthetic host" package (~80 LOC scaffold, used in tests and as a reference) imports Rings 1+2+3 and runs `executeAgent('polish', …)` end-to-end.
+
+## 11. Open questions
+
+- **Should `RunContext.workspaceRoot` be a string or a `WorkspaceProvider`?** Today's `WorkspaceProvider` is platform-level (one per process); `workspaceRoot` is per-run. The CLI's `--cwd` flag needs to override per-run; the extension's multi-root workspace also wants per-run. Lean: keep it a string, derive from `WorkspaceProvider` at context-build time, override-aware.
+- **Should `RunCapabilities` be open or closed?** Open (free-form `{ [k]: unknown }` plus typed accessors) is more future-proof; closed is type-safer. Lean: closed for v1, open for v2 if external plugins ever ship.
+- **Is `child()` enough for delegate semantics, or do we need a dedicated `delegationContext` field?** Today's delegate flow recursively calls `executeAgent` with new options; the recursion is handled at the call site, not in the context. Lean: keep `child()` only; don't add a delegation field until a concrete reader needs it.
+- **Should the singleton retirement land before or after the kernel package split (`packages/core/`)?** Lean: before. Singleton retirement makes the package split safer (fewer reader sites that depend on module-load order across packages).
+- **Should `ctx.signal` chain into modelHandler-level abort signals automatically?** Today every modelHandler accepts an explicit `signal` parameter from `ExecuteAgentOptions`. Lean: keep both — `ctx.signal` is the canonical run-cancel; modelHandler params take precedence when explicitly passed.
+
+## 12. Tech stack one-liner
+
+```
+Single AsyncLocalStorage + RunContext threaded explicitly through the kernel call graph
+- packages/core/src/runtime/runContext.ts as the only allowed scope
+- Phased deletion of ~14 module-level setter pairs and 3 singleton coordinators
+- Three concentric rings under packages/core/ (pure logic / runtime / platform defaults)
+- ESLint rule no-ambient-runtime-state guards the agnostic zones
+- Independently mergeable phases; CLI v1.0 consumes Phase 1, v1.1 consumes Phase 2
+```
+
+The kernel stays small. The rules stay simple. Concurrent runs stop leaking into each other. That's the whole story.

--- a/prds/prd-runcontext-refactor.md
+++ b/prds/prd-runcontext-refactor.md
@@ -29,7 +29,7 @@ The kernel migration is independently valuable to all three hosts (extension, de
 ## 3. Non-goals
 
 - **Not** a pure-explicit refactor — we keep one ALS scope (`runContextScope`) for ergonomic adoption. The OpenTelemetry, Vercel AI SDK, and Encore ecosystems all settled on this hybrid; we copy that.
-- **Not** an OS-level sandbox / capability-based-security project. `RunCapabilities` is a *value-typed* capability bag ("does this run have a github token?"), not a syscall sandbox.
+- **Not** an OS-level sandbox / capability-based-security project. `RunCapabilities` is a _value-typed_ capability bag ("does this run have a github token?"), not a syscall sandbox.
 - **Not** an attempt to delete `getConfig`-style platform service lookups. `platform()` from `@platform` is composition-root state, not per-run state, and stays.
 - **Not** a rewrite of any modelHandler, flow node, or tool. Their interfaces gain a `ctx: RunContext` parameter; their bodies do not change.
 - **Not** a host-specific logger redesign. Logger v2 is its own PRD (`prd-logger-v2.md`); this PRD only states that `Logger` is a field on `RunContext`.
@@ -40,27 +40,27 @@ A May 2026 audit of `src/agent/`, `src/tools/approval/`, `src/auth/`, `src/event
 
 ### 4.1 AsyncLocalStorage scopes (2)
 
-| Scope | File:line | Holds | Entered by | Read by |
-| ----- | --------- | ----- | ---------- | ------- |
-| `runtimeHostScope` | `src/agent/runtime/AgentRuntimeHost.ts:12` | Current `AgentRuntimeHost` (≡ `ProgressSink`) | `runWithAgentRuntimeHost(host, fn)` (line 27) | `getAgentRuntimeHost()` (line 23) — falls back to `defaultAgentRuntimeHost` (line 11), then `getDefaultProgressSink()` |
-| `contextStorage` | `src/logger/logUtils.ts:10` | `Map<channel-key, group-id stack>` for log grouping | `runWithGroupContext()` (line 130) | `getActiveGroupStack()` (line 63), `runWithGroupContext` (line 136) |
+| Scope              | File:line                                  | Holds                                               | Entered by                                    | Read by                                                                                                                |
+| ------------------ | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `runtimeHostScope` | `src/agent/runtime/AgentRuntimeHost.ts:12` | Current `AgentRuntimeHost` (≡ `ProgressSink`)       | `runWithAgentRuntimeHost(host, fn)` (line 27) | `getAgentRuntimeHost()` (line 23) — falls back to `defaultAgentRuntimeHost` (line 11), then `getDefaultProgressSink()` |
+| `contextStorage`   | `src/logger/logUtils.ts:10`                | `Map<channel-key, group-id stack>` for log grouping | `runWithGroupContext()` (line 130)            | `getActiveGroupStack()` (line 63), `runWithGroupContext` (line 136)                                                    |
 
 ### 4.2 Module-level setter/getter pairs (~12 in audit, plus the 8 the controllers list)
 
-| Concern | Setter | File:line |
-| ------- | ------ | --------- |
-| Default progress sink | `setDefaultProgressSink` | `src/agent/runtime/ProgressSink.ts:14` |
-| Default runtime host | `setDefaultAgentRuntimeHost` | `src/agent/runtime/AgentRuntimeHost.ts:11` |
-| Run storage service | `setRunStorageService` | `src/agent/runtime/RunStorageService.ts:10` |
-| Tool-edit approval handler | `setToolEditApprovalHandler` | `src/tools/approval/toolEditApproval.ts:74,113` |
-| Latex-preview handler | `setLatexBuildDisplay` | `src/tools/approval/latexPreview.ts:21` |
-| GitHub token provider | `setGitHubTokenProvider` | `src/tools/github/githubAuth.ts:13` |
-| Extension checker | `setExtensionChecker` | `src/tools/externalToolDefs.ts:35` |
-| Server-side key service | `setServerSideKeyService` | `src/auth/serverKeys/index.ts:34` |
-| Tier service | `setTierService` | `src/auth/tier/index.ts:31` |
-| Auth callback resolver | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183` |
-| Runtime extension id | `setRuntimeExtensionId` | `src/auth/config.ts:137` |
-| Output-channel factory (logger) | `setOutputChannelFactory` | `src/logger/logUtils.ts:108` |
+| Concern                         | Setter                            | File:line                                       |
+| ------------------------------- | --------------------------------- | ----------------------------------------------- |
+| Default progress sink           | `setDefaultProgressSink`          | `src/agent/runtime/ProgressSink.ts:14`          |
+| Default runtime host            | `setDefaultAgentRuntimeHost`      | `src/agent/runtime/AgentRuntimeHost.ts:11`      |
+| Run storage service             | `setRunStorageService`            | `src/agent/runtime/RunStorageService.ts:10`     |
+| Tool-edit approval handler      | `setToolEditApprovalHandler`      | `src/tools/approval/toolEditApproval.ts:74,113` |
+| Latex-preview handler           | `setLatexBuildDisplay`            | `src/tools/approval/latexPreview.ts:21`         |
+| GitHub token provider           | `setGitHubTokenProvider`          | `src/tools/github/githubAuth.ts:13`             |
+| Extension checker               | `setExtensionChecker`             | `src/tools/externalToolDefs.ts:35`              |
+| Server-side key service         | `setServerSideKeyService`         | `src/auth/serverKeys/index.ts:34`               |
+| Tier service                    | `setTierService`                  | `src/auth/tier/index.ts:31`                     |
+| Auth callback resolver          | `setExternalAuthCallbackResolver` | `src/auth/config.ts:183`                        |
+| Runtime extension id            | `setRuntimeExtensionId`           | `src/auth/config.ts:137`                        |
+| Output-channel factory (logger) | `setOutputChannelFactory`         | `src/logger/logUtils.ts:108`                    |
 
 ### 4.3 Exported singleton coordinators (3)
 
@@ -77,7 +77,7 @@ These are problematic because they fan out events to whoever the current global 
 - Output-poll timer + in-flight flag — `src/agent/runtime/executionRegistry.ts:335-336`
 - Polish-model template cache — `src/agent/runtime/polishModel.ts:11-12`
 
-These are intentional caches of *immutable* data (registry, model templates) and stay. They are not the target of this PRD; they're listed only to bound the audit.
+These are intentional caches of _immutable_ data (registry, model templates) and stay. They are not the target of this PRD; they're listed only to bound the audit.
 
 ### 4.5 Why this is the right time
 
@@ -156,7 +156,10 @@ Because the audit found ~30 reader sites of singletons today, a hard cutover is 
 // packages/core/src/runtime/runContext.ts
 export const runContextScope = new AsyncLocalStorage<RunContext>();
 
-export function withRunContext<T>(ctx: RunContext, fn: () => T | Promise<T>): T | Promise<T> {
+export function withRunContext<T>(
+  ctx: RunContext,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
   return runContextScope.run(ctx, fn);
 }
 
@@ -176,7 +179,7 @@ export function tryUseRunContext(): RunContext | undefined {
 - Every `executeAgent()` call becomes `withRunContext(ctx, () => /* existing body */)`.
 - The existing `runWithAgentRuntimeHost()` keeps working — it now reads from `runContextScope.getStore()?.progress` and falls back to its current path.
 - Every singleton getter (`getDefaultProgressSink`, `getRunStorageService`, `getServerSideKeyService`, …) gets a `// LEGACY:` comment plus a path forward: read `runContextScope.getStore()?.<field>` first, fall back to the module global, log a `DEBUG` if the fallback was used.
-- Internal kernel call sites convert in batches (one per phase). Each batch deletes a module global once *all* its readers take an explicit `ctx`.
+- Internal kernel call sites convert in batches (one per phase). Each batch deletes a module global once _all_ its readers take an explicit `ctx`.
 
 ## 7. Migration phases
 
@@ -215,7 +218,7 @@ Each phase is independently mergeable and ships a concrete kernel improvement.
 ### Phase 4 — Auth singletons (~1 week)
 
 - `tierService` (`auth/tier/index.ts:31`), `serverSideKeyService` (`auth/serverKeys/index.ts:34`), `externalAuthCallbackResolver` (`auth/config.ts:183`), `runtimeExtensionId` (`auth/config.ts:137`) — replaced by per-`RunContext` resolutions backed by a kernel-side `AuthRegistry`.
-- The auth registry itself is composition-root state (initialized once at `initPlatform()`), so it's allowed to be a module global; what's *per-run* is which session/keys/tier resolution applies. That distinction collapses today.
+- The auth registry itself is composition-root state (initialized once at `initPlatform()`), so it's allowed to be a module global; what's _per-run_ is which session/keys/tier resolution applies. That distinction collapses today.
 - **Exit criteria:** auth tests no longer install global services in `beforeEach`.
 
 ### Phase 5 — `then()`-boundary fix + sweep (~3 days)
@@ -226,15 +229,15 @@ Each phase is independently mergeable and ships a concrete kernel improvement.
 
 ### Aggregate timeline
 
-| Phase | Singletons retired | Files touched | Net LOC | Engineering weeks |
-| ----- | ------------------ | ------------- | ------- | ----------------- |
-| 0 | — (foundations) | `runContext.ts` (new), `executeAgent.ts`, `runtime/testing.ts` | +220 / -10 | 1.5 |
-| 1 | 3 coordinators | `Plan/Retry/AgentProposalCoordinator.ts` + 5 readers | +60 / -30 | 1 |
-| 2 | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 readers | +20 / -160 | 1.5 |
-| 3 | 4 capability setters | `tools/{approval,github,externalToolDefs}/*` | +60 / -110 | 1 |
-| 4 | 4 auth singletons + extension-id setter | `auth/*` | +80 / -130 | 1 |
-| 5 | (sweep) | `executionRegistry.ts` + lint rule cleanups | +20 / -30 | 0.5 |
-| **Total** | **~14 ambient bindings + 3 coordinators** | | **+460 / -470** | **~6.5** |
+| Phase     | Singletons retired                                                    | Files touched                                                                  | Net LOC         | Engineering weeks |
+| --------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------- | ----------------- |
+| 0         | — (foundations)                                                       | `runContext.ts` (new), `executeAgent.ts`, `runtime/testing.ts`                 | +220 / -10      | 1.5               |
+| 1         | 3 coordinators                                                        | `Plan/Retry/AgentProposalCoordinator.ts` + 5 readers                           | +60 / -30       | 1                 |
+| 2         | `defaultProgressSink`, `defaultAgentRuntimeHost`, `runStorageService` | `ProgressSink.ts`, `AgentRuntimeHost.ts`, `RunStorageService.ts` + ~40 readers | +20 / -160      | 1.5               |
+| 3         | 4 capability setters                                                  | `tools/{approval,github,externalToolDefs}/*`                                   | +60 / -110      | 1                 |
+| 4         | 4 auth singletons + extension-id setter                               | `auth/*`                                                                       | +80 / -130      | 1                 |
+| 5         | (sweep)                                                               | `executionRegistry.ts` + lint rule cleanups                                    | +20 / -30       | 0.5               |
+| **Total** | **~14 ambient bindings + 3 coordinators**                             |                                                                                | **+460 / -470** | **~6.5**          |
 
 Net code change: **~-10 LOC** (the refactor pays for itself in deleted boilerplate). The CLI consumes Phase 1 deliverables for v1.0 and Phase 2 for v1.1; the extension and desktop benefit from every phase but don't gate on them.
 
@@ -275,11 +278,11 @@ Adding a new Node-based host (e.g. a `texra serve` daemon, or a future Tauri-bas
 
 Crisp rule: **the host package's `src/` is allowed to import `vscode` / `electron` / `commander` / Ink, and nothing under `core/` is.**
 
-| Host | Owns | Doesn't own |
-| ---- | ---- | ----------- |
+| Host                  | Owns                                                                                                                            | Doesn't own                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
 | `packages/extension/` | `vscode.commands`, webview hosts, `frontend/vscode/*`, controllers wired to webview message handlers, `VscodeOutputChannelSink` | The agent runtime (in core); coordinators (in core) |
-| `packages/desktop/` | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging | Same |
-| `packages/cli/` | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner | Same |
+| `packages/desktop/`   | Electron `main`, preload bridges, BrowserWindow lifecycle, `electronLogSink`, packaging                                         | Same                                                |
+| `packages/cli/`       | `commander` parsing, Ink TUI, `texra mcp serve`, `StderrTextSink`, `NdjsonStdoutSink`, hook command-runner                      | Same                                                |
 
 ### 8.3 ESLint enforcement
 
@@ -301,16 +304,16 @@ A flat-config rule that the host of each package can import only the rings it ca
 
 ## 9. Risks & mitigations
 
-| Risk | Likelihood | Impact | Mitigation |
-| ---- | ---------- | ------ | ---------- |
-| ALS context lost across `.then()` boundary (the LangSmith-style foot-gun) | Medium | Medium | Phase 5 fixes the one known site (`executionRegistry.ts:335`); ESLint rule + dev review for new timers. |
-| Phase 1 coordinator change breaks an in-flight reader site no one tested | Medium | Medium | Each coordinator's per-context factory keeps the same observable interface; existing tests catch the regression. |
-| `RunContext.child()` semantics get wrong (e.g., child's `signal` doesn't chain) | Low | Medium | Implement child via `AbortSignal.any([parent.signal, childAbort])`; covered by a tabletop test in `runContext.test.ts`. |
-| Singleton retirement merges before consumers update | Low | High | Each phase's exit criteria require zero `git grep` hits for the deleted symbols before merge; CI gate. |
-| `RunCapabilities` shape drifts as new capabilities are added | Medium | Low | Add capabilities incrementally; Zod schema validates at construction; ESLint rule forbids reading capabilities outside `useRunContext()`. |
-| Test setup churn during migration | Medium | Low | `runtime/testing.ts` exposes `synthesizeRunContext({ overrides })` — one call replaces ~5–10 LOC of `beforeEach` setup. |
-| Three-ring ESLint rule produces noisy false positives | Medium | Low | Soft-fail mode in CI for the first two weeks; harden after. |
-| Per-context coordinator instances over-allocate (one set per run) | Low | Low | Coordinators are tiny (Map + a Resolver list); per-run cost is sub-µs. Profiled in tabletop benchmark. |
+| Risk                                                                            | Likelihood | Impact | Mitigation                                                                                                                                |
+| ------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| ALS context lost across `.then()` boundary (the LangSmith-style foot-gun)       | Medium     | Medium | Phase 5 fixes the one known site (`executionRegistry.ts:335`); ESLint rule + dev review for new timers.                                   |
+| Phase 1 coordinator change breaks an in-flight reader site no one tested        | Medium     | Medium | Each coordinator's per-context factory keeps the same observable interface; existing tests catch the regression.                          |
+| `RunContext.child()` semantics get wrong (e.g., child's `signal` doesn't chain) | Low        | Medium | Implement child via `AbortSignal.any([parent.signal, childAbort])`; covered by a tabletop test in `runContext.test.ts`.                   |
+| Singleton retirement merges before consumers update                             | Low        | High   | Each phase's exit criteria require zero `git grep` hits for the deleted symbols before merge; CI gate.                                    |
+| `RunCapabilities` shape drifts as new capabilities are added                    | Medium     | Low    | Add capabilities incrementally; Zod schema validates at construction; ESLint rule forbids reading capabilities outside `useRunContext()`. |
+| Test setup churn during migration                                               | Medium     | Low    | `runtime/testing.ts` exposes `synthesizeRunContext({ overrides })` — one call replaces ~5–10 LOC of `beforeEach` setup.                   |
+| Three-ring ESLint rule produces noisy false positives                           | Medium     | Low    | Soft-fail mode in CI for the first two weeks; harden after.                                                                               |
+| Per-context coordinator instances over-allocate (one set per run)               | Low        | Low    | Coordinators are tiny (Map + a Resolver list); per-run cost is sub-µs. Profiled in tabletop benchmark.                                    |
 
 ## 10. Success criteria
 


### PR DESCRIPTION
Adds §§21–32 to prd-cli-app.md as an iteration round on top of round 1,
without repeating round-1 material. The deltas, in dependency order:

- §22 RunContext: explicit per-run context replacing the audited 20+
  module-level setter/getter pairs and 3 singleton coordinators across
  src/agent/runtime, src/tools/approval, src/auth, src/logger. ALS-with-
  explicit-context shim path; singleton retirement scheduled across
  v1.0–v1.3.
- §23 Logger v2: structured LogRecord + LogSink interface; one schema
  shared with the §11.2 progress NDJSON; per-host sinks (vscode output
  channel, electron-log, stderr text, ndjson stdout, MCP progress,
  in-memory tests); BootstrapLogger for boot-time emission.
- §24 texra mcp serve promoted from v1.1 to v1: stdio JSON-RPC server
  exposing run_workflow / run_chat / list_agents tools, callable from
  Claude Code (.mcp.json) and Codex (~/.codex/config.toml).
- §25 Hook system spec'd against Claude Code's wire contract
  (stdin JSON → exit code + stdout JSON, permissionDecision under
  hookSpecificOutput). HookHost interface in core; CLI ships command +
  prompt handlers in v1.1.
- §26 Approval policy stays 1D per user feedback — no sandbox-mode
  axis. Adds concrete in-project predicate and a small bash safe-list.
- §27 Session JSONL under ~/.texra/projects/<hash>/sessions/<id>.jsonl;
  byte-equivalent to --output-format ndjson; --continue / --fork-session
  semantics.
- §28 GitHub Action reversed from JS Action to composite+Bun (matches
  claude-code-base-action). No dist/ checked in; CLI version pinnable
  per release.
- §29 Cross-platform shared structure: three concentric rings under
  packages/core/ (pure logic / runtime orchestration / platform
  defaults). New host-port catalog (LogSink, HookHost, SessionStore)
  alongside the existing PromptHost / ExternalOpener / etc.
- §30 Container target matrix refined; node:20-alpine downgraded to
  best-effort; texlive/texlive: first-class. Adds an integration test
  that drives texra mcp serve from Claude Code and Codex on every PR.
- §31 Aggregate phase + LOC delta: kernel work grows by ~940 LOC,
  CLI shell by ~730. Total v1: ~5.7–6.7 KLOC.
- §32 Parking lot: unified agent/message SDK + compaction (per user
  feedback — nice but not v1), OS-level sandbox, texra serve daemon,
  MCP resources, replay/cost guards, http+agent hook handlers.

https://claude.ai/code/session_017pa2sVWiofqS6iP75MxsmT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (PRDs) with no production code modifications; risk is limited to potential downstream implementation misinterpretation.
> 
> **Overview**
> Adds *Round 2* design material to `prd-cli-app.md`, promoting two kernel-wide refactors into dedicated PRDs and expanding the v1 CLI scope.
> 
> Introduces new PRDs for `RunContext` (explicit per-run context + ambient-state/singleton retirement plan + core layering rules) and Logger v2 (structured `LogRecord`/`LogSink`, unified NDJSON schema with progress, bootstrap buffering, and per-host sinks).
> 
> Updates the CLI plan to include `texra mcp serve` as a v1 deliverable (stdio MCP server with `run_workflow`, `run_chat`, `list_agents`), specifies a Claude Code-style hook contract, tightens approval predicates (in-project + bash safe-list), defines JSONL session transcript storage/resume semantics, and revises the GitHub Action approach to a composite action that installs the CLI at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5389f9b9d5482c802e8da07d763af8e453f319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->