### PR TITLE
feat(wa,desktop): wa-dialog onboarding + shared empty-state pattern

### DIFF
--- a/packages/desktop/src/renderer/desktopOnboarding.ts
+++ b/packages/desktop/src/renderer/desktopOnboarding.ts
@@ -1,3 +1,4 @@
+import '@awesome.me/webawesome/dist/components/dialog/dialog.js';
 import { html, render } from 'lit';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
@@ -16,9 +17,6 @@ export interface DesktopFirstRunWalkthrough {
   show(): void;
   hide(): void;
 }
-
-const FOCUSABLE_SELECTOR =
-  'wa-button, button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 const ONBOARDING_STEPS: ReadonlyArray<{
   readonly index: string;
@@ -52,149 +50,115 @@ export function createFirstRunWalkthrough({
   dismiss: postDismissed,
   setRoute,
 }: DesktopFirstRunWalkthroughOptions): DesktopFirstRunWalkthrough {
-  const element = document.createElement('section');
-  element.className = 'desktop-onboarding';
-  element.hidden = true;
-  element.setAttribute('role', 'dialog');
-  element.setAttribute('aria-modal', 'true');
-  element.setAttribute('aria-labelledby', 'desktop-onboarding-title');
+  const dialog = document.createElement('wa-dialog');
+  dialog.classList.add('desktop-onboarding');
+  dialog.withoutHeader = true;
+  // The visible <h1> inside the body is the dialog's accessible name; ARIA
+  // resolves it via aria-labelledby below. Skip the redundant `label`
+  // attribute that would otherwise add an extra aria-label.
+  dialog.setAttribute('aria-labelledby', 'desktop-onboarding-title');
 
-  let previousFocus: HTMLElement | null = null;
+  // Distinguishes user-initiated close (Escape / button click) — which posts
+  // the dismissed signal back to the host — from programmatic close from
+  // setState(shouldShow=false), which would otherwise feedback-loop.
+  let suppressNextPost = false;
 
-  const dismissAndShowRoute = (route: DesktopRoute): void => {
-    dismiss();
+  const closeDialog = (): void => {
+    dialog.open = false;
+  };
+  const navigateAndClose = (route: DesktopRoute): void => {
+    closeDialog();
     setRoute(route);
   };
 
   render(
     html`
-      <div class="desktop-onboarding-panel">
-        <header class="desktop-onboarding-header">
-          ${waIcon('circle-info', { className: 'desktop-onboarding-icon' })}
-          <div>
-            <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
-            <p>
-              Start from a workspace, configure model access, choose an agent,
-              and run without switching to VS Code.
-            </p>
-          </div>
-        </header>
-        <ol class="desktop-onboarding-steps">
-          ${ONBOARDING_STEPS.map(
-            (step) => html`
-              <li>
-                <span class="desktop-onboarding-step-index">${step.index}</span>
-                <div>
-                  <strong>${step.title}</strong>
-                  <span>${step.body}</span>
-                </div>
-              </li>
-            `,
-          )}
-        </ol>
-        <footer class="desktop-onboarding-actions">
-          <wa-button
-            class="desktop-secondary-button"
-            appearance="outlined"
-            @click=${() => dismissAndShowRoute('settings')}
-          >
-            Open Settings
-          </wa-button>
-          <wa-button
-            class="desktop-secondary-button"
-            appearance="outlined"
-            @click=${() => dismissAndShowRoute('main')}
-          >
-            Go to Launcher
-          </wa-button>
-          <wa-button
-            class="desktop-primary-button"
-            appearance="filled"
-            variant="brand"
-            data-onboarding-dismiss
-            @click=${() => dismiss()}
-          >
-            Got it
-          </wa-button>
-        </footer>
+      <header class="desktop-onboarding-header">
+        ${waIcon('circle-info', { className: 'desktop-onboarding-icon' })}
+        <div>
+          <h1 id="desktop-onboarding-title">Welcome to TeXRA Desktop</h1>
+          <p>
+            Start from a workspace, configure model access, choose an agent, and
+            run without switching to VS Code.
+          </p>
+        </div>
+      </header>
+      <ol class="desktop-onboarding-steps">
+        ${ONBOARDING_STEPS.map(
+          (step) => html`
+            <li>
+              <span class="desktop-onboarding-step-index">${step.index}</span>
+              <div>
+                <strong>${step.title}</strong>
+                <span>${step.body}</span>
+              </div>
+            </li>
+          `,
+        )}
+      </ol>
+      <div slot="footer" class="desktop-onboarding-actions">
+        <wa-button
+          appearance="outlined"
+          @click=${() => navigateAndClose('settings')}
+        >
+          Open Settings
+        </wa-button>
+        <wa-button
+          appearance="outlined"
+          @click=${() => navigateAndClose('main')}
+        >
+          Go to Launcher
+        </wa-button>
+        <wa-button
+          appearance="filled"
+          variant="brand"
+          data-onboarding-dismiss
+          @click=${closeDialog}
+        >
+          Got it
+        </wa-button>
       </div>
     `,
-    element,
+    dialog,
   );
 
-  const getFocusableElements = (): HTMLElement[] =>
-    [...element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
-      (candidate) =>
-        !candidate.hasAttribute('disabled') &&
-        candidate.getAttribute('aria-hidden') !== 'true',
-    );
-
-  const hide = (): void => {
-    const restoreFocus = previousFocus;
-    element.hidden = true;
-    previousFocus = null;
-    restoreFocus?.focus();
-  };
-  const focusFirstControl = (): void => {
-    const dismissButton = element.querySelector<HTMLElement>(
-      '[data-onboarding-dismiss]',
-    );
-    (dismissButton ?? getFocusableElements()[0])?.focus();
-  };
-  const show = (): void => {
-    if (element.hidden) {
-      previousFocus =
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null;
-    }
-    element.hidden = false;
-    focusFirstControl();
-  };
-  function dismiss(): void {
-    hide();
-    postDismissed();
-  }
-
-  document.addEventListener('focusin', (event) => {
-    if (element.hidden) return;
-    if (event.target instanceof Node && element.contains(event.target)) return;
-    focusFirstControl();
+  // wa-dialog handles modal backdrop, focus trap, escape key, and focus
+  // restoration automatically. Restore the dismiss-first focus policy
+  // (the previous hand-rolled trap focused "Got it" first), and intercept
+  // the command-palette shortcut so it doesn't fire while open.
+  dialog.addEventListener('wa-after-show', () => {
+    dialog.querySelector<HTMLElement>('[data-onboarding-dismiss]')?.focus();
   });
-  document.addEventListener(
-    'keydown',
-    (event) => {
-      if (element.hidden) return;
-      if (isCommandPaletteShortcut(event)) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      }
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        dismiss();
-        return;
-      }
-      if (event.key !== 'Tab') return;
-      const focusable = getFocusableElements();
-      if (focusable.length === 0) {
-        event.preventDefault();
-        return;
-      }
-      const focusedIndex = focusable.indexOf(
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : focusable[0],
-      );
-      const currentIndex = focusedIndex === -1 ? 0 : focusedIndex;
-      const nextIndex = event.shiftKey
-        ? (currentIndex - 1 + focusable.length) % focusable.length
-        : (currentIndex + 1) % focusable.length;
+  // Every user-initiated dismissal (Escape, footer buttons) posts the
+  // dismissed signal back to the host. Programmatic hide() suppresses the
+  // post via suppressNextPost to avoid a feedback loop with setState messages.
+  dialog.addEventListener('wa-after-hide', () => {
+    if (suppressNextPost) {
+      suppressNextPost = false;
+      return;
+    }
+    postDismissed();
+  });
+  // Scoped to the dialog so it only runs while open and only for keys that
+  // originate inside it. stopPropagation prevents the global command-palette
+  // listener (on document) from firing.
+  dialog.addEventListener('keydown', (event) => {
+    if (isCommandPaletteShortcut(event)) {
       event.preventDefault();
-      focusable[nextIndex]?.focus();
-    },
-    true,
-  );
+      event.stopPropagation();
+    }
+  });
 
-  return { element, isVisible: () => !element.hidden, show, hide };
+  return {
+    element: dialog,
+    isVisible: () => dialog.open,
+    show: () => {
+      dialog.open = true;
+    },
+    hide: () => {
+      if (!dialog.open) return;
+      suppressNextPost = true;
+      dialog.open = false;
+    },
+  };
 }

--- a/packages/desktop/src/renderer/main.ts
+++ b/packages/desktop/src/renderer/main.ts
@@ -5,10 +5,10 @@ import './codiconStylesheet';
 import '@shared/wa';
 import '@awesome.me/webawesome/dist/components/button/button.js';
 import '@awesome.me/webawesome/dist/components/icon/icon.js';
-import '@awesome.me/webawesome/dist/components/input/input.js';
 import type WaButton from '@awesome.me/webawesome/dist/components/button/button.js';
 import { html, nothing, render, type TemplateResult } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
+import { renderEmptyState } from '@shared/wa/emptyState';
 import { waIcon } from '@shared/wa/webAwesomeIcons';
 
 import { COMMON_COMMANDS } from '@common/webview/commands';
@@ -361,44 +361,42 @@ function createNoWorkspacePlaceholder(kind: 'launcher' | 'progress'): Element {
   container.className = 'desktop-empty-workspace';
   const { title, body } = EMPTY_WORKSPACE_COPY[kind];
   render(
-    html`
-      <div class="desktop-empty-workspace-panel">
-        ${waIcon('folder-open', { className: 'desktop-empty-workspace-icon' })}
-        <h1>${title}</h1>
-        <p>${body}</p>
-        <div class="desktop-empty-workspace-actions">
-          <wa-button
-            class="desktop-primary-button"
-            appearance="filled"
-            variant="brand"
-            @click=${() =>
-              postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER)}
-          >
-            Open Folder
-          </wa-button>
-          <wa-button
-            class="desktop-secondary-button"
-            appearance="outlined"
-            @click=${() => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER)}
-          >
-            Logs
-          </wa-button>
-        </div>
-      </div>
-    `,
+    renderEmptyState({
+      className: 'desktop-empty-workspace-panel',
+      icon: 'folder-open',
+      title,
+      body,
+      actions: [
+        {
+          label: 'Open Folder',
+          appearance: 'filled',
+          variant: 'brand',
+          onClick: () =>
+            postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
+        },
+        {
+          label: 'Logs',
+          appearance: 'outlined',
+          onClick: () => postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_LOG_FOLDER),
+        },
+      ],
+    }),
     container,
   );
   return container;
 }
 
