### PR TITLE
refactor: use native SDK error classes in helpers

### DIFF
--- a/prds/prd-cli-app.md
+++ b/prds/prd-cli-app.md
@@ -1275,7 +1275,7 @@ stdio JSON-RPC 2.0, one process per client connection, exactly the Claude Code /
 
 ### 24.4 Permission propagation
 
-The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the _call_ (e.g., Claude Code asked the user "let texra\_\_run_polish run?"). What TeXRA still owns is what the _agent inside_ TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
+The MCP client (Claude Code, Codex, etc.) is itself a permission boundary. TeXRA's MCP-server mode trusts the client to have already obtained user approval for the _call_ (e.g., Claude Code asked the user "let texra\_\_run*polish run?"). What TeXRA still owns is what the \_agent inside* TeXRA does — the bash and edit gates inside a `run_chat` orchestrator session.
 
 Three policies for those inner gates, selected by tool argument:
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,5 +1,13 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
+  APIError as AnthropicAPIError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+} from '@anthropic-ai/sdk';
+import {
+  APIError as OpenAIAPIError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+} from 'openai';
+import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -228,6 +236,13 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
+  if (err instanceof OpenAIAPIError) {
+    return 'openai';
+  }
+  if (err instanceof AnthropicAPIError) {
+    return 'anthropic';
+  }
+
   if (!isObject(err)) {
     return undefined;
   }
@@ -326,6 +341,12 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
+  if (
+    err instanceof OpenAIAPIUserAbortError ||
+    err instanceof AnthropicAPIUserAbortError
+  ) {
+    return true;
+  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 


### PR DESCRIPTION
## Summary
- use native OpenAI/Anthropic SDK error classes in `sdkErrorUtils` before string-class fallbacks
- switch provider detection to `instanceof` checks for `APIError` classes
- switch user-abort detection to `instanceof` checks for `APIUserAbortError` classes

## Validation
- npm run -s typecheck
- npm run -s lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how provider identity and user-abort errors are detected, which can affect retry/logging behavior if SDK error instances differ across runtimes or versions.
> 
> **Overview**
> Updates `sdkErrorUtils` to prefer native OpenAI/Anthropic SDK error classes over string/class-name heuristics.
> 
> `detectProvider` now returns `openai`/`anthropic` via `instanceof APIError` checks before falling back to object inspection, and `isUserAbort` now detects aborts via `instanceof APIUserAbortError` (with the prior class-name fallback retained).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f758a8a1f7d7d93291afa39ba0adb5ff194dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->