### PR TITLE
[codex] Wire desktop agent proposal setup

### DIFF
--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -199,13 +199,19 @@ export class DesktopProgressBridge {
     this.agentProposalController = new ProgressAgentProposalController({
       getPendingProposal: (proposalId) => this.agentProposals.get(proposalId),
       restoreTaskState: async (taskState) => {
+        let state: ReturnType<typeof buildMainViewState>;
+        try {
+          state = buildMainViewState(taskState);
+        } catch {
+          return false;
+        }
         this.postToRenderer({
           command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
           route: 'main',
         });
         this.postToRenderer({
           command: COMMON_COMMANDS.STATE_RESTORE,
-          state: buildMainViewState(taskState),
+          state,
         });
         return true;
       },

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -5,6 +5,8 @@ import {
   prepareMainViewExecutionRequest,
   type MainViewExecuteMessage,
 } from '@controllers/mainView/MainViewExecutionController';
+import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
+import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { emitAcceptedWorkspaceFile } from '@controllers/progressView/workflowFileActionsEvents';
 import { nodeFilesystem } from '@platform/defaults/nodeFilesystem';
@@ -30,6 +32,7 @@ import {
   type ListableFileType,
 } from '@common/files/fileListingRules';
 import { listWorkspaceFiles } from '@common/files/workspaceFileListing';
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { DiffViewHost } from '@hosts/diffViewHost';
@@ -42,6 +45,7 @@ import { StreamLogStore } from '@logger/StreamLogStore';
 import {
   STREAM_STATUS,
   type ActiveChildInfo,
+  type AgentProposalPermission,
   type AgentCategory,
   type AgentCategoryFilter,
   type ConversationProgress,
@@ -119,9 +123,11 @@ function toFileLocation(filePath: string): FileLocation {
 export class DesktopProgressBridge {
   private readonly streamLogs = new StreamLogStore();
   private readonly logger = new AgentLogger('DesktopProgressBridge');
+  private readonly agentProposalController: ProgressAgentProposalController;
   private readonly workflowFileActions: ProgressWorkflowFileActionsController;
   private readonly cursors = new Map<StreamTabId, number>();
   private readonly taskStates = new Map<StreamTabId, TaskState>();
+  private readonly agentProposals = new Map<string, AgentProposalPermission>();
   private readonly outputFiles = new Map<StreamTabId, OutputFilesByRound>();
   private readonly statuses = new Map<StreamTabId, StreamStatus>();
   private readonly categories = new Map<StreamTabId, AgentCategory>();
@@ -190,11 +196,47 @@ export class DesktopProgressBridge {
         await this.sendFollowUp(stream, text);
       },
     });
+    this.agentProposalController = new ProgressAgentProposalController({
+      getPendingProposal: (proposalId) => this.agentProposals.get(proposalId),
+      restoreTaskState: async (taskState) => {
+        this.postToRenderer({
+          command: DESKTOP_SHELL_COMMANDS.SET_ROUTE,
+          route: 'main',
+        });
+        this.postToRenderer({
+          command: COMMON_COMMANDS.STATE_RESTORE,
+          state: buildMainViewState(taskState),
+        });
+        return true;
+      },
+      resolveProposal: (proposalId, result) => {
+        proposalCoordinator.resolveRequest(proposalId, result);
+      },
+      onMissingProposal: (proposalId) => {
+        this.logger.warn(
+          `No pending agent proposal found for setup: ${proposalId}`,
+        );
+      },
+      onInvalidProposal: (issues) => {
+        this.logger.warn('Invalid proposal config', {
+          data: { errors: issues },
+        });
+      },
+      onSetupComplete: (proposal) => {
+        this.logger.info(
+          `Agent proposal ${proposal.proposalId} set up in main view`,
+          {
+            data: { agent: proposal.agent },
+          },
+        );
+      },
+    });
   }
 
   dispose(): void {
     this.toolEditApprovals.dispose();
     this.unsubscribe();
+    this.agentProposals.clear();
     this.cursors.clear();
     this.taskStates.clear();
     this.outputFiles.clear();
@@ -602,18 +644,21 @@ export class DesktopProgressBridge {
         break;
       }
       case 'showAgentProposal': {
+        const data = payload as ProgressEventPayloads['showAgentProposal'];
+        this.agentProposals.set(data.proposalId, data);
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
           action: 'show',
           permission: {
             kind: 'proposal',
-            data: payload as ProgressEventPayloads['showAgentProposal'],
+            data,
           },
         });
         break;
       }
       case 'resolveAgentProposal': {
         const data = payload as ProgressEventPayloads['resolveAgentProposal'];
+        this.agentProposals.delete(data.proposalId);
         this.send({
           command: PROGRESS_VIEW_COMMANDS.UPDATE_PERMISSION,
           action: 'resolve',
@@ -730,6 +775,7 @@ export class DesktopProgressBridge {
     this.statuses.delete(streamId);
     this.categories.delete(streamId);
     this.executionIds.delete(streamId);
+    this.deleteAgentProposalsForStream(streamId);
     this.descriptions.delete(streamId);
     this.parentStreams.delete(streamId);
     this.creationTimestamps.delete(streamId);
@@ -770,6 +816,7 @@ export class DesktopProgressBridge {
     this.statuses.clear();
     this.categories.clear();
     this.executionIds.clear();
+    this.agentProposals.clear();
     this.descriptions.clear();
     this.parentStreams.clear();
     this.creationTimestamps.clear();
@@ -900,23 +947,13 @@ export class DesktopProgressBridge {
     });
   }
 
-  handleAgentProposalAction(
+  async handleAgentProposalAction(
     message: Extract<
       ProgressViewInboundMessage,
       { command: typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION }
     >,
-  ): boolean {
-    if (message.action === 'setup') return false;
-
-    proposalCoordinator.resolveRequest(message.proposalId, {
-      action: message.action,
-      ...(message.action === 'approve' && {
-        model: message.model,
-        agent: message.agent,
-      }),
-      ...(message.action === 'reject' && { feedback: message.feedback }),
-    });
-    return true;
+  ): Promise<boolean> {
+    return this.agentProposalController.handleAction(message);
   }
 
   async runExecution(request: ValidatedExecutionRequest): Promise<void> {
@@ -1055,6 +1092,14 @@ export class DesktopProgressBridge {
     }
 
     return false;
+  }
+
+  private deleteAgentProposalsForStream(streamId: StreamTabId): void {
+    for (const [proposalId, proposal] of this.agentProposals.entries()) {
+      if (proposal.streamId === streamId) {
+        this.agentProposals.delete(proposalId);
+      }
+    }
   }
 
   private async listWorkspaceFiles(

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -220,17 +220,17 @@ export class DesktopProgressBridge {
       },
       onMissingProposal: (proposalId) => {
         this.logger.warn(
-          `No pending agent proposal found for setup: ${proposalId}`,
+          `No pending desktop agent proposal found for setup: ${proposalId}`,
         );
       },
       onInvalidProposal: (issues) => {
-        this.logger.warn('Invalid proposal config', {
+        this.logger.warn('Invalid desktop agent proposal config', {
           data: { errors: issues },
         });
       },
       onSetupComplete: (proposal) => {
         this.logger.info(
-          `Agent proposal ${proposal.proposalId} set up in main view`,
+          `Desktop agent proposal ${proposal.proposalId} set up in main view`,
           {
             data: { agent: proposal.agent },
           },

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -90,9 +90,7 @@ export function createDesktopProgressIpc(
           runAsync(
             options.progress
               .handleAgentProposalAction(result.data)
-              .then((handled) => {
-                if (!handled) onUnsupportedCommand(result.data);
-              }),
+              .then(() => {}),
           );
           return true;
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE:

--- a/packages/desktop/src/main/desktopProgressIpc.ts
+++ b/packages/desktop/src/main/desktopProgressIpc.ts
@@ -87,10 +87,13 @@ export function createDesktopProgressIpc(
           options.progress.handlePlanApprovalAction(result.data);
           return true;
         case PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION:
-          if (options.progress.handleAgentProposalAction(result.data)) {
-            return true;
-          }
-          onUnsupportedCommand(result.data);
+          runAsync(
+            options.progress
+              .handleAgentProposalAction(result.data)
+              .then((handled) => {
+                if (!handled) onUnsupportedCommand(result.data);
+              }),
+          );
           return true;
         case PROGRESS_VIEW_COMMANDS.OPEN_FILE:
           runAsync(

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -29,7 +29,7 @@ export function registerStateRestoreCommand(
 async function restoreState(
   state: unknown,
   executeImmediately?: boolean,
-): Promise<void> {
+): Promise<boolean> {
   logger.debug(CHANNEL, 'Restoring main webview state', {
     data: { executeImmediately },
   });
@@ -40,7 +40,7 @@ async function restoreState(
       data: { validationError: parsed.error.message },
     });
     await vscode.window.showErrorMessage(RESTORE_MALFORMED_MESSAGE);
-    return;
+    return false;
   }
 
   try {
@@ -56,7 +56,7 @@ async function restoreState(
         executeImmediately,
       });
       logger.info(CHANNEL, 'State restored via direct webview access');
-      return;
+      return true;
     }
 
     setPendingState(nextState, executeImmediately);
@@ -64,7 +64,9 @@ async function restoreState(
     logger.info(CHANNEL, 'State stored for later restoration', {
       data: { executeImmediately },
     });
+    return true;
   } catch (error) {
     await showLoggedErrorMessage(CHANNEL, 'Failed to restore state', error);
+    return false;
   }
 }

--- a/packages/extension/src/commands/history/stateRestoreCommand.ts
+++ b/packages/extension/src/commands/history/stateRestoreCommand.ts
@@ -1,10 +1,12 @@
 // Third-party imports
 import * as vscode from 'vscode';
 
+// Local imports - controllers
+import { buildMainViewState } from '@controllers/mainView/MainViewStateRestoreController';
+
 // Local imports
 import { setPendingState } from '@common/state';
 import { COMMON_COMMANDS } from '@common/webview/commands';
-import { buildMainViewState } from '@frontend/mainViewStateUtils';
 import { showLoggedErrorMessage } from '@frontend/ui/errorHandlingUtils';
 import { getMainWebview } from '@frontend/system/commandUtils';
 import * as logger from '@logger/logUtils';

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -248,7 +248,22 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         await this.agentProposalController.handleAction(data);
       },
       [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
-        await this.agentProposalController.restoreProposalConfig(data.proposal);
+        const restored =
+          await this.agentProposalController.restoreProposalConfig(
+            data.proposal,
+          );
+        if (restored) {
+          this.logger.info(
+            this.channel,
+            'Restored proposal config to main view',
+            {
+              data: {
+                agent: data.proposal.agent,
+                agentCategory: data.proposal.agentCategory,
+              },
+            },
+          );
+        }
       },
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
         handleProgressViewBashApprovalAction(data),

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -498,9 +498,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
       getPendingProposal: (proposalId) =>
         this.provider.getPendingAgentProposal(proposalId),
       restoreTaskState: async (taskState) => {
-        await vscode.commands.executeCommand('texra.showMainView');
-        await vscode.commands.executeCommand('texra.restoreState', taskState);
-        return true;
+        return (
+          (await vscode.commands.executeCommand<boolean>(
+            'texra.restoreState',
+            taskState,
+          )) === true
+        );
       },
       resolveProposal: (proposalId, result) => {
         proposalCoordinator.resolveRequest(proposalId, result);

--- a/packages/extension/src/progressView/ProgressViewMessageHandler.ts
+++ b/packages/extension/src/progressView/ProgressViewMessageHandler.ts
@@ -5,11 +5,10 @@ import {
   ProgressFollowUpController,
   type ProgressFollowUpPlan,
 } from '@controllers/progressView/ProgressFollowUpController';
+import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
 import { ProgressWorkflowActionsController } from '@controllers/progressView/ProgressWorkflowActionsController';
 import { ProgressWorkflowFileActionsController } from '@controllers/progressView/ProgressWorkflowFileActionsController';
 import { getAgent } from '@agent/index';
-import { AgentCategory } from '@agent/core/AgentDataclass';
-import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { proposalCoordinator } from '@agent/runtime/AgentProposalCoordinator';
 import { planApprovalCoordinator } from '@agent/runtime/PlanApprovalCoordinator';
 import { retryCoordinator } from '@agent/runtime/RetryRequestCoordinator';
@@ -31,10 +30,8 @@ import { SecretManager, type ApiProvider } from '@frontend/secretManager';
 import { loadOptions } from '@frontend/agents/optionsLoader';
 import { handleProgressViewToolEditApprovalAction } from '@frontend/approval/nativeToolEditApproval';
 import { safeExecuteCommand } from '@frontend/system/commandUtils';
-import type { TaskState } from '@logger/TaskState';
 import { invalidateModelOptionsCache } from '@model/computeModelOptions';
 import type { StreamTabId } from '@shared/schemas';
-import type { AgentProposal } from '@shared/schemas/prompts';
 import {
   dispatchProgressViewInbound,
   type ProgressViewInboundHandlerRegistry,
@@ -81,6 +78,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
   private readonly streamLifecycleController: ProgressStreamLifecycleController;
   private readonly workflowActionsController: ProgressWorkflowActionsController;
   private readonly workflowFileActionsController: ProgressWorkflowFileActionsController;
+  private readonly agentProposalController: ProgressAgentProposalController;
   private readonly followUpController: ProgressFollowUpController;
   private readonly modelOutputBackups = new Map<
     StreamTabId,
@@ -117,6 +115,7 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     this.workflowActionsController = this.createWorkflowActionsController();
     this.workflowFileActionsController =
       this.createWorkflowFileActionsController();
+    this.agentProposalController = this.createAgentProposalController();
     this.followUpController = this.createFollowUpController();
 
     const unsubscribeRemoveStream = bus.on('removeStream', ({ streamId }) => {
@@ -245,10 +244,12 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
           : 'Delegated task auto-approval disabled for this stream.';
         await vscode.window.showInformationMessage(msg);
       },
-      [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: (data) =>
-        this.handleAgentProposalAction(data),
-      [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: (data) =>
-        this.handleRestoreProposalConfig(data),
+      [PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION]: async (data) => {
+        await this.agentProposalController.handleAction(data);
+      },
+      [PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG]: async (data) => {
+        await this.agentProposalController.restoreProposalConfig(data.proposal);
+      },
       [PROGRESS_VIEW_COMMANDS.BASH_APPROVAL_ACTION]: (data) =>
         handleProgressViewBashApprovalAction(data),
       [PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION]: (data) =>
@@ -477,6 +478,41 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     });
   }
 
+  private createAgentProposalController(): ProgressAgentProposalController {
+    return new ProgressAgentProposalController({
+      getPendingProposal: (proposalId) =>
+        this.provider.getPendingAgentProposal(proposalId),
+      restoreTaskState: async (taskState) => {
+        await vscode.commands.executeCommand('texra.showMainView');
+        await vscode.commands.executeCommand('texra.restoreState', taskState);
+        return true;
+      },
+      resolveProposal: (proposalId, result) => {
+        proposalCoordinator.resolveRequest(proposalId, result);
+      },
+      onMissingProposal: (proposalId) => {
+        this.logger.warn(
+          this.channel,
+          `No pending agent proposal found for setup: ${proposalId}`,
+        );
+      },
+      onInvalidProposal: (issues) => {
+        this.logger.warn(this.channel, 'Invalid proposal config', {
+          data: { errors: issues },
+        });
+      },
+      onSetupComplete: (proposal) => {
+        this.logger.info(
+          this.channel,
+          `Agent proposal ${proposal.proposalId} set up in main view`,
+          {
+            data: { agent: proposal.agent },
+          },
+        );
+      },
+    });
+  }
+
   private createFollowUpController(): ProgressFollowUpController {
     return new ProgressFollowUpController({
       getAgentCategory: (agent) => getAgent(agent, true)?.category,
@@ -667,30 +703,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
     );
   }
 
-  private async handleAgentProposalAction(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION>,
-  ): Promise<void> {
-    const { proposalId, action } = data;
-    switch (action) {
-      case 'setup':
-        await this.handleAgentProposalSetup(proposalId);
-        break;
-      case 'approve':
-        proposalCoordinator.resolveRequest(proposalId, {
-          action: 'approve',
-          model: data.model,
-          agent: data.agent,
-        });
-        break;
-      case 'reject':
-        proposalCoordinator.resolveRequest(proposalId, {
-          action: 'reject',
-          feedback: data.feedback,
-        });
-        break;
-    }
-  }
-
   private handlePlanApprovalAction(
     data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION>,
   ): void {
@@ -708,98 +720,6 @@ export class ProgressViewMessageHandler extends BaseViewMessageHandler<
         });
         break;
     }
-  }
-
-  private async handleAgentProposalSetup(proposalId: string): Promise<void> {
-    const proposal = this.provider.getPendingAgentProposal(proposalId);
-    if (!proposal) {
-      this.logger.warn(
-        this.channel,
-        `No pending agent proposal found for setup: ${proposalId}`,
-      );
-      return;
-    }
-
-    const success = await this.restoreProposalToMainView(proposal);
-    if (!success) return;
-
-    proposalCoordinator.resolveRequest(proposalId, { action: 'setup' });
-
-    this.logger.info(
-      this.channel,
-      `Agent proposal ${proposalId} set up in main view`,
-      {
-        data: { agent: proposal.agent },
-      },
-    );
-  }
-
-  private async handleRestoreProposalConfig(
-    data: MessageFor<typeof PROGRESS_VIEW_COMMANDS.RESTORE_PROPOSAL_CONFIG>,
-  ): Promise<void> {
-    const { proposal } = data;
-    const success = await this.restoreProposalToMainView(proposal);
-    if (success) {
-      this.logger.info(this.channel, `Restored proposal config to main view`, {
-        data: {
-          agent: proposal.agent,
-          agentCategory: proposal.agentCategory,
-        },
-      });
-    }
-  }
-
-  /** Build TaskState from proposal fields and restore to main view. */
-  private async restoreProposalToMainView(
-    proposal: AgentProposal,
-  ): Promise<boolean> {
-    const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
-
-    // Use discriminant directly so TypeScript narrows to WorkflowAgentProposal
-    const activeFiles =
-      proposal.agentCategory === AgentCategory.Workflow
-        ? {
-            input: proposal.inputFiles.length > 0,
-            reference: proposal.referenceFiles.length > 0,
-            auxiliary: proposal.auxiliaryFiles.length > 0,
-            media: proposal.mediaFiles.length > 0,
-            output: proposal.outputFiles.length > 0,
-          }
-        : {
-            input: false,
-            reference: false,
-            auxiliary: false,
-            media: false,
-            output: false,
-          };
-
-    const result = AgentConfigSchema.safeParse({
-      ...proposal,
-      ...(isWorkflow && {
-        inputFilesActive: activeFiles.input,
-        referenceFilesActive: activeFiles.reference,
-        auxiliaryFilesActive: activeFiles.auxiliary,
-        mediaFilesActive: activeFiles.media,
-        outputFilesActive: activeFiles.output,
-      }),
-    });
-
-    if (!result.success) {
-      this.logger.warn(this.channel, 'Invalid proposal config', {
-        data: { errors: result.error.issues },
-      });
-      return false;
-    }
-
-    const taskState = (
-      isWorkflow
-        ? { agentConfig: result.data, activeFiles }
-        : { agentConfig: result.data }
-    ) as TaskState;
-
-    await vscode.commands.executeCommand('texra.showMainView');
-    await vscode.commands.executeCommand('texra.restoreState', taskState);
-    return true;
   }
 
   // ============================================================

--- a/src/controllers/mainView/MainViewStateRestoreController.ts
+++ b/src/controllers/mainView/MainViewStateRestoreController.ts
@@ -7,6 +7,8 @@ import {
   isWorkflowTaskState,
   type TaskState,
 } from '@logger/TaskState';
+
+// Local imports - shared schemas
 import {
   MainViewPersistedStateSchema,
   type MainViewPersistedState,
@@ -22,7 +24,7 @@ export function buildMainViewState(
   const activeFiles = isWorkflow ? taskState.activeFiles : undefined;
   const toolConfig = agentConfig.toolConfig ?? {};
 
-  // Resolve agent name to full key (e.g., "criticize" → "builtIn:criticize")
+  // Resolve agent name to full key (e.g., "criticize" -> "builtIn:criticize").
   // This ensures the frontend receives the exact key used in dropdown options.
   // Pass isToolUse to prefer builtInToolUse source for tool-use sessions,
   // preventing workflow agents from shadowing tool-use agents with same name.

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -8,14 +8,12 @@ import type { TaskState } from '@logger/TaskState';
 
 // Local imports - shared
 import type { AgentProposal, AgentProposalPermission } from '@shared/schemas';
+import type { ProgressAgentProposalActionMessage } from '@shared/schemas/progressView';
 
-interface AgentProposalActionInput {
-  proposalId: string;
-  action: 'approve' | 'reject' | 'setup';
-  feedback?: string;
-  model?: string;
-  agent?: string;
-}
+type AgentProposalActionInput = Omit<
+  ProgressAgentProposalActionMessage,
+  'command'
+>;
 
 export interface ProgressAgentProposalControllerDeps {
   getPendingProposal(proposalId: string): AgentProposalPermission | undefined;
@@ -46,6 +44,8 @@ export class ProgressAgentProposalController {
           feedback: input.feedback,
         });
         return true;
+      default:
+        return false;
     }
   }
 

--- a/src/controllers/progressView/ProgressAgentProposalController.ts
+++ b/src/controllers/progressView/ProgressAgentProposalController.ts
@@ -1,0 +1,120 @@
+// Local imports - agent
+import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import type { ProposalResult } from '@agent/runtime/AgentProposalCoordinator';
+
+// Local imports - logger
+import type { TaskState } from '@logger/TaskState';
+
+// Local imports - shared
+import type { AgentProposal, AgentProposalPermission } from '@shared/schemas';
+
+interface AgentProposalActionInput {
+  proposalId: string;
+  action: 'approve' | 'reject' | 'setup';
+  feedback?: string;
+  model?: string;
+  agent?: string;
+}
+
+export interface ProgressAgentProposalControllerDeps {
+  getPendingProposal(proposalId: string): AgentProposalPermission | undefined;
+  restoreTaskState(taskState: TaskState): Promise<boolean>;
+  resolveProposal(proposalId: string, result: ProposalResult): void;
+  onMissingProposal?(proposalId: string): void;
+  onInvalidProposal?(issues: unknown): void;
+  onSetupComplete?(proposal: AgentProposalPermission): void;
+}
+
+export class ProgressAgentProposalController {
+  constructor(private readonly deps: ProgressAgentProposalControllerDeps) {}
+
+  async handleAction(input: AgentProposalActionInput): Promise<boolean> {
+    switch (input.action) {
+      case 'setup':
+        return this.setupProposal(input.proposalId);
+      case 'approve':
+        this.deps.resolveProposal(input.proposalId, {
+          action: 'approve',
+          model: input.model,
+          agent: input.agent,
+        });
+        return true;
+      case 'reject':
+        this.deps.resolveProposal(input.proposalId, {
+          action: 'reject',
+          feedback: input.feedback,
+        });
+        return true;
+    }
+  }
+
+  async restoreProposalConfig(proposal: AgentProposal): Promise<boolean> {
+    const taskState = this.buildTaskState(proposal);
+    if (!taskState) return false;
+    return this.deps.restoreTaskState(taskState);
+  }
+
+  private async setupProposal(proposalId: string): Promise<boolean> {
+    const proposal = this.deps.getPendingProposal(proposalId);
+    if (!proposal) {
+      this.deps.onMissingProposal?.(proposalId);
+      return false;
+    }
+
+    const restored = await this.restoreProposalConfig(proposal);
+    if (!restored) {
+      this.deps.resolveProposal(proposalId, {
+        action: 'reject',
+        feedback: 'Unable to restore the proposal configuration for setup.',
+      });
+      return false;
+    }
+
+    this.deps.resolveProposal(proposalId, { action: 'setup' });
+    this.deps.onSetupComplete?.(proposal);
+    return true;
+  }
+
+  private buildTaskState(proposal: AgentProposal): TaskState | null {
+    const isWorkflow = proposal.agentCategory === AgentCategory.Workflow;
+    const activeFiles =
+      proposal.agentCategory === AgentCategory.Workflow
+        ? {
+            input: proposal.inputFiles.length > 0,
+            reference: proposal.referenceFiles.length > 0,
+            auxiliary: proposal.auxiliaryFiles.length > 0,
+            media: proposal.mediaFiles.length > 0,
+            output: proposal.outputFiles.length > 0,
+          }
+        : {
+            input: false,
+            reference: false,
+            auxiliary: false,
+            media: false,
+            output: false,
+          };
+
+    const result = AgentConfigSchema.safeParse({
+      ...proposal,
+      ...(isWorkflow && {
+        inputFilesActive: activeFiles.input,
+        referenceFilesActive: activeFiles.reference,
+        auxiliaryFilesActive: activeFiles.auxiliary,
+        mediaFilesActive: activeFiles.media,
+        outputFilesActive: activeFiles.output,
+      }),
+    });
+
+    if (!result.success) {
+      this.deps.onInvalidProposal?.(result.error.issues);
+      return null;
+    }
+
+    return (
+      isWorkflow
+        ? { agentConfig: result.data, activeFiles }
+        : { agentConfig: result.data }
+    ) as TaskState & { agentConfig: AgentConfig };
+  }
+}

--- a/src/shared/schemas/progressView.ts
+++ b/src/shared/schemas/progressView.ts
@@ -642,6 +642,9 @@ const AgentProposalActionMessageSchema = z.object({
   model: z.string().optional(),
   agent: z.string().optional(),
 });
+export type ProgressAgentProposalActionMessage = z.infer<
+  typeof AgentProposalActionMessageSchema
+>;
 
 const PlanApprovalActionMessageSchema = z.object({
   command: z.literal(PROGRESS_VIEW_COMMANDS.PLAN_APPROVAL_ACTION),

--- a/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
+++ b/src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts
@@ -1,0 +1,190 @@
+// Standard library imports
+import { strict as assert } from 'node:assert';
+
+// Third-party imports
+import { describe, it } from 'vitest';
+
+// Local imports - controllers
+import { ProgressAgentProposalController } from '@controllers/progressView/ProgressAgentProposalController';
+
+// Local imports - shared
+import { AGENT_CATEGORY, type AgentProposalPermission } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
+
+function createWorkflowProposal(
+  overrides: Partial<AgentProposalPermission> = {},
+): AgentProposalPermission {
+  return {
+    proposalId: 'proposal-1',
+    streamId: 'stream-1',
+    agentCategory: AGENT_CATEGORY.WORKFLOW,
+    agent: 'proofreader',
+    model: 'gemini31p',
+    instruction: 'Check the paper.',
+    inputFile: 'main.tex',
+    inputFiles: ['appendix.tex'],
+    referenceFile: null,
+    referenceFiles: ['refs.bib'],
+    auxiliaryFile: null,
+    auxiliaryFiles: [],
+    mediaFile: null,
+    mediaFiles: [],
+    outputFiles: ['main.review.tex'],
+    useMultipleOutputs: false,
+    toolConfig: DEFAULT_TOOL_CONFIG,
+    ...overrides,
+  } as AgentProposalPermission;
+}
+
+describe('ProgressAgentProposalController', () => {
+  it('restores pending setup proposals and resolves the coordinator', async () => {
+    const proposal = createWorkflowProposal();
+    const restored: unknown[] = [];
+    const resolved: unknown[] = [];
+    const controller = new ProgressAgentProposalController({
+      getPendingProposal: () => proposal,
+      restoreTaskState: async (taskState) => {
+        restored.push(taskState);
+        return true;
+      },
+      resolveProposal: (proposalId, result) => {
+        resolved.push({ proposalId, result });
+      },
+    });
+
+    assert.equal(
+      await controller.handleAction({
+        proposalId: proposal.proposalId,
+        action: 'setup',
+      }),
+      true,
+    );
+    assert.equal(restored.length, 1);
+    assert.deepEqual(resolved, [
+      { proposalId: 'proposal-1', result: { action: 'setup' } },
+    ]);
+    assert.deepEqual(restored[0], {
+      agentConfig: {
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agent: 'proofreader',
+        model: 'gemini31p',
+        instruction: 'Check the paper.',
+        inputFile: 'main.tex',
+        inputFiles: ['appendix.tex'],
+        referenceFile: null,
+        referenceFiles: ['refs.bib'],
+        auxiliaryFile: null,
+        auxiliaryFiles: [],
+        mediaFile: null,
+        mediaFiles: [],
+        outputFiles: ['main.review.tex'],
+        useMultipleOutputs: false,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+        editedFile: null,
+        editedFiles: [],
+        memories: [],
+      },
+      activeFiles: {
+        input: true,
+        reference: true,
+        auxiliary: false,
+        media: false,
+        output: true,
+      },
+    });
+  });
+
+  it('returns false for missing setup proposals', async () => {
+    let missingProposalId = '';
+    const controller = new ProgressAgentProposalController({
+      getPendingProposal: () => undefined,
+      restoreTaskState: async () => {
+        throw new Error('restore should not run');
+      },
+      resolveProposal: () => {
+        throw new Error('resolve should not run');
+      },
+      onMissingProposal: (proposalId) => {
+        missingProposalId = proposalId;
+      },
+    });
+
+    assert.equal(
+      await controller.handleAction({
+        proposalId: 'missing-proposal',
+        action: 'setup',
+      }),
+      false,
+    );
+    assert.equal(missingProposalId, 'missing-proposal');
+  });
+
+  it('rejects pending setup proposals when restore fails', async () => {
+    const resolved: unknown[] = [];
+    const controller = new ProgressAgentProposalController({
+      getPendingProposal: () => createWorkflowProposal(),
+      restoreTaskState: async () => false,
+      resolveProposal: (proposalId, result) => {
+        resolved.push({ proposalId, result });
+      },
+    });
+
+    assert.equal(
+      await controller.handleAction({
+        proposalId: 'proposal-1',
+        action: 'setup',
+      }),
+      false,
+    );
+    assert.deepEqual(resolved, [
+      {
+        proposalId: 'proposal-1',
+        result: {
+          action: 'reject',
+          feedback: 'Unable to restore the proposal configuration for setup.',
+        },
+      },
+    ]);
+  });
+
+  it('passes approve and reject actions through without restoring state', async () => {
+    const resolved: unknown[] = [];
+    const controller = new ProgressAgentProposalController({
+      getPendingProposal: () => createWorkflowProposal(),
+      restoreTaskState: async () => {
+        throw new Error('restore should not run');
+      },
+      resolveProposal: (proposalId, result) => {
+        resolved.push({ proposalId, result });
+      },
+    });
+
+    assert.equal(
+      await controller.handleAction({
+        proposalId: 'proposal-approve',
+        action: 'approve',
+        model: 'gpt-5.4',
+        agent: 'critic',
+      }),
+      true,
+    );
+    assert.equal(
+      await controller.handleAction({
+        proposalId: 'proposal-reject',
+        action: 'reject',
+        feedback: 'too broad',
+      }),
+      true,
+    );
+    assert.deepEqual(resolved, [
+      {
+        proposalId: 'proposal-approve',
+        result: { action: 'approve', model: 'gpt-5.4', agent: 'critic' },
+      },
+      {
+        proposalId: 'proposal-reject',
+        result: { action: 'reject', feedback: 'too broad' },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Local imports - progress schemas
+import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { PROGRESS_VIEW_COMMANDS } from '@common/webview/progressViewCommands';
 import {
   AGENT_CATEGORY,
@@ -10,9 +11,11 @@ import {
   STREAM_STATUS,
   type StreamTabId,
 } from '@shared/schemas';
+import { DEFAULT_TOOL_CONFIG } from '@shared/schemas/toolConfig';
 
 // Local imports - desktop test paths
 import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+import { DESKTOP_SHELL_COMMANDS } from '../../../packages/desktop/src/desktopShellMessages';
 
 type Bridge = {
   openFileCompile(filePath: string): Promise<void>;
@@ -24,6 +27,11 @@ type TestableBridge = Bridge & {
   setActiveStream(streamId: StreamTabId): void;
   deleteStream(streamId: StreamTabId): Promise<void>;
   deleteAllStreams(): Promise<void>;
+  handleAgentProposalAction(message: {
+    command: typeof PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION;
+    proposalId: string;
+    action: 'setup';
+  }): Promise<boolean>;
   streamLogs: {
     append(
       streamId: StreamTabId,
@@ -740,6 +748,60 @@ describe('DesktopProgressBridge', () => {
       );
     } finally {
       execution.dispose();
+    }
+  });
+
+  it('restores agent proposal setup into the desktop launcher', async () => {
+    const messages: unknown[] = [];
+    const bridge = await createBridge(messages);
+
+    try {
+      bridge.handleProgressEvent('showAgentProposal', {
+        proposalId: 'proposal-1',
+        streamId: 'stream-1',
+        agentCategory: AGENT_CATEGORY.WORKFLOW,
+        agent: 'proofreader',
+        model: 'gemini31p',
+        instruction: 'Check this draft.',
+        inputFile: 'main.tex',
+        inputFiles: ['appendix.tex'],
+        referenceFile: null,
+        referenceFiles: [],
+        auxiliaryFile: null,
+        auxiliaryFiles: [],
+        mediaFile: null,
+        mediaFiles: [],
+        outputFiles: ['main.review.tex'],
+        useMultipleOutputs: false,
+        toolConfig: DEFAULT_TOOL_CONFIG,
+      });
+      messages.length = 0;
+
+      await expect(
+        bridge.handleAgentProposalAction({
+          command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+          proposalId: 'proposal-1',
+          action: 'setup',
+        }),
+      ).resolves.toBe(true);
+
+      expect(messages).toEqual([
+        { command: DESKTOP_SHELL_COMMANDS.SET_ROUTE, route: 'main' },
+        expect.objectContaining({
+          command: COMMON_COMMANDS.STATE_RESTORE,
+          state: expect.objectContaining({
+            sessionType: 'workflow',
+            model: 'gemini31p',
+            instruction: 'Check this draft.',
+            inputFile: 'main.tex',
+            inputFiles: ['appendix.tex'],
+            outputFiles: ['main.review.tex'],
+            outputFilesVisible: true,
+          }),
+        }),
+      ]);
+    } finally {
+      bridge.dispose();
     }
   });
 });

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -427,4 +427,32 @@ describe('desktop Progress IPC', () => {
     });
     expect(onUnsupportedCommand).not.toHaveBeenCalled();
   });
+
+  it('does not report failed agent proposal setup as unsupported', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    progress.handleAgentProposalAction.mockResolvedValueOnce(false);
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress,
+      onUnsupportedCommand,
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-1',
+        action: 'setup',
+      }),
+    ).toBe(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(progress.handleAgentProposalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+      proposalId: 'proposal-1',
+      action: 'setup',
+    });
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
+  });
 });

--- a/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
+++ b/src/test-kernel/desktop/DesktopProgressIpc.vitest.mts
@@ -57,7 +57,7 @@ interface DesktopProgressIpcModule {
         feedback?: string;
         model?: string;
         agent?: string;
-      }): boolean;
+      }): Promise<boolean>;
     };
     onUnsupportedCommand?: (message: { command: string }) => void;
     onAsyncError?: (error: unknown) => void;
@@ -100,7 +100,7 @@ function createProgress() {
     handleToolEditApprovalAction: vi.fn(() => true),
     handleBashApprovalAction: vi.fn(async () => {}),
     handlePlanApprovalAction: vi.fn(),
-    handleAgentProposalAction: vi.fn(() => true),
+    handleAgentProposalAction: vi.fn(async () => true),
   };
 }
 
@@ -399,5 +399,32 @@ describe('desktop Progress IPC', () => {
       requestId: 'edit-2',
       action: 'openDiff',
     });
+  });
+
+  it('routes agent proposal setup through the desktop bridge', async () => {
+    const { createDesktopProgressIpc } = await loadDesktopProgressIpc();
+    const progress = createProgress();
+    const onUnsupportedCommand = vi.fn();
+    const ipc = createDesktopProgressIpc({
+      progress,
+      onUnsupportedCommand,
+    });
+
+    expect(
+      ipc.handleMessage({
+        command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+        proposalId: 'proposal-1',
+        action: 'setup',
+      }),
+    ).toBe(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(progress.handleAgentProposalAction).toHaveBeenCalledWith({
+      command: PROGRESS_VIEW_COMMANDS.AGENT_PROPOSAL_ACTION,
+      proposalId: 'proposal-1',
+      action: 'setup',
+    });
+    expect(onUnsupportedCommand).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- share main-view state restore mapping through a controller helper used by extension and desktop
- move agent proposal setup/approve/reject handling into a platform-neutral progress controller
- wire desktop progress IPC so setup restores the proposal into the launcher route before resolving the coordinator

Fixes #3571.

## Validation
- npx vitest run --config vitest.config.mjs src/test-kernel/controllers/ProgressAgentProposalController.vitest.ts src/test-kernel/desktop/DesktopProgressIpc.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast
- npm run compile-tests
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-surface (desktop + extension) agent-proposal approval/setup flow and main-view state restoration wiring; regressions could break proposal setup or restore the wrong state, but changes are localized and covered by new tests.
> 
> **Overview**
> Adds a shared `ProgressAgentProposalController` to centralize agent proposal `setup`/`approve`/`reject` handling and proposal->`TaskState` restoration.
> 
> Desktop now persists pending proposals, restores proposal setup into the launcher by routing to `main` and sending `COMMON_COMMANDS.STATE_RESTORE`, and cleans up proposals on stream deletion; desktop Progress IPC also treats `AGENT_PROPOSAL_ACTION` as async.
> 
> Extension state restore is switched to the shared `buildMainViewState` mapper and now returns a boolean success value, while ProgressView delegates proposal actions/config restoration to the new controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58ca16f95f22d9a56b4b52a7bdfc31840ea9e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->