### PR TITLE
[codex] Add desktop first-run walkthrough

### DIFF
--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -15,6 +15,7 @@ import type { DesktopRoute } from './desktopShellMessages.js';
 export const DESKTOP_LOCAL_COMMANDS = {
   OPEN_LOG_FOLDER: 'texra.desktop.openLogFolder',
   OPEN_WORKSPACE_FOLDER: 'texra.desktop.openWorkspaceFolder',
+  SHOW_FIRST_RUN_WALKTHROUGH: 'texra.desktop.showFirstRunWalkthrough',
 } as const;
 
 type DesktopLocalCommandId =
@@ -25,6 +26,7 @@ export const DESKTOP_COMMAND_IDS = [
   'texra.showProgressView',
   DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
   DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
+  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   'texra.openSettings',
   'texra.showMemory',
   'texra.showAgentHistory',
@@ -48,6 +50,7 @@ export interface DesktopCommandActions {
   showSettings(tabIndex?: SettingsTab, agentSubTab?: AgentCategory): void;
   openLogFolder?(): void;
   openWorkspaceFolder?(): void;
+  showFirstRunWalkthrough?(): void;
 }
 
 export interface DesktopSettingsTabMessage {
@@ -74,6 +77,10 @@ const DESKTOP_MENU_GROUPS = [
   ],
 ] as const satisfies readonly (readonly DesktopCommandId[])[];
 
+const DESKTOP_HELP_COMMANDS = [
+  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
+] as const satisfies readonly DesktopCommandId[];
+
 const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
   DesktopLocalCommandId,
   DesktopCommandMenuEntry
@@ -93,6 +100,14 @@ const DESKTOP_LOCAL_COMMAND_ENTRIES = new Map<
       id: DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
       label: 'Open Logs Folder',
       category: 'TeXRA',
+    },
+  ],
+  [
+    DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
+    {
+      id: DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
+      label: 'Show First-Run Walkthrough',
+      category: 'Help',
     },
   ],
 ]);
@@ -181,6 +196,9 @@ export function dispatchDesktopCommand(
     case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
       actions.openWorkspaceFolder?.();
       return true;
+    case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
+      actions.showFirstRunWalkthrough?.();
+      return true;
     default:
       return assertNever(id);
   }
@@ -257,7 +275,10 @@ export function buildDesktopMenuTemplate(
     { role: 'editMenu' },
     { role: 'viewMenu' },
     { role: 'windowMenu' },
-    { role: 'help' },
+    {
+      role: 'help',
+      submenu: DESKTOP_HELP_COMMANDS.map(commandItem),
+    },
   ];
 }
 

