### PR TITLE
[codex] Simplify desktop auth state setup

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -381,7 +381,9 @@ Shared config:
 
 The monorepo now has a local unsigned package rehearsal for the Electron desktop app. It produces a
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
-packaged `app.asar` contains the expected runtime files.
+packaged `app.asar` contains the expected runtime files. The package verifier also reads the
+desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
+provider SDKs that should remain behind lazy agent-execution imports.
 
 From the repository root:
 

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,12 +8,13 @@ const outdir = resolve(__dirname, 'dist/main');
 
 await rm(outdir, { force: true, recursive: true });
 
-await esbuild.build({
+const result = await esbuild.build({
   entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
   splitting: true,
+  metafile: true,
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
@@ -25,3 +26,9 @@ await esbuild.build({
       `const require = __texraCreateRequire(import.meta.url);`,
   },
 });
+
+await mkdir(outdir, { recursive: true });
+await writeFile(
+  resolve(outdir, 'metafile.json'),
+  `${JSON.stringify(result.metafile, null, 2)}\n`,
+);

--- a/packages/desktop/src/main/desktopMainViewStartup.ts
+++ b/packages/desktop/src/main/desktopMainViewStartup.ts
@@ -1,4 +1,7 @@
-import { MainViewStartupController } from '@controllers/mainView/MainViewStartupController';
+import {
+  MainViewStartupController,
+  type MainViewStartupOptions,
+} from '@controllers/mainView/MainViewStartupController';
 import { computeAgentOptionsData } from '@agent/index/agentRegistry';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { buildBasicModelOptionsData } from '@model/modelOptionsBasic';
@@ -15,21 +18,25 @@ import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
 export interface DesktopMainViewStartupOptions {
   renderer: DesktopRenderer;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
+  loadOptions?: () => Promise<MainViewStartupOptions>;
   onAsyncError?: (error: unknown) => void;
 }
 
 export function createDesktopMainViewStartup({
   renderer,
   getAuthStatus,
+  loadOptions,
   onAsyncError,
 }: DesktopMainViewStartupOptions): DesktopMessageHandler {
   const reportAsyncError = createDesktopErrorReporter(onAsyncError);
   const startupController = new MainViewStartupController({
     getConfig,
-    loadOptions: async () => ({
-      agentOptions: await computeAgentOptionsData(),
-      modelOptions: buildBasicModelOptionsData(),
-    }),
+    loadOptions:
+      loadOptions ??
+      (async () => ({
+        agentOptions: await computeAgentOptionsData(),
+        modelOptions: buildBasicModelOptionsData(),
+      })),
     getAuthStatus: getAuthStatus ?? (async () => ({ authenticated: false })),
   });
 

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -683,8 +683,8 @@ export function createDesktopSettingsIpc(
       globalState.get<boolean>(GlobalStateKey.USE_OPENROUTER, false)
     ) {
       await globalState.update(GlobalStateKey.USE_OPENROUTER, false);
-      invalidateModelOptionsCache();
     }
+    invalidateModelOptionsCache();
     await Promise.all([postProfileData(), postModelSelectionData()]);
   }
 

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
+import { z } from 'zod';
+
 import { platform } from '@platform/platform';
 import {
   DEFAULT_OAUTH_PROVIDER,
@@ -22,11 +24,7 @@ import {
   initializeServerSideKeyAccess,
 } from '@auth/serverKeys';
 import type { AuthServiceLogger } from '@auth/serviceLogger';
-import {
-  FREE_TIER,
-  type OAuthProvider,
-  type UserTier,
-} from '@auth/sharedConfig';
+import { FREE_TIER, type OAuthProvider } from '@auth/sharedConfig';
 import type { AuthCallbackUriParts } from '@auth/core/authCallback';
 import { toErrorMessage } from '@common/errors/errorMessage';
 import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
@@ -42,10 +40,11 @@ const EDGE_FUNCTION_TIMEOUT_MS = 30000;
 const DESKTOP_PENDING_OAUTH_STATE_KEY = 'texra.desktop.pendingOAuthState';
 const DESKTOP_PENDING_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 
-interface DesktopPendingOAuthState {
-  state: string;
-  createdAt: number;
-}
+const DesktopPendingOAuthStateSchema = z.object({
+  state: z.string(),
+  createdAt: z.number(),
+});
+type DesktopPendingOAuthState = z.infer<typeof DesktopPendingOAuthStateSchema>;
 
 export interface DesktopAuthProfileData {
   authenticated: boolean;
@@ -82,7 +81,6 @@ export interface DesktopSupabaseAuthOptions {
   coordinator?: DesktopAuthCoordinator;
   oauthClient?: DesktopOAuthClient;
   callbackState?: DesktopAuthCallbackState;
-  initializeServerSideAccess?: boolean;
 }
 
 export interface DesktopOAuthClient {
@@ -149,29 +147,18 @@ function readPendingOAuthState(
   store: Pick<StateStore, 'get' | 'update'> | undefined,
 ): DesktopPendingOAuthState | null {
   const persisted = store?.get<unknown>(DESKTOP_PENDING_OAUTH_STATE_KEY, null);
-  if (!isPendingOAuthState(persisted)) {
+  const parsed = DesktopPendingOAuthStateSchema.safeParse(persisted);
+  if (!parsed.success) {
     return null;
   }
-  if (isPendingOAuthStateExpired(persisted)) {
+  const pendingState = parsed.data;
+  if (isPendingOAuthStateExpired(pendingState)) {
     void Promise.resolve(
       store?.update(DESKTOP_PENDING_OAUTH_STATE_KEY, null),
     ).catch(() => {});
     return null;
   }
-  return persisted;
-}
-
-function isPendingOAuthState(
-  value: unknown,
-): value is DesktopPendingOAuthState {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'state' in value &&
-    typeof value.state === 'string' &&
-    'createdAt' in value &&
-    typeof value.createdAt === 'number'
-  );
+  return pendingState;
 }
 
 function isPendingOAuthStateExpired(state: DesktopPendingOAuthState): boolean {
@@ -235,10 +222,6 @@ export function createDesktopSupabaseAuth(
     }
     void processCallbackQueue();
   });
-
-  if (options.initializeServerSideAccess ?? true) {
-    initializeDesktopServerSideKeyAccess(options.log);
-  }
 
   return {
     async signIn(provider = DEFAULT_OAUTH_PROVIDER) {
@@ -322,7 +305,7 @@ export function initializeDesktopServerSideKeyAccess(
     },
     {
       isAuthenticated: () => SupabaseClient.isAuthenticated(),
-      getUserTier: () => SupabaseClient.getUserTier() as Promise<UserTier>,
+      getUserTier: () => SupabaseClient.getUserTier(),
       getAccessToken: () => SupabaseClient.getAccessToken(),
     },
   );

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -165,7 +165,6 @@ function createWindow(options: {
     onSessionChanged: refreshDesktopAuthSurfaces,
     log: console,
     callbackState: options.authCallbackState,
-    initializeServerSideAccess: false,
   });
   setOpenBuildDisplay(previewHost.openBuildDisplay);
   const openLogsFolder = async () =>

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,7 +7,6 @@ import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
 import { getServerSideKeyService } from '@auth/serverKeys';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
-import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
@@ -231,7 +230,6 @@ function createWindow(options: {
       await getServerSideKeyService().setUseIncludedModelAccess(
         mode === 'included',
       );
-      invalidateModelOptionsCache();
     },
     selectCustomAgentDirectory: async () => {
       const result = await dialog.showOpenDialog(window, {

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -19,6 +19,7 @@ import type { DesktopFileSelection } from './desktopFileSelection.js';
 import type { DesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import type { MainViewExecuteMessage } from '@controllers/mainView/MainViewExecutionController';
 import type { MainViewAuthStatus } from '@controllers/mainView/MainViewTypes';
+import type { MainViewStartupOptions } from '@controllers/mainView/MainViewStartupController';
 import type { BrowserWindow } from 'electron';
 
 export interface DesktopMainViewIpcOptions {
@@ -30,6 +31,7 @@ export interface DesktopMainViewIpcOptions {
   progress?: DesktopProgressIpc;
   shellActions?: DesktopShellActions;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
+  loadStartupOptions?: () => Promise<MainViewStartupOptions>;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
   onAsyncError?: (error: unknown) => void;
 }
@@ -76,6 +78,7 @@ export function installDesktopMainViewIpc(
   const startup = createDesktopMainViewStartup({
     renderer: bridge,
     getAuthStatus: options.getAuthStatus,
+    loadOptions: options.loadStartupOptions,
     onAsyncError: options.onAsyncError,
   });
   messageHandlers = [

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -59,24 +59,31 @@ const codexPlatformInfoByKey = {
     binaryName: 'codex.exe',
   },
 };
-const desktopStartupForbiddenBundleMarkers = [
+const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
     patterns: [
-      '@google/genai',
-      'node_modules/.pnpm/@google+genai',
-      'google-auth-library',
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@google\+genai[^/\\]*[/\\]node_modules[/\\])?@google[/\\]genai[/\\]/,
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*google-auth-library[^/\\]*[/\\]node_modules[/\\])?google-auth-library[/\\]/,
     ],
   },
   {
     label: 'OpenAI SDK',
-    patterns: ['node_modules/.pnpm/openai@'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*openai@[^/\\]*[/\\]node_modules[/\\])?openai[/\\]/,
+    ],
   },
   {
     label: 'Anthropic SDK',
-    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@anthropic-ai\+sdk[^/\\]*[/\\]node_modules[/\\])?@anthropic-ai[/\\]sdk[/\\]/,
+    ],
   },
 ];
+const desktopStartupEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+]);
 
 async function exists(path) {
   try {
@@ -145,6 +152,22 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = normalizeMetafilePath(importPath);
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {
@@ -323,66 +346,81 @@ async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
   return bundles.sort();
 }
 
-function parseStaticRelativeImports(source) {
-  const imports = [];
-  const staticImportPattern =
-    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
-  for (const match of source.matchAll(staticImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function parseDynamicRelativeImports(source) {
-  const imports = [];
-  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
-  for (const match of source.matchAll(dynamicImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
 async function checkDesktopStartupBundles(app, failures) {
   const entryPath = 'dist/main/index.js';
+  const metafilePath = 'dist/main/metafile.json';
   if (!(await app.exists(entryPath))) return;
-
-  const pending = [entryPath];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const bundlePath = pending.shift();
-    if (!bundlePath || visited.has(bundlePath)) continue;
-    visited.add(bundlePath);
-
-    const source = await app.readText(bundlePath);
-    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
-      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+  if (!(await app.exists(metafilePath))) {
+    failures.push(
+      `Packaged desktop app is missing the esbuild metafile used to verify startup imports: ${metafilePath}`,
     );
-    if (forbidden.length > 0) {
+    return;
+  }
+
+  const metafile = await app.readJson(metafilePath);
+  const outputByPath = new Map();
+  for (const [outputPath, output] of Object.entries(metafile.outputs ?? {})) {
+    outputByPath.set(normalizeMetafilePath(outputPath), output);
+  }
+
+  const pending = [];
+  for (const [outputPath, output] of outputByPath) {
+    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
+    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+  }
+  if (pending.length === 0) {
+    failures.push(
+      `Packaged desktop startup graph is missing expected esbuild entry points: ${[
+        ...desktopStartupEntryPoints,
+      ].join(', ')}`,
+    );
+    return;
+  }
+
+  const visitedOutputs = new Set();
+  const startupInputsByForbiddenLabel = new Map();
+  while (pending.length > 0) {
+    const outputPath = pending.shift();
+    if (!outputPath || visitedOutputs.has(outputPath)) continue;
+    visitedOutputs.add(outputPath);
+
+    const output = outputByPath.get(normalizeMetafilePath(outputPath));
+    if (!output) {
       failures.push(
-        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
-          .map(({ label }) => label)
-          .join(', ')}): ${bundlePath}`,
+        `Packaged desktop startup bundle is missing from the esbuild metafile: ${outputPath}`,
       );
+      continue;
     }
 
-    const imports = parseStaticRelativeImports(source);
-    if (bundlePath === entryPath) {
-      const dynamicImports = parseDynamicRelativeImports(source);
-      if (dynamicImports.length !== 1) {
-        failures.push(
-          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
-        );
+    for (const inputPath of Object.keys(output.inputs ?? {})) {
+      const normalizedInput = normalizeMetafilePath(inputPath);
+      for (const { label, patterns } of desktopStartupForbiddenInputPackages) {
+        if (!patterns.some((pattern) => pattern.test(normalizedInput))) {
+          continue;
+        }
+        const inputPaths = startupInputsByForbiddenLabel.get(label) ?? [];
+        inputPaths.push(normalizedInput);
+        startupInputsByForbiddenLabel.set(label, inputPaths);
       }
-      imports.push(...dynamicImports);
     }
-    for (const specifier of imports) {
-      const importedPath = posix.normalize(
-        posix.join(posix.dirname(bundlePath), specifier),
+
+    for (const importedOutput of output.imports ?? []) {
+      if (importedOutput.external) continue;
+      if (importedOutput.kind !== 'import-statement') continue;
+      const importedPath = resolveMetafileImportPath(
+        outputPath,
+        importedOutput.path,
       );
-      if (await app.exists(importedPath)) {
-        pending.push(importedPath);
-      }
+      if (outputByPath.has(importedPath)) pending.push(importedPath);
     }
+  }
+
+  for (const [label, inputPaths] of startupInputsByForbiddenLabel) {
+    failures.push(
+      `Packaged desktop startup graph eagerly includes provider SDK code (${label}): ${[
+        ...new Set(inputPaths),
+      ].join(', ')}`,
+    );
   }
 }
 
@@ -633,7 +671,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
-  '- desktop startup bundles exclude provider SDKs',
+  '- desktop startup import graph excludes provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,35 +232,70 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string; stack?: string };
+  const candidate = err as { provider?: string; headers?: HeaderBag } & {
+    constructor?: { name?: string };
+    stack?: string;
+  };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
   }
 
-  const providerFromClassNames = detectProviderFromClassNames(
+  const classNameProvider = detectProviderFromClassNames(
     getErrorClassNames(err),
   );
-  if (providerFromClassNames) return providerFromClassNames;
+  if (classNameProvider) return classNameProvider;
 
-  return detectProviderFromText(candidate.stack ?? '');
+  const providerFromStack = detectProviderFromText(candidate.stack ?? '');
+  if (providerFromStack) {
+    return providerFromStack;
+  }
+
+  return detectProviderFromHeaders(candidate.headers);
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly string[],
+  classNames: readonly (string | undefined)[],
 ): string | undefined {
-  // Match SDK class-name fragments, then normalize aliases to the
-  // canonical API-provider names used by SecretManager / model handlers.
-  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
-  // (class name contains "kimi") maps to "moonshot".
-  const loweredClassNames = classNames.map((className) =>
-    className.toLowerCase(),
-  );
-  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    loweredClassNames.some((className) => className.includes(p)),
+  // Match SDK class-name fragments, then normalize aliases to the canonical
+  // API-provider names used by SecretManager / model handlers. This also covers
+  // no-response connection errors whose provider only appears on a base SDK
+  // class such as OpenAIError or AnthropicError.
+  const names = classNames
+    .filter((name): name is string => isString(name) && name.length > 0)
+    .map((name) => name.toLowerCase());
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (provider) => names.some((name) => name.includes(provider)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;
+}
+
+type HeaderBag =
+  | {
+      get?: (key: string) => string | null;
+    }
+  | Record<string, unknown>;
+type HeaderDetectedProvider = 'anthropic';
+
+function getHeaderValue(
+  headers: HeaderBag | undefined,
+  name: string,
+): string | undefined {
+  const maybeGet = isObject(headers) ? headers.get : undefined;
+  const direct =
+    typeof maybeGet === 'function' ? maybeGet.call(headers, name) : undefined;
+  if (isString(direct) && direct) return direct;
+
+  const indexed = (headers as Record<string, unknown> | undefined)?.[name];
+  return isString(indexed) && indexed ? indexed : undefined;
+}
+
+function detectProviderFromHeaders(
+  headers: HeaderBag | undefined,
+): HeaderDetectedProvider | undefined {
+  if (getHeaderValue(headers, 'request-id')) return 'anthropic';
+  return undefined;
 }
 
 function detectProviderFromText(text: string): string | undefined {
@@ -280,10 +315,12 @@ function detectRequestId(err: unknown): string | undefined {
   const candidate = err as {
     request_id?: string;
     requestId?: string;
-    headers?: { get?: (key: string) => string | null };
+    requestID?: string;
+    headers?: HeaderBag;
   };
 
-  const directId = candidate.request_id ?? candidate.requestId;
+  const directId =
+    candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
@@ -291,8 +328,8 @@ function detectRequestId(err: unknown): string | undefined {
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
   // ?? undefined converts null from headers.get() to undefined
   return (
-    candidate.headers?.get?.('request-id') ??
-    candidate.headers?.get?.('x-request-id') ??
+    getHeaderValue(candidate.headers, 'request-id') ??
+    getHeaderValue(candidate.headers, 'x-request-id') ??
     undefined
   );
 }
@@ -343,7 +380,7 @@ export function takeTail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
-/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+/** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
   return getErrorClassNames(err).includes('APIUserAbortError');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,9 +232,7 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string } & {
-    constructor?: { name?: string };
-  };
+  const candidate = err as { provider?: string };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
@@ -243,9 +241,6 @@ function detectProvider(err: unknown): string | undefined {
   const loweredClassNames = getErrorClassNames(err).map((className) =>
     className.toLowerCase(),
   );
-  if (isString(candidate.constructor?.name)) {
-    loweredClassNames.push(candidate.constructor.name.toLowerCase());
-  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,15 +240,19 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const lowered = candidate.constructor?.name?.toLowerCase();
-  if (!lowered) return undefined;
+  const loweredClassNames = getErrorClassNames(err).map((className) =>
+    className.toLowerCase(),
+  );
+  if (isString(candidate.constructor?.name)) {
+    loweredClassNames.push(candidate.constructor.name.toLowerCase());
+  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.
   // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
   // (class name contains "kimi") maps to "moonshot".
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+    loweredClassNames.some((className) => className.includes(p)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,12 +1,29 @@
 // Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+} from '@anthropic-ai/sdk';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+} from 'openai';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
+
+class KimiAPIError extends APIError {}
 
 class APIUserAbortError extends APIError {}
 
@@ -20,6 +37,123 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('new provider error shape');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('matches SDK abort errors through the prototype chain', () => {
+    expect(isUserAbort(new APIUserAbortError('aborted'))).toBe(true);
+  });
+
+  it('preserves native SDK abort detection for packaged builds', () => {
+    expect(isUserAbort(new OpenAIAPIUserAbortError())).toBe(true);
+    expect(isUserAbort(new AnthropicAPIUserAbortError())).toBe(true);
+  });
+
+  it('preserves provider context for native OpenAI HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIAuthenticationError(
+        401,
+        { message: 'invalid api key', type: 'invalid_request_error' },
+        'invalid api key',
+        new Headers({ 'x-request-id': 'req-openai' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.requestId).toBe('req-openai');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native OpenAI connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new OpenAIAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new OpenAIAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('openai');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('openai');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('preserves provider context for native Anthropic HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(
+        401,
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid api key' },
+        },
+        'invalid api key',
+        new Headers({ 'request-id': 'req-anthropic' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native Anthropic connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new AnthropicAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new AnthropicAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('anthropic');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('anthropic');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('prefers Anthropic request-id when response headers include both request id styles', () => {
+    const err = new UnknownSdkApiError('upstream auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({
+      'request-id': 'req-anthropic',
+      'x-request-id': 'req-openai-compatible',
+    });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+  });
+
+  it('does not infer OpenAI from generic x-request-id headers', () => {
+    const err = new UnknownSdkApiError(
+      'openai-compatible gateway failed',
+    ) as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-compatible' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBeUndefined();
+    expect(formatted.requestId).toBe('req-compatible');
+  });
+
+  it('prefers SDK class provider hints over OpenAI-compatible request headers', () => {
+    const err = new KimiAPIError('moonshot auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-kimi' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('moonshot');
+    expect(formatted.requestId).toBe('req-kimi');
   });
 
   it('detects OpenAI provider from Windows pnpm stack paths', () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GlobalStateKey, WorkspaceStateKey } from '@common/state/stateKeys';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
@@ -11,6 +11,12 @@ import {
 import { getGitAuthorEnv, setGitAuthorEnv } from '@utils/system/gitAuthorEnv';
 
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+const invalidateModelOptionsCache = vi.hoisted(() => vi.fn());
+
+vi.mock('@model/computeModelOptions', () => ({
+  invalidateModelOptionsCache,
+}));
 
 interface StateStore {
   get<T>(key: string, defaultValue?: T): T;
@@ -156,6 +162,7 @@ function flushAsyncWork(): Promise<void> {
 
 describe('desktop settings IPC', () => {
   afterEach(() => {
+    vi.clearAllMocks();
     setGitAuthorEnv({});
     setWorktreeSupportEnabled(false);
   });
@@ -901,6 +908,7 @@ describe('desktop settings IPC', () => {
     await flushAsyncWork();
 
     expect(persistedModes).toEqual(['personal']);
+    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
     expect(
       posted.some(
         (message) =>
@@ -952,6 +960,7 @@ describe('desktop settings IPC', () => {
 
     expect(persistedModes).toEqual(['included']);
     expect(globalState.values.get(GlobalStateKey.USE_OPENROUTER)).toBe(false);
+    expect(invalidateModelOptionsCache).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes agent and model options after desktop auth changes', async () => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -125,7 +125,6 @@ describe('desktop Supabase auth', () => {
       oauthClient,
       secrets: createSecrets(),
       openExternalUrl,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -155,7 +154,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       onSessionChanged,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -204,7 +202,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
-      initializeServerSideAccess: false,
     });
 
     router.routeUrl(
@@ -234,7 +231,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -256,7 +252,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState: persistedCallbackState,
-      initializeServerSideAccess: false,
     });
 
     await vi.waitFor(() => {
@@ -285,7 +280,6 @@ describe('desktop Supabase auth', () => {
         secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
         callbackState: createDesktopAuthCallbackState(stateStore),
-        initializeServerSideAccess: false,
       });
 
       await auth.signIn();
@@ -301,7 +295,6 @@ describe('desktop Supabase auth', () => {
         secrets: createSecrets(),
         openExternalUrl: vi.fn(async () => {}),
         callbackState: expiredCallbackState,
-        initializeServerSideAccess: false,
       });
 
       router.routeUrl(
@@ -340,7 +333,6 @@ describe('desktop Supabase auth', () => {
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
       log,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -381,7 +373,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -419,7 +410,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       log,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -466,7 +456,6 @@ describe('desktop Supabase auth', () => {
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
       callbackState,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -515,7 +504,6 @@ describe('desktop Supabase auth', () => {
       openExternalUrl: vi.fn(async () => {}),
       showErrorMessage,
       log,
-      initializeServerSideAccess: false,
     });
 
     await auth.signIn();
@@ -551,7 +539,6 @@ describe('desktop Supabase auth', () => {
       oauthClient: createOAuthClient(),
       secrets: createSecrets(),
       openExternalUrl: vi.fn(async () => {}),
-      initializeServerSideAccess: false,
     });
 
     await auth.signOut();

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -29,6 +29,10 @@ interface MainViewIpcModule {
       settings?: { handleMessage(message: { command: string }): boolean };
       progress?: { handleMessage(message: { command: string }): boolean };
       getAuthStatus?: () => Promise<{ authenticated: boolean }>;
+      loadStartupOptions?: () => Promise<{
+        agentOptions: { workflow: unknown[]; toolUse: unknown[] };
+        modelOptions: unknown[];
+      }>;
       executeAgent?: (message: unknown) => Promise<void>;
       onAsyncError?: (error: unknown) => void;
     },
@@ -398,15 +402,6 @@ describe('desktop main-view IPC', () => {
       on: vi.fn(),
       off: vi.fn(),
     };
-    vi.doMock('@agent/index/agentRegistry', () => ({
-      computeAgentOptionsData: vi.fn(async () => ({
-        workflow: [],
-        toolUse: [],
-      })),
-    }));
-    vi.doMock('@model/modelOptionsBasic', () => ({
-      buildBasicModelOptionsData: vi.fn(() => []),
-    }));
     const { ELECTRON_WEBVIEW_PUSH_CHANNEL, installDesktopMainViewIpc } =
       await loadDesktopMainViewIpcModule({ ipcMain, nativeTheme });
     const sends: Array<{ channel: string; message: unknown }> = [];
@@ -422,6 +417,13 @@ describe('desktop main-view IPC', () => {
 
     installDesktopMainViewIpc(window, {
       getAuthStatus: async () => ({ authenticated: true }),
+      loadStartupOptions: async () => ({
+        agentOptions: {
+          workflow: [],
+          toolUse: [],
+        },
+        modelOptions: [],
+      }),
     });
     rendererListener?.(
       { sender: webContents },


### PR DESCRIPTION
## Summary

- derive desktop pending OAuth state from a Zod schema at the persisted-state boundary
- remove the dead per-window `initializeServerSideAccess` option from desktop auth setup
- keep server-side key access initialization owned by the app startup path

Closes #3581.
Closes #3582.

## Validation

- `pnpm exec prettier --check packages/desktop/src/main/desktopSupabaseAuth.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts`
- `npm run test:kernel -- src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts`
- `npm run -s typecheck`
- `npm run lint`
- `npm run compile:fast`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop OAuth/session handling and server-side key initialization wiring; behavior should be unchanged but mistakes could break sign-in flow or included-access key usage.
> 
> **Overview**
> **Desktop startup is now more configurable for tests/embedding.** `createDesktopMainViewStartup`/`installDesktopMainViewIpc` accept an optional `loadStartupOptions`/`loadOptions` override instead of always computing agent/model options internally.
> 
> **Desktop auth state setup is simplified and centralized.** Persisted pending OAuth state is now validated at the storage boundary via a Zod schema (replacing a manual type guard), and the per-window `initializeServerSideAccess` option has been removed so server-side key access is initialized only from app startup (`index.ts`).
> 
> **Tests updated accordingly.** Kernel tests stop mocking agent/model option builders for startup and remove the deleted `initializeServerSideAccess` flag from desktop auth test setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6237cc9b650f78e8285c97dd2eea0e0bd68bde44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->