### PR TITLE
[codex] Publish desktop beta docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -123,6 +123,10 @@ const baseConfig = {
           items: [
             { text: 'Introduction', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
+            {
+              text: 'Desktop Migration',
+              link: '/guide/desktop-migration',
+            },
             { text: 'Quick Start', link: '/guide/quick-start' },
           ],
         },

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -123,6 +123,7 @@ const baseConfig = {
           items: [
             { text: 'Introduction', link: '/guide/' },
             { text: 'Installation', link: '/guide/installation' },
+            { text: 'Desktop App', link: '/guide/desktop' },
             {
               text: 'Desktop Migration',
               link: '/guide/desktop-migration',

--- a/docs/guide/desktop-migration.md
+++ b/docs/guide/desktop-migration.md
@@ -1,0 +1,78 @@
+# Migrating to the Desktop App
+
+The TeXRA desktop app is a separate host from the VS Code extension. Treat the
+first desktop launch as a fresh setup: open your project folder, sign in again,
+and reconfigure the providers and workspace settings you want to use.
+
+The desktop app shares TeXRA's agent logic, model handlers, LaTeX processing,
+and webview UI with the extension, but it uses its own application storage and
+secure credential store. It does not read VS Code's Secret Storage, user
+settings, workspace state, or extension global storage.
+
+## What Carries Over
+
+Your project files remain the source of truth. If you open the same repository,
+paper folder, or Overleaf Git checkout in the desktop app, TeXRA can work with
+the same `.tex`, `.bib`, figure, and configuration files already in that
+workspace.
+
+These items usually carry over because they live outside the VS Code extension:
+
+- Manuscript source files and repository history.
+- Workspace-local `.env` files, if you already use them for provider API keys.
+- LaTeX, Perl, GraphicsMagick, ImageMagick, Ghostscript, Git, and other system
+  tools installed on your machine.
+- Custom agent YAML files that live inside the project folder.
+- Team-owned files such as `.latexindent.yaml`, `tex-fmt.toml`, or shared
+  `.vscode/settings.json` files committed to the repository.
+
+After opening the project in the desktop app, verify the LaTeX tool paths and
+run a small agent task before relying on the migrated setup for production work.
+
+## What To Reconfigure
+
+Re-enter credentials and preferences that were stored by the extension host:
+
+- Model provider API keys from the Models tab.
+- TeXRA account or remote-agent sign-in.
+- GitHub token for PR and issue subscription tools.
+- Agent visibility, custom agent directory, model list, and tool approval
+  preferences.
+- LaTeX formatting, diff, TikZ, file-extension, and ignored-path settings if
+  they were only stored in VS Code user settings.
+- Execution history and task-storage archives that lived in the extension's
+  global storage.
+
+If a setting was committed to the workspace, keep using the committed copy. If
+it was only a personal VS Code user setting, set it again in the desktop app.
+
+## Recommended First Launch
+
+1. Install and open the desktop app.
+2. Open the same project folder you used with the VS Code extension.
+3. Sign in to TeXRA again if you use remote agents or account-backed features.
+4. Open the Models tab and set the provider API keys you want available.
+5. Review the Agents and Tools tabs and enable the same agents and approvals you
+   use in the extension.
+6. Open the LaTeX settings and confirm formatter, diff, TikZ, and tool-path
+   preferences.
+7. Run a small command, such as a short polish task or LaTeX compile check, and
+   confirm the output lands in the expected task storage.
+
+## Export And Import
+
+Automatic export/import from the VS Code extension is deferred. Phase 7 defaults
+to explicit re-authentication and manual reconfiguration so the desktop app does
+not need access to VS Code's private storage or credentials.
+
+A future migration tool may export non-secret preferences, custom agent
+registrations, or execution-history metadata into a reviewable file. It should
+not export API keys or session tokens. Track that work separately from the first
+desktop release.
+
+## Related Docs
+
+- [Installation](/guide/installation) - install TeXRA and required local tools.
+- [Configuration](/guide/configuration) - review provider, Git, LaTeX, and agent
+  settings.
+- [Remote Agents](/guide/remote-agents) - sign in and manage remote agent access.

--- a/docs/guide/desktop.md
+++ b/docs/guide/desktop.md
@@ -1,0 +1,90 @@
+# Desktop App
+
+The TeXRA desktop app is the standalone Electron host for TeXRA. It is intended
+for researchers who want the TeXRA agent workflow without installing VS Code.
+The desktop app shares the same agent runtime, model providers, LaTeX tools,
+settings UI, and progress view as the extension, but it stores credentials and
+state in desktop app storage.
+
+## Availability
+
+The desktop app is in beta development. Public signed installers and automatic
+updates are not enabled until the Phase 6 release pipeline is complete.
+
+Supported packaging targets:
+
+| Platform | Planned artifact         | Current expectation               |
+| -------- | ------------------------ | --------------------------------- |
+| macOS    | Universal `.dmg` and zip | Beta builds may be unsigned       |
+| Windows  | x64 NSIS installer       | Beta builds may be unsigned       |
+| Linux    | x64 AppImage and `.deb`  | Manual install and manual updates |
+
+When public distribution is ready, this page will link to the desktop release
+repository that contains only installer artifacts and update manifests. The
+desktop client must not require a `GH_TOKEN` or any other GitHub credential to
+check for updates.
+
+## Installation
+
+Until signed public installers are published, use the VS Code extension for
+normal work and treat desktop builds as beta artifacts.
+
+When a desktop installer is available:
+
+1. Download the installer for your platform from the linked desktop release
+   page.
+2. Install TeXRA using the normal operating-system flow.
+3. Launch TeXRA and open the project folder that contains your manuscript.
+4. Complete first-run setup in the Models, Agents, Tools, and LaTeX settings.
+
+For the system dependencies TeXRA needs, follow the same setup as the extension:
+[Installation](/guide/installation).
+
+## First Run
+
+On first launch, configure the desktop app explicitly:
+
+- Open the same folder or Git repository you already use for your paper.
+- Sign in again if you use TeXRA account features or remote agents.
+- Add model provider API keys in the Models tab, or configure workspace-local
+  `.env` variables.
+- Review agent visibility, tool approval settings, Git integration, and LaTeX
+  tool paths.
+- Run a small LaTeX or polish task and confirm the output appears in the
+  Progress view.
+
+If you are moving from the VS Code extension, see
+[Migrating to the Desktop App](/guide/desktop-migration). The recommended v1
+path is re-authentication and manual reconfiguration.
+
+## Logs
+
+The desktop app writes a local session log named `texra-desktop.log`. Use the
+**Logs** button in the desktop toolbar or **TeXRA > Open Logs Folder** from the
+application menu to open the folder in your operating system.
+
+Include relevant log excerpts when reporting beta desktop issues. Avoid sharing
+API keys, unpublished manuscript text, or private file paths.
+
+## Updates
+
+Automatic desktop updates are not available until the Phase 6 release pipeline
+lands. Beta users should install newer builds manually.
+
+The intended update model is:
+
+- signed installers are built in CI for macOS, Windows, and Linux;
+- release artifacts and update manifests are published to a public desktop
+  release repository;
+- the installed app checks that public release location without embedding or
+  asking for a GitHub token;
+- update downloads require user consent for v1.
+
+Docs will be updated when signed installers and auto-update manifests are live.
+
+## Related Docs
+
+- [Migrating to the Desktop App](/guide/desktop-migration)
+- [Configuration](/guide/configuration)
+- [Remote Agents](/guide/remote-agents)
+- [Troubleshooting](/guide/troubleshooting)

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -97,6 +97,7 @@ API keys are stored in VS Code's built-in Secret Storage.
 ## Next steps
 
 - [Installation](/guide/installation) — set up TeXRA and its dependencies
+- [Desktop App](/guide/desktop) — install and configure the standalone desktop beta
 - [Desktop Migration](/guide/desktop-migration) — move from the VS Code extension to the desktop app
 - [Quick Start](/guide/quick-start) — your first agent run in under five minutes
 - [Built-in Agents](/guide/built-in-agents) — the full catalog of available agents

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -97,6 +97,7 @@ API keys are stored in VS Code's built-in Secret Storage.
 ## Next steps
 
 - [Installation](/guide/installation) — set up TeXRA and its dependencies
+- [Desktop Migration](/guide/desktop-migration) — move from the VS Code extension to the desktop app
 - [Quick Start](/guide/quick-start) — your first agent run in under five minutes
 - [Built-in Agents](/guide/built-in-agents) — the full catalog of available agents
 - [Agent Architecture](/guide/agent-architecture) — how the multi-agent system works under the hood

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -35,6 +35,13 @@ You can also install TeXRA directly in your preferred editor using protocol-base
 - [Open in Cursor](cursor:extension/texra-ai.texra)
 - [Open in Windsurf](windsurf:extension/texra-ai.texra)
 
+::: tip Desktop app migration
+If you are moving from the VS Code extension to the desktop app, treat the first
+desktop launch as a fresh setup. Open the same project folder, then
+re-authenticate and reconfigure local provider, agent, Git, and LaTeX settings.
+See [Migrating to the Desktop App](./desktop-migration.md).
+:::
+
 ### From VSIX File
 
 1. Open VS Code

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -35,6 +35,13 @@ You can also install TeXRA directly in your preferred editor using protocol-base
 - [Open in Cursor](cursor:extension/texra-ai.texra)
 - [Open in Windsurf](windsurf:extension/texra-ai.texra)
 
+### Desktop App Beta
+
+The standalone desktop app is in beta development. Public signed installers and
+automatic updates are not enabled until the desktop release pipeline is
+complete. See [Desktop App](./desktop.md) for supported platforms, current beta
+installation expectations, logs, and update behavior.
+
 ::: tip Desktop app migration
 If you are moving from the VS Code extension to the desktop app, treat the first
 desktop launch as a fresh setup. Open the same project folder, then

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,7 @@ features:
   <div class="cta-buttons">
     <a href="/guide/quick-start" class="cta-button cta-primary">Quick Start Guide</a>
     <a href="/guide/built-in-agents" class="cta-button cta-secondary">Browse All Agents</a>
+    <a href="/guide/desktop" class="cta-button cta-secondary">Desktop Beta</a>
   </div>
 </section>
 
@@ -207,6 +208,11 @@ features:
   <details>
     <summary>Can I build custom agents?</summary>
     <p>Yes — agents are YAML files you can modify or create from scratch. See <a href="/guide/custom-agents">Custom Agents</a>.</p>
+  </details>
+
+  <details>
+    <summary>Is there a standalone desktop app?</summary>
+    <p>The desktop app is in beta development. See the <a href="/guide/desktop">Desktop App guide</a> for platform, setup, log, and update notes.</p>
   </details>
 
   <details>

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -15,7 +15,10 @@ import type { DesktopRoute } from './desktopShellMessages.js';
 export const DESKTOP_LOCAL_COMMANDS = {
   OPEN_LOG_FOLDER: 'texra.desktop.openLogFolder',
   OPEN_WORKSPACE_FOLDER: 'texra.desktop.openWorkspaceFolder',
+  OPEN_DESKTOP_DOCS: 'texra.desktop.openDesktopDocs',
 } as const;
+
+export const DESKTOP_DOCS_URL = 'https://texra.ai/guide/desktop';
 
 type DesktopLocalCommandId =
   (typeof DESKTOP_LOCAL_COMMANDS)[keyof typeof DESKTOP_LOCAL_COMMANDS];
@@ -32,6 +35,7 @@ export const DESKTOP_COMMAND_IDS = [
   'texra.showAgents',
   'texra.showTools',
   'texra.showMultiAgent',
+  DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
 ] as const satisfies readonly (CommandId | DesktopLocalCommandId)[];
 
 export type DesktopCommandId = (typeof DESKTOP_COMMAND_IDS)[number];
@@ -46,6 +50,7 @@ export interface DesktopCommandMenuEntry {
 export interface DesktopCommandActions {
   showRoute(route: DesktopRoute): void;
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
+  openDesktopDocs?(): void;
   openLogFolder?(): void;
   openWorkspaceFolder?(): void;
 }
@@ -78,6 +83,14 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
   DesktopLocalCommandId,
   DesktopCommandMenuEntry
 >([
+  [
+    DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
+    {
+      id: DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
+      label: 'Desktop Documentation',
+      category: 'Help',
+    },
+  ],
   [
     DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
     {
@@ -181,6 +194,9 @@ export function dispatchDesktopCommand(
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
       actions.openWorkspaceFolder?.();
       return true;
+    case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
+      actions.openDesktopDocs?.();
+      return true;
     default:
       return assertNever(id);
   }
@@ -257,7 +273,11 @@ export function buildDesktopMenuTemplate(
     { role: 'editMenu' },
     { role: 'viewMenu' },
     { role: 'windowMenu' },
-    { role: 'help' },
+    {
+      label: 'Help',
+      role: 'help',
+      submenu: [commandItem(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS)],
+    },
   ];
 }
 

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -21,6 +21,7 @@ import {
 } from './desktopIpcTypes.js';
 import {
   buildDesktopSettingsTabMessage,
+  DESKTOP_DOCS_URL,
   DESKTOP_LOCAL_COMMANDS,
   type DesktopCommandActions,
 } from '../desktopCommandSurface.js';
@@ -32,6 +33,7 @@ export type DesktopShellIpcOptions =
 export interface DesktopShellActionFactoryOptions {
   actions?: never;
   getCustomAgentDirectory?: () => Promise<string>;
+  openExternalUrl?: (url: string) => Promise<void>;
   openLogFolder?: () => Promise<void>;
   openPath?: (filePath: string) => Promise<void>;
   openWorkspaceFolder?: () => Promise<void>;
@@ -113,6 +115,10 @@ export function createDesktopShellActions(
     void options.openWorkspaceFolder?.().catch(reportAsyncError);
   }
 
+  function openDesktopDocs() {
+    void options.openExternalUrl?.(DESKTOP_DOCS_URL).catch(reportAsyncError);
+  }
+
   function signIn() {
     if (!options.signIn) {
       postSettingsRoute(SETTINGS_TAB.MODELS);
@@ -124,6 +130,7 @@ export function createDesktopShellActions(
   return {
     signIn,
     openAgentDirectory,
+    openDesktopDocs,
     openLogFolder,
     openWorkspaceFolder,
     setRecentCommitsUnavailable: () => {
@@ -192,6 +199,9 @@ export function createDesktopShellIpc(
           return true;
         case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
           actions.openWorkspaceFolder?.();
+          return true;
+        case DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS:
+          actions.openDesktopDocs?.();
           return true;
         default:
           return false;

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -271,6 +271,7 @@ function createWindow(options: {
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     {
       getCustomAgentDirectory: () => getAgentDirectories().custom(),
+      openExternalUrl: previewHost.openExternal,
       openLogFolder: openLogsFolder,
       openPath: previewHost.openPath,
       openWorkspaceFolder,

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -174,6 +174,9 @@ const commandPalette = createDesktopCommandPalette({
         getWindowTargetOrigin(),
       );
     },
+    openDesktopDocs: () => {
+      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS);
+    },
     openLogFolder: () => {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER);
     },

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -17,6 +17,7 @@ import type { DesktopCommandActions } from '../../../packages/desktop/src/deskto
 
 interface DesktopCommandSurfaceModule {
   DESKTOP_LOCAL_COMMANDS: {
+    OPEN_DESKTOP_DOCS: string;
     OPEN_LOG_FOLDER: string;
     OPEN_WORKSPACE_FOLDER: string;
   };
@@ -69,15 +70,18 @@ async function loadDesktopCommandSurface(): Promise<DesktopCommandSurfaceModule>
 
 describe('desktop command surface', () => {
   it('builds desktop menu entries from the shared command catalog', async () => {
-    const { DESKTOP_COMMAND_IDS, getDesktopCommandMenuEntries } =
-      await loadDesktopCommandSurface();
+    const {
+      DESKTOP_COMMAND_IDS,
+      DESKTOP_LOCAL_COMMANDS,
+      getDesktopCommandMenuEntries,
+    } = await loadDesktopCommandSurface();
     const entries = getDesktopCommandMenuEntries(undefined, 'darwin');
 
     expect(entries.map((entry) => entry.id)).toEqual(DESKTOP_COMMAND_IDS);
     for (const entry of entries) {
       const catalogEntry = commandCatalogById.get(entry.id as CommandId);
       if (!catalogEntry) {
-        expect(entry.category).toBe('TeXRA');
+        expect(['TeXRA', 'Help']).toContain(entry.category);
         continue;
       }
       expect(catalogEntry).toBeDefined();
@@ -95,6 +99,11 @@ describe('desktop command surface', () => {
       label: 'Show Progress',
       category: 'TeXRA',
       accelerator: 'Command+Option+P',
+    });
+    expect(entries).toContainEqual({
+      id: DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
+      label: 'Desktop Documentation',
+      category: 'Help',
     });
   });
 
@@ -119,6 +128,7 @@ describe('desktop command surface', () => {
     const { DESKTOP_LOCAL_COMMANDS, dispatchDesktopCommand } =
       await loadDesktopCommandSurface();
     const actions = {
+      openDesktopDocs: vi.fn(),
       openLogFolder: vi.fn(),
       openWorkspaceFolder: vi.fn(),
       showRoute: vi.fn(),
@@ -141,6 +151,9 @@ describe('desktop command surface', () => {
     expect(
       dispatchDesktopCommand(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER, actions),
     ).toBe(true);
+    expect(
+      dispatchDesktopCommand(DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS, actions),
+    ).toBe(true);
 
     expect(actions.showRoute).toHaveBeenNthCalledWith(1, 'main');
     expect(actions.showRoute).toHaveBeenNthCalledWith(2, 'progress');
@@ -155,6 +168,7 @@ describe('desktop command surface', () => {
     );
     expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
     expect(actions.openLogFolder).toHaveBeenCalledOnce();
+    expect(actions.openDesktopDocs).toHaveBeenCalledOnce();
   });
 
   it('builds settings-tab messages from one shared helper', async () => {
@@ -180,6 +194,7 @@ describe('desktop command surface', () => {
   it('wires menu clicks to the catalog-backed dispatcher', async () => {
     const { buildDesktopMenuTemplate } = await loadDesktopCommandSurface();
     const actions = {
+      openDesktopDocs: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };
@@ -192,7 +207,7 @@ describe('desktop command surface', () => {
       'editMenu',
       'viewMenu',
       'windowMenu',
-      'help',
+      'Help',
     ]);
     const texraMenu = menu.find((item) => item.label === 'TeXRA');
     const submenu = texraMenu?.submenu ?? [];
@@ -215,5 +230,13 @@ describe('desktop command surface', () => {
     submenu[8].click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+
+    const helpMenu = menu.find((item) => item.label === 'Help');
+    const helpSubmenu = helpMenu?.submenu ?? [];
+    expect(helpSubmenu.map((item) => item.label)).toEqual([
+      'Desktop Documentation',
+    ]);
+    helpSubmenu[0].click?.();
+    expect(actions.openDesktopDocs).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- add a desktop beta guide covering supported platforms, first-run setup, logs, and update expectations
- link the desktop guide from the docs sidebar, guide index, install guide, and home page
- add a desktop Help menu command that opens the public desktop guide

Fixes #3620

Stacked on #3625 / #3622 so the desktop guide can link to the migration guide.

## Validation
- corepack pnpm install --frozen-lockfile
- /Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/prettier --write docs/guide/desktop.md docs/.vitepress/config.js docs/guide/index.md docs/guide/installation.md docs/index.md packages/desktop/src/desktopCommandSurface.ts packages/desktop/src/main/desktopShellIpc.ts packages/desktop/src/main/index.ts packages/desktop/src/renderer/main.ts src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast
- npm run desktop:build
- git diff --check
- npm --prefix docs ci --legacy-peer-deps && npm --prefix docs run docs:build *(fails on existing docs/pocketflow/core_abstraction/communication.md:25 markdown parse error before the new page)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily documentation and a new desktop menu command that opens an external URL, with minimal impact on core runtime behavior.
> 
> **Overview**
> Publishes a new **Desktop App beta** guide (`docs/guide/desktop.md`) and surfaces it throughout the site (sidebar, guide index, install guide, and home page CTA/FAQ).
> 
> In the desktop Electron app, adds a `Help -> Desktop Documentation` command (`texra.desktop.openDesktopDocs`) that opens the public docs URL (`https://texra.ai/guide/desktop`) via the existing external-url opener path, with accompanying IPC wiring and test updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3974c137ecfa47e1487aabdd6dbe0af95b985ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->