### PR TITLE
[codex] Verify desktop startup imports with esbuild metafile

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -381,7 +381,9 @@ Shared config:
 
 The monorepo now has a local unsigned package rehearsal for the Electron desktop app. It produces a
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
-packaged `app.asar` contains the expected runtime files.
+packaged `app.asar` contains the expected runtime files. The package verifier also reads the
+desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
+provider SDKs that should remain behind lazy agent-execution imports.
 
 From the repository root:
 

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,12 +8,13 @@ const outdir = resolve(__dirname, 'dist/main');
 
 await rm(outdir, { force: true, recursive: true });
 
-await esbuild.build({
+const result = await esbuild.build({
   entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
   splitting: true,
+  metafile: true,
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
@@ -25,3 +26,9 @@ await esbuild.build({
       `const require = __texraCreateRequire(import.meta.url);`,
   },
 });
+
+await mkdir(outdir, { recursive: true });
+await writeFile(
+  resolve(outdir, 'metafile.json'),
+  `${JSON.stringify(result.metafile, null, 2)}\n`,
+);

--- a/scripts/desktop-package-metafile-paths.d.mts
+++ b/scripts/desktop-package-metafile-paths.d.mts
@@ -1,0 +1,6 @@
+export function normalizeMetafilePath(path: string): string;
+
+export function resolveMetafileImportPath(
+  outputPath: string,
+  importPath: string,
+): string;

--- a/scripts/desktop-package-metafile-paths.mjs
+++ b/scripts/desktop-package-metafile-paths.mjs
@@ -1,0 +1,17 @@
+import { posix } from 'node:path';
+
+export function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+export function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = importPath.replaceAll('\\', '/');
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
+}

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -59,24 +59,31 @@ const codexPlatformInfoByKey = {
     binaryName: 'codex.exe',
   },
 };
-const desktopStartupForbiddenBundleMarkers = [
+const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
     patterns: [
-      '@google/genai',
-      'node_modules/.pnpm/@google+genai',
-      'google-auth-library',
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@google\+genai[^/\\]*[/\\]node_modules[/\\])?@google[/\\]genai[/\\]/,
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*google-auth-library[^/\\]*[/\\]node_modules[/\\])?google-auth-library[/\\]/,
     ],
   },
   {
     label: 'OpenAI SDK',
-    patterns: ['node_modules/.pnpm/openai@'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*openai@[^/\\]*[/\\]node_modules[/\\])?openai[/\\]/,
+    ],
   },
   {
     label: 'Anthropic SDK',
-    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@anthropic-ai\+sdk[^/\\]*[/\\]node_modules[/\\])?@anthropic-ai[/\\]sdk[/\\]/,
+    ],
   },
 ];
