### PR TITLE
fix: include webview font assets in VSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - **Current DeepSeek V4 pricing** — DeepSeek V4 Flash and Pro now use DeepSeek's current cache-hit pricing, and V4 Pro reflects the active discounted input and output rates.
+- **Codicon font packaging** — installed VSIX builds now include the webview icon font assets, so toolbar and settings icons render as icons instead of fallback squares.
 
 ## [0.37.7] - 2026-05-01
 

--- a/packages/extension/.vscodeignore
+++ b/packages/extension/.vscodeignore
@@ -38,9 +38,9 @@ CLAUDE.md
 !node_modules/split.js/**
 !node_modules/@vscode-elements/elements/dist/**
 
-# Exclude codicon font AFTER negations (loaded via VS Code webview URI, not bundled)
+# Exclude dependency codicon fonts, but keep Vite-emitted webview fonts.
 **/codicon.ttf
-
+!dist/**/codicon.ttf
 
 !resources/**
 !src/webview/*.js

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1477,6 +1477,9 @@
   ],
   "requiredPackagedPaths": [
     "LICENSE.txt",
+    "dist/progressView/codicon.ttf",
+    "dist/settingsView/codicon.ttf",
+    "dist/webview/codicon.ttf",
     "resources/agents",
     "resources/docs/agent-creation",
     "resources/examples",
@@ -1493,6 +1496,7 @@
   ],
   "requiredVscodeIgnoreLines": [
     "src/**",
+    "!dist/**/codicon.ttf",
     "!resources/**",
     "!src/common/styles/*.css",
     "!src/progressView/*.html",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -1477,9 +1477,6 @@
   ],
   "requiredPackagedPaths": [
     "LICENSE.txt",
-    "dist/progressView/codicon.ttf",
-    "dist/settingsView/codicon.ttf",
-    "dist/webview/codicon.ttf",
     "resources/agents",
     "resources/docs/agent-creation",
     "resources/examples",

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,10 +17,7 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": [
-      "onStartupFinished",
-      "onColorTheme"
-    ],
+    "activationEvents": ["onStartupFinished", "onColorTheme"],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -590,13 +587,7 @@
               "type": "array"
             },
             "texra.files.included.auxiliaryExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".cls",
-                ".md",
-                ".sty"
-              ],
+              "default": [".txt", ".tex", ".cls", ".md", ".sty"],
               "description": "File extensions to include when searching for auxiliary files",
               "editPresentation": "multilineText",
               "items": {
@@ -606,10 +597,7 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [
-                ".txt",
-                ".tex"
-              ],
+              "default": [".txt", ".tex"],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -619,11 +607,7 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md"
-              ],
+              "default": [".txt", ".tex", ".md"],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -663,13 +647,7 @@
               "type": "array"
             },
             "texra.files.included.referenceExtensions": {
-              "default": [
-                ".txt",
-                ".tex",
-                ".md",
-                ".bib",
-                ".bbl"
-              ],
+              "default": [".txt", ".tex", ".md", ".bib", ".bbl"],
               "description": "File extensions to include when searching for reference files",
               "editPresentation": "multilineText",
               "items": {
@@ -865,10 +843,7 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": [
-                "sameDirectory",
-                "workspaceTemp"
-              ],
+              "enum": ["sameDirectory", "workspaceTemp"],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1368,9 +1343,7 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": [
-                "onCommand:texra.runSetupAssistant"
-              ],
+              "completionEvents": ["onCommand:texra.runSetupAssistant"],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1379,9 +1352,7 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.createSampleProject"
-              ],
+              "completionEvents": ["onCommand:texra.createSampleProject"],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1390,9 +1361,7 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.setApiKey"
-              ],
+              "completionEvents": ["onCommand:texra.setApiKey"],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1402,9 +1371,7 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.auth.signIn"
-              ],
+              "completionEvents": ["onCommand:texra.auth.signIn"],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1414,9 +1381,7 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showMainView"
-              ],
+              "completionEvents": ["onCommand:texra.showMainView"],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Reference** -- papers or notes for context (optional)\n- **Auxiliary** -- bib files, style files, preambles (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1435,9 +1400,7 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.showDashboard"
-              ],
+              "completionEvents": ["onCommand:texra.showDashboard"],
               "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
@@ -1460,9 +1423,7 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": [
-                "onCommand:texra.execute"
-              ],
+              "completionEvents": ["onCommand:texra.execute"],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/scripts/extension-package-invariants.snapshot.json
+++ b/scripts/extension-package-invariants.snapshot.json
@@ -17,7 +17,10 @@
       "Education",
       "Data Science"
     ],
