### PR TITLE
feat(extension): migrate webview banners to wa-callout + wa-button

### DIFF
--- a/packages/desktop/src/renderer/themeTokens.css
+++ b/packages/desktop/src/renderer/themeTokens.css
@@ -205,6 +205,34 @@
   --wa-color-brand-fill-loud: var(--desktop-color-accent);
   --wa-color-brand-on-loud: #ffffff;
   --wa-color-brand-border-loud: transparent;
+
+  /* Variant tokens for wa-callout / wa-button — wire desktop palette
+     through the WA color stack so warning/danger/success callouts blend
+     with the host theme rather than the WA defaults. */
+  --wa-color-brand-fill-quiet: var(--desktop-color-info-background);
+  --wa-color-brand-border-quiet: var(--desktop-color-info);
+  --wa-color-brand-on-quiet: var(--desktop-color-info);
+
+  --wa-color-warning-fill-loud: var(--desktop-color-warning);
+  --wa-color-warning-on-loud: #ffffff;
+  --wa-color-warning-border-loud: transparent;
+  --wa-color-warning-fill-quiet: var(--desktop-color-warning-background);
+  --wa-color-warning-border-quiet: var(--desktop-color-warning);
+  --wa-color-warning-on-quiet: var(--desktop-color-warning);
+
+  --wa-color-danger-fill-loud: var(--desktop-color-error);
+  --wa-color-danger-on-loud: #ffffff;
+  --wa-color-danger-border-loud: transparent;
+  --wa-color-danger-fill-quiet: var(--desktop-color-error);
+  --wa-color-danger-border-quiet: var(--desktop-color-error);
+  --wa-color-danger-on-quiet: #ffffff;
+
+  --wa-color-success-fill-loud: var(--desktop-color-success);
+  --wa-color-success-on-loud: #ffffff;
+  --wa-color-success-border-loud: transparent;
+  --wa-color-success-fill-quiet: var(--desktop-color-success);
+  --wa-color-success-border-quiet: var(--desktop-color-success);
+  --wa-color-success-on-quiet: #ffffff;
 }
 
 body.vscode-light,

--- a/packages/extension/src/common/styles/common.css
+++ b/packages/extension/src/common/styles/common.css
@@ -241,6 +241,31 @@
   --wa-color-brand-fill-loud: var(--texra-button-background);
   --wa-color-brand-on-loud: var(--texra-button-foreground);
   --wa-color-brand-border-loud: var(--texra-button-border);
