### PR TITLE
fix: wire desktop settings actions

### DIFF
--- a/packages/desktop/src/main/desktopPrompt.ts
+++ b/packages/desktop/src/main/desktopPrompt.ts
@@ -1,0 +1,107 @@
+import type { BrowserWindow } from 'electron';
+
+export interface DesktopPromptOptions {
+  title: string;
+  prompt: string;
+  password?: boolean;
+}
+
+export async function promptInRenderer(
+  window: BrowserWindow,
+  options: DesktopPromptOptions,
+): Promise<string | undefined> {
+  const result = await window.webContents.executeJavaScript(
+    `(() => new Promise((resolve) => {
+      const existing = document.querySelector('[data-texra-desktop-prompt]');
+      existing?.remove();
+
+      const overlay = document.createElement('div');
+      overlay.dataset.texraDesktopPrompt = 'true';
+      overlay.style.cssText = [
+        'position:fixed',
+        'inset:0',
+        'z-index:2147483647',
+        'display:flex',
+        'align-items:center',
+        'justify-content:center',
+        'background:rgba(0,0,0,.28)',
+        'font-family:system-ui,-apple-system,BlinkMacSystemFont,sans-serif'
+      ].join(';');
+
+      const panel = document.createElement('form');
+      panel.style.cssText = [
+        'width:min(520px,calc(100vw - 48px))',
+        'box-sizing:border-box',
+        'padding:20px',
+        'border:1px solid var(--texra-panel-border,#d0d7de)',
+        'border-radius:6px',
+        'background:var(--texra-editor-background,Canvas)',
+        'color:var(--texra-editor-foreground,CanvasText)',
+        'box-shadow:0 18px 48px rgba(0,0,0,.24)'
+      ].join(';');
+
+      const title = document.createElement('h2');
+      title.textContent = ${JSON.stringify(options.title)};
+      title.style.cssText = 'margin:0 0 10px;font-size:16px;font-weight:600';
+
+      const label = document.createElement('label');
+      label.textContent = ${JSON.stringify(options.prompt)};
+      label.style.cssText = 'display:block;margin-bottom:8px;font-size:13px';
+
+      const input = document.createElement('input');
+      input.type = ${JSON.stringify(options.password ? 'password' : 'text')};
+      input.autocomplete = 'off';
+      input.spellcheck = false;
+      input.style.cssText = [
+        'width:100%',
+        'box-sizing:border-box',
+        'padding:8px 10px',
+        'border:1px solid var(--texra-input-border,#d0d7de)',
+        'border-radius:4px',
+        'background:var(--texra-input-background,Field)',
+        'color:var(--texra-input-foreground,FieldText)',
+        'font:inherit'
+      ].join(';');
+
+      const actions = document.createElement('div');
+      actions.style.cssText = 'display:flex;justify-content:flex-end;gap:8px;margin-top:16px';
+
+      const cancel = document.createElement('button');
+      cancel.type = 'button';
+      cancel.textContent = 'Cancel';
+      cancel.style.cssText = 'padding:6px 12px';
+
+      const submit = document.createElement('button');
+      submit.type = 'submit';
+      submit.textContent = 'Save';
+      submit.style.cssText = 'padding:6px 12px';
+
+      const cleanup = (value) => {
+        document.removeEventListener('keydown', onKeyDown, true);
+        overlay.remove();
+        resolve(value);
+      };
+      const onKeyDown = (event) => {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          cleanup(null);
+        }
+      };
+
+      cancel.addEventListener('click', () => cleanup(null));
+      panel.addEventListener('submit', (event) => {
+        event.preventDefault();
+        cleanup(input.value);
+      });
+      document.addEventListener('keydown', onKeyDown, true);
+
+      actions.append(cancel, submit);
+      panel.append(title, label, input, actions);
+      overlay.append(panel);
+      document.body.append(overlay);
+      input.focus();
+    }))()`,
+    true,
+  );
+  return typeof result === 'string' ? result : undefined;
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -1,6 +1,7 @@
-import { platform } from '@platform/platform';
+import { platform, tryPlatform } from '@platform/platform';
 
 import { LatexConfigPersistenceController } from '@controllers/settingsView/LatexConfigPersistenceController';
+import { LatexToolingController } from '@controllers/settingsView/LatexToolingController';
 import {
   SettingsAgentCatalogController,
   type SettingsAgentCatalogState,
@@ -22,13 +23,35 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { GlobalStateKey, WorkspaceStateKey } from '@common/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import {
+  API_PROVIDERS,
+  apiKeySecretName,
+  invalidateApiKeyCache,
+  loadApiKeyStatusMap,
+  type ApiProvider,
+} from '@model/apiProviders';
+import {
   DEFAULT_MODELS,
   buildBasicModelOptionsData,
 } from '@model/modelOptionsBasic';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
+import {
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_URLS,
+} from '@shared/constants/providers';
+import {
+  LATEX_WORKSHOP_EXT_ID,
+  normalizePlatform,
+} from '@shared/constants/latex';
+import {
+  NESTED_DELEGATION_DEPTH_RANGE,
+  clampNestedDelegationDepth,
+} from '@shared/constants/delegationPolicy';
 import type { LatexConfigField } from '@shared/constants/latex';
 import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
   SettingsViewInboundMessageSchema,
+  type LatexSettingsStatus,
+  type ProviderKeyStatus,
   type ReasoningLevel,
   type ToolDashboardItem,
 } from '@shared/schemas/settingsViewMessages';
