### PR TITLE
[codex] consolidate Claude automation prompts

### DIFF
--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -14,9 +14,6 @@ inputs:
   creator-name:
     description: 'Human-readable creator name for the PR body (e.g. "Claude Code action")'
     required: true
-  event-name:
-    description: 'github.event_name for the triggering event'
-    required: true
   gh-token:
     description: 'Token with PR write access'
     required: true
@@ -32,7 +29,6 @@ runs:
         REPO: ${{ inputs.repo }}
         BRANCH_PREFIX: ${{ inputs.branch-prefix }}
         CREATOR_NAME: ${{ inputs.creator-name }}
-        EVENT_NAME: ${{ inputs.event-name }}
       run: |
         set -euo pipefail
 

--- a/.github/actions/auto-create-issue-pr/action.yml
+++ b/.github/actions/auto-create-issue-pr/action.yml
@@ -1,0 +1,102 @@
+name: 'Auto-create PR for issue work'
+description: 'Find the bot-pushed branch for an issue and open a PR'
+
+inputs:
+  issue-number:
+    description: 'The GitHub issue number'
+    required: true
+  repo:
+    description: 'owner/repo slug'
+    required: true
+  branch-prefix:
+    description: 'Branch prefix the bot uses, for example "claude/issue-"'
+    required: true
+  creator-name:
+    description: 'Human-readable creator name for the PR body (e.g. "Claude Code action")'
+    required: true
+  event-name:
+    description: 'github.event_name for the triggering event'
+    required: true
+  gh-token:
+    description: 'Token with PR write access'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - id: open-pr
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        ISSUE_NUMBER: ${{ inputs.issue-number }}
+        REPO: ${{ inputs.repo }}
+        BRANCH_PREFIX: ${{ inputs.branch-prefix }}
+        CREATOR_NAME: ${{ inputs.creator-name }}
+        EVENT_NAME: ${{ inputs.event-name }}
+      run: |
+        set -euo pipefail
+
+        echo "Looking for branches matching ${BRANCH_PREFIX}${ISSUE_NUMBER}-*"
+
+        # Targeted refspec; works on shallow clones without full history.
+        git fetch origin --no-tags \
+          "refs/heads/${BRANCH_PREFIX}${ISSUE_NUMBER}-*:refs/remotes/origin/${BRANCH_PREFIX}${ISSUE_NUMBER}-*" \
+          || true
+
+        BRANCH=$(git for-each-ref --sort=-committerdate --format='%(refname:lstrip=3)' \
+          "refs/remotes/origin/${BRANCH_PREFIX}${ISSUE_NUMBER}-*" | head -1)
+
+        if [ -z "$BRANCH" ]; then
+          echo "No branch found for issue #${ISSUE_NUMBER} — bot likely just replied without code changes."
+          exit 0
+        fi
+
+        echo "Found branch: $BRANCH"
+
+        EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all --json number --jq 'length')
+        if [ "$EXISTING" -gt 0 ]; then
+          echo "PR already exists for branch $BRANCH — skipping."
+          exit 0
+        fi
+
+        ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+        ISSUE_URL=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json url --jq '.url')
+
+        CHANGED_FILES=$(
+          git diff --name-only "origin/main...origin/$BRANCH" 2>/dev/null \
+            | sed 's/^/- `/' \
+            | sed 's/$/`/' \
+            || true
+        )
+        if [ -z "$CHANGED_FILES" ]; then
+          CHANGED_FILES="- See the commits on \`$BRANCH\`."
+        fi
+
+        echo "Creating PR from $BRANCH → main for issue #${ISSUE_NUMBER}"
+
+        PR_BODY=$(cat <<EOF
+        ### Motivation
+        - Addresses #${ISSUE_NUMBER}: ${ISSUE_TITLE}.
+        - Source issue: ${ISSUE_URL}
+
+        ### Description
+        - This PR was opened from \`${BRANCH}\` by ${CREATOR_NAME}.
+        - Changed files:
+        ${CHANGED_FILES}
+
+        ### Testing
+        - CI should run the TypeScript, lint, build, and packaging checks for this branch.
+
+        ---
+        Addresses #${ISSUE_NUMBER}
+        EOF
+        )
+
+        PR_URL=$(gh pr create \
+          --repo "$REPO" \
+          --head "$BRANCH" \
+          --base main \
+          --title "feat: ${ISSUE_TITLE}" \
+          --body "$PR_BODY")
+
+        echo "PR created successfully: $PR_URL"

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -54,12 +54,12 @@ inputs:
     required: false
     default: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
 
-  allowed_tools:
+  allowed-tools:
     description: 'Optional --allowedTools value applied by default.'
     required: false
     default: ''
-  allowed_tools_preset:
-    description: 'Named --allowedTools preset. Ignored when allowed_tools is set.'
+  allowed-tools-preset:
+    description: 'Named --allowedTools preset. Ignored when allowed-tools is set.'
     required: false
     default: ''
 
@@ -81,7 +81,7 @@ inputs:
     required: false
     default: ''
 
-  plugin_marketplaces:
+  plugin-marketplaces:
     description: 'Plugin marketplaces.'
     required: false
     default: ''
@@ -115,7 +115,7 @@ inputs:
     required: false
     default: ''
 
-  claude_args:
+  claude-args:
     description: 'Additional claude args. The action prepends --model automatically.'
     required: false
     default: ''
@@ -143,16 +143,16 @@ runs:
         INPUT_BOT_ID: ${{ inputs['bot-id'] }}
         INPUT_BOT_NAME: ${{ inputs['bot-name'] }}
         INPUT_ADDITIONAL_PERMISSIONS: ${{ inputs['additional-permissions'] }}
-        INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
+        INPUT_PLUGIN_MARKETPLACES: ${{ inputs['plugin-marketplaces'] }}
         INPUT_PLUGINS: ${{ inputs['plugins'] }}
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_PROMPT_FILE: ${{ inputs['claude-prompt-file'] }}
         INPUT_PROMPT_CONTEXT: ${{ inputs['claude-prompt-context'] }}
-        INPUT_ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
-        INPUT_ALLOWED_TOOLS_PRESET: ${{ inputs.allowed_tools_preset }}
+        INPUT_ALLOWED_TOOLS: ${{ inputs['allowed-tools'] }}
+        INPUT_ALLOWED_TOOLS_PRESET: ${{ inputs['allowed-tools-preset'] }}
         INPUT_SYSTEM_PROMPT: ${{ inputs['system-prompt'] }}
         INPUT_SYSTEM_PROMPT_FILE: ${{ inputs['system-prompt-file'] }}
-        INPUT_CLAUDE_ARGS: ${{ inputs.claude_args }}
+        INPUT_CLAUDE_ARGS: ${{ inputs['claude-args'] }}
       run: |
         set -euo pipefail
 
@@ -269,7 +269,7 @@ runs:
             preset_allowed_tools="Read,Glob,Grep,mcp__github__*"
             ;;
           *)
-            echo "::error::Unknown allowed_tools_preset: ${allowed_tools_preset}"
+            echo "::error::Unknown allowed-tools-preset: ${allowed_tools_preset}"
             exit 1
             ;;
         esac
@@ -317,10 +317,6 @@ runs:
           else
             prompt="$prompt_context"
           fi
-        fi
-
-        if [ -n "$prompt" ]; then
-          prompt="$(printf '%s' "$prompt" | tr '\n' ' ')"
         fi
 
         claude_args="$INPUT_CLAUDE_ARGS"

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -279,6 +279,9 @@ runs:
         if [ -z "$allowed_tools" ]; then
           allowed_tools="${CLAUDE_ALLOWED_TOOLS-}"
         fi
+        if [ -n "$allowed_tools" ]; then
+          allowed_tools="$(printf '%s' "$allowed_tools")"
+        fi
 
         system_prompt="$INPUT_SYSTEM_PROMPT"
         system_prompt_path=""
@@ -348,7 +351,6 @@ runs:
         write_output anthropic_api_key "$anthropic_api_key"
         write_output base_url "$base_url"
         write_output model "$model"
-        write_output provider "$provider"
         write_output allowed_bots "$allowed_bots"
         write_output branch_name_template "$branch_name_template"
         write_output bot_id "$bot_id"
@@ -358,7 +360,6 @@ runs:
         write_output plugins "$plugins"
         write_output prompt "$prompt"
         write_output claude_args "$claude_args"
-        write_output append_system_prompt "$append_system_prompt"
 
     - name: Run Claude Code
       uses: anthropics/claude-code-action@v1

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -166,6 +166,37 @@ runs:
             printf '%s\n' "$delimiter"
           } >> "$GITHUB_OUTPUT"
         }
+        shell_quote() {
+          local value="$1"
+          value="${value//\'/\'\\\'\'}"
+          printf "'%s'" "$value"
+        }
+        append_arg_line() {
+          local value="$1"
+          if [ -n "$claude_args" ]; then
+            claude_args="${claude_args}"$'\n'
+          fi
+          claude_args="${claude_args}${value}"
+        }
+        trim_tool_name() {
+          local value="$1"
+          value="${value#"${value%%[![:space:]]*}"}"
+          value="${value%"${value##*[![:space:]]}"}"
+          printf '%s' "$value"
+        }
+        format_allowed_tools_args() {
+          local tools_csv="$1"
+          local result=''
+          local tool=''
+          while IFS= read -r tool; do
+            tool="$(trim_tool_name "$tool")"
+            if [ -z "$tool" ]; then
+              continue
+            fi
+            result="${result} $(shell_quote "$tool")"
+          done < <(printf '%s' "$tools_csv" | tr ',' '\n')
+          printf '%s' "$result"
+        }
 
         provider="$INPUT_PROVIDER"
         provider="${provider,,}"
@@ -323,19 +354,12 @@ runs:
         fi
 
         claude_args="$INPUT_CLAUDE_ARGS"
-        append_system_prompt=''
         if [ -n "$system_prompt" ] && ! printf '%s\n' "$claude_args" | grep -q -- '--append-system-prompt'; then
-          append_system_prompt="$system_prompt"
-          if [ -n "$claude_args" ]; then
-            claude_args="${claude_args}"$'\n'
-          fi
-          claude_args="${claude_args}--append-system-prompt \"${append_system_prompt}\""
+          append_arg_line "--append-system-prompt $(shell_quote "$system_prompt")"
         fi
         if [ -n "$allowed_tools" ] && ! printf '%s\n' "$claude_args" | grep -q -- '--allowedTools'; then
-          if [ -n "$claude_args" ]; then
-            claude_args="${claude_args}"$'\n'
-          fi
-          claude_args="${claude_args}--allowedTools \"${allowed_tools}\""
+          claude_args_allowed_tools="$(format_allowed_tools_args "$allowed_tools")"
+          append_arg_line "--allowedTools${claude_args_allowed_tools}"
         fi
 
         case "$model_tier" in

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -1,0 +1,385 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
+name: 'Claude Code with Provider'
+description: 'Run anthropics/claude-code-action with automatic Anthropic/DeepSeek provider selection'
+
+inputs:
+  provider:
+    description: 'Provider name (anthropic or deepseek)'
+    required: false
+    default: ''
+  claude-oauth-token:
+    description: 'Anthropic OAuth token for Claude Code'
+    required: false
+    default: ''
+  anthropic-api-key:
+    description: 'Anthropic API key for Claude Code'
+    required: false
+    default: ''
+  deepseek-api-key:
+    description: 'DeepSeek API key for deepseek provider mode'
+    required: false
+    default: ''
+  anthropic-base-url:
+    description: 'Anthropic-compatible base URL'
+    required: false
+    default: ''
+  deepseek-base-url:
+    description: 'DeepSeek Anthropic-compatible base URL'
+    required: false
+    default: 'https://api.deepseek.com/anthropic'
+  claude-opus-model:
+    description: 'Anthropic model name for Opus-tier runs'
+    required: false
+    default: ''
+  claude-sonnet-model:
+    description: 'Anthropic model name for Sonnet-tier runs'
+    required: false
+    default: ''
+  deepseek-opus-model:
+    description: 'DeepSeek model name for Opus-tier runs'
+    required: false
+    default: ''
+  deepseek-sonnet-model:
+    description: 'DeepSeek model name for Sonnet-tier runs'
+    required: false
+    default: ''
+  model-tier:
+    description: 'Model tier to select: opus or sonnet'
+    required: false
+    default: opus
+
+  allowed-bots:
+    description: 'Allowed bots override.'
+    required: false
+    default: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
+
+  allowed_tools:
+    description: 'Optional --allowedTools value applied by default.'
+    required: false
+    default: ''
+  allowed_tools_preset:
+    description: 'Named --allowedTools preset. Ignored when allowed_tools is set.'
+    required: false
+    default: ''
+
+  branch-name-template:
+    description: 'Branch-name template for the checkout branch.'
+    required: false
+    default: ''
+  bot-id:
+    description: 'GitHub user ID to use for git operations.'
+    required: false
+    default: '41898282'
+  bot-name:
+    description: 'GitHub username to use for git operations.'
+    required: false
+    default: 'claude[bot]'
+
+  additional-permissions:
+    description: 'Additional permissions for the Claude bot.'
+    required: false
+    default: ''
+
+  plugin_marketplaces:
+    description: 'Plugin marketplaces.'
+    required: false
+    default: ''
+
+  plugins:
+    description: 'Plugins loaded into Claude Code.'
+    required: false
+    default: ''
+
+  prompt:
+    description: 'Prompt for Claude Code.'
+    required: false
+    default: ''
+
+  claude-prompt-file:
+    description: 'Path to a prompt file for Claude Code.'
+    required: false
+    default: ''
+
+  claude-prompt-context:
+    description: 'Optional context to append to the selected prompt.'
+    required: false
+    default: ''
+
+  system-prompt:
+    description: 'Optional system prompt to inject via appendSystemPrompt.'
+    required: false
+    default: ''
+  system-prompt-file:
+    description: 'Optional path to a system-prompt file.'
+    required: false
+    default: ''
+
+  claude_args:
+    description: 'Additional claude args. The action prepends --model automatically.'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve Claude provider settings
+      id: resolve
+      shell: bash
+      env:
+        INPUT_PROVIDER: ${{ inputs['provider'] }}
+        INPUT_CLAUDE_OAUTH_TOKEN: ${{ inputs['claude-oauth-token'] }}
+        INPUT_ANTHROPIC_API_KEY: ${{ inputs['anthropic-api-key'] }}
+        INPUT_DEEPSEEK_API_KEY: ${{ inputs['deepseek-api-key'] }}
+        INPUT_ANTHROPIC_BASE_URL: ${{ inputs['anthropic-base-url'] }}
+        INPUT_DEEPSEEK_BASE_URL: ${{ inputs['deepseek-base-url'] }}
+        INPUT_CLAUDE_OPUS_MODEL: ${{ inputs['claude-opus-model'] }}
+        INPUT_CLAUDE_SONNET_MODEL: ${{ inputs['claude-sonnet-model'] }}
+        INPUT_DEEPSEEK_OPUS_MODEL: ${{ inputs['deepseek-opus-model'] }}
+        INPUT_DEEPSEEK_SONNET_MODEL: ${{ inputs['deepseek-sonnet-model'] }}
+        INPUT_MODEL_TIER: ${{ inputs['model-tier'] }}
+        INPUT_ALLOWED_BOTS: ${{ inputs['allowed-bots'] }}
+        INPUT_BRANCH_NAME_TEMPLATE: ${{ inputs['branch-name-template'] }}
+        INPUT_BOT_ID: ${{ inputs['bot-id'] }}
+        INPUT_BOT_NAME: ${{ inputs['bot-name'] }}
+        INPUT_ADDITIONAL_PERMISSIONS: ${{ inputs['additional-permissions'] }}
+        INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
+        INPUT_PLUGINS: ${{ inputs['plugins'] }}
+        INPUT_PROMPT: ${{ inputs.prompt }}
+        INPUT_PROMPT_FILE: ${{ inputs['claude-prompt-file'] }}
+        INPUT_PROMPT_CONTEXT: ${{ inputs['claude-prompt-context'] }}
+        INPUT_ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        INPUT_ALLOWED_TOOLS_PRESET: ${{ inputs.allowed_tools_preset }}
+        INPUT_SYSTEM_PROMPT: ${{ inputs['system-prompt'] }}
+        INPUT_SYSTEM_PROMPT_FILE: ${{ inputs['system-prompt-file'] }}
+        INPUT_CLAUDE_ARGS: ${{ inputs.claude_args }}
+      run: |
+        set -euo pipefail
+
+        write_output() {
+          local name="$1"
+          local value="$2"
+          local delimiter="__${name}_$(date +%s%N)__"
+          {
+            printf '%s<<%s\n' "$name" "$delimiter"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+        }
+
+        provider="$INPUT_PROVIDER"
+        provider="${provider,,}"
+        provider="${provider:-anthropic}"
+        model_tier="$INPUT_MODEL_TIER"
+        model_tier="${model_tier:-opus}"
+
+        claude_oauth_token_input="$INPUT_CLAUDE_OAUTH_TOKEN"
+        if [ -z "$claude_oauth_token_input" ]; then
+          claude_oauth_token_input="${CLAUDE_CODE_OAUTH_TOKEN-}"
+        fi
+
+        anthropic_api_key_input="$INPUT_ANTHROPIC_API_KEY"
+        if [ -z "$anthropic_api_key_input" ]; then
+          anthropic_api_key_input="${ANTHROPIC_API_KEY-}"
+        fi
+
+        deepseek_api_key_input="$INPUT_DEEPSEEK_API_KEY"
+        if [ -z "$deepseek_api_key_input" ]; then
+          deepseek_api_key_input="${DEEPSEEK_API_KEY-}"
+        fi
+
+        claude_code_oauth_token=""
+        anthropic_api_key=""
+
+        if [ "$provider" = "deepseek" ]; then
+          token="$deepseek_api_key_input"
+          if [ -z "$token" ]; then
+            token="${DEEPSEEK_API_KEY-}"
+          fi
+          anthropic_api_key="$token"
+
+          model_opus="$INPUT_DEEPSEEK_OPUS_MODEL"
+          if [ -z "$model_opus" ]; then
+            model_opus="deepseek-v4-pro[1m]"
+          fi
+
+          model_sonnet="$INPUT_DEEPSEEK_SONNET_MODEL"
+          if [ -z "$model_sonnet" ]; then
+            model_sonnet="deepseek-v4-pro[1m]"
+          fi
+
+          base_url="$INPUT_DEEPSEEK_BASE_URL"
+          if [ -z "$base_url" ]; then
+            base_url="${DEEPSEEK_BASE_URL:-https://api.deepseek.com/anthropic}"
+          fi
+        else
+          token="$claude_oauth_token_input"
+          if [ -z "$token" ]; then
+            token="$anthropic_api_key_input"
+          fi
+          if [ -n "$claude_oauth_token_input" ]; then
+            claude_code_oauth_token="$claude_oauth_token_input"
+          else
+            anthropic_api_key="$token"
+          fi
+
+          model_opus="$INPUT_CLAUDE_OPUS_MODEL"
+          if [ -z "$model_opus" ]; then
+            model_opus="${CLAUDE_OPUS_MODEL:-claude-opus-4-7}"
+          fi
+
+          model_sonnet="$INPUT_CLAUDE_SONNET_MODEL"
+          if [ -z "$model_sonnet" ]; then
+            model_sonnet="${CLAUDE_SONNET_MODEL:-claude-sonnet-4-6}"
+          fi
+
+          base_url="$INPUT_ANTHROPIC_BASE_URL"
+          if [ -z "$base_url" ]; then
+            base_url="${ANTHROPIC_BASE_URL:-}"
+          fi
+        fi
+
+        allowed_bots="$INPUT_ALLOWED_BOTS"
+        branch_name_template="$INPUT_BRANCH_NAME_TEMPLATE"
+        bot_id="$INPUT_BOT_ID"
+        bot_name="$INPUT_BOT_NAME"
+        additional_permissions="$INPUT_ADDITIONAL_PERMISSIONS"
+        plugin_marketplaces="$INPUT_PLUGIN_MARKETPLACES"
+        plugins="$INPUT_PLUGINS"
+
+        allowed_tools="$INPUT_ALLOWED_TOOLS"
+        allowed_tools_preset="$INPUT_ALLOWED_TOOLS_PRESET"
+        preset_allowed_tools=""
+        case "$allowed_tools_preset" in
+          "")
+            ;;
+          claude-interactive)
+            preset_allowed_tools="Read,Edit,Write,Glob,Grep,Bash(corepack pnpm install),Bash(pnpm install),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run compile:fast),Bash(npm run compile:safe),Bash(npm run build:fast),Bash(npm run check:*),Bash(npm run test:kernel),Bash(node *),Bash(git diff *),Bash(git status),Bash(gh pr:*),Bash(gh issue:*),mcp__github__*"
+            ;;
+          quality-improver)
+            preset_allowed_tools="mcp__github__*,Bash(find:*),Bash(grep:*),Bash(wc:*),Bash(jq:*),Bash(git log:*),Bash(git diff:*)"
+            ;;
+          issue-tracker)
+            preset_allowed_tools="mcp__github__*,Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+            ;;
+          issue-tree)
+            preset_allowed_tools="mcp__github__*"
+            ;;
+          github-read)
+            preset_allowed_tools="Read,Glob,Grep,mcp__github__*"
+            ;;
+          *)
+            echo "::error::Unknown allowed_tools_preset: ${allowed_tools_preset}"
+            exit 1
+            ;;
+        esac
+        if [ -z "$allowed_tools" ] && [ -n "$preset_allowed_tools" ]; then
+          allowed_tools="$preset_allowed_tools"
+        fi
+        if [ -z "$allowed_tools" ]; then
+          allowed_tools="${CLAUDE_ALLOWED_TOOLS-}"
+        fi
+
+        system_prompt="$INPUT_SYSTEM_PROMPT"
+        system_prompt_path=""
+        if [ -z "$system_prompt" ]; then
+          system_prompt_path="$INPUT_SYSTEM_PROMPT_FILE"
+        fi
+        if [ -n "$system_prompt_path" ]; then
+          if [ ! -f "$system_prompt_path" ]; then
+            echo "::error::System prompt file not found: ${system_prompt_path}"
+            exit 1
+          fi
+          system_prompt="$(cat "$system_prompt_path")"
+        fi
+        if [ -z "$system_prompt" ] && [ -n "${CLAUDE_APPEND_SYSTEM_PROMPT-}" ]; then
+          system_prompt="${CLAUDE_APPEND_SYSTEM_PROMPT}"
+        fi
+        if [ -n "$system_prompt" ]; then
+          system_prompt="$(printf '%s' "$system_prompt" | tr '\n' ' ')"
+        fi
+
+        prompt="$INPUT_PROMPT"
+        prompt_file="$INPUT_PROMPT_FILE"
+        prompt_context="$INPUT_PROMPT_CONTEXT"
+
+        if [ -z "$prompt" ] && [ -n "$prompt_file" ]; then
+          if [ ! -f "$prompt_file" ]; then
+            echo "::error::Prompt file not found: ${prompt_file}"
+            exit 1
+          fi
+          prompt="$(cat "$prompt_file")"
+        fi
+
+        if [ -n "$prompt_context" ]; then
+          if [ -n "$prompt" ]; then
+            prompt="${prompt}"$'\n'"${prompt_context}"
+          else
+            prompt="$prompt_context"
+          fi
+        fi
+
+        if [ -n "$prompt" ]; then
+          prompt="$(printf '%s' "$prompt" | tr '\n' ' ')"
+        fi
+
+        claude_args="$INPUT_CLAUDE_ARGS"
+        append_system_prompt=''
+        if [ -n "$system_prompt" ] && ! printf '%s\n' "$claude_args" | grep -q -- '--append-system-prompt'; then
+          append_system_prompt="$system_prompt"
+          if [ -n "$claude_args" ]; then
+            claude_args="${claude_args}"$'\n'
+          fi
+          claude_args="${claude_args}--append-system-prompt \"${append_system_prompt}\""
+        fi
+        if [ -n "$allowed_tools" ] && ! printf '%s\n' "$claude_args" | grep -q -- '--allowedTools'; then
+          if [ -n "$claude_args" ]; then
+            claude_args="${claude_args}"$'\n'
+          fi
+          claude_args="${claude_args}--allowedTools \"${allowed_tools}\""
+        fi
+
+        case "$model_tier" in
+          sonnet)
+            model="$model_sonnet"
+            ;;
+          *)
+            model="$model_opus"
+            ;;
+        esac
+
+        write_output claude_code_oauth_token "$claude_code_oauth_token"
+        write_output anthropic_api_key "$anthropic_api_key"
+        write_output base_url "$base_url"
+        write_output model "$model"
+        write_output provider "$provider"
+        write_output allowed_bots "$allowed_bots"
+        write_output branch_name_template "$branch_name_template"
+        write_output bot_id "$bot_id"
+        write_output bot_name "$bot_name"
+        write_output additional_permissions "$additional_permissions"
+        write_output plugin_marketplaces "$plugin_marketplaces"
+        write_output plugins "$plugins"
+        write_output prompt "$prompt"
+        write_output claude_args "$claude_args"
+        write_output append_system_prompt "$append_system_prompt"
+
+    - name: Run Claude Code
+      uses: anthropics/claude-code-action@v1
+      env:
+        ANTHROPIC_BASE_URL: ${{ steps.resolve.outputs.base_url }}
+        ANTHROPIC_API_KEY: ${{ steps.resolve.outputs.anthropic_api_key }}
+      with:
+        claude_code_oauth_token: ${{ steps.resolve.outputs.claude_code_oauth_token }}
+        anthropic_api_key: ${{ steps.resolve.outputs.anthropic_api_key }}
+        allowed_bots: ${{ steps.resolve.outputs.allowed_bots }}
+        branch_name_template: ${{ steps.resolve.outputs.branch_name_template }}
+        bot_id: ${{ steps.resolve.outputs.bot_id }}
+        bot_name: ${{ steps.resolve.outputs.bot_name }}
+        additional_permissions: ${{ steps.resolve.outputs.additional_permissions }}
+        plugin_marketplaces: ${{ steps.resolve.outputs.plugin_marketplaces }}
+        plugins: ${{ steps.resolve.outputs.plugins }}
+        prompt: ${{ steps.resolve.outputs.prompt }}
+        claude_args: |
+          --model ${{ steps.resolve.outputs.model }}
+          ${{ steps.resolve.outputs.claude_args }}

--- a/.github/actions/claude-code-with-provider/action.yml
+++ b/.github/actions/claude-code-with-provider/action.yml
@@ -52,7 +52,7 @@ inputs:
   allowed-bots:
     description: 'Allowed bots override.'
     required: false
-    default: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
+    default: 'claude[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
 
   allowed-tools:
     description: 'Optional --allowedTools value applied by default.'
@@ -269,6 +269,14 @@ runs:
             base_url="${ANTHROPIC_BASE_URL:-}"
           fi
         fi
+        if [ -z "$token" ]; then
+          if [ "$provider" = "deepseek" ]; then
+            echo "::error::DeepSeek provider requires deepseek-api-key or DEEPSEEK_API_KEY."
+          else
+            echo "::error::Anthropic provider requires claude-code-oauth-token, anthropic-api-key, CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_API_KEY."
+          fi
+          exit 1
+        fi
 
         allowed_bots="$INPUT_ALLOWED_BOTS"
         branch_name_template="$INPUT_BRANCH_NAME_TEMPLATE"
@@ -328,9 +336,6 @@ runs:
         fi
         if [ -z "$system_prompt" ] && [ -n "${CLAUDE_APPEND_SYSTEM_PROMPT-}" ]; then
           system_prompt="${CLAUDE_APPEND_SYSTEM_PROMPT}"
-        fi
-        if [ -n "$system_prompt" ]; then
-          system_prompt="$(printf '%s' "$system_prompt" | tr '\n' ' ')"
         fi
 
         prompt="$INPUT_PROMPT"

--- a/.github/prompts/claude-code-review-prompt.md
+++ b/.github/prompts/claude-code-review-prompt.md
@@ -1,0 +1,27 @@
+Review this TeXRA pull request.
+
+Step 0: Load the local review instructions before doing anything else.
+
+1. Read `.claude/skills/code-review/SKILL.md`.
+2. Read `.claude/skills/code-review/references/review-checklist.md`.
+3. Consult `CLAUDE.md` and `AGENTS.md` for the repository rules referenced by
+   the changed files.
+
+Get the diff with `gh pr diff`, then group changed files by the architectural
+zones described in the review skill. For PRD or documentation-only diffs, review
+the document as the product: check claims against the current tree and avoid
+irrelevant TypeScript findings.
+
+Prioritize correctness, security, platform decoupling, type safety, Zod v4
+schema correctness, PocketFlow invariants, webview lifecycle issues,
+configuration and storage correctness, and CI/toolchain hygiene. Do not run
+`npm test`, and do not ask the author to add speculative abstractions.
+
+Before posting new feedback, read existing inline review threads and PR comments.
+Avoid re-raising issues that are already discussed, acknowledged, or fixed. On
+`synchronize` events, resolve previous unresolved bot review threads only when
+the new commits actually address them; never resolve human review threads.
+
+For each concrete issue, post an inline comment on the relevant line. At the end,
+post a concise PR-level summary in the format required by the local review skill,
+including a `Verified` section with the files and line ranges actually opened.

--- a/.github/prompts/claude-code-review-system-prompt.md
+++ b/.github/prompts/claude-code-review-system-prompt.md
@@ -1,0 +1,10 @@
+This is TeXRA, a VS Code extension and desktop application written in
+TypeScript. It uses Zod v4, PocketFlow, a platform abstraction layer, and several
+repo-specific webview and error-handling conventions. Review according to
+`AGENTS.md`, `CLAUDE.md`, and `.claude/skills/code-review/`; generic JavaScript
+review heuristics are insufficient.
+
+Never recommend new abstractions, factories, wrappers, or future-flexibility
+hooks unless they remove concrete duplication in the diff. Trust the type system
+and existing schemas at internal boundaries. Cite `path:line` for every finding
+and include a `Verified` section listing the files actually opened.

--- a/.github/prompts/claude-code-system-prompt.md
+++ b/.github/prompts/claude-code-system-prompt.md
@@ -1,0 +1,9 @@
+You are working in TeXRA, a VS Code extension and desktop application for
+LLM-assisted LaTeX research workflows. Read `AGENTS.md` and `CLAUDE.md` before
+making code changes. For code review tasks, read `.claude/skills/code-review/SKILL.md`.
+
+Respect the repository's TypeScript, Zod v4, PocketFlow, platform abstraction,
+webview, and error-handling conventions. Do not run `npm test`; use
+`npm run typecheck`, `npm run lint`, `npm run compile:fast`, `npm run compile:safe`,
+and `npm run test:kernel` as appropriate. Keep changes narrowly scoped and do not
+add speculative abstractions.

--- a/.github/prompts/issue-tracker-prompt.md
+++ b/.github/prompts/issue-tracker-prompt.md
@@ -1,0 +1,154 @@
+You are the issue tracker agent for this repository. A GitHub event has just
+occurred. Determine what happened and take the appropriate action.
+
+Use the GitHub MCP tools, not the `gh` CLI, for all GitHub operations.
+
+## Runtime Context
+
+The workflow appends the event name, repository, actor, issue or pull request
+number, labels, and merge metadata after this prompt. Use that runtime context
+to choose the playbook below.
+
+## Finding Tracking Issues
+
+For all playbooks, find tracking issues. These are open issues that have a
+`tracking` label, or titles starting with `Tracking:`, `Epic:`, or `Meta:`, and
+contain task lists using `- [ ]` and `- [x]` checkboxes.
+
+## Playbook A: Issue Closed As Completed
+
+When: `issues` / `closed` with `state_reason=completed`.
+
+1. Find tracking issues that reference the closed issue by `#number`, URL, or
+   title keyword in task-list items.
+2. Check off matching items by changing `- [ ]` to `- [x]`.
+3. Comment: `#N (title) has been resolved. Updated checklist.`
+4. If all items are now checked, suggest closing the tracking issue.
+
+## Playbook B: Pull Request Merged
+
+When: `pull_request` / `closed` with `merged=true`.
+
+Do both B1 and B2.
+
+B1: update tracking checklists, as in Playbook A but for the pull request.
+
+1. Find tracking issues referencing this pull request.
+2. Check off matching items.
+3. Comment with a resolution summary.
+
+B2: scan for follow-ups.
+
+1. Read the pull request body, comments, review threads, and linked issues via
+   MCP tools.
+2. Get the code diff with `git diff <base-sha>..<head-sha>`.
+3. Search the diff for new TODO, FIXME, HACK, XXX, and WORKAROUND markers.
+
+Identify actionable follow-ups. Prioritize human reviewer suggestions: comments
+from real people, not bots, carry the most weight. Bot accounts typically have
+`[bot]` in their username or are known services such as Dependabot, Renovate,
+Copilot, Cursor, and Codex.
+
+Look for:
+
+- Human reviewer feedback that was acknowledged but deferred.
+- Explicit deferred scope, such as "out of scope", "follow-up", "separate PR",
+  "later", or "Phase 2".
+- New TODO, FIXME, HACK, XXX, or WORKAROUND comments in the diff.
+- Unresolved review threads or open questions.
+- Roadmap implications for tracked work.
+
+Do not create issues for:
+
+- Work already completed in this pull request.
+- Pre-existing TODOs not introduced by this pull request.
+- Nitpick-level comments.
+- Speculative future work not discussed in the pull request.
+- Bot suggestions already addressed or dismissed.
+
+For each genuine follow-up, create an issue with:
+
+- Title: short and imperative, for example `Add error handling for X`.
+- Body:
+
+  ```markdown
+  ## Context
+
+  Follow-up from #<PR-number> (<PR title>).
+
+  <Why this work is needed>
+
+  ## Details
+
+  <What needs to be done>
+
+  ## References
+
+  - PR: #<PR-number>
+  - <Related issues or review comments>
+  ```
+
+- Labels: always `follow-up`, plus when applicable:
+  - one type-equivalent label: `bug`, `enhancement`, `tech-debt`, or
+    `documentation`;
+  - any matching `area:*` label from the parent pull request's changed paths;
+  - one `risk:*` label reflecting blast radius;
+  - one `status:*` label reflecting current state;
+  - `priority:p0` only for blocker, data-loss, or security follow-ups.
+
+Umbrella versus flat decision:
+
+- Zero follow-ups: skip B2 entirely.
+- One follow-up: create the issue flat and reference the parent pull request in
+  the body. Do not create an umbrella issue.
+- Two or more follow-ups from the same pull request: create a tracking umbrella
+  first, then create each child as a native sub-issue of the umbrella.
+
+For an umbrella:
+
+1. Create the umbrella with `mcp__github__issue_write`, `method=create`.
+   - Title: `Tracking: follow-ups from #<PR-number> (<short PR title>)`.
+   - Body: brief context, bulleted preview of child titles, and link to the
+     parent pull request.
+   - Labels: `tracking`, plus the parent pull request's `area:*` labels.
+   - Capture both `number` and `id` from the response. The `id` is the numeric
+     REST database id, not `node_id`.
+2. For each child, call `mcp__github__issue_write`, `method=create`, with the
+   body and labels.
+3. For each child, attach it to the umbrella with `mcp__github__sub_issue_write`,
+   `method=add`, `issue_number=<umbrella-number>`, and
+   `sub_issue_id=<child-id>`. The `sub_issue_id` is the child's numeric REST id,
+   not its issue number and not its `node_id`.
+
+Then add new issues to relevant tracking issue checklists:
+
+- For one flat follow-up, append `- [ ] #<issue> - <title>` to the relevant
+  section.
+- For an umbrella, append `- [ ] #<umbrella> - Tracking: ...` as a single line.
+- Comment on the parent pull request: `Filed follow-ups from this PR:
+#<umbrella-or-issue>`.
+
+Be conservative. Only create issues for genuine, actionable follow-ups. When in
+doubt, skip it. False positives create noise.
+
+## Playbook C: Pull Request Activity
+
+When: any pull request event that is not a merge or close.
+
+This is lightweight. Most events need no action.
+
+1. Find tracking issues referencing this pull request or related issues.
+2. Only act if the event is meaningful for tracking:
+   - Pull request opened for a tracked task: comment `#<PR> opened to address this`.
+   - Pull request approved: comment `#<PR> approved, ready to merge`.
+   - Changes requested: comment `Changes requested on #<PR>`.
+3. Skip everything else silently.
+
+## Final Report
+
+Summarize what you did:
+
+- Which playbook or playbooks you followed.
+- What tracking issues were updated.
+- What follow-up issues were created, if any.
+- Or state that no action was needed.

--- a/.github/prompts/issue-tree-prompt.md
+++ b/.github/prompts/issue-tree-prompt.md
@@ -1,0 +1,70 @@
+You maintain the issue tree for the repository named in the runtime context.
+Daily, cluster orphan issues into parents, then close completed trackers. Run
+both phases in this order.
+
+Use the GitHub MCP tools, not the `gh` CLI, for all GitHub operations.
+
+## Phase A: Cluster Orphan Issues Into Parents
+
+1. List up to 100 open issues without a parent. Drop any item that has a
+   `pull_request` field: GitHub's issues endpoint returns pull requests
+   alongside issues, and pull requests must never be clustered or linked as
+   sub-issues. Then exclude issues labeled `tracking` or with titles starting
+   `Tracking:`, `[Parent]`, `Epic:`, or `Meta:`, matching this repository's
+   tracker convention from `issue-tracker.yml`.
+2. Find clusters of five or more orphans sharing a clear theme. A common
+   `area:*` label is the strongest signal; root-cause overlap or feature
+   decomposition also count.
+3. Skip a cluster if the cluster's theme is already covered by an existing open
+   tracker. Match on either a tracker title whose wording overlaps the cluster
+   theme, or an open issue labeled `tracking` whose `area:*` labels overlap the
+   cluster's `area:*` labels and whose body or title indicates the same theme.
+   Do not skip merely because some unrelated tracker exists in the repository:
+   the check is theme-scoped, not global.
+4. From the `list_issues` response, capture each child's integer `id`, namely
+   the REST database id. This is not the issue `number` and not the GraphQL
+   `node_id` string.
+5. For each surviving cluster, create the parent via `mcp__github__issue_write`
+   with `method=create`.
+   - Title: `Tracking: <theme>`.
+   - Labels: `tracking` plus the cluster's `area:*` labels.
+   - Body: one-paragraph theme plus checklist rows of the form `- [ ] #N - title`.
+   - Capture both `number` and integer `id` from the response.
+6. Link each child as a native sub-issue with `mcp__github__sub_issue_write`,
+   `method=add`, `issue_number=<parent-number>`, and
+   `sub_issue_id=<child-id>`. The `sub_issue_id` is the child's numeric REST id,
+   not its issue number and not its `node_id`.
+
+Phase A caps:
+
+- At most five new parents per run.
+- At most 50 sub-issue links per run.
+- Precision over recall: link only when the relationship is unambiguous.
+
+## Phase B: Close Completed Trackers
+
+For each open issue labeled `tracking` in the repository named in the runtime
+context, excluding any parent created in Phase A this run:
+
+- Read its sub-issues via `mcp__github__issue_read`.
+- It qualifies for closure only if it has at least one sub-issue and every
+  sub-issue is closed with `state_reason=completed`. Skip if any sub-issue is
+  `not_planned` or `duplicate`.
+- Skip parents created less than 24 hours ago.
+- Process leaf-up: close inner trackers first, then re-check outer ones in the
+  same run.
+
+To close, comment:
+
+```text
+All N sub-issues closed as completed. Auto-closing this tracker.
+```
+
+Then call `mcp__github__issue_write` with `method=update`, `state=closed`, and
+`state_reason=completed`.
+
+Phase B cap: at most 20 closures per run.
+
+## Final Report
+
+Give a one-line summary per phase. Skip silently when nothing matches.

--- a/.github/prompts/repository-quality-improver-prompt.md
+++ b/.github/prompts/repository-quality-improver-prompt.md
@@ -1,0 +1,36 @@
+You are the Quality Improvement Agent for TeXRA.
+Pick one focus area, scan the codebase, and file at most one issue.
+
+## Dedup Gate
+
+Use the repository named in the runtime context. Search
+`repo:<repository> is:issue in:title "[quality]"` across open and closed issues.
+If any result was created in the last 24 hours, exit with a one-line summary.
+This prevents duplicate firings on the same UTC day from manual redispatch, even
+if the prior issue was closed quickly as `not planned`.
+
+## Focus Area
+
+Read `CLAUDE.md` and `AGENTS.md` to ground choices. Look at the last five closed
+`[quality]` issues to see what has been covered recently, then choose a
+different focus. Bias toward TeXRA-specific concerns, such as VS Code coupling
+violations, render-time workarounds, abstraction layers worth flattening, stale
+`_multiple` agent variants, and Zod schema duplication, rather than generic
+categories.
+
+## Scan And File
+
+Run targeted bash analysis. File an issue only if there are at least three
+findings backed by `file:line` citations. Otherwise exit silently.
+
+Use this title form:
+
+```text
+[quality] <area>: <2-4 word finding>
+```
+
+Use one of `bug`, `enhancement`, `tech-debt`, or `documentation`, plus the
+matching `area:*` label from `.github/labels.yml`.
+
+The issue body should contain a brief findings list with `file:line` references
+and an action checklist. State that closing as `not planned` is a valid outcome.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         provider: ${{ fromJson(vars.CLAUDE_CODE_REVIEW_PROVIDERS || format('["{0}"]', vars.CLAUDE_CODE_PROVIDER || 'anthropic')) }}
+    # Repository variable kill switch:
+    #   CLAUDE_REVIEW_ENABLED=false disables Claude-powered PR review.
+    #   unset or any other value preserves the default enabled behavior.
     if: vars.CLAUDE_REVIEW_ENABLED != 'false'
     runs-on: ubuntu-latest
     permissions:
@@ -37,7 +40,20 @@ jobs:
         Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),mcp__github_inline_comment__create_inline_comment,mcp__github__*
 
     steps:
