### PR TITLE
[codex] Tighten desktop startup package checks

### DIFF
--- a/packages/desktop/src/main/bootstrap.ts
+++ b/packages/desktop/src/main/bootstrap.ts
@@ -1,59 +1,10 @@
-import { app, dialog } from 'electron';
-
 import { installDesktopAppLog } from './desktopAppLog.js';
-
-let fatalStartupErrorReported = false;
+import {
+  installFatalStartupHandlers,
+  reportFatalStartupError,
+} from './fatalStartupError.js';
 
 installDesktopAppLog();
-
-function formatFatalStartupError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
-  }
-  return String(error);
-}
-
-function reportFatalStartupError(error: unknown): void {
-  if (fatalStartupErrorReported) return;
-  fatalStartupErrorReported = true;
-
-  const detail = formatFatalStartupError(error);
-  console.error(`Fatal TeXRA desktop error:\n${detail}`);
-
-  const showFailureDialog = () => {
-    dialog.showErrorBox(
-      'TeXRA failed to start',
-      [
-        'TeXRA hit a startup error before the desktop window was ready.',
-        '',
-        detail,
-      ].join('\n'),
-    );
-    app.quit();
-  };
-
-  if (app.isReady()) {
-    showFailureDialog();
-    return;
-  }
-
-  app.once('ready', showFailureDialog);
-}
-
-function installFatalStartupHandlers(): () => void {
-  const onUncaughtException = (error: unknown) =>
-    reportFatalStartupError(error);
-  const onUnhandledRejection = (error: unknown) =>
-    reportFatalStartupError(error);
-
-  process.on('uncaughtException', onUncaughtException);
-  process.on('unhandledRejection', onUnhandledRejection);
-
-  return () => {
-    process.off('uncaughtException', onUncaughtException);
-    process.off('unhandledRejection', onUnhandledRejection);
-  };
-}
 
 const removeFatalStartupHandlers = installFatalStartupHandlers();
 try {

--- a/packages/desktop/src/main/fatalStartupError.ts
+++ b/packages/desktop/src/main/fatalStartupError.ts
@@ -1,0 +1,52 @@
+import { app, dialog } from 'electron';
+
+let fatalStartupErrorReported = false;
+
+function formatFatalStartupError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+export function reportFatalStartupError(error: unknown): void {
+  if (fatalStartupErrorReported) return;
+  fatalStartupErrorReported = true;
+
+  const detail = formatFatalStartupError(error);
+  console.error(`Fatal TeXRA desktop error:\n${detail}`);
+
+  const showFailureDialog = () => {
+    dialog.showErrorBox(
+      'TeXRA failed to start',
+      [
+        'TeXRA hit a startup error before the desktop window was ready.',
+        '',
+        detail,
+      ].join('\n'),
+    );
+    app.quit();
+  };
+
+  if (app.isReady()) {
+    showFailureDialog();
+    return;
+  }
+
+  app.once('ready', showFailureDialog);
+}
+
+export function installFatalStartupHandlers(): () => void {
+  const onUncaughtException = (error: unknown) =>
+    reportFatalStartupError(error);
+  const onUnhandledRejection = (error: unknown) =>
+    reportFatalStartupError(error);
+
+  process.on('uncaughtException', onUncaughtException);
+  process.on('unhandledRejection', onUnhandledRejection);
+
+  return () => {
+    process.off('uncaughtException', onUncaughtException);
+    process.off('unhandledRejection', onUnhandledRejection);
+  };
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -31,6 +31,7 @@ import {
   type DesktopAuthCallbackState,
   type DesktopAuthCoordinator,
 } from './desktopSupabaseAuth.js';
+import { reportFatalStartupError } from './fatalStartupError.js';
 import { installDesktopMainViewIpc } from './mainViewIpc.js';
 import { initializeElectronPlatform } from './platform/index.js';
 import {
@@ -337,9 +338,7 @@ if (protocolLifecycle.shouldContinue) {
       });
     })
     .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`Failed to start TeXRA desktop: ${message}`);
