### PR TITLE
feat: add desktop workspace file explorer

### DIFF
--- a/packages/desktop/src/desktopWorkspaceExplorerMessages.ts
+++ b/packages/desktop/src/desktopWorkspaceExplorerMessages.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+import { WorkspaceTreeNodeSchema } from './workspaceTreeSchema.js';
+
+export const DESKTOP_WORKSPACE_EXPLORER_COMMANDS = {
+  REQUEST_TREE: 'desktop:requestWorkspaceTree',
+  SET_TREE: 'desktop:setWorkspaceTree',
+  OPEN_FILE: 'desktop:openWorkspaceFile',
+  SELECT_FILE: 'desktop:selectWorkspaceFile',
+} as const;
+
+export const DesktopWorkspaceFileCategorySchema = z.enum([
+  'input',
+  'reference',
+  'auxiliary',
+  'media',
+]);
+export type DesktopWorkspaceFileCategory = z.infer<
+  typeof DesktopWorkspaceFileCategorySchema
+>;
+
+export const DesktopWorkspaceTreeMessageSchema = z.object({
+  command: z.literal(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SET_TREE),
+  workspaceName: z.string().nullish(),
+  files: z.array(z.string()),
+  tree: z.array(WorkspaceTreeNodeSchema),
+});
+
+export const DesktopWorkspaceOpenFileMessageSchema = z.object({
+  command: z.literal(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.OPEN_FILE),
+  filePath: z.string().min(1),
+});
+
+export const DesktopWorkspaceSelectFileMessageSchema = z.object({
+  command: z.literal(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SELECT_FILE),
+  filePath: z.string().min(1),
+  fileType: DesktopWorkspaceFileCategorySchema,
+});
+
+export type DesktopWorkspaceTreeMessage = z.infer<
+  typeof DesktopWorkspaceTreeMessageSchema
+>;
+export type DesktopWorkspaceOpenFileMessage = z.infer<
+  typeof DesktopWorkspaceOpenFileMessageSchema
+>;
+export type DesktopWorkspaceSelectFileMessage = z.infer<
+  typeof DesktopWorkspaceSelectFileMessageSchema
+>;

