### PR TITLE
[codex] Expand desktop command surface

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -32,6 +32,13 @@ export const DESKTOP_COMMAND_IDS = [
   DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
   DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
   'texra.openSettings',
+  'texra.mainView.reset',
+  'texra.execute',
+  'texra.runSetupAssistant',
+  'texra.showImportOptions',
+  'texra.openGettingStarted',
+  'texra.cleanOutput',
+  'texra.cleanBuild',
   'texra.showMemory',
   'texra.showAgentHistory',
   'texra.showModels',
@@ -49,6 +56,8 @@ export interface DesktopCommandMenuEntry {
   label: string;
   category: string;
   accelerator?: string;
+  enabled: boolean;
+  unavailableReason?: string;
 }
 
 export interface DesktopCommandActions {
@@ -58,6 +67,7 @@ export interface DesktopCommandActions {
   openLogFolder?(): void;
   openWorkspaceFolder?(): void;
   showFirstRunWalkthrough?(): void;
+  resetMainView?(): void;
 }
 
 export interface DesktopSettingsTabMessage {
@@ -74,14 +84,21 @@ const DESKTOP_MENU_GROUPS = [
     DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
     DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
     'texra.openSettings',
+    'texra.mainView.reset',
   ],
   [
+    'texra.execute',
+    'texra.runSetupAssistant',
+    'texra.showImportOptions',
     'texra.showMemory',
     'texra.showAgentHistory',
     'texra.showModels',
     'texra.showAgents',
     'texra.showTools',
     'texra.showMultiAgent',
+    'texra.openGettingStarted',
+    'texra.cleanOutput',
+    'texra.cleanBuild',
   ],
 ] as const satisfies readonly (readonly DesktopCommandId[])[];
 
@@ -100,6 +117,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
       label: 'Desktop Documentation',
       category: 'Help',
+      enabled: true,
     },
   ],
   [
@@ -108,6 +126,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
       label: 'Show Logs',
       category: 'TeXRA',
+      enabled: true,
     },
   ],
   [
@@ -117,6 +136,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       label: 'Open Folder',
       category: 'TeXRA',
       accelerator: 'CommandOrControl+O',
+      enabled: true,
     },
   ],
   [
@@ -125,6 +145,7 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
       label: 'Open Logs Folder',
       category: 'TeXRA',
+      enabled: true,
     },
   ],
   [
@@ -133,7 +154,32 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
       label: 'Show First-Run Walkthrough',
       category: 'Help',
+      enabled: true,
     },
+  ],
+]);
+
+const DESKTOP_UNAVAILABLE_COMMANDS = new Map<CommandId, string>([
+  [
+    'texra.execute',
+    'Use the Launcher execute button after choosing an agent and files.',
+  ],
+  [
+    'texra.runSetupAssistant',
+    'The setup assistant agent is still VS Code-only.',
+  ],
+  ['texra.showImportOptions', 'Project import choices are still VS Code-only.'],
+  [
+    'texra.openGettingStarted',
+    'The VS Code walkthrough is not available in desktop.',
+  ],
+  [
+    'texra.cleanOutput',
+    'Workspace cleanup commands are not wired in desktop yet.',
+  ],
+  [
+    'texra.cleanBuild',
+    'Workspace cleanup commands are not wired in desktop yet.',
   ],
 ]);
 
@@ -148,6 +194,7 @@ export function getDesktopCommandMenuEntries(
 
     const entry = commandCatalogById.get(id);
     if (!entry) throw new Error(`Missing command catalog entry: ${id}`);
+    const unavailableReason = DESKTOP_UNAVAILABLE_COMMANDS.get(id);
 
     const accelerator =
       entry.keybinding == null
@@ -158,6 +205,8 @@ export function getDesktopCommandMenuEntries(
       label: entry.shortTitle ?? entry.title,
       category: entry.category,
       ...(accelerator && { accelerator }),
+      enabled: unavailableReason == null,
+      ...(unavailableReason && { unavailableReason }),
     };
   });
 }
