### PR TITLE
fix: load desktop tools dashboard

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -25,7 +25,6 @@ import {
   DEFAULT_MODELS,
   buildBasicModelOptionsData,
 } from '@model/modelOptionsBasic';
-import { buildToolDashboardItems as buildDefaultToolDashboardItems } from '@settingsView/utils/toolDashboardData';
 import type { LatexConfigField } from '@shared/constants/latex';
 import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
@@ -33,13 +32,7 @@ import {
   type ReasoningLevel,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
-import {
-  getLastCheckResults,
-  refreshDisabledToolCache,
-  refreshToolAvailability as refreshDefaultToolAvailability,
-  type ExternalToolCheckResult,
-} from '@tools/toolAvailability';
-import { findExternalToolDef } from '@tools/externalToolDefs';
+import type { ExternalToolCheckResult } from '@tools/toolAvailability';
 import {
   parseCodexApprovalPolicy,
   parseCodexReasoningEffort,
@@ -71,6 +64,7 @@ export interface DesktopSettingsIpcOptions {
   config?: ConfigProvider;
   buildToolDashboardItems?: ToolDashboardBuilder;
   refreshToolAvailability?: () => Promise<void>;
+  getCustomAgentDirectory?: () => Promise<string>;
   selectCustomAgentDirectory?: () => Promise<string | undefined>;
   openExternalUrl?: (url: string) => Promise<void>;
   installToolExtension?: (extensionId: string) => Promise<void>;
@@ -83,6 +77,40 @@ export interface DesktopSettingsIpcOptions {
 }
 
 export type DesktopSettingsIpc = DesktopMessageHandler;
+
+async function buildDefaultToolDashboardItems(
+  cachedResults?: ExternalToolCheckResult[],
+): Promise<ToolDashboardItem[]> {
+  const { buildToolDashboardItems } =
+    await import('@settingsView/utils/toolDashboardData');
+  return buildToolDashboardItems(cachedResults);
+}
+
+async function refreshDefaultToolAvailability(): Promise<void> {
+  const { refreshToolAvailability } = await import('@tools/toolAvailability');
+  await refreshToolAvailability();
+}
+
+async function getCachedToolCheckResults(): Promise<
+  ExternalToolCheckResult[] | undefined
+> {
+  const { getLastCheckResults } = await import('@tools/toolAvailability');
+  return getLastCheckResults() ?? undefined;
+}
+
+async function refreshDefaultDisabledToolCache(): Promise<void> {
+  const { refreshDisabledToolCache } = await import('@tools/toolAvailability');
+  refreshDisabledToolCache();
+}
+
+async function findToolCommand(
+  toolId: string,
+  kind: 'install' | 'auth',
+): Promise<string | undefined> {
+  const { findExternalToolDef } = await import('@tools/externalToolDefs');
+  const def = findExternalToolDef(toolId);
+  return kind === 'install' ? def?.installCommand : def?.authCommand;
+}
 
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
@@ -97,10 +125,14 @@ export function createDesktopSettingsIpc(
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
+  const usesDefaultToolDashboardBuilder =
+    options.buildToolDashboardItems == null;
   const buildToolDashboardItems =
     options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
   const refreshToolAvailability =
     options.refreshToolAvailability ?? refreshDefaultToolAvailability;
+  const getCustomAgentDirectory =
+    options.getCustomAgentDirectory ?? (() => getAgentDirectories().custom());
   const latexConfigPersistenceController =
     new LatexConfigPersistenceController();
   const agentCatalogState: SettingsAgentCatalogState = {
@@ -133,7 +165,7 @@ export function createDesktopSettingsIpc(
           customDir || undefined,
         );
       },
-      getCustomDir: () => getAgentDirectories().custom(),
+      getCustomDir: getCustomAgentDirectory,
       getSourceDir: getAgentDirectory,
       getAgent: (source, name) => getAgent(`${source}:${name}`) ?? null,
     },
@@ -234,7 +266,7 @@ export function createDesktopSettingsIpc(
     const directories = getAgentDirectories();
     switch (source) {
       case 'custom':
-        return directories.custom();
+        return getCustomAgentDirectory();
       case 'builtInWorkflow':
         return directories.builtIn();
       case 'builtInToolUse':
@@ -305,9 +337,10 @@ export function createDesktopSettingsIpc(
   async function postToolDashboardData(postOptions?: {
     skipChecks?: boolean;
   }): Promise<void> {
-    const cachedResults = postOptions?.skipChecks
-      ? (getLastCheckResults() ?? undefined)
-      : undefined;
+    const cachedResults =
+      postOptions?.skipChecks && usesDefaultToolDashboardBuilder
+        ? await getCachedToolCheckResults()
+        : undefined;
     const items = await buildToolDashboardItems(cachedResults);
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
@@ -441,7 +474,9 @@ export function createDesktopSettingsIpc(
       disabled.add(toolId);
     }
     await globalState.update(GlobalStateKey.DISABLED_TOOLS, [...disabled]);
-    refreshDisabledToolCache();
+    if (usesDefaultToolDashboardBuilder) {
+      await refreshDefaultDisabledToolCache();
+    }
     await postToolDashboardData({ skipChecks: true });
   }
 
@@ -454,9 +489,7 @@ export function createDesktopSettingsIpc(
     toolId: string;
     kind: 'install' | 'auth';
   }): Promise<void> {
-    const def = findExternalToolDef(input.toolId);
-    const command =
-      input.kind === 'install' ? def?.installCommand : def?.authCommand;
+    const command = await findToolCommand(input.toolId, input.kind);
     if (!command) return;
     await options.runToolCommand?.({ ...input, command });
   }

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -25,21 +25,41 @@ import {
   DEFAULT_MODELS,
   buildBasicModelOptionsData,
 } from '@model/modelOptionsBasic';
+import { buildToolDashboardItems as buildDefaultToolDashboardItems } from '@settingsView/utils/toolDashboardData';
 import type { LatexConfigField } from '@shared/constants/latex';
 import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
   SettingsViewInboundMessageSchema,
   type ReasoningLevel,
+  type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
+import {
+  getLastCheckResults,
+  refreshDisabledToolCache,
+  refreshToolAvailability as refreshDefaultToolAvailability,
+  type ExternalToolCheckResult,
+} from '@tools/toolAvailability';
+import { findExternalToolDef } from '@tools/externalToolDefs';
+import {
+  parseCodexApprovalPolicy,
+  parseCodexReasoningEffort,
+  parseCodexSandboxMode,
+} from '@tools/codexConfig';
+import { BASH_APPROVAL_CONFIG_KEY } from '@tools/approval/bashApproval';
 import {
   applyGitAuthorSettings,
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
+import type { ConfigProvider } from '@platform/interfaces/config';
 import type { StateStore } from '@platform/interfaces/state';
 import type {
   DesktopCommandMessage,
   DesktopMessageHandler,
 } from './desktopIpcTypes.js';
+
+type ToolDashboardBuilder = (
+  cachedResults?: ExternalToolCheckResult[],
+) => Promise<ToolDashboardItem[]>;
 
 export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
@@ -48,7 +68,17 @@ export interface DesktopSettingsIpcOptions {
   loadAgentOptionsData?: typeof computeAgentOptionsData;
   globalState?: StateStore;
   workspaceState?: StateStore;
+  config?: ConfigProvider;
+  buildToolDashboardItems?: ToolDashboardBuilder;
+  refreshToolAvailability?: () => Promise<void>;
   selectCustomAgentDirectory?: () => Promise<string | undefined>;
+  openExternalUrl?: (url: string) => Promise<void>;
+  installToolExtension?: (extensionId: string) => Promise<void>;
+  runToolCommand?: (input: {
+    toolId: string;
+    command: string;
+    kind: 'install' | 'auth';
+  }) => Promise<void>;
   onError?: (error: unknown) => void;
 }
 
@@ -67,6 +97,10 @@ export function createDesktopSettingsIpc(
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
+  const buildToolDashboardItems =
+    options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
+  const refreshToolAvailability =
+    options.refreshToolAvailability ?? refreshDefaultToolAvailability;
   const latexConfigPersistenceController =
     new LatexConfigPersistenceController();
   const agentCatalogState: SettingsAgentCatalogState = {
@@ -150,6 +184,10 @@ export function createDesktopSettingsIpc(
 
   function readCurrentGitAuthorSettings() {
     return readGitAuthorSettingsFromState(workspaceState);
+  }
+
+  function getConfigProvider(): ConfigProvider {
+    return options.config ?? platform().config;
   }
 
   function applyCurrentGitAuthorSettings() {
@@ -264,12 +302,58 @@ export function createDesktopSettingsIpc(
     });
   }
 
+  async function postToolDashboardData(postOptions?: {
+    skipChecks?: boolean;
+  }): Promise<void> {
+    const cachedResults = postOptions?.skipChecks
+      ? (getLastCheckResults() ?? undefined)
+      : undefined;
+    const items = await buildToolDashboardItems(cachedResults);
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items,
+    });
+  }
+
+  function postApprovalSettings(): void {
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
+      bashApprovalEnabled: getConfigProvider().get<boolean>(
+        BASH_APPROVAL_CONFIG_KEY,
+        true,
+      ),
+      codexSandboxMode: parseCodexSandboxMode(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CODEX_SANDBOX_MODE,
+          'workspace-write',
+        ) ?? 'workspace-write',
+      ),
+      codexReasoningEffort: parseCodexReasoningEffort(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CODEX_REASONING_EFFORT,
+          'high',
+        ) ?? 'high',
+      ),
+      codexApprovalPolicy: parseCodexApprovalPolicy(
+        workspaceState.get<string>(
+          WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+          'never',
+        ) ?? 'never',
+      ),
+    });
+  }
+
   async function postInitialSettingsData(): Promise<void> {
     postGitAuthorSettings();
     postLatexConfigValues();
     postProfileData();
     postModelSelectionData();
-    await Promise.all([postAgentSelectionData(), postCustomAgentDir()]);
+    postApprovalSettings();
+    await Promise.all([
+      postAgentSelectionData(),
+      postCustomAgentDir(),
+      postToolDashboardData(),
+    ]);
   }
 
   async function updateGitAuthorSetting(
@@ -323,6 +407,58 @@ export function createDesktopSettingsIpc(
   async function updatePreferShortModelNames(enabled: boolean): Promise<void> {
     await modelSelectionController.setPreferShortModelNames(enabled);
     postModelSelectionData();
+  }
+
+  async function updateCodexSetting(
+    key: WorkspaceStateKey,
+    value: string,
+  ): Promise<void> {
+    await workspaceState.update(key, value);
+    postApprovalSettings();
+  }
+
+  async function updateBashApprovalEnabled(enabled: boolean): Promise<void> {
+    await getConfigProvider().update(
+      BASH_APPROVAL_CONFIG_KEY,
+      enabled,
+      'workspace',
+    );
+    postApprovalSettings();
+  }
+
+  async function setToolEnabled(
+    toolId: string,
+    enabled: boolean,
+  ): Promise<void> {
+    const current = globalState.get<string[]>(
+      GlobalStateKey.DISABLED_TOOLS,
+      [],
+    );
+    const disabled = new Set(current);
+    if (enabled) {
+      disabled.delete(toolId);
+    } else {
+      disabled.add(toolId);
+    }
+    await globalState.update(GlobalStateKey.DISABLED_TOOLS, [...disabled]);
+    refreshDisabledToolCache();
+    await postToolDashboardData({ skipChecks: true });
+  }
+
+  async function recheckToolStatus(): Promise<void> {
+    await refreshToolAvailability();
+    await postToolDashboardData({ skipChecks: true });
+  }
+
+  async function runToolCommand(input: {
+    toolId: string;
+    kind: 'install' | 'auth';
+  }): Promise<void> {
+    const def = findExternalToolDef(input.toolId);
+    const command =
+      input.kind === 'install' ? def?.installCommand : def?.authCommand;
+    if (!command) return;
+    await options.runToolCommand?.({ ...input, command });
   }
 
   async function updateAgentEnabled(input: {
@@ -414,6 +550,64 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_PREFER_SHORT_MODEL_NAMES:
           runAsync(updatePreferShortModelNames(result.data.enabled));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_APPROVAL_SETTINGS:
+          postApprovalSettings();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED:
+          runAsync(updateBashApprovalEnabled(result.data.enabled));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CODEX_SANDBOX_MODE:
+          runAsync(
+            updateCodexSetting(
+              WorkspaceStateKey.CODEX_SANDBOX_MODE,
+              result.data.mode,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CODEX_REASONING_EFFORT:
+          runAsync(
+            updateCodexSetting(
+              WorkspaceStateKey.CODEX_REASONING_EFFORT,
+              result.data.effort,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_CODEX_APPROVAL_POLICY:
+          runAsync(
+            updateCodexSetting(
+              WorkspaceStateKey.CODEX_APPROVAL_POLICY,
+              result.data.policy,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA:
+          runAsync(postToolDashboardData());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.OPEN_TOOL_INSTALL_URL:
+          runAsync(
+            options.openExternalUrl?.(result.data.url) ?? Promise.resolve(),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.INSTALL_TOOL_EXTENSION:
+          runAsync(
+            options.installToolExtension?.(result.data.extensionId) ??
+              Promise.resolve(),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS:
+          runAsync(recheckToolStatus());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL:
+          runAsync(setToolEnabled(result.data.toolId, result.data.enabled));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.RUN_TOOL_COMMAND:
+          runAsync(
+            runToolCommand({
+              toolId: result.data.toolId,
+              kind: result.data.kind,
+            }),
+          );
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_AGENT_ENABLED:
           runAsync(

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -133,6 +133,21 @@ function createWindow(options: { workspacePath: string | undefined }): void {
       });
       return result.canceled ? undefined : result.filePaths[0];
     },
+    openExternalUrl: async (url) => {
+      await shell.openExternal(url);
+    },
+    installToolExtension: async (extensionId) => {
+      await shell.openExternal(
+        `https://marketplace.visualstudio.com/items?itemName=${encodeURIComponent(extensionId)}`,
+      );
+    },
+    runToolCommand: async ({ command }) => {
+      await dialog.showMessageBox(window, {
+        type: 'info',
+        message: 'Run this setup command in a terminal',
+        detail: command,
+      });
+    },
     onError: reportAsyncError,
   });
   const progressIpc = createDesktopProgressIpc({

--- a/packages/extension/src/settingsView/utils/toolDashboardData.ts
+++ b/packages/extension/src/settingsView/utils/toolDashboardData.ts
@@ -1,9 +1,8 @@
 /**
  * Tool dashboard data builder.
  *
- * Enriches tool groups with runtime availability and per-tool descriptions
- * from the registry. External tool definitions (SSOT) live in
- * {@link @tools/externalToolDefs}.
+ * Enriches tool groups with runtime availability. External tool definitions
+ * (SSOT) live in {@link @tools/externalToolDefs}.
  */
 
 // Local imports
@@ -12,10 +11,7 @@ import type {
   ToolInfo,
 } from '@shared/schemas/settingsViewMessages';
 import { findExternalToolDef } from '@tools/externalToolDefs';
-import {
-  getDefaultToolRegistry,
-  type RegisteredToolName,
-} from '@tools/registry';
+import type { RegisteredToolName } from '@tools/registry';
 import {
   runExternalToolChecks,
   type ExternalToolCheckResult,
@@ -26,19 +22,8 @@ import { getDisabledToolIds } from '@utils/config/constants';
 // Tool description enrichment
 // ============================================================
 
-/**
- * Look up per-tool descriptions from the registry.
- * Falls back to name-only when a tool isn't registered.
- */
 function enrichTools(toolNames: readonly string[]): ToolInfo[] {
-  const registry = getDefaultToolRegistry();
-  return toolNames.map((name) => {
-    const tool = registry.get(name);
-    return {
-      name,
-      description: tool?.definition.description,
-    };
-  });
+  return toolNames.map((name) => ({ name }));
 }
 
 // ============================================================

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -44,6 +44,7 @@ interface DesktopSettingsIpcModule {
     }>;
     buildToolDashboardItems?: (cachedResults?: unknown[]) => Promise<unknown[]>;
     refreshToolAvailability?: () => Promise<void>;
+    getCustomAgentDirectory?: () => Promise<string>;
     selectCustomAgentDirectory?: () => Promise<string | undefined>;
     onError?: (error: unknown) => void;
   }): {
@@ -108,7 +109,9 @@ async function loadDesktopSettingsIpc(): Promise<DesktopSettingsIpcModule> {
 }
 
 function flushAsyncWork(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
+  return new Promise((resolve) =>
+    setImmediate(() => setImmediate(() => resolve())),
+  );
 }
 
 describe('desktop settings IPC', () => {
@@ -468,6 +471,7 @@ describe('desktop settings IPC', () => {
       config,
       sendStartupCatalogData: true,
       loadAgents: async () => undefined,
+      getCustomAgentDirectory: async () => '',
       buildToolDashboardItems: async () => [
         {
           id: 'file-ops',

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -20,13 +20,30 @@ interface StateStore {
 interface DesktopSettingsIpcModule {
   createDesktopSettingsIpc(options: {
     postToRenderer(message: unknown): void;
+    sendStartupCatalogData?: boolean;
     globalState?: StateStore;
     workspaceState?: StateStore;
+    config?: {
+      get<T>(key: string, defaultValue?: T): T;
+      update<T>(
+        key: string,
+        value: T,
+        target?: 'global' | 'workspace',
+      ): Promise<void>;
+      inspect<T = unknown>(key: string): { effectiveValue?: T } | undefined;
+      isExplicitlySet(key: string): boolean;
+      watch(
+        key: string | readonly string[] | RegExp,
+        listener: () => void,
+      ): { dispose(): void };
+    };
     loadAgents?: () => Promise<void>;
     loadAgentOptionsData?: () => Promise<{
       workflow: unknown[];
       toolUse: unknown[];
     }>;
+    buildToolDashboardItems?: (cachedResults?: unknown[]) => Promise<unknown[]>;
+    refreshToolAvailability?: () => Promise<void>;
     selectCustomAgentDirectory?: () => Promise<string | undefined>;
     onError?: (error: unknown) => void;
   }): {
@@ -49,6 +66,38 @@ class MemoryStateStore implements StateStore {
     } else {
       this.values.set(key, value);
     }
+  }
+}
+
+class MemoryConfigStore {
+  readonly values = new Map<string, unknown>();
+
+  get<T>(key: string, defaultValue?: T): T {
+    return (this.values.has(key) ? this.values.get(key) : defaultValue) as T;
+  }
+
+  async update<T>(
+    key: string,
+    value: T,
+    _target?: 'global' | 'workspace',
+  ): Promise<void> {
+    if (value === undefined) {
+      this.values.delete(key);
+    } else {
+      this.values.set(key, value);
+    }
+  }
+
+  inspect<T = unknown>(key: string): { effectiveValue?: T } | undefined {
+    return { effectiveValue: this.get<T>(key) };
+  }
+
+  isExplicitlySet(key: string): boolean {
+    return this.values.has(key);
+  }
+
+  watch(): { dispose(): void } {
+    return { dispose: () => undefined };
   }
 }
 
@@ -400,6 +449,142 @@ describe('desktop settings IPC', () => {
       command: SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
       preferShortModelNames: true,
     });
+  });
+
+  it('loads desktop tool dashboard and approval settings on settings readiness', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    workspaceState.values.set(
+      WorkspaceStateKey.CODEX_SANDBOX_MODE,
+      'danger-full-access',
+    );
+    const config = new MemoryConfigStore();
+    config.values.set('texra.toolUse.requireBashApproval', false);
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      globalState: new MemoryStateStore(),
+      config,
+      sendStartupCatalogData: true,
+      loadAgents: async () => undefined,
+      buildToolDashboardItems: async () => [
+        {
+          id: 'file-ops',
+          name: 'File & Shell Operations',
+          category: 'file',
+          description: 'Built-in file tools',
+          tools: [],
+          status: 'available',
+          requiresSetup: false,
+        },
+      ],
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.WEBVIEW_READY,
+        view: 'settings',
+      }),
+    ).toBe(false);
+    await flushAsyncWork();
+
+    expect(
+      posted.find(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
+      ),
+    ).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_APPROVAL_SETTINGS,
+      bashApprovalEnabled: false,
+      codexSandboxMode: 'danger-full-access',
+    });
+    expect(
+      posted.find(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      ),
+    ).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items: [expect.objectContaining({ id: 'file-ops' })],
+    });
+  });
+
+  it('handles desktop tool dashboard refreshes and toggles', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const globalState = new MemoryStateStore();
+    const posted: unknown[] = [];
+    let refreshCount = 0;
+    const buildCalls: unknown[][] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState,
+      config: new MemoryConfigStore(),
+      buildToolDashboardItems: async (cachedResults = []) => {
+        buildCalls.push(cachedResults);
+        return [
+          {
+            id: 'zotero',
+            name: 'Zotero Integration',
+            category: 'academic',
+            description: 'Citation tools',
+            tools: [],
+            status: 'available',
+            requiresSetup: true,
+            toggleable: true,
+            enabled: !(
+              globalState.values.get(GlobalStateKey.DISABLED_TOOLS) as
+                | string[]
+                | undefined
+            )?.includes('zotero'),
+          },
+        ];
+      },
+      refreshToolAvailability: async () => {
+        refreshCount++;
+      },
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_TOOL_DASHBOARD_DATA,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items: [expect.objectContaining({ id: 'zotero', enabled: true })],
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.TOGGLE_TOOL,
+        toolId: 'zotero',
+        enabled: false,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+    expect(globalState.values.get(GlobalStateKey.DISABLED_TOOLS)).toEqual([
+      'zotero',
+    ]);
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
+      items: [expect.objectContaining({ id: 'zotero', enabled: false })],
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.RECHECK_TOOL_STATUS,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+    expect(refreshCount).toBe(1);
+    expect(buildCalls.length).toBeGreaterThanOrEqual(3);
   });
 
   it('refreshes launcher agent options after agent visibility changes', async () => {


### PR DESCRIPTION
## Summary

- implement the desktop Settings IPC contract for Tools dashboard data
- send approval settings and tool dashboard data on desktop settings startup
- handle Tools tab refresh, enable/disable, install URL, extension install, and setup command actions in the desktop host
- add desktop IPC regression tests for startup loading, refresh, and tool toggles

Closes #3541.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `npm run compile:fast`
- `git diff --check`

## Notes

The shared Lit Tools tab was already waiting for `updateToolDashboard`; the Electron host was the missing piece. This PR keeps the frontend contract shared with the VS Code extension instead of adding desktop-specific loading logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Electron settings IPC to read/write tool enablement and approval-related config/state, which affects how tool execution is gated and displayed. Risk is moderate due to new IPC message handling and state/config mutations, though changes are localized to settings flows.
> 
> **Overview**
> Adds **desktop-side support for the shared Settings Tools tab** by extending `desktopSettingsIpc` to build/post tool dashboard items, refresh tool availability, toggle tool enablement (persisted via `GlobalStateKey.DISABLED_TOOLS`), and surface install/auth actions (open URL, install extension, show setup command).
> 
> Also wires **approval settings** into the desktop settings flow: posts initial approval state on settings startup and handles updates for bash approval plus Codex sandbox/reasoning/approval policy settings. Includes Electron host wiring in `main/index.ts`, trims tool description enrichment in `toolDashboardData.ts`, and adds regression tests covering startup loading, refresh, and toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad2189cb4244e95b05e3a066bf27d8fee730ab0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->