### PR TITLE
[codex] Route output progress through runtime host

### DIFF
--- a/packages/desktop/esbuild.main.mjs
+++ b/packages/desktop/esbuild.main.mjs
@@ -4,12 +4,14 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const outdir = resolve(__dirname, 'dist/main');
+const outdir = 'dist/main';
+const outdirPath = resolve(__dirname, outdir);
 
-await rm(outdir, { force: true, recursive: true });
+await rm(outdirPath, { force: true, recursive: true });
 
 const result = await esbuild.build({
-  entryPoints: { index: resolve(__dirname, 'src/main/bootstrap.ts') },
+  absWorkingDir: __dirname,
+  entryPoints: { index: 'src/main/bootstrap.ts' },
   bundle: true,
   platform: 'node',
   format: 'esm',
@@ -18,7 +20,7 @@ const result = await esbuild.build({
   outdir,
   chunkNames: 'chunks/[name]-[hash]',
   external: ['electron', 'fsevents'],
-  tsconfig: resolve(__dirname, 'tsconfig.main.json'),
+  tsconfig: 'tsconfig.main.json',
   target: 'node22',
   banner: {
     js:
@@ -27,8 +29,8 @@ const result = await esbuild.build({
   },
 });
 
-await mkdir(outdir, { recursive: true });
+await mkdir(outdirPath, { recursive: true });
 await writeFile(
-  resolve(outdir, 'metafile.json'),
+  resolve(outdirPath, 'metafile.json'),
   `${JSON.stringify(result.metafile, null, 2)}\n`,
 );

--- a/scripts/desktop-package-metafile-paths.mjs
+++ b/scripts/desktop-package-metafile-paths.mjs
@@ -4,14 +4,23 @@ export function normalizeMetafilePath(path) {
   return path.replaceAll('\\', '/').replace(/^\.\//, '');
 }
 
+function isRelativeMetafileImportPath(path) {
+  return (
+    path === '.' ||
+    path === '..' ||
+    path.startsWith('./') ||
+    path.startsWith('../')
+  );
+}
+
 export function resolveMetafileImportPath(outputPath, importPath) {
   const normalizedImportPath = importPath.replaceAll('\\', '/');
-  if (normalizedImportPath.startsWith('.')) {
+  if (isRelativeMetafileImportPath(normalizedImportPath)) {
     return normalizeMetafilePath(
       posix.normalize(
         posix.join(posix.dirname(outputPath), normalizedImportPath),
       ),
     );
   }
-  return posix.normalize(normalizedImportPath);
+  return normalizeMetafilePath(posix.normalize(normalizedImportPath));
 }

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -89,6 +89,10 @@ const desktopStartupEntryPoints = new Set([
   'src/main/bootstrap.ts',
   'src/main/index.ts',
 ]);
+const desktopStartupImportKinds = new Set([
+  'dynamic-import',
+  'import-statement',
+]);
 
 async function exists(path) {
   try {
@@ -163,6 +167,19 @@ function mergeDirectoryEntries(...entryGroups) {
   return [...new Set(entryGroups.flat())].sort((left, right) =>
     left.localeCompare(right),
   );
+}
+
+function isDesktopStartupEntryPoint(entryPoint) {
+  const normalizedEntryPoint = normalizeMetafilePath(entryPoint);
+  for (const expectedEntryPoint of desktopStartupEntryPoints) {
+    if (
+      normalizedEntryPoint === expectedEntryPoint ||
+      normalizedEntryPoint.endsWith(`/${expectedEntryPoint}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function createAsarAppReader(asarPath) {
@@ -360,8 +377,9 @@ async function checkDesktopStartupBundles(app, failures) {
 
   const pending = [];
   for (const [outputPath, output] of outputByPath) {
-    const entryPoint = normalizeMetafilePath(output.entryPoint ?? '');
-    if (desktopStartupEntryPoints.has(entryPoint)) pending.push(outputPath);
+    if (isDesktopStartupEntryPoint(output.entryPoint ?? '')) {
+      pending.push(outputPath);
+    }
   }
   if (pending.length === 0) {
     failures.push(
@@ -401,7 +419,7 @@ async function checkDesktopStartupBundles(app, failures) {
 
     for (const importedOutput of output.imports ?? []) {
       if (importedOutput.external) continue;
-      if (importedOutput.kind !== 'import-statement') continue;
+      if (!desktopStartupImportKinds.has(importedOutput.kind)) continue;
       const importedPath = resolveMetafileImportPath(
         outputPath,
         importedOutput.path,

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -89,6 +89,9 @@ const desktopStartupEntryPoints = new Set([
   'src/main/bootstrap.ts',
   'src/main/index.ts',
 ]);
+const desktopStartupDynamicImportEntryPoints = new Set([
+  'src/main/bootstrap.ts',
+]);
 const desktopStartupImportKinds = new Set([
   'dynamic-import',
   'import-statement',
@@ -171,7 +174,17 @@ function mergeDirectoryEntries(...entryGroups) {
 
 function isDesktopStartupEntryPoint(entryPoint) {
   const normalizedEntryPoint = normalizeMetafilePath(entryPoint);
-  for (const expectedEntryPoint of desktopStartupEntryPoints) {
+  return hasMetafileEntryPointSuffix(
+    normalizedEntryPoint,
+    desktopStartupEntryPoints,
+  );
+}
+
+function hasMetafileEntryPointSuffix(
+  normalizedEntryPoint,
+  expectedEntryPoints,
+) {
+  for (const expectedEntryPoint of expectedEntryPoints) {
     if (
       normalizedEntryPoint === expectedEntryPoint ||
       normalizedEntryPoint.endsWith(`/${expectedEntryPoint}`)
@@ -180,6 +193,17 @@ function isDesktopStartupEntryPoint(entryPoint) {
     }
   }
   return false;
+}
+
+function shouldTraverseStartupImport(output, importedOutput) {
+  if (importedOutput.external) return false;
+  if (importedOutput.kind === 'import-statement') return true;
+  if (importedOutput.kind !== 'dynamic-import') return false;
+
+  return hasMetafileEntryPointSuffix(
+    normalizeMetafilePath(output.entryPoint ?? ''),
+    desktopStartupDynamicImportEntryPoints,
+  );
 }
 
 function createAsarAppReader(asarPath) {
@@ -418,8 +442,8 @@ async function checkDesktopStartupBundles(app, failures) {
     }
 
     for (const importedOutput of output.imports ?? []) {
-      if (importedOutput.external) continue;
       if (!desktopStartupImportKinds.has(importedOutput.kind)) continue;
+      if (!shouldTraverseStartupImport(output, importedOutput)) continue;
       const importedPath = resolveMetafileImportPath(
         outputPath,
         importedOutput.path,

--- a/src/agent/implementations/flows/reflection/ReflectionServices.ts
+++ b/src/agent/implementations/flows/reflection/ReflectionServices.ts
@@ -3,6 +3,7 @@ import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { OutputState } from '@agent/output/outputState';
 import type { LatexDiffManager } from '@agent/output/LatexDiffManager';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { LatexMediaManager } from '@latex';
 import type { PromptBuilder } from '@utils/prompt';
 import type {
@@ -18,6 +19,7 @@ import type {
 export interface ReflectionServices<
   C = unknown,
 > extends BaseFlowContextInit<C> {
+  readonly runtimeHost: AgentRuntimeHost;
   readonly setting: AgentWorkflowSetting;
   readonly outputState: OutputState;
   readonly xmlManager: XmlOutputManager;

--- a/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
+++ b/src/agent/implementations/flows/reflection/nodes/OutputNode.ts
@@ -18,7 +18,6 @@ import {
 } from '@agent/output/roundSummary';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 import type { CompileFailure, RoundOutput } from '@shared/schemas';
 import type { AgentFileLocation, FileLocation } from '@utils/files';
 import { flexibleFS } from '@utils/files';
@@ -218,18 +217,18 @@ export class OutputNode<C = unknown> extends Node<
     prepRes: OutputPrepInput,
     execRes: OutputExecResult,
   ): Promise<string | undefined> {
-    const { streamId, logger, outputState } = this.services;
+    const { streamId, logger, outputState, runtimeHost } = this.services;
     const { outputLocation, currentRound, endTurn } = prepRes;
     const { summary, roundOutput } = execRes;
 
     // Emit output files event
-    bus.emit('addOutputFiles', {
+    runtimeHost.emit('addOutputFiles', {
       streamId,
       filesByRound: { [currentRound]: summary.fileInfos },
     });
 
     if (execRes.emitCompileFailures) {
-      bus.emit('updateCompileFailures', {
+      runtimeHost.emit('updateCompileFailures', {
         streamId,
         filesByRound: { [currentRound]: execRes.compileFailures },
       });
@@ -237,7 +236,7 @@ export class OutputNode<C = unknown> extends Node<
 
     // Open files that haven't been opened yet
     for (const location of summary.filesToOpen) {
-      bus.emit('requestOpenFile', { location, preserveFocus: true });
+      runtimeHost.emit('requestOpenFile', { location, preserveFocus: true });
     }
 
     // Validate expected outputs if turn ended
@@ -253,13 +252,13 @@ export class OutputNode<C = unknown> extends Node<
             summary.stage,
           );
 
-          bus.emit('updateMissingOutputs', {
+          runtimeHost.emit('updateMissingOutputs', {
             streamId,
             filesByRound: { [currentRound]: validationResult.missing },
           });
 
           if (validationResult.missing.length > 0) {
-            bus.emit('requestShowInstruction', {
+            runtimeHost.emit('requestShowInstruction', {
               key: 'missingOutputsInfo',
               message: 'Missing output files detected',
             });

--- a/src/agent/implementations/flows/reflection/runReflectionFlow.ts
+++ b/src/agent/implementations/flows/reflection/runReflectionFlow.ts
@@ -23,6 +23,7 @@ import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
 import { flowKey, type FlowRecord } from '@agent/node/persistedFlow';
 import { RoundPersistedFlow } from '@agent/node/roundPersistedFlow';
 import type { UsageMonitor } from '@agent/utils/UsageMonitor';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { executionToEndStatus } from '@common/constants/streamStatus';
 import { LatexMediaManager } from '@latex';
 import type { AgentLogStage } from '@logger/AgentLogger';
@@ -105,6 +106,7 @@ export async function runReflectionFlow<C = unknown>(
     onRoundFinalized = async () => {},
     usageMonitor,
   } = input;
+  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
 
   let status: EndGroupStatus = END_GROUP_STATUS.STOPPED;
   let shared: ReflectionFlowShared | undefined;
@@ -182,7 +184,16 @@ export async function runReflectionFlow<C = unknown>(
 
   setActiveRun(
     outputState,
-    { setting, config, baseFiles, logger, fileService, executionId, streamId },
+    {
+      setting,
+      config,
+      baseFiles,
+      logger,
+      fileService,
+      executionId,
+      streamId,
+      runtimeHost,
+    },
     storageKey,
   );
 
@@ -260,6 +271,7 @@ export async function runReflectionFlow<C = unknown>(
 
     services = {
       ...input,
+      runtimeHost,
       onRoundFinalized,
       outputState,
       xmlManager,

--- a/src/agent/implementations/flows/tooluse/ToolUseServices.ts
+++ b/src/agent/implementations/flows/tooluse/ToolUseServices.ts
@@ -1,6 +1,7 @@
 import type { AgentToolUseSetting } from '@agent/core/AgentDataclass';
 import type { RoundFinalizedCallback } from '@agent/core/flows/CycleServices';
 import type { IToolRegistry } from '@agent/core/ToolTypes';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { ToolDefinition } from '@model';
 import type { SubagentProgressUpdate, TodoItem } from '@shared/schemas';
 import type {
@@ -11,6 +12,7 @@ import type { IToolUseSession } from './ToolUseSessionLifecycle';
 import type { ToolUseSessionSnapshot } from './ToolUseSessionTypes';
 
 export interface ToolUseServices<C = unknown> extends BaseFlowContextInit<C> {
+  readonly runtimeHost: AgentRuntimeHost;
   readonly setting: AgentToolUseSetting;
   readonly session: IToolUseSession;
   readonly resolvedTools: ToolDefinition[];

--- a/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
+++ b/src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts
@@ -7,7 +7,6 @@ import {
 } from '@agent/core/flows/ToolUseCycleFlow';
 import type { ProviderMessage } from '@agent/modelHandlers/types/ProviderMessage';
 import { formatProviderHttpError } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 
 import {
   type ToolUseRunShared,
@@ -42,17 +41,23 @@ export class ToolUseCycleNode<C> extends Node<
   }
 
   async exec(prepRes: CyclePrepResult): Promise<ToolUseCycleOutcome> {
-    const { streamId, setting, resolvedTools, modelHandler, config } =
-      this.services;
+    const {
+      streamId,
+      setting,
+      resolvedTools,
+      modelHandler,
+      config,
+      runtimeHost,
+    } = this.services;
 
     if (prepRes.shouldSkip) {
       const { todos } = prepRes.workspaceState.todos;
       const { plan } = prepRes.workspaceState.plan;
       if (todos.length) {
-        bus.emit('updateTodos', { streamId, todos });
+        runtimeHost.emit('updateTodos', { streamId, todos });
       }
       if (plan) {
-        bus.emit('updatePlan', { streamId, plan });
+        runtimeHost.emit('updatePlan', { streamId, plan });
       }
       return { outcome: 'skipped' };
     }
@@ -85,7 +90,7 @@ export class ToolUseCycleNode<C> extends Node<
     const { onProgress, persistTodos } = this.services;
     let todoPersistChain = Promise.resolve();
     prepRes.workspaceState.todos.setOnUpdate((todos) => {
-      bus.emit('updateTodos', { streamId, todos });
+      runtimeHost.emit('updateTodos', { streamId, todos });
       if (persistTodos) {
         todoPersistChain = todoPersistChain
           .then(() => persistTodos(todos))
@@ -94,7 +99,7 @@ export class ToolUseCycleNode<C> extends Node<
       onProgress?.({ kind: 'todos', todos });
     });
     prepRes.workspaceState.plan.setOnUpdate((plan) => {
-      bus.emit('updatePlan', { streamId, plan });
+      runtimeHost.emit('updatePlan', { streamId, plan });
       onProgress?.({ kind: 'plan', plan });
     });
 

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -75,6 +75,7 @@ export interface RunToolUseFlowResult {
 export interface ToolUseFlowContext {
   readonly session: ToolUseSessionLifecycle;
   readonly modelHandler: ToolUseServices['modelHandler'];
+  readonly runtimeHost: ToolUseServices['runtimeHost'];
   interrupt(): void;
 }
 
@@ -176,6 +177,7 @@ export async function runToolUseFlow<C = unknown>(
   const flowContext: ToolUseFlowContext = {
     session: sessionLifecycle,
     modelHandler: input.modelHandler,
+    runtimeHost,
     interrupt(): void {
       onInterrupt?.();
       retryCoordinator.clearRequest(streamId);

--- a/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
+++ b/src/agent/implementations/flows/tooluse/runToolUseFlow.ts
@@ -15,6 +15,7 @@ import type { IToolRegistry } from '@agent/core/ToolTypes';
 import type { BaseFlowContextInit } from '@agent/implementations/flows/common/BaseFlowServices';
 import { FlowTransition } from '@agent/core/flows/FlowTransitions';
 import { getGlobalState } from '@agent/core/stateStore';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { readNestedDelegationConfig } from '@agent/runtime/delegationPolicy';
 import { GlobalStateKey } from '@common/state/stateKeys';
 import { executionToEndStatus } from '@common/constants/streamStatus';
@@ -140,6 +141,7 @@ export async function runToolUseFlow<C = unknown>(
   onSetup?: ToolUseFlowSetupCallback,
 ): Promise<RunToolUseFlowResult> {
   const { logger, streamId, executionId, setting, onInterrupt } = input;
+  const runtimeHost = input.runtimeHost ?? getAgentRuntimeHost();
   const sessionLifecycle = new ToolUseSessionLifecycle(streamId);
   const registry = toolRegistry ?? getDefaultToolRegistry();
   const delegationDepth = input.delegationDepth ?? 0;
@@ -159,6 +161,7 @@ export async function runToolUseFlow<C = unknown>(
 
   const services: ToolUseServices<C> = {
     ...input,
+    runtimeHost,
     session: sessionLifecycle,
     resolvedTools,
     toolRegistry: registry,

--- a/src/agent/output/OutputFileProcessor.ts
+++ b/src/agent/output/OutputFileProcessor.ts
@@ -1,6 +1,6 @@
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
 import {
   MESSAGE_TYPES,
@@ -22,6 +22,7 @@ export interface ProcessingContext {
   agentSetting: AgentWorkflowSetting;
   baseFiles: FileLocation[];
   streamId: string;
+  runtimeHost: AgentRuntimeHost;
   logger: AgentLogger;
   xmlManager: XmlOutputManager;
   setRoundOutputs: (round: number, outputs: OutputFileInfo[]) => void;
@@ -134,7 +135,7 @@ export class OutputFileProcessor {
         documentTag: agentSetting.documentTag,
       };
       logger.missingOutputs(missingOutputsData);
-      bus.emit('updateMissingOutputs', {
+      this.ctx.runtimeHost.emit('updateMissingOutputs', {
         streamId: this.ctx.streamId,
         filesByRound: { [currRound]: [] },
       });

--- a/src/agent/output/outputState.ts
+++ b/src/agent/output/outputState.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentWorkflowSetting } from '@agent/core/AgentDataclass';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { normalizeRunId } from '@common/constants/runIds';
 import type { AgentLogger, AgentLogStage } from '@logger/AgentLogger';
 import {
@@ -51,6 +52,7 @@ export interface OutputDependencies {
   fileService: TaskRunFileService;
   executionId: string;
   streamId: string;
+  runtimeHost: AgentRuntimeHost;
 }
 
 export function createOutputState(): OutputState {

--- a/src/agent/output/xmlExtraction.ts
+++ b/src/agent/output/xmlExtraction.ts
@@ -77,6 +77,7 @@ export async function extractFilesFromXml(
         agentSetting: deps.setting,
         baseFiles: deps.baseFiles,
         streamId: deps.streamId,
+        runtimeHost: deps.runtimeHost,
         logger: deps.logger,
         xmlManager,
         setRoundOutputs: (round: number, outputs) => {

--- a/src/agent/toolUse/ToolFileInteractionContext.ts
+++ b/src/agent/toolUse/ToolFileInteractionContext.ts
@@ -4,7 +4,10 @@ import type {
   PlanState,
   TodoState,
 } from '@agent/core/AgentWorkspaceState';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import type { ExecutionId, StreamTabId } from '@shared/schemas';
 import type { NestedDelegationConfig } from '@shared/constants/delegationPolicy';
 
@@ -70,4 +73,10 @@ export function getCurrentToolFileInteractionContext():
   | ToolFileInteractionContext
   | undefined {
   return contextStack.at(-1);
+}
+
+export function getCurrentToolRuntimeHost(): AgentRuntimeHost {
+  return (
+    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
+  );
 }

--- a/src/agent/toolUse/ToolUseFollowUp.ts
+++ b/src/agent/toolUse/ToolUseFollowUp.ts
@@ -13,7 +13,6 @@
 import { getActiveChildren } from '@agent/runtime/executionRegistry';
 import { getToolUseFlowContext } from '@agent/toolUse/ToolUseAgentRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import { STREAM_STATUS, type StreamTabId } from '@shared/schemas';
 import { ToolUseFollowUpQueue } from './ToolUseFollowUpQueueManager';
@@ -50,7 +49,7 @@ export async function sendFollowUp(
   if (flowContext) {
     flowContext.session.appendFollowUp(text);
     // Notify blocking tools (e.g. ExecutionsTool wait) so they can abort early
-    bus.emit('followUpSent', { streamId });
+    flowContext.runtimeHost.emit('followUpSent', { streamId });
     return { status: 'sent' };
   }
 

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -11,9 +11,7 @@ import {
   type ProcessingContext,
 } from '@agent/output/OutputFileProcessor';
 import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { normalizeRunId } from '@common/constants/runIds';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { AgentLogger } from '@logger/AgentLogger';
 import type {
   AgentFileLocation,
@@ -22,24 +20,7 @@ import type {
   OutputXmlSummary,
   RoundOutput,
 } from '@shared/schemas';
-
-type RecordedEvent = {
-  event: keyof ProgressEventPayloads;
-  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
-};
-
-function createRecordingHost(): {
-  events: RecordedEvent[];
-  host: AgentRuntimeHost;
-} {
-  const events: RecordedEvent[] = [];
-  return {
-    events,
-    host: {
-      emit: (event, payload) => events.push({ event, payload }),
-    },
-  };
-}
+import { createRecordingHost } from '../progressTestUtils';
 
 function createLocation(path: string): FileLocation {
   return { kind: 'external', absolutePath: path };

--- a/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/output/OutputProgressEvents.vitest.ts
@@ -1,0 +1,183 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { OutputNode } from '@agent/implementations/flows/reflection/nodes/OutputNode';
+import type { ReflectionServices } from '@agent/implementations/flows/reflection/ReflectionServices';
+import { createOutputState, type RoundData } from '@agent/output/outputState';
+import {
+  OutputFileProcessor,
+  type ProcessingContext,
+} from '@agent/output/OutputFileProcessor';
+import type { XmlOutputManager } from '@agent/output/XmlOutputManager';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { normalizeRunId } from '@common/constants/runIds';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { AgentLogger } from '@logger/AgentLogger';
+import type {
+  AgentFileLocation,
+  FileLocation,
+  OutputFileInfo,
+  OutputXmlSummary,
+  RoundOutput,
+} from '@shared/schemas';
+
+type RecordedEvent = {
+  event: keyof ProgressEventPayloads;
+  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+};
+
+function createRecordingHost(): {
+  events: RecordedEvent[];
+  host: AgentRuntimeHost;
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    host: {
+      emit: (event, payload) => events.push({ event, payload }),
+    },
+  };
+}
+
+function createLocation(path: string): FileLocation {
+  return { kind: 'external', absolutePath: path };
+}
+
+function createAgentLocation(path: string): AgentFileLocation {
+  return { kind: 'workspace', absolutePath: path, relativePath: path };
+}
+
+const emptyXmlSummary: OutputXmlSummary = {
+  tagContents: {},
+  documents: [],
+  singleOutputFile: null,
+  sourceLocation: null,
+};
+
+describe('output progress events', () => {
+  it('publishes reflection output-node events through the runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const outputNode = new OutputNode().setServices({
+      streamId: 'stream:output-node',
+      logger: { warn: () => {} },
+      outputState: createOutputState(),
+      runtimeHost: host,
+    } as unknown as ReflectionServices);
+    const outputLocation = createAgentLocation('/tmp/output.xml');
+    const openedLocation = createLocation('/tmp/rendered.tex');
+    const fileInfo: OutputFileInfo = {
+      source: 'document',
+      location: openedLocation,
+      round: 2,
+      lineage: null,
+      diff: null,
+    };
+    const roundOutput: RoundOutput = {
+      round: 2,
+      rawOutput: outputLocation,
+      outputs: [fileInfo],
+      compileFailures: [],
+      xmlSummary: emptyXmlSummary,
+    };
+
+    const transition = await outputNode.post(
+      { roundOutputs: [] } as never,
+      {
+        outputLocation,
+        currentRound: 2,
+        endTurn: false,
+      },
+      {
+        roundOutput,
+        summary: {
+          storageKey: normalizeRunId('run:output-node'),
+          currRound: 2,
+          fileInfos: [fileInfo],
+          filesToOpen: [openedLocation],
+          outputFile: outputLocation,
+          endTurn: false,
+        },
+        compileFailures: [],
+        emitCompileFailures: false,
+      },
+    );
+
+    expect(transition).toBe('default');
+    expect(events).toEqual([
+      {
+        event: 'addOutputFiles',
+        payload: {
+          streamId: 'stream:output-node',
+          filesByRound: { 2: [fileInfo] },
+        },
+      },
+      {
+        event: 'requestOpenFile',
+        payload: { location: openedLocation, preserveFocus: true },
+      },
+    ]);
+  });
+
+  it('publishes missing-output processing events through the runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const roundData = new Map<number, RoundData>();
+    const logger = {
+      debug: () => {},
+      missingOutputs: () => {},
+    } as unknown as AgentLogger;
+    const xmlManager = {
+      processSingleXmlOutput: async () => {
+        throw new Error('invalid xml');
+      },
+    } as unknown as XmlOutputManager;
+    const ensureRound = (round: number): RoundData => {
+      let data = roundData.get(round);
+      if (!data) {
+        data = {
+          outputs: [],
+          compileFailures: [],
+          rawOutput: null,
+          xmlSummary: emptyXmlSummary,
+        };
+        roundData.set(round, data);
+      }
+      return data;
+    };
+    const setRoundOutputs = (round: number, outputs: OutputFileInfo[]) => {
+      const data = ensureRound(round);
+      data.outputs = outputs;
+    };
+    const context: ProcessingContext = {
+      agentSetting: {
+        agentCategory: AgentCategory.Workflow,
+        documentTag: 'latex_document',
+      } as ProcessingContext['agentSetting'],
+      baseFiles: [],
+      streamId: 'stream:processor',
+      runtimeHost: host,
+      logger,
+      xmlManager,
+      setRoundOutputs,
+      ensureRoundData: ensureRound,
+    };
+
+    await new OutputFileProcessor(context).processSingleOutput(
+      createLocation('/tmp/broken-output.xml'),
+      3,
+      createLocation('/tmp/raw-output.xml'),
+    );
+
+    expect(events).toEqual([
+      {
+        event: 'updateMissingOutputs',
+        payload: {
+          streamId: 'stream:processor',
+          filesByRound: { 3: [] },
+        },
+      },
+    ]);
+    expect(roundData.get(3)?.outputs).toEqual([]);
+  });
+});

--- a/src/test-kernel/agent/progressTestUtils.ts
+++ b/src/test-kernel/agent/progressTestUtils.ts
@@ -1,0 +1,21 @@
+// Local imports
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export type RecordedProgressEvent = {
+  event: keyof ProgressEventPayloads;
+  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+};
+
+export function createRecordingHost(): {
+  events: RecordedProgressEvent[];
+  host: AgentRuntimeHost;
+} {
+  const events: RecordedProgressEvent[] = [];
+  return {
+    events,
+    host: {
+      emit: (event, payload) => events.push({ event, payload }),
+    },
+  };
+}

--- a/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts
@@ -1,0 +1,96 @@
+// Third-party imports
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Local imports
+import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import type { ExecutionId, StreamTabId } from '@shared/schemas';
+import { AcceptRunFilesTool } from '@tools/AcceptRunFilesTool';
+import {
+  cleanupAllApprovals,
+  setToolEditApprovalHandler,
+} from '@tools/approval';
+import { flexibleFS, StorageFS, WorkspaceFS } from '@utils/files';
+import { createRecordingHost } from '../progressTestUtils';
+
+const executionId = 'abcdef' as ExecutionId;
+const streamId = 'stream:accept-run-files' as StreamTabId;
+const workspacePath = '/workspace';
+const storagePath = '/storage';
+
+describe('accept_run_files progress events', () => {
+  let originalStorageExists: typeof StorageFS.exists;
+  let originalStorageFullPath: typeof StorageFS.fullPath;
+  let originalWorkspaceLocatePath: typeof WorkspaceFS.locatePath;
+  let originalWorkspaceExists: typeof WorkspaceFS.exists;
+  let originalWorkspaceRead: typeof WorkspaceFS.read;
+  let originalWorkspaceWrite: typeof WorkspaceFS.write;
+  let originalWorkspaceDelete: typeof WorkspaceFS.delete;
+  let originalFlexibleRead: typeof flexibleFS.read;
+
+  beforeEach(() => {
+    originalStorageExists = StorageFS.exists;
+    originalStorageFullPath = StorageFS.fullPath;
+    originalWorkspaceLocatePath = WorkspaceFS.locatePath;
+    originalWorkspaceExists = WorkspaceFS.exists;
+    originalWorkspaceRead = WorkspaceFS.read;
+    originalWorkspaceWrite = WorkspaceFS.write;
+    originalWorkspaceDelete = WorkspaceFS.delete;
+    originalFlexibleRead = flexibleFS.read;
+    cleanupAllApprovals();
+  });
+
+  afterEach(() => {
+    StorageFS.exists = originalStorageExists;
+    StorageFS.fullPath = originalStorageFullPath;
+    WorkspaceFS.locatePath = originalWorkspaceLocatePath;
+    WorkspaceFS.exists = originalWorkspaceExists;
+    WorkspaceFS.read = originalWorkspaceRead;
+    WorkspaceFS.write = originalWorkspaceWrite;
+    WorkspaceFS.delete = originalWorkspaceDelete;
+    flexibleFS.read = originalFlexibleRead;
+    setToolEditApprovalHandler();
+    cleanupAllApprovals();
+  });
+
+  it('publishes accepted workspace files through the tool runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const tool = new AcceptRunFilesTool();
+
+    StorageFS.exists = async (target) =>
+      target === `executions/${executionId}` ||
+      target === `executions/${executionId}/output.tex`;
+    StorageFS.fullPath = (target) => `${storagePath}/${target}`;
+    WorkspaceFS.locatePath = (target) => ({
+      kind: 'workspace',
+      absolutePath: `${workspacePath}/${target}`,
+      relativePath: target,
+    });
+    WorkspaceFS.exists = async () => false;
+    WorkspaceFS.read = async () => '';
+    WorkspaceFS.write = async () => undefined;
+    WorkspaceFS.delete = async () => undefined;
+    flexibleFS.read = async () => 'accepted content';
+
+    setToolEditApprovalHandler(async () => ({ accepted: true }));
+
+    const result = await withToolFileInteractionContext(
+      {
+        streamId,
+        executionId,
+        runtimeHost: host,
+        tracker: {} as never,
+      },
+      () =>
+        tool.call({
+          execution_id: executionId,
+          files: [{ path: 'output.tex', original: 'paper.tex' }],
+        }),
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(events).toContainEqual({
+      event: 'workspaceFilesWritten',
+      payload: { absolutePaths: [`${workspacePath}/paper.tex`] },
+    });
+  });
+});

--- a/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts
@@ -1,0 +1,115 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import type { AgentConfig } from '@agent/core/AgentConfig';
+import { AgentCategory } from '@agent/core/AgentDataclass';
+import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import {
+  STREAM_STATUS,
+  type ExecutionId,
+  type StreamTabId,
+} from '@shared/schemas';
+import { createChildStream, finalizeChildStream } from '@tools/childStream';
+import { createRecordingHost } from '../progressTestUtils';
+
+const executionId = 'exec:child-stream' as ExecutionId;
+const parentStreamId = 'stream:parent' as StreamTabId;
+const childStreamId = 'bash#exec:child-stream' as StreamTabId;
+const config = {
+  agentCategory: AgentCategory.ToolUse,
+  model: 'test-model',
+  agent: 'test-agent',
+} as unknown as AgentConfig;
+
+describe('child stream progress events', () => {
+  it('publishes child stream lifecycle events through the tool runtime host', async () => {
+    const { events, host } = createRecordingHost();
+
+    await withToolFileInteractionContext(
+      {
+        streamId: parentStreamId,
+        executionId,
+        runtimeHost: host,
+        tracker: {} as never,
+      },
+      () => {
+        const { childStreamId: actualChildStreamId, logger } =
+          createChildStream(executionId, parentStreamId, {
+            streamPrefix: 'bash',
+            streamCategory: AgentCategory.ToolUse,
+            agentName: 'test-agent',
+            description: 'Run a background bash command',
+            config,
+            toolName: 'bash',
+          });
+
+        expect(actualChildStreamId).toBe(childStreamId);
+
+        finalizeChildStream(childStreamId, executionId, logger, {
+          autoClose: true,
+        });
+      },
+    );
+
+    expect(events.map((entry) => entry.event)).toEqual([
+      'updateStreamStatus',
+      'setActiveStream',
+      'setTaskState',
+      'updateStreamDescription',
+      'updateActiveSubagents',
+      'setParentStream',
+      'updateStreamStatus',
+      'updateActiveSubagents',
+      'updateActiveSubagents',
+      'removeStream',
+    ]);
+    expect(events[0]).toEqual({
+      event: 'updateStreamStatus',
+      payload: {
+        streamId: childStreamId,
+        status: STREAM_STATUS.RUNNING,
+        previousStatus: STREAM_STATUS.READY,
+      },
+    });
+    expect(events[2]).toEqual({
+      event: 'setTaskState',
+      payload: {
+        streamId: childStreamId,
+        executionId,
+        taskState: {
+          agentConfig: config,
+          toolSessionState: {},
+        },
+      },
+    });
+    expect(events[4].payload).toEqual({
+      parentStreamId,
+      children: [
+        expect.objectContaining({
+          executionId,
+          childStreamId,
+          agentName: 'test-agent',
+          status: STREAM_STATUS.RUNNING,
+          toolName: 'bash',
+        }),
+      ],
+    });
+    expect(events[6]).toEqual({
+      event: 'updateStreamStatus',
+      payload: {
+        streamId: childStreamId,
+        status: STREAM_STATUS.READY,
+        previousStatus: STREAM_STATUS.RUNNING,
+      },
+    });
+    expect(events[8]).toEqual({
+      event: 'updateActiveSubagents',
+      payload: { parentStreamId, children: [] },
+    });
+    expect(events[9]).toEqual({
+      event: 'removeStream',
+      payload: { streamId: childStreamId },
+    });
+  });
+});

--- a/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts
@@ -1,0 +1,112 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent
+import {
+  getDefaultAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+
+// Local imports - shared
+import type {
+  ExecutionId,
+  StreamTabId,
+  TodoItem,
+  TokenUsageStats,
+} from '@shared/schemas';
+
+// Local imports - tools
+import { publishCodexStreamUsage, publishCodexTodos } from '@tools/codex';
+
+// Local imports - test
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = 'stream:codex-child' as StreamTabId;
+const executionId = 'exec:codex-child' as ExecutionId;
+
+const todos: TodoItem[] = [
+  {
+    content: 'Route Codex progress through the runtime host',
+    status: 'pending',
+    activeForm: 'Routing Codex progress through the runtime host',
+  },
+];
+
+const usage: TokenUsageStats = {
+  inputTokens: 10,
+  outputTokens: 5,
+  cost: 0,
+};
+
+describe('codex progress events', () => {
+  it('publishes todos and usage through the active tool runtime host', async () => {
+    const active = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    setDefaultAgentRuntimeHost(fallback.host);
+
+    try {
+      await withToolFileInteractionContext(
+        {
+          streamId,
+          executionId,
+          runtimeHost: active.host,
+          tracker: {} as never,
+        },
+        () => {
+          publishCodexTodos(streamId, todos);
+          publishCodexStreamUsage(streamId, executionId, usage);
+        },
+      );
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+
+    expect(active.events).toEqual([
+      {
+        event: 'updateTodos',
+        payload: { streamId, todos },
+      },
+      {
+        event: 'updateStreamUsage',
+        payload: {
+          streamId,
+          storageKey: executionId,
+          executionId,
+          usage,
+        },
+      },
+    ]);
+    expect(fallback.events).toEqual([]);
+  });
+
+  it('falls back to the default agent runtime host without tool context', () => {
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    setDefaultAgentRuntimeHost(fallback.host);
+
+    try {
+      publishCodexTodos(streamId, todos);
+      publishCodexStreamUsage(streamId, executionId, usage);
+    } finally {
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+
+    expect(fallback.events).toEqual([
+      {
+        event: 'updateTodos',
+        payload: { streamId, todos },
+      },
+      {
+        event: 'updateStreamUsage',
+        payload: {
+          streamId,
+          storageKey: executionId,
+          executionId,
+          usage,
+        },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/GitHubSubscriptionProgressEvents.vitest.ts
@@ -1,0 +1,72 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - agent
+import {
+  getDefaultAgentRuntimeHost,
+  runWithAgentRuntimeHost,
+  setDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+
+// Local imports - event bus
+import { bus } from '@eventBus/ProgressEventBus';
+
+// Local imports - tools
+import { emitGitHubSubscriptionChanged } from '@tools/github/subscriptionEventEmitter';
+
+// Local imports - test
+import { createRecordingHost } from '../progressTestUtils';
+
+describe('GitHub subscription progress events', () => {
+  it('publishes binding changes to the bus and scoped runtime host', () => {
+    const active = createRecordingHost();
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const busEvents: unknown[] = [];
+    const off = bus.on('repoSubscriptionBindingsChanged', (payload) => {
+      busEvents.push(payload);
+    });
+    setDefaultAgentRuntimeHost(fallback.host);
+
+    try {
+      runWithAgentRuntimeHost(active.host, () => {
+        emitGitHubSubscriptionChanged(
+          'repoSubscriptionBindingsChanged',
+          undefined,
+        );
+      });
+    } finally {
+      off();
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+
+    expect(busEvents).toEqual([undefined]);
+    expect(active.events).toEqual([
+      { event: 'repoSubscriptionBindingsChanged', payload: undefined },
+    ]);
+    expect(fallback.events).toEqual([]);
+  });
+
+  it('does not duplicate binding changes through the default runtime host', () => {
+    const fallback = createRecordingHost();
+    const previousDefault = getDefaultAgentRuntimeHost();
+    const busEvents: unknown[] = [];
+    const off = bus.on('issueSubscriptionBindingsChanged', (payload) => {
+      busEvents.push(payload);
+    });
+    setDefaultAgentRuntimeHost(fallback.host);
+
+    try {
+      emitGitHubSubscriptionChanged(
+        'issueSubscriptionBindingsChanged',
+        undefined,
+      );
+    } finally {
+      off();
+      setDefaultAgentRuntimeHost(previousDefault);
+    }
+
+    expect(busEvents).toEqual([undefined]);
+    expect(fallback.events).toEqual([]);
+  });
+});

--- a/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts
@@ -1,0 +1,124 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports
+import { withToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import type { StreamTabId } from '@shared/schemas';
+import {
+  handleProgressViewBashApprovalAction,
+  requestBashApproval,
+} from '@tools/approval/bashApproval';
+import {
+  ExternalInquiryTool,
+  handleExternalInquiryAction,
+} from '@tools/inquiry/ExternalInquiryTool';
+import { createRecordingHost } from '../progressTestUtils';
+
+async function waitForRecordedEvent<TEvent extends string>(
+  events: Array<{ event: TEvent; payload: unknown }>,
+  eventName: TEvent,
+): Promise<{ event: TEvent; payload: any }> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const event = events.find((entry) => entry.event === eventName);
+    if (event) return event;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`Timed out waiting for ${eventName}`);
+}
+
+describe('human prompt progress events', () => {
+  it('publishes bash approval events through the tool runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const streamId = 'stream:bash-approval' as StreamTabId;
+
+    const approval = withToolFileInteractionContext(
+      {
+        streamId,
+        runtimeHost: host,
+        tracker: {} as never,
+      },
+      () => requestBashApproval({ command: 'echo hello' }),
+    );
+
+    const show = await waitForRecordedEvent(events, 'showBashPermission');
+    await handleProgressViewBashApprovalAction({
+      requestId: show.payload.requestId,
+      action: 'approve',
+    });
+
+    await expect(approval).resolves.toMatchObject({ accepted: true });
+
+    expect(events).toEqual([
+      { event: 'requestEnsureProgressView', payload: {} },
+      { event: 'setActiveStream', payload: { streamId } },
+      {
+        event: 'showBashPermission',
+        payload: {
+          requestId: show.payload.requestId,
+          command: 'echo hello',
+          allowBypass: true,
+          streamId,
+        },
+      },
+      {
+        event: 'resolveBashPermission',
+        payload: { requestId: show.payload.requestId },
+      },
+    ]);
+  });
+
+  it('publishes external inquiry events through the tool runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const streamId = 'stream:external-inquiry' as StreamTabId;
+    const tool = new ExternalInquiryTool();
+
+    const result = withToolFileInteractionContext(
+      {
+        streamId,
+        runtimeHost: host,
+        tracker: {} as never,
+      },
+      () =>
+        tool.call({
+          question: 'What should the agent check next?',
+          context: 'Runtime host boundary test',
+          suggestSearch: true,
+          attachFiles: ['notes.tex'],
+        }),
+    );
+
+    const show = await waitForRecordedEvent(events, 'showExternalInquiry');
+    await handleExternalInquiryAction({
+      requestId: show.payload.requestId,
+      action: 'skip',
+      feedback: 'Use local evidence instead.',
+    });
+
+    await expect(result).resolves.toMatchObject({
+      summary: 'User rejected external inquiry with feedback',
+    });
+
+    expect(events).toEqual([
+      { event: 'requestEnsureProgressView', payload: {} },
+      { event: 'setActiveStream', payload: { streamId } },
+      {
+        event: 'showExternalInquiry',
+        payload: {
+          requestId: show.payload.requestId,
+          question: 'What should the agent check next?',
+          threadId: undefined,
+          context: 'Runtime host boundary test',
+          suggestSearch: true,
+          attachFiles: ['notes.tex'],
+          sessionLinks: undefined,
+          allowBypass: false,
+          streamId,
+        },
+      },
+      {
+        event: 'resolveExternalInquiry',
+        payload: { requestId: show.payload.requestId },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts
@@ -1,0 +1,43 @@
+// Third-party imports
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import type { ToolUseFlowContext } from '@agent/implementations/flows/tooluse';
+import {
+  registerInterruptible,
+  unregisterInterruptible,
+} from '@agent/toolUse/ToolUseAgentRegistry';
+import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
+import type { StreamTabId } from '@shared/schemas';
+import { createRecordingHost } from '../progressTestUtils';
+
+const streamId = 'stream:follow-up' as StreamTabId;
+
+describe('tool-use follow-up progress events', () => {
+  afterEach(() => {
+    unregisterInterruptible(streamId);
+  });
+
+  it('publishes sent follow-up events through the active runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const appendFollowUp = vi.fn();
+
+    registerInterruptible(streamId, {
+      session: { appendFollowUp },
+      modelHandler: {},
+      runtimeHost: host,
+      interrupt: vi.fn(),
+    } as unknown as ToolUseFlowContext);
+
+    const result = await sendFollowUp(streamId, 'please continue');
+
+    expect(result).toEqual({ status: 'sent' });
+    expect(appendFollowUp).toHaveBeenCalledWith('please continue');
+    expect(events).toEqual([
+      {
+        event: 'followUpSent',
+        payload: { streamId },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
@@ -6,27 +6,8 @@ import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
 import { ToolUseCycleNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseCycleNode';
 import type { CyclePrepResult } from '@agent/implementations/flows/tooluse/nodes/types';
 import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
-import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 import type { Plan, TodoItem } from '@shared/schemas';
-
-type RecordedEvent = {
-  event: keyof ProgressEventPayloads;
-  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
-};
-
-function createRecordingHost(): {
-  events: RecordedEvent[];
-  host: AgentRuntimeHost;
-} {
-  const events: RecordedEvent[] = [];
-  return {
-    events,
-    host: {
-      emit: (event, payload) => events.push({ event, payload }),
-    },
-  };
-}
+import { createRecordingHost } from '../progressTestUtils';
 
 const todo: TodoItem = {
   content: 'Wire progress events through runtime host',

--- a/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
+++ b/src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts
@@ -1,0 +1,97 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports
+import { AgentWorkspaceState } from '@agent/core/AgentWorkspaceState';
+import { ToolUseCycleNode } from '@agent/implementations/flows/tooluse/nodes/ToolUseCycleNode';
+import type { CyclePrepResult } from '@agent/implementations/flows/tooluse/nodes/types';
+import type { ToolUseServices } from '@agent/implementations/flows/tooluse/ToolUseServices';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import type { ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+import type { Plan, TodoItem } from '@shared/schemas';
+
+type RecordedEvent = {
+  event: keyof ProgressEventPayloads;
+  payload: ProgressEventPayloads[keyof ProgressEventPayloads];
+};
+
+function createRecordingHost(): {
+  events: RecordedEvent[];
+  host: AgentRuntimeHost;
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    events,
+    host: {
+      emit: (event, payload) => events.push({ event, payload }),
+    },
+  };
+}
+
+const todo: TodoItem = {
+  content: 'Wire progress events through runtime host',
+  status: 'in_progress',
+  activeForm: 'Wiring progress events',
+};
+
+const plan: Plan = {
+  summary: 'Move progress publication behind the runtime host',
+  steps: [
+    {
+      title: 'Replace bus events',
+      description: 'Publish tool-use cycle state through runtimeHost',
+      status: 'in_progress',
+      files: [],
+    },
+  ],
+};
+
+function createPrepResult(
+  workspaceState: AgentWorkspaceState,
+): CyclePrepResult {
+  return {
+    shouldSkip: true,
+    messages: [],
+    runState: { totalRounds: 0 } as CyclePrepResult['runState'],
+    workspaceState,
+    userChannels: {} as CyclePrepResult['userChannels'],
+  };
+}
+
+describe('tool-use progress events', () => {
+  it('publishes skipped-cycle todo and plan events through the runtime host', async () => {
+    const { events, host } = createRecordingHost();
+    const workspaceState = AgentWorkspaceState.create();
+    workspaceState.todos.updateTodos([todo]);
+    workspaceState.plan.updatePlan(plan);
+
+    const node = new ToolUseCycleNode().setServices({
+      streamId: 'stream:tool-use-cycle',
+      runtimeHost: host,
+      modelHandler: { getClient: vi.fn() },
+      config: { model: 'test-model', agent: 'test-agent' },
+      setting: { tools: [] },
+      resolvedTools: [],
+    } as unknown as ToolUseServices);
+
+    const result = await node.exec(createPrepResult(workspaceState));
+
+    expect(result).toEqual({ outcome: 'skipped' });
+    expect(events).toEqual([
+      {
+        event: 'updateTodos',
+        payload: {
+          streamId: 'stream:tool-use-cycle',
+          todos: [todo],
+        },
+      },
+      {
+        event: 'updatePlan',
+        payload: {
+          streamId: 'stream:tool-use-cycle',
+          plan,
+        },
+      },
+    ]);
+  });
+});

--- a/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
+++ b/src/test-kernel/desktop/DesktopPackageVerifier.vitest.mts
@@ -39,6 +39,12 @@ describe('desktop package verifier metafile paths', () => {
       ),
     ).toBe('dist/main/chunks/provider.js');
   });
+
+  it('does not treat package-like dot-prefixed paths as relative imports', () => {
+    expect(
+      resolveMetafileImportPath('dist/main/index.js', '.pnpm/chunk.js'),
+    ).toBe('.pnpm/chunk.js');
+  });
 });
 
 describe('desktop package verifier target inference', () => {

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -15,9 +15,15 @@ import * as path from 'path';
 // Third-party imports
 import { z } from 'zod';
 
-// Local imports - shared
+// Local imports - agent
 import { getExecutionStore } from '@agent/storage';
-import { bus } from '@eventBus/ProgressEventBus';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+
+// Local imports - shared
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
 import { stripCriticizeAnnotations } from '@replacement/advanced';
 import { ExecutionIdSchema } from '@shared/schemas';
@@ -88,6 +94,12 @@ const AcceptRunFilesInputSchema = z.strictObject({
 });
 
 export type AcceptRunFilesInput = z.infer<typeof AcceptRunFilesInputSchema>;
+
+function getToolRuntimeHost(): AgentRuntimeHost {
+  return (
+    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
+  );
+}
 
 // ============================================================================
 // Tool Implementation
@@ -251,7 +263,7 @@ Optional:
 
     // Badge all accepted workspace files
     if (acceptedEntries.length > 0) {
-      bus.emit('workspaceFilesWritten', {
+      getToolRuntimeHost().emit('workspaceFilesWritten', {
         absolutePaths: acceptedEntries.map((e) => e.destAbsolutePath),
       });
     }

--- a/src/tools/AcceptRunFilesTool.ts
+++ b/src/tools/AcceptRunFilesTool.ts
@@ -17,11 +17,7 @@ import { z } from 'zod';
 
 // Local imports - agent
 import { getExecutionStore } from '@agent/storage';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { getCurrentToolRuntimeHost } from '@agent/toolUse/ToolFileInteractionContext';
 
 // Local imports - shared
 import { generateDiffFileName } from '@latex/latexdiff/diffFileNameManager';
@@ -94,12 +90,6 @@ const AcceptRunFilesInputSchema = z.strictObject({
 });
 
 export type AcceptRunFilesInput = z.infer<typeof AcceptRunFilesInputSchema>;
-
-function getToolRuntimeHost(): AgentRuntimeHost {
-  return (
-    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
-  );
-}
 
 // ============================================================================
 // Tool Implementation
@@ -263,7 +253,7 @@ Optional:
 
     // Badge all accepted workspace files
     if (acceptedEntries.length > 0) {
-      getToolRuntimeHost().emit('workspaceFilesWritten', {
+      getCurrentToolRuntimeHost().emit('workspaceFilesWritten', {
         absolutePaths: acceptedEntries.map((e) => e.destAbsolutePath),
       });
     }

--- a/src/tools/approval/bashApproval.ts
+++ b/src/tools/approval/bashApproval.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
-import { bus } from '@eventBus/ProgressEventBus';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import type { ToolResult } from '@tools/result';
 import { truncateWithEllipsis } from '@utils/text/stringUtils';
@@ -42,6 +45,7 @@ export async function requestBashApproval(
 
   const context = getCurrentToolFileInteractionContext();
   const streamId = request.streamId ?? context?.streamId;
+  const runtimeHost = context?.runtimeHost ?? getAgentRuntimeHost();
 
   if (
     !approvalsEnabled ||
@@ -51,13 +55,14 @@ export async function requestBashApproval(
   }
 
   return bashApprovalController.enqueue(() =>
-    showApprovalPrompt(request, streamId),
+    showApprovalPrompt(request, streamId, runtimeHost),
   );
 }
 
 async function showApprovalPrompt(
   request: BashApprovalRequest,
   streamId?: StreamTabId,
+  runtimeHost: AgentRuntimeHost = getAgentRuntimeHost(),
 ): Promise<BashApprovalResult> {
   if (streamId && isApprovalBypassedForStream(streamId)) {
     return { accepted: true };
@@ -80,14 +85,14 @@ async function showApprovalPrompt(
         isSettled: () => settled,
       });
 
-      bus.emit('requestEnsureProgressView', {});
+      runtimeHost.emit('requestEnsureProgressView', {});
 
       // Activate the stream that needs approval so user sees the prompt immediately
       if (streamId) {
-        bus.emit('setActiveStream', { streamId });
+        runtimeHost.emit('setActiveStream', { streamId });
       }
 
-      bus.emit('showBashPermission', {
+      runtimeHost.emit('showBashPermission', {
         requestId,
         command: request.command,
         allowBypass: true,
@@ -96,7 +101,7 @@ async function showApprovalPrompt(
     });
   } finally {
     bashApprovalController.unregisterPending(requestId);
-    bus.emit('resolveBashPermission', { requestId });
+    runtimeHost.emit('resolveBashPermission', { requestId });
   }
 }
 

--- a/src/tools/approval/proposalApproval.ts
+++ b/src/tools/approval/proposalApproval.ts
@@ -1,11 +1,11 @@
 /** Per-stream bypass state for agent delegation proposals. */
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { StreamTabId } from '@shared/schemas';
 
 const bypassedByStream = new Map<StreamTabId, boolean>();
 
 function notifyBypassState(streamId: StreamTabId): void {
-  bus.emit('updateSuperYoloBypassState', {
+  getAgentRuntimeHost().emit('updateSuperYoloBypassState', {
     streamId,
     bypassActive: bypassedByStream.get(streamId) ?? false,
   });

--- a/src/tools/approval/toolEditApproval.ts
+++ b/src/tools/approval/toolEditApproval.ts
@@ -6,9 +6,9 @@ import {
 } from 'diff-match-patch';
 import { z } from 'zod';
 
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { getConfig } from '@agent/core/config';
-import { bus } from '@eventBus/ProgressEventBus';
 import { StreamTabIdSchema, type StreamTabId } from '@shared/schemas';
 import {
   LineChangesSchema,
@@ -64,7 +64,7 @@ export const toolEditApprovalController =
   createStreamApprovalController<ToolEditApprovalResult>({
     rejectionResult: () => ({ accepted: false }),
     notifyBypassChange: (streamId, bypassActive) => {
-      bus.emit('updateToolEditApprovalBypassState', {
+      getAgentRuntimeHost().emit('updateToolEditApprovalBypassState', {
         streamId,
         bypassActive,
       });

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -1,10 +1,6 @@
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentCategory } from '@agent/core/AgentDataclass';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
@@ -12,7 +8,7 @@ import {
   trackExecution,
   untrackExecution,
 } from '@agent/runtime/executionRegistry';
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import { getCurrentToolRuntimeHost } from '@agent/toolUse/ToolFileInteractionContext';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
 // Local imports - errors
@@ -51,12 +47,6 @@ interface FinalizeChildStreamOptions {
   autoClose?: boolean;
 }
 
-function getToolRuntimeHost(): AgentRuntimeHost {
-  return (
-    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
-  );
-}
-
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
   executionId: ExecutionId,
@@ -64,7 +54,7 @@ export function createChildStream(
   options: CreateChildStreamOptions,
 ): { childStreamId: StreamTabId; logger: AgentLogger } {
   const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
-  const runtimeHost = getToolRuntimeHost();
+  const runtimeHost = getCurrentToolRuntimeHost();
 
   StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
     runtimeHost,
@@ -107,9 +97,7 @@ export function finalizeChildStream(
 ): void {
   const hasError = options?.error != null || options?.errorMessage != null;
   const runtimeHost =
-    getHandle(executionId)?.runtimeHost ??
-    getCurrentToolFileInteractionContext()?.runtimeHost ??
-    getAgentRuntimeHost();
+    getHandle(executionId)?.runtimeHost ?? getCurrentToolRuntimeHost();
 
   if (options?.errorMessage) {
     logger.error(options.errorMessage);

--- a/src/tools/childStream.ts
+++ b/src/tools/childStream.ts
@@ -1,17 +1,22 @@
 // Local imports - agent
 import type { AgentConfig } from '@agent/core/AgentConfig';
 import type { AgentCategory } from '@agent/core/AgentDataclass';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import {
   AgentExecutionHandle,
+  getHandle,
   trackExecution,
   untrackExecution,
 } from '@agent/runtime/executionRegistry';
+import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
 import { agentConfigToTaskState } from '@agent/utils/agentConfigToTaskState';
 
-// Local imports - event bus
+// Local imports - errors
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 
 // Local imports - logger
 import { AgentLogger } from '@logger/AgentLogger';
@@ -46,6 +51,12 @@ interface FinalizeChildStreamOptions {
   autoClose?: boolean;
 }
 
+function getToolRuntimeHost(): AgentRuntimeHost {
+  return (
+    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
+  );
+}
+
 /** Create a child stream tab and execution handle for a background child task. */
 export function createChildStream(
   executionId: ExecutionId,
@@ -53,18 +64,21 @@ export function createChildStream(
   options: CreateChildStreamOptions,
 ): { childStreamId: StreamTabId; logger: AgentLogger } {
   const childStreamId = `${options.streamPrefix}#${executionId}` as StreamTabId;
+  const runtimeHost = getToolRuntimeHost();
 
-  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING);
-  bus.emit('setActiveStream', {
+  StreamStatusService.set(childStreamId, STREAM_STATUS.RUNNING, {
+    runtimeHost,
+  });
+  runtimeHost.emit('setActiveStream', {
     streamId: childStreamId,
     agentCategory: options.streamCategory,
   });
-  bus.emit('setTaskState', {
+  runtimeHost.emit('setTaskState', {
     streamId: childStreamId,
     executionId,
     taskState: agentConfigToTaskState(options.config),
   });
-  bus.emit('updateStreamDescription', {
+  runtimeHost.emit('updateStreamDescription', {
     streamId: childStreamId,
     description: truncateWithEllipsis(options.description, 80),
   });
@@ -76,6 +90,7 @@ export function createChildStream(
     childStreamId,
     options.agentName,
     'toolUse',
+    runtimeHost,
   );
   if (options.toolName) handle.toolName = options.toolName;
   trackExecution(handle);
@@ -91,6 +106,10 @@ export function finalizeChildStream(
   options?: FinalizeChildStreamOptions,
 ): void {
   const hasError = options?.error != null || options?.errorMessage != null;
+  const runtimeHost =
+    getHandle(executionId)?.runtimeHost ??
+    getCurrentToolFileInteractionContext()?.runtimeHost ??
+    getAgentRuntimeHost();
 
   if (options?.errorMessage) {
     logger.error(options.errorMessage);
@@ -112,11 +131,12 @@ export function finalizeChildStream(
     StreamStatusService.set(
       childStreamId,
       hasError ? STREAM_STATUS.ERROR : STREAM_STATUS.READY,
+      { runtimeHost },
     );
   }
   untrackExecution(executionId);
 
   if (options?.autoClose) {
-    bus.emit('removeStream', { streamId: childStreamId });
+    runtimeHost.emit('removeStream', { streamId: childStreamId });
   }
 }

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -27,13 +27,13 @@ import {
   writeTerminalStatus,
 } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
-import {
-  getAgentRuntimeHost,
-  type AgentRuntimeHost,
-} from '@agent/runtime/AgentRuntimeHost';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
-import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
+import {
+  getCurrentToolFileInteractionContext,
+  getCurrentToolRuntimeHost,
+} from '@agent/toolUse/ToolFileInteractionContext';
 import {
   getInterruptible,
   registerInterruptible,
@@ -268,16 +268,10 @@ function formatCodexError(
 // Stream tab helpers
 // ============================================================================
 
-function getCodexToolRuntimeHost(): AgentRuntimeHost {
-  return (
-    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
-  );
-}
-
 export function publishCodexTodos(
   childStreamId: StreamTabId,
   todos: TodoItem[],
-  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
+  runtimeHost: AgentRuntimeHost = getCurrentToolRuntimeHost(),
 ): void {
   runtimeHost.emit('updateTodos', { streamId: childStreamId, todos });
 }
@@ -286,7 +280,7 @@ export function publishCodexStreamUsage(
   childStreamId: StreamTabId,
   executionId: ExecutionId,
   usage: TokenUsageStats,
-  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
+  runtimeHost: AgentRuntimeHost = getCurrentToolRuntimeHost(),
 ): void {
   runtimeHost.emit('updateStreamUsage', {
     streamId: childStreamId,
@@ -301,7 +295,7 @@ function logCodexItem(
   item: ThreadItem,
   childStreamId: StreamTabId,
   logger: AgentLogger,
-  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
+  runtimeHost: AgentRuntimeHost = getCurrentToolRuntimeHost(),
 ): void {
   switch (item.type) {
     case 'command_execution': {
@@ -431,7 +425,7 @@ function startCodexLoop(params: {
 
   const session = new CodexFollowUpSession();
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
-  const runtimeHost = getCodexToolRuntimeHost();
+  const runtimeHost = getCurrentToolRuntimeHost();
   session.setQueue(queue);
   registerInterruptible(childStreamId, session);
 

--- a/src/tools/codex.ts
+++ b/src/tools/codex.ts
@@ -27,6 +27,10 @@ import {
   writeTerminalStatus,
 } from '@agent/storage';
 import { AgentCategory } from '@agent/core/AgentDataclass';
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { untrackExecution } from '@agent/runtime/executionRegistry';
 import { StreamStatusService } from '@agent/runtime/StreamStatusService';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
@@ -39,9 +43,14 @@ import {
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
 import type { FollowUpQueue } from '@agent/toolUse/FollowUpQueue';
 import { toErrorMessage } from '@common/errors';
-import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
-import type { StreamTabId, ExecutionId, StorageKey } from '@shared/schemas';
+import type {
+  StreamTabId,
+  ExecutionId,
+  StorageKey,
+  TodoItem,
+  TokenUsageStats,
+} from '@shared/schemas';
 import { MESSAGE_TYPES, STREAM_STATUS } from '@shared/schemas';
 import { ToolError, type ToolResult } from '@tools/result';
 import { parseWorkingDirectory } from '@tools/pathResolution';
@@ -259,11 +268,40 @@ function formatCodexError(
 // Stream tab helpers
 // ============================================================================
 
+function getCodexToolRuntimeHost(): AgentRuntimeHost {
+  return (
+    getCurrentToolFileInteractionContext()?.runtimeHost ?? getAgentRuntimeHost()
+  );
+}
+
+export function publishCodexTodos(
+  childStreamId: StreamTabId,
+  todos: TodoItem[],
+  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
+): void {
+  runtimeHost.emit('updateTodos', { streamId: childStreamId, todos });
+}
+
+export function publishCodexStreamUsage(
+  childStreamId: StreamTabId,
+  executionId: ExecutionId,
+  usage: TokenUsageStats,
+  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
+): void {
+  runtimeHost.emit('updateStreamUsage', {
+    streamId: childStreamId,
+    storageKey: executionId as StorageKey,
+    executionId,
+    usage,
+  });
+}
+
 /** Log a completed codex thread item to the child stream's logger. */
 function logCodexItem(
   item: ThreadItem,
   childStreamId: StreamTabId,
   logger: AgentLogger,
+  runtimeHost: AgentRuntimeHost = getCodexToolRuntimeHost(),
 ): void {
   switch (item.type) {
     case 'command_execution': {
@@ -296,7 +334,7 @@ function logCodexItem(
         status: t.completed ? ('completed' as const) : ('pending' as const),
         activeForm: t.text,
       }));
-      bus.emit('updateTodos', { streamId: childStreamId, todos });
+      publishCodexTodos(childStreamId, todos, runtimeHost);
       break;
     }
     case 'error':
@@ -329,6 +367,7 @@ async function runStreamedTurn(
   prompt: string,
   childStreamId: StreamTabId,
   logger: AgentLogger,
+  runtimeHost: AgentRuntimeHost,
   signal?: AbortSignal,
 ): Promise<RunResult> {
   logger.info(prompt, { messageType: MESSAGE_TYPES.USER_MESSAGE });
@@ -340,7 +379,7 @@ async function runStreamedTurn(
     switch (event.type) {
       case 'item.completed': {
         const { item } = event;
-        logCodexItem(item, childStreamId, logger);
+        logCodexItem(item, childStreamId, logger, runtimeHost);
         if (item.type === 'agent_message') {
           responseParts.push(item.text);
         }
@@ -392,6 +431,7 @@ function startCodexLoop(params: {
 
   const session = new CodexFollowUpSession();
   const queue = ToolUseFollowUpQueue.acquire(childStreamId);
+  const runtimeHost = getCodexToolRuntimeHost();
   session.setQueue(queue);
   registerInterruptible(childStreamId, session);
 
@@ -437,6 +477,7 @@ function startCodexLoop(params: {
             prompt,
             childStreamId,
             logger,
+            runtimeHost,
             signal,
           );
           logTurnSummary(logger, Date.now() - startedAt, turn.usage);
@@ -460,12 +501,12 @@ function startCodexLoop(params: {
         }
 
         if (turn?.usage) {
-          bus.emit('updateStreamUsage', {
-            streamId: childStreamId,
-            storageKey: executionId as StorageKey,
+          publishCodexStreamUsage(
+            childStreamId,
             executionId,
-            usage: buildCodexUsageStats(turn.usage),
-          });
+            buildCodexUsageStats(turn.usage),
+            runtimeHost,
+          );
         }
 
         const msg =

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,7 +14,7 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -98,7 +98,7 @@ export class IssuePollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
-    bus.emit('issueSubscriptionsChanged', { keys });
+    getAgentRuntimeHost().emit('issueSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -15,6 +15,7 @@
  */
 
 import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { bus } from '@eventBus/ProgressEventBus';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -98,6 +99,7 @@ export class IssuePollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
+    bus.emit('issueSubscriptionsChanged', { keys });
     getAgentRuntimeHost().emit('issueSubscriptionsChanged', { keys });
   }
 

--- a/src/tools/github/IssuePollingSource.ts
+++ b/src/tools/github/IssuePollingSource.ts
@@ -14,9 +14,6 @@
  * file only owns the per-issue endpoint set and the dedup state.
  */
 
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { bus } from '@eventBus/ProgressEventBus';
-
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatIssueClosed,
@@ -31,6 +28,7 @@ import {
   type BasePollSubscriptionState,
   type Disposable,
 } from './PollingSourceBase';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import type { GhIssue, GhIssueComment } from './prTypes';
 
 const MAX_SEEN_IDS = 1000;
@@ -99,8 +97,7 @@ export class IssuePollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
-    bus.emit('issueSubscriptionsChanged', { keys });
-    getAgentRuntimeHost().emit('issueSubscriptionsChanged', { keys });
+    emitGitHubSubscriptionChanged('issueSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,9 +11,6 @@
  * layer above.
  */
 
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { bus } from '@eventBus/ProgressEventBus';
-
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatCheckAnnotations,
@@ -55,6 +52,7 @@ import {
   type GhReview,
   type GhReviewComment,
 } from './prTypes';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 
 function createInitialState(pr: PRKey): SubscriptionState {
   return {
@@ -203,8 +201,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
-    bus.emit('prSubscriptionsChanged', { keys });
-    getAgentRuntimeHost().emit('prSubscriptionsChanged', { keys });
+    emitGitHubSubscriptionChanged('prSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -12,6 +12,7 @@
  */
 
 import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { bus } from '@eventBus/ProgressEventBus';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -202,6 +203,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
+    bus.emit('prSubscriptionsChanged', { keys });
     getAgentRuntimeHost().emit('prSubscriptionsChanged', { keys });
   }
 

--- a/src/tools/github/PRPollingSource.ts
+++ b/src/tools/github/PRPollingSource.ts
@@ -11,7 +11,7 @@
  * layer above.
  */
 
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -202,7 +202,7 @@ export class PRPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly string[]): void {
-    bus.emit('prSubscriptionsChanged', { keys });
+    getAgentRuntimeHost().emit('prSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/PollingSourceBase.ts
+++ b/src/tools/github/PollingSourceBase.ts
@@ -11,7 +11,7 @@
  * 24 h detach gate) lives here once.
  */
 
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { AgentLogger } from '@logger/AgentLogger';
 
 import {
@@ -201,7 +201,9 @@ export abstract class PollingSourceBase<
       );
       this.emit(state, this.formatErrorEvent(key, state, err.message));
       this.detach(key);
-      bus.emit('githubTokenInvalid', { message: err.message });
+      getAgentRuntimeHost().emit('githubTokenInvalid', {
+        message: err.message,
+      });
       return;
     }
     if (err instanceof GitHubPermanentError) {

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,7 +34,7 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -178,7 +178,7 @@ export class RepoPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly RepoKey[]): void {
-    bus.emit('repoSubscriptionsChanged', { keys });
+    getAgentRuntimeHost().emit('repoSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -35,6 +35,7 @@
  */
 
 import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+import { bus } from '@eventBus/ProgressEventBus';
 
 import { shouldDropBotEvent } from './botFilter';
 import {
@@ -178,6 +179,7 @@ export class RepoPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly RepoKey[]): void {
+    bus.emit('repoSubscriptionsChanged', { keys });
     getAgentRuntimeHost().emit('repoSubscriptionsChanged', { keys });
   }
 

--- a/src/tools/github/RepoPollingSource.ts
+++ b/src/tools/github/RepoPollingSource.ts
@@ -34,9 +34,6 @@
  * - **CI / check-run status and inline annotations.** Per-PR by design.
  */
 
-import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
-import { bus } from '@eventBus/ProgressEventBus';
-
 import { shouldDropBotEvent } from './botFilter';
 import {
   formatRepoIssueComment,
@@ -61,6 +58,7 @@ import {
   type GhPullsListEntry,
   type GhReviewComment,
 } from './prTypes';
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 
 // We pull all "updated since" data; a sufficiently large window guarantees we
 // catch transitions even after a brief network outage. GitHub caps these
@@ -179,8 +177,7 @@ export class RepoPollingSource extends PollingSourceBase<
   }
 
   protected emitKeysChangedBusEvent(keys: readonly RepoKey[]): void {
-    bus.emit('repoSubscriptionsChanged', { keys });
-    getAgentRuntimeHost().emit('repoSubscriptionsChanged', { keys });
+    emitGitHubSubscriptionChanged('repoSubscriptionsChanged', { keys });
   }
 
   protected formatErrorEvent(

--- a/src/tools/github/SubscriptionBinder.ts
+++ b/src/tools/github/SubscriptionBinder.ts
@@ -13,6 +13,7 @@
 
 import { sendFollowUp } from '@agent/toolUse/ToolUseFollowUp';
 import { ToolUseFollowUpQueue } from '@agent/toolUse/ToolUseFollowUpQueueManager';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId } from '@shared/schemas';
@@ -86,7 +87,7 @@ export class SubscriptionBinder<K extends string, Input> {
       disposable = this.opts.source.subscribe(input, (text) => {
         void sendFollowUp(streamId, text).then((result) => {
           if (result.status === 'sent' || result.status === 'queued') {
-            bus.emit('updateQueuedFollowUps', { streamId });
+            getAgentRuntimeHost().emit('updateQueuedFollowUps', { streamId });
           }
         });
       });
@@ -193,6 +194,6 @@ export class SubscriptionBinder<K extends string, Input> {
   }
 
   private emitBindingsChanged(): void {
-    bus.emit(this.opts.bindingsChangedEvent, undefined);
+    getAgentRuntimeHost().emit(this.opts.bindingsChangedEvent, undefined);
   }
 }

--- a/src/tools/github/SubscriptionBinder.ts
+++ b/src/tools/github/SubscriptionBinder.ts
@@ -18,6 +18,7 @@ import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { StreamTabId } from '@shared/schemas';
 
+import { emitGitHubSubscriptionChanged } from './subscriptionEventEmitter';
 import type { Disposable } from './PollingSourceBase';
 
 export interface SubscriptionBinding<K extends string> {
@@ -194,6 +195,6 @@ export class SubscriptionBinder<K extends string, Input> {
   }
 
   private emitBindingsChanged(): void {
-    getAgentRuntimeHost().emit(this.opts.bindingsChangedEvent, undefined);
+    emitGitHubSubscriptionChanged(this.opts.bindingsChangedEvent, undefined);
   }
 }

--- a/src/tools/github/subscriptionEventEmitter.ts
+++ b/src/tools/github/subscriptionEventEmitter.ts
@@ -1,0 +1,21 @@
+import {
+  getAgentRuntimeHost,
+  getDefaultAgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
+import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
+
+export type GitHubSubscriptionChangedEvent =
+  | 'prSubscriptionsChanged'
+  | 'repoSubscriptionsChanged'
+  | 'issueSubscriptionsChanged';
+
+export function emitGitHubSubscriptionChanged<
+  K extends GitHubSubscriptionChangedEvent,
+>(event: K, payload: ProgressEventPayloads[K]): void {
+  bus.emit(event, payload);
+
+  const runtimeHost = getAgentRuntimeHost();
+  if (runtimeHost !== getDefaultAgentRuntimeHost()) {
+    runtimeHost.emit(event, payload);
+  }
+}

--- a/src/tools/github/subscriptionEventEmitter.ts
+++ b/src/tools/github/subscriptionEventEmitter.ts
@@ -7,7 +7,10 @@ import { bus, type ProgressEventPayloads } from '@eventBus/ProgressEventBus';
 export type GitHubSubscriptionChangedEvent =
   | 'prSubscriptionsChanged'
   | 'repoSubscriptionsChanged'
-  | 'issueSubscriptionsChanged';
+  | 'issueSubscriptionsChanged'
+  | 'prSubscriptionBindingsChanged'
+  | 'repoSubscriptionBindingsChanged'
+  | 'issueSubscriptionBindingsChanged';
 
 export function emitGitHubSubscriptionChanged<
   K extends GitHubSubscriptionChangedEvent,

--- a/src/tools/inquiry/ExternalInquiryTool.ts
+++ b/src/tools/inquiry/ExternalInquiryTool.ts
@@ -10,8 +10,11 @@
 
 import { z } from 'zod';
 
+import {
+  getAgentRuntimeHost,
+  type AgentRuntimeHost,
+} from '@agent/runtime/AgentRuntimeHost';
 import { getCurrentToolFileInteractionContext } from '@agent/toolUse/ToolFileInteractionContext';
-import { bus } from '@eventBus/ProgressEventBus';
 import { AgentLogger } from '@logger/AgentLogger';
 import type { ExternalInquiryAction, StreamTabId } from '@shared/schemas';
 import {
@@ -133,6 +136,7 @@ async function awaitExternalInquiryResponse(params: {
   input: ExternalInquiryInput;
   streamId?: StreamTabId;
   existingThread: ExternalInquiryThreadManifest | null;
+  runtimeHost: AgentRuntimeHost;
 }): Promise<ExternalInquiryResult> {
   return new Promise<ExternalInquiryResult>((resolve) => {
     let settled = false;
@@ -148,13 +152,13 @@ async function awaitExternalInquiryResponse(params: {
       isSettled: () => settled,
     });
 
-    bus.emit('requestEnsureProgressView', {});
+    params.runtimeHost.emit('requestEnsureProgressView', {});
 
     if (params.streamId) {
-      bus.emit('setActiveStream', { streamId: params.streamId });
+      params.runtimeHost.emit('setActiveStream', { streamId: params.streamId });
     }
 
-    bus.emit('showExternalInquiry', {
+    params.runtimeHost.emit('showExternalInquiry', {
       requestId: params.requestId,
       question: params.input.question,
       threadId: params.input.thread_id ?? undefined,
@@ -246,6 +250,7 @@ When you have multiple independent questions for external models, you can call e
     const context = getCurrentToolFileInteractionContext();
     const streamId = context?.streamId;
     const executionId = context?.executionId;
+    const runtimeHost = context?.runtimeHost ?? getAgentRuntimeHost();
 
     const requestId = `inquiry-${Date.now().toString(36)}-${++inquiryCounter}`;
     const threadLabel = input.thread_id ?? 'new';
@@ -262,6 +267,7 @@ When you have multiple independent questions for external models, you can call e
         input,
         streamId,
         existingThread,
+        runtimeHost,
       });
 
       if (!result.submitted) {
@@ -297,7 +303,7 @@ When you have multiple independent questions for external models, you can call e
       });
     } finally {
       pendingInquiries.delete(requestId);
-      bus.emit('resolveExternalInquiry', { requestId });
+      runtimeHost.emit('resolveExternalInquiry', { requestId });
     }
   }
 }

--- a/src/tools/toolAvailability.ts
+++ b/src/tools/toolAvailability.ts
@@ -13,7 +13,7 @@
  */
 
 // Local imports
-import { bus } from '@eventBus/ProgressEventBus';
+import { getAgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
 import type { RegisteredToolName } from '@tools/registry';
 import { EXTERNAL_TOOL_DEFS } from '@tools/externalToolDefs';
 import { getDisabledToolIds } from '@utils/config/constants';
@@ -207,7 +207,7 @@ export function getLastCheckResults(): ExternalToolCheckResult[] | null {
  */
 export async function refreshToolAvailability(): Promise<void> {
   await runExternalToolChecks();
-  bus.emit('toolAvailabilityChanged', undefined);
+  getAgentRuntimeHost().emit('toolAvailabilityChanged', undefined);
 }
 
 /**


### PR DESCRIPTION
## Summary
- route reflection output-node progress events through `runtimeHost` instead of the global progress event bus
- route tool-use todo/plan progress events through `runtimeHost` instead of the global progress event bus
- route active tool-use follow-up notifications through the registered flow `runtimeHost`
- route tool-spawned child stream lifecycle events through the tool runtime host
- route accept-run file-write, Codex tool progress, bash approval, and external inquiry prompt events through the active tool runtime host
- centralize active tool runtime-host resolution for tool files after Cursor review feedback
- route approval-bypass, tool-availability, GitHub subscription, and queued-follow-up broadcasts through the runtime host
- pass the runtime host into XML output extraction and `OutputFileProcessor` so missing-output events use the injected boundary
- add focused Vitest coverage for output-node, processor, tool-use progress/follow-up, child streams, human prompts, accept-run file writes, Codex tool progress, and shared progress-event test recording

## Audit
Moved in this slice:
- `src/agent/implementations/flows/reflection/nodes/OutputNode.ts`: `addOutputFiles`, `updateCompileFailures`, `requestOpenFile`, `updateMissingOutputs`, `requestShowInstruction` now emit via `runtimeHost`
- `src/agent/output/OutputFileProcessor.ts`: single-output failure `updateMissingOutputs` now emits via the injected host
- `src/agent/implementations/flows/tooluse/nodes/ToolUseCycleNode.ts`: `updateTodos` and `updatePlan` now emit via the resolved tool-use `runtimeHost`
- `src/agent/implementations/flows/tooluse/runToolUseFlow.ts`: resolves `runtimeHost` once for the flow services and registered flow context
- `src/agent/toolUse/ToolUseFollowUp.ts`: active-session `followUpSent` notifications now emit through the flow context runtime host
- `src/agent/toolUse/ToolFileInteractionContext.ts`: exports the shared active tool runtime-host helper used by tool files
- `src/tools/childStream.ts`: child stream status/task/description/parent/removal events now use the tool runtime host and attach it to the child execution handle
- `src/tools/AcceptRunFilesTool.ts`: `workspaceFilesWritten` now emits through the active tool runtime host
- `src/tools/codex.ts`: `updateTodos` and `updateStreamUsage` now emit through the active tool runtime host
- `src/tools/approval/bashApproval.ts`: bash approval prompt and resolution events now emit through the active tool runtime host captured for the approval request
- `src/tools/inquiry/ExternalInquiryTool.ts`: external inquiry prompt and resolution events now emit through the active tool runtime host captured for the inquiry request
- `src/tools/approval/toolEditApproval.ts` and `src/tools/approval/proposalApproval.ts`: bypass-state broadcasts now emit through the runtime host
- `src/tools/toolAvailability.ts`: availability refresh broadcasts now emit through the runtime host
- `src/tools/github/`: subscription key, binding, queued-follow-up, and invalid-token broadcasts now emit through the runtime host
- `src/test-kernel/agent/progressTestUtils.ts`: shares the runtime-host event recorder across progress-event tests

Owned by the base PR #3596, not this slice:
- SDK/provider attribution changes in `src/common/errors/sdkErrorUtils.ts`
- desktop package verifier/metafile changes in `scripts/verify-desktop-package.mjs`

Remaining out of scope for follow-up slices:
- GitHub polling/subscription helper listeners
- executions follow-up listener wiring

Refs #3372

## Validation
- `npm run -s test:kernel -- src/test-kernel/agent/output/OutputProgressEvents.vitest.ts src/test-kernel/agent/toolUse/ToolUseProgressEvents.vitest.ts src/test-kernel/agent/toolUse/ToolUseFollowUpProgressEvents.vitest.ts src/test-kernel/agent/toolUse/ChildStreamProgressEvents.vitest.ts src/test-kernel/agent/toolUse/AcceptRunFilesProgressEvents.vitest.ts src/test-kernel/agent/toolUse/CodexProgressEvents.vitest.ts src/test-kernel/agent/toolUse/HumanPromptProgressEvents.vitest.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check origin/codex/desktop-package-metafile-verifier...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many progress-notification paths (reflection output, tool-use cycles, approvals, tool availability, GitHub subscriptions), so regressions could manifest as missing/duplicated UI updates or mis-scoped events across streams. Packaging verifier tweaks are low risk but could affect CI/package validation if path inference is wrong.
> 
> **Overview**
> **Progress events are now scoped via `AgentRuntimeHost` instead of the global `ProgressEventBus`** for reflection output processing (`OutputNode`, XML extraction, `OutputFileProcessor` missing-output handling) and tool-use flows (todos/plan updates, follow-up `followUpSent`).
> 
> Tools that trigger UI/progress updates (`accept_run_files`, Codex, child streams, bash approvals, external inquiry) now resolve an *active tool runtime host* from `ToolFileInteractionContext`, with new helper `getCurrentToolRuntimeHost()` and flow runners defaulting to `getAgentRuntimeHost()` when none is provided.
> 
> Desktop packaging verification is tightened: esbuild main build now uses `absWorkingDir` with relative paths, metafile import path normalization avoids treating `.pnpm/...` as relative, and startup import-graph traversal is expanded to selectively include `dynamic-import` edges (with added Vitest coverage for these path rules and the new runtime-host event routing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee90ff4f3265f126449fdd69fbf7028d75e6981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->