### PR TITLE
[codex] Add run context foundation

### DIFF
--- a/src/agent/runtime/RunContext.ts
+++ b/src/agent/runtime/RunContext.ts
@@ -1,0 +1,63 @@
+// Local imports - runtime
+import type { AgentRuntimeHost } from './AgentRuntimeHost';
+
+export type RunLogData = Record<string, unknown>;
+
+export interface RunLogger {
+  debug(message: string, data?: RunLogData): void;
+  info(message: string, data?: RunLogData): void;
+  warn(message: string, data?: RunLogData): void;
+  error(message: string, data?: RunLogData): void;
+}
+
+export type ApprovalHandler<TRequest = unknown, TResult = unknown> = (
+  request: TRequest,
+) => Promise<TResult> | TResult;
+
+export interface ApprovalHandlers {
+  agentProposal?: ApprovalHandler;
+  bash?: ApprovalHandler;
+  plan?: ApprovalHandler;
+  toolEdit?: ApprovalHandler;
+}
+
+export interface RunContext {
+  readonly runtimeHost: AgentRuntimeHost;
+  readonly logger: RunLogger;
+  readonly approvals: ApprovalHandlers;
+}
+
+export interface CreateRunContextOptions {
+  runtimeHost: AgentRuntimeHost;
+  logger?: Partial<RunLogger>;
+  approvals?: ApprovalHandlers;
+}
+
+const noopLog = (): void => undefined;
+
+function createRunLogger(logger?: Partial<RunLogger>): RunLogger {
+  return Object.freeze({
+    debug: logger?.debug ?? noopLog,
+    info: logger?.info ?? noopLog,
+    warn: logger?.warn ?? noopLog,
+    error: logger?.error ?? noopLog,
+  });
+}
+
+function createApprovalHandlers(
+  approvals?: ApprovalHandlers,
+): ApprovalHandlers {
+  return Object.freeze({ ...approvals });
+}
+
+export function createRunContext(options: CreateRunContextOptions): RunContext {
+  if (options.runtimeHost == null) {
+    throw new Error('createRunContext requires an explicit runtimeHost');
+  }
+
+  return Object.freeze({
+    runtimeHost: options.runtimeHost,
+    logger: createRunLogger(options.logger),
+    approvals: createApprovalHandlers(options.approvals),
+  });
+}

--- a/src/test-kernel/agent/runtime/RunContext.vitest.ts
+++ b/src/test-kernel/agent/runtime/RunContext.vitest.ts
@@ -1,0 +1,43 @@
+// Third-party imports
+import { describe, expect, it, vi } from 'vitest';
+
+// Local imports - runtime
+import { createRunContext } from '@agent/runtime/RunContext';
+import type { AgentRuntimeHost } from '@agent/runtime/AgentRuntimeHost';
+
+function createRuntimeHost(): AgentRuntimeHost {
+  return {
+    emit: vi.fn(),
+  };
+}
+
+describe('RunContext', () => {
+  it('freezes the context and per-run containers', () => {
+    const context = createRunContext({ runtimeHost: createRuntimeHost() });
+
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context.logger)).toBe(true);
+    expect(Object.isFrozen(context.approvals)).toBe(true);
+
+    expect(() => {
+      (context as { logger: unknown }).logger = {};
+    }).toThrow(TypeError);
+  });
+
+  it('requires an explicit runtime host', () => {
+    expect(() =>
+      createRunContext({
+        runtimeHost: undefined as unknown as AgentRuntimeHost,
+      }),
+    ).toThrow(/explicit runtimeHost/);
+  });
+
+  it('isolates approval and log objects across contexts', () => {
+    const first = createRunContext({ runtimeHost: createRuntimeHost() });
+    const second = createRunContext({ runtimeHost: createRuntimeHost() });
+
+    expect(first).not.toBe(second);
+    expect(first.logger).not.toBe(second.logger);
+    expect(first.approvals).not.toBe(second.approvals);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `RunContext`, `RunLogger`, and `ApprovalHandlers` foundation types.
- Add `createRunContext(...)`, which requires an explicit `runtimeHost` and returns frozen per-run context objects.
- Add focused kernel coverage for freezing, explicit host validation, and isolated logger/approval containers.

References #3397.

Migration of existing runtime, flow, and approval consumers is intentionally out of this additive slice and waits for #3617.

## Validation

- `npm run -s test:kernel -- src/test-kernel/agent/runtime/RunContext.vitest.ts`
- `npm run typecheck`
- `npm run compile:safe`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive runtime scaffolding with basic validation and immutability; minimal behavioral impact until adopted by other runtime/flow code.
> 
> **Overview**
> Introduces a new per-run `RunContext` foundation (`RunLogger`, `ApprovalHandlers`) plus `createRunContext(...)`, which **requires an explicit** `runtimeHost` and returns **frozen** context/logger/approval objects (defaulting logger methods to no-ops).
> 
> Adds kernel tests asserting immutability, runtime host validation, and that separate contexts don’t share logger/approval container instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49266d922d1733d43dfda6188124ed283ed25b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->