### PR TITLE
fix: open desktop workspace folders

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
+import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
@@ -16,7 +17,11 @@ import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
-import { serializeWorkspacePresenceArg } from '../workspacePath.js';
+import {
+  DESKTOP_WORKSPACE_PATH_STATE_KEY,
+  serializeWorkspacePresenceArg,
+  withWorkspacePathArg,
+} from '../workspacePath.js';
 
 const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
@@ -94,13 +99,21 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   };
   const openLogsFolder = async () => openPath(getDesktopLogDirectory());
   const openWorkspaceFolder = async () => {
-    console.warn('Desktop workspace folder switching is disabled.');
-    await dialog.showMessageBox(window, {
-      type: 'info',
-      message: 'Open Folder is not enabled in this desktop build yet.',
-      detail:
-        'Folder switching needs the same workspace lifecycle guarantees as the VS Code extension. For now, launch TeXRA with --texra-workspace <path>, set TEXRA_WORKSPACE_PATH, or use the TeXRA VS Code extension for folder-aware workflows.',
+    const result = await dialog.showOpenDialog(window, {
+      title: 'Open Workspace Folder',
+      properties: ['openDirectory'],
     });
+    const selectedPath = result.canceled ? undefined : result.filePaths[0];
+    if (!selectedPath) return;
+
+    await platform().globalState.update(
+      DESKTOP_WORKSPACE_PATH_STATE_KEY,
+      selectedPath,
+    );
+    app.relaunch({
+      args: withWorkspacePathArg(process.argv.slice(1), selectedPath),
+    });
+    app.exit(0);
   };
   attachRendererConsoleLog(window.webContents);
   const agentExecution = createDesktopAgentExecution({

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -15,6 +15,7 @@ import { ElectronStorageProvider } from './electronStorage.js';
 import { JsonStore } from './jsonStore.js';
 import { repairLaunchPath } from './pathFix.js';
 import { resolveResourcesPath, resolveWorkspacePath } from './paths.js';
+import { DESKTOP_WORKSPACE_PATH_STATE_KEY } from '../../workspacePath.js';
 
 export interface ElectronPlatformInitResult {
   workspacePath: string | undefined;
@@ -24,11 +25,15 @@ export async function initializeElectronPlatform(
   mainDirname: string,
 ): Promise<ElectronPlatformInitResult> {
   const userDataPath = app.getPath('userData');
-  const workspacePath = resolveWorkspacePath();
-  const storage = new ElectronStorageProvider(userDataPath, workspacePath);
   const globalStateStore = await JsonStore.open(
     join(userDataPath, 'state', 'global.json'),
   );
+  const workspacePath = resolveWorkspacePath({
+    storedWorkspacePath: globalStateStore.get<string>(
+      DESKTOP_WORKSPACE_PATH_STATE_KEY,
+    ),
+  });
+  const storage = new ElectronStorageProvider(userDataPath, workspacePath);
   const workspaceStateStore = await JsonStore.open(
     join(storage.getStoragePath(), 'state.json'),
   );

--- a/packages/desktop/src/main/platform/paths.ts
+++ b/packages/desktop/src/main/platform/paths.ts
@@ -10,6 +10,7 @@ export { hasWorkspacePath } from '../../workspacePath.js';
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;
   argv?: readonly string[];
+  storedWorkspacePath?: string;
 }
 
 interface ResourcesPathOptions {

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -1,9 +1,11 @@
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;
   argv?: readonly string[];
+  storedWorkspacePath?: string;
 }
 
 const WORKSPACE_PRESENT_ARG = '--texra-has-workspace=';
+export const DESKTOP_WORKSPACE_PATH_STATE_KEY = 'texra.desktop.workspacePath';
 
 export function getWorkspacePathInput(
   options: WorkspacePathOptions = {},
@@ -16,7 +18,7 @@ export function getWorkspacePathInput(
   const configured = env.TEXRA_WORKSPACE_PATH?.trim();
   if (configured) return configured;
 
-  return undefined;
+  return options.storedWorkspacePath?.trim() || undefined;
 }
 
 export function hasWorkspacePath(options: WorkspacePathOptions = {}): boolean {
@@ -25,6 +27,28 @@ export function hasWorkspacePath(options: WorkspacePathOptions = {}): boolean {
 
 export function serializeWorkspacePresenceArg(hasWorkspace: boolean): string {
   return `${WORKSPACE_PRESENT_ARG}${hasWorkspace ? '1' : '0'}`;
+}
+
+export function withWorkspacePathArg(
+  argv: readonly string[],
+  workspacePath: string,
+): string[] {
+  const nextArgs: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg == null) continue;
+    if (arg === '--texra-workspace') {
+      const value = argv[index + 1];
+      if (value != null && !value.startsWith('--')) {
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('--texra-workspace=')) continue;
+    nextArgs.push(arg);
+  }
+  nextArgs.push('--texra-workspace', workspacePath);
+  return nextArgs;
 }
 
 export function hasResolvedWorkspacePath(

--- a/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
+++ b/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
@@ -7,20 +7,41 @@ import {
   hasResolvedWorkspacePath,
   hasWorkspacePath,
   serializeWorkspacePresenceArg,
+  withWorkspacePathArg,
 } from '../../../packages/desktop/src/workspacePath';
 
 describe('desktop workspace path', () => {
-  it('resolves CLI workspace path before env and stored state', () => {
+  it('resolves CLI workspace path before env and stored workspace', () => {
     assert.equal(
       resolveWorkspacePath({
         argv: ['--texra-workspace', 'cli-workspace'],
         env: { TEXRA_WORKSPACE_PATH: 'env-workspace' },
+        storedWorkspacePath: 'stored-workspace',
       }),
       resolve('cli-workspace'),
     );
   });
 
-  it('does not persist or restore selected workspace folders yet', () => {
+  it('resolves env workspace before stored workspace', () => {
+    assert.equal(
+      resolveWorkspacePath({
+        argv: [],
+        env: { TEXRA_WORKSPACE_PATH: 'env-workspace' },
+        storedWorkspacePath: 'stored-workspace',
+      }),
+      resolve('env-workspace'),
+    );
+  });
+
+  it('restores the last desktop-opened workspace when CLI and env are absent', () => {
+    assert.equal(
+      resolveWorkspacePath({
+        argv: [],
+        env: {},
+        storedWorkspacePath: 'stored-workspace',
+      }),
+      resolve('stored-workspace'),
+    );
     assert.equal(
       resolveWorkspacePath({
         argv: [],
@@ -75,6 +96,29 @@ describe('desktop workspace path', () => {
         ],
       }),
       false,
+    );
+  });
+
+  it('replaces existing workspace CLI args when relaunching into a selected folder', () => {
+    assert.deepEqual(
+      withWorkspacePathArg(
+        [
+          '/Applications/TeXRA.app',
+          '--inspect',
+          '--texra-workspace',
+          'old-workspace',
+          '--flag',
+          '--texra-workspace=/tmp/other-workspace',
+        ],
+        '/Users/ray/paper',
+      ),
+      [
+        '/Applications/TeXRA.app',
+        '--inspect',
+        '--flag',
+        '--texra-workspace',
+        '/Users/ray/paper',
+      ],
     );
   });
 });


### PR DESCRIPTION
## Summary

- make the desktop Open Folder action select a workspace directory instead of showing the disabled placeholder message
- persist the selected folder as the desktop workspace and relaunch into it with `--texra-workspace`
- resolve future desktop launches from CLI, env, then the stored workspace folder
- add workspace-path tests for stored workspace fallback and relaunch arg replacement

Closes #3540.

## Verification

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/desktopWorkspacePath.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `npm run compile:fast`
- `git diff --check`

## Notes

The selected folder becomes the desktop workspace. The app relaunches instead of hot-swapping the platform singleton, so workspace state, storage, file discovery, and agent execution are initialized cleanly for the opened folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop workspace selection and initialization by persisting a user-chosen path and relaunching with updated CLI args; bugs here could lead to launching into the wrong workspace or confusing state resets.
> 
> **Overview**
> Enables **Desktop "Open Folder"** to actually pick a directory, persist it in global state, and **relaunch** the app into that workspace using `--texra-workspace`.
> 
> Updates workspace-path resolution to fall back to the last stored desktop workspace when CLI/env are absent, and adds `withWorkspacePathArg` plus tests to ensure relaunch args replace any existing workspace flags and that resolution precedence is *CLI → env → stored*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ea6cd8426649557c858db8c5397d6611756ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->