### PR TITLE
[codex] Infer desktop Codex package target from artifact path

### DIFF
--- a/scripts/desktop-package-targets.mjs
+++ b/scripts/desktop-package-targets.mjs
@@ -1,0 +1,39 @@
+export function expectedCodexPlatformKeysFromLabel(label) {
+  const normalizedLabel = label.replaceAll('\\', '/').toLowerCase();
+  if (normalizedLabel.includes('.app/contents/resources/app')) {
+    if (
+      normalizedLabel.includes('mac-arm64') ||
+      normalizedLabel.includes('darwin-arm64')
+    ) {
+      return ['darwin-arm64'];
+    }
+    if (
+      normalizedLabel.includes('mac-x64') ||
+      normalizedLabel.includes('darwin-x64')
+    ) {
+      return ['darwin-x64'];
+    }
+    if (normalizedLabel.includes('universal')) {
+      return ['darwin-x64', 'darwin-arm64'];
+    }
+    return ['darwin-x64', 'darwin-arm64'];
+  }
+
+  if (normalizedLabel.includes('linux')) {
+    return [
+      normalizedLabel.includes('arm64') || normalizedLabel.includes('aarch64')
+        ? 'linux-arm64'
+        : 'linux-x64',
+    ];
+  }
+
+  if (normalizedLabel.includes('win')) {
+    return [
+      normalizedLabel.includes('arm64') || normalizedLabel.includes('aarch64')
+        ? 'win32-arm64'
+        : 'win32-x64',
+    ];
+  }
+
+  return [];
+}

