### PR TITLE
docs: update monorepo path guidance

### DIFF
--- a/.claude/skills/code-review/references/review-checklist.md
+++ b/.claude/skills/code-review/references/review-checklist.md
@@ -12,7 +12,7 @@ The full zone list lives in `CLAUDE.md` → "Separation of Concerns: VS Code Cou
 - **`vscode.FileType.File` / `.Directory`** → `isFile()` / `isDirectory()` from `@common/files/fsEntryType`.
 - **`vscode.window.show*Message()` in business logic** → return error results; let the command/frontend layer handle UI.
 - **`process.env`, `os.homedir()`, raw `fs/promises`, `child_process.exec`** in agnostic zones → platform interfaces or `executeCommand` from `@utils/system/execUtils`.
-- **`initPlatform()`** called outside the host entry point (`src/extension.ts`) → bug. Read access uses `platform()`; module-init facades use `tryPlatform()`.
+- **`initPlatform()`** called outside the host entry point (`packages/extension/src/extension.ts`) → bug. Read access uses `platform()`; module-init facades use `tryPlatform()`.
 
 ## 2. Zod v4 schema correctness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ The project has two build systems with different trade-offs:
 
 - Use `compile:fast` during development for speed
 - Use `compile:safe` before committing to catch type errors
+- Use `build:initial` when validating a full initial build because it builds the desktop app and VSIX artifacts
 - CI should always run `typecheck` or use safe variants
 
 ## Commit messages
@@ -54,7 +55,7 @@ The project has two build systems with different trade-offs:
 
 ## Coding style
 
-- All code in `src/` is written in TypeScript targeting ES2022.
+- TypeScript code in repo-root `src/` and `packages/*/src/` targets ES2022.
 - Use the provided ESLint configuration (`eslint.config.mjs`) and Prettier settings (`.prettierrc`). Run `npm run format` before committing.
 - Prefer `const` and `let` over `var`.
 - Group imports by source and prefix each block with a descriptive comment (e.g., `// Third-party imports`, `// Local imports - component`).
@@ -62,7 +63,7 @@ The project has two build systems with different trade-offs:
 - Document functions with concise comments. Use JSDoc style for public APIs.
 - Keep functions small and focused; extract helpers or modules when logic becomes complex.
 - Keep the directory structure aligned among different webviews (webview, progressView, settingsView). Use the same folder names for modules of the same type and functionality but in different webviews.
-- Place view-specific manager classes under each view's `managers` folder. For example, `WebviewUpdater.ts` lives in `src/progressView/managers/`.
+- Place view-specific manager classes under each view's `managers` folder. For example, `WebviewUpdater.ts` lives in `packages/extension/src/progressView/managers/`.
 
 ### Naming conventions
 
@@ -73,7 +74,11 @@ The project has two build systems with different trade-offs:
 
 ### Directory organization
 
-- `src/frontend/` contains extension-host utilities that power shared UI flows (agent directories, file listers, instruction banners, tool workflows). Prefer these helpers over duplicating logic in commands or webviews.
+This repository is a pnpm workspace. Repo-root `src/` contains shared core logic and host-neutral tests,
+`packages/extension/` contains the VS Code extension, `packages/desktop/` contains the Electron shell, and
+`packages/core/` exposes the shared package surface.
+
+- `packages/extension/src/frontend/` contains extension-host utilities that power shared UI flows (agent directories, file listers, instruction banners, tool workflows). Prefer these helpers over duplicating logic in commands or webviews.
   - `frontend/system/` - VS Code command utilities (`safeExecuteCommand`)
   - `frontend/ui/` - Dialog helpers, diff views, message utilities
   - `frontend/editor/` - Active file guards and editor utilities
@@ -92,8 +97,14 @@ The project has two build systems with different trade-offs:
   - `utils/system/` - Shell command execution (`execUtils`)
   - `utils/text/` - Text and XML processing utilities
   - `utils/prompt/` - Prompt builder utilities
-- `src/settingsView/` - Unified settings webview combining History, Memory, Models, Agents, Multi-Agent, LaTeX, and Tools tabs
+- `packages/extension/src/commands/` - VS Code commands grouped by domain
+- `packages/extension/src/settingsView/` - Unified settings webview combining History, Memory, Models, Agents, Multi-Agent, LaTeX, and Tools tabs
+- `packages/extension/src/progressView/` - Task tracking board webview
+- `packages/extension/src/webview/` - Main agent interaction webview
+- `packages/extension/resources/` - Packaged agents, tool-use agents, docs, templates, examples, and extension assets
 - `src/platform/` - Platform abstraction layer (composition root). Hosts call `initPlatform()` once at startup; agnostic code uses `platform()` from `@platform`.
