### PR TITLE
feat(wa): expand icon registry with codicon aliases

### DIFF
--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -5,13 +5,13 @@ import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
-import { TEXRA_ICON_LIBRARY } from './webAwesomeIcons';
+import { TEXRA_ICON_LIBRARY, type TeXRAIconName } from './webAwesomeIcons';
 
 type ActionButtonAppearance = 'filled' | 'outlined' | 'plain';
 type ActionButtonVariant = 'brand' | 'neutral';
 
 export interface IconActionButtonOptions {
-  readonly icon: string;
+  readonly icon: TeXRAIconName;
   readonly label: string;
   readonly title?: string;
   readonly action?: string;

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -45,6 +45,7 @@ import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons/faEllipsis';
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
 import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
+import { faFlask } from '@fortawesome/free-solid-svg-icons/faFlask';
 import { faFileCirclePlus } from '@fortawesome/free-solid-svg-icons/faFileCirclePlus';
 import { faFileCode } from '@fortawesome/free-solid-svg-icons/faFileCode';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
@@ -65,6 +66,7 @@ import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faLightbulb } from '@fortawesome/free-solid-svg-icons/faLightbulb';
 import { faLink } from '@fortawesome/free-solid-svg-icons/faLink';
 import { faListCheck } from '@fortawesome/free-solid-svg-icons/faListCheck';
+import { faListUl } from '@fortawesome/free-solid-svg-icons/faListUl';
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
 import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlassChart';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