+      - name: Check Claude review switch
+        id: claude-switch
+        env:
+          CLAUDE_REVIEW_ENABLED: ${{ vars.CLAUDE_REVIEW_ENABLED }}
+        run: |
+          if [ "$CLAUDE_REVIEW_ENABLED" = "false" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude code review: CLAUDE_REVIEW_ENABLED=false"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check review provider token
+        if: steps.claude-switch.outputs.skip != 'true'
         id: provider-token
         env:
           REVIEW_PROVIDER: ${{ matrix.provider }}
@@ -61,13 +77,13 @@ jobs:
           fi
 
       - name: Checkout repository under review
-        if: steps.provider-token.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Checkout trusted automation
-        if: steps.provider-token.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -75,7 +91,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check trusted provider wrapper
-        if: steps.provider-token.outputs.skip != 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true'
         id: trusted-provider-wrapper
         run: |
           if [ -f .trusted-actions/.github/actions/claude-code-with-provider/action.yml ]; then
@@ -86,7 +102,7 @@ jobs:
           fi
 
       - name: Run Claude Code Review
-        if: steps.provider-token.outputs.skip != 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
+        if: steps.claude-switch.outputs.skip != 'true' && steps.provider-token.outputs.skip != 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
         id: claude-review
         uses: ./.trusted-actions/.github/actions/claude-code-with-provider
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           provider: ${{ matrix.provider }}
           model-tier: opus
-          allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
+          allowed-bots: 'claude[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
           plugin-marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude-prompt-file: .trusted-actions/.github/prompts/claude-code-review-prompt.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
 name: Claude Code Review
 
 on:
@@ -10,388 +12,96 @@ concurrency:
 
 jobs:
   claude-review:
+    name: claude-review-${{ matrix.provider }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJson(vars.CLAUDE_CODE_REVIEW_PROVIDERS || format('["{0}"]', vars.CLAUDE_CODE_PROVIDER || 'anthropic')) }}
+    if: vars.CLAUDE_REVIEW_ENABLED != 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: write
       actions: read
