### PR TITLE
[codex] Wire desktop workflow file actions

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -1,10 +1,21 @@
+import { access, readFile, writeFile } from 'node:fs/promises';
 import path, { basename } from 'node:path';
 
 import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
+import {
+  emitAcceptedWorkspaceFile,
+  getAcceptedFileTarget,
+  ProgressWorkflowFileActionsController,
+} from '@controllers/progressView/ProgressWorkflowFileActionsController';
+import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
+import { tryPlatform } from '@platform/platform';
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
+import { getWorkspaceProvider } from '@agent/core/workspace';
+import { executeMergeAgent } from '@agent/runtime/executeAgent';
+import { getHelperModelName } from '@agent/runtime/helperModel';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
@@ -18,9 +29,18 @@ import { setRunStorageService } from '@agent/runtime/RunStorageService';
 import { getInterruptible } from '@agent/toolUse/ToolUseAgentRegistry';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import {
+  getFileListConfig,
+  loadFileListSettings,
+  type ListableFileType,
+} from '@common/files/fileListingRules';
+import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { DiffViewHost } from '@hosts/diffViewHost';
 import type { ExternalOpener } from '@hosts/externalOpener';
+import { LaTeXdiffService } from '@latex/latexdiff';
+import { DEFAULT_MATH_MARKUP } from '@latex/latexdiff/mathMarkup';
 import { AgentLogger } from '@logger/AgentLogger';
 import { StreamLogStore } from '@logger/StreamLogStore';
 import {
@@ -29,6 +49,7 @@ import {
   type AgentCategory,
   type AgentCategoryFilter,
   type ConversationProgress,
+  type OutputFileInfo,
   type ProgressViewInboundMessage,
   type ProgressViewOutboundMessage,
   type StreamMetadata,
@@ -49,6 +70,7 @@ import {
   pathToLocation,
   type FileLocation,
 } from '@utils/files';
+import { getConfig } from '@utils/config/configUtils';
 
 import { DESKTOP_SHELL_COMMANDS } from '../desktopShellMessages.js';
 
@@ -57,7 +79,10 @@ export interface DesktopAgentExecutionOptions {
   opener?: Pick<ExternalOpener, 'openPath'> & {
     openBuildDisplay?: BuildDisplayFn;
   };
+  diff?: Pick<DiffViewHost, 'openDiff'>;
+  confirmAcceptFile?: (message: string) => Promise<boolean>;
   showErrorMessage?: (message: string) => Promise<void> | void;
+  showInfoMessage?: (message: string) => Promise<void> | void;
 }
 
 export interface DesktopAgentExecution {
@@ -67,6 +92,7 @@ export interface DesktopAgentExecution {
 }
 
 type TaskState = ProgressEventPayloads['setTaskState']['taskState'];
+type OutputFilesByRound = Map<number, OutputFileInfo[]>;
 
 type StreamBadgeSnapshot = {
   activeSubagents: ActiveChildInfo[];
@@ -79,7 +105,10 @@ export interface DesktopProgressBridgeOptions {
   detachSubagentsOnStop?: boolean;
   openPath?: (filePath: string) => Promise<void>;
   openBuildDisplay?: BuildDisplayFn;
-  showMessage?: (message: string) => Promise<void>;
+  openDiff?: DiffViewHost['openDiff'];
+  confirmAcceptFile?: (message: string) => Promise<boolean>;
+  showInfoMessage?: (message: string) => Promise<void>;
+  showErrorMessage?: (message: string) => Promise<void>;
 }
 
 function toFileLocation(filePath: string): FileLocation {
@@ -90,8 +119,10 @@ function toFileLocation(filePath: string): FileLocation {
 
 export class DesktopProgressBridge {
   private readonly streamLogs = new StreamLogStore();
+  private readonly workflowFileActions: ProgressWorkflowFileActionsController;
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly taskStates = new Map<StreamTabId, TaskState>();
+  private readonly outputFiles = new Map<StreamTabId, OutputFilesByRound>();
   private readonly statuses = new Map<StreamTabId, StreamStatus>();
   private readonly categories = new Map<StreamTabId, AgentCategory>();
   private readonly executionIds = new Map<StreamTabId, string>();
@@ -121,12 +152,40 @@ export class DesktopProgressBridge {
     this.runtimeHost = {
       emit: (event, payload) => this.handleProgressEvent(event, payload),
     };
+    this.workflowFileActions = new ProgressWorkflowFileActionsController({
+      state: {
+        getActiveStream: () => this.activeStream,
+        getExecutionId: (stream) => this.executionIds.get(stream),
+        getOutputFiles: (stream) => new Map(this.outputFiles.get(stream) ?? []),
+      },
+      host: {
+        compareFiles: (baseFile, editedFile) =>
+          this.compareFiles(baseFile, editedFile),
+        acceptEditedFile: (baseFile, editedFile) =>
+          this.acceptEditedFile(baseFile, editedFile),
+        mergeFile: (baseFile, editedFile) =>
+          executeMergeAgent(getHelperModelName(), baseFile, editedFile),
+        latexdiffFile: (baseFile, editedFile) =>
+          this.runLatexdiffFile(baseFile, editedFile),
+        openDirectory: async (directory) => {
+          await this.options.openPath?.(directory);
+        },
+        openLabel: (label) => this.findAndOpenLabel(label),
+        readFile: (file) => readFile(file, 'utf8'),
+        showInfo: (message) => this.showInfoMessage(message),
+        showError: (message) => this.showErrorMessage(message),
+      },
+      sendFollowUp: async (stream, text) => {
+        await this.sendFollowUp(stream, text);
+      },
+    });
   }
 
   dispose(): void {
     this.unsubscribe();
     this.cursors.clear();
     this.taskStates.clear();
+    this.outputFiles.clear();
     this.statuses.clear();
     this.categories.clear();
     this.executionIds.clear();
@@ -135,6 +194,7 @@ export class DesktopProgressBridge {
     this.creationTimestamps.clear();
     this.conversationProgress.clear();
     this.streamBadges.clear();
+    this.workflowFileActions.clearAllBackups();
   }
 
   private send(message: ProgressViewOutboundMessage): void {
@@ -385,6 +445,11 @@ export class DesktopProgressBridge {
       }
       case 'addOutputFiles': {
         const data = payload as ProgressEventPayloads['addOutputFiles'];
+        const existing = this.outputFiles.get(data.streamId) ?? new Map();
+        for (const [round, files] of Object.entries(data.filesByRound)) {
+          existing.set(Number(round), files);
+        }
+        this.outputFiles.set(data.streamId, existing);
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_FILES,
           stream: data.streamId,
@@ -649,6 +714,7 @@ export class DesktopProgressBridge {
 
     await this.streamLogs.delete(streamId);
     this.taskStates.delete(streamId);
+    this.outputFiles.delete(streamId);
     this.statuses.delete(streamId);
     this.categories.delete(streamId);
     this.executionIds.delete(streamId);
@@ -657,6 +723,7 @@ export class DesktopProgressBridge {
     this.creationTimestamps.delete(streamId);
     this.conversationProgress.delete(streamId);
     this.streamBadges.delete(streamId);
+    this.workflowFileActions.clearStreamBackups(streamId);
     this.cursors.delete(streamId);
 
     const shouldSelectFallback = this.activeStream === streamId;
@@ -687,6 +754,7 @@ export class DesktopProgressBridge {
     await this.streamLogs.clear();
     this.cursors.clear();
     this.taskStates.clear();
+    this.outputFiles.clear();
     this.statuses.clear();
     this.categories.clear();
     this.executionIds.clear();
@@ -695,6 +763,7 @@ export class DesktopProgressBridge {
     this.creationTimestamps.clear();
     this.conversationProgress.clear();
     this.streamBadges.clear();
+    this.workflowFileActions.clearAllBackups();
     this.activeStream = '';
     this.send({ command: PROGRESS_VIEW_COMMANDS.DELETE_ALL });
     this.syncStreams();
@@ -738,7 +807,7 @@ export class DesktopProgressBridge {
       return;
     }
 
-    await this.options.showMessage?.(
+    await this.showInfoMessage(
       'No active session. Start a new agent task to continue.',
     );
   }
@@ -753,6 +822,38 @@ export class DesktopProgressBridge {
       return;
     }
     await this.openFile(filePath);
+  }
+
+  async openTaskStorage(streamId: StreamTabId): Promise<void> {
+    await this.workflowFileActions.openTaskStorage(streamId);
+  }
+
+  async compareOriginal(file: string, base?: string): Promise<void> {
+    await this.workflowFileActions.compareOriginal(file, base);
+  }
+
+  async comparePrevious(
+    file: string,
+    base?: string,
+    previous?: string,
+  ): Promise<void> {
+    await this.workflowFileActions.comparePrevious(file, base, previous);
+  }
+
+  async acceptFile(file: string, base?: string): Promise<void> {
+    await this.workflowFileActions.acceptFile(file, base);
+  }
+
+  async mergeFile(file: string, base?: string): Promise<void> {
+    await this.workflowFileActions.mergeFile(file, base);
+  }
+
+  async latexdiffFile(file: string, base?: string): Promise<void> {
+    await this.workflowFileActions.latexdiffFile(file, base);
+  }
+
+  async openLabel(label: string): Promise<void> {
+    await this.workflowFileActions.openLabel(label);
   }
 
   async handleBashApprovalAction(
@@ -828,6 +929,149 @@ export class DesktopProgressBridge {
       },
     });
   }
+
+  private async compareFiles(
+    baseFile: string,
+    editedFile: string,
+  ): Promise<void> {
+    if (!this.options.openDiff) {
+      await this.showErrorMessage(
+        'Desktop file comparison is not available in this host yet.',
+      );
+      return;
+    }
+
+    await this.options.openDiff(
+      { filePath: baseFile },
+      { filePath: editedFile },
+      `Compare: ${path.basename(editedFile)} <-> ${path.basename(baseFile)}`,
+    );
+  }
+
+  private async acceptEditedFile(
+    baseFile: string,
+    editedFile: string,
+  ): Promise<void> {
+    const baseLocation = pathToLocation(baseFile);
+    const editedLocation = pathToLocation(editedFile);
+    const { targetLocation, targetFileName, isNewFile } = getAcceptedFileTarget(
+      baseLocation,
+      editedFile,
+    );
+    const targetExists =
+      isNewFile && (await fileExists(targetLocation.absolutePath));
+    const action = targetExists
+      ? 'overwrite existing'
+      : isNewFile
+        ? 'create'
+        : 'overwrite';
+    const extensionNote = isNewFile
+      ? `Extensions differ (${path.extname(baseFile).toLowerCase()} vs ${path.extname(editedFile).toLowerCase()}). `
+      : '';
+    const confirmMessage = `${extensionNote}This will ${action} '${targetFileName}' with content from '${path.basename(editedFile)}'. Are you sure?`;
+
+    if (this.options.confirmAcceptFile) {
+      const confirmed = await this.options.confirmAcceptFile(confirmMessage);
+      if (!confirmed) return;
+    }
+
+    const editedContent = await readFile(editedLocation.absolutePath, 'utf8');
+    await writeFile(targetLocation.absolutePath, editedContent, 'utf8');
+    emitAcceptedWorkspaceFile(targetLocation);
+
+    const operation = isNewFile && !targetExists ? 'created' : 'replaced';
+    await this.showInfoMessage(
+      `Successfully ${operation} '${targetFileName}' with content from '${path.basename(editedFile)}'`,
+    );
+  }
+
+  private async runLatexdiffFile(
+    baseFile: string,
+    editedFile: string,
+  ): Promise<void> {
+    const service = new LaTeXdiffService('DesktopProgressBridge');
+    const result = await service.runDiff(
+      pathToLocation(baseFile),
+      pathToLocation(editedFile),
+      '_diff',
+      false,
+      DEFAULT_MATH_MARKUP,
+    );
+
+    if (!result.success || !result.diffFileName) {
+      await this.showErrorMessage(
+        result.message ?? 'Failed to generate diff file.',
+      );
+      return;
+    }
+
+    const diffFilePath = path.join(path.dirname(baseFile), result.diffFileName);
+    if (this.options.openBuildDisplay) {
+      await this.options.openBuildDisplay(createExternalLocation(diffFilePath));
+      return;
+    }
+    await this.options.openPath?.(diffFilePath);
+  }
+
+  private async findAndOpenLabel(label: string): Promise<boolean> {
+    const workspacePath = getWorkspaceProvider().getWorkspacePath();
+    if (!workspacePath) return false;
+
+    const escape = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
+    const candidates = new Set([
+      ...(await this.listWorkspaceFiles('input')),
+      ...(await this.listWorkspaceFiles('reference')),
+    ]);
+
+    for (const file of candidates) {
+      const filePath = path.isAbsolute(file)
+        ? file
+        : path.join(workspacePath, file);
+      try {
+        const content = await readFile(filePath, 'utf8');
+        if (pattern.test(content)) {
+          await this.options.openPath?.(filePath);
+          return true;
+        }
+      } catch {
+        // Ignore unreadable candidates and continue scanning.
+      }
+    }
+
+    return false;
+  }
+
+  private async listWorkspaceFiles(
+    fileType: ListableFileType,
+  ): Promise<string[]> {
+    const workspacePath = getWorkspaceProvider().getWorkspacePath();
+    const config = getFileListConfig(fileType, loadFileListSettings(getConfig));
+    if (!workspacePath || !config) return [];
+    return listWorkspaceFiles({
+      root: workspacePath,
+      config,
+      readDirectory: (directory) =>
+        (tryPlatform()?.fs ?? nodeFilesystem).readDirectory(directory),
+    });
+  }
+
+  private async showInfoMessage(message: string): Promise<void> {
+    await this.options.showInfoMessage?.(message);
+  }
+
+  private async showErrorMessage(message: string): Promise<void> {
+    await this.options.showErrorMessage?.(message);
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function createDesktopAgentExecution(
@@ -836,7 +1080,10 @@ export function createDesktopAgentExecution(
   const progress = new DesktopProgressBridge(options.postToRenderer, {
     openPath: options.opener?.openPath,
     openBuildDisplay: options.opener?.openBuildDisplay,
-    showMessage: async (message) => options.showErrorMessage?.(message),
+    openDiff: options.diff?.openDiff,
+    confirmAcceptFile: options.confirmAcceptFile,
+    showInfoMessage: async (message) => options.showInfoMessage?.(message),
+    showErrorMessage: async (message) => options.showErrorMessage?.(message),
   });
 
   return {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -115,6 +115,7 @@ function toFileLocation(filePath: string): FileLocation {
 
 export class DesktopProgressBridge {
   private readonly streamLogs = new StreamLogStore();
+  private readonly logger = new AgentLogger('DesktopProgressBridge');
   private readonly workflowFileActions: ProgressWorkflowFileActionsController;
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly taskStates = new Map<StreamTabId, TaskState>();
@@ -170,6 +171,11 @@ export class DesktopProgressBridge {
         readFile: (file) => readFile(file, 'utf8'),
         showInfo: (message) => this.showInfoMessage(message),
         showError: (message) => this.showErrorMessage(message),
+        logError: (message, error) => {
+          this.logger.error(message, {
+            data: error instanceof Error ? error : { error },
+          });
+        },
       },
       sendFollowUp: async (stream, text) => {
         await this.sendFollowUp(stream, text);
@@ -963,7 +969,7 @@ export class DesktopProgressBridge {
     const editedLocation = pathToLocation(editedFile);
     const { targetLocation, targetFileName, isNewFile } = getAcceptedFileTarget(
       baseLocation,
-      editedFile,
+      editedLocation.absolutePath,
     );
     const targetExists =
       isNewFile && (await fileExists(targetLocation.absolutePath));

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -5,11 +5,8 @@ import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
-import {
-  emitAcceptedWorkspaceFile,
-  getAcceptedFileTarget,
-  ProgressWorkflowFileActionsController,
-} from '@controllers/progressView/ProgressWorkflowFileActionsController';
+import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
+import { emitAcceptedWorkspaceFile } from '@controllers/progressView/workflowFileActionsEvents';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { tryPlatform } from '@platform/platform';
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
@@ -39,6 +36,7 @@ import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { DiffViewHost } from '@hosts/diffViewHost';
 import type { ExternalOpener } from '@hosts/externalOpener';
+import { getAcceptedFileTarget } from '@latex/acceptedFileTarget';
 import { LaTeXdiffService } from '@latex/latexdiff';
 import { DEFAULT_MATH_MARKUP } from '@latex/latexdiff/mathMarkup';
 import { AgentLogger } from '@logger/AgentLogger';

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -949,7 +949,7 @@ export class DesktopProgressBridge {
   private async acceptEditedFile(
     baseFile: string,
     editedFile: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const baseLocation = pathToLocation(baseFile);
     const editedLocation = pathToLocation(editedFile);
     const { targetLocation, targetFileName, isNewFile } = getAcceptedFileTarget(
@@ -970,7 +970,7 @@ export class DesktopProgressBridge {
 
     if (this.options.confirmAcceptFile) {
       const confirmed = await this.options.confirmAcceptFile(confirmMessage);
-      if (!confirmed) return;
+      if (!confirmed) return false;
     }
 
     const editedContent = await readFile(editedLocation.absolutePath, 'utf8');
@@ -981,6 +981,7 @@ export class DesktopProgressBridge {
     await this.showInfoMessage(
       `Successfully ${operation} '${targetFileName}' with content from '${path.basename(editedFile)}'`,
     );
+    return true;
   }
 
   private async runLatexdiffFile(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -101,7 +101,7 @@ type StreamBadgeSnapshot = {
 
 export interface DesktopProgressBridgeOptions {
   detachSubagentsOnStop?: boolean;
-  openPath?: (filePath: string) => Promise<void>;
+  openPath?: (filePath: string, line?: number) => Promise<void>;
   openBuildDisplay?: BuildDisplayFn;
   openDiff?: DiffViewHost['openDiff'];
   confirmAcceptFile?: (message: string) => Promise<boolean>;
@@ -810,8 +810,8 @@ export class DesktopProgressBridge {
     );
   }
 
-  async openFile(filePath: string): Promise<void> {
-    await this.options.openPath?.(filePath);
+  async openFile(filePath: string, line?: number): Promise<void> {
+    await this.options.openPath?.(filePath, line);
   }
 
   async openFileCompile(filePath: string): Promise<void> {

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -11,8 +11,6 @@ import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
 import { tryPlatform } from '@platform/platform';
 import type { ValidatedExecutionRequest } from '@agent/core/executionRequests';
 import { getWorkspaceProvider } from '@agent/core/workspace';
-import { executeMergeAgent } from '@agent/runtime/executeAgent';
-import { getHelperModelName } from '@agent/runtime/helperModel';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
@@ -162,7 +160,7 @@ export class DesktopProgressBridge {
         acceptEditedFile: (baseFile, editedFile) =>
           this.acceptEditedFile(baseFile, editedFile),
         mergeFile: (baseFile, editedFile) =>
-          executeMergeAgent(getHelperModelName(), baseFile, editedFile),
+          this.runMergeFile(baseFile, editedFile),
         latexdiffFile: (baseFile, editedFile) =>
           this.runLatexdiffFile(baseFile, editedFile),
         openDirectory: async (directory) => {
@@ -944,6 +942,17 @@ export class DesktopProgressBridge {
       { filePath: editedFile },
       `Compare: ${path.basename(editedFile)} <-> ${path.basename(baseFile)}`,
     );
+  }
+
+  private async runMergeFile(
+    baseFile: string,
+    editedFile: string,
+  ): Promise<void> {
+    const [{ executeMergeAgent }, { getHelperModelName }] = await Promise.all([
+      import('@agent/runtime/executeAgent'),
+      import('@agent/runtime/helperModel'),
+    ]);
+    await executeMergeAgent(getHelperModelName(), baseFile, editedFile);
   }
 
   private async acceptEditedFile(

--- a/packages/desktop/src/main/desktopDiffHost.ts
+++ b/packages/desktop/src/main/desktopDiffHost.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  type DiffSession,
+  type DiffSource,
+  type DiffViewHost,
+} from '@hosts/diffViewHost';
+import { computeUserPatch } from '@tools/approval/toolEditApproval';
+
+export interface DesktopDiffHostOptions {
+  openPath(filePath: string): Promise<void>;
+}
+
+export function createDesktopDiffHost(
+  options: DesktopDiffHostOptions,
+): Pick<DiffViewHost, 'openDiff'> {
+  async function openDiff(
+    original: DiffSource,
+    proposed: DiffSource,
+    title: string,
+  ): Promise<DiffSession> {
+    const [originalContent, proposedContent] = await Promise.all([
+      readFile(original.filePath, 'utf8'),
+      readFile(proposed.filePath, 'utf8'),
+    ]);
+    const patch =
+      computeUserPatch(originalContent, proposedContent) ??
+      `No textual changes for ${path.basename(proposed.filePath)}.\n`;
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-desktop-diff-'));
+    const diffPath = path.join(tempDir, `${randomUUID()}.diff`);
+
+    await writeFile(diffPath, patch, 'utf8');
+    await options.openPath(diffPath);
+
+    return { original, proposed, title };
+  }
+
+  return { openDiff };
+}

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -98,6 +98,44 @@ export function createDesktopProgressIpc(
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE:
           runAsync(options.progress.openFileCompile(result.data.file));
           return true;
+        case PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE:
+          runAsync(options.progress.openTaskStorage(result.data.stream));
+          return true;
+        case PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL:
+          runAsync(
+            options.progress.compareOriginal(
+              result.data.file,
+              result.data.base,
+            ),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS:
+          runAsync(
+            options.progress.comparePrevious(
+              result.data.file,
+              result.data.base,
+              result.data.prev,
+            ),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.ACCEPT_FILE:
+          runAsync(
+            options.progress.acceptFile(result.data.file, result.data.base),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.MERGE_FILE:
+          runAsync(
+            options.progress.mergeFile(result.data.file, result.data.base),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE:
+          runAsync(
+            options.progress.latexdiffFile(result.data.file, result.data.base),
+          );
+          return true;
+        case PROGRESS_VIEW_COMMANDS.OPEN_LABEL:
+          runAsync(options.progress.openLabel(result.data.label));
+          return true;
         default:
           if (passThroughCommands.has(result.data.command)) return false;
           onUnsupportedCommand(result.data);

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -93,7 +93,9 @@ export function createDesktopProgressIpc(
           onUnsupportedCommand(result.data);
           return true;
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE:
-          runAsync(options.progress.openFile(result.data.file));
+          runAsync(
+            options.progress.openFile(result.data.file, result.data.line),
+          );
           return true;
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE:
           runAsync(options.progress.openFileCompile(result.data.file));

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -192,6 +192,19 @@ function createWindow(options: {
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     opener: previewHost,
+    confirmAcceptFile: async (message) => {
+      const result = await dialog.showMessageBox(window, {
+        type: 'warning',
+        message,
+        buttons: ['Yes', 'Cancel'],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      return result.response === 0;
+    },
+    showInfoMessage: async (message) => {
+      await dialog.showMessageBox(window, { type: 'info', message });
+    },
     showErrorMessage,
   });
   const fileSelection = createDesktopFileSelection({

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import { setOpenBuildDisplay } from '@tools/approval/latexPreview';
 import { createDesktopAgentExecution } from './desktopAgentExecution.js';
+import { createDesktopDiffHost } from './desktopDiffHost.js';
 import { createDesktopFileSelection } from './desktopFileSelection.js';
 import { createDesktopPreviewHost } from './desktopPreviewHost.js';
 import { installDesktopProtocolCallbackLifecycle } from './desktopProtocolCallbacks.js';
@@ -192,6 +193,9 @@ function createWindow(options: {
   const agentExecution = createDesktopAgentExecution({
     postToRenderer: (message) => ipcRef.current?.postToRenderer(message),
     opener: previewHost,
+    diff: createDesktopDiffHost({
+      openPath: previewHost.openPath,
+    }),
     confirmAcceptFile: async (message) => {
       const result = await dialog.showMessageBox(window, {
         type: 'warning',

--- a/packages/desktop/tsconfig.paths.json
+++ b/packages/desktop/tsconfig.paths.json
@@ -30,6 +30,8 @@
       "@auth/*": ["src/auth/*"],
       "@platform": ["src/platform"],
       "@platform/*": ["src/platform/*"],
+      "node-pandoc": ["src/types/node-pandoc.d.ts"],
+      "turndown-plugin-gfm": ["src/types/turndown-plugin-gfm.d.ts"],
       "@openrouter/sdk": ["node_modules/@openrouter/sdk/esm/index.d.ts"],
       "@openrouter/sdk/models": [
         "node_modules/@openrouter/sdk/esm/models/index.d.ts"

--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -22,6 +22,10 @@ export const openFileCommands = {
   openLabel: 'texra.openLabel',
 };
 
+export interface OpenLabelOptions {
+  notifyNotFound?: boolean;
+}
+
 function revealPosition(editor: vscode.TextEditor, pos: vscode.Position): void {
   const range = new vscode.Range(pos, pos);
   editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
@@ -40,7 +44,10 @@ export async function openFile(file: string, line?: number): Promise<void> {
   }
 }
 
-export async function openLabel(label: string): Promise<boolean> {
+export async function openLabel(
+  label: string,
+  options: OpenLabelOptions = {},
+): Promise<boolean> {
   const escape = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
   const candidates = new Set([
@@ -70,7 +77,9 @@ export async function openLabel(label: string): Promise<boolean> {
     }
   }
 
-  vscode.window.showInformationMessage(`Label "${label}" not found.`);
+  if (options.notifyNotFound ?? true) {
+    vscode.window.showInformationMessage(`Label "${label}" not found.`);
+  }
   return false;
 }
 

--- a/packages/extension/src/commands/files/openFileCommands.ts
+++ b/packages/extension/src/commands/files/openFileCommands.ts
@@ -40,7 +40,7 @@ export async function openFile(file: string, line?: number): Promise<void> {
   }
 }
 
-export async function openLabel(label: string): Promise<void> {
+export async function openLabel(label: string): Promise<boolean> {
   const escape = label.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`\\\\label\\{${escape}\\}`, 'm');
   const candidates = new Set([
@@ -60,7 +60,7 @@ export async function openLabel(label: string): Promise<void> {
           preview: true,
         });
         revealPosition(editor, doc.positionAt(match.index));
-        return;
+        return true;
       }
     } catch (error) {
       logger.debug(
@@ -71,6 +71,7 @@ export async function openLabel(label: string): Promise<void> {
   }
 
   vscode.window.showInformationMessage(`Label "${label}" not found.`);
+  return false;
 }
 
 export function registerOpenFileCommands(

--- a/packages/extension/src/commands/latex/compareCommands.ts
+++ b/packages/extension/src/commands/latex/compareCommands.ts
@@ -5,21 +5,16 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 // Local imports
-import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 import { bus } from '@eventBus/ProgressEventBus';
 import {
   showLoggedErrorMessage,
   toErrorMessage,
 } from '@frontend/ui/errorHandlingUtils';
 import { registerDiffRefresh } from '@frontend/ui/diffView';
+import { getAcceptedFileTarget } from '@latex/acceptedFileTarget';
 import * as logger from '@logger/logUtils';
 import { DIFF_REGISTRATION_DELAY_MS } from '@shared/constants/latex';
-import {
-  flexibleFS,
-  createWorkspaceLocation,
-  createRunStorageLocation,
-  createExternalLocation,
-} from '@utils/files';
+import { flexibleFS } from '@utils/files';
 import type { FileLocation } from '@utils/files';
 
 const CHANNEL = 'CompareCommands';
@@ -159,14 +154,10 @@ async function handleAcceptEdited(
     const baseExt = path.extname(basePath).toLowerCase();
     const editedExt = path.extname(editedPath).toLowerCase();
 
-    const { targetLocation, targetFileName, isNewFile } =
-      baseExt !== editedExt
-        ? getNewFileTarget(fileToUseLocation, editedPath)
-        : {
-            targetLocation: fileToUseLocation,
-            targetFileName: path.basename(basePath),
-            isNewFile: false,
-          };
+    const { targetLocation, targetFileName, isNewFile } = getAcceptedFileTarget(
+      fileToUseLocation,
+      editedPath,
+    );
 
     const targetExists = isNewFile && (await flexibleFS.exists(targetLocation));
 
@@ -211,44 +202,4 @@ async function handleAcceptEdited(
   } catch (err) {
     await showLoggedErrorMessage(CHANNEL, 'Error accepting changes', err);
   }
-}
-
-function getNewFileTarget(
-  baseLocation: FileLocation,
-  editedPath: string,
-): { targetLocation: FileLocation; targetFileName: string; isNewFile: true } {
-  const basePath = baseLocation.absolutePath;
-  const baseNameWithoutExt = path.parse(basePath).name;
-  const editedNameWithoutExt = path.parse(editedPath).name;
-  const editedExt = path.extname(editedPath);
-
-  const agentSuffix = extractAgentSuffix(
-    baseNameWithoutExt,
-    editedNameWithoutExt,
-  );
-  const targetFileName = agentSuffix
-    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
-    : path.basename(editedPath);
-
-  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
-
-  let targetLocation: FileLocation;
-  if (baseLocation.kind === 'external') {
-    targetLocation = createExternalLocation(targetAbsolutePath);
-  } else {
-    const targetRelativePath = path.join(
-      path.dirname(baseLocation.relativePath),
-      targetFileName,
-    );
-    targetLocation =
-      baseLocation.kind === 'workspace'
-        ? createWorkspaceLocation(targetAbsolutePath, targetRelativePath)
-        : createRunStorageLocation(
-            targetAbsolutePath,
-            targetRelativePath,
-            baseLocation.executionId,
-          );
-  }
-
-  return { targetLocation, targetFileName, isNewFile: true };
 }

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as vscode from 'vscode';
 
 import { ProgressStreamLifecycleController } from '@controllers/progressView/ProgressStreamLifecycleController';
@@ -7,6 +6,7 @@ import {
   type ProgressFollowUpPlan,
 } from '@controllers/progressView/ProgressFollowUpController';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
+import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
 import { AgentCategory } from '@agent/core/AgentDataclass';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
@@ -33,7 +33,7 @@ import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nat
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
 import type { TaskState } from '@logger/TaskState';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
-import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+import type { StreamTabId } from '@shared/schemas';
 import type { AgentProposal } from '@shared/schemas/prompts';
 import {
   dispatchProgressViewInbound,
@@ -54,11 +54,6 @@ import {
   pathToLocation,
   WorkspaceFS,
 } from '@utils/files';
-import {
-  resolveRunDir,
-  ensureRunDir,
-  getRunDir,
-} from '@utils/files/taskRunStorage';
 import {
   buildFileContextFromTaskState,
   polishTextWithAI,
@@ -85,6 +80,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly recordingManager: RecordingManager;
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
   private readonly workflowActionsController: ProgressWorkflowActionsController;
+  private readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
@@ -119,6 +115,8 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.handlerRegistry = this.createHandlerRegistry();
     this.streamLifecycleController = this.createStreamLifecycleController();
     this.workflowActionsController = this.createWorkflowActionsController();
+    this.workflowFileActionsController =
+      this.createWorkflowFileActionsController();
     this.followUpController = this.createFollowUpController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
@@ -206,7 +204,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         });
       },
       [PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE]: (data) =>
-        this.handleOpenTaskStorage(data),
+        this.workflowFileActionsController.openTaskStorage(data.stream),
       [PROGRESS_VIEW_COMMANDS.POLISH_FOLLOW_UP]: (data) =>
         this.handlePolishFollowUp(data),
       [PROGRESS_VIEW_COMMANDS.START_RECORDING]: async () => {
@@ -282,16 +280,24 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       [PROGRESS_VIEW_COMMANDS.OPEN_FILE_COMPILE]: async (data) =>
         vscode.commands.executeCommand('texra.openFileCompile', data.file),
       [PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL]: (data) =>
-        this.handleCompareOriginal(data),
+        this.workflowFileActionsController.compareOriginal(
+          data.file,
+          data.base,
+        ),
       [PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS]: (data) =>
-        this.handleComparePrevious(data),
+        this.workflowFileActionsController.comparePrevious(
+          data.file,
+          data.base,
+          data.prev,
+        ),
       [PROGRESS_VIEW_COMMANDS.ACCEPT_FILE]: (data) =>
-        this.handleAcceptFile(data),
-      [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (data) => this.handleMergeFile(data),
+        this.workflowFileActionsController.acceptFile(data.file, data.base),
+      [PROGRESS_VIEW_COMMANDS.MERGE_FILE]: (data) =>
+        this.workflowFileActionsController.mergeFile(data.file, data.base),
       [PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE]: (data) =>
-        this.handleLatexdiffFile(data),
+        this.workflowFileActionsController.latexdiffFile(data.file, data.base),
       [PROGRESS_VIEW_COMMANDS.OPEN_LABEL]: async (data) =>
-        vscode.commands.executeCommand('texra.openLabel', data.label),
+        this.workflowFileActionsController.openLabel(data.label),
     };
   }
 
@@ -389,6 +395,75 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       runFileOperation: async (operation, request) => {
         await vscode.commands.executeCommand(`texra.${operation}`, request);
       },
+    });
+  }
+
+  private createWorkflowFileActionsController(): ProgressWorkflowFileActionsController {
+    return new ProgressWorkflowFileActionsController({
+      state: {
+        getActiveStream: () => this.provider.state.activeStream,
+        getExecutionId: (stream) =>
+          this.provider.state.meta.getExecutionId(stream),
+        getOutputFiles: (stream) =>
+          this.provider.state.outputFiles.getFiles(stream),
+      },
+      host: {
+        compareFiles: async (baseFile, editedFile) => {
+          await vscode.commands.executeCommand(
+            'texra.compare',
+            pathToLocation(''), // inputFile unused
+            pathToLocation(baseFile),
+            pathToLocation(editedFile),
+          );
+        },
+        acceptEditedFile: async (baseFile, editedFile) => {
+          await vscode.commands.executeCommand(
+            'texra.acceptEdited',
+            pathToLocation(''), // inputFile unused
+            pathToLocation(baseFile),
+            pathToLocation(editedFile),
+          );
+        },
+        mergeFile: async (baseFile, editedFile) => {
+          await vscode.commands.executeCommand(
+            'texra.merge',
+            undefined,
+            baseFile,
+            editedFile,
+          );
+        },
+        latexdiffFile: async (baseFile, editedFile) => {
+          await vscode.commands.executeCommand(
+            'texra.latexdiff',
+            undefined,
+            baseFile,
+            editedFile,
+          );
+        },
+        openDirectory: async (directory) => {
+          await safeExecuteCommand('revealFileInOS', [
+            vscode.Uri.file(directory),
+          ]);
+        },
+        openLabel: async (label) => {
+          await vscode.commands.executeCommand('texra.openLabel', label);
+          return true;
+        },
+        readFile: (file) => flexibleFS.read(createExternalLocation(file)),
+        showInfo: async (message) => {
+          await vscode.window.showInformationMessage(message);
+        },
+        showError: async (message) => {
+          await vscode.window.showErrorMessage(message);
+        },
+      },
+      sendFollowUp: async (stream, text) => {
+        await vscode.commands.executeCommand('texra.sendFollowUp', {
+          stream,
+          text,
+        });
+      },
+      modelOutputBackups: this.modelOutputBackups,
     });
   }
 
@@ -717,216 +792,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     return true;
   }
 
-  private async handleOpenTaskStorage(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE>,
-  ): Promise<void> {
-    const streamId = data.stream;
-    const runOutputs = this.provider.state.outputFiles.getFiles(streamId);
-
-    const executionId = this.provider.state.meta.getExecutionId(streamId);
-
-    try {
-      let directoryToReveal: string | undefined;
-
-      if (executionId) {
-        // Check existing locations (primary + legacy) first; create only if neither exists
-        directoryToReveal = await resolveRunDir(executionId);
-        if (!directoryToReveal) {
-          await ensureRunDir(executionId);
-          directoryToReveal = getRunDir(executionId);
-        }
-      } else if (runOutputs) {
-        directoryToReveal = this.findOutputDirectory(runOutputs);
-      }
-
-      if (!directoryToReveal) {
-        await vscode.window.showInformationMessage(
-          'No task storage folder is available for this run yet.',
-        );
-        return;
-      }
-
-      await safeExecuteCommand('revealFileInOS', [
-        vscode.Uri.file(directoryToReveal),
-      ]);
-    } catch (error) {
-      const errorMessage = toErrorMessage(error);
-      this.logger.error(
-        this.channel,
-        `Failed to open task storage for stream ${streamId}, executionId ${executionId ?? 'unknown'}: ${errorMessage}`,
-        {
-          data: {
-            error: error instanceof Error ? error : undefined,
-            stream: streamId,
-            executionId,
-          },
-        },
-      );
-      await vscode.window.showErrorMessage(
-        'Unable to open the task storage folder for this run.',
-      );
-    }
-  }
-
-  // ============================================================
-  // File operation handlers
-  // ============================================================
-
-  private async handleCompareOriginal(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL>,
-  ): Promise<void> {
-    const { file, base } = data;
-    await this.executeWithBaseFile(
-      file,
-      base,
-      'Compare original',
-      async (targetFile, baseFile) => {
-        const streamId = this.provider.state.activeStream;
-        if (streamId && targetFile) {
-          try {
-            const fileLocation = createExternalLocation(targetFile);
-            const content = await flexibleFS.read(fileLocation);
-            const streamBackups =
-              this.modelOutputBackups.get(streamId) ?? new Map();
-            streamBackups.set(targetFile, { content, streamId });
-            this.modelOutputBackups.set(streamId, streamBackups);
-          } catch {
-            // Ignore backup errors
-          }
-        }
-
-        await vscode.commands.executeCommand(
-          'texra.compare',
-          pathToLocation(''), // inputFile unused
-          pathToLocation(baseFile),
-          pathToLocation(targetFile),
-        );
-      },
-    );
-  }
-
-  private async handleComparePrevious(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS>,
-  ): Promise<void> {
-    const { file, base, prev } = data;
-    const previousFile = prev ?? base;
-
-    if (!previousFile) {
-      this.logger.warn(
-        this.channel,
-        'Compare previous requested without base',
-        {
-          data: { file },
-        },
-      );
-      return;
-    }
-
-    await vscode.commands.executeCommand(
-      'texra.latexdiff',
-      undefined,
-      previousFile,
-      file,
-    );
-
-    await vscode.commands.executeCommand(
-      'texra.compare',
-      pathToLocation(''), // inputFile unused
-      pathToLocation(previousFile),
-      pathToLocation(file),
-    );
-  }
-
-  private async handleAcceptFile(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.ACCEPT_FILE>,
-  ): Promise<void> {
-    const { file, base } = data;
-    const streamId = this.provider.state.activeStream;
-    const backup =
-      file && streamId
-        ? this.modelOutputBackups.get(streamId)?.get(file)
-        : null;
-    let currentContent: string | null = null;
-
-    if (backup) {
-      try {
-        const fileLocation = createExternalLocation(file);
-        currentContent = await flexibleFS.read(fileLocation);
-      } catch {
-        // Ignore errors
-      }
-    }
-
-    await this.executeWithBaseFile(
-      file,
-      base,
-      'Accept',
-      (targetFile, baseFile) =>
-        vscode.commands.executeCommand(
-          'texra.acceptEdited',
-          pathToLocation(''), // inputFile unused
-          pathToLocation(baseFile),
-          pathToLocation(targetFile),
-        ),
-    );
-
-    // Inform the model about user modifications via follow-up
-    if (
-      backup &&
-      currentContent !== null &&
-      currentContent !== backup.content
-    ) {
-      const fileName = path.basename(file);
-      await vscode.commands.executeCommand('texra.sendFollowUp', {
-        stream: backup.streamId,
-        text: `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`,
-      });
-    }
-
-    // Clean up the backup entry for this file
-    if (backup && streamId) {
-      const streamBackups = this.modelOutputBackups.get(streamId);
-      streamBackups?.delete(file);
-      if (streamBackups?.size === 0) {
-        this.modelOutputBackups.delete(streamId);
-      }
-    }
-  }
-
-  private async handleMergeFile(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.MERGE_FILE>,
-  ): Promise<void> {
-    await this.executeWithBaseFile(
-      data.file,
-      data.base,
-      'Merge',
-      (targetFile, baseFile) =>
-        vscode.commands.executeCommand(
-          'texra.merge',
-          undefined,
-          baseFile,
-          targetFile,
-        ),
-    );
-  }
-
-  private async handleLatexdiffFile(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE>,
-  ): Promise<void> {
-    await this.executeWithBaseFile(
-      data.file,
-      data.base,
-      'Latexdiff',
-      (targetFile, baseFile) =>
-        vscode.commands.executeCommand(
-          'texra.latexdiff',
-          undefined,
-          baseFile,
-          targetFile,
-        ),
-    );
-  }
-
   // ============================================================
   // Helper methods
   // ============================================================
@@ -943,39 +808,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     }
     await safeExecuteCommand('texra.execute', [validation.request]);
     return true;
-  }
-
-  private async executeWithBaseFile(
-    file: string,
-    base: string | undefined,
-    actionName: string,
-    execute: (file: string, base: string) => Thenable<unknown>,
-  ): Promise<void> {
-    if (!base) {
-      this.logger.warn(
-        this.channel,
-        `${actionName} requested without a base path.`,
-        {
-          data: { file },
-        },
-      );
-      return;
-    }
-    await execute(file, base);
-  }
-
-  private findOutputDirectory(
-    runOutputs: Map<number, OutputFileInfo[]>,
-  ): string | undefined {
-    for (const infos of runOutputs.values()) {
-      for (const info of infos) {
-        const kind = info.location.kind;
-        if (kind === 'runStorage' || kind === 'workspace') {
-          return path.dirname(info.location.absolutePath);
-        }
-      }
-    }
-    return undefined;
   }
 
   private async handleGetFollowupOptions(streamId: StreamTabId): Promise<void> {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -446,8 +446,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           ]);
         },
         openLabel: async (label) => {
-          await vscode.commands.executeCommand('texra.openLabel', label);
-          return true;
+          return (
+            (await vscode.commands.executeCommand<boolean>(
+              'texra.openLabel',
+              label,
+            )) ?? false
+          );
         },
         readFile: (file) => flexibleFS.read(createExternalLocation(file)),
         showInfo: async (message) => {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -461,6 +461,11 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         showError: async (message) => {
           await vscode.window.showErrorMessage(message);
         },
+        logError: (message, error) => {
+          this.logger.error(this.channel, message, {
+            data: error instanceof Error ? error : undefined,
+          });
+        },
       },
       sendFollowUp: async (stream, text) => {
         await vscode.commands.executeCommand('texra.sendFollowUp', {

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -450,6 +450,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
             (await vscode.commands.executeCommand<boolean>(
               'texra.openLabel',
               label,
+              { notifyNotFound: false },
             )) ?? false
           );
         },

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -37,6 +37,8 @@
       "@auth/*": ["../../src/auth/*"],
       "@platform": ["../../src/platform"],
       "@platform/*": ["../../src/platform/*"],
+      "node-pandoc": ["../../src/types/node-pandoc.d.ts"],
+      "turndown-plugin-gfm": ["../../src/types/turndown-plugin-gfm.d.ts"],
       "@openrouter/sdk": ["../../node_modules/@openrouter/sdk/esm/index.d.ts"],
       "@openrouter/sdk/models": [
         "../../node_modules/@openrouter/sdk/esm/models/index.d.ts"

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -1,23 +1,10 @@
 import path from 'path';
 
-// Local imports - event bus
-import { bus } from '@eventBus/ProgressEventBus';
-
-// Local imports - latex
-import { getAcceptedFileTarget } from '@latex/acceptedFileTarget';
-
 // Local imports - shared
 import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 
 // Local imports - utilities
-import {
-  ensureRunDir,
-  getRunDir,
-  resolveRunDir,
-  type FileLocation,
-} from '@utils/files';
-
-export { getAcceptedFileTarget };
+import { ensureRunDir, getRunDir, resolveRunDir } from '@utils/files';
 
 export interface ProgressWorkflowFileActionsState {
   getActiveStream(): StreamTabId | '';
@@ -237,13 +224,5 @@ export class ProgressWorkflowFileActionsController {
       }
     }
     return undefined;
-  }
-}
-
-export function emitAcceptedWorkspaceFile(location: FileLocation): void {
-  if (location.kind === 'workspace') {
-    bus.emit('workspaceFilesWritten', {
-      absolutePaths: [location.absolutePath],
-    });
   }
 }

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -17,7 +17,10 @@ export interface ProgressWorkflowFileActionsState {
 
 export interface ProgressWorkflowFileActionsHost {
   compareFiles(baseFile: string, editedFile: string): Promise<void>;
-  acceptEditedFile(baseFile: string, editedFile: string): Promise<void>;
+  acceptEditedFile(
+    baseFile: string,
+    editedFile: string,
+  ): Promise<boolean | void>;
   mergeFile(baseFile: string, editedFile: string): Promise<void>;
   latexdiffFile(baseFile: string, editedFile: string): Promise<void>;
   openDirectory(directory: string): Promise<void>;
@@ -132,7 +135,7 @@ export class ProgressWorkflowFileActionsController {
       base,
       'Accept',
       async (targetFile, baseFile) => {
-        await this.deps.host.acceptEditedFile(baseFile, targetFile);
+        return this.deps.host.acceptEditedFile(baseFile, targetFile);
       },
     );
     if (!accepted) return;
@@ -199,14 +202,13 @@ export class ProgressWorkflowFileActionsController {
     file: string,
     base: string | undefined,
     actionName: string,
-    execute: (file: string, base: string) => Promise<void>,
+    execute: (file: string, base: string) => Promise<boolean | void>,
   ): Promise<boolean> {
     if (!base) {
       await this.deps.host.showInfo(`${actionName} needs a base file.`);
       return false;
     }
-    await execute(file, base);
-    return true;
+    return (await execute(file, base)) !== false;
   }
 
   private async backupModelOutput(file: string): Promise<void> {

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -1,0 +1,308 @@
+// Node.js imports
+import path from 'path';
+
+// Local imports - agent
+import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
+
+// Local imports - event bus
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - shared
+import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
+
+// Local imports - utilities
+import {
+  ensureRunDir,
+  getRunDir,
+  resolveRunDir,
+  type FileLocation,
+} from '@utils/files';
+
+export interface ProgressWorkflowFileActionsState {
+  getActiveStream(): StreamTabId | '';
+  getExecutionId(stream: StreamTabId): string | undefined;
+  getOutputFiles(stream: StreamTabId): Map<number, OutputFileInfo[]>;
+}
+
+export interface ProgressWorkflowFileActionsHost {
+  compareFiles(baseFile: string, editedFile: string): Promise<void>;
+  acceptEditedFile(baseFile: string, editedFile: string): Promise<void>;
+  mergeFile(baseFile: string, editedFile: string): Promise<void>;
+  latexdiffFile(baseFile: string, editedFile: string): Promise<void>;
+  openDirectory(directory: string): Promise<void>;
+  openLabel(label: string): Promise<boolean>;
+  readFile(file: string): Promise<string>;
+  showInfo(message: string): Promise<void>;
+  showError(message: string): Promise<void>;
+}
+
+export interface ProgressWorkflowFileActionsControllerDeps {
+  state: ProgressWorkflowFileActionsState;
+  host: ProgressWorkflowFileActionsHost;
+  sendFollowUp(stream: StreamTabId, text: string): Promise<void>;
+  modelOutputBackups?: Map<StreamTabId, Map<string, ModelOutputBackup>>;
+}
+
+type ModelOutputBackup = {
+  content: string;
+  streamId: StreamTabId;
+};
+
+export class ProgressWorkflowFileActionsController {
+  private readonly modelOutputBackups: Map<
+    StreamTabId,
+    Map<string, ModelOutputBackup>
+  >;
+
+  constructor(
+    private readonly deps: ProgressWorkflowFileActionsControllerDeps,
+  ) {
+    this.modelOutputBackups = deps.modelOutputBackups ?? new Map();
+  }
+
+  async openTaskStorage(stream: StreamTabId): Promise<void> {
+    const executionId = this.deps.state.getExecutionId(stream);
+    const runOutputs = this.deps.state.getOutputFiles(stream);
+    let directoryToReveal: string | undefined;
+
+    if (executionId) {
+      directoryToReveal = await resolveRunDir(executionId);
+      if (!directoryToReveal) {
+        await ensureRunDir(executionId);
+        directoryToReveal = getRunDir(executionId);
+      }
+    } else if (runOutputs.size > 0) {
+      directoryToReveal = this.findOutputDirectory(runOutputs);
+    }
+
+    if (!directoryToReveal) {
+      await this.deps.host.showInfo(
+        'No task storage folder is available for this run yet.',
+      );
+      return;
+    }
+
+    await this.deps.host.openDirectory(directoryToReveal);
+  }
+
+  async compareOriginal(file: string, base?: string): Promise<void> {
+    await this.executeWithBaseFile(
+      file,
+      base,
+      'Compare original',
+      async (targetFile, baseFile) => {
+        await this.backupModelOutput(file);
+        await this.deps.host.compareFiles(baseFile, targetFile);
+      },
+    );
+  }
+
+  async comparePrevious(
+    file: string,
+    base?: string,
+    previous?: string,
+  ): Promise<void> {
+    const previousFile = previous ?? base;
+    if (!previousFile) {
+      await this.deps.host.showInfo('Compare previous needs a base file.');
+      return;
+    }
+
+    await this.deps.host.latexdiffFile(previousFile, file);
+    await this.deps.host.compareFiles(previousFile, file);
+  }
+
+  async acceptFile(file: string, base?: string): Promise<void> {
+    const activeStream = this.deps.state.getActiveStream();
+    const backup =
+      file && activeStream
+        ? this.modelOutputBackups.get(activeStream)?.get(file)
+        : undefined;
+    let currentContent: string | undefined;
+
+    if (backup) {
+      try {
+        currentContent = await this.deps.host.readFile(file);
+      } catch {
+        currentContent = undefined;
+      }
+    }
+
+    const accepted = await this.executeWithBaseFile(
+      file,
+      base,
+      'Accept',
+      async (targetFile, baseFile) => {
+        await this.deps.host.acceptEditedFile(baseFile, targetFile);
+      },
+    );
+    if (!accepted) return;
+
+    if (
+      backup &&
+      currentContent !== undefined &&
+      currentContent !== backup.content
+    ) {
+      const fileName = path.basename(file);
+      await this.deps.sendFollowUp(
+        backup.streamId,
+        `[System: User modified the model's suggested output for "${fileName}" before accepting. The accepted version differs from the original model output.]`,
+      );
+    }
+
+    if (backup && activeStream) {
+      const streamBackups = this.modelOutputBackups.get(activeStream);
+      streamBackups?.delete(file);
+      if (streamBackups?.size === 0) {
+        this.modelOutputBackups.delete(activeStream);
+      }
+    }
+  }
+
+  async mergeFile(file: string, base?: string): Promise<void> {
+    await this.executeWithBaseFile(
+      file,
+      base,
+      'Merge',
+      async (targetFile, baseFile) => {
+        await this.deps.host.mergeFile(baseFile, targetFile);
+      },
+    );
+  }
+
+  async latexdiffFile(file: string, base?: string): Promise<void> {
+    await this.executeWithBaseFile(
+      file,
+      base,
+      'Latexdiff',
+      async (targetFile, baseFile) => {
+        await this.deps.host.latexdiffFile(baseFile, targetFile);
+      },
+    );
+  }
+
+  async openLabel(label: string): Promise<void> {
+    const opened = await this.deps.host.openLabel(label);
+    if (!opened) {
+      await this.deps.host.showInfo(`Label "${label}" not found.`);
+    }
+  }
+
+  clearStreamBackups(stream: StreamTabId): void {
+    this.modelOutputBackups.delete(stream);
+  }
+
+  clearAllBackups(): void {
+    this.modelOutputBackups.clear();
+  }
+
+  private async executeWithBaseFile(
+    file: string,
+    base: string | undefined,
+    actionName: string,
+    execute: (file: string, base: string) => Promise<void>,
+  ): Promise<boolean> {
+    if (!base) {
+      await this.deps.host.showInfo(`${actionName} needs a base file.`);
+      return false;
+    }
+    await execute(file, base);
+    return true;
+  }
+
+  private async backupModelOutput(file: string): Promise<void> {
+    const streamId = this.deps.state.getActiveStream();
+    if (!streamId || !file) return;
+
+    try {
+      const content = await this.deps.host.readFile(file);
+      const streamBackups = this.modelOutputBackups.get(streamId) ?? new Map();
+      streamBackups.set(file, { content, streamId });
+      this.modelOutputBackups.set(streamId, streamBackups);
+    } catch {
+      // Best-effort: backup only informs the accepted-edit follow-up.
+    }
+  }
+
+  private findOutputDirectory(
+    runOutputs: Map<number, OutputFileInfo[]>,
+  ): string | undefined {
+    for (const infos of runOutputs.values()) {
+      for (const info of infos) {
+        const kind = info.location.kind;
+        if (kind === 'runStorage' || kind === 'workspace') {
+          return path.dirname(info.location.absolutePath);
+        }
+      }
+    }
+    return undefined;
+  }
+}
+
+export function getAcceptedFileTarget(
+  baseLocation: FileLocation,
+  editedPath: string,
+): {
+  targetLocation: FileLocation;
+  targetFileName: string;
+  isNewFile: boolean;
+} {
+  const basePath = baseLocation.absolutePath;
+  const baseExt = path.extname(basePath).toLowerCase();
+  const editedExt = path.extname(editedPath);
+
+  if (baseExt === editedExt.toLowerCase()) {
+    return {
+      targetLocation: baseLocation,
+      targetFileName: path.basename(basePath),
+      isNewFile: false,
+    };
+  }
+
+  const baseNameWithoutExt = path.parse(basePath).name;
+  const editedNameWithoutExt = path.parse(editedPath).name;
+  const agentSuffix = extractAgentSuffix(
+    baseNameWithoutExt,
+    editedNameWithoutExt,
+  );
+  const targetFileName = agentSuffix
+    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
+    : path.basename(editedPath);
+  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
+
+  if (baseLocation.kind === 'external') {
+    return {
+      targetLocation: { kind: 'external', absolutePath: targetAbsolutePath },
+      targetFileName,
+      isNewFile: true,
+    };
+  }
+
+  const targetRelativePath = path.join(
+    path.dirname(baseLocation.relativePath),
+    targetFileName,
+  );
+  const targetLocation =
+    baseLocation.kind === 'workspace'
+      ? {
+          kind: 'workspace' as const,
+          absolutePath: targetAbsolutePath,
+          relativePath: targetRelativePath,
+        }
+      : {
+          kind: 'runStorage' as const,
+          absolutePath: targetAbsolutePath,
+          relativePath: targetRelativePath,
+          executionId: baseLocation.executionId,
+        };
+
+  return { targetLocation, targetFileName, isNewFile: true };
+}
+
+export function emitAcceptedWorkspaceFile(location: FileLocation): void {
+  if (location.kind === 'workspace') {
+    bus.emit('workspaceFilesWritten', {
+      absolutePaths: [location.absolutePath],
+    });
+  }
+}

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -1,11 +1,10 @@
-// Node.js imports
 import path from 'path';
-
-// Local imports - agent
-import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
 
 // Local imports - event bus
 import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - latex
+import { getAcceptedFileTarget } from '@latex/acceptedFileTarget';
 
 // Local imports - shared
 import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
@@ -17,6 +16,8 @@ import {
   resolveRunDir,
   type FileLocation,
 } from '@utils/files';
+
+export { getAcceptedFileTarget };
 
 export interface ProgressWorkflowFileActionsState {
   getActiveStream(): StreamTabId | '';
@@ -237,66 +238,6 @@ export class ProgressWorkflowFileActionsController {
     }
     return undefined;
   }
-}
-
-export function getAcceptedFileTarget(
-  baseLocation: FileLocation,
-  editedPath: string,
-): {
-  targetLocation: FileLocation;
-  targetFileName: string;
-  isNewFile: boolean;
-} {
-  const basePath = baseLocation.absolutePath;
-  const baseExt = path.extname(basePath).toLowerCase();
-  const editedExt = path.extname(editedPath);
-
-  if (baseExt === editedExt.toLowerCase()) {
-    return {
-      targetLocation: baseLocation,
-      targetFileName: path.basename(basePath),
-      isNewFile: false,
-    };
-  }
-
-  const baseNameWithoutExt = path.parse(basePath).name;
-  const editedNameWithoutExt = path.parse(editedPath).name;
-  const agentSuffix = extractAgentSuffix(
-    baseNameWithoutExt,
-    editedNameWithoutExt,
-  );
-  const targetFileName = agentSuffix
-    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
-    : path.basename(editedPath);
-  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
-
-  if (baseLocation.kind === 'external') {
-    return {
-      targetLocation: { kind: 'external', absolutePath: targetAbsolutePath },
-      targetFileName,
-      isNewFile: true,
-    };
-  }
-
-  const targetRelativePath = path.join(
-    path.dirname(baseLocation.relativePath),
-    targetFileName,
-  );
-  const targetLocation =
-    baseLocation.kind === 'workspace'
-      ? {
-          kind: 'workspace' as const,
-          absolutePath: targetAbsolutePath,
-          relativePath: targetRelativePath,
-        }
-      : {
-          kind: 'runStorage' as const,
-          absolutePath: targetAbsolutePath,
-          relativePath: targetRelativePath,
-          executionId: baseLocation.executionId,
-        };
-
-  return { targetLocation, targetFileName, isNewFile: true };
 }
 
 export function emitAcceptedWorkspaceFile(location: FileLocation): void {

--- a/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
+++ b/src/controllers/progressView/ProgressWorkflowFileActionsController.ts
@@ -1,5 +1,8 @@
 import path from 'path';
 
+// Local imports - common
+import { toErrorMessage } from '@common/errors';
+
 // Local imports - shared
 import type { OutputFileInfo, StreamTabId } from '@shared/schemas';
 
@@ -22,6 +25,7 @@ export interface ProgressWorkflowFileActionsHost {
   readFile(file: string): Promise<string>;
   showInfo(message: string): Promise<void>;
   showError(message: string): Promise<void>;
+  logError?(message: string, error: unknown): void;
 }
 
 export interface ProgressWorkflowFileActionsControllerDeps {
@@ -49,28 +53,35 @@ export class ProgressWorkflowFileActionsController {
   }
 
   async openTaskStorage(stream: StreamTabId): Promise<void> {
-    const executionId = this.deps.state.getExecutionId(stream);
-    const runOutputs = this.deps.state.getOutputFiles(stream);
-    let directoryToReveal: string | undefined;
+    try {
+      const executionId = this.deps.state.getExecutionId(stream);
+      const runOutputs = this.deps.state.getOutputFiles(stream);
+      let directoryToReveal: string | undefined;
 
-    if (executionId) {
-      directoryToReveal = await resolveRunDir(executionId);
-      if (!directoryToReveal) {
-        await ensureRunDir(executionId);
-        directoryToReveal = getRunDir(executionId);
+      if (executionId) {
+        directoryToReveal = await resolveRunDir(executionId);
+        if (!directoryToReveal) {
+          await ensureRunDir(executionId);
+          directoryToReveal = getRunDir(executionId);
+        }
+      } else if (runOutputs.size > 0) {
+        directoryToReveal = this.findOutputDirectory(runOutputs);
       }
-    } else if (runOutputs.size > 0) {
-      directoryToReveal = this.findOutputDirectory(runOutputs);
-    }
 
-    if (!directoryToReveal) {
-      await this.deps.host.showInfo(
-        'No task storage folder is available for this run yet.',
+      if (!directoryToReveal) {
+        await this.deps.host.showInfo(
+          'No task storage folder is available for this run yet.',
+        );
+        return;
+      }
+
+      await this.deps.host.openDirectory(directoryToReveal);
+    } catch (error) {
+      this.deps.host.logError?.('Failed to open task storage folder', error);
+      await this.deps.host.showError(
+        `Failed to open task storage folder: ${toErrorMessage(error)}`,
       );
-      return;
     }
-
-    await this.deps.host.openDirectory(directoryToReveal);
   }
 
   async compareOriginal(file: string, base?: string): Promise<void> {

--- a/src/controllers/progressView/workflowFileActionsEvents.ts
+++ b/src/controllers/progressView/workflowFileActionsEvents.ts
@@ -1,0 +1,13 @@
+// Local imports - event bus
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - utilities
+import type { FileLocation } from '@utils/files';
+
+export function emitAcceptedWorkspaceFile(location: FileLocation): void {
+  if (location.kind === 'workspace') {
+    bus.emit('workspaceFilesWritten', {
+      absolutePaths: [location.absolutePath],
+    });
+  }
+}

--- a/src/latex/acceptedFileTarget.ts
+++ b/src/latex/acceptedFileTarget.ts
@@ -1,0 +1,70 @@
+// Standard library imports
+import path from 'path';
+
+// Local imports - agent
+import { extractAgentSuffix } from '@agent/utils/mergeFileUtils';
+
+// Local imports - utilities
+import {
+  createExternalLocation,
+  createRunStorageLocation,
+  createWorkspaceLocation,
+  type FileLocation,
+} from '@utils/files';
+
+export type AcceptedFileTarget = {
+  targetLocation: FileLocation;
+  targetFileName: string;
+  isNewFile: boolean;
+};
+
+export function getAcceptedFileTarget(
+  baseLocation: FileLocation,
+  editedPath: string,
+): AcceptedFileTarget {
+  const basePath = baseLocation.absolutePath;
+  const baseExt = path.extname(basePath).toLowerCase();
+  const editedExt = path.extname(editedPath);
+
+  if (baseExt === editedExt.toLowerCase()) {
+    return {
+      targetLocation: baseLocation,
+      targetFileName: path.basename(basePath),
+      isNewFile: false,
+    };
+  }
+
+  const baseNameWithoutExt = path.parse(basePath).name;
+  const editedNameWithoutExt = path.parse(editedPath).name;
+  const agentSuffix = extractAgentSuffix(
+    baseNameWithoutExt,
+    editedNameWithoutExt,
+  );
+  const targetFileName = agentSuffix
+    ? `${baseNameWithoutExt}_${agentSuffix}${editedExt}`
+    : path.basename(editedPath);
+  const targetAbsolutePath = path.join(path.dirname(basePath), targetFileName);
+
+  if (baseLocation.kind === 'external') {
+    return {
+      targetLocation: createExternalLocation(targetAbsolutePath),
+      targetFileName,
+      isNewFile: true,
+    };
+  }
+
+  const targetRelativePath = path.join(
+    path.dirname(baseLocation.relativePath),
+    targetFileName,
+  );
+  const targetLocation =
+    baseLocation.kind === 'workspace'
+      ? createWorkspaceLocation(targetAbsolutePath, targetRelativePath)
+      : createRunStorageLocation(
+          targetAbsolutePath,
+          targetRelativePath,
+          baseLocation.executionId,
+        );
+
+  return { targetLocation, targetFileName, isNewFile: true };
+}

--- a/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
+++ b/src/test-kernel/desktop/DesktopDiffHost.vitest.mts
@@ -1,0 +1,43 @@
+// Standard library imports
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+describe('createDesktopDiffHost', () => {
+  it('opens a generated patch file for compared files', async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), 'texra-diff-host-test-'));
+    const originalPath = path.join(tempDir, 'original.txt');
+    const proposedPath = path.join(tempDir, 'proposed.txt');
+    await Promise.all([
+      writeFile(originalPath, 'hello\nold\n', 'utf8'),
+      writeFile(proposedPath, 'hello\nnew\n', 'utf8'),
+    ]);
+    const openedPaths: string[] = [];
+    const { createDesktopDiffHost } = (await import(
+      moduleFileUrl(desktopSourcePath('main', 'desktopDiffHost.ts'))
+    )) as typeof import('../../../packages/desktop/src/main/desktopDiffHost');
+
+    const host = createDesktopDiffHost({
+      openPath: vi.fn(async (filePath: string) => {
+        openedPaths.push(filePath);
+      }),
+    });
+
+    await host.openDiff(
+      { filePath: originalPath },
+      { filePath: proposedPath },
+      'Compare',
+    );
+
+    expect(openedPaths).toHaveLength(1);
+    expect(path.extname(openedPaths[0])).toBe('.diff');
+    await expect(readFile(openedPaths[0], 'utf8')).resolves.toContain('-old');
+    await expect(readFile(openedPaths[0], 'utf8')).resolves.toContain('+new');
+  });
+});

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -19,7 +19,7 @@ interface DesktopProgressIpcModule {
       resumeStream(stream: string): Promise<void>;
       runNewStream(stream: string): Promise<void>;
       sendFollowUp(stream: string, text: string): Promise<void>;
-      openFile(file: string): Promise<void>;
+      openFile(file: string, line?: number): Promise<void>;
       openFileCompile(file: string): Promise<void>;
       openTaskStorage(stream: string): Promise<void>;
       compareOriginal(file: string, base?: string): Promise<void>;
@@ -86,7 +86,7 @@ function createProgress() {
     resumeStream: vi.fn(async (_stream: string) => {}),
     runNewStream: vi.fn(async (_stream: string) => {}),
     sendFollowUp: vi.fn(async (_stream: string, _text: string) => {}),
-    openFile: vi.fn(async (_file: string) => {}),
+    openFile: vi.fn(async (_file: string, _line?: number) => {}),
     openFileCompile: vi.fn(async (_file: string) => {}),
     openTaskStorage: vi.fn(async (_stream: string) => {}),
     compareOriginal: vi.fn(async (_file: string, _base?: string) => {}),
@@ -165,7 +165,10 @@ describe('desktop Progress IPC', () => {
       }),
     ).toBe(true);
     await Promise.resolve();
-    expect(progress.openFile).toHaveBeenCalledWith('/tmp/output.pdf');
+    expect(progress.openFile).toHaveBeenCalledWith(
+      '/tmp/output.pdf',
+      undefined,
+    );
 
     expect(
       ipc.handleMessage({
@@ -329,7 +332,7 @@ describe('desktop Progress IPC', () => {
       'run-1',
       'continue please',
     );
-    expect(progress.openFile).toHaveBeenCalledWith('/tmp/out.tex');
+    expect(progress.openFile).toHaveBeenCalledWith('/tmp/out.tex', 4);
     expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/out.pdf');
   });
 

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -21,6 +21,17 @@ interface DesktopProgressIpcModule {
       sendFollowUp(stream: string, text: string): Promise<void>;
       openFile(file: string): Promise<void>;
       openFileCompile(file: string): Promise<void>;
+      openTaskStorage(stream: string): Promise<void>;
+      compareOriginal(file: string, base?: string): Promise<void>;
+      comparePrevious(
+        file: string,
+        base?: string,
+        previous?: string,
+      ): Promise<void>;
+      acceptFile(file: string, base?: string): Promise<void>;
+      mergeFile(file: string, base?: string): Promise<void>;
+      latexdiffFile(file: string, base?: string): Promise<void>;
+      openLabel(label: string): Promise<void>;
       handleToolEditApprovalAction(message: {
         command: string;
         requestId: string;
@@ -77,6 +88,15 @@ function createProgress() {
     sendFollowUp: vi.fn(async (_stream: string, _text: string) => {}),
     openFile: vi.fn(async (_file: string) => {}),
     openFileCompile: vi.fn(async (_file: string) => {}),
+    openTaskStorage: vi.fn(async (_stream: string) => {}),
+    compareOriginal: vi.fn(async (_file: string, _base?: string) => {}),
+    comparePrevious: vi.fn(
+      async (_file: string, _base?: string, _previous?: string) => {},
+    ),
+    acceptFile: vi.fn(async (_file: string, _base?: string) => {}),
+    mergeFile: vi.fn(async (_file: string, _base?: string) => {}),
+    latexdiffFile: vi.fn(async (_file: string, _base?: string) => {}),
+    openLabel: vi.fn(async (_label: string) => {}),
     handleToolEditApprovalAction: vi.fn(() => true),
     handleBashApprovalAction: vi.fn(async () => {}),
     handlePlanApprovalAction: vi.fn(),
@@ -155,6 +175,86 @@ describe('desktop Progress IPC', () => {
     ).toBe(true);
     await Promise.resolve();
     expect(progress.openFileCompile).toHaveBeenCalledWith('/tmp/output.tex');
+  });
+
+  it('maps workflow file operations to the desktop bridge', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const ipc = createDesktopProgressIpc({ progress });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_TASK_STORAGE,
+        stream: 'run-1',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_ORIGINAL,
+        file: '/tmp/r1.tex',
+        base: '/tmp/base.tex',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.COMPARE_PREVIOUS,
+        file: '/tmp/r2.tex',
+        base: '/tmp/base.tex',
+        prev: '/tmp/r1.tex',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.ACCEPT_FILE,
+        file: '/tmp/r1.tex',
+        base: '/tmp/base.tex',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.MERGE_FILE,
+        file: '/tmp/r1.tex',
+        base: '/tmp/base.tex',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.LATEXDIFF_FILE,
+        file: '/tmp/r1.tex',
+        base: '/tmp/base.tex',
+      }),
+    ).toBe(true);
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.OPEN_LABEL,
+        label: 'eq:main',
+      }),
+    ).toBe(true);
+
+    await Promise.resolve();
+    expect(progress.openTaskStorage).toHaveBeenCalledWith('run-1');
+    expect(progress.compareOriginal).toHaveBeenCalledWith(
+      '/tmp/r1.tex',
+      '/tmp/base.tex',
+    );
+    expect(progress.comparePrevious).toHaveBeenCalledWith(
+      '/tmp/r2.tex',
+      '/tmp/base.tex',
+      '/tmp/r1.tex',
+    );
+    expect(progress.acceptFile).toHaveBeenCalledWith(
+      '/tmp/r1.tex',
+      '/tmp/base.tex',
+    );
+    expect(progress.mergeFile).toHaveBeenCalledWith(
+      '/tmp/r1.tex',
+      '/tmp/base.tex',
+    );
+    expect(progress.latexdiffFile).toHaveBeenCalledWith(
+      '/tmp/r1.tex',
+      '/tmp/base.tex',
+    );
+    expect(progress.openLabel).toHaveBeenCalledWith('eq:main');
   });
 
   it('routes unsupported Progress commands through an explicit handler', async () => {

--- a/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
@@ -11,10 +11,16 @@ function createDeps(
   overrides: Partial<ProgressWorkflowFileActionsControllerDeps['host']>,
 ): ProgressWorkflowFileActionsControllerDeps {
   const infos: string[] = [];
+  const errors: string[] = [];
+  const logs: { message: string; error: unknown }[] = [];
   const host: ProgressWorkflowFileActionsControllerDeps['host'] & {
     infos: string[];
+    errors: string[];
+    logs: { message: string; error: unknown }[];
   } = {
     infos,
+    errors,
+    logs,
     compareFiles: async () => {},
     acceptEditedFile: async () => {},
     mergeFile: async () => {},
@@ -25,7 +31,12 @@ function createDeps(
     showInfo: async (message) => {
       infos.push(message);
     },
-    showError: async () => {},
+    showError: async (message) => {
+      errors.push(message);
+    },
+    logError: (message, error) => {
+      logs.push({ message, error });
+    },
     ...overrides,
   };
 
@@ -57,5 +68,30 @@ describe('ProgressWorkflowFileActionsController', () => {
       ).infos,
       ['Label "missing-label" not found.'],
     );
+  });
+
+  it('reports task storage open failures', async () => {
+    const failure = new Error('cannot reveal folder');
+    const deps = createDeps({
+      openDirectory: async () => {
+        throw failure;
+      },
+    });
+    deps.state.getExecutionId = () => 'run-1';
+    const controller = new ProgressWorkflowFileActionsController(deps);
+
+    await controller.openTaskStorage('toolUse');
+
+    const host =
+      deps.host as ProgressWorkflowFileActionsControllerDeps['host'] & {
+        errors: string[];
+        logs: { message: string; error: unknown }[];
+      };
+    assert.deepEqual(host.errors, [
+      'Failed to open task storage folder: cannot reveal folder',
+    ]);
+    assert.deepEqual(host.logs, [
+      { message: 'Failed to open task storage folder', error: failure },
+    ]);
   });
 });

--- a/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
@@ -94,4 +94,39 @@ describe('ProgressWorkflowFileActionsController', () => {
       { message: 'Failed to open task storage folder', error: failure },
     ]);
   });
+
+  it('does not send accept follow-up when the host cancels acceptance', async () => {
+    const backups = new Map([
+      [
+        'workflow',
+        new Map([
+          [
+            '/workspace/edited.tex',
+            {
+              content: 'original model output',
+              streamId: 'workflow' as const,
+            },
+          ],
+        ]),
+      ],
+    ]);
+    const followUps: string[] = [];
+    const deps = createDeps({
+      acceptEditedFile: async () => false,
+      readFile: async () => 'user edited output',
+    });
+    deps.state.getActiveStream = () => 'workflow';
+    deps.sendFollowUp = async (_stream, text) => {
+      followUps.push(text);
+    };
+    const controller = new ProgressWorkflowFileActionsController({
+      ...deps,
+      modelOutputBackups: backups,
+    });
+
+    await controller.acceptFile('/workspace/edited.tex', '/workspace/base.tex');
+
+    assert.deepEqual(followUps, []);
+    assert.equal(backups.get('workflow')?.has('/workspace/edited.tex'), true);
+  });
 });

--- a/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
+++ b/src/test/controllers/ProgressWorkflowFileActionsController.test.ts
@@ -1,0 +1,61 @@
+// Standard library imports
+import { strict as assert } from 'assert';
+
+// Local imports - controllers
+import {
+  ProgressWorkflowFileActionsController,
+  type ProgressWorkflowFileActionsControllerDeps,
+} from '@controllers/progressView/ProgressWorkflowFileActionsController';
+
+function createDeps(
+  overrides: Partial<ProgressWorkflowFileActionsControllerDeps['host']>,
+): ProgressWorkflowFileActionsControllerDeps {
+  const infos: string[] = [];
+  const host: ProgressWorkflowFileActionsControllerDeps['host'] & {
+    infos: string[];
+  } = {
+    infos,
+    compareFiles: async () => {},
+    acceptEditedFile: async () => {},
+    mergeFile: async () => {},
+    latexdiffFile: async () => {},
+    openDirectory: async () => {},
+    openLabel: async () => true,
+    readFile: async () => '',
+    showInfo: async (message) => {
+      infos.push(message);
+    },
+    showError: async () => {},
+    ...overrides,
+  };
+
+  return {
+    state: {
+      getActiveStream: () => '',
+      getExecutionId: () => undefined,
+      getOutputFiles: () => new Map(),
+    },
+    host,
+    sendFollowUp: async () => {},
+  };
+}
+
+describe('ProgressWorkflowFileActionsController', () => {
+  it('shows one fallback message when a host cannot open a label', async () => {
+    const deps = createDeps({
+      openLabel: async () => false,
+    });
+    const controller = new ProgressWorkflowFileActionsController(deps);
+
+    await controller.openLabel('missing-label');
+
+    assert.deepEqual(
+      (
+        deps.host as ProgressWorkflowFileActionsControllerDeps['host'] & {
+          infos: string[];
+        }
+      ).infos,
+      ['Label "missing-label" not found.'],
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,8 @@
       "@auth/*": ["src/auth/*"],
       "@platform": ["src/platform"],
       "@platform/*": ["src/platform/*"],
+      "node-pandoc": ["src/types/node-pandoc.d.ts"],
+      "turndown-plugin-gfm": ["src/types/turndown-plugin-gfm.d.ts"],
       "@openrouter/sdk": ["node_modules/@openrouter/sdk/esm/index.d.ts"],
       "@openrouter/sdk/models": [
         "node_modules/@openrouter/sdk/esm/models/index.d.ts"
@@ -51,6 +53,7 @@
     "types": ["node", "mocha", "vscode"]
   },
   "include": [
+    "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "packages/extension/src/**/*.ts",


### PR DESCRIPTION
## Summary

- wire desktop Progress IPC for compare, accept, merge, latexdiff, open label, and open task storage actions
- add a host-neutral workflow file-actions controller for shared progress-card behavior
- keep desktop action coverage aligned with the shared Progress schema in `DesktopProgressIpc.vitest.mts`

Closes #3572

## Validation

- `npx vitest run src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npx prettier --check src/controllers/progressView/ProgressWorkflowFileActionsController.ts packages/desktop/src/main/desktopAgentExecution.ts packages/desktop/src/main/desktopProgressIpc.ts packages/desktop/src/main/index.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts`
- `npm run -s typecheck`
- `corepack pnpm --filter @texra/desktop typecheck`
- `npm run lint`
- `npm run compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new file-system write/overwrite flows (accepting edited files) and new IPC surface area, though changes are mostly additive and covered by targeted tests.
> 
> **Overview**
> Desktop Progress now supports the same workflow file actions as the extension: open task storage, compare original/previous, accept edits, merge, generate `latexdiff`, and open LaTeX `\\label{...}` targets.
> 
> This is implemented by introducing a host-neutral `ProgressWorkflowFileActionsController` and wiring it into both the VS Code `ProgressViewMessageHandler` and the desktop `DesktopProgressBridge`/IPC, including tracking output files per stream for storage discovery.
> 
> Desktop adds `createDesktopDiffHost` (writes a temporary `.diff` patch from two files) plus acceptance safeguards (confirmation prompt, extension-aware target naming via `getAcceptedFileTarget`, and emitting workspace write events).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b63399914a0e7b3308f450fc84c3318411eb2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->