### PR TITLE
[codex] Wire desktop signing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      require_desktop_signing:
+        description: 'Fail desktop installer jobs unless signing secrets are complete'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -149,8 +154,46 @@ jobs:
       - name: Build desktop app
         run: pnpm run desktop:build
 
+      - name: Prepare macOS notarization API key
+        env:
+          DESKTOP_MACOS_APPLE_API_KEY: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY }}
+          DESKTOP_MACOS_APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
+        run: |
+          if [ -n "$DESKTOP_MACOS_APPLE_API_KEY" ]; then
+            key_id="${DESKTOP_MACOS_APPLE_API_KEY_ID:-texra}"
+            key_path="$RUNNER_TEMP/AuthKey_${key_id}.p8"
+            printf '%s' "$DESKTOP_MACOS_APPLE_API_KEY" > "$key_path"
+            chmod 600 "$key_path"
+            echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify macOS signing secrets
+        id: desktop-signing
+        env:
+          TEXRA_REQUIRE_DESKTOP_SIGNING: ${{ github.event_name == 'workflow_dispatch' && inputs.require_desktop_signing && '1' || '0' }}
+          CSC_LINK: ${{ secrets.DESKTOP_MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MACOS_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.DESKTOP_MACOS_APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.DESKTOP_MACOS_APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.DESKTOP_MACOS_APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE }}
+        run: node scripts/verify-desktop-signing-env.mjs mac
+
       - name: Package macOS desktop installers
-        run: pnpm --filter @texra/desktop package:dist
+        env:
+          CSC_LINK: ${{ secrets.DESKTOP_MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MACOS_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.DESKTOP_MACOS_APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.DESKTOP_MACOS_APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.DESKTOP_MACOS_APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE }}
+        run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
       - name: Check macOS packaged desktop app contents
         run: pnpm run check:desktop-package
@@ -251,8 +294,29 @@ jobs:
       - name: Check desktop build artifacts
         run: pnpm run check:desktop-build-artifacts
 
+      - name: Verify Windows signing secrets
+        id: desktop-signing
+        env:
+          TEXRA_REQUIRE_DESKTOP_SIGNING: ${{ github.event_name == 'workflow_dispatch' && inputs.require_desktop_signing && '1' || '0' }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_TENANT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_SECRET }}
+        run: node scripts/verify-desktop-signing-env.mjs win
+
       - name: Package Windows desktop installer
-        run: pnpm --filter @texra/desktop package:dist
+        env:
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_TENANT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_SECRET }}
+        run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
       - name: Check Windows packaged desktop app contents
         run: pnpm run check:desktop-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,16 @@ jobs:
     if: github.event_name == 'push' || inputs.run_desktop_installers
     runs-on: macos-latest
     timeout-minutes: 45
+    env:
+      CSC_LINK: ${{ secrets.DESKTOP_MACOS_CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MACOS_CSC_KEY_PASSWORD }}
+      APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.DESKTOP_MACOS_APPLE_API_ISSUER }}
+      APPLE_ID: ${{ secrets.DESKTOP_MACOS_APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.DESKTOP_MACOS_APPLE_TEAM_ID }}
+      APPLE_KEYCHAIN: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN }}
+      APPLE_KEYCHAIN_PROFILE: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE }}
 
     steps:
       - name: Checkout repository
@@ -171,28 +181,9 @@ jobs:
         id: desktop-signing
         env:
           TEXRA_REQUIRE_DESKTOP_SIGNING: ${{ github.event_name == 'workflow_dispatch' && inputs.require_desktop_signing && '1' || '0' }}
-          CSC_LINK: ${{ secrets.DESKTOP_MACOS_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MACOS_CSC_KEY_PASSWORD }}
-          APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.DESKTOP_MACOS_APPLE_API_ISSUER }}
-          APPLE_ID: ${{ secrets.DESKTOP_MACOS_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.DESKTOP_MACOS_APPLE_TEAM_ID }}
-          APPLE_KEYCHAIN: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN }}
-          APPLE_KEYCHAIN_PROFILE: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE }}
         run: node scripts/verify-desktop-signing-env.mjs mac
 
       - name: Package macOS desktop installers
