### PR TITLE
Refactor desktop shell action wiring

### DIFF
--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -24,10 +24,21 @@ import {
   type DesktopCommandActions,
 } from '../desktopCommandSurface.js';
 
-export interface DesktopShellIpcOptions {
-  actions?: DesktopShellActions;
+export type DesktopShellIpcOptions =
+  | DesktopShellActionFactoryOptions
+  | DesktopShellActionInstanceOptions;
+
+export interface DesktopShellActionFactoryOptions {
+  actions?: never;
   getCustomAgentDirectory?: () => Promise<string>;
   openPath?: (filePath: string) => Promise<void>;
+  onAsyncError?: (error: unknown) => void;
+}
+
+export interface DesktopShellActionInstanceOptions {
+  actions: DesktopShellActions;
+  getCustomAgentDirectory?: never;
+  openPath?: never;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -50,7 +61,7 @@ function getAgentSettingsSubTab(message: DesktopCommandMessage) {
 
 export function createDesktopShellActions(
   renderer: DesktopRenderer,
-  options: DesktopShellIpcOptions = {},
+  options: DesktopShellActionFactoryOptions = {},
 ): DesktopShellActions {
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
@@ -108,7 +119,9 @@ export function createDesktopShellIpc(
   options: DesktopShellIpcOptions = {},
 ): DesktopMessageHandler {
   const actions =
-    options.actions ?? createDesktopShellActions(renderer, options);
+    options.actions != null
+      ? options.actions
+      : createDesktopShellActions(renderer, options);
 
   function postRouteForSwitchView(message: DesktopCommandMessage) {
     const result = SwitchViewMessageSchema.safeParse(message);

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -55,10 +55,15 @@ export function installDesktopMainViewIpc(
     debugMode: options.debugMode,
     getTheme: options.getTheme,
   });
-  const shell = createDesktopShellIpc(bridge, {
-    actions: options.shellActions,
-    onAsyncError: options.onAsyncError,
-  });
+  const shell =
+    options.shellActions == null
+      ? createDesktopShellIpc(bridge, {
+          onAsyncError: options.onAsyncError,
+        })
+      : createDesktopShellIpc(bridge, {
+          actions: options.shellActions,
+          onAsyncError: options.onAsyncError,
+        });
   const execution = createDesktopExecutionIpc({
     executeAgent: options.executeAgent,
     onAsyncError: options.onAsyncError,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -21,8 +21,6 @@ import type { BrowserWindow } from 'electron';
 export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
   getTheme?: () => DesktopTheme;
-  getCustomAgentDirectory?: () => Promise<string>;
-  openPath?: (filePath: string) => Promise<void>;
   fileSelection?: DesktopFileSelection;
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
@@ -59,8 +57,6 @@ export function installDesktopMainViewIpc(
   });
   const shell = createDesktopShellIpc(bridge, {
     actions: options.shellActions,
-    getCustomAgentDirectory: options.getCustomAgentDirectory,
-    openPath: options.openPath,
     onAsyncError: options.onAsyncError,
   });
   const execution = createDesktopExecutionIpc({

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -25,8 +25,6 @@ interface MainViewIpcModule {
     options?: {
       debugMode?: boolean;
       getTheme?: () => 'dark' | 'light' | 'high-contrast';
-      getCustomAgentDirectory?: () => Promise<string>;
-      openPath?: (filePath: string) => Promise<void>;
       fileSelection?: { handleMessage(message: { command: string }): boolean };
       settings?: { handleMessage(message: { command: string }): boolean };
       progress?: { handleMessage(message: { command: string }): boolean };
@@ -105,7 +103,6 @@ describe('desktop main-view IPC', () => {
       installDesktopMainViewIpc,
     } = await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
-    const openPath = vi.fn(async (_filePath: string) => {});
     const fileSelection = {
       handleMessage: vi.fn(
         (message: { command: string }) =>
@@ -140,8 +137,6 @@ describe('desktop main-view IPC', () => {
 
     const ipc = installDesktopMainViewIpc(window, {
       debugMode: true,
-      getCustomAgentDirectory: async () => '/agents/custom',
-      openPath,
       fileSelection,
       settings,
       progress,
@@ -332,10 +327,19 @@ describe('desktop main-view IPC', () => {
       { sender: webContents },
       { command: MAIN_VIEW_COMMANDS.OPEN_AGENT_DIRECTORY, customDirSet: true },
     );
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(openPath).toHaveBeenCalledWith('/agents/custom');
-    expect(sends).toEqual([]);
+    expect(sends).toEqual([
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: { command: 'desktop:setRoute', route: 'settings' },
+      },
+      {
+        channel: ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        message: {
+          command: SETTINGS_VIEW_COMMANDS.SET_TAB,
+          tabIndex: SETTINGS_TAB.AGENTS,
+        },
+      },
+    ]);
 
     const executeMessage = {
       command: MAIN_VIEW_COMMANDS.EXECUTE,


### PR DESCRIPTION
## Summary

- remove custom-agent directory and open-path plumbing from `installDesktopMainViewIpc`
- make desktop shell IPC options explicit: use either prebuilt shell actions or action-construction inputs
- update the main-view IPC test to cover the no-actions fallback route instead of duplicated host wiring

Closes #3503.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `npm run desktop:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `createDesktopShellIpc`/`installDesktopMainViewIpc` decide between injected actions vs constructing defaults, which could alter desktop navigation and agent-directory behavior if callers relied on the old mixed options shape.
> 
> **Overview**
> Refactors desktop shell IPC configuration to be *mutually exclusive*: callers now either pass a prebuilt `actions` instance or the factory inputs (`getCustomAgentDirectory`/`openPath`), enforced via a union type in `desktopShellIpc.ts`.
> 
> Simplifies `installDesktopMainViewIpc` by removing `getCustomAgentDirectory`/`openPath` plumbing and only injecting `shellActions` when provided; otherwise it constructs the default shell IPC.
> 
> Updates the `ElectronMainViewIpc` test to stop mocking `openPath`/custom directory behavior and instead assert the fallback behavior for `OPEN_AGENT_DIRECTORY` (routes to settings/Agents tab when no action factory inputs are provided).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4302c310aaac355a39ffc28996450daf70e5c1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->