### PR TITLE
fix: warn on Linux basic_text secret storage

### DIFF
--- a/packages/desktop/src/main/platform/electronSecrets.ts
+++ b/packages/desktop/src/main/platform/electronSecrets.ts
@@ -4,6 +4,17 @@ import { JsonStore } from './jsonStore.js';
 import type { PlatformSecrets } from '@platform/secrets';
 
 type StoredSecret = { encrypted: true; value: string };
+type SecretStorageMode = 'encrypted' | 'basic_text' | 'unavailable';
+
+interface ElectronSecretsOptions {
+  showWarningMessage?: (message: string) => Promise<void> | void;
+}
+
+export const LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE =
+  'TeXRA cannot store secrets securely because Electron is using Linux basic_text storage. Set up a system keyring such as GNOME Keyring/libsecret or KWallet, then restart TeXRA. Environment variables still work for API keys.';
+
+const SAFE_STORAGE_UNAVAILABLE_MESSAGE =
+  'Electron safeStorage is unavailable for secret writes.';
 
 function isStoredSecret(value: unknown): value is StoredSecret {
   return (
@@ -15,7 +26,12 @@ function isStoredSecret(value: unknown): value is StoredSecret {
 }
 
 export class ElectronSecrets implements PlatformSecrets {
-  constructor(private readonly store: JsonStore) {}
+  private warnedAboutBasicText = false;
+
+  constructor(
+    private readonly store: JsonStore,
+    private readonly options: ElectronSecretsOptions = {},
+  ) {}
 
   /** Environment variables override persisted Electron secrets. */
   async get(key: string): Promise<string | undefined> {
@@ -28,25 +44,55 @@ export class ElectronSecrets implements PlatformSecrets {
   }
 
   async set(key: string, value: string): Promise<void> {
-    if (!isSafeStorageUsable()) {
-      throw new Error('Electron safeStorage is unavailable for secret writes.');
+    const storageMode = getSecretStorageMode();
+    switch (storageMode) {
+      case 'encrypted': {
+        const stored: StoredSecret = {
+          encrypted: true,
+          value: safeStorage.encryptString(value).toString('base64'),
+        };
+        await this.store.set(key, stored);
+        return;
+      }
+      case 'unavailable':
+        throw new Error(SAFE_STORAGE_UNAVAILABLE_MESSAGE);
+      case 'basic_text':
+        await this.warnAboutBasicTextStorage();
+        throw new Error(LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE);
+      default:
+        assertNever(storageMode);
     }
-    const stored: StoredSecret = {
-      encrypted: true,
-      value: safeStorage.encryptString(value).toString('base64'),
-    };
-    await this.store.set(key, stored);
   }
 
   async delete(key: string): Promise<void> {
     await this.store.set(key, undefined);
   }
+
+  private async warnAboutBasicTextStorage(): Promise<void> {
+    if (this.warnedAboutBasicText) return;
+    this.warnedAboutBasicText = true;
+    try {
+      await this.options.showWarningMessage?.(
+        LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
+      );
+    } catch {
+      // Secret writes must still reject with the storage-policy error even if
+      // the warning dialog itself fails.
+    }
+  }
 }
 
-function isSafeStorageUsable(): boolean {
-  if (!safeStorage.isEncryptionAvailable()) return false;
-  return (
-    process.platform !== 'linux' ||
-    safeStorage.getSelectedStorageBackend() !== 'basic_text'
-  );
+export function getSecretStorageMode(): SecretStorageMode {
+  if (!safeStorage.isEncryptionAvailable()) return 'unavailable';
+  if (
+    process.platform === 'linux' &&
+    safeStorage.getSelectedStorageBackend() === 'basic_text'
+  ) {
+    return 'basic_text';
+  }
+  return 'encrypted';
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled Electron secret storage mode: ${value}`);
 }

--- a/packages/desktop/src/main/platform/index.ts
+++ b/packages/desktop/src/main/platform/index.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { app } from 'electron';
+import { app, dialog } from 'electron';
 
 import { consoleLog } from '@platform/defaults/consoleLog';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -54,7 +54,11 @@ export async function initializeElectronPlatform(
     fs: nodeFilesystem,
     workspace: createNodeWorkspace(() => workspacePath),
     storage,
-    secrets: new ElectronSecrets(secretsStore),
+    secrets: new ElectronSecrets(secretsStore, {
+      showWarningMessage: async (message) => {
+        await dialog.showMessageBox({ message, type: 'warning' });
+      },
+    }),
   });
 
   await bootstrapElectronAgentDirectories(

--- a/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
+++ b/src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts
@@ -57,7 +57,14 @@ interface ElectronSecrets {
 }
 
 interface ElectronSecretsModule {
-  ElectronSecrets: new (store: JsonStore) => ElectronSecrets;
+  getSecretStorageMode: () => 'encrypted' | 'basic_text' | 'unavailable';
+  LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE: string;
+  ElectronSecrets: new (
+    store: JsonStore,
+    options?: {
+      showWarningMessage?: (message: string) => Promise<void> | void;
+    },
+  ) => ElectronSecrets;
 }
 
 async function loadJsonStore(): Promise<JsonStoreModule['JsonStore']> {
@@ -164,14 +171,16 @@ describe('desktop platform adapters', () => {
   });
 
   it('stores encrypted secrets, supports env overrides, and deletes persisted values', async () => {
-    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
-      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
-      loadJsonStore(),
-    ]);
+    const [{ ElectronSecrets, getSecretStorageMode }, JsonStore] =
+      await Promise.all([
+        loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+        loadJsonStore(),
+      ]);
     const root = await makeTempDir('texra-electron-secrets-');
     const store = await JsonStore.open(join(root, 'secrets.json'));
     const secrets = new ElectronSecrets(store);
 
+    expect(getSecretStorageMode()).toBe('encrypted');
     await secrets.set(testSecretKey, 'persisted');
 
     expect(await secrets.get(testSecretKey)).toBe('persisted');
@@ -191,36 +200,79 @@ describe('desktop platform adapters', () => {
   });
 
   it('rejects secret writes when Electron safe storage is unavailable', async () => {
-    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
-      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
-      loadJsonStore(),
-    ]);
+    const [{ ElectronSecrets, getSecretStorageMode }, JsonStore] =
+      await Promise.all([
+        loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+        loadJsonStore(),
+      ]);
     const root = await makeTempDir('texra-electron-secrets-');
     const store = await JsonStore.open(join(root, 'secrets.json'));
     const secrets = new ElectronSecrets(store);
 
     configureElectronTestStub({ safeStorageEncryptionAvailable: false });
 
+    expect(getSecretStorageMode()).toBe('unavailable');
     await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
       'Electron safeStorage is unavailable for secret writes.',
     );
     expect(store.snapshot()).toEqual({});
   });
 
-  it('rejects secret writes on the Linux basic_text safe storage backend', async () => {
-    const [{ ElectronSecrets }, JsonStore] = await Promise.all([
+  it('warns once and rejects secret writes on the Linux basic_text safe storage backend', async () => {
+    const [
+      {
+        ElectronSecrets,
+        LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
+        getSecretStorageMode,
+      },
+      JsonStore,
+    ] = await Promise.all([
       loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
       loadJsonStore(),
     ]);
     const root = await makeTempDir('texra-electron-secrets-');
     const store = await JsonStore.open(join(root, 'secrets.json'));
-    const secrets = new ElectronSecrets(store);
+    const showWarningMessage = vi.fn();
+    const secrets = new ElectronSecrets(store, { showWarningMessage });
+
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    configureElectronTestStub({ safeStorageBackend: 'basic_text' });
+
+    expect(getSecretStorageMode()).toBe('basic_text');
+    await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
+      LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
+    );
+    await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
+      LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
+    );
+    expect(showWarningMessage).toHaveBeenCalledTimes(1);
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
+    );
+    expect(store.snapshot()).toEqual({});
+  });
+
+  it('preserves the storage-policy error when the basic_text warning fails', async () => {
+    const [
+      { ElectronSecrets, LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE },
+      JsonStore,
+    ] = await Promise.all([
+      loadDesktopPlatformModule<ElectronSecretsModule>('electronSecrets.ts'),
+      loadJsonStore(),
+    ]);
+    const root = await makeTempDir('texra-electron-secrets-');
+    const store = await JsonStore.open(join(root, 'secrets.json'));
+    const secrets = new ElectronSecrets(store, {
+      showWarningMessage: vi.fn(async () => {
+        throw new Error('dialog failed');
+      }),
+    });
 
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     configureElectronTestStub({ safeStorageBackend: 'basic_text' });
 
     await expect(secrets.set(testSecretKey, 'persisted')).rejects.toThrow(
-      'Electron safeStorage is unavailable for secret writes.',
+      LINUX_BASIC_TEXT_SECRET_STORAGE_MESSAGE,
     );
     expect(store.snapshot()).toEqual({});
   });


### PR DESCRIPTION
## Summary

- classify Electron secret storage as encrypted, unavailable, or Linux `basic_text`
- keep insecure `basic_text` writes blocked, but surface a one-time desktop warning that explains the system keyring fix and environment-variable fallback
- cover encrypted, unavailable, and Linux `basic_text` behavior in the desktop platform adapter tests

Closes #3550.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/ElectronPlatformAdapters.vitest.mts`
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop secret-storage behavior and Electron initialization; while it mainly adds clearer classification and user warning, it affects how secret writes fail on Linux and could impact users’ ability to persist API keys if misdetected.
> 
> **Overview**
> **Improves Electron secret-storage handling by explicitly classifying storage mode** via `getSecretStorageMode()` (`encrypted`, `unavailable`, `basic_text`) and branching `ElectronSecrets.set()` behavior accordingly.
> 
> On Linux when Electron falls back to the insecure `basic_text` backend, secret writes remain blocked but now trigger a **one-time warning** (plumbed from `initializeElectronPlatform` using `dialog.showMessageBox`) with guidance on setting up a system keyring and using env var fallbacks.
> 
> Desktop adapter tests were updated to cover the new mode classification, the one-time warning behavior (including when the warning dialog fails), and to assert the specific error messages per mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b13d6dd0a6c060a9842b7bdfd741dc4c02438d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->