@@ -169,6 +171,7 @@ const icons = {
   ellipsis: faEllipsis,
   eye: faEye,
   file: faFile,
+  flask: faFlask,
   'file-circle-plus': faFileCirclePlus,
   'file-code': faFileCode,
   'file-export': faFileExport,
@@ -189,6 +192,7 @@ const icons = {
   lightbulb: faLightbulb,
   link: faLink,
   'list-check': faListCheck,
+  'list-ul': faListUl,
   'magnifying-glass': faMagnifyingGlass,
   'magnifying-glass-chart': faMagnifyingGlassChart,
   minus: faMinus,
@@ -228,7 +232,7 @@ const CODICON_ALIASES: Readonly<Record<string, string>> = {
   account: 'circle-user',
   add: 'plus',
   'arrow-small-down': 'caret-down',
-  beaker: 'magnifying-glass-chart',
+  beaker: 'flask',
   'check-all': 'check-double',
   checklist: 'list-check',
   'circle-large-outline': 'circle',
@@ -257,6 +261,7 @@ const CODICON_ALIASES: Readonly<Record<string, string>> = {
   info: 'circle-info',
   inspect: 'magnifying-glass-chart',
   library: 'book',
+  'list-tree': 'list-ul',
   loading: 'spinner',
   'mortar-board': 'graduation-cap',
   'new-file': 'file-circle-plus',
@@ -269,6 +274,8 @@ const CODICON_ALIASES: Readonly<Record<string, string>> = {
   question: 'circle-question',
   references: 'link',
   refresh: 'rotate-right',
+  save: 'floppy-disk',
+  search: 'magnifying-glass',
   'server-process': 'server',
   'settings-gear': 'gear',
   'sign-in': 'right-to-bracket',
@@ -279,7 +286,7 @@ const CODICON_ALIASES: Readonly<Record<string, string>> = {
   'symbol-method': 'cube',
   'symbol-number': 'hashtag',
   'symbol-numeric': 'hashtag',
-  'symbol-operator': 'code-branch',
+  'symbol-operator': 'cube',
   'symbol-structure': 'diagram-project',
   sync: 'arrows-rotate',
   tasklist: 'list-check',

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -1,40 +1,99 @@
 // Third-party imports
+import { faArrowDown } from '@fortawesome/free-solid-svg-icons/faArrowDown';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons/faArrowRotateLeft';
+import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons/faArrowsRotate';
+import { faArrowUp } from '@fortawesome/free-solid-svg-icons/faArrowUp';
 import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons/faArrowUpRightFromSquare';
 import { faBackwardStep } from '@fortawesome/free-solid-svg-icons/faBackwardStep';
 import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
+import { faBolt } from '@fortawesome/free-solid-svg-icons/faBolt';
+import { faBook } from '@fortawesome/free-solid-svg-icons/faBook';
+import { faBookmark } from '@fortawesome/free-solid-svg-icons/faBookmark';
+import { faBox } from '@fortawesome/free-solid-svg-icons/faBox';
+import { faBuilding } from '@fortawesome/free-solid-svg-icons/faBuilding';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
+import { faChartLine } from '@fortawesome/free-solid-svg-icons/faChartLine';
+import { faChartPie } from '@fortawesome/free-solid-svg-icons/faChartPie';
+import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
+import { faCheckDouble } from '@fortawesome/free-solid-svg-icons/faCheckDouble';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons/faChevronDown';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons/faChevronRight';
 import { faChevronUp } from '@fortawesome/free-solid-svg-icons/faChevronUp';
+import { faCircle } from '@fortawesome/free-solid-svg-icons/faCircle';
+import { faCircleCheck } from '@fortawesome/free-solid-svg-icons/faCircleCheck';
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons/faCircleExclamation';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons/faCircleInfo';
+import { faCircleQuestion } from '@fortawesome/free-solid-svg-icons/faCircleQuestion';
+import { faCircleStop } from '@fortawesome/free-solid-svg-icons/faCircleStop';
 import { faCircleUser } from '@fortawesome/free-solid-svg-icons/faCircleUser';
+import { faCircleXmark } from '@fortawesome/free-solid-svg-icons/faCircleXmark';
+import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons/faClockRotateLeft';
 import { faCloudArrowDown } from '@fortawesome/free-solid-svg-icons/faCloudArrowDown';
+import { faCloudArrowUp } from '@fortawesome/free-solid-svg-icons/faCloudArrowUp';
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons/faCodeBranch';
+import { faCodeCompare } from '@fortawesome/free-solid-svg-icons/faCodeCompare';
+import { faComment } from '@fortawesome/free-solid-svg-icons/faComment';
+import { faComments } from '@fortawesome/free-solid-svg-icons/faComments';
+import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
+import { faCube } from '@fortawesome/free-solid-svg-icons/faCube';
 import { faDatabase } from '@fortawesome/free-solid-svg-icons/faDatabase';
-import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
+import { faDiagramProject } from '@fortawesome/free-solid-svg-icons/faDiagramProject';
+import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
+import { faEllipsis } from '@fortawesome/free-solid-svg-icons/faEllipsis';
+import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
+import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
+import { faFileCirclePlus } from '@fortawesome/free-solid-svg-icons/faFileCirclePlus';
 import { faFileCode } from '@fortawesome/free-solid-svg-icons/faFileCode';
+import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileLines } from '@fortawesome/free-solid-svg-icons/faFileLines';
 import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf';
+import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk';
+import { faFolder } from '@fortawesome/free-solid-svg-icons/faFolder';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
+import { faFolderTree } from '@fortawesome/free-solid-svg-icons/faFolderTree';
 import { faForwardStep } from '@fortawesome/free-solid-svg-icons/faForwardStep';
 import { faGear } from '@fortawesome/free-solid-svg-icons/faGear';
+import { faGlobe } from '@fortawesome/free-solid-svg-icons/faGlobe';
+import { faGraduationCap } from '@fortawesome/free-solid-svg-icons/faGraduationCap';
+import { faHashtag } from '@fortawesome/free-solid-svg-icons/faHashtag';
+import { faHeart } from '@fortawesome/free-solid-svg-icons/faHeart';
+import { faImage } from '@fortawesome/free-solid-svg-icons/faImage';
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
+import { faLightbulb } from '@fortawesome/free-solid-svg-icons/faLightbulb';
+import { faLink } from '@fortawesome/free-solid-svg-icons/faLink';
+import { faListCheck } from '@fortawesome/free-solid-svg-icons/faListCheck';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
+import { faMagnifyingGlassChart } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlassChart';
+import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
+import { faNoteSticky } from '@fortawesome/free-solid-svg-icons/faNoteSticky';
+import { faPalette } from '@fortawesome/free-solid-svg-icons/faPalette';
 import { faPencil } from '@fortawesome/free-solid-svg-icons/faPencil';
 import { faPictureInPicture } from '@fortawesome/free-solid-svg-icons/faPictureInPicture';
 import { faPlay } from '@fortawesome/free-solid-svg-icons/faPlay';
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { faRightFromBracket } from '@fortawesome/free-solid-svg-icons/faRightFromBracket';
 import { faRightToBracket } from '@fortawesome/free-solid-svg-icons/faRightToBracket';
 import { faRobot } from '@fortawesome/free-solid-svg-icons/faRobot';
+import { faRocket } from '@fortawesome/free-solid-svg-icons/faRocket';
 import { faRotateRight } from '@fortawesome/free-solid-svg-icons/faRotateRight';
 import { faScrewdriverWrench } from '@fortawesome/free-solid-svg-icons/faScrewdriverWrench';
 import { faServer } from '@fortawesome/free-solid-svg-icons/faServer';
+import { faShield } from '@fortawesome/free-solid-svg-icons/faShield';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
 import { faTerminal } from '@fortawesome/free-solid-svg-icons/faTerminal';
 import { faThumbtack } from '@fortawesome/free-solid-svg-icons/faThumbtack';
 import { faThumbtackSlash } from '@fortawesome/free-solid-svg-icons/faThumbtackSlash';
 import { faTrash } from '@fortawesome/free-solid-svg-icons/faTrash';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons/faTriangleExclamation';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
+import { faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons/faWandMagicSparkles';
+import { faWindowMaximize } from '@fortawesome/free-solid-svg-icons/faWindowMaximize';
+import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
 import { faXmark } from '@fortawesome/free-solid-svg-icons/faXmark';
 import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
 
@@ -62,45 +121,174 @@ function iconSvg(iconDefinition: FontAwesomeIconDefinition): string {
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">${paths}</svg>`;
 }
 
+// Canonical Font Awesome names. Use these directly when adding new icons.
 const icons = {
-  // Font Awesome Free icons; Web Awesome renders them from local data URIs.
+  'arrow-down': faArrowDown,
+  'arrow-left': faArrowLeft,
+  'arrow-rotate-left': faArrowRotateLeft,
+  'arrow-up': faArrowUp,
   'arrow-up-right-from-square': faArrowUpRightFromSquare,
+  'arrows-rotate': faArrowsRotate,
   'backward-step': faBackwardStep,
   ban: faBan,
+  bolt: faBolt,
+  book: faBook,
+  bookmark: faBookmark,
+  box: faBox,
+  building: faBuilding,
+  'caret-down': faCaretDown,
+  'chart-line': faChartLine,
+  'chart-pie': faChartPie,
+  check: faCheck,
+  'check-double': faCheckDouble,
   'chevron-down': faChevronDown,
   'chevron-left': faChevronLeft,
   'chevron-right': faChevronRight,
   'chevron-up': faChevronUp,
+  circle: faCircle,
+  'circle-check': faCircleCheck,
+  'circle-exclamation': faCircleExclamation,
+  'circle-info': faCircleInfo,
+  'circle-question': faCircleQuestion,
+  'circle-stop': faCircleStop,
   'circle-user': faCircleUser,
+  'circle-xmark': faCircleXmark,
+  clock: faClock,
   'clock-rotate-left': faClockRotateLeft,
   'cloud-arrow-down': faCloudArrowDown,
+  'cloud-arrow-up': faCloudArrowUp,
   'code-branch': faCodeBranch,
+  'code-compare': faCodeCompare,
+  comment: faComment,
+  comments: faComments,
+  copy: faCopy,
+  cube: faCube,
   database: faDatabase,
+  'diagram-project': faDiagramProject,
+  download: faDownload,
+  ellipsis: faEllipsis,
+  eye: faEye,
+  file: faFile,
+  'file-circle-plus': faFileCirclePlus,
   'file-code': faFileCode,
   'file-export': faFileExport,
   'file-lines': faFileLines,
   'file-pdf': faFilePdf,
+  'floppy-disk': faFloppyDisk,
+  folder: faFolder,
   'folder-open': faFolderOpen,
+  'folder-tree': faFolderTree,
   'forward-step': faForwardStep,
   gear: faGear,
+  globe: faGlobe,
+  'graduation-cap': faGraduationCap,
+  hashtag: faHashtag,
+  heart: faHeart,
+  image: faImage,
   key: faKey,
+  lightbulb: faLightbulb,
+  link: faLink,
+  'list-check': faListCheck,
+  'magnifying-glass': faMagnifyingGlass,
+  'magnifying-glass-chart': faMagnifyingGlassChart,
+  minus: faMinus,
+  'note-sticky': faNoteSticky,
+  palette: faPalette,
   pencil: faPencil,
   'picture-in-picture': faPictureInPicture,
   play: faPlay,
+  plus: faPlus,
   reply: faReply,
   'right-from-bracket': faRightFromBracket,
   'right-to-bracket': faRightToBracket,
   robot: faRobot,
+  rocket: faRocket,
   'rotate-right': faRotateRight,
   'screwdriver-wrench': faScrewdriverWrench,
   server: faServer,
+  shield: faShield,
+  spinner: faSpinner,
   terminal: faTerminal,
   thumbtack: faThumbtack,
   'thumbtack-slash': faThumbtackSlash,
   trash: faTrash,
+  'triangle-exclamation': faTriangleExclamation,
   user: faUser,
   users: faUsers,
+  'wand-magic-sparkles': faWandMagicSparkles,
+  'window-maximize': faWindowMaximize,
+  wrench: faWrench,
   xmark: faXmark,
+} as const;
+
+// Codicon-name aliases. Lets existing markup keep using familiar codicon names
+// (e.g. <wa-icon name="warning">) while resolving to the closest Font Awesome
+// glyph in the registry above. Prefer canonical names for new code.
+const CODICON_ALIASES: Readonly<Record<string, string>> = {
+  account: 'circle-user',
+  add: 'plus',
+  'arrow-small-down': 'caret-down',
+  beaker: 'magnifying-glass-chart',
+  'check-all': 'check-double',
+  checklist: 'list-check',
+  'circle-large-outline': 'circle',
+  'circle-outline': 'circle',
+  'circle-slash': 'circle-xmark',
+  close: 'xmark',
+  'cloud-download': 'cloud-arrow-down',
+  'cloud-upload': 'cloud-arrow-up',
+  'comment-discussion': 'comments',
+  dash: 'minus',
+  'debug-stop': 'circle-stop',
+  'desktop-download': 'download',
+  diff: 'code-compare',
+  discard: 'arrow-rotate-left',
+  edit: 'pencil',
+  error: 'circle-exclamation',
+  'file-media': 'image',
+  files: 'copy',
+  fold: 'chevron-up',
+  'folder-library': 'folder-tree',
+  'folder-opened': 'folder-open',
+  github: 'code-branch',
+  graph: 'chart-line',
+  'graph-line': 'chart-line',
+  history: 'clock-rotate-left',
+  info: 'circle-info',
+  inspect: 'magnifying-glass-chart',
+  library: 'book',
+  loading: 'spinner',
+  'mortar-board': 'graduation-cap',
+  'new-file': 'file-circle-plus',
+  note: 'note-sticky',
+  organization: 'building',
+  package: 'box',
+  'pass-filled': 'circle-check',
+  'pie-chart': 'chart-pie',
+  pulse: 'chart-line',
+  question: 'circle-question',
+  references: 'link',
+  refresh: 'rotate-right',
+  'server-process': 'server',
+  'settings-gear': 'gear',
+  'sign-in': 'right-to-bracket',
+  'sign-out': 'right-from-bracket',
+  'source-control': 'code-branch',
+  sparkle: 'wand-magic-sparkles',
+  stylesheet: 'palette',
+  'symbol-method': 'cube',
+  'symbol-number': 'hashtag',
+  'symbol-numeric': 'hashtag',
+  'symbol-operator': 'code-branch',
+  'symbol-structure': 'diagram-project',
+  sync: 'arrows-rotate',
+  tasklist: 'list-check',
+  tools: 'screwdriver-wrench',
+  'type-hierarchy': 'diagram-project',
+  warning: 'triangle-exclamation',
+  window: 'window-maximize',
+  x: 'xmark',
+  zap: 'bolt',
 } as const;
 
 let isRegistered = false;
@@ -109,14 +297,23 @@ function dataUri(svg: string): string {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+function resolveIcon(name: string): FontAwesomeIconDefinition | undefined {
+  const canonical = CODICON_ALIASES[name] ?? name;
+  return icons[canonical as keyof typeof icons];
+}
+
 export function registerTeXRAWebAwesomeIcons(): void {
   if (isRegistered) return;
 
   registerIconLibrary(TEXRA_ICON_LIBRARY, {
     resolver(name) {
-      const icon = icons[name as keyof typeof icons];
+      const icon = resolveIcon(name);
       return icon ? dataUri(iconSvg(icon)) : '';
     },
   });
   isRegistered = true;
 }
+
+// Names accepted by <wa-icon library="texra" name="..."> — canonical names plus
+// the codicon-style aliases. Exported so callers can type-check icon usage.
+export type TeXRAIconName = keyof typeof icons | keyof typeof CODICON_ALIASES;


### PR DESCRIPTION
## Summary

- Register ~50 additional Font Awesome free-solid icons in `src/shared/wa/webAwesomeIcons.ts` so the texra wa-icon library covers every codicon name currently referenced in source.
- Add a `CODICON_ALIASES` map (e.g. `warning → triangle-exclamation`, `folder-opened → folder-open`, `discard → arrow-rotate-left`) so existing markup keeps working as call sites migrate from \`<i class="codicon codicon-foo">\` to \`<wa-icon library="texra" name="foo">\` without forcing a global rename in the same change.
- Export a `TeXRAIconName` union for type-checked icon usage in callers.

This is the foundation for follow-up PRs that retire the remaining \`codicon-*\` markup across the extension webviews and the desktop renderer.

## Test plan

- [x] \`npm run typecheck\` passes.
- [ ] Visual check that already-migrated wa-icon usages still render unchanged.
- [ ] Spot-check a previously broken alias (e.g. \`<wa-icon name="warning">\`) renders the triangle-exclamation glyph.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI icon registry/type changes only; main risk is missing/incorrect alias mappings causing specific icons to render as blank.
> 
> **Overview**
> Expands the `texra` Web Awesome icon library by registering many additional Font Awesome solid icons and adding a `CODICON_ALIASES` map so codicon-style names (e.g. `warning`, `folder-opened`) resolve to canonical Font Awesome names.
> 
> Updates icon resolution to go through an alias-aware `resolveIcon()` and exports a `TeXRAIconName` union; `actionButtons.ts` now types `IconActionButtonOptions.icon` as `TeXRAIconName` for compile-time checking of icon names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff73dc2cf61854367c4b91c5aada5d46bb77055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->