### PR TITLE
Gate desktop installer CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_desktop_installers:
+        description: 'Build macOS and Linux desktop installers'
+        required: false
+        default: false
+        type: boolean
+      run_windows_desktop:
+        description: 'Build Windows desktop installer'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -110,6 +122,7 @@ jobs:
 
   desktop-macos-installer:
     name: desktop installer (macOS)
+    if: github.event_name == 'push' || inputs.run_desktop_installers
     runs-on: macos-latest
     timeout-minutes: 45
 
@@ -157,6 +170,7 @@ jobs:
 
   desktop-linux-installer:
     name: desktop installer (Linux)
+    if: github.event_name == 'push' || inputs.run_desktop_installers
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -204,6 +218,7 @@ jobs:
 
   desktop-windows-artifact:
     name: desktop artifact (Windows)
+    if: github.event_name == 'push' || inputs.run_windows_desktop
     runs-on: windows-latest
     timeout-minutes: 30
 
@@ -278,15 +293,15 @@ jobs:
             echo 'Validation matrix result: ${{ needs.validate.result }}'
             exit 1
           fi
-          if [ '${{ needs.desktop-macos-installer.result }}' != 'success' ]; then
+          if [ '${{ needs.desktop-macos-installer.result }}' != 'success' ] && [ '${{ needs.desktop-macos-installer.result }}' != 'skipped' ]; then
             echo 'macOS desktop installer result: ${{ needs.desktop-macos-installer.result }}'
             exit 1
           fi
-          if [ '${{ needs.desktop-linux-installer.result }}' != 'success' ]; then
+          if [ '${{ needs.desktop-linux-installer.result }}' != 'success' ] && [ '${{ needs.desktop-linux-installer.result }}' != 'skipped' ]; then
             echo 'Linux desktop installer result: ${{ needs.desktop-linux-installer.result }}'
             exit 1
           fi
-          if [ '${{ needs.desktop-windows-artifact.result }}' != 'success' ]; then
+          if [ '${{ needs.desktop-windows-artifact.result }}' != 'success' ] && [ '${{ needs.desktop-windows-artifact.result }}' != 'skipped' ]; then
             echo 'Windows desktop artifact result: ${{ needs.desktop-windows-artifact.result }}'
             exit 1
           fi


### PR DESCRIPTION
## Summary
- add manual workflow inputs for expensive desktop installer jobs
- run macOS and Linux installer jobs on `main` pushes or when `run_desktop_installers` is selected manually
- run the Windows desktop installer job on `main` pushes or when `run_windows_desktop` is selected manually
- allow the aggregate validation job to accept skipped installer jobs

## Rationale
The normal pull request path already builds and smoke-launches the packaged macOS desktop app, which is the standard CI check needed to catch packaged Electron startup failures. Full installer production is slower and platform-specific, so it should remain available without activating on every pull request.

## Verification
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'workflow yaml parsed'"`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI execution conditions and aggregate status checks, which could allow installer regressions to slip through if the optional jobs aren’t run when needed.
> 
> **Overview**
> Adds `workflow_dispatch` inputs to the CI workflow to optionally run the expensive desktop installer jobs.
> 
> Updates the macOS/Linux installer jobs and the Windows desktop packaging job to run only on `main` pushes or when explicitly requested, and adjusts the final `validate-status` gate to treat those jobs as acceptable when *skipped*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73c57a22ff8c284e5b39c0584be79506dc1b539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->