### PR TITLE
feat: wire desktop OS preview host

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path';
+import path, { basename } from 'node:path';
 
 import {
   prepareMainViewExecutionRequest,
@@ -20,6 +20,7 @@ import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { ExternalOpener } from '@hosts/externalOpener';
 import { AgentLogger } from '@logger/AgentLogger';
 import { StreamLogStore } from '@logger/StreamLogStore';
 import {
@@ -41,13 +42,21 @@ import {
   cleanupApprovalsForStream,
   handleProgressViewBashApprovalAction,
 } from '@tools/approval';
+import type { BuildDisplayFn } from '@tools/approval/latexPreview';
 import { toolEditApprovalController } from '@tools/approval/toolEditApproval';
+import {
+  createExternalLocation,
+  pathToLocation,
+  type FileLocation,
+} from '@utils/files';
 
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 
 export interface DesktopAgentExecutionOptions {
   postToRenderer(message: unknown): void;
-  openPath?: (filePath: string) => Promise<void>;
+  opener?: Pick<ExternalOpener, 'openPath'> & {
+    openBuildDisplay?: BuildDisplayFn;
+  };
   showErrorMessage?: (message: string) => Promise<void> | void;
 }
 
@@ -69,7 +78,14 @@ type StreamBadgeSnapshot = {
 export interface DesktopProgressBridgeOptions {
   detachSubagentsOnStop?: boolean;
   openPath?: (filePath: string) => Promise<void>;
+  openBuildDisplay?: BuildDisplayFn;
   showMessage?: (message: string) => Promise<void>;
+}
+
+function toFileLocation(filePath: string): FileLocation {
+  return path.isAbsolute(filePath)
+    ? createExternalLocation(filePath)
+    : pathToLocation(filePath);
 }
 
 export class DesktopProgressBridge {
@@ -732,6 +748,10 @@ export class DesktopProgressBridge {
   }
 
   async openFileCompile(filePath: string): Promise<void> {
+    if (this.options.openBuildDisplay) {
+      await this.options.openBuildDisplay(toFileLocation(filePath));
+      return;
+    }
     await this.openFile(filePath);
   }
 
@@ -814,7 +834,8 @@ export function createDesktopAgentExecution(
   options: DesktopAgentExecutionOptions,
 ): DesktopAgentExecution {
   const progress = new DesktopProgressBridge(options.postToRenderer, {
-    openPath: options.openPath,
+    openPath: options.opener?.openPath,
+    openBuildDisplay: options.opener?.openBuildDisplay,
     showMessage: async (message) => options.showErrorMessage?.(message),
   });
 

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -26,6 +26,12 @@ function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String(error.code)
+    : undefined;
+}
+
 export function createDesktopPreviewHost(
   options: DesktopPreviewHostOptions,
 ): DesktopPreviewHost {
@@ -37,7 +43,10 @@ export function createDesktopPreviewHost(
   async function ensurePathExists(filePath: string): Promise<void> {
     try {
       await access(filePath);
-    } catch {
+    } catch (error) {
+      if (getErrorCode(error) !== 'ENOENT') {
+        await fail(`Cannot access file ${filePath}: ${toErrorMessage(error)}`);
+      }
       await fail(`File not found: ${filePath}`);
     }
   }

--- a/packages/desktop/src/main/desktopPreviewHost.ts
+++ b/packages/desktop/src/main/desktopPreviewHost.ts
@@ -1,0 +1,97 @@
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+
+import { isLatexFile } from '@common/files/fileTypeUtils';
+import type { ExternalOpener } from '@hosts/externalOpener';
+import { compileLatex2Pdf } from '@latex/texTools';
+import type { BuildDisplayFn } from '@tools/approval/latexPreview';
+import type { FileLocation } from '@utils/files';
+import { createExternalLocation } from '@utils/files';
+
+export interface DesktopShellAdapter {
+  openExternal(url: string): Promise<void>;
+  openPath(filePath: string): Promise<string>;
+}
+
+export interface DesktopPreviewHost extends ExternalOpener {
+  openBuildDisplay: BuildDisplayFn;
+}
+
+export interface DesktopPreviewHostOptions {
+  shell: DesktopShellAdapter;
+  showErrorMessage?: (message: string) => Promise<void> | void;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createDesktopPreviewHost(
+  options: DesktopPreviewHostOptions,
+): DesktopPreviewHost {
+  async function fail(message: string): Promise<never> {
+    await options.showErrorMessage?.(message);
+    throw new Error(message);
+  }
+
+  async function ensurePathExists(filePath: string): Promise<void> {
+    try {
+      await access(filePath);
+    } catch {
+      await fail(`File not found: ${filePath}`);
+    }
+  }
+
+  async function openPath(filePath: string): Promise<void> {
+    await ensurePathExists(filePath);
+
+    let shellError = '';
+    try {
+      shellError = await options.shell.openPath(filePath);
+    } catch (error) {
+      await fail(`Failed to open file ${filePath}: ${toErrorMessage(error)}`);
+    }
+
+    if (shellError) {
+      await fail(`Failed to open file ${filePath}: ${shellError}`);
+    }
+  }
+
+  async function openExternal(url: string): Promise<void> {
+    try {
+      await options.shell.openExternal(url);
+    } catch (error) {
+      await fail(`Failed to open URL ${url}: ${toErrorMessage(error)}`);
+    }
+  }
+
+  async function openBuildDisplay(fileLocation: FileLocation): Promise<void> {
+    const sourcePath = fileLocation.absolutePath;
+    await ensurePathExists(sourcePath);
+
+    if (!isLatexFile(sourcePath)) {
+      await openPath(sourcePath);
+      return;
+    }
+
+    const outputDirectory = path.dirname(sourcePath);
+    const pdfPath = path.join(
+      outputDirectory,
+      `${path.basename(sourcePath, path.extname(sourcePath))}.pdf`,
+    );
+    const built = await compileLatex2Pdf(createExternalLocation(sourcePath), {
+      outputDirectory,
+    });
+    if (!built) {
+      await fail(`LaTeX build failed for ${sourcePath}`);
+    }
+
+    await openPath(pdfPath);
+  }
+
+  return {
+    openBuildDisplay,
+    openExternal,
+    openPath,
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -6,8 +6,10 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
+import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
+import { createDesktopPreviewHost } from './desktopPreviewHost.js';
 import { createDesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import {
   attachRendererConsoleLog,
@@ -98,11 +100,16 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
   } = {};
-  const openPath = async (filePath: string) => {
-    const errorMessage = await shell.openPath(filePath);
-    if (errorMessage) throw new Error(errorMessage);
+  const showErrorMessage = async (message: string) => {
+    await dialog.showMessageBox(window, { message, type: 'error' });
   };
-  const openLogsFolder = async () => openPath(getDesktopLogDirectory());
+  const previewHost = createDesktopPreviewHost({
+    shell,
+    showErrorMessage,
+  });
+  setOpenBuildDisplay(previewHost.openBuildDisplay);
+  const openLogsFolder = async () =>
+    previewHost.openPath(getDesktopLogDirectory());
   const openWorkspaceFolder = async () => {
     const result = await dialog.showOpenDialog(window, {
       title: 'Open Workspace Folder',
@@ -123,10 +130,8 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   attachRendererConsoleLog(window.webContents);
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
-    openPath,
-    showErrorMessage: async (message) => {
-      await dialog.showMessageBox(window, { message, type: 'error' });
-    },
+    opener: previewHost,
+    showErrorMessage,
   });
   const fileSelection = createDesktopFileSelection({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
@@ -143,7 +148,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   });
   const workspaceExplorer = createDesktopWorkspaceExplorer({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
-    openPath,
+    openPath: previewHost.openPath,
     onError: reportAsyncError,
   });
   const settingsIpc = createDesktopSettingsIpc({
@@ -181,11 +186,9 @@ function createWindow(options: { workspacePath: string | undefined }): void {
       });
       return result.canceled ? undefined : result.filePaths[0];
     },
-    openExternalUrl: async (url) => {
-      await shell.openExternal(url);
-    },
+    openExternalUrl: (url) => previewHost.openExternal(url),
     installToolExtension: async (extensionId) => {
-      await shell.openExternal(
+      await previewHost.openExternal(
         `https://marketplace.visualstudio.com/items?itemName=${encodeURIComponent(extensionId)}`,
       );
     },
@@ -214,7 +217,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     {
       getCustomAgentDirectory: () => getAgentDirectories().custom(),
       openLogFolder: openLogsFolder,
-      openPath,
+      openPath: previewHost.openPath,
       openWorkspaceFolder,
       onAsyncError: reportAsyncError,
     },

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -15,6 +15,7 @@ import {
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 type Bridge = {
+  openFileCompile(filePath: string): Promise<void>;
   dispose(): void;
 };
 
@@ -39,8 +40,18 @@ type TestableBridge = Bridge & {
 
 type DesktopExecution = {
   handleExecute(message: unknown): Promise<void>;
+  progress: Bridge;
   dispose(): void;
 };
+
+type RunExecutionRequest = (
+  request: unknown,
+  options: {
+    openWorkflowOutput(result: {
+      outputs: Array<{ absolutePath: string }>;
+    }): Promise<void>;
+  },
+) => Promise<void>;
 
 interface DesktopAgentExecutionModule {
   DesktopProgressBridge: new (
@@ -48,7 +59,10 @@ interface DesktopAgentExecutionModule {
   ) => Bridge;
   createDesktopAgentExecution(options: {
     postToRenderer(message: unknown): void;
-    openPath?: (filePath: string) => Promise<void>;
+    opener?: {
+      openPath(filePath: string): Promise<void>;
+      openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
+    };
     showErrorMessage?: (message: string) => Promise<void> | void;
   }): DesktopExecution;
 }
@@ -182,9 +196,13 @@ async function createBridge(messages: unknown[]): Promise<TestableBridge> {
 
 async function createExecution(options: {
   postToRenderer?: (message: unknown) => void;
+  opener?: {
+    openPath(filePath: string): Promise<void>;
+    openBuildDisplay?(location: { absolutePath: string }): Promise<void>;
+  };
   showErrorMessage?: (message: string) => Promise<void> | void;
   prepareMainViewExecutionRequest: (message: unknown) => unknown;
-  runValidatedExecutionRequest?: () => Promise<void>;
+  runValidatedExecutionRequest?: RunExecutionRequest;
 }): Promise<DesktopExecution> {
   vi.resetModules();
   vi.doMock('@agent/runtime/RunStorageService', () => ({
@@ -236,6 +254,7 @@ async function createExecution(options: {
   )) as DesktopAgentExecutionModule;
   return createDesktopAgentExecution({
     postToRenderer: options.postToRenderer ?? vi.fn(),
+    opener: options.opener,
     showErrorMessage: options.showErrorMessage,
   });
 }
@@ -614,6 +633,60 @@ describe('DesktopProgressBridge', () => {
       await expect(
         execution.handleExecute({ command: 'execute' }),
       ).rejects.toThrow(failure);
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  it('opens workflow outputs through the desktop preview host', async () => {
+    const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
+    const runValidatedExecutionRequest = vi.fn(async (_request, options) => {
+      await options.openWorkflowOutput({
+        outputs: [{ absolutePath: '/tmp/result.pdf' }],
+      });
+    });
+    const execution = await createExecution({
+      opener,
+      runValidatedExecutionRequest,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request: {
+          agentName: 'default',
+          filePath: 'main.tex',
+          prompt: 'run',
+        },
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(opener.openPath).toHaveBeenCalledWith('/tmp/result.pdf');
+    } finally {
+      execution.dispose();
+    }
+  });
+
+  it('opens compile-file actions through the desktop preview host', async () => {
+    const opener = {
+      openPath: vi.fn(async (_filePath: string) => {}),
+      openBuildDisplay: vi.fn(
+        async (_location: { absolutePath: string }) => {},
+      ),
+    };
+    const execution = await createExecution({
+      opener,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: false,
+        message: 'not used',
+      })),
+    });
+
+    try {
+      await execution.progress.openFileCompile('/tmp/output.tex');
+      expect(opener.openBuildDisplay).toHaveBeenCalledWith(
+        expect.objectContaining({ absolutePath: '/tmp/output.tex' }),
+      );
+      expect(opener.openPath).not.toHaveBeenCalled();
     } finally {
       execution.dispose();
     }

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
@@ -1,0 +1,148 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopPreviewHostModule {
+  createDesktopPreviewHost(options: {
+    shell: {
+      openExternal(url: string): Promise<void>;
+      openPath(filePath: string): Promise<string>;
+    };
+    showErrorMessage?: (message: string) => Promise<void> | void;
+  }): {
+    openBuildDisplay(location: { absolutePath: string }): Promise<void>;
+    openExternal(url: string): Promise<void>;
+    openPath(filePath: string): Promise<void>;
+  };
+}
+
+async function loadDesktopPreviewHost(
+  compileLatex2Pdf = vi.fn(async () => true),
+): Promise<DesktopPreviewHostModule> {
+  vi.resetModules();
+  vi.doMock('@latex/texTools', () => ({ compileLatex2Pdf }));
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopPreviewHost.ts'))
+  ) as Promise<DesktopPreviewHostModule>;
+}
+
+describe('desktop preview host', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    vi.doUnmock('@latex/texTools');
+    vi.restoreAllMocks();
+    const dirs = tempDirs.splice(0);
+    await Promise.all(
+      dirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await mkdtemp(path.join(tmpdir(), 'texra-preview-host-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('opens existing files through Electron shell.openPath', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const filePath = path.join(dir, 'output.pdf');
+    await writeFile(filePath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+
+    const host = createDesktopPreviewHost({ shell });
+
+    await host.openPath(filePath);
+    expect(shell.openPath).toHaveBeenCalledWith(filePath);
+  });
+
+  it('reports missing files before calling shell.openPath', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const missingPath = path.join(await makeTempDir(), 'missing.pdf');
+    const showErrorMessage = vi.fn();
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+
+    const host = createDesktopPreviewHost({ shell, showErrorMessage });
+
+    await expect(host.openPath(missingPath)).rejects.toThrow(
+      `File not found: ${missingPath}`,
+    );
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      `File not found: ${missingPath}`,
+    );
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it('reports Electron shell.openPath errors once', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const dir = await makeTempDir();
+    const filePath = path.join(dir, 'blocked.pdf');
+    await writeFile(filePath, 'pdf');
+    const showErrorMessage = vi.fn();
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => 'No associated application'),
+    };
+
+    const host = createDesktopPreviewHost({ shell, showErrorMessage });
+
+    await expect(host.openPath(filePath)).rejects.toThrow(
+      `Failed to open file ${filePath}: No associated application`,
+    );
+    expect(showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      `Failed to open file ${filePath}: No associated application`,
+    );
+  });
+
+  it('builds LaTeX previews and opens the generated PDF path', async () => {
+    const compileLatex2Pdf = vi.fn(async () => true);
+    const { createDesktopPreviewHost } =
+      await loadDesktopPreviewHost(compileLatex2Pdf);
+    const dir = await makeTempDir();
+    const texPath = path.join(dir, 'preview.tex');
+    const pdfPath = path.join(dir, 'preview.pdf');
+    await writeFile(
+      texPath,
+      '\\documentclass{article}\\begin{document}x\\end{document}',
+    );
+    await writeFile(pdfPath, 'pdf');
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+
+    const host = createDesktopPreviewHost({ shell });
+
+    await host.openBuildDisplay({ absolutePath: texPath });
+    expect(compileLatex2Pdf).toHaveBeenCalledWith(
+      expect.objectContaining({ absolutePath: texPath }),
+      { outputDirectory: dir },
+    );
+    expect(shell.openPath).toHaveBeenCalledWith(pdfPath);
+  });
+
+  it('opens external URLs through Electron shell.openExternal', async () => {
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost();
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+
+    const host = createDesktopPreviewHost({ shell });
+
+    await host.openExternal('https://texra.ai');
+    expect(shell.openExternal).toHaveBeenCalledWith('https://texra.ai');
+  });
+});

--- a/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPreviewHost.vitest.mts
@@ -22,9 +22,16 @@ interface DesktopPreviewHostModule {
 
 async function loadDesktopPreviewHost(
   compileLatex2Pdf = vi.fn(async () => true),
+  access?: (filePath: string) => Promise<void>,
 ): Promise<DesktopPreviewHostModule> {
   vi.resetModules();
   vi.doMock('@latex/texTools', () => ({ compileLatex2Pdf }));
+  if (access != null) {
+    vi.doMock('node:fs/promises', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('node:fs/promises')>()),
+      access,
+    }));
+  }
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopPreviewHost.ts'))
   ) as Promise<DesktopPreviewHostModule>;
@@ -35,6 +42,7 @@ describe('desktop preview host', () => {
 
   afterEach(async () => {
     vi.doUnmock('@latex/texTools');
+    vi.doUnmock('node:fs/promises');
     vi.restoreAllMocks();
     const dirs = tempDirs.splice(0);
     await Promise.all(
@@ -80,6 +88,35 @@ describe('desktop preview host', () => {
     );
     expect(showErrorMessage).toHaveBeenCalledWith(
       `File not found: ${missingPath}`,
+    );
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it('preserves access failure details before calling shell.openPath', async () => {
+    const accessError = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    });
+    const access = vi.fn(async (_filePath: string) => {
+      throw accessError;
+    });
+    const { createDesktopPreviewHost } = await loadDesktopPreviewHost(
+      undefined,
+      access,
+    );
+    const filePath = path.join(await makeTempDir(), 'blocked.pdf');
+    const showErrorMessage = vi.fn();
+    const shell = {
+      openExternal: vi.fn(async (_url: string) => {}),
+      openPath: vi.fn(async (_path: string) => ''),
+    };
+
+    const host = createDesktopPreviewHost({ shell, showErrorMessage });
+
+    await expect(host.openPath(filePath)).rejects.toThrow(
+      `Cannot access file ${filePath}: permission denied`,
+    );
+    expect(showErrorMessage).toHaveBeenCalledWith(
+      `Cannot access file ${filePath}: permission denied`,
     );
     expect(shell.openPath).not.toHaveBeenCalled();
   });

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -133,6 +133,30 @@ describe('desktop Progress IPC', () => {
     expect(progress.deleteAllStreams).toHaveBeenCalledTimes(1);
   });
 
+  it('opens Progress file actions through the desktop preview host', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE,
+        file: '/tmp/output.pdf',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(progress.openFile).toHaveBeenCalledWith('/tmp/output.pdf');
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE,
+        file: '/tmp/output.tex',
+      }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/output.tex');
+  });
+
   it('routes unsupported Progress commands through an explicit handler', async () => {
     const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
     const progress = createProgress();

--- a/src/tools/approval/latexPreview.ts
+++ b/src/tools/approval/latexPreview.ts
@@ -18,6 +18,7 @@ type BuildDisplayFn = (
   location: FileLocation,
   options?: { preserveFocus?: boolean },
 ) => Promise<void>;
+export type { BuildDisplayFn };
 let openBuildDisplayIfTex: BuildDisplayFn = async () => {};
 /** Inject the VS Code LaTeX build+display function. Default: no-op. */
 export function setOpenBuildDisplay(fn: BuildDisplayFn): void {


### PR DESCRIPTION
## Summary

- add a tested desktop preview host backed by Electron `shell.openPath` and `shell.openExternal`
- wire generated LaTeX/PDF preview through the shared `setOpenBuildDisplay` hook in the desktop app
- route desktop progress open-file and compile-open actions through the preview host
- surface missing-file and shell-open failures as clear desktop errors

Closes #3555.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopPreviewHost.vitest.mts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop file-opening and LaTeX preview flows, adding new error-handling and build logic that could affect user workflows if paths or compilation fail. Changes are localized but interact with Electron shell integration and runtime output handling.
> 
> **Overview**
> Adds a **desktop preview host** (`createDesktopPreviewHost`) that wraps Electron `shell.openPath`/`shell.openExternal`, validates file existence, and surfaces open failures via desktop error dialogs.
> 
> Wires this host into desktop startup and execution: `createDesktopAgentExecution` now accepts an `opener` (replacing the direct `openPath` callback) and uses it to open workflow output files and to handle *compile-and-open* actions by calling the shared `setOpenBuildDisplay` hook (building `.tex` to `.pdf` before opening). Test coverage is expanded with new vitest suites and cases for preview-host behavior and Progress open-file/compile routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588ca046751e31083751404b682059c7271dc7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->