### PR TITLE
[codex] Tag SDK errors at provider boundary

### DIFF
--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -782,6 +782,7 @@ export class ModelHandlerAnthropic extends ModelHandler<
             }
           }
         } catch (err) {
+          tagAnthropicSdkError(err, this.config.provider);
           // Re-throw context window violations - these are intentional validation errors
           // that should fail fast, not be swallowed by soft failure
           if (isContextWindowError(err)) {

--- a/src/agent/modelHandlers/modelHandlerAnthropic.ts
+++ b/src/agent/modelHandlers/modelHandlerAnthropic.ts
@@ -77,6 +77,7 @@ import {
   type ToolResultPayload,
 } from './utils/toolAttachmentUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
+import { tagAnthropicSdkError } from './support/sdkErrorAdapters';
 
 // Type imports
 import type { ProviderStopReason } from './types/StopReasonTypes';
@@ -542,6 +543,18 @@ export class ModelHandlerAnthropic extends ModelHandler<
   async createResponse(
     requestOptions: CreateResponseOptions<MessageParam, Anthropic>,
   ): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
+    try {
+      return await this.createResponseImpl(requestOptions);
+    } catch (err) {
+      tagAnthropicSdkError(err, this.config.provider);
+      throw err;
+    }
+  }
+
+  /** Creates an Anthropic response after SDK-boundary error tagging is installed. */
+  private async createResponseImpl(
+    requestOptions: CreateResponseOptions<MessageParam, Anthropic>,
+  ): Promise<CreateResponseResult<BetaMessage, MessageParam>> {
     const {
       client,
       messages,
@@ -862,6 +875,8 @@ export class ModelHandlerAnthropic extends ModelHandler<
         // Store thinking blocks for API conversation continuation
         this.processThinkingBlock(response);
       } catch (streamError) {
+        tagAnthropicSdkError(streamError, this.config.provider);
+
         const diagnostics = streamHandler.getDiagnostics();
         const partialText = extractPartialTextTail(
           stream.currentMessage,

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -550,6 +550,7 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
           generationConfig.maxOutputTokens = validation.adjustedMaxTokens;
         }
       } catch (err) {
+        tagGoogleSdkError(err, this.config.provider);
         // Re-throw context window violations - these are intentional validation errors
         // that should fail fast, not be swallowed by soft failure
         if (isContextWindowError(err)) {

--- a/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerGoogleGenAI.ts
@@ -62,6 +62,7 @@ import type { FileLocation } from '@utils/files';
 import { flexibleFS, getShortDisplayPath } from '@utils/files';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
+import { tagGoogleSdkError } from './support/sdkErrorAdapters';
 import { TOOL_USE_SAFETY_BUFFER } from './contextManagementConstants';
 
 // Local file imports
@@ -434,6 +435,18 @@ export class ModelHandlerGoogleGenAI extends ModelHandler<
 
   /** Creates a chat completion response using Google's GenAI API with specified parameters and optional system prompt. */
   async createResponse(
+    options: CreateResponseOptions<Content, GoogleGenAI>,
+  ): Promise<CreateResponseResult<GenerateContentResponse, Content>> {
+    try {
+      return await this.createResponseImpl(options);
+    } catch (err) {
+      tagGoogleSdkError(err, this.config.provider);
+      throw err;
+    }
+  }
+
+  /** Creates a Google response after SDK-boundary error tagging is installed. */
+  private async createResponseImpl(
     options: CreateResponseOptions<Content, GoogleGenAI>,
   ): Promise<CreateResponseResult<GenerateContentResponse, Content>> {
     const {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -50,6 +50,7 @@ import { flexibleFS } from '@utils/files';
 import { objectToLogString } from '@utils/text/stringUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
+import { tagOpenAISdkError } from './support/sdkErrorAdapters';
 
 // Local file imports
 import { OPENAI_CHAT_FINISH } from './types/StopReasonTypes';
@@ -613,6 +614,18 @@ export class ModelHandlerOpenAI<
 
   /** Creates a chat completion with model-specific parameters. */
   async createResponse(
+    options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
+  ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
+    try {
+      return await this.createResponseImpl(options);
+    } catch (err) {
+      tagOpenAISdkError(err, this.config.provider);
+      throw err;
+    }
+  }
+
+  /** Creates a chat completion after SDK-boundary error tagging is installed. */
+  private async createResponseImpl(
     options: CreateResponseOptions<ChatCompletionMessageParam, OpenAI>,
   ): Promise<CreateResponseResult<ChatCompletion, ChatCompletionMessageParam>> {
     const {

--- a/src/agent/modelHandlers/modelHandlerOpenAI.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAI.ts
@@ -737,6 +737,7 @@ export class ModelHandlerOpenAI<
           }
         }
       } catch (err) {
+        tagOpenAISdkError(err, this.config.provider);
         if (isContextWindowError(err)) throw err;
         this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Proceeding without token adjustment.`,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -743,6 +743,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         this.clearPendingBackgroundResponse();
         throw err;
       }
+      tagOpenAISdkError(err, this.config.provider);
       // Transient failures (no status / 5xx / 429 / 408) — the background
       // response is likely still alive server-side, so retain the ID and
       // rethrow so the outer retry resumes the same ID. Definitive failures
@@ -1798,6 +1799,7 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
           maxOutputTokens = validation.adjustedMaxTokens;
         }
       } catch (err) {
+        tagOpenAISdkError(err, this.config.provider);
         if (isContextWindowError(err)) throw err;
         this.logger.debug(
           `Token counting failed: ${getSdkErrorMessage(err)}. Applying fallback cap.`,

--- a/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
+++ b/src/agent/modelHandlers/modelHandlerOpenAIResponse.ts
@@ -47,6 +47,7 @@ import type { FileLocation } from '@utils/files/taskRunStorage';
 import { OFFICE_MIME_TYPES } from '@utils/files/mimeUtils';
 import { computeCachePercentage } from './utils/usageNormalization';
 import { prepareExistingOutputContent } from './utils/fileContentUtils';
+import { tagOpenAISdkError } from './support/sdkErrorAdapters';
 
 // Local file imports
 import {
@@ -1600,6 +1601,9 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
     this.inFlight = true;
     try {
       return await this.createResponseImpl(options);
+    } catch (err) {
+      tagOpenAISdkError(err, this.config.provider);
+      throw err;
     } finally {
       this.inFlight = false;
     }
@@ -2027,6 +2031,8 @@ export class ModelHandlerOpenAIResponse extends ModelHandler<
         updatedMessages: compactedMessages,
       };
     } catch (error) {
+      tagOpenAISdkError(error, this.config.provider);
+
       // Extract error details for diagnostics (useful for relay errors)
       const { rawErrorBody } = formatProviderHttpError(error);
       if (rawErrorBody) {

--- a/src/agent/modelHandlers/support/sdkErrorAdapters.ts
+++ b/src/agent/modelHandlers/support/sdkErrorAdapters.ts
@@ -32,31 +32,9 @@ import {
 // Local imports - common errors
 import {
   attachSdkErrorMetadata,
+  sdkErrorKindFromStatusCode,
   type SdkErrorKind,
 } from '@common/errors/sdkErrorUtils';
-
-function sdkKindFromStatus(statusCode: number | undefined): SdkErrorKind {
-  switch (statusCode) {
-    case 400:
-      return 'bad_request';
-    case 401:
-      return 'authentication';
-    case 403:
-      return 'permission_denied';
-    case 404:
-      return 'not_found';
-    case 409:
-      return 'conflict';
-    case 422:
-      return 'unprocessable_entity';
-    case 429:
-      return 'rate_limit';
-    case 500:
-      return 'internal_server';
-    default:
-      return 'api_error';
-  }
-}
 
 function tagSdkError(
   err: unknown,
@@ -98,13 +76,23 @@ export function tagAnthropicSdkError(
   } else if (err instanceof AnthropicInternalServerError) {
     tagSdkError(err, provider, 'internal_server', err.status);
   } else if (err instanceof AnthropicAPIError) {
-    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+    tagSdkError(
+      err,
+      provider,
+      sdkErrorKindFromStatusCode(err.status),
+      err.status,
+    );
   }
 }
 
 export function tagGoogleSdkError(err: unknown, provider = 'google'): void {
   if (err instanceof GoogleApiError) {
-    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+    tagSdkError(
+      err,
+      provider,
+      sdkErrorKindFromStatusCode(err.status),
+      err.status,
+    );
   }
 }
 
@@ -132,6 +120,11 @@ export function tagOpenAISdkError(err: unknown, provider = 'openai'): void {
   } else if (err instanceof OpenAIInternalServerError) {
     tagSdkError(err, provider, 'internal_server', err.status);
   } else if (err instanceof OpenAIAPIError) {
-    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+    tagSdkError(
+      err,
+      provider,
+      sdkErrorKindFromStatusCode(err.status),
+      err.status,
+    );
   }
 }

--- a/src/agent/modelHandlers/support/sdkErrorAdapters.ts
+++ b/src/agent/modelHandlers/support/sdkErrorAdapters.ts
@@ -1,0 +1,137 @@
+// Third-party imports
+import {
+  APIConnectionError as AnthropicAPIConnectionError,
+  APIConnectionTimeoutError as AnthropicAPIConnectionTimeoutError,
+  APIError as AnthropicAPIError,
+  APIUserAbortError as AnthropicAPIUserAbortError,
+  AuthenticationError as AnthropicAuthenticationError,
+  BadRequestError as AnthropicBadRequestError,
+  ConflictError as AnthropicConflictError,
+  InternalServerError as AnthropicInternalServerError,
+  NotFoundError as AnthropicNotFoundError,
+  PermissionDeniedError as AnthropicPermissionDeniedError,
+  RateLimitError as AnthropicRateLimitError,
+  UnprocessableEntityError as AnthropicUnprocessableEntityError,
+} from '@anthropic-ai/sdk';
+import { ApiError as GoogleApiError } from '@google/genai';
+import {
+  APIConnectionError as OpenAIAPIConnectionError,
+  APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
+  APIError as OpenAIAPIError,
+  APIUserAbortError as OpenAIAPIUserAbortError,
+  AuthenticationError as OpenAIAuthenticationError,
+  BadRequestError as OpenAIBadRequestError,
+  ConflictError as OpenAIConflictError,
+  InternalServerError as OpenAIInternalServerError,
+  NotFoundError as OpenAINotFoundError,
+  PermissionDeniedError as OpenAIPermissionDeniedError,
+  RateLimitError as OpenAIRateLimitError,
+  UnprocessableEntityError as OpenAIUnprocessableEntityError,
+} from 'openai';
+
+// Local imports - common errors
+import {
+  attachSdkErrorMetadata,
+  type SdkErrorKind,
+} from '@common/errors/sdkErrorUtils';
+
+function sdkKindFromStatus(statusCode: number | undefined): SdkErrorKind {
+  switch (statusCode) {
+    case 400:
+      return 'bad_request';
+    case 401:
+      return 'authentication';
+    case 403:
+      return 'permission_denied';
+    case 404:
+      return 'not_found';
+    case 409:
+      return 'conflict';
+    case 422:
+      return 'unprocessable_entity';
+    case 429:
+      return 'rate_limit';
+    case 500:
+      return 'internal_server';
+    default:
+      return 'api_error';
+  }
+}
+
+function tagSdkError(
+  err: unknown,
+  provider: string,
+  kind: SdkErrorKind,
+  statusCode?: number,
+): void {
+  attachSdkErrorMetadata(err, {
+    provider,
+    kind,
+    ...(statusCode !== undefined && { statusCode }),
+  });
+}
+
+export function tagAnthropicSdkError(
+  err: unknown,
+  provider = 'anthropic',
+): void {
+  if (err instanceof AnthropicAPIConnectionTimeoutError) {
+    tagSdkError(err, provider, 'connection_timeout');
+  } else if (err instanceof AnthropicAPIConnectionError) {
+    tagSdkError(err, provider, 'connection');
+  } else if (err instanceof AnthropicAPIUserAbortError) {
+    tagSdkError(err, provider, 'user_abort');
+  } else if (err instanceof AnthropicBadRequestError) {
+    tagSdkError(err, provider, 'bad_request', err.status);
+  } else if (err instanceof AnthropicAuthenticationError) {
+    tagSdkError(err, provider, 'authentication', err.status);
+  } else if (err instanceof AnthropicPermissionDeniedError) {
+    tagSdkError(err, provider, 'permission_denied', err.status);
+  } else if (err instanceof AnthropicNotFoundError) {
+    tagSdkError(err, provider, 'not_found', err.status);
+  } else if (err instanceof AnthropicConflictError) {
+    tagSdkError(err, provider, 'conflict', err.status);
+  } else if (err instanceof AnthropicUnprocessableEntityError) {
+    tagSdkError(err, provider, 'unprocessable_entity', err.status);
+  } else if (err instanceof AnthropicRateLimitError) {
+    tagSdkError(err, provider, 'rate_limit', err.status);
+  } else if (err instanceof AnthropicInternalServerError) {
+    tagSdkError(err, provider, 'internal_server', err.status);
+  } else if (err instanceof AnthropicAPIError) {
+    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+  }
+}
+
+export function tagGoogleSdkError(err: unknown, provider = 'google'): void {
+  if (err instanceof GoogleApiError) {
+    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+  }
+}
+
+export function tagOpenAISdkError(err: unknown, provider = 'openai'): void {
+  if (err instanceof OpenAIAPIConnectionTimeoutError) {
+    tagSdkError(err, provider, 'connection_timeout');
+  } else if (err instanceof OpenAIAPIConnectionError) {
+    tagSdkError(err, provider, 'connection');
+  } else if (err instanceof OpenAIAPIUserAbortError) {
+    tagSdkError(err, provider, 'user_abort');
+  } else if (err instanceof OpenAIBadRequestError) {
+    tagSdkError(err, provider, 'bad_request', err.status);
+  } else if (err instanceof OpenAIAuthenticationError) {
+    tagSdkError(err, provider, 'authentication', err.status);
+  } else if (err instanceof OpenAIPermissionDeniedError) {
+    tagSdkError(err, provider, 'permission_denied', err.status);
+  } else if (err instanceof OpenAINotFoundError) {
+    tagSdkError(err, provider, 'not_found', err.status);
+  } else if (err instanceof OpenAIConflictError) {
+    tagSdkError(err, provider, 'conflict', err.status);
+  } else if (err instanceof OpenAIUnprocessableEntityError) {
+    tagSdkError(err, provider, 'unprocessable_entity', err.status);
+  } else if (err instanceof OpenAIRateLimitError) {
+    tagSdkError(err, provider, 'rate_limit', err.status);
+  } else if (err instanceof OpenAIInternalServerError) {
+    tagSdkError(err, provider, 'internal_server', err.status);
+  } else if (err instanceof OpenAIAPIError) {
+    tagSdkError(err, provider, sdkKindFromStatus(err.status), err.status);
+  }
+}

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -340,9 +340,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  const metadata = detectSdkErrorMetadata(err);
-  if (metadata) return metadata.provider;
-
   if (!isObject(err)) {
     return undefined;
   }

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -187,6 +187,25 @@ const SDK_ERRORS_BY_KIND = new Map(
   SDK_ERRORS.map((entry) => [entry.kind, entry] as const),
 );
 
+const SDK_ERROR_KIND_BY_FALLBACK_STATUS = new Map(
+  SDK_ERRORS.flatMap((entry) =>
+    entry.fallbackStatusCode === undefined
+      ? []
+      : [[entry.fallbackStatusCode, entry.kind] as const],
+  ),
+);
+
+/** Maps known provider HTTP status codes to the shared SDK error kind table. */
+export function sdkErrorKindFromStatusCode(
+  statusCode: number | undefined,
+): SdkErrorKind {
+  return (
+    (statusCode === undefined
+      ? undefined
+      : SDK_ERROR_KIND_BY_FALLBACK_STATUS.get(statusCode)) ?? 'api_error'
+  );
+}
+
 /** Server errors (5xx), rate limits (429), and request timeouts (408) are retryable
  *  — these are transient. Other client errors (4xx) are deterministic. */
 export function isRetryableStatusCode(statusCode?: number): boolean {

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -19,8 +19,98 @@ function safeGetReasonPhrase(statusCode: number): string | undefined {
   }
 }
 
-/** SDK error mapping entry. Provider detected from class name. */
+/** Factory for symbol-keyed error metadata. Creates matched attach/detect
+ *  accessors that share a single Symbol.for key. The optional typeGuard
+ *  validates the value on retrieval; without it, raw retrieval is returned. */
+function createErrorMetadata<T>(
+  name: string,
+  typeGuard?: (v: unknown) => v is T,
+): {
+  attach: (err: unknown, value: T) => void;
+  detect: (err: unknown) => T | undefined;
+} {
+  const key = Symbol.for(`texra.${name}`);
+  return {
+    attach: (err, value) => {
+      if (isObject(err)) {
+        (err as Record<symbol, unknown>)[key] = value;
+      }
+    },
+    detect: (err) => {
+      if (!isObject(err)) return undefined;
+      const value = (err as Record<symbol, unknown>)[key];
+      if (typeGuard) {
+        return typeGuard(value) ? value : undefined;
+      }
+      return value as T | undefined;
+    },
+  };
+}
+
+export type SdkErrorKind =
+  | 'connection_timeout'
+  | 'connection'
+  | 'user_abort'
+  | 'bad_request'
+  | 'authentication'
+  | 'permission_denied'
+  | 'not_found'
+  | 'conflict'
+  | 'unprocessable_entity'
+  | 'rate_limit'
+  | 'internal_server'
+  | 'api_error';
+
+export interface SdkErrorMetadata {
+  provider: string;
+  kind: SdkErrorKind;
+  statusCode?: number;
+}
+
+const SDK_ERROR_KINDS: ReadonlySet<SdkErrorKind> = new Set([
+  'connection_timeout',
+  'connection',
+  'user_abort',
+  'bad_request',
+  'authentication',
+  'permission_denied',
+  'not_found',
+  'conflict',
+  'unprocessable_entity',
+  'rate_limit',
+  'internal_server',
+  'api_error',
+]);
+
+function isSdkErrorMetadata(value: unknown): value is SdkErrorMetadata {
+  if (!isObject(value)) return false;
+  const candidate = value as {
+    provider?: unknown;
+    kind?: unknown;
+    statusCode?: unknown;
+  };
+  return (
+    isString(candidate.provider) &&
+    SDK_ERROR_KINDS.has(candidate.kind as SdkErrorKind) &&
+    (candidate.statusCode === undefined ||
+      pickStatus(candidate.statusCode) !== undefined)
+  );
+}
+
+const sdkErrorMetadata = createErrorMetadata<SdkErrorMetadata>(
+  'sdkError',
+  isSdkErrorMetadata,
+);
+
+/** Tags SDK errors at provider boundaries so common error formatting does not
+ *  need to import SDK classes or inspect SDK-specific prototypes. */
+export const attachSdkErrorMetadata = sdkErrorMetadata.attach;
+
+const detectSdkErrorMetadata = sdkErrorMetadata.detect;
+
+/** SDK error mapping entry. */
 interface SdkErrorEntry {
+  kind: SdkErrorKind;
   classNames: readonly string[];
   message?: string;
   fallbackStatusCode?: number;
@@ -30,57 +120,72 @@ interface SdkErrorEntry {
 const SDK_ERRORS: SdkErrorEntry[] = [
   // Connection errors (retryable)
   {
+    kind: 'connection_timeout',
     classNames: ['APIConnectionTimeoutError'],
     message: 'Connection timed out',
     retryable: true,
   },
   {
+    kind: 'connection',
     classNames: ['APIConnectionError'],
     message: 'Connection error',
     retryable: true,
   },
   // Abort errors (not retryable)
   {
+    kind: 'user_abort',
     classNames: ['APIUserAbortError'],
     message: 'Request aborted',
     retryable: false,
   },
   // HTTP errors (retryable derived from status code)
   {
+    kind: 'bad_request',
     classNames: ['BadRequestError'],
     fallbackStatusCode: StatusCodes.BAD_REQUEST,
   },
   {
+    kind: 'authentication',
     classNames: ['AuthenticationError'],
     fallbackStatusCode: StatusCodes.UNAUTHORIZED,
   },
   {
+    kind: 'permission_denied',
     classNames: ['PermissionDeniedError'],
     fallbackStatusCode: StatusCodes.FORBIDDEN,
   },
   {
+    kind: 'not_found',
     classNames: ['NotFoundError'],
     fallbackStatusCode: StatusCodes.NOT_FOUND,
   },
   {
+    kind: 'conflict',
     classNames: ['ConflictError'],
     fallbackStatusCode: StatusCodes.CONFLICT,
   },
   {
+    kind: 'unprocessable_entity',
     classNames: ['UnprocessableEntityError'],
     fallbackStatusCode: StatusCodes.UNPROCESSABLE_ENTITY,
   },
   {
+    kind: 'rate_limit',
     classNames: ['RateLimitError'],
     fallbackStatusCode: StatusCodes.TOO_MANY_REQUESTS,
   },
   {
+    kind: 'internal_server',
     classNames: ['InternalServerError'],
     fallbackStatusCode: StatusCodes.INTERNAL_SERVER_ERROR,
   },
   // Generic API errors (no fallback)
-  { classNames: ['APIError', 'ApiError'] },
+  { kind: 'api_error', classNames: ['APIError', 'ApiError'] },
 ];
+
+const SDK_ERRORS_BY_KIND = new Map(
+  SDK_ERRORS.map((entry) => [entry.kind, entry] as const),
+);
 
 /** Server errors (5xx), rate limits (429), and request timeouts (408) are retryable
  *  — these are transient. Other client errors (4xx) are deterministic. */
@@ -101,15 +206,15 @@ function matchSdkError(
   err: unknown,
   rawErrorBody: unknown,
 ): SdkMatchResult | undefined {
-  const errorClassNames = getErrorClassNames(err);
-  const entry = SDK_ERRORS.find(({ classNames }) =>
-    classNames.some((className) => errorClassNames.includes(className)),
-  );
+  const metadata = detectSdkErrorMetadata(err);
+  const entry =
+    (metadata ? SDK_ERRORS_BY_KIND.get(metadata.kind) : undefined) ??
+    matchLegacySdkError(err);
   if (!entry) {
     return undefined;
   }
 
-  const provider = detectProvider(err);
+  const provider = metadata?.provider ?? detectProvider(err);
   const requestId = detectRequestId(err);
 
   // Message-only errors (connection, abort) - use the entry's message
@@ -126,7 +231,7 @@ function matchSdkError(
   // If detectStatusCode returns a non-error code (< 400), it's likely misleading
   // (e.g., SSE connection status 200 while the actual error is in the body),
   // so prefer the body-inferred status code in that case.
-  const rawStatusCode = detectStatusCode(err);
+  const rawStatusCode = metadata?.statusCode ?? detectStatusCode(err);
   const statusCode =
     (rawStatusCode !== undefined && rawStatusCode >= 400
       ? rawStatusCode
@@ -162,6 +267,13 @@ function matchSdkError(
     retryable: isRetryableStatusCode(statusCode),
     requestId,
   };
+}
+
+function matchLegacySdkError(err: unknown): SdkErrorEntry | undefined {
+  const errorClassNames = getErrorClassNames(err);
+  return SDK_ERRORS.find(({ classNames }) =>
+    classNames.some((className) => errorClassNames.includes(className)),
+  );
 }
 
 function getErrorClassNames(err: unknown): string[] {
@@ -228,6 +340,9 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
+  const metadata = detectSdkErrorMetadata(err);
+  if (metadata) return metadata.provider;
+
   if (!isObject(err)) {
     return undefined;
   }
@@ -381,35 +496,8 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error by prototype class name. */
 export function isUserAbort(err: unknown): boolean {
+  if (detectSdkErrorMetadata(err)?.kind === 'user_abort') return true;
   return getErrorClassNames(err).includes('APIUserAbortError');
-}
-
-/** Factory for symbol-keyed error metadata. Creates matched attach/detect
- *  accessors that share a single Symbol.for key. The optional typeGuard
- *  validates the value on retrieval; without it, raw retrieval is returned. */
-function createErrorMetadata<T>(
-  name: string,
-  typeGuard?: (v: unknown) => v is T,
-): {
-  attach: (err: unknown, value: T) => void;
-  detect: (err: unknown) => T | undefined;
-} {
-  const key = Symbol.for(`texra.${name}`);
-  return {
-    attach: (err, value) => {
-      if (isObject(err)) {
-        (err as Record<symbol, unknown>)[key] = value;
-      }
-    },
-    detect: (err) => {
-      if (!isObject(err)) return undefined;
-      const value = (err as Record<symbol, unknown>)[key];
-      if (typeGuard) {
-        return typeGuard(value) ? value : undefined;
-      }
-      return value as T | undefined;
-    },
-  };
 }
 
 const streamDiagnosticsMetadata = createErrorMetadata<StreamDiagnostics>(

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -5,17 +5,27 @@ import {
   APIUserAbortError as AnthropicAPIUserAbortError,
   AuthenticationError as AnthropicAuthenticationError,
 } from '@anthropic-ai/sdk';
+import { ApiError as GoogleApiError } from '@google/genai';
 import {
   APIConnectionError as OpenAIAPIConnectionError,
   APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
   APIUserAbortError as OpenAIAPIUserAbortError,
   AuthenticationError as OpenAIAuthenticationError,
+  BadRequestError as OpenAIBadRequestError,
   RateLimitError as OpenAIRateLimitError,
 } from 'openai';
 import { describe, expect, it } from 'vitest';
 
+// Local imports - agent model handlers
+import {
+  tagAnthropicSdkError,
+  tagGoogleSdkError,
+  tagOpenAISdkError,
+} from '@agent/modelHandlers/support/sdkErrorAdapters';
+
 // Local imports - common errors
 import {
+  attachSdkErrorMetadata,
   formatProviderHttpError,
   isUserAbort,
 } from '@common/errors/sdkErrorUtils';
@@ -221,5 +231,83 @@ describe('formatProviderHttpError', () => {
     expect(formatted.message).toBe('Request aborted');
     expect(formatted.provider).toBe('openai');
     expect(formatted.retryable).toBe(false);
+  });
+
+  it('formats symbol-tagged SDK errors without SDK prototype matching', () => {
+    const error = new Error('provider quota');
+    attachSdkErrorMetadata(error, {
+      provider: 'fixture',
+      kind: 'rate_limit',
+      statusCode: 429,
+    });
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('fixture');
+    expect(formatted.statusCode).toBe(429);
+    expect(formatted.message).toBe(
+      'HTTP 429 Too Many Requests – provider quota',
+    );
+    expect(formatted.retryable).toBe(true);
+  });
+
+  it('formats tagged OpenAI connection errors with existing retry behavior', () => {
+    const error = new OpenAIAPIConnectionTimeoutError();
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBeUndefined();
+    expect(formatted.message).toBe('Connection timed out');
+    expect(formatted.retryable).toBe(true);
+  });
+
+  it('formats tagged OpenAI HTTP errors with status metadata', () => {
+    const error = new OpenAIBadRequestError(
+      400,
+      { message: 'bad payload' },
+      'bad payload',
+      new Headers([['x-request-id', 'req_123']]),
+    );
+    tagOpenAISdkError(error, 'openai');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('openai');
+    expect(formatted.statusCode).toBe(400);
+    expect(formatted.statusText).toBe('Bad Request');
+    expect(formatted.message).toContain('HTTP 400 Bad Request');
+    expect(formatted.message).toContain('bad payload');
+    expect(formatted.requestId).toBe('req_123');
+    expect(formatted.retryable).toBe(false);
+  });
+
+  it('formats tagged Anthropic user abort errors', () => {
+    const error = new AnthropicAPIUserAbortError();
+    tagAnthropicSdkError(error, 'anthropic');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('anthropic');
+    expect(formatted.message).toBe('Request aborted');
+    expect(formatted.retryable).toBe(false);
+  });
+
+  it('formats tagged Google API errors with inferred kind from status', () => {
+    const error = new GoogleApiError({
+      message: 'quota exceeded',
+      status: 429,
+    });
+    tagGoogleSdkError(error, 'google');
+
+    const formatted = formatProviderHttpError(error);
+
+    expect(formatted.provider).toBe('google');
+    expect(formatted.statusCode).toBe(429);
+    expect(formatted.message).toBe(
+      'HTTP 429 Too Many Requests – quota exceeded',
+    );
+    expect(formatted.retryable).toBe(true);
   });
 });

--- a/src/test-kernel/common/SdkErrorUtils.vitest.mts
+++ b/src/test-kernel/common/SdkErrorUtils.vitest.mts
@@ -28,6 +28,7 @@ import {
   attachSdkErrorMetadata,
   formatProviderHttpError,
   isUserAbort,
+  sdkErrorKindFromStatusCode,
 } from '@common/errors/sdkErrorUtils';
 
 class APIError extends Error {}
@@ -309,5 +310,18 @@ describe('formatProviderHttpError', () => {
       'HTTP 429 Too Many Requests – quota exceeded',
     );
     expect(formatted.retryable).toBe(true);
+  });
+
+  it('derives SDK error kinds from the shared status mapping', () => {
+    expect(sdkErrorKindFromStatusCode(400)).toBe('bad_request');
+    expect(sdkErrorKindFromStatusCode(401)).toBe('authentication');
+    expect(sdkErrorKindFromStatusCode(403)).toBe('permission_denied');
+    expect(sdkErrorKindFromStatusCode(404)).toBe('not_found');
+    expect(sdkErrorKindFromStatusCode(409)).toBe('conflict');
+    expect(sdkErrorKindFromStatusCode(422)).toBe('unprocessable_entity');
+    expect(sdkErrorKindFromStatusCode(429)).toBe('rate_limit');
+    expect(sdkErrorKindFromStatusCode(500)).toBe('internal_server');
+    expect(sdkErrorKindFromStatusCode(418)).toBe('api_error');
+    expect(sdkErrorKindFromStatusCode(undefined)).toBe('api_error');
   });
 });


### PR DESCRIPTION
## Summary
- add symbol-tagged SDK error metadata carrying provider, kind, and known status code
- move OpenAI, Anthropic, and Google SDK class checks into model-handler boundary adapters
- make common SDK error formatting prefer the tag while preserving legacy fallback matching for unadapted SDK error shapes
- extend SdkErrorUtils coverage with tagged fixtures and real SDK error instances

## Validation
- `npm run -s test:kernel -- src/test-kernel/common/SdkErrorUtils.vitest.mts`
- `npm run -s typecheck`
- `npm run -s lint`
- `npm run -s compile:fast`

Closes #3517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-provider error classification/formatting and adds new tagging paths in the core model handlers, which could affect retryability decisions and diagnostics if mappings are wrong.
> 
> **Overview**
> Adds symbol-based SDK error metadata (`provider`, `kind`, optional `statusCode`) and a new `sdkErrorAdapters` layer that tags Anthropic/OpenAI/Google SDK exceptions at the model-handler boundary.
> 
> Updates Anthropic, OpenAI (Chat + Responses), and Google GenAI handlers to wrap `createResponse` and key internal try/catch blocks to tag thrown SDK errors before rethrowing, and updates `formatProviderHttpError`/`isUserAbort` logic in `sdkErrorUtils` to *prefer tagged metadata* while keeping legacy prototype-name matching as a fallback.
> 
> Extends kernel tests to cover tagged errors and real SDK error instances, including status→kind mapping via `sdkErrorKindFromStatusCode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375f31d8b7658268e1909cf36f5c7da00f8954e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->