--- a/scripts/desktop-package-targets.mjs
+++ b/scripts/desktop-package-targets.mjs
@@ -1,3 +1,9 @@
+function hasLabelToken(label, tokens) {
+  return tokens.some((token) => {
+    return new RegExp(`(^|[^a-z0-9])${token}([^a-z0-9]|$)`).test(label);
+  });
+}
+
 export function expectedCodexPlatformKeysFromLabel(label) {
   const normalizedLabel = label.replaceAll('\\', '/').toLowerCase();
   if (normalizedLabel.includes('.app/contents/resources/app')) {
@@ -19,17 +25,17 @@ export function expectedCodexPlatformKeysFromLabel(label) {
     return ['darwin-x64', 'darwin-arm64'];
   }
 
-  if (normalizedLabel.includes('linux')) {
+  if (hasLabelToken(normalizedLabel, ['linux'])) {
     return [
-      normalizedLabel.includes('arm64') || normalizedLabel.includes('aarch64')
+      hasLabelToken(normalizedLabel, ['arm64', 'aarch64'])
         ? 'linux-arm64'
         : 'linux-x64',
     ];
   }
 
-  if (normalizedLabel.includes('win')) {
+  if (hasLabelToken(normalizedLabel, ['win', 'win32', 'windows'])) {
     return [
-      normalizedLabel.includes('arm64') || normalizedLabel.includes('aarch64')
+      hasLabelToken(normalizedLabel, ['arm64', 'aarch64'])
         ? 'win32-arm64'
         : 'win32-x64',
     ];

--- a/scripts/desktop-package-targets.mjs
+++ b/scripts/desktop-package-targets.mjs
@@ -19,9 +19,6 @@ export function expectedCodexPlatformKeysFromLabel(label) {
     ) {
       return ['darwin-x64'];
     }
-    if (normalizedLabel.includes('universal')) {
-      return ['darwin-x64', 'darwin-arm64'];
-    }
     return ['darwin-x64', 'darwin-arm64'];
   }
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -14,6 +14,7 @@ import {
   normalizeMetafilePath,
   resolveMetafileImportPath,
 } from './desktop-package-metafile-paths.mjs';
+import { expectedCodexPlatformKeysFromLabel } from './desktop-package-targets.mjs';
 
 const require = createRequire(import.meta.url);
 const { extractFile, listPackage, statFile } = require('@electron/asar');
@@ -467,37 +468,7 @@ function codexBinaryPath(prefix, platformInfo) {
 }
 
 function expectedCodexPlatformKeys(app) {
-  const label = app.label.replaceAll('\\', '/').toLowerCase();
-  if (label.includes('.app/contents/resources/app')) {
-    if (label.includes('mac-arm64') || label.includes('darwin-arm64')) {
-      return ['darwin-arm64'];
-    }
-    if (label.includes('mac-x64') || label.includes('darwin-x64')) {
-      return ['darwin-x64'];
-    }
-    if (label.includes('universal')) {
-      return ['darwin-x64', 'darwin-arm64'];
-    }
-    return ['darwin-x64', 'darwin-arm64'];
-  }
-
-  if (label.includes('linux')) {
-    return [
-      label.includes('arm64') || label.includes('aarch64')
-        ? 'linux-arm64'
-        : 'linux-x64',
-    ];
-  }
-
-  if (label.includes('win')) {
-    return [
-      label.includes('arm64') || label.includes('aarch64')
-        ? 'win32-arm64'
-        : 'win32-x64',
-    ];
-  }
-
-  return [];
+  return expectedCodexPlatformKeysFromLabel(app.label);
 }
 
 async function checkCodexUnpackedBinaries(app, failures) {

--- a/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
@@ -6,6 +6,8 @@ import {
   normalizeMetafilePath,
   resolveMetafileImportPath,
 } from '../../../scripts/desktop-package-metafile-paths.mjs';
+// @ts-expect-error verifier helper is JavaScript.
+import { expectedCodexPlatformKeysFromLabel } from '../../../scripts/desktop-package-targets.mjs';
 
 describe('desktop package verifier metafile paths', () => {
   it('normalizes esbuild metafile keys to CWD-relative paths', () => {
@@ -36,5 +38,54 @@ describe('desktop package verifier metafile paths', () => {
         'dist/main/chunks/provider.js',
       ),
     ).toBe('dist/main/chunks/provider.js');
+  });
+});
+
+describe('desktop package verifier target inference', () => {
+  it('uses the packaged artifact path for arch-specific macOS apps', () => {
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/mac-arm64/TeXRA.app/Contents/Resources/app.asar',
+      ),
+    ).toEqual(['darwin-arm64']);
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/mac-x64/TeXRA.app/Contents/Resources/app.asar',
+      ),
+    ).toEqual(['darwin-x64']);
+  });
+
+  it('keeps universal macOS apps on both Darwin Codex binaries', () => {
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/mac-universal/TeXRA.app/Contents/Resources/app.asar',
+      ),
+    ).toEqual(['darwin-x64', 'darwin-arm64']);
+  });
+
+  it('uses Linux and Windows architecture labels instead of the verifier host', () => {
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/TeXRA-0.37.8-linux-arm64.AppImage',
+      ),
+    ).toEqual(['linux-arm64']);
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/TeXRA-0.37.8-win-x64.exe',
+      ),
+    ).toEqual(['win32-x64']);
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/TeXRA-0.37.8-win32-arm64.exe',
+      ),
+    ).toEqual(['win32-arm64']);
+  });
+
+  it('does not classify Darwin labels as Windows', () => {
+    expect(
+      expectedCodexPlatformKeysFromLabel(
+        'packages/desktop/dist-packaged/TeXRA-0.37.8-darwin-x64.zip',
+      ),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- derive expected packaged Codex CLI platform keys from the packaged artifact label instead of the verifier host
- split desktop package target inference into a small helper shared by the verifier and tests
- cover macOS arch-specific, macOS universal, Linux, and Windows path inference

Fixes #3534.

## Validation
- `corepack pnpm exec vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts`
- `npm run -s typecheck`
- `npm run -s lint`
- `npm run -s compile:fast`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors target inference into a small helper and adds tests; behavior change is limited to which Codex platform binaries the desktop package verifier expects based on artifact naming.
> 
> **Overview**
> Desktop package verification now infers the expected bundled Codex CLI platform(s) from the *packaged artifact path/label* rather than the verifier host environment.
> 
> This extracts the inference logic into a shared helper (`expectedCodexPlatformKeysFromLabel`) with stricter token-based matching (avoids misclassifying `darwin` as `win`) and adds Vitest coverage for macOS arch/universal paths plus Linux/Windows arch variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0355fef7fee1a74b5a4be0a47c931b370dc59d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->