### PR TITLE
Migrate root webview tabs to Web Awesome

### DIFF
--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -51,8 +51,16 @@
   --texra-editor-findMatchHighlightForeground: var(
     --vscode-editor-findMatchHighlightForeground
   );
-  --texra-editor-font-family: var(--vscode-editor-font-family);
-  --texra-editor-font-size: var(--vscode-editor-font-size);
+  --texra-editor-font-family: var(
+    --vscode-editor-font-family,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace
+  );
+  --texra-editor-font-size: var(--vscode-editor-font-size, 13px);
   --texra-editor-foreground: var(--vscode-editor-foreground);
   --texra-editor-inactiveSelectionBackground: var(
     --vscode-editor-inactiveSelectionBackground
@@ -83,9 +91,15 @@
   --texra-editorWidget-border: var(--vscode-editorWidget-border);
   --texra-errorForeground: var(--vscode-errorForeground);
   --texra-focusBorder: var(--vscode-focusBorder);
-  --texra-font-family: var(--vscode-font-family);
-  --texra-font-size: var(--vscode-font-size);
-  --texra-font-weight: var(--vscode-font-weight);
+  --texra-font-family: var(
+    --vscode-font-family,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif
+  );
+  --texra-font-size: var(--vscode-font-size, 13px);
+  --texra-font-weight: var(--vscode-font-weight, 400);
   --texra-foreground: var(--vscode-foreground);
   --texra-gitDecoration-addedResourceForeground: var(
     --vscode-gitDecoration-addedResourceForeground
@@ -203,29 +217,30 @@
 /*
  * Web Awesome design-token bridge.
  *
- * WA components read --wa-*. The host (VS Code webview) supplies --vscode-*.
- * This block links the two so --vscode-* is the only host token the rest of
- * the codebase ever sees through this adapter.
+ * WA components read --wa-*. The host (VS Code webview) supplies --vscode-*,
+ * which is normalized once into --texra-* above. This block keeps Web Awesome
+ * dependent on that TeXRA token contract rather than reading host tokens
+ * directly.
  */
 :root {
-  --wa-font-family-body: var(--vscode-font-family);
-  --wa-font-family-heading: var(--vscode-font-family);
-  --wa-font-size-m: var(--vscode-font-size);
-  --wa-font-weight-normal: var(--vscode-font-weight);
+  --wa-font-family-body: var(--texra-font-family);
+  --wa-font-family-heading: var(--texra-font-family);
+  --wa-font-size-m: var(--texra-font-size);
+  --wa-font-weight-normal: var(--texra-font-weight);
 
-  --wa-color-text-normal: var(--vscode-foreground);
-  --wa-color-text-quiet: var(--vscode-descriptionForeground);
-  --wa-color-text-link: var(--vscode-textLink-foreground);
-  --wa-color-surface-default: var(--vscode-editor-background);
-  --wa-color-surface-raised: var(--vscode-editorWidget-background);
-  --wa-color-surface-lowered: var(--vscode-sideBar-background);
-  --wa-color-surface-border: var(--vscode-panel-border);
+  --wa-color-text-normal: var(--texra-foreground);
+  --wa-color-text-quiet: var(--texra-descriptionForeground);
+  --wa-color-text-link: var(--texra-textLink-foreground);
+  --wa-color-surface-default: var(--texra-editor-background);
+  --wa-color-surface-raised: var(--texra-editorWidget-background);
+  --wa-color-surface-lowered: var(--texra-sideBar-background);
+  --wa-color-surface-border: var(--texra-panel-border);
 
-  --wa-color-focus: var(--vscode-focusBorder);
+  --wa-color-focus: var(--texra-focusBorder);
 
-  --wa-color-brand-fill-loud: var(--vscode-button-background);
-  --wa-color-brand-on-loud: var(--vscode-button-foreground);
-  --wa-color-brand-border-loud: var(--vscode-button-border);
+  --wa-color-brand-fill-loud: var(--texra-button-background);
+  --wa-color-brand-on-loud: var(--texra-button-foreground);
+  --wa-color-brand-border-loud: var(--texra-button-border);
 }
 
 body {

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -37,12 +37,14 @@ import {
   select,
   combine,
 } from '@shared/signals';
-import { designTokens } from '@shared/styles';
+import { codiconStyles, designTokens, viewTabStyles } from '@shared/styles';
 import {
   registerTeXRAWebAwesomeIcons,
   TEXRA_ICON_LIBRARY,
 } from '@shared/wa/webAwesomeIcons';
 import { isProcessAgent } from '@shared/streams/agentKind';
+import '@shared/wa/tabs';
+import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 
 // Local imports - progress view frontend
 import { webviewStorage } from './webviewStorage';
@@ -106,8 +108,6 @@ import {
   type StreamLogContextValue,
 } from './contexts/streamContexts';
 import type { FrontendEventHandlerContext } from './eventHandlers';
-import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
-
 // Local imports - progress view components
 import './components/StreamTabs';
 import './components/ToolUseStreamContent';
@@ -142,7 +142,9 @@ const ProgressAppBase = SignalWatcher(
 export class ProgressApp extends ProgressAppBase {
   // Static 'styles' override lost through mixin type erasure; still works at runtime.
   static styles = [
+    codiconStyles,
     designTokens,
+    viewTabStyles,
     css`
       :host {
         display: flex;
@@ -173,13 +175,7 @@ export class ProgressApp extends ProgressAppBase {
         display: none;
       }
 
-      .view-header vscode-tabs {
-        flex: 1;
-        min-width: 0;
-        --panel-display: none;
-      }
-
-      .view-header vscode-tab-header.focus-sidebar-tab {
+      .view-header wa-tab.focus-sidebar-tab {
         opacity: var(--opacity-subtle);
         cursor: default;
       }
@@ -354,6 +350,8 @@ export class ProgressApp extends ProgressAppBase {
   private placement = signal<ProgressViewPlacement>('sidebar');
   private narrowLayout = signal(false);
   private permissions$ = signal<PermissionState[]>([]);
+  private hasHandledInitialProgressTabShow = false;
+  private suppressNextResetProgressTabShow = false;
 
   /** Stream IDs with pending approval requests — drives tab pulse indicator. */
   private _prevApprovalIds: Set<string> = new Set();
@@ -613,12 +611,14 @@ export class ProgressApp extends ProgressAppBase {
         })}
       >
         <div class="view-header">
-          <vscode-tabs
-            .selectedIndex=${1}
-            @vsc-tabs-select=${this.onViewTabSelect}
+          <wa-tab-group
+            class="view-tabs"
+            active="progress"
+            without-scroll-controls
+            @wa-tab-show=${this.onViewTabShow}
           >
-            <vscode-tab-header
-              slot="header"
+            <wa-tab
+              panel="launcher"
               class=${isEditorMode ? 'focus-sidebar-tab' : ''}
               title=${isEditorMode ? 'Focus Launcher sidebar' : ''}
               @click=${this.onFocusLauncherTab}
@@ -629,16 +629,18 @@ export class ProgressApp extends ProgressAppBase {
                 variant="solid"
               ></wa-icon>
               Launcher
-            </vscode-tab-header>
-            <vscode-tab-header slot="header">
+            </wa-tab>
+            <wa-tab panel="progress">
               <wa-icon
                 library=${TEXRA_ICON_LIBRARY}
                 name="robot"
                 variant="solid"
               ></wa-icon>
               Progress
-            </vscode-tab-header>
-          </vscode-tabs>
+            </wa-tab>
+            <wa-tab-panel name="launcher"></wa-tab-panel>
+            <wa-tab-panel name="progress"></wa-tab-panel>
+          </wa-tab-group>
 
           <wa-button
             class="header-action"
@@ -885,12 +887,27 @@ export class ProgressApp extends ProgressAppBase {
     };
   }
 
-  private onViewTabSelect = (event: VscTabsSelectEvent): void => {
-    const view = event.detail.selectedIndex === 0 ? 'main' : 'progress';
+  private onViewTabShow = (event: WaTabShowEvent): void => {
+    if (event.detail.name === 'progress') {
+      if (this.suppressNextResetProgressTabShow) {
+        this.suppressNextResetProgressTabShow = false;
+        this.hasHandledInitialProgressTabShow = true;
+        return;
+      }
+      if (!this.hasHandledInitialProgressTabShow) {
+        this.hasHandledInitialProgressTabShow = true;
+        return;
+      }
+    }
+    const view = event.detail.name === 'launcher' ? 'main' : 'progress';
+    const tabs = event.currentTarget as MutableWaTabGroup;
     if (view === 'main' && this.placement.get() === 'editor') {
-      this.focusLauncherSidebar(
-        event.currentTarget as { selectedIndex?: number },
-      );
+      this.focusLauncherSidebar(tabs);
+      return;
+    }
+    if (view === 'main') {
+      postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });
+      this.resetProgressTab(tabs);
       return;
     }
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });
@@ -901,8 +918,8 @@ export class ProgressApp extends ProgressAppBase {
     event.preventDefault();
     event.stopPropagation();
     const tabs = (event.currentTarget as HTMLElement).closest(
-      'vscode-tabs',
-    ) as { selectedIndex?: number } | null;
+      'wa-tab-group',
+    ) as MutableWaTabGroup | null;
     this.focusLauncherSidebar(tabs ?? undefined);
   };
 
@@ -910,11 +927,17 @@ export class ProgressApp extends ProgressAppBase {
     this.focusLauncherSidebar();
   };
 
-  private focusLauncherSidebar(tabs?: { selectedIndex?: number }): void {
+  private focusLauncherSidebar(tabs?: MutableWaTabGroup): void {
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'main' });
     if (!tabs) return;
+    this.resetProgressTab(tabs);
+  }
+
+  private resetProgressTab(tabs: MutableWaTabGroup): void {
     requestAnimationFrame(() => {
-      tabs.selectedIndex = 1;
+      if (tabs.active === 'progress') return;
+      this.suppressNextResetProgressTabShow = true;
+      tabs.active = 'progress';
     });
   }
 

--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -23,6 +23,7 @@ import {
   codiconStyles,
   commonViewStyles,
   designTokens,
+  waTabThemeTokenStyles,
 } from '@shared/styles';
 
 // Local imports - shared schemas and constants
@@ -32,6 +33,7 @@ import {
   type ProviderKeyStatus,
   type ModelSelectionItem,
   SETTINGS_TAB,
+  SETTINGS_TAB_ORDER,
 } from '@shared/schemas';
 import {
   registerTeXRAWebAwesomeIcons,
@@ -60,12 +62,13 @@ import { NESTED_DELEGATION_DEPTH_RANGE } from '@shared/constants/delegationPolic
 // Local imports - settings view
 import type { AgentCategory } from '@shared/schemas/agent';
 import type { AgentModePreset } from '@shared/schemas/agentPresets';
+import '@shared/wa/tabs';
+import type { WaTabShowEvent } from '@shared/wa/tabs';
 import { settingsViewStyles } from './styles';
 import {
   dispatchSettingsViewMessage,
   type SettingsMessageHandlerContext,
 } from './settingsViewDispatcher';
-import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 // Side-effect: register tab components
 import './tabs/MemoryTab';
@@ -90,6 +93,12 @@ const HISTORY_ACTION_COMMANDS: Record<string, string> = {
 };
 
 const API_KEY_PROVIDER_SET = new Set<string>(API_KEY_PROVIDER_IDS);
+
+function toSettingsTabPanelName(name: string): string {
+  return name.toLowerCase().replaceAll('_', '-');
+}
+
+const SETTINGS_TAB_PANEL_NAMES = SETTINGS_TAB_ORDER.map(toSettingsTabPanelName);
 
 /** Create an event handler that forwards event.detail to a postMessage command. */
 function forwardDetail<T extends Record<string, unknown>>(
@@ -130,16 +139,23 @@ export class SettingsApp extends SettingsAppBase {
         height: 100%;
       }
 
-      vscode-tabs {
+      wa-tab-group.settings-tabs {
         flex: 1;
         display: flex;
         flex-direction: column;
+        min-height: 0;
+        ${waTabThemeTokenStyles}
       }
 
-      vscode-tab-panel {
+      wa-tab-group.settings-tabs::part(body) {
+        flex: 1;
+        min-height: 0;
+      }
+
+      wa-tab-panel {
         flex: 1;
         overflow: auto;
-        padding: var(--spacing-large);
+        --padding: var(--spacing-large);
       }
 
       .settings-unavailable {
@@ -307,8 +323,11 @@ export class SettingsApp extends SettingsAppBase {
     }
   }
 
-  private handleTabSelect(event: VscTabsSelectEvent): void {
-    this.selectedTabIndex.set(event.detail.selectedIndex);
+  private handleTabShow(event: WaTabShowEvent): void {
+    const selectedIndex = SETTINGS_TAB_PANEL_NAMES.indexOf(event.detail.name);
+    if (selectedIndex >= 0) {
+      this.selectedTabIndex.set(selectedIndex);
+    }
   }
 
   // Memory event handlers
@@ -793,44 +812,39 @@ export class SettingsApp extends SettingsAppBase {
       <div class="settings-container">
         ${this.renderHeader()}
 
-        <vscode-tabs
-          .selectedIndex=${this.selectedTabIndex.get()}
-          @vsc-tabs-select=${this.handleTabSelect}
+        <wa-tab-group
+          class="settings-tabs"
+          .active=${SETTINGS_TAB_PANEL_NAMES[this.selectedTabIndex.get()] ??
+          'memory'}
+          @wa-tab-show=${this.handleTabShow}
         >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-database"></span>
-            Memory</vscode-tab-header
+          <wa-tab panel="memory"
+            ><span class="codicon codicon-database"></span> Memory</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-history"></span>
-            History</vscode-tab-header
+          <wa-tab panel="history"
+            ><span class="codicon codicon-history"></span> History</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-server"></span>
-            Models</vscode-tab-header
+          <wa-tab panel="models"
+            ><span class="codicon codicon-server"></span> Models</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-robot"></span>
-            Agents</vscode-tab-header
+          <wa-tab panel="agents"
+            ><span class="codicon codicon-robot"></span> Agents</wa-tab
           >
-          <vscode-tab-header slot="header"
+          <wa-tab panel="multi-agent"
             ><span class="codicon codicon-organization"></span>
-            Multi-Agent</vscode-tab-header
+            Multi-Agent</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-tools"></span>
-            Tools</vscode-tab-header
+          <wa-tab panel="tools"
+            ><span class="codicon codicon-tools"></span> Tools</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-git-commit"></span>
-            Git</vscode-tab-header
+          <wa-tab panel="git"
+            ><span class="codicon codicon-git-commit"></span> Git</wa-tab
           >
-          <vscode-tab-header slot="header"
-            ><span class="codicon codicon-file-code"></span>
-            LaTeX</vscode-tab-header
+          <wa-tab panel="latex"
+            ><span class="codicon codicon-file-code"></span> LaTeX</wa-tab
           >
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="memory">
             ${desktopHost
               ? this.renderDesktopUnavailablePanel(
                   'Memory is not available in desktop yet',
@@ -850,9 +864,9 @@ export class SettingsApp extends SettingsAppBase {
                     @memory-unpin-item=${this.handleMemoryUnpinItem}
                   ></memory-tab>
                 `}
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="history">
             ${desktopHost
               ? this.renderDesktopUnavailablePanel(
                   'History is not available in desktop yet',
@@ -865,9 +879,9 @@ export class SettingsApp extends SettingsAppBase {
                     @history-clear=${this.handleClearHistory}
                   ></history-tab>
                 `}
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="models">
             <models-tab
               .authenticated=${this.authenticated.get()}
               .apiAccessMode=${this.apiAccessMode.get()}
@@ -893,9 +907,9 @@ export class SettingsApp extends SettingsAppBase {
               @prefer-short-model-names-set=${this
                 .handleSetPreferShortModelNames}
             ></models-tab>
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="agents">
             <agents-tab
               .workflowAgents=${this.workflowAgents.get()}
               .toolUseAgents=${this.toolUseAgents.get()}
@@ -917,9 +931,9 @@ export class SettingsApp extends SettingsAppBase {
               @save-agent-mode-preset=${this.handleSaveAgentModePreset}
               @agent-view-remote-prompt=${this.handleViewRemoteAgentPrompt}
             ></agents-tab>
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="multi-agent">
             <multi-agent-tab
               .reliabilitySettings=${this.reliabilitySettings.get()}
               .customPresets=${this.customPresets.get()}
@@ -938,9 +952,9 @@ export class SettingsApp extends SettingsAppBase {
               @apply-agent-mode-preset=${this.handleApplyAgentModePreset}
               @delete-agent-mode-preset=${this.handleDeleteAgentModePreset}
             ></multi-agent-tab>
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="tools">
             <tools-tab
               .items=${this.toolDashboardItems.get()}
               .loaded=${this.toolDashboardLoaded.get()}
@@ -967,9 +981,9 @@ export class SettingsApp extends SettingsAppBase {
               @desktop-crash-reporting-dsn-set=${this
                 .handleDesktopCrashReportingDsnSet}
             ></tools-tab>
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="git">
             <git-tab
               .markCommits=${this.gitMarkCommits.get()}
               .authorName=${this.gitAuthorName.get()}
@@ -988,9 +1002,9 @@ export class SettingsApp extends SettingsAppBase {
               .githubTokenStatus=${this.githubTokenStatus.get()}
               .prSubscriptions=${this.prSubscriptions.get()}
             ></git-tab>
-          </vscode-tab-panel>
+          </wa-tab-panel>
 
-          <vscode-tab-panel>
+          <wa-tab-panel name="latex">
             <latex-tab
               .settings=${this.latexSettingsStatus.get()}
               .loaded=${this.latexSettingsLoaded.get()}
@@ -1002,8 +1016,8 @@ export class SettingsApp extends SettingsAppBase {
               @latex-run-install-command=${this.handleRunInstallCommand}
               @latex-set-config-value=${this.handleSetLatexConfigValue}
             ></latex-tab>
-          </vscode-tab-panel>
-        </vscode-tabs>
+          </wa-tab-panel>
+        </wa-tab-group>
         ${this.renderProviderKeyModal()}
       </div>
     `;

--- a/packages/extension/src/webview/frontend/MainApp.ts
+++ b/packages/extension/src/webview/frontend/MainApp.ts
@@ -10,7 +10,12 @@ import { SignalWatcher, signal, Signal } from '@shared/signals';
 import { BaseWebviewApp } from '@shared/BaseWebviewApp';
 import { hostBridge, postMessage } from '@shared/hostBridge';
 import { PersistedState, createWebviewStorage } from '@shared/state';
-import { designTokens, commonViewStyles, codiconStyles } from '@shared/styles';
+import {
+  designTokens,
+  commonViewStyles,
+  codiconStyles,
+  viewTabStyles,
+} from '@shared/styles';
 import {
   mainViewMessages,
   MainViewPersistedStateSchema,
@@ -54,6 +59,8 @@ import {
 import type { StateRestoreMessage } from '@shared/schemas/commonViewMessages';
 import { agentName } from '@shared/schemas/agent';
 import { capitalize } from '@shared/utils/string';
+import '@shared/wa/tabs';
+import type { MutableWaTabGroup, WaTabShowEvent } from '@shared/wa/tabs';
 
 import './components/FileSelectGroup';
 import './components/BannerGroup';
@@ -99,7 +106,6 @@ import {
   FILE_SELECT_CONFIGS,
 } from './store';
 import { mainViewStyles } from './styles';
-import type { VscTabsSelectEvent } from '@vscode-elements/elements/dist/vscode-tabs/vscode-tabs.js';
 
 registerTeXRAWebAwesomeIcons();
 
@@ -143,6 +149,7 @@ export class MainApp extends MainAppBase {
     designTokens,
     commonViewStyles,
     codiconStyles,
+    viewTabStyles,
     mainViewStyles,
   ];
 
@@ -1842,17 +1849,13 @@ export class MainApp extends MainAppBase {
     postMessage(MAIN_VIEW_COMMANDS.OPEN_MODEL_SETTINGS);
   }
 
-  private onViewTabSelect = (event: VscTabsSelectEvent): void => {
-    const view = event.detail.selectedIndex === 0 ? 'main' : 'progress';
-    if (view === 'progress') {
-      postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });
-      const tabs = event.currentTarget as { selectedIndex?: number };
-      requestAnimationFrame(() => {
-        tabs.selectedIndex = 0;
-      });
-      return;
-    }
-    postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view });
+  private onViewTabShow = (event: WaTabShowEvent): void => {
+    if (event.detail.name !== 'progress') return;
+    postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'progress' });
+    const tabs = event.currentTarget as MutableWaTabGroup;
+    requestAnimationFrame(() => {
+      tabs.active = 'launcher';
+    });
   };
 
   private onOpenDashboard = (): void => {
@@ -1914,27 +1917,31 @@ export class MainApp extends MainAppBase {
     return html`
       <div class="content-wrapper">
         <div class="view-header">
-          <vscode-tabs
-            .selectedIndex=${0}
-            @vsc-tabs-select=${this.onViewTabSelect}
+          <wa-tab-group
+            class="view-tabs"
+            active="launcher"
+            without-scroll-controls
+            @wa-tab-show=${this.onViewTabShow}
           >
-            <vscode-tab-header slot="header">
+            <wa-tab panel="launcher">
               <wa-icon
                 library=${TEXRA_ICON_LIBRARY}
                 name="pencil"
                 variant="solid"
               ></wa-icon>
               Launcher
-            </vscode-tab-header>
-            <vscode-tab-header slot="header">
+            </wa-tab>
+            <wa-tab panel="progress">
               <wa-icon
                 library=${TEXRA_ICON_LIBRARY}
                 name="robot"
                 variant="solid"
               ></wa-icon>
               Progress
-            </vscode-tab-header>
-          </vscode-tabs>
+            </wa-tab>
+            <wa-tab-panel name="launcher"></wa-tab-panel>
+            <wa-tab-panel name="progress"></wa-tab-panel>
+          </wa-tab-group>
           <wa-button
             class="header-action"
             aria-label="Open dashboard"

--- a/packages/extension/src/webview/frontend/styles.ts
+++ b/packages/extension/src/webview/frontend/styles.ts
@@ -34,12 +34,6 @@ export const mainViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
-  .view-header vscode-tabs {
-    flex: 1;
-    min-width: 0;
-    --panel-display: none;
-  }
-
   .header-action {
     flex-shrink: 0;
   }

--- a/src/shared/styles/index.ts
+++ b/src/shared/styles/index.ts
@@ -12,6 +12,7 @@ export { selectStyles } from './selectStyles';
 export { statusIndicatorStyles } from './statusIndicatorStyles';
 export { permissionCardStyles } from './permissionCardStyles';
 export { requestPanelStyles } from './requestPanelStyles';
+export { viewTabStyles, waTabThemeTokenStyles } from './viewTabStyles';
 
 // Badge styles (combined array used by multiple views)
 export { badgeStyles, tintedBadgeStyles } from './badgeStyles';

--- a/src/shared/styles/viewTabStyles.ts
+++ b/src/shared/styles/viewTabStyles.ts
@@ -1,0 +1,19 @@
+import { css, type CSSResult } from 'lit';
+
+export const waTabThemeTokenStyles: CSSResult = css`
+  --track-width: var(--border-thin);
+  --track-color: var(--color-border);
+  --indicator-color: var(--texra-focusBorder);
+`;
+
+export const viewTabStyles: CSSResult = css`
+  .view-header wa-tab-group.view-tabs {
+    flex: 1;
+    min-width: 0;
+    ${waTabThemeTokenStyles}
+  }
+
+  .view-header wa-tab-group.view-tabs::part(body) {
+    display: none;
+  }
+`;

--- a/src/shared/wa/tabs.ts
+++ b/src/shared/wa/tabs.ts
@@ -1,0 +1,10 @@
+// Web Awesome tab components used by root view navigation.
+import '@awesome.me/webawesome/dist/components/tab-group/tab-group.js';
+import '@awesome.me/webawesome/dist/components/tab/tab.js';
+import '@awesome.me/webawesome/dist/components/tab-panel/tab-panel.js';
+
+export type WaTabShowEvent = CustomEvent<{ name: string }>;
+
+export type MutableWaTabGroup = {
+  active?: string;
+};

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -10,6 +10,7 @@ import {
   APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
   APIUserAbortError as OpenAIAPIUserAbortError,
   AuthenticationError as OpenAIAuthenticationError,
+  RateLimitError as OpenAIRateLimitError,
 } from 'openai';
 import { describe, expect, it } from 'vitest';
 
@@ -36,6 +37,26 @@ describe('formatProviderHttpError', () => {
     );
 
     expect(formatted.message).toBe('new provider error shape');
+    expect(formatted.retryable).toBe(false);
+  });
+
+  it('detects OpenAI provider errors without importing SDK classes at runtime', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIRateLimitError(429, {}, 'rate limited', new Headers()),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBe(429);
+    expect(formatted.retryable).toBe(true);
+  });
+
+  it('detects Anthropic provider errors without importing SDK classes at runtime', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(401, {}, 'bad key', new Headers()),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.statusCode).toBe(401);
     expect(formatted.retryable).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- replace root Main, Progress, and Settings vscode-tabs with Web Awesome tab groups
- keep existing launcher/progress switch behavior, including the progress editor-mode focus reset
- route Web Awesome typography through the TeXRA theme token bridge with non-VS Code fallbacks for smoke/Electron hosts

Refs #3543

## Validation
- npm run format
- npm run compile:safe
- npm run lint
- npm run smoke:webviews
- npm run build:fast

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces core webview navigation components (Launcher/Progress and Settings tabs) and adjusts tab-show/reset behavior, which can cause subtle UI/regression issues across sidebar/editor placements. Also tweaks shared theme-token fallbacks that may affect typography/styling in non-VS Code hosts.
> 
> **Overview**
> Migrates the root webview tab UI from `vscode-tabs` to Web Awesome `wa-tab-group` in `MainApp`, `ProgressApp`, and `SettingsApp`, including new `wa-tab-show` handlers to preserve existing Launcher/Progress switching and editor-mode focus/reset behavior.
> 
> Adds shared Web Awesome tab styling (`viewTabStyles`/`waTabThemeTokenStyles`) plus a `@shared/wa/tabs` side-effect module for consistent imports/types, and updates the CSS token bridge so Web Awesome reads from normalized `--texra-*` tokens with non-VS Code font fallbacks.
> 
> Expands `SdkErrorUtils` tests to cover provider error detection for OpenAI/Anthropic errors (e.g., `RateLimitError`) without relying on runtime SDK class imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd6e7b7a586efdd6c97e1f7e8f9ce7a150cb6f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->