### PR TITLE
Remove common storage barrel

### DIFF
--- a/src/common/storage/index.ts
+++ b/src/common/storage/index.ts
@@ -1,1 +1,0 @@
-export { KVStore } from './KVStore';

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -71,7 +71,7 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
   vi.doMock('@agent/runtime/runExecutionRequest', () => ({
     runValidatedExecutionRequest: vi.fn(),
   }));
-  vi.doMock('@common/storage', () => ({
+  vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
       async read(): Promise<undefined> {
         return undefined;
@@ -186,7 +186,7 @@ async function createExecution(options: {
     runValidatedExecutionRequest:
       options.runValidatedExecutionRequest ?? vi.fn(async () => {}),
   }));
-  vi.doMock('@common/storage', () => ({
+  vi.doMock('@common/storage/KVStore', () => ({
     KVStore: class {
       async read(): Promise<undefined> {
         return undefined;
@@ -240,7 +240,7 @@ describe('DesktopProgressBridge', () => {
   afterEach(() => {
     vi.doUnmock('@agent/runtime/RunStorageService');
     vi.doUnmock('@agent/runtime/runExecutionRequest');
-    vi.doUnmock('@common/storage');
+    vi.doUnmock('@common/storage/KVStore');
     vi.doUnmock('@controllers/mainView/MainViewExecutionController');
     vi.doUnmock('@logger/AgentLogger');
     vi.doUnmock('vscode');


### PR DESCRIPTION
## Summary
- delete the orphaned `src/common/storage/index.ts` barrel
- update desktop execution tests to mock `@common/storage/KVStore` directly
- keep remaining `KVStore` consumers on the concrete module path

Closes #3513.

## Verification
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run compile:fast`
- `npm run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused re-export and updates a test mock import path; no runtime logic changes beyond module resolution/import behavior.
> 
> **Overview**
> Removes the orphaned `src/common/storage/index.ts` barrel that re-exported `KVStore`, pushing consumers to import from `@common/storage/KVStore` directly.
> 
> Updates `DesktopAgentExecution.vitest.mts` to mock and unmock `@common/storage/KVStore` instead of `@common/storage`, aligning tests with the new import path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73d6a9b9eedef4729bd33028acbf548a4450ccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->