+
+  /* Variant tokens for wa-callout / wa-button — wire VS Code validation
+     palettes through the WA color stack so brand/warning/danger/success
+     callouts blend with the host theme rather than the WA defaults. */
+  --wa-color-brand-fill-quiet: var(--texra-inputValidation-infoBackground);
+  --wa-color-brand-border-quiet: var(--texra-inputValidation-infoBorder);
+  --wa-color-brand-on-quiet: var(--texra-inputValidation-infoForeground);
+
+  --wa-color-warning-fill-loud: var(--texra-statusBarItem-warningBackground);
+  --wa-color-warning-on-loud: var(--texra-foreground);
+  --wa-color-warning-border-loud: var(--texra-inputValidation-warningBorder);
+  --wa-color-warning-fill-quiet: var(--texra-inputValidation-warningBackground);
+  --wa-color-warning-border-quiet: var(--texra-inputValidation-warningBorder);
+  --wa-color-warning-on-quiet: var(--texra-inputValidation-warningForeground);
+
+  --wa-color-danger-fill-quiet: var(--texra-inputValidation-errorBackground);
+  --wa-color-danger-border-quiet: var(--texra-inputValidation-errorBorder);
+  --wa-color-danger-on-quiet: var(--texra-inputValidation-errorForeground);
+
+  --wa-color-success-fill-quiet: var(
+    --texra-charts-green,
+    var(--texra-inputValidation-infoBackground)
+  );
+  --wa-color-success-border-quiet: var(--texra-inputValidation-infoBorder);
+  --wa-color-success-on-quiet: var(--texra-foreground);
 }
 
 body {

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -1,34 +1,24 @@
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { AgentConfigBannerState } from '@shared/schemas';
 import { warningBannerStyles } from '../styles/warningBannerStyles';
 import { MainViewEvents } from '../events';
 
 @customElement('agent-config-banner')
 export class AgentConfigBanner extends LitElement {
-  static override styles = [
-    designTokens,
-    codiconStyles,
-    commonViewStyles,
-    warningBannerStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, warningBannerStyles];
 
   @property({ attribute: false }) state: AgentConfigBannerState = {
     visible: false,
   };
 
-  private handleActionClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-action]',
-    );
-    const action = button?.dataset.action as
-      | 'edit'
-      | 'dir'
-      | 'docs'
-      | undefined;
-    if (!action) return;
+  private handleAction(action: 'edit' | 'dir' | 'docs'): void {
     this.dispatchEvent(
       MainViewEvents.agentConfigAction({
         action,
@@ -41,40 +31,50 @@ export class AgentConfigBanner extends LitElement {
     if (!this.state.visible) return nothing;
 
     return html`
-      <div
+      <wa-callout
         id="agentConfigBanner"
         class="warning-banner"
+        variant="warning"
         data-custom-dir-set=${this.state.customDirSet ? 'true' : 'false'}
       >
-        <span>
-          ${this.state.agentName
-            ? `Agent file for "${this.state.agentName}" is missing.`
-            : 'Agent configuration is missing.'}
-        </span>
-        <div class="actions" @click=${this.handleActionClick}>
-          <vscode-toolbar-button
-            id="agentConfigEditButton"
-            icon="edit"
-            data-action="edit"
-          >
-            Edit Agents
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDirButton"
-            icon="folder"
-            data-action="dir"
-          >
-            ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="agentConfigDocButton"
-            icon="book"
-            data-action="docs"
-          >
-            Docs
-          </vscode-toolbar-button>
+        ${waIcon('triangle-exclamation', { slot: 'icon' })}
+        <div class="banner-row">
+          <span>
+            ${this.state.agentName
+              ? `Agent file for "${this.state.agentName}" is missing.`
+              : 'Agent configuration is missing.'}
+          </span>
+          <div class="actions">
+            <wa-button
+              id="agentConfigEditButton"
+              appearance="plain"
+              size="small"
+              @click=${() => this.handleAction('edit')}
+            >
+              ${waIcon('pencil', { slot: 'start' })}
+              Edit Agents
+            </wa-button>
+            <wa-button
+              id="agentConfigDirButton"
+              appearance="plain"
+              size="small"
+              @click=${() => this.handleAction('dir')}
+            >
+              ${waIcon('folder', { slot: 'start' })}
+              ${this.state.customDirSet ? 'Open Directory' : 'Set Directory'}
+            </wa-button>
+            <wa-button
+              id="agentConfigDocButton"
+              appearance="plain"
+              size="small"
+              @click=${() => this.handleAction('docs')}
+            >
+              ${waIcon('book', { slot: 'start' })}
+              Docs
+            </wa-button>
+          </div>
         </div>
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
+++ b/packages/extension/src/webview/frontend/components/AgentConfigBanner.ts
@@ -12,7 +12,11 @@ import { MainViewEvents } from '../events';
 
 @customElement('agent-config-banner')
 export class AgentConfigBanner extends LitElement {
-  static override styles = [designTokens, commonViewStyles, warningBannerStyles];
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    warningBannerStyles,
+  ];
 
   @property({ attribute: false }) state: AgentConfigBannerState = {
     visible: false,
@@ -51,8 +55,7 @@ export class AgentConfigBanner extends LitElement {
               size="small"
               @click=${() => this.handleAction('edit')}
             >
-              ${waIcon('pencil', { slot: 'start' })}
-              Edit Agents
+              ${waIcon('pencil', { slot: 'start' })} Edit Agents
             </wa-button>
             <wa-button
               id="agentConfigDirButton"
@@ -69,8 +72,7 @@ export class AgentConfigBanner extends LitElement {
               size="small"
               @click=${() => this.handleAction('docs')}
             >
-              ${waIcon('book', { slot: 'start' })}
-              Docs
+              ${waIcon('book', { slot: 'start' })} Docs
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -13,7 +13,11 @@ import { MainViewEvents } from '../events';
 
 @customElement('api-key-banner')
 export class ApiKeyBanner extends LitElement {
-  static override styles = [designTokens, commonViewStyles, warningBannerStyles];
+  static override styles = [
+    designTokens,
+    commonViewStyles,
+    warningBannerStyles,
+  ];
 
   @property({ attribute: false }) state: ApiKeyBannerState = {
     visible: false,
@@ -31,11 +35,7 @@ export class ApiKeyBanner extends LitElement {
     const providerLabel = provider ? capitalize(provider) : '';
 
     return html`
-      <wa-callout
-        id="apiKeyBanner"
-        class="warning-banner"
-        variant="warning"
-      >
+      <wa-callout id="apiKeyBanner" class="warning-banner" variant="warning">
         ${waIcon('triangle-exclamation', { slot: 'icon' })}
         <div class="banner-row">
           <span>

--- a/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/ApiKeyBanner.ts
@@ -1,7 +1,11 @@
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { ApiKeyBannerState } from '@shared/schemas';
 import { capitalize } from '@shared/utils/string';
 import { warningBannerStyles } from '../styles/warningBannerStyles';
@@ -9,23 +13,13 @@ import { MainViewEvents } from '../events';
 
 @customElement('api-key-banner')
 export class ApiKeyBanner extends LitElement {
-  static override styles = [
-    designTokens,
-    codiconStyles,
-    commonViewStyles,
-    warningBannerStyles,
-  ];
+  static override styles = [designTokens, commonViewStyles, warningBannerStyles];
 
   @property({ attribute: false }) state: ApiKeyBannerState = {
     visible: false,
   };
 
-  private handleActionClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-action]',
-    );
-    const action = button?.dataset.action as 'set' | 'guide' | undefined;
-    if (!action) return;
+  private handleAction(action: 'set' | 'guide'): void {
     const provider = this.state.provider ?? '';
     this.dispatchEvent(MainViewEvents.apiKeyAction({ action, provider }));
   }
@@ -37,34 +31,45 @@ export class ApiKeyBanner extends LitElement {
     const providerLabel = provider ? capitalize(provider) : '';
 
     return html`
-      <div id="apiKeyBanner" class="warning-banner">
-        <span>
-          ${provider
-            ? html`<strong>${providerLabel}</strong> API key missing.`
-            : 'TeXRA requires an API key to run.'}
-        </span>
-        <div class="actions" @click=${this.handleActionClick}>
-          <vscode-toolbar-button
-            id="apiKeyBannerButton"
-            icon="key"
-            data-action="set"
-          >
-            ${provider ? 'Set Key' : 'Set API Key'}
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="apiKeyGuideButton"
-            icon="book"
-            data-action="guide"
-          >
-            ${provider ? 'Get Key' : 'API Key Guide'}
-          </vscode-toolbar-button>
+      <wa-callout
+        id="apiKeyBanner"
+        class="warning-banner"
+        variant="warning"
+      >
+        ${waIcon('triangle-exclamation', { slot: 'icon' })}
+        <div class="banner-row">
+          <span>
+            ${provider
+              ? html`<strong>${providerLabel}</strong> API key missing.`
+              : 'TeXRA requires an API key to run.'}
+          </span>
+          <div class="actions">
+            <wa-button
+              id="apiKeyBannerButton"
+              appearance="plain"
+              size="small"
+              @click=${() => this.handleAction('set')}
+            >
+              ${waIcon('key', { slot: 'start' })}
+              ${provider ? 'Set Key' : 'Set API Key'}
+            </wa-button>
+            <wa-button
+              id="apiKeyGuideButton"
+              appearance="plain"
+              size="small"
+              @click=${() => this.handleAction('guide')}
+            >
+              ${waIcon('book', { slot: 'start' })}
+              ${provider ? 'Get Key' : 'API Key Guide'}
+            </wa-button>
+          </div>
+          <span class="hint">
+            Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include
+            API access. You need a separate API key from the provider's
+            developer platform.
+          </span>
         </div>
-        <span class="hint">
-          Chat subscriptions (ChatGPT Plus, Claude Pro, etc.) do not include API
-          access. You need a separate API key from the provider's developer
-          platform.
-        </span>
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -94,8 +94,7 @@ export class DependencyBanner extends LitElement {
                         size="small"
                         @click=${() => this.handleInstall(tool)}
                       >
-                        ${waIcon('cloud-arrow-down', { slot: 'start' })}
-                        Install
+                        ${waIcon('cloud-arrow-down', { slot: 'start' })} Install
                       </wa-button>
                     </div>
                   `,
@@ -109,8 +108,7 @@ export class DependencyBanner extends LitElement {
               size="small"
               @click=${this.handleRecheck}
             >
-              ${waIcon('rotate-right', { slot: 'start' })}
-              Re-check
+              ${waIcon('rotate-right', { slot: 'start' })} Re-check
             </wa-button>
             <wa-button
               id="dependencyDismissButton"
@@ -119,8 +117,7 @@ export class DependencyBanner extends LitElement {
               title="Dismiss (can be re-enabled in settings)"
               @click=${this.handleDismiss}
             >
-              ${waIcon('xmark', { slot: 'start' })}
-              Dismiss
+              ${waIcon('xmark', { slot: 'start' })} Dismiss
             </wa-button>
           </div>
         </div>

--- a/packages/extension/src/webview/frontend/components/DependencyBanner.ts
+++ b/packages/extension/src/webview/frontend/components/DependencyBanner.ts
@@ -1,9 +1,13 @@
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { when } from 'lit/directives/when.js';
 
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import type { DependencyBannerState } from '@shared/schemas';
 import { warningBannerStyles } from '../styles/warningBannerStyles';
 import { MainViewEvents } from '../events';
@@ -12,7 +16,6 @@ import { MainViewEvents } from '../events';
 export class DependencyBanner extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     warningBannerStyles,
     css`
@@ -43,14 +46,8 @@ export class DependencyBanner extends LitElement {
     this.dispatchEvent(MainViewEvents.recheckDependencies());
   }
 
-  private handleInstallClick(event: MouseEvent): void {
-    const button = (event.target as HTMLElement).closest<HTMLElement>(
-      '[data-tool]',
-    );
-    const tool = button?.dataset.tool;
-    if (tool) {
-      this.dispatchEvent(MainViewEvents.openInstallGuide({ tool }));
-    }
+  private handleInstall(tool: string): void {
+    this.dispatchEvent(MainViewEvents.openInstallGuide({ tool }));
   }
 
   private getToolLabel(tool: string): string {
@@ -73,52 +70,61 @@ export class DependencyBanner extends LitElement {
     );
 
     return html`
-      <div id="dependencyBanner" class="warning-banner">
-        <span class="missing-tools" @click=${this.handleInstallClick}>
-          ${when(
-            tools.length === 0,
-            () => html`Missing dependencies: none`,
-            () =>
-              repeat(
-                tools,
-                (tool) => tool,
-                (tool) => {
-                  const label = this.getToolLabel(tool);
-                  return html`
+      <wa-callout
+        id="dependencyBanner"
+        class="warning-banner"
+        variant="warning"
+      >
+        ${waIcon('triangle-exclamation', { slot: 'icon' })}
+        <div class="banner-row">
+          <span class="missing-tools">
+            ${when(
+              tools.length === 0,
+              () => html`Missing dependencies: none`,
+              () =>
+                repeat(
+                  tools,
+                  (tool) => tool,
+                  (tool) => html`
                     <div class="dependency-item">
-                      <span>${label}</span>
-                      <vscode-toolbar-button
-                        class="btn-secondary dependency-install-button"
-                        icon="cloud-download"
-                        data-tool=${tool}
+                      <span>${this.getToolLabel(tool)}</span>
+                      <wa-button
+                        class="dependency-install-button"
+                        appearance="plain"
+                        size="small"
+                        @click=${() => this.handleInstall(tool)}
                       >
+                        ${waIcon('cloud-arrow-down', { slot: 'start' })}
                         Install
-                      </vscode-toolbar-button>
+                      </wa-button>
                     </div>
-                  `;
-                },
-              ),
-          )}
-        </span>
-        <div class="actions">
-          <vscode-toolbar-button
-            id="dependencyRecheckButton"
-            icon="refresh"
-            @click=${this.handleRecheck}
-          >
-            Re-check
-          </vscode-toolbar-button>
-          <vscode-toolbar-button
-            id="dependencyDismissButton"
-            class="btn-secondary"
-            title="Dismiss (can be re-enabled in settings)"
-            icon="close"
-            @click=${this.handleDismiss}
-          >
-            Dismiss
-          </vscode-toolbar-button>
+                  `,
+                ),
+            )}
+          </span>
+          <div class="actions">
+            <wa-button
+              id="dependencyRecheckButton"
+              appearance="plain"
+              size="small"
+              @click=${this.handleRecheck}
+            >
+              ${waIcon('rotate-right', { slot: 'start' })}
+              Re-check
+            </wa-button>
+            <wa-button
+              id="dependencyDismissButton"
+              appearance="plain"
+              size="small"
+              title="Dismiss (can be re-enabled in settings)"
+              @click=${this.handleDismiss}
+            >
+              ${waIcon('xmark', { slot: 'start' })}
+              Dismiss
+            </wa-button>
+          </div>
         </div>
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
+++ b/packages/extension/src/webview/frontend/components/GettingStartedBanner.ts
@@ -1,65 +1,49 @@
-/**
- * Banner component for the getting started walkthrough.
- *
- * Displays an info banner with links to various getting started
- * actions when no files are found in the workspace.
- *
- * @fires dismiss-getting-started - When dismiss button is clicked
- */
-
-// Third-party imports
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-// Local imports - shared styles
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
-
-// Local imports - shared utilities
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { COMMAND_LINKS } from '@shared/utils/uiConstants';
 
-// Local imports - main view events
 import { MainViewEvents } from '../events';
 
 @customElement('getting-started-banner')
 export class GettingStartedBanner extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
         display: block;
       }
 
-      .getting-started-banner {
-        border-radius: var(--border-radius);
-        padding: var(--spacing-small) var(--spacing-medium);
+      wa-callout.getting-started-banner {
         margin-bottom: var(--spacing-large);
-        background-color: var(--texra-inputValidation-infoBackground);
-        color: var(--texra-inputValidation-infoForeground);
-        border: var(--border-thin) solid var(--texra-inputValidation-infoBorder);
-        line-height: var(--line-height-relaxed);
       }
 
-      .getting-started-banner a {
+      wa-callout.getting-started-banner a {
         color: var(--color-text-link);
         text-decoration: none;
       }
 
-      .getting-started-banner a:hover {
+      wa-callout.getting-started-banner a:hover {
         text-decoration: underline;
-      }
-
-      .getting-started-list {
-        margin: var(--spacing-tiny) 0 0 0;
-        padding-left: var(--spacing-large);
-        line-height: var(--line-height-relaxed);
       }
 
       .getting-started-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
+        gap: var(--spacing-small);
+      }
+
+      .getting-started-list {
+        margin: var(--spacing-tiny) 0 0 0;
+        padding-left: var(--spacing-large);
+        line-height: var(--line-height-relaxed);
       }
     `,
   ];
@@ -74,24 +58,32 @@ export class GettingStartedBanner extends LitElement {
     if (!this.visible) return nothing;
 
     return html`
-      <div id="gettingStartedBanner" class="getting-started-banner">
+      <wa-callout
+        id="gettingStartedBanner"
+        class="getting-started-banner"
+        variant="brand"
+      >
+        ${waIcon('lightbulb', { slot: 'icon' })}
         <div class="getting-started-header">
-          <span class="getting-started-text">
+          <span>
             <strong>Welcome to TeXRA!</strong> No LaTeX files here yet — pick
             how you'd like to start:
           </span>
-          <vscode-toolbar-button
-            icon="close"
+          <wa-button
+            appearance="plain"
+            size="small"
             title="Dismiss (can be re-enabled in settings)"
             aria-label="Dismiss getting started banner"
             @click=${this.handleDismiss}
-          ></vscode-toolbar-button>
+          >
+            ${waIcon('xmark')}
+          </wa-button>
         </div>
         <ul class="getting-started-list">
           <li>
-            <a href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}
-              >Run the setup assistant agent</a
-            >
+            <a href=${COMMAND_LINKS.RUN_SETUP_ASSISTANT}>
+              Run the setup assistant agent
+            </a>
             -- checks tools, credentials, and LaTeX setup
           </li>
           <li>
@@ -99,9 +91,9 @@ export class GettingStartedBanner extends LitElement {
             -- takes a few minutes
           </li>
           <li>
-            <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}
-              >Try the sample project</a
-            >
+            <a href=${COMMAND_LINKS.CREATE_SAMPLE_PROJECT}>
+              Try the sample project
+            </a>
             -- play around risk-free
           </li>
           <li>
@@ -113,7 +105,7 @@ export class GettingStartedBanner extends LitElement {
             -- download a paper's source
           </li>
         </ul>
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -86,8 +86,7 @@ export class LoginBanner extends LitElement {
               size="small"
               @click=${this.handleSignIn}
             >
-              ${waIcon('right-to-bracket', { slot: 'start' })}
-              Sign In
+              ${waIcon('right-to-bracket', { slot: 'start' })} Sign In
             </wa-button>
             <wa-button
               id="loginBannerDismissButton"

--- a/packages/extension/src/webview/frontend/components/LoginBanner.ts
+++ b/packages/extension/src/webview/frontend/components/LoginBanner.ts
@@ -1,88 +1,58 @@
-/**
- * Banner component for the Researcher Access Program sign-in.
- *
- * Displays an info banner encouraging users to sign in for
- * access to AI models without their own API keys.
- *
- * @fires sign-in - When sign in button is clicked
- * @fires dismiss-login - When dismiss button is clicked
- */
-
-// Third-party imports
+import '@awesome.me/webawesome/dist/components/button/button.js';
+import '@awesome.me/webawesome/dist/components/callout/callout.js';
+import '@awesome.me/webawesome/dist/components/icon/icon.js';
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-// Local imports - shared styles
-import { designTokens, codiconStyles, commonViewStyles } from '@shared/styles';
-
-// Local imports - shared copy
+import { designTokens, commonViewStyles } from '@shared/styles';
+import { waIcon } from '@shared/wa/webAwesomeIcons';
 import { PROMO_NOTICE_SHORT } from '@shared/copy/promoNotice';
 
-// Local imports - main view events
 import { MainViewEvents } from '../events';
 
 @customElement('login-banner')
 export class LoginBanner extends LitElement {
   static override styles = [
     designTokens,
-    codiconStyles,
     commonViewStyles,
     css`
       :host {
         display: block;
       }
 
-      .login-banner {
-        background: var(--texra-inputValidation-infoBackground);
-        color: var(--texra-inputValidation-infoForeground);
-        border: var(--border-thin) solid var(--texra-inputValidation-infoBorder);
-        border-radius: var(--border-radius);
-        padding: var(--spacing-medium);
+      wa-callout.login-banner {
         margin-bottom: var(--spacing-large);
+      }
+
+      .banner-row {
         display: flex;
+        align-items: center;
         justify-content: space-between;
-        align-items: center;
         gap: var(--spacing-medium);
       }
 
-      .login-banner-content {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-medium);
-        flex: 1;
-      }
-
-      .login-banner-icon {
-        font-size: 1.5em;
-        color: var(--texra-button-background);
-        display: flex;
-        align-items: center;
-      }
-
-      .login-banner-text {
+      .banner-text {
         display: flex;
         flex-direction: column;
         gap: var(--spacing-tiny);
+        min-width: 0;
       }
 
-      .login-banner-title {
+      .banner-title {
         font-weight: var(--font-weight-semibold);
         font-size: 1em;
       }
 
-      .login-banner-description {
+      .banner-description {
         font-size: var(--font-size-sm);
         opacity: var(--opacity-normal);
-      }
-
-      .login-banner .actions {
-        flex-shrink: 0;
       }
 
       .actions {
         display: flex;
         align-items: center;
         gap: var(--spacing-small);
+        flex-shrink: 0;
       }
     `,
   ];
@@ -101,36 +71,37 @@ export class LoginBanner extends LitElement {
     if (!this.visible) return nothing;
 
     return html`
-      <div id="loginBanner" class="login-banner">
-        <div class="login-banner-content">
-          <span class="login-banner-icon"
-            ><i class="codicon codicon-sparkle"></i
-          ></span>
-          <div class="login-banner-text">
-            <span class="login-banner-title">Researcher Access Program</span>
-            <span class="login-banner-description">
-              ${PROMO_NOTICE_SHORT}
-            </span>
+      <wa-callout id="loginBanner" class="login-banner" variant="brand">
+        ${waIcon('wand-magic-sparkles', { slot: 'icon' })}
+        <div class="banner-row">
+          <div class="banner-text">
+            <span class="banner-title">Researcher Access Program</span>
+            <span class="banner-description">${PROMO_NOTICE_SHORT}</span>
+          </div>
+          <div class="actions">
+            <wa-button
+              id="loginBannerButton"
+              appearance="filled"
+              variant="brand"
+              size="small"
+              @click=${this.handleSignIn}
+            >
+              ${waIcon('right-to-bracket', { slot: 'start' })}
+              Sign In
+            </wa-button>
+            <wa-button
+              id="loginBannerDismissButton"
+              appearance="plain"
+              size="small"
+              title="Dismiss (can be re-enabled in settings)"
+              aria-label="Dismiss login banner"
+              @click=${this.handleDismiss}
+            >
+              ${waIcon('xmark')}
+            </wa-button>
           </div>
         </div>
-        <div class="actions">
-          <vscode-button
-            id="loginBannerButton"
-            appearance="primary"
-            @click=${this.handleSignIn}
-          >
-            <span slot="start" class="codicon codicon-sign-in"></span>
-            Sign In
-          </vscode-button>
-          <vscode-toolbar-button
-            id="loginBannerDismissButton"
-            icon="close"
-            title="Dismiss (can be re-enabled in settings)"
-            aria-label="Dismiss login banner"
-            @click=${this.handleDismiss}
-          ></vscode-toolbar-button>
-        </div>
-      </div>
+      </wa-callout>
     `;
   }
 }

--- a/packages/extension/src/webview/frontend/styles/warningBannerStyles.ts
+++ b/packages/extension/src/webview/frontend/styles/warningBannerStyles.ts
@@ -1,9 +1,6 @@
-/**
- * Shared styles for warning-type banners (API key, agent config, dependency).
- *
- * Provides the common layout (flex row, warning colors, padding/margin)
- * and action button container used by all warning banners.
- */
+// Shared layout for inline banners. wa-callout owns the variant color,
+// border, and padding; this stylesheet just lays out the message + actions
+// inside the callout's default slot.
 
 import { css, type CSSResult } from 'lit';
 
@@ -12,21 +9,19 @@ export const warningBannerStyles: CSSResult = css`
     display: block;
   }
 
-  .warning-banner {
-    border-radius: var(--border-radius);
-    padding: var(--spacing-small) var(--spacing-medium);
+  wa-callout.warning-banner {
     margin-bottom: var(--spacing-large);
-    background-color: var(--texra-inputValidation-warningBackground);
-    color: var(--texra-inputValidation-warningForeground);
-    border: var(--border-thin) solid var(--texra-inputValidation-warningBorder);
+  }
+
+  .banner-row {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     gap: var(--spacing-tiny) var(--spacing-medium);
   }
 
-  .warning-banner .hint {
+  .banner-row .hint {
     width: 100%;
     font-size: var(--font-size-sm);
     opacity: var(--opacity-normal);

--- a/src/shared/wa/webAwesomeIcons.ts
+++ b/src/shared/wa/webAwesomeIcons.ts
@@ -328,7 +328,8 @@ export function registerTeXRAWebAwesomeIcons(): void {
 export type TeXRAIconName = keyof typeof icons | keyof typeof CODICON_ALIASES;
 
 interface WaIconOptions {
-  readonly slot?: 'start' | 'end';
+  // 'start' / 'end' for wa-button; 'icon' for wa-callout / wa-card.
+  readonly slot?: 'start' | 'end' | 'icon';
   readonly className?: string;
   readonly variant?: 'solid' | 'regular';
 }


### PR DESCRIPTION
## Summary

Iterate on the extension's webview banners by replacing hand-rolled \`vscode-toolbar-button\` + codicon markup with native Web Awesome primitives. Continues the cross-host story from #3644 / #3645 / #3646: the icon registry, \`waIcon()\` Lit helper, and theme tokens land here too.

### Banners migrated
- **ApiKeyBanner**, **AgentConfigBanner**, **DependencyBanner** — \`<wa-callout variant="warning">\` with \`triangle-exclamation\` in \`slot="icon"\`; each \`<vscode-toolbar-button>\` becomes \`<wa-button appearance="plain" size="small">\` with \`<wa-icon slot="start">\` (key, book, pencil, folder, cloud-arrow-down, rotate-right, xmark).
- **LoginBanner** — \`<wa-callout variant="brand">\` with \`wand-magic-sparkles\` icon; the Sign In CTA uses \`appearance="filled" variant="brand"\` and the dismiss is an icon-only \`appearance="plain"\` button.
- **GettingStartedBanner** — \`<wa-callout variant="brand">\` with \`lightbulb\` icon; structure preserves the \`<ul>\` action list with \`COMMAND_LINKS\`.

### Style cleanup
- \`warningBannerStyles\` trimmed from ~40 lines to the inner flex layout (\`.banner-row\` + \`.actions\`); wa-callout now owns the background, border, border-radius, padding, and the icon column.
- All five banners drop the \`codiconStyles\` import — every icon now resolves via the \`texra\` wa-icon library.

### Foundation tweak
- \`waIcon()\`'s \`slot\` type now includes \`'icon'\` (wa-callout / wa-card slots) alongside \`'start'\` / \`'end'\` (wa-button).

## Test plan
- [x] \`npm run typecheck\` — clean.
- [x] \`npx vitest run\` — 311 / 311 passing.
- [ ] Visual check: warning banners (api key missing, agent config missing, deps missing) render with warning palette + triangle icon, action buttons aligned right.
- [ ] Visual check: brand banners (login promo, getting started) render with brand palette + sparkles/lightbulb icons.
- [ ] Confirm dismiss-banner buttons still emit the right MainViewEvents and the parent reacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only refactor that swaps banner components and theme tokens; main risk is visual/layout regressions or missed click handlers in the webview.
> 
> **Overview**
> Migrates the extension webview’s inline banners (API key, agent config, dependencies, login promo, getting started) from VS Code webview controls/codicons to Web Awesome primitives using `wa-callout` variants (`warning`/`brand`) and `wa-button`, with icons rendered via the shared `waIcon()` helper.
> 
> Updates shared banner styling so `wa-callout` owns padding/borders/colors, leaving only inner layout rules, and extends both VS Code and desktop theme token bridges with additional `--wa-color-*` variant tokens so warning/brand/success/danger callouts match the host palette. Also broadens `waIcon()`’s slot typing to allow `slot="icon"` for callout/card usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c20842f1dc911a60fb68817813983e181344acd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->