### PR TITLE
Migrate settings list actions to Web Awesome

### DIFF
--- a/packages/extension/src/settingsView/frontend/SettingsApp.ts
+++ b/packages/extension/src/settingsView/frontend/SettingsApp.ts
@@ -20,7 +20,6 @@ import { SignalWatcher, signal } from '@shared/signals';
 // Local imports - shared styles
 import {
   badgeStyles,
-  codiconStyles,
   commonViewStyles,
   designTokens,
   waTabThemeTokenStyles,
@@ -123,7 +122,6 @@ export class SettingsApp extends SettingsAppBase {
   // Static 'styles' override lost through mixin type erasure; still works at runtime.
   static styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     ...badgeStyles,
     settingsViewStyles,
@@ -172,6 +170,17 @@ export class SettingsApp extends SettingsAppBase {
         gap: var(--spacing-small);
         color: var(--text-color);
         font-weight: var(--font-weight-medium);
+      }
+
+      .settings-unavailable-icon,
+      .settings-tab-icon {
+        width: 1em;
+        height: 1em;
+        flex: 0 0 auto;
+      }
+
+      wa-tab .settings-tab-icon {
+        margin-inline-end: var(--spacing-xsmall);
       }
     `,
   ];
@@ -699,7 +708,12 @@ export class SettingsApp extends SettingsAppBase {
       return html`
         <div class="settings-header">
           <div class="settings-header-user">
-            <span class="codicon codicon-account"></span>
+            <wa-icon
+              class="settings-header-user-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="circle-user"
+              variant="solid"
+            ></wa-icon>
             <div class="settings-header-info">
               <span class="settings-header-email">${this.userEmail.get()}</span>
               <span class="settings-header-tier">${this.tier.get()} Plan</span>
@@ -796,7 +810,12 @@ export class SettingsApp extends SettingsAppBase {
       <div class="tab-content-container">
         <div class="settings-unavailable">
           <div class="settings-unavailable-title">
-            <span class="codicon codicon-circle-slash"></span>
+            <wa-icon
+              class="settings-unavailable-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="ban"
+              variant="solid"
+            ></wa-icon>
             ${title}
           </div>
           <div>${description}</div>
@@ -819,29 +838,76 @@ export class SettingsApp extends SettingsAppBase {
           @wa-tab-show=${this.handleTabShow}
         >
           <wa-tab panel="memory"
-            ><span class="codicon codicon-database"></span> Memory</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="database"
+              variant="solid"
+            ></wa-icon>
+            Memory</wa-tab
           >
           <wa-tab panel="history"
-            ><span class="codicon codicon-history"></span> History</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="clock-rotate-left"
+              variant="solid"
+            ></wa-icon>
+            History</wa-tab
           >
           <wa-tab panel="models"
-            ><span class="codicon codicon-server"></span> Models</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="server"
+              variant="solid"
+            ></wa-icon>
+            Models</wa-tab
           >
           <wa-tab panel="agents"
-            ><span class="codicon codicon-robot"></span> Agents</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="robot"
+              variant="solid"
+            ></wa-icon>
+            Agents</wa-tab
           >
           <wa-tab panel="multi-agent"
-            ><span class="codicon codicon-organization"></span>
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="users"
+              variant="solid"
+            ></wa-icon>
             Multi-Agent</wa-tab
           >
           <wa-tab panel="tools"
-            ><span class="codicon codicon-tools"></span> Tools</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="screwdriver-wrench"
+              variant="solid"
+            ></wa-icon>
+            Tools</wa-tab
           >
           <wa-tab panel="git"
-            ><span class="codicon codicon-git-commit"></span> Git</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="code-branch"
+              variant="solid"
+            ></wa-icon>
+            Git</wa-tab
           >
           <wa-tab panel="latex"
-            ><span class="codicon codicon-file-code"></span> LaTeX</wa-tab
+            ><wa-icon
+              class="settings-tab-icon"
+              library=${TEXRA_ICON_LIBRARY}
+              name="file-code"
+              variant="solid"
+            ></wa-icon>
+            LaTeX</wa-tab
           >
 
           <wa-tab-panel name="memory">

--- a/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/HistoryItem.ts
@@ -22,6 +22,7 @@ import { AGENT_CATEGORY } from '@shared/schemas/agent';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import { getAgentCategoryDecorator } from '@shared/utils/icons';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - history view styles
 import { historyViewStyles } from './styles';
@@ -268,45 +269,42 @@ export class HistoryItem extends LitElement {
       <div class="list-item history-item">
         <div class="list-item-header">
           <div class="text-secondary history-timestamp">${timestamp}</div>
-          <vscode-toolbar-container
-            class="history-actions"
+          <div
+            class="history-actions action-button-group"
             @click=${this.handleActionClick}
           >
-            <vscode-toolbar-button
-              icon="trash"
-              label="Delete"
-              title="Delete"
-              data-action="delete"
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              icon="reply"
-              label="Setup"
-              title="Setup"
-              data-action="restore"
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              icon="debug-rerun"
-              label="Rerun"
-              title="Rerun"
-              data-action="rerun"
-            ></vscode-toolbar-button>
+            ${renderIconActionButton({
+              icon: 'trash',
+              label: 'Delete',
+              action: 'delete',
+            })}
+            ${renderIconActionButton({
+              icon: 'reply',
+              label: 'Setup',
+              action: 'restore',
+            })}
+            ${renderIconActionButton({
+              icon: 'rotate-right',
+              label: 'Rerun',
+              action: 'rerun',
+            })}
             ${isToolUse
               ? html`
-                  <vscode-toolbar-button
-                    icon="markdown"
-                    label="Export MD"
-                    title="Export as Markdown"
-                    data-action="export-md"
-                  ></vscode-toolbar-button>
-                  <vscode-toolbar-button
-                    icon="file-pdf"
-                    label="Export PDF"
-                    title="Export as LaTeX/PDF"
-                    data-action="export-tex"
-                  ></vscode-toolbar-button>
+                  ${renderIconActionButton({
+                    icon: 'file-lines',
+                    label: 'Export Markdown',
+                    title: 'Export as Markdown',
+                    action: 'export-md',
+                  })}
+                  ${renderIconActionButton({
+                    icon: 'file-pdf',
+                    label: 'Export PDF',
+                    title: 'Export as LaTeX/PDF',
+                    action: 'export-tex',
+                  })}
                 `
               : nothing}
-          </vscode-toolbar-container>
+          </div>
         </div>
         ${descriptionText
           ? html`<div class="history-description">${descriptionText}</div>`

--- a/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
+++ b/packages/extension/src/settingsView/frontend/components/history/SearchBar.ts
@@ -8,7 +8,8 @@ import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { designTokens, codiconStyles } from '@shared/styles';
+import { commonViewStyles, designTokens } from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 import { historyViewStyles } from './styles';
 
 // Local imports - history view events
@@ -16,7 +17,7 @@ import { HistoryViewEvents } from './events';
 
 @customElement('history-search-bar')
 export class SearchBar extends LitElement {
-  static override styles = [designTokens, codiconStyles, historyViewStyles];
+  static override styles = [designTokens, commonViewStyles, historyViewStyles];
 
   @property({ attribute: false }) searchTerm = '';
   @property({ attribute: false }) matchCount = '';
@@ -76,32 +77,28 @@ export class SearchBar extends LitElement {
           @input=${this.handleInput}
           @keydown=${this.handleKeydown}
         ></vscode-textfield>
-        <vscode-toolbar-container class="search-controls">
-          <vscode-toolbar-button
-            class="search-nav-btn"
-            icon="chevron-up"
-            label="Previous match"
-            title="Previous match"
-            @click=${this.handlePrev}
-          ></vscode-toolbar-button>
-          <vscode-toolbar-button
-            class="search-nav-btn"
-            icon="chevron-down"
-            label="Next match"
-            title="Next match"
-            @click=${this.handleNext}
-          ></vscode-toolbar-button>
+        <div class="search-controls action-button-group">
+          ${renderIconActionButton({
+            icon: 'chevron-up',
+            label: 'Previous match',
+            onClick: this.handlePrev,
+          })}
+          ${renderIconActionButton({
+            icon: 'chevron-down',
+            label: 'Next match',
+            onClick: this.handleNext,
+          })}
           <span class="match-count">${this.matchCount}</span>
           ${this.canClearHistory
-            ? html`<vscode-toolbar-button
-                class="history-clear-btn"
-                icon="trash"
-                label="Clear history"
-                title="Clear all history"
-                @click=${this.handleClearHistory}
-              ></vscode-toolbar-button>`
+            ? renderIconActionButton({
+                icon: 'trash',
+                label: 'Clear history',
+                title: 'Clear all history',
+                action: 'clear-history',
+                onClick: this.handleClearHistory,
+              })
             : ''}
-        </vscode-toolbar-container>
+        </div>
       </div>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -17,6 +17,7 @@ import {
   formatUpdatedDate,
 } from '@shared/utils/string';
 import { getLightweightMd } from '@shared/highlighting/lightweightMd';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
@@ -140,31 +141,31 @@ export class MemoryItem extends LitElement {
       <div class="list-item memory-item ${this.item.pinned ? 'pinned' : ''}">
         <div class="list-item-header">
           <div class="memory-path">${this.item.displayPath}</div>
-          <vscode-toolbar-container>
-            <vscode-toolbar-button
-              class="pin-memory-btn"
-              icon=${this.item.pinned ? 'pinned' : 'pin'}
-              label=${this.item.pinned ? 'Unpin' : 'Pin'}
-              title=${this.item.pinned
+          <div class="action-button-group">
+            ${renderIconActionButton({
+              icon: this.item.pinned ? 'thumbtack-slash' : 'thumbtack',
+              label: this.item.pinned ? 'Unpin' : 'Pin',
+              title: this.item.pinned
                 ? 'Unpin this memory'
-                : 'Pin as core long-term memory'}
-              @click=${this.handleTogglePin}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              class="open-memory-btn"
-              icon="go-to-file"
-              label="Open"
-              title="Open in editor"
-              @click=${this.handleOpen}
-            ></vscode-toolbar-button>
-            <vscode-toolbar-button
-              class="delete-memory-btn"
-              icon="trash"
-              label="Delete"
-              title="Delete this memory"
-              @click=${this.handleDelete}
-            ></vscode-toolbar-button>
-          </vscode-toolbar-container>
+                : 'Pin as core long-term memory',
+              className: 'pin-memory-btn',
+              onClick: this.handleTogglePin,
+            })}
+            ${renderIconActionButton({
+              icon: 'file-export',
+              label: 'Open',
+              title: 'Open in editor',
+              className: 'open-memory-btn',
+              onClick: this.handleOpen,
+            })}
+            ${renderIconActionButton({
+              icon: 'trash',
+              label: 'Delete',
+              title: 'Delete this memory',
+              className: 'delete-memory-btn',
+              onClick: this.handleDelete,
+            })}
+          </div>
         </div>
         <div class="text-secondary memory-meta">
           ${this.renderMeta(this.item)}

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryItem.ts
@@ -8,7 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
 // Local imports - shared styles
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
 import type { MemoryViewItem } from '@shared/schemas';
 import { markdownStyles } from '@shared/styles/markdownStyles';
 import {
@@ -26,7 +26,6 @@ import { MemoryViewEvents } from './events';
 export class MemoryItem extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     markdownStyles,
     css`
@@ -148,21 +147,18 @@ export class MemoryItem extends LitElement {
               title: this.item.pinned
                 ? 'Unpin this memory'
                 : 'Pin as core long-term memory',
-              className: 'pin-memory-btn',
               onClick: this.handleTogglePin,
             })}
             ${renderIconActionButton({
               icon: 'file-export',
               label: 'Open',
               title: 'Open in editor',
-              className: 'open-memory-btn',
               onClick: this.handleOpen,
             })}
             ${renderIconActionButton({
               icon: 'trash',
               label: 'Delete',
               title: 'Delete this memory',
-              className: 'delete-memory-btn',
               onClick: this.handleDelete,
             })}
           </div>

--- a/packages/extension/src/settingsView/frontend/components/memory/MemoryToolbar.ts
+++ b/packages/extension/src/settingsView/frontend/components/memory/MemoryToolbar.ts
@@ -7,7 +7,8 @@ import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - memory view events
 import { MemoryViewEvents } from './events';
@@ -16,7 +17,6 @@ import { MemoryViewEvents } from './events';
 export class MemoryToolbar extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
@@ -40,20 +40,19 @@ export class MemoryToolbar extends LitElement {
   override render(): TemplateResult {
     return html`
       <header class="view-header">
-        <vscode-toolbar-container>
-          <vscode-toolbar-button
-            icon="refresh"
-            label="Refresh"
-            title="Refresh"
-            @click=${this.handleRefresh}
-          ></vscode-toolbar-button>
-          <vscode-toolbar-button
-            icon="folder-opened"
-            label="Open Folder"
-            title="Open in file explorer"
-            @click=${this.handleOpenFolder}
-          ></vscode-toolbar-button>
-        </vscode-toolbar-container>
+        <div class="action-button-group">
+          ${renderIconActionButton({
+            icon: 'rotate-right',
+            label: 'Refresh',
+            onClick: this.handleRefresh,
+          })}
+          ${renderIconActionButton({
+            icon: 'folder-open',
+            label: 'Open Folder',
+            title: 'Open in file explorer',
+            onClick: this.handleOpenFolder,
+          })}
+        </div>
       </header>
     `;
   }

--- a/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProfileInfo.ts
@@ -7,7 +7,8 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { badgeStyles, designTokens } from '@shared/styles';
+import { badgeStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - shared copy
 import { PROMO_NOTICE_LONG } from '@shared/copy/promoNotice';
@@ -20,7 +21,12 @@ import { ProfileViewEvents } from './events';
 
 @customElement('profile-info')
 export class ProfileInfo extends LitElement {
-  static override styles = [designTokens, ...badgeStyles, profileViewStyles];
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    ...badgeStyles,
+    profileViewStyles,
+  ];
 
   @property({ attribute: false }) email = '';
   @property({ attribute: false }) userId = '';
@@ -88,12 +94,12 @@ export class ProfileInfo extends LitElement {
         ${this.showSignOut
           ? html`
               <div class="profile-actions">
-                <vscode-toolbar-button
-                  icon="sign-out"
-                  label="Sign Out"
-                  title="Sign out"
-                  @click=${this.handleSignOut}
-                ></vscode-toolbar-button>
+                ${renderIconActionButton({
+                  icon: 'right-from-bracket',
+                  label: 'Sign Out',
+                  title: 'Sign out',
+                  onClick: this.handleSignOut,
+                })}
               </div>
             `
           : nothing}

--- a/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ProviderKeyList.ts
@@ -8,7 +8,13 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { badgeStyles, codiconStyles, designTokens } from '@shared/styles';
+import {
+  badgeStyles,
+  codiconStyles,
+  commonViewStyles,
+  designTokens,
+} from '@shared/styles';
+import { renderIconActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - profile view styles and events
 import type {
@@ -30,6 +36,7 @@ export class ProviderKeyList extends LitElement {
   static override styles = [
     designTokens,
     codiconStyles,
+    commonViewStyles,
     ...badgeStyles,
     profileViewStyles,
   ];
@@ -50,31 +57,31 @@ export class ProviderKeyList extends LitElement {
     const { provider } = entry;
     const removeButton =
       entry.status === 'set'
-        ? html`<vscode-toolbar-button
-            icon="trash"
-            label="Remove"
-            title="Remove key"
-            @click=${() =>
-              this.dispatchEvent(ProviderKeyEvents.removeKey({ provider }))}
-          ></vscode-toolbar-button>`
+        ? renderIconActionButton({
+            icon: 'trash',
+            label: 'Remove',
+            title: 'Remove key',
+            onClick: () =>
+              this.dispatchEvent(ProviderKeyEvents.removeKey({ provider })),
+          })
         : nothing;
 
     return html`
-      <div class="provider-actions">
-        <vscode-toolbar-button
-          icon="key"
-          label="Set"
-          title="Set API key"
-          @click=${() =>
-            this.dispatchEvent(ProviderKeyEvents.setKey({ provider }))}
-        ></vscode-toolbar-button>
-        <vscode-toolbar-button
-          icon="link-external"
-          label="Get"
-          title="Get API key from provider"
-          @click=${() =>
-            this.dispatchEvent(ProviderKeyEvents.openKeyUrl({ provider }))}
-        ></vscode-toolbar-button>
+      <div class="provider-actions action-button-group">
+        ${renderIconActionButton({
+          icon: 'key',
+          label: 'Set',
+          title: 'Set API key',
+          onClick: () =>
+            this.dispatchEvent(ProviderKeyEvents.setKey({ provider })),
+        })}
+        ${renderIconActionButton({
+          icon: 'arrow-up-right-from-square',
+          label: 'Get',
+          title: 'Get API key from provider',
+          onClick: () =>
+            this.dispatchEvent(ProviderKeyEvents.openKeyUrl({ provider })),
+        })}
         ${removeButton}
       </div>
     `;

--- a/packages/extension/src/settingsView/frontend/styles.ts
+++ b/packages/extension/src/settingsView/frontend/styles.ts
@@ -22,7 +22,10 @@ const settingsHeaderStyles: CSSResult = css`
     gap: var(--spacing-medium);
   }
 
-  .settings-header-user .codicon {
+  .settings-header-user-icon {
+    width: var(--font-size-lg);
+    height: var(--font-size-lg);
+    flex: 0 0 auto;
     font-size: var(--font-size-lg);
     opacity: var(--opacity-subtle);
   }

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -79,6 +79,25 @@ export const commonViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
+  .action-button-group {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-small);
+    flex-wrap: nowrap;
+  }
+
+  .action-icon-button {
+    flex-shrink: 0;
+  }
+
+  .action-icon-button::part(base) {
+    width: var(--height-button);
+    min-width: var(--height-button);
+    height: var(--height-button);
+    min-height: var(--height-button);
+    padding: 0;
+  }
+
   .clickable-link {
     cursor: pointer;
     color: var(--color-text-link);

--- a/src/shared/styles/historyStyles.ts
+++ b/src/shared/styles/historyStyles.ts
@@ -29,13 +29,6 @@ export const searchStyles: CSSResult = css`
     margin-left: auto;
   }
 
-  .search-nav-btn {
-    min-width: var(--height-button);
-    height: var(--height-button);
-    padding: 0;
-    font-size: var(--font-size);
-  }
-
   .match-count {
     font-size: var(--font-size-sm);
     color: var(--color-text-secondary);
@@ -43,16 +36,16 @@ export const searchStyles: CSSResult = css`
     text-align: center;
   }
 
-  .history-clear-btn {
+  .action-icon-button[data-action='clear-history'] {
     color: var(--color-text-secondary);
     margin-left: var(--spacing-small);
   }
 
-  .history-clear-btn::part(control) {
+  .action-icon-button[data-action='clear-history']::part(base) {
     border-radius: var(--border-radius-medium);
   }
 
-  .history-clear-btn:hover {
+  .action-icon-button[data-action='clear-history']:hover {
     color: var(--color-removed);
   }
 `;

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -1,0 +1,48 @@
+// Third-party imports
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import { html, type TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+// Local imports - Web Awesome
+import { TEXRA_ICON_LIBRARY } from './webAwesomeIcons';
+
+export interface IconActionButtonOptions {
+  readonly icon: string;
+  readonly label: string;
+  readonly title?: string;
+  readonly action?: string;
+  readonly className?: string;
+  readonly onClick?: (event: MouseEvent) => void;
+}
+
+export function renderIconActionButton({
+  icon,
+  label,
+  title,
+  action,
+  className,
+  onClick,
+}: IconActionButtonOptions): TemplateResult {
+  const classes = ['action-icon-button', className].filter(Boolean).join(' ');
+
+  return html`
+    <wa-button
+      class=${classes}
+      appearance="outlined"
+      variant="neutral"
+      size="small"
+      type="button"
+      aria-label=${label}
+      title=${title ?? label}
+      data-action=${ifDefined(action)}
+      @click=${onClick}
+    >
+      <wa-icon
+        library=${TEXRA_ICON_LIBRARY}
+        name=${icon}
+        variant="solid"
+      ></wa-icon>
+    </wa-button>
+  `;
+}

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -1,20 +1,40 @@
 // Third-party imports
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons/faArrowUpRightFromSquare';
 import { faBackwardStep } from '@fortawesome/free-solid-svg-icons/faBackwardStep';
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
+import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp';
+import { faCircleUser } from '@fortawesome/free-solid-svg-icons/faCircleUser';
+import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft';
 import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons/faCloudArrowDown';
+import { faCodeBranch } from '@fortawesome/free-solid-svg-icons/faCodeBranch';
+import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase';
+import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
+import { faFileCode } from '@fortawesome/free-solid-svg-icons/faFileCode';
+import { faFileLines } from '@fortawesome/free-solid-svg-icons/faFileLines';
+import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
 import { faForwardStep } from '@fortawesome/free-solid-svg-icons/faForwardStep';
 import { faGear } from '@fortawesome/free-solid-svg-icons/faGear';
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
+import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
+import { faRightFromBracket } from '@fortawesome/free-solid-svg-icons/faRightFromBracket';
 import { faRightToBracket } from '@fortawesome/free-solid-svg-icons/faRightToBracket';
 import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
+import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
+import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons/faScrewdriverWrench';
+import { faServer } from '@fortawesome/free-solid-svg-icons/faServer';
 import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
+import { faThumbtack } from '@fortawesome/free-solid-svg-icons/faThumbtack';
+import { faThumbtackSlash } from '@fortawesome/free-solid-svg-icons/faThumbtackSlash';
+import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
+import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
 import { faXmark } from '@fortawesome/free-solid-svg-icons/faXmark';
 import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
 
@@ -46,20 +66,40 @@ const icons = {
   // Font Awesome Free icons; Web Awesome renders them from local data URIs.
   'arrow-up-right-from-square': faArrowUpRightFromSquare,
   'backward-step': faBackwardStep,
+  ban: faBan,
   'chevron-down': faChevronDown,
   'chevron-left': faChevronLeft,
   'chevron-right': faChevronRight,
+  'chevron-up': faChevronUp,
+  'circle-user': faCircleUser,
+  'clock-rotate-left': faClockRotateLeft,
   'cloud-arrow-down': faCloudArrowDown,
+  'code-branch': faCodeBranch,
+  database: faDatabase,
+  'file-code': faFileCode,
+  'file-export': faFileExport,
+  'file-lines': faFileLines,
+  'file-pdf': faFilePdf,
+  'folder-open': faFolderOpen,
   'forward-step': faForwardStep,
   gear: faGear,
   key: faKey,
   pencil: faPencil,
   'picture-in-picture': faPictureInPicture,
   play: faPlay,
+  reply: faReply,
+  'right-from-bracket': faRightFromBracket,
   'right-to-bracket': faRightToBracket,
   robot: faRobot,
+  'rotate-right': faRotateRight,
+  'screwdriver-wrench': faScrewdriverWrench,
+  server: faServer,
   terminal: faTerminal,
+  thumbtack: faThumbtack,
+  'thumbtack-slash': faThumbtackSlash,
+  trash: faTrash,
   user: faUser,
+  users: faUsers,
   xmark: faXmark,
 } as const;
 


### PR DESCRIPTION
Summary
- Replace settings history, memory, and profile action toolbars with Web Awesome buttons backed by local Font Awesome icons.
- Add a shared renderIconActionButton helper so icon-only actions use one component path instead of repeated manual button markup.
- Keep text fields, checkboxes, provider expanders, and other stateful form controls unchanged for later slices.

Validation
- npm run format
- npm run compile:safe
- npm run lint
- npm run smoke:webviews
- git grep -n "<vscode-toolbar-button" -- packages/extension/src/settingsView/frontend/components/history packages/extension/src/settingsView/frontend/components/memory packages/extension/src/settingsView/frontend/components/profile

Refs #3543

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps toolbar/button components and icon sources; main risk is minor styling/regression in webview action affordances if icon names or button parts differ.
> 
> **Overview**
> Migrates settings webview action controls (History, Memory, Profile, and Settings tabs/header) from VS Code `codicon`/`vscode-toolbar-button` usage to Web Awesome `wa-button` + locally-registered Font Awesome icons.
> 
> Adds a shared `renderIconActionButton` helper and supporting `.action-button-group` / `.action-icon-button` styles, and updates shared history/search and settings header styling to target the new buttons and icon sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a77af68c93c30ff5212dd1a7f51a050c30e6c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->