### PR TITLE
Add desktop texra protocol callback lifecycle

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -1,6 +1,10 @@
 appId: ai.texra.desktop
 productName: TeXRA
 artifactName: ${productName}-${version}-${os}-${arch}.${ext}
+protocols:
+  - name: TeXRA
+    schemes:
+      - texra
 asar: true
 asarUnpack:
   - '**/node_modules/@openai/codex-*/**'

--- a/packages/desktop/src/desktopProtocol.ts
+++ b/packages/desktop/src/desktopProtocol.ts
@@ -1,0 +1,10 @@
+export const TEXRA_PROTOCOL = 'texra';
+export const TEXRA_PROTOCOL_SCHEME = `${TEXRA_PROTOCOL}:`;
+
+export function isDesktopProtocolUrl(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).protocol === TEXRA_PROTOCOL_SCHEME;
+  } catch {
+    return false;
+  }
+}

--- a/packages/desktop/src/main/desktopMainViewStartup.ts
+++ b/packages/desktop/src/main/desktopMainViewStartup.ts
@@ -10,14 +10,17 @@ import {
   type DesktopMessageHandler,
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
+import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
 
 export interface DesktopMainViewStartupOptions {
   renderer: DesktopRenderer;
+  getAuthStatus?: () => Promise<MainViewAuthStatus>;
   onAsyncError?: (error: unknown) => void;
 }
 
 export function createDesktopMainViewStartup({
   renderer,
+  getAuthStatus,
   onAsyncError,
 }: DesktopMainViewStartupOptions): DesktopMessageHandler {
   const reportAsyncError = createDesktopErrorReporter(onAsyncError);
@@ -27,7 +30,7 @@ export function createDesktopMainViewStartup({
       agentOptions: await computeAgentOptionsData(),
       modelOptions: buildBasicModelOptionsData(),
     }),
-    getAuthStatus: async () => ({ authenticated: false }),
+    getAuthStatus: getAuthStatus ?? (async () => ({ authenticated: false })),
   });
 
   async function postStartupMessages(): Promise<void> {

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -113,7 +113,9 @@ export function createDesktopProtocolCallbackRouter(
     routeUrl(rawUrl) {
       const callback = parseDesktopProtocolCallback(rawUrl);
       if (!callback) {
-        options.log?.debug?.('Ignoring unsupported desktop protocol callback URL');
+        options.log?.debug?.(
+          'Ignoring unsupported desktop protocol callback URL',
+        );
         return false;
       }
 

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -5,8 +5,6 @@ import {
   TEXRA_PROTOCOL_SCHEME,
 } from '../desktopProtocol.js';
 
-export { TEXRA_PROTOCOL };
-
 export interface DesktopProtocolCallback {
   rawUrl: string;
   path: string;

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -166,7 +166,8 @@ export function installDesktopProtocolCallbackLifecycle(
 
   app.on('open-url', (event, url) => {
     event.preventDefault();
-    if (router.routeUrl(url)) {
+    const didRoute = router.routeUrl(url);
+    if (didRoute || isDesktopProtocolUrl(url)) {
       options.focusMainWindow?.();
     }
   });
@@ -179,6 +180,14 @@ export function installDesktopProtocolCallbackLifecycle(
 function normalizeProtocolPath(url: URL): string {
   if (url.pathname && url.pathname !== '/') return url.pathname;
   return url.hostname ? `/${url.hostname}` : '';
+}
+
+function isDesktopProtocolUrl(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).protocol === `${TEXRA_PROTOCOL}:`;
+  } catch {
+    return false;
+  }
 }
 
 function registerProtocolClient(options: InstallDesktopProtocolOptions): void {

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -1,6 +1,11 @@
 import { isAuthCallbackPath } from '@auth/core/authCallback';
+import {
+  isDesktopProtocolUrl,
+  TEXRA_PROTOCOL,
+  TEXRA_PROTOCOL_SCHEME,
+} from '../desktopProtocol.js';
 
-export const TEXRA_PROTOCOL = 'texra';
+export { TEXRA_PROTOCOL };
 
 export interface DesktopProtocolCallback {
   rawUrl: string;
@@ -73,7 +78,7 @@ export function parseDesktopProtocolCallback(
     return null;
   }
 
-  if (url.protocol !== `${TEXRA_PROTOCOL}:`) return null;
+  if (url.protocol !== TEXRA_PROTOCOL_SCHEME) return null;
 
   const path = normalizeProtocolPath(url);
   if (!isAuthCallbackPath(path)) return null;
@@ -109,24 +114,26 @@ export function createDesktopProtocolCallbackRouter(
     }
   }
 
-  return {
-    routeUrl(rawUrl) {
-      const callback = parseDesktopProtocolCallback(rawUrl);
-      if (!callback) {
-        options.log?.debug?.(
-          'Ignoring unsupported desktop protocol callback URL',
-        );
-        return false;
-      }
+  function routeUrl(rawUrl: string): boolean {
+    const callback = parseDesktopProtocolCallback(rawUrl);
+    if (!callback) {
+      options.log?.debug?.(
+        'Ignoring unsupported desktop protocol callback URL',
+      );
+      return false;
+    }
 
-      deliver(callback);
-      return true;
-    },
+    deliver(callback);
+    return true;
+  }
+
+  return {
+    routeUrl,
 
     routeArgv(argv) {
       let routedCount = 0;
       for (const rawUrl of findDesktopProtocolUrls(argv)) {
-        routedCount += this.routeUrl(rawUrl) ? 1 : 0;
+        routedCount += routeUrl(rawUrl) ? 1 : 0;
       }
       return routedCount;
     },
@@ -178,16 +185,15 @@ export function installDesktopProtocolCallbackLifecycle(
 }
 
 function normalizeProtocolPath(url: URL): string {
-  if (url.pathname && url.pathname !== '/') return url.pathname;
-  return url.hostname ? `/${url.hostname}` : '';
-}
-
-function isDesktopProtocolUrl(rawUrl: string): boolean {
-  try {
-    return new URL(rawUrl).protocol === `${TEXRA_PROTOCOL}:`;
-  } catch {
-    return false;
-  }
+  const rawPath =
+    url.pathname && url.pathname !== '/'
+      ? url.pathname
+      : url.hostname
+        ? `/${url.hostname}`
+        : '';
+  return rawPath.length > 1 && rawPath.endsWith('/')
+    ? rawPath.slice(0, -1)
+    : rawPath;
 }
 
 function registerProtocolClient(options: InstallDesktopProtocolOptions): void {

--- a/packages/desktop/src/main/desktopProtocolCallbacks.ts
+++ b/packages/desktop/src/main/desktopProtocolCallbacks.ts
@@ -1,0 +1,194 @@
+import { isAuthCallbackPath } from '@auth/core/authCallback';
+
+export const TEXRA_PROTOCOL = 'texra';
+
+export interface DesktopProtocolCallback {
+  rawUrl: string;
+  path: string;
+  query: string;
+  fragment: string;
+}
+
+export interface DesktopProtocolCallbackSubscription {
+  dispose(): void;
+}
+
+export type DesktopProtocolCallbackListener = (
+  callback: DesktopProtocolCallback,
+) => void;
+
+export interface DesktopProtocolCallbackRouter {
+  routeUrl(rawUrl: string): boolean;
+  routeArgv(argv: readonly string[]): number;
+  subscribe(
+    listener: DesktopProtocolCallbackListener,
+  ): DesktopProtocolCallbackSubscription;
+}
+
+export interface DesktopProtocolApp {
+  isPackaged: boolean;
+  setAsDefaultProtocolClient(
+    protocol: string,
+    executable?: string,
+    args?: string[],
+  ): boolean;
+  requestSingleInstanceLock(): boolean;
+  quit(): void;
+  on(
+    event: 'second-instance',
+    listener: (
+      event: unknown,
+      argv: string[],
+      workingDirectory: string,
+      additionalData?: unknown,
+    ) => void,
+  ): void;
+  on(
+    event: 'open-url',
+    listener: (event: { preventDefault(): void }, url: string) => void,
+  ): void;
+}
+
+export interface DesktopProtocolLifecycle {
+  router: DesktopProtocolCallbackRouter;
+  shouldContinue: boolean;
+}
+
+export interface InstallDesktopProtocolOptions {
+  app: DesktopProtocolApp;
+  argv?: readonly string[];
+  execPath?: string;
+  devAppArg?: string;
+  focusMainWindow?: () => void;
+  log?: Pick<Console, 'debug' | 'warn'>;
+}
+
+export function parseDesktopProtocolCallback(
+  rawUrl: string,
+): DesktopProtocolCallback | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== `${TEXRA_PROTOCOL}:`) return null;
+
+  const path = normalizeProtocolPath(url);
+  if (!isAuthCallbackPath(path)) return null;
+
+  return {
+    rawUrl,
+    path,
+    query: url.search.length > 0 ? url.search.slice(1) : '',
+    fragment: url.hash.length > 0 ? url.hash.slice(1) : '',
+  };
+}
+
+export function findDesktopProtocolUrls(argv: readonly string[]): string[] {
+  return argv.filter((arg) => parseDesktopProtocolCallback(arg) != null);
+}
+
+export function createDesktopProtocolCallbackRouter(
+  options: {
+    log?: Pick<Console, 'debug' | 'warn'>;
+  } = {},
+): DesktopProtocolCallbackRouter {
+  const listeners = new Set<DesktopProtocolCallbackListener>();
+  const pendingCallbacks: DesktopProtocolCallback[] = [];
+
+  function deliver(callback: DesktopProtocolCallback): void {
+    if (listeners.size === 0) {
+      pendingCallbacks.push(callback);
+      return;
+    }
+
+    for (const listener of listeners) {
+      listener(callback);
+    }
+  }
+
+  return {
+    routeUrl(rawUrl) {
+      const callback = parseDesktopProtocolCallback(rawUrl);
+      if (!callback) {
+        options.log?.debug?.('Ignoring unsupported desktop protocol callback URL');
+        return false;
+      }
+
+      deliver(callback);
+      return true;
+    },
+
+    routeArgv(argv) {
+      let routedCount = 0;
+      for (const rawUrl of findDesktopProtocolUrls(argv)) {
+        routedCount += this.routeUrl(rawUrl) ? 1 : 0;
+      }
+      return routedCount;
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      for (const callback of pendingCallbacks.splice(0)) {
+        listener(callback);
+      }
+
+      return {
+        dispose: () => {
+          listeners.delete(listener);
+        },
+      };
+    },
+  };
+}
+
+export function installDesktopProtocolCallbackLifecycle(
+  options: InstallDesktopProtocolOptions,
+): DesktopProtocolLifecycle {
+  const { app } = options;
+  const router = createDesktopProtocolCallbackRouter({ log: options.log });
+
+  if (!app.requestSingleInstanceLock()) {
+    app.quit();
+    return { router, shouldContinue: false };
+  }
+
+  registerProtocolClient(options);
+
+  app.on('second-instance', (_event, argv) => {
+    router.routeArgv(argv);
+    options.focusMainWindow?.();
+  });
+
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    if (router.routeUrl(url)) {
+      options.focusMainWindow?.();
+    }
+  });
+
+  router.routeArgv(options.argv ?? []);
+
+  return { router, shouldContinue: true };
+}
+
+function normalizeProtocolPath(url: URL): string {
+  if (url.pathname && url.pathname !== '/') return url.pathname;
+  return url.hostname ? `/${url.hostname}` : '';
+}
+
+function registerProtocolClient(options: InstallDesktopProtocolOptions): void {
+  const { app } = options;
+  const didRegister =
+    app.isPackaged || !options.execPath || !options.devAppArg
+      ? app.setAsDefaultProtocolClient(TEXRA_PROTOCOL)
+      : app.setAsDefaultProtocolClient(TEXRA_PROTOCOL, options.execPath, [
+          options.devAppArg,
+        ]);
+
+  if (!didRegister) {
+    options.log?.warn?.(`Failed to register ${TEXRA_PROTOCOL}:// handler`);
+  }
+}

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -677,6 +677,13 @@ export function createDesktopSettingsIpc(
     mode: 'included' | 'personal',
   ): Promise<void> {
     await options.setApiAccessMode?.(mode);
+    if (
+      mode === 'included' &&
+      globalState.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
+    ) {
+      await globalState.update(GlobalStateKey.USE_OPENROUTER, false);
+      invalidateModelOptionsCache();
+    }
     await Promise.all([postProfileData(), postModelSelectionData()]);
   }
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -139,6 +139,7 @@ export interface DesktopSettingsIpcOptions {
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
   refreshProfileData(): Promise<void>;
+  refreshAuthDependentData(): Promise<void>;
 }
 
 const emptySecrets: PlatformSecrets = {
@@ -687,6 +688,16 @@ export function createDesktopSettingsIpc(
     await Promise.all([postProfileData(), postModelSelectionData()]);
   }
 
+  async function refreshAuthDependentData(): Promise<void> {
+    postModelSelectionData();
+    postMainModelOptionsData();
+    await Promise.all([
+      postProfileData(),
+      postAgentSelectionData(),
+      postMainAgentOptionsData(),
+    ]);
+  }
+
   async function updateCodexSetting(
     key: WorkspaceStateKey,
     value: string,
@@ -830,6 +841,7 @@ export function createDesktopSettingsIpc(
 
   return {
     refreshProfileData: postProfileData,
+    refreshAuthDependentData,
 
     handleMessage(message: DesktopCommandMessage) {
       const result = SettingsViewInboundMessageSchema.safeParse(message);

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -51,6 +51,7 @@ import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
   SettingsViewInboundMessageSchema,
   type LatexSettingsStatus,
+  type RemoteAgent,
   type ProviderKeyStatus,
   type ReasoningLevel,
   type ToolDashboardItem,
@@ -94,6 +95,17 @@ type ToolDashboardBuilder = (
   cachedResults?: ExternalToolCheckResult[],
 ) => Promise<ToolDashboardItem[]>;
 
+export interface DesktopAuthProfileData {
+  authenticated: boolean;
+  user: { email: string; id: string } | null;
+  tier: string;
+  permissions: string[];
+  remoteAgents: RemoteAgent[];
+  apiAccessMode: 'included' | 'personal';
+  allowedModels: string[] | null;
+  accessExpiresAt?: string | null;
+}
+
 export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
   sendStartupCatalogData?: boolean;
@@ -120,6 +132,7 @@ export interface DesktopSettingsIpcOptions {
   showErrorMessage?: (message: string) => Promise<void>;
   signIn?: () => Promise<void>;
   signOut?: () => Promise<void>;
+  getAuthProfileData?: () => Promise<DesktopAuthProfileData>;
   secrets?: PlatformSecrets;
   detectLatexSettingsStatus?: () => Promise<LatexSettingsStatus>;
   runInstallCommand?: (command: string) => Promise<void>;
@@ -131,13 +144,28 @@ export interface DesktopSettingsIpcOptions {
   onError?: (error: unknown) => void;
 }
 
-export type DesktopSettingsIpc = DesktopMessageHandler;
+export interface DesktopSettingsIpc extends DesktopMessageHandler {
+  refreshProfileData(): Promise<void>;
+}
 
 const emptySecrets: PlatformSecrets = {
   get: () => Promise.resolve(undefined),
   set: () => Promise.resolve(),
   delete: () => Promise.resolve(),
 };
+
+function defaultAuthProfileData(): DesktopAuthProfileData {
+  return {
+    authenticated: false,
+    user: null,
+    tier: FREE_TIER,
+    permissions: [],
+    remoteAgents: [],
+    apiAccessMode: 'personal',
+    allowedModels: [],
+    accessExpiresAt: null,
+  };
+}
 
 async function buildDefaultToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
@@ -415,15 +443,11 @@ export function createDesktopSettingsIpc(
   }
 
   async function postProfileData(): Promise<void> {
+    const authProfile =
+      (await options.getAuthProfileData?.()) ?? defaultAuthProfileData();
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
-      authenticated: false,
-      user: null,
-      tier: FREE_TIER,
-      permissions: [],
-      remoteAgents: [],
-      apiAccessMode: 'personal',
-      allowedModels: [],
+      ...authProfile,
       tierConstants: { ultra: ULTRA_TIER, max: MAX_TIER },
       providerKeyStatuses: await getProviderKeyStatuses(),
       globalStreamingDefault: getGlobalStreaming(),
@@ -808,6 +832,8 @@ export function createDesktopSettingsIpc(
   applyCurrentGitAuthorSettings();
 
   return {
+    refreshProfileData: postProfileData,
+
     handleMessage(message: DesktopCommandMessage) {
       const result = SettingsViewInboundMessageSchema.safeParse(message);
       if (!result.success) return false;

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -18,7 +18,7 @@ import {
   type AgentEntry,
 } from '@agent/index/agentRegistry';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { FREE_TIER, MAX_TIER, ULTRA_TIER } from '@auth/sharedConfig';
+import { MAX_TIER, ULTRA_TIER } from '@auth/sharedConfig';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { GlobalStateKey, WorkspaceStateKey } from '@common/state/stateKeys';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
@@ -51,7 +51,6 @@ import type { AgentCategory, AgentSource } from '@shared/schemas/agent';
 import {
   SettingsViewInboundMessageSchema,
   type LatexSettingsStatus,
-  type RemoteAgent,
   type ProviderKeyStatus,
   type ReasoningLevel,
   type ToolDashboardItem,
@@ -83,6 +82,10 @@ import {
   setProviderStreaming,
   supportsCustomEndpoint,
 } from '@utils/config/providerConfig';
+import {
+  unauthenticatedProfileData,
+  type DesktopAuthProfileData,
+} from './desktopSupabaseAuth.js';
 import type { ConfigProvider } from '@platform/interfaces/config';
 import type { StateStore } from '@platform/interfaces/state';
 import type { PlatformSecrets } from '@platform/secrets';
@@ -94,17 +97,6 @@ import type {
 type ToolDashboardBuilder = (
   cachedResults?: ExternalToolCheckResult[],
 ) => Promise<ToolDashboardItem[]>;
-
-export interface DesktopAuthProfileData {
-  authenticated: boolean;
-  user: { email: string; id: string } | null;
-  tier: string;
-  permissions: string[];
-  remoteAgents: RemoteAgent[];
-  apiAccessMode: 'included' | 'personal';
-  allowedModels: string[] | null;
-  accessExpiresAt?: string | null;
-}
 
 export interface DesktopSettingsIpcOptions {
   postToRenderer(message: unknown): void;
@@ -153,19 +145,6 @@ const emptySecrets: PlatformSecrets = {
   set: () => Promise.resolve(),
   delete: () => Promise.resolve(),
 };
-
-function defaultAuthProfileData(): DesktopAuthProfileData {
-  return {
-    authenticated: false,
-    user: null,
-    tier: FREE_TIER,
-    permissions: [],
-    remoteAgents: [],
-    apiAccessMode: 'personal',
-    allowedModels: [],
-    accessExpiresAt: null,
-  };
-}
 
 async function buildDefaultToolDashboardItems(
   cachedResults?: ExternalToolCheckResult[],
@@ -444,7 +423,7 @@ export function createDesktopSettingsIpc(
 
   async function postProfileData(): Promise<void> {
     const authProfile =
-      (await options.getAuthProfileData?.()) ?? defaultAuthProfileData();
+      (await options.getAuthProfileData?.()) ?? unauthenticatedProfileData();
     options.postToRenderer({
       command: SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
       ...authProfile,

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -125,6 +125,7 @@ export interface DesktopSettingsIpcOptions {
   signIn?: () => Promise<void>;
   signOut?: () => Promise<void>;
   getAuthProfileData?: () => Promise<DesktopAuthProfileData>;
+  setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
   secrets?: PlatformSecrets;
   detectLatexSettingsStatus?: () => Promise<LatexSettingsStatus>;
   runInstallCommand?: (command: string) => Promise<void>;
@@ -669,6 +670,13 @@ export function createDesktopSettingsIpc(
     await postProfileData();
   }
 
+  async function setApiAccessMode(
+    mode: 'included' | 'personal',
+  ): Promise<void> {
+    await options.setApiAccessMode?.(mode);
+    await Promise.all([postProfileData(), postModelSelectionData()]);
+  }
+
   async function updateCodexSetting(
     key: WorkspaceStateKey,
     value: string,
@@ -844,11 +852,7 @@ export function createDesktopSettingsIpc(
           runAsync(signOut());
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE:
-          runAsync(
-            result.data.mode === 'included'
-              ? signIn()
-              : Promise.resolve().then(postProfileData),
-          );
+          runAsync(setApiAccessMode(result.data.mode));
           return true;
         case SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY:
           runAsync(setProviderKey(result.data.provider, result.data.apiKey));

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -666,8 +666,11 @@ export function createDesktopSettingsIpc(
   }
 
   async function signOut(): Promise<void> {
-    await options.signOut?.();
-    await postProfileData();
+    if (options.signOut) {
+      await options.signOut();
+    } else {
+      await postProfileData();
+    }
   }
 
   async function setApiAccessMode(

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -138,7 +138,6 @@ export interface DesktopSettingsIpcOptions {
 }
 
 export interface DesktopSettingsIpc extends DesktopMessageHandler {
-  refreshProfileData(): Promise<void>;
   refreshAuthDependentData(): Promise<void>;
 }
 
@@ -841,7 +840,6 @@ export function createDesktopSettingsIpc(
   applyCurrentGitAuthorSettings();
 
   return {
-    refreshProfileData: postProfileData,
     refreshAuthDependentData,
 
     handleMessage(message: DesktopCommandMessage) {

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -658,6 +658,7 @@ export function createDesktopSettingsIpc(
   async function signIn(): Promise<void> {
     if (options.signIn) {
       await options.signIn();
+      return;
     } else {
       await options.showInfoMessage?.(
         'Researcher Access sign-in is not connected in this desktop build. Add a provider API key in Settings > Models to run agents with your own account.',

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -35,6 +35,7 @@ export interface DesktopShellActionFactoryOptions {
   openLogFolder?: () => Promise<void>;
   openPath?: (filePath: string) => Promise<void>;
   openWorkspaceFolder?: () => Promise<void>;
+  signIn?: () => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
 
@@ -46,6 +47,7 @@ export interface DesktopShellActionInstanceOptions {
 }
 
 export interface DesktopShellActions extends DesktopCommandActions {
+  signIn(): void;
   openAgentDirectory(customDirSet?: boolean): void;
   setRecentCommitsUnavailable(): void;
 }
@@ -111,7 +113,16 @@ export function createDesktopShellActions(
     void options.openWorkspaceFolder?.().catch(reportAsyncError);
   }
 
+  function signIn() {
+    if (!options.signIn) {
+      postSettingsRoute(SETTINGS_TAB.MODELS);
+      return;
+    }
+    void options.signIn().catch(reportAsyncError);
+  }
+
   return {
+    signIn,
     openAgentDirectory,
     openLogFolder,
     openWorkspaceFolder,
@@ -161,6 +172,8 @@ export function createDesktopShellIpc(
           actions.showSettings(SETTINGS_TAB.MODELS);
           return true;
         case MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER:
+          actions.signIn();
+          return true;
         case MAIN_VIEW_COMMANDS.OPEN_SET_API_KEY:
         case MAIN_VIEW_COMMANDS.OPEN_SET_PROVIDER_API_KEY:
           actions.showSettings(SETTINGS_TAB.MODELS);

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -100,24 +100,36 @@ export function createDesktopSupabaseAuth(
 ): DesktopSupabaseAuth {
   const coordinator = options.coordinator ?? createSessionCoordinator(options);
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
-  let isProcessingCallback = false;
-  const subscription = options.router.subscribe(async (callback) => {
-    if (isProcessingCallback) {
-      options.log?.debug?.(
-        'Desktop auth callback ignored while another callback is being processed',
-      );
-      return;
-    }
-    isProcessingCallback = true;
+  const callbackQueue: DesktopProtocolCallback[] = [];
+  let isProcessingCallbacks = false;
+  const processCallbackQueue = async (): Promise<void> => {
+    if (isProcessingCallbacks) return;
+    isProcessingCallbacks = true;
     try {
-      await processProtocolCallback(coordinator, callback, options);
-    } catch (error) {
-      const message = toErrorMessage(error);
-      options.log?.error?.(`Desktop auth callback failed: ${message}`);
-      await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+      while (callbackQueue.length > 0) {
+        const callback = callbackQueue.shift();
+        if (!callback) continue;
+        try {
+          await processProtocolCallback(coordinator, callback, options);
+        } catch (error) {
+          const message = toErrorMessage(error);
+          options.log?.error?.(`Desktop auth callback failed: ${message}`);
+          await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+        }
+      }
     } finally {
-      isProcessingCallback = false;
+      isProcessingCallbacks = false;
+      if (callbackQueue.length > 0) void processCallbackQueue();
     }
+  };
+  const subscription = options.router.subscribe((callback) => {
+    callbackQueue.push(callback);
+    if (isProcessingCallbacks) {
+      options.log?.debug?.(
+        'Desktop auth callback queued while another callback is being processed',
+      );
+    }
+    void processCallbackQueue();
   });
 
   if (options.initializeServerSideAccess ?? true) {

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -31,6 +31,7 @@ import type { AuthCallbackUriParts } from '@auth/core/authCallback';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 import { TEXRA_PROTOCOL } from '../desktopProtocol.js';
+import type { StateStore } from '@platform/interfaces/state';
 import type { PlatformSecrets } from '@platform/secrets';
 import type {
   DesktopProtocolCallback,
@@ -38,6 +39,7 @@ import type {
 } from './desktopProtocolCallbacks.js';
 
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
+const DESKTOP_PENDING_OAUTH_STATE_KEY = 'texra.desktop.pendingOAuthState';
 
 export interface DesktopAuthProfileData {
   authenticated: boolean;
@@ -104,15 +106,28 @@ export interface DesktopAuthCoordinator {
   } | null>;
 }
 
-export function createDesktopAuthCallbackState(): DesktopAuthCallbackState {
-  let expectedState: string | null = null;
+export function createDesktopAuthCallbackState(
+  store?: Pick<StateStore, 'get' | 'update'>,
+): DesktopAuthCallbackState {
+  let expectedState =
+    store?.get<string | null>(DESKTOP_PENDING_OAUTH_STATE_KEY, null) ?? null;
+
+  const persistExpectedState = (state: string | null): void => {
+    if (!store) return;
+    void Promise.resolve(
+      store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state),
+    ).catch(() => {});
+  };
+
   return {
     getExpectedState: () => expectedState,
     beginAuthAttempt: (state) => {
       expectedState = state;
+      persistExpectedState(state);
     },
     clearAwaitingCallback: () => {
       expectedState = null;
+      persistExpectedState(null);
     },
   };
 }
@@ -205,6 +220,7 @@ export function createDesktopSupabaseAuth(
     },
 
     async signOut() {
+      callbackState.clearAwaitingCallback();
       await coordinator.clearSession();
       SupabaseClient.setTokenExpiry(null);
       clearDesktopServerSideKeyCaches(options.log);

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -98,7 +98,8 @@ export interface DesktopAuthCoordinator {
 export function createDesktopSupabaseAuth(
   options: DesktopSupabaseAuthOptions,
 ): DesktopSupabaseAuth {
-  const coordinator = options.coordinator ?? createSessionCoordinator(options);
+  const coordinator =
+    options.coordinator ?? createDesktopAuthCoordinator(options);
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
   const callbackQueue: DesktopProtocolCallback[] = [];
   let isProcessingCallbacks = false;
@@ -133,17 +134,7 @@ export function createDesktopSupabaseAuth(
   });
 
   if (options.initializeServerSideAccess ?? true) {
-    initializeServerSideKeyAccess(
-      {
-        state: platform().globalState,
-        logger: createAuthServiceLogger(options.log),
-      },
-      {
-        isAuthenticated: () => SupabaseClient.isAuthenticated(),
-        getUserTier: () => SupabaseClient.getUserTier() as Promise<UserTier>,
-        getAccessToken: () => SupabaseClient.getAccessToken(),
-      },
-    );
+    initializeDesktopServerSideKeyAccess(options.log);
   }
 
   return {
@@ -175,6 +166,7 @@ export function createDesktopSupabaseAuth(
     async signOut() {
       await coordinator.clearSession();
       SupabaseClient.setTokenExpiry(null);
+      clearDesktopServerSideKeyCaches(options.log);
       await options.onSessionChanged?.();
     },
 
@@ -188,7 +180,7 @@ export function createDesktopSupabaseAuth(
   };
 }
 
-function createSessionCoordinator(
+export function createDesktopAuthCoordinator(
   options: Pick<DesktopSupabaseAuthOptions, 'secrets' | 'log'>,
 ): DesktopAuthCoordinator {
   SupabaseClient.initialize(SUPABASE_CONFIG.url, SUPABASE_CONFIG.publicKey);
@@ -213,6 +205,34 @@ function createSessionCoordinator(
   return coordinator;
 }
 
+export function initializeDesktopServerSideKeyAccess(
+  log: DesktopSupabaseAuthOptions['log'],
+): void {
+  initializeServerSideKeyAccess(
+    {
+      state: platform().globalState,
+      logger: createAuthServiceLogger(log),
+    },
+    {
+      isAuthenticated: () => SupabaseClient.isAuthenticated(),
+      getUserTier: () => SupabaseClient.getUserTier() as Promise<UserTier>,
+      getAccessToken: () => SupabaseClient.getAccessToken(),
+    },
+  );
+}
+
+function clearDesktopServerSideKeyCaches(
+  log: DesktopSupabaseAuthOptions['log'],
+): void {
+  try {
+    getServerSideKeyService().clearAllCaches();
+  } catch (error) {
+    log?.debug?.(
+      `Desktop server-side key cache clear skipped: ${toErrorMessage(error)}`,
+    );
+  }
+}
+
 async function processProtocolCallback(
   coordinator: DesktopAuthCoordinator,
   callback: DesktopProtocolCallback,
@@ -234,6 +254,7 @@ async function processProtocolCallback(
   }
 
   await coordinator.storeSession(result.session);
+  clearDesktopServerSideKeyCaches(options.log);
   await options.showInfoMessage?.(
     `Signed in as ${result.session.account.label}`,
   );

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -117,7 +117,9 @@ export function createDesktopAuthCallbackState(
 ): DesktopAuthCallbackState {
   let pendingState = readPendingOAuthState(store);
 
-  const persistPendingState = (state: DesktopPendingOAuthState | null): void => {
+  const persistPendingState = (
+    state: DesktopPendingOAuthState | null,
+  ): void => {
     if (!store) return;
     void Promise.resolve(
       store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state),
@@ -161,7 +163,9 @@ function readPendingOAuthState(
   return persisted;
 }
 
-function isPendingOAuthState(value: unknown): value is DesktopPendingOAuthState {
+function isPendingOAuthState(
+  value: unknown,
+): value is DesktopPendingOAuthState {
   return (
     typeof value === 'object' &&
     value !== null &&

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -140,8 +140,6 @@ export function createDesktopSupabaseAuth(
           const message = toErrorMessage(error);
           options.log?.error?.(`Desktop auth callback failed: ${message}`);
           await options.showErrorMessage?.(`Sign-in failed: ${message}`);
-        } finally {
-          callbackState.clearAwaitingCallback();
         }
       }
     } finally {

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -40,6 +40,12 @@ import type {
 
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
 const DESKTOP_PENDING_OAUTH_STATE_KEY = 'texra.desktop.pendingOAuthState';
+const DESKTOP_PENDING_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+interface DesktopPendingOAuthState {
+  state: string;
+  createdAt: number;
+}
 
 export interface DesktopAuthProfileData {
   authenticated: boolean;
@@ -109,10 +115,9 @@ export interface DesktopAuthCoordinator {
 export function createDesktopAuthCallbackState(
   store?: Pick<StateStore, 'get' | 'update'>,
 ): DesktopAuthCallbackState {
-  let expectedState =
-    store?.get<string | null>(DESKTOP_PENDING_OAUTH_STATE_KEY, null) ?? null;
+  let pendingState = readPendingOAuthState(store);
 
-  const persistExpectedState = (state: string | null): void => {
+  const persistPendingState = (state: DesktopPendingOAuthState | null): void => {
     if (!store) return;
     void Promise.resolve(
       store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state),
@@ -120,16 +125,55 @@ export function createDesktopAuthCallbackState(
   };
 
   return {
-    getExpectedState: () => expectedState,
+    getExpectedState: () => {
+      if (!pendingState) return null;
+      if (isPendingOAuthStateExpired(pendingState)) {
+        pendingState = null;
+        persistPendingState(null);
+        return null;
+      }
+      return pendingState.state;
+    },
     beginAuthAttempt: (state) => {
-      expectedState = state;
-      persistExpectedState(state);
+      pendingState = { state, createdAt: Date.now() };
+      persistPendingState(pendingState);
     },
     clearAwaitingCallback: () => {
-      expectedState = null;
-      persistExpectedState(null);
+      pendingState = null;
+      persistPendingState(null);
     },
   };
+}
+
+function readPendingOAuthState(
+  store: Pick<StateStore, 'get' | 'update'> | undefined,
+): DesktopPendingOAuthState | null {
+  const persisted = store?.get<unknown>(DESKTOP_PENDING_OAUTH_STATE_KEY, null);
+  if (!isPendingOAuthState(persisted)) {
+    return null;
+  }
+  if (isPendingOAuthStateExpired(persisted)) {
+    void Promise.resolve(
+      store?.update(DESKTOP_PENDING_OAUTH_STATE_KEY, null),
+    ).catch(() => {});
+    return null;
+  }
+  return persisted;
+}
+
+function isPendingOAuthState(value: unknown): value is DesktopPendingOAuthState {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'state' in value &&
+    typeof value.state === 'string' &&
+    'createdAt' in value &&
+    typeof value.createdAt === 'number'
+  );
+}
+
+function isPendingOAuthStateExpired(state: DesktopPendingOAuthState): boolean {
+  return Date.now() - state.createdAt > DESKTOP_PENDING_OAUTH_STATE_TTL_MS;
 }
 
 export function createDesktopSupabaseAuth(

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -20,15 +20,19 @@ import {
   initializeServerSideKeyAccess,
 } from '@auth/serverKeys';
 import type { AuthServiceLogger } from '@auth/serviceLogger';
-import type { OAuthProvider, UserTier } from '@auth/sharedConfig';
+import {
+  FREE_TIER,
+  type OAuthProvider,
+  type UserTier,
+} from '@auth/sharedConfig';
 import type { AuthCallbackUriParts } from '@auth/core/authCallback';
 import { toErrorMessage } from '@common/errors/errorMessage';
+import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
 import { TEXRA_PROTOCOL } from '../desktopProtocol.js';
 import type { PlatformSecrets } from '@platform/secrets';
 import type {
   DesktopProtocolCallback,
   DesktopProtocolCallbackRouter,
-  DesktopProtocolCallbackSubscription,
 } from './desktopProtocolCallbacks.js';
 
 const EDGE_FUNCTION_TIMEOUT_MS = 30000;
@@ -38,7 +42,7 @@ export interface DesktopAuthProfileData {
   user: { email: string; id: string } | null;
   tier: string;
   permissions: string[];
-  remoteAgents: [];
+  remoteAgents: RemoteAgent[];
   apiAccessMode: 'included' | 'personal';
   allowedModels: string[] | null;
   accessExpiresAt?: string | null;
@@ -97,18 +101,24 @@ export function createDesktopSupabaseAuth(
   const coordinator = options.coordinator ?? createSessionCoordinator(options);
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
   let isProcessingCallback = false;
-  const subscription = subscribeToProtocolCallbacks(
-    options.router,
-    async (callback) => {
-      if (isProcessingCallback) return;
-      isProcessingCallback = true;
-      try {
-        await processProtocolCallback(coordinator, callback, options);
-      } finally {
-        isProcessingCallback = false;
-      }
-    },
-  );
+  const subscription = options.router.subscribe(async (callback) => {
+    if (isProcessingCallback) {
+      options.log?.debug?.(
+        'Desktop auth callback ignored while another callback is being processed',
+      );
+      return;
+    }
+    isProcessingCallback = true;
+    try {
+      await processProtocolCallback(coordinator, callback, options);
+    } catch (error) {
+      const message = toErrorMessage(error);
+      options.log?.error?.(`Desktop auth callback failed: ${message}`);
+      await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+    } finally {
+      isProcessingCallback = false;
+    }
+  });
 
   if (options.initializeServerSideAccess ?? true) {
     initializeServerSideKeyAccess(
@@ -191,13 +201,6 @@ function createSessionCoordinator(
   return coordinator;
 }
 
-function subscribeToProtocolCallbacks(
-  router: DesktopProtocolCallbackRouter,
-  listener: (callback: DesktopProtocolCallback) => void,
-): DesktopProtocolCallbackSubscription {
-  return router.subscribe(listener);
-}
-
 async function processProtocolCallback(
   coordinator: DesktopAuthCoordinator,
   callback: DesktopProtocolCallback,
@@ -231,7 +234,7 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
 
   const user = await SupabaseClient.getUser();
   let authContext: { tier: string; permissions: string[] } = {
-    tier: 'free',
+    tier: FREE_TIER,
     permissions: [],
   };
   try {
@@ -276,7 +279,7 @@ export function unauthenticatedProfileData(): DesktopAuthProfileData {
   return {
     authenticated: false,
     user: null,
-    tier: 'free',
+    tier: FREE_TIER,
     permissions: [],
     remoteAgents: [],
     apiAccessMode: 'personal',

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { platform } from '@platform/platform';
 import {
   DEFAULT_OAUTH_PROVIDER,
@@ -56,8 +58,8 @@ export interface DesktopSupabaseAuth {
 }
 
 export interface DesktopAuthCallbackState {
-  isAwaitingCallback(): boolean;
-  markAwaitingCallback(): void;
+  getExpectedState(): string | null;
+  beginAuthAttempt(state: string): void;
   clearAwaitingCallback(): void;
 }
 
@@ -79,7 +81,7 @@ export interface DesktopOAuthClient {
   auth: {
     signInWithOAuth(input: {
       provider: OAuthProvider;
-      options: { redirectTo: string };
+      options: { redirectTo: string; queryParams?: Record<string, string> };
     }): Promise<{
       data: { url?: string | null };
       error: { message: string } | null;
@@ -103,14 +105,14 @@ export interface DesktopAuthCoordinator {
 }
 
 export function createDesktopAuthCallbackState(): DesktopAuthCallbackState {
-  let isAwaitingCallback = false;
+  let expectedState: string | null = null;
   return {
-    isAwaitingCallback: () => isAwaitingCallback,
-    markAwaitingCallback: () => {
-      isAwaitingCallback = true;
+    getExpectedState: () => expectedState,
+    beginAuthAttempt: (state) => {
+      expectedState = state;
     },
     clearAwaitingCallback: () => {
-      isAwaitingCallback = false;
+      expectedState = null;
     },
   };
 }
@@ -148,12 +150,20 @@ export function createDesktopSupabaseAuth(
     }
   };
   const subscription = options.router.subscribe((callback) => {
-    if (!callbackState.isAwaitingCallback()) {
+    const expectedState = callbackState.getExpectedState();
+    if (!expectedState) {
       options.log?.debug?.(
         'Desktop auth callback ignored because no sign-in is in progress',
       );
       return;
     }
+    if (!isExpectedAuthCallback(callback, expectedState)) {
+      options.log?.debug?.(
+        'Desktop auth callback ignored because it does not match the active sign-in attempt',
+      );
+      return;
+    }
+    callbackState.clearAwaitingCallback();
     callbackQueue.push(callback);
     if (isProcessingCallbacks) {
       options.log?.debug?.(
@@ -171,9 +181,10 @@ export function createDesktopSupabaseAuth(
     async signIn(provider = DEFAULT_OAUTH_PROVIDER) {
       try {
         const redirectTo = getAuthCallbackUri(TEXRA_PROTOCOL);
+        const state = randomUUID();
         const { data, error } = await oauthClient.auth.signInWithOAuth({
           provider,
-          options: { redirectTo },
+          options: { redirectTo, queryParams: { state } },
         });
         if (error || !data.url) {
           throw new Error(
@@ -181,7 +192,7 @@ export function createDesktopSupabaseAuth(
           );
         }
 
-        callbackState.markAwaitingCallback();
+        callbackState.beginAuthAttempt(state);
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
@@ -263,6 +274,17 @@ function clearDesktopServerSideKeyCaches(
       `Desktop server-side key cache clear skipped: ${toErrorMessage(error)}`,
     );
   }
+}
+
+function isExpectedAuthCallback(
+  callback: DesktopProtocolCallback,
+  expectedState: string,
+): boolean {
+  const fragmentParams = new URLSearchParams(callback.fragment);
+  const queryParams = new URLSearchParams(callback.query);
+  return (
+    (fragmentParams.get('state') ?? queryParams.get('state')) === expectedState
+  );
 }
 
 async function processProtocolCallback(

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -55,6 +55,12 @@ export interface DesktopSupabaseAuth {
   dispose(): void;
 }
 
+export interface DesktopAuthCallbackState {
+  isAwaitingCallback(): boolean;
+  markAwaitingCallback(): void;
+  clearAwaitingCallback(): void;
+}
+
 export interface DesktopSupabaseAuthOptions {
   router: DesktopProtocolCallbackRouter;
   secrets: PlatformSecrets;
@@ -65,6 +71,7 @@ export interface DesktopSupabaseAuthOptions {
   log?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
   coordinator?: DesktopAuthCoordinator;
   oauthClient?: DesktopOAuthClient;
+  callbackState?: DesktopAuthCallbackState;
   initializeServerSideAccess?: boolean;
 }
 
@@ -95,15 +102,29 @@ export interface DesktopAuthCoordinator {
   } | null>;
 }
 
+export function createDesktopAuthCallbackState(): DesktopAuthCallbackState {
+  let isAwaitingCallback = false;
+  return {
+    isAwaitingCallback: () => isAwaitingCallback,
+    markAwaitingCallback: () => {
+      isAwaitingCallback = true;
+    },
+    clearAwaitingCallback: () => {
+      isAwaitingCallback = false;
+    },
+  };
+}
+
 export function createDesktopSupabaseAuth(
   options: DesktopSupabaseAuthOptions,
 ): DesktopSupabaseAuth {
   const coordinator =
     options.coordinator ?? createDesktopAuthCoordinator(options);
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
+  const callbackState =
+    options.callbackState ?? createDesktopAuthCallbackState();
   const callbackQueue: DesktopProtocolCallback[] = [];
   let isProcessingCallbacks = false;
-  let isAwaitingAuthCallback = false;
   const processCallbackQueue = async (): Promise<void> => {
     if (isProcessingCallbacks) return;
     isProcessingCallbacks = true;
@@ -118,7 +139,7 @@ export function createDesktopSupabaseAuth(
           options.log?.error?.(`Desktop auth callback failed: ${message}`);
           await options.showErrorMessage?.(`Sign-in failed: ${message}`);
         } finally {
-          isAwaitingAuthCallback = false;
+          callbackState.clearAwaitingCallback();
         }
       }
     } finally {
@@ -127,7 +148,7 @@ export function createDesktopSupabaseAuth(
     }
   };
   const subscription = options.router.subscribe((callback) => {
-    if (!isAwaitingAuthCallback) {
+    if (!callbackState.isAwaitingCallback()) {
       options.log?.debug?.(
         'Desktop auth callback ignored because no sign-in is in progress',
       );
@@ -160,13 +181,13 @@ export function createDesktopSupabaseAuth(
           );
         }
 
-        isAwaitingAuthCallback = true;
+        callbackState.markAwaitingCallback();
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
         );
       } catch (error) {
-        isAwaitingAuthCallback = false;
+        callbackState.clearAwaitingCallback();
         await options.showErrorMessage?.(
           `Sign-in failed: ${toErrorMessage(error)}`,
         );

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -103,6 +103,7 @@ export function createDesktopSupabaseAuth(
   const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
   const callbackQueue: DesktopProtocolCallback[] = [];
   let isProcessingCallbacks = false;
+  let isAwaitingAuthCallback = false;
   const processCallbackQueue = async (): Promise<void> => {
     if (isProcessingCallbacks) return;
     isProcessingCallbacks = true;
@@ -116,6 +117,8 @@ export function createDesktopSupabaseAuth(
           const message = toErrorMessage(error);
           options.log?.error?.(`Desktop auth callback failed: ${message}`);
           await options.showErrorMessage?.(`Sign-in failed: ${message}`);
+        } finally {
+          isAwaitingAuthCallback = false;
         }
       }
     } finally {
@@ -124,6 +127,12 @@ export function createDesktopSupabaseAuth(
     }
   };
   const subscription = options.router.subscribe((callback) => {
+    if (!isAwaitingAuthCallback) {
+      options.log?.debug?.(
+        'Desktop auth callback ignored because no sign-in is in progress',
+      );
+      return;
+    }
     callbackQueue.push(callback);
     if (isProcessingCallbacks) {
       options.log?.debug?.(
@@ -151,11 +160,13 @@ export function createDesktopSupabaseAuth(
           );
         }
 
+        isAwaitingAuthCallback = true;
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
         );
       } catch (error) {
+        isAwaitingAuthCallback = false;
         await options.showErrorMessage?.(
           `Sign-in failed: ${toErrorMessage(error)}`,
         );

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,0 +1,306 @@
+import { platform } from '@platform/platform';
+import {
+  DEFAULT_OAUTH_PROVIDER,
+  DEFAULT_SESSION_EXPIRY_MS,
+  GITHUB_TOKEN_REFRESH_URL,
+  SUPABASE_CONFIG,
+  SUPABASE_SESSION_KEY,
+  TOKEN_REFRESH_THRESHOLD_MS,
+  getAuthCallbackUri,
+} from '@auth/config';
+import { SupabaseClient } from '@auth/SupabaseClient';
+import {
+  SupabaseSessionCoordinator,
+  type SupabaseCallbackResult,
+  type SupabaseSession,
+  type SupabaseSessionCoordinatorOptions,
+} from '@auth/SupabaseSession';
+import {
+  getServerSideKeyService,
+  initializeServerSideKeyAccess,
+} from '@auth/serverKeys';
+import type { AuthServiceLogger } from '@auth/serviceLogger';
+import type { OAuthProvider, UserTier } from '@auth/sharedConfig';
+import type { AuthCallbackUriParts } from '@auth/core/authCallback';
+import { toErrorMessage } from '@common/errors/errorMessage';
+import { TEXRA_PROTOCOL } from '../desktopProtocol.js';
+import type { PlatformSecrets } from '@platform/secrets';
+import type {
+  DesktopProtocolCallback,
+  DesktopProtocolCallbackRouter,
+  DesktopProtocolCallbackSubscription,
+} from './desktopProtocolCallbacks.js';
+
+const EDGE_FUNCTION_TIMEOUT_MS = 30000;
+
+export interface DesktopAuthProfileData {
+  authenticated: boolean;
+  user: { email: string; id: string } | null;
+  tier: string;
+  permissions: string[];
+  remoteAgents: [];
+  apiAccessMode: 'included' | 'personal';
+  allowedModels: string[] | null;
+  accessExpiresAt?: string | null;
+}
+
+export interface DesktopSupabaseAuth {
+  signIn(provider?: OAuthProvider): Promise<void>;
+  signOut(): Promise<void>;
+  getProfileData(): Promise<DesktopAuthProfileData>;
+  dispose(): void;
+}
+
+export interface DesktopSupabaseAuthOptions {
+  router: DesktopProtocolCallbackRouter;
+  secrets: PlatformSecrets;
+  openExternalUrl(url: string): Promise<void>;
+  showInfoMessage?(message: string): Promise<void> | void;
+  showErrorMessage?(message: string): Promise<void> | void;
+  onSessionChanged?: () => Promise<void> | void;
+  log?: Pick<Console, 'debug' | 'info' | 'warn' | 'error'>;
+  coordinator?: DesktopAuthCoordinator;
+  oauthClient?: DesktopOAuthClient;
+  initializeServerSideAccess?: boolean;
+}
+
+export interface DesktopOAuthClient {
+  auth: {
+    signInWithOAuth(input: {
+      provider: OAuthProvider;
+      options: { redirectTo: string };
+    }): Promise<{
+      data: { url?: string | null };
+      error: { message: string } | null;
+    }>;
+  };
+}
+
+export interface DesktopAuthCoordinator {
+  loadSession(): Promise<SupabaseSession | null>;
+  storeSession(session: SupabaseSession): Promise<void>;
+  clearSession(): Promise<void>;
+  createSessionFromCallback(
+    uri: AuthCallbackUriParts,
+  ): Promise<SupabaseCallbackResult>;
+  whenReady(): Promise<void>;
+  ensureFreshToken(forceRefresh?: boolean): Promise<string | null>;
+  getSessionTokens(): Promise<{
+    accessToken: string;
+    refreshToken: string;
+  } | null>;
+}
+
+export function createDesktopSupabaseAuth(
+  options: DesktopSupabaseAuthOptions,
+): DesktopSupabaseAuth {
+  const coordinator = options.coordinator ?? createSessionCoordinator(options);
+  const oauthClient = options.oauthClient ?? SupabaseClient.getClient();
+  let isProcessingCallback = false;
+  const subscription = subscribeToProtocolCallbacks(
+    options.router,
+    async (callback) => {
+      if (isProcessingCallback) return;
+      isProcessingCallback = true;
+      try {
+        await processProtocolCallback(coordinator, callback, options);
+      } finally {
+        isProcessingCallback = false;
+      }
+    },
+  );
+
+  if (options.initializeServerSideAccess ?? true) {
+    initializeServerSideKeyAccess(
+      {
+        state: platform().globalState,
+        logger: createAuthServiceLogger(options.log),
+      },
+      {
+        isAuthenticated: () => SupabaseClient.isAuthenticated(),
+        getUserTier: () => SupabaseClient.getUserTier() as Promise<UserTier>,
+        getAccessToken: () => SupabaseClient.getAccessToken(),
+      },
+    );
+  }
+
+  return {
+    async signIn(provider = DEFAULT_OAUTH_PROVIDER) {
+      try {
+        const redirectTo = getAuthCallbackUri(TEXRA_PROTOCOL);
+        const { data, error } = await oauthClient.auth.signInWithOAuth({
+          provider,
+          options: { redirectTo },
+        });
+        if (error || !data.url) {
+          throw new Error(
+            `OAuth initialization failed: ${error?.message || 'missing auth URL'}`,
+          );
+        }
+
+        await options.openExternalUrl(data.url);
+        await options.showInfoMessage?.(
+          'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
+        );
+      } catch (error) {
+        await options.showErrorMessage?.(
+          `Sign-in failed: ${toErrorMessage(error)}`,
+        );
+        throw error;
+      }
+    },
+
+    async signOut() {
+      await coordinator.clearSession();
+      SupabaseClient.setTokenExpiry(null);
+      await options.onSessionChanged?.();
+    },
+
+    async getProfileData() {
+      return loadDesktopAuthProfileData();
+    },
+
+    dispose() {
+      subscription.dispose();
+    },
+  };
+}
+
+function createSessionCoordinator(
+  options: Pick<DesktopSupabaseAuthOptions, 'secrets' | 'log'>,
+): DesktopAuthCoordinator {
+  SupabaseClient.initialize(SUPABASE_CONFIG.url, SUPABASE_CONFIG.publicKey);
+  const coordinator = new SupabaseSessionCoordinator({
+    storage: {
+      get: () => options.secrets.get(SUPABASE_SESSION_KEY),
+      store: (sessionData) =>
+        options.secrets.set(SUPABASE_SESSION_KEY, sessionData),
+      delete: () => options.secrets.delete(SUPABASE_SESSION_KEY),
+    },
+    getClient: () => SupabaseClient.getClient(),
+    whenReady: async () => {},
+    tokenRefreshThresholdMs: TOKEN_REFRESH_THRESHOLD_MS,
+    defaultSessionExpiryMs: DEFAULT_SESSION_EXPIRY_MS,
+    githubTokenRefreshUrl: GITHUB_TOKEN_REFRESH_URL,
+    edgeFunctionTimeoutMs: EDGE_FUNCTION_TIMEOUT_MS,
+    log: createSessionLog(options.log),
+    onTokenExpiryChanged: (expiresAt) =>
+      SupabaseClient.setTokenExpiry(expiresAt),
+  } satisfies SupabaseSessionCoordinatorOptions);
+  SupabaseClient.setAuthProvider(coordinator);
+  return coordinator;
+}
+
+function subscribeToProtocolCallbacks(
+  router: DesktopProtocolCallbackRouter,
+  listener: (callback: DesktopProtocolCallback) => void,
+): DesktopProtocolCallbackSubscription {
+  return router.subscribe(listener);
+}
+
+async function processProtocolCallback(
+  coordinator: DesktopAuthCoordinator,
+  callback: DesktopProtocolCallback,
+  options: DesktopSupabaseAuthOptions,
+): Promise<void> {
+  const result = await coordinator.createSessionFromCallback({
+    path: callback.path,
+    query: callback.query,
+    fragment: callback.fragment,
+  });
+
+  if (!result.success) {
+    if (result.isAuthError) {
+      await options.showErrorMessage?.(`Sign-in failed: ${result.error}`);
+    } else {
+      options.log?.debug?.(`Desktop auth callback ignored: ${result.error}`);
+    }
+    return;
+  }
+
+  await coordinator.storeSession(result.session);
+  await options.showInfoMessage?.(
+    `Signed in as ${result.session.account.label}`,
+  );
+  await options.onSessionChanged?.();
+}
+
+async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
+  const authenticated = await SupabaseClient.isAuthenticated();
+  if (!authenticated) return unauthenticatedProfileData();
+
+  const user = await SupabaseClient.getUser();
+  let authContext: { tier: string; permissions: string[] } = {
+    tier: 'free',
+    permissions: [],
+  };
+  try {
+    authContext = await SupabaseClient.getUserAuthContext();
+  } catch {
+    // Keep the UI signed in even if profile metadata is temporarily unavailable.
+  }
+
+  let apiAccessMode: 'included' | 'personal' = 'personal';
+  let allowedModels: string[] | null = [];
+  let accessExpiresAt: string | null = null;
+  try {
+    const serverSideKeyService = getServerSideKeyService();
+    apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()
+      ? 'included'
+      : 'personal';
+    allowedModels = (await serverSideKeyService.canUseServerSideKeys())
+      ? serverSideKeyService.getAllowedModelsForCurrentUser()
+      : [];
+    accessExpiresAt =
+      serverSideKeyService.getAccessExpirationDate()?.toISOString() ?? null;
+  } catch {
+    // Server-side key access is optional; personal provider keys still work.
+  }
+
+  return {
+    authenticated: true,
+    user: {
+      email: user?.email ?? 'N/A',
+      id: user?.id ?? '',
+    },
+    tier: authContext.tier,
+    permissions: authContext.permissions,
+    remoteAgents: [],
+    apiAccessMode,
+    allowedModels,
+    accessExpiresAt,
+  };
+}
+
+export function unauthenticatedProfileData(): DesktopAuthProfileData {
+  return {
+    authenticated: false,
+    user: null,
+    tier: 'free',
+    permissions: [],
+    remoteAgents: [],
+    apiAccessMode: 'personal',
+    allowedModels: [],
+    accessExpiresAt: null,
+  };
+}
+
+function createSessionLog(
+  log: Pick<Console, 'debug' | 'info' | 'warn' | 'error'> | undefined,
+): NonNullable<SupabaseSessionCoordinatorOptions['log']> {
+  return {
+    debug: (source, message) => log?.debug?.(`[${source}] ${message}`),
+    info: (source, message) => log?.info?.(`[${source}] ${message}`),
+    warn: (source, message) => log?.warn?.(`[${source}] ${message}`),
+    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+  };
+}
+
+function createAuthServiceLogger(
+  log: Pick<Console, 'info' | 'error'> | undefined,
+): AuthServiceLogger {
+  return {
+    info: (source, message) => log?.info?.(`[${source}] ${message}`),
+    error: (source, message) => log?.error?.(`[${source}] ${message}`),
+  };
+}

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -67,8 +67,8 @@ export interface DesktopSupabaseAuth {
 
 export interface DesktopAuthCallbackState {
   getExpectedState(): string | null;
-  beginAuthAttempt(state: string): void;
-  clearAwaitingCallback(): void;
+  beginAuthAttempt(state: string): Promise<void>;
+  clearAwaitingCallback(): Promise<void>;
 }
 
 export interface DesktopSupabaseAuthOptions {
@@ -117,13 +117,11 @@ export function createDesktopAuthCallbackState(
 ): DesktopAuthCallbackState {
   let pendingState = readPendingOAuthState(store);
 
-  const persistPendingState = (
+  const persistPendingState = async (
     state: DesktopPendingOAuthState | null,
-  ): void => {
+  ): Promise<void> => {
     if (!store) return;
-    void Promise.resolve(
-      store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state),
-    ).catch(() => {});
+    await store.update(DESKTOP_PENDING_OAUTH_STATE_KEY, state);
   };
 
   return {
@@ -131,18 +129,18 @@ export function createDesktopAuthCallbackState(
       if (!pendingState) return null;
       if (isPendingOAuthStateExpired(pendingState)) {
         pendingState = null;
-        persistPendingState(null);
+        void persistPendingState(null).catch(() => {});
         return null;
       }
       return pendingState.state;
     },
-    beginAuthAttempt: (state) => {
+    async beginAuthAttempt(state) {
       pendingState = { state, createdAt: Date.now() };
-      persistPendingState(pendingState);
+      await persistPendingState(pendingState);
     },
-    clearAwaitingCallback: () => {
+    async clearAwaitingCallback() {
       pendingState = null;
-      persistPendingState(null);
+      await persistPendingState(null);
     },
   };
 }
@@ -224,7 +222,11 @@ export function createDesktopSupabaseAuth(
       );
       return;
     }
-    callbackState.clearAwaitingCallback();
+    void callbackState.clearAwaitingCallback().catch((error: unknown) => {
+      options.log?.debug?.(
+        `Desktop auth callback state clear failed: ${toErrorMessage(error)}`,
+      );
+    });
     callbackQueue.push(callback);
     if (isProcessingCallbacks) {
       options.log?.debug?.(
@@ -253,13 +255,13 @@ export function createDesktopSupabaseAuth(
           );
         }
 
-        callbackState.beginAuthAttempt(state);
+        await callbackState.beginAuthAttempt(state);
         await options.openExternalUrl(data.url);
         await options.showInfoMessage?.(
           'Complete sign-in in your browser. TeXRA will update when the browser returns to the desktop app.',
         );
       } catch (error) {
-        callbackState.clearAwaitingCallback();
+        await callbackState.clearAwaitingCallback();
         await options.showErrorMessage?.(
           `Sign-in failed: ${toErrorMessage(error)}`,
         );
@@ -268,7 +270,7 @@ export function createDesktopSupabaseAuth(
     },
 
     async signOut() {
-      callbackState.clearAwaitingCallback();
+      await callbackState.clearAwaitingCallback();
       await coordinator.clearSession();
       SupabaseClient.setTokenExpiry(null);
       clearDesktopServerSideKeyCaches(options.log);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -151,7 +151,7 @@ function createWindow(options: {
         ? MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER
         : MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
     });
-    await settingsIpcRef.current?.refreshProfileData();
+    await settingsIpcRef.current?.refreshAuthDependentData();
   };
   const desktopAuth = createDesktopSupabaseAuth({
     router: protocolLifecycle.router,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -5,6 +5,8 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
+import { getServerSideKeyService } from '@auth/serverKeys';
+import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
@@ -20,7 +22,12 @@ import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
-import { createDesktopSupabaseAuth } from './desktopSupabaseAuth.js';
+import {
+  createDesktopAuthCoordinator,
+  createDesktopSupabaseAuth,
+  initializeDesktopServerSideKeyAccess,
+  type DesktopAuthCoordinator,
+} from './desktopSupabaseAuth.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 import {
@@ -93,7 +100,10 @@ function installContentSecurityPolicy(): void {
   });
 }
 
-function createWindow(options: { workspacePath: string | undefined }): void {
+function createWindow(options: {
+  workspacePath: string | undefined;
+  authCoordinator: DesktopAuthCoordinator;
+}): void {
   const window = new BrowserWindow({
     width: 960,
     height: 680,
@@ -127,6 +137,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   });
   const desktopAuth = createDesktopSupabaseAuth({
     router: protocolLifecycle.router,
+    coordinator: options.authCoordinator,
     secrets: platform().secrets,
     openExternalUrl: (url) => previewHost.openExternal(url),
     showInfoMessage: async (message) => {
@@ -135,6 +146,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     showErrorMessage,
     onSessionChanged: () => settingsIpcRef.current?.refreshProfileData(),
     log: console,
+    initializeServerSideAccess: false,
   });
   setOpenBuildDisplay(previewHost.openBuildDisplay);
   const openLogsFolder = async () =>
@@ -195,6 +207,12 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     signIn: () => desktopAuth.signIn(),
     signOut: () => desktopAuth.signOut(),
     getAuthProfileData: () => desktopAuth.getProfileData(),
+    setApiAccessMode: async (mode) => {
+      await getServerSideKeyService().setUseIncludedModelAccess(
+        mode === 'included',
+      );
+      invalidateModelOptionsCache();
+    },
     selectCustomAgentDirectory: async () => {
       const result = await dialog.showOpenDialog(window, {
         title: 'Select Custom Agents Folder',
@@ -271,12 +289,23 @@ if (protocolLifecycle.shouldContinue) {
     .whenReady()
     .then(async () => {
       const platformInit = await initializeElectronPlatform(__dirname);
+      const authCoordinator = createDesktopAuthCoordinator({
+        secrets: platform().secrets,
+        log: console,
+      });
+      initializeDesktopServerSideKeyAccess(console);
       installContentSecurityPolicy();
-      createWindow({ workspacePath: platformInit.workspacePath });
+      createWindow({
+        workspacePath: platformInit.workspacePath,
+        authCoordinator,
+      });
 
       app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {
-          createWindow({ workspacePath: platformInit.workspacePath });
+          createWindow({
+            workspacePath: platformInit.workspacePath,
+            authCoordinator,
+          });
         }
       });
     })

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -24,6 +24,7 @@ import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
 import {
+  createDesktopAuthCallbackState,
   createDesktopAuthCoordinator,
   createDesktopSupabaseAuth,
   initializeDesktopServerSideKeyAccess,
@@ -41,6 +42,7 @@ const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
 let mainWindow: BrowserWindow | null = null;
 let reopenMainWindow: (() => void) | undefined;
+const desktopAuthCallbackState = createDesktopAuthCallbackState();
 
 function focusOrReopenMainWindow(): void {
   if (!mainWindow) {
@@ -162,6 +164,7 @@ function createWindow(options: {
     showErrorMessage,
     onSessionChanged: refreshDesktopAuthSurfaces,
     log: console,
+    callbackState: desktopAuthCallbackState,
     initializeServerSideAccess: false,
   });
   setOpenBuildDisplay(previewHost.openBuildDisplay);

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
 import { createDesktopPreviewHost } from './desktopPreviewHost.js';
+import { installDesktopProtocolCallbackLifecycle } from './desktopProtocolCallbacks.js';
 import { createDesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import {
   attachRendererConsoleLog,
@@ -32,6 +33,21 @@ import {
 
 const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
+let mainWindow: BrowserWindow | null = null;
+
+const protocolLifecycle = installDesktopProtocolCallbackLifecycle({
+  app,
+  argv: process.argv.slice(1),
+  execPath: process.execPath,
+  devAppArg: process.argv[1],
+  focusMainWindow: () => {
+    if (!mainWindow) return;
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.show();
+    mainWindow.focus();
+  },
+  log: console,
+});
 
 function findDesktopMainDir(startDir: string): string {
   let currentDir = startDir;
@@ -96,6 +112,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
       ],
     },
   });
+  mainWindow = window;
   const reportAsyncError = (error: unknown) => console.error(error);
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
@@ -233,7 +250,12 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   });
   ipcRef.current = mainViewIpc;
   installDesktopMenu(shellActions);
-  window.once('closed', () => agentExecution.dispose());
+  window.once('closed', () => {
+    if (mainWindow === window) {
+      mainWindow = null;
+    }
+    agentExecution.dispose();
+  });
 
   if (process.env.ELECTRON_RENDERER_URL) {
     void window.loadURL(process.env.ELECTRON_RENDERER_URL);
@@ -243,24 +265,26 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   void window.loadFile(join(__dirname, '../renderer/index.html'));
 }
 
-app
-  .whenReady()
-  .then(async () => {
-    const platformInit = await initializeElectronPlatform(__dirname);
-    installContentSecurityPolicy();
-    createWindow({ workspacePath: platformInit.workspacePath });
+if (protocolLifecycle.shouldContinue) {
+  app
+    .whenReady()
+    .then(async () => {
+      const platformInit = await initializeElectronPlatform(__dirname);
+      installContentSecurityPolicy();
+      createWindow({ workspacePath: platformInit.workspacePath });
 
-    app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        createWindow({ workspacePath: platformInit.workspacePath });
-      }
+      app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+          createWindow({ workspacePath: platformInit.workspacePath });
+        }
+      });
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Failed to start TeXRA desktop: ${message}`);
+      app.quit();
     });
-  })
-  .catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`Failed to start TeXRA desktop: ${message}`);
-    app.quit();
-  });
+}
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -138,11 +138,11 @@ function createWindow(options: {
   });
   const refreshDesktopAuthSurfaces = async () => {
     const profile = await desktopAuth.getProfileData();
-    if (profile.authenticated) {
-      ipcRef.current?.postToRenderer({
-        command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
-      });
-    }
+    ipcRef.current?.postToRenderer({
+      command: profile.authenticated
+        ? MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER
+        : MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
+    });
     await settingsIpcRef.current?.refreshProfileData();
   };
   const desktopAuth = createDesktopSupabaseAuth({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -274,6 +274,7 @@ function createWindow(options: {
       openLogFolder: openLogsFolder,
       openPath: previewHost.openPath,
       openWorkspaceFolder,
+      signIn: () => desktopAuth.signIn(),
       onAsyncError: reportAsyncError,
     },
   );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -28,6 +28,7 @@ import {
   createDesktopAuthCoordinator,
   createDesktopSupabaseAuth,
   initializeDesktopServerSideKeyAccess,
+  type DesktopAuthCallbackState,
   type DesktopAuthCoordinator,
 } from './desktopSupabaseAuth.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
@@ -42,7 +43,6 @@ const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
 let mainWindow: BrowserWindow | null = null;
 let reopenMainWindow: (() => void) | undefined;
-const desktopAuthCallbackState = createDesktopAuthCallbackState();
 
 function focusOrReopenMainWindow(): void {
   if (!mainWindow) {
@@ -112,6 +112,7 @@ function installContentSecurityPolicy(): void {
 function createWindow(options: {
   workspacePath: string | undefined;
   authCoordinator: DesktopAuthCoordinator;
+  authCallbackState: DesktopAuthCallbackState;
 }): void {
   const window = new BrowserWindow({
     width: 960,
@@ -164,7 +165,7 @@ function createWindow(options: {
     showErrorMessage,
     onSessionChanged: refreshDesktopAuthSurfaces,
     log: console,
-    callbackState: desktopAuthCallbackState,
+    callbackState: options.authCallbackState,
     initializeServerSideAccess: false,
   });
   setOpenBuildDisplay(previewHost.openBuildDisplay);
@@ -315,12 +316,16 @@ if (protocolLifecycle.shouldContinue) {
         secrets: platform().secrets,
         log: console,
       });
+      const authCallbackState = createDesktopAuthCallbackState(
+        platform().globalState,
+      );
       initializeDesktopServerSideKeyAccess(console);
       installContentSecurityPolicy();
       reopenMainWindow = () =>
         createWindow({
           workspacePath: platformInit.workspacePath,
           authCoordinator,
+          authCallbackState,
         });
       reopenMainWindow();
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -40,18 +40,24 @@ import {
 const moduleDirname = fileURLToPath(new URL('.', import.meta.url));
 const __dirname = findDesktopMainDir(moduleDirname);
 let mainWindow: BrowserWindow | null = null;
+let reopenMainWindow: (() => void) | undefined;
+
+function focusOrReopenMainWindow(): void {
+  if (!mainWindow) {
+    reopenMainWindow?.();
+    return;
+  }
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
+}
 
 const protocolLifecycle = installDesktopProtocolCallbackLifecycle({
   app,
   argv: process.argv.slice(1),
   execPath: process.execPath,
   devAppArg: process.argv[1] ? resolvePath(process.argv[1]) : undefined,
-  focusMainWindow: () => {
-    if (!mainWindow) return;
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.show();
-    mainWindow.focus();
-  },
+  focusMainWindow: focusOrReopenMainWindow,
   log: console,
 });
 
@@ -308,17 +314,16 @@ if (protocolLifecycle.shouldContinue) {
       });
       initializeDesktopServerSideKeyAccess(console);
       installContentSecurityPolicy();
-      createWindow({
-        workspacePath: platformInit.workspacePath,
-        authCoordinator,
-      });
+      reopenMainWindow = () =>
+        createWindow({
+          workspacePath: platformInit.workspacePath,
+          authCoordinator,
+        });
+      reopenMainWindow();
 
       app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {
-          createWindow({
-            workspacePath: platformInit.workspacePath,
-            authCoordinator,
-          });
+          reopenMainWindow?.();
         }
       });
     })

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,11 +1,10 @@
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow, dialog, session, shell } from 'electron';
 
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
-import { SETTINGS_TAB } from '@shared/schemas/settingsViewMessages';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
@@ -21,10 +20,9 @@ import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
 import { createDesktopShellActions } from './desktopShellIpc.js';
+import { createDesktopSupabaseAuth } from './desktopSupabaseAuth.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
-import { buildDesktopSettingsTabMessage } from '../desktopCommandSurface.js';
-import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 import {
   DESKTOP_WORKSPACE_PATH_STATE_KEY,
   serializeWorkspacePresenceArg,
@@ -39,7 +37,7 @@ const protocolLifecycle = installDesktopProtocolCallbackLifecycle({
   app,
   argv: process.argv.slice(1),
   execPath: process.execPath,
-  devAppArg: process.argv[1],
+  devAppArg: process.argv[1] ? resolvePath(process.argv[1]) : undefined,
   focusMainWindow: () => {
     if (!mainWindow) return;
     if (mainWindow.isMinimized()) mainWindow.restore();
@@ -117,12 +115,26 @@ function createWindow(options: { workspacePath: string | undefined }): void {
   const ipcRef: {
     current?: ReturnType<typeof installDesktopMainViewIpc>;
   } = {};
+  const settingsIpcRef: {
+    current?: ReturnType<typeof createDesktopSettingsIpc>;
+  } = {};
   const showErrorMessage = async (message: string) => {
     await dialog.showMessageBox(window, { message, type: 'error' });
   };
   const previewHost = createDesktopPreviewHost({
     shell,
     showErrorMessage,
+  });
+  const desktopAuth = createDesktopSupabaseAuth({
+    router: protocolLifecycle.router,
+    secrets: platform().secrets,
+    openExternalUrl: (url) => previewHost.openExternal(url),
+    showInfoMessage: async (message) => {
+      await dialog.showMessageBox(window, { type: 'info', message });
+    },
+    showErrorMessage,
+    onSessionChanged: () => settingsIpcRef.current?.refreshProfileData(),
+    log: console,
   });
   setOpenBuildDisplay(previewHost.openBuildDisplay);
   const openLogsFolder = async () =>
@@ -180,22 +192,9 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     showErrorMessage: async (message) => {
       await dialog.showMessageBox(window, { type: 'error', message });
     },
-    signIn: async () => {
-      await dialog.showMessageBox(window, {
-        type: 'info',
-        message:
-          'Researcher Access sign-in is not connected in this desktop build',
-        detail:
-          'Use Settings > Models to add a provider API key, or use the TeXRA VS Code extension for included-access sign-in while desktop auth is completed.',
-      });
-      ipcRef.current?.postToRenderer({
-        command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
-        route: 'settings',
-      });
-      ipcRef.current?.postToRenderer(
-        buildDesktopSettingsTabMessage(SETTINGS_TAB.MODELS),
-      );
-    },
+    signIn: () => desktopAuth.signIn(),
+    signOut: () => desktopAuth.signOut(),
+    getAuthProfileData: () => desktopAuth.getProfileData(),
     selectCustomAgentDirectory: async () => {
       const result = await dialog.showOpenDialog(window, {
         title: 'Select Custom Agents Folder',
@@ -225,6 +224,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
     },
     onError: reportAsyncError,
   });
+  settingsIpcRef.current = settingsIpc;
   const progressIpc = createDesktopProgressIpc({
     progress: agentExecution.progress,
     onAsyncError: reportAsyncError,
@@ -255,6 +255,7 @@ function createWindow(options: { workspacePath: string | undefined }): void {
       mainWindow = null;
     }
     agentExecution.dispose();
+    desktopAuth.dispose();
   });
 
   if (process.env.ELECTRON_RENDERER_URL) {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { app, BrowserWindow, dialog, session, shell } from 'electron';
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
@@ -135,6 +136,15 @@ function createWindow(options: {
     shell,
     showErrorMessage,
   });
+  const refreshDesktopAuthSurfaces = async () => {
+    const profile = await desktopAuth.getProfileData();
+    if (profile.authenticated) {
+      ipcRef.current?.postToRenderer({
+        command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER,
+      });
+    }
+    await settingsIpcRef.current?.refreshProfileData();
+  };
   const desktopAuth = createDesktopSupabaseAuth({
     router: protocolLifecycle.router,
     coordinator: options.authCoordinator,
@@ -144,7 +154,7 @@ function createWindow(options: {
       await dialog.showMessageBox(window, { type: 'info', message });
     },
     showErrorMessage,
-    onSessionChanged: () => settingsIpcRef.current?.refreshProfileData(),
+    onSessionChanged: refreshDesktopAuthSurfaces,
     log: console,
     initializeServerSideAccess: false,
   });
@@ -264,6 +274,9 @@ function createWindow(options: {
     settings: settingsIpc,
     progress: progressIpc,
     shellActions,
+    getAuthStatus: async () => ({
+      authenticated: (await desktopAuth.getProfileData()).authenticated,
+    }),
     onAsyncError: reportAsyncError,
   });
   ipcRef.current = mainViewIpc;

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -18,6 +18,7 @@ import type { DesktopSettingsIpc } from './desktopSettingsIpc.js';
 import type { DesktopFileSelection } from './desktopFileSelection.js';
 import type { DesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
+import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
 import type { BrowserWindow } from 'electron';
 
 export interface DesktopMainViewIpcOptions {
@@ -28,6 +29,7 @@ export interface DesktopMainViewIpcOptions {
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
   shellActions?: DesktopShellActions;
+  getAuthStatus?: () => Promise<MainViewAuthStatus>;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
@@ -73,6 +75,7 @@ export function installDesktopMainViewIpc(
   });
   const startup = createDesktopMainViewStartup({
     renderer: bridge,
+    getAuthStatus: options.getAuthStatus,
     onAsyncError: options.onAsyncError,
   });
   messageHandlers = [

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -39,7 +39,7 @@ export function withWorkspacePathArg(
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg == null) continue;
-    if (isDesktopProtocolCallbackArg(arg)) continue;
+    if (isDesktopProtocolUrl(arg)) continue;
     if (arg === '--texra-workspace') {
       const value = argv[index + 1];
       if (value != null && !value.startsWith('--')) {
@@ -82,16 +82,8 @@ function getPositionalWorkspacePathArg(
   arg: string | undefined,
 ): string | undefined {
   const trimmed = arg?.trim();
-  if (
-    !trimmed ||
-    trimmed.startsWith('--') ||
-    isDesktopProtocolCallbackArg(trimmed)
-  ) {
+  if (!trimmed || trimmed.startsWith('--') || isDesktopProtocolUrl(trimmed)) {
     return undefined;
   }
   return trimmed;
-}
-
-function isDesktopProtocolCallbackArg(arg: string): boolean {
-  return isDesktopProtocolUrl(arg);
 }

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -5,6 +5,7 @@ interface WorkspacePathOptions {
 }
 
 const WORKSPACE_PRESENT_ARG = '--texra-has-workspace=';
+const DESKTOP_PROTOCOL = 'texra:';
 export const DESKTOP_WORKSPACE_PATH_STATE_KEY = 'texra.desktop.workspacePath';
 
 export function getWorkspacePathInput(
@@ -37,6 +38,7 @@ export function withWorkspacePathArg(
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg == null) continue;
+    if (isDesktopProtocolCallbackArg(arg)) continue;
     if (arg === '--texra-workspace') {
       const value = argv[index + 1];
       if (value != null && !value.startsWith('--')) {
@@ -67,7 +69,9 @@ function getWorkspacePathArg(argv: readonly string[]): string | undefined {
       return getPositionalWorkspacePathArg(argv[index + 1]);
     }
     if (arg.startsWith('--texra-workspace=')) {
-      return arg.slice('--texra-workspace='.length).trim() || undefined;
+      return getPositionalWorkspacePathArg(
+        arg.slice('--texra-workspace='.length),
+      );
     }
   }
   return undefined;
@@ -77,6 +81,20 @@ function getPositionalWorkspacePathArg(
   arg: string | undefined,
 ): string | undefined {
   const trimmed = arg?.trim();
-  if (!trimmed || trimmed.startsWith('--')) return undefined;
+  if (
+    !trimmed ||
+    trimmed.startsWith('--') ||
+    isDesktopProtocolCallbackArg(trimmed)
+  ) {
+    return undefined;
+  }
   return trimmed;
+}
+
+function isDesktopProtocolCallbackArg(arg: string): boolean {
+  try {
+    return new URL(arg).protocol === DESKTOP_PROTOCOL;
+  } catch {
+    return false;
+  }
 }

--- a/packages/desktop/src/workspacePath.ts
+++ b/packages/desktop/src/workspacePath.ts
@@ -1,3 +1,5 @@
+import { isDesktopProtocolUrl } from './desktopProtocol.js';
+
 interface WorkspacePathOptions {
   env?: Partial<Pick<NodeJS.ProcessEnv, 'TEXRA_WORKSPACE_PATH'>>;
   argv?: readonly string[];
@@ -5,7 +7,6 @@ interface WorkspacePathOptions {
 }
 
 const WORKSPACE_PRESENT_ARG = '--texra-has-workspace=';
-const DESKTOP_PROTOCOL = 'texra:';
 export const DESKTOP_WORKSPACE_PATH_STATE_KEY = 'texra.desktop.workspacePath';
 
 export function getWorkspacePathInput(
@@ -92,9 +93,5 @@ function getPositionalWorkspacePathArg(
 }
 
 function isDesktopProtocolCallbackArg(arg: string): boolean {
-  try {
-    return new URL(arg).protocol === DESKTOP_PROTOCOL;
-  } catch {
-    return false;
-  }
+  return isDesktopProtocolUrl(arg);
 }

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -29,6 +29,7 @@ import {
   type HistoryItem,
   type ProviderKeyStatus,
   type ModelSelectionItem,
+  SETTINGS_TAB,
 } from '@shared/schemas';
 import {
   type AgentSelectionItem,
@@ -43,7 +44,11 @@ import {
   DEFAULT_GIT_AUTHOR_EMAIL,
   DEFAULT_GIT_MARK_COMMITS,
 } from '@shared/constants/git';
-import { DEFAULT_HELPER_MODEL } from '@shared/constants/providers';
+import {
+  DEFAULT_HELPER_MODEL,
+  PROVIDER_DISPLAY_NAMES,
+} from '@shared/constants/providers';
+import { API_KEY_PROVIDER_IDS } from '@shared/constants/apiKeyProviders';
 import { NESTED_DELEGATION_DEPTH_RANGE } from '@shared/constants/delegationPolicy';
 
 // Local imports - settings view
@@ -75,6 +80,8 @@ const HISTORY_ACTION_COMMANDS: Record<string, string> = {
   'export-md': SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_MD,
   'export-tex': SETTINGS_VIEW_COMMANDS.EXPORT_CHAT_TEX,
 };
+
+const API_KEY_PROVIDER_SET = new Set<string>(API_KEY_PROVIDER_IDS);
 
 /** Create an event handler that forwards event.detail to a postMessage command. */
 function forwardDetail<T extends Record<string, unknown>>(
@@ -359,6 +366,45 @@ export class SettingsApp extends SettingsAppBase {
     this.providerKeyModal.set(null);
   };
 
+  private getDefaultProviderKeyTarget(): {
+    provider: string;
+    displayName: string;
+  } {
+    const helperProvider = this.modelSelectionItems
+      .get()
+      .find((model) => model.name === this.helperModel.get())?.provider;
+    const providerKeyStatuses = this.providerKeyStatuses.get();
+    const fallbackProvider =
+      providerKeyStatuses.find((entry) => entry.status === 'not-set')
+        ?.provider ?? API_KEY_PROVIDER_IDS[0];
+    const provider =
+      helperProvider && API_KEY_PROVIDER_SET.has(helperProvider)
+        ? helperProvider
+        : fallbackProvider;
+    const status = providerKeyStatuses.find(
+      (entry) => entry.provider === provider,
+    );
+    return {
+      provider,
+      displayName:
+        status?.displayName ?? PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+    };
+  }
+
+  private readonly handleSetDefaultProviderKey = (): void => {
+    const target = this.getDefaultProviderKeyTarget();
+    this.selectedTabIndex.set(SETTINGS_TAB.MODELS);
+
+    if (!this.isDesktopHost()) {
+      postMessage(SETTINGS_VIEW_COMMANDS.SET_PROVIDER_KEY, {
+        provider: target.provider,
+      });
+      return;
+    }
+
+    this.providerKeyModal.set(target);
+  };
+
   private handleRemoveProviderKey = forwardDetail(
     SETTINGS_VIEW_COMMANDS.REMOVE_PROVIDER_KEY,
   );
@@ -609,6 +655,14 @@ export class SettingsApp extends SettingsAppBase {
         </span>
         <div class="settings-header-actions">
           ${settingsButton}
+          <button
+            class="tab-action-btn settings-header-auth-button"
+            title="Set provider API key"
+            @click=${this.handleSetDefaultProviderKey}
+          >
+            <span class="codicon codicon-key"></span>
+            Set API key
+          </button>
           <button
             class="tab-action-btn settings-header-auth-button"
             title="Sign in"

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -21,6 +21,7 @@ interface DesktopShellIpcModule {
     options?: {
       getCustomAgentDirectory?: () => Promise<string>;
       openPath?: (filePath: string) => Promise<void>;
+      signIn?: () => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
   ): {
@@ -198,6 +199,21 @@ describe('desktop IPC adapters', () => {
       command: SETTINGS_VIEW_COMMANDS.SET_TAB,
       tabIndex: SETTINGS_TAB.AGENTS,
     });
+  });
+
+  it('wires the main login banner to desktop sign-in', async () => {
+    const { createDesktopShellIpc } = await loadDesktopShellIpc();
+    const postToRenderer = vi.fn();
+    const signIn = vi.fn(async () => {});
+    const shellIpc = createDesktopShellIpc({ postToRenderer }, { signIn });
+
+    expect(
+      shellIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER }),
+    ).toBe(true);
+    await Promise.resolve();
+
+    expect(signIn).toHaveBeenCalledOnce();
+    expect(postToRenderer).not.toHaveBeenCalled();
   });
 
   it('keeps execution forwarding in the execution adapter', async () => {

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -208,7 +208,9 @@ describe('desktop IPC adapters', () => {
     const shellIpc = createDesktopShellIpc({ postToRenderer }, { signIn });
 
     expect(
-      shellIpc.handleMessage({ command: MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER }),
+      shellIpc.handleMessage({
+        command: MAIN_VIEW_COMMANDS.SIGN_IN_FROM_BANNER,
+      }),
     ).toBe(true);
     await Promise.resolve();
 

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -79,6 +79,19 @@ describe('desktop protocol callbacks', () => {
     });
   });
 
+  it('accepts full callback URLs with a trailing slash', () => {
+    expect(
+      parseDesktopProtocolCallback(
+        'texra://texra-ai.texra/auth-callback/?state=abc',
+      ),
+    ).toEqual({
+      rawUrl: 'texra://texra-ai.texra/auth-callback/?state=abc',
+      path: '/auth-callback',
+      query: 'state=abc',
+      fragment: '',
+    });
+  });
+
   it('accepts extension-auth-callback URLs for shared auth parsing', () => {
     expect(
       parseDesktopProtocolCallback(
@@ -125,6 +138,21 @@ describe('desktop protocol callbacks', () => {
         path: '/auth-callback',
         query: 'state=startup',
       }),
+    );
+  });
+
+  it('routes argv callbacks when routeArgv is passed as a standalone function', () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const listener = vi.fn();
+    router.subscribe(listener);
+
+    const { routeArgv } = router;
+    expect(
+      routeArgv(['texra://texra-ai.texra/auth-callback?state=standalone']),
+    ).toBe(1);
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'state=standalone' }),
     );
   });
 

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -194,6 +194,25 @@ describe('desktop protocol callbacks', () => {
     expect(focusMainWindow).toHaveBeenCalled();
   });
 
+  it('focuses the existing window for unsupported texra open-url events', () => {
+    const app = createFakeProtocolApp();
+    const focusMainWindow = vi.fn();
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+      focusMainWindow,
+    });
+    const listener = vi.fn();
+    const event = { preventDefault: vi.fn() };
+    lifecycle.router.subscribe(listener);
+
+    app.listeners.openUrl?.(event, 'texra://texra-ai.texra/help');
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+    expect(focusMainWindow).toHaveBeenCalledTimes(1);
+  });
+
   it('quits when another desktop instance owns the protocol lifecycle', () => {
     const app = createFakeProtocolApp({
       requestSingleInstanceLock: vi.fn(() => false),

--- a/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createDesktopProtocolCallbackRouter,
+  findDesktopProtocolUrls,
+  installDesktopProtocolCallbackLifecycle,
+  parseDesktopProtocolCallback,
+  type DesktopProtocolApp,
+} from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+
+function createFakeProtocolApp(
+  overrides: Partial<DesktopProtocolApp> = {},
+): DesktopProtocolApp & {
+  listeners: {
+    secondInstance?: (
+      event: unknown,
+      argv: string[],
+      workingDirectory: string,
+    ) => void;
+    openUrl?: (event: { preventDefault(): void }, url: string) => void;
+  };
+} {
+  const listeners: {
+    secondInstance?: (
+      event: unknown,
+      argv: string[],
+      workingDirectory: string,
+    ) => void;
+    openUrl?: (event: { preventDefault(): void }, url: string) => void;
+  } = {};
+
+  return {
+    isPackaged: true,
+    listeners,
+    setAsDefaultProtocolClient: vi.fn(() => true),
+    requestSingleInstanceLock: vi.fn(() => true),
+    quit: vi.fn(),
+    on: vi.fn((event: 'second-instance' | 'open-url', listener) => {
+      if (event === 'second-instance') {
+        listeners.secondInstance = listener as typeof listeners.secondInstance;
+      } else {
+        listeners.openUrl = listener as typeof listeners.openUrl;
+      }
+    }),
+    ...overrides,
+  };
+}
+
+describe('desktop protocol callbacks', () => {
+  it('parses texra auth callback URLs into host-neutral callback parts', () => {
+    expect(
+      parseDesktopProtocolCallback(
+        'texra://texra-ai.texra/auth-callback?state=abc#access_token=tok&refresh_token=ref',
+      ),
+    ).toEqual({
+      rawUrl:
+        'texra://texra-ai.texra/auth-callback?state=abc#access_token=tok&refresh_token=ref',
+      path: '/auth-callback',
+      query: 'state=abc',
+      fragment: 'access_token=tok&refresh_token=ref',
+    });
+  });
+
+  it('accepts compact texra://auth-callback URLs from argv handlers', () => {
+    expect(parseDesktopProtocolCallback('texra://auth-callback')).toEqual({
+      rawUrl: 'texra://auth-callback',
+      path: '/auth-callback',
+      query: '',
+      fragment: '',
+    });
+  });
+
+  it('accepts compact callback URLs with a trailing slash', () => {
+    expect(parseDesktopProtocolCallback('texra://auth-callback/')).toEqual({
+      rawUrl: 'texra://auth-callback/',
+      path: '/auth-callback',
+      query: '',
+      fragment: '',
+    });
+  });
+
+  it('accepts extension-auth-callback URLs for shared auth parsing', () => {
+    expect(
+      parseDesktopProtocolCallback(
+        'texra://extension-auth-callback?access_token=query&refresh_token=refresh',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        path: '/extension-auth-callback',
+        query: 'access_token=query&refresh_token=refresh',
+      }),
+    );
+  });
+
+  it('ignores malformed, non-texra, and unrelated protocol URLs', () => {
+    expect(parseDesktopProtocolCallback('not a url')).toBeNull();
+    expect(
+      parseDesktopProtocolCallback('https://texra.ai/auth-callback'),
+    ).toBeNull();
+    expect(
+      parseDesktopProtocolCallback('texra://texra-ai.texra/help'),
+    ).toBeNull();
+  });
+
+  it('finds only TeXRA callback URLs in process argv', () => {
+    expect(
+      findDesktopProtocolUrls([
+        '--flag',
+        'texra://texra-ai.texra/auth-callback?code=1',
+        'texra://texra-ai.texra/help',
+      ]),
+    ).toEqual(['texra://texra-ai.texra/auth-callback?code=1']);
+  });
+
+  it('queues startup callbacks until auth code subscribes', () => {
+    const router = createDesktopProtocolCallbackRouter();
+    router.routeUrl('texra://texra-ai.texra/auth-callback?state=startup');
+
+    const listener = vi.fn();
+    router.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawUrl: 'texra://texra-ai.texra/auth-callback?state=startup',
+        path: '/auth-callback',
+        query: 'state=startup',
+      }),
+    );
+  });
+
+  it('registers protocol handling and routes warm-start argv callbacks', () => {
+    const app = createFakeProtocolApp();
+    const focusMainWindow = vi.fn();
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+      focusMainWindow,
+    });
+    const listener = vi.fn();
+    lifecycle.router.subscribe(listener);
+
+    app.listeners.secondInstance?.(
+      {},
+      ['TeXRA.app', 'texra://texra-ai.texra/auth-callback?state=warm'],
+      '/tmp',
+    );
+
+    expect(app.setAsDefaultProtocolClient).toHaveBeenCalledWith('texra');
+    expect(app.requestSingleInstanceLock).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'state=warm' }),
+    );
+    expect(focusMainWindow).toHaveBeenCalled();
+  });
+
+  it('focuses the existing window on second-instance launches without callbacks', () => {
+    const app = createFakeProtocolApp();
+    const focusMainWindow = vi.fn();
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+      focusMainWindow,
+    });
+    const listener = vi.fn();
+    lifecycle.router.subscribe(listener);
+
+    app.listeners.secondInstance?.({}, ['TeXRA.app'], '/tmp');
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(focusMainWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes macOS open-url callbacks and prevents default handling', () => {
+    const app = createFakeProtocolApp();
+    const focusMainWindow = vi.fn();
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: [],
+      focusMainWindow,
+    });
+    const listener = vi.fn();
+    const event = { preventDefault: vi.fn() };
+    lifecycle.router.subscribe(listener);
+
+    app.listeners.openUrl?.(
+      event,
+      'texra://texra-ai.texra/auth-callback#access_token=tok',
+    );
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ fragment: 'access_token=tok' }),
+    );
+    expect(focusMainWindow).toHaveBeenCalled();
+  });
+
+  it('quits when another desktop instance owns the protocol lifecycle', () => {
+    const app = createFakeProtocolApp({
+      requestSingleInstanceLock: vi.fn(() => false),
+    });
+
+    const lifecycle = installDesktopProtocolCallbackLifecycle({
+      app,
+      argv: ['texra://texra-ai.texra/auth-callback'],
+    });
+
+    expect(lifecycle.shouldContinue).toBe(false);
+    expect(app.quit).toHaveBeenCalled();
+  });
+});

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -481,6 +481,35 @@ describe('desktop settings IPC', () => {
     expect(secrets.values.get('apiKey.google')).toBe('sk-prompt');
   });
 
+  it('delegates desktop sign-in without posting stale profile data', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+    let signInCalls = 0;
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: (message) => posted.push(message),
+      signIn: async () => {
+        signInCalls += 1;
+      },
+    });
+
+    expect(
+      settings.handleMessage({ command: SETTINGS_VIEW_COMMANDS.SIGN_IN }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(signInCalls).toBe(1);
+    expect(
+      posted.some(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toBe(false);
+  });
+
   it('round-trips LaTeX config writes through workspace state and refreshes the renderer', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const workspaceState = new MemoryStateStore();

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -59,6 +59,9 @@ interface DesktopSettingsIpcModule {
     showInfoMessage?: (message: string) => Promise<void>;
     showErrorMessage?: (message: string) => Promise<void>;
     signIn?: () => Promise<void>;
+    signOut?: () => Promise<void>;
+    getAuthProfileData?: () => Promise<Record<string, unknown>>;
+    setApiAccessMode?: (mode: 'included' | 'personal') => Promise<void>;
     secrets?: {
       get(key: string): Promise<string | undefined>;
       set(key: string, value: string): Promise<void>;
@@ -831,6 +834,55 @@ describe('desktop settings IPC', () => {
         (message) =>
           (message as { command?: string }).command ===
           MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      ),
+    ).toBe(true);
+  });
+
+  it('persists desktop API access mode changes before refreshing settings data', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+    const persistedModes: string[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: (message) => posted.push(message),
+      setApiAccessMode: async (mode) => {
+        persistedModes.push(mode);
+      },
+      getAuthProfileData: async () => ({
+        authenticated: false,
+        user: null,
+        tier: 'free',
+        permissions: [],
+        remoteAgents: [],
+        apiAccessMode: 'personal',
+        allowedModels: [],
+        accessExpiresAt: null,
+      }),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE,
+        mode: 'personal',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(persistedModes).toEqual(['personal']);
+    expect(
+      posted.some(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toBe(true);
+    expect(
+      posted.some(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
       ),
     ).toBe(true);
   });

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -887,6 +887,45 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
   });
 
+  it('does not duplicate profile refresh after delegated desktop sign-out', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+    let signOutCalls = 0;
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: (message) => posted.push(message),
+      signOut: async () => {
+        signOutCalls += 1;
+      },
+      getAuthProfileData: async () => ({
+        authenticated: false,
+        user: null,
+        tier: 'free',
+        permissions: [],
+        remoteAgents: [],
+        apiAccessMode: 'personal',
+        allowedModels: [],
+        accessExpiresAt: null,
+      }),
+    });
+
+    expect(
+      settings.handleMessage({ command: SETTINGS_VIEW_COMMANDS.SIGN_OUT }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(signOutCalls).toBe(1);
+    expect(
+      posted.filter(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+      ),
+    ).toEqual([]);
+  });
+
   it('ignores unsupported or malformed settings messages', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const posted: unknown[] = [];

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -887,6 +887,43 @@ describe('desktop settings IPC', () => {
     ).toBe(true);
   });
 
+  it('clears OpenRouter routing when desktop users enable included access', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const globalState = new MemoryStateStore();
+    globalState.values.set(GlobalStateKey.USE_OPENROUTER, true);
+    const persistedModes: string[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState,
+      postToRenderer: () => {},
+      setApiAccessMode: async (mode) => {
+        persistedModes.push(mode);
+      },
+      getAuthProfileData: async () => ({
+        authenticated: false,
+        user: null,
+        tier: 'free',
+        permissions: [],
+        remoteAgents: [],
+        apiAccessMode: 'personal',
+        allowedModels: [],
+        accessExpiresAt: null,
+      }),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SET_API_ACCESS_MODE,
+        mode: 'included',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(persistedModes).toEqual(['included']);
+    expect(globalState.values.get(GlobalStateKey.USE_OPENROUTER)).toBe(false);
+  });
+
   it('does not duplicate profile refresh after delegated desktop sign-out', async () => {
     const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
     const posted: unknown[] = [];

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -71,6 +71,7 @@ interface DesktopSettingsIpcModule {
     runInstallCommand?: (command: string) => Promise<void>;
     onError?: (error: unknown) => void;
   }): {
+    refreshAuthDependentData(): Promise<void>;
     handleMessage(
       message: { command: string } & Record<string, unknown>,
     ): boolean;
@@ -922,6 +923,50 @@ describe('desktop settings IPC', () => {
 
     expect(persistedModes).toEqual(['included']);
     expect(globalState.values.get(GlobalStateKey.USE_OPENROUTER)).toBe(false);
+  });
+
+  it('refreshes agent and model options after desktop auth changes', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const posted: unknown[] = [];
+    let loadCount = 0;
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState: new MemoryStateStore(),
+      globalState: new MemoryStateStore(),
+      postToRenderer: (message) => posted.push(message),
+      loadAgents: async () => {
+        loadCount += 1;
+      },
+      loadAgentOptionsData: async () => ({
+        workflow: [{ name: 'remote-workflow' }],
+        toolUse: [{ name: 'remote-tool' }],
+      }),
+      getAuthProfileData: async () => ({
+        authenticated: true,
+        user: { email: 'user@example.com', id: 'user-1' },
+        tier: 'free',
+        permissions: [],
+        remoteAgents: [],
+        apiAccessMode: 'included',
+        allowedModels: [],
+        accessExpiresAt: null,
+      }),
+    });
+
+    await settings.refreshAuthDependentData();
+
+    expect(loadCount).toBe(1);
+    expect(
+      posted.map((message) => (message as { command?: string }).command),
+    ).toEqual(
+      expect.arrayContaining([
+        SETTINGS_VIEW_COMMANDS.UPDATE_PROFILE,
+        SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+        SETTINGS_VIEW_COMMANDS.UPDATE_MODEL_SELECTION,
+        MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+        MAIN_VIEW_COMMANDS.SET_MODEL_OPTIONS,
+      ]),
+    );
   });
 
   it('does not duplicate profile refresh after delegated desktop sign-out', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -270,6 +270,58 @@ describe('desktop Supabase auth', () => {
     recreatedAuth.dispose();
   });
 
+  it('expires persisted pending sign-in state across recreation', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-06T00:00:00Z'));
+      const router = createDesktopProtocolCallbackRouter();
+      const coordinator = createCoordinator();
+      const stateStore = createStateStore();
+      const oauthClient = createOAuthClient();
+      const auth = createDesktopSupabaseAuth({
+        router,
+        coordinator,
+        oauthClient,
+        secrets: createSecrets(),
+        openExternalUrl: vi.fn(async () => {}),
+        callbackState: createDesktopAuthCallbackState(stateStore),
+        initializeServerSideAccess: false,
+      });
+
+      await auth.signIn();
+      const state = getOAuthState(oauthClient);
+      auth.dispose();
+
+      vi.setSystemTime(Date.now() + 11 * 60 * 1000);
+      const expiredCallbackState =
+        createDesktopAuthCallbackState(stateStore);
+      const recreatedAuth = createDesktopSupabaseAuth({
+        router,
+        coordinator,
+        oauthClient: createOAuthClient(),
+        secrets: createSecrets(),
+        openExternalUrl: vi.fn(async () => {}),
+        callbackState: expiredCallbackState,
+        initializeServerSideAccess: false,
+      });
+
+      router.routeUrl(
+        authCallbackUrl({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          state,
+        }),
+      );
+      await Promise.resolve();
+
+      expect(expiredCallbackState.getExpectedState()).toBeNull();
+      expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+      recreatedAuth.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('cancels pending callback state on sign-out', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -121,4 +121,52 @@ describe('desktop Supabase auth', () => {
     expect(profile.authenticated).toBe(false);
     auth.dispose();
   });
+
+  it('surfaces rejected routed callback processing failures', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    coordinator.createSessionFromCallback.mockRejectedValueOnce(
+      new Error('network down'),
+    );
+    const showErrorMessage = vi.fn(async () => {});
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: {
+        auth: {
+          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
+        },
+      },
+      secrets: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+        delete: vi.fn(async () => {}),
+      },
+      openExternalUrl: vi.fn(async () => {}),
+      showErrorMessage,
+      log,
+      initializeServerSideAccess: false,
+    });
+
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+    );
+
+    await vi.waitFor(() => {
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        'Sign-in failed: network down',
+      );
+    });
+    expect(log.error).toHaveBeenCalledWith(
+      'Desktop auth callback failed: network down',
+    );
+    expect(coordinator.storeSession).not.toHaveBeenCalled();
+    auth.dispose();
+  });
 });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -43,31 +43,43 @@ function createCoordinator() {
   };
 }
 
+function createSecrets() {
+  return {
+    get: vi.fn(async () => undefined),
+    set: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+  };
+}
+
+function createOAuthClient() {
+  return {
+    auth: {
+      signInWithOAuth: vi.fn(async () => ({
+        data: { url: 'https://auth.example.test/start' },
+        error: null,
+      })),
+    },
+  };
+}
+
 describe('desktop Supabase auth', () => {
   it('opens Supabase OAuth with the desktop texra callback URI', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const signInWithOAuth = vi.fn(async () => ({
-      data: { url: 'https://auth.example.test/start' },
-      error: null,
-    }));
+    const oauthClient = createOAuthClient();
     const openExternalUrl = vi.fn(async () => {});
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: { auth: { signInWithOAuth } },
-      secrets: {
-        get: vi.fn(async () => undefined),
-        set: vi.fn(async () => {}),
-        delete: vi.fn(async () => {}),
-      },
+      oauthClient,
+      secrets: createSecrets(),
       openExternalUrl,
       initializeServerSideAccess: false,
     });
 
     await auth.signIn();
 
-    expect(signInWithOAuth).toHaveBeenCalledWith({
+    expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: 'github',
       options: { redirectTo: 'texra://texra-ai.texra/auth-callback' },
     });
@@ -84,21 +96,14 @@ describe('desktop Supabase auth', () => {
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: {
-        auth: {
-          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
-        },
-      },
-      secrets: {
-        get: vi.fn(async () => undefined),
-        set: vi.fn(async () => {}),
-        delete: vi.fn(async () => {}),
-      },
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
       initializeServerSideAccess: false,
     });
 
+    await auth.signIn();
     router.routeUrl(
       'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
     );
@@ -123,6 +128,39 @@ describe('desktop Supabase auth', () => {
     auth.dispose();
   });
 
+  it('ignores routed callbacks until desktop sign-in starts', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      log,
+      initializeServerSideAccess: false,
+    });
+
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+    );
+
+    await Promise.resolve();
+
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+    expect(coordinator.storeSession).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      'Desktop auth callback ignored because no sign-in is in progress',
+    );
+    auth.dispose();
+  });
+
   it('processes routed callbacks sequentially when they are replayed together', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
@@ -135,21 +173,14 @@ describe('desktop Supabase auth', () => {
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: {
-        auth: {
-          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
-        },
-      },
-      secrets: {
-        get: vi.fn(async () => undefined),
-        set: vi.fn(async () => {}),
-        delete: vi.fn(async () => {}),
-      },
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
       initializeServerSideAccess: false,
     });
 
+    await auth.signIn();
     router.routeUrl(
       'texra://texra-ai.texra/auth-callback#access_token=first&refresh_token=first',
     );
@@ -183,22 +214,15 @@ describe('desktop Supabase auth', () => {
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: {
-        auth: {
-          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
-        },
-      },
-      secrets: {
-        get: vi.fn(async () => undefined),
-        set: vi.fn(async () => {}),
-        delete: vi.fn(async () => {}),
-      },
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       showErrorMessage,
       log,
       initializeServerSideAccess: false,
     });
 
+    await auth.signIn();
     router.routeUrl(
       'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
     );
@@ -223,16 +247,8 @@ describe('desktop Supabase auth', () => {
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: {
-        auth: {
-          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
-        },
-      },
-      secrets: {
-        get: vi.fn(async () => undefined),
-        set: vi.fn(async () => {}),
-        delete: vi.fn(async () => {}),
-      },
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       initializeServerSideAccess: false,
     });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SupabaseSession } from '@auth/SupabaseSession';
+import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
+import {
+  createDesktopSupabaseAuth,
+  type DesktopAuthProfileData,
+} from '../../../packages/desktop/src/main/desktopSupabaseAuth';
+
+function createCoordinator() {
+  const storedSession: { current: SupabaseSession | null } = { current: null };
+  return {
+    loadSession: vi.fn(async () => storedSession.current),
+    storeSession: vi.fn(async (session: SupabaseSession) => {
+      storedSession.current = session;
+    }),
+    clearSession: vi.fn(async () => {
+      storedSession.current = null;
+    }),
+    createSessionFromCallback: vi.fn(async () => ({
+      success: true as const,
+      session: {
+        id: 'user-1',
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        account: { id: 'user-1', label: 'user@example.com' },
+        expiresAt: Date.now() + 60_000,
+      },
+    })),
+    whenReady: vi.fn(async () => {}),
+    ensureFreshToken: vi.fn(
+      async () => storedSession.current?.accessToken ?? null,
+    ),
+    getSessionTokens: vi.fn(async () =>
+      storedSession.current
+        ? {
+            accessToken: storedSession.current.accessToken,
+            refreshToken: storedSession.current.refreshToken,
+          }
+        : null,
+    ),
+  };
+}
+
+describe('desktop Supabase auth', () => {
+  it('opens Supabase OAuth with the desktop texra callback URI', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const signInWithOAuth = vi.fn(async () => ({
+      data: { url: 'https://auth.example.test/start' },
+      error: null,
+    }));
+    const openExternalUrl = vi.fn(async () => {});
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: { auth: { signInWithOAuth } },
+      secrets: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+        delete: vi.fn(async () => {}),
+      },
+      openExternalUrl,
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signIn();
+
+    expect(signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'github',
+      options: { redirectTo: 'texra://texra-ai.texra/auth-callback' },
+    });
+    expect(openExternalUrl).toHaveBeenCalledWith(
+      'https://auth.example.test/start',
+    );
+    auth.dispose();
+  });
+
+  it('stores routed callback sessions and refreshes settings profile state', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const onSessionChanged = vi.fn(async () => {});
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: {
+        auth: {
+          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
+        },
+      },
+      secrets: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+        delete: vi.fn(async () => {}),
+      },
+      openExternalUrl: vi.fn(async () => {}),
+      onSessionChanged,
+      initializeServerSideAccess: false,
+    });
+
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+    );
+
+    await vi.waitFor(() => {
+      expect(coordinator.storeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        }),
+      );
+    });
+    expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith({
+      path: '/auth-callback',
+      query: '',
+      fragment: 'access_token=access-token&refresh_token=refresh-token',
+    });
+    expect(onSessionChanged).toHaveBeenCalled();
+
+    const profile = (await auth.getProfileData()) as DesktopAuthProfileData;
+    expect(profile.authenticated).toBe(false);
+    auth.dispose();
+  });
+});

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -6,6 +6,7 @@ import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/s
 import {
   createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
+  type DesktopOAuthClient,
   type DesktopAuthProfileData,
 } from '../../../packages/desktop/src/main/desktopSupabaseAuth';
 
@@ -53,14 +54,38 @@ function createSecrets() {
 }
 
 function createOAuthClient() {
+  type SignInInput = Parameters<
+    DesktopOAuthClient['auth']['signInWithOAuth']
+  >[0];
   return {
     auth: {
-      signInWithOAuth: vi.fn(async () => ({
+      signInWithOAuth: vi.fn(async (_input: SignInInput) => ({
         data: { url: 'https://auth.example.test/start' },
         error: null,
       })),
     },
   };
+}
+
+function getOAuthState(oauthClient: ReturnType<typeof createOAuthClient>) {
+  const state =
+    oauthClient.auth.signInWithOAuth.mock.calls.at(-1)?.[0].options.queryParams
+      ?.state;
+  expect(state).toEqual(expect.any(String));
+  return state!;
+}
+
+function authCallbackUrl(input: {
+  accessToken: string;
+  refreshToken: string;
+  state: string;
+}): string {
+  const fragment = new URLSearchParams({
+    access_token: input.accessToken,
+    refresh_token: input.refreshToken,
+    state: input.state,
+  });
+  return `texra://texra-ai.texra/auth-callback#${fragment}`;
 }
 
 describe('desktop Supabase auth', () => {
@@ -82,7 +107,10 @@ describe('desktop Supabase auth', () => {
 
     expect(oauthClient.auth.signInWithOAuth).toHaveBeenCalledWith({
       provider: 'github',
-      options: { redirectTo: 'texra://texra-ai.texra/auth-callback' },
+      options: {
+        redirectTo: 'texra://texra-ai.texra/auth-callback',
+        queryParams: { state: expect.any(String) },
+      },
     });
     expect(openExternalUrl).toHaveBeenCalledWith(
       'https://auth.example.test/start',
@@ -94,10 +122,11 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const onSessionChanged = vi.fn(async () => {});
+    const oauthClient = createOAuthClient();
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: createOAuthClient(),
+      oauthClient,
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
@@ -105,8 +134,13 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
+    const state = getOAuthState(oauthClient);
     router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state,
+      }),
     );
 
     await vi.waitFor(() => {
@@ -120,7 +154,7 @@ describe('desktop Supabase auth', () => {
     expect(coordinator.createSessionFromCallback).toHaveBeenCalledWith({
       path: '/auth-callback',
       query: '',
-      fragment: 'access_token=access-token&refresh_token=refresh-token',
+      fragment: `access_token=access-token&refresh_token=refresh-token&state=${state}`,
     });
     expect(onSessionChanged).toHaveBeenCalled();
 
@@ -166,10 +200,11 @@ describe('desktop Supabase auth', () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const callbackState = createDesktopAuthCallbackState();
+    const oauthClient = createOAuthClient();
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: createOAuthClient(),
+      oauthClient,
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
@@ -177,9 +212,14 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
+    const state = getOAuthState(oauthClient);
     auth.dispose();
     router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state,
+      }),
     );
 
     const recreatedAuth = createDesktopSupabaseAuth({
@@ -203,7 +243,46 @@ describe('desktop Supabase auth', () => {
     recreatedAuth.dispose();
   });
 
-  it('processes routed callbacks sequentially when they are replayed together', async () => {
+  it('claims only the first matching callback for an OAuth attempt', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const oauthClient = createOAuthClient();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      log,
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signIn();
+    const state = getOAuthState(oauthClient);
+    router.routeUrl(
+      authCallbackUrl({ accessToken: 'first', refreshToken: 'first', state }),
+    );
+    router.routeUrl(
+      authCallbackUrl({ accessToken: 'second', refreshToken: 'second', state }),
+    );
+
+    await vi.waitFor(() => {
+      expect(coordinator.createSessionFromCallback).toHaveBeenCalledTimes(1);
+    });
+    expect(coordinator.storeSession).toHaveBeenCalledTimes(1);
+    expect(log.debug).toHaveBeenCalledWith(
+      'Desktop auth callback ignored because no sign-in is in progress',
+    );
+    auth.dispose();
+  });
+
+  it('ignores callbacks that do not match the active OAuth state', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
     const log = {
@@ -224,18 +303,18 @@ describe('desktop Supabase auth', () => {
 
     await auth.signIn();
     router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=first&refresh_token=first',
-    );
-    router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=second&refresh_token=second',
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state: 'wrong-state',
+      }),
     );
 
-    await vi.waitFor(() => {
-      expect(coordinator.createSessionFromCallback).toHaveBeenCalledTimes(2);
-    });
-    expect(coordinator.storeSession).toHaveBeenCalledTimes(2);
+    await Promise.resolve();
+
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
     expect(log.debug).toHaveBeenCalledWith(
-      'Desktop auth callback queued while another callback is being processed',
+      'Desktop auth callback ignored because it does not match the active sign-in attempt',
     );
     auth.dispose();
   });
@@ -253,10 +332,11 @@ describe('desktop Supabase auth', () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
+    const oauthClient = createOAuthClient();
     const auth = createDesktopSupabaseAuth({
       router,
       coordinator,
-      oauthClient: createOAuthClient(),
+      oauthClient,
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       showErrorMessage,
@@ -265,8 +345,13 @@ describe('desktop Supabase auth', () => {
     });
 
     await auth.signIn();
+    const state = getOAuthState(oauthClient);
     router.routeUrl(
-      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state,
+      }),
     );
 
     await vi.waitFor(() => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -293,8 +293,7 @@ describe('desktop Supabase auth', () => {
       auth.dispose();
 
       vi.setSystemTime(Date.now() + 11 * 60 * 1000);
-      const expiredCallbackState =
-        createDesktopAuthCallbackState(stateStore);
+      const expiredCallbackState = createDesktopAuthCallbackState(stateStore);
       const recreatedAuth = createDesktopSupabaseAuth({
         router,
         coordinator,

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -9,6 +9,7 @@ import {
   type DesktopOAuthClient,
   type DesktopAuthProfileData,
 } from '../../../packages/desktop/src/main/desktopSupabaseAuth';
+import type { StateStore } from '@platform/interfaces/state';
 
 function createCoordinator() {
   const storedSession: { current: SupabaseSession | null } = { current: null };
@@ -50,6 +51,22 @@ function createSecrets() {
     get: vi.fn(async () => undefined),
     set: vi.fn(async () => {}),
     delete: vi.fn(async () => {}),
+  };
+}
+
+function createStateStore(): Pick<StateStore, 'get' | 'update'> {
+  const state = new Map<string, unknown>();
+  return {
+    get<T>(key: string, defaultValue?: T): T {
+      return state.has(key) ? (state.get(key) as T) : (defaultValue as T);
+    },
+    async update(key: string, value: unknown): Promise<void> {
+      if (value == null) {
+        state.delete(key);
+      } else {
+        state.set(key, value);
+      }
+    },
   };
 }
 
@@ -207,7 +224,8 @@ describe('desktop Supabase auth', () => {
   it('preserves pending sign-in across desktop auth recreation', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
-    const callbackState = createDesktopAuthCallbackState();
+    const stateStore = createStateStore();
+    const callbackState = createDesktopAuthCallbackState(stateStore);
     const oauthClient = createOAuthClient();
     const auth = createDesktopSupabaseAuth({
       router,
@@ -222,6 +240,7 @@ describe('desktop Supabase auth', () => {
     await auth.signIn();
     const state = getOAuthState(oauthClient);
     auth.dispose();
+    const persistedCallbackState = createDesktopAuthCallbackState(stateStore);
     router.routeUrl(
       authCallbackUrl({
         accessToken: 'access-token',
@@ -236,7 +255,7 @@ describe('desktop Supabase auth', () => {
       oauthClient: createOAuthClient(),
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
-      callbackState,
+      callbackState: persistedCallbackState,
       initializeServerSideAccess: false,
     });
 
@@ -249,6 +268,49 @@ describe('desktop Supabase auth', () => {
       );
     });
     recreatedAuth.dispose();
+  });
+
+  it('cancels pending callback state on sign-out', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const callbackState = createDesktopAuthCallbackState();
+    const oauthClient = createOAuthClient();
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      callbackState,
+      log,
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signIn();
+    const state = getOAuthState(oauthClient);
+    await auth.signOut();
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state,
+      }),
+    );
+
+    await Promise.resolve();
+
+    expect(callbackState.getExpectedState()).toBeNull();
+    expect(coordinator.createSessionFromCallback).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      'Desktop auth callback ignored because no sign-in is in progress',
+    );
+    auth.dispose();
   });
 
   it('claims only the first matching callback for an OAuth attempt', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { SupabaseSession } from '@auth/SupabaseSession';
+import { setServerSideKeyService } from '@auth/serverKeys';
 import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
 import {
   createDesktopSupabaseAuth,
@@ -211,6 +212,35 @@ describe('desktop Supabase auth', () => {
       'Desktop auth callback failed: network down',
     );
     expect(coordinator.storeSession).not.toHaveBeenCalled();
+    auth.dispose();
+  });
+
+  it('clears included-access caches on sign-out', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const clearAllCaches = vi.fn();
+    setServerSideKeyService({ clearAllCaches } as never);
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: {
+        auth: {
+          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
+        },
+      },
+      secrets: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+        delete: vi.fn(async () => {}),
+      },
+      openExternalUrl: vi.fn(async () => {}),
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signOut();
+
+    expect(coordinator.clearSession).toHaveBeenCalled();
+    expect(clearAllCaches).toHaveBeenCalledOnce();
     auth.dispose();
   });
 });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -122,6 +122,50 @@ describe('desktop Supabase auth', () => {
     auth.dispose();
   });
 
+  it('processes routed callbacks sequentially when they are replayed together', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const log = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: {
+        auth: {
+          signInWithOAuth: vi.fn(async () => ({ data: {}, error: null })),
+        },
+      },
+      secrets: {
+        get: vi.fn(async () => undefined),
+        set: vi.fn(async () => {}),
+        delete: vi.fn(async () => {}),
+      },
+      openExternalUrl: vi.fn(async () => {}),
+      log,
+      initializeServerSideAccess: false,
+    });
+
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=first&refresh_token=first',
+    );
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=second&refresh_token=second',
+    );
+
+    await vi.waitFor(() => {
+      expect(coordinator.createSessionFromCallback).toHaveBeenCalledTimes(2);
+    });
+    expect(coordinator.storeSession).toHaveBeenCalledTimes(2);
+    expect(log.debug).toHaveBeenCalledWith(
+      'Desktop auth callback queued while another callback is being processed',
+    );
+    auth.dispose();
+  });
+
   it('surfaces rejected routed callback processing failures', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -88,6 +88,14 @@ function authCallbackUrl(input: {
   return `texra://texra-ai.texra/auth-callback#${fragment}`;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('desktop Supabase auth', () => {
   it('opens Supabase OAuth with the desktop texra callback URI', async () => {
     const router = createDesktopProtocolCallbackRouter();
@@ -316,6 +324,59 @@ describe('desktop Supabase auth', () => {
     expect(log.debug).toHaveBeenCalledWith(
       'Desktop auth callback ignored because it does not match the active sign-in attempt',
     );
+    auth.dispose();
+  });
+
+  it('does not clear a newer sign-in while a claimed callback finishes', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const callbackState = createDesktopAuthCallbackState();
+    const oauthClient = createOAuthClient();
+    const callbackProcessing = createDeferred<void>();
+    coordinator.createSessionFromCallback.mockImplementationOnce(async () => {
+      await callbackProcessing.promise;
+      return {
+        success: true as const,
+        session: {
+          id: 'user-1',
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          account: { id: 'user-1', label: 'user@example.com' },
+          expiresAt: Date.now() + 60_000,
+        },
+      };
+    });
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient,
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      callbackState,
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signIn();
+    const firstState = getOAuthState(oauthClient);
+    router.routeUrl(
+      authCallbackUrl({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        state: firstState,
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(coordinator.createSessionFromCallback).toHaveBeenCalledOnce();
+    });
+
+    await auth.signIn();
+    const secondState = getOAuthState(oauthClient);
+    callbackProcessing.resolve();
+
+    await vi.waitFor(() => {
+      expect(coordinator.storeSession).toHaveBeenCalledOnce();
+    });
+    expect(callbackState.getExpectedState()).toBe(secondState);
     auth.dispose();
   });
 

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -4,6 +4,7 @@ import type { SupabaseSession } from '@auth/SupabaseSession';
 import { setServerSideKeyService } from '@auth/serverKeys';
 import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
 import {
+  createDesktopAuthCallbackState,
   createDesktopSupabaseAuth,
   type DesktopAuthProfileData,
 } from '../../../packages/desktop/src/main/desktopSupabaseAuth';
@@ -159,6 +160,47 @@ describe('desktop Supabase auth', () => {
       'Desktop auth callback ignored because no sign-in is in progress',
     );
     auth.dispose();
+  });
+
+  it('preserves pending sign-in across desktop auth recreation', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const coordinator = createCoordinator();
+    const callbackState = createDesktopAuthCallbackState();
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      callbackState,
+      initializeServerSideAccess: false,
+    });
+
+    await auth.signIn();
+    auth.dispose();
+    router.routeUrl(
+      'texra://texra-ai.texra/auth-callback#access_token=access-token&refresh_token=refresh-token',
+    );
+
+    const recreatedAuth = createDesktopSupabaseAuth({
+      router,
+      coordinator,
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      callbackState,
+      initializeServerSideAccess: false,
+    });
+
+    await vi.waitFor(() => {
+      expect(coordinator.storeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        }),
+      );
+    });
+    recreatedAuth.dispose();
   });
 
   it('processes routed callbacks sequentially when they are replayed together', async () => {

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -28,6 +28,7 @@ interface MainViewIpcModule {
       fileSelection?: { handleMessage(message: { command: string }): boolean };
       settings?: { handleMessage(message: { command: string }): boolean };
       progress?: { handleMessage(message: { command: string }): boolean };
+      getAuthStatus?: () => Promise<{ authenticated: boolean }>;
       executeAgent?: (message: unknown) => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
@@ -73,9 +74,17 @@ async function loadDesktopMainViewIpcModule(electron: {
   return { ...mainViewIpc, ...hostBridge };
 }
 
+function flushAsyncWork(): Promise<void> {
+  return new Promise((resolve) =>
+    setImmediate(() => setImmediate(() => resolve())),
+  );
+}
+
 describe('desktop main-view IPC', () => {
   afterEach(() => {
     vi.doUnmock('electron');
+    vi.doUnmock('@agent/index/agentRegistry');
+    vi.doUnmock('@model/modelOptionsBasic');
   });
 
   it('pushes theme and debug state over the fixed host bridge channel', async () => {
@@ -371,5 +380,74 @@ describe('desktop main-view IPC', () => {
     expect(ipcMain.off).toHaveBeenCalledTimes(1);
     closedListeners.forEach((listener) => listener());
     expect(ipcMain.off).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses desktop auth status when posting main-view startup login state', async () => {
+    let rendererListener:
+      | ((event: { sender: unknown }, message: unknown) => void)
+      | undefined;
+    const ipcMain = {
+      on: vi.fn((channel, listener) => {
+        rendererListener = listener;
+      }),
+      off: vi.fn(),
+    };
+    const nativeTheme = {
+      shouldUseDarkColors: false,
+      shouldUseHighContrastColors: false,
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    vi.doMock('@agent/index/agentRegistry', () => ({
+      computeAgentOptionsData: vi.fn(async () => ({
+        workflow: [],
+        toolUse: [],
+      })),
+    }));
+    vi.doMock('@model/modelOptionsBasic', () => ({
+      buildBasicModelOptionsData: vi.fn(() => []),
+    }));
+    const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =
+      await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
+    const sends: Array<{ channel: string; message: unknown }> = [];
+    const webContents = {
+      isDestroyed: () => false,
+      send: vi.fn((channel, message) => sends.push({ channel, message })),
+    };
+    const window = {
+      isDestroyed: () => false,
+      once: vi.fn(),
+      webContents,
+    };
+
+    installDesktopMainViewIpc(window, {
+      getAuthStatus: async () => ({ authenticated: true }),
+    });
+    rendererListener?.(
+      { sender: webContents },
+      { command: MAIN_VIEW_COMMANDS.WEBVIEW_READY, view: 'main' },
+    );
+    await flushAsyncWork();
+
+    await vi.waitFor(() =>
+      expect(
+        sends.filter(
+          ({ channel }) => channel === ELECTRON_WEBVIEW_PUSH_CHANNEL,
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: { command: MAIN_VIEW_COMMANDS.HIDE_LOGIN_BANNER },
+          }),
+        ]),
+      ),
+    );
+    expect(
+      sends.some(
+        ({ message }) =>
+          (message as { command?: string }).command ===
+          MAIN_VIEW_COMMANDS.SHOW_LOGIN_BANNER,
+      ),
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
+++ b/src/test-kernel/desktop/desktopWorkspacePath.vitest.ts
@@ -80,6 +80,37 @@ describe('desktop workspace path', () => {
     );
   });
 
+  it('does not treat desktop protocol callback URLs as workspace paths', () => {
+    assert.equal(
+      hasWorkspacePath({
+        argv: ['--texra-workspace', 'texra://auth-callback?code=1'],
+        env: {},
+      }),
+      false,
+    );
+    assert.equal(
+      resolveWorkspacePath({
+        argv: ['--texra-workspace', 'texra://auth-callback?code=1'],
+        env: {},
+      }),
+      undefined,
+    );
+    assert.equal(
+      hasWorkspacePath({
+        argv: ['--texra-workspace=texra://auth-callback?code=1'],
+        env: {},
+      }),
+      false,
+    );
+    assert.equal(
+      resolveWorkspacePath({
+        argv: ['--texra-workspace=texra://auth-callback?code=1'],
+        env: {},
+      }),
+      undefined,
+    );
+  });
+
   it('uses main-process workspace resolution when exposing renderer state', () => {
     assert.equal(
       hasResolvedWorkspacePath({
@@ -108,6 +139,7 @@ describe('desktop workspace path', () => {
           '--texra-workspace',
           'old-workspace',
           '--flag',
+          'texra://texra-ai.texra/auth-callback?state=old',
           '--texra-workspace=/tmp/other-workspace',
         ],
         '/Users/ray/paper',


### PR DESCRIPTION
## Summary

- add a desktop `texra://` callback router with safe parsing, cold-start replay, warm-start `second-instance`, and macOS `open-url` handling
- subscribe the desktop auth bridge to routed callbacks, store successful Supabase sessions, and refresh settings profile state after sign-in/sign-out
- open the desktop Supabase OAuth flow from Settings with `texra://texra-ai.texra/auth-callback` as the redirect URI
- persist desktop included/personal API access mode through the server-side key service and clear included-access caches when sessions change
- share desktop protocol URL detection with workspace relaunch parsing so callback URLs are not treated as workspace paths

Refs #3549.

## Verification

- `npm run test:kernel -- src/test-kernel/desktop/DesktopProtocolCallbacks.vitest.mts src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts src/test-kernel/desktop/desktopWorkspacePath.vitest.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run desktop:build`
- Electron remote-debug renderer check: Settings > Models contains `API Configuration`, 10 provider rows, and provider `Set API key` / `Get API key` actions in the built desktop renderer

## Known packaging note

- `npm run check:desktop-package` still reports the existing #3545 Codex binary packaging/verifier mismatch for the local arm64 directory package: it expects the darwin-x64 Codex binary to be present. The packaged app launch smoke passes, and #3545 tracks the packaging-size/verifier cleanup separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a custom protocol handler and rewires desktop authentication/session lifecycle (OAuth callbacks, session storage, included-access key mode), which can impact sign-in reliability and security-sensitive flows across platforms.
> 
> **Overview**
> Adds first-class `texra://` deep-link support to the desktop app (registered in `electron-builder.yml`) with a callback router/lifecycle that handles cold-start argv URLs, warm-start `second-instance`, and macOS `open-url` events.
> 
> Hooks desktop Supabase OAuth into this protocol flow: Settings/launcher sign-in now opens the browser OAuth flow, validates callback `state`, stores sessions via a coordinator, clears included-access caches on sign-out, and refreshes main-view login banner plus settings/profile/model/agent data after auth changes.
> 
> Updates settings UX and IPC to be auth-aware: profile payload now comes from `getAuthProfileData`, `SET_API_ACCESS_MODE` persists via a provided setter (and disables OpenRouter when switching to included), adds `refreshAuthDependentData()`, and the settings header gains a "Set API key" action with a sensible default provider selection; workspace relaunch arg parsing now ignores `texra://` URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 641d9dc9d3c57530e9fc4a6c4d2711ab464c69d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->