+const desktopStartupEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+]);
 
 async function exists(path) {
   try {
@@ -145,6 +152,22 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = normalizeMetafilePath(importPath);
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {
@@ -323,66 +346,81 @@ async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
   return bundles.sort();
 }
 
-function parseStaticRelativeImports(source) {
-  const imports = [];
-  const staticImportPattern =
-    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
-  for (const match of source.matchAll(staticImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function parseDynamicRelativeImports(source) {
-  const imports = [];
-  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
-  for (const match of source.matchAll(dynamicImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
 async function checkDesktopStartupBundles(app, failures) {
   const entryPath = 'dist/main/index.js';
+  const metafilePath = 'dist/main/metafile.json';
   if (!(await app.exists(entryPath))) return;
-
-  const pending = [entryPath];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const bundlePath = pending.shift();
-    if (!bundlePath || visited.has(bundlePath)) continue;
-    visited.add(bundlePath);
-
-    const source = await app.readText(bundlePath);
-    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
-      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+  if (!(await app.exists(metafilePath))) {
+    failures.push(
+      `Packaged desktop app is missing the esbuild metafile used to verify startup imports: ${metafilePath}`,
     );
-    if (forbidden.length > 0) {
+    return;
+  }
+
+  const metafile = await app.readJson(metafilePath);
+  const outputByPath = new Map();
+  for (const [outputPath, output] of Object.entries(metafile.outputs ?? {})) {
+    outputByPath.set(normalizeMetafilePath(outputPath), output);
+  }
+
+  const pending = [];
+  for (const [outputPath, output] of outputByPath) {
+    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
+    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+  }
+  if (pending.length === 0) {
+    failures.push(
+      `Packaged desktop startup graph is missing expected esbuild entry points: ${[
+        ...desktopStartupEntryPoints,
+      ].join(', ')}`,
+    );
+    return;
+  }
+
+  const visitedOutputs = new Set();
+  const startupInputsByForbiddenLabel = new Map();
+  while (pending.length > 0) {
+    const outputPath = pending.shift();
+    if (!outputPath || visitedOutputs.has(outputPath)) continue;
+    visitedOutputs.add(outputPath);
+
+    const output = outputByPath.get(normalizeMetafilePath(outputPath));
+    if (!output) {
       failures.push(
-        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
-          .map(({ label }) => label)
-          .join(', ')}): ${bundlePath}`,
+        `Packaged desktop startup bundle is missing from the esbuild metafile: ${outputPath}`,
       );
+      continue;
     }
 
-    const imports = parseStaticRelativeImports(source);
-    if (bundlePath === entryPath) {
-      const dynamicImports = parseDynamicRelativeImports(source);
-      if (dynamicImports.length !== 1) {
-        failures.push(
-          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
-        );
+    for (const inputPath of Object.keys(output.inputs ?? {})) {
+      const normalizedInput = normalizeMetafilePath(inputPath);
+      for (const { label, patterns } of desktopStartupForbiddenInputPackages) {
+        if (!patterns.some((pattern) => pattern.test(normalizedInput))) {
+          continue;
+        }
+        const inputPaths = startupInputsByForbiddenLabel.get(label) ?? [];
+        inputPaths.push(normalizedInput);
+        startupInputsByForbiddenLabel.set(label, inputPaths);
       }
-      imports.push(...dynamicImports);
     }
-    for (const specifier of imports) {
-      const importedPath = posix.normalize(
-        posix.join(posix.dirname(bundlePath), specifier),
+
+    for (const importedOutput of output.imports ?? []) {
+      if (importedOutput.external) continue;
+      if (importedOutput.kind !== 'import-statement') continue;
+      const importedPath = resolveMetafileImportPath(
+        outputPath,
+        importedOutput.path,
       );
-      if (await app.exists(importedPath)) {
-        pending.push(importedPath);
-      }
+      if (outputByPath.has(importedPath)) pending.push(importedPath);
     }
+  }
+
+  for (const [label, inputPaths] of startupInputsByForbiddenLabel) {
+    failures.push(
+      `Packaged desktop startup graph eagerly includes provider SDK code (${label}): ${[
+        ...new Set(inputPaths),
+      ].join(', ')}`,
+    );
   }
 }
 
@@ -633,7 +671,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
-  '- desktop startup bundles exclude provider SDKs',
+  '- desktop startup import graph excludes provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -10,6 +10,10 @@ import {
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
+import {
+  normalizeMetafilePath,
+  resolveMetafileImportPath,
+} from './desktop-package-metafile-paths.mjs';
 
 const require = createRequire(import.meta.url);
 const { extractFile, listPackage, statFile } = require('@electron/asar');
@@ -152,22 +156,6 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
-}
-
-function normalizeMetafilePath(path) {
-  return path.replaceAll('\\', '/').replace(/^\.\//, '');
-}
-
-function resolveMetafileImportPath(outputPath, importPath) {
-  const normalizedImportPath = normalizeMetafilePath(importPath);
-  if (normalizedImportPath.startsWith('.')) {
-    return normalizeMetafilePath(
-      posix.normalize(
-        posix.join(posix.dirname(outputPath), normalizedImportPath),
-      ),
-    );
-  }
-  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,35 +232,70 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string; stack?: string };
+  const candidate = err as { provider?: string; headers?: HeaderBag } & {
+    constructor?: { name?: string };
+    stack?: string;
+  };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
   }
 
-  const providerFromClassNames = detectProviderFromClassNames(
+  const classNameProvider = detectProviderFromClassNames(
     getErrorClassNames(err),
   );
-  if (providerFromClassNames) return providerFromClassNames;
+  if (classNameProvider) return classNameProvider;
 
-  return detectProviderFromText(candidate.stack ?? '');
+  const providerFromStack = detectProviderFromText(candidate.stack ?? '');
+  if (providerFromStack) {
+    return providerFromStack;
+  }
+
+  return detectProviderFromHeaders(candidate.headers);
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly string[],
+  classNames: readonly (string | undefined)[],
 ): string | undefined {
-  // Match SDK class-name fragments, then normalize aliases to the
-  // canonical API-provider names used by SecretManager / model handlers.
-  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
-  // (class name contains "kimi") maps to "moonshot".
-  const loweredClassNames = classNames.map((className) =>
-    className.toLowerCase(),
-  );
-  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    loweredClassNames.some((className) => className.includes(p)),
+  // Match SDK class-name fragments, then normalize aliases to the canonical
+  // API-provider names used by SecretManager / model handlers. This also covers
+  // no-response connection errors whose provider only appears on a base SDK
+  // class such as OpenAIError or AnthropicError.
+  const names = classNames
+    .filter((name): name is string => isString(name) && name.length > 0)
+    .map((name) => name.toLowerCase());
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (provider) => names.some((name) => name.includes(provider)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;
+}
+
+type HeaderBag =
+  | {
+      get?: (key: string) => string | null;
+    }
+  | Record<string, unknown>;
+type HeaderDetectedProvider = 'anthropic';
+
+function getHeaderValue(
+  headers: HeaderBag | undefined,
+  name: string,
+): string | undefined {
+  const maybeGet = isObject(headers) ? headers.get : undefined;
+  const direct =
+    typeof maybeGet === 'function' ? maybeGet.call(headers, name) : undefined;
+  if (isString(direct) && direct) return direct;
+
+  const indexed = (headers as Record<string, unknown> | undefined)?.[name];
+  return isString(indexed) && indexed ? indexed : undefined;
+}
+
+function detectProviderFromHeaders(
+  headers: HeaderBag | undefined,
+): HeaderDetectedProvider | undefined {
+  if (getHeaderValue(headers, 'request-id')) return 'anthropic';
+  return undefined;
 }
 
 function detectProviderFromText(text: string): string | undefined {
@@ -280,10 +315,12 @@ function detectRequestId(err: unknown): string | undefined {
   const candidate = err as {
     request_id?: string;
     requestId?: string;
-    headers?: { get?: (key: string) => string | null };
+    requestID?: string;
+    headers?: HeaderBag;
   };
 
-  const directId = candidate.request_id ?? candidate.requestId;
+  const directId =
+    candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
@@ -291,8 +328,8 @@ function detectRequestId(err: unknown): string | undefined {
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
   // ?? undefined converts null from headers.get() to undefined
   return (
-    candidate.headers?.get?.('request-id') ??
-    candidate.headers?.get?.('x-request-id') ??
+    getHeaderValue(candidate.headers, 'request-id') ??
+    getHeaderValue(candidate.headers, 'x-request-id') ??
     undefined
   );
 }
@@ -343,7 +380,7 @@ export function takeTail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
-/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+/** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
   return getErrorClassNames(err).includes('APIUserAbortError');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,9 +232,7 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string } & {
-    constructor?: { name?: string };
-  };
+  const candidate = err as { provider?: string };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
@@ -243,9 +241,6 @@ function detectProvider(err: unknown): string | undefined {
   const loweredClassNames = getErrorClassNames(err).map((className) =>
     className.toLowerCase(),
   );
-  if (isString(candidate.constructor?.name)) {
-    loweredClassNames.push(candidate.constructor.name.toLowerCase());
-  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,15 +240,19 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const lowered = candidate.constructor?.name?.toLowerCase();
-  if (!lowered) return undefined;
+  const loweredClassNames = getErrorClassNames(err).map((className) =>
+    className.toLowerCase(),
+  );
+  if (isString(candidate.constructor?.name)) {
+    loweredClassNames.push(candidate.constructor.name.toLowerCase());
+  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.
   // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
   // (class name contains "kimi") maps to "moonshot".
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+    loweredClassNames.some((className) => className.includes(p)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,12 +1,29 @@
 // Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+} from '@anthropic-ai/sdk';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+} from 'openai';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
+
+class KimiAPIError extends APIError {}
 
 class APIUserAbortError extends APIError {}
 
@@ -20,6 +37,123 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('new provider error shape');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('matches SDK abort errors through the prototype chain', () => {
+    expect(isUserAbort(new APIUserAbortError('aborted'))).toBe(true);
+  });
+
+  it('preserves native SDK abort detection for packaged builds', () => {
+    expect(isUserAbort(new OpenAIAPIUserAbortError())).toBe(true);
+    expect(isUserAbort(new AnthropicAPIUserAbortError())).toBe(true);
+  });
+
+  it('preserves provider context for native OpenAI HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIAuthenticationError(
+        401,
+        { message: 'invalid api key', type: 'invalid_request_error' },
+        'invalid api key',
+        new Headers({ 'x-request-id': 'req-openai' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.requestId).toBe('req-openai');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native OpenAI connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new OpenAIAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new OpenAIAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('openai');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('openai');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('preserves provider context for native Anthropic HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(
+        401,
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid api key' },
+        },
+        'invalid api key',
+        new Headers({ 'request-id': 'req-anthropic' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native Anthropic connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new AnthropicAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new AnthropicAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('anthropic');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('anthropic');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('prefers Anthropic request-id when response headers include both request id styles', () => {
+    const err = new UnknownSdkApiError('upstream auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({
+      'request-id': 'req-anthropic',
+      'x-request-id': 'req-openai-compatible',
+    });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+  });
+
+  it('does not infer OpenAI from generic x-request-id headers', () => {
+    const err = new UnknownSdkApiError(
+      'openai-compatible gateway failed',
+    ) as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-compatible' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBeUndefined();
+    expect(formatted.requestId).toBe('req-compatible');
+  });
+
+  it('prefers SDK class provider hints over OpenAI-compatible request headers', () => {
+    const err = new KimiAPIError('moonshot auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-kimi' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('moonshot');
+    expect(formatted.requestId).toBe('req-kimi');
   });
 
   it('detects OpenAI provider from Windows pnpm stack paths', () => {

--- a/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
@@ -1,0 +1,40 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop package verifier
+import {
+  normalizeMetafilePath,
+  resolveMetafileImportPath,
+} from '../../../scripts/desktop-package-metafile-paths.mjs';
+
+describe('desktop package verifier metafile paths', () => {
+  it('normalizes esbuild metafile keys to CWD-relative paths', () => {
+    expect(normalizeMetafilePath('./dist/main/index.js')).toBe(
+      'dist/main/index.js',
+    );
+    expect(normalizeMetafilePath('.\\dist\\main\\index.js')).toBe(
+      'dist/main/index.js',
+    );
+  });
+
+  it('resolves dot-prefixed chunk imports relative to their output', () => {
+    expect(
+      resolveMetafileImportPath('dist/main/index.js', './chunks/provider.js'),
+    ).toBe('dist/main/chunks/provider.js');
+    expect(
+      resolveMetafileImportPath(
+        'dist/main/chunks/startup.js',
+        '../shared/provider.js',
+      ),
+    ).toBe('dist/main/shared/provider.js');
+  });
+
+  it('leaves CWD-relative import paths addressable as metafile keys', () => {
+    expect(
+      resolveMetafileImportPath(
+        'dist/main/index.js',
+        'dist/main/chunks/provider.js',
+      ),
+    ).toBe('dist/main/chunks/provider.js');
+  });
+});

--- a/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
+++ b/src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts
@@ -63,14 +63,12 @@ async function loadDesktopMainViewIpcModule(electron: {
 }): Promise<MainViewIpcModule & HostBridgeModule> {
   vi.resetModules();
   vi.doMock('electron', () => electron);
-  const [mainViewIpc, hostBridge] = await Promise.all([
-    import(
-      moduleFileUrl(desktopSourcePath('main', 'mainViewIpc.ts'))
-    ) as Promise<MainViewIpcModule>,
-    import(
-      moduleFileUrl(desktopSourcePath('preload', 'hostBridge.ts'))
-    ) as Promise<HostBridgeModule>,
-  ]);
+  const hostBridge = (await import(
+    moduleFileUrl(desktopSourcePath('hostBridgeChannels.ts'))
+  )) as HostBridgeModule;
+  const mainViewIpc = (await import(
+    moduleFileUrl(desktopSourcePath('main', 'mainViewIpc.ts'))
+  )) as MainViewIpcModule;
   return { ...mainViewIpc, ...hostBridge };
 }
 


### PR DESCRIPTION
## Summary
- emit the desktop main esbuild metafile alongside packaged startup bundles
- verify provider SDK exclusion from the metafile startup graph instead of substring-scanning bundle text
- remove runtime OpenAI/Anthropic SDK imports from shared error utilities so the desktop startup graph stays clean

Closes #3518.

## Validation
- pnpm exec prettier --check src/common/errors/sdkErrorUtils.ts scripts/verify-desktop-package.mjs packages/desktop/esbuild.main.mjs docs/electron-migration-plan.md
- npm run -s typecheck
- npm run desktop:package:local
- npm run check:desktop-package
- npm run lint
- npm run compile:fast
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes desktop packaging/build output (adds `metafile.json`) and tightens the desktop package verifier, which could cause new packaging failures; also tweaks provider/error attribution logic used across runtime error formatting.
> 
> **Overview**
> **Desktop packaging now emits and consumes an esbuild metafile to validate startup imports.** The desktop main build (`packages/desktop/esbuild.main.mjs`) enables `metafile: true` and writes `dist/main/metafile.json` into build output.
> 
> **Desktop package verification switches from bundle substring scanning to import-graph analysis.** `scripts/verify-desktop-package.mjs` reads the metafile, walks startup entrypoints’ output graph, and fails if forbidden provider SDK packages appear in the startup inputs; it also adds path-normalization helpers (`scripts/desktop-package-metafile-paths.mjs`) with new unit tests.
> 
> **Provider SDK coupling is reduced in error utilities.** `sdkErrorUtils.ts` refines provider/request-id detection (class-name + header-based heuristics) to avoid requiring SDK imports in shared code, with expanded vitest coverage; docs are updated to reflect the new metafile-based verifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf91c7dfa03765630c51f01d5de9ebc256fafbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->