### PR TITLE
[codex] Polish desktop progress layout

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -381,7 +381,9 @@ Shared config:
 
 The monorepo now has a local unsigned package rehearsal for the Electron desktop app. It produces a
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
-packaged `app.asar` contains the expected runtime files.
+packaged `app.asar` contains the expected runtime files. The package verifier also reads the
+desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
+provider SDKs that should remain behind lazy agent-execution imports.
 
 From the repository root:
 

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,12 +8,13 @@ const outdir = resolve(__dirname, 'dist/main');
 
 await rm(outdir, { force: true, recursive: true });
 
-await esbuild.build({
+const result = await esbuild.build({
   entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
   splitting: true,
+  metafile: true,
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
@@ -25,3 +26,9 @@ await esbuild.build({
       `const require = __texraCreateRequire(import.meta.url);`,
   },
 });
+
+await mkdir(outdir, { recursive: true });
+await writeFile(
+  resolve(outdir, 'metafile.json'),
+  `${JSON.stringify(result.metafile, null, 2)}\n`,
+);

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -161,6 +161,10 @@ export class ProgressApp extends ProgressAppBase {
         flex-shrink: 0;
       }
 
+      .main-container.desktop .view-header {
+        display: none;
+      }
+
       .view-header vscode-tabs {
         flex: 1;
         min-width: 0;
@@ -196,6 +200,11 @@ export class ProgressApp extends ProgressAppBase {
         min-width: 48px;
       }
 
+      .main-container.desktop stream-tabs {
+        min-width: 240px;
+        max-width: 360px;
+      }
+
       .content-area {
         display: flex;
         flex-direction: column;
@@ -210,6 +219,56 @@ export class ProgressApp extends ProgressAppBase {
       workflow-stream-content,
       process-stream-content {
         display: contents;
+      }
+
+      .desktop-empty-progress {
+        display: grid;
+        place-items: center;
+        flex: 1;
+        min-height: 0;
+        padding: clamp(32px, 8vh, 72px) 32px;
+        box-sizing: border-box;
+        background: var(--texra-editor-background, var(--background-color));
+      }
+
+      .desktop-empty-progress__body {
+        display: grid;
+        justify-items: center;
+        gap: var(--spacing-medium);
+        max-width: 560px;
+        text-align: center;
+        color: var(--texra-descriptionForeground, var(--color-text-secondary));
+      }
+
+      .desktop-empty-progress__icon {
+        color: var(--texra-button-background, var(--color-text-link));
+        font-size: 44px;
+      }
+
+      .desktop-empty-progress h1 {
+        margin: var(--spacing-small) 0 0;
+        color: var(--texra-foreground, var(--color-text-primary));
+        font-size: 24px;
+        font-weight: 600;
+        letter-spacing: 0;
+      }
+
+      .desktop-empty-progress p {
+        margin: 0;
+        font-size: var(--font-size-md, 14px);
+        line-height: 1.5;
+      }
+
+      .desktop-empty-progress__actions {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: var(--spacing-medium);
+        margin-top: var(--spacing-small);
+      }
+
+      .desktop-empty-progress vscode-button::part(control) {
+        min-height: 32px;
       }
     `,
   ];
@@ -334,6 +393,11 @@ export class ProgressApp extends ProgressAppBase {
     () => this.tabStreams$.get().length > 0,
   );
 
+  /** True only when the backend knows no streams at all, independent of filter. */
+  private hasAnyStreams$ = new Signal.Computed(
+    () => this.streamById$.get().size > 0,
+  );
+
   /** Only changes when the ACTIVE stream's state changes, not any stream. */
   private activeStreamState$ = new Signal.Computed(() => {
     const info = this.activeStreamInfo$.get();
@@ -409,6 +473,7 @@ export class ProgressApp extends ProgressAppBase {
       isToolUse: this.activeIsToolUse$.get(),
       hasStreams,
       streamName: activeStreamInfo.name,
+      streamStatus: this.activeStreamState$.get()?.status ?? null,
       // Process agents emit raw stdout/stderr; render them terminal-style
       // (monospace, no timestamps, tight spacing) rather than logger entries.
       terminalMode: isProcessAgent(activeStreamInfo.agent),
@@ -460,76 +525,117 @@ export class ProgressApp extends ProgressAppBase {
 
   render(): TemplateResult {
     const isEditorMode = this.placement.get() === 'editor';
+    const isDesktopMode = this.hasAttribute('data-desktop-view');
     const compactTabs = this.narrowLayout.get() && !isEditorMode;
+    const splitHandlePosition = isDesktopMode ? '72%' : '80%';
 
     return html`
       <div
         class=${classMap({
           'main-container': true,
           narrow: compactTabs,
+          desktop: isDesktopMode,
         })}
       >
-        <div class="view-header">
-          <vscode-tabs
-            .selectedIndex=${1}
-            @vsc-tabs-select=${this.onViewTabSelect}
-          >
-            <vscode-tab-header
-              slot="header"
-              class=${isEditorMode ? 'focus-sidebar-tab' : ''}
-              title=${isEditorMode ? 'Focus Launcher sidebar' : ''}
-              @click=${this.onFocusLauncherTab}
-            >
-              <span class="codicon codicon-edit"></span>
-              Launcher
-            </vscode-tab-header>
-            <vscode-tab-header slot="header">
-              <span class="codicon codicon-server-process"></span>
-              Progress
-            </vscode-tab-header>
-          </vscode-tabs>
+        ${isDesktopMode && !this.hasAnyStreams$.get()
+          ? this.renderDesktopEmptyProgress()
+          : html`
+              <div class="view-header">
+                <vscode-tabs
+                  .selectedIndex=${1}
+                  @vsc-tabs-select=${this.onViewTabSelect}
+                >
+                  <vscode-tab-header
+                    slot="header"
+                    class=${isEditorMode ? 'focus-sidebar-tab' : ''}
+                    title=${isEditorMode ? 'Focus Launcher sidebar' : ''}
+                    @click=${this.onFocusLauncherTab}
+                  >
+                    <span class="codicon codicon-edit"></span>
+                    Launcher
+                  </vscode-tab-header>
+                  <vscode-tab-header slot="header">
+                    <span class="codicon codicon-server-process"></span>
+                    Progress
+                  </vscode-tab-header>
+                </vscode-tabs>
 
-          <vscode-toolbar-button
-            class="header-action"
-            icon="gear"
-            title="Open dashboard"
-            @click=${this.onOpenDashboard}
-          ></vscode-toolbar-button>
-          <vscode-toolbar-button
-            class="header-action"
-            icon=${isEditorMode ? 'layout-sidebar-right' : 'link-external'}
-            title=${isEditorMode ? 'Back to sidebar' : 'Open in editor'}
-            @click=${isEditorMode ? this.onPopBack : this.onPopOut}
-          ></vscode-toolbar-button>
-        </div>
+                <vscode-toolbar-button
+                  class="header-action"
+                  icon="gear"
+                  title="Open dashboard"
+                  @click=${this.onOpenDashboard}
+                ></vscode-toolbar-button>
+                <vscode-toolbar-button
+                  class="header-action"
+                  icon=${isEditorMode
+                    ? 'layout-sidebar-right'
+                    : 'link-external'}
+                  title=${isEditorMode ? 'Back to sidebar' : 'Open in editor'}
+                  @click=${isEditorMode ? this.onPopBack : this.onPopOut}
+                ></vscode-toolbar-button>
+              </div>
 
-        <div class="split-container">
-          <vscode-split-layout initial-handle-position="80%">
-            <div
-              slot="start"
-              class="content-area"
-              @stream-switch=${this.onStreamSwitch}
-            >
-              ${this.renderStreamContent()}
-            </div>
+              <div class="split-container">
+                <vscode-split-layout
+                  initial-handle-position=${splitHandlePosition}
+                >
+                  <div
+                    slot="start"
+                    class="content-area"
+                    @stream-switch=${this.onStreamSwitch}
+                  >
+                    ${this.renderStreamContent()}
+                  </div>
 
-            <stream-tabs
-              slot="end"
-              .compact=${compactTabs}
-              .streams=${this.tabStreams$.get()}
-              .activeStreamId=${this.activeStreamId$.get()}
-              .filter=${this.streamFilter$.get()}
-              .streamStates=${this.streamStates$.get()}
-              .pendingApprovalStreamIds=${this.pendingApprovalIds$.get()}
-              .childStreamsByParent=${this.childStreamsByParent$.get()}
-              @stream-switch=${this.onStreamSwitch}
-              @stream-delete=${this.onStreamDelete}
-              @filter-change=${this.onFilterChange}
-              @delete-all=${this.onDeleteAll}
-            ></stream-tabs>
-          </vscode-split-layout>
-        </div>
+                  <stream-tabs
+                    slot="end"
+                    .compact=${compactTabs}
+                    .streams=${this.tabStreams$.get()}
+                    .activeStreamId=${this.activeStreamId$.get()}
+                    .filter=${this.streamFilter$.get()}
+                    .streamStates=${this.streamStates$.get()}
+                    .pendingApprovalStreamIds=${this.pendingApprovalIds$.get()}
+                    .childStreamsByParent=${this.childStreamsByParent$.get()}
+                    @stream-switch=${this.onStreamSwitch}
+                    @stream-delete=${this.onStreamDelete}
+                    @filter-change=${this.onFilterChange}
+                    @delete-all=${this.onDeleteAll}
+                  ></stream-tabs>
+                </vscode-split-layout>
+              </div>
+            `}
       </div>
+    `;
+  }
+
+  private renderDesktopEmptyProgress(): TemplateResult {
+    return html`
+      <section class="desktop-empty-progress" aria-label="Progress">
+        <div class="desktop-empty-progress__body">
+          <i
+            class="codicon codicon-server-process desktop-empty-progress__icon"
+          ></i>
+          <h1>No runs yet</h1>
+          <p>
+            Start a TeXRA run from the Launcher. Open Settings if agents or
+            models need configuration first.
+          </p>
+          <div class="desktop-empty-progress__actions">
+            <vscode-button @click=${this.onShowLauncher}>
+              <span slot="start" class="codicon codicon-edit"></span>
+              Launcher
+            </vscode-button>
+            <vscode-button
+              appearance="secondary"
+              @click=${this.onOpenDashboard}
+            >
+              <span slot="start" class="codicon codicon-gear"></span>
+              Settings
+            </vscode-button>
+          </div>
+        </div>
+      </section>
     `;
   }
 
@@ -691,6 +797,10 @@ export class ProgressApp extends ProgressAppBase {
 
   private onOpenDashboard = (): void => {
     postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'dashboard' });
+  };
+
+  private onShowLauncher = (): void => {
+    postMessage(COMMON_COMMANDS.SWITCH_VIEW, { view: 'main' });
   };
 
   private onPopOut = (): void => {

--- a/packages/extension/src/progressView/frontend/ProgressApp.ts
+++ b/packages/extension/src/progressView/frontend/ProgressApp.ts
@@ -247,7 +247,7 @@ export class ProgressApp extends ProgressAppBase {
 
       .desktop-empty-progress h1 {
         margin: var(--spacing-small) 0 0;
-        color: var(--texra-foreground, var(--color-text-primary));
+        color: var(--texra-foreground);
         font-size: 24px;
         font-weight: 600;
         letter-spacing: 0;

--- a/packages/extension/src/progressView/frontend/components/LogList.ts
+++ b/packages/extension/src/progressView/frontend/components/LogList.ts
@@ -63,6 +63,7 @@ interface CachedStream {
   messages: LogMessageData[];
   toggleStates: ToggleStateStore;
   ref: Ref<TaskGroupList>;
+  status: string | null;
   /** Whether to render this stream's logs in terminal style. */
   terminalMode: boolean;
 }
@@ -117,6 +118,7 @@ export class LogList extends LitElement {
       const entry = this.getOrCreateEntry(streamId);
       entry.groups = this.streamContext.taskGroups;
       entry.messages = this.streamContext.logs;
+      entry.status = this.streamContext.streamStatus;
       entry.terminalMode = this.streamContext.terminalMode;
 
       // Evict oldest non-active entries when cache exceeds cap
@@ -128,6 +130,7 @@ export class LogList extends LitElement {
     if (this.streamCache.size === 0 || !this.streamContext.hasStreams) {
       return html`<task-group-list
         .hasStreams=${this.streamContext.hasStreams}
+        .streamStatus=${this.streamContext.streamStatus}
       ></task-group-list>`;
     }
 
@@ -141,6 +144,7 @@ export class LogList extends LitElement {
           .groups=${data.groups}
           .messages=${data.messages}
           .hasStreams=${this.streamContext.hasStreams}
+          .streamStatus=${data.status}
           .toggleStates=${data.toggleStates}
           ?terminal=${data.terminalMode}
         ></task-group-list>
@@ -218,6 +222,7 @@ export class LogList extends LitElement {
       messages: [],
       toggleStates,
       ref: createRef<TaskGroupList>(),
+      status: null,
       terminalMode: false,
     };
     this.streamCache.set(streamId, entry);

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -23,19 +23,15 @@ import {
 } from '@shared/utils/icons';
 import { formatRelativeTime } from '@shared/utils/string';
 import { layoutStyles } from '../styles/logStyles';
-import { ELEMENT_IDS, FILTER_BUTTONS } from '../constants';
+import {
+  ACTIVE_STREAM_STATUSES,
+  ELEMENT_IDS,
+  FILTER_BUTTONS,
+} from '../constants';
 import { ProgressEvents } from '../events';
 import { getComposedPathElement, getRadioValue, setsEqual } from '../utils';
 import type { StreamState } from '../store';
 import type { StreamFilter } from '../store';
-
-/** Stream statuses considered active (non-terminal) for child stream display. */
-const ACTIVE_CHILD_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.WAITING,
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.RESUMING,
-]);
 
 type ChildActivity = 'active' | 'finished' | 'unknown';
 
@@ -51,7 +47,7 @@ function classifyChild(
 ): ChildActivity {
   const status = streamStates.get(name)?.status;
   if (status === undefined) return 'unknown';
-  return ACTIVE_CHILD_STATUSES.has(status) ? 'active' : 'finished';
+  return ACTIVE_STREAM_STATUSES.has(status) ? 'active' : 'finished';
 }
 
 function buildTooltip(

--- a/packages/extension/src/progressView/frontend/components/StreamTabs.ts
+++ b/packages/extension/src/progressView/frontend/components/StreamTabs.ts
@@ -800,7 +800,7 @@ export class StreamTabs extends LitElement {
               </div>`,
           )}
         </div>
-        ${this.compact
+        ${this.compact || (this.streams.length === 0 && this.filter === 'all')
           ? nothing
           : html`<div class="stream-list-footer">
               <div class="stream-list-controls">

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -29,7 +29,11 @@ import { formatDuration } from '@utils/core';
 // Local imports - shared styles
 
 // Local imports - progress view constants
-import { ELEMENT_IDS, GROUP_DOM_IDS } from '../constants';
+import {
+  ACTIVE_STREAM_STATUSES,
+  ELEMENT_IDS,
+  GROUP_DOM_IDS,
+} from '../constants';
 
 // Local imports - progress view styles
 import { logStyles } from '../styles/logStyles';
@@ -50,13 +54,6 @@ interface GroupTree {
 const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
-
-const ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set([
-  STREAM_STATUS.INITIALIZING,
-  STREAM_STATUS.RUNNING,
-  STREAM_STATUS.RESUMING,
-  STREAM_STATUS.WAITING,
-]);
 
 const ESCAPE_CHARACTER = String.fromCharCode(27);
 // Null byte used as a sentinel for ANSI erase-line sequences inside processTerminalText.

--- a/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
+++ b/packages/extension/src/progressView/frontend/components/TaskGroupList.ts
@@ -51,6 +51,13 @@ const PLACEHOLDER_HTML = getGettingStartedHtml(
   'No runs yet—use TeXRA commands to start. Try ',
 );
 
+const ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set([
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.RESUMING,
+  STREAM_STATUS.WAITING,
+]);
+
 const ESCAPE_CHARACTER = String.fromCharCode(27);
 // Null byte used as a sentinel for ANSI erase-line sequences inside processTerminalText.
 // Real null bytes in the input are stripped first so the sentinel is unambiguous.
@@ -125,6 +132,9 @@ export class TaskGroupList extends LitElement {
 
   /** Whether there are any streams in the current filter (controls placeholder) */
   @property({ attribute: false }) hasStreams = false;
+
+  /** Status for the active stream, used while a run exists before logs arrive. */
+  @property({ attribute: false }) streamStatus: string | null = null;
 
   /** Toggle state store for persistence */
   @property({ attribute: false }) toggleStates: ToggleStateStore | null = null;
@@ -769,6 +779,29 @@ export class TaskGroupList extends LitElement {
           @vsc-scrollable-scroll=${this.handleVscScroll}
         >
           <div class="log-placeholder">${unsafeHTML(PLACEHOLDER_HTML)}</div>
+        </vscode-scrollable>
+      `;
+    }
+
+    if (
+      !this.terminal &&
+      this.messages.length === 0 &&
+      this.groups.length === 0
+    ) {
+      const active = this.streamStatus
+        ? ACTIVE_STREAM_STATUSES.has(this.streamStatus)
+        : false;
+      return html`
+        <vscode-scrollable
+          id=${ELEMENT_IDS.LOG_CONTENT}
+          class="log-container"
+          @vsc-scrollable-scroll=${this.handleVscScroll}
+        >
+          <div class="log-placeholder">
+            ${active
+              ? 'Run is starting. Progress updates will appear here.'
+              : 'No log output for this stream yet.'}
+          </div>
         </vscode-scrollable>
       `;
     }

--- a/packages/extension/src/progressView/frontend/constants.ts
+++ b/packages/extension/src/progressView/frontend/constants.ts
@@ -1,5 +1,5 @@
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/commands';
-import type { AgentCategoryFilter } from '@shared/schemas';
+import { STREAM_STATUS, type AgentCategoryFilter } from '@shared/schemas';
 
 /**
  * DOM element IDs used across the progress view.
@@ -50,6 +50,13 @@ export const GROUP_DOM_IDS = Object.freeze({
   HEADER_PREFIX: 'group-header-',
   CONTENT_PREFIX: 'group-content-',
 });
+
+export const ACTIVE_STREAM_STATUSES: ReadonlySet<string> = new Set([
+  STREAM_STATUS.INITIALIZING,
+  STREAM_STATUS.RUNNING,
+  STREAM_STATUS.RESUMING,
+  STREAM_STATUS.WAITING,
+]);
 
 const STOP_STREAM_BUTTON = Object.freeze({
   id: ELEMENT_IDS.STOP_STREAM_BTN,

--- a/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
+++ b/packages/extension/src/progressView/frontend/contexts/streamContexts.ts
@@ -10,6 +10,7 @@ import { createContext } from '@lit/context';
 // Local imports - progress view
 import type {
   LogMessageData,
+  StreamStatus,
   StreamTabId,
   StreamTabInfo,
   TaskGroup,
@@ -55,6 +56,8 @@ export interface StreamLogContextValue {
   hasStreams: boolean;
   /** Stream name for switch detection in LogList */
   streamName: string | null;
+  /** Current active stream status for pre-output empty states. */
+  streamStatus: StreamStatus | null;
   /** Render log output in terminal style (monospace, no timestamps, etc). */
   terminalMode: boolean;
 }
@@ -65,6 +68,7 @@ export const EMPTY_LOG_CONTEXT: StreamLogContextValue = {
   isToolUse: false,
   hasStreams: false,
   streamName: null,
+  streamStatus: null,
   terminalMode: false,
 };
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -59,24 +59,31 @@ const codexPlatformInfoByKey = {
     binaryName: 'codex.exe',
   },
 };
-const desktopStartupForbiddenBundleMarkers = [
+const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
     patterns: [
-      '@google/genai',
-      'node_modules/.pnpm/@google+genai',
-      'google-auth-library',
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@google\+genai[^/\\]*[/\\]node_modules[/\\])?@google[/\\]genai[/\\]/,
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*google-auth-library[^/\\]*[/\\]node_modules[/\\])?google-auth-library[/\\]/,
     ],
   },
   {
     label: 'OpenAI SDK',
-    patterns: ['node_modules/.pnpm/openai@'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*openai@[^/\\]*[/\\]node_modules[/\\])?openai[/\\]/,
+    ],
   },
   {
     label: 'Anthropic SDK',
-    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@anthropic-ai\+sdk[^/\\]*[/\\]node_modules[/\\])?@anthropic-ai[/\\]sdk[/\\]/,
+    ],
   },
 ];
