### PR TITLE
Migrate profile action buttons to Web Awesome

### DIFF
--- a/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/AgentSelectionPanel.ts
@@ -16,7 +16,8 @@ import {
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, designTokens } from '@shared/styles';
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - shared schemas and events
 import {
@@ -53,6 +54,7 @@ export class AgentSelectionPanel extends LitElement {
   static override styles = [
     designTokens,
     codiconStyles,
+    commonViewStyles,
     css`
       :host {
         display: block;
@@ -245,30 +247,7 @@ export class AgentSelectionPanel extends LitElement {
       }
 
       .agent-action-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: var(--spacing-small);
-        padding: var(--spacing-small) var(--spacing-medium);
-        font-size: var(--font-size-sm);
-        font-family: inherit;
-        color: var(--texra-foreground);
-        background: var(--texra-input-background);
-        border: var(--border-thin) solid var(--color-border);
-        border-radius: var(--border-radius);
-        cursor: pointer;
-        transition:
-          background var(--transition-fast),
-          border-color var(--transition-fast);
-      }
-
-      .agent-action-btn:hover {
-        background: var(--texra-list-hoverBackground);
-        border-color: var(--texra-focusBorder);
-      }
-
-      .agent-action-btn:focus-visible {
-        outline: var(--border-thin) solid var(--texra-focusBorder);
-        outline-offset: 1px;
+        flex-shrink: 0;
       }
 
       .agent-count {
@@ -328,28 +307,17 @@ export class AgentSelectionPanel extends LitElement {
         white-space: nowrap;
       }
 
-      .agent-action-btn--danger {
+      .agent-action-btn--danger::part(base) {
         color: var(--texra-errorForeground, #f44);
         border-color: var(--texra-errorForeground, #f44);
       }
 
-      .agent-action-btn--danger:hover {
+      .agent-action-btn--danger:hover::part(base) {
         background: var(
           --texra-inputValidation-errorBackground,
           rgba(255, 0, 0, 0.1)
         );
         border-color: var(--texra-errorForeground, #f44);
-      }
-
-      .agent-action-btn--primary {
-        color: var(--texra-button-foreground, #fff);
-        background: var(--texra-button-background);
-        border-color: var(--texra-button-background);
-      }
-
-      .agent-action-btn--primary:hover {
-        background: var(--texra-button-hoverBackground);
-        border-color: var(--texra-button-hoverBackground);
       }
 
       .agent-delete-confirm {
@@ -722,14 +690,13 @@ export class AgentSelectionPanel extends LitElement {
         <div class="agent-detail-actions">
           ${agent.hasPath
             ? html`
-                <button
-                  class="agent-action-btn"
-                  @click=${() => this.handleOpenYaml(agent, 'base')}
-                  title="Open agent YAML definition"
-                >
-                  <span class="codicon codicon-file-code"></span>
-                  Open YAML
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'file-lines',
+                  text: 'Open YAML',
+                  label: 'Open agent YAML definition',
+                  className: 'agent-action-btn',
+                  onClick: () => this.handleOpenYaml(agent, 'base'),
+                })}
               `
             : nothing}
           ${agent.source === AGENT_SOURCE.REMOTE &&
@@ -737,62 +704,66 @@ export class AgentSelectionPanel extends LitElement {
           !agent.hasPath &&
           !this.desktopHost
             ? html`
-                <button
-                  class="agent-action-btn"
-                  @click=${() => this.handleViewRemotePrompt(agent)}
-                  title="View the remote agent's prompt definition (read-only)"
-                >
-                  <span class="codicon codicon-file-code"></span>
-                  View Prompt
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'file-lines',
+                  text: 'View Prompt',
+                  label: "View the remote agent's prompt definition",
+                  title:
+                    "View the remote agent's prompt definition (read-only)",
+                  className: 'agent-action-btn',
+                  onClick: () => this.handleViewRemotePrompt(agent),
+                })}
               `
             : nothing}
           ${agent.hasMultiplePath
             ? html`