-const LOG_VIEWER_DEFAULTS = {
+interface LogViewerState {
+  meta: string;
+  text: string;
+}
+
+let logViewerState: LogViewerState = {
   meta: 'Recent redacted log entries appear here.',
   text: 'Open Logs to load recent entries.',
 };
 
-let logViewerState = { ...LOG_VIEWER_DEFAULTS };
-
-function logViewerTemplate(state: typeof logViewerState): TemplateResult {
+function logViewerTemplate(state: LogViewerState): TemplateResult {
   const action = (
     icon: 'rotate-right' | 'copy' | 'download' | 'folder-open',
     label: string,
@@ -532,22 +530,21 @@ function explorerTemplate(): TemplateResult {
 }
 
 function explorerNoWorkspaceTemplate(): TemplateResult {
-  return html`
-    <section class="desktop-explorer-empty">
-      ${waIcon('folder-open')}
-      <h2>No workspace</h2>
-      <p>Open a folder before selecting files for agents.</p>
-      <wa-button
-        class="desktop-primary-button"
-        appearance="filled"
-        variant="brand"
-        @click=${() =>
-          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER)}
-      >
-        Open Folder
-      </wa-button>
-    </section>
-  `;
+  return renderEmptyState({
+    className: 'desktop-explorer-empty',
+    icon: 'folder-open',
+    title: 'No workspace',
+    body: 'Open a folder before selecting files for agents.',
+    actions: [
+      {
+        label: 'Open Folder',
+        appearance: 'filled',
+        variant: 'brand',
+        onClick: () =>
+          postMessage(DESKTOP_LOCAL_COMMANDS.OPEN_WORKSPACE_FOLDER),
+      },
+    ],
+  });
 }
 
 function explorerHeaderTemplate(
@@ -617,7 +614,7 @@ function treeNodeTemplate(
       role="treeitem"
       title=${node.path}
       data-file-path=${node.path}
-      data-selected=${selectedExplorerFile === node.path ? 'true' : 'false'}
+      data-selected=${selectedExplorerFile === node.path}
       style=${`--tree-depth: ${depth}`}
       @click=${() => selectExplorerFile(node.path)}
       @dblclick=${() => openWorkspaceFile(node.path)}

--- a/packages/desktop/src/renderer/styles.css
+++ b/packages/desktop/src/renderer/styles.css
@@ -259,19 +259,19 @@ wa-button.desktop-explorer-icon-button[disabled]::part(base) {
   text-align: center;
 }
 
-.desktop-explorer-empty wa-icon {
+.desktop-explorer-empty .empty-state-icon {
   color: var(--texra-button-background);
   font-size: 30px;
 }
 
-.desktop-explorer-empty h2 {
+.desktop-explorer-empty .empty-state-title {
   margin: 12px 0 6px;
   color: var(--texra-foreground);
   font-size: 16px;
   font-weight: 600;
 }
 
-.desktop-explorer-empty p {
+.desktop-explorer-empty .empty-state-body {
   margin: 0 0 14px;
 }
 
@@ -396,26 +396,26 @@ wa-button.desktop-explorer-icon-button[disabled]::part(base) {
   text-align: center;
 }
 
-.desktop-empty-workspace-icon {
+.desktop-empty-workspace-panel .empty-state-icon {
   color: var(--texra-button-background);
   font-size: 44px;
 }
 
-.desktop-empty-workspace h1 {
+.desktop-empty-workspace-panel .empty-state-title {
   margin: 20px 0 10px;
   color: var(--texra-foreground);
   font-size: 24px;
   font-weight: 600;
 }
 
-.desktop-empty-workspace p {
+.desktop-empty-workspace-panel .empty-state-body {
   margin: 0;
   color: var(--texra-descriptionForeground);
   font-size: 15px;
   line-height: 1.5;
 }
 
-.desktop-empty-workspace-actions {
+.desktop-empty-workspace-panel .empty-state-actions {
   display: flex;
   justify-content: center;
   gap: 10px;
@@ -498,36 +498,18 @@ wa-button.desktop-secondary-button::part(base):hover {
   background: var(--texra-button-secondaryHoverBackground);
 }
 
-.desktop-onboarding {
-  position: fixed;
-  inset: 0;
-  z-index: 1100;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  box-sizing: border-box;
-  background: rgb(0 0 0 / 40%);
-}
-
-.desktop-onboarding[hidden] {
-  display: none;
-}
-
-.desktop-onboarding-panel {
-  width: min(640px, 100%);
-  max-height: min(720px, calc(100vh - 48px));
-  overflow: auto;
-  border: 1px solid var(--texra-panel-border);
-  border-radius: 6px;
-  background: var(--texra-editor-background);
-  box-shadow: 0 18px 46px rgb(0 0 0 / 34%);
+/* wa-dialog supplies the backdrop, modal positioning, focus trap, and panel
+   chrome; only the body content layout lives here. */
+wa-dialog.desktop-onboarding {
+  --width: min(640px, calc(100vw - 32px));
 }
 
 .desktop-onboarding-header {
   display: grid;
   grid-template-columns: 38px minmax(0, 1fr);
   gap: 14px;
-  padding: 22px 24px 18px;
+  padding-bottom: 18px;
+  margin-bottom: 18px;
   border-bottom: 1px solid var(--texra-panel-border);
 }
 
@@ -560,7 +542,7 @@ wa-button.desktop-secondary-button::part(base):hover {
   display: grid;
   gap: 0;
   margin: 0;
-  padding: 8px 24px 4px;
+  padding: 0;
   list-style: none;
 }
 
@@ -612,21 +594,9 @@ wa-button.desktop-secondary-button::part(base):hover {
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 8px;
-  padding: 16px 24px 22px;
 }
 
 @media (max-width: 560px) {
-  .desktop-onboarding {
-    padding: 12px;
-  }
-
-  .desktop-onboarding-header,
-  .desktop-onboarding-steps,
-  .desktop-onboarding-actions {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
   .desktop-onboarding-actions {
     justify-content: stretch;
   }

--- a/src/shared/wa/actionButtons.ts
+++ b/src/shared/wa/actionButtons.ts
@@ -5,7 +5,7 @@ import { html, type TemplateResult } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 // Local imports - Web Awesome
-import { TEXRA_ICON_LIBRARY, type TeXRAIconName } from './webAwesomeIcons';
+import { type TeXRAIconName, waIcon } from './webAwesomeIcons';
 
 type ActionButtonAppearance = 'filled' | 'outlined' | 'plain';
 type ActionButtonVariant = 'brand' | 'neutral';
@@ -39,7 +39,6 @@ function renderActionButtonBase({
   const classes = [text ? 'action-button' : 'action-icon-button', className]
     .filter(Boolean)
     .join(' ');
-  const iconSlot = text ? 'start' : undefined;
 
   return html`
     <wa-button
@@ -53,13 +52,7 @@ function renderActionButtonBase({
       data-action=${ifDefined(action)}
       @click=${onClick}
     >
-      <wa-icon
-        slot=${ifDefined(iconSlot)}
-        library=${TEXRA_ICON_LIBRARY}
-        name=${icon}
-        variant="solid"
-      ></wa-icon>
-      ${text}
+      ${waIcon(icon, { slot: text ? 'start' : undefined })} ${text}
     </wa-button>
   `;
 }

--- a/src/shared/wa/emptyState.ts
+++ b/src/shared/wa/emptyState.ts
@@ -1,0 +1,57 @@
+// Hero empty-state pattern shared between hosts. Consumers style via the
+// .empty-state-* class hooks; the helper owns the structure.
+
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
+import { html, nothing, type TemplateResult } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import { waIcon, type TeXRAIconName } from './webAwesomeIcons';
+
+export interface EmptyStateAction {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly appearance?: 'filled' | 'outlined';
+  readonly variant?: 'brand' | 'neutral';
+}
+
+export interface EmptyStateOptions {
+  readonly icon: TeXRAIconName;
+  readonly title: string;
+  readonly body?: string;
+  readonly actions?: readonly EmptyStateAction[];
+  readonly className?: string;
+}
+
+export function renderEmptyState({
+  icon,
+  title,
+  body,
+  actions,
+  className,
+}: EmptyStateOptions): TemplateResult {
+  return html`
+    <section class=${ifDefined(className)}>
+      ${waIcon(icon, { className: 'empty-state-icon' })}
+      <h2 class="empty-state-title">${title}</h2>
+      ${body ? html`<p class="empty-state-body">${body}</p>` : nothing}
+      ${actions && actions.length > 0
+        ? html`
+            <div class="empty-state-actions">
+              ${actions.map(
+                (action) => html`
+                  <wa-button
+                    appearance=${action.appearance ?? 'outlined'}
+                    variant=${action.variant ?? 'neutral'}
+                    @click=${action.onClick}
+                  >
+                    ${action.label}
+                  </wa-button>
+                `,
+              )}
+            </div>
+          `
+        : nothing}
+    </section>
+  `;
+}

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -45,12 +45,12 @@ import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons/faEllipsis';
 import { faEye } from '@fortawesome/free-solid-svg-icons/faEye';
 import { faFile } from '@fortawesome/free-solid-svg-icons/faFile';
-import { faFlask } from '@fortawesome/free-solid-svg-icons/faFlask';
 import { faFileCirclePlus } from '@fortawesome/free-solid-svg-icons/faFileCirclePlus';
 import { faFileCode } from '@fortawesome/free-solid-svg-icons/faFileCode';
 import { faFileExport } from '@fortawesome/free-solid-svg-icons/faFileExport';
 import { faFileLines } from '@fortawesome/free-solid-svg-icons/faFileLines';
 import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf';
+import { faFlask } from '@fortawesome/free-solid-svg-icons/faFlask';
 import { faFloppyDisk } from '@fortawesome/free-solid-svg-icons/faFloppyDisk';
 import { faFolder } from '@fortawesome/free-solid-svg-icons/faFolder';
 import { faFolderOpen } from '@fortawesome/free-solid-svg-icons/faFolderOpen';
@@ -173,12 +173,12 @@ const icons = {
   ellipsis: faEllipsis,
   eye: faEye,
   file: faFile,
-  flask: faFlask,
   'file-circle-plus': faFileCirclePlus,
   'file-code': faFileCode,
   'file-export': faFileExport,
   'file-lines': faFileLines,
   'file-pdf': faFilePdf,
+  flask: faFlask,
   'floppy-disk': faFloppyDisk,
   folder: faFolder,
   'folder-open': faFolderOpen,

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -85,11 +85,13 @@ describe('desktop renderer shell', () => {
     );
     // wa-dialog handles focus trap, escape, and modal backdrop natively.
     // Assert the dialog wiring + the one custom keydown interceptor.
+    expect(rendererOnboarding).toContain("document.createElement('wa-dialog')");
     expect(rendererOnboarding).toContain(
-      "document.createElement('wa-dialog')",
+      "dialog.addEventListener('wa-after-show'",
     );
-    expect(rendererOnboarding).toContain("dialog.addEventListener('wa-after-show'");
-    expect(rendererOnboarding).toContain("dialog.addEventListener('wa-after-hide'");
+    expect(rendererOnboarding).toContain(
+      "dialog.addEventListener('wa-after-hide'",
+    );
     expect(rendererOnboarding).toContain("dialog.addEventListener('keydown'");
     expect(rendererOnboarding).toContain('isCommandPaletteShortcut(event)');
   });

--- a/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
+++ b/src/test-kernel/desktop/ElectronRendererShell.vitest.mts
@@ -83,11 +83,15 @@ describe('desktop renderer shell', () => {
     expect(rendererMain).toContain(
       'canOpen: () => !firstRunWalkthrough.isVisible()',
     );
-    expect(rendererOnboarding).toContain('previousFocus');
-    expect(rendererOnboarding).toContain("document.addEventListener('focusin'");
-    expect(rendererOnboarding).toContain("'keydown'");
+    // wa-dialog handles focus trap, escape, and modal backdrop natively.
+    // Assert the dialog wiring + the one custom keydown interceptor.
+    expect(rendererOnboarding).toContain(
+      "document.createElement('wa-dialog')",
+    );
+    expect(rendererOnboarding).toContain("dialog.addEventListener('wa-after-show'");
+    expect(rendererOnboarding).toContain("dialog.addEventListener('wa-after-hide'");
+    expect(rendererOnboarding).toContain("dialog.addEventListener('keydown'");
     expect(rendererOnboarding).toContain('isCommandPaletteShortcut(event)');
-    expect(rendererOnboarding).toContain("event.key !== 'Tab'");
   });
 
   it('mounts an in-app log viewer with copy and export actions', () => {


### PR DESCRIPTION
## Summary

Iterate on the desktop chrome by replacing ad-hoc CSS modal/empty-state markup with native Web Awesome components, and extract the empty-state pattern to a shared helper for the extension webviews to adopt next.

### wa-dialog for the first-run walkthrough
- \`desktopOnboarding.ts\` now wraps the panel in \`<wa-dialog withoutHeader>\` with \`show()\`/\`hide()\` toggling the \`open\` property.
- **Deletes ~50 lines of hand-rolled focus-trap code**: \`FOCUSABLE_SELECTOR\`, \`focusin\` handler, Tab cycling, Escape handling, focus restoration on close. \`wa-dialog\` handles modal semantics, focus containment, Escape, and \`originalTrigger\` restoration natively.
- The single remaining custom keyboard handler is the \`isCommandPaletteShortcut\` interceptor (suppress Cmd/Ctrl-K while the dialog is open).
- \`styles.css\` drops the ~40 lines of fixed-positioning + backdrop + panel-chrome rules. Only the dialog body's layout (header grid, steps list, footer row) remains.

### Shared empty-state helper
- New \`src/shared/wa/emptyState.ts\` exports \`renderEmptyState({ icon, title, body, actions, className })\` — a Lit template producing the centered icon + title + body + action-button pattern with generic class hooks (\`.empty-state-icon\`, \`.empty-state-title\`, \`.empty-state-body\`, \`.empty-state-actions\`).
- Reused by \`createNoWorkspacePlaceholder\` and \`explorerNoWorkspaceTemplate\` in the desktop renderer; host CSS in \`styles.css\` targets the generic class hooks scoped under \`.desktop-empty-workspace-panel\` and \`.desktop-explorer-empty\`.
- Re-exported from \`@shared/wa\` so the extension webview banners (LoginBanner, ApiKeyBanner, GettingStartedBanner, AgentConfigBanner, DependencyBanner) can drop their hand-rolled banner styles in a follow-up PR.

## Out of scope
- The desktop command palette still uses a custom \`<div role="dialog">\`; converting to \`wa-dialog\` is a larger change that needs filtering + listbox keyboard nav reconciled with wa-dialog focus management.
- Extension banner adoption of \`renderEmptyState\` follows in a separate PR — those banners also still use \`vscode-button\` / \`vscode-toolbar-button\` and need the form-control migration first.
- The workspace-tree \`<details>\` recursion can move to native \`wa-tree\` for a11y/keyboard wins; queued for the next iteration.

## Stacked on
#3645 (Web Awesome bootstrap + Lit refactor of desktop chrome). Merge that one first; this PR's base is set to that branch.

## Test plan
- [x] \`npm run typecheck\` passes.
- [x] \`vite build\` for desktop renderer succeeds.
- [ ] Open desktop, verify first-run walkthrough renders centered with backdrop, no scroll lock issues.
- [ ] Tab from inside walkthrough → focus stays trapped within wa-dialog.
- [ ] Escape closes the walkthrough and restores focus to the trigger.
- [ ] Cmd/Ctrl-K does *not* open the command palette while walkthrough is visible.
- [ ] Empty workspace prompt + explorer "no workspace" prompt render the same icon/title/body/buttons as before, with light/dark/HC themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/a11y behavior change: replaces a custom modal focus/escape implementation with `wa-dialog` and tweaks dismissal signaling, which could affect keyboard handling and onboarding state synchronization.
> 
> **Overview**
> Replaces the desktop first-run onboarding overlay with a native `wa-dialog`, deleting the hand-rolled focus trap/Tab cycling/Escape handling and wiring dismissal through `wa-after-hide` (with suppression to avoid host feedback loops) while still blocking the command-palette shortcut.
> 
> Introduces a shared `renderEmptyState` helper in `src/shared/wa/emptyState.ts` and migrates desktop “no workspace” placeholders to use it; desktop CSS is updated to style the new `.empty-state-*` hooks.
> 
> Simplifies shared WA action buttons to render icons via the centralized `waIcon` helper, and updates the renderer-shell test to assert the new `wa-dialog` wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b2bc1661956d676fa510af48fefaa662c7438e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->