### PR TITLE
[codex] Wire desktop team presets

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -381,7 +381,9 @@ Shared config:
 
 The monorepo now has a local unsigned package rehearsal for the Electron desktop app. It produces a
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
-packaged `app.asar` contains the expected runtime files.
+packaged `app.asar` contains the expected runtime files. The package verifier also reads the
+desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
+provider SDKs that should remain behind lazy agent-execution imports.
 
 From the repository root:
 

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,12 +8,13 @@ const outdir = resolve(__dirname, 'dist/main');
 
 await rm(outdir, { force: true, recursive: true });
 
-await esbuild.build({
+const result = await esbuild.build({
   entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
   splitting: true,
+  metafile: true,
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
@@ -25,3 +26,9 @@ await esbuild.build({
       `const require = __texraCreateRequire(import.meta.url);`,
   },
 });
+
+await mkdir(outdir, { recursive: true });
+await writeFile(
+  resolve(outdir, 'metafile.json'),
+  `${JSON.stringify(result.metafile, null, 2)}\n`,
+);

--- a/packages/desktop/src/main/desktopSettingsIpc.ts
+++ b/packages/desktop/src/main/desktopSettingsIpc.ts
@@ -13,6 +13,7 @@ import {
   computeAgentOptionsData,
   getAgent,
   getToolUseAgents,
+  getVisibleAgents as getVisibleRegistryAgents,
   getWorkflowAgents,
   loadAgents,
   type AgentEntry,
@@ -103,6 +104,8 @@ export interface DesktopSettingsIpcOptions {
   sendStartupCatalogData?: boolean;
   loadAgents?: typeof loadAgents;
   loadAgentOptionsData?: typeof computeAgentOptionsData;
+  getAgents?: (category: AgentCategory) => AgentEntry[];
+  getVisibleAgents?: (category: AgentCategory) => AgentEntry[];
   globalState?: StateStore;
   workspaceState?: StateStore;
   config?: ConfigProvider;
@@ -198,6 +201,9 @@ export function createDesktopSettingsIpc(
   const loadAgentRegistry = options.loadAgents ?? loadAgents;
   const loadAgentOptionsData =
     options.loadAgentOptionsData ?? computeAgentOptionsData;
+  const getAgentEntries = options.getAgents ?? getAgentRegistryEntries;
+  const getVisibleAgentEntries =
+    options.getVisibleAgents ?? getVisibleRegistryAgents;
   const usesDefaultToolDashboardBuilder =
     options.buildToolDashboardItems == null;
   const buildToolDashboardItems =
@@ -227,8 +233,8 @@ export function createDesktopSettingsIpc(
     setEnabledAgentKeys: async (category, enabledKeys) => {
       await workspaceState.update(getAgentStateKey(category), enabledKeys);
     },
-    getAgents,
-    getVisibleAgents: getAgents,
+    getAgents: getAgentEntries,
+    getVisibleAgents: getVisibleAgentEntries,
     getCustomPresetsRaw: () =>
       workspaceState.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, []),
     setCustomPresets: async (presets) => {
@@ -261,7 +267,7 @@ export function createDesktopSettingsIpc(
       getEnabledAgentKeys: agentCatalogState.getEnabledAgentKeys,
       setEnabledAgentKeys: agentCatalogState.setEnabledAgentKeys,
       getAgents: (category) =>
-        getAgents(category).map((entry) => ({
+        getAgentEntries(category).map((entry) => ({
           source: entry.source,
           name: entry.name,
         })),
@@ -338,7 +344,7 @@ export function createDesktopSettingsIpc(
     });
   }
 
-  function getAgents(category: AgentCategory): AgentEntry[] {
+  function getAgentRegistryEntries(category: AgentCategory): AgentEntry[] {
     return category === 'workflow' ? getWorkflowAgents() : getToolUseAgents();
   }
 
@@ -824,12 +830,17 @@ export function createDesktopSettingsIpc(
     });
     if (!name?.trim()) return;
     await loadAgentRegistry();
-    await agentCatalogController.saveCurrentPreset(name);
+    const preset = await agentCatalogController.saveCurrentPreset(name);
     postAgentModePresets();
+    await options.showInfoMessage?.(`Saved team "${preset.name}"`);
   }
 
   async function deleteAgentModePreset(presetId: string): Promise<void> {
-    await agentCatalogController.deleteCustomPreset(presetId);
+    const deleted = await agentCatalogController.deleteCustomPreset(presetId);
+    if (!deleted) {
+      await options.showErrorMessage?.(`Unknown custom team: ${presetId}`);
+      return;
+    }
     postAgentModePresets();
   }
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -59,24 +59,31 @@ const codexPlatformInfoByKey = {
     binaryName: 'codex.exe',
   },
 };
-const desktopStartupForbiddenBundleMarkers = [
+const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
     patterns: [
-      '@google/genai',
-      'node_modules/.pnpm/@google+genai',
-      'google-auth-library',
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@google\+genai[^/\\]*[/\\]node_modules[/\\])?@google[/\\]genai[/\\]/,
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*google-auth-library[^/\\]*[/\\]node_modules[/\\])?google-auth-library[/\\]/,
     ],
   },
   {
     label: 'OpenAI SDK',
-    patterns: ['node_modules/.pnpm/openai@'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*openai@[^/\\]*[/\\]node_modules[/\\])?openai[/\\]/,
+    ],
   },
   {
     label: 'Anthropic SDK',
-    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@anthropic-ai\+sdk[^/\\]*[/\\]node_modules[/\\])?@anthropic-ai[/\\]sdk[/\\]/,
+    ],
   },
 ];
+const desktopStartupEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+]);
 
 async function exists(path) {
   try {
@@ -145,6 +152,22 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = normalizeMetafilePath(importPath);
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {
@@ -323,66 +346,81 @@ async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
   return bundles.sort();
 }
 
-function parseStaticRelativeImports(source) {
-  const imports = [];
-  const staticImportPattern =
-    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
-  for (const match of source.matchAll(staticImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function parseDynamicRelativeImports(source) {
-  const imports = [];
-  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
-  for (const match of source.matchAll(dynamicImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
 async function checkDesktopStartupBundles(app, failures) {
   const entryPath = 'dist/main/index.js';
+  const metafilePath = 'dist/main/metafile.json';
   if (!(await app.exists(entryPath))) return;
-
-  const pending = [entryPath];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const bundlePath = pending.shift();
-    if (!bundlePath || visited.has(bundlePath)) continue;
-    visited.add(bundlePath);
-
-    const source = await app.readText(bundlePath);
-    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
-      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+  if (!(await app.exists(metafilePath))) {
+    failures.push(
+      `Packaged desktop app is missing the esbuild metafile used to verify startup imports: ${metafilePath}`,
     );
-    if (forbidden.length > 0) {
+    return;
+  }
+
+  const metafile = await app.readJson(metafilePath);
+  const outputByPath = new Map();
+  for (const [outputPath, output] of Object.entries(metafile.outputs ?? {})) {
+    outputByPath.set(normalizeMetafilePath(outputPath), output);
+  }
+
+  const pending = [];
+  for (const [outputPath, output] of outputByPath) {
+    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
+    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+  }
+  if (pending.length === 0) {
+    failures.push(
+      `Packaged desktop startup graph is missing expected esbuild entry points: ${[
+        ...desktopStartupEntryPoints,
+      ].join(', ')}`,
+    );
+    return;
+  }
+
+  const visitedOutputs = new Set();
+  const startupInputsByForbiddenLabel = new Map();
+  while (pending.length > 0) {
+    const outputPath = pending.shift();
+    if (!outputPath || visitedOutputs.has(outputPath)) continue;
+    visitedOutputs.add(outputPath);
+
+    const output = outputByPath.get(normalizeMetafilePath(outputPath));
+    if (!output) {
       failures.push(
-        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
-          .map(({ label }) => label)
-          .join(', ')}): ${bundlePath}`,
+        `Packaged desktop startup bundle is missing from the esbuild metafile: ${outputPath}`,
       );
+      continue;
     }
 
-    const imports = parseStaticRelativeImports(source);
-    if (bundlePath === entryPath) {
-      const dynamicImports = parseDynamicRelativeImports(source);
-      if (dynamicImports.length !== 1) {
-        failures.push(
-          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
-        );
+    for (const inputPath of Object.keys(output.inputs ?? {})) {
+      const normalizedInput = normalizeMetafilePath(inputPath);
+      for (const { label, patterns } of desktopStartupForbiddenInputPackages) {
+        if (!patterns.some((pattern) => pattern.test(normalizedInput))) {
+          continue;
+        }
+        const inputPaths = startupInputsByForbiddenLabel.get(label) ?? [];
+        inputPaths.push(normalizedInput);
+        startupInputsByForbiddenLabel.set(label, inputPaths);
       }
-      imports.push(...dynamicImports);
     }
-    for (const specifier of imports) {
-      const importedPath = posix.normalize(
-        posix.join(posix.dirname(bundlePath), specifier),
+
+    for (const importedOutput of output.imports ?? []) {
+      if (importedOutput.external) continue;
+      if (importedOutput.kind !== 'import-statement') continue;
+      const importedPath = resolveMetafileImportPath(
+        outputPath,
+        importedOutput.path,
       );
-      if (await app.exists(importedPath)) {
-        pending.push(importedPath);
-      }
+      if (outputByPath.has(importedPath)) pending.push(importedPath);
     }
+  }
+
+  for (const [label, inputPaths] of startupInputsByForbiddenLabel) {
+    failures.push(
+      `Packaged desktop startup graph eagerly includes provider SDK code (${label}): ${[
+        ...new Set(inputPaths),
+      ].join(', ')}`,
+    );
   }
 }
 
@@ -633,7 +671,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
-  '- desktop startup bundles exclude provider SDKs',
+  '- desktop startup import graph excludes provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,35 +232,70 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string; stack?: string };
+  const candidate = err as { provider?: string; headers?: HeaderBag } & {
+    constructor?: { name?: string };
+    stack?: string;
+  };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
   }
 
-  const providerFromClassNames = detectProviderFromClassNames(
+  const classNameProvider = detectProviderFromClassNames(
     getErrorClassNames(err),
   );
-  if (providerFromClassNames) return providerFromClassNames;
+  if (classNameProvider) return classNameProvider;
 
-  return detectProviderFromText(candidate.stack ?? '');
+  const providerFromStack = detectProviderFromText(candidate.stack ?? '');
+  if (providerFromStack) {
+    return providerFromStack;
+  }
+
+  return detectProviderFromHeaders(candidate.headers);
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly string[],
+  classNames: readonly (string | undefined)[],
 ): string | undefined {
-  // Match SDK class-name fragments, then normalize aliases to the
-  // canonical API-provider names used by SecretManager / model handlers.
-  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
-  // (class name contains "kimi") maps to "moonshot".
-  const loweredClassNames = classNames.map((className) =>
-    className.toLowerCase(),
-  );
-  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    loweredClassNames.some((className) => className.includes(p)),
+  // Match SDK class-name fragments, then normalize aliases to the canonical
+  // API-provider names used by SecretManager / model handlers. This also covers
+  // no-response connection errors whose provider only appears on a base SDK
+  // class such as OpenAIError or AnthropicError.
+  const names = classNames
+    .filter((name): name is string => isString(name) && name.length > 0)
+    .map((name) => name.toLowerCase());
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (provider) => names.some((name) => name.includes(provider)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;
+}
+
+type HeaderBag =
+  | {
+      get?: (key: string) => string | null;
+    }
+  | Record<string, unknown>;
+type HeaderDetectedProvider = 'anthropic';
+
+function getHeaderValue(
+  headers: HeaderBag | undefined,
+  name: string,
+): string | undefined {
+  const maybeGet = isObject(headers) ? headers.get : undefined;
+  const direct =
+    typeof maybeGet === 'function' ? maybeGet.call(headers, name) : undefined;
+  if (isString(direct) && direct) return direct;
+
+  const indexed = (headers as Record<string, unknown> | undefined)?.[name];
+  return isString(indexed) && indexed ? indexed : undefined;
+}
+
+function detectProviderFromHeaders(
+  headers: HeaderBag | undefined,
+): HeaderDetectedProvider | undefined {
+  if (getHeaderValue(headers, 'request-id')) return 'anthropic';
+  return undefined;
 }
 
 function detectProviderFromText(text: string): string | undefined {
@@ -280,10 +315,12 @@ function detectRequestId(err: unknown): string | undefined {
   const candidate = err as {
     request_id?: string;
     requestId?: string;
-    headers?: { get?: (key: string) => string | null };
+    requestID?: string;
+    headers?: HeaderBag;
   };
 
-  const directId = candidate.request_id ?? candidate.requestId;
+  const directId =
+    candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
@@ -291,8 +328,8 @@ function detectRequestId(err: unknown): string | undefined {
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
   // ?? undefined converts null from headers.get() to undefined
   return (
-    candidate.headers?.get?.('request-id') ??
-    candidate.headers?.get?.('x-request-id') ??
+    getHeaderValue(candidate.headers, 'request-id') ??
+    getHeaderValue(candidate.headers, 'x-request-id') ??
     undefined
   );
 }
@@ -343,7 +380,7 @@ export function takeTail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
-/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+/** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
   return getErrorClassNames(err).includes('APIUserAbortError');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,9 +232,7 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string } & {
-    constructor?: { name?: string };
-  };
+  const candidate = err as { provider?: string };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
@@ -243,9 +241,6 @@ function detectProvider(err: unknown): string | undefined {
   const loweredClassNames = getErrorClassNames(err).map((className) =>
     className.toLowerCase(),
   );
-  if (isString(candidate.constructor?.name)) {
-    loweredClassNames.push(candidate.constructor.name.toLowerCase());
-  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,15 +240,19 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const lowered = candidate.constructor?.name?.toLowerCase();
-  if (!lowered) return undefined;
+  const loweredClassNames = getErrorClassNames(err).map((className) =>
+    className.toLowerCase(),
+  );
+  if (isString(candidate.constructor?.name)) {
+    loweredClassNames.push(candidate.constructor.name.toLowerCase());
+  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.
   // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
   // (class name contains "kimi") maps to "moonshot".
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+    loweredClassNames.some((className) => className.includes(p)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,12 +1,29 @@
 // Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+} from '@anthropic-ai/sdk';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+} from 'openai';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
+
+class KimiAPIError extends APIError {}
 
 class APIUserAbortError extends APIError {}
 
@@ -20,6 +37,123 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('new provider error shape');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('matches SDK abort errors through the prototype chain', () => {
+    expect(isUserAbort(new APIUserAbortError('aborted'))).toBe(true);
+  });
+
+  it('preserves native SDK abort detection for packaged builds', () => {
+    expect(isUserAbort(new OpenAIAPIUserAbortError())).toBe(true);
+    expect(isUserAbort(new AnthropicAPIUserAbortError())).toBe(true);
+  });
+
+  it('preserves provider context for native OpenAI HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIAuthenticationError(
+        401,
+        { message: 'invalid api key', type: 'invalid_request_error' },
+        'invalid api key',
+        new Headers({ 'x-request-id': 'req-openai' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.requestId).toBe('req-openai');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native OpenAI connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new OpenAIAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new OpenAIAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('openai');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('openai');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('preserves provider context for native Anthropic HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(
+        401,
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid api key' },
+        },
+        'invalid api key',
+        new Headers({ 'request-id': 'req-anthropic' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native Anthropic connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new AnthropicAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new AnthropicAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('anthropic');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('anthropic');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('prefers Anthropic request-id when response headers include both request id styles', () => {
+    const err = new UnknownSdkApiError('upstream auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({
+      'request-id': 'req-anthropic',
+      'x-request-id': 'req-openai-compatible',
+    });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+  });
+
+  it('does not infer OpenAI from generic x-request-id headers', () => {
+    const err = new UnknownSdkApiError(
+      'openai-compatible gateway failed',
+    ) as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-compatible' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBeUndefined();
+    expect(formatted.requestId).toBe('req-compatible');
+  });
+
+  it('prefers SDK class provider hints over OpenAI-compatible request headers', () => {
+    const err = new KimiAPIError('moonshot auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-kimi' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('moonshot');
+    expect(formatted.requestId).toBe('req-kimi');
   });
 
   it('detects OpenAI provider from Windows pnpm stack paths', () => {

--- a/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
@@ -42,6 +42,26 @@ interface DesktopSettingsIpcModule {
       workflow: unknown[];
       toolUse: unknown[];
     }>;
+    getAgents?: (category: 'workflow' | 'toolUse') => Array<{
+      name: string;
+      source: 'builtInWorkflow' | 'builtInToolUse' | 'custom' | 'remote';
+      category: 'workflow' | 'toolUse';
+      description?: string;
+      path?: string;
+      multiplePath?: string;
+      isMultiple?: boolean;
+      tools?: string[];
+    }>;
+    getVisibleAgents?: (category: 'workflow' | 'toolUse') => Array<{
+      name: string;
+      source: 'builtInWorkflow' | 'builtInToolUse' | 'custom' | 'remote';
+      category: 'workflow' | 'toolUse';
+      description?: string;
+      path?: string;
+      multiplePath?: string;
+      isMultiple?: boolean;
+      tools?: string[];
+    }>;
     buildToolDashboardItems?: (cachedResults?: unknown[]) => Promise<unknown[]>;
     refreshToolAvailability?: () => Promise<void>;
     getCustomAgentDirectory?: () => Promise<string>;
@@ -866,6 +886,279 @@ describe('desktop settings IPC', () => {
           MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
       ),
     ).toBe(true);
+  });
+
+  it('applies desktop team presets and refreshes settings plus launcher options', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+    const infoMessages: string[] = [];
+    const errorMessages: string[] = [];
+    let loadCount = 0;
+
+    const catalog = {
+      workflow: [
+        {
+          source: 'builtInWorkflow' as const,
+          name: 'criticize',
+          category: 'workflow' as const,
+        },
+        {
+          source: 'custom' as const,
+          name: 'generic',
+          category: 'workflow' as const,
+        },
+      ],
+      toolUse: [
+        {
+          source: 'builtInToolUse' as const,
+          name: 'orchestrator',
+          category: 'toolUse' as const,
+          tools: ['delegate'],
+        },
+        {
+          source: 'custom' as const,
+          name: 'research',
+          category: 'toolUse' as const,
+        },
+      ],
+    };
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      globalState: new MemoryStateStore(),
+      loadAgents: async () => {
+        loadCount += 1;
+      },
+      loadAgentOptionsData: async () => ({
+        workflow: [{ value: 'builtInWorkflow:criticize', label: 'criticize' }],
+        toolUse: [
+          { value: 'builtInToolUse:orchestrator', label: 'orchestrator' },
+        ],
+      }),
+      getAgents: (category) => catalog[category],
+      getVisibleAgents: (category) => catalog[category],
+      showInfoMessage: async (message) => {
+        infoMessages.push(message);
+      },
+      showErrorMessage: async (message) => {
+        errorMessages.push(message);
+      },
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+        presetId: 'physicist',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(loadCount).toBeGreaterThanOrEqual(1);
+    expect(workspaceState.values.get(WorkspaceStateKey.ENABLED_AGENTS)).toEqual(
+      ['builtInWorkflow:criticize', 'custom:generic'],
+    );
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toEqual(['builtInToolUse:orchestrator', 'custom:research']);
+    expect(errorMessages).toEqual([]);
+    expect(infoMessages).toEqual(['Applied "Physicist" team']);
+
+    expect(
+      posted.find(
+        (message) =>
+          (message as { command?: string }).command ===
+          SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+      ),
+    ).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_SELECTION,
+      workflow: expect.arrayContaining([
+        expect.objectContaining({ name: 'criticize', enabled: true }),
+        expect.objectContaining({ name: 'generic', enabled: true }),
+      ]),
+      toolUse: expect.arrayContaining([
+        expect.objectContaining({ name: 'orchestrator', enabled: true }),
+        expect.objectContaining({ name: 'research', enabled: true }),
+      ]),
+    });
+    expect(
+      posted.find(
+        (message) =>
+          (message as { command?: string }).command ===
+          MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      ),
+    ).toMatchObject({
+      command: MAIN_VIEW_COMMANDS.SET_AGENT_OPTIONS,
+      optionsData: {
+        workflow: [
+          expect.objectContaining({ value: 'builtInWorkflow:criticize' }),
+        ],
+        toolUse: [
+          expect.objectContaining({ value: 'builtInToolUse:orchestrator' }),
+        ],
+      },
+    });
+  });
+
+  it('saves desktop team presets from currently visible agents', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+    const infoMessages: string[] = [];
+    const catalog = {
+      workflow: [
+        {
+          source: 'builtInWorkflow' as const,
+          name: 'correct',
+          category: 'workflow' as const,
+        },
+        {
+          source: 'builtInWorkflow' as const,
+          name: 'polish',
+          category: 'workflow' as const,
+        },
+      ],
+      toolUse: [
+        {
+          source: 'builtInToolUse' as const,
+          name: 'review',
+          category: 'toolUse' as const,
+        },
+        {
+          source: 'builtInToolUse' as const,
+          name: 'latexFixer',
+          category: 'toolUse' as const,
+        },
+      ],
+    };
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      globalState: new MemoryStateStore(),
+      loadAgents: async () => undefined,
+      getAgents: (category) => catalog[category],
+      getVisibleAgents: (category) =>
+        category === 'workflow' ? [catalog.workflow[0]] : [catalog.toolUse[0]],
+      promptText: async () => '  Paper Team  ',
+      showInfoMessage: async (message) => {
+        infoMessages.push(message);
+      },
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.SAVE_AGENT_MODE_PRESET,
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+    ).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(/^custom-/),
+        name: 'Paper Team',
+        workflowAgents: ['correct'],
+        toolUseAgents: ['review'],
+      }),
+    ]);
+    expect(infoMessages).toEqual(['Saved team "Paper Team"']);
+    expect(posted.at(-1)).toMatchObject({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: [
+        expect.objectContaining({
+          name: 'Paper Team',
+          workflowAgents: ['correct'],
+          toolUseAgents: ['review'],
+        }),
+      ],
+    });
+  });
+
+  it('deletes desktop custom team presets and reports unknown team ids', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const posted: unknown[] = [];
+    const errorMessages: string[] = [];
+    workspaceState.values.set(WorkspaceStateKey.CUSTOM_AGENT_PRESETS, [
+      {
+        id: 'custom-team',
+        name: 'Custom Team',
+        description: 'test',
+        icon: 'codicon-bookmark',
+        workflowAgents: ['correct'],
+        toolUseAgents: ['review'],
+      },
+    ]);
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      globalState: new MemoryStateStore(),
+      showErrorMessage: async (message) => {
+        errorMessages.push(message);
+      },
+      postToRenderer: (message) => posted.push(message),
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
+        presetId: 'custom-team',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(
+      workspaceState.values.get(WorkspaceStateKey.CUSTOM_AGENT_PRESETS),
+    ).toEqual([]);
+    expect(posted.at(-1)).toEqual({
+      command: SETTINGS_VIEW_COMMANDS.UPDATE_AGENT_MODE_PRESETS,
+      customPresets: [],
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.DELETE_AGENT_MODE_PRESET,
+        presetId: 'missing-team',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(errorMessages).toEqual(['Unknown custom team: missing-team']);
+  });
+
+  it('surfaces a visible desktop error for unknown team presets', async () => {
+    const { createDesktopSettingsIpc } = await loadDesktopSettingsIpc();
+    const workspaceState = new MemoryStateStore();
+    const errorMessages: string[] = [];
+
+    const settings = createDesktopSettingsIpc({
+      workspaceState,
+      globalState: new MemoryStateStore(),
+      loadAgents: async () => undefined,
+      showErrorMessage: async (message) => {
+        errorMessages.push(message);
+      },
+      postToRenderer: () => {},
+    });
+
+    expect(
+      settings.handleMessage({
+        command: SETTINGS_VIEW_COMMANDS.APPLY_AGENT_MODE_PRESET,
+        presetId: 'missing-team',
+      }),
+    ).toBe(true);
+    await flushAsyncWork();
+
+    expect(errorMessages).toEqual(['Unknown team: missing-team']);
+    expect(workspaceState.values.has(WorkspaceStateKey.ENABLED_AGENTS)).toBe(
+      false,
+    );
+    expect(
+      workspaceState.values.has(WorkspaceStateKey.ENABLED_TOOL_USE_AGENTS),
+    ).toBe(false);
   });
 
   it('persists desktop API access mode changes before refreshing settings data', async () => {


### PR DESCRIPTION
## Summary

Fixes #3564.

- Wire desktop Settings team preset actions through the same agent catalog controller paths used by the extension settings view.
- Save desktop custom teams from the currently visible/enabled agents instead of the full catalog.
- Refresh Settings agent selection and launcher agent options after applying a team, and surface visible desktop errors for unknown team IDs.
- Add focused desktop IPC regression coverage for applying, saving, deleting, and rejecting unknown team presets.

## Stack

- Stacked on #3596 / codex/desktop-package-metafile-verifier for the shared SDK provider attribution and desktop package verifier changes.
- This PR now carries only the desktop team preset IPC implementation and tests.

## Validation

- npm run test:kernel -- src/test-kernel/desktop/DesktopSettingsIpc.vitest.mts
- npm run typecheck
- npm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop settings IPC behavior and shared provider error formatting, plus adds stricter desktop packaging verification based on esbuild metafiles; regressions could affect desktop UX and release checks.
> 
> **Overview**
> Wires desktop **team preset** actions to the shared `SettingsAgentCatalogController`, including saving presets from *currently visible* agents, refreshing both Settings selection and launcher agent options after applying, and showing user-visible errors for unknown preset IDs.
> 
> Strengthens desktop packaging checks by emitting an esbuild `metafile.json` for the desktop main build and updating `verify-desktop-package.mjs` to validate the **startup import graph** (via the metafile) does not eagerly include provider SDK dependencies.
> 
> Improves `sdkErrorUtils` provider/request-id inference (prototype-chain class name detection, header bag support, Anthropic header-based provider hinting) and adds targeted kernel tests for both desktop preset flows and SDK error attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b740df0b7557f7c4f789a142b81d39cd0f1c42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->