@@ -43,8 +66,25 @@ import {
   applyGitAuthorSettings,
   readGitAuthorSettingsFromState,
 } from '@utils/system/gitAuthorSettings';
+import { BinaryResolver } from '@utils/system/binaryResolver';
+import {
+  checkToolInstalled,
+  detectPackageManager,
+} from '@utils/system/toolUtils';
+import {
+  getGlobalStreaming,
+  getProviderDisplayName,
+  getProviderEndpoint,
+  getProviderKeyUrl,
+  getProviderStreaming,
+  setGlobalStreaming,
+  setProviderEndpoint,
+  setProviderStreaming,
+  supportsCustomEndpoint,
+} from '@utils/config/providerConfig';
 import type { ConfigProvider } from '@platform/interfaces/config';
 import type { StateStore } from '@platform/interfaces/state';
+import type { PlatformSecrets } from '@platform/secrets';
 import type {
   DesktopCommandMessage,
   DesktopMessageHandler,
@@ -68,6 +108,21 @@ export interface DesktopSettingsIpcOptions {
   selectCustomAgentDirectory?: () => Promise<string | undefined>;
   openExternalUrl?: (url: string) => Promise<void>;
   installToolExtension?: (extensionId: string) => Promise<void>;
+  promptSecret?: (input: {
+    title: string;
+    prompt: string;
+  }) => Promise<string | undefined>;
+  promptText?: (input: {
+    title: string;
+    prompt: string;
+  }) => Promise<string | undefined>;
+  showInfoMessage?: (message: string) => Promise<void>;
+  showErrorMessage?: (message: string) => Promise<void>;
+  signIn?: () => Promise<void>;
+  signOut?: () => Promise<void>;
+  secrets?: PlatformSecrets;
+  detectLatexSettingsStatus?: () => Promise<LatexSettingsStatus>;
+  runInstallCommand?: (command: string) => Promise<void>;
   runToolCommand?: (input: {
     toolId: string;
     command: string;
@@ -77,6 +132,12 @@ export interface DesktopSettingsIpcOptions {
 }
 
 export type DesktopSettingsIpc = DesktopMessageHandler;
+
+const emptySecrets: PlatformSecrets = {
+  get: () => Promise.resolve(undefined),
+  set: () => Promise.resolve(),
+  delete: () => Promise.resolve(),
+};
 
 async function buildDefaultToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
@@ -112,6 +173,10 @@ async function findToolCommand(
   return kind === 'install' ? def?.installCommand : def?.authCommand;
 }
 
+function isApiProvider(provider: string): provider is ApiProvider {
+  return (API_PROVIDERS as readonly string[]).includes(provider);
+}
+
 export function createDesktopSettingsIpc(
   options: DesktopSettingsIpcOptions,
 ): DesktopSettingsIpc {
@@ -131,10 +196,23 @@ export function createDesktopSettingsIpc(
     options.buildToolDashboardItems ?? buildDefaultToolDashboardItems;
   const refreshToolAvailability =
     options.refreshToolAvailability ?? refreshDefaultToolAvailability;
+  const secrets = options.secrets ?? tryPlatform()?.secrets ?? emptySecrets;
   const getCustomAgentDirectory =
     options.getCustomAgentDirectory ?? (() => getAgentDirectories().custom());
   const latexConfigPersistenceController =
     new LatexConfigPersistenceController();
+  const latexToolingController = new LatexToolingController({
+    checkToolInstalled: (tool) => checkToolInstalled(tool, false),
+    findPath: (tool) => BinaryResolver.findPath(tool),
+    detectPackageManager,
+    getPlatform: () => normalizePlatform(process.platform),
+    isLatexWorkshopInstalled: () => false,
+    getRecommendedStatus: () => ({
+      outDir: true,
+      autoRevealExclude: true,
+    }),
+    onDetectionError: onError,
+  });
   const agentCatalogState: SettingsAgentCatalogState = {
     getEnabledAgentKeys: (category) =>
       workspaceState.get<string[]>(getAgentStateKey(category)),
@@ -295,6 +373,7 @@ export function createDesktopSettingsIpc(
   }
 
   function postMainModelOptionsData(): void {
+    invalidateModelOptionsCache();
     options.postToRenderer({
       command: MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
       optionsData: buildBasicModelOptionsData(
@@ -318,7 +397,24 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  function postProfileData(): void {
+  async function getProviderKeyStatuses(): Promise<ProviderKeyStatus[]> {
+    const statuses = await loadApiKeyStatusMap(secrets, API_PROVIDERS);
+    return API_PROVIDERS.map((provider) => ({
+      provider,
+      displayName: getProviderDisplayName(
+        provider,
+        PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+      ),
+      status: statuses[provider],
+      keyUrl: getProviderKeyUrl(provider, PROVIDER_URLS[provider] ?? ''),
+      streaming: getProviderStreaming(provider),
+      customEndpoint: getProviderEndpoint(provider),
+      supportsCustomEndpoint: supportsCustomEndpoint(provider),
+      vscodeSettings: [],
+    }));
+  }
+
+  async function postProfileData(): Promise<void> {
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
       authenticated: false,
@@ -329,8 +425,8 @@ export function createDesktopSettingsIpc(
       apiAccessMode: 'personal',
       allowedModels: [],
       tierConstants: { ultra: ULTRA_TIER, max: MAX_TIER },
-      providerKeyStatuses: [],
-      globalStreamingDefault: true,
+      providerKeyStatuses: await getProviderKeyStatuses(),
+      globalStreamingDefault: getGlobalStreaming(),
     });
   }
 
@@ -345,6 +441,45 @@ export function createDesktopSettingsIpc(
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_TOOL_DASHBOARD,
       items,
+    });
+  }
+
+  async function postLatexSettingsStatus(): Promise<void> {
+    const settings =
+      (await options.detectLatexSettingsStatus?.()) ??
+      (await latexToolingController.detectStatus());
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
+      settings,
+    });
+  }
+
+  function postSuperYoloEnabled(): void {
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_SUPER_YOLO_ENABLED,
+      enabled: true,
+      reliabilitySettings: [],
+      allowOrchestratorKill: workspaceState.get<boolean>(
+        WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+        true,
+      ),
+      detachSubagentsOnStop: workspaceState.get<boolean>(
+        WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+        false,
+      ),
+      nestedDelegationMaxDepth: clampNestedDelegationDepth(
+        workspaceState.get<number>(
+          WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
+          NESTED_DELEGATION_DEPTH_RANGE.default,
+        ),
+      ),
+    });
+  }
+
+  function postAgentModePresets(): void {
+    options.postToRenderer({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: agentCatalogController.getCustomPresets(),
     });
   }
 
@@ -379,10 +514,13 @@ export function createDesktopSettingsIpc(
   async function postInitialSettingsData(): Promise<void> {
     postGitAuthorSettings();
     postLatexConfigValues();
-    postProfileData();
     postModelSelectionData();
+    postSuperYoloEnabled();
+    postAgentModePresets();
     postApprovalSettings();
     await Promise.all([
+      postProfileData(),
+      postLatexSettingsStatus(),
       postAgentSelectionData(),
       postCustomAgentDir(),
       postToolDashboardData(),
@@ -442,6 +580,86 @@ export function createDesktopSettingsIpc(
     postModelSelectionData();
   }
 
+  async function refreshAfterCredentialChange(): Promise<void> {
+    invalidateApiKeyCache();
+    invalidateModelOptionsCache();
+    await postProfileData();
+    postModelSelectionData();
+    postMainModelOptionsData();
+  }
+
+  async function setProviderKey(provider: string): Promise<void> {
+    if (!isApiProvider(provider)) {
+      await options.showErrorMessage?.(`Unknown API provider: ${provider}`);
+      return;
+    }
+    const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+    const apiKey = await options.promptSecret?.({
+      title: `Set ${displayName} API key`,
+      prompt: `Enter ${displayName} API key`,
+    });
+    const trimmed = apiKey?.trim();
+    if (!trimmed) return;
+
+    await secrets.set(apiKeySecretName(provider), trimmed);
+    await options.showInfoMessage?.(`${displayName} API key has been set`);
+    await refreshAfterCredentialChange();
+  }
+
+  async function removeProviderKey(provider: string): Promise<void> {
+    if (!isApiProvider(provider)) {
+      await options.showErrorMessage?.(`Unknown API provider: ${provider}`);
+      return;
+    }
+    const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+    await secrets.delete(apiKeySecretName(provider));
+    await options.showInfoMessage?.(`${displayName} API key has been removed`);
+    await refreshAfterCredentialChange();
+  }
+
+  async function openProviderKeyUrl(provider: string): Promise<void> {
+    const defaultUrl = PROVIDER_URLS[provider];
+    if (!defaultUrl) return;
+    await options.openExternalUrl?.(getProviderKeyUrl(provider, defaultUrl));
+  }
+
+  async function updateProviderStreaming(input: {
+    provider: string;
+    enabled: boolean;
+  }): Promise<void> {
+    await setProviderStreaming(input.provider, input.enabled);
+    await postProfileData();
+  }
+
+  async function updateProviderEndpoint(input: {
+    provider: string;
+    endpoint: string;
+  }): Promise<void> {
+    await setProviderEndpoint(input.provider, input.endpoint);
+    await postProfileData();
+  }
+
+  async function updateGlobalStreaming(enabled: boolean): Promise<void> {
+    await setGlobalStreaming(enabled);
+    await postProfileData();
+  }
+
+  async function signIn(): Promise<void> {
+    if (options.signIn) {
+      await options.signIn();
+    } else {
+      await options.showInfoMessage?.(
+        'Researcher Access sign-in is not connected in this desktop build. Add a provider API key in Settings > Models to run agents with your own account.',
+      );
+    }
+    await postProfileData();
+  }
+
+  async function signOut(): Promise<void> {
+    await options.signOut?.();
+    await postProfileData();
+  }
+
   async function updateCodexSetting(
     key: WorkspaceStateKey,
     value: string,
@@ -457,6 +675,22 @@ export function createDesktopSettingsIpc(
       'workspace',
     );
     postApprovalSettings();
+  }
+
+  async function updateBooleanWorkspaceSetting(
+    key: WorkspaceStateKey,
+    enabled: boolean,
+  ): Promise<void> {
+    await workspaceState.update(key, enabled);
+    postSuperYoloEnabled();
+  }
+
+  async function updateNestedDelegationMaxDepth(value: number): Promise<void> {
+    await workspaceState.update(
+      WorkspaceStateKey.NESTED_DELEGATION_MAX_DEPTH,
+      clampNestedDelegationDepth(value),
+    );
+    postSuperYoloEnabled();
   }
 
   async function setToolEnabled(
@@ -534,6 +768,33 @@ export function createDesktopSettingsIpc(
     ]);
   }
 
+  async function applyAgentModePreset(presetId: string): Promise<void> {
+    await loadAgentRegistry();
+    const result = await agentCatalogController.applyPreset(presetId);
+    if (!result.ok) {
+      await options.showErrorMessage?.(`Unknown team: ${presetId}`);
+      return;
+    }
+    await Promise.all([postAgentSelectionData(), postMainAgentOptionsData()]);
+    await options.showInfoMessage?.(`Applied "${result.preset.name}" team`);
+  }
+
+  async function saveAgentModePreset(): Promise<void> {
+    const name = await options.promptText?.({
+      title: 'Save agent team',
+      prompt: 'Name for the new team',
+    });
+    if (!name?.trim()) return;
+    await loadAgentRegistry();
+    await agentCatalogController.saveCurrentPreset(name);
+    postAgentModePresets();
+  }
+
+  async function deleteAgentModePreset(presetId: string): Promise<void> {
+    await agentCatalogController.deleteCustomPreset(presetId);
+    postAgentModePresets();
+  }
+
   function runAsync(work: Promise<void>): void {
     void work.catch(onError);
   }
@@ -562,6 +823,55 @@ export function createDesktopSettingsIpc(
         case SETTINGS_VIEW_COMMANDS.GET_MODEL_SELECTION:
           postModelSelectionData();
           return true;
+        case SETTINGS_VIEW_COMMANDS.GET_PROFILE_DATA:
+          runAsync(postProfileData());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SIGN_IN:
+          runAsync(signIn());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SIGN_OUT:
+          runAsync(signOut());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE:
+          runAsync(
+            result.data.mode === 'included'
+              ? signIn()
+              : Promise.resolve().then(postProfileData),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY:
+          runAsync(setProviderKey(result.data.provider));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY:
+          runAsync(removeProviderKey(result.data.provider));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.OPEN_PROVIDER_KEY_URL:
+          runAsync(openProviderKeyUrl(result.data.provider));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_PROVIDER_STREAMING:
+          runAsync(
+            updateProviderStreaming({
+              provider: result.data.provider,
+              enabled: result.data.enabled,
+            }),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_PROVIDER_ENDPOINT:
+          runAsync(
+            updateProviderEndpoint({
+              provider: result.data.provider,
+              endpoint: result.data.endpoint,
+            }),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_GLOBAL_STREAMING:
+          runAsync(updateGlobalStreaming(result.data.enabled));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.OPEN_EXTERNAL_URL:
+          runAsync(
+            options.openExternalUrl?.(result.data.url) ?? Promise.resolve(),
+          );
+          return true;
         case SETTINGS_VIEW_COMMANDS.SET_MODEL_ENABLED:
           runAsync(
             updateModelEnabled({
@@ -586,6 +896,31 @@ export function createDesktopSettingsIpc(
           return true;
         case SETTINGS_VIEW_COMMANDS.GET_APPROVAL_SETTINGS:
           postApprovalSettings();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_SUPER_YOLO_ENABLED:
+          postSuperYoloEnabled();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_SUPER_YOLO_ENABLED:
+          postSuperYoloEnabled();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_ALLOW_ORCHESTRATOR_KILL:
+          runAsync(
+            updateBooleanWorkspaceSetting(
+              WorkspaceStateKey.ALLOW_ORCHESTRATOR_KILL,
+              result.data.enabled,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_DETACH_SUBAGENTS_ON_STOP:
+          runAsync(
+            updateBooleanWorkspaceSetting(
+              WorkspaceStateKey.DETACH_SUBAGENTS_ON_STOP,
+              result.data.enabled,
+            ),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SET_NESTED_DELEGATION_MAX_DEPTH:
+          runAsync(updateNestedDelegationMaxDepth(result.data.value));
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_BASH_APPROVAL_ENABLED:
           runAsync(updateBashApprovalEnabled(result.data.enabled));
@@ -670,8 +1005,38 @@ export function createDesktopSettingsIpc(
         case SETTINGS_VIEW_COMMANDS.RESET_CUSTOM_AGENT_DIR:
           runAsync(resetCustomAgentDir());
           return true;
+        case SETTINGS_VIEW_COMMANDS.GET_AGENT_MODE_PRESETS:
+          postAgentModePresets();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET:
+          runAsync(applyAgentModePreset(result.data.presetId));
+          return true;
+        case SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET:
+          runAsync(saveAgentModePreset());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET:
+          runAsync(deleteAgentModePreset(result.data.presetId));
+          return true;
         case SETTINGS_VIEW_COMMANDS.GET_GIT_AUTHOR_SETTINGS:
           postGitAuthorSettings();
+          return true;
+        case SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS:
+          runAsync(postLatexSettingsStatus());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.APPLY_LATEX_SETTINGS:
+          runAsync(postLatexSettingsStatus());
+          return true;
+        case SETTINGS_VIEW_COMMANDS.INSTALL_LATEX_WORKSHOP:
+          runAsync(
+            options.installToolExtension?.(LATEX_WORKSHOP_EXT_ID) ??
+              Promise.resolve(),
+          );
+          return true;
+        case SETTINGS_VIEW_COMMANDS.RUN_INSTALL_COMMAND:
+          runAsync(
+            options.runInstallCommand?.(result.data.installCommand) ??
+              Promise.resolve(),
+          );
           return true;
         case SETTINGS_VIEW_COMMANDS.GET_LATEX_CONFIG_VALUES:
           postLatexConfigValues();

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -160,6 +160,11 @@ export function createDesktopShellIpc(
         case MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS:
           actions.showSettings(SETTINGS_TAB.MODELS);
           return true;
+        case MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER:
+        case MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY:
+        case MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY:
+          actions.showSettings(SETTINGS_TAB.MODELS);
+          return true;
         case MAIN_VIEW_COMMANDS.OPEN_MULTI_AGENT_SETTINGS:
           actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
           return true;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
 import {
@@ -12,11 +13,14 @@ import {
   getDesktopLogDirectory,
 } from './desktopAppLog.js';
 import { installDesktopMenu } from './desktopMenu.js';
+import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
+import { buildDesktopSettingsTabMessage } from '../desktopCommandSurface.js';
+import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
   serializeWorkspacePresenceArg,
@@ -139,6 +143,31 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     sendStartupCatalogData: true,
+    promptSecret: (input) =>
+      promptInRenderer(window, { ...input, password: true }),
+    promptText: (input) => promptInRenderer(window, input),
+    showInfoMessage: async (message) => {
+      await dialog.showMessageBox(window, { type: 'info', message });
+    },
+    showErrorMessage: async (message) => {
+      await dialog.showMessageBox(window, { type: 'error', message });
+    },
+    signIn: async () => {
+      await dialog.showMessageBox(window, {
+        type: 'info',
+        message:
+          'Researcher Access sign-in is not connected in this desktop build',
+        detail:
+          'Use Settings > Models to add a provider API key, or use the TeXRA VS Code extension for included-access sign-in while desktop auth is completed.',
+      });
+      ipcRef.current?.postToRenderer({
+        command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+        route: 'settings',
+      });
+      ipcRef.current?.postToRenderer(
+        buildDesktopSettingsTabMessage(SETTINGS_TAB.MODELS),
+      );
+    },
     selectCustomAgentDirectory: async () => {
       const result = await dialog.showOpenDialog(window, {
         title: 'Select Custom Agents Folder',
@@ -155,6 +184,13 @@ function createWindow(options: { workspacePath: string | undefined }): void {
       );
     },
     runToolCommand: async ({ command }) => {
+      await dialog.showMessageBox(window, {
+        type: 'info',
+        message: 'Run this setup command in a terminal',
+        detail: command,
+      });
+    },
+    runInstallCommand: async (command) => {
       await dialog.showMessageBox(window, {
         type: 'info',
         message: 'Run this setup command in a terminal',

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -113,6 +113,11 @@ export class ModelsTab extends LitElement {
     return html`
       <div class="models-container tab-content-container">
         ${this.renderTabHint()} ${apiAccessSection}
+        <provider-key-list
+          .providerKeyStatuses=${this.providerKeyStatuses}
+          .apiAccessMode=${this.apiAccessMode}
+          .globalStreamingDefault=${this.globalStreamingDefault}
+        ></provider-key-list>
         <model-selection-list
           .models=${this.modelSelectionItems}
           .helperModel=${this.helperModel}
@@ -121,11 +126,6 @@ export class ModelsTab extends LitElement {
           .allowedModels=${this.allowedModels}
           .preferShortModelNames=${this.preferShortModelNames}
         ></model-selection-list>
-        <provider-key-list
-          .providerKeyStatuses=${this.providerKeyStatuses}
-          .apiAccessMode=${this.apiAccessMode}
-          .globalStreamingDefault=${this.globalStreamingDefault}
-        ></provider-key-list>
       </div>
     `;
   }

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -46,6 +46,26 @@ interface DesktopSettingsIpcModule {
     refreshToolAvailability?: () => Promise<void>;
     getCustomAgentDirectory?: () => Promise<string>;
     selectCustomAgentDirectory?: () => Promise<string | undefined>;
+    openExternalUrl?: (url: string) => Promise<void>;
+    installToolExtension?: (extensionId: string) => Promise<void>;
+    promptSecret?: (input: {
+      title: string;
+      prompt: string;
+    }) => Promise<string | undefined>;
+    promptText?: (input: {
+      title: string;
+      prompt: string;
+    }) => Promise<string | undefined>;
+    showInfoMessage?: (message: string) => Promise<void>;
+    showErrorMessage?: (message: string) => Promise<void>;
+    signIn?: () => Promise<void>;
+    secrets?: {
+      get(key: string): Promise<string | undefined>;
+      set(key: string, value: string): Promise<void>;
+      delete(key: string): Promise<void>;
+    };
+    detectLatexSettingsStatus?: () => Promise<unknown>;
+    runInstallCommand?: (command: string) => Promise<void>;
     onError?: (error: unknown) => void;
   }): {
     handleMessage(
@@ -99,6 +119,22 @@ class MemoryConfigStore {
 
   watch(): { dispose(): void } {
     return { dispose: () => undefined };
+  }
+}
+
+class MemorySecrets {
+  readonly values = new Map<string, string>();
+
+  async get(key: string): Promise<string | undefined> {
+    return this.values.get(key);
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.values.delete(key);
   }
 }
 
@@ -298,6 +334,106 @@ describe('desktop settings IPC', () => {
     });
   });
 
+  it('loads desktop LaTeX tooling status instead of leaving the tab spinning', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      detectLatexSettingsStatus: async () => ({
+        outDir: true,
+        autoRevealExclude: true,
+        texDistributionInstalled: true,
+        latexWorkshopInstalled: false,
+        latexdiffInstalled: true,
+        latexindentInstalled: false,
+        texcountInstalled: true,
+        imageProcessingInstalled: false,
+        platform: 'darwin',
+        pdflatexPath: '/Library/TeX/texbin/pdflatex',
+        latexmkPath: '/Library/TeX/texbin/latexmk',
+        latexdiffPath: '/opt/homebrew/bin/latexdiff',
+        latexindentPath: null,
+        texcountPath: '/opt/homebrew/bin/texcount',
+        ghostscriptPath: null,
+        graphicsmagickPath: null,
+        packageManager: 'brew',
+      }),
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_LATEX_SETTINGS_STATUS,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_LATEX_SETTINGS_STATUS,
+      settings: expect.objectContaining({
+        platform: 'darwin',
+        texDistributionInstalled: true,
+        latexdiffInstalled: true,
+      }),
+    });
+  });
+
+  it('shows provider key rows and stores desktop API keys', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const secrets = new MemorySecrets();
+    const posted: unknown[] = [];
+    const infoMessages: string[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      secrets,
+      promptSecret: async () => '  sk-test  ',
+      showInfoMessage: async (message) => {
+        infoMessages.push(message);
+      },
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.GET_PROFILE_DATA,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      providerKeyStatuses: expect.arrayContaining([
+        expect.objectContaining({ provider: 'google', status: 'not-set' }),
+      ]),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY,
+        provider: 'google',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(secrets.values.get('apiKey.google')).toBe('sk-test');
+    expect(infoMessages).toEqual(['Google API key has been set']);
+    expect(
+      posted.findLast(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toMatchObject({
+      providerKeyStatuses: expect.arrayContaining([
+        expect.objectContaining({ provider: 'google', status: 'set' }),
+      ]),
+    });
+  });
+
   it('round-trips LaTeX config writes through workspace state and refreshes the renderer', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const workspaceState = new MemoryStateStore();
@@ -483,6 +619,25 @@ describe('desktop settings IPC', () => {
           requiresSetup: false,
         },
       ],
+      detectLatexSettingsStatus: async () => ({
+        outDir: true,
+        autoRevealExclude: true,
+        texDistributionInstalled: false,
+        latexWorkshopInstalled: false,
+        latexdiffInstalled: false,
+        latexindentInstalled: false,
+        texcountInstalled: false,
+        imageProcessingInstalled: false,
+        platform: 'linux',
+        pdflatexPath: null,
+        latexmkPath: null,
+        latexdiffPath: null,
+        latexindentPath: null,
+        texcountPath: null,
+        ghostscriptPath: null,
+        graphicsmagickPath: null,
+        packageManager: null,
+      }),
       postToRenderer: (message) => posted.push(message),
     });
 


### PR DESCRIPTION
## Summary

This makes the standalone desktop Settings view use real main-process handlers instead of leaving several controls in a loaded-but-inert state.

- publish LaTeX tooling status to the renderer so the LaTeX tab stops sitting on `Loading LaTeX settings...`
- load provider API-key status while signed out, move API Configuration above the model matrix, and wire Set/Get/Remove key actions through desktop secrets and external URLs
- route sign-in entry points to a visible desktop path instead of a no-op; included-access OAuth is still not connected in desktop, so the dialog points users to provider keys for this build
- wire multi-agent preset and delegation settings to the shared settings controllers
- add regression coverage for LaTeX status loading and provider-key storage

Fixes #3561.
Addresses #3562 and #3564.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new desktop settings IPC handlers that write/delete API keys via platform secrets and update model options, plus LaTeX tooling detection and delegation/preset controls; mistakes could lead to incorrect secret persistence or stale UI state. Changes are contained to desktop settings/shell plumbing and include new regression tests.
> 
> **Overview**
> Unblocks multiple previously inert **desktop Settings** controls by expanding `createDesktopSettingsIpc` to serve profile data on demand, load provider API key status while signed out, and handle setting/removing keys (via `PlatformSecrets`) plus streaming/endpoint toggles and external key URLs.
> 
> Adds desktop-side **LaTeX tooling status** detection/publishing so the LaTeX tab can render real install/config state, and wires **agent team presets** and delegation-related workspace toggles to settings messages.
> 
> Introduces a simple `promptInRenderer` overlay for collecting text/secrets, routes sign-in/banner entry points to the Models settings tab (with an informational dialog for unimplemented desktop OAuth), reorders Models tab UI to show API configuration above the model matrix, and adds tests covering LaTeX status loading and provider-key storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c856391ddbb6da84aaa943b5adbb54c89249475d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->