-                <button
-                  class="agent-action-btn"
-                  @click=${() => this.handleOpenYaml(agent, 'multiple')}
-                  title="Open the multi-output prompts — alternate instructions used when generating multiple alternatives"
-                >
-                  <span class="codicon codicon-files"></span>
-                  Multi-Output Prompts
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'file-lines',
+                  text: 'Multi-Output Prompts',
+                  label: 'Open the multi-output prompts',
+                  title:
+                    'Open the multi-output prompts — alternate instructions used when generating multiple alternatives',
+                  className: 'agent-action-btn',
+                  onClick: () => this.handleOpenYaml(agent, 'multiple'),
+                })}
               `
             : nothing}
           ${agent.hasPath
             ? html`
-                <button
-                  class="agent-action-btn"
-                  @click=${() => this.handleRevealAgentFile(agent)}
-                  title="Show this file in your system file explorer"
-                >
-                  <span class="codicon codicon-folder-opened"></span>
-                  Reveal in File Explorer
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'folder-open',
+                  text: 'Reveal in File Explorer',
+                  label: 'Reveal in File Explorer',
+                  title: 'Show this file in your system file explorer',
+                  className: 'agent-action-btn',
+                  onClick: () => this.handleRevealAgentFile(agent),
+                })}
               `
             : nothing}
           ${builtIn && !this.desktopHost
             ? html`
-                <button
-                  class="agent-action-btn agent-action-btn--primary"
-                  @click=${() => this.handleCustomizeAgent(agent)}
-                  title="Create an editable copy in your custom agents folder"
-                >
-                  <span class="codicon codicon-copy"></span>
-                  Customize
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'pencil',
+                  text: 'Customize',
+                  label: 'Customize agent',
+                  title: 'Create an editable copy in your custom agents folder',
+                  className: 'agent-action-btn',
+                  appearance: 'filled',
+                  variant: 'brand',
+                  onClick: () => this.handleCustomizeAgent(agent),
+                })}
               `
             : nothing}
           ${isCustom && !this.desktopHost
             ? html`
-                <button
-                  class="agent-action-btn agent-action-btn--danger"
-                  @click=${() => this.handleDeleteCustomAgent(agent)}
-                  title="Delete this custom agent"
-                >
-                  <span class="codicon codicon-trash"></span>
-                  Delete
-                </button>
+                ${renderLabeledActionButton({
+                  icon: 'trash',
+                  text: 'Delete',
+                  label: 'Delete custom agent',
+                  title: 'Delete this custom agent',
+                  className: 'agent-action-btn agent-action-btn--danger',
+                  onClick: () => this.handleDeleteCustomAgent(agent),
+                })}
               `
             : nothing}
         </div>
@@ -804,18 +775,20 @@ export class AgentSelectionPanel extends LitElement {
                   Delete custom agent "${agent.name}"? This cannot be undone.
                 </span>
                 <div class="agent-delete-confirm-actions">
-                  <button
-                    class="agent-action-btn agent-action-btn--danger"
-                    @click=${() => this.handleDeleteCustomAgent(agent)}
-                  >
-                    Delete
-                  </button>
-                  <button
-                    class="agent-action-btn"
-                    @click=${() => this.cancelDelete()}
-                  >
-                    Cancel
-                  </button>
+                  ${renderLabeledActionButton({
+                    icon: 'trash',
+                    text: 'Delete',
+                    label: 'Confirm delete custom agent',
+                    className: 'agent-action-btn agent-action-btn--danger',
+                    onClick: () => this.handleDeleteCustomAgent(agent),
+                  })}
+                  ${renderLabeledActionButton({
+                    icon: 'xmark',
+                    text: 'Cancel',
+                    label: 'Cancel delete custom agent',
+                    className: 'agent-action-btn',
+                    onClick: () => this.cancelDelete(),
+                  })}
                 </div>
               </div>
             `