@@ -200,6 +249,10 @@ export function dispatchDesktopCommand(
     case 'texra.openSettings':
       actions.showSettings();
       return true;
+    case 'texra.mainView.reset':
+      if (!actions.resetMainView) return false;
+      actions.resetMainView();
+      return true;
     case 'texra.showMemory':
       actions.showSettings(SETTINGS_TAB.MEMORY);
       return true;
@@ -219,10 +272,12 @@ export function dispatchDesktopCommand(
       actions.showSettings(SETTINGS_TAB.MULTI_AGENT);
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER:
-      actions.openLogFolder?.();
+      if (!actions.openLogFolder) return false;
+      actions.openLogFolder();
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
-      actions.openWorkspaceFolder?.();
+      if (!actions.openWorkspaceFolder) return false;
+      actions.openWorkspaceFolder();
       return true;
     case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
       actions.showFirstRunWalkthrough?.();
@@ -230,6 +285,13 @@ export function dispatchDesktopCommand(
     case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
       actions.openDesktopDocs?.();
       return true;
+    case 'texra.execute':
+    case 'texra.runSetupAssistant':
+    case 'texra.showImportOptions':
+    case 'texra.openGettingStarted':
+    case 'texra.cleanOutput':
+    case 'texra.cleanBuild':
+      return false;
     default:
       return assertNever(id);
   }
@@ -281,7 +343,10 @@ export function buildDesktopMenuTemplate(
     return {
       label: entry.label,
       ...(entry.accelerator && { accelerator: entry.accelerator }),
+      ...(entry.unavailableReason && { toolTip: entry.unavailableReason }),
+      enabled: entry.enabled,
       click: () => {
+        if (!entry.enabled) return;
         dispatchDesktopCommand(id, actions);
       },
     };

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -273,10 +273,12 @@ export function dispatchDesktopCommand(
       actions.openWorkspaceFolder();
       return true;
     case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
-      actions.showFirstRunWalkthrough?.();
+      if (!actions.showFirstRunWalkthrough) return false;
+      actions.showFirstRunWalkthrough();
       return true;
     case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
-      actions.openDesktopDocs?.();
+      if (!actions.openDesktopDocs) return false;
+      actions.openDesktopDocs();
       return true;
     case 'texra.execute':
     case 'texra.runSetupAssistant':

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -3,6 +3,7 @@ import {
   type CommandId,
   type CommandKeybinding,
 } from '@commands/catalog';
+import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { SETTINGS_VIEW_COMMANDS } from '@common/webview/settingsViewCommands';
 import { type AgentCategory } from '@shared/schemas/agent';
 import {
@@ -91,6 +92,12 @@ export interface DesktopSettingsTabMessage {
   command: typeof SETTINGS_VIEW_COMMANDS.SET_TAB;
   tabIndex: SettingsTab;
   agentSubTab?: AgentCategory;
+}
+
+export interface DesktopMainViewResetMessage {
+  command: typeof MAIN_VIEW_COMMANDS.STATE_RESTORE;
+  state: Record<string, never>;
+  isResetOperation: true;
 }
 
 const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
@@ -310,6 +317,14 @@ export function buildDesktopSettingsTabMessage(
     command: SETTINGS_VIEW_COMMANDS.SET_TAB,
     tabIndex,
     ...(agentSubTab && { agentSubTab }),
+  };
+}
+
+export function buildDesktopMainViewResetMessage(): DesktopMainViewResetMessage {
+  return {
+    command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+    state: {},
+    isResetOperation: true,
   };
 }
 

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -25,31 +25,48 @@ export const DESKTOP_DOCS_URL = 'https://texra.ai/guide/desktop';
 type DesktopLocalCommandId =
   (typeof DESKTOP_LOCAL_COMMANDS)[keyof typeof DESKTOP_LOCAL_COMMANDS];
 
-export const DESKTOP_COMMAND_IDS = [
-  'texra.showMainView',
-  'texra.showProgressView',
-  DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
-  DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
-  DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
-  'texra.openSettings',
-  'texra.mainView.reset',
-  'texra.execute',
-  'texra.runSetupAssistant',
-  'texra.showImportOptions',
-  'texra.openGettingStarted',
-  'texra.cleanOutput',
-  'texra.cleanBuild',
-  'texra.showMemory',
-  'texra.showAgentHistory',
-  'texra.showModels',
-  'texra.showAgents',
-  'texra.showTools',
-  'texra.showMultiAgent',
+const DESKTOP_MENU_GROUPS = [
+  [
+    'texra.showMainView',
+    'texra.showProgressView',
+    DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
+    DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
+    'texra.openSettings',
+    'texra.mainView.reset',
+  ],
+  [
+    'texra.execute',
+    'texra.runSetupAssistant',
+    'texra.showImportOptions',
+    'texra.showMemory',
+    'texra.showAgentHistory',
+    'texra.showModels',
+    'texra.showAgents',
+    'texra.showTools',
+    'texra.showMultiAgent',
+    'texra.openGettingStarted',
+    'texra.cleanOutput',
+    'texra.cleanBuild',
+  ],
+] as const satisfies readonly (readonly (
+  | CommandId
+  | DesktopLocalCommandId
+)[])[];
+
+const DESKTOP_HELP_COMMANDS = [
   DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
-] as const satisfies readonly (CommandId | DesktopLocalCommandId)[];
+] as const satisfies readonly DesktopLocalCommandId[];
 
-export type DesktopCommandId = (typeof DESKTOP_COMMAND_IDS)[number];
+type DesktopMenuCommandId = (typeof DESKTOP_MENU_GROUPS)[number][number];
+type DesktopHelpCommandId = (typeof DESKTOP_HELP_COMMANDS)[number];
+export type DesktopCommandId = DesktopMenuCommandId | DesktopHelpCommandId;
+
+export const DESKTOP_COMMAND_IDS: readonly DesktopCommandId[] = [
+  ...DESKTOP_MENU_GROUPS.flat(),
+  ...DESKTOP_HELP_COMMANDS,
+];
 
 export interface DesktopCommandMenuEntry {
   id: DesktopCommandId;
@@ -75,37 +92,6 @@ export interface DesktopSettingsTabMessage {
   tabIndex: SettingsTab;
   agentSubTab?: AgentCategory;
 }
-
-const DESKTOP_MENU_GROUPS = [
-  [
-    'texra.showMainView',
-    'texra.showProgressView',
-    DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
-    DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
-    DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
-    'texra.openSettings',
-    'texra.mainView.reset',
-  ],
-  [
-    'texra.execute',
-    'texra.runSetupAssistant',
-    'texra.showImportOptions',
-    'texra.showMemory',
-    'texra.showAgentHistory',
-    'texra.showModels',
-    'texra.showAgents',
-    'texra.showTools',
-    'texra.showMultiAgent',
-    'texra.openGettingStarted',
-    'texra.cleanOutput',
-    'texra.cleanBuild',
-  ],
-] as const satisfies readonly (readonly DesktopCommandId[])[];
-
-const DESKTOP_HELP_COMMANDS = [
-  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
-  DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
-] as const satisfies readonly DesktopCommandId[];
 
 const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
   DesktopLocalCommandId,

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -21,6 +21,7 @@ import {
   type DesktopRenderer,
 } from './desktopIpcTypes.js';
 import {
+  buildDesktopMainViewResetMessage,
   buildDesktopSettingsTabMessage,
   DESKTOP_DOCS_URL,
   DESKTOP_LOCAL_COMMANDS,
@@ -130,11 +131,7 @@ export function createDesktopShellActions(
 
   function resetMainView() {
     postRoute('main');
-    renderer.postToRenderer({
-      command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-      state: {},
-      isResetOperation: true,
-    });
+    renderer.postToRenderer(buildDesktopMainViewResetMessage());
   }
 
   return {

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -128,12 +128,22 @@ export function createDesktopShellActions(
     void options.signIn().catch(reportAsyncError);
   }
 
+  function resetMainView() {
+    postRoute('main');
+    renderer.postToRenderer({
+      command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+      state: {},
+      isResetOperation: true,
+    });
+  }
+
   return {
     signIn,
     openAgentDirectory,
     openDesktopDocs,
     openLogFolder,
     openWorkspaceFolder,
+    resetMainView,
     setRecentCommitsUnavailable: () => {
       renderer.postToRenderer({
         command: MAIN_VIEW_COMMANDS.SET_RECENT_COMMITS,

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -94,6 +94,7 @@ export function createDesktopCommandPalette({
       const item = document.createElement('button');
       item.className = 'desktop-command-palette-item';
       item.type = 'button';
+      item.disabled = !entry.enabled;
       item.dataset.commandId = entry.id;
       item.setAttribute('role', 'option');
       item.setAttribute(
@@ -107,7 +108,8 @@ export function createDesktopCommandPalette({
 
       const meta = document.createElement('span');
       meta.className = 'desktop-command-palette-meta';
-      meta.textContent = entry.accelerator ?? entry.category;
+      meta.textContent =
+        entry.unavailableReason ?? entry.accelerator ?? entry.category;
 
       item.append(label, meta);
       item.addEventListener('mouseenter', () => {

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -45,6 +45,14 @@ export function getNextDesktopCommandPaletteIndex(
   return (currentIndex + delta + itemCount) % itemCount;
 }
 
+export function executeDesktopCommandPaletteEntry(
+  entry: DesktopCommandMenuEntry | undefined,
+  actions: DesktopCommandActions,
+): boolean {
+  if (!entry?.enabled) return false;
+  return dispatchDesktopCommand(entry.id, actions);
+}
+
 export function createDesktopCommandPalette({
   document,
   actions,
@@ -84,8 +92,7 @@ export function createDesktopCommandPalette({
 
   const executeActiveCommand = (): void => {
     const entry = visibleEntries[activeIndex];
-    if (!entry) return;
-    if (dispatchDesktopCommand(entry.id, actions)) close();
+    if (executeDesktopCommandPaletteEntry(entry, actions)) close();
   };
 
   const renderEntries = (): void => {
@@ -117,7 +124,7 @@ export function createDesktopCommandPalette({
         syncActiveItem();
       });
       item.addEventListener('click', () => {
-        if (dispatchDesktopCommand(entry.id, actions)) close();
+        if (executeDesktopCommandPaletteEntry(entry, actions)) close();
       });
       list.append(item);
     });

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -26,6 +26,7 @@ import {
   type DesktopSetLogMessage,
 } from '../desktopLogMessages';
 import {
+  buildDesktopMainViewResetMessage,
   buildDesktopSettingsTabMessage,
   DESKTOP_LOCAL_COMMANDS,
 } from '../desktopCommandSurface';
@@ -209,11 +210,7 @@ const commandPalette = createDesktopCommandPalette({
     resetMainView: () => {
       setRoute('main');
       window.postMessage(
-        {
-          command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
-          state: {},
-          isResetOperation: true,
-        },
+        buildDesktopMainViewResetMessage(),
         getWindowTargetOrigin(),
       );
     },

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -206,6 +206,17 @@ const commandPalette = createDesktopCommandPalette({
     showFirstRunWalkthrough: () => {
       firstRunWalkthrough.show();
     },
+    resetMainView: () => {
+      setRoute('main');
+      window.postMessage(
+        {
+          command: MAIN_VIEW_COMMANDS.STATE_RESTORE,
+          state: {},
+          isResetOperation: true,
+        },
+        getWindowTargetOrigin(),
+      );
+    },
   },
 });
 appRoot.append(commandPalette.element);

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,7 +240,9 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const classNameProvider = detectProviderFromClassNames(getErrorClassNames(err));
+  const classNameProvider = detectProviderFromClassNames(
+    getErrorClassNames(err),
+  );
   if (classNameProvider) return classNameProvider;
 
   const providerFromStack = detectProviderFromText(candidate.stack ?? '');

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -233,7 +233,6 @@ function detectProvider(err: unknown): string | undefined {
   }
 
   const candidate = err as { provider?: string; headers?: HeaderBag } & {
-    constructor?: { name?: string };
     stack?: string;
   };
 
@@ -241,10 +240,7 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const classNameProvider = detectProviderFromClassNames([
-    candidate.constructor?.name,
-    ...getErrorClassNames(err),
-  ]);
+  const classNameProvider = detectProviderFromClassNames(getErrorClassNames(err));
   if (classNameProvider) return classNameProvider;
 
   const providerFromStack = detectProviderFromText(candidate.stack ?? '');

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -31,6 +31,13 @@ interface DesktopCommandPaletteModule {
     itemCount: number,
     delta: number,
   ): number;
+  executeDesktopCommandPaletteEntry(
+    entry: DesktopPaletteEntry | undefined,
+    actions: {
+      showRoute(route: string): void;
+      showSettings(tabIndex?: number): void;
+    },
+  ): boolean;
   isCommandPaletteShortcut(event: KeyboardEvent): boolean;
 }
 
@@ -100,6 +107,28 @@ describe('desktop command palette', () => {
     expect(getNextDesktopCommandPaletteIndex(2, 3, 1)).toBe(0);
     expect(getNextDesktopCommandPaletteIndex(0, 3, -1)).toBe(2);
     expect(getNextDesktopCommandPaletteIndex(0, 0, 1)).toBe(-1);
+  });
+
+  it('does not dispatch disabled command palette entries', async () => {
+    const { executeDesktopCommandPaletteEntry } =
+      await loadDesktopCommandPalette();
+    const actions = {
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
+
+    expect(
+      executeDesktopCommandPaletteEntry(
+        {
+          id: 'texra.showModels',
+          label: 'Show Models',
+          category: 'TeXRA',
+          enabled: false,
+        },
+        actions,
+      ),
+    ).toBe(false);
+    expect(actions.showSettings).not.toHaveBeenCalled();
   });
 
   it('uses the native command palette shortcut shape', async () => {

--- a/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandPalette.vitest.mts
@@ -39,6 +39,8 @@ interface DesktopPaletteEntry {
   label: string;
   category: string;
   accelerator?: string;
+  enabled: boolean;
+  unavailableReason?: string;
 }
 
 async function loadDesktopCommandPalette(): Promise<DesktopCommandPaletteModule> {
@@ -54,17 +56,20 @@ describe('desktop command palette', () => {
       label: 'Show Launcher',
       category: 'TeXRA',
       accelerator: 'Command+Option+M',
+      enabled: true,
     },
     {
       id: 'texra.showProgressView',
       label: 'Show Progress',
       category: 'TeXRA',
       accelerator: 'Command+Option+P',
+      enabled: true,
     },
     {
       id: 'texra.showModels',
       label: 'Show Models',
       category: 'TeXRA',
+      enabled: true,
     },
   ];
 

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -258,7 +258,8 @@ describe('desktop command surface', () => {
   });
 
   it('wires menu clicks to the catalog-backed dispatcher', async () => {
-    const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
+    const { buildDesktopMenuTemplate, getDesktopCommandMenuEntries } =
+      await loadDesktopCommandSurface();
     const actions = {
       openDesktopDocs: vi.fn(),
       resetMainView: vi.fn(),
@@ -301,6 +302,15 @@ describe('desktop command surface', () => {
       'Clean LLM Outputs',
       'Clean Build Files',
     ]);
+    expect(
+      submenu
+        .filter((item) => item.type !== 'separator')
+        .map((item) => item.label),
+    ).toEqual(
+      getDesktopCommandMenuEntries(undefined, 'darwin')
+        .filter((entry) => entry.category !== 'Help')
+        .map((entry) => entry.label),
+    );
 
     submenu[0].click?.();
     submenu[8].click?.();

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -41,6 +41,8 @@ interface DesktopCommandSurfaceModule {
     label: string;
     category: string;
     accelerator?: string;
+    enabled: boolean;
+    unavailableReason?: string;
   }>;
   toElectronAccelerator(
     keybinding: { key: string; mac?: string },
@@ -59,6 +61,8 @@ interface DesktopCommandSurfaceModule {
 interface DesktopMenuItem {
   label?: string;
   accelerator?: string;
+  enabled?: boolean;
+  toolTip?: string;
   submenu?: DesktopMenuItem[];
   type?: 'separator';
   click?: () => void;
@@ -99,22 +103,26 @@ describe('desktop command surface', () => {
       label: 'Show Launcher',
       category: 'TeXRA',
       accelerator: 'Command+Option+M',
+      enabled: true,
     });
     expect(entries).toContainEqual({
       id: 'texra.showProgressView',
       label: 'Show Progress',
       category: 'TeXRA',
       accelerator: 'Command+Option+P',
+      enabled: true,
     });
     expect(entries).toContainEqual({
       id: DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
       label: 'Desktop Documentation',
       category: 'Help',
+      enabled: true,
     });
     expect(entries).toContainEqual({
       id: DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
       label: 'Show Logs',
       category: 'TeXRA',
+      enabled: true,
     });
     const firstHelpIndex = entries.findIndex(
       (entry) => entry.category === 'Help',
@@ -150,6 +158,7 @@ describe('desktop command surface', () => {
       openLogFolder: vi.fn(),
       openWorkspaceFolder: vi.fn(),
       showFirstRunWalkthrough: vi.fn(),
+      resetMainView: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };
@@ -162,6 +171,7 @@ describe('desktop command surface', () => {
       dispatchDesktopCommand(DESKTOP_LOCAL_COMMANDS.SHOW_LOGS, actions),
     ).toBe(true);
     expect(dispatchDesktopCommand('texra.openSettings', actions)).toBe(true);
+    expect(dispatchDesktopCommand('texra.mainView.reset', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showModels', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showAgents', actions)).toBe(true);
     expect(
@@ -195,6 +205,7 @@ describe('desktop command surface', () => {
       3,
       SETTINGS_TAB.AGENTS,
     );
+    expect(actions.resetMainView).toHaveBeenCalledOnce();
     expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
     expect(actions.openLogFolder).toHaveBeenCalledOnce();
     expect(actions.showFirstRunWalkthrough).toHaveBeenCalledOnce();
@@ -204,6 +215,26 @@ describe('desktop command surface', () => {
       ),
     ).toBe(false);
     expect(actions.openDesktopDocs).toHaveBeenCalledOnce();
+  });
+
+  it('marks VS Code-only commands as unavailable instead of clickable no-ops', async () => {
+    const { dispatchDesktopCommand, getDesktopCommandMenuEntries } =
+      await loadDesktopCommandSurface();
+    const actions = {
+      showRoute: vi.fn(),
+      showSettings: vi.fn(),
+    };
+    const entries = getDesktopCommandMenuEntries();
+    const executeEntry = entries.find((entry) => entry.id === 'texra.execute');
+
+    expect(executeEntry).toMatchObject({
+      enabled: false,
+      unavailableReason:
+        'Use the Launcher execute button after choosing an agent and files.',
+    });
+    expect(dispatchDesktopCommand('texra.execute', actions)).toBe(false);
+    expect(actions.showRoute).not.toHaveBeenCalled();
+    expect(actions.showSettings).not.toHaveBeenCalled();
   });
 
   it('builds settings-tab messages from one shared helper', async () => {
@@ -230,6 +261,7 @@ describe('desktop command surface', () => {
     const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
     const actions = {
       openDesktopDocs: vi.fn(),
+      resetMainView: vi.fn(),
       showFirstRunWalkthrough: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
@@ -254,19 +286,32 @@ describe('desktop command surface', () => {
       'Open Folder',
       'Open Logs Folder',
       'Open TeXRA Settings',
+      'New',
       'separator',
+      'Execute Agent',
+      'Run Setup Assistant Agent (Setup Wizard)',
+      'Import or Create LaTeX Project',
       'Show Memory',
       'Show Agent Execution History',
       'Show Models',
       'Show Agents',
       'Show Tool Dashboard',
       'Show Multi-Agent Settings',
+      'Open Getting Started Walkthrough',
+      'Clean LLM Outputs',
+      'Clean Build Files',
     ]);
 
     submenu[0].click?.();
-    submenu[9].click?.();
+    submenu[8].click?.();
+    submenu[13].click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+    expect(submenu[8]).toMatchObject({
+      enabled: false,
+      toolTip:
+        'Use the Launcher execute button after choosing an agent and files.',
+    });
 
     const helpMenu = menu.find((item) => item.label === 'Help');
     expect(helpMenu?.submenu?.map((item) => item.label)).toEqual([


### PR DESCRIPTION
## Summary
- add explicit enabled/unavailable metadata for desktop command entries shared by native menu and command palette
- wire a real desktop New Session command that resets the launcher through the existing state-restore message
- expose top setup/workflow commands as disabled with reasons instead of clickable no-ops until their desktop handlers exist

Fixes #3547.

## Validation
- npx vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopCommandPalette.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast
- npm run compile-tests
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop command dispatch/menu wiring and adjusts SDK provider detection, which could subtly affect UX command behavior and error attribution if mappings are incorrect.
> 
> **Overview**
> Desktop command entries now carry explicit `enabled`/`unavailableReason` metadata and the native menu + command palette honor it (disabled items, tooltip/reason text, and no dispatch on click/enter).
> 
> Adds a real `texra.mainView.reset` ("New") command that routes to the launcher and posts a `MAIN_VIEW_COMMANDS.STATE_RESTORE` reset message, wired through both the shell IPC actions and renderer actions.
> 
> Exposes several VS Code-only workflow commands in the desktop menu/palette as **disabled with explanatory reasons** instead of clickable no-ops, and updates tests accordingly; separately, `sdkErrorUtils.detectProvider` now relies solely on prototype-derived class names (dropping `constructor.name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc88d38264bea1b4d11bf2716853971dec127fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->