### PR TITLE
refactor: use SDK-native stop reason types

### DIFF
--- a/src/agent/core/flows/ResponseCycleFlow.ts
+++ b/src/agent/core/flows/ResponseCycleFlow.ts
@@ -502,7 +502,7 @@ class ResponseContinuationNode<C> extends BaseNode<
     return {
       shouldSkip,
       interrupted,
-      stopReason: shared.stopReason,
+      stopReason: shared.stopReason ?? undefined,
       processedResponse: shared.processedResponse,
       messages: shared.messages,
     };

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -14,7 +14,7 @@ export const OPENAI_CHAT_FINISH = {
   TOOL_CALLS: 'tool_calls',
   CONTENT_FILTER: 'content_filter',
   FUNCTION_CALL: 'function_call',
-} as const;
+} as const satisfies Record<string, NonNullable<OpenAIChatFinishReason>>;
 export type OpenAIChatFinishReason = ChatCompletion.Choice['finish_reason'];
 
 /**
@@ -25,7 +25,7 @@ export const OPENAI_COMPLETION_FINISH = {
   STOP: 'stop',
   LENGTH: 'length',
   CONTENT_FILTER: 'content_filter',
-} as const;
+} as const satisfies Record<string, NonNullable<OpenAICompletionFinishReason>>;
 export type OpenAICompletionFinishReason = CompletionChoice['finish_reason'];
 
 /** Stop reasons defined in the Model Context Protocol SDK. */

--- a/src/agent/modelHandlers/types/StopReasonTypes.ts
+++ b/src/agent/modelHandlers/types/StopReasonTypes.ts
@@ -1,6 +1,8 @@
 // Third-party imports
 import { FinishReason } from '@google/genai';
 import type { StopReason as AnthropicSDKStopReason } from '@anthropic-ai/sdk/resources/messages';
+import type { ChatCompletion } from 'openai/resources/chat/completions';
+import type { CompletionChoice } from 'openai/resources/completions';
 
 /**
  * Finish reasons returned by the OpenAI Chat Completion API.
@@ -13,10 +15,7 @@ export const OPENAI_CHAT_FINISH = {
   CONTENT_FILTER: 'content_filter',
   FUNCTION_CALL: 'function_call',
 } as const;
-export const OPENAI_CHAT_FINISH_REASONS = Object.values(OPENAI_CHAT_FINISH);
-export type OpenAIChatFinishReason =
-  | (typeof OPENAI_CHAT_FINISH_REASONS)[number]
-  | null;
+export type OpenAIChatFinishReason = ChatCompletion.Choice['finish_reason'];
 
 /**
  * Finish reasons for the legacy OpenAI text completion API.
@@ -27,11 +26,7 @@ export const OPENAI_COMPLETION_FINISH = {
   LENGTH: 'length',
   CONTENT_FILTER: 'content_filter',
 } as const;
-export const OPENAI_COMPLETION_FINISH_REASONS = Object.values(
-  OPENAI_COMPLETION_FINISH,
-);
-export type OpenAICompletionFinishReason =
-  (typeof OPENAI_COMPLETION_FINISH_REASONS)[number];
+export type OpenAICompletionFinishReason = CompletionChoice['finish_reason'];
 
 /** Stop reasons defined in the Model Context Protocol SDK. */
 export const MCP_STOP = {
@@ -39,8 +34,7 @@ export const MCP_STOP = {
   STOP_SEQUENCE: 'stopSequence',
   MAX_TOKENS: 'maxTokens',
 } as const;
-export const MCP_STOP_REASONS = Object.values(MCP_STOP);
-export type MCPStopReason = (typeof MCP_STOP_REASONS)[number];
+export type MCPStopReason = (typeof MCP_STOP)[keyof typeof MCP_STOP];
 
 /**
  * Stop reasons for Anthropic models.


### PR DESCRIPTION
## Summary
- replace hand-rolled OpenAI finish-reason union types with SDK-native types
- keep runtime stop-reason constants for comparisons
- normalize nullable stop reason in response flow (null to undefined)

## Validation
- npm run -s typecheck
- npm run -s lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily TypeScript typing refinements around stop/finish reasons plus a small null-to-undefined normalization in continuation prep logic.
> 
> **Overview**
> Switches OpenAI stop/finish reason typing to use the OpenAI SDK’s native `finish_reason` types (chat and legacy completions) while keeping the existing runtime constants for comparisons.
> 
> Normalizes `ResponseContinuationNode` prep output by converting `stopReason` from `null` to `undefined`, reducing nullable handling differences in the continuation decision path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c85570e2037688696be4b4ea12f27c2e94709921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->