### PR TITLE
[codex] Add desktop Monaco diff view

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "markdown-it-texmath": "^1.0.0",
     "mime-types": "^3.0.1",
     "minimatch": "^10.2.5",
+    "monaco-editor": "^0.55.1",
     "mutative": "^1.3.0",
     "nanoid": "^5.1.11",
     "node-pandoc": "^0.3.0",

--- a/packages/desktop/src/main/desktopViewStateIpc.ts
+++ b/packages/desktop/src/main/desktopViewStateIpc.ts
@@ -2,6 +2,10 @@ import { nativeTheme } from 'electron';
 
 import { COMMON_COMMANDS } from '@common/webview/commonCommands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
+import {
+  DESKTOP_THEME_KIND,
+  type DesktopThemeKind,
+} from '@shared/constants/desktopTheme';
 
 import type {
   DesktopCommandMessage,
@@ -9,20 +13,24 @@ import type {
   DesktopRenderer,
 } from './desktopIpcTypes.js';
 
-export type DesktopTheme = 'dark' | 'light' | 'high-contrast';
+export type DesktopTheme = DesktopThemeKind;
 
 export interface DesktopViewStateIpcOptions {
   debugMode?: boolean;
-  getTheme?: () => DesktopTheme;
+  getTheme?: () => DesktopThemeKind;
 }
 
 export interface DesktopViewStateIpc extends DesktopMessageHandler {
   dispose(): void;
 }
 
-function getNativeTheme(): DesktopTheme {
-  if (nativeTheme.shouldUseHighContrastColors) return 'high-contrast';
-  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+function getNativeTheme(): DesktopThemeKind {
+  if (nativeTheme.shouldUseHighContrastColors) {
+    return DESKTOP_THEME_KIND.HIGH_CONTRAST;
+  }
+  return nativeTheme.shouldUseDarkColors
+    ? DESKTOP_THEME_KIND.DARK
+    : DESKTOP_THEME_KIND.LIGHT;
 }
 
 export function createDesktopViewStateIpc(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,10 +6,9 @@ import { COMMON_COMMANDS } from '@common/webview/commands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { postMessage } from '@shared/hostBridge';
 import {
-  isDesktopThemeKind,
-  type DesktopThemeKind,
-} from '@shared/constants/desktopTheme';
-import { SetThemeMessageSchema } from '@shared/schemas/commonViewMessages';
+  SetThemeMessageSchema,
+  type SetThemeMessage,
+} from '@shared/schemas/commonViewMessages';
 import '@vscode-elements/elements/dist/bundled.js';
 import '@progressView/frontend';
 import '@progressView/frontend/components/TexraDiffView';
@@ -242,12 +241,8 @@ function isDesktopSetLogMessage(
   return DesktopSetLogMessageSchema.safeParse(message).success;
 }
 
-function isThemeMessage(message: unknown): message is {
-  command: typeof COMMON_COMMANDS.THEME_SET;
-  theme: DesktopThemeKind;
-} {
-  const result = SetThemeMessageSchema.safeParse(message);
-  return result.success && isDesktopThemeKind(result.data.theme);
+function isThemeMessage(message: unknown): message is SetThemeMessage {
+  return SetThemeMessageSchema.safeParse(message).success;
 }
 
 function setRoute(route: DesktopRoute): void {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,9 +6,10 @@ import { COMMON_COMMANDS } from '@common/webview/commands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { postMessage } from '@shared/hostBridge';
 import {
-  SetThemeMessageSchema,
-  type Theme,
-} from '@shared/schemas/commonViewMessages';
+  isDesktopThemeKind,
+  type DesktopThemeKind,
+} from '@shared/constants/desktopTheme';
+import { SetThemeMessageSchema } from '@shared/schemas/commonViewMessages';
 import '@vscode-elements/elements/dist/bundled.js';
 import '@progressView/frontend';
 import '@progressView/frontend/components/TexraDiffView';
@@ -241,6 +242,14 @@ function isDesktopSetLogMessage(
   return DesktopSetLogMessageSchema.safeParse(message).success;
 }
 
+function isThemeMessage(message: unknown): message is {
+  command: typeof COMMON_COMMANDS.THEME_SET;
+  theme: DesktopThemeKind;
+} {
+  const result = SetThemeMessageSchema.safeParse(message);
+  return result.success && isDesktopThemeKind(result.data.theme);
+}
+
 function setRoute(route: DesktopRoute): void {
   for (const [candidate, container] of routeContainers) {
     container.hidden = candidate !== route;
@@ -261,7 +270,7 @@ window.addEventListener('message', (event) => {
     } else {
       firstRunWalkthrough.hide();
     }
-  } else if (isDesktopSetThemeMessage(event.data)) {
+  } else if (isThemeMessage(event.data)) {
     applyDesktopTheme(event.data.theme);
   } else if (isWorkspaceTreeMessage(event.data)) {
     renderWorkspaceExplorer(event.data);
@@ -272,17 +281,7 @@ window.addEventListener('message', (event) => {
 requestWorkspaceTree();
 postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
 
-function isDesktopSetThemeMessage(
-  message: unknown,
-): message is { theme: Theme } {
-  return (
-    (message as { command?: unknown } | null)?.command ===
-      COMMON_COMMANDS.THEME_SET &&
-    SetThemeMessageSchema.safeParse(message).success
-  );
-}
-
-function applyDesktopTheme(theme: Theme): void {
+function applyDesktopTheme(theme: DesktopThemeKind): void {
   document.body.classList.remove(
     'vscode-light',
     'vscode-dark',

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -11,6 +11,7 @@ import {
 } from '@shared/schemas/commonViewMessages';
 import '@vscode-elements/elements/dist/bundled.js';
 import '@progressView/frontend';
+import '@progressView/frontend/components/TexraDiffView';
 import '@settingsView/frontend';
 import '@webview/frontend';
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -5,6 +5,7 @@ import './codiconStylesheet';
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { postMessage } from '@shared/hostBridge';
+import type { DesktopThemeKind } from '@shared/constants/desktopTheme';
 import {
   SetThemeMessageSchema,
   type SetThemeMessage,

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -1,0 +1,274 @@
+// Third-party imports
+import { LitElement, css, html, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+// Local imports - shared styles
+import { commonViewStyles, designTokens } from '@shared/styles';
+
+type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js');
+type MonacoWorkerModule = { default: new () => Worker };
+type DiffEditor = ReturnType<MonacoModule['editor']['createDiffEditor']>;
+type TextModel = ReturnType<MonacoModule['editor']['createModel']>;
+type MonacoEnvironmentHost = typeof self & {
+  MonacoEnvironment?: {
+    getWorker(workerId: string, label: string): Worker;
+  };
+};
+
+interface MonacoWorkerConstructors {
+  editor: new () => Worker;
+  json: new () => Worker;
+  css: new () => Worker;
+  html: new () => Worker;
+  ts: new () => Worker;
+}
+
+let monacoLoad: Promise<MonacoModule> | undefined;
+let workersConfigured = false;
+
+function setupMonacoWorkers(workers: MonacoWorkerConstructors): void {
+  if (workersConfigured) return;
+  (self as MonacoEnvironmentHost).MonacoEnvironment = {
+    getWorker(_workerId: string, label: string): Worker {
+      switch (label) {
+        case 'json':
+          return new workers.json();
+        case 'css':
+        case 'scss':
+        case 'less':
+          return new workers.css();
+        case 'html':
+        case 'handlebars':
+        case 'razor':
+          return new workers.html();
+        case 'typescript':
+        case 'javascript':
+          return new workers.ts();
+        default:
+          return new workers.editor();
+      }
+    },
+  };
+  workersConfigured = true;
+}
+
+async function loadMonaco(): Promise<MonacoModule> {
+  monacoLoad ??= Promise.all([
+    import('monaco-editor/esm/vs/editor/editor.api.js'),
+    import('monaco-editor/esm/vs/editor/editor.worker?worker'),
+    import('monaco-editor/esm/vs/language/json/json.worker?worker'),
+    import('monaco-editor/esm/vs/language/css/css.worker?worker'),
+    import('monaco-editor/esm/vs/language/html/html.worker?worker'),
+    import('monaco-editor/esm/vs/language/typescript/ts.worker?worker'),
+  ]).then(
+    ([monaco, editorWorker, jsonWorker, cssWorker, htmlWorker, tsWorker]) => {
+      setupMonacoWorkers({
+        editor: (editorWorker as MonacoWorkerModule).default,
+        json: (jsonWorker as MonacoWorkerModule).default,
+        css: (cssWorker as MonacoWorkerModule).default,
+        html: (htmlWorker as MonacoWorkerModule).default,
+        ts: (tsWorker as MonacoWorkerModule).default,
+      });
+      return monaco;
+    },
+  );
+  return monacoLoad;
+}
+
+function monacoThemeForDocument(): 'vs' | 'vs-dark' {
+  const themeKind = document.body.dataset.vscodeThemeKind;
+  if (themeKind === 'light') return 'vs';
+  if (themeKind === 'dark' || themeKind === 'high-contrast') return 'vs-dark';
+  return document.body.classList.contains('vscode-light') ? 'vs' : 'vs-dark';
+}
+
+@customElement('texra-diff-view')
+export class TexraDiffView extends LitElement {
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    css`
+      :host {
+        display: block;
+        min-height: 240px;
+      }
+
+      .diff-view {
+        display: flex;
+        min-height: 240px;
+        height: 42vh;
+        max-height: 640px;
+        border: var(--border-thin) solid var(--color-border);
+        background: var(--color-background);
+      }
+
+      .editor {
+        flex: 1;
+        min-width: 0;
+        min-height: 0;
+      }
+
+      .placeholder,
+      .error {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 240px;
+        padding: var(--spacing-medium);
+        border: var(--border-thin) solid var(--color-border);
+        color: var(--color-text-muted);
+        background: var(--color-background-secondary);
+      }
+
+      .error {
+        color: var(--color-error);
+      }
+    `,
+  ];
+
+  @property({ attribute: false }) originalText = '';
+  @property({ attribute: false }) proposedText = '';
+  @property() language = 'plaintext';
+
+  @state() private loading = false;
+  @state() private errorMessage = '';
+
+  private editor?: DiffEditor;
+  private monaco?: MonacoModule;
+  private originalModel?: TextModel;
+  private proposedModel?: TextModel;
+  private resizeObserver?: ResizeObserver;
+  private mutationObserver?: MutationObserver;
+  private loadGeneration = 0;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.observeTheme();
+  }
+
+  override disconnectedCallback(): void {
+    this.loadGeneration += 1;
+    this.resizeObserver?.disconnect();
+    this.mutationObserver?.disconnect();
+    this.disposeMonacoObjects();
+    super.disconnectedCallback();
+  }
+
+  protected override firstUpdated(): void {
+    void this.ensureEditor();
+  }
+
+  protected override updated(changed: Map<string, unknown>): void {
+    if (
+      changed.has('originalText') ||
+      changed.has('proposedText') ||
+      changed.has('language')
+    ) {
+      this.syncModels();
+    }
+  }
+
+  override render(): TemplateResult {
+    if (this.errorMessage) {
+      return html`<div class="error">${this.errorMessage}</div>`;
+    }
+    return html`
+      ${this.loading
+        ? html`<div class="placeholder">Loading diff...</div>`
+        : nothing}
+      <div class="diff-view" ?hidden=${this.loading}>
+        <div class="editor"></div>
+      </div>
+    `;
+  }
+
+  private async ensureEditor(): Promise<void> {
+    if (this.editor) return;
+    const generation = ++this.loadGeneration;
+    this.loading = true;
+    this.errorMessage = '';
+
+    try {
+      const monaco = await loadMonaco();
+      if (!this.isConnected || generation !== this.loadGeneration) return;
+      const container = this.renderRoot.querySelector<HTMLElement>('.editor');
+      if (!container) return;
+
+      this.monaco = monaco;
+      this.applyTheme();
+      this.editor = monaco.editor.createDiffEditor(container, {
+        automaticLayout: false,
+        enableSplitViewResizing: true,
+        originalEditable: false,
+        readOnly: true,
+        renderOverviewRuler: true,
+        renderSideBySide: true,
+        scrollBeyondLastLine: false,
+      });
+      this.syncModels();
+      this.observeResize(container);
+    } catch (error) {
+      this.errorMessage =
+        error instanceof Error ? error.message : 'Failed to load diff editor.';
+    } finally {
+      if (generation === this.loadGeneration) this.loading = false;
+    }
+  }
+
+  private syncModels(): void {
+    if (!this.monaco || !this.editor) return;
+    this.originalModel?.dispose();
+    this.proposedModel?.dispose();
+    this.originalModel = this.monaco.editor.createModel(
+      this.originalText,
+      this.language,
+    );
+    this.proposedModel = this.monaco.editor.createModel(
+      this.proposedText,
+      this.language,
+    );
+    this.editor.setModel({
+      original: this.originalModel,
+      modified: this.proposedModel,
+    });
+  }
+
+  private observeResize(container: HTMLElement): void {
+    if (typeof ResizeObserver === 'undefined') {
+      this.editor?.layout();
+      return;
+    }
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = new ResizeObserver(() => this.editor?.layout());
+    this.resizeObserver.observe(container);
+    this.editor?.layout();
+  }
+
+  private observeTheme(): void {
+    if (typeof MutationObserver === 'undefined') return;
+    this.mutationObserver = new MutationObserver(() => this.applyTheme());
+    this.mutationObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'data-vscode-theme-kind'],
+    });
+  }
+
+  private applyTheme(): void {
+    this.monaco?.editor.setTheme(monacoThemeForDocument());
+  }
+
+  private disposeMonacoObjects(): void {
+    this.editor?.dispose();
+    this.editor = undefined;
+    this.originalModel?.dispose();
+    this.originalModel = undefined;
+    this.proposedModel?.dispose();
+    this.proposedModel = undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'texra-diff-view': TexraDiffView;
+  }
+}

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -5,6 +5,9 @@ import { customElement, property, state } from 'lit/decorators.js';
 // Local imports - shared styles
 import { commonViewStyles, designTokens } from '@shared/styles';
 
+// Local imports - shared constants
+import { DESKTOP_THEME_KIND } from '@shared/constants/desktopTheme';
+
 type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js');
 type MonacoWorkerModule = { default: new () => Worker };
 type DiffEditor = ReturnType<MonacoModule['editor']['createDiffEditor']>;
@@ -82,10 +85,9 @@ async function loadMonaco(): Promise<MonacoModule> {
 
 function monacoThemeForDocument(): 'vs' | 'vs-dark' | 'hc-black' | 'hc-light' {
   const themeKind = document.body.dataset.vscodeThemeKind;
-  if (themeKind === 'light') return 'vs';
-  if (themeKind === 'high-contrast') return 'hc-black';
-  if (themeKind === 'high-contrast-light') return 'hc-light';
-  if (themeKind === 'dark') return 'vs-dark';
+  if (themeKind === DESKTOP_THEME_KIND.LIGHT) return 'vs';
+  if (themeKind === DESKTOP_THEME_KIND.HIGH_CONTRAST) return 'hc-black';
+  if (themeKind === DESKTOP_THEME_KIND.DARK) return 'vs-dark';
   return document.body.classList.contains('vscode-light') ? 'vs' : 'vs-dark';
 }
 

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -80,10 +80,11 @@ async function loadMonaco(): Promise<MonacoModule> {
   return monacoLoad;
 }
 
-function monacoThemeForDocument(): 'vs' | 'vs-dark' | 'hc-black' {
+function monacoThemeForDocument(): 'vs' | 'vs-dark' | 'hc-black' | 'hc-light' {
   const themeKind = document.body.dataset.vscodeThemeKind;
   if (themeKind === 'light') return 'vs';
   if (themeKind === 'high-contrast') return 'hc-black';
+  if (themeKind === 'high-contrast-light') return 'hc-light';
   if (themeKind === 'dark') return 'vs-dark';
   return document.body.classList.contains('vscode-light') ? 'vs' : 'vs-dark';
 }

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -75,10 +75,11 @@ async function loadMonaco(): Promise<MonacoModule> {
   return monacoLoad;
 }
 
-function monacoThemeForDocument(): 'vs' | 'vs-dark' {
+function monacoThemeForDocument(): 'vs' | 'vs-dark' | 'hc-black' {
   const themeKind = document.body.dataset.vscodeThemeKind;
   if (themeKind === 'light') return 'vs';
-  if (themeKind === 'dark' || themeKind === 'high-contrast') return 'vs-dark';
+  if (themeKind === 'high-contrast') return 'hc-black';
+  if (themeKind === 'dark') return 'vs-dark';
   return document.body.classList.contains('vscode-light') ? 'vs' : 'vs-dark';
 }
 

--- a/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
+++ b/packages/extension/src/progressView/frontend/components/TexraDiffView.ts
@@ -60,18 +60,23 @@ async function loadMonaco(): Promise<MonacoModule> {
     import('monaco-editor/esm/vs/language/css/css.worker?worker'),
     import('monaco-editor/esm/vs/language/html/html.worker?worker'),
     import('monaco-editor/esm/vs/language/typescript/ts.worker?worker'),
-  ]).then(
-    ([monaco, editorWorker, jsonWorker, cssWorker, htmlWorker, tsWorker]) => {
-      setupMonacoWorkers({
-        editor: (editorWorker as MonacoWorkerModule).default,
-        json: (jsonWorker as MonacoWorkerModule).default,
-        css: (cssWorker as MonacoWorkerModule).default,
-        html: (htmlWorker as MonacoWorkerModule).default,
-        ts: (tsWorker as MonacoWorkerModule).default,
-      });
-      return monaco;
-    },
-  );
+  ])
+    .then(
+      ([monaco, editorWorker, jsonWorker, cssWorker, htmlWorker, tsWorker]) => {
+        setupMonacoWorkers({
+          editor: (editorWorker as MonacoWorkerModule).default,
+          json: (jsonWorker as MonacoWorkerModule).default,
+          css: (cssWorker as MonacoWorkerModule).default,
+          html: (htmlWorker as MonacoWorkerModule).default,
+          ts: (tsWorker as MonacoWorkerModule).default,
+        });
+        return monaco;
+      },
+    )
+    .catch((error: unknown) => {
+      monacoLoad = undefined;
+      throw error;
+    });
   return monacoLoad;
 }
 

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -251,7 +251,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   };
 
   private hasInlineDiff(data: ToolEditPermission): boolean {
-    return data.originalContent != null && data.proposedContent != null;
+    return data.originalContent != null || data.proposedContent != null;
   }
 }
 

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -37,6 +37,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   ];
 
   @state() private diffMenuOpen = false;
+  @state() private inlineDiffOpen = false;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -50,7 +51,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
 
   protected override handleExtraKey(key: string): boolean {
     if (key === 'd') {
-      this.emitAction('openDiff');
+      this.handleDiffAction();
       return true;
     }
     return false;
@@ -93,6 +94,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
           'approval-request__feedback',
           'approval-request__feedback-input',
         )}
+        ${this.renderInlineDiff(data)}
       </div>
     `;
   }
@@ -104,16 +106,25 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
   private renderDiffActions(): TemplateResult {
     const data = this.permission.data as ToolEditPermission;
     const showDropdown = Boolean(data.isLatex);
+    const hasInlineDiff = this.hasInlineDiff(data);
 
     return html`
       <div class="diff-dropdown">
         <vscode-toolbar-button
           icon="diff"
           class="diff-main-button"
-          label="Open diff"
-          title="Open diff (d)"
-          @click=${() => this.emitAction('openDiff')}
-          >Open diff</vscode-toolbar-button
+          label=${hasInlineDiff && this.inlineDiffOpen
+            ? 'Hide diff'
+            : 'Open diff'}
+          title=${hasInlineDiff
+            ? this.inlineDiffOpen
+              ? 'Hide inline diff (d)'
+              : 'Open inline diff (d)'
+            : 'Open diff (d)'}
+          @click=${this.handleDiffAction}
+          >${hasInlineDiff && this.inlineDiffOpen
+            ? 'Hide diff'
+            : 'Open diff'}</vscode-toolbar-button
         >
         ${showDropdown
           ? html`
@@ -139,6 +150,23 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
             `
           : nothing}
       </div>
+    `;
+  }
+
+  private renderInlineDiff(
+    data: ToolEditPermission,
+  ): TemplateResult | typeof nothing {
+    if (!this.inlineDiffOpen || !this.hasInlineDiff(data)) {
+      return nothing;
+    }
+
+    return html`
+      <texra-diff-view
+        class="approval-request__inline-diff"
+        .originalText=${data.originalContent ?? ''}
+        .proposedText=${data.proposedContent ?? ''}
+        .language=${data.isLatex ? 'latex' : 'plaintext'}
+      ></texra-diff-view>
     `;
   }
 
@@ -209,6 +237,19 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
     event.stopPropagation();
     this.diffMenuOpen = !this.diffMenuOpen;
   };
+
+  private handleDiffAction = (): void => {
+    const data = this.permission.data as ToolEditPermission;
+    if (this.hasInlineDiff(data)) {
+      this.inlineDiffOpen = !this.inlineDiffOpen;
+      return;
+    }
+    this.emitAction('openDiff');
+  };
+
+  private hasInlineDiff(data: ToolEditPermission): boolean {
+    return data.originalContent != null && data.proposedContent != null;
+  }
 }
 
 declare global {

--- a/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
+++ b/packages/extension/src/progressView/frontend/components/ToolEditRequestPanel.ts
@@ -21,11 +21,14 @@ import {
   requestPanelStyles,
 } from '@shared/styles';
 
-// Local imports - base class
+// Local imports - shared schemas
 import type { ToolEditPermission } from '@shared/schemas';
+
+// Local imports - base class
 import { BaseFeedbackPanel } from './BaseFeedbackPanel';
 
-// Local imports - shared schemas
+// Local imports - helpers
+import { monacoLanguageForPath } from './monacoLanguage';
 
 @customElement('tool-edit-request-panel')
 export class ToolEditRequestPanel extends BaseFeedbackPanel {
@@ -165,7 +168,7 @@ export class ToolEditRequestPanel extends BaseFeedbackPanel {
         class="approval-request__inline-diff"
         .originalText=${data.originalContent ?? ''}
         .proposedText=${data.proposedContent ?? ''}
-        .language=${data.isLatex ? 'latex' : 'plaintext'}
+        .language=${monacoLanguageForPath(data.path)}
       ></texra-diff-view>
     `;
   }

--- a/packages/extension/src/progressView/frontend/components/monacoLanguage.ts
+++ b/packages/extension/src/progressView/frontend/components/monacoLanguage.ts
@@ -1,0 +1,58 @@
+const MONACO_LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  '.c': 'c',
+  '.cc': 'cpp',
+  '.cpp': 'cpp',
+  '.cs': 'csharp',
+  '.css': 'css',
+  '.cts': 'typescript',
+  '.cxx': 'cpp',
+  '.go': 'go',
+  '.h': 'c',
+  '.hpp': 'cpp',
+  '.html': 'html',
+  '.java': 'java',
+  '.js': 'javascript',
+  '.json': 'json',
+  '.jsx': 'javascript',
+  '.less': 'less',
+  '.md': 'markdown',
+  '.mdx': 'mdx',
+  '.mjs': 'javascript',
+  '.mts': 'typescript',
+  '.php': 'php',
+  '.py': 'python',
+  '.rb': 'ruby',
+  '.rs': 'rust',
+  '.scss': 'scss',
+  '.sh': 'shell',
+  '.sql': 'sql',
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.xml': 'xml',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.zsh': 'shell',
+};
+
+const MONACO_LANGUAGE_BY_BASENAME: Record<string, string> = {
+  dockerfile: 'dockerfile',
+};
+
+const PLAINTEXT_LANGUAGE_ID = 'plaintext';
+
+/**
+ * Return a Monaco language id for syntax highlighting based on a file path.
+ */
+export function monacoLanguageForPath(filePath: string): string {
+  const basename = filePath.split(/[\\/]/).at(-1)?.toLowerCase() ?? '';
+  if (!basename) return PLAINTEXT_LANGUAGE_ID;
+
+  const basenameLanguage = MONACO_LANGUAGE_BY_BASENAME[basename];
+  if (basenameLanguage) return basenameLanguage;
+
+  const extensionIndex = basename.lastIndexOf('.');
+  if (extensionIndex <= 0) return PLAINTEXT_LANGUAGE_ID;
+
+  const extension = basename.slice(extensionIndex);
+  return MONACO_LANGUAGE_BY_EXTENSION[extension] ?? PLAINTEXT_LANGUAGE_ID;
+}

--- a/packages/extension/src/progressView/frontend/components/monacoLanguage.ts
+++ b/packages/extension/src/progressView/frontend/components/monacoLanguage.ts
@@ -1,41 +1,43 @@
-const MONACO_LANGUAGE_BY_EXTENSION: Record<string, string> = {
-  '.c': 'c',
-  '.cc': 'cpp',
-  '.cpp': 'cpp',
-  '.cs': 'csharp',
-  '.css': 'css',
-  '.cts': 'typescript',
-  '.cxx': 'cpp',
-  '.go': 'go',
-  '.h': 'c',
-  '.hpp': 'cpp',
-  '.html': 'html',
-  '.java': 'java',
-  '.js': 'javascript',
-  '.json': 'json',
-  '.jsx': 'javascript',
-  '.less': 'less',
-  '.md': 'markdown',
-  '.mdx': 'mdx',
-  '.mjs': 'javascript',
-  '.mts': 'typescript',
-  '.php': 'php',
-  '.py': 'python',
-  '.rb': 'ruby',
-  '.rs': 'rust',
-  '.scss': 'scss',
-  '.sh': 'shell',
-  '.sql': 'sql',
-  '.ts': 'typescript',
-  '.tsx': 'typescript',
-  '.xml': 'xml',
-  '.yaml': 'yaml',
-  '.yml': 'yaml',
-  '.zsh': 'shell',
-};
+// Local imports - progress view helpers
+import {
+  languageForPath,
+  SPECIAL_BASENAME_LANGUAGES,
+} from '@progressView/frontend/languageForPath';
 
-const MONACO_LANGUAGE_BY_BASENAME: Record<string, string> = {
-  dockerfile: 'dockerfile',
+const MONACO_LANGUAGE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  c: 'c',
+  cc: 'cpp',
+  cpp: 'cpp',
+  cs: 'csharp',
+  css: 'css',
+  cts: 'typescript',
+  cxx: 'cpp',
+  go: 'go',
+  h: 'c',
+  hpp: 'cpp',
+  html: 'html',
+  java: 'java',
+  js: 'javascript',
+  json: 'json',
+  jsx: 'javascript',
+  less: 'less',
+  md: 'markdown',
+  mdx: 'mdx',
+  mjs: 'javascript',
+  mts: 'typescript',
+  php: 'php',
+  py: 'python',
+  rb: 'ruby',
+  rs: 'rust',
+  scss: 'scss',
+  sh: 'shell',
+  sql: 'sql',
+  ts: 'typescript',
+  tsx: 'typescript',
+  xml: 'xml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  zsh: 'shell',
 };
 
 const PLAINTEXT_LANGUAGE_ID = 'plaintext';
@@ -44,15 +46,9 @@ const PLAINTEXT_LANGUAGE_ID = 'plaintext';
  * Return a Monaco language id for syntax highlighting based on a file path.
  */
 export function monacoLanguageForPath(filePath: string): string {
-  const basename = filePath.split(/[\\/]/).at(-1)?.toLowerCase() ?? '';
-  if (!basename) return PLAINTEXT_LANGUAGE_ID;
-
-  const basenameLanguage = MONACO_LANGUAGE_BY_BASENAME[basename];
-  if (basenameLanguage) return basenameLanguage;
-
-  const extensionIndex = basename.lastIndexOf('.');
-  if (extensionIndex <= 0) return PLAINTEXT_LANGUAGE_ID;
-
-  const extension = basename.slice(extensionIndex);
-  return MONACO_LANGUAGE_BY_EXTENSION[extension] ?? PLAINTEXT_LANGUAGE_ID;
+  return languageForPath(filePath, {
+    basenameLanguages: SPECIAL_BASENAME_LANGUAGES,
+    extensionLanguages: MONACO_LANGUAGE_BY_EXTENSION,
+    fallbackLanguage: PLAINTEXT_LANGUAGE_ID,
+  });
 }

--- a/packages/extension/src/progressView/frontend/formatters/constants.ts
+++ b/packages/extension/src/progressView/frontend/formatters/constants.ts
@@ -2,9 +2,14 @@
  * Constants and configuration for progress view formatters.
  */
 
+// Local imports - progress view helpers
+import {
+  languageForPath,
+  SPECIAL_BASENAME_LANGUAGES,
+} from '@progressView/frontend/languageForPath';
+
 // Local imports - shared schemas
 import type { LogLevel } from '@shared/schemas';
-import { getBasename } from '@shared/utils/path';
 
 export const EMOJI_BY_LEVEL: Record<LogLevel, string> = {
   error: '🔴',
@@ -105,24 +110,12 @@ const EXTENSION_ALIASES = new Map<string, string>([
 
 /** Get highlight.js language from file path based on extension. Uses alias map for non-standard extensions, otherwise tries the extension directly. */
 export function getLanguageFromPath(filePath: string): string {
-  if (!filePath) return 'plaintext';
-
-  const fileName = getBasename(filePath) || filePath;
-  const lowerFileName = fileName.toLowerCase();
-
-  // Handle special filenames
-  if (lowerFileName === 'dockerfile') return 'dockerfile';
-  if (lowerFileName === 'makefile') return 'makefile';
-
-  const lastDot = fileName.lastIndexOf('.');
-  if (lastDot === -1 || lastDot === fileName.length - 1) {
-    return 'plaintext';
-  }
-
-  const ext = fileName.slice(lastDot + 1).toLowerCase();
-
-  // Check alias map first, then use extension directly
-  return EXTENSION_ALIASES.get(ext) || ext;
+  return languageForPath(filePath, {
+    basenameLanguages: SPECIAL_BASENAME_LANGUAGES,
+    extensionLanguages: EXTENSION_ALIASES,
+    fallbackLanguage: 'plaintext',
+    unknownExtensionLanguage: (extension) => extension,
+  });
 }
 
 // Threshold constants for diff detection heuristics

--- a/packages/extension/src/progressView/frontend/languageForPath.ts
+++ b/packages/extension/src/progressView/frontend/languageForPath.ts
@@ -1,0 +1,61 @@
+// Local imports - shared utilities
+import { getBasename } from '@shared/utils/path';
+
+type LanguageMap =
+  | ReadonlyMap<string, string>
+  | Readonly<Record<string, string>>;
+
+interface LanguageForPathConfig {
+  basenameLanguages: LanguageMap;
+  extensionLanguages: LanguageMap;
+  fallbackLanguage: string;
+  unknownExtensionLanguage?: (extension: string) => string | undefined;
+}
+
+export const SPECIAL_BASENAME_LANGUAGES: Readonly<Record<string, string>> = {
+  dockerfile: 'dockerfile',
+  makefile: 'makefile',
+};
+
+function languageFromMap(
+  languages: LanguageMap,
+  key: string,
+): string | undefined {
+  if (languages instanceof Map) {
+    return languages.get(key);
+  }
+
+  const languageRecord = languages as Readonly<Record<string, string>>;
+  return Object.hasOwn(languageRecord, key) ? languageRecord[key] : undefined;
+}
+
+/**
+ * Resolve a language id from shared path parsing with caller-specific language tables.
+ */
+export function languageForPath(
+  filePath: string,
+  config: LanguageForPathConfig,
+): string {
+  if (!filePath) return config.fallbackLanguage;
+
+  const fileName = getBasename(filePath) || filePath;
+  const lowerFileName = fileName.toLowerCase();
+
+  const basenameLanguage = languageFromMap(
+    config.basenameLanguages,
+    lowerFileName,
+  );
+  if (basenameLanguage) return basenameLanguage;
+
+  const lastDot = fileName.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === fileName.length - 1) {
+    return config.fallbackLanguage;
+  }
+
+  const extension = fileName.slice(lastDot + 1).toLowerCase();
+  return (
+    languageFromMap(config.extensionLanguages, extension) ??
+    config.unknownExtensionLanguage?.(extension) ??
+    config.fallbackLanguage
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.95.0
-        version: 0.95.0(zod@4.4.3)
+        version: 0.95.1(zod@4.4.3)
       '@awesome.me/webawesome':
         specifier: ^3.6.0
         version: 3.6.0(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
@@ -366,7 +366,7 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.95.0
-        version: 0.95.0(zod@4.4.3)
+        version: 0.95.1(zod@4.4.3)
       '@awesome.me/webawesome':
         specifier: ^3.6.0
         version: 3.6.0(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
@@ -680,8 +680,8 @@ packages:
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
-  '@anthropic-ai/sdk@0.95.0':
-    resolution: {integrity: sha512-7It2B76OFJH9jC/a0TicXFMq0ZZM25ei+i/mK7JnsE1Ibmo0Yfkqm+DXOHeU/ZxxKwLLGPP6qaAvKmQmgV6XhA==}
+  '@anthropic-ai/sdk@0.95.1':
+    resolution: {integrity: sha512-OO9AF7hmAoU492c/mD7Q2cPqI2WNAj7rAPHlawgBeUgpwiboLRiDs+grsErGWeHHP9ZRWfzq2OVrODTt8aITVg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1845,8 +1845,8 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -3403,18 +3403,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
-    engines: {node: '>=14.14'}
-
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
-    engines: {node: '>=14.14'}
-
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
@@ -6054,7 +6042,7 @@ snapshots:
 
   7zip-bin@5.2.0: {}
 
-  '@anthropic-ai/sdk@0.95.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.95.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -6669,7 +6657,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@nodable/entities@2.1.0': {}
@@ -7336,7 +7324,7 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.16
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7767,7 +7755,7 @@ snapshots:
       '@vue/shared': 3.5.27
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.14
+      postcss: 8.5.13
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.27':
@@ -9289,13 +9277,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-
-  fs-extra@11.3.5:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       mutative:
         specifier: ^1.3.0
         version: 1.3.0
@@ -2922,6 +2925,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -4291,6 +4297,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -4406,6 +4417,9 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8614,6 +8628,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -10165,6 +10183,8 @@ snapshots:
 
   marked@11.2.0: {}
 
+  marked@14.0.0: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -10269,6 +10289,11 @@ snapshots:
       yargs-unparser: 2.0.0
 
   module-details-from-path@1.0.4: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 

--- a/scripts/extension-package-utils.mjs
+++ b/scripts/extension-package-utils.mjs
@@ -7,6 +7,14 @@ export const vscodeRuntimeImportPattern =
 export const vscodeBackedStateImportPattern =
   /(?:^\s*(?:(?:import(?:\s+type)?(?:\s+[^;]*?\s+from)?)|(?:export(?:\s+type)?\s+[^;]*?\s+from))\s+['"]@common\/state(?:\/stateManager)?['"])|(?:\bimport\s*\(\s*['"]@common\/state(?:\/stateManager)?['"]\s*\))/m;
 
+export const requiredMonacoWorkers = [
+  'editor.worker',
+  'json.worker',
+  'css.worker',
+  'html.worker',
+  'ts.worker',
+];
+
 const desktopSharedSourceDirSegments = [
   ['packages', 'desktop', 'src'],
   ['src', 'agent'],

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -69,11 +69,29 @@ const rendererAssetsDir = path.join(desktopDir, 'dist', 'renderer', 'assets');
 const rendererAssets = fs.existsSync(rendererAssetsDir)
   ? collectFiles(rendererAssetsDir)
   : [];
+const requiredMonacoWorkers = [
+  'editor.worker',
+  'json.worker',
+  'css.worker',
+  'html.worker',
+  'ts.worker',
+];
 if (!rendererAssets.some((filePath) => filePath.endsWith('.js'))) {
   failures.push('Desktop renderer build did not emit a JavaScript asset.');
 }
 if (!rendererAssets.some((filePath) => filePath.endsWith('.css'))) {
   failures.push('Desktop renderer build did not emit a CSS asset.');
+}
+for (const workerName of requiredMonacoWorkers) {
+  if (
+    !rendererAssets.some((filePath) =>
+      path.basename(filePath).includes(workerName),
+    )
+  ) {
+    failures.push(
+      `Desktop renderer build did not emit Monaco worker asset: ${workerName}`,
+    );
+  }
 }
 if (
   fileExists(manifestMain) &&
@@ -128,3 +146,4 @@ const artifactList = [
 console.log('Desktop build artifact check passed:');
 for (const artifact of artifactList) console.log(`- ${artifact}`);
 console.log('- desktop-shared source avoids VS Code runtime imports');
+console.log('- Monaco worker assets are present');

--- a/scripts/verify-desktop-build-artifacts.mjs
+++ b/scripts/verify-desktop-build-artifacts.mjs
@@ -7,6 +7,7 @@ import {
   getDesktopSharedSourceDirs,
   getDesktopVscodeFreeSourceDirs,
   readJson,
+  requiredMonacoWorkers,
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
@@ -69,13 +70,6 @@ const rendererAssetsDir = path.join(desktopDir, 'dist', 'renderer', 'assets');
 const rendererAssets = fs.existsSync(rendererAssetsDir)
   ? collectFiles(rendererAssetsDir)
   : [];
-const requiredMonacoWorkers = [
-  'editor.worker',
-  'json.worker',
-  'css.worker',
-  'html.worker',
-  'ts.worker',
-];
 if (!rendererAssets.some((filePath) => filePath.endsWith('.js'))) {
   failures.push('Desktop renderer build did not emit a JavaScript asset.');
 }

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -17,6 +17,7 @@ import {
 import {
   getDesktopSharedSourceDirs,
   getDesktopVscodeFreeSourceDirs,
+  requiredMonacoWorkers,
   vscodeBackedStateImportPattern,
   vscodeRuntimeImportPattern,
 } from './extension-package-utils.mjs';
@@ -74,13 +75,6 @@ const desktopStartupImportKinds = new Set([
   'dynamic-import',
   'import-statement',
 ]);
-const requiredMonacoWorkers = [
-  'editor.worker',
-  'json.worker',
-  'css.worker',
-  'html.worker',
-  'ts.worker',
-];
 
 async function exists(path) {
   try {

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -74,6 +74,13 @@ const desktopStartupImportKinds = new Set([
   'dynamic-import',
   'import-statement',
 ]);
+const requiredMonacoWorkers = [
+  'editor.worker',
+  'json.worker',
+  'css.worker',
+  'html.worker',
+  'ts.worker',
+];
 
 async function exists(path) {
   try {
@@ -621,6 +628,17 @@ async function checkBundledResources(app, failures) {
   }
 }
 
+async function checkMonacoWorkerAssets(app, failures) {
+  const assets = await app.listDir('dist/renderer/assets');
+  for (const workerName of requiredMonacoWorkers) {
+    if (!assets.some((asset) => asset.includes(workerName))) {
+      failures.push(
+        `Packaged desktop app is missing Monaco worker asset: dist/renderer/assets/${workerName}*.js`,
+      );
+    }
+  }
+}
+
 async function checkMacIcon(app, failures) {
   if (!app.label.includes('.app/Contents/Resources/app.asar')) return false;
 
@@ -663,6 +681,7 @@ if (!app) {
   await checkExists(app, 'dist/preload/index.cjs', 'preload bundle', failures);
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
   await checkBundledResources(app, failures);
+  await checkMonacoWorkerAssets(app, failures);
   checkedMacIcon = await checkMacIcon(app, failures);
   codexPayloadResult = await checkCodexPayload(app, failures);
   await checkNoVscodeRuntimeImport(app, failures);
@@ -693,6 +712,7 @@ const summary = [
   '- dist/renderer/index.html',
   '- dist/renderer/assets/*.js',
   '- dist/renderer/assets/*.css',
+  '- dist/renderer/assets Monaco worker chunks',
   '- resources/agents and resources/tool_use_agents',
   '- package.json runtime dependencies',
   '- node_modules runtime dependency packages',

--- a/src/shared/constants/desktopTheme.ts
+++ b/src/shared/constants/desktopTheme.ts
@@ -7,11 +7,3 @@ export const DESKTOP_THEME_KIND = {
 } as const satisfies Record<string, Theme>;
 
 export type DesktopThemeKind = Theme;
-
-export const DESKTOP_THEME_KINDS = Object.values(
-  DESKTOP_THEME_KIND,
-) as DesktopThemeKind[];
-
-export function isDesktopThemeKind(theme: string): theme is DesktopThemeKind {
-  return DESKTOP_THEME_KINDS.includes(theme as DesktopThemeKind);
-}

--- a/src/shared/constants/desktopTheme.ts
+++ b/src/shared/constants/desktopTheme.ts
@@ -1,0 +1,16 @@
+export const DESKTOP_THEME_KIND = {
+  DARK: 'dark',
+  LIGHT: 'light',
+  HIGH_CONTRAST: 'high-contrast',
+} as const;
+
+export type DesktopThemeKind =
+  (typeof DESKTOP_THEME_KIND)[keyof typeof DESKTOP_THEME_KIND];
+
+export const DESKTOP_THEME_KINDS = Object.values(
+  DESKTOP_THEME_KIND,
+) as DesktopThemeKind[];
+
+export function isDesktopThemeKind(theme: string): theme is DesktopThemeKind {
+  return DESKTOP_THEME_KINDS.includes(theme as DesktopThemeKind);
+}

--- a/src/shared/constants/desktopTheme.ts
+++ b/src/shared/constants/desktopTheme.ts
@@ -1,11 +1,12 @@
+import type { Theme } from '@shared/schemas/commonViewMessages';
+
 export const DESKTOP_THEME_KIND = {
   DARK: 'dark',
   LIGHT: 'light',
   HIGH_CONTRAST: 'high-contrast',
-} as const;
+} as const satisfies Record<string, Theme>;
 
-export type DesktopThemeKind =
-  (typeof DESKTOP_THEME_KIND)[keyof typeof DESKTOP_THEME_KIND];
+export type DesktopThemeKind = Theme;
 
 export const DESKTOP_THEME_KINDS = Object.values(
   DESKTOP_THEME_KIND,

--- a/src/shared/schemas/prompts.ts
+++ b/src/shared/schemas/prompts.ts
@@ -30,6 +30,8 @@ export const ToolEditPermissionSchema = PermissionBaseSchema.extend({
   addedLines: z.int().nonnegative(),
   removedLines: z.int().nonnegative(),
   isLatex: z.boolean(),
+  originalContent: z.string().optional(),
+  proposedContent: z.string().optional(),
 });
 export type ToolEditPermission = z.infer<typeof ToolEditPermissionSchema>;
 

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -28,9 +28,7 @@ const extensionPackageUtilsUrl = pathToFileURL(
   repoPath('scripts/extension-package-utils.mjs'),
 ).href;
 
-const { requiredMonacoWorkers } = (await import(
-  extensionPackageUtilsUrl
-)) as {
+const { requiredMonacoWorkers } = (await import(extensionPackageUtilsUrl)) as {
   requiredMonacoWorkers: string[];
 };
 

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -24,6 +24,15 @@ const payloadUrl = pathToFileURL(
 const pruneHookUrl = pathToFileURL(
   repoPath('scripts/prune-desktop-codex-payload.mjs'),
 ).href;
+const extensionPackageUtilsUrl = pathToFileURL(
+  repoPath('scripts/extension-package-utils.mjs'),
+).href;
+
+const { requiredMonacoWorkers } = (await import(
+  extensionPackageUtilsUrl
+)) as {
+  requiredMonacoWorkers: string[];
+};
 
 const codexPlatforms = {
   'darwin-arm64': {
@@ -227,6 +236,12 @@ function createFakeDesktopPackage(
   writeText(join(appRoot, 'dist/renderer/index.html'), '<!doctype html>\n');
   writeText(join(appRoot, 'dist/renderer/assets/app.js'), 'export {};\n');
   writeText(join(appRoot, 'dist/renderer/assets/app.css'), ':root {}\n');
+  for (const workerName of requiredMonacoWorkers) {
+    writeText(
+      join(appRoot, 'dist/renderer/assets', `${workerName}-fake.js`),
+      'self.onmessage = () => {};\n',
+    );
+  }
   writeText(join(appRoot, 'resources/agents/example.yaml'), 'name: example\n');
   writeText(
     join(appRoot, 'resources/tool_use_agents/example.yaml'),

--- a/src/test-kernel/progressView/MonacoLanguage.vitest.mts
+++ b/src/test-kernel/progressView/MonacoLanguage.vitest.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 // Local imports - progress view helpers
 import { monacoLanguageForPath } from '@progressView/frontend/components/monacoLanguage';
+import { getLanguageFromPath } from '@progressView/frontend/formatters/constants';
 
 describe('monacoLanguageForPath', () => {
   it('maps common source file extensions to Monaco language ids', () => {
@@ -13,6 +14,7 @@ describe('monacoLanguageForPath', () => {
     expect(monacoLanguageForPath('styles/main.scss')).toBe('scss');
     expect(monacoLanguageForPath('README.md')).toBe('markdown');
     expect(monacoLanguageForPath('Dockerfile')).toBe('dockerfile');
+    expect(monacoLanguageForPath('Makefile')).toBe('makefile');
   });
 
   it('falls back to plaintext for unregistered or unknown extensions', () => {
@@ -20,5 +22,15 @@ describe('monacoLanguageForPath', () => {
     expect(monacoLanguageForPath('paper/references.bib')).toBe('plaintext');
     expect(monacoLanguageForPath('notes')).toBe('plaintext');
     expect(monacoLanguageForPath('')).toBe('plaintext');
+  });
+});
+
+describe('getLanguageFromPath', () => {
+  it('uses the shared path parsing and basename logic for highlight ids', () => {
+    expect(getLanguageFromPath('/workspace/Dockerfile')).toBe('dockerfile');
+    expect(getLanguageFromPath('build/Makefile')).toBe('makefile');
+    expect(getLanguageFromPath('paper/main.tex')).toBe('latex');
+    expect(getLanguageFromPath('src/component.unknownext')).toBe('unknownext');
+    expect(getLanguageFromPath('notes')).toBe('plaintext');
   });
 });

--- a/src/test-kernel/progressView/MonacoLanguage.vitest.mts
+++ b/src/test-kernel/progressView/MonacoLanguage.vitest.mts
@@ -1,0 +1,24 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - progress view helpers
+import { monacoLanguageForPath } from '@progressView/frontend/components/monacoLanguage';
+
+describe('monacoLanguageForPath', () => {
+  it('maps common source file extensions to Monaco language ids', () => {
+    expect(monacoLanguageForPath('/workspace/src/index.ts')).toBe('typescript');
+    expect(monacoLanguageForPath('src/component.tsx')).toBe('typescript');
+    expect(monacoLanguageForPath('scripts/check.mjs')).toBe('javascript');
+    expect(monacoLanguageForPath('config/settings.json')).toBe('json');
+    expect(monacoLanguageForPath('styles/main.scss')).toBe('scss');
+    expect(monacoLanguageForPath('README.md')).toBe('markdown');
+    expect(monacoLanguageForPath('Dockerfile')).toBe('dockerfile');
+  });
+
+  it('falls back to plaintext for unregistered or unknown extensions', () => {
+    expect(monacoLanguageForPath('paper/main.tex')).toBe('plaintext');
+    expect(monacoLanguageForPath('paper/references.bib')).toBe('plaintext');
+    expect(monacoLanguageForPath('notes')).toBe('plaintext');
+    expect(monacoLanguageForPath('')).toBe('plaintext');
+  });
+});

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -142,5 +142,8 @@ describe('texra-diff-view', () => {
 
     dom.window.document.body.dataset.vscodeThemeKind = 'high-contrast';
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-black'));
+
+    dom.window.document.body.dataset.vscodeThemeKind = 'high-contrast-light';
+    await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-light'));
   });
 });

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -1,0 +1,143 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports - progress view component type
+import type { TexraDiffView } from '@progressView/frontend/components/TexraDiffView';
+
+const workerModuleIds = [
+  'monaco-editor/esm/vs/editor/editor.worker?worker',
+  'monaco-editor/esm/vs/language/json/json.worker?worker',
+  'monaco-editor/esm/vs/language/css/css.worker?worker',
+  'monaco-editor/esm/vs/language/html/html.worker?worker',
+  'monaco-editor/esm/vs/language/typescript/ts.worker?worker',
+];
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  customElements: globalThis.customElements,
+  HTMLElement: globalThis.HTMLElement,
+  Element: globalThis.Element,
+  Document: globalThis.Document,
+  ShadowRoot: globalThis.ShadowRoot,
+  CSSStyleSheet: globalThis.CSSStyleSheet,
+  MutationObserver: globalThis.MutationObserver,
+  ResizeObserver: globalThis.ResizeObserver,
+  self: globalThis.self,
+};
+
+class MockResizeObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+}
+
+class MockWorker {
+  onerror: ((this: AbstractWorker, ev: ErrorEvent) => unknown) | null = null;
+  onmessage: ((this: Worker, ev: MessageEvent) => unknown) | null = null;
+  onmessageerror: ((this: Worker, ev: MessageEvent) => unknown) | null = null;
+
+  addEventListener = vi.fn();
+  dispatchEvent = vi.fn(() => true);
+  postMessage = vi.fn();
+  removeEventListener = vi.fn();
+  terminate = vi.fn();
+}
+
+function installDom(): JSDOM {
+  const dom = new JSDOM('<!doctype html><body class="vscode-dark"></body>', {
+    url: 'http://localhost',
+  });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.customElements = dom.window.customElements;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Element = dom.window.Element;
+  globalThis.Document = dom.window.Document;
+  globalThis.ShadowRoot = dom.window.ShadowRoot;
+  globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
+  globalThis.MutationObserver = dom.window.MutationObserver;
+  globalThis.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+  globalThis.self = dom.window as unknown as Window & typeof globalThis;
+  return dom;
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+  globalThis.customElements = originalGlobals.customElements;
+  globalThis.HTMLElement = originalGlobals.HTMLElement;
+  globalThis.Element = originalGlobals.Element;
+  globalThis.Document = originalGlobals.Document;
+  globalThis.ShadowRoot = originalGlobals.ShadowRoot;
+  globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
+  globalThis.MutationObserver = originalGlobals.MutationObserver;
+  globalThis.ResizeObserver = originalGlobals.ResizeObserver;
+  globalThis.self = originalGlobals.self;
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  restoreDom();
+});
+
+describe('texra-diff-view', () => {
+  it('mounts with mock content and creates a read-only Monaco diff editor', async () => {
+    const dom = installDom();
+    const disposeOriginal = vi.fn();
+    const disposeProposed = vi.fn();
+    const diffEditor = {
+      dispose: vi.fn(),
+      layout: vi.fn(),
+      setModel: vi.fn(),
+    };
+    const createModel = vi
+      .fn()
+      .mockReturnValueOnce({ dispose: disposeOriginal })
+      .mockReturnValueOnce({ dispose: disposeProposed });
+    const createDiffEditor = vi.fn(() => diffEditor);
+    const setTheme = vi.fn();
+
+    vi.doMock('monaco-editor/esm/vs/editor/editor.api.js', () => ({
+      editor: {
+        createDiffEditor,
+        createModel,
+        setTheme,
+      },
+    }));
+    for (const workerModuleId of workerModuleIds) {
+      vi.doMock(workerModuleId, () => ({ default: MockWorker }));
+    }
+
+    await import('@progressView/frontend/components/TexraDiffView');
+    const element = document.createElement('texra-diff-view') as TexraDiffView;
+    element.originalText = 'alpha\nbeta\n';
+    element.proposedText = 'alpha\ngamma\n';
+    element.language = 'latex';
+    document.body.append(element);
+
+    await element.updateComplete;
+    await vi.waitFor(() => expect(createDiffEditor).toHaveBeenCalledTimes(1));
+
+    expect(createDiffEditor).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        readOnly: true,
+        originalEditable: false,
+      }),
+    );
+    expect(createModel).toHaveBeenNthCalledWith(1, 'alpha\nbeta\n', 'latex');
+    expect(createModel).toHaveBeenNthCalledWith(2, 'alpha\ngamma\n', 'latex');
+    expect(diffEditor.setModel).toHaveBeenCalledWith({
+      original: { dispose: disposeOriginal },
+      modified: { dispose: disposeProposed },
+    });
+    expect(setTheme).toHaveBeenCalledWith('vs-dark');
+
+    dom.window.document.body.dataset.vscodeThemeKind = 'light';
+    await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs'));
+  });
+});

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -5,6 +5,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Local imports - progress view component type
 import type { TexraDiffView } from '@progressView/frontend/components/TexraDiffView';
 
+// Local imports - shared constants
+import { DESKTOP_THEME_KIND } from '@shared/constants/desktopTheme';
+
 const workerModuleIds = [
   'monaco-editor/esm/vs/editor/editor.worker?worker',
   'monaco-editor/esm/vs/language/json/json.worker?worker',
@@ -137,13 +140,14 @@ describe('texra-diff-view', () => {
     });
     expect(setTheme).toHaveBeenCalledWith('vs-dark');
 
-    dom.window.document.body.dataset.vscodeThemeKind = 'light';
+    dom.window.document.body.dataset.vscodeThemeKind = DESKTOP_THEME_KIND.LIGHT;
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs'));
 
-    dom.window.document.body.dataset.vscodeThemeKind = 'high-contrast';
+    dom.window.document.body.dataset.vscodeThemeKind =
+      DESKTOP_THEME_KIND.HIGH_CONTRAST;
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-black'));
 
-    dom.window.document.body.dataset.vscodeThemeKind = 'high-contrast-light';
-    await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-light'));
+    dom.window.document.body.dataset.vscodeThemeKind = DESKTOP_THEME_KIND.DARK;
+    await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs-dark'));
   });
 });

--- a/src/test-kernel/progressView/TexraDiffView.vitest.mts
+++ b/src/test-kernel/progressView/TexraDiffView.vitest.mts
@@ -139,5 +139,8 @@ describe('texra-diff-view', () => {
 
     dom.window.document.body.dataset.vscodeThemeKind = 'light';
     await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('vs'));
+
+    dom.window.document.body.dataset.vscodeThemeKind = 'high-contrast';
+    await vi.waitFor(() => expect(setTheme).toHaveBeenCalledWith('hc-black'));
   });
 });

--- a/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
+++ b/src/test-kernel/progressView/ToolEditRequestPanel.vitest.mts
@@ -1,0 +1,136 @@
+// Third-party imports
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// Local imports - progress view component types
+import type { PermissionState } from '@progressView/frontend/components/PermissionCard';
+import type { ToolEditRequestPanel } from '@progressView/frontend/components/ToolEditRequestPanel';
+
+// Local imports - shared schemas
+import type { ToolEditPermission } from '@shared/schemas';
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  customElements: globalThis.customElements,
+  HTMLElement: globalThis.HTMLElement,
+  Element: globalThis.Element,
+  Document: globalThis.Document,
+  ShadowRoot: globalThis.ShadowRoot,
+  CSSStyleSheet: globalThis.CSSStyleSheet,
+};
+
+function installDom(): JSDOM {
+  const dom = new JSDOM('<!doctype html><body></body>', {
+    url: 'http://localhost',
+  });
+  globalThis.window = dom.window as unknown as Window & typeof globalThis;
+  globalThis.document = dom.window.document;
+  globalThis.customElements = dom.window.customElements;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  globalThis.Element = dom.window.Element;
+  globalThis.Document = dom.window.Document;
+  globalThis.ShadowRoot = dom.window.ShadowRoot;
+  globalThis.CSSStyleSheet = dom.window.CSSStyleSheet;
+  return dom;
+}
+
+function restoreDom(): void {
+  globalThis.document = originalGlobals.document;
+  globalThis.window = originalGlobals.window;
+  globalThis.customElements = originalGlobals.customElements;
+  globalThis.HTMLElement = originalGlobals.HTMLElement;
+  globalThis.Element = originalGlobals.Element;
+  globalThis.Document = originalGlobals.Document;
+  globalThis.ShadowRoot = originalGlobals.ShadowRoot;
+  globalThis.CSSStyleSheet = originalGlobals.CSSStyleSheet;
+}
+
+function createPermission(data: Partial<ToolEditPermission>): PermissionState {
+  return {
+    kind: 'toolEdit',
+    data: {
+      requestId: 'request-1',
+      allowBypass: false,
+      streamId: '',
+      path: '/workspace/example.ts',
+      relativePath: 'example.ts',
+      sourceTool: 'edit',
+      addedLines: 1,
+      removedLines: 0,
+      isLatex: false,
+      ...data,
+    },
+  };
+}
+
+async function mountPanel(
+  permission: PermissionState,
+): Promise<ToolEditRequestPanel> {
+  const element = document.createElement(
+    'tool-edit-request-panel',
+  ) as ToolEditRequestPanel;
+  element.permission = permission;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+beforeAll(async () => {
+  installDom();
+  await import('@progressView/frontend/components/ToolEditRequestPanel');
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+afterAll(() => {
+  restoreDom();
+});
+
+describe('tool-edit-request-panel', () => {
+  it('renders inline diff when only proposed content is available', async () => {
+    const element = await mountPanel(
+      createPermission({
+        proposedContent: 'new content\n',
+      }),
+    );
+
+    element.handleKeyboardShortcut('d');
+    await element.updateComplete;
+
+    const diffView = element.shadowRoot?.querySelector('texra-diff-view') as
+      | HTMLElement
+      | undefined;
+    expect(diffView).toBeTruthy();
+    expect(
+      (diffView as HTMLElement & { originalText?: string }).originalText,
+    ).toBe('');
+    expect(
+      (diffView as HTMLElement & { proposedText?: string }).proposedText,
+    ).toBe('new content\n');
+  });
+
+  it('renders inline diff when only original content is available', async () => {
+    const element = await mountPanel(
+      createPermission({
+        originalContent: 'deleted content\n',
+      }),
+    );
+
+    element.handleKeyboardShortcut('d');
+    await element.updateComplete;
+
+    const diffView = element.shadowRoot?.querySelector('texra-diff-view') as
+      | HTMLElement
+      | undefined;
+    expect(diffView).toBeTruthy();
+    expect(
+      (diffView as HTMLElement & { originalText?: string }).originalText,
+    ).toBe('deleted content\n');
+    expect(
+      (diffView as HTMLElement & { proposedText?: string }).proposedText,
+    ).toBe('');
+  });
+});

--- a/src/types/vite-worker.d.ts
+++ b/src/types/vite-worker.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+declare module '*?worker' {
+  const WorkerConstructor: new () => Worker;
+  export default WorkerConstructor;
+}
+
+declare module '*?inline' {
+  const content: string;
+  export default content;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,7 +56,6 @@
     "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
-    "src/**/*.d.ts",
     "packages/extension/src/**/*.ts",
     "packages/extension/src/**/*.tsx"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,7 @@
     "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.d.ts",
     "packages/extension/src/**/*.ts",
     "packages/extension/src/**/*.tsx"
   ],


### PR DESCRIPTION
## Summary
- add a renderer-only `<texra-diff-view>` Lit component that lazy-loads Monaco and its worker entries when an inline diff is opened
- let tool-edit approval cards host inline original/proposed content while preserving the existing native diff action when content is not provided
- extend desktop build/package verification to fail when Monaco worker chunks are missing

Fixes #3554.
Fixes #3556.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/progressView/TexraDiffView.vitest.mts`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `corepack pnpm run compile:fast`
- `corepack pnpm run compile-tests`
- `corepack pnpm run desktop:build && corepack pnpm run check:desktop-build-artifacts`
- `corepack pnpm --filter @texra/desktop package:dir`
- `corepack pnpm run check:desktop-package` currently fails on pre-existing desktop startup bundle provider SDK guard: `dist/main/chunks/chunk-SUOENWQ3.js` includes OpenAI SDK and Anthropic SDK. The new Monaco worker package check did not report missing worker assets; direct asar inspection shows editor/json/css/html/ts worker assets present.
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Monaco (with web workers) to the desktop renderer and wires it into approval UX, which can impact bundle size, worker asset packaging, and runtime stability in the Electron environment.
> 
> **Overview**
> Adds an inline, renderer-only diff experience for tool-edit approval cards via a new Lit component `texra-diff-view` that lazy-loads Monaco and its worker entries and tracks desktop theme changes.
> 
> Extends `ToolEditPermission` payloads with optional `originalContent`/`proposedContent` and updates `ToolEditRequestPanel` so the diff button/`d` shortcut toggles the inline diff when content is provided, while preserving the existing external `openDiff` action otherwise.
> 
> Standardizes desktop theme handling around a shared `DESKTOP_THEME_KIND`/`DesktopThemeKind`, and hardens desktop build/package verification + tests to require Monaco worker chunks to be emitted and packaged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d026ce4786221bf6b24bd1b6d21d80bde9e9bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->