### PR TITLE
Fix desktop model API key entry points

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -96,7 +96,9 @@ export class ModelSelectionList extends LitElement {
     );
   }
 
-  private getProviderKeyStatus(provider: string): ProviderKeyStatus | undefined {
+  private getProviderKeyStatus(
+    provider: string,
+  ): ProviderKeyStatus | undefined {
     return resolveProviderKeyRows(this.providerKeyStatuses).find(
       (entry) => entry.provider === provider,
     );

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -24,10 +24,12 @@ import {
 import {
   ReasoningLevelSchema,
   type ModelSelectionItem,
+  type ProviderKeyStatus,
   type ReasoningLevel,
 } from '@shared/schemas/settingsViewMessages';
 import { profileViewStyles } from './styles';
-import { ModelSelectionEvents } from './events';
+import { ModelSelectionEvents, ProviderKeyEvents } from './events';
+import { resolveProviderKeyRows } from './providerKeyRows';
 
 /** Display labels for reasoning level options. */
 const REASONING_LEVEL_LABELS: Record<ReasoningLevel, string> = {
@@ -65,6 +67,7 @@ export class ModelSelectionList extends LitElement {
   @property({ attribute: false }) apiAccessMode: 'included' | 'personal' =
     'personal';
   @property({ attribute: false }) allowedModels: string[] | null = [];
+  @property({ attribute: false }) providerKeyStatuses: ProviderKeyStatus[] = [];
 
   @property({ type: Boolean, attribute: 'prefer-short-model-names' })
   preferShortModelNames = false;
@@ -90,6 +93,12 @@ export class ModelSelectionList extends LitElement {
           deprecated: models.filter((m) => m.deprecated),
         };
       },
+    );
+  }
+
+  private getProviderKeyStatus(provider: string): ProviderKeyStatus | undefined {
+    return resolveProviderKeyRows(this.providerKeyStatuses).find(
+      (entry) => entry.provider === provider,
     );
   }
 
@@ -245,23 +254,65 @@ export class ModelSelectionList extends LitElement {
     const isExpanded = this.expandedProvider === group.provider;
     const enabledCount = group.current.filter((m) => m.enabled).length;
     const totalCount = group.current.length;
+    const keyStatus = this.getProviderKeyStatus(group.provider);
+    const keyStatusLabel =
+      keyStatus?.status === 'set'
+        ? 'Key set'
+        : keyStatus?.status === 'env'
+          ? 'Env key'
+          : 'No key';
+    const providerKeyActions = keyStatus
+      ? html`
+          <span
+            class="provider-group-key-status key-status-badge ${keyStatus.status}"
+            >${keyStatusLabel}</span
+          >
+          <button
+            class="provider-group-key-button"
+            type="button"
+            title="Set ${group.displayName} API key"
+            @click=${() =>
+              this.dispatchEvent(
+                ProviderKeyEvents.setKey({ provider: group.provider }),
+              )}
+          >
+            <span class="codicon codicon-key"></span>
+            Set key
+          </button>
+          <button
+            class="provider-group-key-button"
+            type="button"
+            title="Get ${group.displayName} API key"
+            @click=${() =>
+              this.dispatchEvent(
+                ProviderKeyEvents.openKeyUrl({ provider: group.provider }),
+              )}
+          >
+            <span class="codicon codicon-link-external"></span>
+            Get key
+          </button>
+        `
+      : nothing;
 
     return html`
       <div class="provider-group">
-        <button
-          class="provider-group-header"
-          @click=${() => this.toggleProvider(group.provider)}
-        >
-          <span
-            class="provider-group-chevron codicon codicon-chevron-right ${isExpanded
-              ? 'expanded'
-              : ''}"
-          ></span>
-          <span class="provider-group-name">${group.displayName}</span>
-          <span class="provider-group-count">
-            ${enabledCount}/${totalCount} enabled
-          </span>
-        </button>
+        <div class="provider-group-header">
+          <button
+            class="provider-group-toggle"
+            @click=${() => this.toggleProvider(group.provider)}
+          >
+            <span
+              class="provider-group-chevron codicon codicon-chevron-right ${isExpanded
+                ? 'expanded'
+                : ''}"
+            ></span>
+            <span class="provider-group-name">${group.displayName}</span>
+            <span class="provider-group-count">
+              ${enabledCount}/${totalCount} enabled
+            </span>
+          </button>
+          <div class="provider-group-actions">${providerKeyActions}</div>
+        </div>
         ${isExpanded
           ? html`
               <div class="provider-group-content">

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -467,12 +467,11 @@ export const profileViewStyles: CSSResult = css`
   .provider-group-header {
     display: flex;
     align-items: center;
+    gap: var(--spacing-medium);
     width: 100%;
-    padding: var(--spacing-medium);
     background: var(--texra-editor-background);
     border: none;
     color: var(--texra-foreground);
-    cursor: pointer;
     font-size: var(--font-size-sm);
     font-family: inherit;
     text-align: left;
@@ -482,7 +481,21 @@ export const profileViewStyles: CSSResult = css`
     background: var(--texra-list-hoverBackground);
   }
 
-  .provider-group-header:focus-visible {
+  .provider-group-toggle {
+    display: flex;
+    align-items: center;
+    flex: 1;
+    min-width: 0;
+    padding: var(--spacing-medium);
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+  }
+
+  .provider-group-toggle:focus-visible {
     outline: var(--border-thin) solid var(--texra-focusBorder);
     outline-offset: 1px;
     border-radius: var(--border-radius-small);
@@ -506,12 +519,50 @@ export const profileViewStyles: CSSResult = css`
   .provider-group-name {
     font-weight: var(--font-weight-medium);
     flex: 1;
+    min-width: 0;
   }
 
   .provider-group-count {
     color: var(--color-text-secondary);
     font-size: var(--font-size-sm);
     white-space: nowrap;
+  }
+
+  .provider-group-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    padding-right: var(--spacing-medium);
+    white-space: nowrap;
+  }
+
+  .provider-group-key-status {
+    flex-shrink: 0;
+  }
+
+  .provider-group-key-button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-tiny);
+    padding: var(--spacing-tiny) var(--spacing-small);
+    border: var(--border-thin) solid var(--color-border);
+    border-radius: var(--border-radius-small);
+    background: var(--texra-button-secondaryBackground, transparent);
+    color: var(--texra-button-secondaryForeground, var(--texra-foreground));
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .provider-group-key-button:hover {
+    background: var(
+      --texra-button-secondaryHoverBackground,
+      var(--texra-list-hoverBackground)
+    );
+  }
+
+  .provider-group-key-button:focus-visible {
+    outline: var(--border-thin) solid var(--texra-focusBorder);
+    outline-offset: 1px;
   }
 
   .provider-group-content {

--- a/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
+++ b/packages/extension/src/settingsView/frontend/tabs/ModelsTab.ts
@@ -120,6 +120,7 @@ export class ModelsTab extends LitElement {
           .authenticated=${this.authenticated}
           .apiAccessMode=${this.apiAccessMode}
           .allowedModels=${this.allowedModels}
+          .providerKeyStatuses=${this.providerKeyStatuses}
           .preferShortModelNames=${this.preferShortModelNames}
         ></model-selection-list>
       </div>

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -22,8 +22,9 @@ const deepseekModel: ModelSelectionItem = {
 };
 
 describe('ModelSelectionList provider key actions', () => {
-  useLitComponentTestDom(() =>
-    import('@settingsView/frontend/components/profile/ModelSelectionList'),
+  useLitComponentTestDom(
+    () =>
+      import('@settingsView/frontend/components/profile/ModelSelectionList'),
   );
 
   it('shows direct API-key actions in model provider groups before profile load', async () => {

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ModelSelectionItem } from '@shared/schemas/settingsViewMessages';
+import type {
+  ModelSelectionItem,
+  ProviderKeyStatus,
+} from '@shared/schemas/settingsViewMessages';
 import { useLitComponentTestDom } from './litComponentTestUtils';
 
 type ModelSelectionListElement = HTMLElement & {
   models: ModelSelectionItem[];
-  providerKeyStatuses: unknown[];
+  providerKeyStatuses: ProviderKeyStatus[];
   updateComplete: Promise<boolean>;
 };
 

--- a/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
+++ b/src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ModelSelectionItem } from '@shared/schemas/settingsViewMessages';
+import { useLitComponentTestDom } from './litComponentTestUtils';
+
+type ModelSelectionListElement = HTMLElement & {
+  models: ModelSelectionItem[];
+  providerKeyStatuses: unknown[];
+  updateComplete: Promise<boolean>;
+};
+
+const deepseekModel: ModelSelectionItem = {
+  name: 'deepseek',
+  label: 'DeepSeek V4 Flash',
+  provider: 'deepseek',
+  enabled: true,
+  deprecated: false,
+  supportsReasoningLevel: false,
+  contextWindow: '1.0M',
+  cost: '$0.140/$0.280',
+  isFast: true,
+};
+
+describe('ModelSelectionList provider key actions', () => {
+  useLitComponentTestDom(() =>
+    import('@settingsView/frontend/components/profile/ModelSelectionList'),
+  );
+
+  it('shows direct API-key actions in model provider groups before profile load', async () => {
+    const list = document.createElement(
+      'model-selection-list',
+    ) as ModelSelectionListElement;
+    list.models = [deepseekModel];
+    list.providerKeyStatuses = [];
+    document.body.append(list);
+    await list.updateComplete;
+
+    const shadow = list.shadowRoot!;
+    expect(shadow.textContent).toContain('No key');
+
+    const setKeyButton = shadow.querySelector<HTMLElement>(
+      '[title="Set DeepSeek API key"]',
+    );
+    expect(setKeyButton).toBeTruthy();
+
+    const events: unknown[] = [];
+    list.addEventListener('provider-key-set', (event) => {
+      events.push((event as CustomEvent).detail);
+    });
+
+    setKeyButton!.click();
+
+    expect(events).toEqual([{ provider: 'deepseek' }]);
+  });
+});

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -9,8 +9,8 @@ type ProviderKeyModalElement = HTMLElement & {
 };
 
 describe('ProviderKeyModal', () => {
-  useLitComponentTestDom(() =>
-    import('@settingsView/frontend/components/profile/ProviderKeyModal'),
+  useLitComponentTestDom(
+    () => import('@settingsView/frontend/components/profile/ProviderKeyModal'),
   );
 
   it('emits the trimmed key on submit without rendering it back after save', async () => {

--- a/src/test-kernel/settings/ProviderKeyModal.vitest.ts
+++ b/src/test-kernel/settings/ProviderKeyModal.vitest.ts
@@ -1,5 +1,6 @@
-import { JSDOM } from 'jsdom';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
+import { useLitComponentTestDom } from './litComponentTestUtils';
 
 type ProviderKeyModalElement = HTMLElement & {
   provider: string;
@@ -7,79 +8,10 @@ type ProviderKeyModalElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-let dom: JSDOM;
-const domGlobalKeys = [
-  'window',
-  'document',
-  'Document',
-  'customElements',
-  'HTMLElement',
-  'HTMLInputElement',
-  'CustomEvent',
-  'Event',
-  'KeyboardEvent',
-  'MouseEvent',
-  'ShadowRoot',
-] as const;
-const previousGlobals = new Map<
-  (typeof domGlobalKeys)[number],
-  { hadValue: boolean; value: unknown }
->();
-
 describe('ProviderKeyModal', () => {
-  beforeAll(async () => {
-    dom = new JSDOM('<!doctype html><html><body></body></html>', {
-      url: 'https://texra.local',
-    });
-
-    const replacements = {
-      window: dom.window,
-      document: dom.window.document,
-      Document: dom.window.Document,
-      customElements: dom.window.customElements,
-      HTMLElement: dom.window.HTMLElement,
-      HTMLInputElement: dom.window.HTMLInputElement,
-      CustomEvent: dom.window.CustomEvent,
-      Event: dom.window.Event,
-      KeyboardEvent: dom.window.KeyboardEvent,
-      MouseEvent: dom.window.MouseEvent,
-      ShadowRoot: dom.window.ShadowRoot,
-    } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
-
-    for (const key of domGlobalKeys) {
-      previousGlobals.set(key, {
-        hadValue: Object.hasOwn(globalThis, key),
-        value: globalThis[key as keyof typeof globalThis],
-      });
-      Object.defineProperty(globalThis, key, {
-        configurable: true,
-        writable: true,
-        value: replacements[key],
-      });
-    }
-
-    await import('@settingsView/frontend/components/profile/ProviderKeyModal');
-  });
-
-  beforeEach(() => {
-    document.body.replaceChildren();
-  });
-
-  afterAll(() => {
-    dom.window.close();
-    for (const key of domGlobalKeys) {
-      const previous = previousGlobals.get(key);
-      if (previous?.hadValue) {
-        Object.defineProperty(globalThis, key, {
-          configurable: true,
-          writable: true,
-          value: previous.value,
-        });
-      } else {
-        delete (globalThis as Record<string, unknown>)[key];
-      }
-    }
-  });
+  useLitComponentTestDom(() =>
+    import('@settingsView/frontend/components/profile/ProviderKeyModal'),
+  );
 
   it('emits the trimmed key on submit without rendering it back after save', async () => {
     const modal = document.createElement(

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -1,0 +1,84 @@
+import { JSDOM } from 'jsdom';
+import { afterAll, beforeAll, beforeEach } from 'vitest';
+
+const domGlobalKeys = [
+  'window',
+  'document',
+  'Document',
+  'customElements',
+  'HTMLElement',
+  'HTMLInputElement',
+  'CustomEvent',
+  'Event',
+  'KeyboardEvent',
+  'MouseEvent',
+  'ShadowRoot',
+] as const;
+
+/**
+ * Install the browser globals Lit components need, import the component module,
+ * and reset the document between tests.
+ */
+export function useLitComponentTestDom(
+  importComponents: () => Promise<unknown>,
+): void {
+  let dom: JSDOM;
+  const previousGlobals = new Map<
+    (typeof domGlobalKeys)[number],
+    { hadValue: boolean; value: unknown }
+  >();
+
+  beforeAll(async () => {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      url: 'https://texra.local',
+    });
+
+    const replacements = {
+      window: dom.window,
+      document: dom.window.document,
+      Document: dom.window.Document,
+      customElements: dom.window.customElements,
+      HTMLElement: dom.window.HTMLElement,
+      HTMLInputElement: dom.window.HTMLInputElement,
+      CustomEvent: dom.window.CustomEvent,
+      Event: dom.window.Event,
+      KeyboardEvent: dom.window.KeyboardEvent,
+      MouseEvent: dom.window.MouseEvent,
+      ShadowRoot: dom.window.ShadowRoot,
+    } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
+
+    for (const key of domGlobalKeys) {
+      previousGlobals.set(key, {
+        hadValue: Object.hasOwn(globalThis, key),
+        value: globalThis[key as keyof typeof globalThis],
+      });
+      Object.defineProperty(globalThis, key, {
+        configurable: true,
+        writable: true,
+        value: replacements[key],
+      });
+    }
+
+    await importComponents();
+  });
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  afterAll(() => {
+    dom.window.close();
+    for (const key of domGlobalKeys) {
+      const previous = previousGlobals.get(key);
+      if (previous?.hadValue) {
+        Object.defineProperty(globalThis, key, {
+          configurable: true,
+          writable: true,
+          value: previous.value,
+        });
+      } else {
+        delete (globalThis as Record<string, unknown>)[key];
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Surface provider API-key status and Set/Get actions directly in the Settings > Models provider groups.
- Reuse the existing provider-key events and modal so the model list, API Configuration section, and signed-out header share the same key flow.
- Add a shared Lit component test helper and a regression test for pre-profile-load provider key actions.

## Why

Signed-out desktop users could land on Model Selection and see enabled providers without an obvious place to add a personal API key. The API Configuration table exists, but the key action needs to be visible where users choose providers and models.

Fixes #3562.

## Validation

- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/settings/ModelSelectionProviderKeys.vitest.ts src/test-kernel/settings/ProviderKeyModal.vitest.ts src/test-kernel/settings/ProviderKeyRows.vitest.mts`
- `corepack pnpm --filter @texra/desktop typecheck`
- `npm run typecheck`
- `npm run lint`
- `npm run desktop:build`
- `git diff --check HEAD~1..HEAD`

Playwright is not installed in this workspace, so this pass verifies the rebuilt desktop bundle by build output and bundle content rather than Playwright screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI wiring and styling changes that reuse existing provider-key events; main risk is minor regressions in settings view rendering or event dispatch.
> 
> **Overview**
> Surfaces provider API-key status plus **Set key / Get key** actions directly in each provider group header in `ModelSelectionList`, reusing existing `ProviderKeyEvents` and normalizing key status display via `resolveProviderKeyRows`.
> 
> Updates `ModelsTab` to pass `providerKeyStatuses` into the model list and adds supporting styles for the new header layout/actions.
> 
> Adds a shared JSDOM/Lit test harness (`useLitComponentTestDom`) and new regression coverage ensuring provider-group key actions render and emit `provider-key-set` even before profile/key status data is loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcd1369b6b34a18647c22ebe87f30ca48c5ea666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->