### PR TITLE
feat: wire desktop progress action IPC

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -4,8 +4,19 @@ import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
+import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
+import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
+import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
 import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { StreamStatusService } from '@agent/runtime/StreamStatusService';
+import {
+  detachActiveChildren,
+  interruptActiveChildren,
+} from '@agent/runtime/executionRegistry';
 import { setRunStorageService } from '@agent/runtime/RunStorageService';
+import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
+import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
@@ -16,6 +27,7 @@ import {
   type AgentCategory,
   type AgentCategoryFilter,
   type ConversationProgress,
+  type ProgressViewInboundMessage,
   type ProgressViewOutboundMessage,
   type StreamMetadata,
   type StreamStatus,
@@ -23,6 +35,12 @@ import {
   type StreamTabInfo,
 } from '@shared/schemas';
 import { AGENT_CATEGORY } from '@shared/schemas/agent';
+import {
+  cleanupAllApprovals,
+  cleanupApprovalsForStream,
+  handleProgressViewBashApprovalAction,
+} from '@tools/approval';
+import { toolEditApprovalController } from '@tools/approval/toolEditApproval';
 
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 
@@ -47,6 +65,12 @@ type StreamBadgeSnapshot = {
   finishedProcessCount: number;
 };
 
+export interface DesktopProgressBridgeOptions {
+  detachSubagentsOnStop?: boolean;
+  openPath?: (filePath: string) => Promise<void>;
+  showMessage?: (message: string, type?: 'info' | 'warning') => Promise<void>;
+}
+
 export class DesktopProgressBridge {
   private readonly streamLogs = new StreamLogStore();
   private readonly cursors = new Map<StreamTabId, number>();
@@ -68,7 +92,10 @@ export class DesktopProgressBridge {
 
   readonly runtimeHost: AgentRuntimeHost;
 
-  constructor(private readonly postToRenderer: (message: unknown) => void) {
+  constructor(
+    private readonly postToRenderer: (message: unknown) => void,
+    private readonly options: DesktopProgressBridgeOptions = {},
+  ) {
     AgentLogger.setStreamLogStore(this.streamLogs);
     setRunStorageService({ isViewVisible: () => true });
     this.unsubscribe = this.streamLogs.onChange((streamId) =>
@@ -426,6 +453,122 @@ export class DesktopProgressBridge {
         });
         break;
       }
+      case 'showToolEditPermission': {
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'show',
+          permission: {
+            kind: 'toolEdit',
+            data: payload as ProgressEventPayloads['showToolEditPermission'],
+          },
+        });
+        break;
+      }
+      case 'resolveToolEditPermission': {
+        const data =
+          payload as ProgressEventPayloads['resolveToolEditPermission'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'resolve',
+          kind: 'toolEdit',
+          id: data.requestId,
+        });
+        break;
+      }
+      case 'updateToolEditApprovalBypassState': {
+        const data =
+          payload as ProgressEventPayloads['updateToolEditApprovalBypassState'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
+          stream: data.streamId,
+          type: 'toolEdit',
+          bypassActive: data.bypassActive,
+        });
+        break;
+      }
+      case 'showBashPermission': {
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'show',
+          permission: {
+            kind: 'bash',
+            data: payload as ProgressEventPayloads['showBashPermission'],
+          },
+        });
+        break;
+      }
+      case 'resolveBashPermission': {
+        const data = payload as ProgressEventPayloads['resolveBashPermission'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'resolve',
+          kind: 'bash',
+          id: data.requestId,
+        });
+        break;
+      }
+      case 'showAgentProposal': {
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'show',
+          permission: {
+            kind: 'proposal',
+            data: payload as ProgressEventPayloads['showAgentProposal'],
+          },
+        });
+        break;
+      }
+      case 'resolveAgentProposal': {
+        const data = payload as ProgressEventPayloads['resolveAgentProposal'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'resolve',
+          kind: 'proposal',
+          id: data.proposalId,
+        });
+        break;
+      }
+      case 'showPlanApproval': {
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'show',
+          permission: {
+            kind: 'planApproval',
+            data: payload as ProgressEventPayloads['showPlanApproval'],
+          },
+        });
+        break;
+      }
+      case 'resolvePlanApproval': {
+        const data = payload as ProgressEventPayloads['resolvePlanApproval'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
+          action: 'resolve',
+          kind: 'planApproval',
+          id: data.approvalId,
+        });
+        break;
+      }
+      case 'updateSuperYoloBypassState': {
+        const data =
+          payload as ProgressEventPayloads['updateSuperYoloBypassState'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_BYPASS,
+          stream: data.streamId,
+          type: 'superYolo',
+          bypassActive: data.bypassActive,
+        });
+        break;
+      }
+      case 'updateQueuedFollowUps': {
+        const data = payload as ProgressEventPayloads['updateQueuedFollowUps'];
+        this.send({
+          command: PROGRESS_VIEW_COMMANDS.UPDATE_QUEUED_FOLLOW_UPS,
+          stream: data.streamId,
+          messages: ToolUseFollowUpQueue.getAll(data.streamId),
+        });
+        break;
+      }
     }
   }
 
