### PR TITLE
[codex] Wire desktop Supabase auth remote agents

### DIFF
--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -381,7 +381,9 @@ Shared config:
 
 The monorepo now has a local unsigned package rehearsal for the Electron desktop app. It produces a
 macOS `.app` bundle from the built desktop main, preload, and renderer artifacts, then verifies the
-packaged `app.asar` contains the expected runtime files.
+packaged `app.asar` contains the expected runtime files. The package verifier also reads the
+desktop main esbuild metafile and checks that the startup import graph does not eagerly pull in
+provider SDKs that should remain behind lazy agent-execution imports.
 
 From the repository root:
 

--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -1,5 +1,5 @@
 import * as esbuild from 'esbuild';
-import { rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -8,12 +8,13 @@ const outdir = resolve(__dirname, 'dist/main');
 
 await rm(outdir, { force: true, recursive: true });
 
-await esbuild.build({
+const result = await esbuild.build({
   entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
   bundle: true,
   platform: 'node',
   format: 'esm',
   splitting: true,
+  metafile: true,
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
@@ -25,3 +26,9 @@ await esbuild.build({
       `const require = __texraCreateRequire(import.meta.url);`,
   },
 });
+
+await mkdir(outdir, { recursive: true });
+await writeFile(
+  resolve(outdir, 'metafile.json'),
+  `${JSON.stringify(result.metafile, null, 2)}\n`,
+);

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { platform } from '@platform/platform';
+import { getAgentsBySource, loadAgents } from '@agent/index/agentRegistry';
 import {
   DEFAULT_OAUTH_PROVIDER,
   DEFAULT_SESSION_EXPIRY_MS,
@@ -411,6 +412,17 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
     // Server-side key access is optional; personal provider keys still work.
   }
 
+  await loadAgents();
+  const remoteAgents: RemoteAgent[] = getAgentsBySource('remote').map(
+    (entry) => ({
+      name: entry.name,
+      description: entry.description ?? '',
+      visibility: entry.visibility ?? ['public'],
+      category: entry.category,
+      supportsMultipleOutput: entry.isMultiple ?? false,
+    }),
+  );
+
   return {
     authenticated: true,
     user: {
@@ -419,7 +431,7 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
     },
     tier: authContext.tier,
     permissions: authContext.permissions,
-    remoteAgents: [],
+    remoteAgents,
     apiAccessMode,
     allowedModels,
     accessExpiresAt,

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { platform } from '@platform/platform';
 import { getAgentsBySource, loadAgents } from '@agent/index/agentRegistry';
+import { toRemoteAgentProfileData } from '@agent/index/remoteAgentProfileData';
 import {
   DEFAULT_OAUTH_PROVIDER,
   DEFAULT_SESSION_EXPIRY_MS,
@@ -412,16 +413,13 @@ async function loadDesktopAuthProfileData(): Promise<DesktopAuthProfileData> {
     // Server-side key access is optional; personal provider keys still work.
   }
 
-  await loadAgents();
-  const remoteAgents: RemoteAgent[] = getAgentsBySource('remote').map(
-    (entry) => ({
-      name: entry.name,
-      description: entry.description ?? '',
-      visibility: entry.visibility ?? ['public'],
-      category: entry.category,
-      supportsMultipleOutput: entry.isMultiple ?? false,
-    }),
-  );
+  let remoteAgents: RemoteAgent[] = [];
+  try {
+    await loadAgents();
+    remoteAgents = getAgentsBySource('remote').map(toRemoteAgentProfileData);
+  } catch {
+    // Keep auth/profile UI usable even if agent registry refresh fails.
+  }
 
   return {
     authenticated: true,

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
 import { platform } from '@platform/platform';
-import { getAgentsBySource, loadAgents } from '@agent/index/agentRegistry';
-import { toRemoteAgentProfileData } from '@agent/index/remoteAgentProfileData';
+import {
+  getAgentsBySource,
+  loadAgents,
+  toRemoteAgentProfileData,
+} from '@agent/index';
 import {
   DEFAULT_OAUTH_PROVIDER,
   DEFAULT_SESSION_EXPIRY_MS,

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -25,6 +25,7 @@ import {
   deleteExecution,
   deleteAllExecutions,
 } from '@agent/storage';
+import { toRemoteAgentProfileData } from '@agent/index/remoteAgentProfileData';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
@@ -788,13 +789,7 @@ export class SettingsViewMessageHandler extends BaseViewMessageHandler<
 
     await loadAgents();
     const remoteAgents: RemoteAgent[] = getAgentsBySource('remote').map(
-      (entry) => ({
-        name: entry.name,
-        description: entry.description ?? '',
-        visibility: entry.visibility ?? ['public'],
-        category: entry.category,
-        supportsMultipleOutput: entry.isMultiple ?? false,
-      }),
+      toRemoteAgentProfileData,
     );
 
     const apiAccessMode = serverSideKeyService.getUseIncludedModelAccess()

--- a/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
+++ b/packages/extension/src/settingsView/SettingsViewMessageHandler.ts
@@ -18,14 +18,17 @@ import {
 import { SettingsModelSelectionController } from '@controllers/settingsView/SettingsModelSelectionController';
 import { SettingsProfileKeyController } from '@controllers/settingsView/SettingsProfileKeyController';
 import { platform } from '@platform/platform';
-import { getAgentsBySource, loadAgents } from '@agent/index';
+import {
+  getAgentsBySource,
+  loadAgents,
+  toRemoteAgentProfileData,
+} from '@agent/index';
 import {
   getExecutionStore,
   listExecutions,
   deleteExecution,
   deleteAllExecutions,
 } from '@agent/storage';
-import { toRemoteAgentProfileData } from '@agent/index/remoteAgentProfileData';
 import { AgentConfigSchema, type AgentConfig } from '@agent/core/AgentConfig';
 import { getActiveExecutionIds } from '@agent/runtime/executionRegistry';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -59,24 +59,31 @@ const codexPlatformInfoByKey = {
     binaryName: 'codex.exe',
   },
 };
-const desktopStartupForbiddenBundleMarkers = [
+const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
     patterns: [
-      '@google/genai',
-      'node_modules/.pnpm/@google+genai',
-      'google-auth-library',
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@google\+genai[^/\\]*[/\\]node_modules[/\\])?@google[/\\]genai[/\\]/,
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*google-auth-library[^/\\]*[/\\]node_modules[/\\])?google-auth-library[/\\]/,
     ],
   },
   {
     label: 'OpenAI SDK',
-    patterns: ['node_modules/.pnpm/openai@'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*openai@[^/\\]*[/\\]node_modules[/\\])?openai[/\\]/,
+    ],
   },
   {
     label: 'Anthropic SDK',
-    patterns: ['node_modules/.pnpm/@anthropic-ai'],
+    patterns: [
+      /(?:^|[/\\])node_modules[/\\](?:\.pnpm[/\\][^/\\]*@anthropic-ai\+sdk[^/\\]*[/\\]node_modules[/\\])?@anthropic-ai[/\\]sdk[/\\]/,
+    ],
   },
 ];
+const desktopStartupEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+  'src/main/index.ts',
+]);
 
 async function exists(path) {
   try {
@@ -145,6 +152,22 @@ async function findPackagedApp() {
 function normalizeAsarPath(path) {
   const normalized = path.replaceAll('\\', '/');
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
+}
+
+function normalizeMetafilePath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function resolveMetafileImportPath(outputPath, importPath) {
+  const normalizedImportPath = normalizeMetafilePath(importPath);
+  if (normalizedImportPath.startsWith('.')) {
+    return normalizeMetafilePath(
+      posix.normalize(
+        posix.join(posix.dirname(outputPath), normalizedImportPath),
+      ),
+    );
+  }
+  return posix.normalize(normalizedImportPath);
 }
 
 function createAsarAppReader(asarPath) {
@@ -323,66 +346,81 @@ async function collectMainJavaScriptBundles(app, dir = 'dist/main') {
   return bundles.sort();
 }
 
-function parseStaticRelativeImports(source) {
-  const imports = [];
-  const staticImportPattern =
-    /^(?:import\s+(?:[^'"]*?\s+from\s+)?|export\s+(?:\*|{[^}]*}|\*\s+as\s+\w+)\s+from\s+)['"](\.\/[^'"]+)['"];?/gm;
-  for (const match of source.matchAll(staticImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function parseDynamicRelativeImports(source) {
-  const imports = [];
-  const dynamicImportPattern = /import\(\s*['"](\.\/[^'"]+)['"]\s*\)/g;
-  for (const match of source.matchAll(dynamicImportPattern)) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
 async function checkDesktopStartupBundles(app, failures) {
   const entryPath = 'dist/main/index.js';
+  const metafilePath = 'dist/main/metafile.json';
   if (!(await app.exists(entryPath))) return;
-
-  const pending = [entryPath];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const bundlePath = pending.shift();
-    if (!bundlePath || visited.has(bundlePath)) continue;
-    visited.add(bundlePath);
-
-    const source = await app.readText(bundlePath);
-    const forbidden = desktopStartupForbiddenBundleMarkers.filter(
-      ({ patterns }) => patterns.some((pattern) => source.includes(pattern)),
+  if (!(await app.exists(metafilePath))) {
+    failures.push(
+      `Packaged desktop app is missing the esbuild metafile used to verify startup imports: ${metafilePath}`,
     );
-    if (forbidden.length > 0) {
+    return;
+  }
+
+  const metafile = await app.readJson(metafilePath);
+  const outputByPath = new Map();
+  for (const [outputPath, output] of Object.entries(metafile.outputs ?? {})) {
+    outputByPath.set(normalizeMetafilePath(outputPath), output);
+  }
+
+  const pending = [];
+  for (const [outputPath, output] of outputByPath) {
+    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
+    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+  }
+  if (pending.length === 0) {
+    failures.push(
+      `Packaged desktop startup graph is missing expected esbuild entry points: ${[
+        ...desktopStartupEntryPoints,
+      ].join(', ')}`,
+    );
+    return;
+  }
+
+  const visitedOutputs = new Set();
+  const startupInputsByForbiddenLabel = new Map();
+  while (pending.length > 0) {
+    const outputPath = pending.shift();
+    if (!outputPath || visitedOutputs.has(outputPath)) continue;
+    visitedOutputs.add(outputPath);
+
+    const output = outputByPath.get(normalizeMetafilePath(outputPath));
+    if (!output) {
       failures.push(
-        `Packaged desktop startup bundle eagerly includes provider SDK code (${forbidden
-          .map(({ label }) => label)
-          .join(', ')}): ${bundlePath}`,
+        `Packaged desktop startup bundle is missing from the esbuild metafile: ${outputPath}`,
       );
+      continue;
     }
 
-    const imports = parseStaticRelativeImports(source);
-    if (bundlePath === entryPath) {
-      const dynamicImports = parseDynamicRelativeImports(source);
-      if (dynamicImports.length !== 1) {
-        failures.push(
-          `Packaged desktop bootstrap entry should have exactly one startup dynamic import, found ${dynamicImports.length}.`,
-        );
+    for (const inputPath of Object.keys(output.inputs ?? {})) {
+      const normalizedInput = normalizeMetafilePath(inputPath);
+      for (const { label, patterns } of desktopStartupForbiddenInputPackages) {
+        if (!patterns.some((pattern) => pattern.test(normalizedInput))) {
+          continue;
+        }
+        const inputPaths = startupInputsByForbiddenLabel.get(label) ?? [];
+        inputPaths.push(normalizedInput);
+        startupInputsByForbiddenLabel.set(label, inputPaths);
       }
-      imports.push(...dynamicImports);
     }
-    for (const specifier of imports) {
-      const importedPath = posix.normalize(
-        posix.join(posix.dirname(bundlePath), specifier),
+
+    for (const importedOutput of output.imports ?? []) {
+      if (importedOutput.external) continue;
+      if (importedOutput.kind !== 'import-statement') continue;
+      const importedPath = resolveMetafileImportPath(
+        outputPath,
+        importedOutput.path,
       );
-      if (await app.exists(importedPath)) {
-        pending.push(importedPath);
-      }
+      if (outputByPath.has(importedPath)) pending.push(importedPath);
     }
+  }
+
+  for (const [label, inputPaths] of startupInputsByForbiddenLabel) {
+    failures.push(
+      `Packaged desktop startup graph eagerly includes provider SDK code (${label}): ${[
+        ...new Set(inputPaths),
+      ].join(', ')}`,
+    );
   }
 }
 
@@ -633,7 +671,7 @@ const summary = [
   '- node_modules runtime dependency packages',
   '- no VS Code extension host runtime import',
   '- desktop main dynamic require shim',
-  '- desktop startup bundles exclude provider SDKs',
+  '- desktop startup import graph excludes provider SDKs',
   '- desktop-shared source uses vscode-free state keys',
   '- desktop-shared source avoids VS Code runtime imports',
 ];

--- a/src/agent/index/index.ts
+++ b/src/agent/index/index.ts
@@ -38,6 +38,8 @@ export {
   setAgentDirectories,
 } from './agentDirectoriesRegistry';
 
+export { toRemoteAgentProfileData } from './remoteAgentProfileData';
+
 export {
   // Types
   type AgentEntry,

--- a/src/agent/index/remoteAgentProfileData.ts
+++ b/src/agent/index/remoteAgentProfileData.ts
@@ -1,0 +1,12 @@
+import type { RemoteAgent } from '@shared/schemas/profileViewMessages';
+import type { AgentEntry } from './agentRegistry';
+
+export function toRemoteAgentProfileData(entry: AgentEntry): RemoteAgent {
+  return {
+    name: entry.name,
+    description: entry.description ?? '',
+    visibility: entry.visibility ?? ['public'],
+    category: entry.category,
+    supportsMultipleOutput: entry.isMultiple ?? false,
+  };
+}

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,35 +232,70 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string; stack?: string };
+  const candidate = err as { provider?: string; headers?: HeaderBag } & {
+    constructor?: { name?: string };
+    stack?: string;
+  };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
   }
 
-  const providerFromClassNames = detectProviderFromClassNames(
+  const classNameProvider = detectProviderFromClassNames(
     getErrorClassNames(err),
   );
-  if (providerFromClassNames) return providerFromClassNames;
+  if (classNameProvider) return classNameProvider;
 
-  return detectProviderFromText(candidate.stack ?? '');
+  const providerFromStack = detectProviderFromText(candidate.stack ?? '');
+  if (providerFromStack) {
+    return providerFromStack;
+  }
+
+  return detectProviderFromHeaders(candidate.headers);
 }
 
 function detectProviderFromClassNames(
-  classNames: readonly string[],
+  classNames: readonly (string | undefined)[],
 ): string | undefined {
-  // Match SDK class-name fragments, then normalize aliases to the
-  // canonical API-provider names used by SecretManager / model handlers.
-  // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
-  // (class name contains "kimi") maps to "moonshot".
-  const loweredClassNames = classNames.map((className) =>
-    className.toLowerCase(),
-  );
-  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    loweredClassNames.some((className) => className.includes(p)),
+  // Match SDK class-name fragments, then normalize aliases to the canonical
+  // API-provider names used by SecretManager / model handlers. This also covers
+  // no-response connection errors whose provider only appears on a base SDK
+  // class such as OpenAIError or AnthropicError.
+  const names = classNames
+    .filter((name): name is string => isString(name) && name.length > 0)
+    .map((name) => name.toLowerCase());
+  const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find(
+    (provider) => names.some((name) => name.includes(provider)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;
+}
+
+type HeaderBag =
+  | {
+      get?: (key: string) => string | null;
+    }
+  | Record<string, unknown>;
+type HeaderDetectedProvider = 'anthropic';
+
+function getHeaderValue(
+  headers: HeaderBag | undefined,
+  name: string,
+): string | undefined {
+  const maybeGet = isObject(headers) ? headers.get : undefined;
+  const direct =
+    typeof maybeGet === 'function' ? maybeGet.call(headers, name) : undefined;
+  if (isString(direct) && direct) return direct;
+
+  const indexed = (headers as Record<string, unknown> | undefined)?.[name];
+  return isString(indexed) && indexed ? indexed : undefined;
+}
+
+function detectProviderFromHeaders(
+  headers: HeaderBag | undefined,
+): HeaderDetectedProvider | undefined {
+  if (getHeaderValue(headers, 'request-id')) return 'anthropic';
+  return undefined;
 }
 
 function detectProviderFromText(text: string): string | undefined {
@@ -280,10 +315,12 @@ function detectRequestId(err: unknown): string | undefined {
   const candidate = err as {
     request_id?: string;
     requestId?: string;
-    headers?: { get?: (key: string) => string | null };
+    requestID?: string;
+    headers?: HeaderBag;
   };
 
-  const directId = candidate.request_id ?? candidate.requestId;
+  const directId =
+    candidate.request_id ?? candidate.requestId ?? candidate.requestID;
   if (isString(directId) && directId) {
     return directId;
   }
@@ -291,8 +328,8 @@ function detectRequestId(err: unknown): string | undefined {
   // Try headers (Anthropic SDK uses 'request-id'; relay may use 'x-request-id')
   // ?? undefined converts null from headers.get() to undefined
   return (
-    candidate.headers?.get?.('request-id') ??
-    candidate.headers?.get?.('x-request-id') ??
+    getHeaderValue(candidate.headers, 'request-id') ??
+    getHeaderValue(candidate.headers, 'x-request-id') ??
     undefined
   );
 }
@@ -343,7 +380,7 @@ export function takeTail(text: string, maxChars: number): string {
   return text.length <= maxChars ? text : text.slice(text.length - maxChars);
 }
 
-/** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
+/** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
   return getErrorClassNames(err).includes('APIUserAbortError');
 }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -232,9 +232,7 @@ function detectProvider(err: unknown): string | undefined {
     return undefined;
   }
 
-  const candidate = err as { provider?: string } & {
-    constructor?: { name?: string };
-  };
+  const candidate = err as { provider?: string };
 
   if (isString(candidate.provider)) {
     return candidate.provider;
@@ -243,9 +241,6 @@ function detectProvider(err: unknown): string | undefined {
   const loweredClassNames = getErrorClassNames(err).map((className) =>
     className.toLowerCase(),
   );
-  if (isString(candidate.constructor?.name)) {
-    loweredClassNames.push(candidate.constructor.name.toLowerCase());
-  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -240,15 +240,19 @@ function detectProvider(err: unknown): string | undefined {
     return candidate.provider;
   }
 
-  const lowered = candidate.constructor?.name?.toLowerCase();
-  if (!lowered) return undefined;
+  const loweredClassNames = getErrorClassNames(err).map((className) =>
+    className.toLowerCase(),
+  );
+  if (isString(candidate.constructor?.name)) {
+    loweredClassNames.push(candidate.constructor.name.toLowerCase());
+  }
 
   // Match SDK class-name fragments, then normalize aliases to the
   // canonical API-provider names used by SecretManager / model handlers.
   // Kimi models live under the `moonshot` provider, so a `KimiAPIError`
   // (class name contains "kimi") maps to "moonshot".
   const match = (['openai', 'anthropic', 'google', 'kimi'] as const).find((p) =>
-    lowered.includes(p),
+    loweredClassNames.some((className) => className.includes(p)),
   );
   if (match === 'kimi') return 'moonshot';
   return match;

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -1,12 +1,29 @@
 // Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+} from '@anthropic-ai/sdk';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+} from 'openai';
 import { describe, expect, it } from 'vitest';
 
 // Local imports - common errors
-import { formatProviderHttpError } from '@common/errors/sdkErrorUtils';
+import {
+  formatProviderHttpError,
+  isUserAbort,
+} from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
 
 class BadRequestError extends APIError {}
+
+class KimiAPIError extends APIError {}
 
 class APIUserAbortError extends APIError {}
 
@@ -20,6 +37,123 @@ describe('formatProviderHttpError', () => {
 
     expect(formatted.message).toBe('new provider error shape');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('matches SDK abort errors through the prototype chain', () => {
+    expect(isUserAbort(new APIUserAbortError('aborted'))).toBe(true);
+  });
+
+  it('preserves native SDK abort detection for packaged builds', () => {
+    expect(isUserAbort(new OpenAIAPIUserAbortError())).toBe(true);
+    expect(isUserAbort(new AnthropicAPIUserAbortError())).toBe(true);
+  });
+
+  it('preserves provider context for native OpenAI HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new OpenAIAuthenticationError(
+        401,
+        { message: 'invalid api key', type: 'invalid_request_error' },
+        'invalid api key',
+        new Headers({ 'x-request-id': 'req-openai' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.requestId).toBe('req-openai');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native OpenAI connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new OpenAIAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new OpenAIAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('openai');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('openai');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('preserves provider context for native Anthropic HTTP errors', () => {
+    const formatted = formatProviderHttpError(
+      new AnthropicAuthenticationError(
+        401,
+        {
+          type: 'error',
+          error: { type: 'authentication_error', message: 'invalid api key' },
+        },
+        'invalid api key',
+        new Headers({ 'request-id': 'req-anthropic' }),
+      ),
+    );
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+    expect(formatted.statusCode).toBe(401);
+  });
+
+  it('preserves provider context for native Anthropic connection errors without response headers', () => {
+    const connectionError = formatProviderHttpError(
+      new AnthropicAPIConnectionError({
+        message: 'network unavailable',
+        cause: new Error('socket closed'),
+      }),
+    );
+    const timeoutError = formatProviderHttpError(
+      new AnthropicAPIConnectionTimeoutError({ message: 'timed out' }),
+    );
+
+    expect(connectionError.provider).toBe('anthropic');
+    expect(connectionError.retryable).toBe(true);
+    expect(timeoutError.provider).toBe('anthropic');
+    expect(timeoutError.retryable).toBe(true);
+  });
+
+  it('prefers Anthropic request-id when response headers include both request id styles', () => {
+    const err = new UnknownSdkApiError('upstream auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({
+      'request-id': 'req-anthropic',
+      'x-request-id': 'req-openai-compatible',
+    });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.requestId).toBe('req-anthropic');
+  });
+
+  it('does not infer OpenAI from generic x-request-id headers', () => {
+    const err = new UnknownSdkApiError(
+      'openai-compatible gateway failed',
+    ) as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-compatible' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBeUndefined();
+    expect(formatted.requestId).toBe('req-compatible');
+  });
+
+  it('prefers SDK class provider hints over OpenAI-compatible request headers', () => {
+    const err = new KimiAPIError('moonshot auth failed') as APIError & {
+      headers: Headers;
+    };
+    err.headers = new Headers({ 'x-request-id': 'req-kimi' });
+
+    const formatted = formatProviderHttpError(err);
+
+    expect(formatted.provider).toBe('moonshot');
+    expect(formatted.requestId).toBe('req-kimi');
   });
 
   it('detects OpenAI provider from Windows pnpm stack paths', () => {

--- a/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAgentExecution.vitest.mts
@@ -638,6 +638,34 @@ describe('DesktopProgressBridge', () => {
     }
   });
 
+  it('passes remote agent launches to the shared runtime unchanged', async () => {
+    const request = {
+      agentName: 'remote:remoteWriter',
+      filePath: 'main.tex',
+      prompt: 'draft',
+    };
+    const runValidatedExecutionRequest = vi.fn(async () => {});
+    const execution = await createExecution({
+      runValidatedExecutionRequest,
+      prepareMainViewExecutionRequest: vi.fn(() => ({
+        valid: true,
+        request,
+      })),
+    });
+
+    try {
+      await execution.handleExecute({ command: 'execute' });
+      expect(runValidatedExecutionRequest).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          openWorkflowOutput: expect.any(Function),
+        }),
+      );
+    } finally {
+      execution.dispose();
+    }
+  });
+
   it('opens workflow outputs through the desktop preview host', async () => {
     const opener = { openPath: vi.fn(async (_filePath: string) => {}) };
     const runValidatedExecutionRequest = vi.fn(async (_request, options) => {

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import * as agentRegistry from '@agent/index/agentRegistry';
+import { SupabaseClient } from '@auth/SupabaseClient';
 import type { SupabaseSession } from '@auth/SupabaseSession';
 import { setServerSideKeyService } from '@auth/serverKeys';
 import { createDesktopProtocolCallbackRouter } from '../../../packages/desktop/src/main/desktopProtocolCallbacks';
@@ -113,7 +116,34 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
+function installAuthenticatedSupabaseProvider() {
+  const ensureFreshToken = vi.fn(async () => 'fresh-access-token');
+  SupabaseClient.initialize('https://example.supabase.co', 'public-key');
+  SupabaseClient.setAuthProvider({
+    whenReady: vi.fn(async () => {}),
+    ensureFreshToken,
+    getSessionTokens: vi.fn(async () => ({
+      accessToken: 'fresh-access-token',
+      refreshToken: 'refresh-token',
+    })),
+  });
+  vi.spyOn(SupabaseClient, 'getUser').mockResolvedValue({
+    id: 'user-1',
+    email: 'user@example.com',
+  } as never);
+  vi.spyOn(SupabaseClient, 'getUserAuthContext').mockResolvedValue({
+    tier: 'free',
+    permissions: ['public'],
+  });
+  return { ensureFreshToken };
+}
+
 describe('desktop Supabase auth', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    SupabaseClient.resetForTests();
+  });
+
   it('opens Supabase OAuth with the desktop texra callback URI', async () => {
     const router = createDesktopProtocolCallbackRouter();
     const coordinator = createCoordinator();
@@ -558,6 +588,54 @@ describe('desktop Supabase auth', () => {
 
     expect(coordinator.clearSession).toHaveBeenCalled();
     expect(clearAllCaches).toHaveBeenCalledOnce();
+    auth.dispose();
+  });
+
+  it('refreshes desktop session state and exposes remote agents in profile data', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    const { ensureFreshToken } = installAuthenticatedSupabaseProvider();
+    const loadAgents = vi
+      .spyOn(agentRegistry, 'loadAgents')
+      .mockResolvedValue(undefined);
+    vi.spyOn(agentRegistry, 'getAgentsBySource').mockReturnValue([
+      {
+        name: 'remoteWriter',
+        source: 'remote',
+        path: '',
+        isMultiple: true,
+        category: AgentCategory.Workflow,
+        description: 'Remote writer',
+        visibility: ['public', 'researcher'],
+      },
+    ]);
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator: createCoordinator(),
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      initializeServerSideAccess: false,
+    });
+
+    const profile = await auth.getProfileData();
+
+    expect(ensureFreshToken).toHaveBeenCalled();
+    expect(loadAgents).toHaveBeenCalled();
+    expect(profile).toMatchObject({
+      authenticated: true,
+      user: { email: 'user@example.com', id: 'user-1' },
+      tier: 'free',
+      permissions: ['public'],
+      remoteAgents: [
+        {
+          name: 'remoteWriter',
+          description: 'Remote writer',
+          visibility: ['public', 'researcher'],
+          category: 'workflow',
+          supportsMultipleOutput: true,
+        },
+      ],
+    });
     auth.dispose();
   });
 });

--- a/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
+++ b/src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts
@@ -638,4 +638,33 @@ describe('desktop Supabase auth', () => {
     });
     auth.dispose();
   });
+
+  it('keeps authenticated profile data when remote agent refresh fails', async () => {
+    const router = createDesktopProtocolCallbackRouter();
+    installAuthenticatedSupabaseProvider();
+    vi.spyOn(agentRegistry, 'loadAgents').mockRejectedValue(
+      new Error('agent directory unavailable'),
+    );
+    const getAgentsBySource = vi
+      .spyOn(agentRegistry, 'getAgentsBySource')
+      .mockReturnValue([]);
+    const auth = createDesktopSupabaseAuth({
+      router,
+      coordinator: createCoordinator(),
+      oauthClient: createOAuthClient(),
+      secrets: createSecrets(),
+      openExternalUrl: vi.fn(async () => {}),
+      initializeServerSideAccess: false,
+    });
+
+    const profile = await auth.getProfileData();
+
+    expect(profile).toMatchObject({
+      authenticated: true,
+      user: { email: 'user@example.com', id: 'user-1' },
+      remoteAgents: [],
+    });
+    expect(getAgentsBySource).not.toHaveBeenCalled();
+    auth.dispose();
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
     "types": ["node", "mocha", "vscode"]
   },
   "include": [
+    "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "packages/extension/src/**/*.ts",

--- a/tsconfig.test-kernel.json
+++ b/tsconfig.test-kernel.json
@@ -5,5 +5,5 @@
     "moduleResolution": "bundler",
     "types": ["node"]
   },
-  "include": ["src/test-kernel/**/*.mts"]
+  "include": ["src/test-kernel/**/*.mts", "src/types/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary

- Populate desktop authenticated profile data from the shared remote-agent registry instead of returning an empty remote-agent list.
- Keep desktop launcher/settings refreshes on the existing shared agent runtime path so remote agent launches flow through `runValidatedExecutionRequest` unchanged.
- Share the AgentEntry-to-RemoteAgent profile mapping through the `@agent/index` barrel and keep profile loading fail-soft when agent refresh fails.
- Stack on #3596 for the shared desktop package-verifier/provider SDK fixes instead of carrying those changes in this PR.

Fixes #3551

## Validation

- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopSupabaseAuth.vitest.mts src/test-kernel/desktop/DesktopAgentExecution.vitest.mts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check origin/codex/desktop-package-metafile-verifier...HEAD`