-        env:
-          CSC_LINK: ${{ secrets.DESKTOP_MACOS_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_MACOS_CSC_KEY_PASSWORD }}
-          APPLE_API_KEY_ID: ${{ secrets.DESKTOP_MACOS_APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.DESKTOP_MACOS_APPLE_API_ISSUER }}
-          APPLE_ID: ${{ secrets.DESKTOP_MACOS_APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.DESKTOP_MACOS_APPLE_TEAM_ID }}
-          APPLE_KEYCHAIN: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN }}
-          APPLE_KEYCHAIN_PROFILE: ${{ secrets.DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE }}
         run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
       - name: Check macOS packaged desktop app contents
@@ -264,6 +255,14 @@ jobs:
     if: github.event_name == 'push' || inputs.run_windows_desktop
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+      TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT }}
+      TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+      TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+      AZURE_TENANT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_SECRET }}
 
     steps:
       - name: Checkout repository
@@ -298,24 +297,9 @@ jobs:
         id: desktop-signing
         env:
           TEXRA_REQUIRE_DESKTOP_SIGNING: ${{ github.event_name == 'workflow_dispatch' && inputs.require_desktop_signing && '1' || '0' }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
-          AZURE_TENANT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_SECRET }}
         run: node scripts/verify-desktop-signing-env.mjs win
 
       - name: Package Windows desktop installer
-        env:
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
-          TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
-          AZURE_TENANT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_WINDOWS_AZURE_CLIENT_SECRET }}
         run: pnpm --filter @texra/desktop exec electron-builder --config ${{ steps.desktop-signing.outputs.electron_builder_config }} --publish never
 
       - name: Check Windows packaged desktop app contents

--- a/docs/desktop-signing-ci.md
+++ b/docs/desktop-signing-ci.md
@@ -1,0 +1,78 @@
+# Desktop Signing CI
+
+The desktop installer jobs can sign release artifacts when the repository
+secrets are configured. Local packaging commands still work without these
+secrets and produce unsigned artifacts for development.
+
+## macOS
+
+The macOS installer job signs and notarizes with
+`packages/desktop/electron-builder.signed.config.mjs` when it finds both a
+Developer ID certificate and one complete Apple notarization credential set.
+
+Required certificate secrets:
+
+- `DESKTOP_MACOS_CSC_LINK` - base64, `file://`, HTTPS, or path value for the
+  exported Developer ID Application certificate.
+- `DESKTOP_MACOS_CSC_KEY_PASSWORD` - password for `DESKTOP_MACOS_CSC_LINK`.
+
+Recommended notarization secrets:
+
+- `DESKTOP_MACOS_APPLE_API_KEY` - contents of the downloaded `.p8` API key.
+- `DESKTOP_MACOS_APPLE_API_KEY_ID`
+- `DESKTOP_MACOS_APPLE_API_ISSUER`
+
+The workflow also supports Electron Builder's Apple ID and keychain
+notarization environment variables if the repository chooses that path later:
+
+- `DESKTOP_MACOS_APPLE_ID`
+- `DESKTOP_MACOS_APPLE_APP_SPECIFIC_PASSWORD`
+- `DESKTOP_MACOS_APPLE_TEAM_ID`
+- `DESKTOP_MACOS_APPLE_KEYCHAIN`
+- `DESKTOP_MACOS_APPLE_KEYCHAIN_PROFILE`
+
+## Windows
+
+The Windows installer job signs with Azure Trusted Signing when all Azure
+configuration and service-principal secrets are present.
+
+Required Azure Trusted Signing configuration secrets:
+
+- `DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME`
+- `DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT`
+- `DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME`
+- `DESKTOP_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME`
+
+Required Azure authentication secrets:
+
+- `DESKTOP_WINDOWS_AZURE_TENANT_ID`
+- `DESKTOP_WINDOWS_AZURE_CLIENT_ID`
+- `DESKTOP_WINDOWS_AZURE_CLIENT_SECRET`
+
+The service principal must have permission to use the Trusted Signing
+certificate profile.
+
+## Verification
+
+Run the installer jobs manually from GitHub Actions with
+`run_desktop_installers`, `run_windows_desktop`, and `require_desktop_signing`
+enabled before relying on signed beta artifacts. With
+`require_desktop_signing` enabled, CI fails fast if any required secret is
+missing or only partially configured.
+
+Without `require_desktop_signing`, CI uses signed configuration only when a
+complete secret set is available. If no signing secrets are present, the jobs
+continue producing unsigned installer artifacts for development validation.
+
+## Failure Modes
+
+- Missing or partial macOS secrets fail in the `Verify macOS signing secrets`
+  step when signing is required, or whenever a partial secret set is present.
+- Missing or partial Windows secrets fail in the
+  `Verify Windows signing secrets` step under the same conditions.
+- Apple notarization failures surface during the Electron Builder package step.
+  Check Apple API key, issuer, team, bundle identifier, and Developer ID
+  certificate validity.
+- Azure Trusted Signing failures surface during the Windows package step. Check
+  the endpoint region, publisher name, certificate profile name, signing account
+  name, service-principal credentials, and role assignment.

