### PR TITLE
[codex] Add desktop log viewer

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -13,6 +13,7 @@ import type { MenuItemConstructorOptions } from 'electron';
 import type { DesktopRoute } from './desktopShellMessages.js';
 
 export const DESKTOP_LOCAL_COMMANDS = {
+  SHOW_LOGS: 'texra.desktop.showLogs',
   OPEN_LOG_FOLDER: 'texra.desktop.openLogFolder',
   OPEN_WORKSPACE_FOLDER: 'texra.desktop.openWorkspaceFolder',
 } as const;
@@ -23,6 +24,7 @@ type DesktopLocalCommandId =
 export const DESKTOP_COMMAND_IDS = [
   'texra.showMainView',
   'texra.showProgressView',
+  DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
   DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
   DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
   'texra.openSettings',
@@ -60,6 +62,7 @@ const DESKTOP_MENU_GROUPS = [
   [
     'texra.showMainView',
     'texra.showProgressView',
+    DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
     DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
     DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
     'texra.openSettings',
@@ -78,6 +81,14 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
   DesktopLocalCommandId,
   DesktopCommandMenuEntry
 >([
+  [
+    DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+    {
+      id: DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+      label: 'Show Logs',
+      category: 'TeXRA',
+    },
+  ],
   [
     DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
     {
@@ -153,6 +164,9 @@ export function dispatchDesktopCommand(
       return true;
     case 'texra.showProgressView':
       actions.showRoute('progress');
+      return true;
+    case DESKTOP_LOCAL_COMMANDS.SHOW_LOGS:
+      actions.showRoute('logs');
       return true;
     case 'texra.openSettings':
       actions.showSettings();

--- a/packages/desktop/src/desktopLogMessages.ts
+++ b/packages/desktop/src/desktopLogMessages.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const DESKTOP_LOG_COMMANDS = {
+  REQUEST_LOG: 'desktop:requestLog',
+  SET_LOG: 'desktop:setLog',
+  COPY_LOG: 'desktop:copyLog',
+  EXPORT_LOG: 'desktop:exportLog',
+} as const;
+
+export const DesktopLogSnapshotSchema = z.object({
+  text: z.string(),
+  truncated: z.boolean(),
+  path: z.string().nullish(),
+});
+
+export const DesktopSetLogMessageSchema = z.object({
+  command: z.literal(DESKTOP_LOG_COMMANDS.SET_LOG),
+  log: DesktopLogSnapshotSchema,
+});
+
+export type DesktopLogSnapshot = z.infer<typeof DesktopLogSnapshotSchema>;
+export type DesktopSetLogMessage = z.infer<typeof DesktopSetLogMessageSchema>;

--- a/packages/desktop/src/desktopShellMessages.ts
+++ b/packages/desktop/src/desktopShellMessages.ts
@@ -4,7 +4,12 @@ export const DESKTOP_SHELL_COMMANDS = {
   SET_ROUTE: 'desktop:setRoute',
 } as const;
 
-export const DesktopRouteSchema = z.enum(['main', 'progress', 'settings']);
+export const DesktopRouteSchema = z.enum([
+  'main',
+  'progress',
+  'settings',
+  'logs',
+]);
 export type DesktopRoute = z.infer<typeof DesktopRouteSchema>;
 
 export const DesktopSetRouteMessageSchema = z.object({

--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -17,7 +17,10 @@ import {
   type WebContentsConsoleMessageEventParams,
 } from 'electron';
 
-import { redactDesktopLog } from './desktopLogRedaction.js';
+import {
+  redactDesktopLog,
+  type DesktopLogRedactionOptions,
+} from './desktopLogRedaction.js';
 import type { DesktopLogSnapshot } from '../desktopLogMessages.js';
 
 type ConsoleLevel = 'debug' | 'error' | 'info' | 'log' | 'warn';
@@ -64,32 +67,26 @@ export function readDesktopLogSnapshot(options: {
   maxBytes?: number | undefined;
 }): DesktopLogSnapshot {
   const path = getDesktopLogFilePath();
-  const maxBytes = options.maxBytes ?? MAX_VIEWER_LOG_BYTES;
+  const maxBytes = Math.max(0, options.maxBytes ?? MAX_VIEWER_LOG_BYTES);
+  const redactionOptions = makeDesktopLogRedactionOptions(options);
   try {
-    const stats = statSync(path);
-    const text = readFileSync(path, 'utf8');
-    const excerpt =
-      stats.size > maxBytes
-        ? text.slice(Math.max(0, text.length - maxBytes))
-        : text;
+    const buffer = readFileSync(path);
+    const truncated = buffer.length > maxBytes;
+    const excerpt = truncated
+      ? buffer.subarray(buffer.length - maxBytes)
+      : buffer;
     return {
-      path,
-      truncated: stats.size > maxBytes,
-      text: redactDesktopLog(excerpt, {
-        homeDir: homedir(),
-        workspacePath: options.workspacePath,
-      }),
+      path: redactDesktopLog(path, redactionOptions),
+      truncated,
+      text: redactDesktopLog(excerpt.toString('utf8'), redactionOptions),
     };
   } catch (error) {
     return {
-      path,
+      path: redactDesktopLog(path, redactionOptions),
       truncated: false,
       text: redactDesktopLog(
         format('Desktop log is not available: %s', error),
-        {
-          homeDir: homedir(),
-          workspacePath: options.workspacePath,
-        },
+        redactionOptions,
       ),
     };
   }
@@ -168,6 +165,15 @@ function rotateDesktopLogFile(path: string): void {
   } catch {
     // Log rotation is best-effort; app startup should continue without it.
   }
+}
+
+function makeDesktopLogRedactionOptions(options: {
+  workspacePath?: string | undefined;
+}): DesktopLogRedactionOptions {
+  return {
+    homeDir: homedir(),
+    workspacePath: options.workspacePath,
+  };
 }
 
 function getConsoleMessageDetails(

--- a/packages/desktop/src/main/desktopAppLog.ts
+++ b/packages/desktop/src/main/desktopAppLog.ts
@@ -2,9 +2,11 @@ import {
   appendFileSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   renameSync,
   statSync,
 } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { format } from 'node:util';
 
@@ -15,6 +17,9 @@ import {
   type WebContentsConsoleMessageEventParams,
 } from 'electron';
 
+import { redactDesktopLog } from './desktopLogRedaction.js';
+import type { DesktopLogSnapshot } from '../desktopLogMessages.js';
+
 type ConsoleLevel = 'debug' | 'error' | 'info' | 'log' | 'warn';
 type RendererConsoleMessage = Pick<
   WebContentsConsoleMessageEventParams,
@@ -23,6 +28,7 @@ type RendererConsoleMessage = Pick<
 
 const LOG_FILE_NAME = 'texra-desktop.log';
 const MAX_LOG_BYTES = 5 * 1024 * 1024;
+const MAX_VIEWER_LOG_BYTES = 160 * 1024;
 const CONSOLE_LEVELS = ['debug', 'error', 'info', 'log', 'warn'] as const;
 
 let logFilePath: string | undefined;
@@ -51,6 +57,42 @@ export function getDesktopLogDirectory(): string {
 
 export function getDesktopLogFilePath(): string {
   return logFilePath ?? join(getDesktopLogDirectory(), LOG_FILE_NAME);
+}
+
+export function readDesktopLogSnapshot(options: {
+  workspacePath?: string | undefined;
+  maxBytes?: number | undefined;
+}): DesktopLogSnapshot {
+  const path = getDesktopLogFilePath();
+  const maxBytes = options.maxBytes ?? MAX_VIEWER_LOG_BYTES;
+  try {
+    const stats = statSync(path);
+    const text = readFileSync(path, 'utf8');
+    const excerpt =
+      stats.size > maxBytes
+        ? text.slice(Math.max(0, text.length - maxBytes))
+        : text;
+    return {
+      path,
+      truncated: stats.size > maxBytes,
+      text: redactDesktopLog(excerpt, {
+        homeDir: homedir(),
+        workspacePath: options.workspacePath,
+      }),
+    };
+  } catch (error) {
+    return {
+      path,
+      truncated: false,
+      text: redactDesktopLog(
+        format('Desktop log is not available: %s', error),
+        {
+          homeDir: homedir(),
+          workspacePath: options.workspacePath,
+        },
+      ),
+    };
+  }
 }
 
 export function attachRendererConsoleLog(webContents: WebContents): void {

--- a/packages/desktop/src/main/desktopLogIpc.ts
+++ b/packages/desktop/src/main/desktopLogIpc.ts
@@ -1,0 +1,70 @@
+import {
+  createDesktopErrorReporter,
+  type DesktopMessageHandler,
+  type DesktopRenderer,
+} from './desktopIpcTypes.js';
+import {
+  DESKTOP_LOG_COMMANDS,
+  type DesktopLogSnapshot,
+} from '../desktopLogMessages.js';
+
+export interface DesktopLogIpcOptions {
+  readLog?: () => DesktopLogSnapshot;
+  copyLog?: (text: string) => Promise<void>;
+  exportLog?: (text: string) => Promise<void>;
+  onAsyncError?: (error: unknown) => void;
+}
+
+export function createDesktopLogIpc(
+  renderer: DesktopRenderer,
+  options: DesktopLogIpcOptions = {},
+): DesktopMessageHandler {
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
+  function readSnapshot(): DesktopLogSnapshot {
+    return (
+      options.readLog?.() ?? {
+        path: undefined,
+        text: 'Desktop log is not available.',
+        truncated: false,
+      }
+    );
+  }
+
+  function postSnapshot(): DesktopLogSnapshot {
+    const log = readSnapshot();
+    renderer.postToRenderer({
+      command: DESKTOP_LOG_COMMANDS.SET_LOG,
+      log,
+    });
+    return log;
+  }
+
+  function copyLog() {
+    const log = postSnapshot();
+    void options.copyLog?.(log.text).catch(reportAsyncError);
+  }
+
+  function exportLog() {
+    const log = postSnapshot();
+    void options.exportLog?.(log.text).catch(reportAsyncError);
+  }
+
+  return {
+    handleMessage(message): boolean {
+      switch (message.command) {
+        case DESKTOP_LOG_COMMANDS.REQUEST_LOG:
+          postSnapshot();
+          return true;
+        case DESKTOP_LOG_COMMANDS.COPY_LOG:
+          copyLog();
+          return true;
+        case DESKTOP_LOG_COMMANDS.EXPORT_LOG:
+          exportLog();
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopLogRedaction.ts
+++ b/packages/desktop/src/main/desktopLogRedaction.ts
@@ -1,0 +1,34 @@
+const REDACTED = '[redacted]';
+
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)\s*[:=]\s*([^\s,;]+)/gi;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=_-]+/g;
+const PROVIDER_KEY_PATTERN =
+  /\b(?:sk-[A-Za-z0-9_-]{12,}|sk-ant-[A-Za-z0-9_-]{12,}|xai-[A-Za-z0-9_-]{12,})\b/g;
+
+export interface DesktopLogRedactionOptions {
+  homeDir?: string | undefined;
+  workspacePath?: string | undefined;
+}
+
+export function redactDesktopLog(
+  text: string,
+  options: DesktopLogRedactionOptions = {},
+): string {
+  const prefixes = [options.workspacePath, options.homeDir]
+    .filter((prefix): prefix is string => Boolean(prefix))
+    .sort((a, b) => b.length - a.length);
+
+  let redacted = text
+    .replaceAll(SECRET_ASSIGNMENT_PATTERN, (_match, name: string) => {
+      return `${name}=${REDACTED}`;
+    })
+    .replaceAll(BEARER_PATTERN, `Bearer ${REDACTED}`)
+    .replaceAll(PROVIDER_KEY_PATTERN, REDACTED);
+
+  for (const prefix of prefixes) {
+    redacted = redacted.replaceAll(prefix, '[path]');
+  }
+
+  return redacted;
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,7 +1,15 @@
 import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, dialog, session, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  session,
+  shell,
+} from 'electron';
 
 import { platform } from '@platform/platform';
 import { getAgentDirectories } from '@agent/index/agentDirectoriesRegistry';
@@ -17,6 +25,7 @@ import { createDesktopWorkspaceExplorer } from './desktopWorkspaceExplorer.js';
 import {
   attachRendererConsoleLog,
   getDesktopLogDirectory,
+  readDesktopLogSnapshot,
 } from './desktopAppLog.js';
 import { installDesktopMenu } from './desktopMenu.js';
 import { promptInRenderer } from './desktopPrompt.js';
@@ -284,6 +293,22 @@ function createWindow(options: {
     workspaceExplorer,
     settings: settingsIpc,
     progress: progressIpc,
+    logs: {
+      readLog: () =>
+        readDesktopLogSnapshot({ workspacePath: options.workspacePath }),
+      copyLog: async (text) => {
+        clipboard.writeText(text);
+      },
+      exportLog: async (text) => {
+        const result = await dialog.showSaveDialog(window, {
+          title: 'Export TeXRA Desktop Log',
+          defaultPath: 'texra-desktop-log.txt',
+          filters: [{ name: 'Text Logs', extensions: ['txt', 'log'] }],
+        });
+        if (result.canceled || !result.filePath) return;
+        await writeFile(result.filePath, text, 'utf8');
+      },
+    },
     shellActions,
     getAuthStatus: async () => ({
       authenticated: (await desktopAuth.getProfileData()).authenticated,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -1,5 +1,9 @@
 import { installDesktopHostBridge } from './hostBridge.js';
 import { createDesktopExecutionIpc } from './desktopExecutionIpc.js';
+import {
+  createDesktopLogIpc,
+  type DesktopLogIpcOptions,
+} from './desktopLogIpc.js';
 import { createDesktopMainViewStartup } from './desktopMainViewStartup.js';
 import {
   isDesktopCommandMessage,
@@ -28,6 +32,7 @@ export interface DesktopMainViewIpcOptions {
   workspaceExplorer?: DesktopWorkspaceExplorer;
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
+  logs?: DesktopLogIpcOptions;
   shellActions?: DesktopShellActions;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
@@ -73,6 +78,10 @@ export function installDesktopMainViewIpc(
     executeAgent: options.executeAgent,
     onAsyncError: options.onAsyncError,
   });
+  const logs = createDesktopLogIpc(bridge, {
+    ...options.logs,
+    onAsyncError: options.onAsyncError,
+  });
   const startup = createDesktopMainViewStartup({
     renderer: bridge,
     getAuthStatus: options.getAuthStatus,
@@ -85,6 +94,7 @@ export function installDesktopMainViewIpc(
     options.settings,
     options.progress,
     viewState,
+    logs,
     shell,
     execution,
   ].filter((handler): handler is DesktopMessageHandler => handler != null);

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -17,6 +17,11 @@ import {
   type DesktopSetRouteMessage,
 } from '../desktopShellMessages';
 import {
+  DESKTOP_LOG_COMMANDS,
+  DesktopSetLogMessageSchema,
+  type DesktopSetLogMessage,
+} from '../desktopLogMessages';
+import {
   buildDesktopSettingsTabMessage,
   DESKTOP_LOCAL_COMMANDS,
 } from '../desktopCommandSurface';
@@ -35,6 +40,8 @@ interface WorkspaceTreeNode {
   children?: WorkspaceTreeNode[];
   categories?: string[];
 }
+
+const DESKTOP_ROUTES = ['main', 'progress', 'settings', 'logs'] as const;
 
 const root = document.querySelector<HTMLElement>('#app');
 
@@ -56,11 +63,11 @@ appRoot.innerHTML = `
       <button class="desktop-nav-button" type="button" data-route-button="settings" aria-pressed="false">
         Settings
       </button>
+      <button class="desktop-nav-button" type="button" data-route-button="logs" aria-pressed="false">
+        Logs
+      </button>
       <button class="desktop-command-button" type="button" data-command-palette-button aria-haspopup="dialog">
         Commands
-      </button>
-      <button class="desktop-log-button" type="button" data-open-log-button>
-        Logs
       </button>
       <button class="desktop-folder-button" type="button" data-open-workspace-button>
         Open Folder
@@ -72,6 +79,7 @@ appRoot.innerHTML = `
         <section class="desktop-route" data-route="main"></section>
         <section class="desktop-route" data-route="progress" hidden></section>
         <section class="desktop-route" data-route="settings" hidden></section>
+        <section class="desktop-route" data-route="logs" hidden></section>
       </main>
     </div>
   </section>
@@ -91,7 +99,7 @@ if (workspaceExplorerElement == null) {
 const workspaceExplorerContainer: HTMLElement = workspaceExplorerElement;
 
 const routeContainers = new Map<DesktopRoute, HTMLElement>();
-for (const route of ['main', 'progress', 'settings'] as const) {
+for (const route of DESKTOP_ROUTES) {
   const container = desktopViewContainer.querySelector<HTMLElement>(
     `[data-route="${route}"]`,
   );
@@ -102,7 +110,7 @@ for (const route of ['main', 'progress', 'settings'] as const) {
 }
 
 const routeButtons = new Map<DesktopRoute, HTMLButtonElement>();
-for (const route of ['main', 'progress', 'settings'] as const) {
+for (const route of DESKTOP_ROUTES) {
   const button = appRoot.querySelector<HTMLButtonElement>(
     `[data-route-button="${route}"]`,
   );
@@ -140,6 +148,7 @@ if (hasWorkspace) {
 const settingsApp = document.createElement('settings-app');
 settingsApp.setAttribute('data-desktop-view', 'settings');
 routeContainers.get('settings')?.replaceChildren(settingsApp);
+routeContainers.get('logs')?.replaceChildren(createLogViewer());
 
 const commandPaletteButton = appRoot.querySelector<HTMLButtonElement>(
   '[data-command-palette-button]',
@@ -153,13 +162,6 @@ const openWorkspaceButton = appRoot.querySelector<HTMLButtonElement>(
 );
 if (openWorkspaceButton == null) {
   throw new Error('TeXRA desktop open workspace button was not found.');
-}
-
-const openLogButton = appRoot.querySelector<HTMLButtonElement>(
-  '[data-open-log-button]',
-);
-if (openLogButton == null) {
-  throw new Error('TeXRA desktop open log button was not found.');
 }
 
 const commandPalette = createDesktopCommandPalette({
@@ -187,9 +189,6 @@ commandPaletteButton.addEventListener('click', commandPalette.open);
 openWorkspaceButton.addEventListener('click', () =>
   postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
 );
-openLogButton.addEventListener('click', () =>
-  postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
-);
 requestWorkspaceTree();
 
 function isDesktopSetRouteMessage(
@@ -204,6 +203,12 @@ function isThemeMessage(
   return SetThemeMessageSchema.safeParse(message).success;
 }
 
+function isDesktopSetLogMessage(
+  message: unknown,
+): message is DesktopSetLogMessage {
+  return DesktopSetLogMessageSchema.safeParse(message).success;
+}
+
 function setRoute(route: DesktopRoute): void {
   for (const [candidate, container] of routeContainers) {
     container.hidden = candidate !== route;
@@ -212,6 +217,7 @@ function setRoute(route: DesktopRoute): void {
     button.setAttribute('aria-pressed', candidate === route ? 'true' : 'false');
   }
   document.body.dataset.desktopRoute = route;
+  if (route === 'logs') requestLogSnapshot();
 }
 
 window.addEventListener('message', (event) => {
@@ -221,6 +227,8 @@ window.addEventListener('message', (event) => {
     applyDesktopTheme(event.data.theme);
   } else if (isWorkspaceTreeMessage(event.data)) {
     renderWorkspaceExplorer(event.data);
+  } else if (isDesktopSetLogMessage(event.data)) {
+    renderLogSnapshot(event.data);
   }
 });
 
@@ -282,6 +290,62 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
   return container;
+}
+
+function createLogViewer(): HTMLElement {
+  const container = document.createElement('section');
+  container.className = 'desktop-log-viewer';
+  container.innerHTML = `
+    <header class="desktop-log-viewer-header">
+      <div>
+        <h2>Desktop Logs</h2>
+        <p data-log-meta>Recent redacted log entries appear here.</p>
+      </div>
+      <div class="desktop-log-viewer-actions">
+        <button class="desktop-secondary-button" type="button" data-log-refresh>Refresh</button>
+        <button class="desktop-secondary-button" type="button" data-log-copy>Copy</button>
+        <button class="desktop-secondary-button" type="button" data-log-export>Export</button>
+        <button class="desktop-secondary-button" type="button" data-log-folder>Open Folder</button>
+      </div>
+    </header>
+    <pre class="desktop-log-viewer-output" data-log-output>Open Logs to load recent entries.</pre>
+  `;
+  container
+    .querySelector<HTMLButtonElement>('[data-log-refresh]')
+    ?.addEventListener('click', requestLogSnapshot);
+  container
+    .querySelector<HTMLButtonElement>('[data-log-copy]')
+    ?.addEventListener('click', () =>
+      postMessage(DESKTOP_LOG_COMMANDS.COPY_LOG),
+    );
+  container
+    .querySelector<HTMLButtonElement>('[data-log-export]')
+    ?.addEventListener('click', () =>
+      postMessage(DESKTOP_LOG_COMMANDS.EXPORT_LOG),
+    );
+  container
+    .querySelector<HTMLButtonElement>('[data-log-folder]')
+    ?.addEventListener('click', () =>
+      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
+    );
+  return container;
+}
+
+function requestLogSnapshot(): void {
+  postMessage(DESKTOP_LOG_COMMANDS.REQUEST_LOG);
+}
+
+function renderLogSnapshot(message: DesktopSetLogMessage): void {
+  const container = routeContainers.get('logs');
+  const output = container?.querySelector<HTMLElement>('[data-log-output]');
+  const meta = container?.querySelector<HTMLElement>('[data-log-meta]');
+  if (output == null || meta == null) return;
+
+  output.textContent = message.log.text || 'No desktop log entries yet.';
+  const path = message.log.path ?? 'desktop log file';
+  meta.textContent = message.log.truncated
+    ? `Showing the most recent redacted entries from ${path}.`
+    : `Showing redacted entries from ${path}.`;
 }
 
 function isWorkspaceTreeMessage(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -12,6 +12,7 @@ import '@settingsView/frontend';
 import '@webview/frontend';
 
 import {
+  DesktopRouteSchema,
   DesktopSetRouteMessageSchema,
   type DesktopRoute,
   type DesktopSetRouteMessage,
@@ -41,7 +42,7 @@ interface WorkspaceTreeNode {
   categories?: string[];
 }
 
-const DESKTOP_ROUTES = ['main', 'progress', 'settings', 'logs'] as const;
+const DESKTOP_ROUTES = DesktopRouteSchema.options;
 
 const root = document.querySelector<HTMLElement>('#app');
 

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -424,6 +424,59 @@ body {
   margin-top: 24px;
 }
 
+.desktop-log-viewer {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+  gap: 12px;
+}
+
+.desktop-log-viewer-header {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--texra-panel-border);
+}
+
+.desktop-log-viewer-header h2 {
+  margin: 0 0 4px;
+  color: var(--texra-foreground);
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.desktop-log-viewer-header p {
+  margin: 0;
+  color: var(--texra-descriptionForeground);
+  font-size: 12px;
+}
+
+.desktop-log-viewer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.desktop-log-viewer-output {
+  min-height: 0;
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid var(--texra-panel-border);
+  border-radius: 6px;
+  background: var(--texra-editor-background);
+  color: var(--texra-editor-foreground);
+  font-family: var(--texra-font-family-monospace);
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .desktop-primary-button,
 .desktop-secondary-button {
   min-height: 34px;

--- a/src/test-kernel/desktop/DesktopAppLog.vitest.mts
+++ b/src/test-kernel/desktop/DesktopAppLog.vitest.mts
@@ -1,6 +1,7 @@
 // Node imports
+import { Buffer } from 'node:buffer';
 import { randomUUID } from 'node:crypto';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -16,6 +17,10 @@ import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
 
 interface DesktopAppLogModule {
   installDesktopAppLog(): string | undefined;
+  readDesktopLogSnapshot(options: {
+    workspacePath?: string | undefined;
+    maxBytes?: number | undefined;
+  }): { path: string; text: string; truncated: boolean };
 }
 
 async function loadDesktopAppLogModule(): Promise<DesktopAppLogModule> {
@@ -57,5 +62,26 @@ describe('desktop app log', () => {
       'TeXRA desktop file logging is disabled.',
       expect.anything(),
     );
+  });
+
+  it('truncates viewer snapshots by bytes and redacts log paths', async () => {
+    const root = await makeTempDir('texra-electron-log-');
+    const userDataPath = join(root, 'userData');
+    const logsPath = join(userDataPath, 'logs');
+    const logPath = join(logsPath, 'texra-desktop.log');
+    await mkdir(logsPath, { recursive: true });
+    await writeFile(logPath, `${'🙂'.repeat(8)}tail`);
+    configureElectronTestStub({ userDataPath });
+    const { readDesktopLogSnapshot } = await loadDesktopAppLogModule();
+
+    const snapshot = readDesktopLogSnapshot({
+      workspacePath: root,
+      maxBytes: 12,
+    });
+
+    expect(snapshot.truncated).toBe(true);
+    expect(snapshot.text).toBe('🙂🙂tail');
+    expect(Buffer.byteLength(snapshot.text)).toBe(12);
+    expect(snapshot.path).toBe('[path]/userData/logs/texra-desktop.log');
   });
 });

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -17,6 +17,7 @@ import type { DesktopCommandActions } from '../../../packages/desktop/src/deskto
 
 interface DesktopCommandSurfaceModule {
   DESKTOP_LOCAL_COMMANDS: {
+    SHOW_LOGS: string;
     OPEN_LOG_FOLDER: string;
     OPEN_WORKSPACE_FOLDER: string;
   };
@@ -69,8 +70,11 @@ async function loadDesktopCommandSurface(): Promise<DesktopCommandSurfaceModule>
 
 describe('desktop command surface', () => {
   it('builds desktop menu entries from the shared command catalog', async () => {
-    const { DESKTOP_COMMAND_IDS, getDesktopCommandMenuEntries } =
-      await loadDesktopCommandSurface();
+    const {
+      DESKTOP_COMMAND_IDS,
+      DESKTOP_LOCAL_COMMANDS,
+      getDesktopCommandMenuEntries,
+    } = await loadDesktopCommandSurface();
     const entries = getDesktopCommandMenuEntries(undefined, 'darwin');
 
     expect(entries.map((entry) => entry.id)).toEqual(DESKTOP_COMMAND_IDS);
@@ -95,6 +99,11 @@ describe('desktop command surface', () => {
       label: 'Show Progress',
       category: 'TeXRA',
       accelerator: 'Command+Option+P',
+    });
+    expect(entries).toContainEqual({
+      id: DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
+      label: 'Show Logs',
+      category: 'TeXRA',
     });
   });
 
@@ -129,6 +138,9 @@ describe('desktop command surface', () => {
     expect(dispatchDesktopCommand('texra.showProgressView', actions)).toBe(
       true,
     );
+    expect(
+      dispatchDesktopCommand(DESKTOP_LOCAL_COMMANDS.SHOW_LOGS, actions),
+    ).toBe(true);
     expect(dispatchDesktopCommand('texra.openSettings', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showModels', actions)).toBe(true);
     expect(dispatchDesktopCommand('texra.showAgents', actions)).toBe(true);
@@ -144,6 +156,7 @@ describe('desktop command surface', () => {
 
     expect(actions.showRoute).toHaveBeenNthCalledWith(1, 'main');
     expect(actions.showRoute).toHaveBeenNthCalledWith(2, 'progress');
+    expect(actions.showRoute).toHaveBeenNthCalledWith(3, 'logs');
     expect(actions.showSettings).toHaveBeenNthCalledWith(1);
     expect(actions.showSettings).toHaveBeenNthCalledWith(
       2,
@@ -199,6 +212,7 @@ describe('desktop command surface', () => {
     expect(submenu.map((item) => item.label ?? item.type)).toEqual([
       'Show Launcher',
       'Show Progress',
+      'Show Logs',
       'Open Folder',
       'Open Logs Folder',
       'Open TeXRA Settings',
@@ -212,7 +226,7 @@ describe('desktop command surface', () => {
     ]);
 
     submenu[0].click?.();
-    submenu[8].click?.();
+    submenu[9].click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
   });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -31,6 +31,20 @@ interface DesktopShellIpcModule {
   };
 }
 
+interface DesktopLogIpcModule {
+  createDesktopLogIpc(
+    renderer: DesktopRenderer,
+    options?: {
+      readLog?: () => { text: string; truncated: boolean; path?: string };
+      copyLog?: (text: string) => Promise<void>;
+      exportLog?: (text: string) => Promise<void>;
+      onAsyncError?: (error: unknown) => void;
+    },
+  ): {
+    handleMessage(message: { command: string }): boolean;
+  };
+}
+
 interface DesktopExecutionIpcModule {
   createDesktopExecutionIpc(options?: {
     executeAgent?: (message: unknown) => Promise<void>;
@@ -65,6 +79,12 @@ async function loadDesktopExecutionIpc(): Promise<DesktopExecutionIpcModule> {
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopExecutionIpc.ts'))
   ) as Promise<DesktopExecutionIpcModule>;
+}
+
+async function loadDesktopLogIpc(): Promise<DesktopLogIpcModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopLogIpc.ts'))
+  ) as Promise<DesktopLogIpcModule>;
 }
 
 async function loadDesktopViewStateIpc(nativeTheme: {
@@ -243,5 +263,43 @@ describe('desktop IPC adapters', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(onAsyncError).toHaveBeenCalledWith(error);
+  });
+
+  it('serves desktop log snapshots and copy/export actions', async () => {
+    const { createDesktopLogIpc } = await loadDesktopLogIpc();
+    const postToRenderer = vi.fn();
+    const copyLog = vi.fn(async (_text: string) => {});
+    const exportLog = vi.fn(async (_text: string) => {});
+    const readLog = vi.fn(() => ({
+      path: '/logs/texra-desktop.log',
+      text: '2026-05-07T00:00:00.000Z [info] safe log line',
+      truncated: false,
+    }));
+    const logs = createDesktopLogIpc(
+      { postToRenderer },
+      { readLog, copyLog, exportLog },
+    );
+
+    expect(logs.handleMessage({ command: 'desktop:requestLog' })).toBe(true);
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: 'desktop:setLog',
+      log: {
+        path: '/logs/texra-desktop.log',
+        text: '2026-05-07T00:00:00.000Z [info] safe log line',
+        truncated: false,
+      },
+    });
+
+    expect(logs.handleMessage({ command: 'desktop:copyLog' })).toBe(true);
+    await Promise.resolve();
+    expect(copyLog).toHaveBeenCalledWith(
+      '2026-05-07T00:00:00.000Z [info] safe log line',
+    );
+
+    expect(logs.handleMessage({ command: 'desktop:exportLog' })).toBe(true);
+    await Promise.resolve();
+    expect(exportLog).toHaveBeenCalledWith(
+      '2026-05-07T00:00:00.000Z [info] safe log line',
+    );
   });
 });

--- a/src/test-kernel/desktop/DesktopLogRedaction.vitest.mts
+++ b/src/test-kernel/desktop/DesktopLogRedaction.vitest.mts
@@ -1,0 +1,45 @@
+// Third-party imports
+import { describe, expect, it } from 'vitest';
+
+// Local imports - desktop test paths
+import { desktopSourcePath, moduleFileUrl } from './desktopTestPaths.mjs';
+
+interface DesktopLogRedactionModule {
+  redactDesktopLog(
+    text: string,
+    options?: { homeDir?: string; workspacePath?: string },
+  ): string;
+}
+
+async function loadDesktopLogRedaction(): Promise<DesktopLogRedactionModule> {
+  return import(
+    moduleFileUrl(desktopSourcePath('main', 'desktopLogRedaction.ts'))
+  ) as Promise<DesktopLogRedactionModule>;
+}
+
+describe('desktop log redaction', () => {
+  it('redacts obvious secrets and sensitive path prefixes', async () => {
+    const { redactDesktopLog } = await loadDesktopLogRedaction();
+
+    const redacted = redactDesktopLog(
+      [
+        'OPENAI_API_KEY=sk-1234567890abcdef',
+        'Authorization: Bearer ghp_1234567890abcdef',
+        '/Users/alice/private-paper/main.tex',
+        '/Users/alice/.config/texra',
+      ].join('\n'),
+      {
+        homeDir: '/Users/alice',
+        workspacePath: '/Users/alice/private-paper',
+      },
+    );
+
+    expect(redacted).not.toContain('sk-1234567890abcdef');
+    expect(redacted).not.toContain('ghp_1234567890abcdef');
+    expect(redacted).not.toContain('/Users/alice/private-paper');
+    expect(redacted).not.toContain('/Users/alice/.config');
+    expect(redacted).toContain('OPENAI_API_KEY=[redacted]');
+    expect(redacted).toContain('Bearer [redacted]');
+    expect(redacted).toContain('[path]/main.tex');
+  });
+});

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -40,6 +40,7 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('data-route-button="main"');
     expect(rendererMain).toContain('data-route-button="progress"');
     expect(rendererMain).toContain('data-route-button="settings"');
+    expect(rendererMain).toContain('data-route-button="logs"');
     expect(rendererMain).toContain("button.addEventListener('click'");
     expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
   });
@@ -61,5 +62,15 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('data-command-palette-button');
     expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
     expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
+  });
+
+  it('mounts an in-app log viewer with copy and export actions', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('DESKTOP_LOG_COMMANDS.REQUEST_LOG');
+    expect(rendererMain).toContain('DESKTOP_LOG_COMMANDS.COPY_LOG');
+    expect(rendererMain).toContain('DESKTOP_LOG_COMMANDS.EXPORT_LOG');
+    expect(rendererMain).toContain('DesktopSetLogMessageSchema.safeParse');
+    expect(rendererMain).toContain('data-log-output');
   });
 });


### PR DESCRIPTION
## Summary
- add a desktop Logs route and menu/command-palette entry for viewing recent app logs in-app
- add log IPC for refresh, copy, and export actions using redacted log snapshots
- redact obvious secrets and home/workspace path prefixes before showing or exporting log excerpts

Fixes #3621

## Validation
- corepack pnpm install --frozen-lockfile
- /Users/siruilu/Local/AI-Projects/coauthor/node_modules/.bin/prettier --write packages/desktop/src/desktopLogMessages.ts packages/desktop/src/desktopShellMessages.ts packages/desktop/src/desktopCommandSurface.ts packages/desktop/src/main/desktopAppLog.ts packages/desktop/src/main/desktopLogIpc.ts packages/desktop/src/main/desktopLogRedaction.ts packages/desktop/src/main/index.ts packages/desktop/src/main/mainViewIpc.ts packages/desktop/src/renderer/main.ts packages/desktop/src/renderer/styles.css src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/DesktopLogRedaction.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/DesktopLogRedaction.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast
- npm run desktop:build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new desktop IPC + UI for reading/copying/exporting local logs and introduces custom redaction logic; mistakes could leak sensitive data or affect renderer/main routing.
> 
> **Overview**
> Adds a new **Desktop Logs** route and command/menu entry (`texra.desktop.showLogs`) so users can view recent app logs inside the Electron shell.
> 
> Implements log IPC (`desktop:requestLog`/`copyLog`/`exportLog`) backed by `readDesktopLogSnapshot`, which reads and *byte-truncates* the tail of the log file and redacts obvious secrets plus home/workspace path prefixes before displaying, copying to clipboard, or exporting to a user-selected file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3893ddfaec9872ea78b9a52d9e170e3cf09de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->