### PR TITLE
[codex] Document desktop migration guidance

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -123,6 +123,10 @@ const baseConfig = {
           items: [
             { text: 'Introduction', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
+            {
+              text: 'Desktop Migration',
+              link: '/guide/desktop-migration',
+            },
             { text: 'Quick Start', link: '/guide/quick-start' },
           ],
         },

--- a/docs/guide/desktop-migration.md
+++ b/docs/guide/desktop-migration.md
@@ -1,0 +1,78 @@
+# Migrating to the Desktop App
+
+The TeXRA desktop app is a separate host from the VS Code extension. Treat the
+first desktop launch as a fresh setup: open your project folder, sign in again,
+and reconfigure the providers and workspace settings you want to use.
+
+The desktop app shares TeXRA's agent logic, model handlers, LaTeX processing,
+and webview UI with the extension, but it uses its own application storage and
+secure credential store. It does not read VS Code's Secret Storage, user
+settings, workspace state, or extension global storage.
+
+## What Carries Over
+
+Your project files remain the source of truth. If you open the same repository,
+paper folder, or Overleaf Git checkout in the desktop app, TeXRA can work with
+the same `.tex`, `.bib`, figure, and configuration files already in that
+workspace.
+
+These items usually carry over because they live outside the VS Code extension:
+
+- Manuscript source files and repository history.
+- Workspace-local `.env` files, if you already use them for provider API keys.
+- LaTeX, Perl, GraphicsMagick, ImageMagick, Ghostscript, Git, and other system
+  tools installed on your machine.
+- Custom agent YAML files that live inside the project folder.
+- Team-owned files such as `.latexindent.yaml`, `tex-fmt.toml`, or shared
+  `.vscode/settings.json` files committed to the repository.
+
+After opening the project in the desktop app, verify the LaTeX tool paths and
+run a small agent task before relying on the migrated setup for production work.
+
+## What To Reconfigure
+
+Re-enter credentials and preferences that were stored by the extension host:
+
+- Model provider API keys from the Models tab.
+- TeXRA account or remote-agent sign-in.
+- GitHub token for PR and issue subscription tools.
+- Agent visibility, custom agent directory, model list, and tool approval
+  preferences.
+- LaTeX formatting, diff, TikZ, file-extension, and ignored-path settings if
+  they were only stored in VS Code user settings.
+- Execution history and task-storage archives that lived in the extension's
+  global storage.
+
+If a setting was committed to the workspace, keep using the committed copy. If
+it was only a personal VS Code user setting, set it again in the desktop app.
+
+## Recommended First Launch
+
+1. Install and open the desktop app.
+2. Open the same project folder you used with the VS Code extension.
+3. Sign in to TeXRA again if you use remote agents or account-backed features.
+4. Open the Models tab and set the provider API keys you want available.
+5. Review the Agents and Tools tabs and enable the same agents and approvals you
+   use in the extension.
+6. Open the LaTeX settings and confirm formatter, diff, TikZ, and tool-path
+   preferences.
+7. Run a small command, such as a short polish task or LaTeX compile check, and
+   confirm the output lands in the expected task storage.
+
+## Export And Import
+
+Automatic export/import from the VS Code extension is deferred. Phase 7 defaults
+to explicit re-authentication and manual reconfiguration so the desktop app does
+not need access to VS Code's private storage or credentials.
+
+A future migration tool may export non-secret preferences, custom agent
+registrations, or execution-history metadata into a reviewable file. It should
+not export API keys or session tokens. Track that work separately from the first
+desktop release.
+
+## Related Docs
+
+- [Installation](/guide/installation) - install TeXRA and required local tools.
+- [Configuration](/guide/configuration) - review provider, Git, LaTeX, and agent
+  settings.
+- [Remote Agents](/guide/remote-agents) - sign in and manage remote agent access.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -97,6 +97,7 @@ API keys are stored in VS Code's built-in Secret Storage.
 ## Next steps
 
 - [Installation](/guide/installation) — set up TeXRA and its dependencies
+- [Desktop Migration](/guide/desktop-migration) — move from the VS Code extension to the desktop app
 - [Quick Start](/guide/quick-start) — your first agent run in under five minutes
 - [Built-in Agents](/guide/built-in-agents) — the full catalog of available agents
 - [Agent Architecture](/guide/agent-architecture) — how the multi-agent system works under the hood

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -35,6 +35,13 @@ You can also install TeXRA directly in your preferred editor using protocol-base
 - [Open in Cursor](cursor:extension/texra-ai.texra)
 - [Open in Windsurf](windsurf:extension/texra-ai.texra)
 
+::: tip Desktop app migration
+If you are moving from the VS Code extension to the desktop app, treat the first
+desktop launch as a fresh setup. Open the same project folder, then
+re-authenticate and reconfigure local provider, agent, Git, and LaTeX settings.
+See [Migrating to the Desktop App](./desktop-migration.md).
+:::
+
 ### From VSIX File
 
 1. Open VS Code


### PR DESCRIPTION
## Summary
- add a desktop migration guide that defaults to fresh desktop setup, re-authentication, and manual reconfiguration
- document what carries over from the VS Code extension and what must be re-entered
- mark automatic export/import as deferred and link the guide from installation/sidebar/index docs

Fixes #3622

## Validation
- /Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/prettier --write docs/guide/desktop-migration.md docs/.vitepress/config.js docs/guide/installation.md docs/guide/index.md
- git diff --check
- npm --prefix docs run docs:build *(fails before this page on existing docs/pocketflow/core_abstraction/communication.md:25 markdown parse error)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new guide page and links to it; no product logic is modified.
> 
> **Overview**
> Adds a new `docs/guide/desktop-migration.md` guide describing how to move from the VS Code extension to the desktop app, emphasizing **fresh setup**, what data/settings carry over, what must be re-entered, and that automatic export/import is deferred.
> 
> Surfaces this guide in the docs UI by linking it from the VitePress sidebar (`docs/.vitepress/config.js`), the introduction "Next steps" list (`docs/guide/index.md`), and a tip callout in the installation guide (`docs/guide/installation.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1769dbe3cd815cc4c775c8cec6356e725c9749f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->