--- a/packages/desktop/src/main/desktopFileSelection.ts
+++ b/packages/desktop/src/main/desktopFileSelection.ts
@@ -1,6 +1,7 @@
-import { readdir } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { tryPlatform } from '@platform/platform';
 import { getWorkspaceProvider } from '@agent/core/workspace';
 import { getFilterExtensions } from '@common/files/fileTypeUtils';
 import {
@@ -8,12 +9,10 @@ import {
   getFileListConfig,
   loadFileListSettings,
   matchesEditedFile,
-  passesFileFilters,
-  prepareFileFilters,
-  shouldVisitDirectory,
   type FileListConfig,
   type ListableFileType,
 } from '@common/files/fileListingRules';
+import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { normalizeFilePath } from '@shared/utils/path';
 import { getConfig } from '@utils/config/configUtils';
@@ -71,32 +70,19 @@ function getListSettings() {
   return loadFileListSettings(getConfig);
 }
 
+function readDirectory(directory: string) {
+  return (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory);
+}
+
 async function listFiles(
   root: string,
   rawConfig: FileListConfig,
 ): Promise<string[]> {
-  const filters = prepareFileFilters(rawConfig);
-  const results: string[] = [];
-
-  async function visit(directory: string): Promise<void> {
-    const entries = await readdir(directory, { withFileTypes: true });
-    for (const entry of entries) {
-      const absolutePath = join(directory, entry.name);
-      const relativePath = normalizeFilePath(relative(root, absolutePath));
-      if (entry.isDirectory()) {
-        if (shouldVisitDirectory(relativePath, filters)) {
-          await visit(absolutePath);
-        }
-        continue;
-      }
-      if (entry.isFile() && passesFileFilters(relativePath, filters)) {
-        results.push(relativePath);
-      }
-    }
-  }
-
-  await visit(root);
-  return results.sort((a, b) => a.localeCompare(b));
+  return listWorkspaceFiles({
+    root,
+    config: rawConfig,
+    readDirectory,
+  });
 }
 
 function resolveWorkspaceFile(workspacePath: string, filePath: string): string {

--- a/packages/desktop/src/main/desktopWorkspaceExplorer.ts
+++ b/packages/desktop/src/main/desktopWorkspaceExplorer.ts
@@ -1,0 +1,195 @@
+import { basename, isAbsolute, relative, resolve } from 'node:path';
+
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { tryPlatform } from '@platform/platform';
+import { getWorkspaceProvider } from '@agent/core/workspace';
+import {
+  getFileListConfig,
+  loadFileListSettings,
+  type ListableFileType,
+} from '@common/files/fileListingRules';
+import {
+  buildWorkspaceTree,
+  listWorkspaceFiles,
+  type WorkspaceTreeNode,
+} from '@common/files/workspaceFileListing';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import { normalizeFilePath } from '@shared/utils/path';
+import { getConfig } from '@utils/config/configUtils';
+
+import {
+  DESKTOP_WORKSPACE_EXPLORER_COMMANDS,
+  DesktopWorkspaceOpenFileMessageSchema,
+  DesktopWorkspaceSelectFileMessageSchema,
+  type DesktopWorkspaceFileCategory,
+} from '../desktopWorkspaceExplorerMessages.js';
+import type {
+  DesktopCommandMessage,
+  DesktopMessageHandler,
+} from './desktopIpcTypes.js';
+
+export interface DesktopWorkspaceExplorerOptions {
+  postToRenderer(message: unknown): void;
+  getWorkspacePath?: () => string | undefined;
+  openPath?: (filePath: string) => Promise<void>;
+  onError?: (error: unknown) => void;
+}
+
+export type DesktopWorkspaceExplorer = DesktopMessageHandler;
+
+const SELECTED_COMMAND_BY_FILE_TYPE = {
+  input: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
+  reference: MAIN_VIEW_COMMANDS.REFERENCE_FILE_SELECTED,
+  auxiliary: MAIN_VIEW_COMMANDS.AUXILIARY_FILE_SELECTED,
+  media: MAIN_VIEW_COMMANDS.MEDIA_FILE_SELECTED,
+} as const satisfies Record<DesktopWorkspaceFileCategory, string>;
+
+function getListSettings() {
+  return loadFileListSettings(getConfig);
+}
+
+function readDirectory(directory: string) {
+  return (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory);
+}
+
+function resolveWorkspaceFile(workspacePath: string, filePath: string): string {
+  return isAbsolute(filePath) ? filePath : resolve(workspacePath, filePath);
+}
+
+function toWorkspaceRelative(workspacePath: string, filePath: string): string {
+  const absolutePath = resolveWorkspaceFile(workspacePath, filePath);
+  const relativePath = relative(workspacePath, absolutePath);
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    throw new Error(
+      'Workspace explorer file paths must stay in the workspace.',
+    );
+  }
+  return normalizeFilePath(relativePath);
+}
+
+async function listForConfig(
+  workspacePath: string,
+  fileType: ListableFileType,
+): Promise<string[]> {
+  const config = getFileListConfig(fileType, getListSettings());
+  if (!config) return [];
+  return listWorkspaceFiles({
+    root: workspacePath,
+    config,
+    readDirectory,
+  });
+}
+
+function addCategories(
+  categoriesByFile: Map<string, DesktopWorkspaceFileCategory[]>,
+  fileType: DesktopWorkspaceFileCategory,
+  files: readonly string[],
+): void {
+  for (const file of files) {
+    const categories = categoriesByFile.get(file) ?? [];
+    if (!categories.includes(fileType)) {
+      categories.push(fileType);
+    }
+    categoriesByFile.set(file, categories);
+  }
+}
+
+async function loadWorkspaceTree(
+  workspacePath: string,
+): Promise<{ files: string[]; tree: WorkspaceTreeNode[] }> {
+  const [inputFiles, referenceFiles, auxiliaryFiles, mediaFiles] =
+    await Promise.all([
+      listForConfig(workspacePath, 'input'),
+      listForConfig(workspacePath, 'reference'),
+      listForConfig(workspacePath, 'auxiliary'),
+      listForConfig(workspacePath, 'media'),
+    ]);
+  const files = [
+    ...new Set([
+      ...inputFiles,
+      ...referenceFiles,
+      ...auxiliaryFiles,
+      ...mediaFiles,
+    ]),
+  ].sort((left, right) => left.localeCompare(right));
+  const categoriesByFile = new Map<string, DesktopWorkspaceFileCategory[]>();
+  addCategories(categoriesByFile, 'input', inputFiles);
+  addCategories(categoriesByFile, 'reference', referenceFiles);
+  addCategories(categoriesByFile, 'auxiliary', auxiliaryFiles);
+  addCategories(categoriesByFile, 'media', mediaFiles);
+  return { files, tree: buildWorkspaceTree(files, categoriesByFile) };
+}
+
+export function createDesktopWorkspaceExplorer(
+  options: DesktopWorkspaceExplorerOptions,
+): DesktopWorkspaceExplorer {
+  const getWorkspacePath =
+    options.getWorkspacePath ??
+    (() => getWorkspaceProvider().getWorkspacePath());
+  const onError =
+    options.onError ??
+    ((error) => {
+      console.error(error);
+    });
+
+  function runAsync(work: Promise<void>): void {
+    void work.catch(onError);
+  }
+
+  async function requestTree(): Promise<void> {
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) {
+      options.postToRenderer({
+        command: DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SET_TREE,
+        workspaceName: undefined,
+        files: [],
+        tree: [],
+      });
+      return;
+    }
+    const { files, tree } = await loadWorkspaceTree(workspacePath);
+    options.postToRenderer({
+      command: DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SET_TREE,
+      workspaceName: basename(workspacePath),
+      files,
+      tree,
+    });
+  }
+
+  async function openFile(message: DesktopCommandMessage): Promise<void> {
+    const parsed = DesktopWorkspaceOpenFileMessageSchema.parse(message);
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath || !options.openPath) return;
+    const relativePath = toWorkspaceRelative(workspacePath, parsed.filePath);
+    await options.openPath(resolve(workspacePath, relativePath));
+  }
+
+  async function selectFile(message: DesktopCommandMessage): Promise<void> {
+    const parsed = DesktopWorkspaceSelectFileMessageSchema.parse(message);
+    const workspacePath = getWorkspacePath();
+    if (!workspacePath) return;
+    const relativePath = toWorkspaceRelative(workspacePath, parsed.filePath);
+    options.postToRenderer({
+      command: SELECTED_COMMAND_BY_FILE_TYPE[parsed.fileType],
+      filePath: relativePath,
+    });
+  }
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      switch (message.command) {
+        case DESKTOP_WORKSPACE_EXPLORER_COMMANDS.REQUEST_TREE:
+          runAsync(requestTree());
+          return true;
+        case DESKTOP_WORKSPACE_EXPLORER_COMMANDS.OPEN_FILE:
+          runAsync(openFile(message));
+          return true;
+        case DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SELECT_FILE:
+          runAsync(selectFile(message));
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
+import { createDesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import {
   attachRendererConsoleLog,
   getDesktopLogDirectory,
@@ -136,6 +137,11 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     },
     onError: reportAsyncError,
   });