+- `src/hosts/` - Host capability interfaces for clipboard, prompts, terminals, diff views, and openers.
+- `src/test-kernel/` - Vitest suites for host-neutral and Electron-facing behavior.
 
 ### Pragmatic implementations
 
@@ -259,7 +270,7 @@ For good separation of concerns and platform independence, core business logic s
 - Use `getConfig`, `updateConfig`, and `watchConfig` from `@utils/config` to read and react to settings changes.
 - Interact with the filesystem through `@utils/files` helpers (`WorkspaceFS`, `RelativeFS`, `StorageFS`, `GlobalStorageFS`, `AbsoluteFS`). They resolve workspace paths, manage global storage, and expose cleanup helpers like `RelativeFS.cleanupOldFiles`.
 - Generate and resolve pasted-image paths with `@utils/files/pastedImageUtils` so temporary assets map correctly back to storage.
-- Surface files and agent directories through the shared frontend utilities (`fileLister` in `src/frontend/files/fileLister.ts`, `agentDirectories` in `src/frontend/agents/AgentDirectoryManager.ts`) instead of duplicating discovery logic.
+- Surface files and agent directories through the shared frontend utilities (`fileLister` in `packages/extension/src/frontend/files/fileLister.ts`, `agentDirectories` in `packages/extension/src/frontend/agents/AgentDirectoryManager.ts`) instead of duplicating discovery logic.
 
 **Logging and telemetry**
 
@@ -292,14 +303,14 @@ See `docs/pocketflow/` for full framework documentation.
 
 **Webviews and UI**
 
-- Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
+- Generate HTML through `BaseViewContentProvider` (`src/common/webview/BaseViewContentProvider.ts`) and `buildWebviewHtml` (`packages/extension/src/frontend/webview/html.ts`). Extend `BaseViewMessageHandler` for consistent lifecycle management across views.
 - Use codicon-based controls and shared utilities from `@utils/text/stringUtils` and `@utils/files/pathUtils` for consistent interactions.
 - For webview dependencies, prefer CDN builds (jsdelivr for static assets, esm.sh for ES modules) for complex packages like markdown-it, KaTeX, or highlight.js, while keeping lightweight bundles (split.js, `@vscode/codicons`) local to reduce extension size.
 - Keep CSS modular (per-component styles as TypeScript in each view's `frontend/` directory, shared tokens in `src/common/styles/common.css`) and use codicon chevrons (e.g., `<i class="codicon codicon-chevron-down"></i>`) for toggle affordances.
 
 **Progress view**
 
-- Extend the existing Lit components in `src/progressView/frontend/components/` (`StreamTabs`, `LogList`, `UsagePanel`, `TaskGroupList`, etc.) and managers in `src/progressView/managers/` (`OutputFilesManager`, `UsageStatsManager`, `WebviewUpdater`) — augment them rather than manipulating the DOM directly.
+- Extend the existing Lit components in `packages/extension/src/progressView/frontend/components/` (`StreamTabs`, `LogList`, `UsagePanel`, `TaskGroupList`, etc.) and managers in `packages/extension/src/progressView/managers/` (`OutputFilesManager`, `UsageStatsManager`, `WebviewUpdater`) — augment them rather than manipulating the DOM directly.
 - Tool-use and workflow sessions surface in separate filters; continue emitting usage, status, and log events through the established progress event commands so filters, counts, and badges update automatically.
 
 **Error handling and types**
@@ -310,13 +321,13 @@ See `docs/pocketflow/` for full framework documentation.
 **Miscellaneous**
 
 - Maintain text cleanup rules in the `src/replacement` modules.
-- Execute VS Code commands with `safeExecuteCommand` from `src/frontend/system/commandUtils.ts` and shell commands with `executeCommand` from `src/utils/system/execUtils.ts` so logging and error handling stay uniform.
+- Execute VS Code commands with `safeExecuteCommand` from `packages/extension/src/frontend/system/commandUtils.ts` and shell commands with `executeCommand` from `src/utils/system/execUtils.ts` so logging and error handling stay uniform.
 - Retrieve included file extensions via `getIncludedExtensions` in `src/common/files/fileTypeUtils.ts`.
-- Initialize new agent YAML files from the templates in `resources/agents/` and `resources/tool_use_agents/`.
+- Initialize new agent YAML files from the templates in `packages/extension/resources/agents/` and `packages/extension/resources/tool_use_agents/`.
 - Dispose event listeners and watchers when webviews close to prevent leaks.
 - Prefer enums or discriminated unions over bare booleans in configuration objects.
 - Favor debug logs for routine events and reserve info/error levels for notable outcomes.
-- Use the helpers in `src/frontend/ui/dialogs.ts` and `src/frontend/ui/instruction.ts` for consistent notification primitives shared across the extension.
+- Use the helpers in `packages/extension/src/frontend/ui/dialogs.ts` and `packages/extension/src/frontend/ui/instruction.ts` for consistent notification primitives shared across the extension.
 
 ### Webview Consistency Patterns
 
@@ -333,7 +344,10 @@ See `docs/pocketflow/` for full framework documentation.
 
 ### Source Organization
 
-Commands live under `src/commands/` and are grouped by domain. Key folders include `agent/` for agent lifecycle and merge commands, `housekeeping/` for cleanup and packaging, `latex/` for LaTeX document tasks, `settings/` for settings view commands, and `system/` for editor helpers along with XML/YAML utilities. This structure keeps each area focused and aligns with the design philosophy of deep modules.
+VS Code commands live under `packages/extension/src/commands/` and are grouped by domain. Key folders include
+`agent/` for agent lifecycle and merge commands, `housekeeping/` for cleanup and packaging, `latex/` for
+LaTeX document tasks, `settings/` for settings view commands, and `system/` for editor helpers along with
+XML/YAML utilities. This structure keeps each area focused and aligns with the design philosophy of deep modules.
 
 ## Design and refactoring
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ npm run package:fast
 npm run build:fast
 # Creates: releases/texra-{version}.vsix
 
+# Build both the desktop app and VSIX, then verify release artifacts
+npm run build:initial
+
 # Run linting only
 npm run lint
 
@@ -46,6 +49,7 @@ The project supports fast builds using esbuild (for the extension host) and Vite
 - `npm run watch:fast` - Watch mode for development
 - `npm run package:fast` - Production build
 - `npm run build:fast` - Build VSIX extension file
+- `npm run build:initial` - Build desktop plus VSIX artifacts and verify both
 
 These commands are significantly faster and do not require increased memory allocation.
 
@@ -70,14 +74,25 @@ npm run package
 
 ### Agent System
 
-The core of TeXRA is its agent architecture in `src/agent/`:
+The core of TeXRA is its agent architecture in repo-root `src/agent/`:
 
 - **Core interfaces** define agent behavior and state management
 - **Implementations** provide reasoning strategies (Direct, Chain-of-Thought, Merge, Workflow)
 - **Model handlers** abstract AI provider APIs (Anthropic, OpenAI, Google, etc.)
-- Agents are configured via YAML files in `resources/agents/`
+- Agents are configured via YAML files in `packages/extension/resources/agents/`
 
 `_multiple` YAML files provide alternate prompts for agents supporting multiple outputs. This preference only applies to the initial agent; parent definitions via `inherits` use base files.
+
+### Workspace Layout
+
+This repository is a pnpm workspace:
+
+- Repo-root `src/` holds host-agnostic core logic, platform interfaces, shared schemas, and test harness code.
+- `packages/extension/` holds the VS Code extension entrypoint, commands, webviews, and packaged resources.
+- `packages/desktop/` holds the Electron desktop shell and adapters around the shared core.
+- `packages/core/` exposes the shared core package surface for workspace consumers.
+- `src/hosts/` defines host capability ports used by both VS Code and Electron integrations.
+- `src/test-kernel/` contains Vitest suites for host-neutral and Electron-facing behavior.
 
 ### Source Organization
 
@@ -86,30 +101,36 @@ Key directories in `src/`:
 - `agent/` - Agent core, implementations, model handlers, runtime, toolUse, output, storage, remote, node
   - `implementations/flows/` - PocketFlow-based flow implementations (reflection, tooluse)
 - `platform/` - Platform abstraction layer (composition root). Hosts (VS Code, future CLI/Electron) call `initPlatform()` once at startup; core code accesses host services via `platform()` from `@platform`. See `src/platform/platform.ts`.
-- `commands/` - Commands organized by domain (see below)
 - `common/` - Backend-only helpers (errors, state, files, webview base classes)
-- `frontend/` - Extension-host utilities for shared UI flows
 - `utils/` - Utilities shared between extension host and webviews
 - `tools/` - Tool implementations for tool-use agents
 - `model/` - Model configuration, registry, and providers
 - `latex/` - LaTeX processing (formatting, diff, TikZ, PDF)
-- `webview/` - Main agent interaction interface
-- `progressView/` - Task tracking board
-- `settingsView/` - Unified settings webview (History, Memory, Models, Agents, Multi-Agent, LaTeX, Tools tabs)
 - `shared/` - Shared schemas and message handlers across webviews
 - `auth/` - Authentication logic
 - `housekeeping/` - Cleanup and packing operations
-- `types/` - Shared type definitions
+- `hosts/` - Host capability interfaces for clipboard, prompts, terminals, diff views, and openers
 - `logger/` - Logging infrastructure
 - `eventBus/` - Progress event system
 - `replacement/` - Text cleanup rules
 - `test/` - Mocha test suites (do NOT run via `npm test`; see Development Commands)
+- `test-kernel/` - Vitest suites for host-neutral and Electron-facing logic
+
+Key directories in `packages/extension/`:
+
+- `packages/extension/src/extension.ts` - VS Code extension entry point
+- `packages/extension/src/commands/` - VS Code commands organized by domain (see below)
+- `packages/extension/src/frontend/` - Extension-host utilities for shared UI flows
+- `packages/extension/src/webview/` - Main agent interaction interface
+- `packages/extension/src/progressView/` - Task tracking board
+- `packages/extension/src/settingsView/` - Unified settings webview (History, Memory, Models, Agents, Multi-Agent, LaTeX, Tools tabs)
+- `packages/extension/resources/` - Packaged agents, tool-use agents, docs, templates, examples, and extension assets
 
 Key documentation in `docs/`:
 
 - `pocketflow/` - PocketFlow framework documentation (core abstractions, design patterns, utility functions)
 
-### Commands (`src/commands/`)
+### Commands (`packages/extension/src/commands/`)
 
 - `agent/` - Running and managing agents, merge operations
 - `api/` - API key management
@@ -265,20 +286,20 @@ For good separation of concerns, testability, and platform independence, core bu
 - `src/shared/` (IPC schemas, message types)
 - `src/replacement/` (text cleanup rules)
 - `src/eventBus/` (progress event system)
-- Webview frontends (`src/webview/frontend/`, `src/progressView/frontend/`, `src/settingsView/frontend/`)
+- Webview frontends (`packages/extension/src/webview/frontend/`, `packages/extension/src/progressView/frontend/`, `packages/extension/src/settingsView/frontend/`)
 
 **VS Code-allowed zones** — platform-specific wiring belongs here:
 
-- `src/extension.ts` (entry point — calls `initPlatform()` exactly once with the VS Code-backed services)
+- `packages/extension/src/extension.ts` (entry point — calls `initPlatform()` exactly once with the VS Code-backed services)
 - `src/platform/` interfaces themselves (interface definitions; concrete VS Code implementations are wired from `extension.ts`)
-- `src/commands/` (VS Code command handlers)
-- `src/frontend/` (VS Code UI utilities)
+- `packages/extension/src/commands/` (VS Code command handlers)
+- `packages/extension/src/frontend/` (VS Code UI utilities)
 - `src/common/webview/` (webview base classes)
 - `src/common/state/` (state managers backed by VS Code Memento)
 - `src/utils/config/` (wraps `vscode.workspace.getConfiguration`)
 - `src/utils/files/workspaceFS.ts`, `storageFS.ts` (wraps `vscode.workspace.fs`)
 - `src/auth/` (authentication providers)
-- `src/logger/LogChannelRegistry.ts` (creates `vscode.OutputChannel`)
+- VS Code logging output-channel creation belongs in the extension-host wiring, not in repo-root logger modules.
 
 **Patterns for keeping code platform-agnostic:**
 
@@ -302,13 +323,13 @@ Common aliases (full list in `tsconfig.json`):
 
 ### New Command
 
-1. Create file in appropriate `src/commands/` subdirectory
+1. Create file in appropriate `packages/extension/src/commands/` subdirectory
 2. Export command function following existing patterns
-3. Register in `src/commands.ts`
+3. Register in `packages/extension/src/commands.ts`
 
 ### New Agent
 
-1. Create YAML definition in `resources/agents/`
+1. Create YAML definition in `packages/extension/resources/agents/`
 2. If needed, implement new agent type in `src/agent/implementations/`
 
 ### New Model Provider


### PR DESCRIPTION
## Summary
- update CLAUDE.md and AGENTS.md to distinguish repo-root core paths from packages/extension paths
- document the pnpm workspace layout, src/hosts, src/test-kernel, and build:initial
- refresh the optional review checklist entrypoint path

Closes #3447.

## Validation
- corepack pnpm install
- git diff --check origin/main...HEAD
- corepack pnpm exec prettier --check CLAUDE.md AGENTS.md .claude/skills/code-review/references/review-checklist.md
- focused stale-path grep for repo-root extension/resource paths
- path-existence audit for documented concrete paths
- npm run lint
- npm run compile:fast

## Scope
- This PR now owns documentation/path guidance only. Shared SDK/provider/package-verifier changes remain owned by #3596.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior. Main risk is minor confusion if any referenced paths are still incorrect.
> 
> **Overview**
> Clarifies the pnpm workspace/monorepo layout across `CLAUDE.md` and `AGENTS.md`, explicitly distinguishing repo-root core code (`src/`) from VS Code extension code and resources under `packages/extension/`.
> 
> Documents `npm run build:initial` and refreshes multiple path references (commands, webviews, frontend helpers, agent/resource locations), plus updates the code-review checklist to treat `packages/extension/src/extension.ts` as the sole `initPlatform()` entry point and removes stale logging-output guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bd073f639859fe83c8eba68933484f5b6edb7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->