+      issues: write
       id-token: write
 
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+      CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
+      CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
+      DEEPSEEK_BASE_URL: https://api.deepseek.com/anthropic
+      CLAUDE_ALLOWED_TOOLS: >
+        Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),mcp__github_inline_comment__create_inline_comment,mcp__github__*
+
     steps:
-      - name: Checkout repository
+      - name: Check review provider token
+        id: provider-token
+        env:
+          REVIEW_PROVIDER: ${{ matrix.provider }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          set -euo pipefail
+          case "$REVIEW_PROVIDER" in
+            anthropic) provider_token="$CLAUDE_CODE_OAUTH_TOKEN" ;;
+            deepseek) provider_token="$DEEPSEEK_API_KEY" ;;
+            *)
+              echo "::error::Unsupported review provider: $REVIEW_PROVIDER"
+              exit 1
+              ;;
+          esac
+          if [ -n "$provider_token" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=$REVIEW_PROVIDER token is not configured" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository under review
+        if: steps.provider-token.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
+      - name: Checkout trusted automation
+        if: steps.provider-token.outputs.skip != 'true'
+        uses: actions/checkout@v6
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'claude[bot],chatgpt-codex-connector[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: .trusted-actions
+          fetch-depth: 1
+
+      - name: Check trusted provider wrapper
+        if: steps.provider-token.outputs.skip != 'true'
+        id: trusted-provider-wrapper
+        run: |
+          if [ -f .trusted-actions/.github/actions/claude-code-with-provider/action.yml ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude code review: trusted base branch does not yet contain claude-code-with-provider."
+          fi
+
+      - name: Run Claude Code Review
+        if: steps.provider-token.outputs.skip != 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
+        id: claude-review
+        uses: ./.trusted-actions/.github/actions/claude-code-with-provider
+        with:
+          provider: ${{ matrix.provider }}
+          model-tier: opus
+          allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: |
+          claude-prompt-file: .trusted-actions/.github/prompts/claude-code-review-prompt.md
+          claude-prompt-context: |
+            PR number: ${{ github.event.pull_request.number }}
+            Repository: ${{ github.repository }}
+            Repository owner: ${{ github.repository_owner }}
+            Repository name: ${{ github.event.repository.name }}
             Review this TeXRA pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            Review provider: ${{ matrix.provider }}
             Trigger event: ${{ github.event.action }}
-
-            TeXRA is a VS Code extension (TypeScript, ES2022, Zod v4, PocketFlow) that uses LLMs to
-            assist with LaTeX research workflows. It has many narrow, repo-specific conventions —
-            generic JS/TS review passes will miss most of them.
-
-            **Step 0 — Load the local code-review skill before doing anything else:**
-            1. Read `.claude/skills/code-review/SKILL.md` (workflow + output format).
-            2. Read `.claude/skills/code-review/references/review-checklist.md` (greps + concrete fixes).
-            3. Consult `CLAUDE.md` and `AGENTS.md` only for the specific sections cited inline below — do not skim end-to-end.
-            The `Verified` section at the end of your review is mandatory and must list the
-            files you actually opened (path + line ranges).
-
-            **Step 1 — Get the diff:**
-            Use `gh pr diff ${{ github.event.pull_request.number }}` and group changed files into
-            VS Code-free zones (`src/agent/`, `src/model/`, `src/latex/`, `src/tools/`, `src/shared/`,
-            `src/replacement/`, `src/eventBus/`, any webview `frontend/`) vs. VS Code-allowed zones
-            (`packages/extension/src/extension.ts`, `packages/extension/src/commands/`,
-            `packages/extension/src/frontend/`, `src/common/webview/`, `src/common/state/`,
-            `src/auth/`, `src/platform/`, `src/utils/config/`) vs. PRD/design-doc zones
-            (`prds/**`, `docs/prd/**`, `docs/**`, `*.md`). For PRD/design-doc-only diffs, make the
-            PRD itself the reviewed product: fact-check claims against the current tree and avoid
-            filling the review with code categories that do not apply.
-
-            ---
-
-            **Severity levels:**
-            - 🔴 **Blocker** — must be fixed before merge. Request changes if any are found.
-            - 🟡 **Requires changes** — must be addressed before approval. These are NOT nits.
-              Do NOT approve while issues in this category remain unresolved.
-            - ℹ️ **Advisory** — flag for awareness, acceptable with justification.
-
-            ---
-
-            **Review categories (severity is fixed — do not downgrade):**
-
-            1. 🔴 **Platform decoupling** (CLAUDE.md → "Separation of Concerns: VS Code Coupling").
-               Any `import ... from 'vscode'` inside a VS Code-free zone is a blocker. Also flag:
-               direct `vscode.workspace.getConfiguration` / `workspace.fs` / `secrets` /
-               `vscode.window.show*Message` in agnostic code (use `platform().config|fs|secrets`,
-               return error results); `instanceof vscode.FileSystemError` (use `isFileNotFoundError`);
-               `vscode.FileType.File|Directory` (use `isFile()` / `isDirectory()` from
-               `@common/files/fsEntryType`); raw `process.env`, `os.homedir()`, `fs/promises`,
-               `child_process.exec` in agnostic zones (use platform interfaces or `executeCommand`
-               from `@utils/system/execUtils`); `initPlatform()` called outside
-               `packages/extension/src/extension.ts`.
-
-            2. 🔴 **Security & exec hygiene**. String-interpolated shell commands or
-               `child_process.exec` calls (use `executeCommand` with arg arrays). Path joins of
-               user/LLM-derived strings without `WorkspaceFS` / `RelativeFS` canonicalization
-               (path-traversal). Workspace contents are LLM-influenced — treat as untrusted.
-               Bypassing pre-commit / signing hooks (`--no-verify`, `--no-gpg-sign`).
-
-            3. 🔴 **Build & toolchain hygiene**. Any addition of `npm test` invocations anywhere
-               (scripts, CI, docs) — must not exist; downloads VS Code test env. Type-sensitive
-               diffs that landed without `npm run typecheck` / `compile:safe` (fast builds skip
-               type checking). Removed CI steps. Hard-coded secrets or tokens.
-
-            4. 🟡 **Zod v4 schema correctness** (CLAUDE.md → "Schema and Type Guidelines",
-               AGENTS.md → "Zod v4 Schema Patterns"). Tool input schemas using `.optional()`
-               instead of `.nullish()` (breaks DeepSeek/Kimi structured output) — also flag
-               `=== undefined` checks at the use sites (must be `== null`). Verbose old-style
-               types: `.string().int()`, `.string().uuid()`, `.string().datetime()`,
-               `.nativeEnum`, `.passthrough()` → `.int()`, `.uuid()`, `.iso.datetime()`,
-               `.enum()`, `.looseObject()`. Manual `safeParse` + ternary fallbacks → `.catch()`.
-               `z.custom<T>()` without an explanatory comment. Wrong default semantics:
-               `.prefault` (normalize input pre-validation), `.default` (post-validation
-               fallback), `.catch` (recover from throw) — confusing them silently corrupts state.
-               Persisted-state shape changes that don't tolerate the legacy form via
-               `z.union([NewSchema, LegacyConfigSchema.transform(...)])`. Provider-handler
-               `switch` over a discriminated union with no `assertNever` / `satisfies never`
-               default branch.
-
-            5. 🟡 **PocketFlow & agent runtime** (AGENTS.md → "PocketFlow architecture",
-               `docs/pocketflow/`). String literals `'continue' | 'finalize' | 'complete' |
-               'default'` instead of `FlowTransition.*` from `@agent/core/flows/FlowTransitions`.
-               Mutable values passed to `flow.setServices()` (services must be immutable;
-               mutable state belongs in the shared store). Init/finalize logic appearing inside
-               flows or nodes (agents own lifecycle; nodes throw, `agent.run()` catches). State
-               mutations in `exec` instead of `post`. Ad-hoc retry loops instead of `maxRetries`
-               / `retryDelay` getters. Plain `console.log` or untagged `logger.info` inside
-               agent flows (must wrap with `AgentLogger` from `@logger`). Log payloads built
-               by string interpolation instead of structured `data` arguments. Commands
-               invoking flow factories directly instead of `executeAgent`
-               (`src/agent/runtime/executeAgent.ts`).
-
-            6. 🟡 **Configuration, storage, files**. Inline config string literals scattered
-               across modules instead of typed accessors (`platform().config` in agnostic code;
-               `getConfig` / `watchConfig` from `@utils/config` in VS Code-allowed code). New
-               settings keys not registered in `package.json` `contributes.configuration`.
-               Manual workspace path joining instead of `WorkspaceFS.getPath()` and
-               `@utils/files` helpers. Pasted-image paths handled manually instead of via
-               `pastedImageUtils`. Long-running writers without retention
-               (`RelativeFS.cleanupOldFiles` or equivalent).
-
-            7. 🟡 **Webview / render-time** (CLAUDE.md → "Render-Time Workarounds").
-               `Date.now()` or synthetic IDs generated inside render functions / Lit components
-               (timestamp + ID creation belongs at the producer). Lit components mutating shared
-               state directly instead of dispatching events to managers (`StreamTabs`,
-               `LogList`, `OutputFilesManager`, `WebviewUpdater`, `UsageStatsManager`). Direct
-               DOM manipulation alongside Lit components. New webview providers/handlers not
-               extending `BaseViewContentProvider` / `BaseViewMessageHandler` from
-               `src/common/webview/`. String literals for webview commands (use constants in
-               `src/common/webview/commands.ts`). New shared module path referenced without
-               updating `localResourceRoots` (401 at runtime).
-
-            8. 🟡 **Error handling & logging**. Ad-hoc `vscode.window.showErrorMessage` in
-               business logic instead of `logErrorMessage` / `showLoggedErrorMessage` /
-               `showLoggedMessageWithDocs` from `@common/errors/errorHandlingUtils`. Swallowed
-               errors (`catch {}` / `catch (_) {}`) without an explanatory comment.
-               `instanceof Error` narrowing where the standard helpers above apply. Multiple
-               error paths instead of the single shared one (AGENTS.md "One error path").
-
-            9. 🟡 **Design philosophy** (CLAUDE.md "Doing tasks", "Flattening Abstraction
-               Layers", "Discouraged Factory Patterns"; AGENTS.md "Pragmatic implementations",
-               "Design and refactoring"). Flag and require removal of:
-               - Speculative scaffolding: features, error handling, fallbacks, validation, or
-                 feature flags introduced for hypothetical future requirements rather than the
-                 task at hand. Internal call sites should trust their inputs; validate only at
-                 true system boundaries.
-               - Two-layer factories called from exactly one place (`createX` → `buildX` where
-                 `buildX` is only called by `createX`) — inline.
-               - Trivial identity factories (`function f(x) { return { ...x } }`) — use the
-                 object literal directly.
-               - Wrapper functions that only forward to a single callee with no added logic
-                 (`Node.exec → wrapperFn → coreFn → flow.run`) — nodes and call sites should
-                 invoke the underlying flow / function directly. Empty re-export shim files
-                 left after a rename should be deleted, not stubbed.
-               - Shallow pass-through modules — apply the Ousterhout deep-module test: does
-                 the module hide enough behind its interface to justify its existence?
-               - Duplicate sources of truth: hand-written TypeScript types beside a Zod
-                 schema for the same data, or consumers re-deriving schema information
-                 instead of using `z.infer<typeof Schema>`. The schema is the single source
-                 of truth; types and validators flow from it.
-               - Backward-compatibility hacks: renamed `_unused` placeholder vars,
-                 `// removed` comments, re-export shims for code that's actually deleted,
-                 conditional handling for "old vs. new" formats scattered through consumers
-                 (normalize once at the entry point via `z.union` + `.transform`).
-               - Information leakage: the same data shape decoded / re-encoded in multiple
-                 places, or one module reaching into another's internals.
-               - Overlapping responsibilities: multiple methods, classes, or modules doing
-                 substantially the same job with slight variations (e.g. three "save state"
-                 methods that differ only in serialization format; two helpers that both
-                 normalize a path differently). Flag the duplication AND propose the
-                 minimal consolidated design.
-
-               **Distinguish two directions of advice — they're not contradictory:**
-               - **Speculative scaffolding** (forbidden): adding new abstractions, helpers,
-                 factories, wrappers, or "for future flexibility" hooks for hypothetical
-                 future requirements that the current diff doesn't need. Only flag existing
-                 violations; never recommend adding a new layer.
-               - **Consolidating existing duplication** (encouraged): when the diff (or the
-                 surrounding code it touches) has multiple methods with overlapping
-                 responsibilities, propose collapsing them into the smallest universal set
-                 of operations using an established, industry-tested pattern. Cite the
-                 pattern by name and explain the separation of concerns it enforces. Useful
-                 references for this codebase:
-                 - **Strategy** for swappable algorithms behind one call site (model
-                   handlers, agent reasoning strategies).
-                 - **Discriminated union + exhaustive `switch` with `assertNever`** for
-                   typed dispatch over closed variant sets (provider handlers, message
-                   types) — already the repo's preferred pattern.
-                 - **Single source of truth via Zod schema + `z.infer`** to remove parallel
-                   type definitions.
-                 - **Composition root / dependency injection** at the host entry point
-                   (`platform()`) instead of scattered service lookups.
-                 - **Façade** to hide a multi-step subsystem (PocketFlow flow factories
-                   like `executeAgent`) behind one entry point — but only when the façade
-                   actually deepens the module per Ousterhout, not just renames calls.
-                 - **Adapter** at true system boundaries (filesystem, model APIs) to keep
-                   internal types stable while external SDKs change.
-                 - **Observer / event bus** when one producer fans out to many independent
-                   consumers — but never as a workaround for a missing direct call.
-                 The bar for proposing a pattern: it must remove more code than it adds,
-                 deepen the surviving module, and resolve a concrete duplication present
-                 in the diff. If those conditions don't hold, don't propose it.
-
-            10. 🟡 **Spaghetti code & round trips**. Tangled control flow that obscures data
-                flow at a glance, or work done two ways when one suffices:
-                - Deep nesting (3+ levels of `if`/`else`, `try`/`catch`, `for`/`while`) that
-                  should be flattened with early returns or guard clauses.
-                - Long ternary chains (`a ? x : b ? y : c ? z : ...`) — convert to lookup
-                  table, switch, or if/else-if cascade.
-                - Prop / parameter drilling: data threaded through 4+ functions just to reach
-                  its consumer. Promote to shared state, dependency injection, or push the
-                  consumer closer to the producer.
-                - Round-trip serialization: `JSON.stringify` → `JSON.parse` of the same data,
-                  or read file → parse → mutate one field → reserialize → write where an
-                  in-memory transform would do.
-                - Round-trip type erasure: passing a typed object as `unknown` / `any`,
-                  re-validating with the same schema, then narrowing again — keep the type
-                  through the call chain.
-                - Repeated work in hot paths: same file read multiple times in one flow,
-                  same API call duplicated, computed value recomputed inside a loop instead
-                  of cached above it.
-                - N+1 patterns: looping over an array with a per-item async lookup when a
-                  batch fetch exists.
-                - Multi-pass loops over the same collection that could be fused (`.filter`
-                  then `.map` then `.find` — collapse into one walk).
-                - Sequential `await` on independent operations that should run via
-                  `Promise.all`.
-                - Cross-module ping-pong: A calls B, B calls back into A for state — push
-                  the data once instead of inverting the dependency.
-                - Effect / event handlers that fire only to dispatch a direct call the
-                  producer could have made itself (related to "Render-Time Workarounds").
-                - State changes that fan out to listeners with no change-detection guard,
-                  so downstream consumers re-render on no-op updates.
-
-            11. 🟡 **Style, naming, and import hygiene**. PascalCase for service singletons
-                (`StreamStatusService`, `ModelRegistry`); camelCase for command/function
-                namespaces (`agentCommands`, `latexCommands`); UPPER_SNAKE_CASE for true
-                constants (`MAX_ERROR_LENGTH`). Long relative imports (`../../../../`) where
-                a path alias (`@agent`, `@common`, `@utils`, `@platform`, …) exists. Imports
-                not grouped with descriptive prefix comments. Helpers placed in `src/utils/`
-                that are actually specific to one side (belong under `frontend/` or
-                `common/`). View-specific managers not under each view's `managers/` folder.
-                Webview naming not following `[Domain]View[Component]`.
-
-            12. 🟡 **Concurrency & resources**. Shared mutable state held across `await`
-                (race risk — capture locals before `await`). Webview `dispose` paths that
-                don't unregister listeners or FS watchers (leak). Long-running model handlers
-                / tool calls without `signal.aborted` checks between awaits.
-
-            13. ℹ️ **Comments**. WHAT-comments on well-named code (delete). Process tags
-                (`// added for issue #123`, `// per Codex review`, `// TODO from PR #45`) —
-                belong in PR description, not the code (delete). Multi-paragraph docstrings
-                on private helpers (one short line max). Commenting WHY belongs only when
-                non-obvious — hidden constraint, subtle invariant, workaround for a specific
-                bug, behavior that would surprise a reader.
-
-            14. ℹ️ **Documentation drift**. CHANGELOG.md not updated for user-visible changes
-                (Features / Bug Fixes / rarely Breaking Changes). New public APIs without
-                JSDoc. Module-level doc comments missing for new top-level files. Mathematical
-                or domain-specific docstrings that explain TS syntax instead of meaning.
-                Changed PRDs under `prds/**` or `docs/prd/**` must be reviewed against the
-                implementation plan they describe: flag stale acceptance criteria, missing
-                dependency/ordering updates, claims contradicted by current code, and checklist
-                items marked done without matching artifacts in the diff.
-
-            ---
-
-            **Verdict rules (internal — drive your `REQUEST_CHANGES` vs `APPROVE` decision,
-            not visible to readers):**
-            - If any Blocker or Requires-changes issue is found, submit the review as
-              `REQUEST_CHANGES`.
-            - Submit `APPROVE` only when no Blocker or Requires-changes issues remain.
-            - Notes (advisory) alone do not block approval.
-            - Do not relabel a Requires-changes or Blocker issue as a "nit" or "non-blocking"
-              to avoid blocking — keep the verdict honest.
-            - Cite `path:line` for every finding. Open the file before flagging — speculative
-              findings are worse than none.
-            - Prefer 3 grounded findings over 10 generic ones. A "no issues found" review on
-              this repo is almost always wrong; if the diff genuinely is clean, say what you
-              checked and why each category was a no-op.
-            - For PRD/design-doc diffs, factual drift, impossible sequencing, stale file paths,
-              or acceptance criteria contradicted by current repository state are
-              `Requires changes`, not advisory documentation nits.
-
-            **Rendering style for the posted comment (this is what the author sees):**
-            Default to calm, declarative prose. The GitHub review status
-            (REQUEST_CHANGES vs APPROVE) communicates urgency; the comment body
-            communicates substance — state the issue, cite the file and line, propose
-            the fix.
-
-            Emoji and emphasis usage:
-            - Section headers and category discussion: plain text, no emojis. Don't
-              decorate "I checked these categories" with traffic lights.
-            - Clean diff or "no issues found" summaries: no emojis, no exclamation marks.
-              A clean review shouldn't look like an emergency.
-            - Genuine Blocker findings (real platform-decoupling violations, security
-              issues, build-breaking changes): a single 🔴 prefix on the finding line is
-              fine to draw attention. Use sparingly — one per real Blocker, not on
-              every bullet.
-            - Requires-changes and Notes findings: plain bullets, no emoji.
-            - Avoid ALL-CAPS shouting and alarmist words like "BLOCKER" / "CRITICAL" /
-              "MUST FIX NOW" as decoration. If a finding is genuinely a blocker, the
-              prose ("this prevents the extension from loading on Linux") and the
-              REQUEST_CHANGES status do the work.
-
-            For each issue found, post an inline comment on the relevant line using the GitHub
-            inline comment MCP tool. At the end, post a single PR-level summary comment
-            following the output format from `.claude/skills/code-review/SKILL.md`:
-
-            ```
-            ## Findings
-
-            ### Issues to address before merge
-            - `path/file.ts:42` — <one-line summary>. <why / fix>.
-
-            ### Suggestions
-            - ...
-
-            ### Notes
-            - ...
-
-            ## Verified
-            - <files you actually opened, with line ranges>
-            ```
-
-            Use only the headers that have content — omit empty sections rather than
-            writing "(none)". If the diff is clean, say so in one sentence above
-            `## Verified` instead of producing empty headers.
-
-            ---
-
-            **Reading existing feedback (before posting anything new):**
-            1. Read inline review threads via `mcp__github__pull_request_read` (get_review_comments).
-            2. Read PR conversation comments via `mcp__github__issue_read` (get_comments) — bots and
-               humans often post feedback at the PR level, not as inline review comments. Equally
-               important.
-
-            Use this context to:
-            - Avoid re-raising issues that have already been discussed, acknowledged, or fixed.
-            - Understand any ongoing decisions made in earlier threads.
-
-            **Resolving previous bot review comments (synchronize events only):**
-            When triggered by `synchronize` (new push to the PR):
-            1. Fetch all review threads with their GraphQL node IDs — `get_review_comments` does
-               NOT return thread IDs, so use GraphQL.
-            2. For each unresolved thread whose author login starts with `claude`,
-               `copilot-pull-request-reviewer`, or `chatgpt-codex-connector` (GitHub may append
-               `[bot]` — match the base name as a prefix), check whether the new commits address
-               the issue. Do NOT resolve threads from `cursor` / Bugbot — that bot manages its own
-               resolution.
-            3. If a previous comment has been addressed, resolve it via
-               `mcp__github__resolve_review_thread` with the GraphQL thread `id`.
-            4. If still relevant, leave it unresolved.
-            5. Never resolve threads from human reviewers.
-
-            **Fetch thread IDs via GraphQL:**
-
-            ```bash
-            gh api graphql -f query='
-            {
-              repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
-                pullRequest(number: ${{ github.event.pull_request.number }}) {
-                  reviewThreads(first: 100) {
-                    nodes {
-                      id
-                      isResolved
-                      isOutdated
-                      comments(first: 1) {
-                        nodes { author { login } body }
-                      }
-                    }
-                    pageInfo { hasNextPage endCursor }
-                  }
-                }
-              }
-            }'
-            ```
-
-            Returns thread objects with `id` like `"PRRT_kwDO..."`. Paginate via `endCursor` if
-            `hasNextPage` is true.
-
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: |
-            --model claude-opus-4-7
-            --allowedTools "Read" "Glob" "Grep" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh pr comment:*)" "Bash(gh api graphql:*)" "Bash(git diff:*)" "Bash(git log:*)" "mcp__github_inline_comment__create_inline_comment" "mcp__github__*"
-            --append-system-prompt "This is TeXRA, a VS Code extension (TypeScript, Zod v4, PocketFlow) for LLM-assisted LaTeX research. The repo encodes many narrow conventions in CLAUDE.md, AGENTS.md, and .claude/skills/code-review/. Review with those rules as the source of truth — generic JS/TS heuristics will produce false positives and miss real findings. Never recommend adding new abstractions, factories, wrappers, or 'for future flexibility' hooks; only flag existing violations and propose deletion or inlining. Trust the type system and existing schemas; do not suggest extra runtime validation at internal boundaries. Cite path:line for every finding and include a Verified section listing files actually opened."
+          system-prompt-file: .trusted-actions/.github/prompts/claude-code-review-system-prompt.md

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
       CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
       CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
       DEEPSEEK_BASE_URL: https://api.deepseek.com/anthropic
-      CLAUDE_ALLOWED_TOOLS: >
+      CLAUDE_ALLOWED_TOOLS: >-
         Read,Glob,Grep,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),mcp__github_inline_comment__create_inline_comment,mcp__github__*
 
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -93,7 +93,7 @@ jobs:
           provider: ${{ matrix.provider }}
           model-tier: opus
           allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugin-marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           claude-prompt-file: .trusted-actions/.github/prompts/claude-code-review-prompt.md
           claude-prompt-context: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  BOT_PAT: ${{ secrets.BOT_PAT }}
   GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -58,7 +59,7 @@ jobs:
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: opus
-          allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
+          allowed-bots: 'claude[bot],cursor[bot],cursor,copilot-pull-request-reviewer[bot]'
           branch-name-template: '{{prefix}}{{entityType}}-{{entityNumber}}-{{description}}'
           allowed-tools-preset: claude-interactive
           additional-permissions: |