--- a/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/ModelSelectionList.ts
@@ -8,7 +8,8 @@ import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 // Local imports - shared styles
-import { codiconStyles, designTokens } from '@shared/styles';
+import { codiconStyles, commonViewStyles, designTokens } from '@shared/styles';
+import { renderLabeledActionButton } from '@shared/wa/actionButtons';
 
 // Local imports - shared constants
 import {
@@ -59,7 +60,12 @@ function sortFastFirst(items: ModelSelectionItem[]): ModelSelectionItem[] {
 
 @customElement('model-selection-list')
 export class ModelSelectionList extends LitElement {
-  static override styles = [designTokens, codiconStyles, profileViewStyles];
+  static override styles = [
+    designTokens,
+    codiconStyles,
+    commonViewStyles,
+    profileViewStyles,
+  ];
 
   @property({ attribute: false }) models: ModelSelectionItem[] = [];
   @property({ attribute: false }) helperModel = '';
@@ -269,30 +275,26 @@ export class ModelSelectionList extends LitElement {
             class="provider-group-key-status key-status-badge ${keyStatus.status}"
             >${keyStatusLabel}</span
           >
-          <button
-            class="provider-group-key-button"
-            type="button"
-            title="Set ${group.displayName} API key"
-            @click=${() =>
+          ${renderLabeledActionButton({
+            icon: 'key',
+            text: 'Set key',
+            label: `Set ${group.displayName} API key`,
+            className: 'provider-group-key-button',
+            onClick: () =>
               this.dispatchEvent(
                 ProviderKeyEvents.setKey({ provider: group.provider }),
-              )}
-          >
-            <span class="codicon codicon-key"></span>
-            Set key
-          </button>
-          <button
-            class="provider-group-key-button"
-            type="button"
-            title="Get ${group.displayName} API key"
-            @click=${() =>
+              ),
+          })}
+          ${renderLabeledActionButton({
+            icon: 'arrow-up-right-from-square',
+            text: 'Get key',
+            label: `Get ${group.displayName} API key`,
+            className: 'provider-group-key-button',
+            onClick: () =>
               this.dispatchEvent(
                 ProviderKeyEvents.openKeyUrl({ provider: group.provider }),
-              )}
-          >
-            <span class="codicon codicon-link-external"></span>
-            Get key
-          </button>
+              ),
+          })}
         `
       : nothing;
 

--- a/packages/extension/src/settingsView/frontend/components/profile/styles.ts
+++ b/packages/extension/src/settingsView/frontend/components/profile/styles.ts
@@ -541,28 +541,7 @@ export const profileViewStyles: CSSResult = css`
   }
 
   .provider-group-key-button {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-tiny);
-    padding: var(--spacing-tiny) var(--spacing-small);
-    border: var(--border-thin) solid var(--color-border);
-    border-radius: var(--border-radius-small);
-    background: var(--texra-button-secondaryBackground, transparent);
-    color: var(--texra-button-secondaryForeground, var(--texra-foreground));
-    cursor: pointer;
-    font: inherit;
-  }
-
-  .provider-group-key-button:hover {
-    background: var(
-      --texra-button-secondaryHoverBackground,
-      var(--texra-list-hoverBackground)
-    );
-  }
-
-  .provider-group-key-button:focus-visible {
-    outline: var(--border-thin) solid var(--texra-focusBorder);
-    outline-offset: 1px;
+    flex-shrink: 0;
   }
 
   .provider-group-content {

--- a/src/shared/styles/commonViewStyles.ts
+++ b/src/shared/styles/commonViewStyles.ts
@@ -90,6 +90,14 @@ export const commonViewStyles: CSSResult = css`
     flex-shrink: 0;
   }
 
+  .action-button::part(base) {
+    gap: var(--spacing-small);
+  }
+
+  .action-button wa-icon {
+    font-size: var(--font-size-sm);
+  }
+
   .action-icon-button::part(base) {
     width: var(--height-button);
     min-width: var(--height-button);

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -39,6 +39,7 @@ function renderActionButtonBase({
   const classes = [text ? 'action-button' : 'action-icon-button', className]
     .filter(Boolean)
     .join(' ');
+  const iconSlot = text ? 'start' : undefined;
 
   return html`
     <wa-button
@@ -53,6 +54,7 @@ function renderActionButtonBase({
       @click=${onClick}
     >
       <wa-icon
+        slot=${ifDefined(iconSlot)}
         library=${TEXRA_ICON_LIBRARY}
         name=${icon}
         variant="solid"

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -7,30 +7,44 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 // Local imports - Web Awesome
 import { TEXRA_ICON_LIBRARY } from './webAwesomeIcons';
 
+type ActionButtonAppearance = 'filled' | 'outlined' | 'plain';
+type ActionButtonVariant = 'brand' | 'neutral';
+
 export interface IconActionButtonOptions {
   readonly icon: string;
   readonly label: string;
   readonly title?: string;
   readonly action?: string;
   readonly className?: string;
+  readonly appearance?: ActionButtonAppearance;
+  readonly variant?: ActionButtonVariant;
   readonly onClick?: (event: MouseEvent) => void;
 }
 
-export function renderIconActionButton({
+export interface LabeledActionButtonOptions extends IconActionButtonOptions {
+  readonly text: string;
+}
+
+function renderActionButtonBase({
   icon,
   label,
+  text,
   title,
   action,
   className,
+  appearance = 'outlined',
+  variant = 'neutral',
   onClick,
-}: IconActionButtonOptions): TemplateResult {
-  const classes = ['action-icon-button', className].filter(Boolean).join(' ');
+}: IconActionButtonOptions & { readonly text?: string }): TemplateResult {
+  const classes = [text ? 'action-button' : 'action-icon-button', className]
+    .filter(Boolean)
+    .join(' ');
 
   return html`
     <wa-button
       class=${classes}
-      appearance="outlined"
-      variant="neutral"
+      appearance=${appearance}
+      variant=${variant}
       size="small"
       type="button"
       aria-label=${label}
@@ -43,6 +57,19 @@ export function renderIconActionButton({
         name=${icon}
         variant="solid"
       ></wa-icon>
+      ${text}
     </wa-button>
   `;
+}
+
+export function renderIconActionButton(
+  options: IconActionButtonOptions,
+): TemplateResult {
+  return renderActionButtonBase(options);
+}
+
+export function renderLabeledActionButton(
+  options: LabeledActionButtonOptions,
+): TemplateResult {
+  return renderActionButtonBase(options);
 }

--- a/src/test-kernel/settings/litComponentTestUtils.ts
+++ b/src/test-kernel/settings/litComponentTestUtils.ts
@@ -1,6 +1,23 @@
 import { JSDOM } from 'jsdom';
 import { afterAll, beforeAll, beforeEach } from 'vitest';
 
+type TestElementInternals = {
+  validity?: ValidityState;
+  validationMessage?: string;
+  willValidate?: boolean;
+  form?: HTMLFormElement | null;
+  setValidity?: (flags?: ValidityStateFlags) => void;
+  setFormValue?: (value: unknown, state?: unknown) => void;
+  checkValidity?: () => boolean;
+  reportValidity?: () => boolean;
+};
+
+type TestDomWindow = JSDOM['window'] & {
+  ElementInternals?: {
+    prototype: TestElementInternals;
+  };
+};
+
 const domGlobalKeys = [
   'window',
   'document',
@@ -13,7 +30,98 @@ const domGlobalKeys = [
   'KeyboardEvent',
   'MouseEvent',
   'ShadowRoot',
+  'Node',
 ] as const;
+
+const DEFAULT_VALIDITY = {
+  badInput: false,
+  customError: false,
+  patternMismatch: false,
+  rangeOverflow: false,
+  rangeUnderflow: false,
+  stepMismatch: false,
+  tooLong: false,
+  tooShort: false,
+  typeMismatch: false,
+  valid: true,
+  valueMissing: false,
+} satisfies ValidityState;
+
+function installElementInternalsPolyfill(window: TestDomWindow): void {
+  const ElementInternalsCtor = window.ElementInternals;
+  if (!ElementInternalsCtor) {
+    return;
+  }
+
+  const validityByInternals = new WeakMap<object, ValidityState>();
+  const prototype = ElementInternalsCtor.prototype;
+
+  if (!('validity' in prototype)) {
+    Object.defineProperty(prototype, 'validity', {
+      configurable: true,
+      get() {
+        return validityByInternals.get(this) ?? DEFAULT_VALIDITY;
+      },
+    });
+  }
+
+  if (!('validationMessage' in prototype)) {
+    Object.defineProperty(prototype, 'validationMessage', {
+      configurable: true,
+      get() {
+        return '';
+      },
+    });
+  }
+
+  if (!('willValidate' in prototype)) {
+    Object.defineProperty(prototype, 'willValidate', {
+      configurable: true,
+      get() {
+        return true;
+      },
+    });
+  }
+
+  if (!('form' in prototype)) {
+    Object.defineProperty(prototype, 'form', {
+      configurable: true,
+      get() {
+        return null;
+      },
+    });
+  }
+
+  if (!prototype.setValidity) {
+    prototype.setValidity = function setValidity(
+      this: object,
+      flags?: ValidityStateFlags,
+    ) {
+      const invalid = Object.values(flags ?? {}).some(Boolean);
+      validityByInternals.set(this, {
+        ...DEFAULT_VALIDITY,
+        ...(flags ?? {}),
+        valid: !invalid,
+      });
+    };
+  }
+
+  if (!prototype.setFormValue) {
+    prototype.setFormValue = () => {
+      /* jsdom does not implement form-associated custom element state. */
+    };
+  }
+
+  if (!prototype.checkValidity) {
+    prototype.checkValidity = function checkValidity(this: object) {
+      return (validityByInternals.get(this) ?? DEFAULT_VALIDITY).valid;
+    };
+  }
+
+  if (!prototype.reportValidity) {
+    prototype.reportValidity = prototype.checkValidity;
+  }
+}
 
 /**
  * Install the browser globals Lit components need, import the component module,
@@ -45,6 +153,7 @@ export function useLitComponentTestDom(
       KeyboardEvent: dom.window.KeyboardEvent,
       MouseEvent: dom.window.MouseEvent,
       ShadowRoot: dom.window.ShadowRoot,
+      Node: dom.window.Node,
     } satisfies Record<(typeof domGlobalKeys)[number], unknown>;
 
     for (const key of domGlobalKeys) {
@@ -59,6 +168,7 @@ export function useLitComponentTestDom(
       });
     }
 
+    installElementInternalsPolyfill(dom.window);
     await importComponents();
   });
 


### PR DESCRIPTION
## Summary
- add a shared Web Awesome helper for labeled action buttons, reusing the same Font Awesome-backed icon library as the icon-only helper
- migrate model provider API-key actions to Web Awesome button controls
- migrate agent detail actions and delete confirmation actions to Web Awesome buttons, removing the hand-rolled button styling

Stacked on #3588. Continues #3543 and #3576.

## Validation
- npm run format
- npm run compile:safe
- npm run lint
- npm run smoke:webviews
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI refactoring: replaces hand-rolled `<button>`s with shared Web Awesome `wa-button` helpers; risk is limited to styling/behavior regressions in settings webviews.
> 
> **Overview**
> Migrates profile/settings webview action buttons to Web Awesome components by introducing `renderLabeledActionButton` (built on the existing icon-button helper) and adopting it in `AgentSelectionPanel` and `ModelSelectionList` (agent detail actions, delete confirmation, and provider API-key actions).
> 
> Removes component-specific button CSS in favor of shared `commonViewStyles` (`.action-button` parts styling plus minor icon sizing), and updates tests (`litComponentTestUtils`) to better support Web Awesome/form-associated elements in jsdom via an `ElementInternals` polyfill and a `Node` global.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebdd99933218bbdf82f3ece9080f407280fc487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->