### PR TITLE
[codex] publish desktop update artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
           path: |
             packages/desktop/dist-packaged/*.dmg
             packages/desktop/dist-packaged/*.zip
+            packages/desktop/dist-packaged/*.blockmap
+            packages/desktop/dist-packaged/latest-mac.yml
           if-no-files-found: error
           retention-days: 14
 
@@ -213,6 +215,8 @@ jobs:
           path: |
             packages/desktop/dist-packaged/*.AppImage
             packages/desktop/dist-packaged/*.deb
+            packages/desktop/dist-packaged/*.blockmap
+            packages/desktop/dist-packaged/latest-linux.yml
           if-no-files-found: error
           retention-days: 14
 
@@ -263,8 +267,11 @@ jobs:
       - name: Upload Windows desktop installer
         uses: actions/upload-artifact@v7
         with:
-          name: texra-desktop-installer-Windows
-          path: packages/desktop/dist-packaged/*.exe
+          name: texra-desktop-installers-Windows
+          path: |
+            packages/desktop/dist-packaged/*.exe
+            packages/desktop/dist-packaged/*.blockmap
+            packages/desktop/dist-packaged/latest.yml
           if-no-files-found: error
           retention-days: 14
 
@@ -276,6 +283,82 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  publish-desktop-release-artifacts:
+    name: publish desktop release artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - desktop-macos-installer
+      - desktop-linux-installer
+      - desktop-windows-artifact
+    permissions:
+      contents: read
+    env:
+      DESKTOP_RELEASE_REPO: texra-ai/texra-desktop-releases
+      GH_TOKEN: ${{ secrets.DESKTOP_RELEASES_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download desktop installer artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: texra-desktop-installers-*
+          path: artifacts/desktop-release
+          merge-multiple: true
+
+      - name: Verify downloaded desktop release artifacts
+        env:
+          TEXRA_DESKTOP_INSTALLER_PLATFORM: all
+          TEXRA_DESKTOP_INSTALLER_ROOT: artifacts/desktop-release
+        run: node scripts/verify-desktop-installer-artifacts.mjs
+
+      - name: Publish desktop artifacts to public release repository
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo 'Missing DESKTOP_RELEASES_TOKEN secret for publishing desktop updates.'
+            exit 1
+          fi
+
+          actual_repo="$(gh repo view "$DESKTOP_RELEASE_REPO" --json nameWithOwner --jq .nameWithOwner)"
+          visibility="$(gh repo view "$DESKTOP_RELEASE_REPO" --json visibility --jq .visibility)"
+
+          if [ "$actual_repo" != "$DESKTOP_RELEASE_REPO" ]; then
+            echo "Desktop release repo target mismatch: expected $DESKTOP_RELEASE_REPO, got $actual_repo"
+            exit 1
+          fi
+
+          if [ "$visibility" != 'PUBLIC' ]; then
+            echo "Desktop release repo must be public for token-free clients; got visibility $visibility"
+            exit 1
+          fi
+
+          version="$(node -p "require('./packages/desktop/package.json').version")"
+          tag="v${version}"
+          notes_file="$(mktemp)"
+          printf 'TeXRA desktop %s update artifacts.\n\nSource run: %s/%s/actions/runs/%s\nSource commit: %s\n' \
+            "$version" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" "$GITHUB_SHA" \
+            > "$notes_file"
+
+          assets=(artifacts/desktop-release/*)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo 'No downloaded desktop release assets found.'
+            exit 1
+          fi
+
+          if gh release view "$tag" --repo "$DESKTOP_RELEASE_REPO" >/dev/null 2>&1; then
+            gh release upload "$tag" "${assets[@]}" --repo "$DESKTOP_RELEASE_REPO" --clobber
+          else
+            gh release create "$tag" "${assets[@]}" \
+              --repo "$DESKTOP_RELEASE_REPO" \
+              --title "TeXRA Desktop ${version}" \
+              --notes-file "$notes_file"
+          fi
+
   validate-status:
     name: validate
     runs-on: ubuntu-latest
@@ -284,6 +367,7 @@ jobs:
       - desktop-macos-installer
       - desktop-linux-installer
       - desktop-windows-artifact
+      - publish-desktop-release-artifacts
     if: always()
 
     steps:
@@ -303,5 +387,9 @@ jobs:
           fi
           if [ '${{ needs.desktop-windows-artifact.result }}' != 'success' ] && [ '${{ needs.desktop-windows-artifact.result }}' != 'skipped' ]; then
             echo 'Windows desktop artifact result: ${{ needs.desktop-windows-artifact.result }}'
+            exit 1
+          fi
+          if [ '${{ needs.publish-desktop-release-artifacts.result }}' != 'success' ] && [ '${{ needs.publish-desktop-release-artifacts.result }}' != 'skipped' ]; then
+            echo 'Desktop release publish result: ${{ needs.publish-desktop-release-artifacts.result }}'
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,7 @@ jobs:
             "$version" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" "$GITHUB_SHA" \
             > "$notes_file"
 
+          shopt -s nullglob
           assets=(artifacts/desktop-release/*)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo 'No downloaded desktop release assets found.'

--- a/docs/electron-migration-plan.md
+++ b/docs/electron-migration-plan.md
@@ -447,6 +447,25 @@ signing jobs are wired. Local smoke tests should continue using
 `npm run desktop:package:local` because the unpacked directory target launches faster and keeps
 startup regression coverage separate from installer generation.
 
+### Desktop Update Artifact Publishing
+
+Electron Builder is configured to generate public GitHub update metadata for
+`texra-ai/texra-desktop-releases`. Local distributable builds still pass `--publish never`, so
+running `npm run desktop:package:dist` produces unsigned local artifacts without uploading them.
+
+On pushes to `main`, CI collects the per-OS installer outputs and update metadata:
+
+- macOS: DMG, ZIP, ZIP blockmap, and `latest-mac.yml`
+- Windows: NSIS executable, blockmap, and `latest.yml`
+- Linux: AppImage, deb, blockmap, and `latest-linux.yml`
+
+The `publish desktop release artifacts` job downloads those workflow artifacts, verifies that the
+Electron Builder publish target is still the public `texra-ai/texra-desktop-releases` repository,
+checks that update metadata exists and points at a generated update-capable installer, and then
+uploads the files to the matching public GitHub release. The GitHub credential is confined to CI via
+the `DESKTOP_RELEASES_TOKEN` secret; installed desktop clients should read the public update metadata
+and artifacts without a client-side `GH_TOKEN`.
+
 ---
 
 ## What Stays the Same

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -1,6 +1,12 @@
 appId: ai.texra.desktop
 productName: TeXRA
 artifactName: ${productName}-${version}-${os}-${arch}.${ext}
+publish:
+  provider: github
+  owner: texra-ai
+  repo: texra-desktop-releases
+  private: false
+  releaseType: release
 protocols:
   - name: TeXRA
     schemes:

--- a/scripts/verify-desktop-installer-artifacts.mjs
+++ b/scripts/verify-desktop-installer-artifacts.mjs
@@ -1,17 +1,23 @@
-import { readdir, stat } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { basename, join, relative } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
-const desktopPackageRoot = join(
+const desktopPackageRoot =
+  process.env.TEXRA_DESKTOP_INSTALLER_ROOT ??
+  join(repoRoot, 'packages', 'desktop', 'dist-packaged');
+const electronBuilderConfigPath = join(
   repoRoot,
   'packages',
   'desktop',
-  'dist-packaged',
+  'electron-builder.yml',
 );
+const expectedReleaseOwner = 'texra-ai';
+const expectedReleaseRepo = 'texra-desktop-releases';
 
 const platformAlias = {
+  all: 'all',
   darwin: 'mac',
   mac: 'mac',
   macos: 'mac',
@@ -25,16 +31,22 @@ const platformRequirements = {
   mac: {
     label: 'macOS',
     extensions: ['.dmg', '.zip'],
+    updateMetadata: 'latest-mac.yml',
+    updateExtensions: ['.zip'],
     iconPath: join(repoRoot, 'packages', 'desktop', 'build', 'icon.icns'),
   },
   win: {
     label: 'Windows',
     extensions: ['.exe'],
+    updateMetadata: 'latest.yml',
+    updateExtensions: ['.exe'],
     iconPath: join(repoRoot, 'packages', 'desktop', 'build', 'icon.ico'),
   },
   linux: {
     label: 'Linux',
     extensions: ['.AppImage', '.deb'],
+    updateMetadata: 'latest-linux.yml',
+    updateExtensions: ['.AppImage'],
     iconPath: join(repoRoot, 'packages', 'desktop', 'build', 'icon.png'),
   },
 };
@@ -45,7 +57,7 @@ const platformKey = platformAlias[requestedPlatform.toLowerCase()];
 
 if (!platformKey) {
   console.error(
-    `Unsupported desktop installer platform: ${requestedPlatform}. Expected mac, win, or linux.`,
+    `Unsupported desktop installer platform: ${requestedPlatform}. Expected mac, win, linux, or all.`,
   );
   process.exit(1);
 }
@@ -65,7 +77,6 @@ function isInstallerArtifact(filePath, extension) {
   return filePath.endsWith(extension) && !filePath.endsWith('.blockmap');
 }
 
-const requirement = platformRequirements[platformKey];
 const failures = [];
 let files = [];
 
@@ -81,47 +92,171 @@ try {
   }
 }
 
-const matchedArtifacts = new Map();
-for (const extension of requirement.extensions) {
-  matchedArtifacts.set(
-    extension,
-    files.filter((filePath) => isInstallerArtifact(filePath, extension)),
-  );
+function getTopLevelYamlBlock(source, key) {
+  const lines = source.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === `${key}:`);
+  if (startIndex === -1) return '';
+
+  const block = [];
+  for (const line of lines.slice(startIndex + 1)) {
+    if (/^\S/.test(line)) break;
+    block.push(line);
+  }
+  return block.join('\n');
 }
 
-try {
-  const iconStat = await stat(requirement.iconPath);
-  if (iconStat.size === 0) {
+function requireYamlValue(block, key, expectedValue) {
+  const valuePattern = expectedValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (!new RegExp(`^\\s+${key}:\\s+${valuePattern}\\s*$`, 'm').test(block)) {
     failures.push(
-      `${requirement.label} installer icon is empty: ${relative(repoRoot, requirement.iconPath)}`,
+      `Desktop release publish target must set ${key}: ${expectedValue} in ${relative(repoRoot, electronBuilderConfigPath)}`,
     );
   }
-} catch (error) {
-  if (error?.code === 'ENOENT') {
-    failures.push(
-      `Missing ${requirement.label} installer icon: ${relative(repoRoot, requirement.iconPath)}`,
-    );
-  } else {
+}
+
+async function verifyPublishTarget() {
+  let configText = '';
+  try {
+    configText = await readFile(electronBuilderConfigPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      failures.push(
+        `Missing desktop electron-builder config: ${relative(repoRoot, electronBuilderConfigPath)}`,
+      );
+      return;
+    }
     throw error;
   }
-}
 
-for (const [extension, artifacts] of matchedArtifacts.entries()) {
-  if (artifacts.length === 0) {
+  const publishBlock = getTopLevelYamlBlock(configText, 'publish');
+  if (publishBlock.length === 0) {
     failures.push(
-      `Missing ${requirement.label} installer artifact with extension ${extension}`,
+      `Missing desktop release publish target in ${relative(repoRoot, electronBuilderConfigPath)}`,
     );
-    continue;
+    return;
   }
 
-  for (const artifact of artifacts) {
-    const artifactStat = await stat(artifact);
-    if (artifactStat.size === 0) {
+  requireYamlValue(publishBlock, 'provider', 'github');
+  requireYamlValue(publishBlock, 'owner', expectedReleaseOwner);
+  requireYamlValue(publishBlock, 'repo', expectedReleaseRepo);
+  requireYamlValue(publishBlock, 'private', 'false');
+}
+
+function getPlatformKeys() {
+  return platformKey === 'all'
+    ? Object.keys(platformRequirements)
+    : [platformKey];
+}
+
+async function verifyIcon(requirement) {
+  try {
+    const iconStat = await stat(requirement.iconPath);
+    if (iconStat.size === 0) {
       failures.push(
-        `Installer artifact is empty: ${relative(repoRoot, artifact)}`,
+        `${requirement.label} installer icon is empty: ${relative(repoRoot, requirement.iconPath)}`,
+      );
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      failures.push(
+        `Missing ${requirement.label} installer icon: ${relative(repoRoot, requirement.iconPath)}`,
+      );
+    } else {
+      throw error;
+    }
+  }
+}
+
+async function verifyUpdateMetadata(requirement, matchedArtifacts) {
+  const metadataPath = join(desktopPackageRoot, requirement.updateMetadata);
+  let metadata = '';
+  try {
+    metadata = await readFile(metadataPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      failures.push(
+        `Missing ${requirement.label} update metadata: ${relative(repoRoot, metadataPath)}`,
+      );
+      return;
+    }
+    throw error;
+  }
+
+  if (metadata.trim().length === 0) {
+    failures.push(
+      `${requirement.label} update metadata is empty: ${relative(repoRoot, metadataPath)}`,
+    );
+    return;
+  }
+
+  for (const marker of ['sha512:', 'releaseDate:']) {
+    if (!metadata.includes(marker)) {
+      failures.push(
+        `${requirement.label} update metadata is missing ${marker} in ${relative(repoRoot, metadataPath)}`,
       );
     }
   }
+
+  const updateArtifacts = requirement.updateExtensions.flatMap(
+    (extension) => matchedArtifacts.get(extension) ?? [],
+  );
+  if (updateArtifacts.length === 0) {
+    failures.push(
+      `${requirement.label} update metadata has no matching update-capable installer artifact`,
+    );
+    return;
+  }
+
+  const referencesUpdateArtifact = updateArtifacts.some((artifact) =>
+    metadata.includes(basename(artifact)),
+  );
+  if (!referencesUpdateArtifact) {
+    failures.push(
+      `${requirement.label} update metadata does not reference a generated update artifact`,
+    );
+  }
+}
+
+async function verifyPlatformArtifacts(platform) {
+  const requirement = platformRequirements[platform];
+  const matchedArtifacts = new Map();
+  for (const extension of requirement.extensions) {
+    matchedArtifacts.set(
+      extension,
+      files.filter((filePath) => isInstallerArtifact(filePath, extension)),
+    );
+  }
+
+  await verifyIcon(requirement);
+
+  for (const [extension, artifacts] of matchedArtifacts.entries()) {
+    if (artifacts.length === 0) {
+      failures.push(
+        `Missing ${requirement.label} installer artifact with extension ${extension}`,
+      );
+      continue;
+    }
+
+    for (const artifact of artifacts) {
+      const artifactStat = await stat(artifact);
+      if (artifactStat.size === 0) {
+        failures.push(
+          `Installer artifact is empty: ${relative(repoRoot, artifact)}`,
+        );
+      }
+    }
+  }
+
+  await verifyUpdateMetadata(requirement, matchedArtifacts);
+
+  return { requirement, matchedArtifacts };
+}
+
+await verifyPublishTarget();
+
+const verifiedPlatforms = [];
+for (const platform of getPlatformKeys()) {
+  verifiedPlatforms.push(await verifyPlatformArtifacts(platform));
 }
 
 if (failures.length > 0) {
@@ -130,10 +265,18 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`${requirement.label} desktop installer artifact check passed:`);
-console.log(`- ${relative(repoRoot, requirement.iconPath)}`);
-for (const artifacts of matchedArtifacts.values()) {
-  for (const artifact of artifacts) {
-    console.log(`- ${relative(repoRoot, artifact)}`);
+for (const { requirement, matchedArtifacts } of verifiedPlatforms) {
+  console.log(`${requirement.label} desktop installer artifact check passed:`);
+  console.log(
+    `- release target: ${expectedReleaseOwner}/${expectedReleaseRepo}`,
+  );
+  console.log(`- ${relative(repoRoot, requirement.iconPath)}`);
+  console.log(
+    `- ${relative(repoRoot, join(desktopPackageRoot, requirement.updateMetadata))}`,
+  );
+  for (const artifacts of matchedArtifacts.values()) {
+    for (const artifact of artifacts) {
+      console.log(`- ${relative(repoRoot, artifact)}`);
+    }
   }
 }

--- a/scripts/verify-desktop-installer-artifacts.mjs
+++ b/scripts/verify-desktop-installer-artifacts.mjs
@@ -94,7 +94,7 @@ try {
 
 function getTopLevelYamlBlock(source, key) {
   const lines = source.split(/\r?\n/);
-  const startIndex = lines.findIndex((line) => line.trim() === `${key}:`);
+  const startIndex = lines.findIndex((line) => line.startsWith(`${key}:`));
   if (startIndex === -1) return '';
 
   const block = [];


### PR DESCRIPTION
## Summary

- Configure Electron Builder to generate public GitHub release update metadata for `texra-ai/texra-desktop-releases` while preserving local `--publish never` packaging.
- Upload per-OS installer metadata/blockmaps in CI and add a main-branch aggregator job that verifies the public release target before publishing artifacts with a CI-only `DESKTOP_RELEASES_TOKEN`.
- Extend the desktop installer verifier and migration docs to cover missing update metadata and wrong release repository targets.

Closes #3623.

## Validation

- `node --check scripts/verify-desktop-installer-artifacts.mjs`
- synthetic all-platform verifier fixture with `TEXRA_DESKTOP_INSTALLER_PLATFORM=all`
- `npm run check:desktop-electron-binary`
- `npm run desktop:package:dist`
- `npm run check:desktop-installers`
- `npm run format`
- `npm run check:desktop-package`
- `npm run typecheck`
- `npm run lint`

## Notes

The current GitHub account could not resolve `texra-ai/texra-desktop-releases` directly, so the publish job intentionally verifies that repository name and `PUBLIC` visibility at runtime and fails before upload if the repo or CI token is misconfigured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline by introducing a tokened publish job and new artifact expectations (blockmaps/`latest*.yml`), so misconfigurations could break desktop update distribution on `main`.
> 
> **Overview**
> Enables **auto-update artifact publishing** for the Electron desktop app by configuring `electron-builder` to target the public `texra-ai/texra-desktop-releases` GitHub repo.
> 
> CI now uploads per-OS installer *update metadata + blockmaps* alongside installers, then a new `publish-desktop-release-artifacts` job (main-branch pushes only) downloads, verifies (`scripts/verify-desktop-installer-artifacts.mjs`) the publish target/metadata, and creates or updates the corresponding GitHub Release using `DESKTOP_RELEASES_TOKEN`.
> 
> Docs are updated to describe the new update-artifact publishing flow and the CI safeguards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c457d99ec30ea20691e6c68ce3a1e28f90492b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->