-      app.quit();
+      reportFatalStartupError(error);
     });
 }
 

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -147,6 +147,12 @@ function normalizeAsarPath(path) {
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
 }
 
+function mergeDirectoryEntries(...entryGroups) {
+  return [...new Set(entryGroups.flat())].sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
 function createAsarAppReader(asarPath) {
   const entryPathByNormalizedPath = new Map(
     listPackage(asarPath).map((entry) => [normalizeAsarPath(entry), entry]),
@@ -233,11 +239,11 @@ function createAsarAppReader(asarPath) {
         .map((entry) => entry.slice(prefix.length))
         .filter((entry) => entry && !entry.includes('/'))
         .map((entry) => basename(entry));
-      if (asarEntries.length > 0) return asarEntries;
       try {
-        return await readdir(join(resourceRoot, path));
+        const resourceEntries = await readdir(join(resourceRoot, path));
+        return mergeDirectoryEntries(asarEntries, resourceEntries);
       } catch (error) {
-        if (error?.code === 'ENOENT') return [];
+        if (error?.code === 'ENOENT') return mergeDirectoryEntries(asarEntries);
         throw error;
       }
     },

--- a/src/common/errors/sdkErrorUtils.ts
+++ b/src/common/errors/sdkErrorUtils.ts
@@ -1,13 +1,5 @@
 import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import {
-  APIError as AnthropicAPIError,
-  APIUserAbortError as AnthropicAPIUserAbortError,
-} from '@anthropic-ai/sdk';
-import {
-  APIError as OpenAIAPIError,
-  APIUserAbortError as OpenAIAPIUserAbortError,
-} from 'openai';
-import {
   type ErrorContext,
   type ErrorLogData,
   type ProviderError,
@@ -236,13 +228,6 @@ function detectStatusText(
 }
 
 function detectProvider(err: unknown): string | undefined {
-  if (err instanceof OpenAIAPIError) {
-    return 'openai';
-  }
-  if (err instanceof AnthropicAPIError) {
-    return 'anthropic';
-  }
-
   if (!isObject(err)) {
     return undefined;
   }
@@ -341,12 +326,6 @@ export function takeTail(text: string, maxChars: number): string {
 
 /** True if `err` is an SDK user-abort error (OpenAI or Anthropic). */
 export function isUserAbort(err: unknown): boolean {
-  if (
-    err instanceof OpenAIAPIUserAbortError ||
-    err instanceof AnthropicAPIUserAbortError
-  ) {
-    return true;
-  }
   return getErrorClassNames(err).includes('APIUserAbortError');
 }
 


### PR DESCRIPTION
## Summary

- Merge `app.asar` and adjacent resource directory listings in `verify-desktop-package` so checks see files from both package locations.
- Reuse the desktop fatal startup dialog for async failures from the Electron `app.whenReady()` startup path.
- Remove runtime OpenAI/Anthropic SDK imports from shared SDK error formatting so desktop startup can use common error helpers without eagerly evaluating provider SDK packages.

Closes #3512.

## Validation

- `node --check scripts/verify-desktop-package.mjs`
- `npm run -s test:kernel -- src/test-kernel/common/SdkErrorUtils.vitest.mts`
- `npm run -s typecheck`
- `npm run -s lint`
- `npm run -s compile:fast`
- `npm run -s desktop:package:local`
- `npm run -s check:desktop-package`
- `npm run -s desktop:package:smoke`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily refactors fatal-startup error reporting into a shared helper and improves packaging verification directory listings, with minimal impact on runtime behavior beyond more consistent startup failure handling.
> 
> **Overview**
> Centralizes desktop fatal-startup handling by extracting the startup error dialog/handlers into `fatalStartupError.ts`, and reuses `reportFatalStartupError` for failures from the `app.whenReady()` startup path.
> 
> Tightens `scripts/verify-desktop-package.mjs` by merging directory listings from `app.asar` and adjacent resource directories so package checks see files regardless of whether they’re archived or unpacked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1b82e6ab28206646c344fd2901f1d99f4a7493e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->