--- a/packages/desktop/src/desktopCommandSurface.ts
+++ b/packages/desktop/src/desktopCommandSurface.ts
@@ -31,7 +31,6 @@ export const DESKTOP_COMMAND_IDS = [
   DESKTOP_LOCAL_COMMANDS.SHOW_LOGS,
   DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER,
   DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER,
-  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   'texra.openSettings',
   'texra.showMemory',
   'texra.showAgentHistory',
@@ -39,6 +38,7 @@ export const DESKTOP_COMMAND_IDS = [
   'texra.showAgents',
   'texra.showTools',
   'texra.showMultiAgent',
+  DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
   DESKTOP_LOCAL_COMMANDS.OPEN_DESKTOP_DOCS,
 ] as const satisfies readonly (CommandId | DesktopLocalCommandId)[];
 

--- a/packages/desktop/src/desktopOnboardingMessages.ts
+++ b/packages/desktop/src/desktopOnboardingMessages.ts
@@ -17,3 +17,12 @@ export const DesktopOnboardingSetStateMessageSchema = z.object({
 export type DesktopOnboardingSetStateMessage = z.infer<
   typeof DesktopOnboardingSetStateMessageSchema
 >;
+
+export function buildDesktopOnboardingSetStateMessage(
+  shouldShow: boolean,
+): DesktopOnboardingSetStateMessage {
+  return {
+    command: DESKTOP_ONBOARDING_COMMANDS.SET_STATE,
+    shouldShow,
+  };
+}

--- a/packages/desktop/src/desktopOnboardingMessages.ts
+++ b/packages/desktop/src/desktopOnboardingMessages.ts
@@ -6,7 +6,6 @@ export const DESKTOP_ONBOARDING_DISMISSED_STATE_KEY =
 export const DESKTOP_ONBOARDING_COMMANDS = {
   REQUEST_STATE: 'desktop:requestOnboarding',
   DISMISS: 'desktop:dismissOnboarding',
-  SHOW: 'desktop:showOnboarding',
   SET_STATE: 'desktop:setOnboarding',
 } as const;
 

--- a/packages/desktop/src/desktopOnboardingMessages.ts
+++ b/packages/desktop/src/desktopOnboardingMessages.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const DESKTOP_ONBOARDING_DISMISSED_STATE_KEY =
+  'texra.desktop.firstRunWalkthroughDismissed';
+
+export const DESKTOP_ONBOARDING_COMMANDS = {
+  REQUEST_STATE: 'desktop:requestOnboarding',
+  DISMISS: 'desktop:dismissOnboarding',
+  SHOW: 'desktop:showOnboarding',
+  SET_STATE: 'desktop:setOnboarding',
+} as const;
+
+export const DesktopOnboardingSetStateMessageSchema = z.object({
+  command: z.literal(DESKTOP_ONBOARDING_COMMANDS.SET_STATE),
+  shouldShow: z.boolean(),
+});
+
+export type DesktopOnboardingSetStateMessage = z.infer<
+  typeof DesktopOnboardingSetStateMessageSchema
+>;

--- a/packages/desktop/src/main/desktopAgentExecution.ts
+++ b/packages/desktop/src/main/desktopAgentExecution.ts
@@ -823,7 +823,7 @@ export class DesktopProgressBridge {
       await this.options.openBuildDisplay(toFileLocation(filePath));
       return;
     }
-    await this.options.showInfoMessage?.(
+    await this.showErrorMessage(
       'Desktop LaTeX preview is unavailable. Cannot compile and open this file.',
     );
   }

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -1,0 +1,66 @@
+import { platform } from '@platform/platform';
+import {
+  DESKTOP_ONBOARDING_COMMANDS,
+  DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
+  type DesktopOnboardingSetStateMessage,
+} from '../desktopOnboardingMessages.js';
+import {
+  createDesktopErrorReporter,
+  type DesktopCommandMessage,
+  type DesktopMessageHandler,
+  type DesktopRenderer,
+} from './desktopIpcTypes.js';
+import type { StateStore } from '@platform/interfaces/state';
+
+export interface DesktopOnboardingIpcOptions {
+  state?: StateStore;
+  onAsyncError?: (error: unknown) => void;
+}
+
+export function createDesktopOnboardingIpc(
+  renderer: DesktopRenderer,
+  options: DesktopOnboardingIpcOptions = {},
+): DesktopMessageHandler {
+  const state = options.state ?? platform().globalState;
+  const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
+
+  function makeSetStateMessage(
+    shouldShow: boolean,
+  ): DesktopOnboardingSetStateMessage {
+    return {
+      command: DESKTOP_ONBOARDING_COMMANDS.SET_STATE,
+      shouldShow,
+    };
+  }
+
+  function postCurrentState(): void {
+    const dismissed = state.get<boolean>(
+      DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
+      false,
+    );
+    renderer.postToRenderer(makeSetStateMessage(!dismissed));
+  }
+
+  async function dismiss(): Promise<void> {
+    await state.update(DESKTOP_ONBOARDING_DISMISSED_STATE_KEY, true);
+    renderer.postToRenderer(makeSetStateMessage(false));
+  }
+
+  return {
+    handleMessage(message: DesktopCommandMessage): boolean {
+      switch (message.command) {
+        case DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE:
+          postCurrentState();
+          return true;
+        case DESKTOP_ONBOARDING_COMMANDS.DISMISS:
+          void dismiss().catch(reportAsyncError);
+          return true;
+        case DESKTOP_ONBOARDING_COMMANDS.SHOW:
+          renderer.postToRenderer(makeSetStateMessage(true));
+          return true;
+        default:
+          return false;
+      }
+    },
+  };
+}

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -55,9 +55,6 @@ export function createDesktopOnboardingIpc(
         case DESKTOP_ONBOARDING_COMMANDS.DISMISS:
           void dismiss().catch(reportAsyncError);
           return true;
-        case DESKTOP_ONBOARDING_COMMANDS.SHOW:
-          renderer.postToRenderer(makeSetStateMessage(true));
-          return true;
         default:
           return false;
       }

--- a/packages/desktop/src/main/desktopOnboardingIpc.ts
+++ b/packages/desktop/src/main/desktopOnboardingIpc.ts
@@ -1,8 +1,8 @@
 import { platform } from '@platform/platform';
 import {
+  buildDesktopOnboardingSetStateMessage,
   DESKTOP_ONBOARDING_COMMANDS,
   DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
-  type DesktopOnboardingSetStateMessage,
 } from '../desktopOnboardingMessages.js';
 import {
   createDesktopErrorReporter,
@@ -24,26 +24,17 @@ export function createDesktopOnboardingIpc(
   const state = options.state ?? platform().globalState;
   const reportAsyncError = createDesktopErrorReporter(options.onAsyncError);
 
-  function makeSetStateMessage(
-    shouldShow: boolean,
-  ): DesktopOnboardingSetStateMessage {
-    return {
-      command: DESKTOP_ONBOARDING_COMMANDS.SET_STATE,
-      shouldShow,
-    };
-  }
-
   function postCurrentState(): void {
     const dismissed = state.get<boolean>(
       DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
       false,
     );
-    renderer.postToRenderer(makeSetStateMessage(!dismissed));
+    renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(!dismissed));
   }
 
   async function dismiss(): Promise<void> {
     await state.update(DESKTOP_ONBOARDING_DISMISSED_STATE_KEY, true);
-    renderer.postToRenderer(makeSetStateMessage(false));
+    renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(false));
   }
 
   return {

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -13,6 +13,7 @@ import {
   DESKTOP_SHELL_COMMANDS,
   type DesktopRoute,
 } from '../desktopShellMessages.js';
+import { DESKTOP_ONBOARDING_COMMANDS } from '../desktopOnboardingMessages.js';
 import {
   createDesktopErrorReporter,
   type DesktopCommandMessage,
@@ -113,6 +114,13 @@ export function createDesktopShellActions(
     void options.openWorkspaceFolder?.().catch(reportAsyncError);
   }
 
+  function showFirstRunWalkthrough() {
+    renderer.postToRenderer({
+      command: DESKTOP_ONBOARDING_COMMANDS.SET_STATE,
+      shouldShow: true,
+    });
+  }
+
   function signIn() {
     if (!options.signIn) {
       postSettingsRoute(SETTINGS_TAB.MODELS);
@@ -135,6 +143,7 @@ export function createDesktopShellActions(
     },
     showRoute: postRoute,
     showSettings: postSettingsRoute,
+    showFirstRunWalkthrough,
   };
 }
 
@@ -192,6 +201,9 @@ export function createDesktopShellIpc(
           return true;
         case DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER:
           actions.openWorkspaceFolder?.();
+          return true;
+        case DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH:
+          actions.showFirstRunWalkthrough?.();
           return true;
         default:
           return false;

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -116,10 +116,6 @@ export function createDesktopShellActions(
     void options.openWorkspaceFolder?.().catch(reportAsyncError);
   }
 
-  function showFirstRunWalkthrough() {
-    renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
-  }
-
   function openDesktopDocs() {
     void options.openExternalUrl?.(DESKTOP_DOCS_URL).catch(reportAsyncError);
   }
@@ -147,7 +143,9 @@ export function createDesktopShellActions(
     },
     showRoute: postRoute,
     showSettings: postSettingsRoute,
-    showFirstRunWalkthrough,
+    showFirstRunWalkthrough: () => {
+      renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
+    },
   };
 }
 

--- a/packages/desktop/src/main/desktopShellIpc.ts
+++ b/packages/desktop/src/main/desktopShellIpc.ts
@@ -13,7 +13,7 @@ import {
   DESKTOP_SHELL_COMMANDS,
   type DesktopRoute,
 } from '../desktopShellMessages.js';
-import { DESKTOP_ONBOARDING_COMMANDS } from '../desktopOnboardingMessages.js';
+import { buildDesktopOnboardingSetStateMessage } from '../desktopOnboardingMessages.js';
 import {
   createDesktopErrorReporter,
   type DesktopCommandMessage,
@@ -117,10 +117,7 @@ export function createDesktopShellActions(
   }
 
   function showFirstRunWalkthrough() {
-    renderer.postToRenderer({
-      command: DESKTOP_ONBOARDING_COMMANDS.SET_STATE,
-      shouldShow: true,
-    });
+    renderer.postToRenderer(buildDesktopOnboardingSetStateMessage(true));
   }
 
   function openDesktopDocs() {

--- a/packages/desktop/src/main/desktopSupabaseAuth.ts
+++ b/packages/desktop/src/main/desktopSupabaseAuth.ts
@@ -81,6 +81,7 @@ export interface DesktopSupabaseAuthOptions {
   coordinator?: DesktopAuthCoordinator;
   oauthClient?: DesktopOAuthClient;
   callbackState?: DesktopAuthCallbackState;
+  initializeServerSideAccess?: boolean;
 }
 
 export interface DesktopOAuthClient {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -19,6 +19,7 @@ import {
   getDesktopLogDirectory,
 } from './desktopAppLog.js';
 import { installDesktopMenu } from './desktopMenu.js';
+import { createDesktopOnboardingIpc } from './desktopOnboardingIpc.js';
 import { promptInRenderer } from './desktopPrompt.js';
 import { createDesktopProgressIpc } from './desktopProgressIpc.js';
 import { createDesktopSettingsIpc } from './desktopSettingsIpc.js';
@@ -267,6 +268,10 @@ function createWindow(options: {
     progress: agentExecution.progress,
     onAsyncError: reportAsyncError,
   });
+  const onboardingIpc = createDesktopOnboardingIpc(
+    { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
+    { onAsyncError: reportAsyncError },
+  );
   const shellActions = createDesktopShellActions(
     { postToRenderer: (message) => ipcRef.current?.postToRenderer(message) },
     {
@@ -284,6 +289,7 @@ function createWindow(options: {
     workspaceExplorer,
     settings: settingsIpc,
     progress: progressIpc,
+    onboarding: onboardingIpc,
     shellActions,
     getAuthStatus: async () => ({
       authenticated: (await desktopAuth.getProfileData()).authenticated,

--- a/packages/desktop/src/main/mainViewIpc.ts
+++ b/packages/desktop/src/main/mainViewIpc.ts
@@ -28,6 +28,7 @@ export interface DesktopMainViewIpcOptions {
   workspaceExplorer?: DesktopWorkspaceExplorer;
   settings?: DesktopSettingsIpc;
   progress?: DesktopProgressIpc;
+  onboarding?: DesktopMessageHandler;
   shellActions?: DesktopShellActions;
   getAuthStatus?: () => Promise<MainViewAuthStatus>;
   executeAgent?: (message: MainViewExecuteMessage) => Promise<void>;
@@ -84,6 +85,7 @@ export function installDesktopMainViewIpc(
     options.fileSelection,
     options.settings,
     options.progress,
+    options.onboarding,
     viewState,
     shell,
     execution,

--- a/packages/desktop/src/renderer/desktopCommandPalette.ts
+++ b/packages/desktop/src/renderer/desktopCommandPalette.ts
@@ -9,6 +9,7 @@ export interface DesktopCommandPaletteOptions {
   document: Document;
   actions: DesktopCommandActions;
   platform?: NodeJS.Platform;
+  canOpen?: () => boolean;
 }
 
 export interface DesktopCommandPaletteController {
@@ -48,6 +49,7 @@ export function createDesktopCommandPalette({
   document,
   actions,
   platform = getRendererPlatform(document.defaultView),
+  canOpen,
 }: DesktopCommandPaletteOptions): DesktopCommandPaletteController {
   const view = document.defaultView;
   const entries = getDesktopCommandMenuEntries(undefined, platform);
@@ -139,6 +141,7 @@ export function createDesktopCommandPalette({
   };
 
   const open = (): void => {
+    if (canOpen?.() === false) return;
     if (element.hidden) {
       previouslyFocusedElement = isHTMLElement(view, document.activeElement)
         ? document.activeElement

--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -1,0 +1,172 @@
+import type { DesktopRoute } from '../desktopShellMessages';
+import { isCommandPaletteShortcut } from './desktopCommandPalette';
+
+export interface DesktopFirstRunWalkthroughOptions {
+  document: Document;
+  dismiss(): void;
+  setRoute(route: DesktopRoute): void;
+}
+
+export interface DesktopFirstRunWalkthrough {
+  element: HTMLElement;
+  isVisible(): boolean;
+  show(): void;
+  hide(): void;
+}
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+export function createFirstRunWalkthrough({
+  document,
+  dismiss: postDismissed,
+  setRoute,
+}: DesktopFirstRunWalkthroughOptions): DesktopFirstRunWalkthrough {
+  const element = document.createElement('section');
+  element.className = 'desktop-onboarding';
+  element.hidden = true;
+  element.setAttribute('role', 'dialog');
+  element.setAttribute('aria-modal', 'true');
+  element.setAttribute('aria-labelledby', 'desktop-onboarding-title');
+  element.innerHTML = `
+    <div class="desktop-onboarding-panel">
+      <header class="desktop-onboarding-header">
+        <span class="codicon codicon-info desktop-onboarding-icon" aria-hidden="true"></span>
+        <div>
+          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
+          <p>Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.</p>
+        </div>
+      </header>
+      <ol class="desktop-onboarding-steps">
+        <li>
+          <span class="desktop-onboarding-step-index">1</span>
+          <div>
+            <strong>Open a workspace</strong>
+            <span>Pick the folder that contains the paper or project files.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">2</span>
+          <div>
+            <strong>Set up model access</strong>
+            <span>Sign in for included access or add provider keys in Settings.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">3</span>
+          <div>
+            <strong>Choose an agent</strong>
+            <span>Select a workflow agent, direct agent, or tool-use agent.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">4</span>
+          <div>
+            <strong>Start a run</strong>
+            <span>Use the launcher and follow live output in Progress.</span>
+          </div>
+        </li>
+      </ol>
+      <footer class="desktop-onboarding-actions">
+        <button class="desktop-secondary-button" type="button" data-onboarding-settings>
+          Open Settings
+        </button>
+        <button class="desktop-secondary-button" type="button" data-onboarding-launcher>
+          Go to Launcher
+        </button>
+        <button class="desktop-primary-button" type="button" data-onboarding-dismiss>
+          Got it
+        </button>
+      </footer>
+    </div>
+  `;
+  let previousFocus: HTMLElement | null = null;
+
+  const getFocusableElements = (): HTMLElement[] =>
+    [...element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
+      (candidate) =>
+        !candidate.hasAttribute('disabled') &&
+        candidate.getAttribute('aria-hidden') !== 'true',
+    );
+
+  const hide = (): void => {
+    const restoreFocus = previousFocus;
+    element.hidden = true;
+    previousFocus = null;
+    restoreFocus?.focus();
+  };
+  const focusFirstControl = (): void => {
+    const dismissButton = element.querySelector<HTMLButtonElement>(
+      '[data-onboarding-dismiss]',
+    );
+    (dismissButton ?? getFocusableElements()[0])?.focus();
+  };
+  const show = (): void => {
+    if (element.hidden) {
+      previousFocus =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+    }
+    element.hidden = false;
+    focusFirstControl();
+  };
+  const dismiss = (): void => {
+    hide();
+    postDismissed();
+  };
+  const dismissAndShowRoute = (route: DesktopRoute): void => {
+    dismiss();
+    setRoute(route);
+  };
+  const onClick = (selector: string, handler: () => void): void => {
+    element
+      .querySelector<HTMLButtonElement>(selector)
+      ?.addEventListener('click', handler);
+  };
+
+  onClick('[data-onboarding-settings]', () => dismissAndShowRoute('settings'));
+  onClick('[data-onboarding-launcher]', () => dismissAndShowRoute('main'));
+  onClick('[data-onboarding-dismiss]', dismiss);
+  document.addEventListener('focusin', (event) => {
+    if (element.hidden) return;
+    if (event.target instanceof Node && element.contains(event.target)) return;
+    focusFirstControl();
+  });
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (element.hidden) return;
+      if (isCommandPaletteShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        dismiss();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const focusedIndex = focusable.indexOf(
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : focusable[0],
+      );
+      const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + focusable.length) % focusable.length
+        : (currentIndex + 1) % focusable.length;
+      event.preventDefault();
+      focusable[nextIndex]?.focus();
+    },
+    true,
+  );
+
+  return { element, isVisible: () => !element.hidden, show, hide };
+}

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -438,16 +438,15 @@ function createFirstRunWalkthrough(): {
     dismiss();
     setRoute(route);
   };
+  const onClick = (selector: string, handler: () => void): void => {
+    element
+      .querySelector<HTMLButtonElement>(selector)
+      ?.addEventListener('click', handler);
+  };
 
-  element
-    .querySelector<HTMLButtonElement>('[data-onboarding-settings]')
-    ?.addEventListener('click', () => dismissAndShowRoute('settings'));
-  element
-    .querySelector<HTMLButtonElement>('[data-onboarding-launcher]')
-    ?.addEventListener('click', () => dismissAndShowRoute('main'));
-  element
-    .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
-    ?.addEventListener('click', dismiss);
+  onClick('[data-onboarding-settings]', () => dismissAndShowRoute('settings'));
+  onClick('[data-onboarding-launcher]', () => dismissAndShowRoute('main'));
+  onClick('[data-onboarding-dismiss]', dismiss);
   document.addEventListener('focusin', (event) => {
     if (element.hidden) return;
     if (event.target instanceof Node && element.contains(event.target)) return;

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -450,31 +450,35 @@ function createFirstRunWalkthrough(): {
     if (event.target instanceof Node && element.contains(event.target)) return;
     focusFirstControl();
   });
-  document.addEventListener('keydown', (event) => {
-    if (element.hidden) return;
-    if (event.key === 'Escape') {
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (element.hidden) return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        dismiss();
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const focusedIndex = focusable.indexOf(
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : focusable[0],
+      );
+      const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + focusable.length) % focusable.length
+        : (currentIndex + 1) % focusable.length;
       event.preventDefault();
-      dismiss();
-      return;
-    }
-    if (event.key !== 'Tab') return;
-    const focusable = getFocusableElements();
-    if (focusable.length === 0) {
-      event.preventDefault();
-      return;
-    }
-    const focusedIndex = focusable.indexOf(
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : focusable[0],
-    );
-    const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
-    const nextIndex = event.shiftKey
-      ? (currentIndex - 1 + focusable.length) % focusable.length
-      : (currentIndex + 1) % focusable.length;
-    event.preventDefault();
-    focusable[nextIndex]?.focus();
-  }, true);
+      focusable[nextIndex]?.focus();
+    },
+    true,
+  );
 
   return { element, isVisible: () => !element.hidden, show, hide };
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -21,6 +21,11 @@ import {
   DESKTOP_LOCAL_COMMANDS,
 } from '../desktopCommandSurface';
 import {
+  DESKTOP_ONBOARDING_COMMANDS,
+  DesktopOnboardingSetStateMessageSchema,
+  type DesktopOnboardingSetStateMessage,
+} from '../desktopOnboardingMessages';
+import {
   DESKTOP_WORKSPACE_EXPLORER_COMMANDS,
   DesktopWorkspaceTreeMessageSchema,
   type DesktopWorkspaceFileCategory,
@@ -162,6 +167,9 @@ if (openLogButton == null) {
   throw new Error('TeXRA desktop open log button was not found.');
 }
 
+const firstRunWalkthrough = createFirstRunWalkthrough();
+appRoot.append(firstRunWalkthrough.element);
+
 const commandPalette = createDesktopCommandPalette({
   document,
   actions: {
@@ -180,6 +188,9 @@ const commandPalette = createDesktopCommandPalette({
     openWorkspaceFolder: () => {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER);
     },
+    showFirstRunWalkthrough: () => {
+      firstRunWalkthrough.show();
+    },
   },
 });
 appRoot.append(commandPalette.element);
@@ -191,6 +202,7 @@ openLogButton.addEventListener('click', () =>
   postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
 );
 requestWorkspaceTree();
+postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
 
 function isDesktopSetRouteMessage(
   message: unknown,
@@ -202,6 +214,12 @@ function isThemeMessage(
   message: unknown,
 ): message is { command: typeof COMMON_COMMANDS.THEME_SET; theme: string } {
   return SetThemeMessageSchema.safeParse(message).success;
+}
+
+function isDesktopOnboardingSetStateMessage(
+  message: unknown,
+): message is DesktopOnboardingSetStateMessage {
+  return DesktopOnboardingSetStateMessageSchema.safeParse(message).success;
 }
 
 function setRoute(route: DesktopRoute): void {
@@ -217,6 +235,12 @@ function setRoute(route: DesktopRoute): void {
 window.addEventListener('message', (event) => {
   if (isDesktopSetRouteMessage(event.data)) {
     setRoute(event.data.route);
+  } else if (isDesktopOnboardingSetStateMessage(event.data)) {
+    if (event.data.shouldShow) {
+      firstRunWalkthrough.show();
+    } else {
+      firstRunWalkthrough.hide();
+    }
   } else if (isThemeMessage(event.data)) {
     applyDesktopTheme(event.data.theme);
   } else if (isWorkspaceTreeMessage(event.data)) {
@@ -282,6 +306,102 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
   return container;
+}
+
+function createFirstRunWalkthrough(): {
+  element: HTMLElement;
+  show(): void;
+  hide(): void;
+} {
+  const element = document.createElement('section');
+  element.className = 'desktop-onboarding';
+  element.hidden = true;
+  element.setAttribute('role', 'dialog');
+  element.setAttribute('aria-modal', 'true');
+  element.setAttribute('aria-labelledby', 'desktop-onboarding-title');
+  element.innerHTML = `
+    <div class="desktop-onboarding-panel">
+      <header class="desktop-onboarding-header">
+        <span class="codicon codicon-info desktop-onboarding-icon" aria-hidden="true"></span>
+        <div>
+          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
+          <p>Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.</p>
+        </div>
+      </header>
+      <ol class="desktop-onboarding-steps">
+        <li>
+          <span class="desktop-onboarding-step-index">1</span>
+          <div>
+            <strong>Open a workspace</strong>
+            <span>Pick the folder that contains the paper or project files.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">2</span>
+          <div>
+            <strong>Set up model access</strong>
+            <span>Sign in for included access or add provider keys in Settings.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">3</span>
+          <div>
+            <strong>Choose an agent</strong>
+            <span>Select a workflow agent, direct agent, or tool-use agent.</span>
+          </div>
+        </li>
+        <li>
+          <span class="desktop-onboarding-step-index">4</span>
+          <div>
+            <strong>Start a run</strong>
+            <span>Use the launcher and follow live output in Progress.</span>
+          </div>
+        </li>
+      </ol>
+      <footer class="desktop-onboarding-actions">
+        <button class="desktop-secondary-button" type="button" data-onboarding-settings>
+          Open Settings
+        </button>
+        <button class="desktop-secondary-button" type="button" data-onboarding-launcher>
+          Go to Launcher
+        </button>
+        <button class="desktop-primary-button" type="button" data-onboarding-dismiss>
+          Got it
+        </button>
+      </footer>
+    </div>
+  `;
+
+  const hide = (): void => {
+    element.hidden = true;
+  };
+  const show = (): void => {
+    element.hidden = false;
+    element
+      .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
+      ?.focus();
+  };
+  const dismiss = (): void => {
+    hide();
+    postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS);
+  };
+
+  element
+    .querySelector<HTMLButtonElement>('[data-onboarding-settings]')
+    ?.addEventListener('click', () => setRoute('settings'));
+  element
+    .querySelector<HTMLButtonElement>('[data-onboarding-launcher]')
+    ?.addEventListener('click', () => setRoute('main'));
+  element
+    .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
+    ?.addEventListener('click', dismiss);
+  element.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    dismiss();
+  });
+
+  return { element, show, hide };
 }
 
 function isWorkspaceTreeMessage(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -411,6 +411,12 @@ function createFirstRunWalkthrough(): {
     previousFocus = null;
     restoreFocus?.focus();
   };
+  const focusFirstControl = (): void => {
+    const dismissButton = element.querySelector<HTMLButtonElement>(
+      '[data-onboarding-dismiss]',
+    );
+    (dismissButton ?? getFocusableElements()[0])?.focus();
+  };
   const show = (): void => {
     if (element.hidden) {
       previousFocus =
@@ -419,10 +425,7 @@ function createFirstRunWalkthrough(): {
           : null;
     }
     element.hidden = false;
-    const dismissButton = element.querySelector<HTMLButtonElement>(
-      '[data-onboarding-dismiss]',
-    );
-    (dismissButton ?? getFocusableElements()[0])?.focus();
+    focusFirstControl();
   };
   const dismiss = (): void => {
     hide();
@@ -442,7 +445,13 @@ function createFirstRunWalkthrough(): {
   element
     .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
     ?.addEventListener('click', dismiss);
-  element.addEventListener('keydown', (event) => {
+  document.addEventListener('focusin', (event) => {
+    if (element.hidden) return;
+    if (event.target instanceof Node && element.contains(event.target)) return;
+    focusFirstControl();
+  });
+  document.addEventListener('keydown', (event) => {
+    if (element.hidden) return;
     if (event.key === 'Escape') {
       event.preventDefault();
       dismiss();
@@ -465,7 +474,7 @@ function createFirstRunWalkthrough(): {
       : (currentIndex + 1) % focusable.length;
     event.preventDefault();
     focusable[nextIndex]?.focus();
-  });
+  }, true);
 
   return { element, isVisible: () => !element.hidden, show, hide };
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -204,8 +204,6 @@ commandPaletteButton.addEventListener('click', commandPalette.open);
 openWorkspaceButton.addEventListener('click', () =>
   postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
 );
-requestWorkspaceTree();
-postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
 
 function isDesktopSetRouteMessage(
   message: unknown,
@@ -259,6 +257,8 @@ window.addEventListener('message', (event) => {
     renderLogSnapshot(event.data);
   }
 });
+requestWorkspaceTree();
+postMessage(DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE);
 
 function applyDesktopTheme(theme: string): void {
   document.body.classList.remove(
@@ -383,15 +383,37 @@ function createFirstRunWalkthrough(): {
       </footer>
     </div>
   `;
+  let previousFocus: HTMLElement | null = null;
+
+  const getFocusableElements = (): HTMLElement[] =>
+    [
+      ...element.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      ),
+    ].filter(
+      (candidate) =>
+        !candidate.hasAttribute('disabled') &&
+        candidate.getAttribute('aria-hidden') !== 'true',
+    );
 
   const hide = (): void => {
+    const restoreFocus = previousFocus;
     element.hidden = true;
+    previousFocus = null;
+    restoreFocus?.focus();
   };
   const show = (): void => {
+    if (element.hidden) {
+      previousFocus =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+    }
     element.hidden = false;
-    element
-      .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
-      ?.focus();
+    const dismissButton = element.querySelector<HTMLButtonElement>(
+      '[data-onboarding-dismiss]',
+    );
+    (dismissButton ?? getFocusableElements()[0])?.focus();
   };
   const dismiss = (): void => {
     hide();
@@ -412,9 +434,28 @@ function createFirstRunWalkthrough(): {
     .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
     ?.addEventListener('click', dismiss);
   element.addEventListener('keydown', (event) => {
-    if (event.key !== 'Escape') return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      dismiss();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const focusedIndex = focusable.indexOf(
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : focusable[0],
+    );
+    const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
+    const nextIndex = event.shiftKey
+      ? (currentIndex - 1 + focusable.length) % focusable.length
+      : (currentIndex + 1) % focusable.length;
     event.preventDefault();
-    dismiss();
+    focusable[nextIndex]?.focus();
   });
 
   return { element, show, hide };

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -175,6 +175,7 @@ appRoot.append(firstRunWalkthrough.element);
 
 const commandPalette = createDesktopCommandPalette({
   document,
+  canOpen: () => !firstRunWalkthrough.isVisible(),
   actions: {
     showRoute: setRoute,
     showSettings: (tabIndex, agentSubTab) => {
@@ -322,6 +323,7 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
 
 function createFirstRunWalkthrough(): {
   element: HTMLElement;
+  isVisible(): boolean;
   show(): void;
   hide(): void;
 } {
@@ -458,7 +460,7 @@ function createFirstRunWalkthrough(): {
     focusable[nextIndex]?.focus();
   });
 
-  return { element, show, hide };
+  return { element, isVisible: () => !element.hidden, show, hide };
 }
 
 function createLogViewer(): HTMLElement {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -40,10 +40,8 @@ import {
   type DesktopWorkspaceFileCategory,
   type DesktopWorkspaceTreeMessage,
 } from '../desktopWorkspaceExplorerMessages';
-import {
-  createDesktopCommandPalette,
-  isCommandPaletteShortcut,
-} from './desktopCommandPalette';
+import { createDesktopCommandPalette } from './desktopCommandPalette';
+import { createFirstRunWalkthrough } from './desktopOnboarding';
 
 interface WorkspaceTreeNode {
   name: string;
@@ -176,7 +174,11 @@ if (openWorkspaceButton == null) {
   throw new Error('TeXRA desktop open workspace button was not found.');
 }
 
-const firstRunWalkthrough = createFirstRunWalkthrough();
+const firstRunWalkthrough = createFirstRunWalkthrough({
+  document,
+  dismiss: () => postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS),
+  setRoute,
+});
 appRoot.append(firstRunWalkthrough.element);
 
 const commandPalette = createDesktopCommandPalette({
@@ -329,165 +331,6 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
   return container;
-}
-
-function createFirstRunWalkthrough(): {
-  element: HTMLElement;
-  isVisible(): boolean;
-  show(): void;
-  hide(): void;
-} {
-  const element = document.createElement('section');
-  element.className = 'desktop-onboarding';
-  element.hidden = true;
-  element.setAttribute('role', 'dialog');
-  element.setAttribute('aria-modal', 'true');
-  element.setAttribute('aria-labelledby', 'desktop-onboarding-title');
-  element.innerHTML = `
-    <div class="desktop-onboarding-panel">
-      <header class="desktop-onboarding-header">
-        <span class="codicon codicon-info desktop-onboarding-icon" aria-hidden="true"></span>
-        <div>
-          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
-          <p>Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.</p>
-        </div>
-      </header>
-      <ol class="desktop-onboarding-steps">
-        <li>
-          <span class="desktop-onboarding-step-index">1</span>
-          <div>
-            <strong>Open a workspace</strong>
-            <span>Pick the folder that contains the paper or project files.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">2</span>
-          <div>
-            <strong>Set up model access</strong>
-            <span>Sign in for included access or add provider keys in Settings.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">3</span>
-          <div>
-            <strong>Choose an agent</strong>
-            <span>Select a workflow agent, direct agent, or tool-use agent.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">4</span>
-          <div>
-            <strong>Start a run</strong>
-            <span>Use the launcher and follow live output in Progress.</span>
-          </div>
-        </li>
-      </ol>
-      <footer class="desktop-onboarding-actions">
-        <button class="desktop-secondary-button" type="button" data-onboarding-settings>
-          Open Settings
-        </button>
-        <button class="desktop-secondary-button" type="button" data-onboarding-launcher>
-          Go to Launcher
-        </button>
-        <button class="desktop-primary-button" type="button" data-onboarding-dismiss>
-          Got it
-        </button>
-      </footer>
-    </div>
-  `;
-  let previousFocus: HTMLElement | null = null;
-
-  const getFocusableElements = (): HTMLElement[] =>
-    [
-      ...element.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      ),
-    ].filter(
-      (candidate) =>
-        !candidate.hasAttribute('disabled') &&
-        candidate.getAttribute('aria-hidden') !== 'true',
-    );
-
-  const hide = (): void => {
-    const restoreFocus = previousFocus;
-    element.hidden = true;
-    previousFocus = null;
-    restoreFocus?.focus();
-  };
-  const focusFirstControl = (): void => {
-    const dismissButton = element.querySelector<HTMLButtonElement>(
-      '[data-onboarding-dismiss]',
-    );
-    (dismissButton ?? getFocusableElements()[0])?.focus();
-  };
-  const show = (): void => {
-    if (element.hidden) {
-      previousFocus =
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null;
-    }
-    element.hidden = false;
-    focusFirstControl();
-  };
-  const dismiss = (): void => {
-    hide();
-    postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS);
-  };
-  const dismissAndShowRoute = (route: DesktopRoute): void => {
-    dismiss();
-    setRoute(route);
-  };
-  const onClick = (selector: string, handler: () => void): void => {
-    element
-      .querySelector<HTMLButtonElement>(selector)
-      ?.addEventListener('click', handler);
-  };
-
-  onClick('[data-onboarding-settings]', () => dismissAndShowRoute('settings'));
-  onClick('[data-onboarding-launcher]', () => dismissAndShowRoute('main'));
-  onClick('[data-onboarding-dismiss]', dismiss);
-  document.addEventListener('focusin', (event) => {
-    if (element.hidden) return;
-    if (event.target instanceof Node && element.contains(event.target)) return;
-    focusFirstControl();
-  });
-  document.addEventListener(
-    'keydown',
-    (event) => {
-      if (element.hidden) return;
-      if (isCommandPaletteShortcut(event)) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      }
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        dismiss();
-        return;
-      }
-      if (event.key !== 'Tab') return;
-      const focusable = getFocusableElements();
-      if (focusable.length === 0) {
-        event.preventDefault();
-        return;
-      }
-      const focusedIndex = focusable.indexOf(
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : focusable[0],
-      );
-      const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
-      const nextIndex = event.shiftKey
-        ? (currentIndex - 1 + focusable.length) % focusable.length
-        : (currentIndex + 1) % focusable.length;
-      event.preventDefault();
-      focusable[nextIndex]?.focus();
-    },
-    true,
-  );
-
-  return { element, isVisible: () => !element.hidden, show, hide };
 }
 
 function createLogViewer(): HTMLElement {

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -40,7 +40,10 @@ import {
   type DesktopWorkspaceFileCategory,
   type DesktopWorkspaceTreeMessage,
 } from '../desktopWorkspaceExplorerMessages';
-import { createDesktopCommandPalette } from './desktopCommandPalette';
+import {
+  createDesktopCommandPalette,
+  isCommandPaletteShortcut,
+} from './desktopCommandPalette';
 
 interface WorkspaceTreeNode {
   name: string;
@@ -454,6 +457,11 @@ function createFirstRunWalkthrough(): {
     'keydown',
     (event) => {
       if (element.hidden) return;
+      if (isCommandPaletteShortcut(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       if (event.key === 'Escape') {
         event.preventDefault();
         dismiss();

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -385,13 +385,17 @@ function createFirstRunWalkthrough(): {
     hide();
     postMessage(DESKTOP_ONBOARDING_COMMANDS.DISMISS);
   };
+  const dismissAndShowRoute = (route: DesktopRoute): void => {
+    dismiss();
+    setRoute(route);
+  };
 
   element
     .querySelector<HTMLButtonElement>('[data-onboarding-settings]')
-    ?.addEventListener('click', () => setRoute('settings'));
+    ?.addEventListener('click', () => dismissAndShowRoute('settings'));
   element
     .querySelector<HTMLButtonElement>('[data-onboarding-launcher]')
-    ?.addEventListener('click', () => setRoute('main'));
+    ?.addEventListener('click', () => dismissAndShowRoute('main'));
   element
     .querySelector<HTMLButtonElement>('[data-onboarding-dismiss]')
     ?.addEventListener('click', dismiss);

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -448,3 +448,141 @@ body {
 .desktop-secondary-button:hover {
   background: var(--texra-button-secondaryHoverBackground);
 }
+
+.desktop-onboarding {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  box-sizing: border-box;
+  background: rgb(0 0 0 / 40%);
+}
+
+.desktop-onboarding[hidden] {
+  display: none;
+}
+
+.desktop-onboarding-panel {
+  width: min(640px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  overflow: auto;
+  border: 1px solid var(--texra-panel-border);
+  border-radius: 6px;
+  background: var(--texra-editor-background);
+  box-shadow: 0 18px 46px rgb(0 0 0 / 34%);
+}
+
+.desktop-onboarding-header {
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr);
+  gap: 14px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--texra-panel-border);
+}
+
+.desktop-onboarding-icon {
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
+  background: var(--texra-button-secondaryBackground);
+  color: var(--texra-button-background);
+  font-size: 20px;
+}
+
+.desktop-onboarding h1 {
+  margin: 0;
+  color: var(--texra-foreground);
+  font-size: 21px;
+  font-weight: 600;
+}
+
+.desktop-onboarding p {
+  margin: 8px 0 0;
+  color: var(--texra-descriptionForeground);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.desktop-onboarding-steps {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 8px 24px 4px;
+  list-style: none;
+}
+
+.desktop-onboarding-steps li {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--texra-panel-border);
+}
+
+.desktop-onboarding-steps li:last-child {
+  border-bottom: 0;
+}
+
+.desktop-onboarding-step-index {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--texra-panel-border);
+  border-radius: 50%;
+  color: var(--texra-foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.desktop-onboarding-steps strong,
+.desktop-onboarding-steps span {
+  display: block;
+  min-width: 0;
+}
+
+.desktop-onboarding-steps strong {
+  color: var(--texra-foreground);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.desktop-onboarding-steps span {
+  margin-top: 4px;
+  color: var(--texra-descriptionForeground);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.desktop-onboarding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px 22px;
+}
+
+@media (max-width: 560px) {
+  .desktop-onboarding {
+    padding: 12px;
+  }
+
+  .desktop-onboarding-header,
+  .desktop-onboarding-steps,
+  .desktop-onboarding-actions {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .desktop-onboarding-actions {
+    justify-content: stretch;
+  }
+
+  .desktop-onboarding-actions button {
+    flex: 1 1 150px;
+  }
+}

--- a/scripts/verify-desktop-package.mjs
+++ b/scripts/verify-desktop-package.mjs
@@ -158,22 +158,6 @@ function normalizeAsarPath(path) {
   return normalized.startsWith('/') ? normalized : `/${normalized}`;
 }
 
-function normalizeMetafilePath(path) {
-  return path.replaceAll('\\', '/').replace(/^\.\//, '');
-}
-
-function resolveMetafileImportPath(outputPath, importPath) {
-  const normalizedImportPath = normalizeMetafilePath(importPath);
-  if (normalizedImportPath.startsWith('.')) {
-    return normalizeMetafilePath(
-      posix.normalize(
-        posix.join(posix.dirname(outputPath), normalizedImportPath),
-      ),
-    );
-  }
-  return posix.normalize(normalizedImportPath);
-}
-
 function createAsarAppReader(asarPath) {
   const entryPathByNormalizedPath = new Map(
     listPackage(asarPath).map((entry) => [normalizeAsarPath(entry), entry]),

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -116,6 +116,13 @@ describe('desktop command surface', () => {
       label: 'Show Logs',
       category: 'TeXRA',
     });
+    const firstHelpIndex = entries.findIndex(
+      (entry) => entry.category === 'Help',
+    );
+    expect(firstHelpIndex).toBe(entries.length - 2);
+    expect(entries.slice(firstHelpIndex).map((entry) => entry.category)).toEqual(
+      ['Help', 'Help'],
+    );
   });
 
   it('normalizes catalog keybindings to Electron accelerators', async () => {

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -120,9 +120,9 @@ describe('desktop command surface', () => {
       (entry) => entry.category === 'Help',
     );
     expect(firstHelpIndex).toBe(entries.length - 2);
-    expect(entries.slice(firstHelpIndex).map((entry) => entry.category)).toEqual(
-      ['Help', 'Help'],
-    );
+    expect(
+      entries.slice(firstHelpIndex).map((entry) => entry.category),
+    ).toEqual(['Help', 'Help']);
   });
 
   it('normalizes catalog keybindings to Electron accelerators', async () => {

--- a/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
+++ b/src/test-kernel/desktop/DesktopCommandSurface.vitest.mts
@@ -19,6 +19,7 @@ interface DesktopCommandSurfaceModule {
   DESKTOP_LOCAL_COMMANDS: {
     OPEN_LOG_FOLDER: string;
     OPEN_WORKSPACE_FOLDER: string;
+    SHOW_FIRST_RUN_WALKTHROUGH: string;
   };
   DESKTOP_COMMAND_IDS: readonly string[];
   buildDesktopMenuTemplate(
@@ -77,6 +78,10 @@ describe('desktop command surface', () => {
     for (const entry of entries) {
       const catalogEntry = commandCatalogById.get(entry.id as CommandId);
       if (!catalogEntry) {
+        if (entry.id === 'texra.desktop.showFirstRunWalkthrough') {
+          expect(entry.category).toBe('Help');
+          continue;
+        }
         expect(entry.category).toBe('TeXRA');
         continue;
       }
@@ -121,6 +126,7 @@ describe('desktop command surface', () => {
     const actions = {
       openLogFolder: vi.fn(),
       openWorkspaceFolder: vi.fn(),
+      showFirstRunWalkthrough: vi.fn(),
       showRoute: vi.fn(),
       showSettings: vi.fn(),
     };
@@ -141,6 +147,12 @@ describe('desktop command surface', () => {
     expect(
       dispatchDesktopCommand(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER, actions),
     ).toBe(true);
+    expect(
+      dispatchDesktopCommand(
+        DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH,
+        actions,
+      ),
+    ).toBe(true);
 
     expect(actions.showRoute).toHaveBeenNthCalledWith(1, 'main');
     expect(actions.showRoute).toHaveBeenNthCalledWith(2, 'progress');
@@ -155,6 +167,12 @@ describe('desktop command surface', () => {
     );
     expect(actions.openWorkspaceFolder).toHaveBeenCalledOnce();
     expect(actions.openLogFolder).toHaveBeenCalledOnce();
+    expect(actions.showFirstRunWalkthrough).toHaveBeenCalledOnce();
+    expect(
+      commandCatalogById.has(
+        DESKTOP_LOCAL_COMMANDS.SHOW_FIRST_RUN_WALKTHROUGH as CommandId,
+      ),
+    ).toBe(false);
   });
 
   it('builds settings-tab messages from one shared helper', async () => {
@@ -215,5 +233,10 @@ describe('desktop command surface', () => {
     submenu[8].click?.();
     expect(actions.showRoute).toHaveBeenCalledWith('main');
     expect(actions.showSettings).toHaveBeenCalledWith(SETTINGS_TAB.MODELS);
+
+    const helpMenu = menu.find((item) => item.role === 'help');
+    expect(helpMenu?.submenu?.map((item) => item.label)).toEqual([
+      'Show First-Run Walkthrough',
+    ]);
   });
 });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -325,10 +325,6 @@ describe('desktop IPC adapters', () => {
 
     expect(
       onboarding.handleMessage({ command: 'desktop:showOnboarding' }),
-    ).toBe(true);
-    expect(postToRenderer).toHaveBeenLastCalledWith({
-      command: 'desktop:setOnboarding',
-      shouldShow: true,
-    });
+    ).toBe(false);
   });
 });

--- a/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
+++ b/src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts
@@ -42,6 +42,22 @@ interface DesktopExecutionIpcModule {
   };
 }
 
+interface DesktopOnboardingIpcModule {
+  DESKTOP_ONBOARDING_DISMISSED_STATE_KEY: string;
+  createDesktopOnboardingIpc(
+    renderer: DesktopRenderer,
+    options?: {
+      state?: {
+        get<T>(key: string, defaultValue?: T): T;
+        update(key: string, value: unknown): PromiseLike<void>;
+      };
+      onAsyncError?: (error: unknown) => void;
+    },
+  ): {
+    handleMessage(message: { command: string }): boolean;
+  };
+}
+
 interface DesktopViewStateIpcModule {
   createDesktopViewStateIpc(
     renderer: DesktopRenderer,
@@ -65,6 +81,18 @@ async function loadDesktopExecutionIpc(): Promise<DesktopExecutionIpcModule> {
   return import(
     moduleFileUrl(desktopSourcePath('main', 'desktopExecutionIpc.ts'))
   ) as Promise<DesktopExecutionIpcModule>;
+}
+
+async function loadDesktopOnboardingIpc(): Promise<DesktopOnboardingIpcModule> {
+  const [onboardingIpc, onboardingMessages] = await Promise.all([
+    import(
+      moduleFileUrl(desktopSourcePath('main', 'desktopOnboardingIpc.ts'))
+    ) as Promise<DesktopOnboardingIpcModule>,
+    import(
+      moduleFileUrl(desktopSourcePath('desktopOnboardingMessages.ts'))
+    ) as Promise<{ DESKTOP_ONBOARDING_DISMISSED_STATE_KEY: string }>,
+  ]);
+  return { ...onboardingIpc, ...onboardingMessages };
 }
 
 async function loadDesktopViewStateIpc(nativeTheme: {
@@ -243,5 +271,64 @@ describe('desktop IPC adapters', () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(onAsyncError).toHaveBeenCalledWith(error);
+  });
+
+  it('persists first-run walkthrough dismissal in the onboarding adapter', async () => {
+    const {
+      DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
+      createDesktopOnboardingIpc,
+    } = await loadDesktopOnboardingIpc();
+    const values = new Map<string, unknown>();
+    const update = vi.fn(async (key: string, value: unknown) => {
+      values.set(key, value);
+    });
+    const state = {
+      get<T>(key: string, defaultValue?: T): T {
+        return (values.has(key) ? values.get(key) : defaultValue) as T;
+      },
+      update,
+    };
+    const postToRenderer = vi.fn();
+    const onboarding = createDesktopOnboardingIpc(
+      { postToRenderer },
+      { state },
+    );
+
+    expect(
+      onboarding.handleMessage({ command: 'desktop:requestOnboarding' }),
+    ).toBe(true);
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: 'desktop:setOnboarding',
+      shouldShow: true,
+    });
+
+    expect(
+      onboarding.handleMessage({ command: 'desktop:dismissOnboarding' }),
+    ).toBe(true);
+    await Promise.resolve();
+    expect(update).toHaveBeenCalledWith(
+      DESKTOP_ONBOARDING_DISMISSED_STATE_KEY,
+      true,
+    );
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: 'desktop:setOnboarding',
+      shouldShow: false,
+    });
+
+    expect(
+      onboarding.handleMessage({ command: 'desktop:requestOnboarding' }),
+    ).toBe(true);
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: 'desktop:setOnboarding',
+      shouldShow: false,
+    });
+
+    expect(
+      onboarding.handleMessage({ command: 'desktop:showOnboarding' }),
+    ).toBe(true);
+    expect(postToRenderer).toHaveBeenLastCalledWith({
+      command: 'desktop:setOnboarding',
+      shouldShow: true,
+    });
   });
 });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -75,6 +75,8 @@ describe('desktop renderer shell', () => {
       'canOpen: () => !firstRunWalkthrough.isVisible()',
     );
     expect(rendererMain).toContain('previousFocus');
+    expect(rendererMain).toContain("document.addEventListener('focusin'");
+    expect(rendererMain).toContain("document.addEventListener('keydown'");
     expect(rendererMain).toContain("event.key !== 'Tab'");
   });
 

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -76,7 +76,8 @@ describe('desktop renderer shell', () => {
     );
     expect(rendererMain).toContain('previousFocus');
     expect(rendererMain).toContain("document.addEventListener('focusin'");
-    expect(rendererMain).toContain("document.addEventListener('keydown'");
+    expect(rendererMain).toContain("'keydown'");
+    expect(rendererMain).toContain('isCommandPaletteShortcut(event)');
     expect(rendererMain).toContain("event.key !== 'Tab'");
   });
 

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -62,4 +62,13 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('buildDesktopSettingsTabMessage');
     expect(rendererMain).toContain('showSettings: (tabIndex, agentSubTab)');
   });
+
+  it('mounts desktop-only first-run onboarding controls', () => {
+    const rendererMain = readRendererMain();
+
+    expect(rendererMain).toContain('createFirstRunWalkthrough');
+    expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE');
+    expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.DISMISS');
+    expect(rendererMain).toContain('showFirstRunWalkthrough');
+  });
 });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -14,6 +14,13 @@ function readRendererMain(): string {
   );
 }
 
+function readRendererOnboarding(): string {
+  return readFileSync(
+    repoPath('packages/desktop/src/renderer/desktopOnboarding.ts'),
+    'utf8',
+  );
+}
+
 describe('desktop renderer shell', () => {
   it('mounts the reused launcher, progress, and settings Lit apps', () => {
     const rendererMain = readRendererMain();
@@ -66,6 +73,7 @@ describe('desktop renderer shell', () => {
 
   it('mounts desktop-only first-run onboarding controls', () => {
     const rendererMain = readRendererMain();
+    const rendererOnboarding = readRendererOnboarding();
 
     expect(rendererMain).toContain('createFirstRunWalkthrough');
     expect(rendererMain).toContain('DESKTOP_ONBOARDING_COMMANDS.REQUEST_STATE');
@@ -74,11 +82,11 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain(
       'canOpen: () => !firstRunWalkthrough.isVisible()',
     );
-    expect(rendererMain).toContain('previousFocus');
-    expect(rendererMain).toContain("document.addEventListener('focusin'");
-    expect(rendererMain).toContain("'keydown'");
-    expect(rendererMain).toContain('isCommandPaletteShortcut(event)');
-    expect(rendererMain).toContain("event.key !== 'Tab'");
+    expect(rendererOnboarding).toContain('previousFocus');
+    expect(rendererOnboarding).toContain("document.addEventListener('focusin'");
+    expect(rendererOnboarding).toContain("'keydown'");
+    expect(rendererOnboarding).toContain('isCommandPaletteShortcut(event)');
+    expect(rendererOnboarding).toContain("event.key !== 'Tab'");
   });
 
   it('mounts an in-app log viewer with copy and export actions', () => {


### PR DESCRIPTION
## Summary
- add a desktop-only first-run walkthrough modal with setup steps for workspace, model access, agents, and running
- persist walkthrough dismissal through desktop global state and allow reopening from the Help menu / command palette
- keep the extension command catalog untouched by using a desktop-local command

Fixes #3618

## Validation
- corepack pnpm install --frozen-lockfile
- corepack pnpm vitest run --config vitest.config.mjs src/test-kernel/desktop/DesktopCommandSurface.vitest.mts src/test-kernel/desktop/DesktopIpcAdapters.vitest.mts src/test-kernel/desktop/ElectronMainViewIpc.vitest.mts src/test-kernel/desktop/ElectronRendererShell.vitest.mts
- npm run typecheck
- npm run lint
- npm run compile:fast
- npm run desktop:build
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new renderer modal + IPC/state persistence and wires it into shell/menu/command palette, so regressions could affect desktop startup messaging and global keyboard handling. No auth/remote I/O logic changes beyond a small option cleanup.
> 
> **Overview**
> Adds a desktop-only **first-run walkthrough** modal that can be shown on startup and reopened later, with dismissal persisted in global state via a new `desktopOnboarding` IPC adapter (`desktop:requestOnboarding`/`desktop:dismissOnboarding` -> `desktop:setOnboarding`).
> 
> Extends the desktop command surface with a new local command `texra.desktop.showFirstRunWalkthrough`, surfaces it in the **Help** menu and command palette, and prevents the command palette from opening while the walkthrough is visible via an added `canOpen` guard.
> 
> Includes styling and focus/keyboard trapping for the onboarding dialog, updates main/renderer wiring to request onboarding state on load, and adjusts tests accordingly; also removes an unused Supabase auth option and deletes now-unneeded metafile path helpers from the desktop package verification script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8c685b5e4a741e715133f0c3230851149908eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->