### PR TITLE
[codex] Limit desktop Codex CLI payload

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -15,6 +15,7 @@ asar: true
 asarUnpack:
   - '**/node_modules/@openai/codex-*/**'
 npmRebuild: false
+afterPack: ../../scripts/prune-desktop-codex-payload.mjs
 directories:
   output: dist-packaged
   buildResources: build

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -320,5 +320,9 @@ function normalizeArch(arch, normalizedPath, normalizedPlatform) {
     return process.arch === 'arm64' ? 'arm64' : 'x64';
   }
 
+  if (normalizedPlatform === 'linux' || normalizedPlatform === 'win32') {
+    return 'x64';
+  }
+
   return null;
 }

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -1,0 +1,314 @@
+import { access, readdir, realpath, rm, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const MEBIBYTE = 1024 * 1024;
+
+export const CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES = 325 * MEBIBYTE;
+export const CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES = 625 * MEBIBYTE;
+
+export const codexPlatformInfoByKey = {
+  'linux-x64': {
+    pkg: '@openai/codex-linux-x64',
+    triple: 'x86_64-unknown-linux-musl',
+    binaryName: 'codex',
+  },
+  'linux-arm64': {
+    pkg: '@openai/codex-linux-arm64',
+    triple: 'aarch64-unknown-linux-musl',
+    binaryName: 'codex',
+  },
+  'darwin-x64': {
+    pkg: '@openai/codex-darwin-x64',
+    triple: 'x86_64-apple-darwin',
+    binaryName: 'codex',
+  },
+  'darwin-arm64': {
+    pkg: '@openai/codex-darwin-arm64',
+    triple: 'aarch64-apple-darwin',
+    binaryName: 'codex',
+  },
+  'win32-x64': {
+    pkg: '@openai/codex-win32-x64',
+    triple: 'x86_64-pc-windows-msvc',
+    binaryName: 'codex.exe',
+  },
+  'win32-arm64': {
+    pkg: '@openai/codex-win32-arm64',
+    triple: 'aarch64-pc-windows-msvc',
+    binaryName: 'codex.exe',
+  },
+};
+
+const archNameByElectronBuilderArch = {
+  1: 'x64',
+  3: 'arm64',
+  4: 'universal',
+};
+
+const platformKeyByPackageName = new Map(
+  Object.entries(codexPlatformInfoByKey).map(([platformKey, info]) => [
+    info.pkg,
+    platformKey,
+  ]),
+);
+
+export function codexBinaryPath(prefix, platformInfo) {
+  return join(
+    prefix,
+    'node_modules',
+    ...platformInfo.pkg.split('/'),
+    'vendor',
+    platformInfo.triple,
+    'codex',
+    platformInfo.binaryName,
+  ).replaceAll('\\', '/');
+}
+
+export function formatBytes(bytes) {
+  return `${(bytes / MEBIBYTE).toFixed(1)} MiB`;
+}
+
+export function expectedCodexPayloadBudgetBytes(expectedPlatformKeys) {
+  return expectedPlatformKeys.length > 1
+    ? CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES
+    : CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES;
+}
+
+export function inferCodexPlatformKeys({ platform, arch, appPath } = {}) {
+  const normalizedPath = (appPath ?? '').replaceAll('\\', '/').toLowerCase();
+  const normalizedPlatform = normalizePlatform(platform, normalizedPath);
+  const normalizedArch = normalizeArch(
+    arch,
+    normalizedPath,
+    normalizedPlatform,
+  );
+
+  if (normalizedPlatform == null || normalizedArch == null) return [];
+
+  if (normalizedPlatform === 'darwin' && normalizedArch === 'universal') {
+    return ['darwin-x64', 'darwin-arm64'];
+  }
+  if (normalizedArch !== 'x64' && normalizedArch !== 'arm64') return [];
+
+  return [`${normalizedPlatform}-${normalizedArch}`];
+}
+
+export function packageNameForCodexPlatformKey(platformKey) {
+  return codexPlatformInfoByKey[platformKey]?.pkg ?? platformKey;
+}
+
+export function describeBundledCodexPackages(packages) {
+  if (packages.length === 0) return 'none';
+  return packages
+    .map(({ platformKey, pkg, locations, sizeBytes }) => {
+      const locationSummary =
+        locations.length > 0 ? ` at ${locations.join(', ')}` : '';
+      const sizeSummary = sizeBytes > 0 ? ` (${formatBytes(sizeBytes)})` : '';
+      return `${pkg} [${platformKey}]${sizeSummary}${locationSummary}`;
+    })
+    .join('; ');
+}
+
+export async function collectBundledCodexPackages(resourcesDir) {
+  const unpackedRoot = join(resourcesDir, 'app.asar.unpacked');
+  const candidates = await collectCodexPackageCandidates(unpackedRoot);
+  const byPlatformKey = new Map();
+  const sizedRealPaths = new Set();
+
+  for (const candidate of candidates) {
+    const existingPath = await existingCandidatePath(candidate.path);
+    if (existingPath == null) continue;
+
+    const current = byPlatformKey.get(candidate.platformKey) ?? {
+      platformKey: candidate.platformKey,
+      pkg: packageNameForCodexPlatformKey(candidate.platformKey),
+      locations: [],
+      sizeBytes: 0,
+    };
+    current.locations.push(relative(unpackedRoot, candidate.path));
+    const candidateRealPath = await realpath(existingPath);
+    if (!sizedRealPaths.has(candidateRealPath)) {
+      current.sizeBytes += await directorySize(existingPath);
+      sizedRealPaths.add(candidateRealPath);
+    }
+    byPlatformKey.set(candidate.platformKey, current);
+  }
+
+  return [...byPlatformKey.values()].sort((left, right) =>
+    left.platformKey.localeCompare(right.platformKey),
+  );
+}
+
+export async function pruneBundledCodexPackages(resourcesDir, expectedKeys) {
+  const expected = new Set(expectedKeys);
+  const unpackedRoot = join(resourcesDir, 'app.asar.unpacked');
+  const candidates = await collectCodexPackageCandidates(unpackedRoot);
+  const pruned = [];
+
+  for (const candidate of candidates) {
+    if (expected.has(candidate.platformKey)) continue;
+    if (!(await exists(candidate.path))) continue;
+
+    await rm(candidate.path, { recursive: true, force: true });
+    pruned.push({
+      platformKey: candidate.platformKey,
+      pkg: packageNameForCodexPlatformKey(candidate.platformKey),
+      path: relative(unpackedRoot, candidate.path),
+    });
+  }
+
+  return pruned.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function resourcesDirForElectronBuilderContext(context) {
+  if (typeof context.packager?.getResourcesDir === 'function') {
+    return context.packager.getResourcesDir(context.appOutDir);
+  }
+
+  if (context.electronPlatformName === 'darwin') {
+    const productName =
+      context.packager?.appInfo?.productFilename ??
+      context.packager?.appInfo?.productName ??
+      'TeXRA';
+    return join(
+      context.appOutDir,
+      `${productName}.app`,
+      'Contents',
+      'Resources',
+    );
+  }
+
+  if (
+    context.electronPlatformName === 'linux' ||
+    context.electronPlatformName === 'win32'
+  ) {
+    return join(context.appOutDir, 'resources');
+  }
+
+  return context.appOutDir;
+}
+
+async function collectCodexPackageCandidates(unpackedRoot) {
+  return [
+    ...(await collectOpenAiAliasCandidates(unpackedRoot)),
+    ...(await collectPnpmStoreCandidates(unpackedRoot)),
+  ];
+}
+
+async function collectOpenAiAliasCandidates(unpackedRoot) {
+  const openAiDir = join(unpackedRoot, 'node_modules', '@openai');
+  const entries = await readDirNames(openAiDir);
+  return entries
+    .map((entry) => {
+      const pkg = `@openai/${entry}`;
+      const platformKey = platformKeyByPackageName.get(pkg);
+      if (platformKey == null) return null;
+      return { platformKey, path: join(openAiDir, entry) };
+    })
+    .filter((candidate) => candidate != null);
+}
+
+async function collectPnpmStoreCandidates(unpackedRoot) {
+  const pnpmDir = join(unpackedRoot, 'node_modules', '.pnpm');
+  const entries = await readDirNames(pnpmDir);
+  return entries
+    .map((entry) => {
+      const platformKey = inferPlatformKeyFromPnpmEntry(entry);
+      if (platformKey == null) return null;
+      return { platformKey, path: join(pnpmDir, entry) };
+    })
+    .filter((candidate) => candidate != null);
+}
+
+function inferPlatformKeyFromPnpmEntry(entry) {
+  for (const platformKey of Object.keys(codexPlatformInfoByKey)) {
+    if (entry.includes(`-${platformKey}`)) return platformKey;
+  }
+  return null;
+}
+
+async function directorySize(path) {
+  const entryStat = await stat(path);
+  if (!entryStat.isDirectory()) return entryStat.size;
+
+  let total = 0;
+  const entries = await readdir(path, { withFileTypes: true });
+  for (const entry of entries) {
+    total += await directorySize(join(path, entry.name));
+  }
+  return total;
+}
+
+async function existingCandidatePath(path) {
+  try {
+    await stat(path);
+    return path;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readDirNames(path) {
+  try {
+    return await readdir(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+function normalizePlatform(platform, normalizedPath) {
+  if (platform === 'darwin' || platform === 'mac') return 'darwin';
+  if (platform === 'linux') return 'linux';
+  if (platform === 'win32' || platform === 'win') return 'win32';
+
+  if (normalizedPath.includes('.app/contents/resources')) return 'darwin';
+  if (normalizedPath.includes('/mac') || normalizedPath.includes('\\mac')) {
+    return 'darwin';
+  }
+  if (normalizedPath.includes('linux')) return 'linux';
+  if (normalizedPath.includes('win')) return 'win32';
+
+  return null;
+}
+
+function normalizeArch(arch, normalizedPath, normalizedPlatform) {
+  const archName = archNameByElectronBuilderArch[arch] ?? arch;
+  if (archName === 'universal' || normalizedPath.includes('universal')) {
+    return 'universal';
+  }
+  if (
+    archName === 'arm64' ||
+    normalizedPath.includes('arm64') ||
+    normalizedPath.includes('aarch64')
+  ) {
+    return 'arm64';
+  }
+  if (
+    archName === 'x64' ||
+    normalizedPath.includes('x64') ||
+    normalizedPath.includes('x86_64') ||
+    normalizedPath.includes('amd64')
+  ) {
+    return 'x64';
+  }
+
+  if (
+    normalizedPlatform != null &&
+    normalizedPlatform === normalizePlatform(process.platform, '')
+  ) {
+    return process.arch === 'arm64' ? 'arm64' : 'x64';
+  }
+
+  return null;
+}

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -273,13 +273,23 @@ function normalizePlatform(platform, normalizedPath) {
   if (platform === 'win32' || platform === 'win') return 'win32';
 
   if (normalizedPath.includes('.app/contents/resources')) return 'darwin';
-  if (normalizedPath.includes('/mac') || normalizedPath.includes('\\mac')) {
+  if (hasPathToken(normalizedPath, 'mac', 'darwin')) {
     return 'darwin';
   }
-  if (normalizedPath.includes('linux')) return 'linux';
-  if (normalizedPath.includes('win')) return 'win32';
+  if (hasPathToken(normalizedPath, 'linux')) return 'linux';
+  if (hasPathToken(normalizedPath, 'win', 'win32', 'windows')) return 'win32';
 
   return null;
+}
+
+function hasPathToken(normalizedPath, ...tokens) {
+  return normalizedPath
+    .split('/')
+    .some((segment) =>
+      tokens.some((token) =>
+        new RegExp(`(^|[-_])${token}($|[-_])`).test(segment),
+      ),
+    );
 }
 
 function normalizeArch(arch, normalizedPath, normalizedPlatform) {

--- a/scripts/desktop-codex-payload.mjs
+++ b/scripts/desktop-codex-payload.mjs
@@ -3,8 +3,8 @@ import { join, relative } from 'node:path';
 
 const MEBIBYTE = 1024 * 1024;
 
-export const CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES = 325 * MEBIBYTE;
-export const CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES = 625 * MEBIBYTE;
+const CODEX_SINGLE_PLATFORM_PAYLOAD_BUDGET_BYTES = 325 * MEBIBYTE;
+const CODEX_UNIVERSAL_PAYLOAD_BUDGET_BYTES = 625 * MEBIBYTE;
 
 export const codexPlatformInfoByKey = {
   'linux-x64': {
@@ -285,33 +285,33 @@ function normalizePlatform(platform, normalizedPath) {
 function hasPathToken(normalizedPath, ...tokens) {
   return normalizedPath
     .split('/')
-    .some((segment) =>
-      tokens.some((token) =>
-        new RegExp(`(^|[-_])${token}($|[-_])`).test(segment),
-      ),
-    );
+    .some((segment) => hasSegmentToken(segment, ...tokens));
+}
+
+function hasSegmentToken(segment, ...tokens) {
+  return tokens.some((token) =>
+    new RegExp(`(^|[-_])${token}($|[-_])`).test(segment),
+  );
+}
+
+function archFromPathToken(normalizedPath) {
+  const segments = normalizedPath.split('/').reverse();
+  for (const segment of segments) {
+    if (hasSegmentToken(segment, 'universal')) return 'universal';
+    if (hasSegmentToken(segment, 'arm64', 'aarch64')) return 'arm64';
+    if (hasSegmentToken(segment, 'x64', 'x86_64', 'amd64')) return 'x64';
+  }
+  return null;
 }
 
 function normalizeArch(arch, normalizedPath, normalizedPlatform) {
   const archName = archNameByElectronBuilderArch[arch] ?? arch;
-  if (archName === 'universal' || normalizedPath.includes('universal')) {
-    return 'universal';
-  }
-  if (
-    archName === 'arm64' ||
-    normalizedPath.includes('arm64') ||
-    normalizedPath.includes('aarch64')
-  ) {
-    return 'arm64';
-  }
-  if (
-    archName === 'x64' ||
-    normalizedPath.includes('x64') ||
-    normalizedPath.includes('x86_64') ||
-    normalizedPath.includes('amd64')
-  ) {
-    return 'x64';
-  }
+  if (archName === 'universal') return 'universal';
+  if (archName === 'arm64') return 'arm64';
+  if (archName === 'x64') return 'x64';
+
+  const pathArch = archFromPathToken(normalizedPath);
+  if (pathArch != null) return pathArch;
 
   if (
     normalizedPlatform != null &&

--- a/scripts/prune-desktop-codex-payload.mjs
+++ b/scripts/prune-desktop-codex-payload.mjs
@@ -1,0 +1,56 @@
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  describeBundledCodexPackages,
+  inferCodexPlatformKeys,
+  pruneBundledCodexPackages,
+  resourcesDirForElectronBuilderContext,
+} from './desktop-codex-payload.mjs';
+
+export default async function pruneDesktopCodexPayload(context) {
+  const expectedPlatformKeys = inferCodexPlatformKeys({
+    platform: context.electronPlatformName,
+    arch: context.arch,
+    appPath: context.appOutDir,
+  });
+
+  if (expectedPlatformKeys.length === 0) {
+    throw new Error(
+      `Could not infer expected Codex CLI platform packages for ${context.electronPlatformName}/${context.arch} at ${context.appOutDir}`,
+    );
+  }
+
+  const resourcesDir = resourcesDirForElectronBuilderContext(context);
+  const pruned = await pruneBundledCodexPackages(
+    resourcesDir,
+    expectedPlatformKeys,
+  );
+
+  if (pruned.length === 0) {
+    console.log(
+      `Codex CLI payload pruning kept expected packages: ${expectedPlatformKeys.join(
+        ', ',
+      )}`,
+    );
+    return;
+  }
+
+  console.log(
+    `Codex CLI payload pruning removed unused packages: ${describeBundledCodexPackages(
+      pruned.map(({ platformKey, pkg, path }) => ({
+        platformKey,
+        pkg,
+        locations: [path],
+        sizeBytes: 0,
+      })),
+    )}`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  console.error(
+    'prune-desktop-codex-payload.mjs is an electron-builder afterPack hook and must be loaded by electron-builder.',
+  );
+  process.exit(1);
+}

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -24,7 +24,6 @@ import {
   normalizeMetafilePath,
   resolveMetafileImportPath,
 } from './desktop-package-metafile-paths.mjs';
-import { expectedCodexPlatformKeysFromLabel } from './desktop-package-targets.mjs';
 
 const require = createRequire(import.meta.url);
 const { extractFile, listPackage, statFile } = require('@electron/asar');

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -5,6 +5,16 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  codexBinaryPath,
+  codexPlatformInfoByKey,
+  collectBundledCodexPackages,
+  describeBundledCodexPackages,
+  expectedCodexPayloadBudgetBytes,
+  formatBytes,
+  inferCodexPlatformKeys,
+  packageNameForCodexPlatformKey,
+} from './desktop-codex-payload.mjs';
+import {
   getDesktopSharedSourceDirs,
   getDesktopVscodeFreeSourceDirs,
   vscodeBackedStateImportPattern,
@@ -21,7 +31,8 @@ const { extractFile, listPackage, statFile } = require('@electron/asar');
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const desktopRoot = join(repoRoot, 'packages', 'desktop');
-const packageRoot = join(desktopRoot, 'dist-packaged');
+const packageRoot =
+  process.env.TEXRA_DESKTOP_PACKAGE_ROOT ?? join(desktopRoot, 'dist-packaged');
 const desktopPackageJsonPath = join(desktopRoot, 'package.json');
 const desktopIconPath = join(desktopRoot, 'build', 'icon.icns');
 const desktopSharedSourceDirs = getDesktopSharedSourceDirs(repoRoot);
@@ -32,38 +43,6 @@ const desktopSourceBoundaryDirs = [
   ...new Set([...desktopSharedSourceDirs, ...desktopVscodeFreeSourceDirs]),
 ];
 const bundledAgentResourceDirs = ['agents', 'tool_use_agents'];
-const codexPlatformInfoByKey = {
-  'linux-x64': {
-    pkg: '@openai/codex-linux-x64',
-    triple: 'x86_64-unknown-linux-musl',
-    binaryName: 'codex',
-  },
-  'linux-arm64': {
-    pkg: '@openai/codex-linux-arm64',
-    triple: 'aarch64-unknown-linux-musl',
-    binaryName: 'codex',
-  },
-  'darwin-x64': {
-    pkg: '@openai/codex-darwin-x64',
-    triple: 'x86_64-apple-darwin',
-    binaryName: 'codex',
-  },
-  'darwin-arm64': {
-    pkg: '@openai/codex-darwin-arm64',
-    triple: 'aarch64-apple-darwin',
-    binaryName: 'codex',
-  },
-  'win32-x64': {
-    pkg: '@openai/codex-win32-x64',
-    triple: 'x86_64-pc-windows-msvc',
-    binaryName: 'codex.exe',
-  },
-  'win32-arm64': {
-    pkg: '@openai/codex-win32-arm64',
-    triple: 'aarch64-pc-windows-msvc',
-    binaryName: 'codex.exe',
-  },
-};
 const desktopStartupForbiddenInputPackages = [
   {
     label: '@google/genai',
@@ -244,6 +223,9 @@ function createAsarAppReader(asarPath) {
     async isUnpacked(path) {
       return isAsarEntryUnpacked(path);
     },
+    fsPath(path) {
+      return join(resourceRoot, path);
+    },
     async listDir(path) {
       const prefix = `${normalizeAsarPath(path)}/`;
       const asarEntries = [...entries]
@@ -296,6 +278,9 @@ function createDirectoryAppReader(appRoot) {
     },
     async isUnpacked() {
       return false;
+    },
+    fsPath(path) {
+      return join(appRoot, path);
     },
   };
 }
@@ -455,32 +440,44 @@ function dependencyPackageJsonPath(name) {
   return join('node_modules', name, 'package.json');
 }
 
-function codexBinaryPath(prefix, platformInfo) {
-  return posix.join(
-    prefix,
-    'node_modules',
-    ...platformInfo.pkg.split('/'),
-    'vendor',
-    platformInfo.triple,
-    'codex',
-    platformInfo.binaryName,
+async function checkCodexPayload(app, failures) {
+  const expectedPlatformKeys = inferCodexPlatformKeys({ appPath: app.label });
+  const bundledPackages = await collectBundledCodexPackages(app.fsPath(''));
+  const payloadSizeBytes = bundledPackages.reduce(
+    (sum, pkg) => sum + pkg.sizeBytes,
+    0,
   );
-}
+  const budgetBytes = expectedCodexPayloadBudgetBytes(expectedPlatformKeys);
+  const bundledPackageSummary = describeBundledCodexPackages(bundledPackages);
 
-function expectedCodexPlatformKeys(app) {
-  return expectedCodexPlatformKeysFromLabel(app.label);
-}
-
-async function checkCodexUnpackedBinaries(app, failures) {
-  const platformKeys = expectedCodexPlatformKeys(app);
-  if (platformKeys.length === 0) {
+  if (expectedPlatformKeys.length === 0) {
     failures.push(
       `Could not infer expected Codex CLI platform from packaged app path: ${app.label}`,
     );
-    return false;
+    return {
+      checked: false,
+      expectedPlatformKeys,
+      bundledPackages,
+      payloadSizeBytes,
+      budgetBytes,
+    };
   }
 
-  for (const platformKey of platformKeys) {
+  const expectedPlatformKeySet = new Set(expectedPlatformKeys);
+  const extraPackages = bundledPackages.filter(
+    ({ platformKey }) => !expectedPlatformKeySet.has(platformKey),
+  );
+  if (extraPackages.length > 0) {
+    failures.push(
+      `Packaged desktop app bundles extra Codex CLI platform packages for ${expectedPlatformKeys.join(
+        ', ',
+      )}: ${describeBundledCodexPackages(
+        extraPackages,
+      )}. Bundled Codex packages: ${bundledPackageSummary}`,
+    );
+  }
+
+  for (const platformKey of expectedPlatformKeys) {
     const platformInfo = codexPlatformInfoByKey[platformKey];
     const unpackedBinaryPath = codexBinaryPath(
       'app.asar.unpacked',
@@ -505,7 +502,25 @@ async function checkCodexUnpackedBinaries(app, failures) {
     }
   }
 
-  return true;
+  if (payloadSizeBytes > budgetBytes) {
+    failures.push(
+      `Packaged desktop app Codex CLI payload is ${formatBytes(
+        payloadSizeBytes,
+      )}, above the ${formatBytes(
+        budgetBytes,
+      )} budget for ${expectedPlatformKeys.join(
+        ', ',
+      )}. Bundled Codex packages: ${bundledPackageSummary}`,
+    );
+  }
+
+  return {
+    checked: true,
+    expectedPlatformKeys,
+    bundledPackages,
+    payloadSizeBytes,
+    budgetBytes,
+  };
 }
 
 async function checkRuntimeDependencies(app, appPackageJson, failures) {
@@ -589,7 +604,7 @@ async function checkMacIcon(app, failures) {
 const app = await findPackagedApp();
 const failures = [];
 let checkedMacIcon = false;
-let checkedCodexUnpackedBinaries = false;
+let codexPayloadResult = null;
 
 if (!app) {
   failures.push(`No packaged Electron app found under ${packageRoot}`);
@@ -608,10 +623,7 @@ if (!app) {
   await checkExists(app, 'dist/renderer/index.html', 'renderer HTML', failures);
   await checkBundledResources(app, failures);
   checkedMacIcon = await checkMacIcon(app, failures);
-  checkedCodexUnpackedBinaries = await checkCodexUnpackedBinaries(
-    app,
-    failures,
-  );
+  codexPayloadResult = await checkCodexPayload(app, failures);
   await checkNoVscodeRuntimeImport(app, failures);
   await checkDesktopMainDynamicRequireShim(app, failures);
   await checkDesktopStartupBundles(app, failures);
@@ -651,11 +663,16 @@ const summary = [
 ];
 
 if (checkedMacIcon) summary.splice(7, 0, '- macOS app icon');
-if (checkedCodexUnpackedBinaries) {
+if (codexPayloadResult?.checked) {
   summary.splice(
     checkedMacIcon ? 8 : 7,
     0,
-    '- unpacked Codex CLI platform binaries',
+    `- Codex CLI packages: ${codexPayloadResult.bundledPackages
+      .map(({ platformKey }) => packageNameForCodexPlatformKey(platformKey))
+      .join(', ')}`,
+    `- Codex CLI payload size: ${formatBytes(
+      codexPayloadResult.payloadSizeBytes,
+    )} / ${formatBytes(codexPayloadResult.budgetBytes)}`,
   );
 }
 

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -18,6 +18,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { repoPath } from './desktopTestPaths.mjs';
 
 const verifierPath = repoPath('scripts/verify-desktop-package.mjs');
+const payloadUrl = pathToFileURL(
+  repoPath('scripts/desktop-codex-payload.mjs'),
+).href;
 const pruneHookUrl = pathToFileURL(
   repoPath('scripts/prune-desktop-codex-payload.mjs'),
 ).href;
@@ -82,6 +85,18 @@ describe('desktop Codex package payload', () => {
     expect(output).toContain('@openai/codex-darwin-arm64');
     expect(output).not.toContain('@openai/codex-darwin-x64');
     expect(output).toContain('Codex CLI payload size');
+  });
+
+  it('does not infer Windows from a darwin path segment', async () => {
+    const { inferCodexPlatformKeys } = (await import(payloadUrl)) as {
+      inferCodexPlatformKeys: (input: { appPath: string }) => string[];
+    };
+
+    expect(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/TeXRA-darwin-arm64/TeXRA.app',
+      }),
+    ).toEqual(['darwin-arm64']);
   });
 });
 

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -116,6 +116,23 @@ describe('desktop Codex package payload', () => {
     ).toEqual(['darwin-arm64']);
   });
 
+  it('defaults Linux and Windows package paths without architecture tokens to x64', async () => {
+    const { inferCodexPlatformKeys } = (await import(payloadUrl)) as {
+      inferCodexPlatformKeys: (input: { appPath: string }) => string[];
+    };
+
+    expect(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/dist/linux-unpacked/resources/app.asar',
+      }),
+    ).toEqual(['linux-x64']);
+    expect(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/dist/win-unpacked/resources/app.asar',
+      }),
+    ).toEqual(['win32-x64']);
+  });
+
   it('uses the universal Codex payload budget only for universal builds', async () => {
     const { expectedCodexPayloadBudgetBytes, inferCodexPlatformKeys } =
       (await import(payloadUrl)) as {

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -1,0 +1,201 @@
+// Node imports
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// Third-party imports
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { repoPath } from './desktopTestPaths.mjs';
+
+const verifierPath = repoPath('scripts/verify-desktop-package.mjs');
+const pruneHookUrl = pathToFileURL(
+  repoPath('scripts/prune-desktop-codex-payload.mjs'),
+).href;
+
+const codexPlatforms = {
+  'darwin-arm64': {
+    packageName: '@openai/codex-darwin-arm64',
+    triple: 'aarch64-apple-darwin',
+    binaryName: 'codex',
+  },
+  'darwin-x64': {
+    packageName: '@openai/codex-darwin-x64',
+    triple: 'x86_64-apple-darwin',
+    binaryName: 'codex',
+  },
+} as const;
+
+let tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const tempRoot of tempRoots) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+  tempRoots = [];
+});
+
+describe('desktop Codex package payload', () => {
+  it('fails arch-specific package verification when an extra Codex platform package is bundled', () => {
+    const { packageRoot } = createFakeDesktopPackage([
+      'darwin-arm64',
+      'darwin-x64',
+    ]);
+
+    const result = runVerifierResult(packageRoot);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'bundles extra Codex CLI platform packages',
+    );
+  });
+
+  it('prunes unused Codex platform packages before verification', () => {
+    const { appOutDir, packageRoot, resourcesDir } = createFakeDesktopPackage([
+      'darwin-arm64',
+      'darwin-x64',
+    ]);
+
+    execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        `const { default: prune } = await import(${JSON.stringify(
+          pruneHookUrl,
+        )}); await prune({ electronPlatformName: 'darwin', arch: 3, appOutDir: ${JSON.stringify(
+          appOutDir,
+        )}, packager: { getResourcesDir: () => ${JSON.stringify(resourcesDir)} } });`,
+      ],
+      { encoding: 'utf8' },
+    );
+
+    const output = runVerifier(packageRoot);
+    expect(output).toContain('@openai/codex-darwin-arm64');
+    expect(output).not.toContain('@openai/codex-darwin-x64');
+    expect(output).toContain('Codex CLI payload size');
+  });
+});
+
+function createFakeDesktopPackage(
+  platforms: Array<keyof typeof codexPlatforms>,
+): {
+  appOutDir: string;
+  packageRoot: string;
+  resourcesDir: string;
+} {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'texra-desktop-codex-'));
+  tempRoots.push(tempRoot);
+
+  const packageRoot = join(tempRoot, 'dist-packaged');
+  const appOutDir = join(packageRoot, 'mac-arm64');
+  const resourcesDir = join(appOutDir, 'TeXRA.app', 'Contents', 'Resources');
+  const appRoot = join(resourcesDir, 'app');
+
+  writeJson(join(appRoot, 'package.json'), {
+    main: './dist/main/index.js',
+    dependencies: readDesktopDependencies(),
+  });
+  writeText(join(appRoot, 'dist/main/index.js'), "import('./bootstrap.js');\n");
+  writeText(join(appRoot, 'dist/main/bootstrap.js'), 'export {};\n');
+  writeText(join(appRoot, 'dist/preload/index.cjs'), "'use strict';\n");
+  writeText(join(appRoot, 'dist/renderer/index.html'), '<!doctype html>\n');
+  writeText(join(appRoot, 'dist/renderer/assets/app.js'), 'export {};\n');
+  writeText(join(appRoot, 'dist/renderer/assets/app.css'), ':root {}\n');
+  writeText(join(appRoot, 'resources/agents/example.yaml'), 'name: example\n');
+  writeText(
+    join(appRoot, 'resources/tool_use_agents/example.yaml'),
+    'name: example\n',
+  );
+
+  for (const dependencyName of Object.keys(readDesktopDependencies())) {
+    writeJson(join(appRoot, 'node_modules', dependencyName, 'package.json'), {
+      name: dependencyName,
+      version: '0.0.0',
+    });
+  }
+
+  for (const platform of platforms) {
+    writeCodexPlatformPackage(appRoot, platform);
+  }
+
+  return { appOutDir, packageRoot, resourcesDir: appRoot };
+}
+
+function writeCodexPlatformPackage(
+  appRoot: string,
+  platform: keyof typeof codexPlatforms,
+): void {
+  const info = codexPlatforms[platform];
+  const packageRoot = join(
+    appRoot,
+    'app.asar.unpacked',
+    'node_modules',
+    ...info.packageName.split('/'),
+  );
+
+  writeJson(join(packageRoot, 'package.json'), {
+    name: '@openai/codex',
+    version: `0.128.0-${platform}`,
+  });
+  writeText(
+    join(packageRoot, 'vendor', info.triple, 'codex', info.binaryName),
+    'fake codex binary\n',
+  );
+}
+
+function runVerifier(packageRoot: string): string {
+  return execFileSync(process.execPath, [verifierPath], {
+    cwd: repoPath('.'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TEXRA_DESKTOP_PACKAGE_ROOT: packageRoot,
+    },
+  });
+}
+
+function runVerifierResult(packageRoot: string): {
+  status: number | null;
+  stderr: string;
+  stdout: string;
+} {
+  const result = spawnSync(process.execPath, [verifierPath], {
+    cwd: repoPath('.'),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TEXRA_DESKTOP_PACKAGE_ROOT: packageRoot,
+    },
+  });
+
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+function readDesktopDependencies(): Record<string, string> {
+  const packageJson = JSON.parse(
+    readFileSync(repoPath('packages/desktop/package.json'), 'utf8'),
+  ) as { dependencies?: Record<string, string> };
+  return packageJson.dependencies ?? {};
+}
+
+function writeJson(path: string, data: unknown): void {
+  writeText(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function writeText(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -99,6 +99,44 @@ describe('desktop Codex package payload', () => {
     ).toEqual(['darwin-arm64']);
   });
 
+  it('infers architecture from path tokens nearest the app bundle', async () => {
+    const { inferCodexPlatformKeys } = (await import(payloadUrl)) as {
+      inferCodexPlatformKeys: (input: { appPath: string }) => string[];
+    };
+
+    expect(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/arm64-compat-lib/dist/mac-x64/TeXRA.app',
+      }),
+    ).toEqual(['darwin-x64']);
+    expect(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/universal-cache/dist/mac-arm64/TeXRA.app',
+      }),
+    ).toEqual(['darwin-arm64']);
+  });
+
+  it('uses the universal Codex payload budget only for universal builds', async () => {
+    const { expectedCodexPayloadBudgetBytes, inferCodexPlatformKeys } =
+      (await import(payloadUrl)) as {
+        expectedCodexPayloadBudgetBytes: (platformKeys: string[]) => number;
+        inferCodexPlatformKeys: (input: { appPath: string }) => string[];
+      };
+
+    const singlePlatformBudget = expectedCodexPayloadBudgetBytes(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/universal-cache/dist/mac-arm64/TeXRA.app',
+      }),
+    );
+    const universalBudget = expectedCodexPayloadBudgetBytes(
+      inferCodexPlatformKeys({
+        appPath: '/tmp/dist/mac-universal/TeXRA.app',
+      }),
+    );
+
+    expect(universalBudget).toBeGreaterThan(singlePlatformBudget);
+  });
+
   it('resolves relative metafile imports from the importing output directory', () => {
     const { packageRoot } = createFakeDesktopPackage(['darwin-arm64'], {
       startupImportPath: './bootstrap.js',

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -121,6 +121,33 @@ function createFakeDesktopPackage(
   });
   writeText(join(appRoot, 'dist/main/index.js'), "import('./bootstrap.js');\n");
   writeText(join(appRoot, 'dist/main/bootstrap.js'), 'export {};\n');
+  writeJson(join(appRoot, 'dist/main/metafile.json'), {
+    outputs: {
+      'dist/main/index.js': {
+        entryPoint: 'src/main/index.ts',
+        inputs: {
+          'src/main/index.ts': {
+            bytesInOutput: 1,
+          },
+        },
+        imports: [
+          {
+            path: './bootstrap.js',
+            kind: 'import-statement',
+          },
+        ],
+      },
+      'dist/main/bootstrap.js': {
+        entryPoint: 'src/main/bootstrap.ts',
+        inputs: {
+          'src/main/bootstrap.ts': {
+            bytesInOutput: 1,
+          },
+        },
+        imports: [],
+      },
+    },
+  });
   writeText(join(appRoot, 'dist/preload/index.cjs'), "'use strict';\n");
   writeText(join(appRoot, 'dist/renderer/index.html'), '<!doctype html>\n');
   writeText(join(appRoot, 'dist/renderer/assets/app.js'), 'export {};\n');

--- a/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCodexPayload.vitest.mts
@@ -98,10 +98,31 @@ describe('desktop Codex package payload', () => {
       }),
     ).toEqual(['darwin-arm64']);
   });
+
+  it('resolves relative metafile imports from the importing output directory', () => {
+    const { packageRoot } = createFakeDesktopPackage(['darwin-arm64'], {
+      startupImportPath: './bootstrap.js',
+      bootstrapInputs: {
+        'node_modules/.pnpm/openai@0.0.0/node_modules/openai/index.js': {
+          bytesInOutput: 1,
+        },
+      },
+    });
+
+    const result = runVerifierResult(packageRoot);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Packaged desktop startup graph eagerly includes provider SDK code (OpenAI SDK)',
+    );
+  });
 });
 
 function createFakeDesktopPackage(
   platforms: Array<keyof typeof codexPlatforms>,
+  options: {
+    bootstrapInputs?: Record<string, { bytesInOutput: number }>;
+    startupImportPath?: string;
+  } = {},
 ): {
   appOutDir: string;
   packageRoot: string;
@@ -119,7 +140,7 @@ function createFakeDesktopPackage(
     main: './dist/main/index.js',
     dependencies: readDesktopDependencies(),
   });
-  writeText(join(appRoot, 'dist/main/index.js'), "import('./bootstrap.js');\n");
+  writeText(join(appRoot, 'dist/main/index.js'), "import './bootstrap.js';\n");
   writeText(join(appRoot, 'dist/main/bootstrap.js'), 'export {};\n');
   writeJson(join(appRoot, 'dist/main/metafile.json'), {
     outputs: {
@@ -132,14 +153,13 @@ function createFakeDesktopPackage(
         },
         imports: [
           {
-            path: './bootstrap.js',
+            path: options.startupImportPath ?? 'dist/main/bootstrap.js',
             kind: 'import-statement',
           },
         ],
       },
       'dist/main/bootstrap.js': {
-        entryPoint: 'src/main/bootstrap.ts',
-        inputs: {
+        inputs: options.bootstrapInputs ?? {
           'src/main/bootstrap.ts': {
             bytesInOutput: 1,
           },


### PR DESCRIPTION
## Summary
- Add an electron-builder afterPack hook that prunes unused bundled Codex CLI platform packages from arch-specific desktop apps while keeping @openai/codex-sdk available.
- Share Codex platform metadata between pruning and package verification.
- Make the desktop package verifier report bundled Codex packages, reject extras in arch-specific builds, and enforce a Codex payload size budget.
- Add focused desktop verifier tests for extra-package detection and pruning.

Closes #3545.

## Validation
- `corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCodexPayload.vitest.mts`
- `npm run -s typecheck`
- `npm run -s lint`
- `npm run -s compile:fast`
- `corepack pnpm run desktop:package:local` (confirmed mac-arm64 pruning removed @openai/codex-darwin-x64)
- `npm run check:desktop-package` currently fails on the existing startup bundle provider-SDK check: `dist/main/chunks/chunk-LJRYQD76.js` includes OpenAI SDK and Anthropic SDK markers; related PR #3596 is already addressing that verifier area.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Electron packaging pipeline via an `afterPack` hook and tightens package verification checks, which could break desktop builds/releases if platform inference or pruning logic is wrong.
> 
> **Overview**
> Adds an electron-builder `afterPack` hook to **prune unused `@openai/codex-*` platform packages** from the packaged desktop app, reducing installer size for arch-specific builds.
> 
> Introduces shared Codex payload utilities (`scripts/desktop-codex-payload.mjs`) and updates `scripts/verify-desktop-package.mjs` to **detect extra bundled Codex platform packages**, **enforce per-build payload size budgets**, and report bundled Codex packages/payload size in the verifier output.
> 
> Adds Vitest coverage (`DesktopCodexPayload.vitest.mts`) to validate platform inference edge cases, extra-package detection, and that pruning runs before verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275f0e6c7351b1031695e20ba01f755ecb30a598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->