-    "activationEvents": ["onStartupFinished", "onColorTheme"],
+    "activationEvents": [
+      "onStartupFinished",
+      "onColorTheme"
+    ],
     "main": "./dist/extension.js",
     "capabilities": {
       "untrustedWorkspaces": {
@@ -587,7 +590,13 @@
               "type": "array"
             },
             "texra.files.included.auxiliaryExtensions": {
-              "default": [".txt", ".tex", ".cls", ".md", ".sty"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".cls",
+                ".md",
+                ".sty"
+              ],
               "description": "File extensions to include when searching for auxiliary files",
               "editPresentation": "multilineText",
               "items": {
@@ -597,7 +606,10 @@
               "type": "array"
             },
             "texra.files.included.editedExtensions": {
-              "default": [".txt", ".tex"],
+              "default": [
+                ".txt",
+                ".tex"
+              ],
               "description": "File extensions to include when searching for edited files",
               "editPresentation": "multilineText",
               "items": {
@@ -607,7 +619,11 @@
               "type": "array"
             },
             "texra.files.included.inputExtensions": {
-              "default": [".txt", ".tex", ".md"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md"
+              ],
               "description": "File extensions to include when searching for input files",
               "editPresentation": "multilineText",
               "items": {
@@ -647,7 +663,13 @@
               "type": "array"
             },
             "texra.files.included.referenceExtensions": {
-              "default": [".txt", ".tex", ".md", ".bib", ".bbl"],
+              "default": [
+                ".txt",
+                ".tex",
+                ".md",
+                ".bib",
+                ".bbl"
+              ],
               "description": "File extensions to include when searching for reference files",
               "editPresentation": "multilineText",
               "items": {
@@ -843,7 +865,10 @@
             "texra.latexdiff.tempFileLocation": {
               "default": "sameDirectory",
               "description": "Where to create temporary files for LaTeX preview and diff operations during tool edit approval.",
-              "enum": ["sameDirectory", "workspaceTemp"],
+              "enum": [
+                "sameDirectory",
+                "workspaceTemp"
+              ],
               "enumDescriptions": [
                 "Create temp files in the same directory as the original file. Best for resolving \\input{} and relative paths.",
                 "Create temp files in .texra-temp directory at workspace root. Keeps source directories clean but may break relative paths."
@@ -1343,7 +1368,9 @@
           "id": "texra.gettingStarted",
           "steps": [
             {
-              "completionEvents": ["onCommand:texra.runSetupAssistant"],
+              "completionEvents": [
+                "onCommand:texra.runSetupAssistant"
+              ],
               "description": "Start here. TeXRA's setup assistant agent checks your environment, installs any missing LaTeX tools, adds an API key or signs you in, and verifies that you're ready to go. It asks before every command and explains what it's doing.\n\n[Run Setup Assistant Agent](command:texra.runSetupAssistant)\n\nPrefer to do it yourself? The remaining steps walk you through the same checklist manually.",
               "id": "texra.gettingStarted.setupAssistant",
               "media": {
@@ -1352,7 +1379,9 @@
               "title": "Run the setup assistant agent"
             },
             {
-              "completionEvents": ["onCommand:texra.createSampleProject"],
+              "completionEvents": [
+                "onCommand:texra.createSampleProject"
+              ],
               "description": "Not sure where to start? We've bundled a small LaTeX project you can play with.\n\n[Create the sample project](command:texra.createSampleProject)\n\nYou'll get a folder with example `.tex` files and a README that explains the layout.",
               "id": "texra.gettingStarted.sampleWorkspace",
               "media": {
@@ -1361,7 +1390,9 @@
               "title": "Try the sample project"
             },
             {
-              "completionEvents": ["onCommand:texra.setApiKey"],
+              "completionEvents": [
+                "onCommand:texra.setApiKey"
+              ],
               "description": "You'll need an API key from a provider like Anthropic, OpenAI, or Google. Just one is enough.\n\n[Set API key](command:texra.setApiKey)\n\nHeads up: chat subscriptions (ChatGPT Plus, Claude Pro) don't come with API access. You need a separate key from the provider's developer platform.\n\n**No API key?** No problem -- sign in with the Researcher Access Program in the next step instead.",
               "id": "texra.gettingStarted.apiKeys",
               "media": {
@@ -1371,7 +1402,9 @@
               "title": "Add your API key"
             },
             {
-              "completionEvents": ["onCommand:texra.auth.signIn"],
+              "completionEvents": [
+                "onCommand:texra.auth.signIn"
+              ],
               "description": "The **Researcher Access Program** lets you use AI models and remote agents for free -- no API key needed.\n\n[Sign In](command:texra.auth.signIn)\n\nAlready set an API key? You can skip this, but signing in still unlocks extra agents you can't get with a key alone.",
               "id": "texra.gettingStarted.signIn",
               "media": {
@@ -1381,7 +1414,9 @@
               "title": "Or just sign in"
             },
             {
-              "completionEvents": ["onCommand:texra.showMainView"],
+              "completionEvents": [
+                "onCommand:texra.showMainView"
+              ],
               "description": "Open the main view and tell TeXRA what to work on:\n\n- **Input** -- the manuscript you want edited\n- **Reference** -- papers or notes for context (optional)\n- **Auxiliary** -- bib files, style files, preambles (optional)\n- **Media** -- figures and images (optional)\n\nYou really only need an Input file to get going.\n\n[Open the TeXRA main view](command:texra.showMainView)",
               "id": "texra.gettingStarted.stageFiles",
               "media": {
@@ -1400,7 +1435,9 @@
               "title": "Use the orchestrator"
             },
             {
-              "completionEvents": ["onCommand:texra.showDashboard"],
+              "completionEvents": [
+                "onCommand:texra.showDashboard"
+              ],
               "description": "We have teams for different disciplines that give the orchestrator the right set of tools for your work:\n\n- **Physicist** -- derivations, numerical experiments, literature, presentations\n- **Mathematician** -- proofs, formalization, research\n- **Lean Project** -- Lean 4 with theorem search and blueprints\n\n[Open Settings](command:texra.showDashboard) and go to the **Multi-Agent** tab to pick one. You can always tweak it or make your own later.",
               "id": "texra.gettingStarted.multiAgent",
               "media": {
@@ -1423,7 +1460,9 @@
               "title": "Auto-extract figures (optional)"
             },
             {
-              "completionEvents": ["onCommand:texra.execute"],
+              "completionEvents": [
+                "onCommand:texra.execute"
+              ],
               "description": "You're all set. Click Execute and the orchestrator will start working through your paper.\n\n[Execute](command:texra.execute)\n\nIt'll propose tasks as it goes -- you'll see each one pop up in the [Progress view](command:texra.showProgressView) where you can approve, tweak, or skip it.\n\nWant it to just run without asking? Turn on **auto-approve** in Settings > Multi-Agent.",
               "id": "texra.gettingStarted.progress",
               "media": {

--- a/scripts/smoke-webviews-electron.mjs
+++ b/scripts/smoke-webviews-electron.mjs
@@ -18,7 +18,6 @@ const nonce = 'texra-webview-smoke';
 const commonReplacements = {
   cspSource: 'file:',
   codiconUri: fileUri('node_modules/@vscode/codicons/dist/codicon.css'),
-  codiconsFontUri: fileUri('node_modules/@vscode/codicons/dist/codicon.ttf'),
   commonStyleUri: fileUri('packages/extension/src/common/styles/common.css'),
   commonsBundleUri: fileUri('packages/extension/dist/shared/commons.js'),
   nonce,
@@ -33,6 +32,7 @@ const views = [
     tagName: 'main-app',
     templatePath: join(extensionRoot, 'src', 'webview', 'index.html'),
     replacements: {
+      codiconsFontUri: fileUri('packages/extension/dist/webview/codicon.ttf'),
       mainViewBundleUri: fileUri('packages/extension/dist/webview/bundle.js'),
     },
   },
@@ -41,6 +41,9 @@ const views = [
     tagName: 'progress-app',
     templatePath: join(extensionRoot, 'src', 'progressView', 'index.html'),
     replacements: {
+      codiconsFontUri: fileUri(
+        'packages/extension/dist/progressView/codicon.ttf',
+      ),
       progressBundleUri: fileUri(
         'packages/extension/dist/progressView/bundle.js',
       ),
@@ -54,6 +57,9 @@ const views = [
     tagName: 'settings-app',
     templatePath: join(extensionRoot, 'src', 'settingsView', 'index.html'),
     replacements: {
+      codiconsFontUri: fileUri(
+        'packages/extension/dist/settingsView/codicon.ttf',
+      ),
       settingsBundleUri: fileUri(
         'packages/extension/dist/settingsView/bundle.js',
       ),

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -37,6 +37,9 @@ const MANIFEST_KEYS = [
 
 const REQUIRED_PACKAGED_PATHS = [
   'LICENSE.txt',
+  'dist/progressView/codicon.ttf',
+  'dist/settingsView/codicon.ttf',
+  'dist/webview/codicon.ttf',
   'resources/agents',
   'resources/docs/agent-creation',
   'resources/examples',
@@ -54,6 +57,7 @@ const REQUIRED_PACKAGED_PATHS = [
 
 const REQUIRED_VSCODEIGNORE_LINES = [
   'src/**',
+  '!dist/**/codicon.ttf',
   '!resources/**',
   '!src/common/styles/*.css',
   '!src/progressView/*.html',

--- a/scripts/verify-extension-package-invariants.mjs
+++ b/scripts/verify-extension-package-invariants.mjs
@@ -37,9 +37,6 @@ const MANIFEST_KEYS = [
 
 const REQUIRED_PACKAGED_PATHS = [
   'LICENSE.txt',
-  'dist/progressView/codicon.ttf',
-  'dist/settingsView/codicon.ttf',
-  'dist/webview/codicon.ttf',
   'resources/agents',
   'resources/docs/agent-creation',
   'resources/examples',

--- a/scripts/verify-vsix-contents.mjs
+++ b/scripts/verify-vsix-contents.mjs
@@ -156,9 +156,12 @@ function readSnapshot() {
 function verifyDistEntrypoints(entries, failures) {
   for (const entryPath of [
     'extension/dist/extension.js',
-    'extension/dist/webview/bundle.js',
     'extension/dist/progressView/bundle.js',
+    'extension/dist/progressView/codicon.ttf',
     'extension/dist/settingsView/bundle.js',
+    'extension/dist/settingsView/codicon.ttf',
+    'extension/dist/webview/bundle.js',
+    'extension/dist/webview/codicon.ttf',
   ]) {
     assertEntryExists(entries, entryPath, failures);
   }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -103,7 +103,6 @@ export abstract class BaseViewContentProvider {
         path: '@vscode-elements/elements/dist/bundled.js',
       },
       { key: 'codiconUri', path: '@vscode/codicons/dist/codicon.css' },
-      { key: 'codiconsFontUri', path: '@vscode/codicons/dist/codicon.ttf' },
     ];
 
   private static readonly SHARED_MODULE_DESCRIPTORS: readonly ModuleDescriptor[] =
@@ -128,6 +127,11 @@ export abstract class BaseViewContentProvider {
         BaseViewContentProvider.SHARED_MODULE_DESCRIPTORS,
         ['dist', 'shared'],
       ),
+      codiconsFontUri: this.buildUri(webview, [
+        'dist',
+        this.getViewPath(),
+        'codicon.ttf',
+      ]),
     };
   }
 }

--- a/src/common/webview/BaseViewContentProvider.ts
+++ b/src/common/webview/BaseViewContentProvider.ts
@@ -127,6 +127,8 @@ export abstract class BaseViewContentProvider {
         BaseViewContentProvider.SHARED_MODULE_DESCRIPTORS,
         ['dist', 'shared'],
       ),
+      // The codicon stylesheet stays in node_modules, but the font file must
+      // come from Vite output because VSIX builds omit node_modules fonts.
       codiconsFontUri: this.buildUri(webview, [
         'dist',
         this.getViewPath(),


### PR DESCRIPTION
## Summary

- keep dependency codicon fonts pruned while preserving Vite-emitted webview codicon fonts in `dist/`
- require progress, settings, and main webview codicon assets in the extension package invariant snapshot
- fail VSIX content verification if any built webview font asset is missing

Closes #3537.

## Verification

- `npm run build:fast`
- `npm run check:vsix-contents`
- `npm run check:extension-package-invariants`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Notes

The installed extension package now includes `dist/progressView/codicon.ttf`, `dist/settingsView/codicon.ttf`, and `dist/webview/codicon.ttf`. This addresses the square fallback glyphs seen in installed VSIX builds while keeping source dependency font files excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging/invariant checks and webview asset URI changes only; main risk is missing or mislocated `dist/**/codicon.ttf` causing icon regressions in packaged builds.
> 
> **Overview**
> Fixes installed VSIX builds showing missing Codicon icons by **packaging the Vite-emitted `codicon.ttf` files** for each webview (`main`, `progress`, `settings`) while still excluding dependency fonts from `node_modules`.
> 
> Updates webview HTML variable wiring to load `codiconsFontUri` from `dist/<view>/codicon.ttf`, and tightens CI checks (`extension-package-invariants` snapshot + `verify-vsix-contents`) to require these font files and fail if they’re absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fde49c536b2ca314ac037cf1acd17067cbf947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->