--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -442,10 +442,11 @@ packages/desktop/dist-packaged/
 ```
 
 For macOS, the distributable targets are a DMG and ZIP. Windows release builds use NSIS, and Linux
-release builds use AppImage and deb. These local artifacts are unsigned and not notarized until the
-signing jobs are wired. Local smoke tests should continue using
-`npm run desktop:package:local` because the unpacked directory target launches faster and keeps
-startup regression coverage separate from installer generation.
+release builds use AppImage and deb. CI release installer jobs can sign and notarize macOS artifacts
+and sign Windows artifacts when the repository secrets in `docs/desktop-signing-ci.md` are
+configured. Local smoke tests should continue using `npm run desktop:package:local` because the
+unpacked directory target launches faster and keeps startup regression coverage separate from
+installer generation.
 
 ---
 

--- a/packages/desktop/electron-builder.signed.config.mjs
+++ b/packages/desktop/electron-builder.signed.config.mjs
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+const configPath = fileURLToPath(
+  new URL('electron-builder.yml', import.meta.url),
+);
+const baseConfig = YAML.parse(readFileSync(configPath, 'utf8')) ?? {};
+
+function hasEnv(name) {
+  return Boolean(process.env[name]);
+}
+
+function hasAppleNotarizationCredentials() {
+  return (
+    (hasEnv('APPLE_API_KEY') &&
+      hasEnv('APPLE_API_KEY_ID') &&
+      hasEnv('APPLE_API_ISSUER')) ||
+    (hasEnv('APPLE_ID') &&
+      hasEnv('APPLE_APP_SPECIFIC_PASSWORD') &&
+      hasEnv('APPLE_TEAM_ID')) ||
+    (hasEnv('APPLE_KEYCHAIN') && hasEnv('APPLE_KEYCHAIN_PROFILE'))
+  );
+}
+
+function hasMacSigningCredentials() {
+  return hasEnv('CSC_LINK') && hasEnv('CSC_KEY_PASSWORD');
+}
+
+function windowsAzureSignOptions() {
+  const {
+    TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: publisherName,
+    TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT: endpoint,
+    TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME:
+      certificateProfileName,
+    TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: codeSigningAccountName,
+  } = process.env;
+
+  if (
+    !publisherName ||
+    !endpoint ||
+    !certificateProfileName ||
+    !codeSigningAccountName
+  ) {
+    return undefined;
+  }
+
+  return {
+    publisherName,
+    endpoint,
+    certificateProfileName,
+    codeSigningAccountName,
+  };
+}
+
+const macSigningReady =
+  hasMacSigningCredentials() && hasAppleNotarizationCredentials();
+const azureSignOptions = windowsAzureSignOptions();
+
+export default {
+  ...baseConfig,
+  mac: {
+    ...baseConfig.mac,
+    hardenedRuntime: true,
+    gatekeeperAssess: false,
+    notarize: macSigningReady,
+    forceCodeSigning: macSigningReady,
+  },
+  win: {
+    ...baseConfig.win,
+    ...(azureSignOptions
+      ? {
+          azureSignOptions,
+          forceCodeSigning: true,
+        }
+      : {}),
+  },
+};

--- a/scripts/verify-desktop-signing-env.mjs
+++ b/scripts/verify-desktop-signing-env.mjs
@@ -1,0 +1,150 @@
+import { appendFileSync } from 'node:fs';
+import process from 'node:process';
+
+const platform = process.argv[2];
+const requireSigning = process.env.TEXRA_REQUIRE_DESKTOP_SIGNING === '1';
+
+if (!['mac', 'win'].includes(platform)) {
+  console.error('Usage: node scripts/verify-desktop-signing-env.mjs <mac|win>');
+  process.exit(1);
+}
+
+function present(name) {
+  return Boolean(process.env[name]);
+}
+
+function collectMissing(names) {
+  return names.filter((name) => !present(name));
+}
+
+function hasAny(names) {
+  return names.some((name) => present(name));
+}
+
+function writeOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function fail(message, missing = []) {
+  console.error(message);
+  for (const name of missing) console.error(`- missing ${name}`);
+  process.exit(1);
+}
+
+function verifyMacSigning() {
+  const certificateNames = ['CSC_LINK', 'CSC_KEY_PASSWORD'];
+  const apiKeyNames = ['APPLE_API_KEY', 'APPLE_API_KEY_ID', 'APPLE_API_ISSUER'];
+  const appleIdNames = [
+    'APPLE_ID',
+    'APPLE_APP_SPECIFIC_PASSWORD',
+    'APPLE_TEAM_ID',
+  ];
+  const keychainNames = ['APPLE_KEYCHAIN', 'APPLE_KEYCHAIN_PROFILE'];
+  const allNames = [
+    ...certificateNames,
+    ...apiKeyNames,
+    ...appleIdNames,
+    ...keychainNames,
+  ];
+
+  const certificateMissing = collectMissing(certificateNames);
+  const apiKeyMissing = collectMissing(apiKeyNames);
+  const appleIdMissing = collectMissing(appleIdNames);
+  const keychainMissing = collectMissing(keychainNames);
+  const hasCompleteNotarization =
+    apiKeyMissing.length === 0 ||
+    appleIdMissing.length === 0 ||
+    keychainMissing.length === 0;
+  const configured = certificateMissing.length === 0 && hasCompleteNotarization;
+  const partial = hasAny(allNames) && !configured;
+
+  if (configured) {
+    writeOutput(
+      'electron_builder_config',
+      'electron-builder.signed.config.mjs',
+    );
+    writeOutput('signed', 'true');
+    console.log(
+      'macOS signing and notarization credentials are configured; using signed Electron Builder config.',
+    );
+    return;
+  }
+
+  writeOutput('electron_builder_config', 'electron-builder.yml');
+  writeOutput('signed', 'false');
+
+  if (partial || requireSigning) {
+    const missing = [
+      ...certificateMissing,
+      ...(apiKeyMissing.length === apiKeyNames.length
+        ? []
+        : apiKeyMissing.map((name) => `${name} (API key notarization set)`)),
+      ...(appleIdMissing.length === appleIdNames.length
+        ? []
+        : appleIdMissing.map((name) => `${name} (Apple ID notarization set)`)),
+      ...(keychainMissing.length === keychainNames.length
+        ? []
+        : keychainMissing.map((name) => `${name} (keychain notarization set)`)),
+    ];
+
+    if (!hasCompleteNotarization) {
+      missing.push(
+        'one complete notarization set: APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER, APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID, or APPLE_KEYCHAIN/APPLE_KEYCHAIN_PROFILE',
+      );
+    }
+
+    fail('macOS desktop signing is incomplete.', missing);
+  }
+
+  console.log(
+    'macOS signing credentials are not configured; packaging will remain unsigned.',
+  );
+}
+
+function verifyWindowsSigning() {
+  const azureConfigNames = [
+    'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_PUBLISHER_NAME',
+    'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ENDPOINT',
+    'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME',
+    'TEXRA_WINDOWS_AZURE_TRUSTED_SIGNING_ACCOUNT_NAME',
+  ];
+  const azureAuthNames = [
+    'AZURE_TENANT_ID',
+    'AZURE_CLIENT_ID',
+    'AZURE_CLIENT_SECRET',
+  ];
+  const allNames = [...azureConfigNames, ...azureAuthNames];
+  const missing = collectMissing(allNames);
+  const configured = missing.length === 0;
+  const partial = hasAny(allNames) && !configured;
+
+  if (configured) {
+    writeOutput(
+      'electron_builder_config',
+      'electron-builder.signed.config.mjs',
+    );
+    writeOutput('signed', 'true');
+    console.log(
+      'Windows Azure Trusted Signing credentials are configured; using signed Electron Builder config.',
+    );
+    return;
+  }
+
+  writeOutput('electron_builder_config', 'electron-builder.yml');
+  writeOutput('signed', 'false');
+
+  if (partial || requireSigning) {
+    fail('Windows desktop signing is incomplete.', missing);
+  }
+
+  console.log(
+    'Windows signing credentials are not configured; packaging will remain unsigned.',
+  );
+}
+
+if (platform === 'mac') {
+  verifyMacSigning();
+} else {
+  verifyWindowsSigning();
+}


### PR DESCRIPTION
## Summary

- Add signed Electron Builder config for macOS signing/notarization and Windows Azure Trusted Signing.
- Teach the desktop installer CI jobs to verify signing secrets, select signed config only for complete secret sets, and fail fast when signing is explicitly required.
- Document required repository secrets, verification steps, and failure modes while preserving unsigned local packaging paths.

Closes #3624.

## Validation

- `corepack pnpm exec prettier --check .github/workflows/ci.yml docs/desktop-signing-ci.md packages/desktop/electron-builder.signed.config.mjs scripts/verify-desktop-signing-env.mjs`
- `node scripts/verify-desktop-signing-env.mjs mac`
- `node scripts/verify-desktop-signing-env.mjs win`
- `env TEXRA_REQUIRE_DESKTOP_SIGNING=1 node scripts/verify-desktop-signing-env.mjs mac` (expected fail-fast)
- `env TEXRA_REQUIRE_DESKTOP_SIGNING=1 node scripts/verify-desktop-signing-env.mjs win` (expected fail-fast)
- dummy complete macOS and Windows signing env verifier checks
- signed config import checks with and without dummy signing env
- `npm run typecheck`
- `npm run lint`
- `npm run workspace:typecheck`
- `npm run check:desktop-electron-binary`
- `npm run desktop:build`
- `npm run check:desktop-build-artifacts`
- `corepack pnpm --filter @texra/desktop package:dir`
- `npm run check:desktop-package`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies release packaging in CI for macOS/Windows by introducing signing/notarization paths and secret validation; misconfiguration could break installer builds or produce unexpectedly unsigned artifacts.
> 
> **Overview**
> CI desktop installer jobs now support **optional signed builds** for macOS (codesign + notarization) and Windows (Azure Trusted Signing), while continuing to build unsigned artifacts when secrets are absent.
> 
> The workflow adds a `require_desktop_signing` dispatch input, exports signing secrets into the macOS/Windows jobs, runs a new `scripts/verify-desktop-signing-env.mjs` step to fail fast on partial/missing credentials (when required) and to select either `electron-builder.yml` or the new `packages/desktop/electron-builder.signed.config.mjs` for packaging.
> 
> Adds `docs/desktop-signing-ci.md` and updates the Electron migration plan to document required secrets, verification steps, and expected failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab9b447be6c18c738a2c3da99ade64a4438b191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->