### PR TITLE
feat(desktop): adopt Web Awesome + Lit declarative chrome in renderer

### DIFF
--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -1,7 +1,8 @@
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import { html, render } from 'lit';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
-import type { DesktopRoute } from '../desktopShellMessages';
 import { isCommandPaletteShortcut } from './desktopCommandPalette';
+import type { DesktopRoute } from '../desktopShellMessages';
 
 export interface DesktopFirstRunWalkthroughOptions {
   document: Document;
@@ -17,7 +18,34 @@ export interface DesktopFirstRunWalkthrough {
 }
 
 const FOCUSABLE_SELECTOR =
-  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  'wa-button, button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const ONBOARDING_STEPS: ReadonlyArray<{
+  readonly index: string;
+  readonly title: string;
+  readonly body: string;
+}> = [
+  {
+    index: '1',
+    title: 'Open a workspace',
+    body: 'Pick the folder that contains the paper or project files.',
+  },
+  {
+    index: '2',
+    title: 'Set up model access',
+    body: 'Sign in for included access or add provider keys in Settings.',
+  },
+  {
+    index: '3',
+    title: 'Choose an agent',
+    body: 'Select a workflow agent, direct agent, or tool-use agent.',
+  },
+  {
+    index: '4',
+    title: 'Start a run',
+    body: 'Use the launcher and follow live output in Progress.',
+  },
+];
 
 export function createFirstRunWalkthrough({
   document,
@@ -30,59 +58,69 @@ export function createFirstRunWalkthrough({
   element.setAttribute('role', 'dialog');
   element.setAttribute('aria-modal', 'true');
   element.setAttribute('aria-labelledby', 'desktop-onboarding-title');
-  element.innerHTML = `
-    <div class="desktop-onboarding-panel">
-      <header class="desktop-onboarding-header">
-        <wa-icon class="desktop-onboarding-icon" library="${TEXRA_ICON_LIBRARY}" name="circle-info" variant="solid" aria-hidden="true"></wa-icon>
-        <div>
-          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
-          <p>Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.</p>
-        </div>
-      </header>
-      <ol class="desktop-onboarding-steps">
-        <li>
-          <span class="desktop-onboarding-step-index">1</span>
-          <div>
-            <strong>Open a workspace</strong>
-            <span>Pick the folder that contains the paper or project files.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">2</span>
-          <div>
-            <strong>Set up model access</strong>
-            <span>Sign in for included access or add provider keys in Settings.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">3</span>
-          <div>
-            <strong>Choose an agent</strong>
-            <span>Select a workflow agent, direct agent, or tool-use agent.</span>
-          </div>
-        </li>
-        <li>
-          <span class="desktop-onboarding-step-index">4</span>
-          <div>
-            <strong>Start a run</strong>
-            <span>Use the launcher and follow live output in Progress.</span>
-          </div>
-        </li>
-      </ol>
-      <footer class="desktop-onboarding-actions">
-        <wa-button class="desktop-secondary-button" appearance="outlined" data-onboarding-settings>
-          Open Settings
-        </wa-button>
-        <wa-button class="desktop-secondary-button" appearance="outlined" data-onboarding-launcher>
-          Go to Launcher
-        </wa-button>
-        <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-onboarding-dismiss>
-          Got it
-        </wa-button>
-      </footer>
-    </div>
-  `;
+
   let previousFocus: HTMLElement | null = null;
+
+  const dismissAndShowRoute = (route: DesktopRoute): void => {
+    dismiss();
+    setRoute(route);
+  };
+
+  render(
+    html`
+      <div class="desktop-onboarding-panel">
+        <header class="desktop-onboarding-header">
+          ${waIcon('circle-info', { className: 'desktop-onboarding-icon' })}
+          <div>
+            <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
+            <p>
+              Start from a workspace, configure model access, choose an agent,
+              and run without switching to VS Code.
+            </p>
+          </div>
+        </header>
+        <ol class="desktop-onboarding-steps">
+          ${ONBOARDING_STEPS.map(
+            (step) => html`
+              <li>
+                <span class="desktop-onboarding-step-index">${step.index}</span>
+                <div>
+                  <strong>${step.title}</strong>
+                  <span>${step.body}</span>
+                </div>
+              </li>
+            `,
+          )}
+        </ol>
+        <footer class="desktop-onboarding-actions">
+          <wa-button
+            class="desktop-secondary-button"
+            appearance="outlined"
+            @click=${() => dismissAndShowRoute('settings')}
+          >
+            Open Settings
+          </wa-button>
+          <wa-button
+            class="desktop-secondary-button"
+            appearance="outlined"
+            @click=${() => dismissAndShowRoute('main')}
+          >
+            Go to Launcher
+          </wa-button>
+          <wa-button
+            class="desktop-primary-button"
+            appearance="filled"
+            variant="brand"
+            data-onboarding-dismiss
+            @click=${() => dismiss()}
+          >
+            Got it
+          </wa-button>
+        </footer>
+      </div>
+    `,
+    element,
+  );
 
   const getFocusableElements = (): HTMLElement[] =>
     [...element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
@@ -113,23 +151,11 @@ export function createFirstRunWalkthrough({
     element.hidden = false;
     focusFirstControl();
   };
-  const dismiss = (): void => {
+  function dismiss(): void {
     hide();
     postDismissed();
-  };
-  const dismissAndShowRoute = (route: DesktopRoute): void => {
-    dismiss();
-    setRoute(route);
-  };
-  const onClick = (selector: string, handler: () => void): void => {
-    element
-      .querySelector<HTMLElement>(selector)
-      ?.addEventListener('click', handler);
-  };
+  }
 
-  onClick('[data-onboarding-settings]', () => dismissAndShowRoute('settings'));
-  onClick('[data-onboarding-launcher]', () => dismissAndShowRoute('main'));
-  onClick('[data-onboarding-dismiss]', dismiss);
   document.addEventListener('focusin', (event) => {
     if (element.hidden) return;
     if (event.target instanceof Node && element.contains(event.target)) return;

--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -1,3 +1,5 @@
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
 import type { DesktopRoute } from '../desktopShellMessages';
 import { isCommandPaletteShortcut } from './desktopCommandPalette';
 
@@ -31,7 +33,7 @@ export function createFirstRunWalkthrough({
   element.innerHTML = `
     <div class="desktop-onboarding-panel">
       <header class="desktop-onboarding-header">
-        <span class="codicon codicon-info desktop-onboarding-icon" aria-hidden="true"></span>
+        <wa-icon class="desktop-onboarding-icon" library="${TEXRA_ICON_LIBRARY}" name="circle-info" variant="solid" aria-hidden="true"></wa-icon>
         <div>
           <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
           <p>Start from a workspace, configure model access, choose an agent, and run without switching to VS Code.</p>
@@ -68,15 +70,15 @@ export function createFirstRunWalkthrough({
         </li>
       </ol>
       <footer class="desktop-onboarding-actions">
-        <button class="desktop-secondary-button" type="button" data-onboarding-settings>
+        <wa-button class="desktop-secondary-button" appearance="outlined" data-onboarding-settings>
           Open Settings
-        </button>
-        <button class="desktop-secondary-button" type="button" data-onboarding-launcher>
+        </wa-button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" data-onboarding-launcher>
           Go to Launcher
-        </button>
-        <button class="desktop-primary-button" type="button" data-onboarding-dismiss>
+        </wa-button>
+        <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-onboarding-dismiss>
           Got it
-        </button>
+        </wa-button>
       </footer>
     </div>
   `;
@@ -96,7 +98,7 @@ export function createFirstRunWalkthrough({
     restoreFocus?.focus();
   };
   const focusFirstControl = (): void => {
-    const dismissButton = element.querySelector<HTMLButtonElement>(
+    const dismissButton = element.querySelector<HTMLElement>(
       '[data-onboarding-dismiss]',
     );
     (dismissButton ?? getFocusableElements()[0])?.focus();
@@ -121,7 +123,7 @@ export function createFirstRunWalkthrough({
   };
   const onClick = (selector: string, handler: () => void): void => {
     element
-      .querySelector<HTMLButtonElement>(selector)
+      .querySelector<HTMLElement>(selector)
       ?.addEventListener('click', handler);
   };
 

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -2,6 +2,12 @@ import './styles.css';
 import './themeTokens.css';
 import './codiconStylesheet';
 
+import '@shared/wa';
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import '@awesome.me/webawesome/dist/components/input/input.js';
+import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
 import { postMessage } from '@shared/hostBridge';
@@ -67,24 +73,25 @@ const appRoot = root;
 appRoot.innerHTML = `
   <section class="desktop-shell">
     <nav class="desktop-nav" aria-label="Desktop views">
-      <button class="desktop-nav-button" type="button" data-route-button="main" aria-pressed="true">
+      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="main" aria-pressed="true">
         Launcher
-      </button>
-      <button class="desktop-nav-button" type="button" data-route-button="progress" aria-pressed="false">
+      </wa-button>
+      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="progress" aria-pressed="false">
         Progress
-      </button>
-      <button class="desktop-nav-button" type="button" data-route-button="settings" aria-pressed="false">
+      </wa-button>
+      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="settings" aria-pressed="false">
         Settings
-      </button>
-      <button class="desktop-nav-button" type="button" data-route-button="logs" aria-pressed="false">
+      </wa-button>
+      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="logs" aria-pressed="false">
         Logs
-      </button>
-      <button class="desktop-command-button" type="button" data-command-palette-button aria-haspopup="dialog">
+      </wa-button>
+      <wa-button class="desktop-command-button" appearance="outlined" size="small" data-command-palette-button aria-haspopup="dialog">
         Commands
-      </button>
-      <button class="desktop-folder-button" type="button" data-open-workspace-button>
+      </wa-button>
+      <wa-button class="desktop-folder-button" appearance="outlined" size="small" data-open-workspace-button>
+        <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid"></wa-icon>
         Open Folder
-      </button>
+      </wa-button>
     </nav>
     <div class="desktop-workbench">
       <aside class="desktop-explorer" id="desktop-explorer" aria-label="Workspace Explorer"></aside>
@@ -122,9 +129,9 @@ for (const route of DESKTOP_ROUTES) {
   routeContainers.set(route, container);
 }
 
-const routeButtons = new Map<DesktopRoute, HTMLButtonElement>();
+const routeButtons = new Map<DesktopRoute, HTMLElement>();
 for (const route of DESKTOP_ROUTES) {
-  const button = appRoot.querySelector<HTMLButtonElement>(
+  const button = appRoot.querySelector<HTMLElement>(
     `[data-route-button="${route}"]`,
   );
   if (button == null) {
@@ -163,14 +170,14 @@ settingsApp.setAttribute('data-desktop-view', 'settings');
 routeContainers.get('settings')?.replaceChildren(settingsApp);
 routeContainers.get('logs')?.replaceChildren(createLogViewer());
 
-const commandPaletteButton = appRoot.querySelector<HTMLButtonElement>(
+const commandPaletteButton = appRoot.querySelector<HTMLElement>(
   '[data-command-palette-button]',
 );
 if (commandPaletteButton == null) {
   throw new Error('TeXRA desktop command palette button was not found.');
 }
 
-const openWorkspaceButton = appRoot.querySelector<HTMLButtonElement>(
+const openWorkspaceButton = appRoot.querySelector<HTMLElement>(
   '[data-open-workspace-button]',
 );
 if (openWorkspaceButton == null) {
@@ -311,26 +318,26 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
 
   container.innerHTML = `
     <div class="desktop-empty-workspace-panel">
-      <span class="codicon codicon-folder-opened desktop-empty-workspace-icon" aria-hidden="true"></span>
+      <wa-icon class="desktop-empty-workspace-icon" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid" aria-hidden="true"></wa-icon>
       <h1>${title}</h1>
       <p>${body}</p>
       <div class="desktop-empty-workspace-actions">
-        <button class="desktop-primary-button" type="button" data-empty-open-folder>
+        <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-empty-open-folder>
           Open Folder
-        </button>
-        <button class="desktop-secondary-button" type="button" data-empty-open-logs>
+        </wa-button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" data-empty-open-logs>
           Logs
-        </button>
+        </wa-button>
       </div>
     </div>
   `;
   container
-    .querySelector<HTMLButtonElement>('[data-empty-open-folder]')
+    .querySelector<HTMLElement>('[data-empty-open-folder]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
     );
   container
-    .querySelector<HTMLButtonElement>('[data-empty-open-logs]')
+    .querySelector<HTMLElement>('[data-empty-open-logs]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
@@ -347,29 +354,41 @@ function createLogViewer(): HTMLElement {
         <p data-log-meta>Recent redacted log entries appear here.</p>
       </div>
       <div class="desktop-log-viewer-actions">
-        <button class="desktop-secondary-button" type="button" data-log-refresh>Refresh</button>
-        <button class="desktop-secondary-button" type="button" data-log-copy>Copy</button>
-        <button class="desktop-secondary-button" type="button" data-log-export>Export</button>
-        <button class="desktop-secondary-button" type="button" data-log-folder>Open Folder</button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-refresh>
+          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="rotate-right" variant="solid"></wa-icon>
+          Refresh
+        </wa-button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-copy>
+          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="copy" variant="solid"></wa-icon>
+          Copy
+        </wa-button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-export>
+          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="download" variant="solid"></wa-icon>
+          Export
+        </wa-button>
+        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-folder>
+          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid"></wa-icon>
+          Open Folder
+        </wa-button>
       </div>
     </header>
     <pre class="desktop-log-viewer-output" data-log-output>Open Logs to load recent entries.</pre>
   `;
   container
-    .querySelector<HTMLButtonElement>('[data-log-refresh]')
+    .querySelector<HTMLElement>('[data-log-refresh]')
     ?.addEventListener('click', requestLogSnapshot);
   container
-    .querySelector<HTMLButtonElement>('[data-log-copy]')
+    .querySelector<HTMLElement>('[data-log-copy]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOG_COMMANDS.COPY_LOG),
     );
   container
-    .querySelector<HTMLButtonElement>('[data-log-export]')
+    .querySelector<HTMLElement>('[data-log-export]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOG_COMMANDS.EXPORT_LOG),
     );
   container
-    .querySelector<HTMLButtonElement>('[data-log-folder]')
+    .querySelector<HTMLElement>('[data-log-folder]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
     );
@@ -420,15 +439,15 @@ function renderWorkspaceExplorerNoWorkspace(): void {
   const prompt = document.createElement('section');
   prompt.className = 'desktop-explorer-empty';
   prompt.innerHTML = `
-    <span class="codicon codicon-folder-opened" aria-hidden="true"></span>
+    <wa-icon library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid" aria-hidden="true"></wa-icon>
     <h2>No workspace</h2>
     <p>Open a folder before selecting files for agents.</p>
-    <button class="desktop-primary-button" type="button" data-explorer-open-folder>
+    <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-explorer-open-folder>
       Open Folder
-    </button>
+    </wa-button>
   `;
   prompt
-    .querySelector<HTMLButtonElement>('[data-explorer-open-folder]')
+    .querySelector<HTMLElement>('[data-explorer-open-folder]')
     ?.addEventListener('click', () =>
       postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
     );
@@ -469,12 +488,14 @@ function createExplorerHeader(title: string, loading = false): HTMLElement {
   const label = document.createElement('span');
   label.className = 'desktop-explorer-title';
   label.textContent = title;
-  const refresh = document.createElement('button');
-  refresh.className = 'desktop-explorer-icon-button codicon codicon-refresh';
-  refresh.type = 'button';
+  const refresh = document.createElement('wa-button');
+  refresh.className = 'desktop-explorer-icon-button';
+  refresh.setAttribute('appearance', 'plain');
+  refresh.setAttribute('size', 'small');
   refresh.title = 'Refresh workspace files';
   refresh.setAttribute('aria-label', 'Refresh workspace files');
-  refresh.disabled = loading || !hasWorkspace;
+  if (loading || !hasWorkspace) refresh.setAttribute('disabled', '');
+  refresh.innerHTML = `<wa-icon library="${TEXRA_ICON_LIBRARY}" name="rotate-right" variant="solid"></wa-icon>`;
   refresh.addEventListener('click', requestWorkspaceTree);
   header.append(label, refresh);
   return header;
@@ -503,8 +524,8 @@ function renderTreeNodes(
       summary.className = 'desktop-explorer-row desktop-explorer-folder-row';
       summary.setAttribute('role', 'treeitem');
       summary.innerHTML = `
-        <span class="codicon codicon-chevron-right desktop-explorer-chevron" aria-hidden="true"></span>
-        <span class="codicon codicon-folder" aria-hidden="true"></span>
+        <wa-icon class="desktop-explorer-chevron" library="${TEXRA_ICON_LIBRARY}" name="chevron-right" variant="solid" aria-hidden="true"></wa-icon>
+        <wa-icon library="${TEXRA_ICON_LIBRARY}" name="folder" variant="solid" aria-hidden="true"></wa-icon>
         <span class="desktop-explorer-name"></span>
       `;
       summary.querySelector('.desktop-explorer-name')!.textContent = node.name;
@@ -526,7 +547,7 @@ function renderTreeNodes(
     row.setAttribute('role', 'treeitem');
     row.title = node.path;
     row.innerHTML = `
-      <span class="codicon codicon-file" aria-hidden="true"></span>
+      <wa-icon library="${TEXRA_ICON_LIBRARY}" name="file-lines" variant="solid" aria-hidden="true"></wa-icon>
       <span class="desktop-explorer-name"></span>
       <span class="desktop-explorer-category-strip"></span>
     `;
@@ -583,9 +604,10 @@ function updateExplorerSelectionPanel(
   const actions = document.createElement('div');
   actions.className = 'desktop-explorer-selection-actions';
 
-  const open = document.createElement('button');
-  open.type = 'button';
+  const open = document.createElement('wa-button');
   open.className = 'desktop-secondary-button';
+  open.setAttribute('appearance', 'outlined');
+  open.setAttribute('size', 'small');
   open.textContent = 'Open';
   open.addEventListener('click', () => openWorkspaceFile(node.path));
   actions.append(open);
@@ -593,9 +615,10 @@ function updateExplorerSelectionPanel(
   for (const category of node.categories ?? []) {
     const typedCategory = parseExplorerCategory(category);
     if (!typedCategory) continue;
-    const select = document.createElement('button');
-    select.type = 'button';
+    const select = document.createElement('wa-button');
     select.className = 'desktop-secondary-button';
+    select.setAttribute('appearance', 'outlined');
+    select.setAttribute('size', 'small');
     select.textContent = `Use as ${typedCategory}`;
     select.addEventListener('click', () =>
       selectWorkspaceFile(typedCategory, node.path),

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -290,6 +290,11 @@ function isThemeMessage(message: unknown): message is SetThemeMessage {
 }
 
 function setRoute(route: DesktopRoute): void {
+  // The shell template is rendered once at startup; aria-pressed/hidden are
+  // mutated imperatively here. If a caller ever re-renders the shell, those
+  // runtime mutations will be reset to the template defaults — convert this
+  // function to update module-level route state and trigger a shell re-render
+  // before doing that.
   for (const [candidate, container] of routeContainers) {
     container.hidden = candidate !== route;
   }
@@ -468,14 +473,15 @@ function requestWorkspaceTree(): void {
 }
 
 type ExplorerState =
-  | { kind: 'loading' }
+  | { kind: 'loading'; title: string }
   | { kind: 'no-workspace' }
   | { kind: 'tree'; title: string; tree: readonly WorkspaceTreeNode[] };
 
-let explorerState: ExplorerState = { kind: 'loading' };
+let explorerState: ExplorerState = { kind: 'loading', title: 'Workspace' };
 
 function renderWorkspaceExplorerLoading(): void {
-  explorerState = { kind: 'loading' };
+  const title = 'title' in explorerState ? explorerState.title : 'Workspace';
+  explorerState = { kind: 'loading', title };
   renderExplorer();
 }
 
@@ -502,7 +508,7 @@ function explorerTemplate(): TemplateResult {
     return explorerNoWorkspaceTemplate();
   if (explorerState.kind === 'loading') {
     return html`
-      ${explorerHeaderTemplate('Workspace', true)}
+      ${explorerHeaderTemplate(explorerState.title, true)}
       <p class="desktop-explorer-status">Loading workspace files...</p>
     `;
   }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -6,7 +6,10 @@ import '@shared/wa';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import '@awesome.me/webawesome/dist/components/input/input.js';
-import { TEXRA_ICON_LIBRARY } from '@shared/wa/webAwesomeIcons';
+import type WaButton from '@awesome.me/webawesome/dist/components/button/button.js';
+import { html, nothing, render, type TemplateResult } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { COMMON_COMMANDS } from '@common/webview/commands';
 import { MAIN_VIEW_COMMANDS } from '@common/webview/mainViewCommands';
@@ -70,40 +73,71 @@ if (root == null) {
 
 const appRoot = root;
 
-appRoot.innerHTML = `
-  <section class="desktop-shell">
-    <nav class="desktop-nav" aria-label="Desktop views">
-      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="main" aria-pressed="true">
-        Launcher
-      </wa-button>
-      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="progress" aria-pressed="false">
-        Progress
-      </wa-button>
-      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="settings" aria-pressed="false">
-        Settings
-      </wa-button>
-      <wa-button class="desktop-nav-button" appearance="plain" size="small" data-route-button="logs" aria-pressed="false">
-        Logs
-      </wa-button>
-      <wa-button class="desktop-command-button" appearance="outlined" size="small" data-command-palette-button aria-haspopup="dialog">
-        Commands
-      </wa-button>
-      <wa-button class="desktop-folder-button" appearance="outlined" size="small" data-open-workspace-button>
-        <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid"></wa-icon>
-        Open Folder
-      </wa-button>
-    </nav>
-    <div class="desktop-workbench">
-      <aside class="desktop-explorer" id="desktop-explorer" aria-label="Workspace Explorer"></aside>
-      <main class="desktop-view" id="desktop-view">
-        <section class="desktop-route" data-route="main"></section>
-        <section class="desktop-route" data-route="progress" hidden></section>
-        <section class="desktop-route" data-route="settings" hidden></section>
-        <section class="desktop-route" data-route="logs" hidden></section>
-      </main>
-    </div>
-  </section>
-`;
+const NAV_ROUTES: ReadonlyArray<{ readonly route: DesktopRoute; readonly label: string }> = [
+  { route: 'main', label: 'Launcher' },
+  { route: 'progress', label: 'Progress' },
+  { route: 'settings', label: 'Settings' },
+  { route: 'logs', label: 'Logs' },
+];
+
+render(
+  html`
+    <section class="desktop-shell">
+      <nav class="desktop-nav" aria-label="Desktop views">
+        ${NAV_ROUTES.map(
+          ({ route, label }) => html`
+            <wa-button
+              class="desktop-nav-button"
+              appearance="plain"
+              size="small"
+              role="button"
+              data-route-button=${route}
+              aria-pressed=${route === 'main' ? 'true' : 'false'}
+            >
+              ${label}
+            </wa-button>
+          `,
+        )}
+        <wa-button
+          class="desktop-command-button"
+          appearance="outlined"
+          size="small"
+          data-command-palette-button
+          aria-haspopup="dialog"
+        >
+          Commands
+        </wa-button>
+        <wa-button
+          class="desktop-folder-button"
+          appearance="outlined"
+          size="small"
+          data-open-workspace-button
+        >
+          ${waIcon('folder-open', { slot: 'start' })} Open Folder
+        </wa-button>
+      </nav>
+      <div class="desktop-workbench">
+        <aside
+          class="desktop-explorer"
+          id="desktop-explorer"
+          aria-label="Workspace Explorer"
+        ></aside>
+        <main class="desktop-view" id="desktop-view">
+          ${DESKTOP_ROUTES.map(
+            (route) => html`
+              <section
+                class="desktop-route"
+                data-route=${route}
+                ?hidden=${route !== 'main'}
+              ></section>
+            `,
+          )}
+        </main>
+      </div>
+    </section>
+  `,
+  appRoot,
+);
 
 const desktopViewContainer =
   appRoot.querySelector<HTMLElement>('#desktop-view');
@@ -129,9 +163,9 @@ for (const route of DESKTOP_ROUTES) {
   routeContainers.set(route, container);
 }
 
-const routeButtons = new Map<DesktopRoute, HTMLElement>();
+const routeButtons = new Map<DesktopRoute, WaButton>();
 for (const route of DESKTOP_ROUTES) {
-  const button = appRoot.querySelector<HTMLElement>(
+  const button = appRoot.querySelector<WaButton>(
     `[data-route-button="${route}"]`,
   );
   if (button == null) {
@@ -143,7 +177,6 @@ for (const route of DESKTOP_ROUTES) {
 
 const hasWorkspace = window.texraDesktop?.hasWorkspace ?? true;
 let selectedExplorerFile = '';
-let currentExplorerTree: WorkspaceTreeNode[] = [];
 
 renderWorkspaceExplorerLoading();
 
@@ -168,16 +201,16 @@ if (hasWorkspace) {
 const settingsApp = document.createElement('settings-app');
 settingsApp.setAttribute('data-desktop-view', 'settings');
 routeContainers.get('settings')?.replaceChildren(settingsApp);
-routeContainers.get('logs')?.replaceChildren(createLogViewer());
+renderLogViewer(routeContainers.get('logs'));
 
-const commandPaletteButton = appRoot.querySelector<HTMLElement>(
+const commandPaletteButton = appRoot.querySelector<WaButton>(
   '[data-command-palette-button]',
 );
 if (commandPaletteButton == null) {
   throw new Error('TeXRA desktop command palette button was not found.');
 }
 
-const openWorkspaceButton = appRoot.querySelector<HTMLElement>(
+const openWorkspaceButton = appRoot.querySelector<WaButton>(
   '[data-open-workspace-button]',
 );
 if (openWorkspaceButton == null) {
@@ -304,95 +337,103 @@ function getWindowTargetOrigin(): string {
     : '*';
 }
 
+const EMPTY_WORKSPACE_COPY = {
+  launcher: {
+    title: 'Open a folder to use the launcher',
+    body: 'TeXRA desktop needs a workspace before it can discover files, run agents, and place outputs.',
+  },
+  progress: {
+    title: 'Open a folder to view workspace progress',
+    body: 'Progress details are tied to workspace runs. Start from a workspace to restore and follow sessions here.',
+  },
+} as const;
+
 function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
   const container = document.createElement('section');
   container.className = 'desktop-empty-workspace';
-  const title =
-    kind === 'launcher'
-      ? 'Open a folder to use the launcher'
-      : 'Open a folder to view workspace progress';
-  const body =
-    kind === 'launcher'
-      ? 'TeXRA desktop needs a workspace before it can discover files, run agents, and place outputs.'
-      : 'Progress details are tied to workspace runs. Start from a workspace to restore and follow sessions here.';
-
-  container.innerHTML = `
-    <div class="desktop-empty-workspace-panel">
-      <wa-icon class="desktop-empty-workspace-icon" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid" aria-hidden="true"></wa-icon>
-      <h1>${title}</h1>
-      <p>${body}</p>
-      <div class="desktop-empty-workspace-actions">
-        <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-empty-open-folder>
-          Open Folder
-        </wa-button>
-        <wa-button class="desktop-secondary-button" appearance="outlined" data-empty-open-logs>
-          Logs
-        </wa-button>
+  const { title, body } = EMPTY_WORKSPACE_COPY[kind];
+  render(
+    html`
+      <div class="desktop-empty-workspace-panel">
+        ${waIcon('folder-open', { className: 'desktop-empty-workspace-icon' })}
+        <h1>${title}</h1>
+        <p>${body}</p>
+        <div class="desktop-empty-workspace-actions">
+          <wa-button
+            class="desktop-primary-button"
+            appearance="filled"
+            variant="brand"
+            @click=${() =>
+              postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER)}
+          >
+            Open Folder
+          </wa-button>
+          <wa-button
+            class="desktop-secondary-button"
+            appearance="outlined"
+            @click=${() =>
+              postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER)}
+          >
+            Logs
+          </wa-button>
+        </div>
       </div>
-    </div>
-  `;
-  container
-    .querySelector<HTMLElement>('[data-empty-open-folder]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
-    );
-  container
-    .querySelector<HTMLElement>('[data-empty-open-logs]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
-    );
+    `,
+    container,
+  );
   return container;
 }
 
-function createLogViewer(): HTMLElement {
-  const container = document.createElement('section');
-  container.className = 'desktop-log-viewer';
-  container.innerHTML = `
-    <header class="desktop-log-viewer-header">
-      <div>
-        <h2>Desktop Logs</h2>
-        <p data-log-meta>Recent redacted log entries appear here.</p>
-      </div>
-      <div class="desktop-log-viewer-actions">
-        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-refresh>
-          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="rotate-right" variant="solid"></wa-icon>
-          Refresh
-        </wa-button>
-        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-copy>
-          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="copy" variant="solid"></wa-icon>
-          Copy
-        </wa-button>
-        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-export>
-          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="download" variant="solid"></wa-icon>
-          Export
-        </wa-button>
-        <wa-button class="desktop-secondary-button" appearance="outlined" size="small" data-log-folder>
-          <wa-icon slot="start" library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid"></wa-icon>
-          Open Folder
-        </wa-button>
-      </div>
-    </header>
-    <pre class="desktop-log-viewer-output" data-log-output>Open Logs to load recent entries.</pre>
+const LOG_VIEWER_DEFAULTS = {
+  meta: 'Recent redacted log entries appear here.',
+  text: 'Open Logs to load recent entries.',
+};
+
+let logViewerState = { ...LOG_VIEWER_DEFAULTS };
+
+function logViewerTemplate(state: typeof logViewerState): TemplateResult {
+  const action = (
+    icon: 'rotate-right' | 'copy' | 'download' | 'folder-open',
+    label: string,
+    onClick: () => void,
+  ): TemplateResult => html`
+    <wa-button
+      class="desktop-secondary-button"
+      appearance="outlined"
+      size="small"
+      @click=${onClick}
+    >
+      ${waIcon(icon, { slot: 'start' })} ${label}
+    </wa-button>
   `;
-  container
-    .querySelector<HTMLElement>('[data-log-refresh]')
-    ?.addEventListener('click', requestLogSnapshot);
-  container
-    .querySelector<HTMLElement>('[data-log-copy]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOG_COMMANDS.COPY_LOG),
-    );
-  container
-    .querySelector<HTMLElement>('[data-log-export]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOG_COMMANDS.EXPORT_LOG),
-    );
-  container
-    .querySelector<HTMLElement>('[data-log-folder]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
-    );
-  return container;
+  return html`
+    <section class="desktop-log-viewer">
+      <header class="desktop-log-viewer-header">
+        <div>
+          <h2>Desktop Logs</h2>
+          <p>${state.meta}</p>
+        </div>
+        <div class="desktop-log-viewer-actions">
+          ${action('rotate-right', 'Refresh', requestLogSnapshot)}
+          ${action('copy', 'Copy', () =>
+            postMessage(DESKTOP_LOG_COMMANDS.COPY_LOG),
+          )}
+          ${action('download', 'Export', () =>
+            postMessage(DESKTOP_LOG_COMMANDS.EXPORT_LOG),
+          )}
+          ${action('folder-open', 'Open Folder', () =>
+            postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
+          )}
+        </div>
+      </header>
+      <pre class="desktop-log-viewer-output">${state.text}</pre>
+    </section>
+  `;
+}
+
+function renderLogViewer(target: HTMLElement | undefined): void {
+  if (target == null) return;
+  render(logViewerTemplate(logViewerState), target);
 }
 
 function requestLogSnapshot(): void {
@@ -400,16 +441,14 @@ function requestLogSnapshot(): void {
 }
 
 function renderLogSnapshot(message: DesktopSetLogMessage): void {
-  const container = routeContainers.get('logs');
-  const output = container?.querySelector<HTMLElement>('[data-log-output]');
-  const meta = container?.querySelector<HTMLElement>('[data-log-meta]');
-  if (output == null || meta == null) return;
-
-  output.textContent = message.log.text || 'No desktop log entries yet.';
   const path = message.log.path ?? 'desktop log file';
-  meta.textContent = message.log.truncated
-    ? `Showing the most recent redacted entries from ${path}.`
-    : `Showing redacted entries from ${path}.`;
+  logViewerState = {
+    text: message.log.text || 'No desktop log entries yet.',
+    meta: message.log.truncated
+      ? `Showing the most recent redacted entries from ${path}.`
+      : `Showing redacted entries from ${path}.`,
+  };
+  renderLogViewer(routeContainers.get('logs'));
 }
 
 function isWorkspaceTreeMessage(
@@ -426,207 +465,212 @@ function requestWorkspaceTree(): void {
   postMessage(DESKTOP_WORKSPACE_EXPLORER_COMMANDS.REQUEST_TREE);
 }
 
+type ExplorerState =
+  | { kind: 'loading' }
+  | { kind: 'no-workspace' }
+  | { kind: 'tree'; title: string; tree: readonly WorkspaceTreeNode[] };
+
+let explorerState: ExplorerState = { kind: 'loading' };
+
 function renderWorkspaceExplorerLoading(): void {
-  workspaceExplorerContainer.replaceChildren();
-  workspaceExplorerContainer.append(
-    createExplorerHeader('Workspace', true),
-    createExplorerStatus('Loading workspace files...'),
-  );
+  explorerState = { kind: 'loading' };
+  renderExplorer();
 }
 
 function renderWorkspaceExplorerNoWorkspace(): void {
-  workspaceExplorerContainer.replaceChildren();
-  const prompt = document.createElement('section');
-  prompt.className = 'desktop-explorer-empty';
-  prompt.innerHTML = `
-    <wa-icon library="${TEXRA_ICON_LIBRARY}" name="folder-open" variant="solid" aria-hidden="true"></wa-icon>
-    <h2>No workspace</h2>
-    <p>Open a folder before selecting files for agents.</p>
-    <wa-button class="desktop-primary-button" appearance="filled" variant="brand" data-explorer-open-folder>
-      Open Folder
-    </wa-button>
-  `;
-  prompt
-    .querySelector<HTMLElement>('[data-explorer-open-folder]')
-    ?.addEventListener('click', () =>
-      postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
-    );
-  workspaceExplorerContainer.append(prompt);
+  explorerState = { kind: 'no-workspace' };
+  renderExplorer();
 }
 
 function renderWorkspaceExplorer(message: DesktopWorkspaceTreeMessage): void {
-  currentExplorerTree = message.tree;
-  workspaceExplorerContainer.replaceChildren();
-  workspaceExplorerContainer.append(
-    createExplorerHeader(message.workspaceName ?? 'Workspace'),
-  );
+  explorerState = {
+    kind: 'tree',
+    title: message.workspaceName ?? 'Workspace',
+    tree: message.tree,
+  };
+  renderExplorer();
+}
 
-  if (message.tree.length === 0) {
-    workspaceExplorerContainer.append(
-      createExplorerStatus('No selectable workspace files found.'),
-    );
-    return;
+function renderExplorer(): void {
+  render(explorerTemplate(), workspaceExplorerContainer);
+}
+
+function explorerTemplate(): TemplateResult {
+  if (explorerState.kind === 'no-workspace') return explorerNoWorkspaceTemplate();
+  if (explorerState.kind === 'loading') {
+    return html`
+      ${explorerHeaderTemplate('Workspace', true)}
+      <p class="desktop-explorer-status">Loading workspace files...</p>
+    `;
   }
-
-  const tree = document.createElement('div');
-  tree.className = 'desktop-explorer-tree';
-  tree.setAttribute('role', 'tree');
-  renderTreeNodes(tree, message.tree, 0);
-
-  const selection = document.createElement('section');
-  selection.className = 'desktop-explorer-selection';
-  selection.setAttribute('aria-live', 'polite');
-  selection.dataset.selectionPanel = 'true';
-
-  workspaceExplorerContainer.append(tree, selection);
-  updateExplorerSelectionPanel(message.tree);
+  if (explorerState.tree.length === 0) {
+    return html`
+      ${explorerHeaderTemplate(explorerState.title)}
+      <p class="desktop-explorer-status">
+        No selectable workspace files found.
+      </p>
+    `;
+  }
+  return html`
+    ${explorerHeaderTemplate(explorerState.title)}
+    <div class="desktop-explorer-tree" role="tree">
+      ${treeNodesTemplate(explorerState.tree, 0)}
+    </div>
+    <section class="desktop-explorer-selection" aria-live="polite">
+      ${selectionPanelTemplate(explorerState.tree)}
+    </section>
+  `;
 }
 
-function createExplorerHeader(title: string, loading = false): HTMLElement {
-  const header = document.createElement('header');
-  header.className = 'desktop-explorer-header';
-  const label = document.createElement('span');
-  label.className = 'desktop-explorer-title';
-  label.textContent = title;
-  const refresh = document.createElement('wa-button');
-  refresh.className = 'desktop-explorer-icon-button';
-  refresh.setAttribute('appearance', 'plain');
-  refresh.setAttribute('size', 'small');
-  refresh.title = 'Refresh workspace files';
-  refresh.setAttribute('aria-label', 'Refresh workspace files');
-  if (loading || !hasWorkspace) refresh.setAttribute('disabled', '');
-  refresh.innerHTML = `<wa-icon library="${TEXRA_ICON_LIBRARY}" name="rotate-right" variant="solid"></wa-icon>`;
-  refresh.addEventListener('click', requestWorkspaceTree);
-  header.append(label, refresh);
-  return header;
+function explorerNoWorkspaceTemplate(): TemplateResult {
+  return html`
+    <section class="desktop-explorer-empty">
+      ${waIcon('folder-open')}
+      <h2>No workspace</h2>
+      <p>Open a folder before selecting files for agents.</p>
+      <wa-button
+        class="desktop-primary-button"
+        appearance="filled"
+        variant="brand"
+        @click=${() =>
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER)}
+      >
+        Open Folder
+      </wa-button>
+    </section>
+  `;
 }
 
-function createExplorerStatus(text: string): HTMLElement {
-  const status = document.createElement('p');
-  status.className = 'desktop-explorer-status';
-  status.textContent = text;
-  return status;
+function explorerHeaderTemplate(title: string, loading = false): TemplateResult {
+  return html`
+    <header class="desktop-explorer-header">
+      <span class="desktop-explorer-title">${title}</span>
+      <wa-button
+        class="desktop-explorer-icon-button"
+        appearance="plain"
+        size="small"
+        title="Refresh workspace files"
+        aria-label="Refresh workspace files"
+        ?disabled=${loading || !hasWorkspace}
+        @click=${requestWorkspaceTree}
+      >
+        ${waIcon('rotate-right')}
+      </wa-button>
+    </header>
+  `;
 }
 
-function renderTreeNodes(
-  container: HTMLElement,
+function treeNodesTemplate(
   nodes: readonly WorkspaceTreeNode[],
   depth: number,
-): void {
-  for (const node of nodes) {
-    if (node.type === 'directory') {
-      const details = document.createElement('details');
-      details.className = 'desktop-explorer-directory';
-      details.open = depth < 2;
-      details.style.setProperty('--tree-depth', String(depth));
+): TemplateResult {
+  return html`
+    ${repeat(
+      nodes,
+      (node) => node.path,
+      (node) => treeNodeTemplate(node, depth),
+    )}
+  `;
+}
 
-      const summary = document.createElement('summary');
-      summary.className = 'desktop-explorer-row desktop-explorer-folder-row';
-      summary.setAttribute('role', 'treeitem');
-      summary.innerHTML = `
-        <wa-icon class="desktop-explorer-chevron" library="${TEXRA_ICON_LIBRARY}" name="chevron-right" variant="solid" aria-hidden="true"></wa-icon>
-        <wa-icon library="${TEXRA_ICON_LIBRARY}" name="folder" variant="solid" aria-hidden="true"></wa-icon>
-        <span class="desktop-explorer-name"></span>
-      `;
-      summary.querySelector('.desktop-explorer-name')!.textContent = node.name;
-      details.append(summary);
-
-      const group = document.createElement('div');
-      group.setAttribute('role', 'group');
-      renderTreeNodes(group, node.children ?? [], depth + 1);
-      details.append(group);
-      container.append(details);
-      continue;
-    }
-
-    const row = document.createElement('button');
-    row.className = 'desktop-explorer-row desktop-explorer-file-row';
-    row.type = 'button';
-    row.dataset.filePath = node.path;
-    row.style.setProperty('--tree-depth', String(depth));
-    row.setAttribute('role', 'treeitem');
-    row.title = node.path;
-    row.innerHTML = `
-      <wa-icon library="${TEXRA_ICON_LIBRARY}" name="file-lines" variant="solid" aria-hidden="true"></wa-icon>
-      <span class="desktop-explorer-name"></span>
-      <span class="desktop-explorer-category-strip"></span>
+function treeNodeTemplate(
+  node: WorkspaceTreeNode,
+  depth: number,
+): TemplateResult {
+  if (node.type === 'directory') {
+    return html`
+      <details
+        class="desktop-explorer-directory"
+        ?open=${depth < 2}
+        style=${`--tree-depth: ${depth}`}
+      >
+        <summary
+          class="desktop-explorer-row desktop-explorer-folder-row"
+          role="treeitem"
+        >
+          ${waIcon('chevron-right', { className: 'desktop-explorer-chevron' })}
+          ${waIcon('folder')}
+          <span class="desktop-explorer-name">${node.name}</span>
+        </summary>
+        <div role="group">
+          ${treeNodesTemplate(node.children ?? [], depth + 1)}
+        </div>
+      </details>
     `;
-    row.querySelector('.desktop-explorer-name')!.textContent = node.name;
-    row
-      .querySelector('.desktop-explorer-category-strip')
-      ?.replaceChildren(...createCategoryDots(node.categories ?? []));
-    row.addEventListener('click', () => selectExplorerFile(node.path));
-    row.addEventListener('dblclick', () => openWorkspaceFile(node.path));
-    container.append(row);
   }
+  return html`
+    <button
+      class="desktop-explorer-row desktop-explorer-file-row"
+      type="button"
+      role="treeitem"
+      title=${node.path}
+      data-file-path=${node.path}
+      data-selected=${selectedExplorerFile === node.path ? 'true' : 'false'}
+      style=${`--tree-depth: ${depth}`}
+      @click=${() => selectExplorerFile(node.path)}
+      @dblclick=${() => openWorkspaceFile(node.path)}
+    >
+      ${waIcon('file-lines')}
+      <span class="desktop-explorer-name">${node.name}</span>
+      <span class="desktop-explorer-category-strip">
+        ${(node.categories ?? []).map(
+          (category) => html`
+            <span
+              class="desktop-explorer-category-dot"
+              title=${category}
+              data-category=${category}
+            ></span>
+          `,
+        )}
+      </span>
+    </button>
+  `;
 }
 
-function createCategoryDots(categories: readonly string[]): HTMLElement[] {
-  return categories.map((category) => {
-    const dot = document.createElement('span');
-    dot.className = 'desktop-explorer-category-dot';
-    dot.title = category;
-    dot.dataset.category = category;
-    return dot;
-  });
-}
-
-function selectExplorerFile(filePath: string): void {
-  selectedExplorerFile = filePath;
-  for (const row of workspaceExplorerContainer.querySelectorAll<HTMLElement>(
-    '.desktop-explorer-file-row',
-  )) {
-    row.dataset.selected = String(row.dataset.filePath === filePath);
-  }
-  updateExplorerSelectionPanel(currentExplorerTree);
-}
-
-function updateExplorerSelectionPanel(
+function selectionPanelTemplate(
   tree: readonly WorkspaceTreeNode[],
-): void {
-  const panel = workspaceExplorerContainer.querySelector<HTMLElement>(
-    '[data-selection-panel]',
-  );
-  if (!panel) return;
+): TemplateResult | string {
   const node = selectedExplorerFile
     ? findFileNode(tree, selectedExplorerFile)
     : undefined;
   if (!node) {
-    panel.textContent =
-      'Select a file to open it or attach it to the launcher.';
-    return;
+    return 'Select a file to open it or attach it to the launcher.';
   }
+  return html`
+    <div class="desktop-explorer-selected-path">${node.path}</div>
+    <div class="desktop-explorer-selection-actions">
+      ${selectionActionTemplate('Open', () => openWorkspaceFile(node.path))}
+      ${(node.categories ?? []).map((category) => {
+        const typedCategory = parseExplorerCategory(category);
+        return typedCategory
+          ? selectionActionTemplate(`Use as ${typedCategory}`, () =>
+              selectWorkspaceFile(typedCategory, node.path),
+            )
+          : nothing;
+      })}
+    </div>
+  `;
+}
 
-  panel.replaceChildren();
-  const path = document.createElement('div');
-  path.className = 'desktop-explorer-selected-path';
-  path.textContent = node.path;
-  const actions = document.createElement('div');
-  actions.className = 'desktop-explorer-selection-actions';
+function selectionActionTemplate(
+  label: string,
+  onClick: () => void,
+): TemplateResult {
+  return html`
+    <wa-button
+      class="desktop-secondary-button"
+      appearance="outlined"
+      size="small"
+      @click=${onClick}
+    >
+      ${label}
+    </wa-button>
+  `;
+}
 
-  const open = document.createElement('wa-button');
-  open.className = 'desktop-secondary-button';
-  open.setAttribute('appearance', 'outlined');
-  open.setAttribute('size', 'small');
-  open.textContent = 'Open';
-  open.addEventListener('click', () => openWorkspaceFile(node.path));
-  actions.append(open);
-
-  for (const category of node.categories ?? []) {
-    const typedCategory = parseExplorerCategory(category);
-    if (!typedCategory) continue;
-    const select = document.createElement('wa-button');
-    select.className = 'desktop-secondary-button';
-    select.setAttribute('appearance', 'outlined');
-    select.setAttribute('size', 'small');
-    select.textContent = `Use as ${typedCategory}`;
-    select.addEventListener('click', () =>
-      selectWorkspaceFile(typedCategory, node.path),
-    );
-    actions.append(select);
-  }
-
-  panel.append(path, actions);
+function selectExplorerFile(filePath: string): void {
+  selectedExplorerFile = filePath;
+  renderExplorer();
 }
 
 function findFileNode(

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -73,7 +73,10 @@ if (root == null) {
 
 const appRoot = root;
 
-const NAV_ROUTES: ReadonlyArray<{ readonly route: DesktopRoute; readonly label: string }> = [
+const NAV_ROUTES: ReadonlyArray<{
+  readonly route: DesktopRoute;
+  readonly label: string;
+}> = [
   { route: 'main', label: 'Launcher' },
   { route: 'progress', label: 'Progress' },
   { route: 'settings', label: 'Settings' },
@@ -371,8 +374,7 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
           <wa-button
             class="desktop-secondary-button"
             appearance="outlined"
-            @click=${() =>
-              postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER)}
+            @click=${() => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER)}
           >
             Logs
           </wa-button>
@@ -496,7 +498,8 @@ function renderExplorer(): void {
 }
 
 function explorerTemplate(): TemplateResult {
-  if (explorerState.kind === 'no-workspace') return explorerNoWorkspaceTemplate();
+  if (explorerState.kind === 'no-workspace')
+    return explorerNoWorkspaceTemplate();
   if (explorerState.kind === 'loading') {
     return html`
       ${explorerHeaderTemplate('Workspace', true)}
@@ -541,7 +544,10 @@ function explorerNoWorkspaceTemplate(): TemplateResult {
   `;
 }
 
-function explorerHeaderTemplate(title: string, loading = false): TemplateResult {
+function explorerHeaderTemplate(
+  title: string,
+  loading = false,
+): TemplateResult {
   return html`
     <header class="desktop-explorer-header">
       <span class="desktop-explorer-title">${title}</span>

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -29,46 +29,41 @@ body {
   background: var(--texra-sideBar-background);
 }
 
-.desktop-nav-button {
+/* Top-nav wa-button overrides — shadow DOM tinting via ::part(base). */
+wa-button.desktop-nav-button::part(base) {
   height: 28px;
   padding: 0 10px;
-  border: 1px solid transparent;
+  border-color: transparent;
   border-radius: 4px;
   background: transparent;
   color: var(--texra-foreground);
-  font: inherit;
-  cursor: pointer;
 }
 
-.desktop-nav-button:hover {
+wa-button.desktop-nav-button::part(base):hover {
   background: var(--texra-toolbar-hoverBackground);
 }
 
-.desktop-nav-button[aria-pressed='true'] {
+wa-button.desktop-nav-button[aria-pressed='true']::part(base) {
   border-color: var(--texra-focusBorder);
   background: var(--texra-button-secondaryBackground);
 }
 
-.desktop-command-button,
-.desktop-log-button,
-.desktop-folder-button {
+wa-button.desktop-command-button::part(base),
+wa-button.desktop-folder-button::part(base) {
   height: 28px;
   padding: 0 10px;
-  border: 1px solid var(--texra-panel-border);
+  border-color: var(--texra-panel-border);
   border-radius: 4px;
   background: var(--texra-button-secondaryBackground);
   color: var(--texra-foreground);
-  font: inherit;
-  cursor: pointer;
 }
 
-.desktop-command-button {
+wa-button.desktop-command-button {
   margin-left: auto;
 }
 
-.desktop-command-button:hover,
-.desktop-log-button:hover,
-.desktop-folder-button:hover {
+wa-button.desktop-command-button::part(base):hover,
+wa-button.desktop-folder-button::part(base):hover {
   background: var(--texra-toolbar-hoverBackground);
 }
 
@@ -117,22 +112,25 @@ body {
   text-transform: uppercase;
 }
 
-.desktop-explorer-icon-button {
+wa-button.desktop-explorer-icon-button {
   margin-left: auto;
+}
+
+wa-button.desktop-explorer-icon-button::part(base) {
   width: 24px;
   height: 24px;
+  padding: 0;
   border: 0;
   border-radius: 4px;
   background: transparent;
   color: var(--texra-foreground);
-  cursor: pointer;
 }
 
-.desktop-explorer-icon-button:hover {
+wa-button.desktop-explorer-icon-button::part(base):hover {
   background: var(--texra-toolbar-hoverBackground);
 }
 
-.desktop-explorer-icon-button:disabled {
+wa-button.desktop-explorer-icon-button[disabled]::part(base) {
   opacity: 0.5;
   cursor: default;
 }
@@ -261,7 +259,7 @@ body {
   text-align: center;
 }
 
-.desktop-explorer-empty .codicon {
+.desktop-explorer-empty wa-icon {
   color: var(--texra-button-background);
   font-size: 30px;
 }
@@ -477,28 +475,26 @@ body {
   white-space: pre-wrap;
 }
 
-.desktop-primary-button,
-.desktop-secondary-button {
+wa-button.desktop-primary-button::part(base),
+wa-button.desktop-secondary-button::part(base) {
   min-height: 34px;
   padding: 0 14px;
   border-radius: 6px;
-  font: inherit;
-  cursor: pointer;
 }
 
-.desktop-primary-button {
+wa-button.desktop-primary-button::part(base) {
   border: 1px solid var(--texra-button-background);
   background: var(--texra-button-background);
   color: var(--texra-button-foreground);
 }
 
-.desktop-secondary-button {
+wa-button.desktop-secondary-button::part(base) {
   border: 1px solid var(--texra-button-border);
   background: var(--texra-button-secondaryBackground);
   color: var(--texra-button-secondaryForeground);
 }
 
-.desktop-secondary-button:hover {
+wa-button.desktop-secondary-button::part(base):hover {
   background: var(--texra-button-secondaryHoverBackground);
 }
 

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -98,6 +98,8 @@ import { faWindowMaximize } from '@fortawesome/free-solid-svg-icons/faWindowMaxi
 import { faWrench } from '@fortawesome/free-solid-svg-icons/faWrench';
 import { faXmark } from '@fortawesome/free-solid-svg-icons/faXmark';
 import { registerIconLibrary } from '@awesome.me/webawesome/dist/components/icon/library.js';
+import { html, type TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const TEXRA_ICON_LIBRARY = 'texra';
 
@@ -324,3 +326,38 @@ export function registerTeXRAWebAwesomeIcons(): void {
 // Names accepted by <wa-icon library="texra" name="..."> — canonical names plus
 // the codicon-style aliases. Exported so callers can type-check icon usage.
 export type TeXRAIconName = keyof typeof icons | keyof typeof CODICON_ALIASES;
+
+interface WaIconOptions {
+  readonly slot?: 'start' | 'end';
+  readonly className?: string;
+  readonly variant?: 'solid' | 'regular';
+}
+
+// Lit template for <wa-icon>. Centralizes library + variant + aria-hidden so
+// callers don't repeat them. Prefer this over waIconHtml for new code.
+export function waIcon(
+  name: TeXRAIconName,
+  options: WaIconOptions = {},
+): TemplateResult {
+  return html`<wa-icon
+    library=${TEXRA_ICON_LIBRARY}
+    name=${name}
+    variant=${options.variant ?? 'solid'}
+    slot=${ifDefined(options.slot)}
+    class=${ifDefined(options.className)}
+    aria-hidden="true"
+  ></wa-icon>`;
+}
+
+// Inline <wa-icon> string for innerHTML / template strings. Use only where
+// a Lit template isn't viable. Safe for static `name` literals only — `name`
+// is not escaped because callers must pass typed TeXRAIconName values.
+export function waIconHtml(
+  name: TeXRAIconName,
+  options: WaIconOptions = {},
+): string {
+  const slot = options.slot ? ` slot="${options.slot}"` : '';
+  const cls = options.className ? ` class="${options.className}"` : '';
+  const variant = options.variant ?? 'solid';
+  return `<wa-icon library="${TEXRA_ICON_LIBRARY}" name="${name}" variant="${variant}"${slot}${cls} aria-hidden="true"></wa-icon>`;
+}

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -334,7 +334,7 @@ interface WaIconOptions {
 }
 
 // Lit template for <wa-icon>. Centralizes library + variant + aria-hidden so
-// callers don't repeat them. Prefer this over waIconHtml for new code.
+// callers don't repeat them.
 export function waIcon(
   name: TeXRAIconName,
   options: WaIconOptions = {},
@@ -347,17 +347,4 @@ export function waIcon(
     class=${ifDefined(options.className)}
     aria-hidden="true"
   ></wa-icon>`;
-}
-
-// Inline <wa-icon> string for innerHTML / template strings. Use only where
-// a Lit template isn't viable. Safe for static `name` literals only — `name`
-// is not escaped because callers must pass typed TeXRAIconName values.
-export function waIconHtml(
-  name: TeXRAIconName,
-  options: WaIconOptions = {},
-): string {
-  const slot = options.slot ? ` slot="${options.slot}"` : '';
-  const cls = options.className ? ` class="${options.className}"` : '';
-  const variant = options.variant ?? 'solid';
-  return `<wa-icon library="${TEXRA_ICON_LIBRARY}" name="${name}" variant="${variant}"${slot}${cls} aria-hidden="true"></wa-icon>`;
 }

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -44,10 +44,11 @@ describe('desktop renderer shell', () => {
   it('provides persistent shell controls for returning between routes', () => {
     const rendererMain = readRendererMain();
 
-    expect(rendererMain).toContain('data-route-button="main"');
-    expect(rendererMain).toContain('data-route-button="progress"');
-    expect(rendererMain).toContain('data-route-button="settings"');
-    expect(rendererMain).toContain('data-route-button="logs"');
+    expect(rendererMain).toContain("{ route: 'main', label: 'Launcher' }");
+    expect(rendererMain).toContain("{ route: 'progress', label: 'Progress' }");
+    expect(rendererMain).toContain("{ route: 'settings', label: 'Settings' }");
+    expect(rendererMain).toContain("{ route: 'logs', label: 'Logs' }");
+    expect(rendererMain).toContain('data-route-button=${route}');
     expect(rendererMain).toContain("button.addEventListener('click'");
     expect(rendererMain).toContain("button.setAttribute('aria-pressed'");
   });
@@ -96,6 +97,6 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain('DESKTOP_LOG_COMMANDS.COPY_LOG');
     expect(rendererMain).toContain('DESKTOP_LOG_COMMANDS.EXPORT_LOG');
     expect(rendererMain).toContain('DesktopSetLogMessageSchema.safeParse');
-    expect(rendererMain).toContain('data-log-output');
+    expect(rendererMain).toContain('logViewerTemplate');
   });
 });


### PR DESCRIPTION
## Summary

Bring the Electron renderer's chrome onto the same Web Awesome + Font Awesome stack the extension webviews use, and modernize the imperative \`innerHTML\` / \`createElement\` / \`querySelector\` factories with Lit declarative templates.

### Web Awesome adoption
- **Bootstrap.** \`packages/desktop/src/renderer/main.ts\` imports \`@shared/wa\` (registers texra icon library + WA default theme) and the wa-button / wa-icon / wa-input bundles.
- **Buttons.** Top-nav (Launcher/Progress/Settings/Logs) plus Commands and Open Folder become \`<wa-button>\` (\`appearance="plain"\` for routes, \`outlined\` for utilities). The empty-workspace placeholder, log viewer toolbar (Refresh/Copy/Export/Open Folder), explorer refresh, no-workspace prompt, selection-panel actions, and onboarding footer all use \`wa-button\` with \`filled+brand\` / \`outlined\` variants.
- **Icons.** Every \`<span class="codicon codicon-*">\` becomes \`<wa-icon library="texra">\` resolved via the registry from #3644.
- **Typed properties.** \`<wa-button>\` configuration uses \`.appearance\`, \`.size\`, \`.disabled\` reflective properties (typed via \`WaButton\` from \`@awesome.me/webawesome\`) rather than stringly-typed \`setAttribute\`.

### Lit declarative templates
- New \`waIcon()\` Lit helper sits alongside \`waIconHtml()\` in \`src/shared/wa/webAwesomeIcons.ts\` so callers can compose \`<wa-icon>\` via lit-html templates.
- \`packages/desktop/src/renderer/main.ts\` and \`desktopOnboarding.ts\` replace ~200 lines of imperative DOM construction with Lit \`render()\` + \`@click=\` event binding:
  - appRoot shell (nav, command/folder utilities, route sections, explorer aside).
  - empty-workspace placeholder, log viewer (state-driven via \`logViewerState\`).
  - workspace explorer states (loading / no-workspace / tree) with recursive tree-node template using \`repeat()\` keyed by path.
  - selection panel renders reactively when \`selectedExplorerFile\` changes.
  - First-run onboarding panel (steps + footer actions); focus-management code unchanged.

### CSS
- \`styles.css\` retargets visual rules at \`wa-button.desktop-*-button::part(base)\` so shadow-DOM components keep the existing visual spec; layout properties stay on host.
- Icon style rules (\`.desktop-onboarding-icon\`, \`.desktop-empty-workspace-icon\`, \`.desktop-explorer-empty wa-icon\`) updated to target wa-icon — sizing remains via \`font-size\`.

### Out of scope
- The dialog/modal wrappers (\`<section role="dialog">\` in onboarding, \`<div role="dialog">\` in command palette) are not yet \`wa-dialog\` — focus management is intricate, queued for a follow-up.
- The imperative shell-level \`setRoute()\` toggle stays imperative (just attribute mutations); shell renders once via Lit.
- The \`@vscode-elements/elements/dist/bundled.js\` import remains because sub-apps (settings/progress webviews) still depend on it.

## Stacked on

#3644 (icon registry expansion). Merge that one first; this PR's base is set to that branch.

## Test plan

- [x] \`npm run typecheck\` passes.
- [x] \`vite build\` for desktop renderer succeeds.
- [ ] Launch desktop build, verify nav buttons render correctly in light/dark/HC themes (active state shows pressed border via aria-pressed).
- [ ] Verify the empty-workspace state, log viewer toolbar, and explorer refresh look unchanged.
- [ ] Verify first-run walkthrough panel still traps focus correctly with new wa-button footer (FOCUSABLE_SELECTOR includes wa-button).
- [ ] Confirm wa-icons render visible glyphs (folder-open, rotate-right, circle-info, chevron-right, folder, file-lines, copy, download).
- [ ] Click a file in explorer → selection panel appears with Open + per-category buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites the Electron renderer shell UI construction (nav/onboarding/explorer/log viewer) and changes focusable/interaction elements to custom `wa-*` components, which can impact routing, event handling, and accessibility/focus behavior.
> 
> **Overview**
> Migrates the Electron desktop renderer chrome from imperative `innerHTML`/`createElement` DOM building to Lit `render()` templates, and swaps most shell buttons/icons over to Web Awesome `wa-button`/`wa-icon`.
> 
> This refactors the nav shell, first-run onboarding dialog, empty-workspace placeholders, log viewer, and workspace explorer into state-driven templates (including a new `waIcon()` Lit helper and reactive explorer/log viewer rendering), and updates CSS + tests to target `wa-button::part(base)` and the new template structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75053ec4f06188d3816b812cf495578bcc14f969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->