### PR TITLE
Fix desktop provider key controls before profile load

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -17,6 +17,7 @@ import type {
 } from '@shared/schemas/settingsViewMessages';
 import { profileViewStyles } from './styles';
 import { ProviderKeyEvents } from './events';
+import { resolveProviderKeyRows } from './providerKeyRows';
 
 const STATUS_LABELS: Record<ProviderKeyStatus['status'], string> = {
   set: 'Set',
@@ -231,9 +232,7 @@ export class ProviderKeyList extends LitElement {
   }
 
   override render(): TemplateResult | typeof nothing {
-    if (this.providerKeyStatuses.length === 0) {
-      return nothing;
-    }
+    const rows = resolveProviderKeyRows(this.providerKeyStatuses);
 
     const description =
       this.apiAccessMode === 'included'
@@ -254,7 +253,7 @@ export class ProviderKeyList extends LitElement {
             </tr>
           </thead>
           <tbody>
-            ${this.providerKeyStatuses.map((entry) => this.renderRow(entry))}
+            ${rows.map((entry) => this.renderRow(entry))}
           </tbody>
         </table>
       </div>

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -231,7 +231,7 @@ export class ProviderKeyList extends LitElement {
     `;
   }
 
-  override render(): TemplateResult | typeof nothing {
+  override render(): TemplateResult {
     const rows = resolveProviderKeyRows(this.providerKeyStatuses);
 
     const description =

--- a/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
@@ -1,0 +1,30 @@
+// Local imports - shared schemas and constants
+import type { ProviderKeyStatus } from '@shared/schemas/settingsViewMessages';
+import {
+  API_KEY_PROVIDER_IDS,
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_URLS,
+} from '@shared/constants/providers';
+
+const DEFAULT_PROVIDER_KEY_STATUSES: ProviderKeyStatus[] =
+  API_KEY_PROVIDER_IDS.map((provider) => ({
+    provider,
+    displayName: PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+    status: 'not-set',
+    keyUrl: PROVIDER_URLS[provider] ?? '',
+    streaming: true,
+    customEndpoint: '',
+    supportsCustomEndpoint: false,
+    vscodeSettings: [],
+  }));
+
+/**
+ * Keep provider API-key controls available even before profile state arrives.
+ */
+export function resolveProviderKeyRows(
+  providerKeyStatuses: ProviderKeyStatus[],
+): ProviderKeyStatus[] {
+  return providerKeyStatuses.length > 0
+    ? providerKeyStatuses
+    : DEFAULT_PROVIDER_KEY_STATUSES;
+}

--- a/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/providerKeyRows.ts
@@ -1,7 +1,7 @@
 // Local imports - shared schemas and constants
 import type { ProviderKeyStatus } from '@shared/schemas/settingsViewMessages';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/apiKeyProviders';
 import {
-  API_KEY_PROVIDER_IDS,
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_URLS,
 } from '@shared/constants/providers';

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -63,11 +63,7 @@ export class ModelsTab extends LitElement {
   private readonly handleScrollToApiConfig = (): void =>
     this.scrollToSection('provider-key-list');
 
-  private renderTabHint(): TemplateResult | typeof nothing {
-    if (this.providerKeyStatuses.length === 0) {
-      return nothing;
-    }
-
+  private renderTabHint(): TemplateResult {
     const description =
       this.apiAccessMode === 'included'
         ? 'Personal provider API keys are optional overrides—configure them in the API Configuration section below.'

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -4,20 +4,10 @@
  * Shared between SecretManager (VS Code), ModelHandler (agent core),
  * and computeModelOptions (model). Platform-agnostic.
  */
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
 import type { PlatformSecrets } from '@platform/secrets';
 
-export const API_PROVIDERS = [
-  'openai',
-  'anthropic',
-  'openRouter',
-  'google',
-  'xai',
-  'deepseek',
-  'moonshot',
-  'dashscope',
-  'minimax',
-  'glm',
-] as const;
+export const API_PROVIDERS = API_KEY_PROVIDER_IDS;
 
 export type ApiProvider = (typeof API_PROVIDERS)[number];
 

--- a/src/model/apiProviders.ts
+++ b/src/model/apiProviders.ts
@@ -4,7 +4,7 @@
  * Shared between SecretManager (VS Code), ModelHandler (agent core),
  * and computeModelOptions (model). Platform-agnostic.
  */
-import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/apiKeyProviders';
 import type { PlatformSecrets } from '@platform/secrets';
 
 export const API_PROVIDERS = API_KEY_PROVIDER_IDS;

--- a/src/shared/constants/apiKeyProviders.ts
+++ b/src/shared/constants/apiKeyProviders.ts
@@ -1,0 +1,19 @@
+/**
+ * Provider IDs where users can configure direct API keys.
+ *
+ * This is the single source for direct key-provider enumeration. It is kept
+ * separate from the provider display registry so model/core key lookup can
+ * depend on a tiny data-only module.
+ */
+export const API_KEY_PROVIDER_IDS = [
+  'openai',
+  'anthropic',
+  'openRouter',
+  'google',
+  'xai',
+  'deepseek',
+  'moonshot',
+  'dashscope',
+  'minimax',
+  'glm',
+] as const;

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -98,20 +98,6 @@ export const MODEL_PROVIDERS_ORDER: ModelProvider[] = PROVIDER_REGISTRY.map(
   (p) => p.id,
 );
 
-/** Providers where users can configure direct API keys. */
-export const API_KEY_PROVIDER_IDS = [
-  'openai',
-  'anthropic',
-  'openRouter',
-  'google',
-  'xai',
-  'deepseek',
-  'moonshot',
-  'dashscope',
-  'minimax',
-  'glm',
-] as const;
-
 /**
  * All providers that support server-side API keys.
  * Derived from PROVIDER_REGISTRY — no manual sync needed.

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -98,6 +98,20 @@ export const MODEL_PROVIDERS_ORDER: ModelProvider[] = PROVIDER_REGISTRY.map(
   (p) => p.id,
 );
 
+/** Providers where users can configure direct API keys. */
+export const API_KEY_PROVIDER_IDS = [
+  'openai',
+  'anthropic',
+  'openRouter',
+  'google',
+  'xai',
+  'deepseek',
+  'moonshot',
+  'dashscope',
+  'minimax',
+  'glm',
+] as const;
+
 /**
  * All providers that support server-side API keys.
  * Derived from PROVIDER_REGISTRY — no manual sync needed.

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -509,6 +509,7 @@ export type UpdateLatexConfigValuesMessage = z.infer<
 // to avoid duplicating definitions. The command literal strings are identical.
 
 // Provider key inbound messages (settings-only)
+// Keep the outer optional: callers may omit apiKey so the host can prompt.
 const SubmittedApiKeySchema = z
   .preprocess(
     (value) =>

--- a/src/shared/schemas/settingsViewMessages.ts
+++ b/src/shared/schemas/settingsViewMessages.ts
@@ -509,11 +509,13 @@ export type UpdateLatexConfigValuesMessage = z.infer<
 // to avoid duplicating definitions. The command literal strings are identical.
 
 // Provider key inbound messages (settings-only)
-const SubmittedApiKeySchema = z.preprocess(
-  (value) =>
-    typeof value === 'string' && value.trim() === '' ? undefined : value,
-  z.string().trim().min(1).optional(),
-);
+const SubmittedApiKeySchema = z
+  .preprocess(
+    (value) =>
+      typeof value === 'string' && value.trim() === '' ? undefined : value,
+    z.string().trim().min(1).optional(),
+  )
+  .optional();
 
 const SetProviderKeyMessageSchema = z.object({
   command: z.literal(CMD.SET_PROVIDER_KEY),

--- a/src/test-kernel/settings/ProviderKeyRows.vitest.mts
+++ b/src/test-kernel/settings/ProviderKeyRows.vitest.mts
@@ -1,10 +1,30 @@
 import { describe, expect, it } from 'vitest';
 
 import { resolveProviderKeyRows } from '@settingsView/frontend/components/profile/providerKeyRows';
-import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/apiKeyProviders';
+import {
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_URLS,
+  SERVER_SIDE_PROVIDER_IDS,
+} from '@shared/constants/providers';
 import type { ProviderKeyStatus } from '@shared/schemas/settingsViewMessages';
 
 describe('settings provider key rows', () => {
+  it('keeps every API-key provider covered by display labels and key URLs', () => {
+    for (const provider of API_KEY_PROVIDER_IDS) {
+      expect(PROVIDER_DISPLAY_NAMES[provider]).toEqual(expect.any(String));
+      expect(PROVIDER_URLS[provider]).toEqual(expect.stringMatching(/^https:/));
+    }
+  });
+
+  it('keeps server-side provider keys available in the direct-key defaults', () => {
+    const apiKeyProviders = new Set<string>(API_KEY_PROVIDER_IDS);
+
+    for (const provider of SERVER_SIDE_PROVIDER_IDS) {
+      expect(apiKeyProviders.has(provider)).toBe(true);
+    }
+  });
+
   it('provides API-key rows before profile state has loaded', () => {
     const rows = resolveProviderKeyRows([]);
 

--- a/src/test-kernel/settings/ProviderKeyRows.vitest.mts
+++ b/src/test-kernel/settings/ProviderKeyRows.vitest.mts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveProviderKeyRows } from '@settingsView/frontend/components/profile/providerKeyRows';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/providers';
+import type { ProviderKeyStatus } from '@shared/schemas/settingsViewMessages';
+
+describe('settings provider key rows', () => {
+  it('provides API-key rows before profile state has loaded', () => {
+    const rows = resolveProviderKeyRows([]);
+
+    expect(rows.map((row) => row.provider)).toEqual([...API_KEY_PROVIDER_IDS]);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: 'deepseek',
+          displayName: 'DeepSeek',
+          status: 'not-set',
+          keyUrl: 'https://platform.deepseek.com/api_keys',
+        }),
+        expect.objectContaining({
+          provider: 'openRouter',
+          displayName: 'OpenRouter',
+          status: 'not-set',
+          keyUrl: 'https://openrouter.ai/keys',
+        }),
+      ]),
+    );
+  });
+
+  it('uses host-reported status rows once they arrive', () => {
+    const loadedRows: ProviderKeyStatus[] = [
+      {
+        provider: 'google',
+        displayName: 'Google',
+        status: 'env',
+        keyUrl: 'https://aistudio.google.com/app/apikey',
+        streaming: false,
+        customEndpoint: 'https://example.invalid',
+        supportsCustomEndpoint: true,
+        vscodeSettings: [],
+      },
+    ];
+
+    expect(resolveProviderKeyRows(loadedRows)).toBe(loadedRows);
+  });
+});


### PR DESCRIPTION
## Summary

- keep Settings > Models provider API-key rows visible before profile data arrives
- move the direct API-key provider list into shared provider constants and reuse it from model key resolution
- allow the desktop provider-key command schema to reach the host prompt path when no key value is submitted

Refs #3562.

## Verification

- `npm run test:kernel -- src/test-kernel/settings/ProviderKeyRows.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts`
- `npm run lint`
- `npm run typecheck`
- `npm run desktop:build`
- `npm run build:fast`
- Playwright Electron smoke: Settings > Models shows API Configuration, DeepSeek/OpenRouter rows, Model Selection, and the Set action opens the provider-key modal before sign-in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider API-key configuration UX and the inbound schema for `setProviderKey`, which can affect key prompting/validation and how provider IDs are enumerated across UI and core.
> 
> **Overview**
> Fixes the Settings Models *API Configuration* area so provider key rows render even before profile data arrives, by supplying a default set of `not-set` rows derived from a shared provider ID list.
> 
> Centralizes the direct API-key provider enumeration in new `API_KEY_PROVIDER_IDS` and reuses it for both settings UI defaults and core `API_PROVIDERS` key resolution.
> 
> Relaxes the `setProviderKey` inbound message schema to allow omitting `apiKey` entirely (enabling the host prompt path), and adds kernel tests to lock in the default-row behavior and provider registry coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e056b9d5a81b4a0172056660be9ef9024db805ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->