+const desktopStartupEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+]);
 
 async function exists(path) {
   try {
@@ -145,6 +152,22 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = normalizeMetafilePath(importPath);
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {
@@ -323,66 +346,81 @@ async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
   return bundles.sort();
 }
 
-function parseStaticRelativeImports(source) {
-  const imports = [];
-  const staticImportPattern =
-    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
-  for (const match of source.matchAll(staticImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function parseDynamicRelativeImports(source) {
-  const imports = [];
-  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
-  for (const match of source.matchAll(dynamicImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
 async function checkDesktopStartupBundles(app, failures) {
   const entryPath = 'dist/main/index.js';
+  const metafilePath = 'dist/main/metafile.json';
   if (!(await app.exists(entryPath))) return;
-
-  const pending = [entryPath];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const bundlePath = pending.shift();
-    if (!bundlePath || visited.has(bundlePath)) continue;
-    visited.add(bundlePath);
-
-    const source = await app.readText(bundlePath);
-    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
-      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+  if (!(await app.exists(metafilePath))) {
+    failures.push(
+      `Packaged desktop app is missing the esbuild metafile used to verify startup imports: ${metafilePath}`,
     );
-    if (forbidden.length > 0) {
+    return;
+  }
+
+  const metafile = await app.readJson(metafilePath);
+  const outputByPath = new Map();
+  for (const [outputPath, output] of Object.entries(metafile.outputs ?? {})) {
+    outputByPath.set(normalizeMetafilePath(outputPath), output);
+  }
+
+  const pending = [];
+  for (const [outputPath, output] of outputByPath) {
+    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
+    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+  }
+  if (pending.length === 0) {
+    failures.push(
+      `Packaged desktop startup graph is missing expected esbuild entry points: ${[
+        ...desktopStartupEntryPoints,
+      ].join(', ')}`,
+    );
+    return;
+  }
+
+  const visitedOutputs = new Set();
+  const startupInputsByForbiddenLabel = new Map();
+  while (pending.length > 0) {
+    const outputPath = pending.shift();
+    if (!outputPath || visitedOutputs.has(outputPath)) continue;
+    visitedOutputs.add(outputPath);
+
+    const output = outputByPath.get(normalizeMetafilePath(outputPath));
+    if (!output) {
       failures.push(
-        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
-          .map(({ label }) => label)
-          .join(', ')}): ${bundlePath}`,
+        `Packaged desktop startup bundle is missing from the esbuild metafile: ${outputPath}`,
       );
+      continue;
     }
 
-    const imports = parseStaticRelativeImports(source);
-    if (bundlePath === entryPath) {
-      const dynamicImports = parseDynamicRelativeImports(source);
-      if (dynamicImports.length !== 1) {
-        failures.push(
-          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
-        );
+    for (const inputPath of Object.keys(output.inputs ?? {})) {
+      const normalizedInput = normalizeMetafilePath(inputPath);
+      for (const { label, patterns } of desktopStartupForbiddenInputPackages) {
+        if (!patterns.some((pattern) => pattern.test(normalizedInput))) {
+          continue;
+        }
+        const inputPaths = startupInputsByForbiddenLabel.get(label) ?? [];
+        inputPaths.push(normalizedInput);
+        startupInputsByForbiddenLabel.set(label, inputPaths);
       }
-      imports.push(...dynamicImports);
     }
-    for (const specifier of imports) {
-      const importedPath = posix.normalize(
-        posix.join(posix.dirname(bundlePath), specifier),
+
+    for (const importedOutput of output.imports ?? []) {
+      if (importedOutput.external) continue;
+      if (importedOutput.kind !== 'import-statement') continue;
+      const importedPath = resolveMetafileImportPath(
+        outputPath,
+        importedOutput.path,
       );
-      if (await app.exists(importedPath)) {
-        pending.push(importedPath);
-      }
+      if (outputByPath.has(importedPath)) pending.push(importedPath);
     }
+  }
+
+  for (const [label, inputPaths] of startupInputsByForbiddenLabel) {
+    failures.push(
+      `Packaged desktop startup graph eagerly includes provider SDK code (${label}): ${[
+        ...new Set(inputPaths),
+      ].join(', ')}`,
+    );
   }
 }
 
@@ -633,7 +671,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
-  '- desktop startup bundles exclude provider SDKs',
+  '- desktop startup import graph excludes provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,35 +232,70 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string; stack?: string };
+  const candidate = err as { provider?: string; headers?: HeaderBag } & {
+    constructor?: { name?: string };
+    stack?: string;
+  };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
   }
 
-  const providerFromClassNames = detectProviderFromClassNames(
+  const classNameProvider = detectProviderFromClassNames(
     getErrorClassNames(err),
   );
-  if (providerFromClassNames) return providerFromClassNames;
+  if (classNameProvider) return classNameProvider;
 
-  return detectProviderFromText(candidate.stack ?? '');
+  const providerFromStack = detectProviderFromText(candidate.stack ?? '');
+  if (providerFromStack) {
+    return providerFromStack;
+  }
+
+  return detectProviderFromHeaders(candidate.headers);
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly string[],
+  classNames: readonly (string | undefined)[],
 ): string | undefined {
-  // Match SDK class-name fragments, then normalize aliases to the
-  // canonical API-provider names used by SecretManager / model handlers.
-  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
-  // (class name contains "kimi") maps to "moonshot".
-  const loweredClassNames = classNames.map((className) =>
-    className.toLowerCase(),
-  );
-  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    loweredClassNames.some((className) => className.includes(p)),
+  // Match SDK class-name fragments, then normalize aliases to the canonical
+  // API-provider names used by SecretManager / model handlers. This also covers
+  // no-response connection errors whose provider only appears on a base SDK
+  // class such as OpenAIError or AnthropicError.
+  const names = classNames
+    .filter((name): name is string => isString(name) && name.length > 0)
+    .map((name) => name.toLowerCase());
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (provider) => names.some((name) => name.includes(provider)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;
+}
+
+type HeaderBag =
+  | {
+      get?: (key: string) => string | null;
+    }
+  | Record<string, unknown>;
+type HeaderDetectedProvider = 'anthropic';
+
+function getHeaderValue(
+  headers: HeaderBag | undefined,
+  name: string,
+): string | undefined {
+  const maybeGet = isObject(headers) ? headers.get : undefined;
+  const direct =
+    typeof maybeGet === 'function' ? maybeGet.call(headers, name) : undefined;
+  if (isString(direct) && direct) return direct;
+
+  const indexed = (headers as Record<string, unknown> | undefined)?.[name];
+  return isString(indexed) && indexed ? indexed : undefined;
+}
+
+function detectProviderFromHeaders(
+  headers: HeaderBag | undefined,
+): HeaderDetectedProvider | undefined {
+  if (getHeaderValue(headers, 'request-id')) return 'anthropic';
+  return undefined;
 }
 
 function detectProviderFromText(text: string): string | undefined {
@@ -280,10 +315,12 @@ function detectRequestId(err: unknown): string | undefined {
   const candidate = err as {
     request_id?: string;
     requestId?: string;
-    headers?: { get?: (key: string) => string | null };
+    requestID?: string;
+    headers?: HeaderBag;
   };
 
-  const directId = candidate.request_id ?? candidate.requestId;
+  const directId =
+    candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
@@ -291,8 +328,8 @@ function detectRequestId(err: unknown): string | undefined {
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
   // ?? undefined converts null from headers.get() to undefined
   return (
-    candidate.headers?.get?.('request-id') ??
-    candidate.headers?.get?.('x-request-id') ??
+    getHeaderValue(candidate.headers, 'request-id') ??
+    getHeaderValue(candidate.headers, 'x-request-id') ??
     undefined
   );
 }
@@ -343,7 +380,7 @@ export function takeTail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
-/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+/** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
   return getErrorClassNames(err).includes('APIUserAbortError');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,9 +232,7 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string } & {
-    constructor?: { name?: string };
-  };
+  const candidate = err as { provider?: string };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
@@ -243,9 +241,6 @@ function detectProvider(err: unknown): string | undefined {
   const loweredClassNames = getErrorClassNames(err).map((className) =>
     className.toLowerCase(),
   );
-  if (isString(candidate.constructor?.name)) {
-    loweredClassNames.push(candidate.constructor.name.toLowerCase());
-  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,15 +240,19 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const lowered = candidate.constructor?.name?.toLowerCase();
-  if (!lowered) return undefined;
+  const loweredClassNames = getErrorClassNames(err).map((className) =>
+    className.toLowerCase(),
+  );
+  if (isString(candidate.constructor?.name)) {
+    loweredClassNames.push(candidate.constructor.name.toLowerCase());
+  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.
   // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
   // (class name contains "kimi") maps to "moonshot".
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+    loweredClassNames.some((className) => className.includes(p)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,12 +1,29 @@
 // Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+} from '@anthropic-ai/sdk';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+} from 'openai';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
+
+class KimiAPIError extends APIError {}
 
 class APIUserAbortError extends APIError {}
 
@@ -20,6 +37,123 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('new provider error shape');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('matches SDK abort errors through the prototype chain', () => {
+    expect(isUserAbort(new APIUserAbortError('aborted'))).toBe(true);
+  });
+
+  it('preserves native SDK abort detection for packaged builds', () => {
+    expect(isUserAbort(new OpenAIAPIUserAbortError())).toBe(true);
+    expect(isUserAbort(new AnthropicAPIUserAbortError())).toBe(true);
+  });
+
+  it('preserves provider context for native OpenAI HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIAuthenticationError(
+        401,
+        { message: 'invalid api key', type: 'invalid_request_error' },
+        'invalid api key',
+        new Headers({ 'x-request-id': 'req-openai' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.requestId).toBe('req-openai');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native OpenAI connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new OpenAIAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new OpenAIAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('openai');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('openai');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('preserves provider context for native Anthropic HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(
+        401,
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid api key' },
+        },
+        'invalid api key',
+        new Headers({ 'request-id': 'req-anthropic' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native Anthropic connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new AnthropicAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new AnthropicAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('anthropic');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('anthropic');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('prefers Anthropic request-id when response headers include both request id styles', () => {
+    const err = new UnknownSdkApiError('upstream auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({
+      'request-id': 'req-anthropic',
+      'x-request-id': 'req-openai-compatible',
+    });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+  });
+
+  it('does not infer OpenAI from generic x-request-id headers', () => {
+    const err = new UnknownSdkApiError(
+      'openai-compatible gateway failed',
+    ) as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-compatible' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBeUndefined();
+    expect(formatted.requestId).toBe('req-compatible');
+  });
+
+  it('prefers SDK class provider hints over OpenAI-compatible request headers', () => {
+    const err = new KimiAPIError('moonshot auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-kimi' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('moonshot');
+    expect(formatted.requestId).toBe('req-kimi');
   });
 
   it('detects OpenAI provider from Windows pnpm stack paths', () => {


### PR DESCRIPTION
## Summary
- Replace the standalone desktop Progress no-run state with a single centered empty state instead of an empty split layout.
- Hide the extension Progress header in desktop mode, tune desktop stream-list proportions, and keep stream filters/actions out of the true empty stream list.
- Add an explicit pre-output log placeholder for selected running streams so the content area communicates that progress is starting.

Stacked on #3596 for shared desktop package verifier and SDK/provider changes.

Closes #3563.

## Validation
- `npm run -s test:kernel -- src/test/progressView src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `corepack pnpm exec prettier --check packages/extension/src/progressView/frontend/ProgressApp.ts packages/extension/src/progressView/frontend/components/LogList.ts packages/extension/src/progressView/frontend/components/StreamTabs.ts packages/extension/src/progressView/frontend/components/TaskGroupList.ts packages/extension/src/progressView/frontend/contexts/streamContexts.ts`
- `git diff --check origin/codex/desktop-package-metafile-verifier...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/layout changes in the Progress webview; the only behavioral change is plumbing `streamStatus` through contexts to adjust placeholders, which is low risk but could affect empty-state rendering logic.
> 
> **Overview**
> **Polishes desktop Progress layout and empty states.** In desktop mode, the Progress header is hidden, the split handle/tab widths are adjusted, and a dedicated centered "No runs yet" screen is shown when there are *no streams at all* (with actions to open Launcher/Settings) instead of rendering an empty split view.
> 
> **Improves placeholder messaging before logs appear.** The active stream’s `status` is now passed through `StreamLogContext`/`LogList` into `TaskGroupList` to show a "Run is starting" placeholder for active (non-terminal) streams with no output yet, and stream-status "active" checks are centralized via `ACTIVE_STREAM_STATUSES`. Stream tab footer controls are also hidden when the list is truly empty and the filter is `all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc1beeb7b7e3973ad4f5a2fa9d7036357e5b1017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->