@@ -69,6 +70,7 @@ jobs:
         if: |
           !cancelled() &&
           steps.claude.outcome == 'success' &&
+          env.BOT_PAT != '' &&
           (github.event_name == 'issues' ||
            (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
         uses: ./.github/actions/auto-create-issue-pr
@@ -77,4 +79,4 @@ jobs:
           repo: ${{ github.repository }}
           branch-prefix: 'claude/issue-'
           creator-name: 'Claude Code action'
-          gh-token: ${{ env.GH_TOKEN }}
+          gh-token: ${{ env.BOT_PAT }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -58,9 +58,27 @@ jobs:
           fetch-depth: 1
           token: ${{ env.GH_TOKEN }}
 
+      - name: Checkout trusted automation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          path: .trusted-actions
+          fetch-depth: 1
+
+      - name: Check trusted provider wrapper
+        id: trusted-provider-wrapper
+        run: |
+          if [ -f .trusted-actions/.github/actions/claude-code-with-provider/action.yml ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping Claude Code: trusted base branch does not yet contain claude-code-with-provider."
+          fi
+
       - name: Run Claude Code
         id: claude
-        uses: ./.github/actions/claude-code-with-provider
+        if: steps.trusted-provider-wrapper.outputs.available == 'true'
+        uses: ./.trusted-actions/.github/actions/claude-code-with-provider
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: opus
@@ -69,7 +87,7 @@ jobs:
           allowed-tools-preset: claude-interactive
           additional-permissions: |
             actions: read
-          system-prompt-file: .github/prompts/claude-code-system-prompt.md
+          system-prompt-file: .trusted-actions/.github/prompts/claude-code-system-prompt.md
 
       - name: Auto-create PR for completed issue work
         if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,8 +22,13 @@ env:
 
 jobs:
   claude:
+    # Repository variable kill switch:
+    #   CLAUDE_CODE_ENABLED=false disables mention-driven Claude runs.
+    #   unset or any other value preserves the default enabled behavior.
     if: |
-      github.event.sender.type != 'Bot' && (
+      vars.CLAUDE_CODE_ENABLED != 'false' &&
+      github.event.sender.type != 'Bot' &&
+      (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
 name: Claude Code
 
 on:
@@ -10,41 +12,70 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: bot-respond-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+      CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
+      CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
+
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          token: ${{ env.GH_TOKEN }}
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/claude-code-with-provider
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
+          provider: ${{ env.CLAUDE_CODE_PROVIDER }}
+          model-tier: opus
+          allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
+          branch-name-template: '{{prefix}}{{entityType}}-{{entityNumber}}-{{description}}'
+          allowed_tools_preset: claude-interactive
+          additional-permissions: |
             actions: read
+          system-prompt-file: .github/prompts/claude-code-system-prompt.md
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-          claude_args: '--model claude-opus-4-7 --allowed-tools Bash(gh pr:*)'
+      - name: Auto-create PR for completed issue work
+        if: |
+          !cancelled() &&
+          steps.claude.outcome == 'success' &&
+          (github.event_name == 'issues' ||
+           (github.event_name == 'issue_comment' && !github.event.issue.pull_request))
+        uses: ./.github/actions/auto-create-issue-pr
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          repo: ${{ github.repository }}
+          branch-prefix: 'claude/issue-'
+          creator-name: 'Claude Code action'
+          event-name: ${{ github.event_name }}
+          gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,7 +60,7 @@ jobs:
           model-tier: opus
           allowed-bots: 'claude,cursor[bot],cursor,copilot-pull-request-reviewer'
           branch-name-template: '{{prefix}}{{entityType}}-{{entityNumber}}-{{description}}'
-          allowed_tools_preset: claude-interactive
+          allowed-tools-preset: claude-interactive
           additional-permissions: |
             actions: read
           system-prompt-file: .github/prompts/claude-code-system-prompt.md
@@ -77,5 +77,4 @@ jobs:
           repo: ${{ github.repository }}
           branch-prefix: 'claude/issue-'
           creator-name: 'Claude Code action'
-          event-name: ${{ github.event_name }}
           gh-token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -23,15 +23,21 @@ jobs:
     # Skip automated review summaries: the Claude action cannot exchange their
     # OIDC token for a repo-writing app token, and Playbook C has no useful
     # tracking action for bot-submitted review events.
+    # Repository variable kill switch:
+    #   ISSUE_TRACKER_ENABLED=false disables tracking issue updates.
+    #   unset or any other value preserves the default enabled behavior.
     if: |
-      (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
-      (github.event_name == 'pull_request' &&
-       (github.event.action == 'opened' ||
-        (github.event.action == 'closed' && github.event.pull_request.merged == true))) ||
-      (github.event_name == 'pull_request_review' &&
-       github.event.review.user.type != 'Bot' &&
-       !endsWith(github.event.review.user.login, '[bot]') &&
-       github.actor != 'Copilot')
+      vars.ISSUE_TRACKER_ENABLED != 'false' &&
+      (
+        (github.event_name == 'issues' && github.event.issue.state_reason == 'completed') ||
+        (github.event_name == 'pull_request' &&
+         (github.event.action == 'opened' ||
+          (github.event.action == 'closed' && github.event.pull_request.merged == true))) ||
+        (github.event_name == 'pull_request_review' &&
+         github.event.review.user.type != 'Bot' &&
+         !endsWith(github.event.review.user.login, '[bot]') &&
+         github.actor != 'Copilot')
+      )
     runs-on: ubuntu-latest
     env:
       CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -81,7 +81,7 @@ jobs:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: opus
           allowed-bots: 'dependabot[bot],github-actions[bot],Copilot,claude[bot],cursor[bot]'
-          allowed_tools_preset: issue-tracker
+          allowed-tools-preset: issue-tracker
           claude-prompt-file: .github/prompts/issue-tracker-prompt.md
           claude-prompt-context: |
             Event: ${{ github.event_name }} / ${{ github.event.action }}

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
 name: Issue Tracker
 
 on:
@@ -31,6 +33,13 @@ jobs:
        !endsWith(github.event.review.user.login, '[bot]') &&
        github.actor != 'Copilot')
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+      CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
+      CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
     permissions:
       contents: read
       pull-requests: read
@@ -67,186 +76,32 @@ jobs:
       - name: Run Claude Code
         id: claude
         if: steps.tracker-gate.outputs.should_run == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/claude-code-with-provider
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'dependabot[bot],github-actions[bot],Copilot,chatgpt-codex-connector,claude[bot],cursor[bot]'
-          claude_args: |
-            --model claude-opus-4-7
-            --allowedTools "mcp__github__*" "Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)"
+          provider: ${{ env.CLAUDE_CODE_PROVIDER }}
+          model-tier: opus
+          allowed-bots: 'dependabot[bot],github-actions[bot],Copilot,claude[bot],cursor[bot]'
+          allowed_tools_preset: issue-tracker
+          claude-prompt-file: .github/prompts/issue-tracker-prompt.md
+          claude-prompt-context: |
+            Event: ${{ github.event_name }} / ${{ github.event.action }}
+            Repository: ${{ github.repository }}
+            Triggered by: ${{ github.event.sender.login }}
 
-          prompt: |
-            You are the issue tracker agent for this repository. A GitHub event just
-            occurred. Determine what happened and take the appropriate actions.
+            ${{ github.event_name == 'issues' && format('Issue number: #{0}', github.event.issue.number) || '' }}
+            ${{ github.event_name == 'issues' && format('Issue title: {0}', github.event.issue.title) || '' }}
+            ${{ github.event_name == 'issues' && format('Issue labels: {0}', join(github.event.issue.labels.*.name, ', ')) || '' }}
 
-            Use the GitHub MCP tools (not gh CLI) for all GitHub operations.
-
-            ## Event Context
-
-            - **Event**: ${{ github.event_name }} / ${{ github.event.action }}
-            - **Repository**: ${{ github.repository }}
-            - **Triggered by**: ${{ github.event.sender.login }}
-
-            ${{ github.event_name == 'issues' && format('- **Issue number**: #{0}', github.event.issue.number) || '' }}
-            ${{ github.event_name == 'issues' && format('- **Issue title**: {0}', github.event.issue.title) || '' }}
-            ${{ github.event_name == 'issues' && format('- **Issue labels**: {0}', join(github.event.issue.labels.*.name, ', ')) || '' }}
-
-            ${{ github.event_name != 'issues' && format('- **PR number**: #{0}', github.event.pull_request.number) || '' }}
-            ${{ github.event_name != 'issues' && format('- **PR title**: {0}', github.event.pull_request.title) || '' }}
-            ${{ github.event_name != 'issues' && format('- **PR labels**: {0}', join(github.event.pull_request.labels.*.name, ', ')) || '' }}
-            ${{ github.event_name != 'issues' && format('- **PR state**: {0}', github.event.pull_request.state) || '' }}
-            ${{ github.event_name != 'issues' && format('- **PR draft**: {0}', github.event.pull_request.draft) || '' }}
-            ${{ github.event_name != 'issues' && format('- **Author**: {0}', github.event.pull_request.user.login) || '' }}
-            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Merged by**: {0}', github.event.pull_request.merged_by.login) || '' }}
-            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Base branch**: {0}', github.event.pull_request.base.ref) || '' }}
-            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Head branch**: {0}', github.event.pull_request.head.ref) || '' }}
-            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Base SHA**: {0}', github.event.pull_request.base.sha) || '' }}
-            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('- **Head SHA**: {0}', github.event.pull_request.head.sha) || '' }}
-            ${{ github.event_name == 'pull_request_review' && format('- **Review state**: {0}', github.event.review.state) || '' }}
-            ${{ github.event_name == 'pull_request_review' && format('- **Reviewer**: {0}', github.event.review.user.login) || '' }}
-
-            ---
-
-            ## What To Do
-
-            Based on the event, follow the appropriate playbook below.
-
-            ### Finding Tracking Issues
-
-            For all playbooks, you'll need to find tracking issues. These are open issues
-            that have a "tracking" label, or titles starting with "Tracking:", "Epic:",
-            or "Meta:", and contain task lists (checkboxes `- [ ]` / `- [x]`).
-
-            ---
-
-            ### Playbook A: Issue Closed as Completed
-
-            **When**: `issues` / `closed` with state_reason `completed`
-
-            1. Find tracking issues that reference the closed issue (by `#number`,
-               URL, or title keyword in task list items)
-            2. Check off matching items: `- [ ]` → `- [x]`
-            3. Comment: "✅ #N (title) has been resolved. Updated checklist."
-            4. If ALL items are now checked, suggest closing the tracking issue
-
-            ---
-
-            ### Playbook B: PR Merged
-
-            **When**: `pull_request` / `closed` with `merged == true`
-
-            Do TWO things:
-
-            **B1 — Update tracking checklists** (same as Playbook A but for the PR):
-            1. Find tracking issues referencing this PR
-            2. Check off matching items
-            3. Comment with resolution summary
-
-            **B2 — Scan for follow-ups**:
-            1. Read the PR body, comments, review threads, and linked issues via MCP tools
-            2. Get the code diff: `git diff <base-sha>..<head-sha>`
-            3. Search the diff for new TODO/FIXME/HACK/XXX/WORKAROUND markers
-
-            Identify actionable follow-ups. **Prioritize human reviewer suggestions** —
-            comments from real people (not bots) carry the most weight. Bot accounts
-            typically have `[bot]` in their username or are known services (dependabot,
-            renovate, copilot, cursor, codex, etc.).
-
-            Look for:
-            - Human reviewer feedback that was acknowledged but deferred (highest priority)
-            - Explicit TODOs or deferred scope ("out of scope", "follow-up", "separate PR",
-              "later", "Phase 2")
-            - New TODO/FIXME/HACK comments in the diff (not pre-existing ones)
-            - Unresolved review threads or open questions
-            - Roadmap implications for tracked work
-
-            Do NOT create issues for:
-            - Work already completed in this PR
-            - Pre-existing TODOs not introduced by this PR
-            - Nitpick-level comments (style, naming)
-            - Speculative future work not discussed in the PR
-            - Bot suggestions already addressed or dismissed
-
-            For each genuine follow-up, create an issue with:
-            - **Title**: Short, imperative (e.g. "Add error handling for X")
-            - **Body**:
-              ```
-              ## Context
-              Follow-up from #<PR-number> (<PR title>).
-
-              <Why this work is needed>
-
-              ## Details
-              <What needs to be done>
-
-              ## References
-              - PR: #<PR-number>
-              - <Related issues or review comments>
-              ```
-            - **Labels**: always `follow-up`. Plus, when applicable:
-              - One type-equivalent: `bug`, `enhancement`, `tech-debt`, or `documentation`.
-              - Any matching `area:*` from the parent PR's changed paths:
-                `area:agent-runtime`, `area:model-handlers`, `area:progress-view`,
-                `area:latex-workflow`, `area:docs`, `area:webview`, `area:ci`, `area:deps`.
-              - One `risk:*` (`risk:low`, `risk:medium`, `risk:high`) reflecting blast radius.
-              - One `status:*` (`status:needs-triage`, `status:needs-validation`,
-                `status:ready-review`, `status:blocked-external`) reflecting current state.
-              - `priority:p0` only for blocker / data-loss / security follow-ups.
-
-            **Umbrella vs flat decision.**
-
-            - **0 follow-ups**: skip B2 entirely.
-            - **1 follow-up**: create the issue flat. Reference the parent PR in the body.
-              Do NOT create an umbrella — sub-issue overhead is not worth it for a single child.
-            - **2+ follow-ups from the same PR**: create a tracking umbrella first,
-              then create each child as a native sub-issue of the umbrella:
-              1. Create umbrella with `mcp__github__issue_write` (method=create):
-                 - Title: `Tracking: follow-ups from #<PR-number> (<short PR title>)`
-                 - Body: brief context + bulleted preview of child titles + link to parent PR
-                 - Labels: `tracking`, plus the parent PR's `area:*` labels
-                 - **Capture both `number` AND `id` from the response.** `id` is the
-                   numeric REST database id (integer), NOT `node_id` (the GraphQL
-                   string). `sub_issue_write` below requires the integer `id`.
-              2. For each child, call `mcp__github__issue_write` (method=create) with
-                 the body and labels (`follow-up` + applicable type/area/risk/status
-                 from the list above).
-                 **Capture both `number` AND `id` (integer) from each child response.**
-              3. For each child, attach to the umbrella:
-                 `mcp__github__sub_issue_write` with method=`add`,
-                 `issue_number=<umbrella-number>`, `sub_issue_id=<child-id>`.
-                 Note: `sub_issue_id` is the child's numeric REST `id` (integer),
-                 NOT its issue `number` and NOT its `node_id`.
-
-            Then add new issues to relevant tracking issue checklists:
-            - For flat (1 follow-up): append `- [ ] #<issue> - <title>` to the relevant section
-            - For umbrella (2+): append `- [ ] #<umbrella> - Tracking: ...` (single line for the umbrella)
-            - Comment on the parent PR: "📋 Filed follow-ups from this PR: #<umbrella-or-issue>"
-
-            **Be conservative.** Only create issues for genuine, actionable follow-ups.
-            When in doubt, skip it. False positives create noise. Two real follow-ups
-            justify an umbrella; two speculative ones do not.
-
-            ---
-
-            ### Playbook C: PR Activity (opened, edited, labeled, review submitted)
-
-            **When**: Any PR event that isn't a merge/close
-
-            This is lightweight — most events need no action.
-
-            1. Find tracking issues referencing this PR or related issues
-            2. Only act if the event is meaningful for tracking:
-               - PR opened for a tracked task → comment "🔄 #<PR> opened to address this"
-               - PR approved → comment "✅ #<PR> approved, ready to merge"
-               - Changes requested → comment "⚠️ Changes requested on #<PR>"
-            3. Skip everything else silently (edits, labels, etc. are usually not worth a comment)
-
-            ---
-
-            ## Final Report
-
-            Summarize what you did:
-            - Which playbook(s) you followed
-            - What tracking issues were updated
-            - What follow-up issues were created (if any)
-            - Or note that no action was needed
+            ${{ github.event_name != 'issues' && format('PR number: #{0}', github.event.pull_request.number) || '' }}
+            ${{ github.event_name != 'issues' && format('PR title: {0}', github.event.pull_request.title) || '' }}
+            ${{ github.event_name != 'issues' && format('PR labels: {0}', join(github.event.pull_request.labels.*.name, ', ')) || '' }}
+            ${{ github.event_name != 'issues' && format('PR state: {0}', github.event.pull_request.state) || '' }}
+            ${{ github.event_name != 'issues' && format('PR draft: {0}', github.event.pull_request.draft) || '' }}
+            ${{ github.event_name != 'issues' && format('Author: {0}', github.event.pull_request.user.login) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('Merged by: {0}', github.event.pull_request.merged_by.login) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('Base branch: {0}', github.event.pull_request.base.ref) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('Head branch: {0}', github.event.pull_request.head.ref) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('Base SHA: {0}', github.event.pull_request.base.sha) || '' }}
+            ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && format('Head SHA: {0}', github.event.pull_request.head.sha) || '' }}
+            ${{ github.event_name == 'pull_request_review' && format('Review state: {0}', github.event.review.state) || '' }}
+            ${{ github.event_name == 'pull_request_review' && format('Reviewer: {0}', github.event.review.user.login) || '' }}

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -79,16 +79,35 @@ jobs:
 
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout trusted automation
+        if: steps.tracker-gate.outputs.should_run == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
+          path: .trusted-actions
+          fetch-depth: 1
+
+      - name: Check trusted provider wrapper
+        if: steps.tracker-gate.outputs.should_run == 'true'
+        id: trusted-provider-wrapper
+        run: |
+          if [ -f .trusted-actions/.github/actions/claude-code-with-provider/action.yml ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping issue tracker: trusted base branch does not yet contain claude-code-with-provider."
+          fi
+
       - name: Run Claude Code
         id: claude
-        if: steps.tracker-gate.outputs.should_run == 'true'
-        uses: ./.github/actions/claude-code-with-provider
+        if: steps.tracker-gate.outputs.should_run == 'true' && steps.trusted-provider-wrapper.outputs.available == 'true'
+        uses: ./.trusted-actions/.github/actions/claude-code-with-provider
         with:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: opus
           allowed-bots: 'dependabot[bot],github-actions[bot],Copilot,claude[bot],cursor[bot]'
           allowed-tools-preset: issue-tracker
-          claude-prompt-file: .github/prompts/issue-tracker-prompt.md
+          claude-prompt-file: .trusted-actions/.github/prompts/issue-tracker-prompt.md
           claude-prompt-context: |
             Event: ${{ github.event_name }} / ${{ github.event.action }}
             Repository: ${{ github.repository }}

--- a/.github/workflows/issue-tracker.yml
+++ b/.github/workflows/issue-tracker.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           should_run=true
 
-          if [[ "$EVENT_NAME" == "pull_request" && "$EVENT_ACTION" == "opened" ]]; then
+          if [[ "$EVENT_NAME" == pull_request* ]]; then
             tracker_workflow_changes="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- .github/workflows/issue-tracker.yml)"
             if [[ -n "$tracker_workflow_changes" ]]; then
               should_run=false

--- a/.github/workflows/issue-tree.yml
+++ b/.github/workflows/issue-tree.yml
@@ -13,6 +13,10 @@ concurrency:
 
 jobs:
   tend:
+    # Repository variable kill switch:
+    #   ISSUE_TREE_ENABLED=false disables scheduled issue-tree maintenance.
+    #   unset or any other value preserves the default enabled behavior.
+    if: vars.ISSUE_TREE_ENABLED != 'false'
     runs-on: ubuntu-latest
     env:
       CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}

--- a/.github/workflows/issue-tree.yml
+++ b/.github/workflows/issue-tree.yml
@@ -35,7 +35,7 @@ jobs:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: sonnet
           allowed-bots: 'github-actions[bot]'
-          allowed_tools_preset: issue-tree
+          allowed-tools-preset: issue-tree
           claude-prompt-file: .github/prompts/issue-tree-prompt.md
           claude-prompt-context: |
             Repository: ${{ github.repository }}

--- a/.github/workflows/issue-tree.yml
+++ b/.github/workflows/issue-tree.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
 name: Issue Tree
 
 on:
@@ -12,6 +14,13 @@ concurrency:
 jobs:
   tend:
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+      CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
+      CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
     permissions:
       contents: read
       issues: write
@@ -21,85 +30,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: ./.github/actions/claude-code-with-provider
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'github-actions[bot]'
-          claude_args: |
-            --model claude-sonnet-4-6
-            --allowedTools "mcp__github__*"
-
-          prompt: |
-            You maintain the issue tree for ${{ github.repository }}. Daily,
-            cluster orphan issues into parents, then close completed trackers.
-            Run both phases in this order.
-
-            Use the GitHub MCP tools (not gh CLI) for all GitHub operations.
-
-            ## Phase A — Cluster orphan issues into parents
-
-            1. List up to 100 open issues without a parent. Drop any item that
-               has a `pull_request` field — GitHub's issues endpoint returns PRs
-               alongside issues, and PRs must never be clustered or linked as
-               sub-issues. Then exclude issues labeled `tracking` or with titles
-               starting `Tracking:` / `[Parent]` / `Epic:` / `Meta:` (matching
-               this repo's tracker convention from `issue-tracker.yml`).
-            2. Find clusters of **5 or more** orphans sharing a clear theme — a
-               common `area:*` label is the strongest signal; root-cause overlap
-               or feature decomposition also count.
-            3. Skip a cluster if the cluster's **theme** is already covered by
-               an existing open tracker. Match on either:
-               - title prefix `Tracking:` / `[Parent]` / `Epic:` / `Meta:` whose
-                 wording overlaps the cluster theme, OR
-               - an open issue labeled `tracking` whose `area:*` labels overlap
-                 the cluster's `area:*` labels and whose body or title indicates
-                 the same theme.
-               Do NOT skip merely because some unrelated tracker exists in the
-               repo — the check is theme-scoped, not global.
-            4. From the `list_issues` response, capture each child's integer `id`
-               (the REST database id, NOT the issue `number` and NOT the GraphQL
-               `node_id` string).
-            5. For each surviving cluster:
-               - Create the parent via `mcp__github__issue_write` (method=create):
-                 - Title: `Tracking: <theme>`
-                 - Labels: `tracking` + the cluster's `area:*` labels
-                 - Body: one-paragraph theme + checklist of `- [ ] #N — title` rows
-                 - Capture both `number` AND integer `id` from the response.
-               - Link each child as a native sub-issue:
-                 `mcp__github__sub_issue_write` with method=`add`,
-                 `issue_number=<parent-number>`,
-                 `sub_issue_id=<child-id>`.
-                 Note: `sub_issue_id` is the child's numeric REST `id` (integer),
-                 NOT its issue `number` and NOT its `node_id`.
-
-            ### Phase A caps
-
-            - Max 5 new parents per run
-            - Max 50 sub-issue links per run
-            - Precision over recall: only link if the relationship is unambiguous
-
-            ## Phase B — Close completed trackers
-
-            For each open issue labeled `tracking` in ${{ github.repository }}
-            (excluding any parent created in Phase A this run):
-
-            - Read its sub-issues via `mcp__github__issue_read`.
-            - Qualifies for close ONLY if it has ≥1 sub-issue AND every sub-issue
-              is `closed` with `state_reason=completed` (skip if any are
-              `not_planned` or `duplicate`).
-            - Skip parents created less than 24 hours ago.
-            - Process leaf-up: close inner trackers first, then re-check outer
-              ones in the same run.
-
-            To close: comment
-            `✅ All N sub-issues closed as completed. Auto-closing this tracker.`,
-            then `mcp__github__issue_write` (method=update) with `state=closed`,
-            `state_reason=completed`.
-
-            ### Phase B caps
-
-            - Max 20 closures per run
-
-            ## Final report
-
-            One-line summary per phase. Skip silently when nothing matches.
+          provider: ${{ env.CLAUDE_CODE_PROVIDER }}
+          model-tier: sonnet
+          allowed-bots: 'github-actions[bot]'
+          allowed_tools_preset: issue-tree
+          claude-prompt-file: .github/prompts/issue-tree-prompt.md
+          claude-prompt-context: |
+            Repository: ${{ github.repository }}

--- a/.github/workflows/repository-quality-improver.yml
+++ b/.github/workflows/repository-quality-improver.yml
@@ -1,3 +1,5 @@
+# ci-sync-version: claude-provider-deepseek-v1
+# ci-sync-source: shared bot automation, prompts externalized under .github/prompts
 name: Repository Quality Improver
 
 on:
@@ -12,6 +14,13 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    env:
+      CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
+      CLAUDE_OPUS_MODEL: ${{ vars.CLAUDE_OPUS_MODEL }}
+      CLAUDE_SONNET_MODEL: ${{ vars.CLAUDE_SONNET_MODEL }}
     permissions:
       contents: read
       issues: write
@@ -21,43 +30,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: ./.github/actions/claude-code-with-provider
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'github-actions[bot]'
-          claude_args: |
-            --model claude-opus-4-7
-            --allowedTools "mcp__github__*" "Bash(find:*)" "Bash(grep:*)" "Bash(wc:*)" "Bash(jq:*)" "Bash(git log:*)" "Bash(git diff:*)"
-
-          prompt: |
-            You are the Quality Improvement Agent for ${{ github.repository }}.
-            Pick ONE focus area, scan the codebase, and file AT MOST ONE issue.
-
-            ## Dedup gate
-
-            Search `repo:${{ github.repository }} is:issue in:title "[quality]"`
-            (any state — open OR closed). If any result was created in the last
-            24 hours, exit with a one-line summary — prevents duplicate firings
-            on the same UTC day from manual re-dispatch, even if the prior issue
-            was closed quickly as `not planned`.
-
-            ## Focus area
-
-            Read CLAUDE.md and AGENTS.md to ground choices. Look at the last 5 closed
-            `[quality]` issues to see what's been covered recently — pick something
-            different. Bias toward TeXRA-specific concerns (VS Code coupling
-            violations, render-time workarounds, abstraction layers worth
-            flattening, stale `_multiple` agent variants, Zod schema duplication)
-            over generic categories.
-
-            ## Scan and file
-
-            Run targeted bash analysis. File an issue only if you have **at least 3
-            findings backed by file:line citations**. Otherwise exit silently.
-
-            Title: `[quality] <area>: <2-4 word finding>`
-            Labels: one of `bug`/`enhancement`/`tech-debt`/`documentation`, plus
-            matching `area:*` from `.github/labels.yml`.
-
-            Body: brief findings list with file:line refs and an actions checklist.
-            Note that closing as `not planned` is a valid outcome.
+          provider: ${{ env.CLAUDE_CODE_PROVIDER }}
+          model-tier: opus
+          allowed-bots: 'github-actions[bot]'
+          allowed_tools_preset: quality-improver
+          claude-prompt-file: .github/prompts/repository-quality-improver-prompt.md
+          claude-prompt-context: |
+            Repository: ${{ github.repository }}

--- a/.github/workflows/repository-quality-improver.yml
+++ b/.github/workflows/repository-quality-improver.yml
@@ -35,7 +35,7 @@ jobs:
           provider: ${{ env.CLAUDE_CODE_PROVIDER }}
           model-tier: opus
           allowed-bots: 'github-actions[bot]'
-          allowed_tools_preset: quality-improver
+          allowed-tools-preset: quality-improver
           claude-prompt-file: .github/prompts/repository-quality-improver-prompt.md
           claude-prompt-context: |
             Repository: ${{ github.repository }}

--- a/.github/workflows/repository-quality-improver.yml
+++ b/.github/workflows/repository-quality-improver.yml
@@ -13,6 +13,10 @@ concurrency:
 
 jobs:
   scan:
+    # Repository variable kill switch:
+    #   REPOSITORY_QUALITY_IMPROVER_ENABLED=false disables scheduled quality scans.
+    #   unset or any other value preserves the default enabled behavior.
+    if: vars.REPOSITORY_QUALITY_IMPROVER_ENABLED != 'false'
     runs-on: ubuntu-latest
     env:
       CLAUDE_CODE_PROVIDER: ${{ vars.CLAUDE_CODE_PROVIDER || 'anthropic' }}


### PR DESCRIPTION
### Motivation
- Keep the GitHub bot workflows maintainable by moving long Claude prompts out of workflow YAML.
- Reuse one provider wrapper for Claude-based automation, including provider selection and model-tier handling.
- Preserve this repository’s scope: Claude automation only, with no Codex mention workflow and no auto-fix workflows.

### Description
- Adds shared composite actions for Claude provider selection and Claude issue-to-PR creation.
- Externalizes prompts for Claude mention handling, Claude code review, issue tracking, issue tree maintenance, and repository quality improvement.
- Updates the corresponding workflows to call prompt files and named allowed-tool presets instead of carrying long inline prompt bodies.
- Leaves existing non-Claude automation unchanged.

### Testing
- `actionlint .github/workflows/claude.yml .github/workflows/claude-code-review.yml .github/workflows/repository-quality-improver.yml .github/workflows/issue-tracker.yml .github/workflows/issue-tree.yml`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml", ".github/actions/**/action.yml"].each { |f| YAML.load_file(f) }'`
- Pre-commit `npm run format` hook passed during commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple GitHub Actions workflows, permissions, and token/branch automation; misconfiguration could skip reviews/trackers or create unexpected PRs. No application runtime code changes, but CI automation behavior changes broadly.
> 
> **Overview**
> Centralizes Claude GitHub automation by adding two composite actions: `claude-code-with-provider` (selects Anthropic vs DeepSeek, model tier, allowed-tool presets, and prompt/system-prompt loading) and `auto-create-issue-pr` (finds a bot-created `claude/issue-<n>-*` branch and opens a PR if none exists).
> 
> Updates the Claude workflows (mention-driven `claude.yml`, `claude-code-review.yml`, `issue-tracker.yml`, `issue-tree.yml`, and `repository-quality-improver.yml`) to use the provider wrapper, move long prompt bodies into new `.github/prompts/*.md` files, add repo-variable kill switches, and gate execution on provider token availability / trusted-base wrapper presence. Also adds optional multi-provider review matrix support for PR reviews via `CLAUDE_CODE_REVIEW_PROVIDERS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38c53131b7da6d57ffbfb61e157163de4b95ffd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->