@@ -456,6 +599,10 @@ export class DesktopProgressBridge {
     const hadStream =
       this.streamLogs.has(streamId) || this.taskStates.has(streamId);
     if (!hadStream) return;
+
+    cleanupApprovalsForStream(streamId);
+    retryCoordinator.clearRequest(streamId);
+    ToolUseFollowUpQueue.release(streamId);
 
     await this.streamLogs.delete(streamId);
     this.taskStates.delete(streamId);
@@ -488,6 +635,12 @@ export class DesktopProgressBridge {
   }
 
   async deleteAllStreams(): Promise<void> {
+    cleanupAllApprovals();
+    for (const streamId of this.streamLogs.keys()) {
+      retryCoordinator.clearRequest(streamId);
+      ToolUseFollowUpQueue.release(streamId);
+    }
+
     await this.streamLogs.clear();
     this.cursors.clear();
     this.taskStates.clear();
@@ -503,12 +656,146 @@ export class DesktopProgressBridge {
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
     this.syncStreams();
   }
+
+  stopStream(streamId: StreamTabId): void {
+    retryCoordinator.clearRequest(streamId);
+    if (this.options.detachSubagentsOnStop === true) {
+      detachActiveChildren(streamId);
+    } else {
+      interruptActiveChildren(streamId);
+    }
+    getInterruptible(streamId)?.interrupt();
+    StreamStatusService.set(streamId, STREAM_STATUS.STOPPED, {
+      runtimeHost: this.runtimeHost,
+    });
+  }
+
+  async resumeStream(streamId: StreamTabId): Promise<void> {
+    const taskState = this.taskStates.get(streamId);
+    if (!taskState) return;
+
+    const executionId = this.executionIds.get(streamId);
+    await this.runExecution({
+      config: taskState.agentConfig,
+      ...(executionId && { executionId }),
+    });
+  }
+
+  async runNewStream(streamId: StreamTabId): Promise<void> {
+    const taskState = this.taskStates.get(streamId);
+    if (!taskState) return;
+
+    await this.runExecution({ config: taskState.agentConfig });
+  }
+
+  async sendFollowUp(streamId: StreamTabId, text: string): Promise<void> {
+    const result = await sendFollowUp(streamId, text);
+    if (result.status === 'sent' || result.status === 'queued') {
+      this.runtimeHost.emit('updateQueuedFollowUps', { streamId });
+      return;
+    }
+
+    await this.options.showMessage?.(
+      'No active session. Start a new agent task to continue.',
+      'warning',
+    );
+  }
+
+  async openFile(filePath: string): Promise<void> {
+    await this.options.openPath?.(filePath);
+  }
+
+  async handleBashApprovalAction(
+    message: Extract<
+      ProgressViewInboundMessage,
+      { command: typeof PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION }
+    >,
+  ): Promise<void> {
+    await handleProgressViewBashApprovalAction(message);
+  }
+
+  handleToolEditApprovalAction(
+    message: Extract<
+      ProgressViewInboundMessage,
+      { command: typeof PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION }
+    >,
+  ): boolean {
+    if (message.action !== 'approve' && message.action !== 'reject') {
+      return false;
+    }
+
+    const entry = toolEditApprovalController.getPending(message.requestId);
+    if (!entry || entry.isSettled()) return true;
+    entry.settle({
+      accepted: message.action === 'approve',
+      userMessage:
+        message.action === 'reject' ? message.feedback?.trim() : undefined,
+    });
+    return true;
+  }
+
+  handlePlanApprovalAction(
+    message: Extract<
+      ProgressViewInboundMessage,
+      { command: typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION }
+    >,
+  ): void {
+    planApprovalCoordinator.resolveRequest(message.approvalId, {
+      action: message.action,
+      ...(message.action === 'reject' && { feedback: message.feedback }),
+    });
+  }
+
+  handleAgentProposalAction(
+    message: Extract<
+      ProgressViewInboundMessage,
+      { command: typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION }
+    >,
+  ): boolean {
+    if (message.action === 'setup') return false;
+
+    proposalCoordinator.resolveRequest(message.proposalId, {
+      action: message.action,
+      ...(message.action === 'approve' && {
+        model: message.model,
+        agent: message.agent,
+      }),
+      ...(message.action === 'reject' && { feedback: message.feedback }),
+    });
+    return true;
+  }
+
+  private async runExecution(request: {
+    config: TaskState['agentConfig'];
+    executionId?: string;
+  }): Promise<void> {
+    const { runValidatedExecutionRequest } =
+      await import('@agent/runtime/runExecutionRequest');
+    await runValidatedExecutionRequest(request, {
+      runtimeHost: this.runtimeHost,
+      openWorkflowOutput: async (result) => {
+        const output = result.outputs.at(-1);
+        if (output) {
+          await this.options.openPath?.(output.absolutePath);
+        }
+      },
+    });
+  }
 }
 
 export function createDesktopAgentExecution(
   options: DesktopAgentExecutionOptions,
 ): DesktopAgentExecution {
-  const progress = new DesktopProgressBridge(options.postToRenderer);
+  const progress = new DesktopProgressBridge(options.postToRenderer, {
+    openPath: options.openPath,
+    showMessage: async (message, type = 'info') => {
+      if (type === 'warning') {
+        await options.showErrorMessage?.(message);
+      } else {
+        await options.showErrorMessage?.(message);
+      }
+    },
+  });
 
   return {
     progress,

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -4,6 +4,7 @@ import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
+import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
@@ -68,7 +69,7 @@ type StreamBadgeSnapshot = {
 export interface DesktopProgressBridgeOptions {
   detachSubagentsOnStop?: boolean;
   openPath?: (filePath: string) => Promise<void>;
-  showMessage?: (message: string, type?: 'info' | 'warning') => Promise<void>;
+  showMessage?: (message: string) => Promise<void>;
 }
 
 export class DesktopProgressBridge {
@@ -569,6 +570,32 @@ export class DesktopProgressBridge {
         });
         break;
       }
+      case 'clearMissingOutputs':
+      case 'showRetryRequest':
+      case 'resolveRetryRequest':
+      case 'showExternalInquiry':
+      case 'resolveExternalInquiry':
+      case 'followUpSent':
+      case 'removeStream':
+      case 'extensionDeactivating':
+      case 'githubTokenInvalid':
+      case 'prSubscriptionsChanged':
+      case 'prSubscriptionBindingsChanged':
+      case 'repoSubscriptionsChanged':
+      case 'repoSubscriptionBindingsChanged':
+      case 'issueSubscriptionsChanged':
+      case 'issueSubscriptionBindingsChanged':
+      case 'toolAvailabilityChanged':
+      case 'workspaceFilesWritten':
+      case 'requestOpenFile':
+      case 'requestShowInstruction':
+      case 'showAgentConfigBanner':
+      case 'requestShowError':
+        break;
+      default: {
+        const exhaustive: never = event;
+        return exhaustive;
+      }
     }
   }
 
@@ -697,12 +724,15 @@ export class DesktopProgressBridge {
 
     await this.options.showMessage?.(
       'No active session. Start a new agent task to continue.',
-      'warning',
     );
   }
 
   async openFile(filePath: string): Promise<void> {
     await this.options.openPath?.(filePath);
+  }
+
+  async openFileCompile(filePath: string): Promise<void> {
+    await this.openFile(filePath);
   }
 
   async handleBashApprovalAction(
@@ -765,10 +795,7 @@ export class DesktopProgressBridge {
     return true;
   }
 
-  private async runExecution(request: {
-    config: TaskState['agentConfig'];
-    executionId?: string;
-  }): Promise<void> {
+  async runExecution(request: ValidatedExecutionRequest): Promise<void> {
     const { runValidatedExecutionRequest } =
       await import('@agent/runtime/runExecutionRequest');
     await runValidatedExecutionRequest(request, {
@@ -788,13 +815,7 @@ export function createDesktopAgentExecution(
 ): DesktopAgentExecution {
   const progress = new DesktopProgressBridge(options.postToRenderer, {
     openPath: options.openPath,
-    showMessage: async (message, type = 'info') => {
-      if (type === 'warning') {
-        await options.showErrorMessage?.(message);
-      } else {
-        await options.showErrorMessage?.(message);
-      }
-    },
+    showMessage: async (message) => options.showErrorMessage?.(message),
   });
 
   return {
@@ -806,17 +827,7 @@ export function createDesktopAgentExecution(
         return;
       }
 
-      const { runValidatedExecutionRequest } =
-        await import('@agent/runtime/runExecutionRequest');
-      await runValidatedExecutionRequest(preparation.request, {
-        runtimeHost: progress.runtimeHost,
-        openWorkflowOutput: async (result) => {
-          const output = result.outputs.at(-1);
-          if (output && options.openPath) {
-            await options.openPath(output.absolutePath);
-          }
-        },
-      });
+      await progress.runExecution(preparation.request);
     },
     dispose() {
       progress.dispose();

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -96,7 +96,7 @@ export function createDesktopProgressIpc(
           runAsync(options.progress.openFile(result.data.file));
           return true;
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE:
-          runAsync(options.progress.openFile(result.data.file));
+          runAsync(options.progress.openFileCompile(result.data.file));
           return true;
         default:
           if (passThroughCommands.has(result.data.command)) return false;

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -60,6 +60,44 @@ export function createDesktopProgressIpc(
         case PROGRESS_VIEW_COMMANDS.DELETE_ALL:
           runAsync(options.progress.deleteAllStreams());
           return true;
+        case PROGRESS_VIEW_COMMANDS.STOP_STREAM:
+          options.progress.stopStream(result.data.stream);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.RESUME:
+          runAsync(options.progress.resumeStream(result.data.stream));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.RUN_NEW:
+          runAsync(options.progress.runNewStream(result.data.stream));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP:
+          runAsync(
+            options.progress.sendFollowUp(result.data.stream, result.data.text),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION:
+          if (options.progress.handleToolEditApprovalAction(result.data)) {
+            return true;
+          }
+          onUnsupportedCommand(result.data);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION:
+          runAsync(options.progress.handleBashApprovalAction(result.data));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION:
+          options.progress.handlePlanApprovalAction(result.data);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION:
+          if (options.progress.handleAgentProposalAction(result.data)) {
+            return true;
+          }
+          onUnsupportedCommand(result.data);
+          return true;
+        case PROGRESS_VIEW_COMMANDS.OPEN_FILE:
+          runAsync(options.progress.openFile(result.data.file));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE:
+          runAsync(options.progress.openFile(result.data.file));
+          return true;
         default:
           if (passThroughCommands.has(result.data.command)) return false;
           onUnsupportedCommand(result.data);

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -98,6 +98,14 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
   vi.doMock('@logger/AgentLogger', () => ({
     AgentLogger: class {
       static setStreamLogStore(): void {}
+
+      debug(): void {}
+
+      info(): void {}
+
+      warn(): void {}
+
+      error(): void {}
     },
   }));
   vi.doMock('vscode', () => ({
@@ -213,6 +221,14 @@ async function createExecution(options: {
   vi.doMock('@logger/AgentLogger', () => ({
     AgentLogger: class {
       static setStreamLogStore(): void {}
+
+      debug(): void {}
+
+      info(): void {}
+
+      warn(): void {}
+
+      error(): void {}
     },
   }));
   const { createDesktopAgentExecution } = (await import(

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -15,6 +15,37 @@ interface DesktopProgressIpcModule {
       setAgentFilter(filter: string): void;
       deleteStream(stream: string): Promise<void>;
       deleteAllStreams(): Promise<void>;
+      stopStream(stream: string): void;
+      resumeStream(stream: string): Promise<void>;
+      runNewStream(stream: string): Promise<void>;
+      sendFollowUp(stream: string, text: string): Promise<void>;
+      openFile(file: string): Promise<void>;
+      handleToolEditApprovalAction(message: {
+        command: string;
+        requestId: string;
+        action: string;
+        feedback?: string;
+      }): boolean;
+      handleBashApprovalAction(message: {
+        command: string;
+        requestId: string;
+        action: string;
+        feedback?: string;
+      }): Promise<void>;
+      handlePlanApprovalAction(message: {
+        command: string;
+        approvalId: string;
+        action: string;
+        feedback?: string;
+      }): void;
+      handleAgentProposalAction(message: {
+        command: string;
+        proposalId: string;
+        action: string;
+        feedback?: string;
+        model?: string;
+        agent?: string;
+      }): boolean;
     };
     onUnsupportedCommand?: (message: { command: string }) => void;
     onAsyncError?: (error: unknown) => void;
@@ -39,6 +70,15 @@ function createProgress() {
     setAgentFilter: vi.fn(),
     deleteStream: vi.fn(async (_stream: string) => {}),
     deleteAllStreams: vi.fn(async () => {}),
+    stopStream: vi.fn(),
+    resumeStream: vi.fn(async (_stream: string) => {}),
+    runNewStream: vi.fn(async (_stream: string) => {}),
+    sendFollowUp: vi.fn(async (_stream: string, _text: string) => {}),
+    openFile: vi.fn(async (_file: string) => {}),
+    handleToolEditApprovalAction: vi.fn(() => true),
+    handleBashApprovalAction: vi.fn(async () => {}),
+    handlePlanApprovalAction: vi.fn(),
+    handleAgentProposalAction: vi.fn(() => true),
   };
 }
 
@@ -106,10 +146,8 @@ describe('desktop Progress IPC', () => {
         stream: 'run-1',
       }),
     ).toBe(true);
-    expect(onUnsupportedCommand).toHaveBeenCalledWith({
-      command: PROGRESS_VIEW_COMMANDS.STOP_STREAM,
-      stream: 'run-1',
-    });
+    expect(progress.stopStream).toHaveBeenCalledWith('run-1');
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
 
     expect(
       ipc.handleMessage({
@@ -117,6 +155,120 @@ describe('desktop Progress IPC', () => {
         view: 'progress',
       }),
     ).toBe(false);
-    expect(onUnsupportedCommand).toHaveBeenCalledTimes(1);
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
+  });
+
+  it('maps high-use Progress action commands to the desktop bridge', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.RESUME,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.RUN_NEW,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.SEND_FOLLOW_UP,
+        stream: 'run-1',
+        text: 'continue please',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: '/tmp/out.tex',
+        line: 4,
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
+        file: '/tmp/out.pdf',
+      }),
+    ).toBe(true);
+
+    await Promise.resolve();
+    expect(progress.resumeStream).toHaveBeenCalledWith('run-1');
+    expect(progress.runNewStream).toHaveBeenCalledWith('run-1');
+    expect(progress.sendFollowUp).toHaveBeenCalledWith(
+      'run-1',
+      'continue please',
+    );
+    expect(progress.openFile).toHaveBeenNthCalledWith(1, '/tmp/out.tex');
+    expect(progress.openFile).toHaveBeenNthCalledWith(2, '/tmp/out.pdf');
+  });
+
+  it('maps approval actions and reports desktop-only unsupported approval variants', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress,
+      onUnsupportedCommand,
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+        requestId: 'bash-1',
+        action: 'approve',
+      }),
+    ).toBe(true);
+    expect(progress.handleBashApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION,
+      requestId: 'bash-1',
+      action: 'approve',
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+        approvalId: 'plan-1',
+        action: 'reject',
+        feedback: 'needs work',
+      }),
+    ).toBe(true);
+    expect(progress.handlePlanApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION,
+      approvalId: 'plan-1',
+      action: 'reject',
+      feedback: 'needs work',
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+        requestId: 'edit-1',
+        action: 'approve',
+      }),
+    ).toBe(true);
+    expect(progress.handleToolEditApprovalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId: 'edit-1',
+      action: 'approve',
+    });
+
+    progress.handleToolEditApprovalAction.mockReturnValueOnce(false);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+        requestId: 'edit-2',
+        action: 'openDiff',
+      }),
+    ).toBe(true);
+    expect(onUnsupportedCommand).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.TOOL_EDIT_APPROVAL_ACTION,
+      requestId: 'edit-2',
+      action: 'openDiff',
+    });
   });
 });

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -20,6 +20,7 @@ interface DesktopProgressIpcModule {
       runNewStream(stream: string): Promise<void>;
       sendFollowUp(stream: string, text: string): Promise<void>;
       openFile(file: string): Promise<void>;
+      openFileCompile(file: string): Promise<void>;
       handleToolEditApprovalAction(message: {
         command: string;
         requestId: string;
@@ -75,6 +76,7 @@ function createProgress() {
     runNewStream: vi.fn(async (_stream: string) => {}),
     sendFollowUp: vi.fn(async (_stream: string, _text: string) => {}),
     openFile: vi.fn(async (_file: string) => {}),
+    openFileCompile: vi.fn(async (_file: string) => {}),
     handleToolEditApprovalAction: vi.fn(() => true),
     handleBashApprovalAction: vi.fn(async () => {}),
     handlePlanApprovalAction: vi.fn(),
@@ -203,8 +205,8 @@ describe('desktop Progress IPC', () => {
       'run-1',
       'continue please',
     );
-    expect(progress.openFile).toHaveBeenNthCalledWith(1, '/tmp/out.tex');
-    expect(progress.openFile).toHaveBeenNthCalledWith(2, '/tmp/out.pdf');
+    expect(progress.openFile).toHaveBeenCalledWith('/tmp/out.tex');
+    expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/out.pdf');
   });
 
   it('maps approval actions and reports desktop-only unsupported approval variants', async () => {


### PR DESCRIPTION
## Summary

- wire desktop progress IPC for stop, resume, run-new, follow-up, file open, and file compile-open actions
- forward visible permission-card and queued-follow-up updates from desktop runtime events to the shared progress view
- handle bash, plan, agent-proposal, and approve/reject tool-edit approval actions in the desktop progress bridge
- clean approval, retry, and follow-up state when desktop streams are deleted

Closes #3546.

## Remaining Phase 3 Gaps

- tool-edit preview actions (`openDiff`, `previewProposed`, `showLatexdiff`) still need the Phase 5 diff/preview host work
- agent proposal setup remains unsupported on desktop
- richer workflow file operations such as compare, accept, merge, latexdiff, open label, and open task storage remain follow-up slices

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new desktop-side IPC handlers that can stop/resume/rerun agent executions and resolve multiple approval flows, which could impact run lifecycle and user-permission gating if miswired. Changes are localized to desktop bridge/IPC plus tests, with no apparent auth/token handling changes.
> 
> **Overview**
> Enables the desktop Progress view to *actively control* agent streams by handling IPC commands for `STOP_STREAM`, `RESUME`, `RUN_NEW`, `SEND_FOLLOW_UP`, and file open actions, and centralizes execution launching via `DesktopProgressBridge.runExecution`.
> 
> Extends the desktop progress bridge to forward new runtime events into the shared Progress UI (permission cards for bash/tool-edit/proposals/plan approvals, bypass toggles, and queued follow-up updates), and to resolve inbound approval actions via the relevant coordinators/controllers.
> 
> Adds stream teardown hygiene by clearing approval, retry, and follow-up state on `deleteStream`/`deleteAllStreams`, and updates/expands Vitest coverage for the new IPC mappings and logging expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1c63999ac6f9ab4ec33b4c40a4e71eb64a29ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->