### PR TITLE
feat: add desktop provider key modal

### DIFF
--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -588,16 +588,21 @@ export function createDesktopSettingsIpc(
     postMainModelOptionsData();
   }
 
-  async function setProviderKey(provider: string): Promise<void> {
+  async function setProviderKey(
+    provider: string,
+    submittedApiKey?: string,
+  ): Promise<void> {
     if (!isApiProvider(provider)) {
       await options.showErrorMessage?.(`Unknown API provider: ${provider}`);
       return;
     }
     const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
-    const apiKey = await options.promptSecret?.({
-      title: `Set ${displayName} API key`,
-      prompt: `Enter ${displayName} API key`,
-    });
+    const apiKey =
+      submittedApiKey ??
+      (await options.promptSecret?.({
+        title: `Set ${displayName} API key`,
+        prompt: `Enter ${displayName} API key`,
+      }));
     const trimmed = apiKey?.trim();
     if (!trimmed) return;
 
@@ -840,7 +845,7 @@ export function createDesktopSettingsIpc(
           );
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY:
-          runAsync(setProviderKey(result.data.provider));
+          runAsync(setProviderKey(result.data.provider, result.data.apiKey));
           return true;
         case SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY:
           runAsync(removeProviderKey(result.data.provider));

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -597,8 +597,9 @@ export function createDesktopSettingsIpc(
       return;
     }
     const displayName = PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+    const trimmedSubmittedKey = submittedApiKey?.trim();
     const apiKey =
-      submittedApiKey ??
+      trimmedSubmittedKey ||
       (await options.promptSecret?.({
         title: `Set ${displayName} API key`,
         prompt: `Enter ${displayName} API key`,

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -4,7 +4,7 @@
  */
 
 // Third-party imports
-import { html, css, type TemplateResult } from 'lit';
+import { html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 
 // Local imports - shared webview
@@ -65,6 +65,7 @@ import './tabs/MultiAgentTab';
 import './tabs/ToolsTab';
 import './tabs/GitTab';
 import './tabs/LaTeXTab';
+import './components/profile/ProviderKeyModal';
 import type { HistoryTab } from './tabs/HistoryTab';
 
 const HISTORY_ACTION_COMMANDS: Record<string, string> = {
@@ -152,6 +153,10 @@ export class SettingsApp extends SettingsAppBase {
   private readonly accessExpiresAt = signal<string | null>(null);
   private readonly providerKeyStatuses = signal<ProviderKeyStatus[]>([]);
   private readonly globalStreamingDefault = signal(true);
+  private readonly providerKeyModal = signal<{
+    provider: string;
+    displayName: string;
+  } | null>(null);
 
   // Model selection state
   private readonly modelSelectionItems = signal<ModelSelectionItem[]>([]);
@@ -321,9 +326,38 @@ export class SettingsApp extends SettingsAppBase {
     SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE,
   );
 
-  private handleSetProviderKey = forwardDetail(
-    SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY,
-  );
+  private isDesktopHost(): boolean {
+    return (
+      this.getAttribute('data-desktop-view') === 'settings' ||
+      Object.hasOwn(window, 'texraDesktop')
+    );
+  }
+
+  private handleSetProviderKey(event: CustomEvent<{ provider: string }>): void {
+    if (!this.isDesktopHost()) {
+      postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY, event.detail);
+      return;
+    }
+
+    const status = this.providerKeyStatuses
+      .get()
+      .find((entry) => entry.provider === event.detail.provider);
+    this.providerKeyModal.set({
+      provider: event.detail.provider,
+      displayName: status?.displayName ?? event.detail.provider,
+    });
+  }
+
+  private handleProviderKeySubmit(
+    event: CustomEvent<{ provider: string; apiKey: string }>,
+  ): void {
+    this.providerKeyModal.set(null);
+    postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY, event.detail);
+  }
+
+  private readonly handleProviderKeyCancel = (): void => {
+    this.providerKeyModal.set(null);
+  };
 
   private handleRemoveProviderKey = forwardDetail(
     SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY,
@@ -588,6 +622,22 @@ export class SettingsApp extends SettingsAppBase {
     `;
   }
 
+  private renderProviderKeyModal(): TemplateResult | typeof nothing {
+    const modal = this.providerKeyModal.get();
+    if (modal == null) {
+      return nothing;
+    }
+
+    return html`
+      <provider-key-modal
+        .provider=${modal.provider}
+        .displayName=${modal.displayName}
+        @provider-key-submit=${this.handleProviderKeySubmit}
+        @provider-key-cancel=${this.handleProviderKeyCancel}
+      ></provider-key-modal>
+    `;
+  }
+
   override render(): TemplateResult {
     return html`
       <div class="settings-container">
@@ -780,6 +830,7 @@ export class SettingsApp extends SettingsAppBase {
             ></latex-tab>
           </vscode-tab-panel>
         </vscode-tabs>
+        ${this.renderProviderKeyModal()}
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -155,15 +155,38 @@ export class ProviderKeyModal extends LitElement {
   @state() private error = '';
 
   @query('input') private keyInput?: HTMLInputElement;
+  @query('.provider-key-dialog') private dialog?: HTMLFormElement;
+
+  private previousFocus: HTMLElement | null = null;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.previousFocus =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+  }
 
   override firstUpdated(): void {
     this.keyInput?.focus();
   }
 
-  private close(): void {
+  private clearSecretValue(): void {
     this.value = '';
+    if (this.keyInput) {
+      this.keyInput.value = '';
+    }
+  }
+
+  private restoreFocus(): void {
+    this.previousFocus?.focus();
+  }
+
+  private close(): void {
+    this.clearSecretValue();
     this.error = '';
     this.dispatchEvent(createEvent('provider-key-cancel'));
+    this.restoreFocus();
   }
 
   private handleBackdropClick(event: MouseEvent): void {
@@ -188,17 +211,53 @@ export class ProviderKeyModal extends LitElement {
       return;
     }
 
+    this.clearSecretValue();
+    this.error = '';
     this.dispatchEvent(
       createEvent('provider-key-submit', {
         provider: this.provider,
         apiKey,
       }),
     );
-    this.value = '';
-    if (this.keyInput) {
-      this.keyInput.value = '';
+    this.restoreFocus();
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    const selector = [
+      'button:not([disabled])',
+      'input:not([disabled])',
+      '[href]',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+    return [...(this.dialog?.querySelectorAll<HTMLElement>(selector) ?? [])];
+  }
+
+  private handleDialogKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close();
+      return;
     }
-    this.error = '';
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = this.getFocusableElements();
+    const first = focusable.at(0);
+    const last = focusable.at(-1);
+    if (!first || !last) {
+      return;
+    }
+
+    const active = this.shadowRoot?.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
   }
 
   override render(): TemplateResult {
@@ -215,6 +274,7 @@ export class ProviderKeyModal extends LitElement {
           aria-modal="true"
           aria-labelledby="provider-key-title"
           @submit=${this.handleSubmit}
+          @keydown=${this.handleDialogKeydown}
         >
           <div class="provider-key-header">
             <h2 id="provider-key-title">Set ${displayName} API key</h2>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyModal.ts
@@ -1,0 +1,267 @@
+/**
+ * ProviderKeyModal component - in-app provider API key entry.
+ * Sends key values only in the submit event; it never receives stored values.
+ */
+
+// Third-party imports
+import { LitElement, css, html, type TemplateResult } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { codiconStyles, designTokens } from '@shared/styles';
+
+// Local imports - shared events
+import { createEvent } from '@shared/utils/events';
+
+@customElement('provider-key-modal')
+export class ProviderKeyModal extends LitElement {
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    css`
+      :host {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+      }
+
+      .provider-key-backdrop {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        padding: var(--spacing-xlarge);
+        background: color-mix(
+          in srgb,
+          var(--texra-editor-background) 35%,
+          transparent
+        );
+      }
+
+      .provider-key-dialog {
+        width: min(560px, 100%);
+        padding: var(--spacing-xlarge);
+        color: var(--texra-foreground);
+        background: var(--texra-editor-background);
+        border: var(--border-thin) solid var(--color-border);
+        border-radius: var(--border-radius-large);
+        box-shadow: 0 12px 32px
+          color-mix(in srgb, var(--texra-editor-foreground) 18%, transparent);
+      }
+
+      .provider-key-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: var(--spacing-large);
+        margin-bottom: var(--spacing-medium);
+      }
+
+      h2 {
+        margin: 0;
+        font-size: var(--font-size-lg);
+      }
+
+      .provider-key-description {
+        margin: 0 0 var(--spacing-large);
+        color: var(--color-text-secondary);
+        line-height: var(--line-height-normal);
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-small);
+        font-weight: var(--font-weight-medium);
+      }
+
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        height: 34px;
+        padding: var(--spacing-small) var(--spacing-medium);
+        color: var(--texra-input-foreground);
+        background: var(--texra-input-background);
+        border: var(--border-thin) solid var(--texra-input-border);
+        border-radius: var(--border-radius);
+        font: inherit;
+      }
+
+      input:focus {
+        outline: var(--border-thin) solid var(--texra-focusBorder);
+        outline-offset: 1px;
+      }
+
+      .provider-key-error {
+        min-height: 1.4em;
+        margin: var(--spacing-small) 0 0;
+        color: var(--texra-errorForeground, var(--color-error));
+        font-size: var(--font-size-sm);
+      }
+
+      .provider-key-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--spacing-medium);
+        margin-top: var(--spacing-large);
+      }
+
+      button {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing-small);
+        min-height: var(--height-button);
+        padding: var(--spacing-small) var(--spacing-large);
+        border-radius: var(--border-radius);
+        font: inherit;
+        cursor: pointer;
+      }
+
+      .provider-key-primary {
+        color: var(--texra-button-foreground);
+        background: var(--texra-button-background);
+        border: var(--border-thin) solid var(--texra-button-background);
+      }
+
+      .provider-key-primary:hover {
+        background: var(--texra-button-hoverBackground);
+      }
+
+      .provider-key-secondary,
+      .provider-key-icon {
+        color: var(--texra-foreground);
+        background: transparent;
+        border: var(--border-thin) solid var(--color-border);
+      }
+
+      .provider-key-secondary:hover,
+      .provider-key-icon:hover {
+        background: var(--texra-list-hoverBackground);
+      }
+
+      .provider-key-icon {
+        min-width: 30px;
+        justify-content: center;
+        padding: var(--spacing-small);
+      }
+    `,
+  ];
+
+  @property() provider = '';
+  @property() displayName = '';
+
+  @state() private value = '';
+  @state() private error = '';
+
+  @query('input') private keyInput?: HTMLInputElement;
+
+  override firstUpdated(): void {
+    this.keyInput?.focus();
+  }
+
+  private close(): void {
+    this.value = '';
+    this.error = '';
+    this.dispatchEvent(createEvent('provider-key-cancel'));
+  }
+
+  private handleBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.close();
+    }
+  }
+
+  private handleInput(event: Event): void {
+    this.value = (event.target as HTMLInputElement).value;
+    if (this.error) {
+      this.error = '';
+    }
+  }
+
+  private handleSubmit(event: SubmitEvent): void {
+    event.preventDefault();
+    const apiKey = this.value.trim();
+    if (!apiKey) {
+      this.error = 'Enter an API key before saving.';
+      this.keyInput?.focus();
+      return;
+    }
+
+    this.dispatchEvent(
+      createEvent('provider-key-submit', {
+        provider: this.provider,
+        apiKey,
+      }),
+    );
+    this.value = '';
+    if (this.keyInput) {
+      this.keyInput.value = '';
+    }
+    this.error = '';
+  }
+
+  override render(): TemplateResult {
+    const displayName = this.displayName || this.provider;
+    return html`
+      <div
+        class="provider-key-backdrop"
+        role="presentation"
+        @click=${this.handleBackdropClick}
+      >
+        <form
+          class="provider-key-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="provider-key-title"
+          @submit=${this.handleSubmit}
+        >
+          <div class="provider-key-header">
+            <h2 id="provider-key-title">Set ${displayName} API key</h2>
+            <button
+              class="provider-key-icon codicon codicon-close"
+              type="button"
+              title="Cancel"
+              aria-label="Cancel"
+              @click=${this.close}
+            ></button>
+          </div>
+          <p class="provider-key-description">
+            The key is stored by TeXRA on this device and is not shown again
+            after saving.
+          </p>
+          <label>
+            ${displayName} API key
+            <input
+              type="password"
+              autocomplete="off"
+              spellcheck="false"
+              .value=${this.value}
+              @input=${this.handleInput}
+            />
+          </label>
+          <p class="provider-key-error" aria-live="polite">${this.error}</p>
+          <div class="provider-key-actions">
+            <button
+              class="provider-key-secondary"
+              type="button"
+              @click=${this.close}
+            >
+              Cancel
+            </button>
+            <button class="provider-key-primary" type="submit">
+              <span class="codicon codicon-key"></span>
+              Save Key
+            </button>
+          </div>
+        </form>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'provider-key-modal': ProviderKeyModal;
+  }
+}

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -509,10 +509,16 @@ export type UpdateLatexConfigValuesMessage = z.infer<
 // to avoid duplicating definitions. The command literal strings are identical.
 
 // Provider key inbound messages (settings-only)
+const SubmittedApiKeySchema = z.preprocess(
+  (value) =>
+    typeof value === 'string' && value.trim() === '' ? undefined : value,
+  z.string().trim().min(1).optional(),
+);
+
 const SetProviderKeyMessageSchema = z.object({
   command: z.literal(CMD.SET_PROVIDER_KEY),
   provider: z.string().min(1),
-  apiKey: z.string().optional(),
+  apiKey: SubmittedApiKeySchema,
 });
 
 const RemoveProviderKeyMessageSchema = z.object({

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -512,6 +512,7 @@ export type UpdateLatexConfigValuesMessage = z.infer<
 const SetProviderKeyMessageSchema = z.object({
   command: z.literal(CMD.SET_PROVIDER_KEY),
   provider: z.string().min(1),
+  apiKey: z.string().optional(),
 });
 
 const RemoveProviderKeyMessageSchema = z.object({

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -385,12 +385,16 @@ describe('desktop settings IPC', () => {
     const secrets = new MemorySecrets();
     const posted: unknown[] = [];
     const infoMessages: string[] = [];
+    let promptCalls = 0;
 
     const settings = createDesktopSettingsIpc({
       workspaceState: new MemoryStateStore(),
       globalState: new MemoryStateStore(),
       secrets,
-      promptSecret: async () => '  sk-test  ',
+      promptSecret: async () => {
+        promptCalls += 1;
+        return '  sk-test  ';
+      },
       showInfoMessage: async (message) => {
         infoMessages.push(message);
       },
@@ -415,11 +419,13 @@ describe('desktop settings IPC', () => {
       settings.handleMessage({
         command: SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY,
         provider: 'google',
+        apiKey: '  sk-modal  ',
       }),
     ).toBe(true);
     await flushAsyncWork();
 
-    expect(secrets.values.get('apiKey.google')).toBe('sk-test');
+    expect(promptCalls).toBe(0);
+    expect(secrets.values.get('apiKey.google')).toBe('sk-modal');
     expect(infoMessages).toEqual(['Google API key has been set']);
     expect(
       posted.findLast(
@@ -432,6 +438,43 @@ describe('desktop settings IPC', () => {
         expect.objectContaining({ provider: 'google', status: 'set' }),
       ]),
     });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY,
+        provider: 'google',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(secrets.values.has('apiKey.google')).toBe(false);
+    expect(infoMessages).toEqual([
+      'Google API key has been set',
+      'Google API key has been removed',
+    ]);
+  });
+
+  it('falls back to the host secret prompt when no provider key is submitted', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const secrets = new MemorySecrets();
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      secrets,
+      promptSecret: async () => '  sk-prompt  ',
+      postToRenderer: () => {},
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY,
+        provider: 'google',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(secrets.values.get('apiKey.google')).toBe('sk-prompt');
   });
 
   it('round-trips LaTeX config writes through workspace state and refreshes the renderer', async () => {

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -1,0 +1,93 @@
+import { JSDOM } from 'jsdom';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+type ProviderKeyModalElement = HTMLElement & {
+  provider: string;
+  displayName: string;
+  updateComplete: Promise<boolean>;
+};
+
+let dom: JSDOM;
+
+describe('ProviderKeyModal', () => {
+  beforeAll(async () => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'https://texra.local',
+    });
+
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      Document: dom.window.Document,
+      customElements: dom.window.customElements,
+      HTMLElement: dom.window.HTMLElement,
+      HTMLInputElement: dom.window.HTMLInputElement,
+      CustomEvent: dom.window.CustomEvent,
+      Event: dom.window.Event,
+      MouseEvent: dom.window.MouseEvent,
+      ShadowRoot: dom.window.ShadowRoot,
+    });
+
+    await import('@settingsView/frontend/components/profile/ProviderKeyModal');
+  });
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  afterAll(() => {
+    dom.window.close();
+  });
+
+  it('emits the trimmed key on submit without rendering it back after save', async () => {
+    const modal = document.createElement(
+      'provider-key-modal',
+    ) as ProviderKeyModalElement;
+    modal.provider = 'google';
+    modal.displayName = 'Google';
+    document.body.append(modal);
+    await modal.updateComplete;
+
+    const submitted: unknown[] = [];
+    modal.addEventListener('provider-key-submit', (event) => {
+      submitted.push((event as CustomEvent).detail);
+    });
+
+    const input = modal.shadowRoot!.querySelector('input')!;
+    input.value = '  sk-test  ';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    modal
+      .shadowRoot!.querySelector('form')!
+      .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await modal.updateComplete;
+
+    expect(submitted).toEqual([{ provider: 'google', apiKey: 'sk-test' }]);
+    expect(input.value).toBe('');
+  });
+
+  it('emits cancel without submitting a key', async () => {
+    const modal = document.createElement(
+      'provider-key-modal',
+    ) as ProviderKeyModalElement;
+    modal.provider = 'google';
+    modal.displayName = 'Google';
+    document.body.append(modal);
+    await modal.updateComplete;
+
+    let cancelled = 0;
+    let submitted = 0;
+    modal.addEventListener('provider-key-cancel', () => {
+      cancelled += 1;
+    });
+    modal.addEventListener('provider-key-submit', () => {
+      submitted += 1;
+    });
+
+    modal
+      .shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-secondary')!
+      .click();
+
+    expect(cancelled).toBe(1);
+    expect(submitted).toBe(0);
+  });
+});

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -8,6 +8,23 @@ type ProviderKeyModalElement = HTMLElement & {
 };
 
 let dom: JSDOM;
+const domGlobalKeys = [
+  'window',
+  'document',
+  'Document',
+  'customElements',
+  'HTMLElement',
+  'HTMLInputElement',
+  'CustomEvent',
+  'Event',
+  'KeyboardEvent',
+  'MouseEvent',
+  'ShadowRoot',
+] as const;
+const previousGlobals = new Map<
+  (typeof domGlobalKeys)[number],
+  { hadValue: boolean; value: unknown }
+>();
 
 describe('ProviderKeyModal', () => {
   beforeAll(async () => {
@@ -15,7 +32,7 @@ describe('ProviderKeyModal', () => {
       url: 'https://texra.local',
     });
 
-    Object.assign(globalThis, {
+    const replacements = {
       window: dom.window,
       document: dom.window.document,
       Document: dom.window.Document,
@@ -24,9 +41,22 @@ describe('ProviderKeyModal', () => {
       HTMLInputElement: dom.window.HTMLInputElement,
       CustomEvent: dom.window.CustomEvent,
       Event: dom.window.Event,
+      KeyboardEvent: dom.window.KeyboardEvent,
       MouseEvent: dom.window.MouseEvent,
       ShadowRoot: dom.window.ShadowRoot,
-    });
+    } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
+
+    for (const key of domGlobalKeys) {
+      previousGlobals.set(key, {
+        hadValue: Object.hasOwn(globalThis, key),
+        value: globalThis[key as keyof typeof globalThis],
+      });
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value: replacements[key],
+      });
+    }
 
     await import('@settingsView/frontend/components/profile/ProviderKeyModal');
   });
@@ -37,6 +67,18 @@ describe('ProviderKeyModal', () => {
 
   afterAll(() => {
     dom.window.close();
+    for (const key of domGlobalKeys) {
+      const previous = previousGlobals.get(key);
+      if (previous?.hadValue) {
+        Object.defineProperty(globalThis, key, {
+          configurable: true,
+          writable: true,
+          value: previous.value,
+        });
+      } else {
+        delete (globalThis as Record<string, unknown>)[key];
+      }
+    }
   });
 
   it('emits the trimmed key on submit without rendering it back after save', async () => {
@@ -65,7 +107,7 @@ describe('ProviderKeyModal', () => {
     expect(input.value).toBe('');
   });
 
-  it('emits cancel without submitting a key', async () => {
+  it('clears input and emits cancel without submitting a key', async () => {
     const modal = document.createElement(
       'provider-key-modal',
     ) as ProviderKeyModalElement;
@@ -83,11 +125,75 @@ describe('ProviderKeyModal', () => {
       submitted += 1;
     });
 
+    const input = modal.shadowRoot!.querySelector('input')!;
+    input.value = 'sk-cancel';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
     modal
       .shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-secondary')!
       .click();
 
     expect(cancelled).toBe(1);
     expect(submitted).toBe(0);
+    expect(input.value).toBe('');
+  });
+
+  it('closes on Escape and traps Tab focus in the dialog', async () => {
+    const trigger = document.createElement('button');
+    document.body.append(trigger);
+    trigger.focus();
+
+    const modal = document.createElement(
+      'provider-key-modal',
+    ) as ProviderKeyModalElement;
+    modal.provider = 'google';
+    modal.displayName = 'Google';
+    document.body.append(modal);
+    await modal.updateComplete;
+
+    let cancelled = 0;
+    modal.addEventListener('provider-key-cancel', () => {
+      cancelled += 1;
+    });
+
+    const input = modal.shadowRoot!.querySelector('input')!;
+    const closeButton =
+      modal.shadowRoot!.querySelector<HTMLButtonElement>('.provider-key-icon')!;
+    const submitButton = modal.shadowRoot!.querySelector<HTMLButtonElement>(
+      '.provider-key-primary',
+    )!;
+
+    submitButton.focus();
+    submitButton.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(modal.shadowRoot!.activeElement).toBe(closeButton);
+
+    closeButton.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(modal.shadowRoot!.activeElement).toBe(submitButton);
+
+    input.value = 'sk-escape';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(cancelled).toBe(1);
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(trigger);
   });
 });


### PR DESCRIPTION
## Summary

- Add an in-app Settings > Models provider API-key modal for the desktop host.
- Let desktop settings IPC accept a submitted key value directly while preserving the existing prompt fallback for non-desktop hosts.
- Refresh provider status after set/remove and cover modal submit/cancel plus desktop secret set/remove paths in tests.

Closes #3553.

## Validation

- `npm run test:kernel -- src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/settings/ProviderKeyModal.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build:fast`
- `corepack pnpm --filter @texra/desktop build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new desktop-only in-app API key entry flow and changes the `SET_PROVIDER_KEY` message shape to optionally carry secrets, which could affect credential handling and host compatibility if miswired.
> 
> **Overview**
> Adds a **desktop-hosted in-app modal** for entering provider API keys in Settings, including focus management, Escape/backdrop close, and clearing the secret from the UI after submit.
> 
> Updates the settings frontend to **open the modal only on desktop hosts** and to submit `{ provider, apiKey }` via `SET_PROVIDER_KEY` (non-desktop continues to use the existing host prompt flow).
> 
> Extends desktop `DesktopSettingsIpc` and `SettingsViewInboundMessageSchema` so `SET_PROVIDER_KEY` can optionally include a trimmed `apiKey`, falling back to `promptSecret` when omitted, and refreshes profile/model state after key set/remove; adds/updates kernel tests for modal behavior and secret set/remove + fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e6e25d4b413bc9c5b02aa81fe14c2863cc7611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->