+  const workspaceExplorer = createDesktopWorkspaceExplorer({
+    postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
+    openPath,
+    onError: reportAsyncError,
+  });
   const settingsIpc = createDesktopSettingsIpc({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     sendStartupCatalogData: true,
@@ -180,6 +186,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   const mainViewIpc = installDesktopMainViewIpc(window, {
     executeAgent: (message) => agentExecution.handleExecute(message),
     fileSelection,
+    workspaceExplorer,
     settings: settingsIpc,
     progress: progressIpc,
     shellActions,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -16,6 +16,7 @@ import {
 import type { DesktopProgressIpc } from './desktopProgressIpc.js';
 import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
+import type { DesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
 import type { BrowserWindow } from 'electron';
 
@@ -23,6 +24,7 @@ export interface DesktopMainViewIpcOptions {
   debugMode?: boolean;
   getTheme?: () => DesktopTheme;
   fileSelection?: DesktopFileSelection;
+  workspaceExplorer?: DesktopWorkspaceExplorer;
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
   shellActions?: DesktopShellActions;
@@ -75,6 +77,7 @@ export function installDesktopMainViewIpc(
   });
   messageHandlers = [
     startup,
+    options.workspaceExplorer,
     options.fileSelection,
     options.settings,
     options.progress,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -3,6 +3,7 @@ import './themeTokens.css';
 import './codiconStylesheet';
 
 import { COMMON_COMMANDS } from '@common/webview/commands';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { postMessage } from '@shared/hostBridge';
 import { SetThemeMessageSchema } from '@shared/schemas/commonViewMessages';
 import '@vscode-elements/elements/dist/bundled.js';
@@ -19,7 +20,21 @@ import {
   buildDesktopSettingsTabMessage,
   DESKTOP_LOCAL_COMMANDS,
 } from '../desktopCommandSurface';
+import {
+  DESKTOP_WORKSPACE_EXPLORER_COMMANDS,
+  DesktopWorkspaceTreeMessageSchema,
+  type DesktopWorkspaceFileCategory,
+  type DesktopWorkspaceTreeMessage,
+} from '../desktopWorkspaceExplorerMessages';
 import { createDesktopCommandPalette } from './desktopCommandPalette';
+
+interface WorkspaceTreeNode {
+  name: string;
+  path: string;
+  type: 'directory' | 'file';
+  children?: WorkspaceTreeNode[];
+  categories?: string[];
+}
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -51,11 +66,14 @@ appRoot.innerHTML = `
         Open Folder
       </button>
     </nav>
-    <main class="desktop-view" id="desktop-view">
-      <section class="desktop-route" data-route="main"></section>
-      <section class="desktop-route" data-route="progress" hidden></section>
-      <section class="desktop-route" data-route="settings" hidden></section>
-    </main>
+    <div class="desktop-workbench">
+      <aside class="desktop-explorer" id="desktop-explorer" aria-label="Workspace Explorer"></aside>
+      <main class="desktop-view" id="desktop-view">
+        <section class="desktop-route" data-route="main"></section>
+        <section class="desktop-route" data-route="progress" hidden></section>
+        <section class="desktop-route" data-route="settings" hidden></section>
+      </main>
+    </div>
   </section>
 `;
 
@@ -64,6 +82,13 @@ const desktopViewContainer =
 if (desktopViewContainer == null) {
   throw new Error('TeXRA desktop view container was not found.');
 }
+
+const workspaceExplorerElement =
+  appRoot.querySelector<HTMLElement>('#desktop-explorer');
+if (workspaceExplorerElement == null) {
+  throw new Error('TeXRA desktop workspace explorer was not found.');
+}
+const workspaceExplorerContainer: HTMLElement = workspaceExplorerElement;
 
 const routeContainers = new Map<DesktopRoute, HTMLElement>();
 for (const route of ['main', 'progress', 'settings'] as const) {
@@ -89,6 +114,10 @@ for (const route of ['main', 'progress', 'settings'] as const) {
 }
 
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
+let selectedExplorerFile = '';
+let currentExplorerTree: WorkspaceTreeNode[] = [];
+
+renderWorkspaceExplorerLoading();
 
 if (hasWorkspace) {
   const mainApp = document.createElement('main-app');
@@ -161,6 +190,7 @@ openWorkspaceButton.addEventListener('click', () =>
 openLogButton.addEventListener('click', () =>
   postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
 );
+requestWorkspaceTree();
 
 function isDesktopSetRouteMessage(
   message: unknown,
@@ -189,6 +219,8 @@ window.addEventListener('message', (event) => {
     setRoute(event.data.route);
   } else if (isThemeMessage(event.data)) {
     applyDesktopTheme(event.data.theme);
+  } else if (isWorkspaceTreeMessage(event.data)) {
+    renderWorkspaceExplorer(event.data);
   }
 });
 
@@ -250,4 +282,257 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
   return container;
+}
+
+function isWorkspaceTreeMessage(
+  message: unknown,
+): message is DesktopWorkspaceTreeMessage {
+  return DesktopWorkspaceTreeMessageSchema.safeParse(message).success;
+}
+
+function requestWorkspaceTree(): void {
+  if (!hasWorkspace) {
+    renderWorkspaceExplorerNoWorkspace();
+    return;
+  }
+  postMessage(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.REQUEST_TREE);
+}
+
+function renderWorkspaceExplorerLoading(): void {
+  workspaceExplorerContainer.replaceChildren();
+  workspaceExplorerContainer.append(
+    createExplorerHeader('Workspace', true),
+    createExplorerStatus('Loading workspace files...'),
+  );
+}
+
+function renderWorkspaceExplorerNoWorkspace(): void {
+  workspaceExplorerContainer.replaceChildren();
+  const prompt = document.createElement('section');
+  prompt.className = 'desktop-explorer-empty';
+  prompt.innerHTML = `
+    <span class="codicon codicon-folder-opened" aria-hidden="true"></span>
+    <h2>No workspace</h2>
+    <p>Open a folder before selecting files for agents.</p>
+    <button class="desktop-primary-button" type="button" data-explorer-open-folder>
+      Open Folder
+    </button>
+  `;
+  prompt
+    .querySelector<HTMLButtonElement>('[data-explorer-open-folder]')
+    ?.addEventListener('click', () =>
+      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
+    );
+  workspaceExplorerContainer.append(prompt);
+}
+
+function renderWorkspaceExplorer(message: DesktopWorkspaceTreeMessage): void {
+  currentExplorerTree = message.tree;
+  workspaceExplorerContainer.replaceChildren();
+  workspaceExplorerContainer.append(
+    createExplorerHeader(message.workspaceName ?? 'Workspace'),
+  );
+
+  if (message.tree.length === 0) {
+    workspaceExplorerContainer.append(
+      createExplorerStatus('No selectable workspace files found.'),
+    );
+    return;
+  }
+
+  const tree = document.createElement('div');
+  tree.className = 'desktop-explorer-tree';
+  tree.setAttribute('role', 'tree');
+  renderTreeNodes(tree, message.tree, 0);
+
+  const selection = document.createElement('section');
+  selection.className = 'desktop-explorer-selection';
+  selection.setAttribute('aria-live', 'polite');
+  selection.dataset.selectionPanel = 'true';
+
+  workspaceExplorerContainer.append(tree, selection);
+  updateExplorerSelectionPanel(message.tree);
+}
+
+function createExplorerHeader(title: string, loading = false): HTMLElement {
+  const header = document.createElement('header');
+  header.className = 'desktop-explorer-header';
+  const label = document.createElement('span');
+  label.className = 'desktop-explorer-title';
+  label.textContent = title;
+  const refresh = document.createElement('button');
+  refresh.className = 'desktop-explorer-icon-button codicon codicon-refresh';
+  refresh.type = 'button';
+  refresh.title = 'Refresh workspace files';
+  refresh.setAttribute('aria-label', 'Refresh workspace files');
+  refresh.disabled = loading || !hasWorkspace;
+  refresh.addEventListener('click', requestWorkspaceTree);
+  header.append(label, refresh);
+  return header;
+}
+
+function createExplorerStatus(text: string): HTMLElement {
+  const status = document.createElement('p');
+  status.className = 'desktop-explorer-status';
+  status.textContent = text;
+  return status;
+}
+
+function renderTreeNodes(
+  container: HTMLElement,
+  nodes: readonly WorkspaceTreeNode[],
+  depth: number,
+): void {
+  for (const node of nodes) {
+    if (node.type === 'directory') {
+      const details = document.createElement('details');
+      details.className = 'desktop-explorer-directory';
+      details.open = depth < 2;
+      details.style.setProperty('--tree-depth', String(depth));
+
+      const summary = document.createElement('summary');
+      summary.className = 'desktop-explorer-row desktop-explorer-folder-row';
+      summary.setAttribute('role', 'treeitem');
+      summary.innerHTML = `
+        <span class="codicon codicon-chevron-right desktop-explorer-chevron" aria-hidden="true"></span>
+        <span class="codicon codicon-folder" aria-hidden="true"></span>
+        <span class="desktop-explorer-name"></span>
+      `;
+      summary.querySelector('.desktop-explorer-name')!.textContent = node.name;
+      details.append(summary);
+
+      const group = document.createElement('div');
+      group.setAttribute('role', 'group');
+      renderTreeNodes(group, node.children ?? [], depth + 1);
+      details.append(group);
+      container.append(details);
+      continue;
+    }
+
+    const row = document.createElement('button');
+    row.className = 'desktop-explorer-row desktop-explorer-file-row';
+    row.type = 'button';
+    row.dataset.filePath = node.path;
+    row.style.setProperty('--tree-depth', String(depth));
+    row.setAttribute('role', 'treeitem');
+    row.title = node.path;
+    row.innerHTML = `
+      <span class="codicon codicon-file" aria-hidden="true"></span>
+      <span class="desktop-explorer-name"></span>
+      <span class="desktop-explorer-category-strip"></span>
+    `;
+    row.querySelector('.desktop-explorer-name')!.textContent = node.name;
+    row
+      .querySelector('.desktop-explorer-category-strip')
+      ?.replaceChildren(...createCategoryDots(node.categories ?? []));
+    row.addEventListener('click', () => selectExplorerFile(node.path));
+    row.addEventListener('dblclick', () => openWorkspaceFile(node.path));
+    container.append(row);
+  }
+}
+
+function createCategoryDots(categories: readonly string[]): HTMLElement[] {
+  return categories.map((category) => {
+    const dot = document.createElement('span');
+    dot.className = 'desktop-explorer-category-dot';
+    dot.title = category;
+    dot.dataset.category = category;
+    return dot;
+  });
+}
+
+function selectExplorerFile(filePath: string): void {
+  selectedExplorerFile = filePath;
+  for (const row of workspaceExplorerContainer.querySelectorAll<HTMLElement>(
+    '.desktop-explorer-file-row',
+  )) {
+    row.dataset.selected = String(row.dataset.filePath === filePath);
+  }
+  updateExplorerSelectionPanel(currentExplorerTree);
+}
+
+function updateExplorerSelectionPanel(
+  tree: readonly WorkspaceTreeNode[],
+): void {
+  const panel = workspaceExplorerContainer.querySelector<HTMLElement>(
+    '[data-selection-panel]',
+  );
+  if (!panel) return;
+  const node = selectedExplorerFile
+    ? findFileNode(tree, selectedExplorerFile)
+    : undefined;
+  if (!node) {
+    panel.textContent =
+      'Select a file to open it or attach it to the launcher.';
+    return;
+  }
+
+  panel.replaceChildren();
+  const path = document.createElement('div');
+  path.className = 'desktop-explorer-selected-path';
+  path.textContent = node.path;
+  const actions = document.createElement('div');
+  actions.className = 'desktop-explorer-selection-actions';
+
+  const open = document.createElement('button');
+  open.type = 'button';
+  open.className = 'desktop-secondary-button';
+  open.textContent = 'Open';
+  open.addEventListener('click', () => openWorkspaceFile(node.path));
+  actions.append(open);
+
+  for (const category of node.categories ?? []) {
+    const typedCategory = parseExplorerCategory(category);
+    if (!typedCategory) continue;
+    const select = document.createElement('button');
+    select.type = 'button';
+    select.className = 'desktop-secondary-button';
+    select.textContent = `Use as ${typedCategory}`;
+    select.addEventListener('click', () =>
+      selectWorkspaceFile(typedCategory, node.path),
+    );
+    actions.append(select);
+  }
+
+  panel.append(path, actions);
+}
+
+function findFileNode(
+  nodes: readonly WorkspaceTreeNode[],
+  filePath: string,
+): WorkspaceTreeNode | undefined {
+  for (const node of nodes) {
+    if (node.type === 'file' && node.path === filePath) return node;
+    const childMatch = node.children
+      ? findFileNode(node.children, filePath)
+      : undefined;
+    if (childMatch) return childMatch;
+  }
+  return undefined;
+}
+
+function parseExplorerCategory(
+  value: string,
+): DesktopWorkspaceFileCategory | undefined {
+  return ['input', 'reference', 'auxiliary', 'media'].includes(value)
+    ? (value as DesktopWorkspaceFileCategory)
+    : undefined;
+}
+
+function openWorkspaceFile(filePath: string): void {
+  postMessage(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.OPEN_FILE, { filePath });
+}
+
+function selectWorkspaceFile(
+  fileType: DesktopWorkspaceFileCategory,
+  filePath: string,
+): void {
+  postMessage(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.SELECT_FILE, {
+    fileType,
+    filePath,
+  });
+  if (fileType === 'input') {
+    postMessage(MAIN_VIEW_COMMANDS.REQUEST_EDITED_FILE, { baseFile: filePath });
+  }
+  setRoute('main');
 }

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -79,6 +79,216 @@ body {
   box-sizing: border-box;
 }
 
+.desktop-workbench {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+}
+
+.desktop-explorer {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid var(--texra-panel-border);
+  background: var(--texra-sideBar-background);
+  color: var(--texra-sideBar-foreground);
+}
+
+.desktop-explorer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 8px 0 12px;
+  border-bottom: 1px solid var(--texra-panel-border);
+  box-sizing: border-box;
+}
+
+.desktop-explorer-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--texra-foreground);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.desktop-explorer-icon-button {
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--texra-foreground);
+  cursor: pointer;
+}
+
+.desktop-explorer-icon-button:hover {
+  background: var(--texra-toolbar-hoverBackground);
+}
+
+.desktop-explorer-icon-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.desktop-explorer-tree {
+  min-width: 0;
+  overflow: auto;
+  padding: 4px 0;
+}
+
+.desktop-explorer-directory {
+  min-width: 0;
+}
+
+.desktop-explorer-directory > summary {
+  list-style: none;
+}
+
+.desktop-explorer-directory > summary::-webkit-details-marker {
+  display: none;
+}
+
+.desktop-explorer-directory[open] > summary .desktop-explorer-chevron {
+  transform: rotate(90deg);
+}
+
+.desktop-explorer-row {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-height: 24px;
+  padding: 0 8px 0 calc(8px + var(--tree-depth, 0) * 14px);
+  border: 0;
+  border-radius: 0;
+  box-sizing: border-box;
+  background: transparent;
+  color: var(--texra-foreground);
+  font: inherit;
+  text-align: left;
+}
+
+.desktop-explorer-folder-row {
+  cursor: pointer;
+}
+
+.desktop-explorer-file-row {
+  cursor: default;
+}
+
+.desktop-explorer-row:hover {
+  background: var(--texra-list-hoverBackground);
+}
+
+.desktop-explorer-file-row[data-selected='true'] {
+  background: var(--texra-list-activeSelectionBackground);
+  color: var(--texra-list-activeSelectionForeground);
+}
+
+.desktop-explorer-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.desktop-explorer-category-strip {
+  display: flex;
+  gap: 3px;
+}
+
+.desktop-explorer-category-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--texra-descriptionForeground);
+}
+
+.desktop-explorer-category-dot[data-category='input'] {
+  background: var(--texra-charts-blue);
+}
+
+.desktop-explorer-category-dot[data-category='reference'] {
+  background: var(--texra-charts-green);
+}
+
+.desktop-explorer-category-dot[data-category='auxiliary'] {
+  background: var(--texra-charts-yellow);
+}
+
+.desktop-explorer-category-dot[data-category='media'] {
+  background: var(--texra-charts-purple);
+}
+
+.desktop-explorer-status,
+.desktop-explorer-selection,
+.desktop-explorer-empty {
+  padding: 12px;
+  color: var(--texra-descriptionForeground);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.desktop-explorer-selection {
+  border-top: 1px solid var(--texra-panel-border);
+}
+
+.desktop-explorer-selected-path {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--texra-foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.desktop-explorer-selection-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.desktop-explorer-empty {
+  align-self: center;
+  text-align: center;
+}
+
+.desktop-explorer-empty .codicon {
+  color: var(--texra-button-background);
+  font-size: 30px;
+}
+
+.desktop-explorer-empty h2 {
+  margin: 12px 0 6px;
+  color: var(--texra-foreground);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.desktop-explorer-empty p {
+  margin: 0 0 14px;
+}
+
+@media (max-width: 760px) {
+  .desktop-workbench {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(160px, 32vh) minmax(0, 1fr);
+  }
+
+  .desktop-explorer {
+    border-right: 0;
+    border-bottom: 1px solid var(--texra-panel-border);
+  }
+}
+
 .desktop-route {
   display: block;
   min-height: 100%;

--- a/packages/desktop/src/workspaceTreeSchema.ts
+++ b/packages/desktop/src/workspaceTreeSchema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import type { WorkspaceTreeNode } from '@common/files/workspaceFileListing';
+
+export const WorkspaceTreeNodeSchema: z.ZodType<WorkspaceTreeNode> = z.lazy(
+  () =>
+    z.object({
+      name: z.string(),
+      path: z.string(),
+      type: z.enum(['directory', 'file']),
+      children: z.array(WorkspaceTreeNodeSchema).optional(),
+      categories: z.array(z.string()).optional(),
+    }),
+);

--- a/src/common/files/workspaceFileListing.ts
+++ b/src/common/files/workspaceFileListing.ts
@@ -1,0 +1,129 @@
+import { join } from 'node:path';
+
+import { isDirectory, isFile } from '@common/files/fsEntryType';
+import { normalizeFilePath } from '@shared/utils/path';
+
+import {
+  passesFileFilters,
+  prepareFileFilters,
+  shouldVisitDirectory,
+  type FileListConfig,
+} from './fileListingRules';
+
+export interface WorkspaceTreeNode {
+  name: string;
+  path: string;
+  type: 'directory' | 'file';
+  children?: WorkspaceTreeNode[];
+  categories?: string[];
+}
+
+export interface WorkspaceFileListingOptions {
+  root: string;
+  config: FileListConfig;
+  readDirectory(path: string): Promise<[string, number][]>;
+}
+
+export async function listWorkspaceFiles(
+  options: WorkspaceFileListingOptions,
+): Promise<string[]> {
+  const filters = prepareFileFilters(options.config);
+  const results: string[] = [];
+
+  async function visit(
+    directory: string,
+    relativeDirectory: string,
+  ): Promise<void> {
+    const entries = await options.readDirectory(directory);
+    entries.sort(([left], [right]) => left.localeCompare(right));
+
+    for (const [name, type] of entries) {
+      const relativePath = normalizeFilePath(
+        relativeDirectory ? `${relativeDirectory}/${name}` : name,
+      );
+      const absolutePath = join(directory, name);
+
+      if (isDirectory(type)) {
+        if (shouldVisitDirectory(relativePath, filters)) {
+          await visit(absolutePath, relativePath);
+        }
+        continue;
+      }
+
+      if (isFile(type) && passesFileFilters(relativePath, filters)) {
+        results.push(relativePath);
+      }
+    }
+  }
+
+  await visit(options.root, '');
+  return results.sort((left, right) => left.localeCompare(right));
+}
+
+export function buildWorkspaceTree(
+  files: readonly string[],
+  categoriesByFile: ReadonlyMap<string, readonly string[]> = new Map(),
+): WorkspaceTreeNode[] {
+  const roots: WorkspaceTreeNode[] = [];
+
+  function getOrCreateDirectory(
+    siblings: WorkspaceTreeNode[],
+    name: string,
+    path: string,
+  ): WorkspaceTreeNode {
+    const existing = siblings.find(
+      (node) => node.type === 'directory' && node.name === name,
+    );
+    if (existing) return existing;
+
+    const created: WorkspaceTreeNode = {
+      name,
+      path,
+      type: 'directory',
+      children: [],
+    };
+    siblings.push(created);
+    return created;
+  }
+
+  for (const file of [...new Set(files)].sort((left, right) =>
+    left.localeCompare(right),
+  )) {
+    const parts = normalizeFilePath(file).split('/').filter(Boolean);
+    let siblings = roots;
+    let currentPath = '';
+
+    parts.forEach((part, index) => {
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      const isLeaf = index === parts.length - 1;
+      if (isLeaf) {
+        siblings.push({
+          name: part,
+          path: currentPath,
+          type: 'file',
+          categories: [...(categoriesByFile.get(file) ?? [])],
+        });
+        return;
+      }
+
+      const directory = getOrCreateDirectory(siblings, part, currentPath);
+      siblings = directory.children ?? [];
+    });
+  }
+
+  sortWorkspaceTree(roots);
+  return roots;
+}
+
+function sortWorkspaceTree(nodes: WorkspaceTreeNode[]): void {
+  nodes.sort((left, right) => {
+    if (left.type !== right.type) {
+      return left.type === 'directory' ? -1 : 1;
+    }
+    return left.name.localeCompare(right.name);
+  });
+
+  for (const node of nodes) {
+    if (node.children) sortWorkspaceTree(node.children);
+  }
+}

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -44,6 +44,16 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
   });
 
+  it('mounts a persistent workspace explorer sidebar', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('id="desktop-explorer"');
+    expect(rendererMain).toContain('REQUEST_TREE');
+    expect(rendererMain).toContain('OPEN_FILE');
+    expect(rendererMain).toContain('SELECT_FILE');
+    expect(rendererMain).toContain('Use as ${typedCategory}');
+  });
+
   it('mounts the catalog-backed command palette', () => {
     const rendererMain = readRendererMain();
 

--- a/src/test-kernel/desktop/ElectronWorkspaceExplorer.vitest.mts
+++ b/src/test-kernel/desktop/ElectronWorkspaceExplorer.vitest.mts
@@ -1,0 +1,144 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+
+import { moduleFileUrl, desktopSourcePath } from './desktopTestPaths.mjs';
+
+interface DesktopWorkspaceExplorerModule {
+  createDesktopWorkspaceExplorer(options: {
+    postToRenderer(message: unknown): void;
+    getWorkspacePath?: () => string | undefined;
+    openPath?: (filePath: string) => Promise<void>;
+    onError?: (error: unknown) => void;
+  }): {
+    handleMessage(
+      message: { command: string } & Record<string, unknown>,
+    ): boolean;
+  };
+}
+
+const COMMANDS = {
+  REQUEST_TREE: 'desktop:requestWorkspaceTree',
+  SET_TREE: 'desktop:setWorkspaceTree',
+  OPEN_FILE: 'desktop:openWorkspaceFile',
+  SELECT_FILE: 'desktop:selectWorkspaceFile',
+} as const;
+
+async function loadDesktopWorkspaceExplorer(): Promise<DesktopWorkspaceExplorerModule> {
+  vi.resetModules();
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopWorkspaceExplorer.ts'))
+  ) as Promise<DesktopWorkspaceExplorerModule>;
+}
+
+describe('desktop workspace explorer', () => {
+  let workspacePath: string;
+
+  beforeEach(async () => {
+    workspacePath = await mkdtemp(join(tmpdir(), 'texra-explorer-'));
+    await mkdir(join(workspacePath, 'sections'), { recursive: true });
+    await mkdir(join(workspacePath, 'figures'), { recursive: true });
+    await mkdir(join(workspacePath, 'build'), { recursive: true });
+    await writeFile(join(workspacePath, 'main.tex'), '');
+    await writeFile(join(workspacePath, 'refs.bib'), '');
+    await writeFile(join(workspacePath, 'sections', 'intro.tex'), '');
+    await writeFile(join(workspacePath, 'figures', 'plot.png'), '');
+    await writeFile(join(workspacePath, 'build', 'ignored.tex'), '');
+  });
+
+  afterEach(async () => {
+    await rm(workspacePath, { recursive: true, force: true });
+  });
+
+  it('loads a filtered workspace tree with file-selection categories', async () => {
+    const { createDesktopWorkspaceExplorer } =
+      await loadDesktopWorkspaceExplorer();
+    const messages: unknown[] = [];
+    const explorer = createDesktopWorkspaceExplorer({
+      postToRenderer: (message) => messages.push(message),
+      getWorkspacePath: () => workspacePath,
+    });
+
+    expect(explorer.handleMessage({ command: COMMANDS.REQUEST_TREE })).toBe(
+      true,
+    );
+
+    await vi.waitFor(() =>
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          command: COMMANDS.SET_TREE,
+          files: [
+            'figures/plot.png',
+            'main.tex',
+            'refs.bib',
+            'sections/intro.tex',
+          ],
+        }),
+      ),
+    );
+
+    const treeMessage = messages[0] as {
+      tree: Array<{
+        name: string;
+        type: string;
+        children?: Array<{ path: string; categories?: string[] }>;
+      }>;
+    };
+    const figureDir = treeMessage.tree.find((node) => node.name === 'figures');
+    expect(figureDir?.children?.[0]).toMatchObject({
+      path: 'figures/plot.png',
+      categories: ['media'],
+    });
+  });
+
+  it('hands an explorer selection to the existing main-view file selection flow', async () => {
+    const { createDesktopWorkspaceExplorer } =
+      await loadDesktopWorkspaceExplorer();
+    const messages: unknown[] = [];
+    const explorer = createDesktopWorkspaceExplorer({
+      postToRenderer: (message) => messages.push(message),
+      getWorkspacePath: () => workspacePath,
+    });
+
+    expect(
+      explorer.handleMessage({
+        command: COMMANDS.SELECT_FILE,
+        fileType: 'input',
+        filePath: 'sections/intro.tex',
+      }),
+    ).toBe(true);
+
+    await vi.waitFor(() =>
+      expect(messages).toContainEqual({
+        command: MAIN_VIEW_COMMANDS.INPUT_FILE_SELECTED,
+        filePath: 'sections/intro.tex',
+      }),
+    );
+  });
+
+  it('opens selected files through the desktop host path bridge', async () => {
+    const { createDesktopWorkspaceExplorer } =
+      await loadDesktopWorkspaceExplorer();
+    const openPath = vi.fn(async () => undefined);
+    const explorer = createDesktopWorkspaceExplorer({
+      postToRenderer: vi.fn(),
+      getWorkspacePath: () => workspacePath,
+      openPath,
+    });
+
+    expect(
+      explorer.handleMessage({
+        command: COMMANDS.OPEN_FILE,
+        filePath: 'main.tex',
+      }),
+    ).toBe(true);
+
+    await vi.waitFor(() =>
+      expect(openPath).toHaveBeenCalledWith(join(workspacePath, 'main.tex')),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a standalone desktop workspace explorer so agent file selection can work from the workspace the user opened instead of relying only on native file dialogs.

- add a shared workspace file listing/tree builder using the existing TeXRA file-listing rules
- add desktop workspace explorer IPC for tree loading, file opening, and selecting input/reference/auxiliary/media files into the existing main-view selection flow
- add a renderer explorer panel with category badges and actions for selecting or opening files
- keep tree messages schema-validated with the shared `WorkspaceTreeNode` type
- cover filtered tree loading, file selection, and shell opening with desktop kernel tests

Fixes #3558.
Addresses #3295.

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/ElectronFileSelection.vitest.mts src/test-kernel/desktop/ElectronWorkspaceExplorer.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new desktop IPC paths and renderer UI for listing/opening workspace files, which could affect file selection behavior and path handling. Risk is mitigated by schema validation, workspace-bound path checks, and new kernel tests.
> 
> **Overview**
> Adds a **desktop workspace explorer** sidebar that requests a filtered workspace file tree from the Electron main process and lets users open files or attach them as `input`/`reference`/`auxiliary`/`media` into the existing main-view selection flow.
> 
> Introduces shared utilities in `src/common/files/workspaceFileListing.ts` to list workspace files using existing file-listing rules and to build a categorized directory tree, then refactors desktop file selection to reuse this shared listing implementation. Updates desktop IPC wiring (`main/index.ts`, `mainViewIpc.ts`) and renderer layout/styles to mount and render the new explorer, with added Vitest coverage for tree loading, selection bridging, and open-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02cccae620eec23a50145cf7ca78d1ba3361f3ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->